### PR TITLE
Archive rfc1060.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1060.txt
+++ b/www.ietf.org/rfc/rfc1060.txt
@@ -1,0 +1,4819 @@
+
+
+
+
+
+
+Network Working Group                                        J. Reynolds
+Request for Comments: 1060                                     J. Postel
+Obsoletes RFCs: 1010, 990, 960, 943, 923, 900, 870,                  ISI
+820, 790, 776, 770, 762, 758,755, 750, 739, 604,              March 1990
+503, 433, 349
+Obsoletes IENs: 127, 117, 93
+
+                            ASSIGNED NUMBERS
+
+STATUS OF THIS MEMO
+
+   This memo is a status report on the parameters (i.e., numbers and
+   keywords) used in protocols in the Internet community.  Distribution
+   of this memo is unlimited.
+
+                             Table of Contents
+
+INTRODUCTION.................................................... 2
+Data Notations.................................................. 3
+Special Addresses............................................... 4
+VERSION NUMBERS................................................. 6
+PROTOCOL NUMBERS................................................ 7
+PORT NUMBERS.................................................... 9
+UNIX PORTS......................................................13
+INTERNET MULTICAST ADDRESSES....................................19
+IANA ETHERNET ADDRESS BLOCK.....................................20
+IP TOS PARAMETERS...............................................21
+IP TIME TO LIVE PARAMETER.......................................23
+DOMAIN SYSTEM PARAMETERS........................................24
+BOOTP PARAMETERS................................................25
+NETWORK MANAGEMENT PARAMETERS...................................26
+ARPANET AND MILNET LOGICAL ADDRESSES............................30
+ARPANET AND MILNET LINK NUMBERS.................................31
+ARPANET AND MILNET X. 25 ADDRESS MAPPINGS.......................32
+IEEE 802 NUMBERS OF INTEREST....................................34
+ETHERNET NUMBERS OF INTEREST....................................35
+ETHERNET VENDOR ADDRESS COMPONENTS..............................38
+ETHERNET MULTICAST ADDRESSES....................................41
+XNS PROTOCOL TYPES..............................................43
+PROTOCOL/TYPE FIELD ASSIGNMENTS.................................44
+PRONET 80 TYPE NUMBERS..........................................45
+ADDRESS RESOLUTION PROTOCOL PARAMETERS..........................46
+REVERSE ADDRESS RESOLUTION PROTOCOL OPERATION CODES.............47
+DYNAMIC REVERSE ARP.............................................47
+X.25 TYPE NUMBERS...............................................48
+PUBLIC DATA NETWORK NUMBERS.....................................49
+TELNET OPTIONS..................................................51
+MAIL ENCRYPTION TYPES...........................................52
+
+
+
+Reynolds & Postel                                               [Page 1]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+MACHINE NAMES...................................................53
+SYSTEM NAMES....................................................57
+PROTOCOL AND SERVICE NAMES......................................58
+TERMINAL TYPE NAMES.............................................62
+DOCUMENTS.......................................................65
+PEOPLE..........................................................76
+Security Considerations.........................................86
+Authors' Addresses..............................................86
+
+INTRODUCTION
+
+   This Network Working Group Request for Comments documents the
+   currently assigned values from several series of numbers used in
+   network protocol implementations.  This RFC will be updated
+   periodically, and in any case current information can be obtained from
+   the Internet Assigned Numbers Authority (IANA).  If you are developing
+   a protocol or application that will require the use of a link, socket,
+   port, protocol, etc., please contact the IANA to receive a number
+   assignment.
+
+   Joyce K. Reynolds
+   Internet Assigned Numbers Authority
+   USC - Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, California  90292-6695
+
+   Phone: (213) 822-1511
+
+   Electronic mail: JKREY@ISI.EDU
+
+   Most of the protocols mentioned here are documented in the RFC series
+   of notes.  Some of the items listed are undocumented.  Further
+   information on protocols can be found in the memo "Official Internet
+   Protocols" [118].  The more prominent and more generally used are
+   documented in the "DDN Protocol Handbook, Volume Two, DARPA Internet
+   Protocols" [45] prepared by the NIC.  Other collections of older or
+   obsolete protocols are contained in the "Internet Protocol Transition
+   Workbook" [76], or in the "ARPANET Protocol Transition Handbook"
+   [47].  For further information on ordering the complete 1985 DDN
+   Protocol Handbook, write: SRI International (SRI-NIC), DDN Network
+   Information Center, Room EJ291, 333 Ravenswood Avenue, Menlo Park,
+   CA., 94025; or call: 1-800-235-3155.  Also, the Internet Activities
+   Board (IAB) publishes the "IAB Official Protocol Standards" [62],
+   which describes the state of standardization of protocols used in the
+   Internet.  This document is issued quarterly.  Current copies may be
+   obtained from the DDN Network Information Center or from the IANA.
+
+   In the entries below, the name and mailbox of the responsible
+
+
+
+Reynolds & Postel                                               [Page 2]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   individual is indicated.  The bracketed entry, e.g., [nn,iii], at the
+   right hand margin of the page indicates a reference for the listed
+   protocol, where the number ("nn") cites the document and the letters
+   ("iii") cites the person.  Whenever possible, the letters are a NIC
+   Ident as used in the WhoIs (NICNAME) service.
+
+Data Notations
+
+   The convention in the documentation of Internet Protocols is to
+   express numbers in decimal and to picture data in "big-endian" order
+   [21].  That is, fields are described left to right, with the most
+   significant octet on the left and the least significant octet on the
+   right.
+
+   The order of transmission of the header and data described in this
+   document is resolved to the octet level.  Whenever a diagram shows a
+   group of octets, the order of transmission of those octets is the
+   normal order in which they are read in English.  For example, in the
+   following diagram the octets are transmitted in the order they are
+   numbered.
+
+
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |       1       |       2       |       3       |       4       |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |       5       |       6       |       7       |       8       |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |       9       |      10       |      11       |      12       |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                        Transmission Order of Bytes
+
+   Whenever an octet represents a numeric quantity the left most bit in
+   the diagram is the high order or most significant bit.  That is, the
+   bit labeled 0 is the most significant bit.  For example, the
+   following diagram represents the value 170 (decimal).
+
+
+                             0 1 2 3 4 5 6 7
+                            +-+-+-+-+-+-+-+-+
+                            |1 0 1 0 1 0 1 0|
+                            +-+-+-+-+-+-+-+-+
+
+                           Significance of Bits
+
+   Similarly, whenever a multi-octet field represents a numeric quantity
+
+
+
+Reynolds & Postel                                               [Page 3]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   the left most bit of the whole field is the most significant bit.
+   When a multi-octet quantity is transmitted the most significant octet
+   is transmitted first.
+
+Special Addresses:
+
+   There are five classes of IP addresses:  Class A through Class E
+   [119].  Of these, Class D and Class E addresses are reserved for
+   experimental use.  A gateway which is not participating in these
+   experiments must ignore all datagrams with a Class D or Class E
+   destination IP address.  ICMP Destination Unreachable or ICMP
+   Redirect messages must not result from receiving such datagrams.
+
+   There are certain special cases for IP addresses [11].  These special
+   cases can be concisely summarized using the earlier notation for an
+   IP address:
+
+         IP-address ::=  { <Network-number>, <Host-number> }
+
+            or
+
+         IP-address ::=  { <Network-number>, <Subnet-number>,
+                                                         <Host-number> }
+
+   if we also use the notation "-1" to mean the field contains all 1
+   bits.  Some common special cases are as follows:
+
+         (a)   {0, 0}
+
+            This host on this network.  Can only be used as a source
+            address (see note later).
+
+         (b)   {0, <Host-number>}
+
+            Specified host on this network.  Can only be used as a
+            source address.
+
+         (c)   { -1, -1}
+
+            Limited broadcast.  Can only be used as a destination
+            address, and a datagram with this address must never be
+            forwarded outside the (sub-)net of the source.
+
+         (d)   {<Network-number>, -1}
+
+            Directed broadcast to specified network.  Can only be used
+            as a destination address.
+
+
+
+
+Reynolds & Postel                                               [Page 4]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+         (e)   {<Network-number>, <Subnet-number>, -1}
+
+            Directed broadcast to specified subnet.  Can only be used as
+            a destination address.
+
+         (f)   {<Network-number>, -1, -1}
+
+            Directed broadcast to all subnets of specified subnetted
+            network.  Can only be used as a destination address.
+
+         (g)   {127, <any>}
+
+            Internal host loopback address.  Should never appear outside
+            a host.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                               [Page 5]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                              VERSION NUMBERS
+
+   In the Internet Protocol (IP) [45,105] there is a field to identify
+   the version of the internetwork general protocol.  This field is 4
+   bits in size.
+
+   Assigned Internet Version Numbers
+
+      Decimal   Keyword    Version                            References
+      -------   -------    -------                            ----------
+          0                Reserved                                [JBP]
+        1-3                Unassigned                              [JBP]
+          4       IP       Internet Protocol                   [105,JBP]
+          5       ST       ST Datagram Mode                     [49,JWF]
+        6-14               Unassigned                              [JBP]
+          15               Reserved                                [JBP]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                               [Page 6]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                               PROTOCOL NUMBERS
+
+   In the Internet Protocol (IP) [45,105] there is a field, called
+   Protocol, to identify the the next level protocol.  This is an 8 bit
+   field.
+
+   Assigned Internet Protocol Numbers
+
+      Decimal    Keyword     Protocol                         References
+      -------    -------     --------                         ----------
+           0                 Reserved                              [JBP]
+           1     ICMP        Internet Control Message           [97,JBP]
+           2     IGMP        Internet Group Management          [43,JBP]
+           3     GGP         Gateway-to-Gateway                  [60,MB]
+           4                 Unassigned                            [JBP]
+           5     ST          Stream                             [49,JWF]
+           6     TCP         Transmission Control              [106,JBP]
+           7     UCL         UCL                                    [PK]
+           8     EGP         Exterior Gateway Protocol        [123,DLM1]
+           9     IGP         any private interior gateway          [JBP]
+          10     BBN-RCC-MON BBN RCC Monitoring                    [SGC]
+          11     NVP-II      Network Voice Protocol             [22,SC3]
+          12     PUP         PUP                               [8,XEROX]
+          13     ARGUS       ARGUS                                [RWS4]
+          14     EMCON       EMCON                                 [BN7]
+          15     XNET        Cross Net Debugger                [56,JFH2]
+          16     CHAOS       Chaos                                 [NC3]
+          17     UDP         User Datagram                     [104,JBP]
+          18     MUX         Multiplexing                       [23,JBP]
+          19     DCN-MEAS    DCN Measurement Subsystems           [DLM1]
+          20     HMP         Host Monitoring                    [59,RH6]
+          21     PRM         Packet Radio Measurement              [ZSU]
+          22     XNS-IDP     XEROX NS IDP                    [133,XEROX]
+          23     TRUNK-1     Trunk-1                              [BWB6]
+          24     TRUNK-2     Trunk-2                              [BWB6]
+          25     LEAF-1      Leaf-1                               [BWB6]
+          26     LEAF-2      Leaf-2                               [BWB6]
+          27     RDP         Reliable Data Protocol            [138,RH6]
+          28     IRTP        Internet Reliable Transaction      [79,TXM]
+          29     ISO-TP4     ISO Transport Protocol Class 4    [63,RC77]
+          30     NETBLT      Bulk Data Transfer Protocol       [20,DDC1]
+          31     MFE-NSP     MFE Network Services Protocol    [124,BCH2]
+          32     MERIT-INP   MERIT Internodal Protocol             [HWB]
+          33     SEP         Sequential Exchange Protocol        [JC120]
+          34     3PC         Third Party Connect Protocol         [SAF3]
+       35-60                 Unassigned                            [JBP]
+          61                 any host internal protocol            [JBP]
+          62     CFTP        CFTP                              [50,HCF2]
+
+
+
+Reynolds & Postel                                               [Page 7]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+          63                 any local network                     [JBP]
+          64     SAT-EXPAK   SATNET and Backroom EXPAK             [SHB]
+          65                 Unassigned                            [JBP]
+          66     RVD         MIT Remote Virtual Disk Protocol      [MBG]
+          67     IPPC        Internet Pluribus Packet Core         [SHB]
+          68                 any distributed file system           [JBP]
+          69     SAT-MON     SATNET Monitoring                     [SHB]
+          70     VISA        VISA Protocol                        [GXT1]
+          71     IPCV        Internet Packet Core Utility          [SHB]
+       72-75                 Unassigned                            [JBP]
+          76     BR-SAT-MON  Backroom SATNET Monitoring            [SHB]
+          77     SUN-ND      SUN ND PROTOCOL-Temporary             [WM3]
+          78     WB-MON      WIDEBAND Monitoring                   [SHB]
+          79     WB-EXPAK    WIDEBAND EXPAK                        [SHB]
+          80     ISO-IP      ISO Internet Protocol                 [MTR]
+          81     VMTP        VMTP                                 [DRC3]
+          82     SECURE-VMTP SECURE-VMTP                          [DRC3]
+          83     VINES       VINES                                 [BXH]
+          84     TTP         TTP                                   [JXS]
+          85     NSFNET-IGP  NSFNET-IGP                            [HWB]
+          86     DGP         Dissimilar Gateway Protocol      [74,ML109]
+          87     TCF         TCF                                  [GAL5]
+          88     IGRP        IGRP                               [18,GXS]
+          89     OSPFIGP     OSPFIGP                           [83,JTM4]
+          90     Sprite-RPC  Sprite RPC Protocol               [143,BXW]
+          91     LARP        Locus Address Resolution Protocol     [BXH]
+       92-254                Unassigned                            [JBP]
+          255                Reserved                              [JBP]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                               [Page 8]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                                 PORT NUMBERS
+
+Ports are used in the TCP [45,106] to name the ends of logical
+connections which carry long term conversations.  For the purpose of
+providing services to unknown callers, a service contact port is
+defined.  This list specifies the port used by the server process as its
+contact port.  The contact port is sometimes called the "well-known
+port".
+
+To the extent possible, these same port assignments are used with the
+UDP [46,104].
+
+To the extent possible, these same port assignments are used with the
+ISO-TP4 [64].
+
+The assigned ports use a small portion of the possible port numbers.
+The assigned ports have all except the low order eight bits cleared to
+zero.  The low order eight bits are specified here.
+
+   Port Assignments:
+
+   Decimal   Keyword    Description                         References
+   -------   -------    -----------                         ----------
+     0                  Reserved                                 [JBP]
+     1       TCPMUX     TCP Port Service Multiplexer             [MKL]
+     2-4                Unassigned                               [JBP]
+     5       RJE        Remote Job Entry                      [12,JBP]
+     7       ECHO       Echo                                  [95,JBP]
+     9       DISCARD    Discard                               [94,JBP]
+    11       USERS      Active Users                          [89,JBP]
+    13       DAYTIME    Daytime                               [93,JBP]
+    15                  Unassigned                               [JBP]
+    17       QUOTE      Quote of the Day                     [100,JBP]
+    19       CHARGEN    Character Generator                   [92,JBP]
+    20       FTP-DATA   File Transfer [Default Data]          [96,JBP]
+    21       FTP        File Transfer [Control]               [96,JBP]
+    23       TELNET     Telnet                               [112,JBP]
+    25       SMTP       Simple Mail Transfer                 [102,JBP]
+    27       NSW-FE     NSW User System FE                    [24,RHT]
+    29       MSG-ICP    MSG ICP                               [85,RHT]
+    31       MSG-AUTH   MSG Authentication                    [85,RHT]
+    33       DSP        Display Support Protocol                 [EXC]
+    35                  any private printer server               [JBP]
+    37       TIME       Time                                 [108,JBP]
+    39       RLP        Resource Location Protocol                [MA]
+    41       GRAPHICS   Graphics                             [129,JBP]
+    42       NAMESERVER Host Name Server                      [99,JBP]
+    43       NICNAME    Who Is                               [55,MARY]
+
+
+
+Reynolds & Postel                                               [Page 9]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+    44       MPM-FLAGS  MPM FLAGS Protocol                       [JBP]
+    45       MPM        Message Processing Module [recv]      [98,JBP]
+    46       MPM-SND    MPM [default send]                    [98,JBP]
+    47       NI-FTP     NI FTP                               [134,SK8]
+    49       LOGIN      Login Host Protocol                     [PHD1]
+    51       LA-MAINT   IMP Logical Address Maintenance       [76,AGM]
+    53       DOMAIN     Domain Name Server                 [81,95,PM1]
+    55       ISI-GL     ISI Graphics Language                  [7,RB9]
+    57                  any private terminal access              [JBP]
+    59                  any private file service                 [JBP]
+    61       NI-MAIL    NI MAIL                                [5,SK8]
+    63       VIA-FTP    VIA Systems - FTP                        [DXD]
+    65       TACACS-DS  TACACS-Database Service               [3,KH43]
+    67       BOOTPS     Bootstrap Protocol Server            [36,WJC2]
+    68       BOOTPC     Bootstrap Protocol Client            [36,WJC2]
+    69       TFTP       Trivial File Transfer               [126,DDC1]
+    71       NETRJS-1   Remote Job Service                   [10,RTB3]
+    72       NETRJS-2   Remote Job Service                   [10,RTB3]
+    73       NETRJS-3   Remote Job Service                   [10,RTB3]
+    74       NETRJS-4   Remote Job Service                   [10,RTB3]
+    75                  any private dial out service             [JBP]
+    77                  any private RJE service                  [JBP]
+    79       FINGER     Finger                                [52,KLH]
+    81       HOSTS2-NS  HOSTS2 Name Server                      [EAK1]
+    83       MIT-ML-DEV MIT ML Device                            [DPR]
+    85       MIT-ML-DEV MIT ML Device                            [DPR]
+    87                  any private terminal link                [JBP]
+    89       SU-MIT-TG  SU/MIT Telnet Gateway                    [MRC]
+    91       MIT-DOV    MIT Dover Spooler                        [EBM]
+    93       DCP        Device Control Protocol                 [DT15]
+    95       SUPDUP     SUPDUP                                [27,MRC]
+    97       SWIFT-RVF  Swift Remote Vitural File Protocol       [MXR]
+    98       TACNEWS    TAC News                                [ANM2]
+    99       METAGRAM   Metagram Relay                          [GEOF]
+   101       HOSTNAME   NIC Host Name Server                 [54,MARY]
+   102       ISO-TSAP   ISO-TSAP                              [16,MTR]
+   103       X400       X400                                    [HCF2]
+   104       X400-SND   X400-SND                                [HCF2]
+   105       CSNET-NS   Mailbox Name Nameserver             [127,MS56]
+   107       RTELNET    Remote Telnet Service                [101,JBP]
+   109       POP2       Post Office Protocol - Version 2     [14,JKR1]
+   110       POP3       Post Office Protocol - Version 3     [122,MTR]
+   111       SUNRPC     SUN Remote Procedure Call                [DXG]
+   113       AUTH       Authentication Service              [130,MCSJ]
+   115       SFTP       Simple File Transfer Protocol        [73,MKL1]
+   117       UUCP-PATH  UUCP Path Service                     [44,MAE]
+   119       NNTP       Network News Transfer Protocol        [65,PL4]
+   121       ERPC       Encore Expedited Remote Proc. Call   [132,JXO]
+
+
+
+Reynolds & Postel                                              [Page 10]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   123       NTP        Network Time Protocol                [80,DLM1]
+   125       LOCUS-MAP  Locus PC-Interface Net Map Server   [137,EP53]
+   127       LOCUS-CON  Locus PC-Interface Conn Server      [137,EP53]
+   129       PWDGEN     Password Generator Protocol          [141,FJW]
+   130       CISCO-FNA  CISCO FNATIVE                            [WXB]
+   131       CISCO-TNA  CISCO TNATIVE                            [WXB]
+   132       CISCO-SYS  CISCO SYSMAINT                           [WXB]
+   133       STATSRV    Statistics Service                      [DLM1]
+   134       INGRES-NET INGRES-NET Service                       [MXB]
+   135       LOC-SRV    Location Service                         [JXP]
+   136       PROFILE    PROFILE Naming System                    [LLP]
+   137       NETBIOS-NS NETBIOS Name Service                     [JBP]
+   138       NETBIOS-DGM NETBIOS Datagram Service                [JBP]
+   139       NETBIOS-SSN NETBIOS Session Service                 [JBP]
+   140       EMFIS-DATA EMFIS Data Service                       [GB7]
+   141       EMFIS-CNTL EMFIS Control Service                    [GB7]
+   142       BL-IDM     Britton-Lee IDM                         [SXS1]
+   143       IMAP2      Interim Mail Access Protocol v2          [MRC]
+   144       NEWS       NewS                                     [JAG]
+   145       UAAC       UAAC Protocol                           [DAG4]
+   146       ISO-TP0    ISO-IP0                               [86,MTR]
+   147       ISO-IP     ISO-IP                                   [MTR]
+   148       CRONUS     CRONUS-SUPPORT                       [135,JXB]
+   149       AED-512    AED 512 Emulation Service                [AXB]
+   150       SQL-NET    SQL-NET                                  [MXP]
+   151       HEMS       HEMS                                  [87,CXT]
+   152       BFTP       Background File Transfer Program        [AD14]
+   153       SGMP       SGMP                                  [37,MS9]
+   154       NETSC-PROD NETSC                                   [SH37]
+   155       NETSC-DEV  NETSC                                   [SH37]
+   156       SQLSRV     SQL Service                              [CMR]
+   157       KNET-CMP   KNET/VM Command/Message Protocol    [77,GSM11]
+   158       PCMail-SRV PCMail Server                         [19,MXL]
+   159       NSS-Routing NSS-Routing                             [JXR]
+   160       SGMP-TRAPS SGMP-TRAPS                            [37,MS9]
+   161       SNMP       SNMP                                  [15,MTR]
+   162       SNMPTRAP   SNMPTRAP                              [15,MTR]
+   163       CMIP-Manage CMIP/TCP Manager                     [4,AXB1]
+   164       CMIP-Agent  CMIP/TCP Agent                       [4,AXB1]
+   165       XNS-Courier Xerox                               [144,SXA]
+   166       S-Net      Sirius Systems                           [BXL]
+   167       NAMP       NAMP                                     [MS9]
+   168       RSVD       RSVD                                    [NT12]
+   169       SEND       SEND                                   [WDW11]
+   170       Print-SRV  Network PostScript                       [BKR]
+   171       Multiplex  Network Innovations Multiplex            [KXD]
+   172       CL/1       Network Innovations CL/1                 [KXD]
+   173       Xyplex-MUX Xyplex                                   [BXS]
+
+
+
+Reynolds & Postel                                              [Page 11]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   174       MAILQ      MAILQ                                    [RXZ]
+   175       VMNET      VMNET                                    [CXT]
+   176       GENRAD-MUX GENRAD-MUX                               [RXT]
+   177       XDMCP      X Display Manager Control Protocol      [RWS4]
+   178       NextStep   NextStep Window Server                   [LXH]
+   179       BGP        Border Gateway Protocol                  [KSL]
+   180       RIS        Intergraph                               [DXB]
+   181       Unify      Unify                                    [VXS]
+   182       Unisys-Cam Unisys-Cam                               [GXG]
+   183       OCBinder   OCBinder                                [JXO1]
+   184       OCServer   OCServer                                [JXO1]
+   185       Remote-KIS Remote-KIS                              [RXD1]
+   186       KIS        KIS Protocol                            [RXD1]
+   187       ACI        Application Communication Interface     [RXC1]
+   188       MUMPS      MUMPS                                   [HS23]
+   189       QFT        Queued File Transport                    [WXS]
+   190       GACP       Gateway Access Control Protocol          [PCW]
+   191       Prospero   Prospero                                 [BCN]
+   192       OSU-NMS    OSU Network Monitoring System            [DXK]
+   193       SRMP       Spider Remote Monitoring Protocol        [TXS]
+   194       IRC        Internet Relay Chat Protocol            [JXO2]
+   195       DN6-NLM-AUD DNSIX Network Level Module Audit       [LL69]
+   196       DN6-SMM-RED DNSIX Session Mgt Module Audit Redirect[LL69]
+   197       DLS        Directory Location Service               [SXB]
+   198       DLS-Mon    Directory Location Service Monitor       [SXB]
+   198-200              Unassigned                               [JBP]
+   201       AT-RMTP    AppleTalk Routing Maintenance            [RXC]
+   202       AT-NBP     AppleTalk Name Binding                   [RXC]
+   203       AT-3       AppleTalk Unused                         [RXC]
+   204       AT-ECHO    AppleTalk Echo                           [RXC]
+   205       AT-5       AppleTalk Unused                         [RXC]
+   206       AT-ZIS     AppleTalk Zone Information               [RXC]
+   207       AT-7       AppleTalk Unused                         [RXC]
+   208       AT-8       AppleTalk Unused                         [RXC]
+   209-223              Unassigned                               [JBP]
+   224-241              Reserved                                 [JBP]
+   243       SUR-MEAS   Survey Measurement                    [6,DDC1]
+   245       LINK       LINK                                  [1,RDB2]
+   246       DSP3270    Display Systems Protocol             [39,WJS1]
+   247-255              Reserved                                 [JBP]
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 12]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                                UNIX PORTS
+
+   By convention, ports in the range 256 to 1024 are used for "Unix
+   Standard" services.  Listed here are some of the normal uses of these
+   port numbers.
+
+   Service Name   Port/Protocol   Description
+   ------------   -------------   -----------
+
+   echo            7/tcp
+   discard         9/tcp          sink null
+   systat          11/tcp         users
+   daytime         13/tcp
+   netstat         15/tcp
+   qotd            17/tcp         quote
+   chargen         19/tcp         ttytst source
+   ftp-data        20/tcp
+   ftp             21/tcp
+   telnet          23/tcp
+   smtp            25/tcp         mail
+   time            37/tcp         timserver
+   name            42/tcp         nameserver
+   whois           43/tcp         nicname
+   nameserver      53/tcp         domain
+   apts            57/tcp         any private terminal service
+   apfs            59/tcp         any private file service
+   rje             77/tcp         netrjs
+   finger          79/tcp
+   link            87/tcp         ttylink
+   supdup          95/tcp
+   newacct         100/tcp        [unauthorized use]
+   hostnames       101/tcp        hostname
+   iso-tsap        102/tcp        tsap
+   x400            103/tcp
+   x400-snd        104/tcp
+   csnet-ns        105/tcp        CSNET Name Service
+   pop-2           109/tcp        pop postoffice
+   sunrpc          111/tcp
+   auth            113/tcp        authentication
+   sftp            115/tcp
+   uucp-path       117/tcp
+   nntp            119/tcp        usenet readnews untp
+   ntp             123/tcp        network time protocol
+   statsrv         133/tcp
+   profile         136/tcp
+   NeWS            144/tcp        news
+   print-srv       170/tcp
+   exec            512/tcp        remote process execution;
+
+
+
+Reynolds & Postel                                              [Page 13]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                                  authentication performed using
+                                  passwords and UNIX loppgin names
+   login           513/tcp        remote login a la telnet;
+                                  automatic authentication performed
+                                  based on priviledged port numbers
+                                  and distributed data bases which
+                                  identify "authentication domains"
+   cmd             514/tcp        like exec, but automatic
+                                  authentication is performed as for
+                                  login server
+   printer         515/tcp        spooler
+   efs             520/tcp        extended file name server
+   tempo           526/tcp        newdate
+   courier         530/tcp        rpc
+   conference      531/tcp        chat
+   netnews         532/tcp        readnews
+   uucp            540/tcp        uucpd
+   klogin          543/tcp
+   kshell          544/tcp        krcmd
+   dsf             555/tcp
+   remotefs        556/tcp        rfs server
+   chshell         562/tcp        chcmd
+   meter           570/tcp        demon
+   pcserver        600/tcp        Sun IPC server
+   nqs             607/tcp        nqs
+   mdqs            666/tcp
+   rfile           750/tcp
+   pump            751/tcp
+   qrh             752/tcp
+   rrh             753/tcp
+   tell            754/tcp        send
+   nlogin          758/tcp
+   con             759/tcp
+   ns              760/tcp
+   rxe             761/tcp
+   quotad          762/tcp
+   cycleserv       763/tcp
+   omserv          764/tcp
+   webster         765/tcp
+   phonebook       767/tcp        phone
+   vid             769/tcp
+   rtip            771/tcp
+   cycleserv2      772/tcp
+   submit          773/tcp
+   rpasswd         774/tcp
+   entomb          775/tcp
+   wpages          776/tcp
+   wpgs            780/tcp
+
+
+
+Reynolds & Postel                                              [Page 14]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   mdbs_daemon     800/tcp
+   device          801/tcp
+   maitrd          997/tcp
+   busboy          998/tcp
+   garcon          999/tcp
+   blackjack       1025/tcp       network blackjack
+   bbn-mmc         1347/tcp       multi media conferencing
+   bbn-mmx         1348/tcp       multi media conferencing
+   orasrv          1525/tcp       oracle
+   ingreslock      1524/tcp
+   issd            1600/tcp
+   nkd             1650/tcp
+   dc              2001/tcp
+   mailbox         2004/tcp
+   berknet         2005/tcp
+   invokator       2006/tcp
+   dectalk         2007/tcp
+   conf            2008/tcp
+   news            2009/tcp
+   search          2010/tcp
+   raid-cc         2011/tcp       raid
+   ttyinfo         2012/tcp
+   raid-am         2013/tcp
+   troff           2014/tcp
+   cypress         2015/tcp
+   cypress-stat    2017/tcp
+   terminaldb      2018/tcp
+   whosockami      2019/tcp
+   servexec        2021/tcp
+   down            2022/tcp
+   ellpack         2025/tcp
+   shadowserver    2027/tcp
+   submitserver    2028/tcp
+   device2         2030/tcp
+   blackboard      2032/tcp
+   glogger         2033/tcp
+   scoremgr        2034/tcp
+   imsldoc         2035/tcp
+   objectmanager   2038/tcp
+   lam             2040/tcp
+   interbase       2041/tcp
+   isis            2042/tcp
+   rimsl           2044/tcp
+   dls             2047/tcp
+   dls-monitor     2048/tcp
+   shilp           2049/tcp
+   NSWS            3049/tcp
+   rfa             4672/tcp       remote file access server
+
+
+
+Reynolds & Postel                                              [Page 15]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   commplex-main   5000/tcp
+   commplex-link   5001/tcp
+   padl2sim        5236/tcp
+   man             9535/tcp
+
+   echo            7/udp
+   discard         9/udp          sink null
+   systat          11/udp         users
+   daytime         13/udp
+   netstat         15/udp
+   qotd            17/udp         quote
+   chargen         19/udp         ttytst source
+   time            37/udp         timserver
+   rlp             39/udp         resource
+   name            42/udp         nameserver
+   whois           43/udp         nicname
+   nameserver      53/udp         domain
+   bootps          67/udp         bootp
+   bootpc          68/udp
+   tftp            69/udp
+   sunrpc          111/udp
+   erpc            121/udp
+   ntp             123/udp
+   statsrv         133/udp
+   profile         136/udp
+   snmp            161/udp
+   snmp-trap       162/udp
+   at-rtmp         201/udp
+   at-nbp          202/udp
+   at-3            203/udp
+   at-echo         204/udp
+   at-5            205/udp
+   at-zis          206/udp
+   at-7            207/udp
+   at-8            208/udp
+   biff            512/udp        used by mail system to notify users
+                                  of new mail received; currently
+                                  receives messages only from
+                                  processes on the same machine
+   who             513/udp        maintains data bases showing who's
+                                  logged in to machines on a local
+                                  net and the load average of the
+                                  machine
+   syslog          514/udp
+   talk            517/udp        like tenex link, but across
+                                  machine - unfortunately, doesn't
+                                  use link protocol (this is actually
+                                  just a rendezvous port from which a
+
+
+
+Reynolds & Postel                                              [Page 16]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                                  tcp connection is established)
+   ntalk           518/udp
+   utime           519/udp        unixtime
+   router          520/udp        local routing process (on site);
+                                  uses variant of Xerox NS routing
+                                  information protocol
+   timed           525/udp        timeserver
+   netwall         533/udp        for emergency broadcasts
+   new-rwho        550/udp        new-who
+   rmonitor        560/udp        rmonitord
+   monitor         561/udp
+   meter           571/udp        udemon
+   elcsd           704/udp        errlog copy/server daemon
+   loadav          750/udp
+   vid             769/udp
+   cadlock         770/udp
+   notify          773/udp
+   acmaint_dbd     774/udp
+   acmaint_transd  775/udp
+   wpages          776/udp
+   puparp          998/udp
+   applix          999/udp        Applix ac
+   puprouter       999/udp
+   cadlock         1000/udp
+   hermes          1248/udp
+   wizard          2001/udp       curry
+   globe           2002/udp
+   emce            2004/udp       CCWS mm conf
+   oracle          2005/udp
+   raid-cc         2006/udp       raid
+   raid-am         2007/udp
+   terminaldb      2008/udp
+   whosockami      2009/udp
+   pipe_server     2010/udp
+   servserv        2011/udp
+   raid-ac         2012/udp
+   raid-cd         2013/udp
+   raid-sf         2014/udp
+   raid-cs         2015/udp
+   bootserver      2016/udp
+   bootclient      2017/udp
+   rellpack        2018/udp
+   about           2019/udp
+   xinupageserver  2020/udp
+   xinuexpansion1  2021/udp
+   xinuexpansion2  2022/udp
+   xinuexpansion3  2023/udp
+   xinuexpansion4  2024/udp
+
+
+
+Reynolds & Postel                                              [Page 17]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   xribs           2025/udp
+   scrabble        2026/udp
+   isis            2042/udp
+   isis-bcast      2043/udp
+   rimsl           2044/udp
+   cdfunc          2045/udp
+   sdfunc          2046/udp
+   dls             2047/udp
+   shilp           2049/udp
+   rmonitor_secure 5145/udp
+   xdsxdm          6558/udp
+   isode-dua       17007/udp
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 18]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                       INTERNET MULTICAST ADDRESSES
+
+   Host Extensions for IP Multicasting (RFC-1112) [43] specifies the
+   extensions required of a host implementation of the Internet Protocol
+   (IP) to support multicasting.  Current addresses are listed below.
+
+      224.0.0.0  Reserved                                       [43,JBP]
+      224.0.0.1  All Hosts on this Subnet                       [43,JBP]
+      224.0.0.2  All Gateways on this Subnet (proposed)            [JBP]
+      224.0.0.3  Unassigned                                        [JBP]
+      224.0.0.4  DVMRP    Routers                              [140,JBP]
+      224.0.0.5  OSPFIGP  OSPFIGP All Routers                  [83,JXM1]
+      224.0.0.6  OSPFIGP  OSPFIGP Designated Routers           [83,JXM1]
+      244.0.0.7-244.0.0.255 Unassigned                             [JBP]
+      224.0.1.0  VMTP Managers Group                           [17,DRC3]
+      224.0.1.1  NTP      Network Time Protocol                [80,DLM1]
+      224.0.1.2  SGI-Dogfight                                      [AXC]
+      224.0.1.3  Rwhod                                             [SXD]
+      224.0.1.4  VNP                                              [DRC3]
+      244.0.1.5-244.0.1.255  Unassigned                            [JBP]
+      224.0.2.1  "rwho" Group (BSD) (unofficial)                   [JBP]
+      232.x.x.x  VMTP transient groups                         [17,DRC3]
+
+      Note that when used on an Ethernet or IEEE 802 network, the 23
+      low-order bits of the IP Multicast address are placed in the low-
+      order 23 bits of the Ethernet or IEEE 802 net multicast address
+      1.0.94.0.0.0.  See the next section on "IANA ETHERNET ADDRESS
+      BLOCK".
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 19]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                         IANA ETHERNET ADDRESS BLOCK
+
+   The IANA owns an Ethernet address block which may be used for
+   multicast address asignments or other special purposes.
+
+   The address block in IEEE binary is (which is in bit transmission
+   order):
+
+                       0000 0000 0000 0000 0111 1010
+
+   In the normal Internet dotted decimal notation this is 0.0.94 since
+   the bytes are transmitted higher order first and bits within bytes
+   are transmitted lower order first (see "Data Notation" in the
+   Introduction).
+
+   IEEE CSMA/CD and Token Bus bit transmission order: 00 00 5E
+
+   IEEE Token Ring bit transmission order: 00 00 7A
+
+   Appearance on the wire (bits transmitted from left to right):
+
+       0                           23                            47
+       |                           |                             |
+       1000 0000 0000 0000 0111 1010 xxxx xxx0 xxxx xxxx xxxx xxxx
+       |                                     |
+       Multicast Bit                         0 = Internet Multicast
+                                             1 = Assigned by IANA for
+                                                 other uses
+
+   Appearance in memory (bits transmitted right-to-left within octets,
+   octets transmitted left-to-right):
+
+       0                           23                            47
+       |                           |                             |
+       0000 0001 0000 0000 0101 1110 0xxx xxxx xxxx xxxx xxxx xxxx
+               |                     |
+               Multicast Bit         0 = Internet Multicast
+                                     1 = Assigned by IANA for other uses
+
+   The latter representation corresponds to the Internet standard bit-
+   order, and is the format that most programmers have to deal with.
+   Using this representation, the range of Internet Multicast addresses
+   is:
+
+          01-00-5E-00-00-00  to  01-00-5E-7F-FF-FF  in hex, or
+
+          1.0.94.0.0.0  to  1.0.94.127.255.255  in dotted decimal
+
+
+
+
+Reynolds & Postel                                              [Page 20]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                             IP TOS PARAMETERS
+
+   This documents the default Type-of-Service values that are currently
+   recommended for the most important Internet protocols.
+
+   There are three binary TOS attributes: low delay, high throughput,
+   and high reliability; in each case, an attribute bit is turned on to
+   indicate "better".  The three attributes cannot all be optimized
+   simultanously, and in fact the TOS algorithms that have been
+   discussed tend to make "better" values of the attributes mutually
+   exclusive.  Therefore, the recommended values have at most one bit
+   on.
+
+   Generally, protocols which are involved in direct interaction with a
+   human should select low delay, while data transfers which may involve
+   large blocks of data are need high throughput.  Finally, high
+   reliability is most important for datagram-based Internet management
+   functions.
+
+   Application protocols not included in these tables should be able to
+   make appropriate choice of low delay (1 0 0) or high throughput (0 1
+   0).
+
+   The following are recommended values for TOS:
+
+                  ----- Type-of-Service Value -----
+
+                    Low        High         High
+      Protocol     Delay    Throughput  Reliability
+
+      TELNET (1)    1           0           0
+
+      FTP
+        Control     1           0           0
+        Data (2)    0           1           0
+
+      TFTP          1           0           0
+
+      SMTP  (3)
+        Cmd phase   1           0           0
+        DATA phase  0           1           0
+
+      Domain Name Service
+        UDP Query   1           0           0
+        TCP Query   0           0           0
+        Zone Tnsfr  0           1           0
+
+      NNTP          0           0           0
+
+
+
+Reynolds & Postel                                              [Page 21]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+      ICMP
+        Errors      0           0           0
+        Queries     0           0           0
+
+      Any IGP       0           0           1
+
+      EGP           0           0           0
+
+      SNMP          0           0           1
+
+      BOOTP         0           0           0
+
+      Notes:
+
+      (1)  Includes all interactive user protocols (e.g., rlogin).
+
+      (2)  Includes all bulk data transfer protocols (e.g., rcp).
+
+      (3)  If the implementation does not support changing the TOS
+           during the lifetime of the connection, then the recommended
+           TOS on opening the connection is (0,0,0).
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 22]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                         IP TIME TO LIVE PARAMETER
+
+   The current recommended default TTL for the Internet Protocol (IP)
+   RFC-791 [45,105] is 32.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 23]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                         DOMAIN SYSTEM PARAMETERS
+
+   The Internet Domain Naming System (DOMAIN) includes several
+   parameters.  These are documented in RFC-1034, [81] and RFC-1035
+   [82].  The CLASS parameter is listed here.  The per CLASS parameters
+   are defined in separate RFCs as indicated.
+
+   Domain System Parameters:
+
+      Decimal   Name                                          References
+      -------   ----                                          ----------
+            0   Reserved                                           [PM1]
+            1   Internet (IN)                                   [81,PM1]
+            2   Unassigned                                         [PM1]
+            3   Chaos (CH)                                         [PM1]
+            4   Hessoid (HS)                                       [PM1]
+      5-65534   Unassigned                                         [PM1]
+        65535   Reserved
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 24]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                               BOOTP PARAMETERS
+
+   The Bootstrap Protocol (BOOTP) RFC-951 [36] describes an IP/UDP
+   bootstrap protocol (BOOTP) which allows a diskless client machine to
+   discover its own IP address, the address of a server host, and the
+   name of a file to be loaded into memory and executed.  The BOOTP
+   Vendor Information Extensions RFC-1084 [117] proposes an addition to
+   the Bootstrap Protocol (BOOTP).
+
+   Vendor Extensions are listed below:
+
+      Tag     Name          Data Length    Meaning          References
+      ---     ----          -----------    -------          ----------
+       0      Pad               0          None
+       1      Subnet Mask       4          Subnet Mask Value
+       2      Time Zone         4          Time Offset in
+                                           Seconds from UTC
+       3      Gateways          N          N/4 Gateway addresses
+       4      Time Server       N          N/4 Timeserver addresses
+       5      Name Server       N          N/4 IEN-116 Server addresses
+       6      Domain Server     N          N/4 DNS Server addresses
+       7      Log Server        N          N/4 Logging Server addresses
+       8      Quotes Server     N          N/4 Quotes Server addresses
+       9      LPR Server        N          N/4 Printer Server addresses
+      10      Impress Server    N          N/4 Impress Server addresses
+      11      RLP Server        N          N/4 RLP Server addresses
+      12      Hostname          N          Hostname string
+      13      Boot File Size    2          Size of boot file in 512 byte
+                                           checks
+      14      Merit Dump File              Client to dump and name
+                                           the file to dump it to
+      15-127  Unassigned
+      128-154 Reserved
+      255     End               0          None
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 25]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                       NETWORK MANAGEMENT PARAMETERS
+
+   For the management of hosts and gateways on the Internet a data
+   structure for the information has been defined.  This data structure
+   should be used with any of several possible management protocols, such
+   as the "Simple Network Management Protocol" (SNMP) RFC-1098 [15], or
+   the "Common Management Information Protocol over TCP" (CMOT) [142].
+
+   The data structure is the "Structure and Indentification of Management
+   Information for TCP/IP-based Internets" (SMI) RFC-1065 [120], and the
+   "Management Information Base for Network Management of TCP/IP-based
+   Internets" (MIB) [121].
+
+   The SMI includes the provision for parameters or codes to indicate
+   experimental or private data structures.  These parameter assignments
+   are listed here.
+
+   The older "Simple Gateway Monitoring Protocol" (SGMP) RFC-1028 [37]
+   also defined a data structure.  The parameter assignments used with
+   SGMP are included here for hist orical completeness.
+
+   SMI Network Management Experimental Codes:
+
+      Prefix: 1.3.6.1.3.
+
+      Decimal   Name          Description                     References
+      -------   ----          -----------                     ----------
+            0   Reserved                                          [JKR1]
+            1   CLNP          ISO CLNP Objects                     [MTR]
+            2   T1-Carrier    T1 Carrier Objects                   [MTR]
+            3   IEEE8023      Ethernet-like Objects                [MTR]
+            4   IEEE8025      Token Ring-like Objects              [MTR]
+
+   SMI Network Management Private Enterprise Codes:
+
+      Prefix: 1.3.6.1.4.1.
+
+      Decimal   Name                                          References
+      -------   ----                                          ----------
+            0   Reserved                                          [JKR1]
+            1   Proteon                                          [GSM11]
+            2   IBM                                                [JXR]
+            3   CMU                                                [SXW]
+            4   Unix                                               [KXS]
+            5   ACC                                               [AB20]
+            6   TWG                                                [KZM]
+            7   CAYMAN                                            [BP52]
+            8   NYSERNET                                           [MS9]
+
+
+
+Reynolds & Postel                                              [Page 26]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+            9   cisco                                              [GXS]
+           10   NSC                                              [GS123]
+           11   HP                                                [RDXS]
+           12   Epilogue                                           [KA4]
+           13   U of Tennessee                                   [JDC20]
+           14   BBN                                                [RH6]
+           15   Xylogics, Inc.                                    [JRL3]
+           16   Unisys                                             [UXW]
+           17   Canstar                                            [SXP]
+           18   Wellfleet                                         [JCB1]
+           19   TRW                                               [GGB2]
+           20   MIT                                               [JR35]
+           21   EON                                                [MXW]
+           22   Spartacus                                          [YXK]
+           23   Excelan                                            [RXB]
+           24   Spider Systems                                     [VXW]
+           25   NSFNET                                             [HWB]
+           26   Hughes LAN Systems                                [AXC1]
+           27   Intergraph                                         [SXC]
+           28   Interlan                                          [FJK2]
+           29   Vitalink Communications                            [FXB]
+           30   Ulana                                              [BXA]
+           31   NSWC                                              [SRN1]
+           32   Santa Cruz Operation                              [KR35]
+           33   Xyplex                                             [BXS]
+           34   Cray                                               [HXE]
+           35   Bell Northern Research                             [GXW]
+           36   DEC                                               [RXB1]
+           37   Touch                                              [BXB]
+           38   Network Research Corp.                             [BXV]
+           39   Baylor College of Medicine                        [SB98]
+           40   NMFECC-LLNL                                        [SXH]
+           41   SRI                                              [DW181]
+           42   Sun Microsystems                                   [DXY]
+           43   3Com                                               [TB6]
+           44   CMC                                                [DXP]
+           45   SynOptics                                         [BXB1]
+           46   Cheyenne Software                                  [RXH]
+           47   Prime Computer                                     [MXS]
+           48   MCNC/North Carolina Data Network                   [KXW]
+           49   Chipcom                                            [JXC]
+           50   Optical Data Systems                               [JXF]
+           51   gated                                              [JXH]
+           52   Cabletron Systems                                  [RXD]
+           53   Apollo Computers                                   [JXB]
+           54   DeskTalk Systems, Inc.                             [DXK]
+           55   SSDS                                               [RXS]
+           56   Castle Rock Computing                             [JXS1]
+
+
+
+Reynolds & Postel                                              [Page 27]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+           57   MIPS Computer Systems                              [CXM]
+           58   TGV, Inc.                                          [KAA]
+           59   Silicon Graphics, Inc.                             [RXJ]
+           60   University of British Columbia                     [DXM]
+           61   Merit                                              [BXN]
+           62   FiberCom                                           [EXR]
+           63   Apple Computer Inc                                [JXH1]
+           64   Gandalf                                            [HXK]
+           65   Dartmouth                                          [PXK]
+           66   David Systems                                      [DXM]
+           67   Reuter                                             [BXZ]
+           68   Cornell                                          [DC126]
+           69   TMAC                                             [MLS34]
+           70   Locus Computing Corp.                              [AXS]
+           71   NASA                                              [SS92]
+           72   Retix                                              [AXM]
+           73   Boeing                                             [JXG]
+           74   AT&T                                              [AXC2]
+           75   Ungermann-Bass                                     [DXM]
+           76   Digital Analysis Corp.                             [SXK]
+           77   LAN Manager                                       [JXG1]
+           78   Netlabs                                          [JB478]
+           79   ICL                                                [JXI]
+           80   Auspex Systems                                     [BXE]
+           81   Lannet Company                                     [EXR]
+           82   Network Computing Devices                        [DM280]
+           83   Raycom Systems                                    [BXW1]
+           84   Pirelli Focom Ltd.                                 [SXL]
+           85   Datability Software Systems                        [LXF]
+           86   Network Application Technology                     [YXW]
+           87   LINK (Lokales Informatik-Netz Karlsruhe)           [GXS]
+           88   NYU                                               [BJR2]
+           89   RND                                                [RXN]
+           90   InterCon Systems Corporation                      [AW90]
+
+   SGMP Vendor Specific Codes:
+
+      Prefix: 1,255,
+
+      Decimal   Name                                          References
+      -------   ----                                          ----------
+            0   Reserved                                          [JKR1]
+            1   Proteon                                           [JS18]
+            2   IBM                                                [JXR]
+            3   CMU                                                [SXW]
+            4   Unix                                               [MS9]
+            5   ACC                                               [AB20]
+            6   TWG                                                [MTR]
+
+
+
+Reynolds & Postel                                              [Page 28]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+            7   CAYMAN                                            [BP52]
+            8   NYSERNET                                           [MS9]
+            9   cisco                                              [GS2]
+           10   BBN                                                [RH6]
+           11   Unassigned                                        [JKR1]
+           12   MIT                                               [JR35]
+       13-254   Unassigned                                        [JKR1]
+          255   Reserved                                          [JKR1]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 29]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                     ARPANET AND MILNET LOGICAL ADDRESSES
+
+   The ARPANET facility for "logical addressing" is described in RFC-878
+   [57] and RFC-1005 [109].  A portion of the possible logical addresses
+   are reserved for standard uses.
+
+   There are 49,152 possible logical host addresses.  Of these, 256 are
+   reserved for assignment to well-known functions.  Assignments for
+   well-known functions are made by the IANA.  Assignments for other
+   logical host addresses are made by the NIC.
+
+   Logical Address Assignments:
+
+      Decimal    Description                                  References
+      -------    -----------                                  ----------
+      0          Reserved                                          [JBP]
+      1          The BBN Core Gateways                              [MB]
+      2-254      Unassigned                                        [JBP]
+      255        Reserved                                          [JBP]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 30]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                       ARPANET AND MILNET LINK NUMBERS
+
+   The word "link" here refers to a field in the original ARPANET
+   Host/IMP interface leader.  The link was originally defined as an 8-
+   bit field.  Later specifications defined this field as the "message-
+   id" with a length of 12 bits.  The name link now refers to the high
+   order 8 bits of this 12-bit message-id field.  The Host/IMP interface
+   is defined in BBN Report 1822 [2].
+
+   The low-order 4 bits of the message-id field are called the sub-link.
+   Unless explicitly specified otherwise for a particular protocol,
+   there is no sender to receiver significance to the sub-link.  The
+   sender may use the sub-link in any way he chooses (it is returned in
+   the RFNM by the destination IMP), the receiver should ignore the
+   sub-link.
+
+   Link Assignments:
+
+      Decimal   Description                                   References
+      -------   -----------                                   ----------
+      0-63      BBNCC Monitoring                                    [MB]
+      64-149    Unassigned                                         [JBP]
+      150       Xerox NS IDP                                 [133,XEROX]
+      151       Unassigned                                         [JBP]
+      152       PARC Universal Protocol                        [8,XEROX]
+      153       TIP Status Reporting                               [JGH]
+      154       TIP Accounting                                     [JGH]
+      155       Internet Protocol [regular]                    [105,JBP]
+      156-158   Internet Protocol [experimental]               [105,JBP]
+      159       Figleaf Link                                      [JBW1]
+      160       Blacker Local Network Protocol                    [DM28]
+      161-194   Unassigned                                         [JBP]
+      195       ISO-IP                                          [64,RXM]
+      196-247   Experimental Protocols                             [JBP]
+      248-255   Network Maintenance                                [JGH]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 31]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                   ARPANET AND MILNET X.25 ADDRESS MAPPINGS
+
+   All MILNET hosts are assigned addresses by the Defense Data Network
+   (DDN).  The address of a MILNET host may be obtained from the Network
+   Information Center (NIC), represented as an ASCII text string in what
+   is called "host table format".  This section describes the process by
+   which MILNET X.25 addresses may be derived from addresses in the NIC
+   host table format.
+
+   A NIC host table address consists of the ASCII text string
+   representations of four decimal numbers separated by periods,
+   corresponding to the four octeted of a thirty-two bit Internet
+   address.  The four decimal numbers are referred to in this section as
+   "n", "h' "l", and "i".  Thus, a host table address may be represented
+   as: "n.h.l.i".  Each of these four numbers will have either one, two,
+   or three decimal digits and will never have a value greater than 255.
+   For example, in the host table, address: "10.2.0.124", n=10, h=2,
+   l=0, and i=124.  To convert a host table address to a MILNET X.25
+   address:
+
+      1.  If h < 64, the host table address corresponds to the X.25
+      physical address:
+
+                             ZZZZ F IIIHHZZ (SS)
+
+      where:
+
+           ZZZZ = 0000    as required
+
+           F = 0          because the address is a physical address;
+
+           III            is a three decimal digit respresentation of
+                          "i", right-adjusted and padded with leading
+                          zeros if required;
+
+           HH             is a two decimal digit representation of "h",
+                          right-adjusted and padded with leading zeros
+                          if required;
+
+           ZZ = 00        and
+
+           (SS)           is optional
+
+      In the example given above, the host table address 10.2.0.124
+      corresponds to the X.25 physical address 000001240200.
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 32]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   2.  If h > 64 or h = 64, the host table address corresponds to the
+   X.25 logical address
+
+                            ZZZZ F RRRRRZZ (SS)
+
+   where:
+
+        ZZZZ = 0000    as required
+
+        F = 1          because the address is a logical address;
+
+        RRRRR          is a five decimal digit representation of
+                       the result "r" of the calculation
+
+                                r = h * 256 + i
+
+                       (Note that the decimal representation of
+                       "r" will always require five digits);
+
+        ZZ = 00        and
+
+        (SS)           is optional
+
+      Thus, the host table address 10.83.0.207 corresponds to the X.25
+      logical address 000012145500.
+
+   In both cases, the "n" and "l" fields of the host table address are
+   not used.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 33]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                       IEEE 802 NUMBERS OF INTEREST
+
+   Some of the networks of all classes are IEEE 802 Networks.  These
+   systems may use a Link Service Access Point (LSAP) field in much the
+   same way the ARPANET uses the "link" field.  Further, there is an
+   extension of the LSAP header called the Sub-Network Access Protocol
+   (SNAP).
+
+   The IEEE likes to describe numbers in binary in bit transmission
+   order, which is the opposite of the big-endian order used throughout
+   the Internet protocol documentation.
+
+   Assignments:
+
+      Link Service Access Point   Description                References
+      -------------------------   -----------                ----------
+      IEEE     Internet
+      binary   binary    decimal
+      00000000 00000000        0   Null LSAP                      [IEEE]
+      01000000 00000010        2   Indiv LLC Sublayer Mgt         [IEEE]
+      11000000 00000011        3   Group LLC Sublayer Mgt         [IEEE]
+      00100000 00000100        4   SNA Path Control               [IEEE]
+      01100000 00000110        6   Reserved (DOD IP)           [104,JBP]
+      01110000 00001110       14   PROWAY-LAN                     [IEEE]
+      01110010 01001110       78   EIA-RS 511                     [IEEE]
+      01111010 01011110       94   ISI IP                          [JBP]
+      01110001 10001110      142   PROWAY-LAN                     [IEEE]
+      01010101 10101010      170   SNAP                           [IEEE]
+      01111111 11111110      254   ISO DIS 8473                 [64,JXJ]
+      11111111 11111111      255   Global DSAP                    [IEEE]
+
+   These numbers (and others) are assigned by the IEEE Standards Office.
+   The address is: IEEE Standards Office, 345 East 47th Street, New
+   York, N.Y. 10017, Attn: Vince Condello.  Phone: (212) 705-7092.
+
+   At an ad hoc special session on "IEEE 802 Networks and ARP", held
+   during the TCP Vendors Workshop (August 1986), an approach to a
+   consistent way to send DoD-IP datagrams and other IP related
+   protocols (such as the Address Resolution Protocol (ARP)) on 802
+   networks was developed, using the SNAP extension (see RFC-1010 and
+   RFC-1042 [90]).
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 34]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                       ETHERNET NUMBERS OF INTEREST
+
+   Many of the networks of all classes are Ethernets (10Mb) or
+   Experimental Ethernets (3Mb).  These systems use a message "type"
+   field in much the same way the ARPANET uses the "link" field.
+
+   If you need an Ethernet type, contact the Xerox Corporation, Xerox
+   Systems Institute, 475 Oakmead Parkway, Sunnyvale, CA 94086, Attn:
+   Ms. Fonda Pallone, (408) 737-4652.
+
+   The following list is contributed unverified information from various
+   sources.
+
+   Assignments:
+
+      Ethernet          Exp. Ethernet    Description          References
+      -------------     -------------   -----------           ----------
+      decimal  Hex      decimal  octal
+         000   0000-05DC   -       -    IEEE802.3 Length Field   [XEROX]
+         257   0101-01FF   -       -    Experimental             [XEROX]
+         512   0200        512   1000   XEROX PUP (see 0A00)   [8,XEROX]
+         513   0201        -      -     PUP Addr Trans (see 0A01)[XEROX]
+        1536   0600       1536   3000   XEROX NS IDP         [133,XEROX]
+        2048   0800        513   1001   DOD IP                 [105,JBP]
+        2049   0801        -      -     X.75 Internet            [XEROX]
+        2050   0802        -      -     NBS Internet             [XEROX]
+        2051   0803        -      -     ECMA Internet            [XEROX]
+        2052   0804        -      -     Chaosnet                 [XEROX]
+        2053   0805        -      -     X.25 Level 3             [XEROX]
+        2054   0806        -      -     ARP                     [88,JBP]
+        2055   0807        -      -     XNS Compatability        [XEROX]
+        2076   081C        -      -     Symbolics Private         [DCP1]
+        2184   0888-088A   -      -     Xyplex                   [XEROX]
+        2304   0900        -      -     Ungermann-Bass net debugr[XEROX]
+        2560   0A00        -      -     Xerox IEEE802.3 PUP      [XEROX]
+        2561   0A01        -      -     PUP Addr Trans           [XEROX]
+        2989   0BAD        -      -     Banyan Systems           [XEROX]
+        4096   1000        -      -     Berkeley Trailer nego    [XEROX]
+        4097   1001-100F   -      -     Berkeley Trailer encap/IP[XEROX]
+        5632   1600        -      -     Valid Systems            [XEROX]
+       16962   4242        -      -     PCS Basic Block Protocol [XEROX]
+       21000   5208        -      -     BBN Simnet               [XEROX]
+       24576   6000        -      -     DEC Unassigned (Exp.)    [XEROX]
+       24577   6001        -      -     DEC MOP Dump/Load        [XEROX]
+       24578   6002        -      -     DEC MOP Remote Console   [XEROX]
+       24579   6003        -      -     DEC DECNET Phase IV Route[XEROX]
+       24580   6004        -      -     DEC LAT                  [XEROX]
+       24581   6005        -      -     DEC Diagnostic Protocol  [XEROX]
+
+
+
+Reynolds & Postel                                              [Page 35]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+       24582   6006        -      -     DEC Customer Protocol    [XEROX]
+       24583   6007        -      -     DEC LAVC, SCA            [XEROX]
+       24584   6008-6009   -      -     DEC Unassigned           [XEROX]
+       24586   6010-6014   -      -     3Com Corporation         [XEROX]
+       28672   7000        -      -     Ungermann-Bass download  [XEROX]
+       28674   7002        -      -     Ungermann-Bass dia/loop  [XEROX]
+       28704   7020-7029   -      -     LRT                      [XEROX]
+       28720   7030        -      -     Proteon                  [XEROX]
+       28724   7034        -      -     Cabletron                [XEROX]
+       32771   8003        -      -     Cronus VLN            [131,DT15]
+       32772   8004        -      -     Cronus Direct         [131,DT15]
+       32773   8005        -      -     HP Probe                 [XEROX]
+       32774   8006        -      -     Nestar                   [XEROX]
+       32776   8008        -      -     AT&T                     [XEROX]
+       32784   8010        -      -     Excelan                  [XEROX]
+       32787   8013        -      -     SGI diagnostics            [AXC]
+       32788   8014        -      -     SGI network games          [AXC]
+       32789   8015        -      -     SGI reserved               [AXC]
+       32780   8016        -      -     SGI bounce server          [AXC]
+       32783   8019        -      -     Apollo Computers         [XEROX]
+       32815   802E        -      -     Tymshare                 [XEROX]
+       32816   802F        -      -     Tigan, Inc.              [XEROX]
+       32821   8035        -      -     Reverse ARP             [48,JXM]
+       32822   8036        -      -     Aeonic Systems           [XEROX]
+       32824   8038        -      -     DEC LANBridge            [XEROX]
+       32825   8039-803C   -      -     DEC Unassigned           [XEROX]
+       32829   803D        -      -     DEC Ethernet Encryption  [XEROX]
+       32830   803E        -      -     DEC Unassigned           [XEROX]
+       32831   803F        -      -     DEC LAN Traffic Monitor  [XEROX]
+       32832   8040-8042   -      -     DEC Unassigned           [XEROX]
+       32836   8044        -      -     Planning Research Corp.  [XEROX]
+       32838   8046        -      -     AT&T                     [XEROX]
+       32839   8047        -      -     AT&T                     [XEROX]
+       32841   8049        -      -     ExperData                [XEROX]
+       32859   805B        -      -     Stanford V Kernel exp.   [XEROX]
+       32860   805C        -      -     Stanford V Kernel prod.  [XEROX]
+       32861   805D        -      -     Evans & Sutherland       [XEROX]
+       32864   8060        -      -     Little Machines          [XEROX]
+       32866   8062        -      -     Counterpoint Computers   [XEROX]
+       32869   8065-8066   -      -     Univ. of Mass. @ Amherst [XEROX]
+       32871   8067        -      -     Veeco Integrated Auto.   [XEROX]
+       32872   8068        -      -     General Dynamics         [XEROX]
+       32873   8069        -      -     AT&T                     [XEROX]
+       32874   806A        -      -     Autophon                 [XEROX]
+       32876   806C        -      -     ComDesign                [XEROX]
+       32877   806D        -      -     Computgraphic Corp.      [XEROX]
+       32878   806E-8077   -      -     Landmark Graphics Corp.  [XEROX]
+       32890   807A        -      -     Matra                    [XEROX]
+
+
+
+Reynolds & Postel                                              [Page 36]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+       32891   807B        -      -     Dansk Data Elektronik    [XEROX]
+       32892   807C        -      -     Merit Internodal           [HWB]
+       32893   807D-807F   -      -     Vitalink Communications  [XEROX]
+       32896   8080        -      -     Vitalink TransLAN III    [XEROX]
+       32897   8081-8083   -      -     Counterpoint Computers   [XEROX]
+       32923   809B        -      -     Appletalk                [XEROX]
+       32924   809C-809E   -      -     Datability               [XEROX]
+       32927   809F        -      -     Spider Systems Ltd.      [XEROX]
+       32931   80A3        -      -     Nixdorf Computers        [XEROX]
+       32932   80A4-80B3   -      -     Siemens Gammasonics Inc. [XEROX]
+       32960   80C0-80C3   -      -     DCA Data Exchange Cluster[XEROX]
+       32966   80C6        -      -     Pacer Software           [XEROX]
+       32967   80C7        -      -     Applitek Corporation     [XEROX]
+       32968   80C8-80CC   -      -     Intergraph Corporation   [XEROX]
+       32973   80CD-80CE   -      -     Harris Corporation       [XEROX]
+       32974   80CF-80D2   -      -     Taylor Instrument        [XEROX]
+       32979   80D3-80D4   -      -     Rosemount Corporation    [XEROX]
+       32981   80D5        -      -     IBM SNA Service on Ether [XEROX]
+       32989   80DD        -      -     Varian Associates        [XEROX]
+       32990   80DE-80DF   -      -     Integrated Solutions TRFS[XEROX]
+       32992   80E0-80E3   -      -     Allen-Bradley            [XEROX]
+       32996   80E4-80F0   -      -     Datability               [XEROX]
+       33010   80F2        -      -     Retix                    [XEROX]
+       33011   80F3        -      -     AppleTalk AARP (Kinetics)[XEROX]
+       33012   80F4-80F5   -      -     Kinetics                 [XEROX]
+       33015   80F7        -      -     Apollo Computer          [XEROX]
+       33023   80FF-8103   -      -     Wellfleet Communications [XEROX]
+       33031   8107-8109   -      -     Symbolics Private        [XEROX]
+       33072   8130        -      -     Waterloo Microsystems    [XEROX]
+       33073   8131        -      -     VG Laboratory Systems    [XEROX]
+       33079   8137-8138   -      -     Novell, Inc.             [XEROX]
+       33081   8139-813D   -      -     KTI                      [XEROX]
+       33100   814C        -      -     SNMP                      [JKR1]
+       36864   9000        -      -     Loopback                 [XEROX]
+       36865   9001        -      -     3Com(Bridge) XNS Sys Mgmt[XEROX]
+       36866   9002        -      -     3Com(Bridge) TCP-IP Sys  [XEROX]
+       36867   9003        -      -     3Com(Bridge) loop detect [XEROX]
+       65280   FF00        -      -     BBN VITAL-LanBridge cache[XEROX]
+
+   The standard for transmission of IP datagrams over Ethernets and
+   Experimental Ethernets is specified in RFC-894 [61] and RFC-895 [91]
+   respectively.
+
+   NOTE:  Ethernet 48-bit address blocks are assigned by the IEEE.
+
+   IEEE Standards Office, 345 East 47th Street, New York, N.Y. 10017,
+   Attn: Vince Condello.  Phone: (212) 705-7092.
+
+
+
+
+Reynolds & Postel                                              [Page 37]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                    ETHERNET VENDOR ADDRESS COMPONENTS
+
+   Ethernet hardware addresses are 48 bits, expressed as 12 hexadecimal
+   digits (0-9, plus A-F, capitalized).  These 12 hex digits consist of
+   the first/left 6 digits (which should match the vendor of the
+   Ethernet interface within the station) and the last/right 6 digits
+   which specify the interface serial number for that interface vendor.
+
+   Ethernet addresses might be written unhyphenated (e.g.,
+   123456789ABC), or with one hyphen (e.g., 123456-789ABC), but should
+   be written hyphenated by octets (e.g., 12-34-56-78-9A-BC).
+
+   These addresses are physical station addresses, not multicast nor
+   broadcast, so the second hex digit (reading from the left) will be
+   even, not odd.
+
+   At present, it is not clear how the IEEE assigns Ethernet block
+   addresses.  Whether in blocks of 2**24 or 2**25, and whether
+   multicasts are assigned with that block or separately.  A portion of
+   the vendor block address is reportedly assigned serially, with the
+   other portion intentionally assigned randomly.  If there is a global
+   algorithm for which addresses are designated to be physical (in a
+   chipset) versus logical (assigned in software), or globally-assigned
+   versus locally-assigned addresses, some of the known addresses do not
+   follow the scheme (e.g., AA0003; 02xxxx).
+
+   00000C  Cisco
+   00000F  NeXT
+   000010  Sytek
+   00001D  Cabletron
+   000020  DIAB (Data Intdustrier AB)
+   000022  Visual Technology
+   00002A  TRW
+   00005A  S & Koch
+   00005E  IANA
+   000065  Network General
+   00006B  MIPS
+   000077  MIPS
+   00007A  Ardent
+   000089  Cayman Systems  Gatorbox
+   000093  Proteon
+   00009F  Ameristar Technology
+   0000A2  Wellfleet
+   0000A3  Network Application Technology
+   0000A6  Network General (internal assignment, not for products)
+   0000A7  NCD             X-terminals
+   0000A9  Network Systems
+   0000AA  Xerox           Xerox machines
+
+
+
+Reynolds & Postel                                              [Page 38]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   0000B3  CIMLinc
+   0000B7  Dove            Fastnet
+   0000BC  Allen-Bradley
+   0000C0  Western Digital
+   0000C6  HP Intelligent Networks Operation (formerly Eon Systems)
+   0000C8  Altos
+   0000C9  Emulex          Terminal Servers
+   0000D7  Dartmouth College (NED Router)
+   0000D8  3Com? Novell?   PS/2
+   0000DD  Gould
+   0000DE  Unigraph
+   0000E2  Acer Counterpoint
+   0000EF  Alantec
+   0000FD  High Level Hardvare (Orion, UK)
+   000102  BBN             BBN internal usage (not registered)
+   001700  Kabel
+   00802D  Xylogics, Inc.  Annex terminal servers
+   00808C  Frontier Software Development
+   00AA00  Intel
+   00DD00  Ungermann-Bass
+   00DD01  Ungermann-Bass
+   020701  MICOM/Interlan  UNIBUS or QBUS machines, Apollo
+   020406  BBN             BBN internal usage (not registered)
+   026086  Satelcom MegaPac (UK)
+   02608C  3Com            IBM PC; Imagen; Valid; Cisco
+   02CF1F  CMC             Masscomp; Silicon Graphics; Prime EXL
+   080002  3Com (Formerly Bridge)
+   080003  ACC (Advanced Computer Communications)
+   080005  Symbolics       Symbolics LISP machines
+   080008  BBN
+   080009  Hewlett-Packard
+   08000A  Nestar Systems
+   08000B  Unisys
+   080010  AT&T
+   080011  Tektronix, Inc.
+   080014  Excelan         BBN Butterfly, Masscomp, Silicon Graphics
+   080017  NSC
+   08001A  Data General
+   08001B  Data General
+   08001E  Apollo
+   080020  Sun             Sun machines
+   080022  NBI
+   080025  CDC
+   080026  Norsk Data (Nord)
+   080027  PCS Computer Systems GmbH
+   080028  TI              Explorer
+   08002B  DEC
+   08002E  Metaphor
+
+
+
+Reynolds & Postel                                              [Page 39]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   08002F  Prime Computer  Prime 50-Series LHC300
+   080036  Intergraph      CAE stations
+   080037  Fujitsu-Xerox
+   080038  Bull
+   080039  Spider Systems
+   080041  DCA Digital Comm. Assoc.
+   080045  ???? (maybe Xylogics, but they claim not to know this number)
+   080046  Sony
+   080047  Sequent
+   080049  Univation
+   08004C  Encore
+   08004E  BICC
+   080056  Stanford University
+   080058  ???             DECsystem-20
+   08005A  IBM
+   080067  Comdesign
+   080068  Ridge
+   080069  Silicon Graphics
+   08006E  Excelan
+   080075  DDE (Danish Data Elektronik A/S)
+   08007C  Vitalink        TransLAN III
+   080080  XIOS
+   080086  Imagen/QMS
+   080087  Xyplex          terminal servers
+   080089  Kinetics        AppleTalk-Ethernet interface
+   08008B  Pyramid
+   08008D  XyVision        XyVision machines
+   080090  Retix Inc       Bridges
+   484453  HDS ???
+   800010  AT&T            [misrepresentation of 080010?]
+   AA0000  DEC             obsolete
+   AA0001  DEC             obsolete
+   AA0002  DEC             obsolete
+   AA0003  DEC             Global physical address for some DEC machines
+   AA0004  DEC             Local logical address for systems running DECNET
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 40]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                       ETHERNET MULTICAST ADDRESSES
+
+   Ethernet                Type
+   Address                 Field   Usage
+
+   Multicast Addresses:
+
+   01-00-5E-00-00-00-      0800    Internet Multicast (RFC-1112) [43]
+   01-00-5E-7F-FF-FF
+   01-00-5E-80-00-00-      ????    Internet reserved by IANA
+   01-00-5E-FF-FF-FF
+   01-80-C2-00-00-00       -802-   Spanning tree (for bridges)
+   09-00-02-04-00-01?      8080?   Vitalink printer
+   09-00-02-04-00-02?      8080?   Vitalink management
+   09-00-09-00-00-01       8005    HP Probe
+   09-00-09-00-00-01       -802-   HP Probe
+   09-00-09-00-00-04       8005?   HP DTC
+   09-00-1E-00-00-00       8019?   Apollo DOMAIN
+   09-00-2B-00-00-00       6009?   DEC MUMPS?
+   09-00-2B-00-00-01       8039?   DEC DSM/DTP?
+   09-00-2B-00-00-02       803B?   DEC VAXELN?
+   09-00-2B-00-00-03       8038    DEC Lanbridge Traffic Monitor (LTM)
+   09-00-2B-00-00-04       ????    DEC MAP End System Hello?
+   09-00-2B-00-00-05       ????    DEC MAP Intermediate System Hello?
+   09-00-2B-00-00-06       803D?   DEC CSMA/CD Encryption?
+   09-00-2B-00-00-07       8040?   DEC NetBios Emulator?
+   09-00-2B-00-00-0F       6004    DEC Local Area Transport (LAT)
+   09-00-2B-00-00-1x       ????    DEC Experimental
+   09-00-2B-01-00-00       8038    DEC LanBridge Copy packets (All bridges)
+   09-00-2B-01-00-01       8038    DEC LanBridge Hello packets (All local bridges)
+                                   1 packet per second, sent by the
+                                   designated LanBridge
+   09-00-2B-02-00-00       ????    DEC DNA Level 2 Routing Layer routers?
+   09-00-2B-02-01-00       803C?   DEC DNA Naming Service Advertisement?
+   09-00-2B-02-01-01       803C?   DEC DNA Naming Service Solicitation?
+   09-00-2B-02-01-02       803E?   DEC DNA Time Service?
+   09-00-2B-03-xx-xx       ????    DEC default filtering by bridges?
+   09-00-2B-04-00-00       8041?   DEC Local Area System Transport (LAST)?
+   09-00-2B-23-00-00       803A?   DEC Argonaut Console?
+   09-00-4E-00-00-02?      8137?   Novell IPX
+   09-00-56-00-00-00-      ????    Stanford reserved
+   09-00-56-FE-FF-FF
+   09-00-56-FF-00-00-      805C    Stanford V Kernel, version 6.0
+   09-00-56-FF-FF-FF
+   09-00-77-00-00-01       ????    Retix spanning tree bridges
+   09-00-7C-02-00-05       8080?   Vitalink diagnostics
+   09-00-7C-05-00-01       8080?   Vitalink gateway?
+   0D-1E-15-BA-DD-06       ????    HP
+
+
+
+Reynolds & Postel                                              [Page 41]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   AB-00-00-01-00-00       6001    DEC Maintenance Operation Protocol (MOP)
+                                   Dump/Load Assistance
+   AB-00-00-02-00-00       6002    DEC Maintenance Operation Protocol (MOP)
+                                   Remote Console
+                                   1 System ID packet every 8-10 minutes,
+                                   by every:
+                                   DEC LanBridge
+                                   DEC DEUNA interface
+                                   DEC DELUA interface
+                                   DEC DEQNA interface (in a certain mode)
+   AB-00-00-03-00-00       6003    DECNET Phase IV end node Hello packets
+                                   1 packet every 15 seconds, sent by
+   each DECNET host
+   AB-00-00-04-00-00       6003    DECNET Phase IV Router Hello packets
+                                   1 packet every 15 seconds, sent by the
+   DECNET router
+   AB-00-00-05-00-00       ????    Reserved DEC
+   through
+   AB-00-03-FF-FF-FF
+   AB-00-03-00-00-00       6004    DEC Local Area Transport (LAT) - old
+   AB-00-04-00-xx-xx       ????    Reserved DEC customer private use
+   AB-00-04-01-xx-yy       6007    DEC Local Area VAX Cluster groups
+                                   System Communication Architecture (SCA)
+   CF-00-00-00-00-00       9000    Ethernet Configuration Test protocol (Loopback)
+
+   Broadcast Address:
+   FF-FF-FF-FF-FF-FF       0600    XNS packets, Hello or gateway search?
+                                   6 packets every 15 seconds, per XNS station
+   FF-FF-FF-FF-FF-FF       0800    IP (e.g. RWHOD via UDP) as needed
+   FF-FF-FF-FF-FF-FF       0804    CHAOS
+   FF-FF-FF-FF-FF-FF       0806    ARP (for IP and CHAOS) as needed
+   FF-FF-FF-FF-FF-FF       0BAD    Banyan
+   FF-FF-FF-FF-FF-FF       1600    VALID packets, Hello or gateway search?
+                                   1 packets every 30 seconds, per VALID station
+   FF-FF-FF-FF-FF-FF       8035    Reverse ARP
+   FF-FF-FF-FF-FF-FF       807C    Merit Internodal (INP)
+   FF-FF-FF-FF-FF-FF       809B    EtherTalk
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 42]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                            XNS PROTOCOL TYPES
+
+   Assigned well-known socket numbers
+
+           Routing Information             1
+           Echo                            2
+           Router Error                    3
+           Experimental                40-77
+
+   Assigned internet packet types
+
+           Routing Information             1
+           Echo                            2
+           Error                           3
+           Packet Exchange                 4
+           Sequenced Packet                5
+           PUP                            12
+           DoD IP                         13
+           Experimental                20-37
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 43]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                      PROTOCOL/TYPE FIELD ASSIGNMENTS
+
+   Below are two tables describing the arrangement of protocol fields or
+   type field assignments so that one could send NS Datagrams on the
+   ARPANET or Internet Datagrams on 10Mb Ethernet, and also protocol and
+   type fields so one could encapsulate each kind of Datagram in the
+   other.
+
+              \   upper| DoD IP |  PUP   | NS IP  |
+         lower \       |        |        |        |
+         --------------|--------|--------|--------|
+                       |  Type  |  Type  |  Type  |
+         3Mb Ethernet  |  1001  |  1000  |  3000  |
+                       |  octal |  octal |  octal |
+         --------------|--------|--------|--------|
+                       |  Type  |  Type  |  Type  |
+         10 Mb Ethernet|  0800  |  0200  |  0600  |
+                       |   hex  |   hex  |   hex  |
+         --------------|--------|--------|--------|
+                       |  Link  |  Link  |  Link  |
+         ARPANET       |  155   |  152   |  150   |
+                       | decimal| decimal| decimal|
+         --------------|--------|--------|--------|
+
+
+
+              \   upper| DoD IP |  PUP   | NS IP  |
+         lower \       |        |        |        |
+         --------------|--------|--------|--------|
+                       |        |Protocol|Protocol|
+         DoD IP        |   X    |   12   |   22   |
+                       |        | decimal| decimal|
+         --------------|--------|--------|--------|
+                       |        |        |        |
+         PUP           |   ?    |   X    |   ?    |
+                       |        |        |        |
+         --------------|--------|--------|--------|
+                       |  Type  |  Type  |        |
+         NS IP         |   13   |   12   |   X    |
+                       | decimal| decimal|        |
+         --------------|--------|--------|--------|
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 44]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                             PRONET 80 TYPE NUMBERS
+
+   Below is the current list of PRONET 80 Type Numbers.  Note: a
+   protocol that is on this list does not necessarily mean that there is
+   any implementation of it on ProNET.
+
+   Of these, protocols 1, 14, and 20 are the only ones that have ever
+   been seen in ARP packets.
+
+   For reference, the header is (one byte/line):
+
+           destination hardware address
+           source hardware address
+           data link header version (2)
+           data link header protocol number
+           data link header reserved (0)
+           data link header reserved (0)
+
+   Some protocols have been known to tuck stuff in the reserved fields.
+
+   Those who need a protocol number on ProNET-10/80 should contact John
+   Shriver (jas@proteon.com).
+
+      1       IP
+      2       IP with trailing headers
+      3       Address Resoloution Protocol
+      4       Proteon HDLC
+      5       VAX Debugging Protocol (MIT)
+      10      Novell NetWare (IPX and pre-IPX) (old format,
+              3 byte trailer)
+      11      Vianetix
+      12      PUP
+      13      Watstar protocol (University of Waterloo)
+      14      XNS
+      15      Diganostics
+      16      Echo protocol (link level)
+      17      Banyan Vines
+      20      DECnet (DEUNA Emulation)
+      21      Chaosnet
+      23      IEEE 802.2 or ISO 8802/2 Data Link
+      24      Reverse Address Resolution Protocol
+      29      TokenVIEW-10
+      31      AppleTalk LAP Data Packet
+      33      Cornell Boot Server Location Protocol
+      34      Novell NetWare IPX (new format, no trailer,
+              new XOR checksum)
+
+
+
+
+
+Reynolds & Postel                                              [Page 45]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                    ADDRESS RESOLUTION PROTOCOL PARAMETERS
+
+   The Address Resolution Protocol (ARP) specified in RFC-826 [88] has
+   several parameters.  The assigned values for these parameters are
+   listed here.
+
+   Assignments:
+
+   Operation Code (op)
+
+            1   REQUEST
+            2   REPLY
+
+   Hardware Type (hrd)
+
+      Type   Description                                   References
+      ----   -----------                                   ----------
+        1    Ethernet (10Mb)                                    [JBP]
+        2    Experimental Ethernet (3Mb)                        [JBP]
+        3    Amateur Radio AX.25                                [PXK]
+        4    Proteon ProNET Token Ring                          [JBP]
+        5    Chaos                                              [GXP]
+        6    IEEE 802 Networks                                  [JBP]
+        7    ARCNET                                             [JBP]
+        8    Hyperchannel                                       [JBP]
+        9    Lanstar                                             [TU]
+       10    Autonet Short Address                             [MXB1]
+       11    LocalTalk                                          [LXE]
+       12    LocalNet (IBM PCNet or SYTEK LocalNET)             [JXM]
+
+   Protocol Type (pro)
+
+      Use the same codes as listed in the section called "Ethernet
+      Numbers of Interest" (all hardware types use this code set for the
+      protocol type).
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 46]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+             REVERSE ADDRESS RESOLUTION PROTOCOL OPERATION CODES
+
+   The Reverse Address Resolution Protocol (RARP) specified in RFC-903
+   [48] has the following operation codes:
+
+   Assignments:
+
+   Operation Code (op)
+
+            3  request Reverse
+            4  reply Reverse
+
+
+                            DYNAMIC REVERSE ARP
+
+   Assignments:
+
+   Operation Code (op)
+
+            5  DRARP-Request
+            6  DRARP-Reply
+            7  DRARP-Error
+
+   For further information, contact: David Brownell
+   (suneast!helium!db@Sun.COM).
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 47]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                             X.25 TYPE NUMBERS
+
+   CCITT defines the high order two bits of the first octet of call user
+   data as follows:
+
+      00 - Used for other CCITT recomendations (such as X.29)
+      01 - Reserved for use by "national" administrative
+           authorities
+      10 - Reserved for use by international administrative authoorities
+      11 - Reserved for arbitrary use between consenting DTEs
+
+      Call User Data (hex)     Protocol                      Reference
+      -------------------      --------                      ---------
+
+      01                       PAD                            [GS2]
+      C5                       Blacker front-end descr dev    [AGM]
+      CC                       IP                             [69,AGM]*
+      CD                       ISO-IP                         [AGM]
+
+      * NOTE: ISO SC6/WG2 approved assignment in ISO 9577 (January 1990).
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 48]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                         PUBLIC DATA NETWORK NUMBERS
+
+One of the Internet Class A Networks is the international system of
+Public Data Networks.  This section lists the mapping between the
+Internet Addresses and the Public Data Network Addresses (X.121).
+
+The numbers below are assigned for networks that are connected to the
+Internet, and for independent networks.  These independent networks
+are marked with an asterisk preceding the number.
+
+Assignments:
+
+      * Internet           Public Data Net    Description     References
+      - --------------   -----------------   -----------      ----------
+       014.000.000.000                       Reserved              [JBP]
+       014.000.000.001   3110-317-00035 00   PURDUE-TN              [TN]
+       014.000.000.002   3110-608-00027 00   UWISC-TN               [TN]
+       014.000.000.003   3110-302-00024 00   UDEL-TN                [TN]
+       014.000.000.004   2342-192-00149 23   UCL-VTEST              [PK]
+       014.000.000.005   2342-192-00300 23   UCL-TG                 [PK]
+       014.000.000.006   2342-192-00300 25   UK-SATNET              [PK]
+       014.000.000.007   3110-608-00024 00   UWISC-IBM            [MS56]
+       014.000.000.008   3110-213-00045 00   RAND-TN               [MO2]
+       014.000.000.009   2342-192-00300 23   UCL-CS                 [PK]
+       014.000.000.010   3110-617-00025 00   BBN-VAN-GW           [JD21]
+      *014.000.000.011   2405-015-50300 00   CHALMERS              [UXB]
+       014.000.000.012   3110-713-00165 00   RICE                 [PAM6]
+       014.000.000.013   3110-415-00261 00   DECWRL               [PAM6]
+       014.000.000.014   3110-408-00051 00   IBM-SJ                [SA1]
+       014.000.000.015   2041-117-01000 00   SHAPE                 [JFW]
+       014.000.000.016   2628-153-90075 00   DFVLR4-X25            [GB7]
+       014.000.000.017   3110-213-00032 00   ISI-VAN-GW           [JD21]
+       014.000.000.018   2624-522-80900 52   FGAN-SIEMENS-X25      [GB7]
+       014.000.000.019   2041-170-10000 00   SHAPE-X25             [JFW]
+       014.000.000.020   5052-737-20000 50   UQNET                 [AXH]
+       014.000.000.021   3020-801-00057 50   DMC-CRC1              [VXT]
+       014.000.000.022   2624-522-80329 02   FGAN-FGANFFMVAX-X25   [GB7]
+      *014.000.000.023   2624-589-00908 01   ECRC-X25              [PXD]
+       014.000.000.024   2342-905-24242 83   UK-MOD-RSRE          [JXE2]
+       014.000.000.025   2342-905-24242 82   UK-VAN-RSRE           [AXM]
+       014.000.000.026   2624-522-80329 05   DFVLRSUN-X25          [GB7]
+       014.000.000.027   2624-457-11015 90   SELETFMSUN-X25        [BXD]
+       014.000.000.028   3110-408-00146 00   CDC-SVL             [RAM57]
+       014.000.000.029   2222-551-04400 00   SUN-CNUCE            [ABB2]
+       014.000.000.030   2222-551-04500 00   ICNUCEVM-CNUCE       [ABB2]
+       014.000.000.031   2222-551-04600 00   SPARE-CNUCE          [ABB2]
+       014.000.000.032   2222-551-04700 00   ICNUCEVX-CNUCE       [ABB2]
+       014.000.000.033   2222-551-04524 00   CISCO-CNUCE          [ABB2]
+
+
+
+Reynolds & Postel                                              [Page 49]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+       014.000.000.034   2342-313-00260 90   SPIDER-GW            [AD67]
+       014.000.000.035   2342-313-00260 91   SPIDER-EXP           [AD67]
+       014.000.000.036   2342-225-00101 22   PRAXIS-X25A           [TXR]
+       014.000.000.037   2342-225-00101 23   PRAXIS-X25B           [TXR]
+       014.000.000.038   2403-712-30250 00   DIAB-TABY-GW          [FXB]
+       014.000.000.039   2403-715-30100 00   DIAB-LKP-GW           [FXB]
+       014.000.000.040   2401-881-24038 00   DIAB-TABY1-GW         [FXB]
+       014.000.000.041   2041-170-10060 00   STC                  [TC27]
+       014.000.000.042-014.255.255.254       Unassigned            [JBP]
+       014.255.255.255                       Reserved              [JBP]
+
+      The standard for transmission of IP datagrams over the Public Data
+      Network is specified in RFC-877 [69].
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 50]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                                TELNET OPTIONS
+
+The Telnet Protocol has a number of options that may be negotiated.
+These options are listed here.  "Official Internet Protocols" [118]
+provides more detailed information.
+
+   Options  Name                                              References
+   -------  -----------------------                           ----------
+      0     Binary Transmission                                [110,JBP]
+      1     Echo                                               [111,JBP]
+      2     Reconnection                                        [42,JBP]
+      3     Suppress Go Ahead                                  [114,JBP]
+      4     Approx Message Size Negotiation                    [133,JBP]
+      5     Status                                             [113,JBP]
+      6     Timing Mark                                        [115,JBP]
+      7     Remote Controlled Trans and Echo                   [107,JBP]
+      8     Output Line Width                                   [40,JBP]
+      9     Output Page Size                                    [41,JBP]
+     10     Output Carriage-Return Disposition                  [28,JBP]
+     11     Output Horizontal Tab Stops                         [32,JBP]
+     12     Output Horizontal Tab Disposition                   [31,JBP]
+     13     Output Formfeed Disposition                         [29,JBP]
+     14     Output Vertical Tabstops                            [34,JBP]
+     15     Output Vertical Tab Disposition                     [33,JBP]
+     16     Output Linefeed Disposition                         [30,JBP]
+     17     Extended ASCII                                     [136,JBP]
+     18     Logout                                              [25,MRC]
+     19     Byte Macro                                          [35,JBP]
+     20     Data Entry Terminal                             [145,38,JBP]
+     22     SUPDUP                                           [26,27,MRC]
+     22     SUPDUP Output                                       [51,MRC]
+     23     Send Location                                      [68,EAK1]
+     24     Terminal Type                                     [128,MS56]
+     25     End of Record                                      [103,JBP]
+     26     TACACS User Identification                           [1,BA4]
+     27     Output Marking                                     [125,SXS]
+     28     Terminal Location Number                            [84,RN6]
+     29     Telnet 3270 Regime                                 [116,JXR]
+     30     X.3 PAD                                            [70,SL70]
+     31     Negotiate About Window Size                      [139,DW183]
+     32     Terminal Speed                                     [57,CLH3]
+     33     Remote Flow Control                                [58,CLH3]
+     34     Linemode                                            [9,DB14]
+     35     X Display Location                                 [75,GM23]
+    255     Extended-Options-List                              [109,JBP]
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 51]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                           MAIL ENCRYPTION TYPES
+
+   RFC-822 specifies that Encryption Types for mail may be assigned.
+   There are currently no RFC-822 encryption types assigned.  Please use
+   instead the Mail Privacy procedures defined in [71,72,66].
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 52]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                               MACHINE NAMES
+
+   These are the Official Machine Names as they appear in the Domain
+   Name System WKS records and the NIC Host Table.  Their use is
+   described in RFC-952 [53].
+
+   A machine name or CPU type may be up to 40 characters taken from the
+   set of uppercase letters, digits, and the two punctuation characters
+   hyphen and slash.  It must start with a letter, and end with a letter
+   or digit.
+
+
+
+
+
+      ALTO                                  DEC-1090
+      ALTOS-6800                            DEC-1090B
+      AMDAHL-V7                             DEC-1090T
+      APOLLO                                DEC-2020T
+      ATARI-104ST                           DEC-2040
+      ATT-3B1                               DEC-2040T
+      ATT-3B20                              DEC-2050T
+      ATT-7300                              DEC-2060
+      BBN-C/60                              DEC-2060T
+      BURROUGHS-B/29                        DEC-2065
+      BURROUGHS-B/4800                      DEC-FALCON
+      BUTTERFLY                             DEC-KS10
+      C/30                                  DEC-VAX-11730
+      C/70                                  DORADO
+      CADLINC                               DPS8/70M
+      CADR                                  ELXSI-6400
+      CDC-170                               EVEREX-386
+      CDC-170/750                           FOONLY-F2
+      CDC-173                               FOONLY-F3
+      CELERITY-1200                         FOONLY-F4
+      CLUB-386                              GOULD
+      COMPAQ-386/20                         GOULD-6050
+      COMTEN-3690                           GOULD-6080
+      CP8040                                GOULD-9050
+      CRAY-1                                GOULD-9080
+      CRAY-X/MP                             H-316
+      CRAY-2                                H-60/68
+      CTIWS-117                             H-68
+      DANDELION                             H-68/80
+      DEC-10                                H-89
+      DEC-1050                              HONEYWELL-DPS-6
+      DEC-1077                              HONEYWELL-DPS-8/70
+      DEC-1080                              HP3000
+
+
+
+Reynolds & Postel                                              [Page 53]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+      HP3000/64                             PDP-11
+      IBM-158                               PDP-11/3
+      IBM-360/67                            PDP-11/23
+      IBM-370/3033                          PDP-11/24
+      IBM-3081                              PDP-11/34
+      IBM-3084QX                            PDP-11/40
+      IBM-3101                              PDP-11/44
+      IBM-4331                              PDP-11/45
+      IBM-4341                              PDP-11/50
+      IBM-4361                              PDP-11/70
+      IBM-4381                              PDP-11/73
+      IBM-4956                              PE-7/32
+      IBM-6152                              PE-3205
+      IBM-PC                                PERQ
+      IBM-PC/AT                             PLEXUS-P/60
+      IBM-PC/RT                             PLI
+      IBM-PC/XT                             PLURIBUS
+      IBM-SERIES/1                          PRIME-2350
+      IMAGEN                                PRIME-2450
+      IMAGEN-8/300                          PRIME-2755
+      IMSAI                                 PRIME-9655
+      INTEGRATED-SOLUTIONS                  PRIME-9755
+      INTEGRATED-SOLUTIONS-68K              PRIME-9955II
+      INTEGRATED-SOLUTIONS-CREATOR          PRIME-2250
+      INTEGRATED-SOLUTIONS-CREATOR-8        PRIME-2655
+      INTEL-386                             PRIME-9955
+      INTEL-IPSC                            PRIME-9950
+      IS-1                                  PRIME-9650
+      IS-68010                              PRIME-9750
+      LMI                                   PRIME-2250
+      LSI-11                                PRIME-750
+      LSI-11/2                              PRIME-850
+      LSI-11/23                             PRIME-550II
+      LSI-11/73                             PYRAMID-90
+      M68000                                PYRAMID-90MX
+      MAC-II                                PYRAMID-90X
+      MASSCOMP                              RIDGE
+      MC500                                 RIDGE-32
+      MC68000                               RIDGE-32C
+      MICROPORT                             ROLM-1666
+      MICROVAX                              S1-MKIIA
+      MICROVAX-I                            SMI
+      MV/8000                               SEQUENT-BALANCE-8000
+      NAS3-5                                SIEMENS
+      NCR-COMTEN-3690                       SILICON-GRAPHICS
+      NEXT/N1000-316                        SILICON-GRAPHICS-IRIS
+      NOW                                   SGI-IRIS-2400
+      ONYX-Z8000                            SGI-IRIS-2500
+
+
+
+Reynolds & Postel                                              [Page 54]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+      SGI-IRIS-3010                         SUN-3/60
+      SGI-IRIS-3020                         SUN-3/75
+      SGI-IRIS-3030                         SUN-3/80
+      SGI-IRIS-3110                         SUN-3/110
+      SGI-IRIS-3115                         SUN-3/140
+      SGI-IRIS-3120                         SUN-3/150
+      SGI-IRIS-3130                         SUN-3/160
+      SGI-IRIS-4D/20                        SUN-3/180
+      SGI-IRIS-4D/20G                       SUN-3/200
+      SGI-IRIS-4D/25                        SUN-3/260
+      SGI-IRIS-4D/25G                       SUN-3/280
+      SGI-IRIS-4D/25S                       SUN-3/470
+      SGI-IRIS-4D/50                        SUN-3/480
+      SGI-IRIS-4D/50G                       SUN-4/60
+      SGI-IRIS-4D/50GT                      SUN-4/110
+      SGI-IRIS-4D/60                        SUN-4/150
+      SGI-IRIS-4D/60G                       SUN-4/200
+      SGI-IRIS-4D/60T                       SUN-4/260
+      SGI-IRIS-4D/60GT                      SUN-4/280
+      SGI-IRIS-4D/70                        SUN-4/330
+      SGI-IRIS-4D/70G                       SUN-4/370
+      SGI-IRIS-4D/70GT                      SUN-4/390
+      SGI-IRIS-4D/80GT                      SUN-50
+      SGI-IRIS-4D/80S                       SUN-100
+      SGI-IRIS-4D/120GTX                    SUN-120
+      SGI-IRIS-4D/120S                      SUN-130
+      SGI-IRIS-4D/210GTX                    SUN-150
+      SGI-IRIS-4D/210S                      SUN-170
+      SGI-IRIS-4D/220GTX                    SUN-386i/250
+      SGI-IRIS-4D/220S                      SUN-68000
+      SGI-IRIS-4D/240GTX                    SYMBOLICS-3600
+      SGI-IRIS-4D/240S                      SYMBOLICS-3670
+      SGI-IRIS-4D/280GTX                    SYMMETRIC-375
+      SGI-IRIS-4D/280S                      SYMULT
+      SGI-IRIS-CS/12                        TANDEM-TXP
+      SGI-IRIS-4SERVER-8                    TANDY-6000
+      SPERRY-DCP/10                         TEK-6130
+      SUN                                   TI-EXPLORER
+      SUN-2                                 TP-4000
+      SUN-2/50                              TRS-80
+      SUN-2/100                             UNIVAC-1100
+      SUN-2/120                             UNIVAC-1100/60
+      SUN-2/130                             UNIVAC-1100/62
+      SUN-2/140                             UNIVAC-1100/63
+      SUN-2/150                             UNIVAC-1100/64
+      SUN-2/160                             UNIVAC-1100/70
+      SUN-2/170                             UNIVAC-1160
+      SUN-3/50                              UNKNOWN
+
+
+
+Reynolds & Postel                                              [Page 55]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+      VAX-11/725
+      VAX-11/730
+      VAX-11/750
+      VAX-11/780
+      VAX-11/785
+      VAX-11/790
+      VAX-11/8600
+      VAX-8600
+      WANG-PC002
+      WANG-VS100
+      WANG-VS400
+      WYSE-386
+      XEROX-1108
+      XEROX-8010
+      ZENITH-148
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 56]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                               SYSTEM NAMES
+
+   These are the Official System Names as they appear in the Domain Name
+   System WKS records and the NIC Host Table.  Their use is described in
+   RFC-952 [53].
+
+   A system name may be up to 40 characters taken from the set of upper-
+   case letters, digits, and the two punctuation characters hyphen and
+   slash.  It must start with a letter, and end with a letter or digit.
+
+   AEGIS                     MACOS                     TP3010
+   APOLLO                    MINOS                     TRSDOS
+   BS-2000                   MOS                       ULTRIX
+   CEDAR                     MPE5                      UNIX
+   CGW                       MSDOS                     UNIX-BSD
+   CHORUS                    MULTICS                   UNIX-V1AT
+   CHRYSALIS                 MVS                       UNIX-V
+   CMOS                      MVS/SP                    UNIX-V.1
+   CMS                       NEXUS                     UNIX-V.2
+   COS                       NMS                       UNIX-V.3
+   CPIX                      NONSTOP                   UNIX-PC
+   CTOS                      NOS-2                     UNKNOWN
+   CTSS                      OS/DDP                    UT2D
+   DCN                       OS4                       V
+   DDNOS                     OS86                      VM
+   DOMAIN                    OSX                       VM/370
+   DOS                       PCDOS                     VM/CMS
+   EDX                       PERQ/OS                   VM/SP
+   ELF                       PLI                       VMS
+   EMBOS                     PSDOS/MIT                 VMS/EUNICE
+   EMMOS                     PRIMOS                    VRTX
+   EPOS                      RMX/RDOS                  WAITS
+   FOONEX                    ROS                       WANG
+   FUZZ                      RSX11M                    X11R3
+   GCOS                      SATOPS                    XDE
+   GPOS                      SCO-XENIX/386             XENIX
+   HDOS                      SCS
+   IMAGEN                    SIMP
+   INTERCOM                  SUN
+   IMPRESS                   SUN OS 3.5
+   INTERLISP                 SUN OS 4.0
+   IOS                       SWIFT
+   IRIX                      TAC
+   ISI-68020                 TANDEM
+   ITS                       TENEX
+   LISP                      TOPS10
+   LISPM                     TOPS20
+   LOCUS                     TOS
+
+
+
+Reynolds & Postel                                              [Page 57]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                        PROTOCOL AND SERVICE NAMES
+
+   These are the Official Protocol Names as they appear in the Domain
+   Name System WKS records and the NIC Host Table.  Their use is
+   described in RFC-952 [53].
+
+   A protocol or service may be up to 40 characters taken from the set
+   of uppercase letters, digits, and the punctuation character hyphen.
+   It must start with a letter, and end with a letter or digit.
+
+   ARGUS               - ARGUS Protocol
+   ARP                 - Address Resolution Protocol
+   AUTH                - Authentication Service
+   BBN-RCC-MON         - BBN RCC Monitoring
+   BL-IDM              - Britton Lee Intelligent Database Machine
+   BOOTP               - Bootstrap Protocol
+   BOOTPC              - Bootstrap Protocol Client
+   BOOTPS              - Bootstrap Protocol Server
+   BR-SAT-MON          - Backroom SATNET Monitoring
+   CFTP                - CFTP
+   CHAOS               - CHAOS Protocol
+   CHARGEN             - Character Generator Protocol
+   CISCO-FNA           - CISCO FNATIVE
+   CISCO-TNA           - CISCO TNATIVE
+   CISCO-SYS           - CISCO SYSMAINT
+   CLOCK               - DCNET Time Server Protocol
+   CMOT                - Common Mgmnt Info Services and Protocol over TCP/IP
+   COOKIE-JAR          - Authentication Scheme
+   CSNET-NS            - CSNET Mailbox Nameserver Protocol
+   DAYTIME             - Daytime Protocol
+   DCN-MEAS            - DCN Measurement Subsystems Protocol
+   DCP                 - Device Control Protocol
+   DGP                 - Dissimilar Gateway Protocol
+   DISCARD             - Discard Protocol
+   DOMAIN              - Domain Name System
+   ECHO                - Echo Protocol
+   EGP                 - Exterior Gateway Protocol
+   EMCON               - Emission Control Protocol
+   EMFIS-CNTL          - EMFIS Control Service
+   EMFIS-DATA          - EMFIS Data Service
+   FINGER              - Finger Protocol
+   FTP                 - File Transfer Protocol
+   FTP-DATA            - File Transfer Protocol Data
+   GGP                 - Gateway Gateway Protocol
+   GRAPHICS            - Graphics Protocol
+   HMP                 - Host Monitoring Protocol
+   HOST2-NS            - Host2 Name Server
+   HOSTNAME            - Hostname Protocol
+
+
+
+Reynolds & Postel                                              [Page 58]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   ICMP                - Internet Control Message Protocol
+   IGMP                - Internet Group Management Protocol
+   IGP                 - Interior Gateway Protocol
+   IMAP2               - Interim Mail Access Protocol version 2
+   INGRES-NET          - INGRES-NET Service
+   IP                  - Internet Protocol
+   IPCU                - Internet Packet Core Utility
+   IPPC                - Internet Pluribus Packet Core
+   IP-ARC              - Internet Protocol on ARCNET
+   IP-ARPA             - Internet Protocol on ARPANET
+   IP-DC               - Internet Protocol on DC Networks
+   IP-DVMRP            - Distance Vector Multicast Routing Protocol
+   IP-E                - Internet Protocol on Ethernet Networks
+   IP-EE               - Internet Protocol on Exp. Ethernet Nets
+   IP-FDDI             - Transmission of IP over FDDI
+   IP-HC               - Internet Protocol on Hyperchannnel
+   IP-IEEE             - Internet Protocol on IEEE 802
+   IP-IPX              - Transmission of 802.2 over IPX Networks
+   IP-MTU              - IP MTU Discovery Options
+   IP-NETBIOS          - Internet Protocol Datagrams over NetBIOS Networks
+   IP-SLIP             - Transmission of IP over Serial Lines
+   IP-WB               - Internet Protocol on Wideband Network
+   IP-X25              - Internet Protocol on X.25 Networks
+   IRTP                - Internet Reliable Transaction Protocol
+   ISI-GL              - ISI Graphics Language Protocol
+   ISO-TP4             - ISO Transport Protocol Class 4
+   ISO-TSAP            - ISO TSAP
+   LA-MAINT            - IMP Logical Address Maintenance
+   LARP                - Locus Address Resoultion Protocol
+   LDP                 - Loader Debugger Protocol
+   LEAF-1              - Leaf-1 Protocol
+   LEAF-2              - Leaf-2 Protocol
+   LINK                - Link Protocol
+   LOC-SRV             - Location Service
+   LOGIN               - Login Host Protocol
+   MAIL                - Format of Electronic Mail Messages
+   MERIT-INP           - MERIT Internodal Protocol
+   METAGRAM            - Metagram Relay
+   MIB                 - Management Information Base
+   MIT-ML-DEV          - MIT ML Device
+   MFE-NSP             - MFE Network Services Protocol
+   MIT-SUBNET          - MIT Subnet Support
+   MIT-DOV             - MIT Dover Spooler
+   MPM                 - Internet Message Protocol (Multimedia Mail)
+   MPM-FLAGS           - MPM Flags Protocol
+   MPM-SND             - MPM Send Protocol
+   MSG-AUTH            - MSG Authentication Protocol
+   MSG-ICP             - MSG ICP Protocol
+
+
+
+Reynolds & Postel                                              [Page 59]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   MUX                 - Multiplexing Protocol
+   NAMESERVER          - Host Name Server
+   NETBIOS-DGM         - NETBIOS Datagram Service
+   NETBIOS-NS          - NETBIOS Name Service
+   NETBIOS-SSN         - NETBIOS Session Service
+   NETBLT              - Bulk Data Transfer Protocol
+   NETED               - Network Standard Text Editor
+   NETRJS              - Remote Job Service
+   NI-FTP              - NI File Transfer Protocol
+   NI-MAIL             - NI Mail Protocol
+   NICNAME             - Who Is Protocol
+   NFILE               - A File Access Protocol
+   NNTP                - Network News Transfer Protocol
+   NSW-FE              - NSW User System Front End
+   NTP                 - Network Time Protocol
+   NVP-II              - Network Voice Protocol
+   OSPF                - Open Shortest Path First Interior GW Protocol
+   PCMAIL              - Pcmail Transport Protocol
+   POP2                - Post Office Protocol - Version 2
+   POP3                - Post Office Protocol - Version 3
+   PPP                 - Point-to-Point Protocol
+   PRM                 - Packet Radio Measurement
+   PUP                 - PUP Protocol
+   PWDGEN              - Password Generator Protocol
+   QUOTE               - Quote of the Day Protocol
+   RARP                - A Reverse Address Resolution Protocol
+   RATP                - Reliable Asynchronous Transfer Protocol
+   RDP                 - Reliable Data Protocol
+   RIP                 - Routing Information Protocol
+   RJE                 - Remote Job Entry
+   RLP                 - Resource Location Protocol
+   RTELNET             - Remote Telnet Service
+   RVD                 - Remote Virtual Disk Protocol
+   SAT-EXPAK           - Satnet and Backroom EXPAK
+   SAT-MON             - SATNET Monitoring
+   SEP                 - Sequential Exchange Protocol
+   SFTP                - Simple File Transfer Protocol
+   SGMP                - Simple Gateway Monitoring Protocol
+   SNMP                - Simple Network Management Protocol
+   SMI                 - Structure of Management Information
+   SMTP                - Simple Mail Transfer Protocol
+   SQLSRV              - SQL Service
+   ST                  - Stream Protocol
+   STATSRV             - Statistics Service
+   SU-MIT-TG           - SU/MIT Telnet Gateway Protocol
+   SUN-RPC             - SUN Remote Procedure Call
+   SUPDUP              - SUPDUP Protocol
+   SUR-MEAS            - Survey Measurement
+
+
+
+Reynolds & Postel                                              [Page 60]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   SWIFT-RVF           - Remote Virtual File Protocol
+   TACACS-DS           - TACACS-Database Service
+   TACNEWS             - TAC News
+   TCP                 - Transmission Control Protocol
+   TELNET              - Telnet Protocol
+   TFTP                - Trivial File Transfer Protocol
+   THINWIRE            - Thinwire Protocol
+   TIME                - Time Server Protocol
+   TP-TCP              - ISO Transport Service on top of the TCP
+   TRUNK-1             - Trunk-1 Protocol
+   TRUNK-2             - Trunk-2 Protocol
+   UCL                 - University College London Protocol
+   UDP                 - User Datagram Protocol
+   NNTP                - Network News Transfer Protocol
+   USERS               - Active Users Protocol
+   UUCP-PATH           - UUCP Path Service
+   VIA-FTP             - VIA Systems-File Transfer Protocol
+   VISA                - VISA Protocol
+   VMTP                - Versatile Message Transaction Protocol
+   WB-EXPAK            - Wideband EXPAK
+   WB-MON              - Wideband Monitoring
+   XNET                - Cross Net Debugger
+   XNS-IDP             - Xerox NS IDP
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 61]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                            TERMINAL TYPE NAMES
+
+These are the Official Terminal Type Names.  Their use is described in
+RFC-930 [128].  The maximum length of a name is 40 characters.
+
+A terminal names may be up to 40 characters taken from the set of upper-
+case letters, digits, and the two punctuation characters hyphen and
+slash.  It must start with a letter, and end with a letter or digit.
+
+   ADDS-CONSUL-980                       DATAMEDIA-1521
+   ADDS-REGENT-100                       DATAMEDIA-2500
+   ADDS-REGENT-20                        DATAMEDIA-3025
+   ADDS-REGENT-200                       DATAMEDIA-3025A
+   ADDS-REGENT-25                        DATAMEDIA-3045
+   ADDS-REGENT-40                        DATAMEDIA-3045A
+   ADDS-REGENT-60                        DATAMEDIA-DT80/1
+   ADDS-VIEWPOINT                        DATAPOINT-2200
+   ADDS-VIEWPOINT-60                     DATAPOINT-3000
+   AED-512                               DATAPOINT-3300
+   AMPEX-DIALOGUE-210                    DATAPOINT-3360
+   AMPEX-DIALOGUE-80                     DEC-DECWRITER-I
+   AMPEX-210                             DEC-DECWRITER-II
+   AMPEX-230                             DEC-GIGI
+   ANDERSON-JACOBSON-510                 DEC-GT40
+   ANDERSON-JACOBSON-630                 DEC-GT40A
+   ANDERSON-JACOBSON-832                 DEC-GT42
+   ANDERSON-JACOBSON-841                 DEC-LA120
+   ANN-ARBOR-AMBASSADOR                  DEC-LA30
+   ANSI                                  DEC-LA36
+   ARDS                                  DEC-LA38
+   BITGRAPH                              DEC-VT05
+   BUSSIPLEXER                           DEC-VT100
+   CALCOMP-565                           DEC-VT101
+   CDC-456                               DEC-VT102
+   CDI-1030                              DEC-VT125
+   CDI-1203                              DEC-VT131
+   C-ITOH-101                            DEC-VT132
+   C-ITOH-50                             DEC-VT200
+   C-ITOH-80                             DEC-VT220
+   CLNZ                                  DEC-VT240
+   COMPUCOLOR-II                         DEC-VT241
+   CONCEPT-100                           DEC-VT300
+   CONCEPT-104                           DEC-VT320
+   CONCEPT-108                           DEC-VT340
+   DATA-100                              DEC-VT50
+   DATA-GENERAL-6053                     DEC-VT50H
+   DATAGRAPHIX-132A                      DEC-VT52
+   DATAMEDIA-1520                        DEC-VT55
+
+
+
+Reynolds & Postel                                              [Page 62]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   DEC-VT61                              HP-2649A
+   DEC-VT62                              IBM-1050
+   DELTA-DATA-5000                       IBM-2741
+   DELTA-DATA-NIH-7000                   IBM-3101
+   DELTA-TELTERM-2                       IBM-3101-10
+   DIABLO-1620                           IBM-3151
+   DIABLO-1640                           IBM-3275-2
+   DIGILOG-333                           IBM-3276-2
+   DTC-300S                              IBM-3276-3
+   DTC-382                               IBM-3276-4
+   EDT-1200                              IBM-3277-2
+   EXECUPORT-4000                        IBM-3278-2
+   EXECUPORT-4080                        IBM-3278-3
+   FACIT-TWIST-4440                      IBM-3278-4
+   FREEDOM-100                           IBM-3278-5
+   FREEDOM-110                           IBM-3279-2
+   FREEDOM-200                           IBM-3279-3
+   GENERAL-TERMINAL-100A                 IBM-5151
+   GENERAL-TERMINAL-101                  IBM-5154
+   GIPSI-TX-M                            IBM-5081
+   GIPSI-TX-ME                           IBM-6153
+   GIPSI-TX-C4                           IBM-6154
+   GIPSI-TX-C8                           IBM-6155
+   GSI                                   IBM-AED
+   HAZELTINE-1420                        IBM-3278-2-E
+   HAZELTINE-1500                        IBM-3278-3-E
+   HAZELTINE-1510                        IBM-3278-4-E
+   HAZELTINE-1520                        IBM-3278-5-E
+   HAZELTINE-1552                        IBM-3279-2-E
+   HAZELTINE-2000                        IBM-3279-3-E
+   HAZELTINE-ESPRIT                      IMLAC
+   HP-2392                               INFOTON-100
+   HP-2621                               INFOTON-400
+   HP-2621A                              INFOTONKAS
+   HP-2621P                              ISC-8001
+   HP-2623                               LSI-ADM-1
+   HP-2626                               LSI-ADM-11
+   HP-2626A                              LSI-ADM-12
+   HP-2626P                              LSI-ADM-2
+   HP-2627                               LSI-ADM-20
+   HP-2640                               LSI-ADM-22
+   HP-2640A                              LSI-ADM-220
+   HP-2640B                              LSI-ADM-3
+   HP-2645                               LSI-ADM-31
+   HP-2645A                              LSI-ADM-3A
+   HP-2648                               LSI-ADM-42
+   HP-2648A                              LSI-ADM-5
+   HP-2649                               MEMOREX-1240
+
+
+
+Reynolds & Postel                                              [Page 63]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   MICROBEE                              TELETEC-DATASCREEN
+   MICROTERM-ACT-IV                      TELETERM-1030
+   MICROTERM-ACT-V                       TELETYPE-33
+   MICROTERM-ERGO-301                    TELETYPE-35
+   MICROTERM-MIME-1                      TELETYPE-37
+   MICROTERM-MIME-2                      TELETYPE-38
+   MICROTERM-ACT-5A                      TELETYPE-40
+   MICROTERM-TWIST                       TELETYPE-43
+   NEC-5520                              TELEVIDEO-910
+   NETRONICS                             TELEVIDEO-912
+   NETWORK-VIRTUAL-TERMINAL              TELEVIDEO-920
+   OMRON-8025AG                          TELEVIDEO-920B
+   PERKIN-ELMER-550                      TELEVIDEO-920C
+   PERKIN-ELMER-1100                     TELEVIDEO-925
+   PERKIN-ELMER-1200                     TELEVIDEO-955
+   PERQ                                  TELEVIDEO-950
+   PLASMA-PANEL                          TELEVIDEO-970
+   QUME-SPRINT-5                         TELEVIDEO-975
+   QUME-101                              TERMINET-1200
+   QUME-102                              TERMINET-300
+   SOROC                                 TI-700
+   SOROC-120                             TI-733
+   SOUTHWEST-TECHNICAL-PRODUCTS-CT82     TI-735
+   SUN                                   TI-743
+   SUPERBEE                              TI-745
+   SUPERBEE-III-M                        TI-800
+   TEC                                   TYCOM
+   TEKTRONIX-4006                        UNIVAC-DCT-500
+   TEKTRONIX-4010                        VIDEO-SYSTEMS-1200
+   TEKTRONIX-4012                        VIDEO-SYSTEMS-5000
+   TEKTRONIX-4013                        VOLKER-CRAIG-303
+   TEKTRONIX-4014                        VOLKER-CRAIG-303A
+   TEKTRONIX-4023                        VOLKER-CRAIG-404
+   TEKTRONIX-4024                        VISUAL-200
+   TEKTRONIX-4025                        VISUAL-55
+   TEKTRONIX-4027                        WYSE-30
+   TEKTRONIX-4105                        WYSE-50
+   TEKTRONIX-4107                        WYSE-60
+   TEKTRONIX-4110                        WYSE-75
+   TEKTRONIX-4112                        WYSE-85
+   TEKTRONIX-4113                        XEROX-1720
+   TEKTRONIX-4114                        XTERM
+   TEKTRONIX-4115                        ZENITH-H19
+   TEKTRONIX-4125                        ZENITH-Z29
+   TEKTRONIX-4404                        ZENTEC-30
+   TELERAY-1061
+   TELERAY-3700
+   TELERAY-3800
+
+
+
+Reynolds & Postel                                              [Page 64]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                                 DOCUMENTS
+
+
+   [1]    Anderson, B., "TACACS User Identification Telnet Option",
+          RFC-927, BBN, December 1984.
+
+   [2]    BBN, "Specifications for the Interconnection of a Host and an
+          IMP", Report 1822, Bolt Beranek and Newman, Cambridge,
+          Massachusetts, revised, December 1981.
+
+   [3]    BBN, "User Manual for TAC User Database Tool", Bolt Beranek
+          and Newman, September 1984.
+
+   [4]    Ben-Artzi, Amatzia, "Network Management for TCP/IP Network: An
+          Overview", 3Com, May 1988.
+
+   [5]    Bennett, C., "A Simple NIFTP-Based Mail System", IEN 169,
+          University College, London, January 1981.
+
+   [6]    Bhushan, A., "A Report on the Survey Project", RFC-530,
+          NIC 17375, June 1973.
+
+   [7]    Bisbey, R., D. Hollingworth, and B. Britt, "Graphics Language
+          (version 2.1)", ISI/TM-80-18, Information Sciences Institute,
+          July 1980.
+
+   [8]    Boggs, D., J. Shoch, E. Taft, and R. Metcalfe, "PUP: An
+          Internetwork Architecture", XEROX Palo Alto Research Center,
+          CSL-79-10, July 1979; also in IEEE Transactions on
+          Communication, Volume COM-28, Number 4, April 1980.
+
+   [9]    Borman, D., Editor, "Telnet Linemode Option",
+          RFC 1116, Cray Research, Inc., August 1989.
+
+   [10]   Braden, R., "NETRJS Protocol", RFC-740, NIC 42423,
+          Information Sciences Institute, November 1977.
+
+   [11]   Braden, R., and J. Postel, "Requirements for Internet
+          Gateways", RFC-1009, Obsoletes RFC-985, Information Sciences
+          Institute, June 1987.
+
+   [12]   Bressler, B., "Remote Job Entry Protocol",  RFC-407,
+          NIC 12112, October 1972.
+
+   [13]   Bressler, R., "Inter-Entity Communication -- An Experiment",
+          RFC-441, NIC 13773, January 1973.
+
+   [14]   Butler, M., J. Postel, D. Chase, J. Goldberger, and
+
+
+
+Reynolds & Postel                                              [Page 65]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+          J. K. Reynolds, "Post Office Protocol - Version 2", RFC-937,
+          Information Sciences Institute, February 1985.
+
+   [15]   Case, J., M. Fedor, M. Schoffstall, and C. Davin,
+          "A Simple Network Management Protocol", RFC-1098,
+          (Obsoletes RFC-1067), University of Tennessee at
+          Knoxville, NYSERNet, Inc., Rensselaer Polytechnic
+          Institute, and MIT Laboratory for Computer Science,
+          April 1989.
+
+   [16]   Cass, D., and M. Rose, "ISO Transport Services on Top of
+          the TCP", RFC-983, NTRC, April 1986.
+
+   [17]   Cheriton, D., "VMTP: Versatile Message Transaction
+          Protocol Specification", RFC-1045, pgs 103 & 104,
+          Stanford University, February 1988.
+
+   [18]   Cisco Systems, "Gateway Server Reference Manual", Manual
+          Revision B, January 10, 1988.
+
+   [19]   Clark, D., "PCMAIL: A Distributed Mail System for Personal
+          Computers", RFC-984, MIT, May 1986.
+
+   [20]   Clark, D., M. Lambert, and L. Zhang, "NETBLT: A Bulk Data
+          Transfer Protocol", RFC-969, MIT Laboratory for Computer
+          Science, December 1985.
+
+   [21]   Cohen, D., "On Holy Wars and a Plea for Peace", IEEE Computer
+          Magazine, October 1981.
+
+   [22]   Cohen, D., "Specifications for the Network Voice Protocol",
+          RFC-741, ISI/RR 7539, Information Sciences Institute,
+          March 1976.
+
+   [23]   Cohen, D. and J. Postel, "Multiplexing Protocol", IEN 90,
+          Information Sciences Institute, May 1979.
+
+   [24]   COMPASS, "Semi-Annual Technical Report", CADD-7603-0411,
+          Massachusetts Computer Associates, 4 March 1976. Also as,
+          "National Software Works, Status Report No. 1,"
+          RADC-TR-76-276, Volume 1, September 1976. And COMPASS. "Second
+          Semi-Annual Report," CADD-7608-1611, Massachusetts Computer
+          Associates, August 1976.
+
+   [25]   Crispin, M., "Telnet Logout Option", Stanford University-AI,
+          RFC-727, April 1977.
+
+   [26]   Crispin, M., "Telnet SUPDUP Option", Stanford University-AI,
+
+
+
+Reynolds & Postel                                              [Page 66]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+          RFC-736, October 1977.
+
+   [27]   Crispin, M., "SUPDUP Protocol", RFC-734, NIC 41953,
+          October 1977.
+
+   [28]   Crocker, D., "Telnet Output Carriage-Return Disposition
+          Option", RFC-652, October 1974.
+
+   [29]   Crocker, D., "Telnet Output Formfeed Disposition Option",
+          RFC-655, October 1974.
+
+   [30]   Crocker, D., "Telnet Output Linefeed Disposition", RFC-658,
+          October 1974.
+
+   [31]   Crocker, D., "Telnet Output Horizontal Tab Disposition
+          Option", RFC-654, October 1974.
+
+   [32]   Crocker, D., "Telnet Output Horizontal Tabstops Option",
+          RFC-653, October 1974.
+
+   [33]   Crocker, D., "Telnet Output Vertical Tab Disposition Option",
+          RFC-657, October 1974.
+
+   [34]   Crocker, D., "Telnet Output Vertical Tabstops Option",
+          RFC-656, October 1974.
+
+   [35]   Crocker, D. and R. Gumpertz, "Revised Telnet Byte Marco
+          Option", RFC-735, November 1977.
+
+   [36]   Croft, B., and J. Gilmore, "BOOTSTRAP Protocol (BOOTP)",
+          RFC-951, Stanford and SUN Microsytems, September 1985.
+
+   [37]   Davin, J., J. Case, M. Fedor, and M. Schoffstall, "A Simple
+          Gateway Monitoring Protocol", RFC-1028, November 1987.
+
+   [38]   Day, J., "Telnet Data Entry Terminal Option", RFC-732,
+          September 1977.
+
+   [39]   DCA, "3270 Display System Protocol", #1981-08.
+
+   [40]   DDN Protocol Handbook, "Telnet Output Line Width Option",
+          NIC 50005, December 1985.
+
+   [41]   DDN Protocol Handbook, "Telnet Output Page Size Option",
+          NIC 50005, December 1985.
+
+   [42]   DDN Protocol Handbook, "Telnet Reconnection Option",
+          NIC 50005, December 1985.
+
+
+
+Reynolds & Postel                                              [Page 67]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   [43]   Deering, S., "Host Extensions for IP Multicasting",
+          RFC-1112, Obsoletes RFC-988, RFC-1054, Stanford University,
+          August 1989.
+
+   [44]   Elvy, M., and R. Nedved, "Network Mail Path Service", RFC-915,
+          Harvard and CMU, July 1986.
+
+   [45]   Feinler, E., editor, "DDN Protocol Handbook", Network
+          Information Center, SRI International, December 1985.
+
+   [46]   Feinler, E., editor, "Internet Protocol Transition Workbook",
+          Network Information Center, SRI International, March 1982.
+
+   [47]   Feinler, E. and J. Postel, eds., "ARPANET Protocol Handbook",
+          NIC 7104, for the Defense Communications Agency by SRI
+          International, Menlo Park, California, Revised January 1978.
+
+   [48]   Finlayson, R., T. Mann, J. Mogul, and M. Theimer, "A Reverse
+          Address Resolution Protocol", RFC-903, Stanford University,
+          June 1984.
+
+   [49]   Forgie, J., "ST - A Proposed Internet Stream Protocol",
+          IEN 119, MIT Lincoln Laboratory, September 1979.
+
+   [50]   Forsdick, H., "CFTP", Network Message, Bolt Beranek and
+          Newman, January 1982.
+
+   [51]   Greenberg, B., "Telnet SUPDUP-OUTPUT Option", RFC-749,
+          MIT-Multics, September 1978.
+
+   [52]   Harrenstien, K., "Name/Finger", RFC-742, NIC 42758,
+          SRI International,  December 1977.
+
+   [53]   Harrenstien, K., M. Stahl, and E. Feinler, "DOD Internet Host
+          Table Specification", RFC-952, Obsoletes RFC-810,
+          October 1985.
+
+   [54]   Harrenstien, K., V. White, and E. Feinler, "Hostnames Server",
+          RFC-811, SRI International, March 1982.
+
+   [55]   Harrenstien, K., and V. White, "Nicname/Whois", RFC-812,
+          SRI International, March 1982.
+
+   [56]   Haverty, J., "XNET Formats for Internet Protocol Version 4",
+          IEN 158, October 1980.
+
+   [57]   Hedrick, C., "Telnet Terminal Speed Option", RFC-1079,
+          Rutgers University, December 1988.
+
+
+
+Reynolds & Postel                                              [Page 68]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   [58]   Hedrick, C., "Telnet Remote Flow Control Option",
+          RFC-1080, Rutgers University, December 1988.
+
+   [59]   Hinden, R., "A Host Monitoring Protocol", RFC-869,
+          Bolt Beranek and Newman, December 1983.
+
+   [60]   Hinden, R., and A. Sheltzer, "The DARPA Internet Gateway",
+          RFC-823, September 1982.
+
+   [61]   Hornig, C., "A Standard for the Transmission of IP Datagrams
+          over Ethernet Networks, RFC-894, Symbolics, April 1984.
+
+   [62]   Internet Activities Board, J. Postel, Editor, "IAB Official
+          Protocol Standards", RFC-1130, Internet Activities
+          October 1989.
+
+   [63]   International Standards Organization, "ISO Transport Protocol
+          Specification - ISO DP 8073", RFC-905, April 1984.
+
+   [64]   International Standards Organization, "Protocol for Providing
+          the Connectionless-Mode Network Services", RFC-926, ISO,
+          December 1984.
+
+   [65]   Kantor, B., and P. Lapsley, "Network News Transfer Protocol",
+          RFC-977, UC San Diego & UC Berkeley, February 1986.
+
+   [66]   Kent, S., and J. Linn, "Privacy Enhancement for Internet
+          Electronic Mail: Part II -- Certificate-Based Key Management",
+          BBNCC and DEC, August 1989.
+
+   [67]   Khanna, A., and A. Malis, "The ARPANET AHIP-E Host Access
+          Protocol (Enhanced AHIP)", RFC-1005, BBN Communications
+          Corporation, May 1987.
+
+   [68]   Killian, E., "Telnet Send-Location Option", RFC-779,
+          April 1981.
+
+   [69]   Korb, J., "A Standard for the Transmission of IP Datagrams
+          Over Public Data Networks", RFC-877, Purdue University,
+          September 1983.
+
+   [70]   Levy, S., and T. Jacobson, "Telnet X.3 PAD Option", RFC-1053,
+          Minnesota Supercomputer Center, April 1988.
+
+   [71]   Linn, J., "Privacy Enhancement for Internet Electronic
+          Mail: Part I: Message Encipherment and Authentication
+          Procedures", RFC-1113, Obsoletes RFC-989 and RFC-1040, DEC,
+          August 1989.
+
+
+
+Reynolds & Postel                                              [Page 69]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   [72]   Linn, J., "Privacy Enhancement for Internet Electronic
+          Mail: Part III -- Algorithms, Modes, and Identifiers",
+          RFC-1115, DEC, August 1989.
+
+   [73]   Lottor, M., "Simple File Transfer Protocol", RFC-913, MIT,
+          September 1984.
+
+   [74]   M/A-COM Government Systems, "Dissimilar Gateway Protocol
+          Specification, Draft Version", Contract no. CS901145,
+          November 16, 1987.
+
+   [75]   Marcy, G., "Telnet X Display Location Option", RFC-1096,
+          Carnegie Mellon University, March 1989.
+
+   [76]   Malis, A., "Logical Addressing Implementation Specification",
+          BBN Report 5256, pp 31-36, May 1983.
+
+   [77]   Malkin, G., "KNET/VM Command Message Protocol Functional
+          Overview", Spartacus, Inc., January 4, 1988.
+
+   [78]   Metcalfe, R. M. and D. R. Boggs, "Ethernet: Distributed Packet
+          Switching for Local Computer Networks", Communications of the
+          ACM, 19 (7), pp 395-402, July 1976.
+
+   [79]   Miller, T., "Internet Reliable Transaction Protocol", RFC-938,
+          ACC, February 1985.
+
+   [80]   Mills, D., "Network Time Protocol (Version 1), Specification
+          and Implementation", RFC-1059, University of Delaware,
+          July 1988.
+
+   [81]   Mockapetris, P., "Domain Names - Concepts and
+          Facilities", RFC-1034, Obsoletes RFCs 882, 883, and
+          973, Information Sciences Institute, November 1987.
+
+   [82]   Mockapetris, P., "Domain Names - Implementation and
+          Specification", RFC-1035, Obsoletes RFCs 882, 883, and
+          973, Information Sciences Institute, November 1987.
+
+   [83]   Moy, J., "The OSPF Specification", RFC 1131, Proteon,
+          October 1989.
+
+   [84]   Nedved, R., "Telnet Terminal Location Number Option", RFC-946,
+          Carnegie-Mellon University, May 1985.
+
+   [85]   NSW Protocol Committee, "MSG: The Interprocess Communication
+          Facility for the National Software Works", CADD-7612-2411,
+          Massachusetts Computer Associates, BBN 3237, Bolt Beranek and
+
+
+
+Reynolds & Postel                                              [Page 70]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+          Newman, Revised December 1976.
+
+   [86]   Onions, J., and M. Rose, "ISO-TP0 bridge between TCP
+          and X.25", RFC-1086, Nottingham, TWG, December 1988.
+
+   [87]   Partridge, C. and G. Trewitt, The High-Level Entity Management
+          System (HEMS), RFCs 1021, 1022, 1023, and 1024, BBN/NNSC,
+          Stanford, October, 1987.
+
+   [88]   Plummer, D., "An Ethernet Address Resolution Protocol or
+          Converting Network Protocol Addresses to 48-bit Ethernet
+          Addresses for Transmission on Ethernet Hardware", RFC-826,
+          MIT-LCS, November 1982.
+
+   [89]   Postel, J., "Active Users", RFC-866, Information
+          Sciences Institute, May 1983.
+
+   [90]   Postel, J., and J. Reynolds, "A Standard for the Transmission
+          of IP Datagrams over IEEE 802 Networks", RFC-1042,
+          USC/Information Sciences Institute, February 1988.
+
+   [91]   Postel, J., "A Standard for the Transmission of IP Datagrams
+          over Experimental Ethernet Networks, RFC-895, Information
+          Sciences Institute, April 1984.
+
+   [92]   Postel, J., "Character Generator Protocol", RFC-864,
+          Information Sciences Institute, May 1983.
+
+   [93]   Postel, J., "Daytime Protocol", RFC-867, Information Sciences
+          Institute, May 1983.
+
+   [94]   Postel, J., "Discard Protocol", RFC-863, Information Sciences
+          Institute, May 1983.
+
+   [95]   Postel, J., "Echo Protocol", RFC-862, Information Sciences
+          Institute, May 1983.
+
+   [96]   Postel, J. and J. Reynolds, "File Transfer Protocol", RFC-959,
+          Information Sciences Institute, October 1985.
+
+   [97]   Postel, J., "Internet Control Message Protocol - DARPA
+          Internet Program Protocol Specification", RFC-792,
+          Information Sciences Institute, September 1981.
+
+   [98]   Postel, J., "Internet Message Protocol", RFC-759, IEN 113,
+          Information Sciences Institute, August 1980.
+
+   [99]   Postel, J., "Name Server", IEN 116, Information Sciences
+
+
+
+Reynolds & Postel                                              [Page 71]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+          Institute, August 1979.
+
+   [100]  Postel, J., "Quote of the Day Protocol", RFC-865,
+          Information Sciences Institute, May 1983.
+
+   [101]  Postel, J., "Remote Telnet Service", RFC-818,
+          Information Sciences Institute, November 1982.
+
+   [102]  Postel, J., "Simple Mail Transfer Protocol", RFC-821,
+          Information Sciences Institute, August 1982.
+
+   [103]  Postel, J., "Telnet End of Record Option", RFC-885,
+          Information Sciences Institute, December 1983.
+
+   [104]  Postel, J., "User Datagram Protocol", RFC-768
+          Information Sciences Institute, August 1980.
+
+   [105]  Postel, J., ed., "Internet Protocol - DARPA Internet Program
+          Protocol Specification", RFC-791, Information Sciences
+          Institute, September 1981.
+
+   [106]  Postel, J., ed., "Transmission Control Protocol - DARPA
+          Internet Program Protocol Specification", RFC-793,
+          Information Sciences Institute, September 1981.
+
+   [107]  Postel, J. and D. Crocker, "Remote Controlled Transmission and
+          Echoing Telnet Option", RFC-726, March 1977.
+
+   [108]  Postel, J., and K. Harrenstien, "Time Protocol", RFC-868,
+          Information Sciences Institute, May 1983.
+
+   [109]  Postel, J. and J. Reynolds, "Telnet Extended Options - List
+          Option", RFC-861, Information Sciences Institute, May 1983.
+
+   [110]  Postel, J. and J. Reynolds, "Telnet Binary Transmission",
+          RFC-856, Information Sciences Institute, May 1983.
+
+   [111]  Postel, J. and J. Reynolds, "Telnet Echo Option", RFC-857,
+          Information Sciences Institute, May 1983.
+
+   [112]  Postel, J., and J. Reynolds, "Telnet Protocol Specification",
+          RFC-854, Information Sciences Institute, May 1983.
+
+   [113]  Postel, J. and J. Reynolds, "Telnet Status Option", RFC-859,
+          Information Sciences Institute, May 1983.
+
+   [114]  Postel, J. and J. Reynolds, "Telnet Suppress Go Ahead Option",
+          RFC-858, Information Sciences Institute, May 1983.
+
+
+
+Reynolds & Postel                                              [Page 72]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   [115]  Postel, J. and J. Reynolds, "Telnet Timing Mark Option",
+          RFC-860, Information Sciences Institute, May 1983.
+
+   [116]  Rekhter, J., "Telnet 3270 Regime Option", RFC-1041,
+          IBM, January 1988.
+
+   [117]  Reynolds, J., "BOOTP Vendor Information Extensions",
+          RFC 1084, Information Sciences Institute, December 1988.
+
+   [118]  Reynolds, J. and J. Postel, "Official Internet Protocols",
+          RFC-1011, USC/Information Sciences Institute, May 1987.
+
+   [119]  Romano, S., M. Stahl, and M. Recker, "Internet Numbers",
+          RFC-1117, SRI-NIC, August 1989.
+
+   [120]  Rose, M., and K. McCloghrie, "Structure and Identification of
+          Management Information for TCP/IP-based internets", RFC-1065,
+          TWG, August 1988.
+
+   [121]  Rose, M., and K. McCloghrie, "Management Information Base for
+          Network Management of TCP/IP-based internets", RFC-1066,
+          TWG, August 1988.
+
+   [122]  Rose, M., "Post Office Protocol - Version 3", RFC-1081,
+          TWG, November 1988.
+
+   [123]  Seamonson, L. J., and E. C. Rosen, "STUB" Exterior Gateway
+          Protocol", RFC-888, BBN Communications Corporation,
+          January 1984.
+
+   [124]  Shuttleworth, B., "A Documentary of MFENet, a National
+          Computer Network", UCRL-52317, Lawrence Livermore Labs,
+          Livermore, California, June 1977.
+
+   [125]  Silverman, S., "Output Marking Telnet Option", RFC-933, MITRE,
+          January 1985.
+
+   [126]  Sollins, K., "The TFTP Protocol (Revision 2)", RFC-783,
+          MIT/LCS, June 1981.
+
+   [127]  Solomon, M., L. Landweber, and D. Neuhengen, "The CSNET Name
+          Server", Computer Networks, v.6, n.3, pp. 161-172, July 1982.
+
+   [128]  Solomon, M., and E. Wimmers, "Telnet Terminal Type Option",
+          RFC-930, Supercedes RFC-884, University of Wisconsin, Madison,
+          January 1985.
+
+   [129]  Sproull, R., and E. Thomas, "A Networks Graphics Protocol",
+
+
+
+Reynolds & Postel                                              [Page 73]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+          NIC 24308, August 1974.
+
+   [130]  St. Johns, M., "Authentication Service", RFC-931, TPSC,
+          January 1985.
+
+   [131]  Tappan, D., "The CRONUS Virtual Local Network", RFC-824,
+          Bolt Beranek and Newman, August 1982.
+
+   [132]  Taylor, J., "ERPC Functional Specification", Version 1.04,
+          HYDRA Computer Systems, Inc., July 1984.
+
+   [133]  "The Ethernet, A Local Area Network: Data Link Layer and
+          Physical Layer Specification", AA-K759B-TK, Digital Equipment
+          Corporation, Maynard, MA.  Also as:  "The Ethernet - A Local
+          Area Network", Version 1.0, Digital Equipment Corporation,
+          Intel Corporation, Xerox Corporation, September 1980.  And:
+          "The Ethernet, A Local Area Network: Data Link Layer and
+          Physical Layer Specifications", Digital, Intel and Xerox,
+          November 1982.  And:  XEROX, "The Ethernet, A Local Area
+          Network: Data Link Layer and Physical Layer Specification",
+          X3T51/80-50, Xerox Corporation, Stamford, CT., October 1980.
+
+   [134]  The High Level Protocol Group, "A Network Independent File
+          Transfer Protocol",  INWG Protocol Note 86, December 1977.
+
+   [135]  Thomas, Bob, "The Interhost Protocol to Support CRONUS/DIAMOND
+          Interprocess Communication", BBN, September 1983.
+
+   [136]  Tovar, "Telnet Extended ASCII Option", RFC-698, Stanford
+          University-AI, July 1975.
+
+   [137]  Uttal, J., J. Rothschild, and C. Kline, "Transparent
+          Integration of UNIX and MS-DOS", Locus Computing Corporation.
+
+   [138]  Velten, D., R. Hinden, and J. Sax, "Reliable Data Protocol",
+          RFC-908, BBN Communications Corporation, July 1984.
+
+   [139]  Waitzman, D., "Telnet Window Size Option", RFC-1073,
+          BBN STC, October, 1988.
+
+   [140]  Waitzman, D., C. Partridge, and S. Deering
+          "Distance Vector Multicast Routing Protocol", RFC-1075,
+          BBN STC and Stanford University, November 1988.
+
+   [141]  Wancho, F., "Password Generator Protocol",  RFC-972, WSMR,
+          January 1986.
+
+   [142]  Warrier, U., and L. Besaw, "The Common Management
+
+
+
+Reynolds & Postel                                              [Page 74]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+          Information Services and Protocol over TCP/IP (CMOT)",
+          RFC-1095, Unisys Corp. and Hewlett-Packard, April 1989.
+
+   [143]  Welch, B., "The Sprite Remote Procedure Call System",
+          Technical Report, UCB/Computer Science Dept., 86/302,
+          University of California at Berkeley, June 1986.
+
+   [144]  Xerox, "Courier: The Remote Procedure Protocol", XSIS 038112,
+          December 1981.
+
+   [145]  Yasuda, A., and T. Thompson, "TELNET Data Entry Terminal
+          Option DODIIS Implementation", RFC-1043, DIA, February 1988.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 75]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+                                  PEOPLE
+
+
+   [AB20]    Art Berggreen       ACC       art@SALT.ACC.ARPA
+
+   [ABB2]    A. Blasco Bonito    CNUCE     blasco@ICNUCEVM.CNUCE.CNR.IT
+
+   [AD14]    Annette DeSchon     ISI       DESCHON@ISI.EDU
+
+   [AGM]     Andy Malis          BBN       Malis@BBN.COM
+
+   [AKH5]    Arthur Hartwig      UQNET
+                   munnari!wombat.decnet.uq.oz.au!ccarthur@UUNET.UU.NET
+
+   [ANM2]    April N. Marine     SRI       APRIL@NIC.DDN.MIL
+
+   [AW90]    Amanda Walker       Intercon  AMANDA@INTERCON.COM
+
+   [AXB]     Albert G. Broscius  UPENN     broscius@DSL.CIS.UPENN.EDU
+
+   [AXB1]    Amatzia Ben-Artzi             ---none---
+
+   [AXC]     Andrew Cherenson    SGI       arc@SGI.COM
+
+   [AXC1]    Anthony Chung       Sytek
+                                    sytek!syteka!anthony@HPLABS.HP.COM
+
+   [AXC2]    Asheem Chandna      AT&T      ac0@mtuxo.att.com
+
+   [AXM]     Alex Martin        Retix      ---none---
+
+   [AXS]     Arthur Salazar     Locus      lcc.arthur@SEAS.UCLA.EDU
+
+   [BA4]     Brian Anderson      BBN       baanders@CCQ.BBN.COM
+
+   [BB257]   Brian W. Brown     SynOptics  BBROWN@MVIS1.SYNOPTICS.COM
+
+   [BCH2]    Barry Howard        LLL       Howard@NMFECC.ARPA
+
+   [BCN]     Clifford B. Newman  UWASH     bcn@CS.WASHINGTON.EDU
+
+   [BD70]    Bernd Doleschal     SEL       Doleschal@A.ISI.EDU
+
+   [BH144]   Bridget Halsey      Banyan    bah@BANYAN.BANYAN.COM
+
+   [BJR2]    Bill Russell        NYU       russell@cmcl2.NYU.EDU
+
+   [BKR]     Brian Reid          DEC       reid@DECWRL.DEC.COM
+
+
+
+Reynolds & Postel                                              [Page 76]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   [BP52]    Brad Parker         CAYMAN    brad@cayman.Cayman.COM
+
+   [BS221]   Bob Stewart         Xyplex    STEWART@XYPLEX.COM
+
+   [BWB6]    Barry Boehm         DARPA     boehm@DARPA.MIL
+
+   [BXA]     Bill Anderson       MITRE     wda@MITRE-BEDFORD.ORG
+
+   [BXB]     Brad Benson         Touch     ---none---
+
+   [BXE]     Brian A. Ehrmantraut Auspex Systems bae@auspex.com
+
+   [BXH]     Brian Horn          Locus     ---none---
+
+   [BXL]     Brian Lloyd         SIRIUS    ---none---
+
+   [BXN]     Bill Norton         Merit     wbn@MERIT.EDU
+
+   [BXV]     Bill Versteeg       NRC       bvs@NRC.COM
+
+   [BXW]     Brent Welch         Sprite
+                        brent%sprite.berkeley.edu@GINGER.BERKELEY.EDU
+
+   [BXW1]    Bruce Willins       Raycom    ---none---
+
+   [BXZ]     Bob Zaniolo         Reuter    ---none---
+
+   [CLH3]    Charles Hedrick     RUTGERS   HEDRICK@ARAMIS.RUTGERS.EDU
+
+   [CMR]     Craig Rogers        ISI       Rogers@ISI.EDU
+
+   [CXM]     Charles Marker II   MIPS      marker@MIPS.COM
+
+   [CXT]     Christopher Tengi   Princeton tengi@Princeton.EDU
+
+   [DAG4]    David A. Gomberg    MITRE     gomberg@GATEWAY.MITRE.ORG
+
+   [DB14]    Dave Borman         Cray      dab@CRAY.COM
+
+   [DC126]   Dick Cogger         Cornell   rhx@CORNELLC.CIT.CORNELL.EDU
+
+   [DCP1]    David Plummer       MIT       DCP@SCRC-QUABBIN.ARPA
+
+   [DDC1]    David Clark         MIT       ddc@LCS.MIT.EDU
+
+   [DJK13]   David Kaufman       DeskTalk  ---none---
+
+   [DLM1]    David Mills         LINKABIT  Mills@HUEY.UDEL.EDU
+
+
+
+Reynolds & Postel                                              [Page 77]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   [DM28]    Dennis Morris       DCA       Morrisd@IMO-UVAX.DCA.MIL
+
+   [DM280]   Dave Mackie         NCD       lupine!djm@UUNET.UU.NET
+
+   [DM354]   Don McWilliam       UBC       mcwillm@CC.UBC.CA
+
+   [DPR]     David Reed          MIT-LCS   Reed@MIT-MULTICS.ARPA
+
+   [DRC3]    Dave Cheriton       STANFORD
+                                 cheriton@PESCADERO.STANFORD.EDU
+
+   [DT15]    Daniel Tappan       BBN       Tappan@BBN.COM
+
+   [DW181]   David Wolfe         SRI       ctabka@TSCA.ISTC.SRI.COM
+
+   [DW183]   David Waitzman      BBN       dwaitzman@BBN.COM
+
+   [DXB]     Dave Buehmann       Intergraph ingr!daveb@UUNET.UU.NET
+
+   [DXD]     Dennis J.W. Dube    VIA SYSTEMS ---none---
+
+   [DXG]     David Goldberg      SMI       sun!dg@UCBARPA.BERKELEY.EDU
+
+   [DXK]     Doug Karl           OSU
+                                     KARL-D@OSU-20.IRCC.OHIO-STATE.EDU
+
+   [DXM]     Didier Moretti      Ungermann-Bass ---none---
+
+   [DXM1]    Donna McMalster     David Systems ---none---
+
+   [DXP]     Dave Preston        CMC       ---none---
+
+   [DY26]    Dennis Yaro         SUN       yaro@SUN.COM
+
+   [EAK4]    Earl Killian        LLL       EAK@MORDOR.S1.GOV
+
+   [EBM]     Eliot Moss          MIT       EBM@XX.LCS.MIT.EDU
+
+   [EP53]    Eric Peterson       Locus     lcc.eric@SEAS.UCLA.EDU
+
+   [EXC]     Ed Cain             DCA       cain@edn-unix.dca.mil
+
+   [EXR]     Eric Rubin          FiberCom  err@FIBERCOM.COM
+
+   [EXR1]    Efrat Ramati        Lannet Co. ---none---
+
+   [FB77]    Fred Baker          Vitalink  baker%vitam6@UUNET.UU.NET
+
+
+
+
+Reynolds & Postel                                              [Page 78]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   [FJK2]    Frank Kastenholz    Interlan  KASTEN@MITVMA.MIT.EDU
+
+   [FJW]     Frank J. Wancho     WSMR      WANCHO@SIMTEL20.ARPA
+
+   [FXB1]    Felix Burton        DIAB      FB@DIAB.SE
+
+   [GAL5]    Guillermo A. Loyola IBM       LOYOLA@IBM.COM
+
+   [GB7]     Gerd Beling         FGAN      GBELING@ISI.EDU
+
+   [GEOF]    Geoff Goodfellow    OSD       Geoff@FERNWOOD.MPK.CA.US
+
+   [GGB2]    Geoff Baehr         SUN       geoffb@ENG.SUN.COM
+
+   [GM23]    Glenn Marcy         CMU       Glenn.Marcy@A.CS.CMU.EDU
+
+   [GS2]     Greg Satz           cisco     satz@CISCO.COM
+
+   [GS123]   Geof Stone          NSC       geof@NETWORK.COM
+
+   [GSM11]   Gary S. Malkin      Proteon   gmalkin@PROTEON.COM
+
+   [GXG]     Gil Greebaum        Unisys    gcole@nisd.cam.unisys.com
+
+   [GXP]     Gill Pratt          MIT       gill%mit-ccc@MC.LCS.MIT.EDU
+
+   [GXS]     Guenther Schreiner  LINK
+                                      guenther%ira.uka.de@RELAY.CS.NET
+
+   [GXT]     Glenn Trewitt       STANFORD  trewitt@AMADEUS.STANFORD.EDU
+
+   [GXT1]    Gene Tsudik         USC       tsudik@USC.EDU
+
+   [GXW]     Glenn Waters        Bell Northern gwaters@BNR.CA
+
+   [HCF2]    Harry Forsdick      BBN       Forsdick@BBN.COM
+
+   [HS23]    Hokey Stenn         Plus5     hokey@PLUS5.COM
+
+   [HWB]     Hans-Werner Braun   MICHIGAN  HWB@MCR.UMICH.EDU
+
+   [HXE]     Hunaid Engineer     Cray      hunaid@OPUS.CRAY.COM
+
+   [HXK]     Henry Kaijak        Gandalf   ---none---
+
+   [IEEE]    Vince Condello      IEEE      ---none---
+
+   [JAG]     James Gosling       SUN       JAG@SUN.COM
+
+
+
+Reynolds & Postel                                              [Page 79]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   [JB478]   Jonathan Biggar     Netlabs   jon@netlabs.com
+
+   [JBP]     Jon Postel          ISI       Postel@ISI.EDU
+
+   [JBW1]    Joseph Walters, Jr. BBN       JWalters@BBN.COM
+
+   [JCB1]    John Burruss        BBN       JBurruss@VAX.BBN.COM
+
+   [JCM48]   Jeff Mogul          DEC       mogul@DECWRL.DEC.COM
+
+   [JD21]    Jonathan Dreyer     BBN       Dreyer@CCV.BBN.COM
+
+   [JDC20]   Jeffrey Case        UTK       case@UTKUX1.UTK.EDU
+
+   [JFH2]    Jack Haverty        BBN       JHaverty@BBN.COM
+
+   [JFW]     Jon F. Wilkes       STC       Wilkes@CCINT1.RSRE.MOD.UK
+
+   [JGH]     Jim Herman          BBN       Herman@CCJ.BBN.COM
+
+   [JJB25]   John Bowe           BBN       jbowe@PINEAPPLE.BBN.COM
+
+   [JKR1]    Joyce K. Reynolds   ISI       JKRey@ISI.EDU
+
+   [JR35]    Jon Rochlis         MIT       jon@ATHENA.MIT.EDU
+
+   [JRL3]    John LoVerso        Xylogics  loverso@XYLOGICS.COM
+
+   [JS28]    John A. Shriver     Proteon   jas@PROTEON.COM
+
+   [JTM4]    John Moy            Proteon   jmoy@PROTEON.COM
+
+   [JWF]     Jim Forgie          MIT/LL    FORGIE@XN.LL.MIT.EDU
+
+   [JXB]     Jeffrey Buffun      Apollo    jbuffum@APOLLO.COM
+
+   [JXC]     John Cook           Chipcom   cook@chipcom.com
+
+   [JXE2]    Jeanne Evans        UKMOD     JME%RSRE.MOD.UK@CS.UCL.AC.UK
+
+   [JXF]     Josh Fielk          Optical Data Systems  ---none---
+
+   [JXG]     Jerry Geisler       Boeing    ---none---
+
+   [JXG1]    Jim Greuel          HP        jimg%hpcndpc@hplabs.hp.com
+
+   [JXH]     Jeff Honig          Cornell   jch@sonne.tn.cornell.edu
+
+
+
+
+Reynolds & Postel                                              [Page 80]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   [JXH1]    Jim Hayes           Apple     Hayes@APPLE.COM
+
+   [JXI]     Jon Infante         ICL       ---none---
+
+   [JXM]     Joseph Murdock      Network Resources Corporation
+                                           ---none---
+
+   [JXO]     Jack O'Neil         ENCORE    ---none---
+
+   [JXO1]    Jerrilynn Okamura   Ontologic ---none---
+
+   [JXO2]    Jarkko Oikarinen    Tolsun    jto@TOLSUN.OULU.FI
+
+   [JXP]     Joe Pato            Apollo    apollo!pato@EDDIE.MIT.EDU
+
+   [JXR]     Jacob Rekhter       IBM       Yakov@IBM.COM
+
+   [JXS]     Jim Stevens         Rockwell  Stevens@ISI.EDU
+
+   [JXS1]    John Sancho         CastleRock ---none---
+
+   [KAA]     Ken Adelman         TGV, Inc. Adelman@TGV.COM
+
+   [KA4]     Karl Auerbach       Epilogue  auerbach@csl.sri.com
+
+   [KH43]    Kathy Huber         BBN       khuber@bbn.com
+
+   [KLH]     Ken Harrenstien     SRI       KLH@NIC.DDN.MIL
+
+   [KR35]    Keith Reynolds      SCO       keithr@SCO.COM
+
+   [KSL]     Kirk Lougheed       cisco     LOUGHEED@MATHOM.CISCO.COM
+
+   [KXD]     Kevin DeVault       NI        ---none---
+
+   [KXS]     Keith Sklower       Berkeley  sklower@okeeffe.berkeley.edu
+
+   [KXW]     Ken Whitfield       MCNC      ken@MCNC.ORG
+
+   [KZM]     Keith McCloghrie    TWG       kzm@TWG.ARPA
+
+   [LL69]    Lawrence Lebahn     DIA       DIA3@PAXRV-NES.NAVY.MIL
+
+   [LLP]     Larry Peterson      ARIZONA   llp@ARIZONA.EDU
+
+   [LXE]     Len Edmondson       SUN       len@TOPS.SUN.COM
+
+   [LXF]     Larry Fischer       DSS       lfischer@dss.com
+
+
+
+Reynolds & Postel                                              [Page 81]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   [LXH]     Leo Hourvitz        NeXt      leo@NEXT.COM
+
+   [MA]      Mike Accetta        CMU       MIKE.ACCETTA@CMU-CS-A.EDU
+
+   [MARY]    Mary K. Stahl       SRI       Stahl@NIC.DDN.MIL
+
+   [MAR10]   Mark A. Rosenstein  MIT       mar@ATHENA.MIT.EDU
+
+   [MB]      Michael Brescia     BBN       Brescia@CCV.BBN.COM
+
+   [MBG]     Michael Greenwald   SYMBOLICS
+                                    Greenwald@SCRC-STONY-BROOK.ARPA
+
+   [MCSJ]    Mike StJohns        TPSC      StJohns@MIT-MULTICS.ARPA
+
+   [ME38]    Marc A. Elvy        Marble    ELVY@CARRARA.MARBLE.COM
+
+   [MKL]     Mark Lottor         SRI       MKL@NIC.DDN.MIL
+
+   [ML109]   Mike Little         MACOM     little@MACOM4.ARPA
+
+   [MLS34]   L. Michael Sabo     TMAC      darth!eniac!sabo@Sun.Com
+
+   [MO2]     Michael O'Brien     AEROSPACE obrien@AEROSPACE.AERO.ORG
+
+   [MRC]     Mark Crispin        Simtel    MRC@SIMTEL20.ARPA
+
+   [MS9]     Marty Schoffstahl   Nysernet  schoff@NISC.NYSER.NET
+
+   [MS56]    Marvin Solomon      WISC      solomon@CS.WISC.EDU
+
+   [MXB]     Mike Berrow         Relational Technology  ---none---
+
+   [MXB1]    Mike Burrows        DEC       burrows@SRC.DEC.COM
+
+   [MXL]     Mark L. Lambert     MIT       markl@PTT.LCS.MIT.EDU
+
+   [MXP]     Martin Picard       Oracle    ---none---
+
+   [MXS]     Mike Spina          Prime
+                                  WIZARD%enr.prime.com@RELAY.CS.NET
+
+   [MXW]     Michael Waters      EON       ---none---
+
+   [NC3]     J. Noel Chiappa     MIT       JNC@XX.LCS.MIT.EDU
+
+   [NT12]    Neil Todd           IST
+                                    mcvax!ist.co.uk!neil@UUNET.UU.NET
+
+
+
+Reynolds & Postel                                              [Page 82]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   [PAM6]    Paul McNabb         RICE      pam@PURDUE.EDU
+
+   [PCW]     C. Philip Wood      LANL      cpw@LANL.GOV
+
+   [PD39]    Pete Delaney        ECRC
+                                        pete%ecrcvax@CSNET-RELAY.ARPA
+
+   [PHD1]    Pieter Ditmars      BBN       pditmars@BBN.COM
+
+   [PK]      Peter Kirstein      UCL       Kirstein@NSS.CS.UCL.AC.UK
+
+   [PL4]     Phil Lapsley        BERKELEY  phil@UCBARPA.BERKELEY.EDU
+
+   [PM1]     Paul Mockapetris    ISI       PVM@ISI.EDU
+
+   [PXK]     Philip Koch         Dartmouth Philip.Koch@DARTMOUTH.EDU
+
+   [RAM57]   Rex Mann            CDC       ---none---
+
+   [RDXS]    R. Dwight Schettler HP        rds%hpcndm@HPLABS.HP.COM
+
+   [RH6]     Robert Hinden       BBN       Hinden@CCV.BBN.COM
+
+   [RHT]     Robert Thomas       BBN       BThomas@F.BBN.COM
+
+   [RN6]     Rudy Nedved         CMU       Rudy.Nedved@CMU-CS-A.EDU
+
+   [RTB3]    Bob Braden          ISI       Braden@ISI.EDU
+
+   [RWS4]    Robert W. Scheifler ARGUS     RWS@XX.LCS.MIT.EDU
+
+   [RXB]     Ramesh Babu         Excelan
+                              mtxinu!excelan!ramesh@UCBVAX.BERKELEY.EDU
+
+   [RXB1]    Ron Bhanukitsiri    DEC       rbhank@DECVAX.DEC.COM
+
+   [RXC]     Rob Chandhok        CMU       chandhok@gnome.cs.cmu.edu
+
+   [RXC1]    Rick Carlos         TI        rick.ticipa.csc.ti.com
+
+   [RXD]     Roger Dev           Cabletron ---none---
+
+   [RXD1]    Ralph Droms         NRI       rdroms@NRI.RESTON.VA.US
+
+   [RXH]     Reijane Huai        Cheyenne  sibal@CSD2.NYU.EDU
+
+   [RXJ]     Ronald Jacoby       SGI       rj@SGI.COM
+
+
+
+
+Reynolds & Postel                                              [Page 83]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   [RXM]     Robert Myhill       BBN       Myhill@CCS.BBN.COM
+
+   [RXN]     Rina Nethaniel      RND       ---none---
+
+   [RXS]     Ron Strich          SSDS      ---none---
+
+   [RXT]     Ron Thornton        GenRad    thornton@qm7501.genrad.com
+
+   [RXZ]     Rayan Zachariassen  Toronto   rayan@AI.TORONTO.EDU
+
+   [SA1]     Sten Andler         IBM
+                                       andler.ibm-sj@RAND-RELAY.ARPA
+
+   [SAF3]    Stuart A. Friedberg UWISC     stuart@CS.WISC.EDU
+
+   [SB98]    Stan Barber         BCM       SOB@BCM.TMC.EDU
+
+   [SC3]     Steve Casner        ISI       Casner@ISI.EDU
+
+   [SGC]     Steve Chipman       BBN       Chipman@F.BBN.COM
+
+   [SHB]     Steven Blumenthal   BBN       BLUMENTHAL@VAX.BBN.COM
+
+   [SH37]    Sergio Heker        JVNC      heker@JVNCC.CSC.ORG
+
+   [SL70]    Stuart Levy         UMN       slevy@UC.MSC.UMN.EDU
+
+   [SRN1]    Stephen Northcutt   NSWC      SNORTHC@RELAY-NSWC.NAVY.MIL
+
+   [SS92]    Steve Schoch        NASA      SCHOCH@AMES.ARC.NASA.GOV
+
+   [SXA]     Susie Armstrong     XEROX     Armstrong.wbst128@XEROX.COM
+
+   [SXB]     Scott Bellows       Purdue    smb@cs.purdue.edu
+
+   [SXC]     Steve Conklin       Intergraph tesla!steve@ingr.com
+
+   [SXD]     Steve Deering       Stanford deering@PECASERO.STANFORD.EDU
+
+   [SXH]     Steven Hunter       LLNL      hunter@CCC.MFECC.LLNL.GOV
+
+   [SXK]     Skip Koppenhaver    DAC       stubby!skip@uunet.UU.NET
+
+   [SXL]     Sam Lau             Pirelli/Focom ---none---
+
+   [SXP]     Sanand Patel        Canstar   sanand@HUB.TORONTO.EDU
+
+   [SXS]     Steve Silverman     MITRE     Blankert@MITRE-GATEWAY.ORG
+
+
+
+Reynolds & Postel                                              [Page 84]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   [SXS1]    Susie Snitzer       Britton-Lee ---none---
+
+   [SXW]     Steve Waldbusser    CMU       sw01+@andrew.cmu.edu
+
+   [TB6]     Todd Baker          3COM      tzb@BRIDGE2.3COM.COM
+
+   [TC27]    Thomas Calderwood   BBN       TCALDERW@BBN.COM
+
+   [TN]      Thomas Narten       Purdue    narten@PURDUE.EDU
+
+   [TU]      Tom Unger           UMich     tom@CITI.UMICH.EDU
+
+   [TXM]     Trudy Miller        ACC       Trudy@ACC.ARPA
+
+   [TXR]     Tim Rylance         Praxis    praxis!tkr@UUNET.UU.NET
+
+   [TXS]     Ted J. Socolofsky   Spider    Teds@SPIDER.CO.UK
+
+   [UB3]     Ulf Bilting         CHALMERS  bilting@PURDUE.EDU
+
+   [UW2]     Unni Warrier        Netlabs   unni@NETLABS.COM
+
+   [VXS]     Vinod Singh         Unify     ---none---
+
+   [VXT]     V. Taylor           CANADA    vktaylor@NCS.DND.CA
+
+   [WDW11]   William D. Wisner             wisner@HAYES.FAI.ALASKA.EDU
+
+   [WJC2]    Bill Croft          STANFORD  Croft@SUMEX-AIM.STANFORD.EDU
+
+   [WJS1]    Weldon J. Showalter DCA       Gamma@EDN-UNIX.ARPA
+
+   [WLB8]    William L. Biagi    Advintech
+                                      CSS002.BLBIAGI@ADVINTECH-MVS.ARPA
+
+   [WM3]     William Melohn      SUN       Melohn@SUN.COM
+
+   [WXS]     Wayne Schroeder     SDSC      schroeder@SDS.SDSC.EDU
+
+   [VXW]     Val Wilson          Spider
+                                     cvax!spider.co.uk!val@uunet.UU.NET
+
+   [YXK]     Yoav Kluger         Spartacus ykluger@HAWK.ULOWELL.EDU
+
+   [YXW]     Y.C. Wang           Network Application Technology
+                                           ---none---
+
+   [XEROX]   Fonda Pallone       Xerox     ---none---
+
+
+
+Reynolds & Postel                                              [Page 85]
+
+RFC 1060                    Assigned Numbers                  March 1990
+
+
+   [ZSU]     Zaw-Sing Su         SRI       ZSu@TSCA.ISTC.SRI.COM
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Authors' Addresses:
+
+   Joyce K. Reynolds
+   University of Southern California
+   Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone: (213) 822-1511
+
+   Email: JKREY@ISI.EDU
+
+
+   Jon Postel
+   University of Southern California
+   Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone: (213) 822-1511
+
+   Email: POSTEL@ISI.EDU
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 86]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1060.txt](<www.ietf.org/rfc/rfc1060.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
