### PR TITLE
Archive rfc104.txt

### DIFF
--- a/www.ietf.org/rfc/rfc104.txt
+++ b/www.ietf.org/rfc/rfc104.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+NIC # 5768                                             J. Postel
+                                                       C. Crocker
+Network Working Group                                  UCLA
+Request for Comments: #104                             Computer Science
+                                                       25 February 71
+
+                                Link 191
+
+At the Network meeting at the University of Illinois, it was agreed to
+reserve a link for use in measurements. The link chosen was the highest
+unassigned link which was incorrectly calculated to be number 223. The
+correct number is 191. Therefore, Link 191 will be assigned for
+measurement use. Use of this link should be cleared with the Liasion
+Officer at the Network Measurement Center (NMC).
+
+       [ This RFC was put into machine readable form for entry ]
+        [ into the online RFC archives by Thomas Nielsen 4/97 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc104.txt](<www.ietf.org/rfc/rfc104.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
