### PR TITLE
Archive jcs.org/2024/

### DIFF
--- a/jcs.org/2024/index.html
+++ b/jcs.org/2024/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta http-equiv="content-type" content="text/html; charset=utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<link rel="stylesheet" type="text/css" href="https://jcs.org/css/jcs.css?1701390388" media="screen">
+		<link rel="alternate" type="application/rss+xml" title="Articles - RSS Feed" href="https://jcs.org/rss">
+		<link rel="alternate" type="application/rss+xml" title="Notes - RSS Feed" href="https://jcs.org/notes/rss">
+		<link rel="me" href="https://social.jcs.org/@jcs">
+		<link rel="me" href="https://jcs.org/@jcs">
+		<title>joshua stein</title>
+	</head>
+	<body bgcolor="#fdfdf8">
+		<div id="sitewrapper">
+			<nav>
+				<h2>
+					<a rel="author" href="https://jcs.org/">joshua stein</a>
+				</h2>
+				<br>
+				<span class="nav_group">
+					<a href="https://jcs.org/">articles</a>
+					<a href="https://jcs.org/rss" class="rss_icon" title="rss feed">
+						<svg width=10 height=10 viewBox="0 0 448 448"
+							xmlns="http://www.w3.org/2000/svg">
+							<g><circle cx="64" cy="384" r="64"/></g>
+							<g><path d="M0,149.344v85.344c117.632,0,213.344,95.68,213.344,213.312h85.312C298.656,283.328,164.672,149.344,0,149.344z"/></g>
+							<g><path d="M0,0v85.344C200,85.344,362.688,248,362.688,448H448C448,200.96,247.04,0,0,0z"/></g>
+						</svg>
+					</a>
+				</span>
+				<span class="bar">|</span>
+				<span class="nav_group">
+					<a href="https://jcs.org/notes">notes</a>
+					<a href="https://jcs.org/notes/rss" class="rss_icon" title="notes rss feed">
+						<svg width=10 height=10 viewBox="0 0 448 448"
+							xmlns="http://www.w3.org/2000/svg">
+							<g><circle cx="64" cy="384" r="64"/></g>
+							<g><path d="M0,149.344v85.344c117.632,0,213.344,95.68,213.344,213.312h85.312C298.656,283.328,164.672,149.344,0,149.344z"/></g>
+							<g><path d="M0,0v85.344C200,85.344,362.688,248,362.688,448H448C448,200.96,247.04,0,0,0z"/></g>
+						</svg>
+					</a>
+				</span>
+				<span class="bar">|</span>
+				<a href="https://jcs.org/projects">projects</a>
+				<span class="bar">|</span>
+				<a href="https://jcs.org/uses">uses</a>
+				<span class="bar">|</span>
+				<a href="https://jcs.org/search">search</a>
+				<span class="bar">|</span>
+				<a href="https://jcs.org/tags">tags</a>
+				<span class="bar">|</span>
+				<a href="https://jcs.org/contact">contact</a>
+			</nav>
+			<main>
+				<h1>ENOENT</h1>
+			</main>
+			<footer>
+				&copy; 2001-2024
+				<a href="https://jcs.org/contact">joshua stein</a>
+			</footer>
+		</div>
+		<script src="https://jcs.org/js/afterdark-min.js" defer></script>
+	</body>
+</html>


### PR DESCRIPTION
Original source: [https://jcs.org/2024/](<https://jcs.org/2024/>)

**NOTE:** This is an automatic commit. See the archive workflow.
