### PR TITLE
Archive rfc1012.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1012.txt
+++ b/www.ietf.org/rfc/rfc1012.txt
@@ -1,0 +1,3712 @@
+
+
+Network Working Group                                        J. Reynolds
+Request for Comments: 1012                                     J. Postel
+                                                                     ISI
+                                                               June 1987
+
+
+           BIBLIOGRAPHY OF REQUEST FOR COMMENTS 1 THROUGH 999
+
+
+STATUS OF THIS MEMO
+
+   This RFC is a reference guide for the Internet community which
+   provides a bibliographic summary of the Request for Comments numbers
+   1 through 999 issued between the years 1969-1987. Distribution of
+   this memo is unlimited.
+
+REQUEST FOR COMMENTS DOCUMENTS
+
+   1   - Crocker, Steve, "Host Software", RFC 1 (NIC 4687), UCLA/NMC,
+         7 April 1969.
+
+   2   - Duvall, Bill, "Links", RFC 2 (NIC4688), SRI, 9 April 1969.
+
+   3   - Crocker, Steve, "Documentation Conventions", RFC 3 (NIC 4689),
+         UCLA/NMC, 9 April 1969.
+
+   4   - Shapiro, Elmer B., "Network Timetable", RFC 4 (NIC 4690), SRI,
+         24 March 1969.
+
+   5   - Rulifson, Jeff, "DEL", RFC 5 (NIC 4691), SRI, 2 June 1969.
+
+   6   - Crocker, Steve, "Conversation with Bob Kahn", RFC 6 (NIC 4692),
+         UCLA/NMC, 10 April 1969.
+
+   7   - Deloche, Gerard, "HOST/IMP Interface", RFC 7 (NIC 4693), UCLA,
+         5 May 1969.
+
+   8   - Deloche, Gerard, "ARPA Network Functional Specifications",
+         RFC 8 (NIC 4694), UCLA, 5 May 1969.
+
+   9   - Deloche, Gerard, "HOST Software", RFC 9 (NIC 4695), UCLA,
+         1 May 1969.
+
+   10  - Crocker, Steve, "Documentation Conventions", RFC 10 (NIC 4696),
+         UCLA/NMC, 9 April 1969.
+
+   11  - Deloche, Gerard, "Implementation of the Host-Host Software
+         Procedures in GORDO", RFC 11 (NIC 4718), UCLA/NMC,
+         1 August 1969.
+
+   12  - Wingfield, Mike, "IMP-HOST Interface Flow Diagram", RFC 12
+         (NIC 4697), UCLA/NMC, 26 August 1969.
+
+
+Reynolds & Postel                                               [Page 1]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   13  - Cerf, Vint, "Referring to NWG/RFC 11", RFC 13 (NIC 4698),
+         UCLA/NMC, 20 August 1969.
+
+   14  - Never Issued.
+
+   15  - Carr, C. Stephen, "Network Subsystem for Time-Sharing Hosts",
+         RFC 15 (NIC 4754), Utah, 25 September 1969.
+
+   16  - Crocker, Steve, "M.I.T. (address)", RFC 16 (NIC 4719),
+         UCLA/NMC, 27 August 1969.
+
+   17  - Kreznar, John E., "Some Questions Re: HOST-IMP Protocol",
+         RFC 17 (NIC 4699), SDC, 27 August 1969.
+
+   17a - Kahn, Robert, "The Following Comments are in Response to John
+         Kreznar's Questions Which Were Raised in RFC 17", RFC 17a, BBN,
+         August 1969.
+
+   18  - Cerf, Vint, "Use of Links 1 and 2", RFC 18 (NIC 4720),
+         UCLA/NMC, September 1969.
+
+   19  - Kreznar, John E., "Two Protocol Suggestions to Reduce
+         Congestion at Swap-Bound Nodes", RFC 19 (NIC 4721), SDC,
+         7 October 1969.
+
+   20  - Cerf, Vint, "ASCII Format for Network Interchange", RFC 20
+         (NIC 4722), UCLA/NMC, 16 October 1969.
+
+   21  - Cerf, Vint, "Report of Network Meeting", RFC 21 (NIC 4723),
+         UCLA/NMC, 17 October 1969.
+
+   22  - Cerf, Vint, "Host-Host Control Message Formats", RFC 22
+         (NIC 4724), UCLA/NMC, 17 October 1969.
+
+   23  - Gregg, George, "Transmission of Multiple Control Messages",
+         RFC 23 (NIC 4725), UCSB, 16 October 1969.
+
+   24  - Crocker, Steve, "Documentation Conventions", RFC 24 (NIC 4726),
+         UCLA/NMC, 21 November 1969.
+
+   25  - Crocker, Steve, "No High Link Numbers", RFC 25 (NIC 4727),
+         UCLA/NMC, 30 October 1969.
+
+   26  - Never Issued.
+
+   27  - Crocker, Steve, "Documentation Conventions", RFC 27 (NIC 4729),
+         UCLA/NMC, 9 December 1969.
+
+
+
+
+Reynolds & Postel                                               [Page 2]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   28  - English, Bill, "Time Standards", RFC 28 (NIC 4730), SRI-ARC,
+         13 January 1970.
+
+   29  - Kahn, Robert, "Note in Response to Bill English's Request for
+         Comments", RFC 29 (NIC 4731), BBN, 19 January 1970.
+
+   30  - Crocker, Steve, "Documentation Conventions", RFC 30 (NIC 4732),
+         UCLA/NMC, 4 February 1970.
+
+   31  - Bobrow, Daniel, and William R. Sutherland, "Binary Message
+         Forms in Computer Networks", RFC 31 (NIC 4733), BBN and LINC,
+         February 1968.
+
+   32  - Cole, Jerry, "Some Thoughts on SRI's Proposed Real Time Clock
+         (re: RFCs 28,29)", RFC 32, MIT-Project MAC, 5 February 1970.
+
+   33  - Crocker, Steve, "New Host-Host Protocol", RFC 33 (NIC 4735),
+         UCLA/NMC, 12 February 1970.
+
+   34  - English, Bill, "Some Brief Preliminary Notes on the ARC Clock",
+         RFC 34 (NIC 4736), SRI-ARC, 26 February 1970.
+
+   35  - Crocker, Steve, "Network Meeting", RFC 35 (NIC 4737), UCLA/NMC,
+         3 March 1970.
+
+   36  - Crocker, Steve, "Protocol Notes", RFC 36 (NIC 4738), UCLA/NMC,
+         16 March 1970.
+
+   37  - Crocker, Steve, "Network Meeting Epilogue, etc.", RFC 37
+         (NIC 4739), UCLA/NMC, 20 March 1970.
+
+   38  - Wolfe, Stephen M., "Comments on Network Protocol from
+         NWG/RFC 36", RFC 38 (NIC 4740), UCLA/CCN, 20 March 1970.
+
+   39  - Harslem, Eric and John Heafner, "Comments on Protocol Re:
+         NWG/RFC 36", RFC 39 (NIC 4741), Rand, 25 March 1970.
+
+   40  - Harslem, Eric and John Heafner, "More Coments on the
+         Forthcoming Protocol", RFC 40 (NIC 4742), Rand, 27 March 1970.
+
+   41  - Melvin, John, "IMP-IMP Teletype Communication", RFC 41
+         (NIC 4743), SRI-ARC, 30 March 1970.
+
+   42  - Ancona, Enrico I., "Message Data Types", RFC 42 (NIC 4744),
+         LINC, 31 March 1970.
+
+   42a - Ancona, Enrico I., "User View of the TSP System (Working
+         Paper)", RFC 42a, LINC, April 1970.
+
+
+
+Reynolds & Postel                                               [Page 3]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   43  - Nemeth, Alan G., "Proposed Meeting", RFC 43 (NIC 4745), LINC,
+         8 April 1970.
+
+   44  - Shoshani, Arie, Robert Long, and Abe Lansberg, "Comments on
+         NWG/RFC 33 and 36", RFC 44 (NIC 4746), SDC, 10 April 1970.
+
+   45  - Postel, Jon and Steve Crocker, "New Protocol is Coming", RFC 45
+         (NIC 4747), UCLA/NMC, 14 April 1970.
+
+   46  - Meyer, Edwin W., Jr., "ARPA Network Protocol Notes", RFC 46
+         (NIC 4748), MIT-Project MAC, 17 April 1970.
+
+   47  - Postel, Jon, and Steve Crocker, "BBN's Comments on NWG/RFC 33",
+         RFC 47 (NIC 4749), UCLA/NMC, 20 April 1970.
+
+   48  - Postel, Jon, and Steve Crocker, "Possible Protocol Plateau",
+         RFC 48 (NIC 4750), UCLA/NMC, 21 April 1970.
+
+   49  - Meyer, Edwin W., Jr., "Conversations with Steve Crocker",
+         RFC 49 (NIC 4728), MIT-Project MAC, 25 April 1970.
+
+   50  - Harslem, Eric, and John Heafner, "Comments on the Meyer
+         Proposal", RFC 50 (NIC 4751), Rand, 30 April 1970.
+
+   51  - Elie, M., "Proposal for a Network Interchange Language", RFC 51
+         (NIC 4752), UCLA/NMC, 4 May 1970.
+
+   52  - Crocker, Steve, and Jon Postel, "Updated Distribution List",
+         RFC 52 (NIC 4753), UCLA/NMC, 1 July 1970.
+
+   53  - Crocker, Steve, "An Official Protocol Mechanism", RFC 53
+         (NIC 4755), UCLA/NMC, 9 June 1970.
+
+   54  - Crocker, Steve, Jon Postel, John Newkirk, and Mike Kraley, "An
+         Official Protocol Proffering", RFC 54 (NIC 4756), UCLA/NMC and
+         Harvard, 18 June 1970.
+
+   55  - Newkirk, John, Mike Kraley, Jon Postel, and Steve Crocker, "A
+         Prototypical Implementation of the NCP", RFC 55 (NIC 4757),
+         Harvard and UCLA/NMC, 19 June 1970.
+
+   56  - Belove, Ed, Dave Black, Bob Flegal, and Lamar G. Farquar,
+         "Third Level Protocol", RFC 56 (NIC 4758), Harvard and Utah,
+         19 June 1970.
+
+   57  - Kraley, Mike, and John Newkirk, "Thoughts and Reflections on
+         NWG/RFC 54", RFC 57 (NIC 4759), Harvard, 19 June 1970.
+
+
+
+
+Reynolds & Postel                                               [Page 4]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   58  - Skinner, Thomas P., "Logical Message Synchronization", RFC 58
+         (NIC 4760), MIT-Project MAC, 26 June 1970.
+
+   59  - Meyer, Edwin W., Jr., "Flow Control - Fixed Versus Demand
+         Allocation", RFC 59 (NIC 4761), MIT-Project MAC, 27 June 1970.
+
+   60  - Kalin, Richard, "A Simplified NCP Protocol", RFC 60 (NIC 4762),
+         LINC, 13 July 1970.
+
+   61  - Walden, Dave, "A Note on Interprocess Communications in a
+         Resource Sharing Computer Network", RFC 61 (NIC 4961),
+         Superseded by RFC 62, BBN, 17 July 1970.
+
+   62  - Walden, Dave, "A System for Interprocess Communication in a
+         Resource Sharing Computer Network", RFC 62 (NIC 4962),
+         Supersedes RFC 61, BBN, 3 August 1970.
+
+   63  - Cerf, Vint, "Belated Network Meeting Report", RFC 63
+         (NIC 4963), UCLA/NMC, 31 July 1970.
+
+   64  - Elie, M., "Getting Rid of Marking", RFC 64 (NIC 4964),
+         UCLA/NMC, Undated Document.
+
+   65  - Walden, Dave, "Comments on Host-Host Protocol Document Number 1
+         (by Steve Crocker, 3 August 1970)", RFC 65 (NIC 4965), BBN,
+         29 August 1970.
+
+   66  - Crocker, Steve, "3rd Level Ideas and Other Noise", RFC 66
+         (NIC 5409), UCLA/NMC, 26 August 1970.
+
+   67  - Crowther, William, "Proposed Change to Host/IMP Spec to
+         Eliminate Marking", RFC 67 (NIC 5410), BBN, Undated Document.
+
+   68  - Elie, M., "Comments on Memory Allocation Control Commands
+         (CEASE, ALL, GVB, RET) and RFNM", RFC 68 (NIC 5411), UCLA/NMC,
+         31 August 1970.
+
+   69  - Bhushan, Abhay, "Distribution List Change for M.I.T.", RFC 69
+         (NIC 5412), MIT-Project MAC, 22 September 1970.
+
+   70  - Crocker, Steve, "A Note on Padding", RFC 70 (NIC 5413),
+         UCLA/NMC, 15 October 1970.
+
+   71  - Schipper, Tjaart, "Reallocation in Case of Input Error", RFC 71
+         (NIC 5414), UCLA/NMC, 25 September 1970.
+
+   72  - Bressler, Bob, "Proposed Moratorium on Changes to Network
+         Protocol", RFC 71 (NIC 5415), MIT-Project MAC,
+         28 September 1970.
+
+
+Reynolds & Postel                                               [Page 5]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   73  - Crocker, Steve, "Response to NWG/RFC 67", RFC 73 (NIC 5416),
+         UCLA/NMC, 25 September 1970.
+
+   74  - White, Jim, "Specifications for Network Use of the UCSB On-Line
+         Systems", RFC 74 (NIC 5417), UCSB, 16 October 1970.
+
+   75  - Crocker, Steve, "Network Meeting", RFC 75 (NIC 5418), UCLA/NMC,
+         14 October 1970.
+
+   76  - Bouknight, Jack, James Madden, and Gary Grossman,
+         "Connection-By-Name: User Oriented Protocol", RFC 76
+         (NIC 5180), Illinois, 28 October 1970.
+
+   77  - Postel, Jon, "Network Meeting Report", RFC 77 (NIC 5604),
+         UCLA/NMC, 20 November 1970.
+
+   78  - Harslem, Eric, John Heafner, and Jim White, "NCP Status Report:
+         UCSB/RAND", RFC 78 (NIC 5199), Rand, 24 November 1970.
+
+   79  - Meyer, Edwin W., "Logger Protocol Error", RFC 79 (NIC 5601),
+         MIT-Project MAC, 16 November 1970.
+
+   80  - Harslem, Eric and John Heafner, "Protocols and Data Formats",
+         RFC 80 (NIC 5608), Rand 1 December 1970.
+
+   81  - Bouknight, Jack, "Request for Reference Information", RFC 81
+         (NIC 5609), Illinois, 3 December 1970.
+
+   82  - Meyer, Edwin W., Jr., "Network Meeting Notes", RFC 82
+         (NIC 5619), MIT-Project MAC, 9 December 1970.
+
+   83  - Anderson, Robert, Eric Harslem, and John Heafner, "Language -
+         Machine for Data Reconfiguration", RFC 83 (NIC 5621), Rand,
+         18 December 1970.
+
+   84  - North, Jeanne B., "List of NWG/RFC's 1-80", RFC 84 (NIC 5620),
+         NIC, 23 December 1970.
+
+   85  - Crocker, Steve, "Network Working Group Meeting", RFC 85
+         (NIC 5624), UCLA/NMC, 28 December 1970.
+
+   86  - Crocker, Steve, "Proposal for a Network Standard Format for a
+         Data Stream to Control Graphics Display", RFC 86 (NIC 5631),
+         UCLA/NMC, 5 January 1971.
+
+   87  - Vezza, Al, "Topic for Discussion at the Next Network Working
+         Group Meeting", RFC 87 (NIC 5632), MIT-Project MAC,
+         12 January 1971.
+
+
+
+Reynolds & Postel                                               [Page 6]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   88  - Braden, Bob, and Stephen Wolfe, "NETRJS - A Third Level
+         Protocol for Remote Job Entry", RFC 88 (NIC 5668), UCLA/CCN,
+         13 January 1971.
+
+   89  - Metcalfe, Bob, "Some Historic Moments in Networking", RFC 89
+         (NIC 5697), Harvard, 19 January 1971.
+
+   90  - Braden, Bob, "CCN as a Network Service Center", RFC 90
+         (NIC 5707), UCLA/CCN, 25 January 1971.
+
+   91  - Mealy, George H., "A Proposed User-User Protocol", RFC 91
+         (NIC 5708), Harvard, 27 December 1970.
+
+   92  - Never Issued.
+
+   93  - McKenzie, Alex, "Initial Connection Protocol", RFC 93
+         (NIC 5721), BBN, 27 January 1971.
+
+   94  - Harslem, Eric, and John Heafner, "Some Thoughts on Network
+         Graphics", RFC 94 (NIC 5725), Rand, 3 February 1971.
+
+   95  - Crocker, Steve, "Distribution of NWG/RFC's Through the NIC",
+         RFC 95 (NIC 5731), UCLA/NMC, 4 February 1971.
+
+   96  - Watson, Richard W., "An Interactive Network Experiment to Study
+         Modes of Accessing the Network Information Center", RFC 96
+         (NIC 5739), SRI-ARC, 12 February 1971.
+
+   97  - Melvin, John T., and Richard W. Watson, "A First Cut at a
+         Proposed Telnet Protocol", RFC 97 (NIC 5740), SRI-ARC,
+         15 February 1971.
+
+   98  - Meyer, Edwin W. Jr., and Thomas P. Skinner, "Logger Protocol
+         Proposal", RFC 98 (NIC 5744), MIT-Project MAC,
+         11 February 1971.
+
+   99  - Karp, Peggy, "Network Meeting", RFC 99 (NIC 5758), MITRE,
+         22 February 1971.
+
+   100 - Karp, Peggy, "Categorization and Guide to NWG/RFCs", RFC 100
+         (NIC 5761), MITRE, 26 February 1971.
+
+   101 - Watson, Richard W., "Notes on the Network Working Group
+         Meeting", RFC 101 (NIC 5762), Illinois, 23 February 1971.
+
+   102 - Crocker, Steve, "Output of the Host/Host Protocol Glitch
+         Cleaning Committee", RFC 102 (NIC 5763), UCLA/NMC,
+         22,23 February 1971.
+
+
+
+Reynolds & Postel                                               [Page 7]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   103 - Kalin, Richard, "Implementation of Interrupt Keys", RFC 103
+         (NIC 5764), MIT/LL, 24 February 1971.
+
+   104 - Postel, Jon, and Steve Crocker "Link 191", RFC 104 (NIC 5768),
+         UCLA, 25 February 1971.
+
+   105 - White, Jim, "Network Specifications for Remote Job Entry and
+         Remote Job Output Retrieval at UCSB", RFC 105 (NIC 5775), UCSB,
+         22 March 1971.
+
+   106 - O'Sullivan, Thomas, "User/Server Site Protocol Network Host
+         Questionnaire", RFC 106 (NIC 5776), Raytheon, 3 March 1971.
+
+   107 - Bressler, Bob, et al., "Output of the Host-Host Protocol Glitch
+         Cleaning Committee", RFC 107 (NIC 5806), MIT-Project MAC,
+         23 March 1971.
+
+   108 - Watson, Richard W., "Attendance List at the Urbana NWG
+         Meeting", RFC 108 (NIC 5807), Illinois, 25 March 1971.
+
+   109 - Winett, Joel M., "Level III Server Protocol for the Lincoln
+         Laboratory NIC-360/67", RFC 109 (NIC 5808), Lincoln Labs,
+         24 March 1971.
+
+   110 - Winett, Joel M., "Conventions for Using an IBM 2741 Terminal as
+         a User Console for Access to Network Server Hosts", RFC 110
+         (NIC 5809), Lincoln Labs, 25 March 1971.
+
+   111 - Crocker, Steve, "Pressure from the Chairman", RFC 111
+         (NIC 5815), UCLA/NMC, 31 March 1971.
+
+   112 - O'Sullivan, Thomas, "User/Server Site Protocol; Network Host
+         Questionnaire Responses", RFC 112 (NIC 5816), Raytheon,
+         1 April 1971.
+
+   113 - Harslem, Eric, John Heafner, and Jim White, "Network Activity
+         Report, UCSB-RAND", RFC 113 (NIC 5820), Rand, 5 April 1971.
+
+   114 - Bhushan, Abhay, "A File Transfer Protocol", RFC 114 (NIC 5823),
+         MIT-Project MAC, 16 April 1971.
+
+   115 - Watson, Richard W., and Jeanne B. North, "Some Network
+         Information Center Policies on Handling Documents", RFC 115
+         (NIC 5822), NIC, 16 April 1971.
+
+   116 - Crocker, Steve, "Structure of the May NWG Meeting", RFC 116
+         (NIC 5825), UCLA/NMC, 12 April 1971.
+
+
+
+
+Reynolds & Postel                                               [Page 8]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   117 - Wong, Johnny, "Some Comments on the Official Protocol", RFC 117
+         (NIC 5826), UCLA/NMC, 7 April 1971.
+
+   118 - Watson, Richard W., "Recommendations for Facility
+         Documentation", RFC 118 (NIC 5830), NIC, 16 April 1971.
+
+   119 - Krilanovich, Mark, "Network Fortran Subprograms", RFC 119
+         (NIC 5831), UCSB, 21 April 1971.
+
+   120 - Krilanovich, Mark, "Network PL1 Subprograms", RFC 120
+         (NIC 5832), UCSB, 21 April 1971.
+
+   121 - Krilanovich, Mark, "Network On-Line Operators", RFC 121
+         (NIC 5833), UCSB, 21 April 1971.
+
+   122 - White, Jim, "Network Specifications for UCSB's Simple-Minded
+         File System", RFC 122 (NIC 5834), UCSB, 26 April 1971.
+
+   123 - Crocker, Steve, "A Proffered Official ICP", RFC 123 (NIC 5837),
+         UCLA/NMC, 20 April 1971.
+
+   124 - Melvin, John, "Typographical Error in RFC 107", RFC 124
+         (NIC 5840), NIC, 19 April 1971.
+
+   125 - McConnell, John, "Response to RFC 86, Proposal for Network
+         Standard Format for a Graphics Data Stream", RFC 125
+         (NIC 5841), Ames Research Center, 18 April 1971.
+
+   126 - McConnell, John, "Ames Graphics Facilities at Ames Research
+         Center", RFC 126 (NIC 5842), Ames Research Center,
+         18 April 1971.
+
+   127 - Postel, Jon, "Comments on RFC 123", RFC 127 (NIC 5843),
+         UCLA/NMC, 20 April 1971.
+
+   128 - Postel, Jon, "Bytes", RFC 128 (NIC 5844), UCLA/NMC,
+         21 April 1971.
+
+   129 - Harslem, Eric, John Heafner and Edwin W. Meyer, Jr., "A Request
+         for Comments on Socket Name Structure", RFC 129 (NIC 5845),
+         Rand and MIT, 22 April 1971.
+
+   130 - Heafner, John, "Response to RFC 111 (Pressure from the
+         Chairman)", RFC 130 (NIC 5848), Rand, 22 April 1971.
+
+   131 - Harslem, Eric, and John Heafner, "Response to RFC 116 (May NWG
+         Meeting)", RFC 131 (NIC 5849), Rand, 22 April 1971.
+
+
+
+
+Reynolds & Postel                                               [Page 9]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   132 - White, Jim, "Typographical Error in RFC 107", RFC 132
+         (NIC 6708), UCSB, 8 April 1971.
+
+   133 - Sundberg, Robert, "File Transfer and Error Recovery", RFC 133
+         (NIC 6710), 27 April 1971.
+
+   134 - Vezza, Al, "Network Graphics Meeting", RFC 134 (NIC 6711),
+         MIT-Project MAC, 29 April 1971.
+
+   135 - Hathaway, Wayne, "Response to NWG/RFC 110", RFC 135 (NIC 6712),
+         Ames Research Center, 29 April 1971.
+
+   136 - Kahn, Robert, "Host Accounting and Administrative Procedures",
+         RFC 136 (NIC 6713), BBN, 29 April 1971.
+
+   137 - O'Sullivan, Thomas C., "Telnet Protocol - A Proposed Document",
+         RFC 137 (NIC 6714), Raytheon, 30 April 1971, revised,
+         8 May 1971.
+
+   138 - Anderson Robert, et al., "Status Report on Proposed Data
+         Reconfiguration Service", RFC 138 (NIC 6715), Rand,
+         28 April 1971.
+
+   139 - O'Sullivan, Thomas C., "Discussion of Telnet Protocol", RFC 139
+         (NIC 6717), Raytheon, 7 May 1971.
+
+   140 - Crocker, Steve, "Agenda for the May NWG Meeting", RFC 140
+         (NIC 6725), UCLA/NMC, 4 May 1971.
+
+   141 - Harslem, Eric, and John Heafner, "Comments on RFC 114 (A File
+         Transfer Protocol)", RFC 141 (NIC 6726), Rand, 29 April 1971.
+
+   142 - Kline, Charley, and Johnny Wong, "Time-Out Mechanism in the
+         Host-Host Protocol", RFC 142 (NIC 6727), UCLA/NMC, 3 May 1971.
+
+   143 - Naylor, William, Johnny Wong, Charley Kline, and Jon Postel,
+         "Regarding Proffered Official ICP", RFC 143 (NIC 6728),
+         UCLA/NMC, 3 May 1971.
+
+   144 - Shoshani, Arie, "Data Sharing on Computer Networks", RFC 144
+         (NIC 6729), SDC, 30 April 1971.
+
+   145 - Postel, Jon, "Initial Connection Protocol Control Commands",
+         RFC 145 (NIC 6739), UCLA/NMC, 4 May 1971.
+
+   146 - Karp, Peggy, Doug McKay, and D. C. Wood, "Views On Issues
+         Relevant to Data Sharing on Computer Networks", RFC 146
+         (NIC 6742), MITRE, 12 May 1971.
+
+
+
+Reynolds & Postel                                              [Page 10]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   147 - Winett, Joel M., "The Definition of a Socket", RFC 147
+         (NIC 6750), Lincoln Labs, 7 May 1971.
+
+   148 - Bhushan, Abhay, "Comments on RFC 123, RFC 148 (NIC 6751),
+         MIT-Project MAC, 7 May 1971.
+
+   149 - Crocker, Steve, "The Best Laid Plans", RFC 149 (NIC 6752),
+         UCLA/NMC, 10 May 1971.
+
+   150 - Kalin, Richard B., "The Use of IPG Facilities - A Working
+         Paper", RFC 150 (NIC 6754), MIT, 5 May 1971.
+
+   151 - Shoshani, Arie, "Comments on a Proffered Official ICP
+         (RFCs 123,127)", RFC 151 (NIC 6755), SDC, 10 May 1971.
+
+   152 - Wilber, Michael, "SRI Artificial Intelligence Status Report",
+         RFC 152 (NIC 6756), SRI-AI, 10 May 1971.
+
+   153 - Melvin, John, and Richard Watson, "SRI-ARC-NIC Status", RFC 153
+         (NIC 6758), SRI-ARC, 15 May 1971.
+
+   154 - Crocker, Steve, "Exposition Style", RFC 154 (NIC 6759),
+         UCLA/NMC, 12 May 1971.
+
+   155 - North, Jeanne B., "ARPA Network Mailing Lists", RFC 155
+         (NIC 6760), NIC,  May 1971.
+
+   156 - Bouknight, Jack, "Status of the Illinois Site (Response to
+         RFC 116)", RFC 156 (NIC 6761), Illinois, 26 April 1971.
+
+   157 - Cerf, Vint, "Invitation to the Second Symposium on Problems in
+         the Optimization of Data Communication Systems", RFC 157
+         (NIC 6762), UCLA/NMC, 12 May 1971.
+
+   158 - O'Sullivan, Thomas C., "Telnet Protocol - A Proposed Document",
+         RFC 158 (NIC 6768), Raytheon, 19 May 1971.
+
+   159 - Never Issued.
+
+   160 - Network Information Center, "RFC Brief List", RFC 160
+         (NIC 6771), NIC, 18 May 1971.
+
+   161 - Shoshani, Arie, "A Solution to the Race Condition in the ICP",
+         RFC 161 (NIC 6772), SDC, 19 May 1971.
+
+   162 - Kampe, M., "NETBUGGER3", RFC 162 (NIC 6774), UCLA/NMC,
+         22 May 1971.
+
+
+
+
+Reynolds & Postel                                              [Page 11]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   163 - Cerf, Vint, "Data Transfer Protocols", RFC 163 (NIC 6775),
+         UCLA/NMC, 19 May 1971.
+
+   164 - Heafner, John, "Minutes of Network Working Group Meeting, 5/16
+         through 5/19/71", RFC 163 (NIC 6778), Rand, 25 May 1971.
+
+   165 - Postel, Jon, "A Proffered Official Initial Connection
+         Protocol", RFC 165 (NIC 6779), UCLA/NMC, 25 May 1971.
+
+   166 - Anderson, Bob, et al., "Data Reconfiguration Service - An
+         Implementation Specification", RFC 166 (NIC 6780), Rand,
+         25 May 1971.
+
+   167 - Bhushan, Abhay, Bob Metcalfe, and Joel Winett, "Socket
+         Conventions Reconsidered", RFC 167 (NIC 6784), MIT-Project MAC,
+         Harvard, and Lincoln Labs, 24 May 1971.
+
+   168 - North, Jeanne B., "ARPA Network Mailing Lists", RFC 168
+         (NIC 6785), NIC, 26 May 1971.
+
+   169 - Crocker, Steve, "Computer Networks", RFC 169 (NIC 6789),
+         UCLA/NMC, 27 May 1971.
+
+   170 - Network Information Center, "RFC List by Number", RFC 170
+         (NIC 6790), NIC, 1 June 1971.
+
+   171 - Bhushan, Abhay, et al, "The Data Transfer Protocol", RFC 171
+         (NIC 6793), MIT-Project MAC, 23 June 1971.
+
+   172 - Bhushan, Abhay, et al, "The File Transfer Protocol", RFC 172
+         (NIC 6794), MIT-Project MAC, 23 June 1971.
+
+   173 - Karp, Peggy, and Doug McKay, "Network Data Management Committee
+         Meeting Announcement", RFC 173 (NIC 6795), MITRE and IBM,
+         4 June 1971.
+
+   174 - Postel, Jon, and Vint Cerf, "UCLA-Computer Science Graphics
+         Overview", RFC 174 (NIC 6799), UCLA/NMC, 8 June 1971.
+
+   175 - Harslem, Eric, and John Heafner, "Comments on Socket
+         Conventions Reconsidered", RFC 175 (NIC 7074), Rand,
+         11 June 1971.
+
+   176 - Bhushan, Abhay, Raj Kanodia, Bob Metcalfe, and Jon Postel,
+         "Comments on Byte Size for Connections", RFC 176 (NIC 7100),
+         MIT-Project MAC, UCLA/NMC, 14 June 1971.
+
+
+
+
+
+Reynolds & Postel                                              [Page 12]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   177 - McConnell, John, "A Device Independent Graphical Display
+         Description", RFC 177 (NIC 7102), Ames Research Center,
+         15 June 1971.
+
+   178 - Cotton, Ira W., "Network Graphic Attention Handling", RFC 178
+         (NIC 7118), MITRE, 27 June 1971.
+
+   179 - McKenzie, Alex, "Link Number Assignments", RFC 179 (NIC 7119),
+         BBN, 22 June 1971.
+
+   180 - McKenzie, Alex,  "File System Questionnaire", RFC 180
+         (NIC 7123), BBN, 25 June 1971.
+
+   181 - McConnell, John, "Modification to RFC 177", RFC 181 (NIC 7124),
+         Ames Research Center, 27 June 1971.
+
+   182 - North, Jeanne B., "Compilation of List of Relevant Site
+         Reports", RFC 182 (NIC 7126), NIC, 25 June 1971.
+
+   183 - Winett, Joel, "The EBCDIC Codes and Their Mapping to ASCII",
+         RFC 183 (NIC 7127), Lincoln Labs, 21 July 1971.
+
+   184 - Kelley, Karl, "Proposed Graphic Display Modes", RFC 184
+         (NIC 7128), Illinois, 6 July 1971.
+
+   185 - North, Jeanne B., "NIC Distribution of Manuals and Handbooks",
+         RFC 185 (NIC 7129), NIC, 7 July 1971.
+
+   186 - Michener, James C., "A Network Graphics Loader", RFC 186
+         (NIC 7130), 12 July 1971.
+
+   187 - McKay, Doug, and Donald P. Karp, "A Network/440 Protocol
+         Concept", RFC 187 (NIC 7131), IBM, July 1971.
+
+   188 - Karp, Peggy, and Doug McKay, "Data Management Meeting
+         Announcement", RFC 188 (NIC 7132), MITRE and IBM, 28 July 1971.
+
+   189 - Braden, Bob, "Interim NETRJS Specifications", RFC 189
+         (NIC 7133), UCLA/CCN, 15 July 1971.
+
+   190 - Deutsch, Peter, "DEC P3P-10 - IMLAC Communication System",
+         RFC 190 (NIC 7135), Xerox, 13 July 1971.
+
+   191 - Irby, Charles, "Graphics Implementation and Conceptualization
+         at ARC", RFC 191 (NIC 7136), SRI-ARC, 13 July 1971.
+
+   192 - Watson, Richard W., "Some Factors which a Network Graphics
+         Protocol must Consider", RFC 192 (NIC 7137), SRI-ARC,
+         12 July 1971.
+
+
+Reynolds & Postel                                              [Page 13]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   193 - Harslem, Eric, and John Heafner, "Network Checkout", RFC 193
+         (NIC 7138), Rand, 14 July 1971.
+
+   194 - Cerf, Vint, et al., "The Data Configuration Service -
+         Compiler/Interpreter Implementation Notes", RFC 194 (NIC 7139),
+         UCLA/NMC,  July 1971.
+
+   195 - Mealy, G., "Data Computers - Data Descriptions and Access
+         Language", RFC 195 (NIC 7140), Harvard, 16 July 1971.
+
+   196 - Watson, Richard W., "A Mail Box Protocol", RFC 196 (NIC 7141),
+         SRI-ARC, 20 July 1971.
+
+   197 - Shoshani, Arie, "Initial Connection Protocol - Reviewed",
+         RFC 197 (NIC 7142), SDC and Rand, 14 July 1971.
+
+   198 - Heafner, John, "Site Certification - Lincoln Labs 360/67",
+         RFC 198 (NIC 7149), Rand, 20 July 1971.
+
+   199 - Williams, T., "Suggestions for a Network Data-Tablet Graphics
+         Protocol", RFC 199 (NIC 7151), SDC, 15 July 1971.
+
+   200 - Network Information Center, "RFC List by Number", RFC 200
+         (NIC 7152), NIC, 1 August 1971.
+
+   201 - Never Issued.
+
+   202 - Wolfe, Stephen, and Jon Postel, "Comments on the Initial
+         Connection Protocol (ICP)", RFC 202 (NIC 7155), UCLA/NMC,
+         26 July 1971.
+
+   203 - Kalin, Richard, "Achieving Reliable Communication", RFC 203
+         (NIC 7168), MIT, 10 August 1971.
+
+   204 - Postel, Jon, "Sockets in use", RFC 204 (NIC 7196), UCLA/NMC,
+         5 August 1971.
+
+   205 - Braden, Bob, "NETCRT - A Character Display Protocol", RFC 205
+         (NIC 7172), UCLA/CCN, 6 August 1971.
+
+   206 - White, Jim, "A User Telnet Description of an Initial
+         Implementation", RFC 206 (NIC 7176), UCSB, 9 August 1971.
+
+   207 - Vezza, Al, "A September Network Working Group Meeting", RFC 207
+         (NIC 7178), MIT, 9 August 1971.
+
+   208 - McKenzie, Alex, "Address Tables", RFC 208 (NIC 7181), BBN,
+         9 August 1971.
+
+
+
+Reynolds & Postel                                              [Page 14]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   209 - Cosell, Bernie, "HOST/IMP Interface Documentation", RFC 209
+         (NIC 7187), BBN, 13 August 1971.
+
+   210 - Conrad, W., "Improvement of Flow Control", RFC 210 (NIC 7189),
+         Harvard, 16 August 1971.
+
+   211 - Network Information Center, "ARPA Network Mailing Lists",
+         RFC 211 (NIC 7191), NIC, 18 August 1971.
+
+   212 - NWG Steering Committee, "NWG Meeting on Network Usage", RFC 212
+         (NIC 7192), 23 August 1971.
+
+   213 - Cosell, Bernie, "IMP System Change Notification", RFC 213
+         (NIC 7194), BBN, 16 August 1971.
+
+   214 - Harslem, Eric, "Network Checkout", RFC 214 (NIC 7195), Rand,
+         21 August 1971.
+
+   215 - McKenzie, Alex, "NCP, ICP and Telnet: The Terminal IMP
+         Implementation", RFC 215 (NIC 7545), BBN, 30 August 1971.
+
+   216 - White, Jim, "Telnet Access to UCSB's On-Line System", RFC 216
+         (NIC 7546), UCSB, 8 September 1971.
+
+   217 - White, Jim, "Specification Changes for OLS, RJE/RJOR, and
+         SMFS", RFC 217 (NIC 7547), UCSB, 8 September 1971.
+
+   218 - Cosell, Bernie, "Notification of the Status Reporting Facility
+         of the IMP", RFC 218 (NIC 7548), BBN, 16 August 1971.
+
+   219 - Winter, R., "User's View of the Datacomputer", RFC 210
+         (NIC 7549), CCA, 3 September 1971.
+
+   220 - Never Issued.
+
+   221 - Watson, Richard W., "A Mail Box Protocol, Version-2", RFC 221
+         (NIC 7612), SRI-ARC, 25 August 1971.
+
+   222 - Metcalfe, Bob, "System Programmer's Workshop", RFC 222
+         (NIC 7621), 13 September 1971.
+
+   223 - Melvin, John, and Richard W. Watson, "Network Information
+         Center Schedule for Network Users", RFC 223 (NIC 7622),
+         SRI-ARC, 14 September 1971.
+
+   224 - McKenzie, Alex, "Comments on Mailbox Protocol", RFC 224
+         (NIC 7623), BBN, 14 September 1971.
+
+
+
+
+Reynolds & Postel                                              [Page 15]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   225 - Harslem, Eric, and Ron Stoughton, "RAND/UCSB Network Graphics
+         Experiment", RFC 225 (NIC 7624), Rand and UCSB,
+         13 September 1971.
+
+   226 - Karp, Peggy, "Standardization of Host Mnemonics", RFC 226
+         (NIC 7625), MITRE, 20 September 1971.
+
+   227 - Heafner, John, and Eric Harslem, "Data Transfer Rates
+         (RAND/UCLA)", RFC 227 (NIC 7631), Rand, 17 September 1971.
+
+   228 - Walden, Dave, "Clarification", RFC 228 (NIC 7645), MIT,
+         22 September 1971.
+
+   229 - Postel, Jon, "Standard Host Names", RFC 229 (NIC 7646), UCLA,
+         22 September 1971.
+
+   230 - Pyke, Thomas N., Jr., "Toward Reliable Operation of
+         Minicomputer-based Terminals on a TIP", RFC 230 (NIC 7647),
+         NBS, 24 September 1971.
+
+   231 - Heafner, John, and Eric Harslem, "Service Center Standards for
+         Remote Usage - A User's View", RFC 231 (NIC 7648), Rand,
+         21 September 1971.
+
+   232 - Vezza, Al, "Network Graphics Meeting Announcement", RFC 232
+         (NIC 7649), MIT, 23 September 1971.
+
+   233 - Bhushan, Abhay, and Bob Metcalfe, "Standardization of Host Call
+         Letters", RFC 233 (NIC 7650), MIT-Project MAC,
+         24 September 1971.
+
+   234 - Vezza, Al, "Network Working Group Meeting Schedule", RFC 234
+         (NIC 7651), MIT, 5 October 1971.
+
+   235 - Westheimer, Ellen, "Site Status", RFC 235 (NIC 7652), BBN,
+         27 September 1971.
+
+   236 - Postel, Jon, "Standard Host Names", RFC 236 (NIC 7661),
+         UCLA/NMC, 27 September 1971.
+
+   237 - Watson, Richard W., "The NIC's View of Standard Host Names",
+         RFC 237 (NIC 7662), SRI-ARC, 29 September 1971.
+
+   238 - Braden, Bob, "Comments on DTP and FTP Proposals", RFC 238
+         (NIC 7663), UCLA/CCN, 29 September 1971.
+
+   239 - Braden, Bob, "Host Mnemonics Proposed in RFC 226", RFC 239
+         (NIC 7664), UCLA/CCN, 23 September 1971.
+
+
+
+Reynolds & Postel                                              [Page 16]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   240 - McKenzie, Alex, "Site Status", RFC 240 (NIC 7665), BBN,
+         30 September 1971.
+
+   241 - McKenzie, Alex, "Connecting Computers to MLC Ports", RFC 241
+         (NIC 7671), BBN, 29 September 1971.
+
+   242 - Haibt, L., and Alvin Mullery, "Data Descriptive Language for
+         Shared Data", RFC 242 (NIC 7672), IBM, 19 July 1971.
+
+   243 - Mullery, Alvin, "Network and Data Sharing Bibliography",
+         RFC 243 (NIC 7673), IBM, 5 October 1971.
+
+   244 - Never Issued.
+
+   245 - Falls, "Reservations for Network Group Meeting", RFC 245
+         (NIC 7675), 5 October 1971.
+
+   246 - Vezza, Al, "Network Graphics Meeting", RFC 246 (NIC 7687), MIT,
+         5 October 1971.
+
+   247 - Karp, Peggy, "Proffered Set of Standard Host Names", RFC 247
+         (NIC 7688), MITRE, 12 October 1971.
+
+   248 - Never Issued.
+
+   249 - Borelli, R. F., "Coordination of Equipment and Supplies
+         Purchase", RFC 249 (NIC 7690), Illinois, 8 October 1971.
+
+   250 - Brodie, H., "Some Thoughts on File Transfer", RFC 250
+         (NIC 7691), UCLA/NMC, 7 October 1971.
+
+   251 - Stern, Dale H., "Weather Data", RFC 251 (NIC 7692), CCA,
+         13 October 1971.
+
+   252 - Westheimer, Ellen, "Site Status", RFC 252 (NIC 7693), BBN,
+         8 October 1971.
+
+   253 - Moorer, James A., "Second Network Graphics Meeting Details",
+         RFC 253 (NIC 7694), Stanford, 19 October 1971.
+
+   254 - Bhushan, Abhay, "Scenarios for Using ARPANET Computers",
+         RFC 254 (NIC 7695), MIT-Project MAC, , 29 October 1971.
+
+   255 - Westheimer, Ellen, "Site Status", RFC 255 (NIC 7696), BBN,
+         7 October 1971.
+
+   256 - Cosell, Bernie, "IMPSYS Change Notification", RFC 256
+         (NIC 7697), BBN, 3 October 1971.
+
+
+
+Reynolds & Postel                                              [Page 17]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   257 - Never Issued.
+
+   258 - Never Issued.
+
+   259 - Never Issued.
+
+   260 - Never Issued.
+
+   261 - Never Issued.
+
+   262 - Never Issued.
+
+   263 - McKenzie, Alex, "`Very Distant' Host Interface", RFC 263
+         (NIC 7811), BBN, 17 December 1971.
+
+   264 - Bhushan, Abhay, et al, "The Data Transfer Protocol", RFC 264
+         (NIC 7812), MIT-Project MAC, 15 November 1971.
+
+   265 - Bhushan, Abhay, et al, "The File Transfer Protocol", RFC 265
+         (NIC 7813), MIT-Project MAC, 17 November 1971.
+
+   266 - Westheimer, Ellen, "Network Host Status", RFC 266 (NIC 7814),
+         BBN, 8 November 1971.
+
+   267 - Westheimer, Ellen, "Network Host Status", RFC 267 (NIC 7815),
+         BBN, 22 November 1971.
+
+   268 - Postel, Jon, "Graphic Facilities Information", RFC 268
+         (NIC 7816), UCLA/NMC, 24 November 1971.
+
+   269 - Brodie, H., "Some Experience with File Transfer", RFC 269
+         (NIC 7817, UCLA/NMC, 6 December 1971.
+
+   270 - McKenzie, Alex, "Correction to BBN Report Number 1822", RFC 270
+         (NIC 7818), BBN, 1 January 1972.
+
+   271 - Cosell, Bernie, "IMP System Change Notification", RFC 271
+         (NIC 7819), BBN, 3 January 1972.
+
+   272 - Never Issued.
+
+   273 - Watson, Richard W., "More on Standard Host Names", RFC 273
+         (NIC 7837), SRI-ARC, 18 October 1971.
+
+   274 - Forman, Ernest, "Establishing a Local Guide for Network Usage",
+         RFC 274 (NIC 7901), MITRE, 1 November 1971.
+
+   275 - Never Issued.
+
+
+
+Reynolds & Postel                                              [Page 18]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   276 - Watson, Richard W., "NIC Course", RFC 276 (NIC 7818), BBN,
+         1 January 1972.
+
+   277 - Never Issued.
+
+   278 - Bhushan, Abhay, et al., "Revision of the Mail Box Protocol",
+         RFC 278 (NIC 8056), MIT-Project MAC, 17 November 1971.
+
+   279 - Never Issued.
+
+   280 - Watson, Richard W., "A Draft Set of Host Names", RFC 280
+         (NIC 8060), SRI-ARC, 17 November 1971.
+
+   281 - McKenzie, Alex, "A Suggested Addition to File Transfer
+         Protocol", RFC 281 (NIC 8163), BBN, 8 December 1971.
+
+   282 - Padlipsky, Michael, "Graphics Meeting Report", RFC 282
+         (NIC 8164), MIT-Project MAC, 8 December 1971.
+
+   283 - Braden, Bob, "A Draft Set of Host Names", RFC 283 (NIC 8165),
+         UCLA/CCN, 20 December 1971.
+
+   284 - Never Issued.
+
+   285 - Huff, Donald, "Network Graphics", RFC 285 (NIC 8271), Case,
+         15 December 1971.
+
+   286 - Forman, Ernest, "Network Library Information System", RFC 286
+         (NIC 8272), MITRE and Case, 21 December 1971.
+
+   287 - Westheimer, Ellen, "Host Status", RFC 287 (NIC 8273), BBN,
+         22 December 1971.
+
+   288 - Westheimer, Ellen, "Network Host Status", RFC 288 (NIC 8274),
+         BBN, 6 January 1972.
+
+   289 - Watson, Richard W., "What We Hope Is An Official List of Host
+         Names", RFC 289 (NIC 8295), SRI-ARC, 21 December 1971.
+
+   290 - Mullery, Alvin, "Computer Networks and Data Sharing: A
+         Bibliography", RFC 290 (NIC 8300), T. J. Watson Research
+         Center, 11 January 1972.
+
+   291 - McKay, Doug, "Data Management Meeting Announcement", RFC 291
+         (NIC 8301), IBM, 14 January 1972.
+
+   292 - Michener, James C., et al, "Graphics Protocol - Level 0 only",
+         RFC 292 (NIC 8302), MIT-Project MAC, 12 January 1972.
+
+
+
+Reynolds & Postel                                              [Page 19]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   293 - Westheimer, Ellen, "Network Host Status", RFC 293 (NIC 8303),
+         BBN, 18 January 1972.
+
+   294 - Bhushan, Abhay, "The Use of `Set Data Type' Transaction in File
+         Transfer Protocol", RFC 294 (NIC 8304), MIT-Project MAC,
+         25 January 1972.
+
+   295 - Postel, Jon, "Report of the Protocol Workshop", RFC 295
+         (NIC 8355), UCLA/NMC, 2 January 1972.
+
+   296 - Liddle, David E., "DS-1 Display System", RFC 296 (NIC 8484),
+         Owens-Illinois, Inc., 27 January 1972.
+
+   297 - Walden, Dave, "TIP Message Buffers", RFC 297 (NIC 8485), BBN,
+         31 January 1972.
+
+   298 - Westheimer, Ellen, "Network Host Status", RFC 298 (NIC 8486),
+         BBN, 1 February 1972.
+
+   299 - Hopkin, Dorothy, "Information Management System", RFC 299
+         (NIC 8487), Illinois, 11 February 1972.
+
+   300 - Network Information Center, "ARPA Network Mailing Lists",
+         RFC 300 (NIC 8468), NIC, 25 January 1972.
+
+   301 - Alter, Ralph, "BBN IMP (No. 5 and NCC Schedule March 4, 1971",
+         RFC 301 (NIC 8971), BBN, 11 February 1972.
+
+   302 - Bryan, Roland F., "Exercising the ARPANET", RFC 302 (NIC 9074),
+         UCSB, 8 February 1972.
+
+   303 - Network Information Center, "ARPA Network Mailing Lists",
+         RFC 303 (NIC 9075), NIC, 23 February 1972.
+
+   304 - McKay, Doug, "A Data Management System Proposal for the ARPA
+         Network", RFC 304 (NIC 9077), IBM, 17 February 1972.
+
+   305 - Alter, Ralph, "Unknown Host Numbers", RFC 305 (NIC 9078), BBN,
+         23 February 1972.
+
+   306 - Westheimer, Ellen, "Network Host Status", RFC 306 (NIC 9257),
+         BBN, 15 February 1972.
+
+   307 - Harslem, Eric, "Using Network Remote Job Entry", RFC 307
+         (NIC 9258), Rand, 24 February 1972.
+
+   308 - Seriff, Marc, "ARPANET Host Availability Data", RFC 308
+         (NIC 9259), MIT-Project MAC, 13 March 1972.
+
+
+
+Reynolds & Postel                                              [Page 20]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   309 - Bhushan, Abhay, "Data And File Transfer Workshop Announcement",
+         RFC 309 (NIC 9260), MIT-Project MAC, 17 March 1972.
+
+   310 - Bhushan, Abhay, "Another Look at Data and File Transfer
+         Protocols", RFC 310 (NIC 9261), MIT-Project MAC, 3 April 1972.
+
+   311 - Bryan, Roland F., "New Console Attachments to the UCSB Host",
+         RFC 311 (NIC 9341), UCSB, 29 February 1972.
+
+   312 - McKenzie, Alex, "Proposed Change in IMP-to-Host Protocol",
+         RFC 312 (NIC 9342), BBN, 22 March 1972.
+
+   313 - O'Sullivan, Tom, "Computer Based Instruction", RFC 313
+         (NIC 9343), Raytheon, 6 March 1972.
+
+   314 - Cotton, Ira, "Next Network Graphics Working Group Meeting",
+         RFC 314 (NIC 9344), MITRE, 14 March 1972.
+
+   315 - Westheimer, Ellen, "Network Host Status", RFC 315 (NIC 9345),
+         BBN, 8 March 1972.
+
+   316 - McKay, Doug, and Alvin Mullery, "ARPA Network Data Management
+         Working Group", RFC 316 (NIC 9346), IBM, 23 & 24 February 1972.
+
+   317 - Postel, Jon, "Official Host-Host Protocol Modification:
+         Assigned Link Numbers", RFC 317 (NIC 9347), UCLA/NMC,
+         20 March 1972.
+
+   318 - Postel, Jon, "Ad Hoc Telnet Protocols", RFC 318 (NIC 9348),
+         References RFCs 139,158, UCLA/NMC, 3 April 1972.
+
+   319 - Westheimer, Ellen, "Network Host Status", RFC 319 (NIC 9349),
+         BBN, 21 March 1972.
+
+   320 - Reddy, Raj, "Workshop on Hard Copy Line Graphics", RFC 320
+         (NIC 9350), CMU, 27 March 1972.
+
+   321 - Karp, Peggy, "CBI Networking Activity at MITRE", RFC 321
+         (NIC 9608), MITRE, 24 March 1972.
+
+   322 - Cerf, Vint, and Jon Postel, "Well Known Socket Numbers",
+         RFC 322 (NIC 9609), UCLA/NMC, 26 March 1972.
+
+   323 - Cerf, Vint, "Formation of Network Measurement Group (NMG)",
+         RFC 323 (NIC 9630), UCLA/NMC, 23 March 1972.
+
+   324 - Postel, Jon, "RJE Protocol Meeting", RFC 324 (NIC 9631), UCLA,
+         3 April 1972.
+
+
+
+Reynolds & Postel                                              [Page 21]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   325 - Hicks, Greg, "Network Remote Job Entry Program - NETRJS",
+         RFC 325 (NIC 9632), Utah, 6 April 1972.
+
+   326 - Westheimer, Ellen, "Network Host Status", RFC 326 (NIC 9633),
+         BBN, 3 April 1972.
+
+   327 - Bhushan, Abhay, "Data and File Transfer Workshop Notes",
+         RFC 327 (NIC 9261), MIT-Project MAC, 27 April 1972.
+
+   328 - Postel, Jon, "Suggested Telnet Protocol Changes", RFC 328
+         (NIC 9635), UCLA/NMC, 29 April 1972.
+
+   329 - Network Information Center, "ARPA Network Mailing Lists",
+         RFC 329 (NIC 9636), NIC, 17 May 1972.
+
+   330 - Westheimer, Ellen, "Network Host Status", RFC 330 (NIC 9923),
+         BBN, 13 April 1972.
+
+   331 - McQuillan, John, "IMP System Change Notification", RFC 331
+         (NIC 9924), BBN, 19 April 1972.
+
+   332 - Westheimer, Ellen, "Network Host Status", RFC 332 (NIC 9923),
+         BBN, 25 April 1972.
+
+   333 - Bressler, Bob, Dan Murphy, and Dave Walden, "A Proposed
+         Experiment with a Message Switching Protocol", RFC 333
+         (NIC 9926), MIT and BBN, 15 May 1972.
+
+   334 - McKenzie, Alex, "Network Use on May 8th", RFC 334 (NIC 9927),
+         BBN, 1 May 1972.
+
+   335 - Bryan, Roland F., "New Interface-IMP/360", RFC 335 (NIC 9928),
+         UCSB, 1 May 1972.
+
+   336 - Cotton, Ira, "Level 0 Graphic Input Protocol", RFC 336
+         (NIC 9929), MITRE, 5 May 1972.
+
+   337 - Never Issued.
+
+   338 - Braden, Bob "EBCDIC/ASCII Mapping for Network RJE", RFC 338
+         (NIC 9931), UCLA/CCN, 17 May 1972.
+
+   339 - Thomas, Bob, "MLTNET - A `Multi-Telnet' Subsystem for TENEX",
+         RFC 339 (NIC 9932), BBN, 5 May 1972.
+
+   340 - O'Sullivan, Tom, "Proposed Telnet Changes", RFC 340 (NIC 9933),
+         Raytheon, 15 May 1972.
+
+   341 - Never Issued.
+
+
+Reynolds & Postel                                              [Page 22]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   342 - Westheimer, Ellen, "Network Host Status", RFC 342 (NIC 10421),
+         BBN, 15 May 1972.
+
+   343 - McKenzie, Alex, "IMP System Change Notification", RFC 343
+         (NIC 10422), BBN, 19 May 1972.
+
+   344 - Westheimer, Ellen, "Network Host Status", RFC 344 (NIC 10423),
+         BBN, 22 May 1972.
+
+   345 - Kelly, Karl, "Interest in Mixed Integer Programming (MPSX on
+         360/91 at CCN)", RFC 345 (NIC 10424), Illinois, 26 May 1972.
+
+   346 - Postel, Jon, "Satellite Considerations", RFC 346 (NIC 10425),
+         UCLA/NMC, 30 May 1972.
+
+   347 - Postel, Jon, "Echo Process", RFC 347 (NIC 10426), UCLA/NMC,
+         30 May 1972.
+
+   348 - Postel, Jon, "Discard Process", RFC 348 (NIC 10427), UCLA/NMC,
+         30 May 1972.
+
+   349 - Postel, Jon, "Proposed Standard Socket Numbers", RFC 349
+         (NIC 10428), UCLA/NMC, 30 May 1972.
+
+   350 - Stoughton, Ron, "User Accounts for UCSB On-line System",
+         RFC 350 (NIC 10549), UCSB, 18 May 1972.
+
+   351 - Crocker, Dave, "(Graphics) Information form for the ARPANET
+         Graphics Resources Notebook", RFC 351 (NIC 10593), UCLA/NMC,
+         5 June 1972.
+
+   352 - Crocker, Dave, "TIP Site Information Form", RFC 352
+         (NIC 10594), UCLA/NMC, 5 June 1972.
+
+   353 - Westheimer, Ellen, "Network Host Status", RFC 353 (NIC 10595),
+         BBN, 12 June 1972.
+
+   354 - Bhushan, Abhay, "The File Transfer Protocol", RFC 354
+         (NIC 10596), MIT-Project MAC, 8 July 1972.
+
+   355 - Davidson, John, "Response to RFC 346", RFC 355 (NIC 10597),
+         University of Hawaii, 9 June 1972.
+
+   356 - Alter, Ralph, "ARPA Network Control Center", RFC 356
+         (NIC 10598), BBN, 21 June 1972.
+
+   357 - Davidson, John, "An Echoing Strategy for Satellite Links",
+         RFC 357 (NIC 10599), University of Hawaii, 26 June 1972.
+
+
+
+Reynolds & Postel                                              [Page 23]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   358 - Never Issued.
+
+   359 - Walden, Dave, "The Status of the Release of the New IMP System
+         (2600)", RFC 358 (NIC 10601), BBN, 22 June 1972.
+
+   360 - Holland, Chuck, "Proposed Remote Job Entry Protocol", RFC 360
+         (NIC 10602), UCSD, 24 June 1972.
+
+   361 - Bressler, Bob, "In Response to RFCs 347 and 348", RFC 361
+         (NIC 10603), MIT-DMCG, 5 July 1972.
+
+   362 - Westheimer, Ellen, "Network Host Status", RFC 362 (NIC 10604),
+         BBN, 28 June 1972.
+
+   363 - Network Information Center, "ARPA Network Mailing Lists", NIC,
+         8 August 1972.
+
+   364 - Abrams, Marshall D., "Serving Remote Users on the ARPANET",
+         RFC 364 (NIC 10606), NBS, 11 July 1972.
+
+   365 - Walden, Dave, "A Letter to All TIP Users", RFC 365 (NIC 10607),
+         BBN, 11 July 1972.
+
+   366 - Westheimer, Ellen, "Network Host Status", RFC 366 (NIC 11013),
+         BBN, 11 July 1972.
+
+   367 - Westheimer, Ellen, "Network Host Status", RFC 367 (NIC 11014),
+         BBN, 19 June 1972.
+
+   368 - Braden, Bob, "Comments on `Proposed Remote Job Entry
+         Protocol'", RFC 368 (NIC 11015), UCLA/CCN, 21 July 1972.
+
+   369 - Pickens, John R., "Evaluation of ARPANET Services", RFC 369
+         (NIC 11016), UCSB, 25 July 1972.
+
+   370 - Westheimer, Ellen, "Network Host Status", RFC 370 (NIC 11017),
+         BBN, 31 July 1972.
+
+   371 - Kahn, Robert, "Demonstration at International Computer
+         Communications Conference", RFC 371 (NIC 11020), BBN,
+         12 July 1972.
+
+   372 - McKenzie, Alex, "Notes on a Conversation with Bob Kahn on the
+         ICCC", RFC 372 (NIC 11022), BBN, 12 July 1972.
+
+   373 - McCarthy, John, "Arbitrary Character Sets", RFC 373
+         (NIC 11058), BBN, 19 July 1972.
+
+
+
+
+Reynolds & Postel                                              [Page 24]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   374 - McKenzie, Alex, "IMP System Announcement", RFC 374 (NIC 11099),
+         BBN, 19 July 1972.
+
+   375 - Never Issued.
+
+   376 - Westheimer, Ellen, "Network Host Status", RFC 376 (NIC 11118),
+         BBN, 8 August 1972.
+
+   377 - Braden, Bob, "Using TSO via ARPA Network Virtual Terminal",
+         RFC 377 (NIC 11119) UCLA/CCN, 10 August 1972.
+
+   378 - McKenzie, Alex, "Traffic Statistics (July 1972)", RFC 378
+         (NIC 11120), BBN, 10 August 1972.
+
+   379 - Braden, Bob, "Using TSO at CCN", RFC 379 (NIC 11121), UCLA/CCN,
+         11 August 1972.
+
+   380 - Never Issued.
+
+   381 - McQuillan, John, and Dave Walden, "Three Aids to Improved
+         Network Operation", RFC 381 (NIC 11151), BBN, 26 July 1972.
+
+   382 - McDaniel, Lawrence, "Mathematical Software on the ARPA
+         Network", RFC 382 (NIC 11122), University of Illinois,
+         3 August 1972.
+
+   383 - Never Issued.
+
+   384 - North, Jeanne B., "Official Site Idents for Organizations in
+         the ARPA Network", RFC 384 (NIC 11356), NIC, 28 August 1972.
+
+   385 - Bhushan, Abhay, "Comments on the File Transfer Protocol
+         (RFC 354)", RFC 385 (NIC 11357), MIT-Project MAC,
+         18 August 1972.
+
+   386 - Cosell, Bernie, and Dave Walden, "Letter to TIP Users - 2",
+         RFC 386 (NIC 11358), BBN, 16 August 1972.
+
+   387 - Kelley, Karl, and Jaacov Meir, "Some Experiences in
+         Implementing Network Graphics Protocol Level 0", RFC 387
+         (NIC 11359), Illinois, 10 August 1972.
+
+   388 - Cerf, Vint, "NCP Statistics", RFC 388 (NIC 11360), UCLA/NMC,
+         23 August 1972.
+
+   389 - Noble, Barbara, "UCLA Campus Computing Network Liaison Staff
+         for ARPA Network", RFC 389 (NIC 11361), UCLA/CCN,
+         30 August 1972.
+
+
+
+Reynolds & Postel                                              [Page 25]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   390 - Braden, Bob, "TSO Scenario Batch Compilation and Foreground
+         Execution", RFC 390 (NIC 11582), UCLA/CCN, 12 September 1972.
+
+   391 - McKenzie, Alex, "Traffic Statistics (August 1972)", RFC 391
+         (NIC 11583), BBN, 15 September 1972.
+
+   392 - Hicks, Greg, and Barry Wessler, "Measurement of Host Costs for
+         Transmitting Network Data", RFC 392 (NIC 11584), Utah,
+         20 September 1972.
+
+   393 - Winett, Joel, "Comments on Telnet Protocol Changes", RFC 393
+         (NIC 11585), Lincoln Labs, 3 October 1972.
+
+   394 - McQuillan, John, "Two Proposed Changes to the IMP-HOST
+         Protocol", RFC 394 (NIC 11586), BBN, 27 September 1972.
+
+   395 - McQuillan, John, "Switch Settings on IMPs and TIPs", RFC 395
+         (NIC 11587), BBN, 3 October 1972.
+
+   396 - Bunch, Steve, "Network Graphics Working Group Meeting - Second
+         Iteration", RFC 396 (NIC 11796), Illinois, 13 November 1973.
+
+   397 - Never Issued.
+
+   398 - Pickens, John "ICP Sockets", RFC 398 (NIC 11911),
+         22 September 1972.
+
+   399 - Krilanovich, Mark, "SMFS Login and Logout", RFC 399
+         (NIC 11917), UCSB, 26 September 1972.
+
+   400 - McKenzie, Alex, "Traffic Statistics (September 1972)", RFC 400
+         (NIC 11922), BBN, 18 October 1972.
+
+   401 - Hanson, Jim, "Conversion of NGP-0 Coordinates to Device
+         Specific Coordinates", RFC 401 (NIC 11923), Illinois,
+         23 October 1972.
+
+   402 - Network Information Center, "ARPA Network Mailing Lists",
+         RFC 402 (NIC 11924), NIC, 26 October 1972.
+
+   403 - Hicks, Greg "Desirability of a Network 1108", RFC 403
+         (NIC 11925), Utah, 10 January 1973.
+
+   404 - McKenzie, Alex, "Host Address Changes Involving RAND and ISI",
+         RFC 404 (NIC 12068), BBN, 5 October 1972.
+
+   405 - McKenzie, Alex, "Correction to RFC 404", RFC 405 (NIC 12110),
+         BBN, 10 October 1972.
+
+
+
+Reynolds & Postel                                              [Page 26]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   406 - McQuillan, John, "Scheduled IMP Software Releases", RFC 406
+         (NIC 12111), BBN, 10 October 1972.
+
+   407 - Bressler, Bob, Rich Guida, and Alex McKenzie, "Remote Job Entry
+         Protocol", RFC 407 (NIC 12112), MIT and BBN, 16 October 1972.
+
+   408 - Owen, Buz, and Jon Postel, "NETBANK", RFC 408 (NIC 12390),
+         SAAC-TIP and UCLA/NMC, 25 October 1972.
+
+   409 - White, Jim, "TENEX Interface to UCSB's Simple-Minded File
+         System", RFC 409 (NIC 12401), SRI-ARC, 8 December 1972.
+
+   410 - McQuillan, John, "Removal of the 30-Second Delay When Hosts
+         Come Up", RFC 410 (NIC 12402), BBN, 10 November 1972.
+
+   411 - Padlipsky, Mike, "New Multics Network Software Features",
+         RFC 411 (NIC 12403), MIT, 14 November 1972.
+
+   412 - Hicks, Greg, "User FTP Documentation", RFC 412 (NIC 12404),
+         Utah, 27 November 1972.
+
+   413 - McKenzie, Alex, "Traffic Statistics (October 1972)", RFC 413
+         (NIC 12405), BBN, 13 November 1972.
+
+   414 - Bhushan, Abhay, "File Transfer Protocol (FTP) Status and
+         Further Comments", RFC 414 (NIC 12406), MIT-Project MAC,
+         20 November 1972.
+
+   415 - Murray, Hal, "TENEX Bandwidth", RFC 415 (NIC 10428), CCA,
+         29 November 1972.
+
+   416 - Norton, James, "The ARC System Will Be Unavailable For Use
+         During Thanksgiving Week", RFC 416 (NIC 12542), SRI-ARC,
+         7 November 1972.
+
+   417 - Postel, Jon, and Chuck Kline, "Link Usage Violation", RFC 417
+         (NIC 12574), UCLA/NMC, 6 November 1972.
+
+   418 - Hathaway, Wayne, "Server File Transfer Under TSS/360 at
+         NASA-Ames Research Center", RFC 418 (NIC 12762), Ames Research
+         Center 27 November 1972.
+
+   419 - Vezza, Al, "Attention: Network Liaisons and Station Agents",
+         RFC 419 (NIC 12763), 12 December 1972.
+
+   420 - Murray, Hal, "CCA ICCC Weather Demo", RFC 420 (NIC 12764), CCA,
+         4 January 1973.
+
+
+
+
+Reynolds & Postel                                              [Page 27]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   421 - McKenzie, Alex, "A Software Consulting Service for Network
+         Users", RFC 421 (NIC 12897), BBN, 27 November 1972.
+
+   422 - McKenzie, Alex, "Traffic Statistics (November 1972)", RFC 422
+         (NIC 13007), BBN, 11 December 1972.
+
+   423 - Noble, Barbara, "UCLA Campus Computing Network Liaison Staff
+         for ARPA Network", RFC 423 (NIC 13008), UCLA/CCN,
+         12 December 1972.
+
+   424 - Never Issued.
+
+   425 - Bressler, Bob, "`But my NCP costs $500 a day...'", RFC 425
+         (NIC 13010), BBN, 19 December 1972.
+
+   426 - Thomas, Bob, "Reconnection Protocol", RFC 426 (NIC 13011), BBN,
+         26 January, 1973.
+
+   427 - Never Issued.
+
+   428 - Never Issued.
+
+   429 - Postel, Jon, "Character Generator Process", RFC 429
+         (NIC 13281), UCLA/NMC, 12 December 1972.
+
+   430 - Braden, Bob, "Comments on File Transfer Protocol", RFC 430
+         (NIC 13299), UCLA/CCN, 7 February 1973.
+
+   431 - Krilanovich, Mark, "Update on SMFS Login and Logout", RFC 431
+         (NIC 13300), UCSB, 15 December 1972.
+
+   432 - Neigus, Nancy, "Network Logical Map", RFC 432 (NIC 13490), BBN,
+         29 December 1972.
+
+   433 - Postel, Jon and Nancy Neigus, "Socket Number List", RFC 433
+         (NIC 13491), UCLA/NMC and BBN, 22 December 1972.
+
+   434 - McKenzie, Alex, "IMP/TIP Memory Retrofit Schedule", RFC 434
+         (NIC 13658), BBN, 4 January 1973.
+
+   435 - Cosell, Bernie, and Dave Walden, "Telnet Issues", RFC 435
+         (NIC 13675), BBN-NET, 5 January 1973.
+
+   436 - Krilanovich, Mark, "Announcement of RJS at UCSB", RFC 436
+         (NIC 13700), UCSB, 10 January 1973.
+
+   437 - Faeh, Ed, "Data Reconfiguration Service at UCSB", RFC 437
+         (NIC 13701), UCSB, 30 June 1973.
+
+
+
+Reynolds & Postel                                              [Page 28]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   438 - Thomas, Bob, and Bob Clements, "FTP Server-Server Interaction",
+         RFC 438 (NIC 13770), BBN, 15 January 1973.
+
+   439 - Cerf, Vint, "PARRY Encounters the DOCTOR", RFC 439 (NIC 13771),
+         SU/ERL, 21 January 1973.
+
+   440 - Walden, Dave, "Scheduled Network Software Maintenance", RFC 440
+         (4IC 13772), BBN, 29 January 1973.
+
+   441 - Bressler, Bob, and Bob Thomas, "Inter-Entity Communication - An
+         Experiment", RFC 441 (NIC 13773), BBN, 19 January 1973.
+
+   442 - Cerf, Vint, "The Current Flow-Control Scheme for IMPSYS",
+         RFC 442 (NIC 13774), SU-ERL, 24 January 1973.
+
+   443 - McKenzie, Alex, "Traffic Statistics (December 1972)", RFC 443
+         (NIC 13899), BBN, 18 January 1973.
+
+   444 - Never Issued.
+
+   445 - McKenzie, Alex, "IMP/TIP Preventive Maintenance Schedule",
+         RFC 445 (NIC 14028), BBN, 22 January 1973.
+
+   446 - Deutsch, L. Peter, "Proposal to Consider a Network Program
+         Resource Notebook", RFC 446 (NIC 14068), XEROX-PARC,
+         25 January 1973.
+
+   447 - McKenzie, Alex, "IMP/TIP Memory Retrofit Schedule", RFC 447
+         (NIC 14104), BBN, 29 January 1973.
+
+   448 - Braden, Bob, "Print Files in FTP", RFC 448 (NIC 13299),
+         UCLA/CCN, 27 February 1973.
+
+   449 - Walden, Dave, "The Current Flow-Control Scheme for IMPSYS",
+         RFC 449 (NIC 14133), BBN, 6 January 1973.
+
+   450 - Padlipsky, Mike, "Multics Sampling Timeout Change", RFC 450
+         (NIC 14134), MIT-Multics, 8 February 1973.
+
+   451 - Padlipsky, Mike, "Tentative Proposal for a Unified User Level
+         Protocol", RFC 451 (NIC 14135), MIT-Multics, 22 February 1973.
+
+   452 - Winett, Joel, "Telnet Command at Host LL", RFC 452 (NIC 14136),
+         Lincoln Labs, 8 February 1973.
+
+   453 - Kudlick, Michael, "Meeting Announcement to Discuss a Network
+         Mail System", RFC 453 (NIC 14317), SRI-ARC, 7 February 1973.
+
+
+
+
+Reynolds & Postel                                              [Page 29]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   454 - McKenzie, Alex, "File Transfer Protocol", RFC 454 (NIC 14333),
+         BBN, 16 February 1973.
+
+   455 - McKenzie, Alex, "Traffic Statistics (January 1973)", RFC 455
+         (NIC 14375), BBN, 12 February 1973.
+
+   456 - Network Information Center, "Memorandum: Date Change of Mail
+         Meeting", RFC 456 (NIC 14376), NIC, 13 February 1973.
+
+   457 - Walden, Dave, "TIPUG", RFC 457 (NIC 14377), BBN-NET,
+         15 February 1973.
+
+   458 - Bressler, Bob, and Bob Thomas, "Mail Retrieval via FTP",
+         RFC 458 (NIC 14378), BBN-NET and BBN-TENEX, 20 February 1973.
+
+   459 - Kantrowitz, W., "Network Questionnaires", RFC 459 (NIC 14379),
+         LL-TX-2, 26 February 1973.
+
+   460 - Kline, Chuck, "NCP Survey", RFC 460 (NIC 14415), UCLA/NMC,
+         13 February 1973.
+
+   461 - McKenzie, Alex, "Telnet Protocol Meeting Announcement", RFC 461
+         (NIC 14416), BBN, 14 February 1973.
+
+   462 - Iseli, Jean, and Dave Crocker, "Responding to User Needs",
+         RFC 462 (NIC 14434), MITRE and UCLA/NMC, 22 February 1973.
+
+   463 - Bhushan, Abhay, "FTP Comments and Response to RFC 430", RFC 463
+         (NIC 14573), MIT-DMCG, 21 February 1973.
+
+   464 - Kudnick, Michael, "Resource Notebook Framework", RFC 464
+         (NIC 14738), SRI-ARC, 27 February 1973.
+
+   465 - Never Issued.
+
+   466 - Winett, Joel, "Telnet LOGGER/SERVER for Host LL-67", RFC 466
+         (NIC 14740), Lincoln Labs, 27 February 1973.
+
+   467 - Burchfiel, Jerry, and Ray Tomlinson, "Proposed Change to
+         Host-Host Protocol Resynchronization of Connection Status",
+         RFC 467 (NIC 14741), BBN, 20 February 1973.
+
+   468 - Braden, Bob, "FTP Data Compression", RFC 468 (NIC 14742),
+         UCLA/CCN, 8 March 1973.
+
+   469 - Kudlick, Michael, "Network Mail Meeting Summary", RFC 469
+         (NIC 14798), SRI-ARC, 8 March 1973.
+
+
+
+
+Reynolds & Postel                                              [Page 30]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   470 - Thomas, Bob, "Change in Socket for TIP News Facility", RFC 470
+         (NIC 14799), BBN-TENEX, 13 March 1973.
+
+   471 - Thomas, Bob, "Announcement of a (Tentative) Workshop on
+         Multi-Site Executive Programs", RFC 471 (NIC 14800), BBN-TENEX,
+         13 March 1973.
+
+   472 - Bunch, Steve, "Illinois' Reply to Maxwell's Request for
+         Graphics Information", RFC 472 (NIC 14801), Illinois,
+          March 1973.
+
+   473 - Walden, Dave, "MIX and MIXAL?", RFC 473 (NIC 14811), BBN-NET,
+         28 February 1973.
+
+   474 - Bunch, Steve, "Announcement of Forthcoming Meeting of the
+         Network Graphics Working Group and Call for RFC's", RFC 474
+         (NIC 14905), Illinois,  March 1973.
+
+   475 - Bhushan, Abhay, "FTP and Network Mail System", RFC 475
+         (NIC 14919), MIT-DMCG, 6 March 1973.
+
+   476 - McKenzie, Alex, "IMP/TIP Memory Retrofit Schedule
+         (Revision 2)", RFC 476 (NIC 14920), BBN-NET, 7 March 1973.
+
+   477 - Krilanovich, Mark, "Remote Job Service at UCSB", RFC 477
+         (NIC 14922), UCSB, 13 March 1973.
+
+   478 - Bressler, Bob, and Bob Thomas "FTP Server-Server
+         Interaction - II", RFC 478 (NIC 14947), BBN-NET and BBN-TENEX,
+         26 March 1973.
+
+   479 - White, Jim, "Use of FTP by the NIC Journal", RFC 479
+         (NIC 14948), SRI-ARC, 8 March 1973.
+
+   480 - White, Jim, "Host-Dependent FTP Parameters", RFC 480
+         (NIC 14949), SRI-ARC, 8 March 1973.
+
+   481 - Never Issued.
+
+   482 - McKenzie, Alex, "Traffic Statistics (February 1973)", RFC 482
+         (NIC 14966), BBN-NET, 12 March 1973.
+
+   483 - Kudlick, Michael, "Cancellation of the Resource Notebook
+         Framework Meeting", RFC 483 (NIC 15061), SRI-ARC,
+         14 March 1973.
+
+   484 - Never Issued.
+
+
+
+
+Reynolds & Postel                                              [Page 31]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   485 - Pickens, John, "MIX and MIXAL at UCSB", RFC 485 (NIC 15063),
+         UCSB, 19 March 1973.
+
+   486 - Bressler, Bob, "Data Transfer Revisited", RFC 486 (NIC 15064),
+         BBN, 20 March 1973.
+
+   487 - Bressler, Bob, "Free File Transfer", RFC 487 (NIC 15065), BBN,
+         6 April 1973.
+
+   488 - Auerbach, Marilyn, et al, "NLS Classes at Network Sites",
+         RFC 488 (NIC 15266), NIC, 23 March 1973.
+
+   489 - Postel, Jon "Comment on Resynchronization of Connection Status
+         Proposal", RFC 489 (NIC 15298), UCLA/NMC, 26 March 1973.
+
+   490 - Pickens, John, "Surrogate RJS for UCLA/CCN", RFC 490
+         (NIC 15355), UCSB, 6 March 1973.
+
+   491 - Padlipsky, Mike, "What is `Free'?", RFC 491 (NIC 15356),
+         MIT-Multics, 12 April 1973.
+
+   492 - Meyer, Edwin W., Jr., "Response to RFC 467", RFC 492
+         (NIC 15357), MIT-Multics, 18 April 1973.
+
+   493 - Michener, James C., et al., "Graphics Protocol", RFC 493
+         (NIC 15358), MIT-Project MAC, 26 April 1973.
+
+   494 - Walden, Dave, "Availability of MIX and MIXAL in the Network",
+         RFC 494 (NIC 15359), BBN-NET, 20 April 1973.
+
+   495 - McKenzie, Alex, "Telnet Protocol Specification", RFC 495
+         (NIC 15371), BBN-NET, 1 May 1973.
+
+   496 - Auerbach, Marilyn, "A TNLS Quick Reference Card is Available",
+         RFC 496 (NIC 15496), NIC, 5 April 1973.
+
+   497 - McKenzie, Alex, "Traffic Statistics (March 1973)", RFC 497
+         (NIC 15651), BBN-NET, 10 April 1973.
+
+   498 - Braden, Bob, "On Mail Service to CCN", RFC 498 (NIC 15715),
+         UCLA/CCN, 17 April 1973.
+
+   499 - Reussow, Bradley A., "Harvard's Network RJE", RFC 499
+         (NIC 15716), Harvard, 1 April 1973.
+
+   500 - Shoshani, Arie, and I. Spiegler, "The Integration of Data
+         Management Systems on a Computer Network", RFC 500 (NIC 15717),
+         SDC, 16 April 1973.
+
+
+
+Reynolds & Postel                                              [Page 32]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   501 - Pogran, Ken, "Un-Muddling `Free File Transfer'", RFC 501
+         (NIC 15718), MIT-Multics, 11 May 1973.
+
+   502 - Never Issued.
+
+   503 - Neigus, Nancy, and Jon Postel "Socket Number List", RFC 503
+         (NIC 15747), BBN-NET and UCLA/NMC, 12 April 1973.
+
+   504 - Thomas, Bob, "Workshop Announcement", RFC 504 (NIC 16155), BBN,
+         30 April 1973.
+
+   505 - Padlipsky, Mike, "Two Solutions to a File Transfer Access
+         Problem", RFC 505 (NIC 16156), MIT-Multics, 25 June 1973.
+
+   506 - Padlipsky, Mike, "An FTP Command-Naming Problem", RFC 506
+         (NIC 16157), MIT-Multics, 26 June 1973.
+
+   507 - Never Issued.
+
+   508 - Pfeifer, Larry, "Real-Time Data Transmission on the ARPANET",
+         RFC 508 (NIC 16159), UCSB, 7 May 1973.
+
+   509 - McKenzie, Alex, "Traffic Statistics (April 1973)", RFC 509
+         (NIC 16294), BBN-NET, 7 May 1973.
+
+   510 - White, Jim, "Request for Network Mailbox Addresses", RFC 510
+         (NIC 16400), SRI-ARC, 30 May 1973.
+
+   511 - North, Jeanne, "Enterprise Phone Service to NIC from ARPANET
+         Sites", RFC 511 (NIC 16442), NIC, 23 May 1973.
+
+   512 - Hathaway, Wayne, "More on Lost Message Detection", RFC 512
+         (NIC 16443), Ames Research Center, 25 May 1973.
+
+   513 - Hathaway, Wayne, "Comments on the New Telnet Specifications",
+         RFC 513 (NIC 16444), Ames Research Center, SRI-ARC,
+         30 May 1973.
+
+   514 - Kantrowitz, W., "Network Make-Work", RFC 514 (NIC 16445),
+         Lincoln Labs, 5 June 1973.
+
+   515 - Winter, R., "Specifications for Datalanguage, Version 0/9",
+         RFC 515 (NIC 16446), CCA, 6 June 1973.
+
+   516 - Postel, Jon, "Lost Message Detection", RFC 516 (NIC 16693),
+         UCLA/NMC, 18 May 1973.
+
+   517 - Never Issued.
+
+
+
+Reynolds & Postel                                              [Page 33]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   518 - Vaughan, Nancy, and Elizabeth Feinler, "ARPANET Accounts",
+         RFC 518 (NIC 16817), SRI-ARC, 19 June 1973.
+
+   519 - Pickens, John, "Resource Evaluation", RFC 519 (NIC 16818),
+         UCSB,  June 1973.
+
+   520 - Day, John, "Memo to FTP Group (Proposal for File Access
+         Protocol)", RFC 520 (NIC 16819), Illinois, 25 June 1973.
+
+   521 - McKenzie, Alex, "Restricted Use of IMP DDT", RFC 521
+         (NIC 16855), BBN, 30 May 1973.
+
+   522 - McKenzie, Alex, "Traffic Statistics (May 1973)", RFC 522
+         (NIC 17033), BBN, 5 June 1973.
+
+   523 - Bhushan, Abhay, "SURVEY is in Operation Again", RFC 523
+         (NIC 17048), MIT-DMCG, 5 June 1973.
+
+   524 - White, Jim, "A Proposed Mail Protocol", RFC 524 (NIC 17140),
+         SRI-ARC, 13 June 1973.
+
+   525 - Parrish, William, and John Pickens, "MIT MATHLAB Meets
+         UCSB-OLS", RFC 525 (NIC 17161), UCSB, 1 June 1973.
+
+   526 - Pratt, William, "Technical Meeting - Digital Image Example of
+         Resource Sharing", RFC 526 (NIC 17162), USC, 25 June 1973.
+
+   527 - Merryman, Robert, "ARPAWOCKY", RFC 527 (NIC 17163), UCSD-CC,
+         22 June 1973.
+
+   528 - McQuillian, John, "Software Checksumming in the IMP and Network
+         Reliability", RFC 528 (NIC 17164), BBN, 20 June 1973.
+
+   529 - McKenzie, Alex, Bob Thomas, Ray Tomlinson, and Ken Pogran, "A
+         Note on Protocol Synch Sequences", RFC 529 (NIC 17165), BBN and
+         MIT, 29 June 1973.
+
+   530 - Bhushan, Abhay, "A Report on the Survey Project", RFC 530
+         (NIC 17375), MIT-DMCG, 22 June 1973.
+
+   531 - Padlipsky, Mike, "A Response to Two Recent RFC's About Network
+         Information", RFC 531 (NIC 17450), MIT-Mulitcs, 26 June 1973.
+
+   532 - Merryman, Robert, "The UCSD-CC Server-FTP Facility", RFC 532
+         (NIC 17451), UCSD-CC, 22 June 1973.
+
+   533 - Walden, Dave, "Message-ID Numbers", RFC 533 (NIC 17452), BBN,
+         17 July 1973.
+
+
+
+Reynolds & Postel                                              [Page 34]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   534 - Walden, Dave, "Lost Message Detection", RFC 534 (NIC 17453),
+         BBN, 17 July 1973.
+
+   535 - Thomas, Bob, "Comments on File Access Protocol", RFC 535
+         (NIC 17454), BBN, 25 July 1973.
+
+   536 - Never Issued.
+
+   537 - Bunch, Steve, "Announcement of NGG Meeting, July 16-17",
+         RFC 537 (NIC 17498), Illinois, 27 June 1973.
+
+   538 - McKenzie, Alex, "Traffic Statistics (June 1973)", RFC 538
+         (NIC 17642), BBN, 5 July 1973.
+
+   539 - Crocker, Dave, and Jon Postel, "Thoughts on the Mail Protocol
+         Proposed in RFC 524", RFC 539 (NIC 17644), UCLA/NMC,
+         7 July 1973.
+
+   540 - Never Issued.
+
+   541 - Never Issued.
+
+   542 - Neigus, Nancy, "File Transfer Protocol", RFC 542 (NIC 17759),
+         BBN, 12 July 1973.
+
+   543 - Meyer, Dean, "Network Journal Submission and Delivery", RFC 543
+         (NIC 17777), SRI-ARC, 13 July 1973.
+
+   544 - Meyer, Dean, and Kirk Kelley, "Locating On-Line Documentation
+         at SRI-ARC", RFC 544 (NIC 17782), SRI-ARC, 13 July 1973.
+
+   545 - Pickens, John, "Of What Quality Be the UCSB Resource
+         Evaluators?", RFC 545 (NIC 17791), UCSB, 23 July 1973.
+
+   546 - Thomas, Bob, "TENEX Load Averages for July 1973", RFC 546
+         (NIC 17792), BBN, 10 August 1973.
+
+   547 - Walden, Dave, "Change to the Very Distant Host Specification",
+         RFC 547 (NIC 17793), BBN, 13 August 1973.
+
+   548 - Walden, Dave, "Hosts Using the IMP Going Down Message", RFC 548
+         (NIC 17794), BBN, 16 August 1973.
+
+   549 - Bunch, Steve, "Minutes of Network Graphics Group", RFC 549
+         (NIC 17795), Illinois,  July 1973.
+
+   550 - Deutsch, L. Peter, "NIC NCP Experiment", RFC 550 (NIC 17796),
+         XEROX-PARC, 24 August 1973.
+
+
+
+Reynolds & Postel                                              [Page 35]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   551 - Feinroth, Yeshiah, and Robert Fink, "Implementation of Local
+         Conventions", RFC 551, NYU and LBL, 27 August 1973.
+
+   552 - Owen, Buzz, "Single Access to Standard Protocols", RFC 552,
+         SAAC-TIP, 13 July 1973.
+
+   553 - Thomas, Elaine, et al., "Draft Design for a Text/Graphics
+         Protocol", RFC 553 (NIC 17810), 14 July, 1973.
+
+   554 - Never Issued.
+
+   555 - White, Jim, "Response to Critiques of the Proposed Mail
+         Protocol", RFC 555 (NIC 17993), SRI-ARC, 27 July 1973.
+
+   556 - McKenzie, Alex, "Traffic Statistics (July 1973)", RFC 556
+         (NIC 18376), 13 August 1973.
+
+   557 - Wessler, Barry, "Revelations in Network Host Measurements",
+         RFC 557 (NIC 18457), 30 August 1973.
+
+   558 - Never Issued.
+
+   559 - Bhushan, Abhay, "Comments on the New Telnet Protocol and Its
+         Implementation", RFC 559 (NIC 18482), 15 August 1973.
+
+   560 - Crocker, Dave, and Jon Postel, "Remote Controlled Transmission
+         and Echoing Telnet Option", RFC 560 (NIC 18492),
+         20 August 1973.
+
+   561 - Bhushan, Abhay, Ken Pogran, Ray Tomlinson, and Jim White,
+         "Standardizing Network Mail Headers", RFC 561 (NIC 18516), MIT,
+         BBN, and SRI-ARC, 5 September 1973.
+
+   562 - McKenzie, Alex, "Modifications to the Telnet Specification",
+         RFC 562 (NIC 18638), BBN, 28 August 1973.
+
+   563 - Davidson, John, "Comments on the RCTE Telnet Option", RFC 563
+         (NIC 18775), University of Hawaii, 28 August 1973.
+
+   564 - Never Issued.
+
+   565 - Cantor, Don, "Storing Network Survey Data at the Datacomputer",
+         RFC 565 (NIC 18777), CCA, 28 August 1973.
+
+   566 - McKenzie, Alex, "Traffic Statistics (August 1983)", RFC 566
+         (NIC 18801), BBN, 4 September 1973.
+
+   567 - Deutsch, L. Peter, "Cross-Country Network Bandwidth", RFC 567
+         (NIC 18970), XEROX-PARC, 6 September 1973.
+
+
+Reynolds & Postel                                              [Page 36]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   568 - McQuillan, John, "Response to RFC 567 - Cross-Country Network
+         Bandwidth", RFC 568 (NIC 18971), BBN, 18 September 1973.
+
+   569 - Padlipsky, Mike, "NETED: A Common Editor for the ARPA Network",
+         RFC 569 (NIC 18972), 15 October 1973.
+
+   570 - Pickens, John, "Experimental Input Mapping Between NVT ASCII
+         and UCSB Online System", RFC 570 (NIC 18973), UCSB,
+         30 October 1973.
+
+   571 - Braden, Bob, "TENEX FTP Problem", RFC 571 (NIC 18974),
+         UCLA/CCN, 15 November 1973.
+
+   572 - Never Issued.
+
+   573 - Bhushan, Abhay, "Data and File Transfer - Some Measurement
+         Results", RFC 573 (NIC 19083), MIT-DM, 14 September 1973.
+
+   574 - Krilanovich, Mark, "Announcement of a Mail Facility at UCSB",
+         RFC 574 (NIC 19144), UCSB, 26 September 1973.
+
+   575 - Never Issued.
+
+   576 - Victor, Ken, "Proposal for Modifying Linking", RFC 576
+         (NIC 19324), SRI, 26 September 1973.
+
+   577 - Crocker, Dave, "Mail Priority", RFC 577 (NIC 19356), UCLA/NMC,
+         18 October 1973.
+
+   578 - Bhushan, Abhay, and Neal Ryan, "Using MIT-MATHLAB MACSYMA from
+         MIT-DMS MUDDLE - An Experiment in Automated Resource Sharing",
+         RFC 578 (NIC 19501), MIT, 8 October 1973.
+
+   579 - McKenzie, Alex, "Traffic Statistics (September 1973)", RFC 579
+         (NIC 19655), BBN, 15 October 1973.
+
+   580 - Postel, Jon, "Note to Protocol Designers and Implementers",
+         RFC 580 (NIC 19849), MITRE, 25 October 1973.
+
+   581 - Crocker, Dave, and Jon Postel, "Corrections to RFC 560 - Remote
+         Controlled Transmission and Echoing Telnet Option", RFC 581
+         (NIC 19860), UCLA and MITRE, 2 November 1973.
+
+   582 - Clements, Robert C., "Comments on RFC 580 - Machine Readable
+         Protocols", RFC 582 (NIC 19962), BBN, 5 November 1973.
+
+   583 - Never Issued.
+
+
+
+
+Reynolds & Postel                                              [Page 37]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   584 - Iseli, Jean, Dave Crocker, and Nancy Neigus, "Charter for
+         ARPANET Users Interest Working Group", RFC 584 (NIC 19025 and
+         20049), MITRE, UCLA/NMC, BBN, 6 November 1973.
+
+   585 - Crocker, Dave, Nancy Neigus, Elizabeth Feinler, and Jean Iseli,
+         "ARPANET Users Interest Working Group Meeting", RFC 585
+         (NIC 18259 and 20050), UCLA/NMC, BBN, SRI-ARC, MITRE,
+         6 November 1973.
+
+   586 - McKenzie, Alex, "Traffic Statistics (October 1973)", RFC 586
+         (NIC 20096), BBN, 8 November 1973.
+
+   587 - Postel, Jon, "Announcing New Telnet Options", RFC 587
+         (NIC 20198), MITRE, 13 November 1973.
+
+   588 - Stokes, Adrian V., "London Node is Now Up", RFC 588
+         (NIC 20217), UKICS, 29 October 1973.
+
+   589 - Braden, Bob, "CCN NETRJS Server Messages to Remote User",
+         RFC 589 (NIC 20268), UCLA/CCN, 26 November 1973.
+
+   590 - Padlipsky, Michael, "Multics Address Change", RFC 590
+         (NIC 20326), MIT-Multics, 19 November 1973.
+
+   591 - Walden, Dave, "Addition to the Very Distant Host
+         Specification", RFC 591 (NIC 20327), BBN-NET, 29 November 1973.
+
+   592 - Watson, Richard W., "Some Thoughts on System Design to
+         Facilitate Resource Sharing", RFC 592 (NIC 20391), SRI-ARC,
+         20 November 1973.
+
+   593 - McKenzie, Alex, and Jon Postel, "Telnet and FTP Implementation
+         - Schedule Change", RFC 593 (NIC 20615), BBN and MITRE,
+         29 November 1973.
+
+   594 - Burchfiel, Jerry, "Speedup of Host-IMP Interface", RFC 594
+         (NIC 20616), BBN, 10 December 1973.
+
+   595 - Hathaway, Wayne, "Some Thoughts in Defense of the Telnet
+         Go-Ahead", RFC 595 (NIC 20617), AMES Research Center,
+         12 December 1973.
+
+   596 - Taft, Edward, "Second Thoughts on Telnet Go-Ahead", RFC 596
+         (NIC 20812), XEROX-PARC, 8 December 1973.
+
+   597 - Neigus, Nancy, and Elizabeth Feinler, "Host Status", RFC 597
+         (NIC 20826), BBN and SRI-ARC, 12 December 1973.
+
+
+
+
+Reynolds & Postel                                              [Page 38]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   598 - Network Information Center, "RFC Index -- December 5, 1973",
+         RFC 598 (NIC 20853), NIC, 5 December 1973.
+
+   599 - Braden, Bob, "Update on NETRJS", RFC 599 (NIC 20854), UCLA/CCN,
+         13 December 1973.
+
+   600 - Berggreen, Arthur, "Interfacing an Illinois Plasma Terminal to
+         the ARPANET", RFC 600 (NIC 20884), UCSB, 26 November 1973.
+
+   601 - McKenzie, Alex, "Traffic Statistics (November 1973)", RFC 601
+         (NIC 20905), BBN, 14 December 1973.
+
+   602 - Metcalfe, Bob, "The Stockings Were Hung by the Chimney With
+         Care", RFC 602 (NIC 21021), XEROX-PARC, 27 December 1973.
+
+   603 - Burchfiel, Jerry, "Response to RFC 597: Host Status", RFC 603
+         (NIC 21022), BBN, 31 December 1973.
+
+   604 - Postel, Jon, "Assigned Link Numbers", RFC 604 (NIC 21186),
+         MITRE, 26 December 1973.
+
+   605 - Never Issued.
+
+   606 - Deutsch, L. Peter, "Host Names On-line", RFC 606 (NIC 21246),
+         XEROX-PARC, 29 December 1973.
+
+   607 - Krilanovich, Mark, and George Gregg, "Comments on the File
+         Transfer Protocol", RFC 607 (NIC 21255), UCSB, 7 January 1974.
+
+   608 - Kudlick, Michael, "Host Names On-line", RFC 608 (NIC 21256),
+         SRI-ARC, 10 January 1974.
+
+   609 - Ferguson, Bill, "Statement of Upcoming Move of NIC/NLS
+         Services", RFC 609 (NIC 21339), SRI-ARC, 10 January 1974.
+
+   610 - Winter, Richard, Jeffrey Hill, and Warren Greiff, "Further
+         Datalanguage Design Concepts", RFC 610 (NIC 21352), CCA,
+         15 December 1973.
+
+   611 - Walden, Dave, "Two Changes to the IMP/Host Protocol to Improve
+         USER/Network Communications", RFC 611 (NIC 21354), BBN,
+         14 February 1974.
+
+   612 - McKenzie, Alex, "Traffic Statistics (December 1973)", RFC 612
+         (NIC 21404), BBN, 16 January 1974.
+
+   613 - McKenzie, Alex, "Network Connectivity: A Response to RFC 603",
+         RFC 613 (NIC 21525), BBN, 21 January 1974.
+
+
+
+Reynolds & Postel                                              [Page 39]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   614 - Pogran, Ken, and Nancy Neigus, "Response to RFC 607 - Comments
+         on the File Transfer Protocol", RFC 614 (NIC 21530), BBN,
+         28 January 1974.
+
+   615 - Crocker, Dave, "Proposed Network Standard Data Pathname
+         Syntax", RFC 615 (NIC 21531), UCLA/NMC, 1 March 1974.
+
+   616 - Walden, Dave, "Latest Network Maps", RFC 616 (NIC 21532), BBN,
+         11 February 1974.
+
+   617 - Taft, Edward, "A Note on Socket Number Assignment", RFC 617
+         (NIC 21771), XEROX-PARC, 19 February 1974.
+
+   618 - Taft, Edward, "A Few Observations on NCP Statistics", RFC 618
+         (NIC 21989), XEROX-PARC, 19 February 1974.
+
+   619 - Naylor, William, and Holger Opderbeck, "Mean Round-Trip Times
+         in the ARPANET", RFC 619 (NIC 21791), UCLA, 7 March 1974.
+
+   620 - Ferguson, Bill, "Request for Monitor Host Table Updates",
+         RFC 620 (NIC 21993), SRI-ARC, 1 March 1974.
+
+   621 - Kudlick, Michael, "NIC User Directories at SRI-ARC", RFC 621
+         (NIC 21994), SRI-ARC, 6 March 1974.
+
+   622 - McKenzie, Alex, "Scheduling IMP/TIP Down Time", RFC 622
+         (NIC 21995), BBN, 13 March 1974.
+
+   623 - Krilanovich, Mark, "Comments on On-line Host Name Service",
+         RFC 623 (NIC 22004), UCSB, 22 February 1974.
+
+   624 - Krilanovich, Mark, George Gregg, Wayne Hathaway, and Jim White,
+         "Comments on the File Transfer Protocol", RFC 624 (NIC 22054),
+         UCSB, Ames Research Center, SRI-ARC, 28 February 1974.
+
+   625 - Kudlick, Mike, and Elizabeth Feinler, "On Line Hostnames
+         Service", RFC 625 (NIC 22152), SRI-ARC, 7 March 1974.
+
+   626 - Kleinrock, Leonard, and Holger Opderbeck, "On a Possible Lockup
+         Condition in the IMP Subnet due to Message Sequencing", RFC 626
+         (NIC 22161), UCLA, 14 March 1974.
+
+   627 - Kudlick, Mike, and Jake Feinler, "ASCII Text File of
+         Hostnames", RFC 627 (NIC 22160), SRI-ARC, 25 March 1974.
+
+   628 - Keeney, Marcia, "Status of RFC Numbers and a Note on
+         Pre-assigned Jourcal Numbers", RFC 628 (NIC 22161), SRI-ARC,
+         27 March 1974.
+
+
+
+Reynolds & Postel                                              [Page 40]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   629 - North, Jeanne, "Scenario for Using the Network Journal",
+         RF0 629 (NIC 22383), SRI-ARC, 27 March 1974.
+
+   630 - Sussman, Julie, "FTP Error Code Usage for More Reliable Mail
+         Service", RFC 630 (NIC 30237), BBN, 10 April 1974.
+
+   631 - Danthine, Andre', "Call for Papers: International Meeting on
+         Minicomputers and Data Communication", RFC 631 (NIC 30238),
+         20 May 1974.
+
+   632 - Opderbeck Holger, "Throughput Degradations for Single Packet
+         Messages", RFC 632 (NIC 30239), UCLA, 10 April 1974.
+
+   633 - McKenzie, Alex, "IMP/TIP Preventive Maintenance Schedule",
+         RFC 633 (NIC 30240), BBN, 18 March 1974.
+
+   634 - McKenzie, Alex, "Change in Network Address for Haskins Lab",
+         RFC 634 (NIC 30445), BBN, 10 April 1974.
+
+   635 - Cerf, Vint, "An Assessment of ARPANET Protocols", RFC 635
+         (NIC 30489), Stanford, 22 April 1974.
+
+   636 - Burchfiel, Jerry, Bernie Cosell, Ray Tomlinson, and Dave
+         Walden, "TIP/TENEX Reliability Improvements", RFC 636
+         (NIC 30490), BBN, 10 June 1974.
+
+   637 - McKenzie, Alex, "Change of Network Address for SU-DSL", RFC 637
+         (NIC 30519), BBN, 23 April 1974.
+
+   638 - McKenzie, Alex, "IMP/TIP Preventive Maintenance Schedule",
+         RFC 638 (NIC 30538), BBN, 25 April 1974.
+
+   639 - Never Issued.
+
+   640 - Postel, Jon, "Revised FTP Reply Codes", RFC 640 (NIC 30843),
+         UCLA/NMC, 5 June 1974.
+
+   641 - Never Issued.
+
+   642 - Burchfiel, Jerry, "Ready Line Philosophy and Implementation",
+         RFC 642 (NIC 30872), BBN, 5 July 1974.
+
+   643 - Mader, Eric, "Network Debugging Protocol", RFC 643 (NIC 30873),
+         July 1974.
+
+   644 - Thomas, Bob, "On The Problem of Signature Authentication for
+         Network Mail", RFC 644 (NIC 30874), BBN, 22 July 1974.
+
+
+
+
+Reynolds & Postel                                              [Page 41]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   645 - Crocker, Dave, "Network Standard Data Specification Syntax",
+         RFC 645 (NIC 30899), UCLA/NMC, 27 June 1974.
+
+   646 - Never Issued.
+
+   647 - Padlipsky, Michael, "A Proposed Protocol for Connecting Host
+         Computers to ARPA-Like Networks Via Directly-Connected Front
+         End Processors", RFC 647 (NIC 31117), MITRE, 12 November 1974.
+
+   648 - Never Issued.
+
+   649 - Never Issued.
+
+   650 - Never Issued.
+
+   651 - Crocker, Dave, "Revised Telnet Status Option", RFC 651
+         (NIC 31154), UCLA/NMC, 25 October 1974.
+
+   652 - Crocker, Dave, "Telnet Output Carriage-Return Disposition
+         Option", RFC 652 (NIC 31155), UCLA/NMC, 25 October 1974.
+
+   653 - Crocker, Dave, "Telnet Output Horizontal Tabstops Option",
+         RFC 653 (NIC 31156), UCLA/NMC, 25 October 1974.
+
+   654 - Crocker, Dave, "Telnet Output Horizontal Tab Disposition
+         Option", RFC 654 (NIC 31157), UCLA/NMC, 25 October 1974.
+
+   655 - Crocker, Dave, "Telnet Output Formfeed Disposition Option",
+         RFC 655 (NIC 31158), UCLA/NMC, 25 October 1974.
+
+   656 - Crocker, Dave, "Telnet Output Vertical Tabstops Option",
+         RFC 656 (NIC 31159), UCLA/NMC, 25 October 1974.
+
+   657 - Crocker, Dave, "Telnet Output Vertical Tab Disposition Option",
+         RFC 657 (NIC 31160), UCLA/NMC, 25 October 1974.
+
+   658 - Crocker, Dave, "Telnet Output Linefeed Disposition", RFC 658
+         (NIC 31161), UCLA/NMC, 25 October 1974.
+
+   659 - Postel, Jon, "Announcing Additional Telnet Options", RFC 659
+         (NIC 31177), SRI-ARC, 18 October 1974.
+
+   660 - Walden, Dave, "Some Changes to the IMP and the IMP/HOST
+         Interface", RFC 660 (NIC 31202), BBN, 23 October 1974.
+
+   661 - Postel, Jon, "Protocol Information", RFC 661 (NIC 31203),
+         SRI-ARC, 23 November 1974.
+
+
+
+
+Reynolds & Postel                                              [Page 42]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   662 - Kanodia, Raj, "Performance Improvement in ARPANET File
+         Transfers from Multics", RFC 662 (NIC 31386), MIT-Project MAC,
+         26 November 1974.
+
+   663 - Kanodia, Raj, "A Lost Message Detection and Recovery Protocol",
+         RFC 663 (NIC 31387), MIT-Project MAC, 29 November 1974.
+
+   664 - Never Issued.
+
+   665 - Never Issued.
+
+   666 - Padlipsky, Michael, "Specification of the Unified User-Level
+         Protocol", RFC 666 (NIC 31396), 26 November 1974.
+
+   667 - Chipman, Steve, "Host Ports", RFC 667 (NIC 31422), BBN,
+         29 November 1974.
+
+   668 - Never Issued.
+
+   669 - Dodds, D.W., "November 1974 Survey of New-Protocol Telnet
+         Servers", RFC 669 (NIC 31435), BBN, 4 December 1974.
+
+   670 - Never Issued.
+
+   671 - Schantz, Richard, "A Note on Reconnection Protocol", RFC 671
+         (NIC 31439), BBN, 6 December 1974.
+
+   672 - Schantz, Richard, "A Multi-Site Data Collection Facility",
+         RFC 669 (NIC 31440), BBN, 6 December 1974.
+
+   673 - Never Issued.
+
+   674 - Postel, Jon, and Jim White, "Procedure Call Protocol Documents,
+         Version 2", RFC 674 (NIC 31484), SRI-ARC, 12 December 1974.
+
+   675 - Cerf, Vint, Yogen Dalal, and Carl Sunshine, "Specification of
+         Internet Transmission Control Program", RFC 675 (NIC 31505),
+         4 December 1974.
+
+   676 - Never Issued.
+
+   677 - Johnson, Paul, and Bob Thomas, "The Maintenance of Duplicate
+         Databases", RFC 677 (NIC 31507), BBN, 27 January 1975.
+
+   678 - Postel, Jon, "Standard File Formats", RFC 678 (NIC 31524),
+         SRI-ARC, 19 December 1974.
+
+   679 - Dodds, D.W., "February 1975, Survey of New-Protocol Telnet
+         Servers", RFC 679 (NIC 31890), BBN, 21 February 1975.
+
+
+Reynolds & Postel                                              [Page 43]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   680 - Meyer, Theodore H., and D. Austin Henderson, "Message
+         Transmission Protocol", RFC 680 (NIC 32116), BBN,
+         30 April 1975.
+
+   681 - Holmgren, "Network UNIX", RFC 681 (NIC 32157), SRI-ARC,
+         14 May 1975.
+
+   682 - Never Issued.
+
+   683 - Clements, Robert, "FTPSRV - TENEX Extensions for Paged Files",
+         RFC 681 (NIC 32251), BBN, 3 April 1975.
+
+   684 - Schantz, Richard, "A Commentary on Procedure Calling as a
+         Network Protocol", RFC 684 (NIC 32252), BBN, 15 April 1975.
+
+   685 - Beeler, Michael, "Response Time in Cross-network Debugging",
+         RFC 685 (NIC 32298), BBN, 16 April 1975.
+
+   686 - Harvey, Brian, "Leaving Well Enough Alone", RFC 686
+         (NIC 32481), SU-AI, 10 May 1975.
+
+   687 - Walden, Dave, "IMP/Host and Host/IMP Protocol Change", RFC 687
+         (NIC 32654), BBN, 2 June 1975.
+
+   688 - Walden, Dave, "Tentative Schedule for the New Telnet
+         Implementation for the TIP", RFC 688 (NIC 32655), BBN,
+         4 June 1975.
+
+   689 - Clements, Robert, "TENEX NCP Finite State Machine for
+         Connections", RFC 689 (NIC 32656), 23 May 1975.
+
+   690 - Postel, Jon, "Comments on the Proposed Host/IMP Protocol
+         Change", RFC 690 (NIC 32699), BBN, 6 June 1975.
+
+   691 - Harvey, Brian, "One More Try on the FTP", RFC 691 (NIC 32700),
+         SU-AI, 28 May 1975.
+
+   692 - Wolfe, Stephen, "Comments on IMP/HOST Protocol Changes
+         (RFCs 687,690)", RFC 692 (NIC 32734), CCN, 20 June 1975.
+
+   693 - Never Issued.
+
+   694 - Postel, Jon, "Protocol Information", RFC 694 (NIC 32793),
+         SRI-ARC, 18 June 1975.
+
+   695 - Krilanovich, Mark, "Official Change in Host-Host Protocol",
+         RFC 695 (NIC 32908), UCSB, 5 July 1975.
+
+
+
+
+Reynolds & Postel                                              [Page 44]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   696 - Cerf, Vint, "Comments on IMP/HOST and HOST/IMP Protocol
+         Changes", RFC 696 (NIC 32962), Stanford, 17 July 1975.
+
+   697 - Lieb, J., "CWD Command of FTP", RFC 697 (NIC 32963),
+         14 July 1975.
+
+   698 - Tovar, "Telnet Extended ASCII Option", RFC 698 (NIC 32964),
+         23 July 1975.
+
+   699 - Postel, Jon, and Jim Vernon, "Requests for Comments Summary
+         Notes: 600-699", RFC 699, ISI, November 1982.
+
+   700 - Mader, Eric, William Plummer, and Ray Tomlinson, "A Protocol
+         Experiment", RFC 700 (NIC 31020), BBN, August 1974.
+
+   701 - Dodds, D.W., "August 1974, Survey of New-Protocol Telnet
+         Servers", RFC 701, BBN, August 1974.
+
+   702 - Dodds, D.W., "September 1974, Survey of New-Protocol Telnet
+         Servers", RFC 702, BBN, September 1974.
+
+   703 - Dodds, D.W., "July 1975, Survey of New-Protocol Telnet
+         Servers", RFC 703, BBN, 11 July 1975.
+
+   704 - Santos, Paul J. Jr., "IMP/Host and Host/IMP Protocol Change",
+         RFC 704 (NIC 33490), BBN, 15 September 1975.
+
+   705 - Bryan, Roland, "Front-End Protocol B6700 Version", RFC 705
+         (NIC 33644), ACC, 5 November 1975.
+
+   706 - Postel, Jon, "On the Junk Mail Problem", RFC 706 (NIC 33861),
+         SRI-ARC, 8 November 1975.
+
+   707 - White, Jim, "A High-Level Framework for Network-Based Resource
+         Sharing", RFC 707 (NIC 34263), SRI-ARC, 14 January 1976.
+
+   708 - White, Jim, "Elements of a Distributed Programming System",
+         RFC 708 (NIC 34353), SRI-ARC, 28 January 1976.
+
+   709 - Never Issued.
+
+   710 - Never Issued.
+
+   711 - Never Issued.
+
+   712 - Donnelley, James E., "A Distributed Capability Computing System
+         (DCCS)", RFC 712 (NIC 34586), 27 February 1976.
+
+
+
+
+Reynolds & Postel                                              [Page 45]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   713 - Haverty, Jack, "MSOTP -- Message Services Data Transmission
+         Protocol", RFC 713 (NIC 34739), MIT, 6 April 1976.
+
+   714 - McKenzie, Alex, "A Host/Host Protocol", RFC 714 (NIC 35144),
+         BBN, 21 April 1976.
+
+   715 - Never Issued.
+
+   716 - Walden, Dave, "Interim Revision to Appendix F of BBN
+         Report 1822", RFC 716 (NIC 35534), BBN, 24 May 1976.
+
+   717 - Postel, Jon, "Assigned Network Numbers", RFC 717 (NIC 35873),
+         SRI-ARC, 1 July 1976.
+
+   718 - Postel, Jon, "Comments on RCTE from the TENEX Implementation
+         Experience", RFC 718 (NIC 35874), SRI-ARC, 30 June 1976.
+
+   719 - Postel, Jon, "Discussion on RCTE", RFC 719 (NIC 36138),
+         SRI-ARC, 22 July 1976.
+
+   720 - Crocker, Dave, "Address Specification Syntax for Network Mail",
+         RFC 720 (NIC 36337), ISI, 5 August 1976.
+
+   721 - Garlick, Larry, "Out-of-Band Control Signals in a Host-to-Host
+         Protocol", RFC 721 (NIC 36636), SRI-ARC, 1 September 1976.
+
+   722 - Haverty, Jack, "Thoughts on Interactions in Distributed
+         Services", RFC 722 (NIC 36806), MIT, 16 September 1976.
+
+   723 - Never Issued.
+
+   724 - Pogran, Ken, John Vittal, Dave Crocker, and D. Austin
+         Henderson, "Proposed Official Standard for the Format of ARPA
+         Network Messages", RFC 724 (NIC 37435), MIT, BBN, and Rand,
+         12 May 1977.
+
+   725 - Day, John, and Gary Grossman, "An RJE Protocol for a Resource
+         Sharing Network", RFC 725 (NIC 38316), Illinois, 1 March 1977.
+
+   726 - Postel, Jon, and Dave Crocker, "Remote Controlled Transmission
+         and Echoing Telnet Option", RFC 726 (NIC 39237), SRI-ARC, and
+         UC Irvine, 8 March 1977.
+
+   727 - Crispin, Mark, "Telnet Logout Option", RFC 727 (NIC 40025),
+         MIT, 27 April 1977.
+
+   728 - Day, John, "A Minor Pitfall in the Telnet Protocol", RFC 728
+         (NIC 40036), Illinois, 27 April 1977.
+
+
+
+Reynolds & Postel                                              [Page 46]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   729 - Crocker, Dave, "Telnet Byte Macro Option", RFC 729 (NIC 40306),
+         Rand, 13 May 1977.
+
+   730 - Postel, Jon, "Extensible Field Addressing", RFC 730
+         (NIC 40400), ISI, 20 May 1977.
+
+   731 - Day, John, "Telnet Data Entry Terminal Option", RFC 731
+         (NIC 40652), Illinois, 27 June 1977.
+
+   732 - Day, John, "Telnet Data Entry Terminal Option", RFC 732
+         (NIC 41762), Illinois, 12 September 1977.
+
+   733 - Crocker, Dave, John Vittal, Ken Pogran, and D. Austin
+         Henderson, "Standard for the Format of ARPA Network Text
+         Messages(1)", RFC 733 (NIC 41952), Rand, BBN, and MIT,
+         21 November 1977.
+
+   734 - Crispin, Mark, "SUPDUP Protocol", RFC 734 (NIC 41953),
+         Stanford, 7 October 1977.
+
+   735 - Crocker, Dave, and Richard Gumpertz, "Revised Telnet Byte Macro
+         Option", RFC 735 (NIC 42083), Rand and CMU, 3 November 1977.
+
+   736 - Crispin, Mark, "Telnet SUPDUP Option", RFC 736 (NIC 42213),
+         Stanford, 31 October 1977.
+
+   737 - Harrenstien, Ken, "FTP Extension: XSEN", RFC 737 (NIC 42217),
+         SRI-KL, 31 October 1977.
+
+   738 - Harrenstien, Ken, "Time Server", RFC 738 (NIC 42218), SRI-KL,
+         31 October 1977.
+
+   739 - Postel, Jon, "Assigned Numbers", RFC 739 (NIC 42341), ISI,
+         11 November 1977.
+
+   740 - Braden, Bob, "NETRJS Protocol", RFC 740 (NIC 42423), UCLA/CCN,
+         22 November 1977.
+
+   741 - Cohen, Danny, "Specifications for the Network Voice Protocol
+         (NVP)", RFC 741 (NIC 42444), ISI, 29 January 1976.
+
+   742 - Harrenstien, Ken, "NAME/FINGER", RFC 742 (NIC 42758), SRI-KL,
+         30 December 1977.
+
+   743 - Harrenstien, Ken, "FTP Extension: XRSQ/XRCP", RFC 743
+         (NIC 42758), SRI-KL, 30 December 1977.
+
+   744 - Sattley, Joanne, "MARS - A Message Archiving and Retrieval
+         Service", RFC 744 (NIC 42857), CCA, 8 January 1978.
+
+
+Reynolds & Postel                                              [Page 47]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   745 - Beeler, Michael, "JANUS Interface Specifications", RFC 745
+         (NIC 43649), BBN, 30 March 1978.
+
+   746 - Stallman, Richard, "The SUPDUP Graphics Extension", RFC 746
+         (NIC 43976), MIT, 17 March 1978.
+
+   747 - Crispin, Mark, "Recent Extensions to the SUPDUP Protocol",
+         RFC 747 (NIC 44015), SU-AI, 21 March 1978.
+
+   748 - Crispin, Mark, "Telnet RANDOMLY-LOSE Option", RFC 748
+         (NIC 44125), SU-AI, 1 April 1978.
+
+   749 - Greenberg, Bernard, "Telnet SUPDUP-OUTPUT Option", RFC 749
+         (NIC 45499), MIT, 18 September 1978.
+
+   750 - Postel, Jon, "Assigned Numbers", RFC 750 (NIC 45500), ISI,
+         26 November 1978.
+
+   751 - Lebling, P. David, "Survey of FTP Mail and MLFL", RFC 751, MIT,
+         10 December 1978.
+
+   752 - Crispin, Mark, "A Universal Host Table", RFC 752, SU-AI,
+         2 January 1979.
+
+   753 - Postel, Jon, "Internet Message Protocol", RFC 753, ISI,
+         March 1979.
+
+   754 - Postel, Jon, "Out-of-Net Host Addresses for Mail", RFC 754,
+         ISI, 6 April 1979.
+
+   755 - Postel, Jon, "Assigned Numbers", RFC 755, ISI, 3 May 1979.
+
+   756 - Pickens, John, Elizabeth Feinler, and James Mathis, "The NIC
+         Name Server - A Datagram Based Information Utility", RFC 756,
+         SRI, July 1979.
+
+   757 - Deutsch, Debra, "A Suggested Solution to the Naming,
+         Addressing, and Delivery Problem for ARPAnet Message Systems",
+         RFC 776, BBN, 10 September 1979.
+
+   758 - Postel, Jon, "Assigned Numbers", RFC 758, ISI, August 1979.
+
+   759 - Postel, Jon, "Internet Message Protocol", RFC 759, ISI,
+         August 1980.
+
+   760 - Postel, Jon, "DOD Standard Internet Protocol", RFC 760, DARPA,
+         January 1980.
+
+
+
+
+Reynolds & Postel                                              [Page 48]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   761 - Postel, Jon, "DOD Standard Transmission Control Protocol",
+         RFC 761, DARPA, January 1980.
+
+   762 - Postel, Jon, "Assigned Numbers", RFC 762, ISI, January 1980.
+
+   763 - Abrams, Marshall, "Role Mailboxes", RFC 763, NBS, 7 May 1980.
+
+   764 - Postel, Jon, "Telnet Protocol Specification", RFC 764, ISI,
+         June 1980.
+
+   765 - Postel, Jon, "File Transfer Protocol Specification", RFC 765,
+         ISI, June 1980.
+
+   766 - Postel, Jon, "Internet Protocol Handbook--Table of Contents",
+         RFC 766, ISI, July 1980.
+
+   767 - Postel, Jon, "A Structured Format for Transmission of
+         Multi-Media Documents", RFC 767, ISI, August 1980.
+
+   768 - Postel, Jon, "User Datagram Protocol", RFC 768, ISI,
+         28 August 1980
+
+   769 - Postel, Jon, "Rapicom 450 Facsimile File Format", RFC 769, ISI,
+         26 September 1980.
+
+   770 - Postel, Jon, "Assigned Numbers", RFC 770, ISI, September 1980.
+
+   771 - Cerf, Vint, and Jon Postel, "Mail Transition Plan", RFC 771,
+         DARPA, and ISI, September 1980.
+
+   772 - Sluizer, Suzanne, and Jon Postel, "Mail Transfer Protocol",
+         RFC 772, ISI, September 1980.
+
+   773 - Cerf, Vint, "Comments on NCP/TCP Mail Service Transition
+         Strategy", RFC 773, DARPA, October 1980.
+
+   774 - Postel, Jon, "Internet Protocol Handbook Table of Contents",
+         RFC 774, ISI, October 1980.
+
+   775 - Mankins, David, Dan Franklin, and Buzz Owen, "Directory
+         Oriented FTP Commands", RFC 776, BBN, December 1980.
+
+   776 - Postel, Jon, "Assigned Numbers", RFC 776, ISI, January 1981.
+
+   777 - Postel, Jon, "Internet Control Message Protocol", RFC 777, ISI,
+         April 1981.
+
+   778 - Mills, Dave, "DCNET Internet Clock Service", RFC 778, COMSAT,
+         18 April 1981.
+
+
+Reynolds & Postel                                              [Page 49]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   779 - Killian, Earl, "Telnet SEND-LOCATION Option", RFC 779, LLL,
+         April 1981.
+
+   780 - Sluizer, Suzanne, and Jon Postel, "Mail Transfer Protocol",
+         RFC 780, ISI, May 1981.
+
+   781 - Su, Zaw-Sing, "A Specification of the Internet Protocol (IP)
+         Timestamp Option", RFC 781, SRI, May 1981.
+
+   782 - Nabielsky, Jose, and Anita Skelton, "A Virtual Terminal
+         Management Model", RFC 782, DCA, 1981.
+
+   783 - Sollins, K.R., "The TFTP Protocol (Revision 2)", RFC 783, MIT,
+         June 1981.
+
+   784 - Sluizer, Suzanne, and Jon Postel, "Mail Transfer Protocol: ISI
+         TOPS20 Implementation", RFC 784, ISI, July 1981.
+
+   785 - Sluizer, Suzanne, and Jon Postel, "Mail Transfer Protocol: ISI
+         TOPS20 File Definitions", RFC 785, ISI, July 1981.
+
+   786 - Sluizer, Suzanne, and Jon Postel, "Mail Transfer Protocol: ISI
+         TOPS20 MTP-NIMAIL Interface", RFC 786, ISI, July 1981.
+
+   787 - Chapin, A. Lyman, "Connectionless Data Transmission
+         Survey/Tutorial", RFC 787, DGC, July 1981.
+
+   788 - Postel, Jon, "Simple Mail Transport Protocol", RFC 788, ISI,
+         November 1981.
+
+   789 - Rosen, Eric, "Vulnerabilities of Network Control Protocols: An
+         Example", RFC 789, BBN, July 1981.
+
+   790 - Postel, Jon, "Assigned Numbers", RFC 790, ISI, September 1981.
+
+   791 - Postel, Jon, "Internet Protocol - DARPA Internet Program
+         Protocol Specification", RFC 791, DARPA, September 1981.
+
+   792 - Postel, Jon, "Internet Control Message Protocol - DARPA
+         Internet Program Protocol Specification", RFC 792, ISI,
+         September 1981.
+
+   793 - Postel, Jon, "Transmission Control Protocol - DARPA Internet
+         Program Protocol Specification", RFC 793, DARPA,
+         September 1981.
+
+   794 - Cerf, Vint, "Pre-Emption", RFC 794, DARPA, September 1981.
+
+   795 - Postel, Jon, "Service Mappings", RFC 795, ISI, September 1981.
+
+
+Reynolds & Postel                                              [Page 50]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   796 - Postel, Jon, "Address Mappings", RFC 796, ISI, September 1981.
+
+   797 - Katz, Alan, "Format for Bitmap Files", RFC 797, ISI,
+         September 1981.
+
+   798 - Katz, Alan, "Decoding Facsimile Data from the Rapicom 450",
+         RFC 798, ISI, September 1981.
+
+   799 - Mills, Dave, "Internet Name Domains", RFC 799, COMSAT,
+         September 1981.
+
+   800 -  Postel, Jon, and Jim Vernon, "Requests for Comments Summary -
+         Notes 700-799", RFC 800, ISI, November 1982.
+
+   801 - Postel, Jon, "NCP/TCP Transition Plan", RFC 801, ISI,
+         November 1981.
+
+   802 - Malis, Andy, "The ARPANET 1822L Host Access Protocol", RFC 802,
+         BBN, November 1981.
+
+   803 - Agarwal, Anil, Mike O'Connor, and Dave Mills, "Dacom 450/500
+         Facsimile Data Transcoding", RFC 803, COMSAT, 2 November 1981.
+
+   804 - CCITT Study Group, "CCITT Draft Recommendation T.4", RFC 804,
+         CCITT, 23 January 1982.
+
+   805 - Postel, Jon, "Computer Mail Meeting Notes", RFC 805, ISI,
+         8 February 1982.
+
+   806 - National Bureau of Standards, "Proposed Federal Information
+         Processing Standard: Specification for Message Format for
+         Computer Based Message Systems", RFC 804, CCITT,
+         23 January 1982.
+
+   807 - Postel, Jon, "Multimedia Mail Meeting Notes", RFC 807, ISI,
+         9 February 1982.
+
+   808 - Postel, Jon, "Summary of a Computer Mail Service Meeting held
+         at BBN on 10 January 1979", RFC 808, ISI, 1 March 1982.
+
+   809 - Chang, Tawei, "UCL Facsimile System", RFC 809, INDRA,
+         February 1982.
+
+   810 - Feinler, Elizabeth, Ken Harrenstien, Zaw-Sing Su, and Vic
+         White, "DoD Internet Host Table Specification", RFC 810, NIC,
+         1 March 1982.
+
+   811 - Harrenstien, Ken, Vic White, and Elizabeth Feinler, "Hostnames
+         Server", RFC 811, NIC, 1 March 1982.
+
+
+Reynolds & Postel                                              [Page 51]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   812 - Harrenstien, Ken, and Vic White, "NICNAME/WHOIS", RFC 812, NIC,
+         1 March 1982.
+
+   813 - Clark, Dave, "Window and Acknowledgement Strategy in TCP",
+         RFC 813, MIT, July 1982.
+
+   814 - Clark, Dave, "Name, Addresses, Ports, and Routes", RFC 814,
+         MIT, July 1982.
+
+   815 - Clark, Dave, "IP Datagram Resassembly Algorithms", RFC 815,
+         MIT, July 1982.
+
+   816 - Clark, Dave, "Fault Isolation and Recovery", RFC 816, MIT,
+         July 1982.
+
+   817 - Clark, Dave, "Modularity and Efficiency in Protocol
+         Implementation", RFC 817, MIT, July 1982.
+
+   818 - Postel, Jon, "The Remote User Telnet Service", RFC 818, ISI,
+         November 1982.
+
+   819 - Su, Zaw-Sing, and Jon Postel, "The Domain Naming Convention for
+         Internet User Applications", RFC 819, SRI, and ISI,
+         August 1982.
+
+   820 - Postel, Jon, and Jim Vernon, "Assigned Numbers", RFC 820, ISI,
+         January 1983.
+
+   821 - Postel, Jon, "Simple Mail Transfer Protocol", RFC 821, ISI,
+         August 1982.
+
+   822 - Crocker, Dave, "Standard for the Format of ARPA-Internet Text
+         Messages", RFC 822, UDEL, 13 August 1982.
+
+   823 - Hinden, Bob, and Alan Sheltzer, "The DARPA Internet Gateway",
+         RFC 823, BBN, September 1982.
+
+   824 - MacGregor, William, and Dan Tappan, "The Cronus Virtual Local
+         Network", RFC 824, BBN, 25 August 1982.
+
+   825 - Postel, Jon, "Request for Comments on Requests for Comments",
+         RFC 825, ISI, November 1982.
+
+   826 - Plummer, Dave, "An Ethernet Address Resolution Protocol - or -
+         Converting Network Protocol Addresses to 48.bit Ethernet
+         Address for Transmission on Ethernet Hardware", RFC 826, MIT,
+         November 1982.
+
+
+
+
+Reynolds & Postel                                              [Page 52]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   827 - Rosen, Eric, "Exterior Gateway Protocol (EGP)", RFC 827, BBN,
+         October 1982.
+
+   828 - Owen, Ken, "Data Communication: IFIP's International `Network'
+         of Experts", RFC 828, IFIP, August 1982.
+
+   829 - Cerf, Vint, "Packet Satellite Technology Reference Sources",
+         RFC 829, DARPA, November 1982.
+
+   830 - Su, Zaw-Sing, "A Distributed System for Internet Name Service",
+         RFC 830, SRI, October 1982.
+
+   831 - Braden, Bob, "Backup Access to the European Side of SATNET",
+         RFC 831, UCL, December 1982.
+
+   832 - Smallberg, Dave, "Who Talks TCP? - Survey of 7-Dec-82",
+         RFC 832, ISI, December 1982.
+
+   833 - Smallberg, Dave, "Who Talks TCP? - Survey of 14-Dec-82",
+         RFC 833, ISI, December 1982.
+
+   834 - Smallberg, Dave, "Who Talks TCP? - Survey of 22-Dec-82",
+         RFC 834, ISI, December 1982.
+
+   835 - Smallberg, Dave, "Who Talks TCP? - Survey of 28-Dec-82",
+         RFC 835, ISI, December 1982.
+
+   836 - Smallberg, Dave, "Who Talks TCP? - Survey of 4-Jan-83",
+         RFC 836, ISI, January 1983.
+
+   837 - Smallberg, Dave, "Who Talks TCP? - Survey of 11-Jan-83",
+         RFC 837, ISI, January 1983.
+
+   838 - Smallberg, Dave, "Who Talks TCP? - Survey of 18-Jan-83",
+         RFC 838, ISI, January 1983.
+
+   839 - Smallberg, Dave, "Who Talks TCP? - Survey of 25-Jan-83",
+         RFC 839, ISI, January 1983.
+
+   840 - Postel, Jon, "Official Protocols", RFC 840, ISI, April 1983.
+
+   841 - National Bureau of Standards, "Specification for Message Format
+         for Computer Based Message Systems", RFC 8401 NBS,
+         27 January 1983.
+
+   842 - Smallberg, Dave, "Who Talks TCP? - Survey of 1-Feb-83",
+         RFC 842, ISI, February 1983.
+
+
+
+
+Reynolds & Postel                                              [Page 53]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   843 - Smallberg, Dave, "Who Talks TCP? - Survey of 8-Feb-83",
+         RFC 843, ISI, February 1983.
+
+   844 - Clements, Robert, "Who Talks ICMP, too? - Survey of 18-Feb-83",
+         RFC 844, February 1983.
+
+   845 - Smallberg, Dave, "Who Talks TCP? - Survey of 15-Feb-83",
+         RFC 845, ISI, February 1983.
+
+   846 - Smallberg, Dave, "Who Talks TCP? - Survey of 22-Feb-83",
+         RFC 846, ISI, February 1983.
+
+   847 - Westine, Ann, "Summary of Smallberg Surveys - February 1983",
+         RFC 847, ISI, February 1983.
+
+   848 - Smallberg, Dave, "Who Provides the Little TCP Services?",
+         RFC 848, ISI, March 1983.
+
+   849 - Crispin, Mark, "Suggestions for Improved Host Table
+         Distribution",  RFC 849, Stanford, May 1983.
+
+   850 - Horton, Mark, "Standard for Interchange of USENET Messages",
+         RFC 850, May 1983.
+
+   851 - Malis, Andrew, "The ARPANET 1822L Host Access Protocol",
+         RFC 851, BBN, April 1983.
+
+   852 - Malis, Andrew, "The ARPANET Short Blocking Feature",  RFC 852,
+         BBN, April 1983.
+
+   853 - Never Issued.
+
+   854 - Postel, Jon, and Joyce Reynolds, "Telnet Protocol
+         Specification", RFC 854, ISI, May 1983.
+
+   855 - Postel, Jon, and Joyce Reynolds, "Telnet Option
+         Specifications", RFC 855, ISI, May 1983.
+
+   856 - Postel, Jon, and Joyce Reynolds, "Telnet Binary Transmission",
+         RFC 856, ISI, May 1983.
+
+   857 - Postel, Jon, and Joyce Reynolds, "Telnet Echo Option", RFC 857,
+         ISI, May 1983.
+
+   858 - Postel, Jon, and Joyce Reynolds, "Telnet Suppress Go Ahead
+         Option", RFC 858, ISI, May 1983.
+
+   859 - Postel, Jon, and Joyce Reynolds, "Telnet Status Option",
+         RFC 859, ISI, May 1983.
+
+
+Reynolds & Postel                                              [Page 54]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   860 - Postel, Jon, and Joyce Reynolds, "Telnet Timing Mark Option",
+         RFC 860, ISI, May 1983.
+
+   861 - Postel, Jon, and Joyce Reynolds, "Telnet Extended Options -
+         List Option", RFC 861, ISI, May 1983.
+
+   862 - Postel, Jon, "Echo Protocol", RFC 862, ISI, May 1983.
+
+   863 - Postel, Jon, "Discard Protocol", RFC 863, ISI, May 1983.
+
+   864 - Postel, Jon, "Character Generator Protocol", RFC 864, ISI,
+         May 1983.
+
+   865 - Postel, Jon, "Quote of the Day Protocol", RFC 865, ISI,
+         May 1983.
+
+   866 - Postel, Jon, "Active Users", RFC 866, ISI, May 1983.
+
+   867 - Postel, Jon, "Daytime Protocol", RFC 867, ISI, May 1983.
+
+   868 - Postel, Jon, and Ken Harrenstien, "Time Protocol", RFC 868,
+         ISI, and SRI, May 1983.
+
+   869 - Hinden, Bob, "A Host Monitoring Protocol", RFC 869, BBN,
+         December 1983.
+
+   870 - Reynolds, Joyce, and Jon Postel, "Assigned Numbers", RFC 870,
+         ISI, October 1983.
+
+   871 - Padlipsky, Mike, "A Perspective on the ARPANET Reference
+         Model", RFC 871, MITRE, September 1982.
+
+   872 - Padlipsky, Mike, "TCP-ON-A-LAN", RFC 872, MITRE,
+         September 1982.
+
+   873 - Padlipsky, Mike, "The Illusion of Vendor Support", RFC 873,
+         MITRE, September 1982.
+
+   874 - Padlipsky, Mike, "A Critique of X.25", RFC 874, MITRE,
+         September 1982.
+
+   875 - Padlipsky, Mike,, "Getways, Architectures, and Heffalumps",
+         RFC 875, MITRE, September 1982.
+
+   876 - Smallberg, Dave, "Survey of SMTP Implementations", RFC 876,
+         ISI, September 1983.
+
+   877 - Korb, John, "A Standard for the Transmission of IP Datagrams
+         Over Public Data Networks", RFC 877, Purdue, September 1983.
+
+
+Reynolds & Postel                                              [Page 55]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   878 - Malis, Andrew, "The ARPANET 1822L Host Access Protocol",
+         RFC 878, BBN, December 1983.
+
+   879 - Postel, Jon, "The TCP Maximum Segment Size and Related Topics",
+         RFC 879, ISI, November 1983.
+
+   880 - Reynolds, Joyce, and Jon Postel, "Official Protocols", RFC 880,
+         ISI, October 1983.
+
+   881 - Postel, Jon, "The Domain Names Plan and Schedule", RFC 881,
+         ISI, November 1983.
+
+   882 - Mockapetris, Paul, "Domain Names - Concepts and Facilities",
+         RFC 882, ISI, November 1983.
+
+   883 - Mockapetris, Paul, "Domain Names - Implementation and
+         Specification", RFC 883, ISI, November 1983.
+
+   884 - Solomon, Marvin, and Edward Wimmers, "Telnet Terminal Type
+         Option", RFC 884, University of Wisconsin - Madison,
+         December 1983.
+
+   885 - Postel, Jon, "Telnet End of Record Option", RFC 885, ISI,
+         December 1983.
+
+   886 - Rose, Marshall, "Proposed Standard for Message Header Munging",
+         RFC 886, UC Irvine, 15 December 1983.
+
+   887 - Accetta, Mike, "Resource Location Protocol", RFC 887, CMU,
+         15 December 1983.
+
+   888 - Seamonson, Linda, and Eric Rosen, "`Stub' Exterior Gateway
+         Protocol", RFC 888, BBN, January 1984.
+
+   889 - Mills, Dave, "Internet Delay Experiments", RFC 889, Linkabit,
+         December 1983.
+
+   890 - Postel, Jon, "Exterior Gateway Protocol Implementation
+         Schedule", RFC 890, ISI, February 1984.
+
+   891 - Mills, Dave, "DCN Local-Network Protocols", RFC 891, Linkabit,
+         December 1983.
+
+   892 - International Standards Organization, "ISO Transport Protocol
+         Specification", RFC 892, ISO, December 1983.
+
+   893 - Leffler, Sam, and Michael Karels, "Trailer Encapsulations",
+         RFC 893, U. C. Berkeley, April 1984.
+
+
+
+Reynolds & Postel                                              [Page 56]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   894 - Hornig, Charles, "A Standard for the Transmission of IP
+         Datagrams over Ethernet Networks", RFC 894, Symbolics,
+         April 1984.
+
+   895 - Postel, Jon, "A Standard for the Transmission of IP Datagrams
+         over Experimental Ethernet Networks", RFC 895, ISI, April 1984.
+
+   896 - Nagle, John, "Congestion Control in IP/TCP Internetworks",
+         RFC 896, FACC, 6 January 1984.
+
+   897 - Postel, Jon, "Domain Name System Implementation Schedule",
+         RFC 897, ISI, February 1984.
+
+   898 - Hinden, Bob, Jon Postel, Mike Muuss, and Joyce Reynolds,
+         "Gateway Special Interest Group Meeting Notes", RFC 898, ISI,
+         April 1984.
+
+   899 - Postel, Jon, and Ann Westine, "Requests for Comments Summary
+         (Notes: 800-899)", RFC 899, ISI, May 1984.
+
+   900 - Reynolds, Joyce, and Jon Postel, "Assigned Numbers", RFC 900,
+         ISI, June 1984.
+
+   901 - Reynolds, Joyce, and Jon Postel, "Official ARPA-Internet
+         Protocols", RFC 901, ISI, June 1984.
+
+   902 - Reynolds, Joyce, and Jon Postel, "ARPA-Internet Protocol
+         Policy", RFC 902, ISI, July 1984.
+
+   903 - Finlayson, Ross, Timothy Mann, Jeffrey Mogul, and Marvin
+         Theimer, "A Reverse Address Resolution Protocol", RFC 903,
+         Stanford, June 1984.
+
+   904 - Mills, Dave, "Exterior Gateway Protocol Formal Specification",
+         RFC 904, BBN, April 1984.
+
+   905 - International Standards Organization, "ISO Transport Protocol
+         Specification", RFC 905, Supercedes RFC 892, ISO, April 1984.
+
+   906 - Finlayson, Ross, "Bootstrap Loading Using TFTP", RFC 906,
+         Stanford, June 1984.
+
+   907 - Bolt Beranek and Newman Laboratories, "Host Access Protocol
+         Specification", RFC 907, DARPA, July 1984.
+
+   908 - Velten, David, Bob Hinden, and Jack Sax, "Reliable Data
+         Protocol", RFC 908, BBN, July 1984.
+
+
+
+
+Reynolds & Postel                                              [Page 57]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   909 - Welles, Christopher, "Loader Debugger Protocol", RFC 909, BBN,
+         July 1984.
+
+   910 - Forsdick, Harry, "Multimedia Mail Meeting Notes", RFC 910, BBN,
+         August 1984.
+
+   911 - Kirton, Paul, "EGP Gateway Under Berkeley UNIX 4.2", RFC 911,
+         ISI, 22 August 1984.
+
+   912 - StJohns, Mike, "Authentication Service", RFC 912, TPSC,
+         September 1984.
+
+   913 - Lottor, Mark, "Simple File Transfer Protocol", RFC 913, MIT,
+         September 1984.
+
+   914 - Farber, Dave, Gary Delp, and Thomas Conte, "A Thinwire Protocol
+         for Connecting Personal Computers to the Internet", RFC 914,
+         UDEL, September 1984.
+
+   915 - Elvy, Marc, and Rudy Nedved, "Network Mail Path Service",
+         RFC 915, Harvard, CMU, December 1984.
+
+   916 - Finn, Greg, "Reliable Asynchronous Transfer Protocol (RATP)",
+         RFC 916, USC/ISI, October 1984.
+
+   917 - Mogul, Jeffrey, "Internet Subnets", RFC 917, Stanford,
+         October 1984.
+
+   918 - Reynolds, Joyce K., "Post Office Protocol", RFC 918, ISI,
+         October 1984.
+
+   919 - Mogul, Jeffrey, "Broadcasting Internet Datagrams", RFC 919,
+         Stanford, October 1984.
+
+   920 - Postel, Jon, and Joyce Reynolds, "Domain Requirements",
+         RFC 920, ISI, October 1984.
+
+   921 - Postel, Jon, "Domain Name System Implementation Schedule -
+         Revised", RFC 921, ISI, October 1984.
+
+   922 - Mogul, Jeffrey, "Broadcasting Internet Datagrams in the
+         Presence of Subnets", RFC 922, Stanford, October 1984.
+
+   923 - Reynolds, Joyce, and Jon Postel, "Assigned Numbers", RFC 923,
+         ISI, October 1984.
+
+   924 - Reynolds, Joyce, and Jon Postel, "Official ARPA-Internet
+         Protocols", RFC 924, ISI, October 1984.
+
+
+
+Reynolds & Postel                                              [Page 58]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   925 - Postel, Jon, "Multi-LAN Address Resolution", RFC 925, ISI,
+         October 1984.
+
+   926 - International Standards Organization, "Protocol for Providing
+         the Connectionless-Mode Network Services", RFC 926, ISO,
+         December 1984.
+
+   927 - Anderson, Brian, "TACACS User Identification Telnet Option",
+         RFC 927, BBN, December 1984.
+
+   928 - Padlipsky, Michael, "Introduction to Proposed DoD Standard
+         H-FP", RFC 928, MITRE, December 1984.
+
+   929 - Lilienkamp, Joel, Richard Mandell, and Mike Padlipsky,
+         "Proposed HOST-FRONT END Protocol", RFC 929, SDC and MITRE,
+         December 1984.
+
+   930 - Solomon, Marvin, and Edward Wimmers, "Telnet Terminal Type
+         Option", RFC 930, University of Wisconsin - Madison,
+         January 1985.
+
+   931 - StJohns, Mike, "Authentication Server", RFC 931, TPSC,
+         January 1985.
+
+   932 - Clark, Dave, "A Subnetwork Addressing Scheme", RFC 932,
+         MIT/LCS, January 1985.
+
+   933 - Silverman, Steve, "Output Marking Telnet Option", RFC 933,
+         MITRE, January 1985.
+
+   934 - Rose, Marshall, and Einar Stefferud, "Proposed Standard for
+         Message Encapsulation", RFC 934, Delaware and NMA,
+         January 1985.
+
+   935 - Robinson, John, "Reliable Link Layer Protocols", RFC 935, BBN,
+         January 1985.
+
+   936 - Karels, Mike, "Another Internet Subnet Addressing Scheme",
+         RFC 936, UCB, February 1985.
+
+   937 - Butler, Michael, Jon Postel, Dale Chase, Joel Goldberger, and
+         Joyce K. Reynolds, "Post Office Protocol - Version 2", RFC 937,
+         ISI, February 1985.
+
+   938 - Miller, Trudy, "Internet Reliable Transaction Protocol
+         Functional and Interface Specification", RFC 938, ACC,
+         February 1985.
+
+
+
+
+Reynolds & Postel                                              [Page 59]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   939 - National Research Council, "Executive Summary of the NRC Report
+         on Transport Protocols for Department of Defense Data
+         Networks", RFC 939, NRC, February 1985.
+
+   940 - Gateway Algorithms and Data Structures (GADS) Task Force,
+         "Toward an Internet Standard Scheme for Subnetting", RFC 940,
+         GADS, April 1985.
+
+   941 - International Standards Organization, "Addendum to the Network
+         Service Definition Covering Network Layer Addressing", RFC 941,
+         ISO, April 1985.
+
+   942 - National Research Council, "Transport Protocols for Department
+         of Defense Data Networks", RFC 942, NRC, February 1985.
+
+   943 - Reynolds, Joyce, and Jon Postel, "Assigned Numbers", RFC 943,
+         ISI, April 1985.
+
+   944 - Reynolds, Joyce, and Jon Postel, "ARPA-Internet Official
+         Protocols", RFC 944, ISI, April 1985.
+
+   945 - Postel Jon, "A DoD Statement on the NRC Report", RFC 945, ISI,
+         May 1985.
+
+   946 - Nedved, Rudy, "Telnet Teminal Location Number Option", RFC 946,
+         CMU, May 1985.
+
+   947 - Lebowitz, Ken, and David Mankins, "Multi-network Broadcasting
+         within the Internet", RFC 947, BBN, June 1985.
+
+   948 - Winston, Ira, "Two Methods for the Transmission of IP Datagrams
+         Over IEEE 802.3 Networks", RFC 948, University of Pennsylvania,
+         June 1985.
+
+   949 - Padlipsky, Michael, "FTP Unique-Named Store Command", RFC 949,
+         MITRE, July 1985.
+
+   950 - Mogul, Jeff, and Jon Postel, "Internet Standard Subnetting
+         Procedure", RFC 950, ISI, August 1985.
+
+   951 - Croft, Bill, and John Gilmore, "BOOTSTRAP Protocol (BOOTP)",
+         RFC 951, Stanford and SUN Microsystems, September 1985.
+
+   952 - Harrenstien, Ken, Mary Stahl, and Elizabeth Feinler, "DoD
+         Internet Host Table Specification", RFC 952, SRI, October 1985.
+
+   953 - Harrenstien, Ken, Mary Stahl, and Elizabeth Feinler, "HOSTNAME
+         Serve", RFC 953, SRI, October 1985.
+
+
+
+Reynolds & Postel                                              [Page 60]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   954 - Harrenstien, Ken, Mary Stahl, and Elizabeth Feinler,
+         "NICNAME/WHOIS", RFC 954, SRI, October 1985.
+
+   955 - Braden, Bob, "Towards a Transport Service for Transaction
+         Processing Applications", RFC 955, UCLA/OAC, September 1985.
+
+   956 - Mills, Dave, "Algorithms for Synchronizing Network Clocks",
+         RFC 956, Linkabit, September 1985.
+
+   957 - Mills, Dave, "Experiments in Network Clock Synchronization",
+         RFC 957, Linkabit, September 1985.
+
+   958 - Mills, Dave, "Network Time Protocol (NTP)", RFC 958, Linkabit,
+         September 1985.
+
+   959 - Postel, Jon, and Joyce Reynolds, "File Transfer Protocol
+         (FTP)", RFC 959, ISI, October 1985.
+
+   960 - Reynolds Joyce, and Jon Postel, "Assigned Numbers", RFC 960,
+         ISI, December 1985.
+
+   961 - Reynolds Joyce, and Jon Postel, "Official ARPA-Internet
+         Protocols", RFC 961, ISI, December 1985.
+
+   962 - Padlipsky, Michael, "TCP-4 Prime", RFC 962, MITRE,
+         November 1985.
+
+   963 - Sidhu, Deepinder P., "Some Problems with the Specification of
+         the Military Standard Internet Protocol", RFC 963, Iowa State,
+         November 1985.
+
+   964 - Sidhu, Deepinder P., and Thomas P. Blumer, "Some Problems with
+         the Specification of the Military Standard Transmission Control
+         Protocol", RFC 964, SDC, November 1985.
+
+   965 - Aguilar, Lorenzo, "A Format for a Graphical Communication
+         Protocol", RFC 965, SRI, December 1985.
+
+   966 - Deering, S. E., and D. T. Cheriton, "Host Groups: A Multicast
+         Extension to the Internet Protocol", RFC 966, Stanford
+         University, December 1985.
+
+   967 - Padlipsky, Michael, "All Victims Together", RFC 967, MITRE,
+         December 1985.
+
+   968 - Cerf, Vint, "'Twas the Night Before Start-up", RFC 968, MCI,
+         December 1985.
+
+
+
+
+Reynolds & Postel                                              [Page 61]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   969 - Clark, David D., Lambert, Mark L. and Lixia Zhang, "NETBLT: A
+         Bulk Data Transfer Protocol", RFC 969, MIT, December 1985.
+
+   970 - Nagle, John, "On Packet Switches With Infinite Storage",
+         RFC 970, FACC Palo Alto, December 1985.
+
+   971 - DeSchon, Annette L., "A Survey of Data Representation
+         Standards", RFC 971, ISI, January 1986.
+
+   972 - Wancho, Frank, "Password Generator Protocol", RFC 972, WSMR,
+         January 1986.
+
+   973 - Mockapetris, Paul, "Domain System Changes and Observations",
+         RFC 973, ISI, January 1986.
+
+   974 - Partridge, Craig, "Mail Routing and the Domain System",
+         RFC 974, CSNET CIC BBN, January 1986.
+
+   975 - Mills, Dave, "Autonomous Confederations", RFC 975, M/A-COM
+         Linkabit, February 1986.
+
+   976 - Horton, Mark R., "UUCP Mail Interchange Format Standard",
+         RFC 976, Bell Labs, February 1986.
+
+   977 - Kantor, Brian, and Phil Lapsley, "Network News Transfer
+         Protocol", RFC 977, UC San Diego & UC Berkeley, February 1986.
+
+   978 - Reynolds, Joyce K., Richard Gillmann, William A. Brackenridge,
+         Andrew Witkowski, and Jon Postel, "Voice File Interchange
+         Protocol (VFIP)", RFC 978, ISI, Inner Loop, and Alembic,
+         February 1986.
+
+   979 - Malis, Andrew G., "PSN End-to-End Functional Specification
+         (EE)", RFC 979, BBN Communications, March 1986.
+
+   980 - Jacobsen, Ole and Jon Postel, "Protocol Document Order
+         Information", RFC 980, SRI and ISI, March 1986.
+
+   981 - Mills, Dave, "An Experimental Multiple-Path Routing Algorithm",
+         RFC 981, M/A-COM Linkabit, March 1986.
+
+   982 - ANSI, "Guidelines for the Specification of the Structure of the
+         Domain Specific Part (DSP) of the ISO Standard NSAP Address",
+         RFC 982, ANSI Working Document X3S3.3/85-258, ANSI, April 1986.
+
+   983 - Cass, D. E., and M. T. Rose, "ISO Transport Services on Top of
+         the TCP", RFC 983, NTRC, April 1986.
+
+
+
+
+Reynolds & Postel                                              [Page 62]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   984 - Clark, David, and Mark Lambert, "PCMAIL: A Distributed Mail
+         System for Personal Computers", RFC 984, MIT, May 1986.
+
+   985 - Mills, Dave, "Requirements for Internet Gateways - Draft",
+         RFC 985, NTAG/NSF, May 1986.
+
+   986 - Callon, Ross, and Hans-Werner Braun, "Working Draft -
+         Guidelines for the Use of Internet-IP Addresses in the ISO
+         Connectionless-Mode Network Protocol", RFC 986, BBN and UMICH,
+         June 1986.
+
+   987 - Kille, S.E., "Mapping Between X.400 and RFC 822", RFC 987, UCL,
+         June 1986.
+
+   988 - Deering, S.E., "Host Extensions for IP Multicasting", RFC 988,
+         Stanford, July 1986.
+
+   989 - Linn, John, "Privacy Enhancement for Internet Electronic Mail:
+         Part I: Message Encipherment and Authentication Procedures",
+         IAB Privacy Task Force, February 1987.
+
+   990 - Reynolds, Joyce, and Jon Postel, "Assigned Numbers", RFC 990,
+         ISI, November 1986.
+
+   991 - Reynolds, Joyce, and Jon Postel, "Official ARPA-Internet
+         Protocols", RFC 991, ISI, November 1986.
+
+   992 - Birman, K. P., and T. A. Joseph, "On Communication Support for
+         Fault Tolerant Process Groups", RFC 992, Cornell,
+         November 1986.
+
+   993 - Clark, David D., and Mark L. Lambert, "PCMAIL: A Distributed
+         Mail System for Personal Computers", RFC 993, MIT,
+         December 1986.
+
+   994 - ANSI, "Final Text of DIS 8473, Protocol For Providing the
+         Connectionless Mode Network Service", RFC 994, ISO, March 1986.
+
+   995 - ANSI, "TSO/TC 97/SC 6, Telecommunications and Information
+         Exchange Between Systems", RFC 995, ISO, April 1986.
+
+   996 - Mills, David L., "Statistics Server", RFC 996, University of
+         Delaware, February 1987.
+
+   997 - Reynolds, Joyce, and Jon Postel, "Internet Numbers", RFC 997,
+         ISI, March 1987.
+
+   998 - Clark, David D., Mark L. Lambert, and Lixia Zhang, "NETBLT: A
+         Bulk Data Transfer Protocol", RFC 998, MIT, March 1987.
+
+
+Reynolds & Postel                                              [Page 63]
+
+
+
+RFC 1012 - Bibliography of RFCs 1 - 999                        June 1987
+
+
+   999 - Westine, Ann, and Jon Postel, "Request For Comments Summary
+         Notes: 900-999", RFC 999, ISI, April 1987.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 64]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1012.txt](<www.ietf.org/rfc/rfc1012.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
