### PR TITLE
Archive rfc1010.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1010.txt
+++ b/www.ietf.org/rfc/rfc1010.txt
@@ -1,0 +1,2552 @@
+
+
+Network Working Group                                        J. Reynolds
+Request for Comments:  1010                                    J. Postel
+                                                                     ISI
+Obsoletes RFCs: 990, 960, 943, 923, 900, 870,                   May 1987
+820, 790, 776, 770, 762, 758,
+755, 750, 739, 604, 503, 433, 349
+Obsoletes IENs: 127, 117, 93
+
+
+                            ASSIGNED NUMBERS
+
+
+Status of this Memo
+
+   This memo is an official status report on the numbers used in
+   protocols in the Internet community.  Distribution of this memo is
+   unlimited.
+
+Introduction
+
+   This Network Working Group Request for Comments documents the
+   currently assigned values from several series of numbers used in
+   network protocol implementations.  This RFC will be updated
+   periodically, and in any case current information can be obtained
+   from Joyce Reynolds.  If you are developing a protocol or application
+   that will require the use of a link, socket, port, protocol, etc.,
+   please contact Joyce to receive a number assignment.
+
+      Joyce K. Reynolds
+      USC - Information Sciences Institute
+      4676 Admiralty Way
+      Marina del Rey, California  90292-6695
+
+      Phone: (213) 822-1511
+
+      Electronic mail: JKREYNOLDS@ISI.EDU
+
+   Most of the protocols mentioned here are documented in the RFC series
+   of notes.  Some of the items listed are undocumented.  Further
+   information on protocols can be found in the memo "Official Internet
+   Protocols" [91].  The more prominent and more generally used are
+   documented in the "DDN Protocol Handbook, Volume Two, DARPA Internet
+   Protocols" [36] prepared by the NIC.  Other collections of older or
+   obsolete protocols are contained in the "Internet Protocol Transition
+   Workbook" [57], or in the "ARPANET Protocol Transition Handbook"
+   [38].  For further information on ordering the complete 1985 DDN
+   Protocol Handbook, write: SRI International (SRI-NIC), DDN Network
+   Information Center, Room EJ291, 333 Ravenswood Avenue, Meno Park,
+   CA., 94025; or call: 1-800-235-3155.
+
+   In the entries below, the name and mailbox of the responsible
+   individual is indicated.  The bracketed entry, e.g., [nn,iii], at the
+
+
+Reynolds & Postel                                               [Page 1]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+
+
+   right hand margin of the page indicates a reference for the listed
+   protocol, where the number ("nn") cites the document and the letters
+   ("iii") cites the person.  Whenever possible, the letters are a NIC
+   Ident as used in the WhoIs (NICNAME) service.
+
+   The convention in the documentation of Internet Protocols is to
+   express numbers in decimal and to picture data in "big-endian" order
+   [14].  That is, fields are described left to right, with the most
+   significant octet on the left and the least significant octet on the
+   right.
+
+   The order of transmission of the header and data described in this
+   document is resolved to the octet level.  Whenever a diagram shows a
+   group of octets, the order of transmission of those octets is the
+   normal order in which they are read in English.  For example, in the
+   following diagram the octets are transmitted in the order they are
+   numbered.
+
+                                    
+    0                   1                   2                   3   
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |       1       |       2       |       3       |       4       |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |       5       |       6       |       7       |       8       |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |       9       |      10       |      11       |      12       |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                      Transmission Order of Bytes
+
+   Whenever an octet represents a numeric quantity the left most bit in
+   the diagram is the high order or most significant bit.  That is, the
+   bit labeled 0 is the most significant bit.  For example, the
+   following diagram represents the value 170 (decimal).
+
+                                    
+                            0 1 2 3 4 5 6 7 
+                           +-+-+-+-+-+-+-+-+
+                           |1 0 1 0 1 0 1 0|
+                           +-+-+-+-+-+-+-+-+
+
+                          Significance of Bits
+
+   Similarly, whenever a multi-octet field represents a numeric quantity
+   the left most bit of the whole field is the most significant bit.
+   When a multi-octet quantity is transmitted the most significant octet
+   is transmitted first.
+
+
+
+Reynolds & Postel                                               [Page 2]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Version Numbers
+
+
+                            VERSION NUMBERS
+
+   In the Internet Protocol (IP) [36,80] there is a field to identify
+   the version of the internetwork general protocol.  This field is 4
+   bits in size.
+
+   Assigned Internet Version Numbers
+
+      Decimal   Keyword    Version                            References
+      -------   -------    -------                            ----------
+          0                Reserved                                [JBP]
+        1-3                Unassigned                              [JBP]
+          4       IP       Internet Protocol                    [80,JBP]
+          5       ST       ST Datagram Mode                     [41,JWF]
+       6-14                Unassigned                              [JBP]
+         15                Reserved                                [JBP]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                               [Page 3]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Protocol Numbers
+
+
+PROTOCOL NUMBERS
+
+   In the Internet Protocol (IP) [36,80] there is a field, called
+   Protocol, to identify the the next level protocol.  This is an 8 bit
+   field.
+
+   Assigned Internet Protocol Numbers
+
+      Decimal    Keyword     Protocol                         References
+      -------    -------     --------                         ----------
+           0                 Reserved                              [JBP]
+           1     ICMP        Internet Control Message           [72,JBP]
+           2     IGMP        Internet Group Management          [34,JBP]
+           3     GGP         Gateway-to-Gateway                  [49,MB]
+           4                 Unassigned                            [JBP]
+           5     ST          Stream                             [41,JWF]
+           6     TCP         Transmission Control               [81,JBP]
+           7     UCL         UCL                                    [PK]
+           8     EGP         Exterior Gateway Protocol         [92,DLM1]
+           9     IGP         any private interior gateway          [JBP]
+          10     BBN-RCC-MON BBN RCC Monitoring                    [SGC]
+          11     NVP-II      Network Voice Protocol             [15,SC3]
+          12     PUP         PUP                               [7,XEROX]
+          13     ARGUS       ARGUS                                [RWS4]
+          14     EMCON       EMCON                                 [BN7]
+          15     XNET        Cross Net Debugger                [47,JFH2]
+          16     CHAOS       Chaos                                 [NC3]
+          17     UDP         User Datagram                      [79,JBP]
+          18     MUX         Multiplexing                       [16,JBP]
+          19     DCN-MEAS    DCN Measurement Subsystems           [DLM1]
+          20     HMP         Host Monitoring                    [48,RH6]
+          21     PRM         Packet Radio Measurement              [ZSU]
+          22     XNS-IDP     XEROX NS IDP                    [102,XEROX]
+          23     TRUNK-1     Trunk-1                               [SA2]
+          24     TRUNK-2     Trunk-2                               [SA2]
+          25     LEAF-1      Leaf-1                                [SA2]
+          26     LEAF-2      Leaf-2                                [SA2]
+          27     RDP         Reliable Data Protocol            [106,RH6]
+          28     IRTP        Internet Reliable Transaction      [59,TXM]
+          29     ISO-TP4     ISO Transport Protocol Class 4    [51,RC77]
+          30     NETBLT      Bulk Data Transfer Protocol       [13,DDC1]
+          31     MFE-NSP     MFE Network Services Protocol     [93,BCH2]
+          32     MERIT-INP   MERIT Internodal Protocol             [HWB]
+          33     SEP         Sequential Exchange Protocol        [JC120]
+       34-60                 Unassigned                            [JBP]
+          61                 any host internal protocol            [JBP]
+          62     CFTP        CFTP                              [42,HCF2]
+          63                 any local network                     [JBP]
+
+
+Reynolds & Postel                                               [Page 4]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Protocol Numbers
+
+
+          64     SAT-EXPAK   SATNET and Backroom EXPAK             [SHB]
+          65     MIT-SUBNET  MIT Subnet Support                    [NC3]
+          66     RVD         MIT Remote Virtual Disk Protocol      [MBG]
+          67     IPPC        Internet Pluribus Packet Core         [SHB]
+          68                 any distributed file system           [JBP]
+          69     SAT-MON     SATNET Monitoring                     [SHB]
+          70                 Unassigned                            [JBP]
+          71     IPCV        Internet Packet Core Utility          [SHB]
+       72-75                 Unassigned                            [JBP]
+          76     BR-SAT-MON  Backroom SATNET Monitoring            [SHB]
+          77                 Unassigned                            [JBP]
+          78     WB-MON      WIDEBAND Monitoring                   [SHB]
+          79     WB-EXPAK    WIDEBAND EXPAK                        [SHB]
+      80-254                 Unassigned                            [JBP]
+         255                 Reserved                              [JBP]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                               [Page 5]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Port Numbers
+
+
+                              PORT NUMBERS
+
+   Ports are used in the TCP [36,81] to name the ends of logical
+   connections which carry long term conversations.  For the purpose of
+   providing services to unknown callers, a service contact port is
+   defined.  This list specifies the port used by the server process as
+   its contact port.  The contact port is sometimes called the
+   "well-known port".
+
+   To the extent possible, these same port assignments are used with the
+   UDP [37,79].
+
+   To the extent possible, these same port assignments are used with the
+   ISO-TP4 [52].
+
+   The assigned ports use a small portion of the possible port numbers.
+   The assigned ports have all except the low order eight bits cleared
+   to zero.  The low order eight bits are specified here.
+
+   Port Assignments:
+
+      Decimal   Keyword   Description                         References
+      -------   -------   -----------                         ----------
+      0                   Reserved                                 [JBP]
+      1-4                 Unassigned                               [JBP]
+      5        RJE        Remote Job Entry                       [9,JBP]
+      7        ECHO       Echo                                  [70,JBP]
+      9        DISCARD    Discard                               [69,JBP]
+      11       USERS      Active Users                          [65,JBP]
+      13       DAYTIME    Daytime                               [68,JBP]
+      15                  Unassigned                               [JBP]
+      17       QUOTE      Quote of the Day                      [75,JBP]
+      19       CHARGEN    Character Generator                   [67,JBP]
+      20       FTP-DATA   File Transfer [Default Data]          [71,JBP]
+      21       FTP        File Transfer [Control]               [71,JBP]
+      23       TELNET     Telnet                                [87,JBP]
+      25       SMTP       Simple Mail Transfer                  [77,JBP]
+      27       NSW-FE     NSW User System FE                    [17,RHT]
+      29       MSG-ICP    MSG ICP                               [63,RHT]
+      31       MSG-AUTH   MSG Authentication                    [63,RHT]
+      33       DSP        Display Support Protocol                 [MLC]
+      35                  any private printer server               [JBP]
+      37       TIME       Time                                  [83,JBP]
+      39       RLP        Resource Location Protocol                [MA]
+      41       GRAPHICS   Graphics                              [98,JBP]
+      42       NAMESERVER Host Name Server                      [74,JBP]
+      43       NICNAME    Who Is                               [46,JAKE]
+      44       MPM-FLAGS  MPM FLAGS Protocol                       [JBP]
+
+
+Reynolds & Postel                                               [Page 6]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Port Numbers
+
+
+      45       MPM        Message Processing Module [recv]      [73,JBP]
+      46       MPM-SND    MPM [default send]                    [73,JBP]
+      47       NI-FTP     NI FTP                               [103,SK8]
+      49       LOGIN      Login Host Protocol                     [PHD1]
+      51       LA-MAINT   IMP Logical Address Maintenance       [58,AGM]
+      53       DOMAIN     Domain Name Server                 [61,70,PM1]
+      55       ISI-GL     ISI Graphics Language                  [6,RB9]
+      57                  any private terminal access              [JBP]
+      59                  any private file service                 [JBP]
+      61       NI-MAIL    NI MAIL                                [4,SK8]
+      63       VIA-FTP    VIA Systems - FTP                        [DXD]
+      65       TACACS-DS  TACACS-Database Service                [3,RHT]
+      67       BOOTPS     Bootstrap Protocol Server            [29,WJC2]
+      68       BOOTPC     Bootstrap Protocol Client            [29,WJC2]
+      69       TFTP       Trivial File Transfer                [95,DDC1]
+      71       NETRJS-1   Remote Job Service                    [8,RTB3]
+      72       NETRJS-2   Remote Job Service                    [8,RTB3]
+      73       NETRJS-3   Remote Job Service                    [8,RTB3]
+      74       NETRJS-4   Remote Job Service                    [8,RTB3]
+      75                  any private dial out service             [JBP]
+      77                  any private RJE service                  [JBP]
+      79       FINGER     Finger                                [44,KLH]
+      81       HOSTS2-NS  HOSTS2 Name Server                      [EAK1]
+      83       MIT-ML-DEV MIT ML Device                            [DPR]
+      85       MIT-ML-DEV MIT ML Device                            [DPR]
+      87                  any private terminal link                [JBP]
+      89       SU-MIT-TG  SU/MIT Telnet Gateway                    [MRC]
+      91       MIT-DOV    MIT Dover Spooler                        [EBM]
+      93       DCP        Device Control Protocol                 [DT15]
+      95       SUPDUP     SUPDUP                                [20,MRC]
+      97       SWIFT-RVF  Swift Remote Vitural File Protocol       [MXR]
+      98       TACNEWS    TAC News                                [FRAN]
+      99       METAGRAM   Metagram Relay                          [GEOF]
+      101      HOSTNAME   NIC Host Name Server                 [45,JAKE]
+      102      ISO-TSAP   ISO-TSAP                              [12,MTR]
+      103      X400       X400                                    [HCF2]
+      104      X400-SND   X400-SND                                [HCF2]
+      105      CSNET-NS   Mailbox Name Nameserver              [96,MAS3]
+      107      RTELNET    Remote Telnet Service                 [76,JBP]
+      109      POP-2      Post Office Protocol - Version 2     [11,JKR1]
+      111      SUNRPC     SUN Remote Procedure Call                [DXG]
+      113      AUTH       Authentication Service               [99,MCSJ]
+      115      SFTP       Simple File Transfer Protocol        [56,MKL1]
+      117      UUCP-PATH  UUCP Path Service                     [35,MAE]
+      119      NNTP       Network News Transfer Protocol        [53,PL4]
+      121      ERPC       HYDRA Expedited Remote Procedure Call[101,JXO]
+      123      NTP        Network Time Protocol                [60,DLM1]
+      125      LOCUS-MAP  Locus PC-Interface Net Map Server    [105,BXG]
+
+
+Reynolds & Postel                                               [Page 7]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Port Numbers
+
+
+      127      LOCUS-CON  Locus PC-Interface Conn Server       [105,BXG]
+      129      PWDGEN     Password Generator Protocol          [107,FJW]
+      130      CISCO-FNA  CISCO FNATIVE                            [WXB]
+      131      CISCO-TNA  CISCO TNATIVE                            [WXB]
+      132      CISCO-SYS  CISCO SYSMAINT                           [WXB]
+      133      STATSRV    Statistics Service                      [DLM1]
+      134      INGRES-NET INGRES-NET Service                       [MXB]
+      135      LOC-SRV    Location Service                         [JXP]
+      136      PROFILE    PROFILE Naming System                    [LLP]
+      137      NETBIOS-NS NETBIOS Name Service                     [JBP]
+      138      NETBIOS-DGM NETBIOS Datagram Service                [JBP]
+      139      NETBIOS-SSN NETBIOS Session Service                 [JBP]
+      140      EMFIS-DATA EMFIS Data Service                       [GB7]
+      141      EMFIS-CNTL EMFIS Control Service                    [GB7]
+      142      BL-IDM     Britton-Lee IDM                         [SXS1]
+      143-159             Unassigned                               [JBP]
+      160-223             Reserved                                 [JBP]
+      224-241             Unassigned                               [JBP]
+      243      SUR-MEAS   Survey Measurement                      [5,AV]
+      245      LINK       LINK                                 [10,RDB2]
+      247-255             Unassigned                               [JBP]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                               [Page 8]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Domain System Parameters
+
+
+                        DOMAIN SYSTEM PARAMETERS
+
+   The Internet Domain Naming System (DOMAIN) includes several
+   parameters.  These are documented in RFC 883 [61].  The CLASS
+   parameter is listed here.  The per CLASS parameters are defined in
+   separate RFCs as indicated.
+
+   Domain System Parameters:
+
+      Decimal   Name                                          References
+      -------   ----                                          ----------
+            0   Reserved                                           [PM1]
+            1   Internet                                        [61,PM1]
+            2   Unassigned                                         [PM1]
+            3   Chaos                                              [PM1]
+      4-65534   Unassigned                                         [PM1]
+        65535   Reserved                                           [PM1]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                               [Page 9]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+ARPANET Logical Addresses
+
+
+                       ARPANET LOGICAL ADDRESSES
+
+   The ARPANET facility for "logical addressing" is described in
+   RFC 878 [57] and RFC 1005 [109].  A portion of the possible logical
+   addresses are reserved for standard uses.
+
+   There are 49,152 possible logical host addresses.  Of these, 256 are
+   reserved for assignment to well-known functions.  Assignments for
+   well-known functions are made by Joyce Reynolds.  Assignments for
+   other logical host addresses are made by the NIC.
+
+   Logical Address Assignments:
+
+      Decimal    Description                                  References
+      -------    -----------                                  ----------
+      0          Reserved                                          [JBP]
+      1          The BBN Core Gateways                              [MB]
+      2-254      Unassigned                                        [JBP]
+      255        Reserved                                          [JBP]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 10]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+ARPANET Link Numbers
+
+
+                          ARPANET LINK NUMBERS
+
+   The word "link" here refers to a field in the original ARPANET
+   Host/IMP interface leader.  The link was originally defined as an
+   8-bit field.  Later specifications defined this field as the
+   "message-id" with a length of 12 bits.  The name link now refers to
+   the high order 8 bits of this 12-bit message-id field.  The Host/IMP
+   interface is defined in BBN Report 1822 [2].
+
+   The low-order 4 bits of the message-id field are called the sub-link.
+   Unless explicitly specified otherwise for a particular protocol,
+   there is no sender to receiver significance to the sub-link.  The
+   sender may use the sub-link in any way he chooses (it is returned in
+   the RFNM by the destination IMP), the receiver should ignore the
+   sub-link.
+
+   Link Assignments:
+
+      Decimal   Description                                   References
+      -------   -----------                                   ----------
+      0         Reserved                                           [JBP]
+      1-149     Unassigned                                         [JBP]
+      150       Xerox NS IDP                                 [102,XEROX]
+      151       Unassigned                                         [JBP]
+      152       PARC Universal Protocol                        [7,XEROX]
+      153       TIP Status Reporting                               [JGH]
+      154       TIP Accounting                                     [JGH]
+      155       Internet Protocol [regular]                     [80,JBP]
+      156-158   Internet Protocol [experimental]                [80,JBP]
+      159       Figleaf Link                                      [JBW1]
+      160-194   Unassigned                                         [JBP]
+      195       ISO-IP                                          [52,RXM]
+      196-247   Experimental Protocols                             [JBP]
+      248-255   Network Maintenance                                [JGH]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 11]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+IEEE 802 SAP Numbers
+
+
+                      IEEE 802 NUMBERS OF INTEREST
+
+   Some of the networks of all classes are IEEE 802 Networks.  These
+   systems may use a Link Service Access Point (LSAP) field in much the
+   same way the ARPANET uses the "link" field.  Further, there is an
+   extension of the LSAP header called the Sub-Network Access Protocol
+   (SNAP).
+
+   The IEEE likes to describe numbers in binary in bit transmission
+   order, which is the opposite of the big-endian order used throughout
+   the Internet protocol documentation.
+
+   Assignments:
+
+      Link Service Access Point               Description     References
+      --------------------------   -----------                ----------
+      IEEE     Internet
+      binary   binary    decimal
+      00000000 00000000        0   Null LSAP                      [IEEE]
+
+      01000000 00000010        2   Indiv LLC Sublayer Mgt         [IEEE]
+
+      11000000 00000011        3   Group LLC Sublayer Mgt         [IEEE]
+
+      00100000 00000100        4   SNA Path Control               [IEEE]
+
+      01100000 00000110        6   DOD IP                       [79,JBP]
+
+      01110000 00001110       14   PROWAY-LAN                     [IEEE]
+
+      01110010 01001110       78   EIA-RS 511                     [IEEE]
+
+      01110001 10001110      142   PROWAY-LAN                     [IEEE]
+
+      01010101 10101010      170   SNAP                           [IEEE]
+
+      01111111 11111110      254   ISO DIS 8473                 [52,JXJ]
+
+      11111111 11111111      255   Global DSAP                    [IEEE]
+
+   These numbers (and others) are assigned by the IEEE Standards Office.
+   The address is: IEEE Standards Office, 345 East 47th Street, New
+   York, N.Y. 10017, Attn: Vince Condello.  Phone: (212) 705-7092.
+
+   At an ad hoc special session on "IEEE 802 Networks and ARP", held
+   during the TCP Vendors Workshop (August 1986), an approach to a
+   consistent way to send DoD-IP datagrams and other IP related
+   protocols on 802 networks was developed.
+
+
+Reynolds & Postel                                              [Page 12]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+IEEE 802 SAP Numbers
+
+
+   Due to some evolution of the IEEE 802.2 standards and the need to
+   provide for a standard way to do additional DoD-IP related protocols
+   (such as the Address Resolution Protocol (ARP) on IEEE 802 network,
+   the following new policy is established, which will replace the old
+   policy (see RFC 960 and RFC 948 [108]).
+
+   The new policy is for the Internet community to use the IEEE 802.2
+   encapsulation on 802.3, 802.4, and 802.5 networks by using the SNAP
+   with an organization code indicating that the following 16 bits
+   specify the EtherType code (where IP = 2048 (0800 hex), see Ethernet
+   Numbers of Interest).
+
+                                                                  Header
+
+   ...--------+--------+--------+
+    MAC Header|      Length     |                        802.{3/4/5} MAC
+   ...--------+--------+--------+
+
+   +--------+--------+--------+
+   | Dsap=K1| Ssap=K1| control|                                802.2 SAP
+   +--------+--------+--------+
+
+   +--------+--------+---------+--------+--------+
+   |protocol id or org code =K2|    Ether Type   |            802.2 SNAP
+   +--------+--------+---------+--------+--------+
+
+   The total length of the SAP Header and the SNAP header is 8-octets,
+   making the 802.2 protocol overhead come out on a nice boundary.
+
+   K1 is 170.  The IEEE likes to talk about things in little-endian bit
+   transmission order and specifies this value as 01010101.  In
+   big-endian order, as used in Internet specifications, this becomes
+   10101010 binary, or AA hex, or 170 decimal.
+
+   K2 is 0 (zero).
+
+   The use of the IP LSAP (K1 = 6) is to be phased out as quickly as
+   possible.
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 13]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Ethernet Numbers
+
+
+                      ETHERNET NUMBERS OF INTEREST
+
+   Many of the networks of all classes are Ethernets (10Mb) or
+   Experimental Ethernets (3Mb).  These systems use a message "type"
+   field in much the same way the ARPANET uses the "link" field.
+
+   If you need an Ethernet type, contact the XEROX Corporation, 2300
+   Geng Road, Palo Alto, California 94303, ATTN: Ms. Pam Cance.
+
+   Assignments:
+
+      Ethernet          Exp. Ethernet    Description          References
+      -------------     -------------   -----------           ----------
+      decimal  Hex      decimal  octal
+         512   0200        512   1000   XEROX PUP              [7,XEROX]
+         513   0201        -      -     PUP Addr. Trans.         [XEROX]
+        1536   0600       1536   3000   XEROX NS IDP         [102,XEROX]
+        2048   0800        513   1001   DOD IP                  [80,JBP]
+        2049   0801        -      -     X.75 Internet            [XEROX]
+        2050   0802        -      -     NBS Internet             [XEROX]
+        2051   0803        -      -     ECMA Internet            [XEROX]
+        2052   0804        -      -     Chaosnet                 [XEROX]
+        2053   0805        -      -     X.25 Level 3             [XEROX]
+        2054   0806        -      -     ARP                     [64,JBP]
+        2055   0807        -      -     XNS Compatability        [XEROX]
+        2076   081C        -      -     Symbolics Private         [DCP1]
+        4096   1000        -      -     Berkeley Trailer         [XEROX]
+        5632   1600        -      -     Valid                    [XEROX]
+       21000   5208        -      -     BBN Simnet               [XEROX]
+       24577   6001        -      -     DEC MOP Dump/Load        [XEROX]
+       24578   6002        -      -     DEC MOP Remote Console   [XEROX]
+       24579   6003        -      -     DEC DECNET Phase IV      [XEROX]
+       24580   6004        -      -     DEC LAT                  [XEROX]
+       24581   6005        -      -     DEC                      [XEROX]
+       24582   6006        -      -     DEC                      [XEROX]
+       32771   8003        -      -     Cronus VLN            [100,DT15]
+       32772   8004        -      -     Cronus Direct         [100,DT15]
+       32773   8005        -      -     HP Probe                 [XEROX]
+       32774   8006        -      -     Nestar                   [XEROX]
+       32784   8010        -      -     Excelan                  [XEROX]
+       32821   8035        -      -     Reverse ARP             [40,JXM]
+       32824   8038        -      -     DEC LANBridge            [XEROX]
+       32859   805B        -      -     Stanford V Kernel experimental 
+      [XEROX]
+       32860   805C        -      -     Stanford V Kernel production 
+      [XEROX]
+       32892   807C        -      -     Merit Internodal           [HWB]
+       32923   809B        -      -     Appletalk                [XEROX]
+
+
+Reynolds & Postel                                              [Page 14]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Ethernet Numbers
+
+
+       36864   9000        -      -     Loopback                 [XEROX]
+
+   The standard for transmission of IP datagrams over Ethernets and
+   Experimental Ethernets is specified in RFC 894 [50] and RFC 895 [66]
+   respectively.
+
+   NOTE:  Ethernet 48-bit address blocks are now assigned by the IEEE.
+
+      IEEE Standards Office, 345 East 47th Street, New York, N.Y. 10017,
+      Attn: Vince Condello.  Phone: (212) 705-7092.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 15]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Address Resolution Protocol
+
+
+                 ADDRESS RESOLUTION PROTOCOL PARAMETERS
+
+   The Address Resolution Protocol (ARP) specified in RFC 826 [64] has
+   several parameters.  The assigned values for these parameters are
+   listed here.
+
+   Assignments:
+
+      Operation Code (op)
+
+         1   REQUEST
+         2   REPLY
+
+      Hardware Type (hrd)
+
+         Type   Description                                   References
+         ----   -----------                                   ----------
+           1    Ethernet (10Mb)                                    [JBP]
+           2    Experimental Ethernet (3Mb)                        [JBP]
+           3    Amateur Radio AX.25                                [PXK]
+           4    Proteon ProNET Token Ring                          [JBP]
+           5    Chaos                                              [GXP]
+           6    IEEE 802 Networks                                  [JBP]
+           7    ARCNET                                             [JBP]
+
+      Protocol Type (pro)
+
+         Use the same codes as listed in the section called "Ethernet
+         Numbers of Interest" (all hardware types use this code set for
+         the protocol type).
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 16]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Public Data Network Numbers
+
+
+                      PUBLIC DATA NETWORK NUMBERS
+
+   One of the Internet Class A Networks is the international system of
+   Public Data Networks.  This section lists the mapping between the
+   Internet Addresses and the Public Data Network Addresses (X.121).
+
+   The numbers below are assigned for networks that are connected to the
+   Internet, and for independent networks.  These independent networks
+   are marked with an asterisk preceding the number.
+
+   Assignments:
+
+      * Internet           Public Data Net    Description     References
+      - --------------   -----------------   -----------      ----------
+       014.000.000.000                       Reserved              [JBP]
+       014.000.000.001   3110-317-00035 00   PURDUE-TN             [CAK]
+       014.000.000.002   3110-608-00027 00   UWISC-TN              [CAK]
+       014.000.000.003   3110-302-00024 00   UDEL-TN               [CAK]
+       014.000.000.004   2342-192-00149 23   UCL-VTEST              [PK]
+       014.000.000.005   2342-192-00300 23   UCL-TG                 [PK]
+       014.000.000.006   2342-192-00300 25   UK-SATNET              [PK]
+       014.000.000.007   3110-608-00024 00   UWISC-IBM            [MAS3]
+       014.000.000.008   3110-213-00045 00   RAND-TN               [MO2]
+       014.000.000.009   2342-192-00300 23   UCL-CS                 [PK]
+       014.000.000.010   3110-617-00025 00   BBN-VAN-GW           [JD21]
+      *014.000.000.011   2405-015-50300 00   CHALMERS              [UXB]
+       014.000.000.012   3110-713-00165 00   RICE                 [PAM6]
+       014.000.000.013   3110-415-00261 00   DECWRL               [PAM6]
+       014.000.000.014   3110-408-00051 00   IBM-SJ                [SA1]
+       014.000.000.015   2041-117-01000 00   SHAPE                 [JFW]
+       014.000.000.016   2628-153-90075 00   DFVLR4-X25            [GB7]
+       014.000.000.017   3110-213-00032 00   ISI-VAN-GW           [JD21]
+       014.000.000.018   2624-522-80900 52   DFVLR5-X25            [GB7]
+       014.000.000.019   2041-170-10000 00   SHAPE-X25             [JFW]
+       014.000.000.020   5052-737-20000 50   UQNET                 [AXH]
+       014.000.000.021   3020-801-00057 50   DMC-CRC1             [JR17]
+       014.000.000.022   2624-522-80902 77   DFVLRVAX-X25          [GB7]
+      *014.000.000.023   2624-589-00908 01   ECRC-X25              [PXD]
+       014.000.000.024   2342-905-24242 83   UK-MOD-RSRE          [JXE2]
+       014.000.000.025   2342-905-24242 82   UK-VAN-RSRE           [AXM]
+       014.000.000.026-014.255.255.254       Unassigned            [JBP]
+       014.255.255.255                       Reserved              [JBP]
+
+   The standard for transmission of IP datagrams over the Public Data
+   Network is specified in RFC 877 [55].
+
+
+
+
+
+Reynolds & Postel                                              [Page 17]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Telnet Options
+
+
+                             TELNET OPTIONS
+
+   The Telnet Protocol has a number of options that may be negotiated.
+   These options are listed here.  "Official Internet Protocols" [91]
+   provides more detailed information.
+
+   Options  Name                                              References
+   -------  -----------------------                           ----------
+      0     Binary Transmission                                 [85,JBP]
+      1     Echo                                                [86,JBP]
+      2     Reconnection                                        [33,JBP]
+      3     Suppress Go Ahead                                   [89,JBP]
+      4     Approx Message Size Negotiation                    [102,JBP]
+      5     Status                                              [88,JBP]
+      6     Timing Mark                                         [90,JBP]
+      7     Remote Controlled Trans and Echo                    [82,JBP]
+      8     Output Line Width                                   [31,JBP]
+      9     Output Page Size                                    [32,JBP]
+     10     Output Carriage-Return Disposition                  [21,JBP]
+     11     Output Horizontal Tab Stops                         [25,JBP]
+     12     Output Horizontal Tab Disposition                   [24,JBP]
+     13     Output Formfeed Disposition                         [22,JBP]
+     14     Output Vertical Tabstops                            [27,JBP]
+     15     Output Vertical Tab Disposition                     [26,JBP]
+     16     Output Linefeed Disposition                         [23,JBP]
+     17     Extended ASCII                                     [104,JBP]
+     18     Logout                                              [18,MRC]
+     19     Byte Macro                                          [28,JBP]
+     20     Data Entry Terminal                                 [30,JBP]
+     22     SUPDUP                                           [19,20,MRC]
+     22     SUPDUP Output                                       [43,MRC]
+     23     Send Location                                      [54,EAK1]
+     24     Terminal Type                                      [97,MAS3]
+     25     End of Record                                       [78,JBP]
+     26     TACACS User Identification                           [1,BA4]
+     27     Output Marking                                      [94,SXS]
+     28     Terminal Location Number                            [62,RN6]
+    255     Extended-Options-List                               [84,JBP]
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 18]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Machine Names
+
+
+                             MACHINE NAMES
+
+   These are the Official Machine Names as they appear in the NIC Host
+   Table.  Their use is described in RFC 810 [39].
+
+   A machine name or CPU type may be up to 40 characters taken from the
+   set of uppercase letters, digits, and the two punctuation characters
+   hyphen and slash.  It must start with a letter, and end with a letter
+   or digit.
+
+   ALTO
+   AMDAHL-V7
+   APOLLO
+   ATT-3B20
+   BBN-C/60
+   BURROUGHS-B/29
+   BURROUGHS-B/4800
+   BUTTERFLY
+   C/30
+   C/70
+   CADLINC
+   CADR
+   CDC-170
+   CDC-170/750
+   CDC-173
+   CELERITY-1200
+   COMTEN-3690
+   CP8040
+   CRAY-1
+   CRAY-X/MP
+   CRAY-2
+   CTIWS-117
+   DANDELION
+   DEC-10
+   DEC-1050
+   DEC-1077
+   DEC-1080
+   DEC-1090
+   DEC-1090B
+   DEC-1090T
+   DEC-2020T
+   DEC-2040
+   DEC-2040T
+   DEC-2050T
+   DEC-2060
+   DEC-2060T
+   DEC-2065
+   DEC-FALCON
+
+
+Reynolds & Postel                                              [Page 19]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Machine Names
+
+
+   DEC-KS10
+   DORADO
+   DPS8/70M
+   ELXSI-6400
+   FOONLY-F2
+   FOONLY-F3
+   FOONLY-F4
+   GOULD
+   GOULD-6050
+   GOULD-6080
+   GOULD-9050
+   GOULD-9080
+   H-316
+   H-60/68
+   H-68
+   H-68/80
+   H-89
+   HONEYWELL-DPS-6
+   HONEYWELL-DPS-8/70
+   HP3000
+   HP3000/64
+   IBM-158
+   IBM-360/67
+   IBM-370/3033
+   IBM-3081
+   IBM-3084QX
+   IBM-3101
+   IBM-4331
+   IBM-4341
+   IBM-4361
+   IBM-4381
+   IBM-4956
+   IBM-PC
+   IBM-PC/AT
+   IBM-PC/XT
+   IBM-SERIES/1
+   IMAGEN
+   IMAGEN-8/300
+   IMSAI
+   INTEGRATED-SOLUTIONS
+   INTEGRATED-SOLUTIONS-68K
+   INTEGRATED-SOLUTIONS-CREATOR
+   INTEGRATED-SOLUTIONS-CREATOR-8
+   INTEL-IPSC
+   IS-1
+   IS-68010
+   LMI
+   LSI-11
+
+
+Reynolds & Postel                                              [Page 20]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Machine Names
+
+
+   LSI-11/2
+   LSI-11/23
+   LSI-11/73
+   M68000
+   MASSCOMP
+   MC500
+   MC68000
+   MICROVAX
+   MICROVAX-I
+   MV/8000
+   NAS3-5
+   NCR-COMTEN-3690
+   NOW
+   ONYX-Z8000
+   PDP-11
+   PDP-11/3
+   PDP-11/23
+   PDP-11/24
+   PDP-11/34
+   PDP-11/40
+   PDP-11/44
+   PDP-11/45
+   PDP-11/50
+   PDP-11/70
+   PDP-11/73
+   PE-7/32
+   PE-3205
+   PERQ
+   PLEXUS-P/60
+   PLI
+   PLURIBUS
+   PRIME-2350
+   PRIME-2450
+   PRIME-2755
+   PRIME-9655
+   PRIME-9755
+   PRIME-9955II
+   PRIME-2250
+   PRIME-2655
+   PRIME-9955
+   PRIME-9950
+   PRIME-9650
+   PRIME-9750
+   PRIME-2250
+   PRIME-750
+   PRIME-850
+   PRIME-550II
+   PYRAMID-90
+
+
+Reynolds & Postel                                              [Page 21]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Machine Names
+
+
+   PYRAMID-90MX
+   PYRAMID-90X
+   RIDGE
+   RIDGE-32
+   RIDGE-32C
+   ROLM-1666
+   S1-MKIIA
+   SMI
+   SEQUENT-BALANCE-8000
+   SIEMENS
+   SILICON-GRAPHICS
+   SILICON-GRAPHICS-IRIS
+   SPERRY-DCP/10
+   SUN
+   SUN-2
+   SUN-2/50
+   SUN-2/100
+   SUN-2/120
+   SUN-2/140
+   SUN-2/150
+   SUN-2/160
+   SUN-2/170
+   SUN-3/160
+   SUN-3/50
+   SUN-3/75
+   SUN-3/110
+   SUN-50
+   SUN-100
+   SUN-120
+   SUN-130
+   SUN-150
+   SUN-170
+   SUN-68000
+   SYMBOLICS-3600
+   SYMBOLICS-3670
+   TANDEM-TXP
+   TEK-6130
+   TI-EXPLORER
+   TP-4000
+   TRS-80
+   UNIVAC-1100
+   UNIVAC-1100/60
+   UNIVAC-1100/62
+   UNIVAC-1100/63
+   UNIVAC-1100/64
+   UNIVAC-1100/70
+   UNIVAC-1160
+   VAX-11/725
+
+
+Reynolds & Postel                                              [Page 22]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Machine Names
+
+
+   VAX-11/730
+   VAX-11/750
+   VAX-11/780
+   VAX-11/785
+   VAX-11/790
+   VAX-11/8600
+   VAX-8600
+   WANG-PC002
+   WANG-VS100
+   WANG-VS400
+   XEROX-1108
+   XEROX-8010
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 23]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+System Names
+
+
+                              SYSTEM NAMES
+
+   These are the Official System Names as they appear in the NIC Host
+   Table.  Their use is described in RFC 810 [39].
+
+   A system name may be up to 40 characters taken from the set of
+   uppercase letters, digits, and the two punctuation characters hyphen
+   and slash.  It must start with a letter, and end with a letter or
+   digit.
+
+   AEGIS
+   APOLLO
+   BS-2000
+   CEDAR
+   CGW
+   CHRYSALIS
+   CMOS
+   CMS
+   COS
+   CPIX
+   CTOS
+   CTSS
+   DCN
+   DDNOS
+   DOMAIN
+   EDX
+   ELF
+   EMBOS
+   EMMOS
+   EPOS
+   FOONEX
+   FUZZ
+   GCOS
+   GPOS
+   HDOS
+   IMAGEN
+   INTERCOM
+   IMPRESS
+   INTERLISP
+   IOS
+   ITS
+   LISP
+   LISPM
+   LOCUS
+   MINOS
+   MOS
+   MPE5
+   MSDOS
+
+
+Reynolds & Postel                                              [Page 24]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+System Names
+
+
+   MULTICS
+   MVS
+   MVS/SP
+   NEXUS
+   NMS
+   NONSTOP
+   NOS-2
+   OS/DDP
+   OS4
+   OS86
+   OSX
+   PCDOS
+   PERQ/OS
+   PLI
+   PSDOS/MIT
+   PRIMOS
+   RMX/RDOS
+   ROS
+   RSX11M
+   SATOPS
+   SCS
+   SIMP
+   SWIFT
+   TAC
+   TANDEM
+   TENEX
+   TOPS10
+   TOPS20
+   TP3010
+   TRSDOS
+   ULTRIX
+   UNIX
+   UT2D
+   V
+   VM
+   VM/370
+   VM/CMS
+   VM/SP
+   VMS
+   VMS/EUNICE
+   VRTX
+   WAITS
+   WANG
+   XDE
+   XENIX
+
+
+
+
+
+Reynolds & Postel                                              [Page 25]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Protocol Names
+
+
+                       PROTOCOL AND SERVICE NAMES
+
+   These are the Official Protocol Names.  Their use is described in
+   greater detail in RFC 810 [39].
+
+   A protocol or service may be up to 40 characters taken from the set
+   of uppercase letters, digits, and the punctuation character hyphen.
+   It must start with a letter, and end with a letter or digit.
+
+   ARGUS               - ARGUS Protocol
+   AUTH                - Authentication Service
+   BBN-RCC-MON         - BBN RCC Monitoring
+   BL-IDM              - Britton Lee Intelligent Database Machine
+   BOOTPC              - Bootstrap Protocol Client
+   BOOTPS              - Bootstrap Protocol Server
+   BR-SAT-MON          - Backroom SATNET Monitoring
+   CFTP                - CFTP
+   CHAOS               - CHAOS Protocol
+   CHARGEN             - Character Generator Protocol
+   CISCO-FNA           - CISCO FNATIVE
+   CISCO-TNA           - CISCO TNATIVE
+   CISCO-SYS           - CISCO SYSMAINT
+   CLOCK               - DCNET Time Server Protocol
+   COOKIE-JAR          - Cookie Jar Authentication Procedure
+   CSNET-NS            - CSNET Mailbox Nameserver Protocol
+   DAYTIME             - Daytime Protocol
+   DCN-MEAS            - DCN Measurement Subsystems Protocol
+   DCP                 - Device Control Protocol
+   DISCARD             - Discard Protocol
+   DOMAIN              - Domain Name Server
+   ECHO                - Echo Protocol
+   EGP                 - Exterior Gateway Protocol
+   EMCON               - Emission Control Protocol
+   EMFIS-CNTL          - EMFIS Control Service
+   EMFIS-DATA          - EMFIS Data Service
+   FINGER              - Finger Protocol
+   FTP                 - File Transfer Protocol
+   FTP-DATA            - File Transfer Protocol Data
+   GGP                 - Gateway Gateway Protocol
+   GRAPHICS            - Graphics Protocol
+   HMP                 - Host Monitoring Protocol
+   HOST2-NS            - Host2 Name Server
+   HOSTNAME            - Hostname Protocol
+   ICMP                - Internet Control Message Protocol
+   IGMP                - Internet Group Management Protocol
+   IGP                 - Interior Gateway Protocol
+   INGRES-NET          - INGRES-NET Service
+   IP                  - Internet Protocol
+
+
+Reynolds & Postel                                              [Page 26]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Protocol Names
+
+
+   IPCU                - Internet Packet Core Utility
+   IPPC                - Internet Pluribus Packet Core
+   IRTP                - Internet Reliable Transaction Protocol
+   ISI-GL              - ISI Graphics Language Protocol
+   ISO-TP4             - ISO Transport Protocol Class 4
+   ISO-TSAP            - ISO TSAP
+   LA-MAINT            - IMP Logical Address Maintenance
+   LEAF-1              - Leaf-1 Protocol
+   LEAF-2              - Leaf-2 Protocol
+   LINK                - Link Protocol
+   LOC-SRV             - Location Service
+   LOGIN               - Login Host Protocol
+   MERIT-INP           - MERIT Internodal Protocol
+   METAGRAM            - Metagram Relay
+   MIT-ML-DEV          - MIT ML Device
+   MFE-NSP             - MFE Network Services Protocol
+   MIT-SUBNET          - MIT Subnet Support
+   MIT-DOV             - MIT Dover Spooler
+   MPM                 - Internet Message Protocol (Multimedia Mail)
+   MPM-FLAGS           - MPM Flags Protocol
+   MPM-SND             - MPM Send Protocol
+   MSG-AUTH            - MSG Authentication Protocol
+   MSG-ICP             - MSG ICP Protocol
+   MUX                 - Multiplexing Protocol
+   NAMESERVER          - Host Name Server
+   NETBIOS-DGM         - NETBIOS Datagram Service
+   NETBIOS-NS          - NETBIOS Name Service
+   NETBIOS-SSN         - NETBIOS Session Service
+   NETBLT              - Bulk Data Transfer Protocol
+   NETED               - Network Standard Text Editor
+   NETRJS              - Remote Job Service
+   NI-FTP              - NI File Transfer Protocol
+   NI-MAIL             - NI Mail Protocol
+   NICNAME             - Who Is Protocol
+   NSW-FE              - NSW User System Front End
+   NTP                 - Network Time Protocol
+   NVP-II              - Network Voice Protocol
+   POP2                - Post Office Protocol - Version 2
+   PRM                 - Packet Radio Measurement
+   PUP                 - PUP Protocol
+   PWDGEN              - Password Generator Protocol
+   QUOTE               - Quote of the Day Protocol
+   RDP                 - Reliable Data Protocol
+   RJE                 - Remote Job Entry
+   RLP                 - Resource Location Protocol
+   RTELNET             - Remote Telnet Service
+   RVD                 - Remote Virtual Disk Protocol
+   SAT-EXPAK           - Satnet and Backroom EXPAK
+
+
+Reynolds & Postel                                              [Page 27]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Protocol Names
+
+
+   SAT-MON             - SATNET Monitoring
+   SEP                 - Sequential Exchange Protocol
+   SFTP                - Simple File Transfer Protocol
+   SMTP                - Simple Mail Transfer Protocol
+   ST                  - Stream Protocol
+   STATSRV             - Statistics Service
+   SU-MIT-TG           - SU/MIT Telnet Gateway Protocol
+   SUNRPC              - SUN Remote Procedure Call
+   SUPDUP              - SUPDUP Protocol
+   SUR-MEAS            - Survey Measurement
+   SWIFT-RVF           - Remote Virtual File Protocol
+   TACACS-DS           - TACACS-Database Service
+   TACNEWS             - TAC News
+   TCP                 - Transmission Control Protocol
+   TELNET              - Telnet Protocol
+   TFTP                - Trivial File Transfer Protocol
+   TIME                - Time Server Protocol
+   TRUNK-1             - Trunk-1 Protocol
+   TRUNK-2             - Trunk-2 Protocol
+   UCL                 - University College London Protocol
+   UDP                 - User Datagram Protocol
+   NNTP                - Network News Transfer Protocol
+   USERS               - Active Users Protocol
+   UUCP-PATH           - UUCP Path Service
+   VIA-FTP             - VIA Systems-File Transfer Protocol
+   WB-EXPAK            - Wideband EXPAK
+   WB-MON              - Wideband Monitoring
+   XNET                - Cross Net Debugger
+   XNS-IDP             - Xerox NS IDP
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 28]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Terminal Type Names
+
+
+                          TERMINAL TYPE NAMES
+
+   These are the Official Terminal Type Names.  Their use is described
+   in RFC 930 [97].  The maximum length of a name is 40 characters.
+
+   A terminal names may be up to 40 characters taken from the set of
+   uppercase letters, digits, and the two punctuation characters hyphen
+   and slash.  It must start with a letter, and end with a letter or
+   digit.
+
+   ADDS-CONSUL-980
+   ADDS-REGENT-100
+   ADDS-REGENT-20
+   ADDS-REGENT-200
+   ADDS-REGENT-25
+   ADDS-REGENT-40
+   ADDS-REGENT-60
+   AMPEX-DIALOGUE-80
+   ANDERSON-JACOBSON-630
+   ANDERSON-JACOBSON-832
+   ANDERSON-JACOBSON-841
+   ANN-ARBOR-AMBASSADOR
+   ARDS
+   BITGRAPH
+   BUSSIPLEXER
+   CALCOMP-565
+   CDC-456
+   CDI-1030
+   CDI-1203
+   CLNZ
+   COMPUCOLOR-II
+   CONCEPT-100
+   CONCEPT-104
+   CONCEPT-108
+   DATA-100
+   DATA-GENERAL-6053
+   DATAGRAPHIX-132A
+   DATAMEDIA-1520
+   DATAMEDIA-1521
+   DATAMEDIA-2500
+   DATAMEDIA-3025
+   DATAMEDIA-3025A
+   DATAMEDIA-3045
+   DATAMEDIA-3045A
+   DATAMEDIA-DT80/1
+   DATAPOINT-2200
+   DATAPOINT-3000
+   DATAPOINT-3300
+
+
+Reynolds & Postel                                              [Page 29]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Terminal Type Names
+
+
+   DATAPOINT-3360
+   DEC-DECWRITER-I
+   DEC-DECWRITER-II
+   DEC-GT40
+   DEC-GT40A
+   DEC-GT42
+   DEC-LA120
+   DEC-LA30
+   DEC-LA36
+   DEC-LA38
+   DEC-VT05
+   DEC-VT100
+   DEC-VT132
+   DEC-VT50
+   DEC-VT50H
+   DEC-VT52
+   DELTA-DATA-5000
+   DELTA-TELTERM-2
+   DIABLO-1620
+   DIABLO-1640
+   DIGILOG-333
+   DTC-300S
+   EDT-1200
+   EXECUPORT-4000
+   EXECUPORT-4080
+   GENERAL-TERMINAL-100A
+   GSI
+   HAZELTINE-1500
+   HAZELTINE-1510
+   HAZELTINE-1520
+   HAZELTINE-2000
+   HP-2621
+   HP-2621A
+   HP-2621P
+   HP-2626
+   HP-2626A
+   HP-2626P
+   HP-2640
+   HP-2640A
+   HP-2640B
+   HP-2645
+   HP-2645A
+   HP-2648
+   HP-2648A
+   HP-2649
+   HP-2649A
+   IBM-3101
+   IBM-3101-10
+
+
+Reynolds & Postel                                              [Page 30]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Terminal Type Names
+
+
+   IBM-3275-2
+   IBM-3276-2
+   IBM-3276-3
+   IBM-3276-4
+   IBM-3277-2
+   IBM-3278-2
+   IBM-3278-3
+   IBM-3278-4
+   IBM-3278-5
+   IBM-3279-2
+   IBM-3279-3
+   IMLAC
+   INFOTON-100
+   INFOTONKAS
+   ISC-8001
+   LSI-ADM-3
+   LSI-ADM-31
+   LSI-ADM-3A
+   LSI-ADM-42
+   MEMOREX-1240
+   MICROBEE
+   MICROTERM-ACT-IV
+   MICROTERM-ACT-V
+   MICROTERM-MIME-1
+   MICROTERM-MIME-2
+   NETRONICS
+   NETWORK-VIRTUAL-TERMINAL
+   OMRON-8025AG
+   PERKIN-ELMER-1100
+   PERKIN-ELMER-1200
+   PERQ
+   PLASMA-PANEL
+   QUME-SPRINT-5
+   SOROC
+   SOROC-120
+   SOUTHWEST-TECHNICAL-PRODUCTS-CT82
+   SUPERBEE
+   SUPERBEE-III-M
+   TEC
+   TEKTRONIX-4010
+   TEKTRONIX-4012
+   TEKTRONIX-4013
+   TEKTRONIX-4014
+   TEKTRONIX-4023
+   TEKTRONIX-4024
+   TEKTRONIX-4025
+   TEKTRONIX-4027
+   TELERAY-1061
+
+
+Reynolds & Postel                                              [Page 31]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Terminal Type Names
+
+
+   TELERAY-3700
+   TELERAY-3800
+   TELETEC-DATASCREEN
+   TELETERM-1030
+   TELETYPE-33
+   TELETYPE-35
+   TELETYPE-37
+   TELETYPE-38
+   TELETYPE-43
+   TELEVIDEO-912
+   TELEVIDEO-920
+   TELEVIDEO-920B
+   TELEVIDEO-920C
+   TELEVIDEO-950
+   TERMINET-1200
+   TERMINET-300
+   TI-700
+   TI-733
+   TI-735
+   TI-743
+   TI-745
+   TYCOM
+   UNIVAC-DCT-500
+   VIDEO-SYSTEMS-1200
+   VIDEO-SYSTEMS-5000
+   VISUAL-200
+   XEROX-1720
+   ZENITH-H19
+   ZENTEC-30
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 32]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Documents
+
+
+                               DOCUMENTS
+
+   [1]    Anderson, B., "TACACS User Identification Telnet Option",
+          RFC 927, BBN, December 1984.
+
+   [2]    BBN, "Specifications for the Interconnection of a Host and an
+          IMP", Report 1822, Bolt Beranek and Newman, Cambridge,
+          Massachusetts, revised, December 1981.
+
+   [3]    BBN, "User Manual for TAC User Database Tool", Bolt Beranek
+          and Newman, September 1984.
+
+   [4]    Bennett, C., "A Simple NIFTP-Based Mail System", IEN 169,
+          University College, London, January 1981.
+
+   [5]    Bhushan, A., "A Report on the Survey Project", RFC 530,
+          NIC 17375, June 1973.
+
+   [6]    Bisbey, R., D. Hollingworth, and B. Britt, "Graphics Language
+          (version 2.1)", ISI/TM-80-18, Information Sciences Institute,
+          July 1980.
+
+   [7]    Boggs, D., J. Shoch, E. Taft, and R. Metcalfe, "PUP: An
+          Internetwork Architecture", XEROX Palo Alto Research Center,
+          CSL-79-10, July 1979; also in IEEE Transactions on
+          Communication, Volume COM-28, Number 4, April 1980.
+
+   [8]    Braden, R., "NETRJS Protocol", RFC 740, NIC 42423,
+          November 1977.
+
+   [9]    Bressler, B., "Remote Job Entry Protocol",  RFC 407,
+          NIC 12112, October 1972.
+
+   [10]   Bressler, R., "Inter-Entity Communication -- An Experiment",
+          RFC 441, NIC 13773, January 1973.
+
+   [11]   Butler, M., J. Postel, D. Chase, J. Goldberger, and
+          J. K. Reynolds, "Post Office Protocol - Version 2", RFC 937,
+          Information Sciences Institute, February 1985.
+
+   [12]   Cass, D. E., and M. T. Rose, "ISO Transport Services on Top of
+          the TCP", RFC 983, NTRC, April 1986.
+
+   [13]   Clark, D., M. Lambert, and L. Zhang, "NETBLT: A Bulk Data
+          Transfer Protocol", RFC 969, MIT Laboratory for Computer
+          Science, December 1985.
+
+
+
+
+Reynolds & Postel                                              [Page 33]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Documents
+
+
+   [14]   Cohen, D., "On Holy Wars and a Plea for Peace", IEEE Computer
+          Magazine, October 1981.
+
+   [15]   Cohen, D., "Specifications for the Network Voice Protocol",
+          RFC 741, ISI/RR 7539, Information Sciences Institute,
+          March 1976.
+
+   [16]   Cohen, D. and J. Postel, "Multiplexing Protocol", IEN 90,
+          Information Sciences Institute, May 1979.
+
+   [17]   COMPASS, "Semi-Annual Technical Report", CADD-7603-0411,
+          Massachusetts Computer Associates, 4 March 1976. Also as,
+          "National Software Works, Status Report No. 1,"
+          RADC-TR-76-276, Volume 1, September 1976. And COMPASS. "Second
+          Semi-Annual Report," CADD-7608-1611, Massachusetts Computer
+          Associates, August 1976.
+
+   [18]   Crispin, M., "Telnet Logout Option", Stanford University-AI,
+          RFC 727, April 1977.
+
+   [19]   Crispin, M., "Telnet SUPDUP Option", Stanford University-AI,
+          RFC 736, October 1977.
+
+   [20]   Crispin, M., "SUPDUP Protocol", RFC 734, NIC 41953,
+          October 1977.
+
+   [21]   Crocker, D., "Telnet Output Carriage-Return Disposition
+          Option", RFC 652, October 1974.
+
+   [22]   Crocker, D., "Telnet Output Formfeed Disposition Option",
+          RFC 655, October 1974.
+
+   [23]   Crocker, D., "Telnet Output Linefeed Disposition", RFC 658,
+          October 1974.
+
+   [24]   Crocker, D., "Telnet Output Horizontal Tab Disposition
+          Option", RFC 654, October 1974.
+
+   [25]   Crocker, D., "Telnet Output Horizontal Tabstops Option",
+          RFC 653, October 1974.
+
+   [26]   Crocker, D., "Telnet Output Vertical Tab Disposition Option",
+          RFC 657, October 1974.
+
+   [27]   Crocker, D., "Telnet Output Vertical Tabstops Option",
+          RFC 656, October 1974.
+
+
+
+
+Reynolds & Postel                                              [Page 34]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Documents
+
+
+   [28]   Crocker, D. H. and R. H. Gumpertz, "Revised Telnet Byte Marco
+          Option", RFC 735, November 1977.
+
+   [29]   Croft, B., and J. Gilmore, "BOOTSTRAP Protocol (BOOTP)",
+          RFC 951, Stanford and SUN Microsytems, September 1985.
+
+   [30]   Day, J., "Telnet Data Entry Terminal Option", RFC 732,
+          September 1977.
+
+   [31]   DDN Protocol Handbook, "Telnet Output Line Width Option",
+          NIC 50005, December 1985.
+
+   [32]   DDN Protocol Handbook, "Telnet Output Page Size Option",
+          NIC 50005, December 1985.
+
+   [33]   DDN Protocol Handbook, "Telnet Reconnection Option",
+          NIC 50005, December 1985.
+
+   [34]   Deering, S. E., "Host Extensions for IP Multicasting",
+          RFC 988, Stanford University, December 1985.
+
+   [35]   Elvy, M., and R. Nedved, "Network Mail Path Service", RFC 915,
+          Harvard and CMU, July 1986.
+
+   [36]   Feinler, E., editor, "DDN Protocol Handbook", Network
+          Information Center, SRI International, December 1985.
+
+   [37]   Feinler, E., editor, "Internet Protocol Transition Workbook",
+          Network Information Center, SRI International, March 1982.
+
+   [38]   Feinler, E. and J. Postel, eds., "ARPANET Protocol Handbook",
+          NIC 7104, for the Defense Communications Agency by SRI
+          International, Menlo Park, California, Revised January 1978.
+
+   [39]   Feinler, E., K. Harrenstien, Z. Su, and V. White, "DoD
+          Internet Host Table Specification", RFC 810, SRI
+          International, March 1982.
+
+   [40]   Finlayson, R., T. Mann, J. Mogul, and M. Theimer, "A Reverse
+          Address Resolution Protocol", RFC 903, Stanford University,
+          June 1984.
+
+   [41]   Forgie, J., "ST - A Proposed Internet Stream Protocol",
+          IEN 119, MIT Lincoln Laboratory, September 1979.
+
+   [42]   Forsdick, H., "CFTP", Network Message, Bolt Beranek and
+          Newman, January 1982.
+
+
+
+Reynolds & Postel                                              [Page 35]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Documents
+
+
+   [43]   Greenberg, B., "Telnet SUPDUP-OUTPUT Option", RFC 749,
+          MIT-Multics, September 1978.
+
+   [44]   Harrenstien, K., "Name/Finger", RFC 742, NIC 42758,
+          SRI International,  December 1977.
+
+   [45]   Harrenstien, K., V. White, and E. Feinler, "Hostnames Server",
+          RFC 811, SRI International, March 1982.
+
+   [46]   Harrenstien, K., and V. White, "Nicname/Whois", RFC 812,
+          SRI International, March 1982.
+
+   [47]   Haverty, J., "XNET Formats for Internet Protocol Version 4",
+          IEN 158, October 1980.
+
+   [48]   Hinden, R. M., "A Host Monitoring Protocol", RFC 869,
+          Bolt Beranek and Newman, December 1983.
+
+   [49]   Hinden, R., and A. Sheltzer, "The DARPA Internet Gateway",
+          RFC 823, September 1982.
+
+   [50]   Hornig, C., "A Standard for the Transmission of IP Datagrams
+          over Ethernet Networks, RFC 894, Symbolics, April 1984.
+
+   [51]   International Standards Organization, "ISO Transport Protocol
+          Specification - ISO DP 8073", RFC 905, April 1984.
+
+   [52]   International Standards Organization, "Protocol for Providing
+          the Connectionless-Mode Network Services", RFC 926, ISO,
+          December 1984.
+
+   [53]   Kantor, B., and P. Lapsley, "Network News Transfer Protocol",
+          RFC 977, UC San Diego & UC Berkeley, February 1986.
+
+   [54]   Killian, E., "Telnet Send-Location Option", RFC 779,
+          April 1981.
+
+   [55]   Korb, J. T., "A Standard for the Transmission of IP Datagrams
+          Over Public Data Networks", RFC 877, Purdue University,
+          September 1983.
+
+   [56]   Lottor, M. K., "Simple File Transfer Protocol", RFC 913, MIT,
+          September 1984.
+
+   [57]   Malis, A., "Logical Addressing Implementation Specification",
+          BBN Report 5256, pp 31-36, May 1983.
+
+
+
+
+Reynolds & Postel                                              [Page 36]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Documents
+
+
+   [58]   Metcalfe, R. M. and D. R. Boggs, "Ethernet: Distributed Packet
+          Switching for Local Computer Networks", Communications of the
+          ACM, 19 (7), pp 395-402, July 1976.
+
+   [59]   Miller, T., "Internet Reliable Transaction Protocol", RFC 938,
+          ACC, February 1985.
+
+   [60]   Mills, D., "Network Time Protocol", RFC 958, M/A-COM Linkabit,
+          September 1985.
+
+   [61]   Mockapetris, P., "Domain Names - Implementation and
+          Specification", RFC 883, Information Sciences Institute,
+          November 1983.
+
+   [62]   Nedved, R., "Telnet Terminal Location Number Option", RFC 946,
+          Carnegie-Mellon University, May 1985.
+
+   [63]   NSW Protocol Committee, "MSG: The Interprocess Communication
+          Facility for the National Software Works", CADD-7612-2411,
+          Massachusetts Computer Associates, BBN 3237, Bolt Beranek and
+          Newman, Revised December 1976.
+
+   [64]   Plummer, D., "An Ethernet Address Resolution Protocol or
+          Converting Network Protocol Addresses to 48-bit Ethernet
+          Addresses for Transmission on Ethernet Hardware", RFC 826,
+          MIT-LCS, November 1982.
+
+   [65]   Postel, J., "Active Users", RFC 866, Information
+          Sciences Institute, May 1983.
+
+   [66]   Postel, J., "A Standard for the Transmission of IP Datagrams
+          over Experimental Ethernet Networks, RFC 895, Information
+          Sciences Institute, April 1984.
+
+   [67]   Postel, J., "Character Generator Protocol", RFC 864,
+          Information Sciences Institute, May 1983.
+
+   [68]   Postel, J., "Daytime Protocol", RFC 867, Information Sciences
+          Institute, May 1983.
+
+   [69]   Postel, J., "Discard Protocol", RFC 863, Information Sciences
+          Institute, May 1983.
+
+   [70]   Postel, J., "Echo Protocol", RFC 862, Information Sciences
+          Institute, May 1983.
+
+   [71]   Postel, J. and J. Reynolds, "File Transfer Protocol", RFC 959,
+          Information Sciences Institute, October 1985.
+
+
+Reynolds & Postel                                              [Page 37]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Documents
+
+
+   [72]   Postel, J., "Internet Control Message Protocol - DARPA
+          Internet Program Protocol Specification", RFC 792,
+          Information Sciences Institute, September 1981.
+
+   [73]   Postel, J., "Internet Message Protocol", RFC 759, IEN 113,
+          Information Sciences Institute, August 1980.
+
+   [74]   Postel, J., "Name Server", IEN 116, Information Sciences
+          Institute, August 1979.
+
+   [75]   Postel, J., "Quote of the Day Protocol", RFC 865,
+          Information Sciences Institute, May 1983.
+
+   [76]   Postel, J., "Remote Telnet Service", RFC 818,
+          Information Sciences Institute, November 1982.
+
+   [77]   Postel, J., "Simple Mail Transfer Protocol", RFC 821,
+          Information Sciences Institute, August 1982.
+
+   [78]   Postel, J., "Telnet End of Record Option", RFC 885,
+          Information Sciences Institute, December 1983.
+
+   [79]   Postel, J., "User Datagram Protocol", RFC 768
+          Information Sciences Institute, August 1980.
+
+   [80]   Postel, J., ed., "Internet Protocol - DARPA Internet Program
+          Protocol Specification", RFC 791, Information Sciences
+          Institute, September 1981.
+
+   [81]   Postel, J., ed., "Transmission Control Protocol - DARPA
+          Internet Program Protocol Specification", RFC 793,
+          Information Sciences Institute, September 1981.
+
+   [82]   Postel, J. and D. Crocker, "Remote Controlled Transmission and
+          Echoing Telnet Option", RFC 726, March 1977.
+
+   [83]   Postel, J., and K. Harrenstien, "Time Protocol", RFC 868,
+          Information Sciences Institute, May 1983.
+
+   [84]   Postel, J. and J. Reynolds, "Telnet Extended Options - List
+          Option", RFC 861, Information Sciences Institute, May 1983.
+
+   [85]   Postel, J. and J. Reynolds, "Telnet Binary Transmission",
+          RFC 856, Information Sciences Institute, May 1983.
+
+   [86]   Postel, J. and J. Reynolds, "Telnet Echo Option", RFC 857,
+          Information Sciences Institute, May 1983.
+
+
+
+Reynolds & Postel                                              [Page 38]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Documents
+
+
+   [87]   Postel, J., and J. Reynolds, "Telnet Protocol Specification",
+          RFC 854, Information Sciences Institute, May 1983.
+
+   [88]   Postel, J. and J. Reynolds, "Telnet Status Option", RFC 859,
+          Information Sciences Institute, May 1983.
+
+   [89]   Postel, J. and J. Reynolds, "Telnet Suppress Go Ahead Option",
+          RFC 858, Information Sciences Institute, May 1983.
+
+   [90]   Postel, J. and J. Reynolds, "Telnet Timing Mark Option",
+          RFC 860, Information Sciences Institute, May 1983.
+
+   [91]   Reynolds, J. and J. Postel, "Official Internet Protocols",
+          RFC 1011, Information Sciences Institute, May 1987.
+
+   [92]   Seamonson, L. J., and E. C. Rosen, "STUB" Exterior Gateway
+          Protocol", RFC 888, BBN Communications Corporation,
+          January 1984.
+
+   [93]   Shuttleworth, B., "A Documentary of MFENet, a National
+          Computer Network", UCRL-52317, Lawrence Livermore Labs,
+          Livermore, California, June 1977.
+
+   [94]   Silverman, S., "Output Marking Telnet Option", RFC 933, MITRE,
+          January 1985.
+
+   [95]   Sollins, K., "The TFTP Protocol (Revision 2)", RFC 783,
+          MIT/LCS, June 1981.
+
+   [96]   Solomon, M., L. Landweber, and D. Neuhengen, "The CSNET Name
+          Server", Computer Networks, v.6, n.3, pp. 161-172, July 1982.
+
+   [97]   Solomon, M., and E. Wimmers, "Telnet Terminal Type Option",
+          RFC 930, Supercedes RFC 884, University of Wisconsin, Madison,
+          January 1985.
+
+   [98]   Sproull, R., and E. Thomas, "A Networks Graphics Protocol",
+          NIC 24308, August 1974.
+
+   [99]   StJohns, M., "Authentication Service", RFC 931, TPSC,
+          January 1985.
+
+   [100]  Tappan, D. C., "The CRONUS Virtual Local Network", RFC 824,
+          Bolt Beranek and Newman, August 1982.
+
+   [101]  Taylor, J., "ERPC Functional Specification", Version 1.04,
+          HYDRA Computer Systems, Inc., July 1984.
+
+
+
+Reynolds & Postel                                              [Page 39]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+Documents
+
+
+   [102]  "The Ethernet, A Local Area Network: Data Link Layer and
+          Physical Layer Specification", AA-K759B-TK, Digital Equipment
+          Corporation, Maynard, MA.  Also as:  "The Ethernet - A Local
+          Area Network", Version 1.0, Digital Equipment Corporation,
+          Intel Corporation, Xerox Corporation, September 1980.  And:
+          "The Ethernet, A Local Area Network: Data Link Layer and
+          Physical Layer Specifications", Digital, Intel and Xerox,
+          November 1982.  And:  XEROX, "The Ethernet, A Local Area
+          Network: Data Link Layer and Physical Layer Specification",
+          X3T51/80-50, Xerox Corporation, Stamford, CT., October 1980.
+
+   [103]  The High Level Protocol Group, "A Network Independent File
+          Transfer Protocol",  INWG Protocol Note 86, December 1977.
+
+   [104]  Tovar, "Telnet Extended ASCII Option", RFC 698, Stanford
+          University-AI, July 1975.
+
+   [105]  Uttal, J, J. Rothschild, and C. Kline, "Transparent
+          Integration of UNIX and MS-DOS", Locus Computing Corporation.
+
+   [106]  Velten, D., R. Hinden, and J. Sax, "Reliable Data Protocol",
+          RFC 908, BBN Communications Corporation, July 1984.
+
+   [107]  Wancho, F., "Password Generator Protocol",  RFC 972, WSMR,
+          January 1986.
+
+   [108]  Winston, I., "Two Methods for the Transmission of IP Datagrams
+          Over IEEE 802.3 Networks", RFC 948, University Of
+          Pennsylvania, June 1985.
+
+   [109]  Khanna, A., and A. Malis, "The ARPANET AHIP-E Host Access
+          Protocol (Enhanced AHIP)", RFC 1005, BBN Communications
+          Corporation, May 1987.
+
+   
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 40]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+People
+
+
+                                 PEOPLE
+
+   [AGM]     Andy Malis          BBN       Malis@CCS.BBN.COM
+
+   [AV]      Al Vezza            MIT       AV@XX.LCS.MIT.EDU
+
+   [AXH]     Arthur Hartwig      UQNET     ---none---
+
+   [BA4]     Brian Anderson      BBN       baanders@CCQ.BBN.COM
+
+   [BCH2]    Barry Howard        LLL       Howard@LLL-MFE.ARPA
+
+   [BN4]     Bill Nowicki        SUN       Nowicki@SUN.COM
+
+   [CAK]     Chris Kent          PURDUE    CAK@PURDUE.EDU
+
+   [DCP1]    David Plummer       MIT       DCP@SYMBOLICS.ARPA
+
+   [DDC1]    David Clark         MIT       DClark@MIT-MULTICS.ARPA
+
+   [DLM1]    David Mills         LINKABIT  Mills@D.ISI.EDU
+
+   [DPR]     David Reed          MIT-LCS   Reed@MIT-MULTICS.ARPA
+
+   [DT15]    Daniel Tappan       BBN       Tappan@BBN.COM
+
+   [DXD]     Dennis J.W. Dube    VIA SYSTEMS ---none---
+
+   [DXG]     David Goldberg      SMI       sun!dg@UCBARPA.BERKELEY.EDU
+
+   [EAK1]    Earl Killian        LLL       EAK@S1-C.ARPA
+
+   [EBM]     Eliot Moss          MIT       EBM@XX.LCS.MIT.EDU
+
+   [FJW]     Frank J. Wancho     WSMR      WANCHO@SIMTEL20.ARPA
+
+   [FRAN]    Francine Perillo    SRI       Perillo@NIC.SRI.COM
+
+   [GB7]     Gerd Beling         DFVLR     GBELING@ISI.EDU
+
+   [GEOF]    Geoff Goodfellow    SRI       Geoff@SRI-CSL.ARPA
+
+   [GXP]     Gill Pratt          MIT       gill%mit-ccc@MC.LCS.MIT.EDU
+
+   [HCF2]    Harry Forsdick      BBN       Forsdick@A.BBN.COM
+
+   [HWB]     Hans-Werner Braun   MICHIGAN  HWB@MCR.UMICH.EDU
+
+
+
+Reynolds & Postel                                              [Page 41]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+People
+
+
+   [IEEE]    Vince Condello      IEEE      ---none---
+
+   [JAKE]    Jake Feinler        SRI       Feinler@SRI-NIC.ARPA
+
+   [JBP]     Jon Postel          ISI       Postel@ISI.EDU
+
+   [JBW1]    Joseph Walters, Jr. BBN       JWalters@CCX.BBN.COM
+
+   [JD21]    Jonathan Dreyer     BBN       JDreyer@CCV.BBN.COM
+
+   [JFH2]    Jack Haverty        BBN       Haverty@CCV.BBN.COM
+
+   [JFW]     Jon F. Wilkes       STC       Wilkes@STC.ARPA
+
+   [JGH]     Jim Herman          BBN       Herman@CCJ.BBN.COM
+
+   [JR17]    John L. Robinson    CANADA    Robinson@DMC-CRC.ARPA
+
+   [JWF]     Jim Forgie          LL        jwf@LL-EN.ARPA
+
+   [JXE2]    Jeanne Evans        UKMOD     JME%RSRE.MOD.UK@CS.UCL.AC.UK
+
+   [JXM]     Jeff Mogul          Stanford  ---none---
+
+   [JXO]     Jack O'Neil         ENCORE    ---none---
+
+   [JXP]     Joe Pato            Apollo    apollo!pato@EDDIE.MIT.EDU
+
+   [KLH]     Ken Harrenstien     SRI       KLH@NIC.SRI.COM
+
+   [LLP]     Larry Peterson      PURDUE    llp@PURDUE.EDU
+
+   [MA]      Mike Accetta        CMU       MIKE.ACCETTA@CMU-CS-A.EDU
+
+   [MAE]     Marc A. Elvy        HARVARD   elvy@HARVARD.EDU
+
+   [MAS3]    Marc Solomon        MDAC      solomon@OFFICE-1.ARPA
+
+   [MB]      Michael Brescia     BBN       Brescia@CCV.BBN.COM
+
+   [MBG]     Michael Greenwald   MIT-LCS   Greenwald@MIT-MULTICS.ARPA
+
+   [MCSJ]    Mike StJohns        TPSC      StJohns@MIT-MULTICS.ARPA
+
+   [MKL1]    Mark Lottor         MIT       MKL@NIC.SRI.COM
+
+   [MLC]     Mike Corrigan       DDN       Corrigan@DDN1.ARPA
+
+
+
+Reynolds & Postel                                              [Page 42]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+People
+
+
+   [MO2]     Michael O'Brien     RAND      OBrien@RAND-UNIX.ARPA
+
+   [MRC]     Mark Crispin        STANFORD
+                                         Admin.MRC@SU-SCORE.STANFORD.EDU
+
+   [MTR]     Marshall Rose       NRTC      MRose@NRTC.ARPA
+
+   [MXB]     Mike Berrow         Relational Technology        ---none---
+
+   [MXR]     Mark A. Rosenstein  MIT       mark@BORAX.LCS.MIT.EDU
+
+   [NC3]     J. Noel Chiappa     MIT       JNC@XX.LCS.MIT.EDU
+
+   [PAM6]    Paul McNabb         RICE      pam@PURDUE.EDU
+
+   [PHD1]    Pieter Ditmars      BBN       pditmars@CCX.BBN.COM
+
+   [PK]      Peter Kirstein      UCL       Kirstein@ISI.EDU
+
+   [PL4]     Phil Lapsley        BERKELEY  phil@UCBARPA.BERKELEY.EDU
+
+   [PM1]     Paul Mockapetris    ISI       Mockapetris@ISI.EDU
+
+   [PXD]     Pete Delaney        ECRC      pete%ecrcvax@CSNET-RELAY.ARPA
+
+   [RDB2]    Robert Bressler     BBN       Bressler@CCW.BBN.COM
+
+   [RH6]     Robert Hinden       BBN       Hinden@CCV.BBN.COM
+
+   [RHT]     Robert Thomas       BBN       BThomas@F.BBN.COM
+
+   [RN6]     Rudy Nedved         CMU       Rudy.Nedved@CMU-CS-A.EDU
+
+   [RTB3]    Bob Braden          ISI       Braden@ISI.EDU
+
+   [RWS4]    Robert W. Scheifler ARGUS     RWS@XX.LCS.MIT.EDU
+
+   [RXM]     Robert Myhill       BBN       Myhill@CCS.BBN.COM
+
+   [SA1]     Sten Andler         ARPA      andler.ibm-sj@RAND-RELAY.ARPA
+
+   [SA2]     Saul Amarel         ARPA      Amarel@ISI.EDU
+
+   [SC3]     Steve Casner        ISI       Casner@ISI.EDU
+
+   [SGC]     Steve Chipman       BBN       Chipman@F.BBN.COM
+
+   [SHB]     Steven Blumenthal   BBN       BLUMENTHAL@VAX.BBN.COM
+
+
+Reynolds & Postel                                              [Page 43]
+
+
+
+RFC 1010 - Assigned Numbers                                     May 1987
+People
+
+
+   [SXS]     Steve Silverman     MITRE     Blankert@MITRE-GATEWAY.ORG
+
+   [SXS1]    Susie Snitzer       Britton-Lee ---none---
+
+   [TXM]     Trudy Miller        ACC       Trudy@ACC.ARPA
+
+   [UXB]     Ulf Bilting         CHALMERS  bilting@PURDUE.EDU
+
+   [WJC2]    Bill Croft          STANFORD  Croft@SUMEX-AIM.ARPA
+
+   [WXB]     William L. Biagi    CISCO     ---none---
+
+   [XEROX]   Pam Cance           XEROX     Cance.OSBUnorth@XEROX.COM
+
+   [ZSU]     Zaw-Sing Su         SRI       ZSu@SRI-TSC.ARPA
+
+      
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 44]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1010.txt](<www.ietf.org/rfc/rfc1010.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
