### PR TITLE
Download vivi.html

### DIFF
--- a/web.archive.org/web/20160305190737/http:/donh.best.vwh.net/Esperanto/Literaturo/Poezio/vivi.html
+++ b/web.archive.org/web/20160305190737/http:/donh.best.vwh.net/Esperanto/Literaturo/Poezio/vivi.html
@@ -1,0 +1,118 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"
+                           "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html lang="eo">
+<head><script type="text/javascript" src="https://web-static.archive.org/_static/js/bundle-playback.js?v=qM_6omlu" charset="utf-8"></script>
+<script type="text/javascript" src="https://web-static.archive.org/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
+<script>window.RufflePlayer=window.RufflePlayer||{};window.RufflePlayer.config={"autoplay":"on","unmuteOverlay":"hidden"};</script>
+<script type="text/javascript" src="https://web-static.archive.org/_static/js/ruffle/ruffle.js"></script>
+<script type="text/javascript">
+    __wm.init("http://web.archive.org/web");
+  __wm.wombat("http://donh.best.vwh.net/Esperanto/Literaturo/Poezio/vivi.html","20160305190737","http://web.archive.org/","web","https://web-static.archive.org/_static/",
+	      "1457204857");
+</script>
+<link rel="stylesheet" type="text/css" href="https://web-static.archive.org/_static/css/banner-styles.css?v=S1zqJCYt" />
+<link rel="stylesheet" type="text/css" href="https://web-static.archive.org/_static/css/iconochive.css?v=qtvMKcIJ" />
+<!-- End Wayback Rewrite JS Include -->
+
+<!--Esperanto-Literaturo en la reto-->
+<title>
+Vivi (Victor HUGO)
+</title>
+<meta http-equiv="description" content="To Live, a poem by Victor Hugo, translated into Esperanto by Charles Chomette"> 
+<meta http-equiv="keywords" content="Esperanto, French literature, Victor Hugo">
+<meta name="author" content="Donald J. Harlow">
+<meta name="copyright" content="2000, Donald J. Harlow">
+<meta name="rating" content="general">
+<meta http-equiv="content-language" content="eo">
+<script language="JavaScript">
+<!--
+if (navigator.appName == "Netscape") {
+	document.write('<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-3">');
+}
+//-->
+</script>
+<link rel="STYLESHEET" href="/web/20160305190737cs_/http://donh.best.vwh.net/Esperanto/Literaturo/esplit.css" type="text/css">
+</head>
+
+<body>
+
+<p class="mailer">
+Enkomputiligis 
+<a href="http://web.archive.org/web/20160305190737/mailto:donh@donh.best.vwh.net?subject=Vivi">
+Don HARLOW
+</a>
+</p>
+
+<h1 align="center">Vivi</h1>
+<h2 align="center">de Victor HUGO</h2>
+<h3 align="center">elfrancigis Charles CHOMETTE</h3>
+<h4 align="center">Aperis en <em>Paco</em>, 3/89, p. 2</h4>
+
+<hr width="50%">
+
+<center>
+
+<a href="http://web.archive.org/web/20160305190737/http://www.esperanto.be/tiparoj.html">
+<img name="lat3nun" src="/web/20160305190737im_/http://donh.best.vwh.net/Esperanto/Literaturo/icons_donh/lat3nun.gif" alt="Klaketu æi tie por Latin-3 literaro"></a>
+
+<a href="viviu.html">
+<img name="unicode" src="/web/20160305190737im_/http://donh.best.vwh.net/Esperanto/Literaturo/icons_donh/unicode.gif" alt="Klaketu æi tie por versio unikoda"></a>
+
+</center>
+
+<hr width="50%">
+
+<table align="center">
+<tr>
+<td>
+Vivi estas strebi<br>
+al la bon' kaj belo<br>
+kaj sin mem oferi<br>
+por merita celo.<br>
+<br>
+Vivi estas grimpi<br>
+la krutan montaron<br>
+kaj destinon iri<br>
+ne timante baron.<br>
+<br>
+Vivi estas marþi<br>
+pri l' estont' pensante<br>
+kaj la flamon gardi<br>
+ne malesperante.<br>
+<br>
+Vivi estas ami<br>
+per la tuta koro<br>
+kaj senlace preni<br>
+øis la lasta horo.
+</td>
+</tr>
+
+</table>
+
+<hr>
+<img src="/web/20160305190737im_/http://donh.best.vwh.net/gifs/literat.gif" alt="">
+
+</body>
+</html>
+
+
+<!--
+     FILE ARCHIVED ON 19:07:37 Mar 05, 2016 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 00:37:31 Jul 01, 2024.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 0.558
+  exclusion.robots: 0.113
+  exclusion.robots.policy: 0.105
+  esindex: 0.009
+  cdx.remote: 13.919
+  LoadShardBlock: 176.671 (3)
+  PetaboxLoader3.datanode: 120.157 (4)
+  PetaboxLoader3.resolve: 88.756 (2)
+  load_resource: 82.815
+-->


### PR DESCRIPTION
Original source: web.archive.org/web/20160305190737/http:/donh.best.vwh.net/Esperanto/Literaturo/Poezio/vivi.html

**NOTE:** This is an automatic commit. See the archive workflow.

Signed-off-by: norwd <106889957+norwd@users.noreply.github.com>
