### PR TITLE
Archive rfc10.txt

### DIFF
--- a/www.ietf.org/rfc/rfc10.txt
+++ b/www.ietf.org/rfc/rfc10.txt
@@ -1,0 +1,122 @@
+Network Working Group                                           S. Crocker
+RFC-10                                                          UCLA
+                                                                29 July 1969
+
+
+
+                          DOCUMENTATION CONVENTIONS
+
+
+
+This note is a revision of NWG/RFC #3
+
+The Network Working Group seems to consist of Steve Carr at Utah, Elmer
+Shapiro and Bill English SRI, Steve Crocker at UCLA, John Haefner at
+RAND, Paul Rovner and Jim Curry at Lincoln Labs.  Membership is not closed.
+
+The Network Working Group (NWG) is concerned with the HOST software, the
+strategies for using the network, and initial experience with the network.
+
+Documentation of the NWG's effort is through notes such as this.  Notes
+may be produced at any site by anybody and included in this series.
+
+CONTENT
+
+The content of a NWG note may be any thought, suggestion, etc. related to
+the HOST software or other aspect of the network.  Notes are encouraged to
+be timely rather than polished.  Philosophical positions without examples
+or other specifics, specific suggestions or implementation techniques
+without introductory or background explication, and explicit questions
+without any attempted answers are all acceptable.  The minimum length for
+a NWG note is one sentence.
+
+These standards (or lack of them) are stated explicitly for two reasons.
+First, there is a tendency to view a written statement as ipso facto
+authoritative, and we hope to promote the exchange and discussion of 
+considerably less than authoritative ideas.  Second, there is a natural
+hesitancy to publish something unpolished, and we hope to ease this
+inhibition.
+
+FORM
+
+Every NWG note should bear the following information:
+
+        1.  "Network Working Group"
+            "Request for Comments:"x (x underscored)
+            where x is a serial number (x underscored)
+            Serial numbers are assigned by Steve Crocker at UCLA
+
+        2.  Author and affiliation
+
+        3.  Date
+
+        4.  Title.  The title need not be unique.
+
+DISTRIBUTION
+
+One copy only will bve sent from the author's site to:
+
+        1.  Steve Crocker, UCLA
+        2.  Ron Stoughton, UCSB
+        3.  Elmer Shapiro, SRI
+        4.  Steve Carr, Utah
+        5.  John Haefner, RAND
+        6.  Paul Rovner, LL
+        7.  Bob Kahn, BB&N
+        8.  Larry Roberts, ARPA
+        9.  Jerry Cole, SDC
+
+Reproduction if desired may be handled locally.
+
+ADDRESSES
+
+Below are the most current addresses I have.  Please correct as necessary.
+
+        Steve Crocker                           UCLA
+        3732 Boelter Hall                       (213) 825-4864
+        UCLA                                          825-2543 Sec'y
+        Los Angeles, California  90024
+
+        Ron Stoughton                           UCSB
+        Computer Research Lab.                  (805) 961-3221
+        UCSB
+        Santa Barbara, California  93106
+
+        Elmer Shapiro                           SRI
+        Stanford Research Institute             (415)326-6200
+        333 Ravenswood
+        Menlo Park, California  94025
+
+        Steve Carr                              Utah
+        Computer Science Dept.                  (801) 322-8224
+        University of Utah
+        Salt Lake City, Utah  84ll2
+
+        John Haefner                            RAND
+        The Rand Corp.                          (213) 393-0411
+        1700 Main Street
+        Santa Monica, California  90406
+
+        Paul D. Rovner                          LL
+        Mass. Inst. of Tech.                    (617) 662-5500
+        Lincoln Laboratory B-115                X7211
+        P.O. Box 73                             
+        Lexington, Mass. 02173
+
+        Robert Kahn                             BBN
+        Bolt, Beranek and Newman                (617) 491-1850
+        50 Moulton St.                                49l-1868
+        Cambridge, Mass.  02138
+
+        Larry Roberts                           ARPA
+        ODS/ARPA                                (202) OX 7-8663
+        3D167 Pentagon                                OX 7-8654
+        Washington, D.C.  2030l
+
+
+        Jerry Cole                              SDC
+        7842 Croyden                            2500 Colorado
+        L.A., California  90045                 Santa Monica, California 90406
+                                                (213) 393-9411
+                                                      X438
+                                                      X6019 Sec'y


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc10.txt](<www.ietf.org/rfc/rfc10.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
