### PR TITLE
Download JutlandoH.html

### DIFF
--- a/web.archive.org/web/20160407214842/http:/donh.best.vwh.net/Esperanto/Literaturo/Poezio/JutlandoH.html
+++ b/web.archive.org/web/20160407214842/http:/donh.best.vwh.net/Esperanto/Literaturo/Poezio/JutlandoH.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html PUBLIC
+                    "-//W3C//DTD XHTML 1.0 Transitional//EN"
+                    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html lang="eo">
+<head><script type="text/javascript" src="https://web-static.archive.org/_static/js/bundle-playback.js?v=qM_6omlu" charset="utf-8"></script>
+<script type="text/javascript" src="https://web-static.archive.org/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
+<script>window.RufflePlayer=window.RufflePlayer||{};window.RufflePlayer.config={"autoplay":"on","unmuteOverlay":"hidden"};</script>
+<script type="text/javascript" src="https://web-static.archive.org/_static/js/ruffle/ruffle.js"></script>
+<script type="text/javascript">
+    __wm.init("http://web.archive.org/web");
+  __wm.wombat("http://donh.best.vwh.net/Esperanto/Literaturo/Poezio/JutlandoH.html","20160407214842","http://web.archive.org/","web","https://web-static.archive.org/_static/",
+	      "1460065722");
+</script>
+<link rel="stylesheet" type="text/css" href="https://web-static.archive.org/_static/css/banner-styles.css?v=S1zqJCYt" />
+<link rel="stylesheet" type="text/css" href="https://web-static.archive.org/_static/css/iconochive.css?v=qtvMKcIJ" />
+<!-- End Wayback Rewrite JS Include -->
+
+<!--Esperanto-Literaturo en la reto-->
+<title>
+
+Jutlando (Hans Christian ANDERSEN)
+</title>
+<meta http-equiv="description" content="Jutland, a poem by Hans Christian Andersen, translated into Esperanto by F. Skeel-Giorling"/> 
+<meta http-equiv="keywords" content="Esperanto, International Language, artificial language, Esperanto literature, Danish literature, Andersen, Hans Christian Andersen, Skeel-Giorling, F. Skeel-Giorling, Jutlando, Jutland"/>
+<meta name="author" content="Donald J. Harlow"/>
+<meta name="copyright" content="2000, Donald J. Harlow"/>
+<meta name="rating" content="general"/>
+<meta http-equiv="content-language" content="eo"/>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<link rel="stylesheet" href="/web/20160407214842cs_/http://donh.best.vwh.net/Esperanto/Literaturo/esplit.css" type="text/css"/>
+</head>
+
+<body>
+
+<table width="100%">
+<tr valign="top">
+<td align="left">
+<img src="/web/20160407214842im_/http://donh.best.vwh.net/gifs/literat.gif" alt=""/>
+</td>
+<td>
+<p class="mailer">
+Enkomputiligis 
+
+<a href="http://web.archive.org/web/20160407214842/mailto:donh@donh.best.vwh.net?subject=Jutlando">
+Don HARLOW
+</a>
+</p>
+</td>
+</tr>
+</table>
+
+
+
+<h1 align="center">Jutlando</h1>
+<h2 align="center">de Hans Christian ANDERSEN</h2>
+<h3 align="center">eldanigis F. SKEEL-GI&Ouml;RLING</h3>
+<h4 align="center">El <em>Esperanto Kantoj,</em> Centra Dana Esperanto-Ligo, 1939</h4>
+
+<hr width="50%"/>
+
+<table align="center">
+<tr>
+<td align="left">
+Jutland' kuŝas inter maroj<br/>
+kiel granda runbaston'.<br/>
+Runoj estas tombegaroj<br/>
+meze de arbara kron'!<br/>
+Sur erikejo revas ni<br/>
+:: en silenta :: fantazi'.<br/>
+<br/>
+Sur la vastaj teroj floras<br/>
+erikeja arbustar';<br/>
+flortapiŝo bonodoras<br/>
+dolĉe vasten tra kampar' ;<br/>
+sed nun baldaŭ ĝia bril'<br/>
+:: malaperas :: sub plugil'.<br/>
+<br/>
+Jutland' kuŝas inter maroj<br/>
+kiel granda runbaston',<br/>
+pri pasintaj mil' da jaroj<br/>
+nun rakontas ĉiu ŝton',<br/>
+Al estonteco el la mar'<br/>
+:: sonas laŭte :: himno klar'. 
+</td>
+</tr>
+</table>
+
+<hr/>
+<img src="/web/20160407214842im_/http://donh.best.vwh.net/Esperanto/Literaturo/gifs/literat.gif" alt=""/>
+
+</body>
+</html>
+
+
+
+
+<!--
+     FILE ARCHIVED ON 21:48:42 Apr 07, 2016 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 00:45:09 Jul 01, 2024.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 1.381
+  exclusion.robots: 0.324
+  exclusion.robots.policy: 0.3
+  esindex: 0.025
+  cdx.remote: 5.737
+  LoadShardBlock: 81.338 (3)
+  PetaboxLoader3.datanode: 63.666 (4)
+  PetaboxLoader3.resolve: 75.202 (2)
+  load_resource: 74.046
+-->


### PR DESCRIPTION
Original source: web.archive.org/web/20160407214842/http:/donh.best.vwh.net/Esperanto/Literaturo/Poezio/JutlandoH.html

**NOTE:** This is an automatic commit. See the archive workflow.

Signed-off-by: norwd <106889957+norwd@users.noreply.github.com>
