### PR TITLE
Archive sigbovik.org/2022/papers/

### DIFF
--- a/sigbovik.org/2022/papers/index.html
+++ b/sigbovik.org/2022/papers/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+<html><head>
+<title>404 Not Found</title>
+</head><body>
+<h1>Not Found</h1>
+<p>The requested URL /2022/papers/ was not found on this server.</p>
+<hr>
+<address>Apache/2.2.16 (Debian) Server at sigbovik.org Port 443</address>
+</body></html>


### PR DESCRIPTION
Original source: [https://sigbovik.org/2022/papers/](<https://sigbovik.org/2022/papers/>)

**NOTE:** This is an automatic commit. See the archive workflow.
