### PR TITLE
Archive rfc1062.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1062.txt
+++ b/www.ietf.org/rfc/rfc1062.txt
@@ -1,0 +1,3637 @@
+Network Working Group                                         S. Romano
+Request for Comments: 1062                                     M. Stahl
+Obsoletes RFCs: 1020, 997, 990, 960, 943,                     M. Recker
+923, 900, 870, 820, 790, 776, 770, 762,                     August 1988
+758, 755, 750, 739, 604, 503, 433, 349
+Obsoletes IENs:  127, 117, 93
+
+
+
+                            INTERNET NUMBERS
+
+
+STATUS OF THIS MEMO
+
+This memo is an official status report on the network numbers used in
+the Internet community.  Distribution of this memo is unlimited.
+
+Introduction
+
+   This Network Working Group Request for Comments documents the
+   currently assigned network numbers and gateway autonomous systems.
+   This RFC will be updated periodically, and in any case current
+   information can be obtained from Hostmaster at the DDN Network
+   Information Center (NIC).
+
+         Hostmaster
+         DDN Network Information Center
+         SRI International
+         333 Ravenswood Avenue
+         Menlo Park, California  94025
+
+         Phone: 1-800-235-3155
+
+         Network mail: HOSTMASTER@SRI-NIC.ARPA
+
+   Most of the protocols used in the Internet are documented in the RFC
+   series of notes.  Some of the items listed are undocumented.  Further
+   information on protocols can be found in the memo "Official Internet
+   Protocols" [32].  The more prominent and more generally used are
+   documented in the "DDN Protocol Handbook" [12] prepared by the NIC.
+   Other collections of older or obsolete protocols are contained in the
+   "Internet Protocol Transition Workbook" [13], or in the "ARPANET
+   Protocol Transition Handbook" [14].  For further information on
+   ordering the complete 1985 DDN Protocol Handbook, contact the
+   Hostmaster.
+
+   The lists below contain the name and network mailbox of the
+   individuals responsible for each registered network or autonomous
+
+
+
+Romano, Stahl & Recker                                          [Page 1]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+   system.  The bracketed entry, e.g., [nn,iii], at the right hand
+   margin of the page indicates a reference for the listed network or
+   autonomous system, where the number ("nn") cites the document and the
+   letters ("iii") cite the NIC Handle of the responsible person.  The
+   NIC Handle is a unique identifier that is used in the NIC
+   WHOIS/NICNAME service.  People occasionally change electronic
+   mailboxes.  To find out the current network mailbox or phone number
+   for an individual, or to get information about a registered network,
+   use the NIC WHOIS/NICNAME service or contact HOSTMASTER@SRI-NIC.ARPA.
+
+   The convention used for the documentation of Internet Protocols is to
+   express numbers in decimal and to picture data in "big-endian" order
+   [8].  That is, fields are described left to right, with the most
+   significant octet on the left and the least significant octet on the
+   right.
+
+   The order of transmission of the header and data described in this
+   document is resolved to the octet level.  Whenever a diagram shows a
+   group of octets, the order of transmission of those octets is the
+   normal order in which they are read in English.  For example, in the
+   following diagram the octets are transmitted in the order they are
+   numbered.
+
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |       1       |       2       |       3       |       4       |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |       5       |       6       |       7       |       8       |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |       9       |      10       |      11       |      12       |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                        Transmission Order of Bytes
+
+   Whenever an octet represents a numeric quantity the left most bit in
+   the diagram is the high order or most significant bit.  That is, the
+   bit labeled 0 is the most significant bit.  For example, the
+   following diagram represents the value 170 (decimal).
+
+                             0 1 2 3 4 5 6 7
+                            +-+-+-+-+-+-+-+-+
+                            |1 0 1 0 1 0 1 0|
+                            +-+-+-+-+-+-+-+-+
+                           Significance of Bits
+
+   Similarly, whenever a multi-octet field represents a numeric quantity
+   the left most bit of the whole field is the most significant bit.
+
+
+
+Romano, Stahl & Recker                                          [Page 2]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+   When a multi-octet quantity is transmitted the most significant octet
+   is transmitted first.
+
+                              NETWORK NUMBERS
+
+   The network numbers listed here are used as internet addresses by the
+   Internet Protocol (IP) [12,27].  The IP uses a 32-bit address field
+   and divides that address into a network part and a "rest" or local
+   address part.  The division takes 4 forms or classes.
+
+   The first type of address, or class A, has a 7-bit network number and
+   a 24-bit local address.  The highest-order bit is set to 0.  This
+   allows 128 class A networks.
+
+                           1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |0|   NETWORK   |                Local Address                  |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                              Class A Address
+
+   The second type of address, class B, has a 14-bit network number and
+   a 16-bit local address.  The two highest-order bits are set to 1-0.
+   This allows 16,384 class B networks.
+
+                           1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |1 0|           NETWORK         |          Local Address        |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                              Class B Address
+
+   The third type of address, class C, has a 21-bit network number and a
+   8-bit local address.  The three highest-order bits are set to 1-1-0.
+   This allows 2,097,152 class C networks.
+
+                           1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |1 1 0|                    NETWORK              | Local Address |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                              Class C Address
+
+   The fourth type of address, class D, is used as a multicast address
+   [11].  The four highest-order bits are set to 1-1-1-0.
+
+
+
+Romano, Stahl & Recker                                          [Page 3]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+                           1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |1 1 1 0|                  multicast address                    |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                              Class D Address
+
+
+   Note:  No addresses are allowed with the four highest-order bits set
+   to 1-1-1-1.  These addresses, called "class E", are reserved.
+
+   One commonly used notation for internet host addresses divides the
+   32-bit address into four 8-bit fields and specifies the value of each
+   field as a decimal number with the fields separated by periods.  This
+   is called the "dotted decimal" notation.  For example, the internet
+   address of VENERA.ISI.EDU in dotted decimal is 010.001.000.052, or
+   10.1.0.52.
+
+   The dotted decimal notation will be used in the listing of assigned
+   network numbers.  The class A networks will have nnn.rrr.rrr.rrr, the
+   class B networks will have nnn.nnn.rrr.rrr, and the class C networks
+   will have nnn.nnn.nnn.rrr, where nnn represents part or all of a
+   network number and rrr represents part or all of a local address.
+
+   There are four catagories of users of Internet Addresses: Research,
+   Defense, Government (Non-Defense), and Commercial.  To reflect the
+   allocation of network identifiers among the categories, a one-
+   character code is placed to the left of the network number: R for
+   Research, D for Defense, G for Government, and C for Commercial (see
+   Appendix A for further details on this division of the network
+   identification).
+
+   Network numbers are assigned for networks that are connected to the
+   research Internet and operational Internet, and for independent
+   networks that use the IP family protocols (these are usually
+   commercial).  These independent networks are marked with an asterisk
+   preceding the number.
+
+   The administrators of independent networks must apply separately for
+   permission to interconnect their network with the Internet.
+   Independent networks should not be listed in the working tables of
+   the Internet hosts or gateways.
+
+   For various reasons, the assigned numbers of networks are sometimes
+   changed.  To ease the transition the old number will be listed for a
+   transition period as well.  These "old number" entries will be marked
+   with a "T" following the number and preceding the name, and the
+
+
+
+Romano, Stahl & Recker                                          [Page 4]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+   network name will be suffixed "-TEMP".
+
+   Special Addresses:
+
+   In certain contexts, it is useful to have fixed addresses with
+   functional significance rather than as identifiers of specific hosts.
+
+              The address zero is to be interpreted as meaning "this",
+              as in "this network".
+
+              For example, the address 0.0.0.37 could be interpreted as
+              meaning host 37 on this network.
+
+   The address of all ones are to be interpreted as meaning "all", as in
+   "all hosts".
+
+   For example, the address 128.9.255.255 could be interpreted as
+   meaning all hosts on the network 128.9.
+
+   The class A network number 127 is assigned the "loopback" function,
+   that is, a datagram sent by a higher level protocol to a network 127
+   address should loop back inside the host.  No datagram "sent" to a
+   network 127 address should ever appear on any network anywhere.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Romano, Stahl & Recker                                          [Page 5]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+Class A Networks
+
+    * Internet Address   Network          Name               References
+    - ----------------   -------          ----               ----------
+      0.rrr.rrr.rrr      Reserved        Reserved                 [JBP]
+      1.rrr.rrr.rrr-2.rrr.rrr.rrr        Unassigned               [NIC]
+    C 3.rrr.rrr.rrr      GE-INTERNET     GE TCP/IP Net          [JEB50]
+    R 4.rrr.rrr.rrr      SATNET          Atlantic Sat Net         [SHB]
+      5.rrr.rrr.rrr      Unassigned      Unassigned               [NIC]
+    D 6.rrr.rrr.rrr  T   YPG-NET         Yuma Proving Grounds   [4,BWA]
+    D 7.rrr.rrr.rrr  T   EDN-TEMP        DCEC EDN                 [EC5]
+    R 8.rrr.rrr.rrr  T   BBN-NET-TEMP    BBN Net                 [JSG5]
+      9.rrr.rrr.rrr      Unassigned      Unassigned               [NIC]
+    R 10.rrr.rrr.rrr     ARPANET         ARPANET              [4,JS283]
+    D 11.rrr.rrr.rrr     DODIIS          DoD Intel Info Sys       [AY5]
+    C 12.rrr.rrr.rrr     ATT             ATT Bell Labs           [MH82]
+    C 13.rrr.rrr.rrr     XEROX-NET       XEROX Internet       [39,JNL1]
+    C 14.rrr.rrr.rrr     PDN             Public Data Net        [JS283]
+    R 15.rrr.rrr.rrr     HP-INTERNET     HP-INTERNET           [13,WU1]
+      16.rrr.rrr.rrr-17.rrr.rrr.rrr      Unassigned               [NIC]
+    R 18.rrr.rrr.rrr  T  MIT-TEMP        MIT Net            [7,31,DDC1]
+      19.rrr.rrr.rrr-20.rrr.rrr.rrr      Unassigned               [NIC]
+    D 21.rrr.rrr.rrr     DDN-RVN         DDN-RVN                  [MLC]
+    D 22.rrr.rrr.rrr     DISNET          DISNET                  [JM28]
+    D 23.rrr.rrr.rrr     DDN-TC-NET      DDN-TestCell-Net        [DH17]
+      24.rrr.rrr.rrr     Unassigned      Unassigned               [NIC]
+    R 25.rrr.rrr.rrr     RSRE-EXP        RSRE-EXP                [CDB4]
+    D 26.rrr.rrr.rrr     MILNET          MILNET                  [TMH6]
+    R 27.rrr.rrr.rrr  T  NOSC-LCCN-TEMP  NOSC/LCCN                [RH6]
+    R 28.rrr.rrr.rrr     WIDEBAND        Wide Band Sat Net       [CJW2]
+    D 29.rrr.rrr.rrr  T  MILX25-TEMP     MILNET X.25 Temp         [MLC]
+    D 30.rrr.rrr.rrr  T  ARPAX25-TEMP    ARPA X.25 Temp           [MLC]
+    G 31.rrr.rrr.rrr     UCDLA-NET       UCDLA-CATALOG-NET       [CL64]
+      32.rrr.rrr.rrr-34.rrr.rrr.rrr      Unassigned               [NIC]
+    R 35.rrr.rrr.rrr     MERIT           MERIT Comp Net           [HWB]
+    R 36.rrr.rrr.rrr  T  SU-NET-TEMP     Stanford Univ Net        [PA5]
+      37.rrr.rrr.rrr-38.rrr.rrr.rrr      Unassigned               [NIC]
+    R 39.rrr.rrr.rrr  T  SRINET-TEMP     SRI Local Net            [JMR]
+      40.rrr.rrr.rrr     Unassigned      Unassigned               [NIC]
+    R 41.rrr.rrr.rrr     BBN-TEST-A      BBN-GATE-TEST-A          [RH6]
+    R 42.rrr.rrr.rrr     CAN-INET        Canadian Rsch Net    [39,PAP4]
+      43.rrr.rrr.rrr     Unassigned      Unassigned               [NIC]
+    R 44.rrr.rrr.rrr     AMPRNET         Amateur Rad Exp Net     [PK28]
+      45.rrr.rrr.rrr-126.rrr.rrr.rrr     Unassigned               [NIC]
+      127.rrr.rrr.rrr    Loopback        Loopback                 [JBP]
+
+
+
+
+
+
+Romano, Stahl & Recker                                          [Page 6]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    Class B Networks
+
+    * Internet Address   Network          Name               References
+    - ----------------   -------          ----               ----------
+      128.0.rrr.rrr      Reserved        Reserved                 [JBP]
+    R 128.1.rrr.rrr      BBN-TEST-B      BBN-GATE-TEST-B          [RH6]
+    R 128.2.rrr.rrr      CMU-NET         CMU-Ether               [HDW2]
+    R 128.3.rrr.rrr      LBL-CSR-NET     LBL-CSR-NET             [JS38]
+    R 128.4.rrr.rrr      DCNET           LINKABIT DCNET       [26,DLM1]
+    R 128.5.rrr.rrr      FORDNET         FORD DCNET           [26,FJB3]
+    R 128.6.rrr.rrr      RUTGERS         RUTGERS                 [CLH3]
+    R 128.7.rrr.rrr      KRAUTNET        KRAUTNET                 [GB7]
+    R 128.8.rrr.rrr      UMDNET          Univ of Maryl DCNET  [26,DLM1]
+    R 128.9.rrr.rrr      ISI-NET         USC-ISI Local Net        [CMR]
+    R 128.10.rrr.rrr     PURDUE-CS-EN    Purdue CS Ether      [39,DT50]
+    R 128.11.rrr.rrr     BBN-CRONUS      BBN DOS Project      [25,PK19]
+    R 128.12.rrr.rrr     SU-NET          Stanford Univ Net        [PA5]
+    D 128.13.rrr.rrr     MATNET          Mob Access Term Net      [SHB]
+    R 128.14.rrr.rrr     BBN-SAT-TEST    BBN SATNET Test Net      [SHB]
+    R 128.15.rrr.rrr     S1NET           LLL-S1-NET             [RAK12]
+    R 128.16.rrr.rrr     UCLNET          Univ Coll London          [PK]
+    D 128.17.rrr.rrr     MATNET-ALT      Mob Access Term Alt      [SHB]
+    R 128.18.rrr.rrr     SRINET          SRI Local Net            [JMR]
+    D 128.19.rrr.rrr     EDN             DCEC EDN                 [EC5]
+    D 128.20.rrr.rrr     BRLNET          BRLNET                [4,MJM2]
+    R 128.21.rrr.rrr     SRI-PR-1        SRI Pck Rad-1 Net       [PEM4]
+    R 128.22.rrr.rrr     SRI-PR-2        SRI Pck Rad-2 Net       [PEM4]
+    R 128.23.rrr.rrr     BBN-PR          BBN Pck Rad Net         [JBW1]
+    R 128.24.rrr.rrr     ROCKWELL-PR     Rockwell Pck Rad Net      [NG]
+    D 128.25.rrr.rrr     BRAGG-PR        Ft. Bragg Pck Rad Net   [LDB3]
+    D 128.26.rrr.rrr     SAPE-AIRNET     RADC-SAPE-PR-NET       [CAD13]
+    D 128.27.rrr.rrr     DEMO-PR-1       Demo-1 Pck Rad Net       [LCS]
+    D 128.28.rrr.rrr     C3-PR-TEMP      Testbed Dev PR NET      [VDC1]
+    R 128.29.rrr.rrr     MITRE           MITRE Cablenet        [37,TML]
+    R 128.30.rrr.rrr     MIT-NET         MIT Local Net           [DDC1]
+    R 128.31.rrr.rrr     MIT-RES         MIT Rsch Net            [DDC1]
+    R 128.32.rrr.rrr     UCB-ETHER       UC Berkeley Ether       [RWH5]
+    R 128.33.rrr.rrr     BBN-NET         BBN Net                 [JSG5]
+    R 128.34.rrr.rrr     NOSC-LCCN       NOSC/LCCN                [RH6]
+    R 128.35.rrr.rrr     CISLTESTNET1    Honeywell        [17,18,JLM23]
+    R 128.36.rrr.rrr     YALE-NET        YALE Net             [39,HML1]
+    D 128.37.rrr.rrr     YUMA            Yuma Proving Grounds   [4,BWA]
+    D 128.38.rrr.rrr     NSWC-NET        NSWC Local Host Net      [VHB]
+    R 128.39.rrr.rrr     NTANET          NDRE-TIU                [PS27]
+    R 128.40.rrr.rrr     UCL-NET-A       Univ Coll London        [BAW9]
+    R 128.41.rrr.rrr     UCL-NET-B       Univ Coll London        [BAW9]
+    R 128.42.rrr.rrr     RICE-NET        Rice Univ            [ 39,PGM]
+    R 128.43.rrr.rrr     DRENET          Canada REF ARPANET    [4,JR17]
+
+
+
+Romano, Stahl & Recker                                          [Page 7]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    D 128.44.rrr.rrr     WSMR-NET        White Sands Net         [CAS1]
+    C 128.45.rrr.rrr     DEC-WRL-NET     DEC WRL Net          [39,RKJ2]
+    R 128.46.rrr.rrr     PURDUE-NET      Purdue Camp Net         [DT50]
+    D 128.47.rrr.rrr     TACTNET         Tactical Pck Net       [3,KTP]
+    G 128.48.rrr.rrr     UCDLA-NET-B     UCDLA-Net-B           [4,CL64]
+    R 128.49.rrr.rrr     NOSC-ETHER      NOSC Ether           [39,RLB3]
+    G 128.50.rrr.rrr     COINS           COINS On-Line Intel Net [RLS6]
+    G 128.51.rrr.rrr     COINSTNET       COINS Test Net          [RLS6]
+    R 128.52.rrr.rrr     MIT-AI-NET      MIT AI NET            [39,MDC]
+    R 128.53.rrr.rrr     SAC-PR-2        SAC PRNET Number 2      [VDC1]
+    R 128.54.rrr.rrr     UCSD            UC San Diego Net     [39,GH29]
+    R*128.55.rrr.rrr     MFENET          LLNL MFE Net         [39,BCH2]
+    D 128.56.rrr.rrr     USNA-NET        US Naval Acad Net        [TS9]
+    D 128.57.rrr.rrr     DEMO-PR-2       Demo-2 Pck Rad Net       [LCS]
+    C 128.58.rrr.rrr     SPAR            Schlumberger PA Net  [39,SL10]
+    R 128.59.rrr.rrr     CU-NET          Columbia Univ        [39,BC14]
+    D 128.60.rrr.rrr     NRL-LAN         NRL Lab Area Net         [WF3]
+    R 128.61.rrr.rrr     GATECH          Georgia Tech         [39,DD11]
+    R 128.62.rrr.rrr     MCC-NET         MCC Corp Net          [39,CBD]
+    R 128.63.rrr.rrr     BRL-SUBNET      BRL-SUBNET-EXP          [MJM2]
+    R 128.64.rrr.rrr-128.79.rrr.rrr      Net Dynamics Exp         [ZSU]
+    D 128.80.rrr.rrr     CECOMNET        CECOM EPR NET           [PFS2]
+    R 128.81.rrr.rrr     SYMBOLICS       SYMBOLICS             [39,CH2]
+    R*128.82.rrr.rrr     ODU             ODU Rsch Net            [AKG2]
+    R 128.83.rrr.rrr     UTAUSTIN        Univ of Texas Austin [39,JSQ1]
+    R 128.84.rrr.rrr     CORNELL-NET     Cornell Backbone Net  [39,DK2]
+    C*128.85.rrr.rrr     DRILL-NET       Teleco Drilltech Net    [DBJ4]
+    R 128.86.rrr.rrr     MRC             UK.CO.GEC.RL.MRC        [RHC3]
+    R 128.87.rrr.rrr     HIRST           UK.CO.GEC.RL.HRC        [RHC3]
+    R*128.88.rrr.rrr     HP-NET          HEWLETT-PACKARD-NET     [AG67]
+    R 128.89.rrr.rrr     BBN-ENET        BBN Ether Net         [39,SGC]
+    C*128.90.rrr.rrr     SCRIBE          Scribe Sys           [39,ERC1]
+    R 128.91.rrr.rrr     UPENN           UPenn Camp Net        [39,IW5]
+    R 128.92.rrr.rrr     INTELLINET      INTELLICORP NET      [39,RJL3]
+    R*128.93.rrr.rrr     INRIA-ROCQU     INRIA Rocquencourt     [MS171]
+    C*128.94.rrr.rrr     SYSNET          AT&T SYSNet              [EY5]
+    R 128.95.rrr.rrr     WASHINGTON      Comp Sci Ether Net   [39,RA17]
+    C 128.96.rrr.rrr     BELLCORE-NET    BELLCORE-NET            [PK28]
+    R 128.97.rrr.rrr     UCLANET         UCLA Net                 [RBW]
+    R 128.98.rrr.rrr     RSRE-EN2        RSRE-EXP-NET-2         [JW156]
+    C 128.99.rrr.rrr     NORTHROP-NET    Northrop Net         [39,RSM1]
+    R*128.100.rrr.rrr    TORONTO         Univ of Toronto Net  [39,BD55]
+    R 128.101.rrr.rrr    UMN-NET         Univ of Minn            [SB12]
+    G 128.102.rrr.rrr    AMES-NET        Ames Backbone Net    [39,MSM1]
+    R 128.103.rrr.rrr    HARV-FIBER      Harv FiberOp Ether   [39,SB28]
+    R 128.104.rrr.rrr    WISC-HERD       Univ of Wisconsin    [39,EJN1]
+    R 128.105.rrr.rrr    WISC            Univ of Wisconsin   [39,JB188]
+    D 128.106.rrr.rrr    SRI-PSON-1      ADEA/SRI Ft. Lewis      [ERK3]
+
+
+
+Romano, Stahl & Recker                                          [Page 8]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    D 128.107.rrr.rrr    LEWIS-PRNET1    ADEA/SRI Ft. Lewis      [ERK3]
+    D 128.108.rrr.rrr    LEWIS-PRNET2    ADEA/SRI Ft. Lewis      [ERK3]
+    R 128.109.rrr.rrr    TUCC-MCNC       TUCC-MCNC NC Net       [JRR14]
+    R 128.110.rrr.rrr    UTAH-NET        UTAH-Camp-NET           [JL15]
+    R 128.111.rrr.rrr    UCSB            Univ of CA, San Bar     [PKH1]
+    R 128.112.rrr.rrr    PRINCETON       Princeton Univ          [LRR1]
+    R 128.113.rrr.rrr    RPINET          RPI-LOCALNET            [JF78]
+    R 128.114.rrr.rrr    UCSC            Univ of CA, San Cruz [39,JHH8]
+    R 128.115.rrr.rrr    LLL-LABNET      LLNL Open Labnet        [LL64]
+    R 128.116.rrr.rrr    USAN            UNIV Sat NET          [39,BLI]
+    R 128.117.rrr.rrr    UCAR            UNIV CORP ATM RSCH    [39,BLI]
+    R 128.118.rrr.rrr    PENN-STATE      Penn State Net         [SJS11]
+    R 128.119.rrr.rrr    UMASS-NET       UMass COINS Dept LAN [39,GW40]
+    R 128.120.rrr.rrr    UCDAVIS         Univ of CA, Davis Net [39,RH5]
+    R 128.121.rrr.rrr    JVNC-NET        John von Neu Ctr Net    [SH37]
+    R 128.122.rrr.rrr    NYU-NET         NYU Camp Net            [BJR2]
+    R 128.123.rrr.rrr    NMSU            N M State Univ       [39,MSP1]
+    R 128.124.rrr.rrr    NTA-TEMP        NTARE BF-TO-PDP11       [TM10]
+    R 128.125.rrr.rrr    USCNET          USC Camp Net         [39,MAB4]
+    R 128.126.rrr.rrr    UNISYS-PRC      UNISYS-PRC           [39,MS22]
+    C 128.127.rrr.rrr    FTP-SOFTWARE    FTP Soft Net            [JBV2]
+    R 128.128.rrr.rrr    WHOINET         WHOI Camp Net           [ARM5]
+    C*128.129.rrr.rrr    CGI             Carnegie Grp            [RA62]
+    R*128.130.rrr.rrr    TUNET-T         TU Wien Term Net     [39,GP56]
+    R*128.131.rrr.rrr    TUNET-F         TU Wien File Net     [39,GP56]
+    G*128.132.rrr.rrr    RADC-LONS       RADC-LONS Net        [39,GG43]
+    G*128.133.rrr.rrr    AFSC-LONS       AFSC-LONS Net        [39,GG43]
+    R 128.134.rrr.rrr    SDN             System Dev Net       [5,6,HC2]
+    R 128.135.rrr.rrr    U-CHICAGO       UnivOFCHICAGO        [39,MC17]
+    R 128.136.rrr.rrr    TEK-ALLNET      Teknowledge-Net      [39,TE16]
+    R*128.137.rrr.rrr    GENNET1         Genentech Corp Net   [39,SM96]
+    R 128.138.rrr.rrr    COLORADO        U Colo Boulder       [39,RAJ8]
+    R 128.139.rrr.rrr    ILAN            Israel Academic Net  [39,DB35]
+    R 128.140.rrr.rrr    EMORY-INET      Emory Internet       [39,AR60]
+    R*128.141.rrr.rrr    CERN-ETHER      DD Main Ether        [39,BMS2]
+    R*128.142.rrr.rrr    CERN-TOKEN      DD Main IBM Token    [39,BMS2]
+    R 128.143.rrr.rrr    VIRGINIA        Univ of Virginia    [39,JAJ17]
+    R*128.144.rrr.rrr    ARC-CALGARY     Alta Rsch Calgary       [DK66]
+    R 128.145.rrr.rrr    NYSERNET        NYSERNET                 [MS9]
+    R 128.146.rrr.rrr    OHIO-STATE      Ohio State Univ         [RSD2]
+    R 128.147.rrr.rrr    U-PGH-NET       Univ Pittsburgh Net      [SM6]
+    R 128.148.rrr.rrr    BROWN-UNIV      Brown Univ Net          [MR29]
+    G 128.149.rrr.rrr    JPL-NET         JPL Central Net         [MSM1]
+    G 128.150.rrr.rrr    NSF-LAN         NSF-LAN                 [FW17]
+    R 128.151.rrr.rrr    UR-NET          Univ of Rochester       [TM57]
+    C 128.152.rrr.rrr    HAC-ENET        Hughes Air VLSI Net     [PH45]
+    R 128.153.rrr.rrr    CLARKSON        Clarkson Univ           [ABS6]
+    G 128.154.rrr.rrr    GSFC-NET        GSFC Central Net        [MSM1]
+
+
+
+Romano, Stahl & Recker                                          [Page 9]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    G 128.155.rrr.rrr    LARC-NET        LARC Central Net        [MSM1]
+    G 128.156.rrr.rrr    LERC-NET        LERC Central Net        [MSM1]
+    G 128.157.rrr.rrr    JSC-NET         JSC Central Net         [MSM1]
+    G 128.158.rrr.rrr    MSFC-NET        MSFC Central NEt        [MSM1]
+    G 128.159.rrr.rrr    KSC-NET         KSC Central Net         [MSM1]
+    G 128.160.rrr.rrr    NSTL-NET        NSTL Central Net        [MSM1]
+    G 128.161.rrr.rrr    NSN-NET         NASA Sci Net            [MSM1]
+    C 128.162.rrr.rrr    CRAY-NET        Cray Rsch               [DB14]
+    R 128.163.rrr.rrr    UKY             Univ of Kentucky        [GB43]
+    R 128.164.rrr.rrr    GWU-GATE        George Wash Univ        [TT35]
+    G 128.165.rrr.rrr    LANL-INET       LANL Inter-Net          [JC11]
+    D*128.166.rrr.rrr    BAC-NET         Boeing Aero Corp Net    [JJ48]
+    R 128.167.rrr.rrr    SURA            SURAnet                 [JH92]
+    C 128.168.rrr.rrr    GOLDHILL        Gold-Hill-Comps         [GM34]
+    R 128.169.rrr.rrr    UTK             Univ Tenn-Knoxville    [JDC20]
+    R 128.170.rrr.rrr    SDC-CAM         SDC Camarillo R&D Net    [DSR]
+    R*128.171.rrr.rrr    HAWAII          Univ of Hawaii          [BC32]
+    R 128.172.rrr.rrr    VCU-LAN         VCU-LAN                 [JN40]
+    R 128.173.rrr.rrr    VA-TECH         Virginia Tech Net       [PB40]
+    R 128.174.rrr.rrr    UIUC-CAMPUS-B   UIUC Camp Net           [PP14]
+    R 128.175.rrr.rrr    UDELNET         U of Delaware Net       [DJG2]
+    R*128.176.rrr.rrr    DMSWWU-ETHER    DMSWWU Ether            [GR26]
+    C*128.177.rrr.rrr    BLI-NET         Britton Lee Net          [EPA]
+    R*128.178.rrr.rrr    EPF-ETHER1      Ecublens Camp Net        [YD2]
+    R*128.179.rrr.rrr    EPF-ETHER2      Cedres Camp Net          [YD2]
+    R 128.180.rrr.rrr    LEHIGH          Lehigh Univ         [39,MM149]
+    C 128.181.rrr.rrr    TEKTRONIX       Tektronix Eng          [JB218]
+    R 128.182.rrr.rrr    PSCNET          PSC Affiliates NEt      [JTE2]
+    R 128.183.rrr.rrr    GSFC            GSFC NASA              [JB113]
+    R*128.184.rrr.rrr    DEAKINET        Deakin Univ Net        [JM303]
+    C 128.185.rrr.rrr    PROTEON-NET     Proteon Net             [JS28]
+    R 128.186.rrr.rrr    FSU             Florida State Univ      [KMH8]
+    R 128.187.rrr.rrr    BYU-NET         BYU-NET                 [KCM2]
+    R 128.188.rrr.rrr    M2CNET          Mass VLSI/CAD Net        [SD1]
+    R 128.189.rrr.rrr    BCNET           British Columbia Net    [DO26]
+    G 128.190.rrr.rrr    BELVOIR         BRADEC SubNet           [DH30]
+    C*128.191.rrr.rrr    NECIS-NET       NEC Info Sys Net        [DP71]
+    R 128.192.rrr.rrr    UGA             UGNET                   [EHH4]
+    R 128.193.rrr.rrr    ORST            Oregon State Univ Ne    [BA26]
+    R 128.194.rrr.rrr    TAMU-NET        Texas A&M Univ          [WM68]
+    R 128.195.rrr.rrr    UCIICS-NET      UCI ICS Net             [RAJ3]
+    R 128.196.rrr.rrr    UNIV-ARIZ       U of Ariz Rsch Net      [ALG4]
+    R 128.197.rrr.rrr    BU-NET          BU-NET                  [JSOL]
+    R 128.198.rrr.rrr    CU-COLOSPGS     CU-Colo-Spgs-Net    [39,RDG12]
+    R*128.199.rrr.rrr    STC             STC PLC Company Net     [AM54]
+    R 128.200.rrr.rrr    UCI-NET         UCI Camp Net            [DW96]
+    R*128.201.rrr.rrr    REUNIR          Reseau des Univ         [RN25]
+    D 128.202.rrr.rrr    CSOCNET         2SW SPACENET LAN       [JJD12]
+
+
+
+Romano, Stahl & Recker                                         [Page 10]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    R*128.203.rrr.rrr    UB-INC          Ungermann-Bass Inc       [DXC]
+    R 128.204.rrr.rrr    ALBNYNET        U at Albany Net         [BEC1]
+    R 128.205.rrr.rrr    UBUFFALONET     UNIVOFBUFFALONET        [CFD4]
+    R 128.206.rrr.rrr    MONET           Univ-of-Mo-Net          [BEC5]
+    C*128.207.rrr.rrr    BOEING-PSN      Boeing-Puget Sound   [39,JSY2]
+    R 128.208.rrr.rrr    WASH-NSF        Wash-NSF             [39,SH47]
+    C 128.209.rrr.rrr    NYNEXSTNET      NYNEX Sci and Tech      [MC65]
+    R 128.210.rrr.rrr    PURDUE-CCNET    Purdue Comp Ctr      [39,JS81]
+    R 128.211.rrr.rrr    PURDUE-CS-CYP   CYPRESS-HUB-PURDUE      [DT50]
+    C*128.212.rrr.rrr    ISCNET          ISC Corp Net            [DM27]
+    R 128.213.rrr.rrr    RPICSNET        RPI CSNet             [39,MS9]
+    R*128.214.rrr.rrr    FUNET           Finnish Univ Net    [39,JH141]
+    C*128.215.rrr.rrr    INTEL-NT        INTEL Eng Net        [12,HC24]
+    D 128.216.rrr.rrr    CC-PRNET        CENTCOM Pck Rad Net   [39,GIH]
+    G*128.217.rrr.rrr    NASA-KSC-OIS    NASA KSC OIS         [39,GG43]
+    R 128.218.rrr.rrr    UCSF-NET        Univ of CA, San Fran  [39,TF6]
+    R 128.219.rrr.rrr    ORNL-NETB1      ORNL Local Area Net   [24,THD]
+    R 128.220.rrr.rrr    JHU             Johns Hopkins Univ   [39,MH98]
+    R 128.221.rrr.rrr    DGPN1           Data Gen Priv Net 1  [39,PSS1]
+    C 128.222.rrr.rrr    DGPN2           Data Gen Priv Net 2  [39,PSS1]
+    R 128.223.rrr.rrr    UONET           Univ of Oregon Net   [39,DS85]
+    C*128.224.rrr.rrr    EPILOGUE        Epilogue Tech            [KA4]
+    C*128.225.rrr.rrr    BOEING-EN       Boeing-East Net      [39,JSY2]
+    R 128.226.rrr.rrr    BINGHAMTON      UNIVATBINGHAMTON    [39,RM120]
+    R 128.227.rrr.rrr    UFNET           Univ of Florida Net  [39,AW48]
+    R 128.228.rrr.rrr    CUNY            City Univ of NY      [39,SMP2]
+    R 128.229.rrr.rrr    ADSNET          Adv Dec Sys Net     [39,JMH10]
+    R 128.230.rrr.rrr    SYR-UNIV-NET    Syracuse Univ Net    [39,JW47]
+    G 128.231.rrr.rrr    NIH-NET         Natl Insts of Health [12,RF57]
+    R*128.232.rrr.rrr    CL-CAM-AC-UK    Univ Camb Comp Lab   [39,MAJ1]
+    R*128.233.rrr.rrr    USASK           Univ of Sask Net     [39,LRC7]
+    R*128.234.rrr.rrr    COS-NET         COS Net              [39,AP25]
+    R 128.235.rrr.rrr    NJIT            NJIT Net             [39,BM79]
+    D 128.236.rrr.rrr    USAFA-NET       US AF Acad Net      [39,GEOFF]
+    R 128.237.rrr.rrr    CMU-SEI-NET     SEI Ether            [39,PDB5]
+    R 128.238.rrr.rrr    POLY-U-NET      Polytech Univ Net   [39,AMM14]
+    R 128.239.rrr.rrr    WM-NET          William and Mary Net [39,SF34]
+    R*128.240.rrr.rrr    NCL             Newcastle Camp Net   [39,AL46]
+    R 128.241.rrr.rrr    SESQUINET       SESQUINET                [GTA]
+    R 128.242.rrr.rrr    MIDNET          Midwest Reg Net        [MM147]
+    R*128.243.rrr.rrr    NOTT-AC-UK      Univ of Notting Net  [39,WA16]
+    D 128.244.rrr.rrr    APL-NET         Applied Phy Lab Net  [39,SAK3]
+    R 128.245.rrr.rrr    SRA-CT-NET      SRA-CONNECTICUT-NET  [15,JSS4]
+    C*128.246.rrr.rrr    CGCH-WIRZ       WIRZ Scientific Net   [12,HN3]
+    C 128.247.rrr.rrr    TI              Texas Instruments       [DF71]
+    R 128.248.rrr.rrr    UIC-NET         Univ of Ill-Chicago   [39,EZ3]
+    R 128.249.rrr.rrr    TMC-NET         Texas Med Ctr Net    [39,SB98]
+    R*128.250.rrr.rrr    UNIMELB         Univ of Melbourne    [39,CC89]
+
+
+
+Romano, Stahl & Recker                                         [Page 11]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    C*128.251.rrr.rrr    ROCKW-TELEDA    Rockwell-Tele       [39,JCW12]
+    R 128.252.rrr.rrr    WASHINGTON-U    Wash Univ Net       [21,DGH13]
+    R 128.253.rrr.rrr    CCS-NET         Cornell U Comp Net     [DC126]
+    R*128.254.rrr.rrr    FMC-NOD         FMC-NOD              [39,WCW7]
+    R 128.255.rrr.rrr    UIOWA           Univ of Iowa Camp Net   [LT28]
+      129.0.rrr.rrr      Reserved        Reserved                 [JBP]
+    R 129.1.rrr.rrr      BGSU            Bowling Green State     [SH71]
+    R 129.2.rrr.rrr      UMD-BOGON-NET   UMD Student Net      [39,LAM1]
+    R 129.3.rrr.rrr      SUNY-OSWEGO-NET SUNY - Oswego        [39,PRT2]
+    C 129.4.rrr.rrr      TRW             TRW Info Net         [39,GGB2]
+    R*129.5.rrr.rrr      HGCNET          HARTFORDGRADCTRGNET  [38,AG61]
+    G 129.6.rrr.rrr      NBS             NBS Net              [39,CWH3]
+    R 129.7.rrr.rrr      UH-NET          Univ of Houston Net [39,JH155]
+    R*129.8.rrr.rrr      CSUFRESNO       CSUFresno CSci Net   [39,RP88]
+    C*129.9.rrr.rrr      CHRYSLER-NET    CHRYSLER-INTERNET      [RER20]
+    R 129.10.rrr.rrr    NORTHEASTERN-NET NORTHEASTERN Net     [39,CJ38]
+    R*129.11.0.rrr       LEEDS           Leeds Univ Net      [39,AJC11]
+    R*129.12.rrr.rrr     UKC             UKC Camp Net         [39,SL55]
+    R*129.13.rrr.rrr     LINK            Karlsruhe Net        [39,MR78]
+    C*129.14.rrr.rrr     SBINY           Salomon Brothers Inc [39,BC72]
+    R 129.15.rrr.rrr     UOKNOR          Univ of Okla, Norman   [JW136]
+    R*129.16.rrr.rrr     CTH-NET         Chalmers Univ           [GL41]
+    R*129.17.rrr.rrr     SSED-NET        Honeywell-SSED-NET     [DM147]
+    C 129.18.rrr.rrr     NEXT-NET        NEXT, Inc Net         [39,PFK]
+    R 129.19.rrr.rrr     WESTNET         Western Reg Net      [39,DCMW]
+    R*129.20.rrr.rrr     VERDUR          VERDUR                  [RN25]
+    R*129.21.rrr.rrr     RIT             Rochester InstofTech [39,CF35]
+    R 129.22.rrr.rrr     CWRUNET         CWRU Camp Net        [39,JAG3]
+    R 129.23.rrr.rrr     SDIO-INTERNET   SDIO Wide Area Inter  [39,KDZ]
+    R 129.24.rrr.rrr     UNM-CDCN        Univ of New Mexico Net  [GB95]
+    R 129.25.rrr.rrr     DREXEL          Drexel Univ          [39,RR97]
+    R*129.26.rrr.rrr     GMD-DE          GMD Net (Germany)    [39,PM72]
+    C*129.27.rrr.rrr     WEDGE-NET       Wedge Comp Net           [DTH]
+    C 129.28.rrr.rrr     ETA-LAN         ETA-LAN St. Paul     [2,DGM18]
+    D 129.29.rrr.rrr     USMANET         US Military Acad Net [39,BAT4]
+    C 129.30.rrr.rrr     HONEYWELL       Honeywell Inc Net    [39,DB97]
+    R*129.31.rrr.rrr     ICNET           Imperial Coll        [39,LM88]
+    R 129.32.rrr.rrr     TEMPLE          Temple Univ Net  [29,39,TES16]
+    R 129.33.rrr.rrr-129.42.rrr.rrr      IBM Research Net         [MT1]
+    R 129.43.rrr.rrr     NCI-FCRF        Frederick Cancer Net [39,WLB5]
+    C*129.44.rrr.rrr     NYTEL1095NET    NYTEL1095NET         [39,HT12]
+    C*129.45.rrr.rrr     NYTELNOCNET1    NYTELNOCNET1         [39,JO54]
+    C 129.46.rrr.rrr     QUALNET         QUALCOMM Ether       [39,TM37]
+    C*129.47.rrr.rrr     SYTEK-INC       Sytek Corp MV           [AB90]
+    D 129.48.rrr.rrr     WPAFB-CDS-NET   WPAFB-CDS-Net        [39,CMC6]
+    R 129.49.rrr.rrr     SUNY-SB         SUNY at Stony Brook [39,JM184]
+    G*129.50.rrr.rrr     PSCN            NASA/PSCN TCP/IP        [BRB8]
+    D 129.51.rrr.rrr     ESMC-LONS       SAMTO-ESMC LONS      [39,SWR3]
+
+
+
+Romano, Stahl & Recker                                         [Page 12]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    D 129.52.rrr.rrr     WPAFB-LONS      W. Patt AFB LONS     [39,SWR3]
+    D 129.53.rrr.rrr     ESD-LONS        Hanscom AFB ESD LONS [39,SWR3]
+    D 129.54.rrr.rrr     WSMC-LONS       SAMTO-WSMC LONS      [39,SWR3]
+    R 129.55.rrr.rrr     LINCOLN-MI      Lincoln Mach Int Net  [39,GAA]
+    D*129.56.rrr.rrr     AUXNET-PR       CAP Pck Rad Net          [KFS]
+    R 129.57.rrr.rrr     CEBAF           CEBAF Local Area Net [39,RG94]
+    D*129.58.rrr.rrr     SRPNET          Savannah Riv Plt Net [39,MJ33]
+    R 129.59.rrr.rrr     VANDERBILT      Vanderbilt Univ         [RHA8]
+    R*129.60.rrr.rrr     NTT-INET        NTT Rsch Lab Net  [21,39,YS10]
+    D 129.61.rrr.rrr     ECONET          Eglin Comp Net        [39,CG1]
+    R*129.62.rrr.rrr     BAYLOR          Baylor Univ Prim Net [39,BL31]
+    R 129.63.rrr.rrr     ULOWELL-NET     Univ of Lowell Net   [39,BP51]
+    R*129.64.rrr.rrr     BRANDEIS        Brandeis Univ          [JSM11]
+    R*129.65.rrr.rrr     CALPOLY         Cal Poly State U-SLO [39,ML95]
+    R 129.66.rrr.rrr     ASN-NET         Alabama Super Net   [27,JRS48]
+    R*129.67.rrr.rrr     OXFORDNET       Oxford Univ Ether   [39,MH118]
+    R*129.68.rrr.rrr     SJU-NET         St. Joseph's Ether  [39,JP147]
+    R*129.69.rrr.rrr     RUS-NET         Univ of Stuttgart Net   [KDM6]
+    R*129.70.rrr.rrr     BINET           Bielefeld Univ Net   [27,WH64]
+    R 129.71.rrr.rrr     WVNET           West Virginia Net      [RL104]
+    R 129.72.rrr.rrr     UWYO            Univ of Wyoming Net [39,RM177]
+    C 129.73.rrr.rrr     SIEMENS         Siemens Rsch        [39,DAM22]
+    R*129.74.rrr.rrr     NOTRE-DAME      Univ of Notre Dame Net  [MDE3]
+    C*129.75.rrr.rrr     MASSCOMP-NET    MASSCOMP Corp Net    [39,BD56]
+    C*129.76.rrr.rrr     ROSEMOUNT       Rosemount Inc        [39,DM69]
+    C*129.77.rrr.rrr     OXFORD-TP       Oxford Trading Part  [39,KRM5]
+    R*129.78.rrr.rrr     SYDNET          Univ of Sydney Info Net [BK46]
+    R 129.79.rrr.rrr     INDIANA-NET     Indiana Univ Net       [BSS69]
+    C*129.80.rrr.rrr     STORTEK         Storage Tek Corp    [21,DB162]
+    R*129.81.rrr.rrr     TULANE-NET      Tulane Univ          [21,JV41]
+    R 129.82.rrr.rrr     CSUNET          Colo State Univ      [39,SM83]
+    D*129.83.rrr.rrr     MITRE-B-NETB    MITRE-BEDFORD EtherB  [39,BSW]
+    C*129.84.rrr.rrr     TWG-NET         The Wollongong Net     [JS171]
+    R 129.85.rrr.rrr     ROCK            Rockefeller Univ     [39,MK38]
+    C*129.86.rrr.rrr     SANDERS         Sanders Assoc, Inc   [39,RT60]
+    C*129.87.rrr.rrr     SLBSDRNET       Schlumberger SDR Net [39,RK75]
+    R*129.88.rrr.rrr     IMAG            Grenoble CS Labs        [PL37]
+    R 129.89.rrr.rrr     MILW-IPNET      UW-Milwaukee IP Net  [39,JSL9]
+    C*129.90.rrr.rrr     INTEVEP         INTEVEP Net          [39,RA66]
+    R 129.91.rrr.rrr     ENCORE          Encore-Marlboro       [39,IRN]
+    D 129.92.rrr.rrr     AFIT            AF Inst of Tech      [21,PHS1]
+    R 129.93.rrr.rrr     HUSKERNET       UNL Camp Net           [MM147]
+    R*129.94.rrr.rrr     UNSW            Univ of NSW Net      [39,PG40]
+    R*129.95.rrr.rrr     OREGRADNET      Oregon Grad Ctr Net    [JC235]
+    R*129.96.rrr.rrr     FLINDERS-UNI    Flinders Camp Net     [21,TGN]
+    R*129.97.rrr.rrr     UWNET           Univ of Waterloo Net [39,WCWI]
+    R*129.98.rrr.rrr     ALNET           Albert Einstein Coll [39,RNB5]
+    G 129.99.rrr.rrr     NAS-NET         NAS Supercomp Net    [39,JL52]
+
+
+
+Romano, Stahl & Recker                                         [Page 13]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    R*129.100.rrr.rrr    UWO-NET         Univ of West Ontario [39,PM81]
+    R*129.101.rrr.rrr    IDAHO-ENGR      Idaho Eng/EE           [WDS11]
+    R*129.102.rrr.rrr    IRCAM           IRCAM                   [MF14]
+    C*129.103.rrr.rrr    NERV            Nixdorf Dev Comp Net    [HG20]
+    R*129.104.rrr.rrr    POLY            Polytechnique Net    [39,GG68]
+    R 129.105.rrr.rrr    NWUNET          Northwest Univ Net   [39,EEW6]
+    R 129.106.rrr.rrr    UTHOUSTON       UT Health Sci Ctr     [39,LSV]
+    R 129.107.rrr.rrr    UTARLINGTON     UT Arlington          [39,LSV]
+    R 129.108.rrr.rrr    UTELPASO        UT El Paso            [39,LSV]
+    R 129.109.rrr.rrr    UTGALVESTON     UT Med Brch Galveston [39,LSV]
+    R 129.110.rrr.rrr    UTDALLAS        UT Dallas             [39,LSV]
+    R 129.111.rrr.rrr    UTSCSA          UT Health Sci Ctr     [39,LSV]
+    R 129.112.rrr.rrr    UTSWMDC         UT SW Med Ctr Dallas  [39,LSV]
+    R 129.113.rrr.rrr    UTPBASIN        UT Permian Basin      [39,LSV]
+    R 129.114.rrr.rrr    UTCCSPRD        UT Sys Cancer Ctr     [39,LSV]
+    R 129.115.rrr.rrr-129.120.rrr        THENET                [39,LSV]
+    R 129.121.rrr.rrr    NMTECHNET       New Mexico Technet   [39,IMK1]
+    C 129.122.rrr.rrr    PRIME           PRIME Comp Inc          [RLU3]
+    R 129.123.rrr.rrr    USU             USU                 [39,RLR36]
+    C 129.124.rrr.rrr    GMRLNET         General Motors Rsch  [39,LR44]
+    R*129.125.rrr.rrr    RUGNET          RUG Univ Net         [39,HH37]
+    C*129.126.rrr.rrr    KODAK           KODAK Net            [39,SA46]
+    R*129.127.rrr.rrr    ADELAIDE-UNI    Univ Adelaide Net   [39,JB254]
+    R*129.128.rrr.rrr    U-ALBERTA       Univ of Alberta Net [39,SS131]
+    R*129.129.rrr.rrr    PSI-ETHER       PSI Camp Net        [39,BH103]
+    R 129.130.rrr.rrr    KSUNET          KSU Camp Net             [BAV]
+    D 129.131.rrr.rrr    NWCNET          NAVWPNCENNET         [39,EG17]
+    R*129.132.rrr.rrr    ETH-ETHER       ETH/UNIZH Camp Net   [23,MA63]
+    R 129.133.rrr.rrr    WESNET          Wesleyan Univ Net    [39,JGD1]
+    C*129.134.rrr.rrr    HCSD-NET        Harris Comp Net      [39,DR49]
+    C*129.135.rrr.rrr    INGR            Intergraph Corp Net  [21,GS91]
+    R*129.136.rrr.rrr    NRCJ            NRC-JAPAN Net       [39,MS195]
+    R 129.137.rrr.rrr    UN-OF-CINCI     Univ of Cincinnati  [39,RB253]
+    R 129.138.rrr.rrr    NMTECH          New Mexico Tech      [39,MR91]
+    D 129.139.rrr.rrr    PICANET         Pica Arsenal LAN     [39,RFD1]
+    R 129.140.rrr.rrr    NSFNET-BB       NSFNET-BACKBONE          [HWB]
+    D 129.141.rrr.rrr    GAFSNET         Gunter AFS X.25 Net     [BPW1]
+    R*129.142.rrr.rrr    DENET           Danish Net             [JPS21]
+    R*129.143.rrr.rrr    BELWUE          Baden-Wuertemberg Ext   [CL80]
+    C 129.144.rrr.rrr-129.159.rrr.rrr    Sun Microsystems, Inc [39,BN4]
+    R*129.160.rrr.rrr    SOLARIUM        The Radian Net      [39,JL152]
+    R*129.161.rrr.rrr    HGCGNET         HARTFORDGRADCTRGNET  [38,AG61]
+    R 129.162.rrr.rrr    SWRI-NET        SW Rsch Inst Net       [RM196]
+    G*129.163.rrr.rrr    NASA-JSCSSE     NASA JSC Space Sta   [21,DGL4]
+    G*129.164.rrr.rrr    NASA-SSPOSSE    NASA SSPO Space Sta  [21,DGL4]
+    G*129.165.rrr.rrr    NASA-GSFCSSE    NASA GSFC Space Sta  [21,DGL4]
+    G*129.166.rrr.rrr    NASA-JFKSSE     NASA JFK Space Sta   [21,DGL4]
+    G*129.167.rrr.rrr    NASA-MSFCSSE    NASA MSFC Space Sta  [21,DGL4]
+
+
+
+Romano, Stahl & Recker                                         [Page 14]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    G*129.168.rrr.rrr    NASA-LRCSSE     NASA LRC Space Sta   [21,DGL4]
+    R*129.169.rrr.rrr    ENG-CAM-UK      Eng, Cambridge, UK   [39,JMRM]
+    R*129.170.rrr.rrr    DART-ETHER      Dartmouth Ether         [SC59]
+    R 129.171.rrr.rrr    MIAMI           Univ of Miami        [39,HWP2]
+    R*129.172.rrr.rrr    ROK             Rockwell Intl Corp      [TGS6]
+    R*129.173.rrr.rrr    DALNET          Dalhousie Univ Net  [39,JS338]
+    R 129.174.rrr.rrr    MASONET         The GMU Univ         [39,TH15]
+    R*129.175.rrr.rrr    PARIS-SUD       Paris-Sud-Orsay        [RD104]
+    R 129.176.rrr.rrr    MAYO            Mayo Med Rsch Net   [39,GB125]
+    R*129.177.rrr.rrr-129.178.rrr.rrr    Norwegian Acad Net   [39,PS27]
+    C*129.179.rrr.rrr    CDCNET-PROD     CDC Corp Net           [RAM57]
+    R*129.180.rrr.rrr    UNE-CAMPUS      UNE Camp Lan        [39,GS119]
+    C*129.181.rrr.rrr    LV-BULL         Louveciennes Bull        [OD8]
+    C*129.182.rrr.rrr    CL-BULL         Les Clayes Bull        [JPW11]
+    C*129.183.rrr.rrr    EC-BULL         Echirolles Bull        [JPC17]
+    C*129.184.rrr.rrr    PR-BULL         Gambetta Bull           [FH35]
+    C*129.185.rrr.rrr    MY-BULL         Massy Bull               [MQ7]
+    R 129.186.rrr.rrr    CYCLONENET      ISU Cyclone Net     [39,RD108]
+    R*129.187.rrr.rrr    BAVARIAN-NET    Bavarian Univ Net    [39,WS94]
+    R 129.188.rrr.rrr    MOTOROLA        Motorola Engineernet [39,CC99]
+    R*129.189.rrr.rrr    ICONET-ORC      Olivetti Rsch Net    [39,DAVE]
+    D*129.190.rrr.rrr    ASECC           ASECC Facilities Net    [RTB8]
+    C*129.191.rrr.rrr    NSCO            Net Sys Corp           [GS123]
+    C 129.192.rrr.rrr    ACC-NET         ACC Int Net             [AB20]
+    C 129.193.rrr.rrr    TRW-ED-NET      TRW Elec and Def Net [39,GGB2]
+    R*129.194.rrr.rrr    UNIGE-CENTER    Univ of Geneva-Ctr  [12,AS116]
+    R*129.195.rrr.rrr    UNIGE-HOP       Univ of Geneva-Hosp [12,AS116]
+    C*129.196.rrr.rrr    JOHN-FLUKE      John Fluke Net      [21,JS210]
+    C*129.197.rrr.rrr    LMSC-CNU        LMSC Net Utility       [DD112]
+    D 129.198.rrr.rrr    ELAN            Edwards AFB LAN      [21,DDK1]
+    R*129.199.rrr.rrr    ENSNET          FNET-ENS-ULM         [39,JV53]
+    D*129.200.rrr.rrr    DAC-BACK-NET    DAC Company Backbone    [RAY4]
+    C*129.201.rrr.rrr-129.204.rrr.rrr    GE-INTERNET         [39,JEB50]
+    R 129.205.rrr.rrr    CDCNET          Control Data Net    [39,JAW34]
+    R*129.206.rrr.rrr    HD-NET          Heidelberg Net         [LB110]
+    R 129.207.rrr.rrr    PVAMU-NET       Prairie View Univ Net    [FE6]
+    R*129.208.rrr.rrr    BIRMINGHAM      Univ of Birmingham  [39,RJH37]
+    D 129.209.rrr.rrr    BRL-SECURE      BRL Secure Net           [DET]
+    R*129.210.rrr.rrr    SCU-NET         San Clara Univ Net      [WD27]
+    C*129.211.rrr.rrr    ISCS-NET        ISC Sys Internet     [21,DS59]
+    R*129.212.rrr.rrr    AMDAHL-UTS      Amdahl UTS Soft Grp [39,LS136]
+    C*129.213.rrr.rrr    BRIDGE          Bridge Comms        [39,JW196]
+    C*129.214.rrr.rrr    PYRAMID-TECH    Pyramid Tech Net     [39,CD83]
+    R*129.215.rrr.rrr    EU-NET          Edinburgh Univ       [21,WSC5]
+    R 129.216.rrr.rrr    NRC-NET         NRC Dev Net           [39,IHM]
+    R*129.217.rrr.rrr    UNIDO-LAN       UniDo Camp Net       [39,RV32]
+    R*129.218.rrr.rrr    UNISYS-SP       Unisys Sperry Park  [39,SJP10]
+    R 129.219.rrr.rrr    ASU-NET         Arizona State Net    [39,AC85]
+
+
+
+Romano, Stahl & Recker                                         [Page 15]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    C*129.220.rrr.rrr-129.227.rrr.rrr    Unisys Net2         [39,CC129]
+    C*129.228.rrr.rrr    WESTINGHOUSE    WESTINGHOUSE IP Net  [39,CWR4]
+    G 129.229.rrr.rrr    USA-CECER       USA Corps of Eng    [39,DB186]
+    C*129.230.rrr.rrr    ARCNET          Amoco Rsch Comp Net     [SG83]
+    C*129.231.rrr.rrr    DIGICOMM-NET    Digital Comm Int Net [39,TFB3]
+    R*129.232.rrr.rrr    BITNET          BITNET II Backbone       [LCV]
+    R*129.233.rrr.rrr    FHG-IAO         IAO Int Net         [39,DW139]
+    R*129.234.rrr.rrr    DURHAM          Durham Camp Net     [39,JC288]
+    R*129.235.rrr.rrr    SRCNET          Honeywell SRC Net    [39,CRT4]
+    R 129.236.rrr.rrr    LDGO-NET        LAMONT-DOHERTY-NET  [39,RGB14]
+    R 129.237.rrr.rrr    JAYHAWKNET      KU Camp Nets            [DN32]
+    R 129.238.rrr.rrr    AFWL-NET        AF Weapons Lab Net      [CF57]
+    G*129.239.rrr.rrr    HI-CFSG         HI Flight Sys        [39,LP71]
+    R*129.240.rrr.rrr    UIONET          Univ Olso Net       [39,JT122]
+    R*129.241.rrr.rrr    UNITNET         Univ Trondheim Net  [39,JT122]
+    R*129.242.rrr.rrr    UIBNET          Univ Bergen Net     [39,JT122]
+    G*129.243.rrr.rrr    MMAGNET         Martin Marietta     [39,DR137]
+    R 129.244.rrr.rrr    KEHNET          Comp Sci and Eng Ether  [PLH8]
+    C*129.245.rrr.rrr    PAC-BELL        Pacific Bell        [39,DSP11]
+    D 129.246.rrr.rrr    IDA             IDA HQ Net          [39,MM227]
+    R 129.247.rrr.rrr    DFVRL-NET       DFVLR-Rsch-NET       [39,CR24]
+    C*129.248.rrr.rrr    APOLLO          Apol Corp Net           [NM31]
+    R*129.249.rrr.rrr    FX-DEV-NET2     FX Allareas-10MB     [39,HH45]
+    R*129.250.rrr.rrr    PRPNET          PA Rsch Net           [39,BE6]
+    D 129.251.rrr.rrr    SLAN-BSN        Base-Support-Net        [LA55]
+    R*129.252.rrr.rrr    SCAROLINA       SC Rsch Net          [21,AY11]
+    C*129.253.rrr.rrr    WESDIGCO        Western Dig Net   [21,39,SD78]
+    R*129.254.rrr.rrr    ETRI            ETRI Comp Net        [39,KH74]
+      129.255.rrr.rrr    Reserved        Reserved                 [JBP]
+      130.0.rrr.rrr      Reserved        Reserved                 [JBP]
+      130.1.rrr.rrr-191.254.rrr.rrr      Unassigned               [NIC]
+     *191.255.rrr.rrr    Reserved        Reserved                 [JBP]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Romano, Stahl & Recker                                         [Page 16]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    Class C Networks
+
+    * Internet Address   Network          Name               References
+    - ----------------   -------          ----               ----------
+      192.0.0.rrr        Reserved        Reserved                 [JBP]
+    R 192.0.1.rrr        BBN-TEST-C      BBN-GATE-TEST-C          [RH6]
+    R*192.0.2.rrr        TEST            TEST                     [JBP]
+      192.0.3.rrr-192.0.255.rrr          Unassigned               [NIC]
+    R 192.1.2.rrr-192.1.4.rrr            BBN Local Nets           [SGC]
+    R 192.1.5.rrr        BBN-ENET2       BBN-ENET2                [SGC]
+    R 192.1.6.rrr        BBN-LAN1        BBN Local Net 1          [SGC]
+    R 192.1.7.rrr        BBN-LAN2        BBN Local Net 2          [SGC]
+    R 192.1.8.rrr        BBN-LAN3        BBN Local Net 3          [SGC]
+    R 192.1.9.rrr        BBN-ENET3       BBN-ENET3                [SGC]
+    R 192.1.10.rrr       BBN-NETR        BBN-NETR                 [SGC]
+    R 192.1.11.rrr       BBN-SPC-ENET    BBN-SPC-ENET             [SGC]
+    R 192.1.12.rrr-192.3.255.rrr         BBN Local Nets           [SGC]
+    R 192.4.0.rrr-192.4.255.rrr          BELLCORE-NET         [39,PK28]
+      192.5.0.rrr        Reserved        Reserved                 [JBP]
+    R 192.5.1.rrr        CISLHYPERNET    Honeywell              [JLM23]
+    R*192.5.2.rrr        UF-NET-A        UF-CIS Dept Ether       [AW48]
+    C 192.5.3.rrr        HP-DESIGN-AIDS  HP Des Aids             [AG67]
+    C 192.5.4.rrr        HP-TCG-UNIX     HP TCG Unix             [AG67]
+    R 192.5.5.rrr        DEC-MRNET       DEC Marlboro Ether   [39,JM60]
+    R 192.5.6.rrr        DEC-MRRAD       DEC Marlboro Dev     [39,JM60]
+    R 192.5.7.rrr        CIT-CS-NET      Caltech-CS-Net        [41,CS2]
+    R 192.5.8.rrr        MACOMNET        MACOM Net               [SB90]
+    R 192.5.9.rrr        AERONET         Aero Labnet            [1,LCN]
+    R 192.5.10.rrr       ECLNET          USC-ECL-Camp-NET        [MAB4]
+    R 192.5.11.rrr       CSS-RING        SEISMIC-Rsch-NET        [RA11]
+    R 192.5.12.rrr       UTAH-NET-C      UTAH-Comp-Sci-NET       [GW22]
+    R 192.5.13.rrr       GSWDNET         Compion Net           [39,FAS]
+    R 192.5.14.rrr       RAND-NET        RAND Net              [39,JDG]
+    R 192.5.15.rrr   T   NYU-NET-TEMP    NYU Net                  [EF5]
+    R 192.5.16.rrr       LANLLAND        Los Alamos Dev LAN   [39,JC11]
+    R 192.5.17.rrr       NRL-NET         Naval Rsch Lab           [MPM]
+    R 192.5.18.rrr       IPTO-NET        ARPA-IPTO Off Net      [JS283]
+    R 192.5.19.rrr       UCIICS          UCI-ICS Rsch Net        [RAJ3]
+    R 192.5.20.rrr       CISLTTYNET      Honeywell              [JLM23]
+    D 192.5.21.rrr       BRLNET1         BRLNET1               [4,MJM2]
+    D 192.5.22.rrr       BRLNET2         BRLNET2               [4,MJM2]
+    D 192.5.23.rrr       BRLNET3         BRLNET3               [4,MJM2]
+    D 192.5.24.rrr       BRLNET4         BRLNET4               [4,MJM2]
+    D 192.5.25.rrr       BRLNET5         BRLNET5               [4,MJM2]
+    D 192.5.26.rrr       NSRDCOA-NET     NSRDC Off Auto Net      [RWT2]
+    D 192.5.27.rrr       DTNSRDC-NET     DTNSRDC-NET             [RWT2]
+    R 192.5.28.rrr       RSRE-NULL       RSRE-NULL               [RNM1]
+    R 192.5.29.rrr       RSRE-ACC        RSRE-ACC                [RNM1]
+
+
+
+Romano, Stahl & Recker                                         [Page 17]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    R 192.5.30.rrr       RSRE-PR         RSRE-PR                 [RNM1]
+    R*192.5.31.rrr       SIEMENS-NET     Siemens Rsch Net        [PN23]
+    R 192.5.32.rrr       CISLTESTNET2    Honeywell        [17,18,JLM23]
+    R 192.5.33.rrr       CISLTESTNET3    Honeywell        [17,18,JLM23]
+    R 192.5.34.rrr       CISLTESTNET4    Honeywell        [17,18,JLM23]
+    R 192.5.35.rrr       RIACS-NET       RIACS-NET             [39,WPJ]
+    R 192.5.36.rrr       CORNELL-CS      Cornell CS Research   [39,DK2]
+    R 192.5.37.rrr       UR-CS-NET       U of R CS 3Mb Net    [39,LB16]
+    R 192.5.38.rrr       SRI-C3ETHER     SRI-AITAD C3Ether    [39,VDC1]
+    R 192.5.39.rrr       UDEL-EECIS      Udel EECIS LAN       [39,DJG2]
+    R 192.5.40.rrr       PUCC-NET-A      Purdue Comp Ctr Net     [JRS8]
+    D 192.5.41.rrr       WISLAN          WIS Rsch LAN         [39,JRM1]
+    D 192.5.42.rrr       HYPER-1ISG      AFDSC Hypernet          [MCA1]
+    R 192.5.43.rrr       CUCSNET         Columbia CS Net      [39,BC14]
+    R 192.5.44.rrr       FARBER-PC-NET   Farber PC Net            [DJF]
+    R 192.5.45.rrr       FCCC            Fox Chase Cancer Ctr    [RKS1]
+    R 192.5.46.rrr       NTA-RING        NDRE-RING               [PS27]
+    R 192.5.47.rrr       NSRDC           NSRDC                   [RWT2]
+    R 192.5.48.rrr       PURDUE-CS-NET   Purdue CS ProNET        [DT50]
+    C 192.5.49.rrr       TISW-NET        TISW Net                 [HKO]
+    R 192.5.50.rrr       CTH-CS-NET      Chalmers CSN Net      [39,UB3]
+    R 192.5.51.rrr       THEORYNET       Cornell Theory Ctr   [39,AB13]
+    R 192.5.52.rrr       NLM-ETHER       NLM-LHNCBC-Ether         [JA1]
+    R 192.5.53.rrr       UR-CS-ETHER     U of R CS 10Mb Net   [39,LB16]
+    R 192.5.54.rrr       AERO-A6         Aero-A6                [1,LCN]
+    R 192.5.55.rrr       UCLA-CECS       UCLA-CECS Net         [39,RBW]
+    C 192.5.56.rrr       TARTAN-NET      Tartan Labs             [ED38]
+    R 192.5.57.rrr       UDEL-CC         UDEL Comp Ctr        [39,RR18]
+    R 192.5.58.rrr       CSNET-PDN       CSNET X.25 Net       [22,RDR4]
+    R*192.5.59.rrr       INRIA-SM90      Inria GIP SM-90        [MS171]
+    R*192.5.60.rrr       SM90-X1         Inria SM-90 Exp 1      [MS171]
+    R*192.5.61.rrr       SM90-X2         Inria SM-90 Exp 2      [MS171]
+    R*192.5.62.rrr       LITP-SM90       LITP SM-90             [MS171]
+    R 192.5.63.rrr       ENCORE-TEMP     Encore-Marlboro          [IRN]
+    R 192.5.64.rrr       AMES-NAS-NET    NASA ARC NAS LAN     [39,MF31]
+    R 192.5.65.rrr       NPRDC-ETHER     NPRDC TRCF Ether         [LRB]
+    R 192.5.66.rrr       HARV-NET        Harvard Comp Sci Net    [SB28]
+    R 192.5.67.rrr       CECOM-ETHER     CECOM ADDCOMPE ETHER  [39,GIH]
+    R 192.5.68.rrr       AERO-130        Aero-130                 [LCN]
+    R 192.5.69.rrr       UIUC-NET        Univ of IL at Urbana  [39,AKC]
+    G 192.5.70.rrr       CELAN           COINS Exp LAN           [RLS6]
+    R 192.5.71.rrr       SAC-ETHER       SAC C3 Ether         [39,VDC1]
+      192.5.72.rrr-192.5.83.rrr          Unassigned               [NIC]
+    R*192.5.84.rrr-192.5.87.rrr          Univ of Chicago         [MC17]
+    R 192.5.88.rrr       YALE-EE-NET     YALE-EE-NET          [39,AG22]
+    R 192.5.89.rrr       HARV-APOLLO     Harvard Univ          [2,SB28]
+    R 192.5.90.rrr       HARV-ETHER      Harvard CS Ethernet   [2,SB28]
+    R 192.5.91.rrr       PURDUE-ECN1     Purdue ECN        [10,20,GG11]
+
+
+
+Romano, Stahl & Recker                                         [Page 18]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    R 192.5.92.rrr       BRAGG-ETHER     SRI Bragg Ether       [39,GIH]
+    R 192.5.93.rrr       SRI-DEMO        SRI Ether Demo        [39,GIH]
+    R*192.5.94.rrr       SDCRDCF-10MB    SDC R&D Prim Net     [39,DJV1]
+    R*192.5.95.rrr       SDCRDCF-3MB     SDC R&D Old Net      [39,DJV1]
+    R*192.5.96.rrr       UBC-CS-NET      UBC Comp Sci Net     [39,PB67]
+    R*192.5.97.rrr       UCLA-CS-LNI     UCLA CS LNI Net          [RBW]
+    R*192.5.98.rrr       UCLA-PIC        UCLA PIC Net          [39,RBW]
+    R 192.5.99.rrr       SPACENET        S-1 WorkSta Net      [39,TW51]
+    R 192.5.100.rrr      HCSC-NET        Honeywell CSC Net    [39,TRG4]
+    R 192.5.101.rrr      PUCC-NET-B      Purdue Gw Net           [JRS8]
+    R 192.5.102.rrr      PUCC-RHF-NET    PUCC RHF Based Net      [JRS8]
+    C*192.5.103.rrr      TYM-NTD-NET     Tymnet NTD Ether        [SMF5]
+    R 192.5.104.rrr      THINK-INET      Thinking Machs       [39,BJN1]
+    R 192.5.105.rrr      CCA-POND        CCA Ether1 (POND)     [42,AL6]
+    C*192.5.106.rrr      BITSTREAM       Bitstream Type Found [39,PGA1]
+    R*192.5.107.rrr      PASC-ETHER      IBM PASC Ether       [39,GAL5]
+    R*192.5.108.rrr      PASC-BB         IBM PASC BRdband     [39,GAL5]
+    R*192.5.109.rrr      CWR-JCC-T       ARJCC TOPS-20 Net    [39,JAG3]
+    R*192.5.110.rrr      CWR-JCC-L       ARJCC Local Net      [39,JAG3]
+    R*192.5.111.rrr      CWR-QUAD        Campus Quad Net      [39,JAG3]
+    R*192.5.112.rrr      CWR-CAISR       CAISR Local Net      [39,JAG3]
+    R*192.5.113.rrr      CWR-CES         CES Local Net        [39,JAG3]
+    C*192.5.114.rrr      I2-RING-1       Intermetrics Pronet   [39,NH2]
+    C*192.5.115.rrr      I2-ETHER-1      Intermetrics Ether    [39,NH2]
+    R 192.5.116.rrr      BRAGGNET-1      BRAGG/ADDCOMPE       [39,BG25]
+    R 192.5.117.rrr      BRAGGNET-2      BRAGG/ADDCOMPE       [39,BG25]
+    R 192.5.118.rrr      BRAGGNET-3      BRAGG/ADDCOMPE       [39,BG25]
+    R 192.5.119.rrr      BRAGGNET-4      BRAGG/ADDCOMPE       [39,BG25]
+    R 192.5.120.rrr      BRAGGNET-5      BRAGG/ADDCOMPE       [39,BG25]
+    R 192.5.121.rrr      BRAGGNET-6      BRAGG/ADDCOMPE       [39,BG25]
+    R 192.5.122.rrr      BRAGGNET-7      BRAGG/ADDCOMPE       [39,BG25]
+    R 192.5.123.rrr      BRAGGNET-8      BRAGG/ADDCOMPE       [39,BG25]
+    R 192.5.124.rrr      BRAGGNET-9      BRAGG/ADDCOMPE       [39,BG25]
+    R 192.5.125.rrr      BRAGGNET-10     BRAGG/ADDCOMPE       [39,BG25]
+    R 192.5.126.rrr      BRAGGNET-11     BRAGG/ADDCOMPE       [39,BG25]
+    R 192.5.127.rrr      BRAGGNET-12     BRAGG/ADDCOMPE       [39,BG25]
+    R 192.5.128.rrr      BRAGGNET-13     BRAGG/ADDCOMPE       [39,BG25]
+    R 192.5.129.rrr      BRAGGNET-14     BRAGG/ADDCOMPE       [39,BG25]
+    R 192.5.130.rrr      BRAGGNET-15     BRAGG/ADDCOMPE       [39,BG25]
+    R 192.5.131.rrr      BRAGGNET-16     BRAGG/ADDCOMPE       [39,BG25]
+    R 192.5.132.rrr      BRAGGNET-17     BRAGG/ADDCOMPE       [39,BG25]
+    R*192.5.133.rrr      PERCEPT-AI      Perceptronics            [KC8]
+    C*192.5.134.rrr      I2-ETHER-2      Intermetrics Ether-2  [39,NH2]
+    R 192.5.135.rrr      LL-SPEECH-NET   LL Speech Net        [39,RH60]
+    R 192.5.136.rrr      LL43-LEX-BACK   Lincoln G43-LEX-BACK [39,BC65]
+    R 192.5.137.rrr      LL43-LEX-SUNA   Lincoln G43-LEX-SUNA [39,BC65]
+    R 192.5.138.rrr      LL43-LEX-SUNB   Lincoln G43-LEX-SUNB [39,BC65]
+    R 192.5.139.rrr      LL43-LEX-APO    Lincoln G43-LEX-APO  [39,BC65]
+
+
+
+Romano, Stahl & Recker                                         [Page 19]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    R 192.5.140.rrr      LL43-TB-BACK    Lincoln G43-TB-BACK  [39,BC65]
+    R 192.5.141.rrr      LL43-TB-APO     Lincoln G43-TB-APO   [39,BC65]
+    R*192.5.142.rrr      CCVR            CCVR Net             [39,RD91]
+    R 192.5.143.rrr      NWU             NORTHWESTERN            [AS62]
+    R 192.5.144.rrr      CRC-ENET        CANADA-CRC-Ether        [JR17]
+    R 192.5.145.rrr      ECRC-SL         ECRC-SL Net             [PD39]
+    R 192.5.146.rrr      CPW-PSC         Pittsburgh SC Ctr       [ML62]
+    R 192.5.147.rrr      ALV-ETHER       MMDAALVVAX              [LJR5]
+    R 192.5.148.rrr      DISE            Dist Sys Eval Envir    [RHS16]
+    R 192.5.149.rrr      RDL-ETHER       RDL                 [39,MS172]
+    G*192.5.150.rrr      SP-ACE-NET      Sperry Space Sys    [39,JM304]
+    R 192.5.151.rrr      PENN-STATE-1    Penn State Net         [SJS11]
+    R 192.5.152.rrr      PENN-STATE-2    Penn State Net         [SJS11]
+    R 192.5.153.rrr      PENN-STATE-3    Penn State Net         [SJS11]
+    R 192.5.154.rrr      PENN-STATE-4    Penn State Net         [SJS11]
+    R 192.5.155.rrr      PENN-STATE-5    Penn State Net         [SJS11]
+    R 192.5.156.rrr      PENN-STATE-6    Penn State Net         [SJS11]
+    R 192.5.157.rrr      PENN-STATE-7    Penn State Net         [SJS11]
+    R 192.5.158.rrr      PENN-STATE-8    Penn State Net         [SJS11]
+    R 192.5.159.rrr      PENN-STATE-9    Penn State Net         [SJS11]
+    R 192.5.160.rrr      PENN-STATE-10   Penn State Net         [SJS11]
+    R 192.5.161.rrr      PENN-STATE-11   Penn State Net         [SJS11]
+    R 192.5.162.rrr      PENN-STATE-12   Penn State Net         [SJS11]
+    C*192.5.163.rrr      I2-SPDNET-1     I2 SPD Ether          [39,NH2]
+    C 192.5.164.rrr      GTEECN          GTE Eng Net          [39,JEE4]
+    R 192.5.165.rrr      SDC-CAM-1       SDC Camarillo R&D Net    [DSR]
+    R*192.5.166.rrr      CRC-WDC-NET     CRC Wash DC             [GEOF]
+    R 192.5.167.rrr      MCC-AI-NET      MCC AI Subnet         [39,CBD]
+    R 192.5.168.rrr      MCC-CAD2-NET    MCC CAD2 Subnet       [39,CBD]
+    R 192.5.169.rrr      MCC-PKG-NET     MCC PKG Subnet        [39,CBD]
+    G 192.5.170.rrr      ANLNET1         Argonne Net          [39,LW26]
+    G 192.5.171.rrr      ANLNET2         Argonne Net          [39,LW26]
+    G 192.5.172.rrr      ANLNET3         Argonne Net          [39,LW26]
+    G 192.5.173.rrr      ANLNET4         Argonne Net          [39,LW26]
+    G 192.5.174.rrr      ANLNET5         Argonne Net          [39,LW26]
+    G 192.5.175.rrr      ANLNET6         Argonne Net          [39,LW26]
+    G 192.5.176.rrr      ANLNET7         Argonne Net          [39,LW26]
+    G 192.5.177.rrr      ANLNET8         Argonne Net          [39,LW26]
+    G 192.5.178.rrr      ANLNET9         Argonne Net          [39,LW26]
+    G 192.5.179.rrr      ANLNET10        Argonne Net          [39,LW26]
+    G 192.5.180.rrr      ANLNET11        Argonne Net          [39,LW26]
+    G 192.5.181.rrr      ANLNET12        Argonne Net          [39,LW26]
+    G 192.5.182.rrr      ANLNET13        Argonne Net          [39,LW26]
+    G 192.5.183.rrr      ANLNET14        Argonne Net          [39,LW26]
+    G 192.5.184.rrr      ANLNET15        Argonne Net          [39,LW26]
+    G 192.5.185.rrr      ANLNET16        Argonne Net          [39,LW26]
+    G 192.5.186.rrr      ANLNET17        Argonne Net          [39,LW26]
+    G 192.5.187.rrr      ANLNET18        Argonne Net          [39,LW26]
+
+
+
+Romano, Stahl & Recker                                         [Page 20]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    G 192.5.188.rrr      ANLNET19        Argonne Net          [39,LW26]
+    G 192.5.189.rrr      ANLNET20        Argonne Net          [39,LW26]
+    G 192.5.190.rrr      ANLNET21        Argonne Net          [39,LW26]
+    G 192.5.191.rrr      ANLNET22        Argonne Net          [39,LW26]
+    G 192.5.192.rrr      ANLNET23        Argonne Net          [39,LW26]
+    G 192.5.193.rrr      ANLNET24        Argonne Net          [39,LW26]
+    G 192.5.194.rrr      ANLNET25        Argonne Net          [39,LW26]
+    G 192.5.195.rrr      ANLNET26        Argonne Net          [39,LW26]
+    G 192.5.196.rrr      ANLNET27        Argonne Net          [39,LW26]
+    G 192.5.197.rrr      ANLNET28        Argonne Net          [39,LW26]
+    G 192.5.198.rrr      ANLNET29        Argonne Net          [39,LW26]
+    G 192.5.199.rrr      ANLNET30        Argonne Net          [39,LW26]
+    G 192.5.200.rrr      ANLNET31        Argonne Net          [39,LW26]
+    G 192.5.201.rrr      ANLNET32        Argonne Net          [39,LW26]
+    R 192.5.202.rrr      FMC-CEL         FMC-CEL Host Net      [39,KW2]
+    R*192.5.203.rrr      OKSTATE-CS      Okla State CS Net    [39,MV24]
+    R 192.5.204.rrr      SKL-ENET        Canada-SKL-Ether        [JR17]
+    R*192.5.205.rrr      ARC-CALGARY     Alta Rsch Calgary       [DK66]
+    R 192.5.206.rrr      BU-MATHNET      BU-MATHNET              [BS24]
+    R 192.5.207.rrr      BU-CHEMNET      BU-CHEMNET              [BS24]
+    R 192.5.208.rrr      BU-CLANET       BU-CLANET               [BS24]
+    D 192.5.209.rrr      SSDF-CDCNET     DCD-DDN-Dev             [RE22]
+    G 192.5.210.rrr      ECSNET          Embedded Comp Sys Net   [CAL7]
+    R 192.5.211.rrr      INTEL-IWARP     Intel Iwarp Net       [39,BT4]
+    R 192.5.212.rrr  T   EMORY-INET4     Emory Internet 4        [AR60]
+    R 192.5.213.rrr      HARRIS          Harris-GSSNet           [DAT4]
+    C 192.5.214.rrr      DECUACNET       Decuac Net           [39,FMA1]
+    R 192.5.215.rrr      MASONNET        GMU Net              [39,TH15]
+    R*192.5.216.rrr      NTT-NET         NTT Rsch Lab Net     [39,YS10]
+    R 192.5.217.rrr      YALE-ZOO-NET    Yale Apol Ed Net        [HML1]
+    D 192.5.218.rrr      ARINC-GW-NET    ARINC-Gw Net              [YN]
+    R 192.5.219.rrr      CLEMSON         Clemson Univ Comp Ctr   [DB28]
+    C 192.5.220.rrr      SCCNET          SPACECOM IP Net      [39,MJO4]
+    C*192.5.221.rrr      CSC-LONS        CSC-LONS Net         [39,GG43]
+    C*192.5.222.rrr      CSC-OIS         CSC-OIS Net          [39,GG43]
+    R*192.5.223.rrr      HWELL-RE        HWELL-RESD-ENGRG     [39,PP36]
+    D*192.5.224.rrr      HAIC-NET        Hughes AI Ctr Net   [39,DMK18]
+    C*192.5.225.rrr-192.5.236.rrr        GE Calma Block       [39,TR38]
+      192.5.237.rrr      Unassigned      Unassigned               [NIC]
+    C*192.5.238.rrr      PALLADIAN-1     Palladian-IN1         [CSTACY]
+    C*192.5.239.rrr      PALLADIAN-2     Palladian-RING        [CSTACY]
+    C*192.5.240.rrr      PALLADIAN-3     Palladian-IN2         [CSTACY]
+    R 192.5.241.rrr      USC-CYPRESS     USC Cypress Net        [6,DE6]
+    C*192.5.242.rrr      MOT-ASIC        Motorola Chandler LAN   [GW49]
+    C*192.5.243.rrr      MOT-MESA        Motorola Mesa LAN       [GW49]
+    C*192.5.244.rrr      MOT-DOVER       Motorola Dover LAN      [GW49]
+    C*192.5.245.rrr      MOT-PRICE       Motorola Price Rd LAN   [GW49]
+    C*192.5.246.rrr      MOT-PICO        Motorola Pico LAN       [GW49]
+
+
+
+Romano, Stahl & Recker                                         [Page 21]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    C*192.5.247.rrr      MOT-52ND        Motorola Semi MIS LAN   [GW49]
+    C*192.5.248.rrr      MOT-AUSTIN      Motorola Austin LAN     [GW49]
+    C*192.5.249.rrr      MOT-OAKHILL     Motorola Oakhill LAN    [GW49]
+    C*192.5.250.rrr      MOT-TELAVIV     Motorola Tel Aviv LAN   [GW49]
+    C*192.5.251.rrr      MOT-GENEVA      Motorola Geneva LAN     [GW49]
+    C*192.5.252.rrr      MOT-TOKYO       Motorola Tokyo LAN      [GW49]
+    C*192.5.253.rrr      MOT-HONGKONG    Motorola Hongkong LAN   [GW49]
+    R*192.5.254.rrr      ANSA            ANSA Project         [39,DO27]
+      192.5.255.rrr      Reserved        Reserved                 [JBP]
+    C*192.6.0.rrr-192.6.200.rrr          Hewlett Packard         [AG67]
+    R 192.6.201.rrr      UTSANANTONIO    UT San Antonio           [LSV]
+    C*192.6.202.rrr-192.6.255.rrr        Hewlett Packard         [AG67]
+    C*192.7.0.rrr-192.7.255.rrr          Computer Consoles, Inc  [RA11]
+    C*192.8.0.rrr-192.8.255.rrr          Spartacus Inc           [FJK2]
+    C*192.9.0.rrr-192.9.255.rrr          SUN Microsystems, Inc    [BN4]
+    C*192.10.0.rrr-192.10.40.rrr         Symbolics, Inc           [CH2]
+      192.10.41.rrr      Unassigned      Unassigned               [NIC]
+    C*192.10.42.rrr-192.10.255.rrr       Symbolics, Inc           [CH2]
+    C*192.11.0.rrr-192.11.255.rrr        ATT, Bell Lab           [MH82]
+    R 192.12.0.rrr       YALE-SUN-NET    YALE-SUN-NET             [LFO]
+    R*192.12.1.rrr       SUSSEX-CSNET    Sussex Comp Sci Net     [PT26]
+    R*192.12.2.rrr       AMDAHL          Amdahl UTS Dev Grp      [LCN2]
+    C*192.12.3.rrr       FLAIR           Fairchild AI Lab Net [39,AMS1]
+    C*192.12.4.rrr       SCG-NET         Hughes SCG Net       [40,MKP2]
+    R 192.12.5.rrr       AIC-LISPMS      SRI-AIC-LISPMachNET   [39,PM4]
+    R 192.12.6.rrr       NPS-C2          NPS-C2               [39,DW15]
+    R 192.12.7.rrr       NYU-CS-ETHER    NYU CompSci Ethernet  [39,LOU]
+    D 192.12.8.rrr       PICANET1        Pica Arsenal LAN1    [39,RFD1]
+      192.12.9.rrr       Unassigned      Unassigned               [NIC]
+    R 192.12.10.rrr      CORNELL-ENG     Cornell-Engineering   [39,DK2]
+    R 192.12.11.rrr      MIT-TEST        MIT Gw Test Net       [39,NC3]
+      192.12.12.rrr      Unassigned      Unassigned               [NIC]
+    R 192.12.13.rrr      JHU-NET1        JHU-NET1             [39,MJO7]
+    R 192.12.14.rrr      JHU-NET2        JHU-NET2             [39,MJO7]
+    R 192.12.15.rrr      BROOKNET        BNL Brooknet III       [39,GC]
+    R 192.12.16.rrr      PRMNET          SRI-SURAN-EN         [39,PEM4]
+    G 192.12.17.rrr      LLL-TIS-NET     LLL-TIS-NET        [39,40,NAL]
+    R 192.12.18.rrr      CIT-CS-10NET    Caltech 10Meg Ether  [41,AD22]
+    R 192.12.19.rrr      CIT-NET         Caltech Camp Net     [41,AD22]
+    R 192.12.20.rrr      CIT-SUN-NET     Caltech Sun Net      [41,AD22]
+    R 192.12.21.rrr      CIT-PHYSCOMP    Caltech Phys Comp    [41,AD22]
+    R 192.12.22.rrr      UTCSRES         UTCS Net Rsch        [39,JSQ1]
+    R 192.12.23.rrr      UTCSTTY         UTCS TTY Kludgenet   [39,JSQ1]
+    R 192.12.24.rrr      MICANET         MITRE-Exp                [WDL]
+    R 192.12.25.rrr      CSS-GRAMINAE    CSS WorkSta Net       [19,RR2]
+    R 192.12.26.rrr      NOSC-NETR       Net-R Testbed at BBN [34,CP10]
+    R 192.12.27.rrr      UR-LASER        UR Laser Energetics  [39,WL31]
+    R*192.12.28.rrr      RIACS           RIACS-Exp-Net           [DG28]
+
+
+
+Romano, Stahl & Recker                                         [Page 22]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    D 192.12.29.rrr      RF-EVANS        ADDCOMPE DC3 LAN1    [39,MB31]
+    D 192.12.30.rrr      RF-HEX-A        ADDCOMPE DC3 LAN2    [39,MB31]
+    D 192.12.31.rrr      USNA-ENET       USNA Eng NEt          [39,TS9]
+    R*192.12.32.rrr      CMU-VINEYARD    CMU File Cluster Net [39,MK68]
+    R 192.12.33.rrr      SRI-CSL-NET     SRI-CSL 10MB Ether      [TONY]
+    C*192.12.34.rrr-192.12.43.rrr        Schlumberger PA Net  [39,SL10]
+    R 192.12.44.rrr      NRTC-NET        Northrop Rsch Net    [39,RSM1]
+    R 192.12.45.rrr      ACC-SB-IMP-NET  ACC San Barb C/30 IMP   [AB20]
+    R 192.12.46.rrr      ACC-SB-ETHER    ACC San Barb Ether      [AB20]
+      192.12.47.rrr      Unassigned      Unassigned               [NIC]
+    G 192.12.48.rrr      AMES-ED-EXPNET  Code ED Exp Net      [39,MSM1]
+    G 192.12.49.rrr      AMES-ED-NET     Code ED IP Net       [39,MSM1]
+    G 192.12.50.rrr      AMES-DB-NET     Ames DBridge Net     [39,MSM1]
+    R 192.12.51.rrr      THINK-CHAOS     TMC Chaos            [39,BJN1]
+    R*192.12.52.rrr      NEURO-NET       NEURO-NET             [39,JXB]
+    R*192.12.53.rrr      PU-LCA          Princeton Univ LCA    [39,CYH]
+    R 192.12.54.rrr      AERO-A3         Aero-A3                  [LCN]
+    R 192.12.55.rrr      HAZ-LPR-BETA    Hazeltine LPR Net    [39,KO11]
+    R 192.12.56.rrr      UTAH-AP-NET     Utah-Apol-Ring-Net      [JL15]
+    R 192.12.57.rrr      MCC-CAD-NET     MCC CAD Subnet        [39,CBD]
+    R 192.12.58.rrr      MCC-PP-NET      MCC AI Subnet         [39,CBD]
+    R 192.12.59.rrr      MCC-DB-NET      MCC DB Subnet         [39,CBD]
+    R 192.12.60.rrr      MCC-HI-NET      MCC HI Subnet         [39,CBD]
+    R 192.12.61.rrr      MCC-SW-NET      MCC SW Subnet         [39,CBD]
+    R 192.12.62.rrr      DREA-ENET       DREA Lispm & Vaxen   [39,GLH5]
+    R 192.12.63.rrr      CYPRESS         CYPRESS Serial Net       [CAK]
+    D 192.12.64.rrr      LOGNET          Logistics Net GW      [4,JR15]
+    D 192.12.65.rrr      HELNET1         HELNET1              [39,MJM2]
+    D 192.12.66.rrr      HELNET2         HELNET2              [39,MJM2]
+    D 192.12.67.rrr      HELNET3         HELNET3              [39,MJM2]
+    G 192.12.68.rrr      ORNL-MSRNET     ORNL Local Area Net    [4,THD]
+    R 192.12.69.rrr      UA-CS-NET       Univ of Ariz CS Dept [39,PAK6]
+    R 192.12.70.rrr      NPRDC-IPD       NPRDC-IPD Rem Ether      [LRB]
+    R 192.12.71.rrr      NPRDC-ISG       NPRDC-ISG Rem Ether      [LRB]
+    R 192.12.72.rrr      ULCC            UK.AC.ULCC              [RHC3]
+    R 192.12.73.rrr      BTRL            UK.CO.BT-Rsch-LABS      [RHC3]
+    R*192.12.74.rrr      APPLE-ETHER     Apple Comp Ether     [39,TM86]
+    R*192.12.75.rrr      PASC-RING       IBM PASC Token Ring     [GAL5]
+    R*192.12.76.rrr      UQ-NET          Univ of Qld Net      [39,AKH5]
+      192.12.77.rrr      Unassigned      Unassigned               [NIC]
+    C*192.12.78.rrr      GENNET          Genentech Net        [39,SM96]
+    C*192.12.79.rrr      SLI             Soft Leverage Inc       [MG58]
+    R 192.12.80.rrr      CAEN            UMICH-CAEN               [HWB]
+    R 192.12.81.rrr      YALE-RING-NET   Yale Rsch Ring          [HML1]
+    C 192.12.82.rrr      CU-CC-NET       Columbia CC Net      [39,BC14]
+    G 192.12.83.rrr      UCDLA-EXNET     UCDLA Exp Net           [CL64]
+    G 192.12.84.rrr      UCDLA-PCNET     UCDLA Personal Net      [CL64]
+    G 192.12.85.rrr      UCDLA-OPNET     UCDLA Optical Disk      [CL64]
+
+
+
+Romano, Stahl & Recker                                         [Page 23]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    G 192.12.86.rrr      UCDLA-RADNET    UCDLA Pck Rad           [CL64]
+    G 192.12.87.rrr      UCDLA-CSLNET    UCDLA State Library     [CL64]
+    R*192.12.88.rrr      RUTGERS-NWK     Rutgers, Newark        [DB150]
+    R 192.12.89.rrr      SBCS-CSDEPT-1   SB Comp Sci            [JS268]
+    R 192.12.90.rrr      SBCS-CSDEPT-2   SB Comp Sci            [JS268]
+    R 192.12.91.rrr      RPICSNET0       RPICS-LOCALNET-0         [MS9]
+    R 192.12.92.rrr      RPICSNET1       RPICS-LOCALNET-1         [MS9]
+    C*192.12.93.rrr      TYMNET-MDC      TYMNET-McDonnellDC      [TDM8]
+    R 192.12.94.rrr      ROCKWELL-AI     Rockwell Palo Alto      [BMW7]
+    C*192.12.95.rrr      NNWSI           SAIC NNWSI Net          [EJ12]
+    R*192.12.96.rrr      SUPELEC-GIF     Reseau Supelec Gif     [DC159]
+    C 192.12.97.rrr      IND-NTC         NTC ARPA Test Net       [AB98]
+    R 192.12.98.rrr      SHIRBAY-ENET    Shirley Bay Site LA     [TS31]
+    C*192.12.99.rrr      FCSL-NET        Ferranti CSL            [SA47]
+    D 192.12.100.rrr     OOG1            OO/ALC-SC-Gw1           [JD86]
+    R*192.12.101.rrr     OSU-CGRG        OSU Comp Graphics    [39,KS62]
+    G 192.12.102.rrr     AMES-NAS-HY     AMES NAS HY Net         [MSM1]
+    R 192.12.103.rrr     CSU-USC-ETHER   Colo State Univ Nets   [RB218]
+    R 192.12.104.rrr     CSU-NREL-ETHER  Colo State Univ Nets   [RB218]
+    R 192.12.105.rrr     CSU-CAMPUS-ASYNC Colo State Univ Nets  [RB218]
+    R 192.12.106.rrr     CSU-LANCE-PRONET Colo State Univ Nets  [RB218]
+    R 192.12.107.rrr     CSU-ATMOS-ETHER Colo State Univ Nets   [RB218]
+    R 192.12.108.rrr     CSU-UCC-ETHER   Colo State Univ Nets   [RB218]
+    R*192.12.109.rrr-192.12.118.rrr      Colo State Univ Nets   [RB218]
+    C*192.12.119.rrr     XYPLEX          Xyplex Eng              [DP91]
+    D 192.12.120.rrr     MITRE-B-NET     MITRE Bedford Ether      [BSW]
+    R*192.12.121.rrr     FSUCS           FSU Comp Sci 1           [TB4]
+    R*192.12.122.rrr     FSUCS2          FSU Comp Sci 2           [TB4]
+    G 192.12.123.rrr     AMES-CCF-NET    AMES CCF Net         [39,MSM1]
+    D 192.12.124.rrr     ETL-LAN         ETL Local Area Net    [39,WWS]
+    D 192.12.125.rrr     CRDEC-NET1      CRDEC-NET1           [39,JY11]
+    D 192.12.126.rrr     CRDEC-NET2      CRDEC-NET2           [39,JY11]
+    R 192.12.127.rrr     LL-MI-NET       LL-Mach Intell        [39,GAA]
+    R 192.12.128.rrr     ISTC-ADMIN      SRI-ISTC Admin Net   [39,VDC1]
+    C*192.12.129.rrr     SYM-CAN         Symbolics/Canada        [MMH5]
+    R 192.12.130.rrr     SDC-SM          SDC San Monica           [CAS]
+    R 192.12.131.rrr     SAC-ADMIN       SRI-SAC Admin Net    [39,KMC3]
+    R 192.12.132.rrr     LLL-MON         LLL Open Labnet-1    [39,LL64]
+    R 192.12.133.rrr     LLL-TUES        LLL Open Labnet-2    [39,LL64]
+    R 192.12.134.rrr     LLL-WED         LLL Open Labnet-3    [39,LL64]
+    R 192.12.135.rrr     LLL-THU         LLL Open Labnet-4    [39,LL64]
+    R 192.12.136.rrr     LLL-FRI         LLL Open Labnet-5    [39,LL64]
+    R 192.12.137.rrr     LLL-SAT         LLL Open Labnet-6    [39,LL64]
+    R 192.12.138.rrr     LLL-SUN         LLL Open Labnet-7    [39,LL64]
+    D 192.12.139.rrr     JTELS-BEN-GW    JUMPS Teleprocessing    [RR26]
+    R*192.12.140.rrr     INFERENCE       INFERENCE               [DGT6]
+    R 192.12.141.rrr     CSS-ETHER       CSS WorkSta Net 2       [RA11]
+    C*192.12.142.rrr     SENTRY          Sentry Adv Prod Net     [LL56]
+
+
+
+Romano, Stahl & Recker                                         [Page 24]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    C*192.12.143.rrr     VSHIC-NET       Sentry VSHIC Test       [LL56]
+    R 192.12.144.rrr     ECRCNET         ECRC Internet        [39,PD39]
+    C*192.12.145.rrr-192.12.154.rrr      RCA-CADNET           [39,RG92]
+    C*192.12.155.rrr-192.12.170.rrr      MTCS-CUST               [SF41]
+    D 192.12.171.rrr     PICANET2        Picatinny Arsenal 2     [RFD1]
+    R 192.12.172.rrr     ROCKWELLENET    Rockwell Ether            [NG]
+    R 192.12.173.rrr     AERO-D8         Aero-D8                  [LCN]
+    R*192.12.174.rrr-192.12.183.rrr      TORONTO              [39,BD55]
+    R 192.12.184.rrr     DSPO-NET        BRL Hyper Proj Net       [BT5]
+    R 192.12.185.rrr     BOSTONU-NET     Boston Univ Net         [BS24]
+    R 192.12.186.rrr     BU-ACCNET       BU Academic             [BS24]
+    R 192.12.187.rrr     BU-BROADB       BU Broadband            [BS24]
+    R 192.12.188.rrr     BU-SCINET       BU Science              [BS24]
+    R 192.12.189.rrr     BU-ENGNET       BU Engineering          [BS24]
+    R 192.12.190.rrr     BU-DSGNET       BU Dist Sys             [BS24]
+    R 192.12.191.rrr     BU-MEDNET       BU Med School           [BS24]
+    R 192.12.192.rrr     CNUCE-LAN1      CNR Pisa Ether          [ABB2]
+    R 192.12.193.rrr     CNUCE-LAN2      CNR Pisa Ether          [ABB2]
+    R 192.12.194.rrr     CNUCE-LAN3      CNR Pisa Ether          [ABB2]
+    R 192.12.195.rrr     SDC-PRC-NET     SDC Paoli R&D Cr        [MS22]
+      192.12.196.rrr     Unassigned      Unassigned               [NIC]
+    D 192.12.197.rrr     ACATT-ETHER1    ADEA/CECOM Adv Tech  [39,ERK3]
+    D 192.12.198.rrr     ACATT-ETHER2    ADEA/CECOM Adv Tech  [39,ERK3]
+    D 192.12.199.rrr     LEWIS-ETHER1    ADEA/SRI Ft. Lewis   [39,ERK3]
+    D 192.12.200.rrr     SRI-PSON-10     ADEA/SRI Ft. Lewis   [39,ERK3]
+    D 192.12.201.rrr     SRI-PSON-11     ADEA/SRI Ft. Lewis   [39,ERK3]
+    D 192.12.202.rrr     SRI-PSON-12     ADEA/SRI Ft. Lewis   [39,ERK3]
+    D 192.12.203.rrr     SRI-PSON-13     ADEA/SRI Ft. Lewis   [39,ERK3]
+    D 192.12.204.rrr     SRI-PSON-14     ADEA/SRI Ft. Lewis   [39,ERK3]
+    R 192.12.205.rrr     OHIO-STATE1     Ohio State Univ         [RSD2]
+    R 192.12.206.rrr     INDIANA         Indiana-Bloomington     [BS69]
+    R 192.12.207.rrr     SUPERCOMP       SDSC-Supercomputer      [GKN1]
+    G*192.12.208.rrr     SUN-IPC         SUN-IPC Net              [BT5]
+    R 192.12.209.rrr     NSF             NSF Int Net             [FW17]
+    D 192.12.210.rrr     FSTC            Army FSTC Net           [BB64]
+    R 192.12.211.rrr     JVNC            NSF/JVNC Net            [HGH1]
+    R 192.12.212.rrr     RAND-NET2       RAND-NET2                [JDG]
+    R 192.12.213.rrr     RAND-NET3       RAND-NET3                [JDG]
+    R*192.12.214.rrr     BUFFALO-CS      SUNY/Buffalo-CS-Ether   [CFD4]
+    R 192.12.215.rrr     XDRENET         DRE X.25 Component      [JR17]
+    R 192.12.216.rrr     STEVENS-TECH    Stevens Inst of Tech [39,RCM9]
+    R 192.12.217.rrr  T  EMORY-INET1     Emory Internet       [39,AR60]
+    R 192.12.218.rrr  T  EMORY-INET2     Emory Internet       [39,AR60]
+    R 192.12.219.rrr  T  EMORY-INET3     Emory Internet       [39,AR60]
+    R 192.12.220.rrr-192.12.234.rrr      UWISC-IPNET          [39,EJN1]
+    R*192.12.235.rrr     IDA-NET         Comp Sc Linkoping S     [MSA1]
+    R 192.12.236.rrr     CITNET          CIT Camp Net         [39,CBR2]
+    R 192.12.237.rrr     HCSC-APOLLO     Honeywell CSC Apol    [2,TRG4]
+
+
+
+Romano, Stahl & Recker                                         [Page 25]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    R*192.12.238.rrr     CU-BOULDER      CU Boulder Camp      [39,DCMW]
+    R*192.12.239.rrr     CU-ACS          CU ACS Net           [39,DCMW]
+    R*192.12.240.rrr     CU-ENGINEER     CU Eng Net           [39,DCMW]
+    R*192.12.241.rrr     CU-SUNNET       CU Sun Net           [39,DCMW]
+    R*192.12.242.rrr     CU-CER          CU CER Net           [39,DCMW]
+    R*192.12.243.rrr     CU-OT           CU Off Tower         [39,DCMW]
+    R*192.12.244.rrr     CU-ENTERPRISE   CU ECE Sun Net       [39,DCMW]
+    R*192.12.245.rrr     CU-LASP         CU LASP Net          [39,DCMW]
+    R*192.12.246.rrr     CU-BOULDER      CU JILA Net          [39,DCMW]
+    R*192.12.247.rrr     TROTTINET       Phy Inst Univ-Zuerich    [US2]
+    R 192.12.248.rrr     ATD1            Harris ATD Net          [TS14]
+    R 192.12.249.rrr     ATD2            Harris ATD Net          [TS14]
+    R 192.12.250.rrr     MRNET           Minn Reg Net            [BTK1]
+    C*192.12.251.rrr     CDCNET-SDD      CDC SDD Test Net       [RAM57]
+    R*192.12.252.rrr     LL-VENET1       LLs Venet1           [39,BC65]
+    R*192.12.253.rrr     LL-VENET2       LLs Venet2           [39,BC65]
+    R*192.12.254.rrr     LL-APOLLO       LLs Apol             [39,BC65]
+    R*192.12.255.rrr     LL-ENET         LLs Enet             [39,BC65]
+    D 192.13.0.rrr-192.14.255.rrr        DODIIS Subnets           [AY5]
+    C*192.15.0.rrr-192.15.255.rrr        NBINET                   [WW2]
+    G 192.16.0.rrr-192.16.15.rrr         LANLLAN              [39,JC11]
+    G 192.16.16.rrr      S3-ETHER1-NET   S3-ETHER1-NET        [39,JC11]
+    G 192.16.17.rrr-192.16.49.rrr        LANLLAN              [39,JC11]
+    R 192.16.50.rrr-192.16.71.rrr        RPI-LOCALNETS         [39,MS9]
+    R 192.16.72.rrr      UTCHPC          U.T. System CHPC     [39,WCB3]
+      192.16.73.rrr      Unassigned      Unassigned               [NIC]
+    R 192.16.74.rrr      UTABRC          U.T. Austin BRC      [39,WCB3]
+    C*192.16.75.rrr-192.16.122.rrr       CSC-Block            [39,GG43]
+    R*192.16.123.rrr-192.16.154.rrr      Swedish Net             [BE10]
+    R*192.16.155.rrr-192.16.166.rrr      CERN-Block              [BMS2]
+    R 192.16.167.rrr     YALE-HP-NET     YALE-HP-NET             [HML1]
+    D 192.16.168.rrr     PICANET3        Picatinny 3             [RFD1]
+    D 192.16.169.rrr     NRL-HUBNET      Exp Hubnet               [MPM]
+    C 192.16.170.rrr     TWG-DEMO-NET    TWG Net for Demos       [JXS1]
+    R 192.16.171.rrr     MACOM           M/A-COM Net            [JMA16]
+    C*192.16.172.rrr     EIK-ENG         Eikonix Eng Net         [SW78]
+    D 192.16.173.rrr     CDA-LAN         Catalog Data Act LAN    [FJS3]
+    R 192.16.174.rrr     LL-MICRO-NET    LL Microelec Net         [GLD]
+    R 192.16.175.rrr     GUACC           GU Academic Net           [SA]
+    R 192.16.176.rrr     LSUNET          LSU Camp Ether          [CFB1]
+      192.16.177.rrr     Unassigned      Unassigned               [NIC]
+    R*192.16.178.rrr     NTT-Y-ETHER     NTT-Y-LAB Ether Net     [RN29]
+    R*192.16.179.rrr     NTT-Y-APOLLO    NTT-Y-LAB Apol Net      [RN29]
+    R 192.16.180.rrr     AMS             American Math Society   [SBW4]
+    R 192.16.181.rrr     LL-DSN-NET      LL Dist Sensor Net       [GAA]
+    R*192.16.182.rrr     GTICS-SUNS      GT ICS Faculty Suns     [DD11]
+    R*192.16.183.rrr-192.16.202.rrr      WCW-LAN                   [JA]
+    R 192.16.203.rrr     HCSC-SUN        Honeywell CSC Sun       [TRG4]
+
+
+
+Romano, Stahl & Recker                                         [Page 26]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    R 192.16.204.rrr     IASNET          Inst for Adv Study       [KHJ]
+      192.16.205.rrr-192.16.255.rrr      Unassigned               [NIC]
+    R*192.17.0.rrr-192.17.4.rrr          NIBELUNG                [MA24]
+    R 192.17.5.rrr       UIUC-CSO-DCLNET UIUC-CSO-DCLNET         [MA24]
+    R*192.17.6.rrr-192.17.255.rrr        NIBELUNG                [MA24]
+    C*192.18.0.rrr-192.18.255.rrr        SUN Microsystems, Inc    [BN4]
+    C*192.19.0.rrr-192.19.255.rrr        SYSNET-2                 [EY5]
+    C*192.20.0.rrr-192.20.255.rrr        ATT-MD-NET           [39,MH82]
+    C*192.21.0.rrr-192.21.255.rrr        FORMATIVE              [SAB17]
+    C*192.22.0.rrr-192.22.255.rrr        APPLICON                [AS90]
+    C*192.23.0.rrr-192.23.255.rrr        FACTNET                [JCB42]
+    C*192.24.0.rrr-192.24.255.rrr        CHROMATICS             [RB219]
+    R*192.25.0.rrr-192.25.255.rrr        Hewlett Packard          [SI8]
+    D*192.26.0.rrr       ACSAD           ACSAD Net              [SLH19]
+    R 192.26.1.rrr       MCC-DB1-NET     MCC DB1 Net              [CBD]
+    R 192.26.2.rrr       MCC-DB2-NET     MCC DB2 Net              [CBD]
+    R 192.26.3.rrr       MCC-DB3-NET     MCC DB3 Net              [CBD]
+    R 192.26.4.rrr       MCC-DB4-NET     MCC DB4 Net              [CBD]
+    R 192.26.5.rrr       MCC-DB5-NET     MCC DB5 Net              [CBD]
+    R 192.26.6.rrr       MCC-DB6-NET     MCC DB6 Net              [CBD]
+    R 192.26.7.rrr       SPAWAR          SPAWAR Sys Command       [JK7]
+    D 192.26.8.rrr       SAIC-CPVB       SAIC-CPVB              [MAW25]
+    R*192.26.9.rrr       ICOT            ICOT Local Net          [ST13]
+    R 192.26.10.rrr      GALLAUDET       Gallaudet Univ           [KBC]
+    D 192.26.11.rrr      NRL-HUBNET1     Exp Hubnet 1             [MPM]
+    D 192.26.12.rrr      NRL-HUBNET2     Exp Hubnet 2             [MPM]
+    D 192.26.13.rrr      NRL-HUBNET3     Exp Hubnet 3             [MPM]
+    D 192.26.14.rrr      NRL-HUBNET4     Exp Hubnet 4             [MPM]
+    D 192.26.15.rrr      NRL-HUBNET5     Exp Hubnet 5             [MPM]
+    D 192.26.16.rrr      NRL-HUBNET6     Exp Hubnet 6             [MPM]
+    D 192.26.17.rrr      NRL-HUBNET7     Exp Hubnet 7             [MPM]
+    D 192.26.18.rrr      NRL-HUBNET8     Exp Hubnet 8             [MPM]
+    D 192.26.19.rrr      NRL-HUBNET9     Exp Hubnet 9             [MPM]
+      192.26.20.rrr      Unassigned      Unassigned               [NIC]
+    R 192.26.21.rrr      SDC-PRC-SW      SDC/PAOLI Soft Tech     [MS22]
+    R 192.26.22.rrr      SDC-PRC-LBS     SDC/PAOLI Artif Int     [MS22]
+    R 192.26.23.rrr      SDC-PRC-SA      SDC/PAOLI Sys Arch      [MS22]
+    R 192.26.24.rrr      SDC-PRC-CR      SDC/PAOLI Comp Res      [MS22]
+    R 192.26.25.rrr      LUCID           Lucid Net               [BM68]
+    D 192.26.26.rrr      NRL-FIBER       NRL Fiber Optic Net      [WF3]
+      192.26.27.rrr      Unassigned      Unassigned               [NIC]
+    R*192.26.28.rrr-192.26.47.rrr        EPFL                     [YD2]
+    G*192.26.48.rrr      FORUM           Region 2 ISC Net       [MR101]
+    R 192.26.49.rrr      DUNET           Univ of Denver Net   [39,WE12]
+    R*192.26.50.rrr      SG-NET          Silicon Graphics, Inc  [RB221]
+    R 192.26.51.rrr      SGI             Silicon Graphics, Inc  [RB221]
+    R*192.26.52.rrr-192.26.82.rrr        Silicon Graphics, Inc  [RB221]
+    R 192.26.83.rrr      CSM-NET         Colo School of Mines    [KL31]
+
+
+
+Romano, Stahl & Recker                                         [Page 27]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    R 192.26.84.rrr      NPRDC-FTC       NPRDC-FTC Rem Ether      [LRB]
+    R 192.26.85.rrr      NUSAN           NU Super Access Net     [EEW6]
+    R 192.26.86.rrr      PHYSICS-SAC     NU Phy                  [EEW6]
+    R 192.26.87.rrr      MS-SAC          NU Material Sci SAC     [EEW6]
+    R 192.26.88.rrr      YALE-ENG-NET    YALE-ENG-NET             [LFO]
+    D 192.26.89.rrr      JTELS-BEN1-GW   JTELS-BEN1-GW           [RR26]
+    C*192.26.90.rrr      SYNTELNET-A     Syntelligence IPNET-A  [RAR22]
+    R*192.26.91.rrr      KDD             KDD Rsch Net            [TA24]
+    R*192.26.92.rrr      WRIGHT          Wright State Univ      [JLS45]
+    R*192.26.93.rrr      AECL-NET        NTT Atsugi Lab Net      [TK43]
+    R*192.26.94.rrr      NTT-AP-NET      NTT ECL Apol Net        [HM38]
+    R 192.26.95.rrr      LL-VLSI-NET     LL VLSI Net              [AHA]
+    R*192.26.96.rrr      FX-STC-NET2     FX-Tokyo-10BM-Net2       [SY8]
+    C*192.26.97.rrr      RCA-SNOOPY      Peanut Net             [RAR23]
+    C*192.26.98.rrr      TASC-CTC-NET    TASC Reading CTC Net    [KDM5]
+    C 192.26.99.rrr      FAI             FAI Local Net          [MWS10]
+    C 192.26.100.rrr     PROTEON-EXP1    Proteon Exp Net 1       [JS28]
+    C 192.26.101.rrr     PROTEON-EXP2    Proteon Exp Net 2       [JS28]
+    C 192.26.102.rrr     PROTEON-EXP3    Proteon Exp Net 3       [JS28]
+    D 192.26.103.rrr     EXNET           CECOM Exp Net           [MB31]
+    R*192.26.104.rrr-192.26.135.rrr      FINLAND                [JH141]
+    R*192.26.136.rrr     UW-TEMP         Univ of Wash            [RA17]
+    R 192.26.137.rrr-192.26.146.rrr      SYR-MH-NET              [JW47]
+    R 192.26.147.rrr     WLV-ETHER       ETN-WLV-ETHER           [SMS1]
+    R 192.26.148.rrr     UMDNJ-NRAC      UMDNJ-NRAC-NJMS          [LPM]
+    R 192.26.149.rrr     LL43-LEX-SUNC   Grp43 Lexington Net C    [VBK]
+    R 192.26.150.rrr     LL43-TB-SUNA    Grp43 Testbed Net A      [VBK]
+    C*192.26.151.rrr     LATICORP        LatiCorp Net        [39,CC108]
+      192.26.152.rrr-192.26.255.rrr      Unassigned               [NIC]
+    C*192.27.0.rrr-192.27.255.rrr        Hughes Aircraft VLSI    [PH45]
+    C*192.28.0.rrr-192.28.99.rrr         MMM                    [LS103]
+      192.28.100.rrr-192.28.255.rrr      Unassigned               [NIC]
+    C*192.29.0.rrr-192.29.255.rrr        SUN-NET                  [BN4]
+    C*192.30.0.rrr-192.30.255.rrr        Hewlett Packard    [13,21,SI8]
+    R 192.31.0.rrr       PURDUE-GEOSC    PURDUE-GEOSciS          [DT50]
+    C*192.31.1.rrr       CSD-GTE-LAN     CSD-GTE-LAN-NEEDHAM [39,MM135]
+      192.31.2.rrr       Unassigned      Unassigned               [NIC]
+    R 192.31.3.rrr       ALCOA-NET       Alcoa Rsch Net        [29,JOG]
+    C*192.31.4.rrr       I2-ETHER-3      I2 RCE Net            [39,NH2]
+    R 192.31.5.rrr       BOEING-ATC      Boeing BCS ATC LAN   [39,PM37]
+    C*192.31.6.rrr       SQ-ETHER        SoftQuad Inc LAN     [39,BG23]
+    C 192.31.7.rrr       CISCO-NET       cisco Sys Net         [39,KSL]
+    G 192.31.8.rrr       USNA-CADNET     US Naval Acad Net     [39,TS9]
+    R 192.31.9.rrr       YALE-SUN2-NET   YALE-SUN2-NET          [RB187]
+    R 192.31.10.rrr      UTACC-ETHER1    US Army Europe Net   [39,EK18]
+    R 192.31.11.rrr      UTACC-ETHER2    US Army Europe Net   [39,EK18]
+    R 192.31.12.rrr      UTACC-ETHER3    US Army Europe Net   [39,EK18]
+    R 192.31.13.rrr      UTACC-ETHER4    US Army Europe Net   [39,EK18]
+
+
+
+Romano, Stahl & Recker                                         [Page 28]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    R 192.31.14.rrr      CUDENVER        Denver Camp Net       [39,FCH]
+    C*192.31.15.rrr      CASETEK         CASE Tech, Inc       [39,PML1]
+    D 192.31.16.rrr      CC1-ENET        CENTCOM Ether         [39,GIH]
+    D 192.31.17.rrr      CENTCOM-TEST    CENTCOM-MILNET-LAN      [KMC3]
+    D 192.31.18.rrr      CC3-ENET        CENTCOM Ether         [39,GIH]
+    D 192.31.19.rrr      CC4-ENET        CENTCOM Ether         [39,GIH]
+    D 192.31.20.rrr      CC5-ENET        CENTCOM Ether         [39,GIH]
+    R 192.31.21.rrr      SDSC-APOLLO     SDSC Apol Ring        [2,GKN1]
+    C*192.31.22.rrr      SDCCARY         SAS Data Ctr - Cary      [DK5]
+    R*192.31.23.rrr      KULEUVEN-CS     Kuleuven Comp Sci    [39,JH18]
+    D 192.31.24.rrr      ALBM-NET        Lockheed ALBM Net    [39,NB16]
+    C*192.31.25.rrr      NBKNET-AI       Northbrook IPNET-AI    [JC272]
+    C*192.31.26.rrr      ISTNET          Imperial Soft Net    [39,NT12]
+    R*192.31.27.rrr      ALTAIRETHER     GIPALTAIR BDBLUES NET    [OG4]
+    R 192.31.28.rrr      STEWARD-OBS     Steward Ob           [39,SS80]
+    R*192.31.29.rrr      AMDAHL-TTD      Amdahl Test Dev      [39,DR71]
+    R 192.31.30.rrr      ADS-DC-NET      ADS Wash              [39,JTN]
+    C*192.31.31.rrr      AXION-NET       BT Axion Net         [39,NT13]
+    C*192.31.32.rrr-192.31.36.rrr        NSKK Local Area Net  [39,AK36]
+    C*192.31.37.rrr      SDCAPOLL        SAS Data Ctr - Cary      [DK5]
+    C*192.31.38.rrr      TIATSPINE       TI Attleboro Spine      [WDR7]
+      192.31.39.rrr      Unassigned      Unassigned               [NIC]
+    R 192.31.40.rrr      YALE-SUN3-NET   YALE-SUN3-NET          [RB187]
+    R 192.31.41.rrr      YALE-RT-NET     YALE-RT-NET            [RB187]
+    R 192.31.42.rrr      YALE-RT2-NET    YALE-RT2-NET           [RB187]
+    R 192.31.43.rrr      CNSNET          Caltech-CNS Bio Net  [39,DC99]
+    C 192.31.44.rrr      MRC-NET         McLean Rsch Ctr         [WLG7]
+    R 192.31.45.rrr      WILLIAMS        Williams Coll       [39,RW101]
+    R*192.31.46.rrr      LFU_ETHER       Lab for Ultrasonics    [GAM27]
+    R 192.31.47.rrr-192.31.61.rrr        Bay Area Regional Net   [AB71]
+    R*192.31.62.rrr      SRI-CAM         SRI Cambridge UK     [39,AGS5]
+    R 192.31.63.rrr      SCUBED-BBONE    SCUBED-BBONE-NET     [39,TH60]
+    R 192.31.64.rrr      S3-RESEARCH     S3-Rsch-NET          [39,TH60]
+    R 192.31.65.rrr      S3-FIBER-NET    S3-FIBER-NET         [39,TH60]
+    R 192.31.66.rrr      S3-ABQNET       S3-ABQNET            [39,TH60]
+    R 192.31.67.rrr      S3-SLIP-NET     S3-SLIP-NET          [39,TH60]
+    R 192.31.68.rrr      S3-THIN-NET     S3-THIN-NET          [39,TH60]
+    R 192.31.69.rrr      S3-BBONE2-NET   S3-BBONE2-NET        [39,TH60]
+    R 192.31.70.rrr      S3-ETHER2-NET   S3-ETHER2-NET        [39,TH60]
+    R 192.31.71.rrr      S3-ETHER3-NET   S3-ETHER3-NET        [39,TH60]
+    R 192.31.72.rrr      S3-ETHER4-NET   S3-ETHER4-NET        [39,TH60]
+    C*192.31.73.rrr      MTEL-APOLLO     M/A-COM MTEL Apol    [39,JF77]
+    C*192.31.74.rrr      GSSD-APOLLO     M/A-COM GSSD Apol    [39,PC55]
+    D 192.31.75.rrr      HQDA-AI         Pentagon Army AI Net [39,DH23]
+    D 192.31.76.rrr      CSTLNET         Combat Sys Tech Lab     [MP20]
+    C*192.31.77.rrr      MAPNET          Mervine & Pallesen   [39,BH80]
+    C*192.31.78.rrr      WELLSNET-A1     Wells Fargo IPNET-A1 [39,JN47]
+    C*192.31.79.rrr      WACHOVIANET-AI  Wachovia IPNET-AI    [39,PMH3]
+
+
+
+Romano, Stahl & Recker                                         [Page 29]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    R*192.31.80.rrr      FERMILAB        FERMILAB                [CD75]
+      192.31.81.rrr      Unassigned      Unassigned               [NIC]
+    D 192.31.82.rrr      HQEIS           HQ AFSC EIS          [39,SMK2]
+    R 192.31.83.rrr      OSUNET          OSU Camp Net            [PW37]
+    C*192.31.84.rrr      CUBI            Cubicomp Corp Net      [2,SFJ]
+    C 192.31.85.rrr      CLINET          Comp Logic Net      [39,WAH11]
+    R 192.31.86.rrr      RAZORNET        UAF Camp Net           [DLM34]
+    R 192.31.87.rrr      HARC-NET        Houston Area Rsch Ctr   [DN22]
+    R 192.31.88.rrr      BCMTECH-NET     BCM Tech Net         [39,SB98]
+    R 192.31.89.rrr      MIAMI-NET       Univ of Miami        [39,HWP2]
+    R*192.31.90.rrr      MORAVIAN        Moravian Coll          [JPS17]
+    R*192.31.91.rrr      NECAM           NECAmerica              [ARS3]
+    R 192.31.92.rrr      CIT-CONTROL     Caltech Control Lab  [39,JD27]
+    R 192.31.93.rrr      CIT-SRLNET      Caltech SRL Net      [39,CJL2]
+      192.31.94.rrr      Unassigned      Unassigned               [NIC]
+    R*192.31.95.rrr      UCCNET          UC Corp, Admin Net   [39,AC42]
+    G 192.31.96.rrr      ORNL-OSTINET    OSTI Local Area Net   [24,THD]
+    R 192.31.97.rrr      KSU-NET         Kansas State Univ    [39,MSM1]
+    D 192.31.98.rrr      PBAS-BEN2-GW    PBAS-BEN2-Gw            [RR26]
+    R 192.31.99.rrr      ISUNET          ISU Camp Net            [RD80]
+    D 192.31.100.rrr     GUNTER-LAN      GUNTER-LAN              [TMD6]
+    R*192.31.101.rrr     TSU-NET         Texas Southern Univ    [39,AZ]
+    R 192.31.102.rrr     M2C-NET         Mass Microelec Ctr Net  [SM67]
+    R 192.31.103.rrr     P-TO-P-NET      CSNET Pt to Pt Net      [LL53]
+    R 192.31.104.rrr     PSCSURA         PSCSURA                 [JH92]
+    R*192.31.105.rrr     UCC-PRO-UCB     UC Corp, Admin Net   [39,AC42]
+    D 192.31.106.rrr     NSWSES-NAVY     PORT-HUENEME-CBC        [DD41]
+      192.31.107.rrr     Unassigned      Unassigned               [NIC]
+    R*192.31.108.rrr     UCFCSNET        UCF CS Deparment Net [39,TB64]
+    R*192.31.109.rrr     FREDONIA        SUC-FREDONIA           [JM278]
+    C*192.31.110.rrr     ADCAPOLL        Austin Data Ctr Apol   [RC113]
+    R*192.31.111.rrr     AIRMICS         AIRMICS Rsch Net        [DFH2]
+    R*192.31.112.rrr     TRINCOLL        Trinity-Hartford     [38,MA54]
+    C*192.31.113.rrr     ODYSSEY         Odyssey Rsch            [JH22]
+    C*192.31.114.rrr     DRINET          DRI Eng Net          [21,KB60]
+    C*192.31.115.rrr     FIRENET-AI      Fireman's Fund IPNET [39,CO16]
+    R*192.31.116.rrr-192.31.124.rrr      Univ of Tokyo Net   [39,JM292]
+    R*192.31.125.rrr-192.31.144.rrr      DUT Net              [39,FD18]
+    R 192.31.145.rrr     SIGNET          Small IP Gw Net       [39,PGM]
+    R 192.31.146.rrr     UCR             UC Rivside          [39,DM157]
+    D 192.31.147.rrr     NUWESNET        NUWES-KEYPORT-LAN      [RM125]
+    C*192.31.148.rrr     AIGNET-AI       AIG IPNET-AI         [39,RK51]
+    C*192.31.149.rrr     WACNET-AI       1st Wachovia IPNET   [39,PMH3]
+    C*192.31.150.rrr     STPNET-AI       St. Paul IPNET-AI   [39,RLP30]
+    C*192.31.151.rrr     COGNITIONNET    CI-Headquarters      [39,DW93]
+    C 192.31.152.rrr     ROSENET         Rosetta Net          [39,SC54]
+    R 192.31.153.rrr     SALKNET         Salk Inst Net         [39,JOO]
+    R 192.31.154.rrr     UNMHC-DEV       U of NM Hyper Net     [39,KDZ]
+
+
+
+Romano, Stahl & Recker                                         [Page 30]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    R 192.31.155.rrr     GEOLOGY-NWU     Northwestern Geology [39,EEW6]
+    R*192.31.156.rrr     CANISIUS-CS     Canisius Comp Sci   [39,MS101]
+    R 192.31.157.rrr     RTNET           C3P Ether Cube       [39,SC81]
+    D 192.31.158.rrr     DAITC           Def Appl Info Tech   [39,CG24]
+    R 192.31.159.rrr     NYTGCYLAB       NYTGCYLAB           [39,SS110]
+    D 192.31.160.rrr     NUWES-C-NET     NUWES-KEYPORT-LAN      [RM125]
+    R 192.31.161.rrr     UCB-UCSC-NET    UCB-UCSC 56K Backup      [CF4]
+    G*192.31.162.rrr     DOL-NET         Dept of Labor Net    [39,DD47]
+    R 192.31.163.rrr     C3P-NET         C3P SUN Subnet       [39,HLW7]
+    D 192.31.164.rrr     MO-NET          MITRE Omaha Net      [39,SM62]
+    R 192.31.165.rrr     NOAO-TUCSON     NOAO-TUCSON Ether     [39,SG1]
+    R*192.31.166.rrr     EUTEA           EUT-Elec-DEPT           [JVE2]
+    R*192.31.167.rrr     EUTES           EUT-Elec-DEPT-ES        [JVE2]
+    R*192.31.168.rrr     EUTEB           EUT-Elec-DEPT-EB        [JVE2]
+    R*192.31.169.rrr     EUTEEB          EUT-Elec-DEPT-EEB       [JVE2]
+    R*192.31.170.rrr     EUTEEA          EUT-Elec-DEPT-EEA       [JVE2]
+    R*192.31.171.rrr     EUTEX           EUT-Elec-DEPT-EX        [JVE2]
+    D 192.31.172.rrr     IH-POE-GW       IH-POE-GW            [39,LK27]
+    R*192.31.173.rrr     NORTHWESTNET    Wiche Northwest Net  [21,GK44]
+    D 192.31.174.rrr     CORONA-GW       FLEET-ANALYSIS-NET   [39,LM35]
+    C*192.31.175.rrr     ZAIAZ           ZAIAZ InterNatl      [39,WDW2]
+    R*192.31.176.rrr     CADR            CAD Rsch Net            [MA56]
+    R 192.31.177.rrr     THINK-INET-1    Thinking Machs Ether  [39,BN9]
+    R 192.31.178.rrr     THINK-INET-2    Thinking Machs Ether  [39,BN9]
+    R 192.31.179.rrr     THINK-INET-3    Thinking Machs Ether  [39,BN9]
+    R 192.31.180.rrr     THINK-INET-4    Thinking Machs Ether  [39,BN9]
+    R 192.31.181.rrr     THINK-INET-5    Thinking Machs Ether  [39,BN9]
+    R 192.31.182.rrr     THINK-INET-6    Thinking Machs Ether  [39,BN9]
+    R 192.31.183.rrr     THINK-INET-7    Thinking Machs Ether  [39,BN9]
+    R 192.31.184.rrr     THINK-INET-8    Thinking Machs Ether  [39,BN9]
+    R 192.31.185.rrr     THINK-INET-9    Thinking Machs Ether  [39,BN9]
+    R 192.31.186.rrr     THINK-INET-10   Thinking Machs Ether  [39,BN9]
+    R 192.31.187.rrr     THINK-INET-11   Thinking Machs Ether  [39,BN9]
+    R 192.31.188.rrr     THINK-INET-12   Thinking Machs Ether  [39,BN9]
+    R 192.31.189.rrr     THINK-INET-13   Thinking Machs Ether  [39,BN9]
+    R 192.31.190.rrr     THINK-INET-14   Thinking Machs Ether  [39,BN9]
+    R 192.31.191.rrr     THINK-INET-15   Thinking Machs Ether  [39,BN9]
+    R 192.31.192.rrr     SUPER           IDA Super Net         [39,RSH]
+    R 192.31.193.rrr     CUA             Catholic Univ        [39,ECM6]
+    R 192.31.194.rrr     YALE-RT3-NET    YALE-RT3-NET           [RB187]
+    R 192.31.195.rrr     YALE-CHAOS-NET  YALE-CHAOS-NET         [RB187]
+    R*192.31.196.rrr     SERC-NET        Purdue SERC Net      [21,DT50]
+    G*192.31.197.rrr-192.31.206.rrr      Electrotech Lab Nets  [30,TO4]
+    R 192.31.207.rrr     HCSC-SUN2       Honeywell CSDD Sun 2 [39,TRG4]
+    D 192.31.208.rrr     CENTERNET       NAVWPNSUPPCEN-LAN       [JA91]
+    C*192.31.209.rrr     PHRED           Physio Redmond       [39,MG95]
+    R 192.31.210.rrr     STSCI-NET       Space Telescope Net     [LAB5]
+    R*192.31.211.rrr     EMSE-INET       RES-LOC Mines Info   [39,JFC6]
+
+
+
+Romano, Stahl & Recker                                         [Page 31]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    C*192.31.212.rrr     LUCID-ETHER1    Lucid Ether 1         [39,LNZ]
+    C*192.31.213.rrr     LUCID-APOLLO    Lucid Apol Net        [39,LNZ]
+    R*192.31.214.rrr     ALASKANET       Univ of Alaska Net   [27,GK44]
+    R*192.31.215.rrr     MONTANANET      Montana State Univ   [27,GK44]
+    R*192.31.216.rrr     WSUNET          WSU Net              [27,GK44]
+    R 192.31.217.rrr     MCC-ACA1-NET    MCC ACA1 Net          [39,CBD]
+    R 192.31.218.rrr     MCC-ACA2-NET    MCC ACA2 Net          [39,CBD]
+    R 192.31.219.rrr     MCC-ACA3-NET    MCC ACA3 Net          [39,CBD]
+    R 192.31.220.rrr     MCC-ACA4-NET    MCC ACA4 Net          [39,CBD]
+    R 192.31.221.rrr     MCC-ACA5-NET    MCC ACA5 Net          [39,CBD]
+    R*192.31.222.rrr     CAYMAN-IP       Cayman Sys IP Net    [39,BP52]
+      192.31.223.rrr     Unassigned      Unassigned               [NIC]
+    R*192.31.224.rrr     ANU             Australian Natl Univ [21,PW44]
+    D 192.31.225.rrr     MINSY-POE       MINSY-POE-NAVSHIPYD  [39,CV14]
+    D 192.31.226.rrr     LOGAIRCOMNET    LOGAIR COMNET           [TEC6]
+    C*192.31.227.rrr     KSR-ETHER-1     KSR Cambridge Ether 1 [39,BIM]
+    R*192.31.228.rrr     OUINET          Univ of SW Louis     [39,SJM9]
+    R*192.31.229.rrr     AMDAHL-DAPE     Amdahl Des Auto Phy  [39,JFD9]
+    R 192.31.230.rrr     INCSYS          Incremental Sys     [38,JS281]
+    R*192.31.231.rrr     VUCS-AMS        VU CS Net            [39,HVS1]
+    C*192.31.232.rrr     CFI-NET         CFI Ether            [39,SL47]
+    C*192.31.233.rrr     CNT-CORP        CNT Backbone Net    [39,RM176]
+    R 192.31.234.rrr     YALE-SUN4-NET   YALE-SUN4-NET           [HML1]
+    R 192.31.235.rrr     YALE-MISC-NET   YALE-MISC-NET           [HML1]
+    R 192.31.236.rrr     YALE-CS-NET     YALE-CS-NET             [HML1]
+    R 192.31.237.rrr     CIT-SEISMO      Caltech Seis Lab    [39,CS124]
+    D 192.31.238.rrr     NCP-LAN         NAVCOMPARS-DDN         [JM246]
+    D 192.31.239.rrr     SEACOMNET       NAVSEA Comm Net         [JH10]
+    C*192.31.240.rrr     LEXICON         Lexicon Etn             [MK75]
+    G 192.31.241.rrr     MSFC-DR-NET     MSFC Data Red Net    [39,MSM1]
+    R 192.31.242.rrr     DIALUP-IP       CSNET-DIALUP-IP-Net     [DBL1]
+    R*192.31.243.rrr     WRIGHT-SE       Wright State Univ   [39,JLS45]
+    C*192.31.244.rrr     WYSE            WYSE-Ether              [MW83]
+    R*192.31.245.rrr     OUINET-2        USL CACS Net         [39,SJM9]
+    C 192.31.246.rrr     MARBLE-NET      Marble R&D Internet  [39,ME38]
+    C*192.31.247.rrr     CVBNET          CV Backbone Net      [39,AC66]
+    R*192.31.248.rrr     AJTNET          Aerojet Tustin Net  [39,RJH33]
+    C*192.31.249.rrr     ADELIE          Adelie Info Net      [39,BAB7]
+    C*192.31.250.rrr     THALATTA-NET    Thalatta Corp Net   [39,JPB17]
+    R*192.31.251.rrr     PHIL-PCG        Philips PCG         [39,JB230]
+    C*192.31.252.rrr     FTC-ETHER-A     Framentec Ether     [39,RS253]
+    R 192.31.253.rrr     CQENET          Quality Eng Net      [39,EEW6]
+    R 192.31.254.rrr     ALFREDNET       CERAMICSOFALFREDNET   [39,GMQ]
+      192.31.255.rrr     Reserved        Reserved                 [JBP]
+    C*192.32.0.rrr-192.32.255.rrr        Wellfleet Customer      [AW56]
+      192.33.0.rrr       Reserved        Reserved                 [JBP]
+    R*192.33.1.rrr       MTHOLYOKE       Mount Holyoke        [39,WB53]
+    C*192.33.2.rrr       MRST-NET        MRS Tech Net         [13,ER42]
+
+
+
+Romano, Stahl & Recker                                         [Page 32]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    D 192.33.3.rrr       DDN-OFFICE      DDN Program Off Net  [39,MCSJ]
+    R 192.33.4.rrr       NYSERLAN        NYSERNETLAN           [39,MS9]
+    D 192.33.5.rrr       CAC-CEN1        CAC Concept Eval Net [21,BG25]
+    D 192.33.6.rrr       CAC-CEN2        CAC Concept Eval Net [21,BG25]
+    D 192.33.7.rrr       CAC-CEN3        CAC Concept Eval Net [21,BG25]
+    D 192.33.8.rrr       CAC-CEN4        CAC Concept Eval Net [21,BG25]
+    D 192.33.9.rrr       CAC-CEN5        CAC Concept Eval Net [21,BG25]
+    R 192.33.10.rrr      NOAO-KPNO       NOAO-KPNO Ether       [39,SG1]
+    R 192.33.11.rrr      NOAO-ORION      NOAO-Tucson-Orion     [39,SG1]
+    R*192.33.12.rrr      HAMPSHIRE       Hampshire Coll       [39,PT23]
+    D 192.33.13.rrr      BRL-CDCNET      BRL CDC Local Net       [GJK1]
+    R 192.33.14.rrr      CIT-WAG-NET     CIT W.A. Goddard Net   [RED22]
+    C*192.33.15.rrr      CHORUS-OPERA    Chorus Sys Int Net   [39,SL68]
+    R*192.33.16.rrr      COGNET          COGS Rsch Net       [39,RS255]
+    R 192.33.17.rrr      CALTECH-AMA     Applied Math Net     [39,DIM2]
+    R*192.33.18.rrr      NDHECNET        North Dakota HEC Net    [GK44]
+    R*192.33.19.rrr      SERI            Solar Ener Rsch Net  [39,AM92]
+    C*192.33.20.rrr      AUX-DEFAULT     Default Net for A/UX [39,HK24]
+    C 192.33.21.rrr      RISC-NET        Rockwell Sci Ctr     [39,WAG5]
+    C*192.33.22.rrr      PORTAL          The Portal System   [39,JL115]
+    R 192.33.23.rrr      ROUTETEST0      Routing Testing Nets     [SSW]
+    R 192.33.24.rrr      ROUTETEST1      Routing Testing Nets     [SSW]
+    R 192.33.25.rrr      ROUTETEST2      Routing Testing Nets     [SSW]
+    R 192.33.26.rrr      ROUTETEST3      Routing Testing Nets     [SSW]
+    R 192.33.27.rrr      ROUTETEST4      Routing Testing Nets     [SSW]
+    R 192.33.28.rrr      ROUTETEST5      Routing Testing Nets     [SSW]
+    R 192.33.29.rrr      ROUTETEST6      Routing Testing Nets     [SSW]
+    R 192.33.30.rrr      ROUTETEST7      Routing Testing Nets     [SSW]
+    R 192.33.31.rrr      ROUTETEST8      Routing Testing Nets     [SSW]
+    R 192.33.32.rrr      ROUTETEST9      Routing Testing Nets     [SSW]
+    D 192.33.33.rrr      NICNET          Net Info Ctr Net      [39,MKL]
+      192.33.34.rrr      Reserved        Reserved                 [NIC]
+    C*192.33.35.rrr      MIZAR           Mizar Digital System [39,MCL9]
+    R*192.33.36.rrr      VUPHYS-AMS      VU PHYS LAN           [39,FU1]
+    C*192.33.37.rrr-192.33.86.rrr        BOEING-LOCALNETS     [39,SGR1]
+    R*192.33.87.rrr-192.33.111.rrr       ETH Nets             [39,MA63]
+    C 192.33.112.rrr     TIS-NET         TIS Net              [39,DID1]
+    C*192.33.113.rrr     MYBULL          MASSY-BULL-SUPPORT  [39,CM116]
+    C*192.33.114.rrr     MYDEMO          MASSY-BULL-DEMO     [39,CM116]
+    R 192.33.115.rrr     NRAO-CV         NRAO-CV Ether        [39,DCW9]
+    R*192.33.116.rrr     NRAO-GB         NRAO-GB Ether       [39,MC147]
+    R*192.33.117.rrr     NRAO-VLA        NRAO-VLA Ether       [39,BP57]
+    R*192.33.118.rrr-192.33.127.rrr      PSI-E/OSI-W         [39,BH103]
+    R 192.33.128.rrr     BNL-AGS         BNL-AGS Apol           [SM111]
+    C*192.33.129.rrr     TYMNET-QA       TYMNET-Quality Assur   [DH161]
+    C*192.33.130.rrr     SPHINX          Sphinx, Maidenhead  [39,BM106]
+    C*192.33.131.rrr     PHIL-CE         Philips CE           [39,HB60]
+    C*192.33.132.rrr     STEREOLITHO     DEC Stereolitho Net  [39,EM67]
+
+
+
+Romano, Stahl & Recker                                         [Page 33]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    R*192.33.133.rrr     PRL-REDHILL     Philips Rsch Labs UK [39,MCH5]
+    C*192.33.134.rrr     ESOSUN          SAIC GeoPhy Net      [39,PW49]
+    G*192.33.135.rrr     AIST-LAN        AIST-LAN-TSUKUBA     [39,MK79]
+    R*192.33.136.rrr     KUBNET          KUBNET Camp Net         [TN17]
+    R*192.33.137.rrr     CT-ETHER        CT Ether            [21,CS136]
+    R*192.33.138.rrr     CT-ATALK        CT Appletalk Net    [21,CS136]
+    R 192.33.139.rrr     CLEMSON-CS      CLEMSON-CS           [39,CR83]
+    R 192.33.140.rrr     SAO-NET         Smithsonian Astro Ob [39,KG35]
+    R 192.33.141.rrr     SAO1-NET        Smithsonian Astro Ob [39,KG35]
+    R 192.33.142.rrr     SAO2-NET        Smithsonian Astro Ob [39,KG35]
+    R*192.33.143.rrr-192.33.182.rrr      French Unix Users    [21,AR41]
+    D 192.33.183.rrr     SAPE-MOBILE     RADC-SAPE-Mob-NODE  [39,CAD13]
+    D 192.33.184.rrr     SAPE-PRNODE     RADC-SAPE-PR-NET     [4,CAD13]
+    G 192.33.185.rrr     SAAD-ARPA       ISC-SAC-SAAD           [DRM24]
+    G 192.33.186.rrr     USACEC-GW       USACEC DDN-OSI GW     [39,DEA]
+    C*192.33.187.rrr     INNONET         Innovative Lib Net  [39,JW181]
+    R*192.33.188.rrr     TG-ETHER        Teledyne Geotech    [39,DC115]
+    C 192.33.189.rrr     FX-NET          FX Corp Net          [39,EJ19]
+    C*192.33.190.rrr     TCP-SECURE      TCP Secure Net       [39,AW65]
+    C*192.33.191.rrr     WEST            West, Inc Symbolics     [BML2]
+    R*192.33.192.rrr     EPFL-DOMAIN-ME  ME Students Apol Sta  [39,YD2]
+    R*192.33.193.rrr     EPFL-DOMAIN-MA  MA Students Apol Sta  [39,YD2]
+    R*192.33.194.rrr     EPFL-DOMAIN-MX  MX Students Apol Sta  [39,YD2]
+    R*192.33.195.rrr     EPFL-DOMAIN-EL  EL Students Apol Sta  [39,YD2]
+    R*192.33.196.rrr     EPFL-DOMAIN-GC  GC Students Apol Sta  [39,YD2]
+    R*192.33.197.rrr     EPFL-DOMAIN-PH  PH Students Apol Sta  [39,YD2]
+    R*192.33.198.rrr     EPFL-DOMAIN-CH  CH Students Apol Sta  [39,YD2]
+    R*192.33.199.rrr     EPFL-DOMAIN-DA  DA Students Apol Sta  [39,YD2]
+    R*192.33.200.rrr     EPFL-DOMAIN-GR  GR Students Apol Sta  [39,YD2]
+    R*192.33.201.rrr     EPFL-DOMAIN-CC  CC Students Apol Sta  [39,YD2]
+    R*192.33.202.rrr     EPFL-APPLE-ME   ME Students Mac Sta   [39,YD2]
+    R*192.33.203.rrr     EPFL-APPLE-MA   MA Students Mac Sta   [39,YD2]
+    R*192.33.204.rrr     EPFL-APPLE-MX   MX Students Mac Sta   [39,YD2]
+    R*192.33.205.rrr     EPFL-APPLE-EL   EL Students Mac Sta   [39,YD2]
+    R*192.33.206.rrr     EPFL-APPLE-GC   GC Students Mac Sta   [39,YD2]
+    R*192.33.207.rrr     EPFL-APPLE-PH   PH Students Mac Sta   [39,YD2]
+    R*192.33.208.rrr     EPFL-APPLE-CH   CH Students Mac Sta   [39,YD2]
+    R*192.33.209.rrr     EPFL-APPLE-DA   DA Students Mac Sta   [39,YD2]
+    R*192.33.210.rrr     EPFL-APPLE-GR   GR Students Mac Sta   [39,YD2]
+    R*192.33.211.rrr     EPFL-APPLE-CC   CC Students Mac Sta   [39,YD2]
+    R*192.33.212.rrr-192.33.231.rrr      Univ of Geneva   [12,21,AS116]
+    R*192.33.232.rrr-192.33.240.rrr      EUT IPNET               [JFAS]
+    C*192.33.241.rrr-192.33.250.rrr      SMI, Atlanta Reg Net [39,KD36]
+    C*192.33.251.rrr     ISA-NET         ISA Company Net     [39,CJB15]
+    R 192.33.252.rrr     CLEMSON-CSD     Clemson Univ CSD Net [39,CR83]
+    R*192.33.253.rrr     CANISIUS-CC     Canisius Comp Ctr    [39,LD46]
+    C*192.33.254.rrr     RMI-NET         RMI Net Comm & Ret Sys [RM213]
+      192.33.255.rrr     Reserved        Reserved                 [JBP]
+
+
+
+Romano, Stahl & Recker                                         [Page 34]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    C*192.34.0.rrr-192.34.255.rrr        NETWORK-ADM-OFFICE       [SI8]
+    C*192.35.0.rrr-192.35.19.rrr         NIXDORF Nets            [PD39]
+    C*192.35.20.rrr-192.35.44.rrr        GE-INTERNET         [39,JEB50]
+    C*192.35.45.rrr      MSDCNET         MSDC Corp Net         [39,PNW]
+    C*192.35.46.rrr      GMHGATE         GMH Medical Sys Gw    [39,PNW]
+    C*192.35.47.rrr      GMHNET          GMH Medical Sys Net   [39,PNW]
+    R 192.35.48.rrr      VIRGINIA-T1     Univ of Virginia    [39,JAJ17]
+    R 192.35.49.rrr      VIRGINIA-T2     Univ of Virginia    [39,JAJ17]
+    C*192.35.50.rrr      CLARIS-NET      Claris Corp         [21,CM130]
+    R*192.35.51.rrr      CARLETON        Carleton Coll Net       [BA41]
+    R*192.35.52.rrr-192.35.61.rrr        ED-DEPTS             [21,WSC5]
+    D 192.35.62.rrr      NOSL-POE        NOSL-POE-GW         [39,DB211]
+    R*192.35.63.rrr-192.35.72.rrr        UniDo Campus Net     [39,RV32]
+    C*192.35.73.rrr      OPTICOM         Opticom CorpInternet    [CJB1]
+    D 192.35.74.rrr      FOTLANHS        FOTLANHS-MONMOUTH    [21,FJH1]
+    D 192.35.75.rrr      FOTLANMS        FOTLANMS-MONMOUTH    [21,FJH1]
+    D 192.35.76.rrr      FOTLANLS        FOTLANLS-MONMOUTH    [21,FJH1]
+    C*192.35.77.rrr      GM-AES-NET      GM AES Net          [39,DS229]
+    R*192.35.78.rrr      IRIS-RING       IRIS Headquarters   [39,JFS22]
+    R 192.35.79.rrr      CCFNET          CCF Net           [21,39,EM75]
+    D 192.35.80.rrr      NUSC-V702M-1    NUSC V702M Local Net [27,SR77]
+    R 192.35.81.rrr      UWP-IPNET       UW-Parkside IP Net   [39,TVF1]
+    R 192.35.82.rrr      CORNELL-DMZ     Cornell Ext Ether   [39,JCH17]
+    C*192.35.83.rrr      SDCCARY2        SAS Data Ctr Cary Two  [RC113]
+    C*192.35.84.rrr      BDM-MCLEAN      BDM Corp, McLean    [39,JS167]
+    R*192.35.85.rrr      MCGILL-TMP01    McGill Kludge Net 1    [MOUSE]
+    R 192.35.86.rrr      UMN-MORRIS-NET  Univ of Minn Morris  [39,AP57]
+    C*192.35.87.rrr      CMPNET          Conn Mach Prod Net      [GC89]
+    R 192.35.88.rrr      ADEL02-NET      Adelphi Site LABCOM [39,CM115]
+    R 192.35.89.rrr      YCC-SYS-TR      YCC Sys Token Ring      [HKG2]
+    R 192.35.90.rrr      CNR-TO-LAN      CNR Torino Ether     [39,SG88]
+    C*192.35.91.rrr      CSR-NET         CSR Demo Net         [39,HKG2]
+    C*192.35.92.rrr      UNISYS-HPW-1    Unisys HPW Net 1     [39,MS22]
+    C*192.35.93.rrr      UNISYS-HPW-2    Unisys HPW Net 2     [39,MS22]
+    G*192.35.94.rrr      RSRE-SLAN       RSRE Site LAN         [39,BO5]
+    R 192.35.95.rrr      HCSC-APPLE      CSDD APPLETALK          [TRG4]
+    R 192.35.96.rrr      UOKECNA         Univ of Okla, ECN-A    [JW136]
+    R 192.35.97.rrr      UOKECNB         Univ of Okla, ECN-B    [JW136]
+    R 192.35.98.rrr      UOKECNC         Univ of Okla, ECN-C    [JW136]
+    D 192.35.99.rrr      ARMTE-NET       WSMR-ARMTE-NET      [21,RHM11]
+    R*192.35.100.rrr     SHI-ETHER       Sci Horizons Ether  [39,MB168]
+    R 192.35.101.rrr     KEYSTONE-NET    Keystone-Acres-Net   [21,GR11]
+    C*192.35.102.rrr     IBINET          InfoBuilders Net        [KM79]
+    C*192.35.103.rrr     SONET           Sinclair Optics Net  [39,SWW6]
+    R 192.35.104.rrr     CIT-OPTICS      CIT Optics Net       [39,AY10]
+    C*192.35.105.rrr     POCI            Pocatello Des Grp Net   [MA56]
+    R*192.35.106.rrr     LMSC-LAMS       Lockheed Marine Sys  [39,GMT6]
+    R*192.35.107.rrr     NOVANET         Nova Camp Net        [39,JPO4]
+
+
+
+Romano, Stahl & Recker                                         [Page 35]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    C*192.35.108.rrr     SGI-UK          Silicon Graphics UK     [RA94]
+    C*192.35.109.rrr-192.35.126.rrr      APOLLO-GW-NET            [SJL]
+    G*192.35.127.rrr     TRLNET          TELECOM-AUST-RES-NET [39,PJT9]
+    G*192.35.128.rrr     NESDIS-NET      NOAA NESDIS NET      [39,MSM1]
+    G*192.35.129.rrr     WWB-NET         NOAA WORLD WEATHER   [39,MSM1]
+    C*192.35.130.rrr     WANG-CAD        WANG-CAD                [WWP8]
+    C*192.35.131.rrr     WANG-TEST       WANG-TEST               [WWP8]
+    D*192.35.132.rrr     WANG-TLAN       WANG-TLAN               [WWP8]
+    R*192.35.133.rrr     WANG-MISC       WANG-MISC               [WWP8]
+    R*192.35.134.rrr     LL-DIV7         LL Div 7             [39,BC65]
+    R*192.35.135.rrr     LL-DIV9         LL Div 9             [39,BC65]
+    R*192.35.136.rrr     LL-GR47-ADT     LL Grp 47 ADT Proj   [39,BC65]
+    R*192.35.137.rrr     LL-GR47-RPV     LL Grp 47 RPV Proj   [39,BC65]
+    C*192.35.138.rrr     SPIDER          Spider Sys R&D Net      [AD67]
+    R*192.35.139.rrr     PAGODA          KAIST Pagoda Net    [39,JK151]
+    R*192.35.140.rrr     WWU-NET         WWU Comp Sci Net     [21,PAN1]
+    C*192.35.141.rrr     QUADRON         Quadron Dev Net      [39,HP32]
+    D 192.35.142.rrr     YKTNPOE-GW      YKTNPOE-GW-NWS       [39,WRR5]
+      192.35.143.rrr-223.255.254.rrr     Unassigned               [NIC]
+     *223.255.255.rrr    Reserved        Reserved                 [JBP]
+
+    Other Reserved Internet Addresses
+
+    * Internet Address  Name          Network         References
+    - ----------------  ----          -------         ----------
+    224.000.000.000-239.255.255.255 Multicast         [11,JBP]
+    240.000.000.000-255.255.255.255 Reserved             [JBP]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Romano, Stahl & Recker                                         [Page 36]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+Network Totals
+
+          Assigned for the ARPA-Internet and the DDN-Internet
+
+
+             Class         A         B         C     Total
+
+
+             Research     14       233      1443      1690
+
+             Defense       9        38       603       650
+
+             Government    1        20        69        90
+
+             Commercial    4        23        22        49
+
+             Total        28       314      2137      2479
+
+          Allocated for Internet and Independent Uses
+
+             Class         A         B         C     Total
+
+             Research     14       333      2431      2778
+
+             Defense       9        44       606       659
+
+             Government    1        32        88       121
+
+             Commercial    4        84      5066      5154
+
+             Total        28       493      8198      8719
+
+          Maximum Allowed
+
+             Class         A         B         C     Total
+
+             Research      8      1024     65536     66568
+
+             Defense      24      3072    458752    461848
+
+             Government   24      3072    458752    461848
+
+             Commercial   74      9214   1114137   1123394
+
+             Total       126     16382   2097150   2113658
+
+
+
+
+
+
+Romano, Stahl & Recker                                         [Page 37]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+                         AUTONOMOUS SYSTEM NUMBERS
+
+   The Exterior Gateway Protocol (EGP) [33,35] specifies that groups of
+   gateways may form autonomous systems.  The EGP provides a 16-bit
+   field for identifying such systems.  The values of this field are
+   registered here.
+
+Autonomous System Numbers:
+
+   Decimal   Name                                          References
+   -------   ----                                          ----------
+    0   Reserved                                               [JBP]
+    1   The BBN Core Gateways                                   [MB]
+    2   DCN-AS                                                [DLM1]
+    3   The MIT Gateways                                     [RH164]
+    4   ISI-AS                                                [JKR1]
+    5   Symbolics                                              [CH2]
+    6   HIS-Multics                                          [JLM23]
+    7   UK-MOD                                                [RNM1]
+    8   RICE-AS                                                [PGM]
+    9   CMU-ROUTER                                              [MA]
+    10  CSNET-PDN-AS                                          [RDR4]
+    11  HARVARD                                               [SB28]
+    12  NYU-DOMAIN                                             [EF5]
+    13  BRL-AS                                                [RR33]
+    14  COLUMBIA-GW                                           [BC14]
+    15  NET DYNAMICS EXP                                       [ZSU]
+    16  LBL                                                     [WG]
+    17  PURDUE-CS                                             [DT50]
+    18  UTEXAS                                                 [LSV]
+    19  CSS-DOMAIN                                             [RR2]
+    20  UR                                                    [LB16]
+    21  RAND                                                   [JDG]
+    22  NOSC                                                  [RLB3]
+    23  RIACS-AS                                              [DG28]
+    24  AMES-NAS-GW                                           [MF31]
+    25  UCB                                                   [MK17]
+    26  CORNELL                                                [BN9]
+    27  UMDNET                                                [MP12]
+    28  DFVLR-SYS                                              [GB7]
+    29  YALE-AS                                               [HML1]
+    30  SRI-AICNET                                             [PM4]
+    31  CIT-CS                                                [AD22]
+    32  STANFORD                                               [PA5]
+    33  DEC-WRL-AS                                            [RKJ2]
+    34  UDEL-EECIS                                             [NMM]
+    35  MICATON                                                [WDL]
+    36  EGP-TESTOR                                            [PEM4]
+
+
+
+Romano, Stahl & Recker                                         [Page 38]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    37  NSWC                                                  [DAF9]
+    38  UIUC                                                   [AKC]
+    39  NRL-ITD                                                 [AP]
+    40  MIT-TEST                                               [NC3]
+    41  AMES                                                  [MSM1]
+    42  THINK-AS                                              [BJN1]
+    43  BNL-AS                                                  [GC]
+    44  S1-DOMAIN                                              [LWR]
+    45  LLL-TIS-AS                                             [NAL]
+    46  RUTGERS                                                [RM8]
+    47  USC-OBERON                                            [DRS4]
+    48  NRL-AS                                                 [WF3]
+    49  ICST-AS                                               [CWH3]
+    50  ORNL-MSRNET                                            [THD]
+    51  USAREUR-EM-AS                                          [FWD]
+    52  UCLA                                                   [RBW]
+    53  NORTHROP-AS                                           [RSM1]
+    54  COA-FIN-NET                                           [RR26]
+    55  UPENN-CIS                                              [IW5]
+    56  OPTIMIS-P                                             [GPL1]
+    57  UMN-REI-UC                                             [HWB]
+    58  DREA-AS                                               [GLH5]
+    59  WISC-MADISON-AS                                       [EJN1]
+    60  DARPA-BFLY                                              [MB]
+    61  DEC-MARLBORO-AS                                       [JM60]
+    62  TEKVAXC                                               [TE16]
+    63  LL-MI                                                  [RTL]
+    64  MITRE-B-AS                                             [BSW]
+    65  LOGNET-AS                                             [JR15]
+    66  ETL-AI                                                [MMM3]
+    67  SDC-PRC-AS                                            [MS22]
+    68  LANL-INET-AS                                          [JC11]
+    69  WHARTON-AS                                             [GBR]
+    70  NLM-GW                                                 [JA1]
+    71  HP-INTERNET-AS                                       [RM142]
+    72  SPAR-AS                                              [RB217]
+    73  WASHINGTON-AS                                         [RA17]
+    74  XDRENET-AS                                            [JR17]
+    75  ANL-AS                                                [LW26]
+    76  SDC-CAM-AS                                             [DSR]
+    77  JHUAPL-AS                                             [SAK3]
+    78  SSDF-CDC-GW                                           [RE22]
+    79  DSPO-HC-AS                                             [BT5]
+    80  GE-CRD                                               [JC106]
+    81  TUCC-MCNC                                            [JRR14]
+    82  TWG-DEMO-AS                                          [JS171]
+    83  PICANET-AS                                            [RFD1]
+    84  DTNSRDC-AS1                                           [RWT2]
+
+
+
+Romano, Stahl & Recker                                         [Page 39]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+    85  AERO-NET                                               [LCN]
+    86  SURANET-AS                                            [JH92]
+    87  INDIANA-AS                                            [BS69]
+    88  PRINCETON-AS                                          [LRR1]
+    89  NUSC-CSTLNET-AS                                       [MP20]
+    90  SUN-AS                                                 [WM3]
+    91  RPI-AS                                                 [MS9]
+    92  CLARKSON-AS                                           [ABS6]
+    93  FORD-AS                                                [KR9]
+    94  BELVOIR-NET                                           [DH30]
+    95  NUSCLSB1                                               [RPP]
+    96  JTELS-BEN1-AS                                         [RR26]
+    97  JVNC-AS                                               [SH37]
+    98  ROCKEFELLER-AS                                        [MK38]
+    99  INTEL-IWARP                                           [WM10]
+   100  FMC-CEL                                                [KW2]
+   101  WASH-NSF-AS                                           [SH47]
+   102  NSF-HQ-AS                                             [FW17]
+   103  NWU-AS                                                [EEW6]
+   104  COLORADO-AS                                           [RAJ8]
+   105  GSWD-VMS-AS                                            [PEK]
+   106  ETN-WLV-AS                                            [SMS1]
+   107  ECSNET-AS                                             [CAL7]
+   108  XEROX-AS                                              [JNL1]
+   109  CISCOSYSTEMS                                           [KSL]
+   110  CCA-AS                                                 [AL6]
+   111  BOSTONU-AS                                            [BS24]
+   112  CMU-SEI-AS                                            [PDB5]
+   113  SCCNET-AS                                             [MJO4]
+   114  SESQUINET-AS                                           [GTA]
+   115  PBAS-BEN2-GW-AS                                       [RR26]
+   116  BELLCORE-AS                                           [PK28]
+   117  ALBM-NET-AS                                           [NB16]
+   118  NSWSES-NAVY-AS                                        [DD41]
+   119  AMS-AS                                                [SBW4]
+   120  MITRE-OMAHA                                           [SM62]
+   121  IH-POE-AS                                             [LK27]
+   122  U-PGH-NET-AS                                           [SM6]
+   123  LOGAIRCOMNET-AS                                       [TEC6]
+   124  ENCORE-GW-AS                                          [DK70]
+   125  HI-NET-AS                                             [DB97]
+   126  MINSY-POE-AS                                          [CV14]
+   127  JPL-AS                                               [JAW16]
+   128  ADS-AS                                                [MB26]
+   129  CDA-AS                                                [FJS3]
+   130  CSOCNET-AS                                           [JJD12]
+   131  UCSB-NET-AS                                           [PKH1]
+   132  WPAFB-CDS-NET-AS                                      [CMC6]
+
+
+
+Romano, Stahl & Recker                                         [Page 40]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+   133  AFIT-AS                                               [PHS1]
+   134  CORONA-GW-AS                                          [LM35]
+   135  BRL-CDCNET-GW-AS                                      [GJK1]
+   136  ECONET-AS                                             [TD40]
+   137  CNUCE-AS                                              [ABB2]
+   138  BRL-CMCGW-AS                                          [RR33]
+   139  NUWESNET-AS                                          [RM125]
+   140  DAITC-NET-AS                                         [SS125]
+   141  NWCNNET-AS                                            [EG17]
+   142  WESTPOINT                                            [RLR23]
+   143  OOG1-AS                                               [JD86]
+   144  ATT-INTERNET                                          [HT19]
+   145  NSFNET-CORE                                            [HWB]
+   146  HQEIS-AS                                              [SMK2]
+   147  NAVCAMS-LAN                                          [JM246]
+   148  NWSC-GW-AS                                            [JA91]
+   149  ADEL-AS                                              [CM115]
+   150  SEANET-AS                                             [JH10]
+   151  IND-NTC-AS                                            [AB98]
+   152  SRI-ACATT-AS                                           [RDQ]
+   153  SAAD-ARPA-AS                                         [DRM24]
+   154  USACEC-NET-AS                                          [DEA]
+   155  CACNET-AS                                             [BG25]
+   156  NORTHEASTERN-GW-AS                                    [CJ38]
+   157  INTELLIAUTON-AS                                       [RJL3]
+   158  ACC-AS                                                [AB20]
+   159  SONNET-AS                                             [MF74]
+   160  U-CHICAGO-AS                                          [MC17]
+   161  TI-AS                                                 [DF71]
+   162  NOSL-POE-GW-AS                                       [DB211]
+   163  IBM-RESEARCH-AS                                        [MT1]
+   164  DDN-MB-AS                                              [RH6]
+   165  NESEA-DDN-GW-AS                                       [DT59]
+   166  IDA-AS                                               [MM227]
+   167  WESLEYAN-AS                                           [JGD1]
+   168  UMASS-AMHERST                                          [ASG]
+   169  HANSCOM-NET-AS                                        [DD63]
+   170  YKTNPOE-GW-AS                                         [WRR5]
+   171  NORTHWESTNET-AS                                       [GK44]
+   172-65534  Unassigned                                       [NIC]
+   65535  Reserved                                             [JBP]
+
+
+
+
+
+
+
+
+
+
+Romano, Stahl & Recker                                         [Page 41]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+                                 DOCUMENTS
+
+   [1]    Aerospace, Internal Report, ATM-83(3920-01)-3, 1982.
+
+   [2]    Apollo Computer, Inc., "Managing TCP/IP-Based
+          Communication Products", Order No. 008543, Chelmsford,
+          MA, 01824, March 1986.
+
+   [3]    BBN Proposal No. P83-COM-40, "Packet Switched Overlay to
+          Tactical Multichannel/Satellite Systems".
+
+   [4]    BBN, "Specifications for the Interconnection of a Host and an
+          IMP", Report 1822, Bolt Beranek and Newman, Cambridge,
+          Massachusetts, revised, December 1981.
+
+   [5]    Chon, K., et al., "SDN: A Computer Network for Korean Research
+          Community", Proc. of the Pacific Computer Communications
+          Symposium, October 1985, pp. 567-570, Seoul, Korea.
+
+   [6]    Chon, K., et al., "System Development Network", Proc. of
+          TENCON, April 1984, pp. 133-135, Singapore.
+
+   [7]    Clark, D., "Revision of DSP Specification", Local Network
+          Note 9, Laboratory for Computer Science, MIT, June 1977.
+
+   [8]    Cohen, D., "On Holy Wars and a Plea for Peace", IEEE Computer
+          Magazine, October 1981.
+
+   [9]    Comer, D., and T. Narten, "The Cypress Multifunction Packet
+          Switch", Technical Report CSD-TR-575, Computer Science Dept.,
+          Purdue University, West LaFayette, IN.
+
+   [10]   Croft, W. J., "Unix Networking at Purdue", USENIX Conference,
+          1980.
+
+   [11]   Deering, S. E., "Host Extensions for IP Multicasting",
+          RFC 988, Stanford University, December 1985.
+
+   [12]   Feinler, E., editor, "DDN Protocol Handbook", Network
+          Information Center, SRI International, December 1985.
+
+   [13]   Feinler, E., editor, "Internet Protocol Transition Workbook",
+          Network Information Center, SRI International, March 1982.
+
+   [14]   Feinler, E. and J. Postel, eds., "ARPANET Protocol Handbook",
+          NIC 7104, for the Defense Communications Agency by SRI
+          International, Menlo Park, California, Revised January 1978.
+
+
+
+
+Romano, Stahl & Recker                                         [Page 42]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+   [15]   Harris Corporation, "Harris Ethernet Data Link Reference
+          Manual", Publication No. 0868010-002, Harris Corporation,
+          Computer Systems Divsion, 2101 West Cypress Creek Road,
+          Ft. Lauderdale, FL 33309-1892.
+
+   [16]   Harris Corporation, "Harris TCP/IP Manager's Guide",
+          Publication No. 0868011-100, Harris Corporation,
+          Computer Systems Divsion, 2101 West Cypress Creek Road,
+          Ft. Lauderdale, FL 33309-1892.
+
+   [17]   Honeywell CISL, Internal Document, "AFSDSC Hyperchannel RPQ
+          Project Plan".
+
+   [18]   Honeywell CISL, Internal Document, "Multics MR11 PFS".
+
+   [19]   Hwang, K., W. J. Croft and G. H. Goble, "A Unix-Based Local
+          Computer Network with Load Balancing", IEEE Computer,
+          April 1982.
+
+   [20]   IBM Corporation, "Technical Reference Manual for the IBM PC
+          Network", 6322505, IBM, Boca Raton, Florida, 1984.
+
+   [21]   IEEE Project 802 Local Area Network Standard, "IEEE Standard
+          802.3 CSMA/CD Access Method and Physical Layer
+          Specifications", Approved IEEE 802.3-1985 ISO/DIS 8802/3,
+          July 1983.
+
+   [22]   Korb, J. T., "A Standard for the Transmission of IP Datagrams
+          Over Public Data Networks", RFC 877, Purdue University,
+          September 1983.
+
+   [23]   Leach, et al., "The Architecture of an Integrated Local
+          Network", IEEE Journal on Selected Areas in Communications,
+          Vol SAC-1, No. 5, November 1983.
+
+   [24]   Leffler, Samuel J., et al., "4.2 BSD Network Implementation
+          Notes", July, 1983, University of California, Berkeley.
+
+   [25]   Macgregor, W., and D. Tappan, "The CRONUS Virtual Local
+          Network", RFC 824, Bolt Beranek and Newman, August 1982.
+
+   [26]   Mills, D., "Network Time Protocol", RFC 958, M/A-COM Linkabit,
+          September 1985.
+
+   [27]   Postel, J., ed., "Internet Protocol - DARPA Internet Program
+          Protocol Specification", RFC 791, Information Sciences
+          Institute, September 1981.
+
+
+
+
+Romano, Stahl & Recker                                         [Page 43]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+   [28]   Prime, "Medusa, The Prime Ethernet", PRIME/WS/AI/86/2,
+          July 1986, Framingham, MA.
+
+   [29]   Proteon, "Linkway Software:  Operating System, Release 7.0",
+          SPD 040-013 and "Linkway Software:  IP Packet Forwarder",
+          SPD 040-016.  Proteon, Inc., 4 Tech Circle, Natick, MA 01760.
+
+   [30]   Proteon, "P4200 Gateway User's Guide", 42-040-012.  Proteon,
+          Inc., 4 Tech Circle, Natick, MA 01760.
+
+   [31]   Reed, D., "Protocols for the LCS Network", Local Network Note
+          3, Laboratory for Computer Science, MIT, November 1976.
+
+   [32]   Reynolds, J. and J. Postel, "Official Internet Protocols",
+          RFC 1011, Information Sciences Institute, May 1987.
+
+   [33]   Rosen, E., "Exterior Gateway Protocol" RFC 827, Bolt Beranek
+          and Newman, October 1982.
+
+   [34]   Saltzer, J. H., "Design of a Ten-megabit/sec Token Ring
+          Network", MIT Laboratory for Computer Science Technical
+          Report.
+
+   [35]   Seamonson, L. J., and E. C. Rosen, "STUB" Exterior Gateway
+          Protocol", RFC 888, BBN Communications Corporation,
+          January 1984.
+
+   [36]   Shuttleworth, B., "A Documentary of MFENet, a National
+          Computer Network", UCRL-52317, Lawrence Livermore Labs,
+          Livermore, California, June 1977.
+
+   [37]   Skelton, A., S. Holmgren, and D. Wood, "The MITRE Cablenet
+          Project", IEN 96, April 1979.
+
+   [38]   Sun Microsystems, "Networking on the Sun Workstation",
+          Part No: 800-1324-03, Revision B of 17 February 1986.
+          Sun Microsystems, Inc., 2550 Garcia Avenue, Mountain
+          View, CA 94043.
+
+   [39]   "The Ethernet, A Local Area Network: Data Link Layer and
+          Physical Layer Specification", AA-K759B-TK, Digital Equipment
+          Corporation, Maynard, MA.  Also as:  "The Ethernet - A Local
+          Area Network", Version 1.0, Digital Equipment Corporation,
+          Intel Corporation, Xerox Corporation, September 1980.  And:
+          "The Ethernet, A Local Area Network: Data Link Layer and
+          Physical Layer Specifications", Digital, Intel and Xerox,
+          November 1982.  And:  XEROX, "The Ethernet, A Local Area
+          Network: Data Link Layer and Physical Layer Specification",
+
+
+
+Romano, Stahl & Recker                                         [Page 44]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+          X3T51/80-50, Xerox Corporation, Stamford, CT., October 1980.
+
+   [40]   The High Level Protocol Group, "A Network Independent File
+          Transfer Protocol",  INWG Protocol Note 86, December 1977.
+
+   [41]   Whelan, D., "The Caltech Computer Science Department Network",
+          5052:D F:82, Caltech Computer Science Department, 1892.
+
+   [42]   XEROX, "Internet Transport Protocols",  XSIS 028112, Xerox
+          Corporation, Stamford, Connecticut, December 1981.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Romano, Stahl & Recker                                         [Page 45]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+                                 CONTACTS
+
+HANDLE       NAME                     MAILBOX
+
+[AB13]       Brown, Alison            alison@TCGOULD.TN.CORNELL.EDU
+[AB20]       Berggreen, Arthur        art@ACC.ARPA
+[AB71]       Bleiberg, Abraham        bleiberg@ARGUS.STANFORD.EDU
+[AB90]       Ben-Artzi, Amatzia       amatzia@AMADEUS.STANFORD.EDU
+[AB98]       Beacham, Albert          hpindda!abeacha@HPLABS.HP.COM
+[ABB2]       Bonito, A. Blasco        BLASCO@CNUCE-VM.ARPA
+[ABS6]       Stine, Arthur B.         abstine@OMNIGATE.CLARKSON.EDU
+[AC42]       Cohen, Adam
+[AC66]       Crotty, Art
+[AC85]       Cantrall, Arthur      icsadc%asuic.bitnet@CUNYVM.CUNY.EDU
+[AD22]       DesJardins, Arlene       Arlene@VLSI.CALTECH.EDU
+[AD67]       Davis, Andy           mcvax!cs.hw.ac.uk!andy@UUNET.UU.NET
+[AG22]       Ganz, Alfred             ganz-alfred@YALE.EDU
+[AG61]       Goodarzi, Afshin
+[AG67]       Garg, Atul
+[AGS5]       Smith, Arnold G.         AGSMITH@WARBUCKS.AI.SRI.COM
+[AHA]        Anderson, Allan H.       anderson@LL-VLSI.ARPA
+[AJC11]      Cole, Andrew J.      AJCOLE%AI.LEEDS.AC.UK@NSS.CS.UCL.AC.UK
+[AK36]       Kondo, Akio       akondo%asevx1%slb-doll.csnet@RELAY.CS.NET
+[AKC]        Cheng, Albert K.         acheng@A.CS.UIUC.EDU
+[AKG2]       Gupta, Ajay K.           ajay%odu.edu@RELAY.CS.NET
+[AKH5]       Hartwig, Arthur K.
+[AL6]        Layton, Alexis           alex@CCA.CCA.COM
+[AL46]       Linton, Andy         Andy_Linton%ncl.ac.uk@NSS.CS.UCL.AC.UK
+[ALG4]       Grijalva, Alma           alma@ARIZRVAX.CCIT.ARIZONA.EDU
+[AM54]       MacPherson, Andrew
+                              mcvax!tcom.stc.co.uk!andrew@seismo.CSS.GOV
+[AM92]       Mott, Arch               froyen#sverre%e.mfenet@NMFECC.ARPA
+[AMM14]      Monteiro, Antonio M.
+                                MONTEIRO%POLYGRAF.BITNET@CUNYVM.CUNY.EDU
+[AMS1]       Schiffman, Allan M.      Schiffman@KL.SRI.COM
+[AP]         Parker, R. Alan          parker@NRL-CSS.ARPA
+[AP25]       Partan, Andrew           hadron!cos!asp@seismo.CSS.GOV
+[AP57]       Palmer, Anthony          tony%umnmor.bitnet@CUNYVM.CUNY.EDU
+[AR41]       Renard, Annie            fr-zone-contact@INRIA.INRIA.FR
+[AR60]       Robbins, Arnold          arnold@EMORYU1.ARPA
+[ARM5]       Maffei, Andrew R.        mit-erl!aqua!arm@EDDIE.MIT.EDU
+[ARS3]       Silverman, Alan R.
+[AS62]       Steiner, Albert        AJS001%NUACC.BITNET@CUNYVM.CUNY.EDU
+[AS90]       Schoener, Anthony
+[AS116]      Schindler, Albert
+                               SHINDLER%CGEUGE51.BITNET@CUNYVM.CUNY.EDU
+[AGG]        Gaylord, Arthur S.       ART@UMASS-GW.CS.UMASS.EDU
+[AW48]       Wilcox, Andy             ajw%ufl.csnet@RELAY.CS.NET
+
+
+
+Romano, Stahl & Recker                                         [Page 46]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+[AW56]       Asher Waldfogel
+[AW65]       Whiteman, Alan
+[AY5]        Yasuda, Akiharu          DIA@PAXRV-NES.ARPA
+[AY10]       Yamamura, Alan           alany@SUNOPTICS.CALTECH.EDU
+[AY11]       Yeh, Arthur          C0298%univscvm.bitnet@CUNYVM.CUNY.EDU
+[AZ]         Zadeh, Ansari            ansariza%tsuunix.uucp@RICE.EDU
+[BA26]       Ayres, Bill           ayres%orstate.bitnet@CUNYVM.CUNY.EDU
+[BA41]       Armstrong, Borden       BArmstro%carleton.edu@RELAY.CS.NET
+[BAB7]       Burke, Barry A.          barry%adelie@HARVARD.HARVARD.EDU
+[BAT4]       Tolliffe, Brin A.        TOLLIFFE@WESTPOINT.ARPA
+[BAV]        Verser, Brick A.         BAV%KSUVM.BITNET@CUNYVM.CUNY.EDU
+[BAW9]       Wilford, Bruce A.        bruce@NSS.CS.UCL.AC.UK
+[BB64]       Boyter, Brian            boyter@NGP.UTEXAS.EDU
+[BC14]       Cattani, Robert          CATTANI@COLUMBIA.EDU
+[BC32]       Cunningham, Bob       cunninghamr%haw.sdscnet@NMFECC.ARPA
+[BC65]       Chiarchiaro, Bill        wjc@XN.LL.MIT.EDU
+[BC72]       Carrihill, Brian         carrhill@NYU.ARPA
+[BCH2]       Howard, Barry C.         HOWARD@NMFECC.ARPA
+[BD55]       Down, Brian        bdown%uturing%toronto.csnet@RELAY.CS.NET
+[BD56]       Daniels, Bob             masscomp!bob@EDDIE.MIT.EDU
+[BE6]        Esposito, Bob            espo@BPA.BELL-ATL.COM
+[BE10]       Eriksen, Bjorn           ber@ENEA.SE
+[BEC1]       Chi, Benjamin E.     sysiln%albnylvx.bitnet@CUNYVM.CUNY.EDU
+[BEC5]       Colley, Ben E.         TPMAINT%UMVMB.BITNET@CUNYVM.CUNY.EDU
+[BG23]       Greasley, Bud            bud@SQ.SQ.COM
+[BG25]       Gorman, Bryan            GORMAN@BRAGGVAX.ARPA
+[BH80]       Haanstra, Bruce
+[BH103]      Housley, Brian           housley@cageir5a.bitnet
+[BIM]        Margulies, Benson I.     KSR!BENSON@HARVARD.HARVARD.EDU
+[BJN1]       Nemnich, Bruce           bruce@THINK.COM
+[BJR2]       Russell, Bill J.         RUSSELL@NYU.ARPA
+[BK46]       Kummerfeld, Bob    unnari!basser.cs.su.oz!bob@UUNET.UU.NET
+[BL31]       Lemley, Bob          lemleyr%baylor.bitnet@CUNYVM.CUNY.EDU
+[BLI]        Irwin, Basil L.          irwin%ncar@RELAY.CS.NET
+[BM68]       Murray, Burton
+[BM79]       Michie, Bob              bob@NJITSC1.NJIT.EDU
+[BM106]      Mulligan, Brian          brian%sphinx.co.uk@EDDIE.MIT.EDU
+[BML2]       Liblong, Breen M.        liblong@GAEA.WEST.SYMBOLICS.COM
+[BMS2]       Segal, Ben M.
+[BMW7]       Wilber, B. Michael       wilber@SCORE.STANFORD.EDU
+[BN4]        Nowicki, Bill            nowicki@SUN.COM
+[BN9]        Nesheim, Bill            nesheim@THINK.COM
+[BO5]        Ogilvy-Morris, Bruce     bom%rsre.mod.uk@RELAY.MOD.UK
+[BP51]       Page, Bob                PAGE@ULOWELL.EDU
+[BP52]       Parker, Brad         cayman!cayman!brad@HARVARD.HARVARD.EDU
+[BP57]       Payne, Bob               bpayne@NRAO.ARPA
+[BPW1]       Wright, Bradley P.       AFDDN.WRIGHT@GUNTER-ADAM.ARPA
+[BRB8]       Bangaru, Babu R.
+
+
+
+Romano, Stahl & Recker                                         [Page 47]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+[BS24]       Shein, Barry             BZS@BU-CS.BU.EDU
+[BS69]       Sweeny, Brent R.         SWEENY@GOLD.BACS.INDIANA.EDU
+[BSW]        Seeber-Wagner, Barbara   bnsw@MITRE-BEDFORD.ARPA
+[BT4]        Teel, Bill
+[BT5]        Tomlinson, Bob           tomlin@HC.DSPO.GOV
+[BTK1]       Koch, Bryan T.           btk%hall.cray.com@UC.MSC.UMN.EDU
+[BWA]        Allen, Bobby W.          allen@YUMA.ARPA
+[CAD13]      DeFranco, Carl A., Jr.   defranco@RADC-TOPS20.ARPA
+[CAK]        Kent, Christopher A.     kent@DECWRL.DEC.COM
+[CAL7]       Leach, Charles A.        CAL@OKC-UNIX.ARPA
+[CAS]        Sunshine, Carl A.        sunshine@JOVE.CAM.UNISYS.COM
+[CAS1]       Steffey, Claude A.       csteffey@WSMR05.ARPA
+[CBD]        Dawson, Clive B.         Clive@MCC.COM
+[CBR2]       Ray, Charles B.
+[CC89]       Chaundy, Chris
+                          munnari!ucsvc.dn.mu.oz!chris@seismo.CSS.GOV
+[CC99]       Catlett, Charlie         catlett@NCSA.NCSA.UIUC.EDU
+[CC108]      Clanton, Charles
+[CC129]      Cline, Carol
+                          s5000!kline%mscunx.sp.unisys.com@RELAY.CS.NET
+[CD75]       Dowat, Cary              dowat%fnal.hepnet@LBL.GOV
+[CD83]       Dimmers, Claudia         postmaster@PYRAMID.COM
+[CDB4]       Barnes, Carol D.         T45@A.ISI.EDU
+[CF4]        Frost, Cliff
+                            cliff%UCBCMSA.Berkeley.EDU@JADE.Berkeley.EDU
+[CF35]       Fung, Charles            cxf@SUNSPOT.RIT.EDU
+[CF57]       Fernandez, Carlos        Fernandez@AFWL-VAX.ARPA
+[CFB1]       Brandt, Carl F.          carl%lsumvs.bitnet@CUNYVM.CUNY.EDU
+[CFD4]       Dunn, Charles F.         CHUCK@UBVM.CC.BUFFALO.EDU
+[CG1]        George, Calvin           GEORGE@EGLIN-VAX.ARPA
+[CG24]       Generous, Curtis         GENEROUS@DAITC.ARPA
+[CH2]        Hornig, Charles          CAH@MC.LCS.MIT.EDU
+[CJ38]       Johnson, Chris        johnson%northeastern.edu@RELAY.CS.NET
+[CJB1]       Bamford, Cliff J.        opticom@APPLE.COM
+[CJB15]      Bedore, Clifford J.,     isavax!cliffb@UMD5.UMD.EDU
+[CJL2]       Lydick, Carl J.          carl@CITHEX.CALTECH.EDU
+[CJW2]       Weinstein, Clifford J.   cjw@LL-SST.ARPA
+[CL64]       Lynch, Clifford      ucdla%ucbtopaz.cc@UCBARPA.Berkeley.EDU
+[CL80]       Leser, C.
+                      leser%comvax.rus.uni-stuttgart.dbp.de@RELAY.CS.NET
+[CLH3]       Hedrick, Charles L.      HEDRICK@ARAMIS.RUTGERS.EDU
+[CM115]      McDonald, Catherine      ddnmgr@ADEL01.ARPA
+[CM116]      Moret, Christophe    sysgeg%frpoly11.bitnet@CUNYVM.CUNY.EDU
+[CM130]      Maeckel, Clay            claris!clay@AMES.ARC.NASA.GOV
+[CMC6]       Chow, Chai M.            chowcm@WPAFB-AMS1.ARPA
+[CMR]        Rogers, Craig Milo       ROGERS@VENERA.ISI.EDU
+[CO16]       Olson, Chris
+[CP10]       Partridge, Craig         craig@BBN.COM
+
+
+
+Romano, Stahl & Recker                                         [Page 48]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+[CR24]       Rokitansky, Carl         ROKI@A.ISI.EDU
+[CR83]       Reynolds, Christine      quirk@HUBCAP.CLEMSON.EDU
+[CRT4]       Tettemer, Clair R., Jr.
+[CS124]      Stork, Christof          clay@DIX.CALTECH.EDU
+[CS136]      Stokely, Celeste         cstokely@COHERENT.COM
+[CS2]        Seitz, Charles           CHUCK@VLSI.CALTECH.EDU
+[CSTACY]     Stacy, Christopher C.    CStacy@AI.AI.MIT.EDU
+[CV14]       Verboom, Charles
+[CWH3]       Hunt, Craig W.           CRAIG@CAM-VAX.ARPA
+[CWR4]       Reece, Carole Warner
+[CYH]        Huang, Chien Y.       6026959%PUCC.BITNET@CUNYVM.CUNY.EDU
+[DAF9]       Futcher, Debbie  A.      DFUTCHE@NSWC-OAS.ARPA
+[DAM22]      Morgan, Deborah A.       deb%siemens@PRINCETON.EDU
+[DAT4]       Thomae, Doug A.
+[DAVE]       Roode, R. David          Roode%orc.uucp@UNIX.SRI.COM
+[DB14]       Borman, Dave             dab@UMN-REI-UC.ARPA
+[DB28]       Bullard, Dave         dave%clemson.bitnet@CUNYVM.CUNY.EDU
+[DB35]       Branis, Danny            danny%israel.csnet@RELAY.CS.NET
+[DB97]       Bergum, Dave             bergum@HI-MULTICS.ARPA
+[DB150]      Bloom, David             andromeda!bloom@TOPAZ.RUTGERS.EDU
+[DB162]      Black, David
+[DB186]      Brooks, Doug             brooks@OSIRIS.CSO.UIUC.EDU
+[DB211]      Boss, Don
+[DBJ4]       Johnson, David B.        drilltech!dbj@RICE.EDU
+[DBL1]       Long, Daniel B.          long@SH.CS.NET
+[DC99]       Chan, David              chan@BEK-MC.CALTECH.EDU
+[DC115]      Comay, David S.          dsc@seismo.CSS.GOV
+[DC126]      Cogger, Dick          rhx%cornellc.bitnet@CUNYVM.CUNY.EDU
+[DC159]      Clar, Daniel          CLAR%FRESE51.BITNET@CUNYVM.CUNY.EDU
+[DCMW]       Wood, David CM           DCMWOOD@COLO.COLORADO.EDU
+[DCW9]       Wells, Donald C.         dwells@NRAO.ARPA
+[DD11]       Deal, Don                don@PYR.GATECH.EDU
+[DD41]       DeGrossa, Dan            NSC-Huen@DDN2.ARPA
+[DD47]       Donaldson, Diane         ANDIE@CVL.UMD.EDU
+[DD63]       Dorosz, Dave             dorosz@ESDVAX.ARPA
+[DD112]      Deeth, Dave
+[DDC1]       Clark, David D.          ddc@LCS.MIT.EDU
+[DDK1]       Knight, Donald D.        CC-SI@EDWARDS-2060.ARPA
+[DE6]        Estrin, Deborah          Estrin@OBERON.USC.EDU
+[DEA]        Anselmi, David E.        USASCEC@SIMTEL20.ARPA
+[DET]        Towson, David E.         TOWSON@AMSAA.ARPA
+[DF71]       Fordyce, David           fordyce@MIPS.CSC.TI.COM
+[DFH2]       Hocking, Dan             DHOCKING@ADA20.ISI.EDU
+[DG28]       Gorham, Delores          dgorham@APG-1.ARPA
+[DGH13]      Hirsh, Donald G.      wucs1!wucs2!don@seismo.CSS.GOV
+[DGL4]       Loudon, Dennis G.
+[DGM18]      McCreary, Daniel G.      dan@ETA.ETA.COM
+[DGT6]       Taylor, David G.         taylor@RAND-UNIX.ARPA
+
+
+
+Romano, Stahl & Recker                                         [Page 49]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+[DH17]       Hirsch, Doug             DHIRSCH@CCS.BBN.COM
+[DH23]       Hayes, David S.          AI01@HIOS-PENT.ARPA
+[DH30]       Hayes, Doc               NS-DDN@DDN2.ARPA
+[DH161]      Houge, Diana
+[DID1]       Dalva, David I.          DID@TIS.ARPA
+[DIM2]       Meiron, Daniel I.        Meiron@DIPOLE.CALTECH.EDU
+[DJF]        Farber, David J.         farber@CIS.UPENN.EDU
+[DJG2]       Grim, Daniel J.          grim@HUEY.UDEL.EDU
+[DJV1]       Van Buer, Darrel J.      VANBUER@ECLA.USC.EDU
+[DK2]        Krafft, Dean B.          dean@GVAX.CS.CORNELL.EDU
+[DK5]        Kirby, Diana
+[DK66]       Konkin, Doug
+                              doug%noah.arc.cdn%ubc.csnet@RELAY.CS.NET
+[DK70]       Kirschen, Dave           kirschen@MULTIMAX.ARPA
+[DLM1]       Mills, Dave              MILLS@HUEY.UDEL.EDU
+[DLM34]      Merrifield, David L.
+[DM27]       McCallum, Doug           mccallum@ICO.ISC.COM
+[DM69]       Marquardt, David R.      rosevax!dave@UUNET.UU.NET
+[DM147]      Morales, Dan
+[DM157]      Michael, Dennis          dennis%ucrmath.UUCP@UCSD.EDU
+[DMK18]      Keirsey, David M.        Keirsey@ECLA.USC.EDU
+[DN22]       Novotny, David           C50DANO@HARC.EDU
+[DN32]       Nordlund, Dave   NORDLUND%UKANVM.BITNET@CUNYVM.CUNY.EDU
+[DO26]       O'Reilly, Dennis
+[DO27]       Oliver, David            ansa%alvey.uk@CS.UCL.AC.UK
+[DP71]       Palus, David
+[DP91]       Pennell, David
+[DR49]       Reynolds, Dick           hcx1!dick@UUNET.UU.NET
+[DR71]       Rettig, Duane
+[DR137]      Rageth, David            rageth@SPOT.COLORADO.EDU
+[DRM24]      Meadows, Donald R.       doim-nm@SAAD.ARPA
+[DRS4]       Smith, Dennis R.         smith@ECLC.USC.EDU
+[DS59]       Schmidt, David           davids@ISCUVA.ISCS.COM
+[DS85]       Smith, Dale C.           dsmith@OREGON.UOREGON.EDU
+[DS229]      Sabino, David            sundc!sneezy!sabino@SUN.COM
+[DSP11]      St. Pierre, David        david@PACBELL.COM
+[DSR]        Russell, Dale            dsr@JOVE.CAM.UNISYS.COM
+[DT50]       Trinkle, Daniel          trinkle@CS.PURDUE.EDU
+[DT59]       Tetreault, David         DJT@NAVELEXNET-STIN.ARPA
+[DTH]        Hsu, David T.            hsu@ENEEVAX.UMD.EDU
+[DW15]       Williams, Doug           WILLIAMSD@A.ISI.EDU
+[DW93]       Watson, David            david@DANDELION.CI.COM
+[DW96]       Walker, David    dhwalker%ucivmsa.bitnet@CUNYVM.CUNY.EDU
+[DW139]      Woerz, Dieter            unido!bossix!woerz@UUNET.UU.NET
+[EC5]        Cain, Edward A.          Cain@EDN-UNIX.ARPA
+[ECM6]       Mulrean, Edward C.
+                                   MULREAN%CUA.BITNET@CUNYVM.CUNY.EDU
+[ED38]       DeHart, Ed               DEHART@TL-20B.ARPA
+
+
+
+Romano, Stahl & Recker                                         [Page 50]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+[EEW6]       Woodward, Ernest E.      ernie@NORTHWESTERN.ARPA
+[EF5]        Franceschini, E.         FRANCESCHINI@NYU.ARPA
+[EG17]       Guglielmo, Eugene        EJG@NWC.ARPA
+[EHH4]       Hunter, Eddie H.
+[EJ12]       Jorgensen, Ed            jorg%lvva.span@SDS.SDSC.EDU
+[EJ19]       James, Ed                edjames@SHADOW.Berkeley.EDU
+[EJN1]       Norman, Eric J.          ejnorman@UNIX2.MACC.WISC.EDU
+[EK18]       King, Edwin              King@SRI-LEWIS.ARPA
+[EM67]       Rehm, Eric               REHM@COGITO.DEC.COM
+[EM75]       Madden, Edward
+[EPA]        Allman, Eric P.          eric@UCBVAX.Berkeley.EDU
+[ER42]       Rose, Eric
+[ERC1]       Crane, Eric R.           Eric.Crane@C.CS.CMU.EDU
+[ERK3]       Kozel, Edward R.         Kozel@SPAM.ISTC.SRI.COM
+[EY5]        Yamin, Elaine
+[EZ3]        Zawacki, Edward   u17375%uicvm.bitnet@CUNYVM.CUNY.EDU
+[FAS]        Segovich, Fred A.        fred@XENURUS.GOULD.COM
+[FCH]        Holtry, Franklin C.
+[FD18]       de Kruijf, F.        FREEK%DUTRUN.UUCP@seismo.CSS.GOV
+[FE6]        Ellis, Frank             ellis@PVAMU.EDU
+[FH35]       Haag, F.
+[FJB3]       Ball, Frederick J.       ball@FORD-VAX.ARPA
+[FJH1]       Halloran, Frank J.       AMSEL-RD-COM-I@CECOM-1.ARPA
+[FJK2]       Kastenholz, Frank J.     Kodinsky@MIT-MULTICS.ARPA
+[FJS3]       Schmidt, F. Jeffery      JSCHMIDT%CDA@AMC-HQ.ARPA
+[FMA1]       Avolio, Frederick M.     avolio@DECUAC.DEC.COM
+[FU1]        Ullings, Fons            fons@NAT.VU.NL
+[FW17]       Wendling, Frederic       FWENDLING@NOTE.NSF.GOV
+[FWD]        Dyner, Wolfgang J.       DYNERW@HEIDELBERG-EMH.ARPA
+[GAA]        Adams, Glenn A., Jr.     glenn@XN.LL.MIT.EDU
+[GAL5]       Loyola, Guillermo A.     loyola%ibm-sj@RELAY.CS.NET
+[GAM27]      Mohr, Gregory A.         wucs1!onemohr!mrh@UUNET.UU.NET
+[GB7]        Beling, Gerd             GBELING@A.ISI.EDU
+[GB43]       Broomell, George      UKT101%UKCC.BITNET@CUNYVM.CUNY.EDU
+[GB95]       Bauerschmidt, Gary       gbauers@ARIEL.UNM.EDU
+[GB125]      Brunkhorst, Geoffrey     gbb@FERMAT.MAY.EDU
+[GBR]        Reilly, G. Brendan       REILLY@WHARTON.UPENN.EDU
+[GC]         Campbell, Graham         gc@BNL.ARPA
+[GC89]       Crawford, Geoff
+[GEOFF]      Mulligan, Geoffrey C.    GEOFF@USAFA.ARPA
+[GG11]       Goble, George            GHG@EE.ECN.PURDUE.EDU
+[GG43]       Gagnon, Gary             ggagnon@CSC-LONS.ARPA
+[GG68]       Guillerm, Gerard    sysdomi%frpoly11.bitnet@CUNYVM.CUNY.EDU
+[GGB2]       Baehr, G. Geoffrey       geoffb@TRWIND.TRW.COM
+[GH29]       Hidley, Gregory R.       hidley@SDCSVAX.UCSD.EDU
+[GIH]        Hastie, Glenn I., II     hastie@SPAM.ISTC.SRI.COM
+[GJK1]       Klem, George J.          KLEM@BRL.ARPA
+[GK44]       Kunis, Gary
+
+
+
+Romano, Stahl & Recker                                         [Page 51]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+[GKN1]       Newman, Gerard           GKN@SDS.SDSC.EDU
+[GL41]       Lindberg, Gunnar         lindberg@CS.CHALMERS.SE
+[GLD]        Durant, Geraldine L.     DURANT@LL.ARPA
+[GLH5]       Hemphill, Gavin L.       HEMPHILL@DREA-XX.ARPA
+[GM34]       Miyata, Gaylord         MIYATA%OZ.AI.MIT.EDU@XX.LCS.MIT.EDU
+[GMQ]        Quinn, George M.      quinn%ceramics.bitnet@CUNYVM.CUNY.EDU
+[GMT6]       Trimble, Gary M.         lams!gmt@AMES.ARC.NASA.GOV
+[GP11]       LeClair, Gene P.         GENE@OPTIMIS-PENT.ARPA
+[GP56]       Petschl, Gottfried
+[GR11]       Ricart, Glenn            glenn@MIMSY.UMD.EDU
+[GR26]       Richter, Georg      urz07%dmswwulc.bitnet@CUNYVM.CUNY.EDU
+[GS91]       Streeter, Guy            ingr!streeter@UUNET.UU.NET
+[GS119]      Smith, Gordon            gordon@UNE.OZ.AU
+[GS123]      Stone, Geof
+[GTA]        Almes, Guy T.            Almes@RICE.EDU
+[GW22]       Weiler, Grant            weiler@CS.UTAH.EDU
+[GW40]       Wallace, Gary            gary%umass.csnet@RELAY.CS.NET
+[GW49]       Ward, George
+[HB60]       Boetzkes, H. A. P. A.    mcvax!nlgvax!henkbo@UUNET.UU.NET
+[HC2]        Cho, Haesoon             hscho%kaist.csnet@RELAY.CS.NET
+[HC24]       Chen, Ho
+[HDW2]       Wactlar, Howard D.       HOWARD.WACTLAR@A.CS.CMU.EDU
+[HG20]       Geist, Harald            unido!nixpbe!geist@UUNET.UU.NET
+[HGH1]       Heard, Harry G.          HEARD@AMES-VMSB.ARPA
+[HH37]       Hesseling, Hans          HESSELING@HGRRUG5.BITNET
+[HH45]       Hori, Hidehiko
+[HK24]       Knight, Holly            myrtle!holly@TSCA.ISTC.SRI.COM
+[HKG2]       Gilbert, Howard K.     gilbert%YALEVM.BITNET@MITVMA.MIT.EDU
+[HKO]        Orman, Hilarie K.        HO@TIS-W.ARPA
+[HLW7]       Lorenz-Wirzba, Heidi     heidi@ELXBSD.CALTECH.EDU
+[HM38]       Mikami, Hirohide       mikami%ntt-20@SUMEX-AIM.STANFORD.EDU
+[HML1]       Long, Morrow H.          LONG-MORROW@CS.YALE.EDU
+[HN3]        Naef, Heinz              mcvax!cgcha!whna@seismo.CSS.GOV
+[HP32]       Price, Harold
+[HT12]       Tam, Henry           rmay%cornelld.bitnet@JADE.Berkeley.EDU
+[HT19]       Trickey, Howard          trickey@ATT.ARPA
+[HVS1]       van Staveren, Hans       mcvax!cs.vu.nl!sater@UUNET.UU.NET
+[HWB]        Braun, Hans-Werner       HWB@MCR.UMICH.EDU
+[HWP2]       Poor, Henry W. (Hank)    poor@RSMAS.MIAMI.EDU
+[IHM]        Merritt, Ian H.          nrcvax!ihm@TRWIND.TRW.COM
+[IMK1]       Kirmer, Irwin M.         kirmer%unmb.bitnet@CUNYVM.CUNY.EDU
+[IRN]        Nassi, Isaac R.          NASSI@MULTIMAX.ARPA
+[IW5]        Winston, Ira             ira@CIS.UPENN.EDU
+[JA]         Akkerhuis, Jaap          jaap@MOUTON.ARPA
+[JA1]        Aronson, Jules P.        ARONSON@MCS.NLM.NIH.GOV
+[JA91]       Angotti, Joseph J.
+[JAG3]       Gumpf, Jeffrey A.        Gumpf@CWRU.CWRU.EDU
+[JAJ17]      Jokl, James A.           jaj@UVAARPA.VIRGINIA.EDU
+
+
+
+Romano, Stahl & Recker                                         [Page 52]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+[JAW16]      Wieclawek, Joseph A.     jaw@SESUN.JPL.NASA.GOV
+[JAW34]      Wabik, Jeff A.           shamash!jwabik@UUNET.UU.NET
+[JB113]      Bennett, Jerome          bennett@DFTNIC.GSFC.NASA.GOV
+[JB188]      Burger, Josef            bolo@SPOOL.WISC.EDU
+[JB218]      Blondeau, Jim          jbb%tektools.tek.csnet@RELAY.CS.NET
+[JB230]      Bottenberg, Jaap         mcvax!nlgvax!jaapb@UUNET.UU.NET
+[JB254]      Blows, Jeff              jeff@SMOKEY.OZ
+[JBP]        Postel, Jon              POSTEL@VENERA.ISI.EDU
+[JBV2]       VanBokkelen, James B.    jbvb@VAX.FTP.COM
+[JBW1]       Walters, Joseph B., Jr.  JWALTERS@CCX.BBN.COM
+[JC11]       Clifford, James R.       jrc@LANL.GOV
+[JC106]      Conklin, Joel            CONKLIN@GE-CRD.ARPA
+[JC235]      Crowhurst, Jon           crowhurst@ADMIN.OGC.EDU
+[JC272]      Cowan, Jack
+[JC288]      Cottrell, Jim         jim%easby.dur.ac.uk@NSS.CS.UCL.AC.UK
+[JCB42]      Bergeron, Jay C.
+[JCH17]      Honig, Jeffrey C.        jch@DEVVAX.TN.CORNELL.EDU
+[JCW12]      Woodard, James C.
+[JD27]       Doyle, John              doyle@CSVAX.CALTECH.EDU
+[JD86]       Duran, Jose              NSC-HILL@DDN2.ARPA
+[JDC20]      Case, Jeffrey D.         case@UTKUX1.UTK.EDU
+[JDG]        Guyton, James D.         guyton@RAND-UNIX.ARPA
+[JEB50]      Bradt, James E.          bradt@GE-CRD.ARPA
+[JEE4]       Ellison, Jan E.          JELLISON@GTEWIS.ARPA
+[JF77]       Fallon, Jim              JFALLON@MACOMW.ARPA
+[JF78]       Finke, John              JFINKE@ITSGW.RPI.EDU
+[JFAS]       Schillemans, Joop F.A.
+                                 RCJOOP%HEITHE5.BITNET@CUNYVM.CUNY.EDU
+[JFC6]       Chambon, J. Francois
+[JFD9]       Detke, John F.
+[JFS22]      Scheimer, James F.       jfs@IRIS.CSS.GOV
+[JGD1]       Deck, Joseph G.
+                        JGD%WCC.WESLYN%WESLEYAN.BITNET@CUNYVM.CUNY.EDU
+[JH10]       Hargrove, Jimmy          jimmy@SEAHUB.ARPA
+[JH18]       Huens, Jean              prlb2!kulcs!jean@seismo.CSS.GOV
+[JH22]       Hook, James              jgh@SVAX.CS.CORNELL.EDU
+[JH92]       Hahn, Jack               hahn%umdc.bitnet@CUNYVM.CUNY.EDU
+[JH141]      Heinanen, Juha
+                          fi-technical-contact%tut.uucp@seismo.CSS.GOV
+[JH155]      Hayward, Jeff            ucc1@UHVAX1.UH.EDU
+[JHH8]       Haynes, James H.         ucscc!haynes@UCBVAX.Berkeley.EDU
+[JJ48]       Jongeward, Jeffrey
+                                 ssc-vax!root@BEAVER.CS.WASHINGTON.EDU
+[JJD12]      Diehl, Jeff J.           hq-spcd-xqr@AFCC-OA2.ARPA
+[JK7]        Koda, Jim                KODA@VENERA.ISI.EDU
+[JK151]      Kim, June             june%sorak.kaist.ac.kr@RELAY.CS.NET
+[JKR1]       Reynolds, Joyce K.       JKREYNOLDS@VENERA.ISI.EDU
+[JL15]       Lepreau, Jay             LEPREAU@CS.UTAH.EDU
+
+
+
+Romano, Stahl & Recker                                         [Page 53]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+[JL52]       Lekashman, John          lekash@ORVILLE.NAS.NASA.GOV
+[JL115]      Little, John             portal!jel@SUN.COM
+[JL152]      Lange, John
+                     hplabs!sun!texsun!radian!altair!johnl@RUTGERS.EDU
+[JLM23]      Mills, John L.           LIAISON@BCO-MULTICS.ARPA
+[JLS45]      Sloan, John L.           jsloan%wright.csnet@RELAY.CS.NET
+[JM60]       McCollum, Jim            MCCOLLUM@TOPS20.DEC.COM
+[JM184]      Macelli, Joseph          joem%suny-sb.csnet@RELAY.CS.NET
+[JM246]      Moretz, Joseph           rogers@NEMS.ARPA
+[JM278]      Mazumdar, Jin
+[JM292]      Murai, Jun               jun%JAPAN.CSNET@RELAY.CS.NET
+[JM303]      Moorfoot, John           jgm%charlie.oz@seismo.CSS.GOV
+[JM304]      McClurg, Jim
+[JMA16]      Adams, James M., III     ADAMS@MACOMW.ARPA
+[JMH10]      Hayes, Jordan Michael    jordan@ADS.COM
+[JMR]        Rushby, John M.          Rushby@CSL.SRI.COM
+[JMRM]       Matheson, James M.R.
+             jmrm%digsys.engineering.cambridge.ac.uk@NSS.CS.UCL.AC.UK
+[JN40]       Noble, John
+[JN47]       Nerbovig, Jerry
+[JNL1]       Larson, John N.          JLarson.PA@XEROX.COM
+[JO54]       O'Connor, John
+[JOG]        Gartley, John O.         gartley%atc.alcoa.com@RELAY.CS.NET
+[JOO]        Ostlund, James O.        ostlund@SALK-ADM.SDSC.EDU
+[JP147]      Petragnani, Joseph     petragna%sjuvax.sju.edu@RELAY.CS.NET
+[JPB17]      Bossert, John
+                         uw-beaver!uw-entropy!thebes!bossert@RUTGERS.EDU
+[JPC17]      Chion, J.P.
+[JPO4]       O'Brien, John P.
+                            cvax!ucf-cs!novavax!john@UCBVAX.Berkeley.EDU
+[JPS17]      Stoneback, John P.     allegra!mc70!stonebac@seismo.CSS.GOV
+[JPS21]      Sorensen, Jan P.       RKUJPS%NEUVM1.BITNET@CUNYVM.CUNY.EDU
+[JPW11]      Wies, J.P.
+[JR15]       Rhodes, John E.          jrhodes@LOGNET2.ARPA
+[JR17]       Robinson, John           ROBINSON@DMC-CRC.ARPA
+[JRM1]       Miller, James R.         jmiller@NOSC.MIL
+[JRR14]      Ragland, Joe R.          TUCJRR@TUCC.TUCC.EDU
+[JRS8]       Schwab, Jeffrey R.       jrs@ECN.PURDUE.EDU
+[JRS48]      Shaeffer, James R.   ASC02%AUDUCVAX.BITNET@CUNYVM.CUNY.EDU
+[JS28]       Shriver, John A.         jas@PROTEON.COM
+[JS38]       Sventek, Joseph S.       JSSventek@LBL.ARPA
+[JS81]       Smith, Jeff              aat@J.CC.PURDUE.EDU
+[JS167]      Shprentz, Joel           shprentz@BDM.COM
+[JS171]      Scott, Jerry             JERRY@TWG.ARPA
+[JS210]      Stearns, Jeff            fluke!jeff@SUN.COM
+[JS268]      Simonetti, J.
+[JS281]      Shultis, Jonathan        daf@ZOG.CS.CMU.EDU
+[JS283]      Schwartz, Jack           JSCHWARTZ@A.ISI.EDU
+
+
+
+Romano, Stahl & Recker                                         [Page 54]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+[JS338]      Sherwood, John     SHERWOOD%DALAC.BITNET@CUNYVM.CUNY.EDU
+[JSG5]       Goodridge, Jon S.        JSG@CCM.BBN.COM
+[JSL9]       Lowe, James S.           james@CSD4.MILW.WISC.EDU
+[JSM11]      Miller, James S.     jmiller%brandeis.csnet@RELAY.CS.NET
+[JSOL]       Solomon, Jon             JSOL@EDDIE.MIT.EDU
+[JSQ1]       Quarterman, John S.      jsq@SALLY.UTEXAS.EDU
+[JSS4]       Sabnis, Jayant S.        sabnix%nrl.decnet@NRL.ARPA
+[JSY2]       Yaplee, Jeffrey S.
+[JT122]      Thomassen, Jens          Jens@IFI.UIO.NO
+[JTE2]       Ellis, James T.          PSN-ADMIN@MORGUL.PSC.EDU
+[JTN]        Nelson, John T.          jtn@POTOMAC.ADS.COM
+[JV41]       Voigt, John          sysbjav%tcsvm.bitnet@CUNYVM.CUNY.EDU
+[JV53]       Vinh, Josianne   mcvax!margaux.inria.fr!vinh@UUNET.UU.NET
+[JVE2]       Eijndhoven, Jos van
+[JW47]       Wobus, John              JMWOBUS@SUVM.ACS.SYR.EDU
+[JW136]      White, James D.          jdw@UOKUCS.UOKNOR.EDU
+[JW156]      Wray, John               JCW2%rsre@CS.UCL.AC.UK
+[JW181]      Washer, James W.         washer@LLL-CRG.LLNL.GOV
+[JW196]      Williams, John
+[JY11]       Yancone, Joe             yancone@CRDEC.ARPA
+[KA4]        Auerbach, Karl           auerbach@CSL.SRI.COM
+[KB60]       Braun, Karl
+[KBC]        Casey, Kevin B.    kbcasey%gallub.bitnet@CUNYVM.CUNY.EDU
+[KC8]        Chen, Ken                PERCEPT@A.ISI.EDU
+[KCM2]       McDonald, Kelly C.   KCM%BYUADMIN.BITNET@CUNYVM.CUNY.EDU
+[KDM5]       Miller, Keith D.
+[KDM6]       Mayer-Spohn, Klaus D.
+                                 ZRAM%DS0RUS1I.BITNET@CUNYVM.CUNY.EDU
+[KDZ]        Zeilenga, Kurt D.        zeilenga@HC.DSPO.GOV
+[KFS]        Sauer, Kurt F.           ks@SVO.DECISION.COM
+[KG35]       Gilmore, Kirk            gilmore@GALILEO.AS.ARIZONA.EDU
+[KH74]       Han, Kisoo        kshan%etrivax.etri.re.kr@RELAY.CS.NET
+[KHJ]        Jobes, Karen H.     jobes%iassns.bitnet@CUNYVM.CUNY.EDU
+[KL31]       Lamb, Kathleen           klamb%csm9a@COLO.COLORADO.EDU
+[KM79]       Moran, Kathy
+[KMC3]       Crepea, Kenneth M.       CREPEA@SPAM.ISTC.SRI.COM
+[KMH8]       Hays, Kenneth M.         hays%fsu.mfenet@NMFECC.ARPA
+[KO11]       O'Keefe, Kevin           HAZELTINE@A.ISI.EDU
+[KR9]        Rohan, Kevin             JJKKRR@FORD-COS1.ARPA
+[KRM5]       Magill, K. Richard       oxtrap!rich@UUNET.UU.NET
+[KS62]       Simpson, Kathy
+[KSL]        Lougheed, Kirk S.        LOUGHEED@KL.SRI.COM
+[KTP]        Pogran, Kenneth          POGRAN@CCQ.BBN.COM
+[KW2]        Wescourt, Keith T.       WESCOURT@CEL.FMC.COM
+[LA55]       Allison, Larry
+[LAB5]       Butler, Lee A.           butler@BRL.ARPA
+[LAM1]       Mamakos, Louis A.        louie@TRANTOR.UMD.EDU
+[LB16]       Bukys, Liudvikas         bukys@CS.ROCHESTER.EDU
+
+
+
+Romano, Stahl & Recker                                         [Page 55]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+[LB110]      Binding, Lothar          $45%dhdurz1.bitnet@CUNYVM.CUNY.EDU
+[LCN]        Nelson, Louis C.         lou@AEROSPACE.AERO.ORG
+[LCN2]       Noll, Landon Curt        chongo@UTS.AMDAHL.COM
+[LCS]        Schreier, Louis C.       schreier@SPAM.ISTC.SRI.COM
+[LCV]        Varian, Lee C.           lvarian@PUCC.PRINCETON.EDU
+[LD46]       Deni, Larry         deni%canisius.bitnet@CUNYVM.CUNY.EDU
+[LDB3]       Borchert, L. David       borchert@BRAGGVAX.ARPA
+[LFO]        Ortiz, Luis F.           ortiz-luis@YALE.ARPA
+[LJR5]       Romero, Louis J.
+[LK27]       Kurtz, Linda             SEAADSA@DDN2.ARPA
+[LL53]       Lanzillo, Leo            leo@SH.CS.NET
+[LL56]       Lattanzi, Len            LATTANZI@SUMEX-AIM.STANFORD.EDU
+[LL64]       Leedom, Leith            casey@LLL-CRG.LLNL.GOV
+[LM35]       Michela, Larry J.        332LJM@FLTAC-POE.ARPA
+[LM88]       McLoughlin, Lee          lmjm%DOC.IC.AC.UK@CS.UCL.AC.UK
+[LNZ]        Zubkoff, Leonard N.      edsel!lnz@LABREA.STANFORD.EDU
+[LOU]        Salkind, Louis           SALKIND@NYU.ARPA
+[LP71]       Paniccia, Larry
+[LPM]        Michelson, Leslie P.     michelso@JVNCF.CSC.ORG
+[LR44]       Roy, Lynette             roy@GMR.COM
+[LRB]        Bierma, Larry R.         BIERMA@NPRDC.ARPA
+[LRC7]       Custead, Larry R.       CUSTEAD%SASK.BITNET@CUNYVM.CUNY.EDU
+[LRR1]       Rogers, Lawrence R.      lrr@PRINCETON.EDU
+[LS136]      Sefton, Laurie           lsefton@UTS.AMDAHL.COM
+[LSV]        Vance, L. Stuart         XXSS520@CHPC.BRC.UTEXAS.EDU
+[LT28]       Taylor, Larry        BPTLCTPB%UIAMVS.BITNET@CUNYVM.CUNY.EDU
+[LW26]       Winkler, Linda          B32357%ANLVM.BITNET@CUNYVM.CUNY.EDU
+[LWR]        Robinson, Lawrence W.    lwr@MORDOR.S1.GOV
+[MA]         Accetta, Michael         MIKE.ACCETTA@A.CS.CMU.EDU
+[MA24]       Anderson, Melanie   melanie%ncsavmsa.bitnet@CUNYVM.CUNY.EDU
+[MA54]       Allegue, Manny          MANNY%TRINCC.BITNET@CUNYVM.CUNY.EDU
+[MA56]       Alexander, Mark
+              kma%SAMSON.CADR.DIALNET.SYMBOLICS.COM@SCRC-RIVERSIDE.ARPA
+[MA63]       Allen, Mike              mcvax!ethz!allen@UUNET.UU.NET
+[MAB4]       Brown, Mark A.           Mark@OBERON.USC.EDU
+[MAJ1]       Johnson, M. A.
+[MAW25]      Waldschmidt, Mark A.     MARKW%CPVB.SPAN@SDS.SDSC.EDU
+[MB]         Brescia, Michael         BRESCIA@CCV.BBN.COM
+[MB26]       Brzustowicz, Mike        MAB@ADS.ARPA
+[MB31]       Bereschinsky, Michael    BERESCHINSKY@A.ISI.EDU
+[MB168]      de Barros, Marcus        marcus@beno.CSS.GOV
+[MC17]       Crawford, Matt           crawford@ANL-MCS.ARPA
+[MC65]       Corn, Michael
+[MC147]      Clark, Mark              mclark@NRAO.ARPA
+[MCA1]       Akers, Mary Crocombe     makers@BBN.COM
+[MCH5]       Holland, M. C.         prlb2!prlvax4!hollandm@UUNET.UU.NET
+[MCL9]       Linimon, Mark C.
+                      ihnp4!killer!mizarvme!linimon:UCBVAX.Berkeley.EDU
+
+
+
+Romano, Stahl & Recker                                         [Page 56]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+[MCSJ]       St. Johns, Michael       StJohns@SRI-NIC.ARPA
+[MDC]        Connor, Martin David     mdc@HT.AI.MIT.EDU
+[MDE3]       Eggers, Mark D.     CF4A8X%IRISHMVS.BITNET@CUNYVM.CUNY.EDU
+[ME38]       Elvy, Marc               ELVY@CARRARA.MARBLE.COM
+[MF14]       Fingerhut, Michael       ircam!mf@UUNET.UU.NET
+[MF31]       Fouts, Martin            FOUTS@AMELIA.ARC.NASA.GOV
+[MF74]       Fidler, Mike         TS0026%OHSTVMA.BITNET@CUNYVM.CUNY.EDU
+[MG58]       Gilbert, Mike            MBALLENTINE@ADA20.ISI.EDU
+[MG95]       Greisen, Marc
+[MH82]       Horton, Mark             stargate.com!mark@RUTGERS.EDU
+[MH98]       Hrybyk, Michael          hrybyk@HOPKINS-EECS-BRAVO.ARPA
+[MH118]      Harper, Malcom     mkh%sevax.prg.oxford.ac.uk@CS.UCL.AC.UK
+[MJ33]       Johnson, Mark
+[MJM2]       Muuss, Michael John      MIKE@BRL.ARPA
+[MJO4]       O'Connor, Michael J.     OCONNOR@SCCGATE.SCC.COM
+[MJO7]       O'Donnell, Michael J.    odonnell@HOPKINS-EECS-BRAVO.ARPA
+[MK17]       Karels, Mike             karels@UCBVAX.Berkeley.EDU
+[MK38]       Kowitz, Mark             mark@ROCKEFELLER.ARPA
+[MK68]       Kazar, Michael           Mike.Kazar@K.CS.CMU.EDU
+[MK75]       Koulopoulos, Mike        well!rk@LLL-LCC.ARPA
+[MK79]       Kito, Masafumi           kokubu%etl.jp@RELAY.CS.NET
+[MKL]        Lottor, Mark K.          MKL@SRI-NIC.ARPA
+[MKP2]       Peterson, Michael K.     scgvaxd!mkp@CSVAX.CALTECH.EDU
+[ML62]       Levine, Michael          LEVINE@A.PSY.CMU.EDU
+[ML95]       Liu, Mei-Ling     DSMEILI%CALSTATE.BITNET@CUNYVM.CUNY.EDU
+[MLC]        Corrigan, Michael        Corrigan@DDN3.ARPA
+[MM135]      Mills, M.
+[MM147]      Meyer, Mark           mark%unlcdc3.bitnet@CUNYVM.CUNY.EDU
+[MM149]      Miller, Mark         LUMM%LEHIIBM1.BITNET@CUNYVM.CUNY.EDU
+[MM227]      Mohar, Mike              csed-1!csed-37!mohar@DAITC.ARPA
+[MMH5]       Hayman, Martin M.
+[MMM3]       McDonnell, Michael M.    MIKE@ETL.ARPA
+[MOUSE]      Parker, Mike             mouse@LARRY.MCRCIM.MCGILL.EDU
+[MP12]       Petry, Michael           petry@TRANTOR.UMD.EDU
+[MP20]       Perras, Mickey           PERRAS@NUSC-ADA.ARPA
+[MPM]        Mullen, M. Preston       MULLEN@NRL-CSS.ARPA
+[MQ7]        Quipourt, M.
+[MR29]       Russell, Mike
+[MR78]       Rotert, Michael          ZORN%GERMANY.CSNET@RELAY.CS.NET
+[MR91]       Reynolds, Mark
+[MR101]      Roberson, Milton
+[MS9]        Schoffstall, Martin Lee  schoff@CSV.RPI.EDU
+[MS22]       Starner, Mark L.         starner@PRC.UNISYS.COM
+[MS101]      Szymendera, Michael      mikey%CANISIUS.EDU@RELAY.CS.NET
+[MS171]      Shapiro, Marc            Marc.Shapiro@C.CS.CMU.EDU
+[MS172]      Simonians, Marina
+[MS195]      Shojima, Makoto
+[MSA1]       Andersson, Mats S.       enea!liuida!msa@seismo.CSS.GOV
+
+
+
+Romano, Stahl & Recker                                         [Page 57]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+[MSM1]       Medin, Milo              MEDIN@AMES.ARPA
+[MSP1]       St. Paul, Mark           stpaul@NMSU.EDU
+[MT1]        Tharenos, Michael        tharenos@IBM.COM
+[MV24]       Vasoll, Mark        vasoll%a.cs.okstate.edu@RELAY.CS.NET
+[MW83]       Wexler, Mike             bigboy!mikew@UUNET.UU.NET
+[MWS10]      Stalnaker, Michael W.    MIKE@NRL-SSD.ARPA
+[NAL]        Lann, Neil               nal@MORDOR.S1.GOV
+[NB16]       Ball, Nancy              NancyB@AUSTIN.LOCKHEED.COM
+[NC3]        Chiappa, Noel            JNC@XX.LCS.MIT.EDU
+[NG]         Gower, Neil E.           GOWER@A.ISI.EDU
+[NH2]        Howard, Nat              nrh@FLASH.BELLCORE.COM
+[NM31]       Mishkin, Nat             apollo!mishkin@EDDIE.MIT.EDU
+[NMM]        Minnich, N. Michael      mminnich@HUEY.UDEL.EDU
+[NT12]       Todd, Neil               mcvax!ist!neil@seismo.CSS.GOV
+[NT13]       Titley, Nigel            mcvax!btnix!titley@seismo.CSS.GOV
+[OD8]        Deguine, O.
+[OG4]        Gremont, O.
+                      mcvax!inria!gipaltair-bdblues!root@seismo.CSS.GOV
+[PA5]        Almquist, Philip         Almquist@SCORE.STANFORD.EDU
+[PAK6]       Kaslo, Philip A.         phil@ARIZONA.EDU
+[PAN1]       Nelson, Philip A.        phil%wwu.edu@RELAY.CS.NET
+[PAP4]       Prindeville, Philip A.   PHILIPP@LARRY.MCRCIM.MCGILL.EDU
+[PB40]       Bowden, Phillip E.       BOWDENPE@VTVM1.CC.VT.EDU
+[PB67]       Boyle, Pat               boyle%ubc.csnet@RELAY.CS.NET
+[PC55]       Charlton, Phyliss
+[PD39]       Delaney, Pete  pete%crcvax.uucp%germany.csnet@RELAY.CS.NET
+[PDB5]       Barron, Patrick D.       pdb@SEI.CMU.EDU
+[PEK]        Kane, Patrick E.         kane@XENURUS.GOULD.COM
+[PEM4]       McKenney, Paul E.        mckenney@SRI.COM
+[PFK]        King, Peter F.           KING%NEXT.COM@RELAY.CS.NET
+[PFS2]       Sass, Paul F.            SASS@A.ISI.EDU
+[PG40]       Gillis, Paul             paulg@USAGE.UNSW.OZ
+[PGA1]       Apley, Phillip G.
+[PGM]        Milazzo, Paul G.         milazzo@RICE.EDU
+[PH45]       Ho, Peter                HO@HAC2ARPA.HAC.COM
+[PHS1]       Schmidt, Paul H.         pschmidt@AFIT-AB.ARPA
+[PJT9]       Tyers, Peter J.          tyers%trlluna.oz@UUNET.UU.NET
+[PK]         Kirstein, Peter T.       KIRSTEIN@NSS.CS.UCL.AC.UK
+[PK19]       Karr, Penny              PKARR@BBN.COM
+[PK28]       Karn, Phil               KARN@THUMPER.BELLCORE.COM
+[PKH1]       Hyder, Paul K.           HYDER@HUB.UCSB.EDU
+[PL37]       LaForgue, Pierre         laforgue@IMAG.IMAG.FR
+[PLH8]       Haymon, Paula Langford   apctrc!bigmac!haymon@UUNET.UU.NET
+[PM4]        Martin, Paul             PMARTIN@KL.SRI.COM
+[PM37]       Melvin, Phyllis          phyllis@BOEING.COM
+[PM72]       Mies, Paul               unido!gmdzi!mies@seismo.CSS.GOV
+[PM81]       Marshall, Peter  p.marshall%UWOVAX.BITNET@WISCVM.WISC.EDU
+[PMH3]       Henderson, P. Marshall
+
+
+
+Romano, Stahl & Recker                                         [Page 58]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+[PML1]       Lashley, Patrick M.      Holems!pat1@SUN.COM
+[PN23]       Nellessen, Peter         CRTVAX!PN@SPICE.CS.CMU.EDU
+[PNW]        Wan, Peter N.            peter%msdc.uucp@GATECH.EDU
+[PP14]       Pomes, Paul              paul@UXC.CSO.UIUC.EDU
+[PP36]       Patton, Paul
+[PRT2]       Taylor, Paul R.   rocksvax!oswego!taylor@CS.ROCHESTER.EDU
+[PS27]       Spilling, Paal           SPILLING@A.ISI.EDU
+[PSS1]       Schwarz, Phil S.
+[PT23]       Tomb, Peter            ptomb%umass.bitnet@CUNYVM.CUNY.EDU
+[PT26]       Taylor, Philip
+                 postmaster%cst%cvaxa.sussex.ac.uk@NSS.CS.UCL.AC.UK
+[PW37]       Woods, Paul
+[PW44]       Wishart, Peter           pjw%anucsd.oz@UUNET.UU.NET
+[PW49]       Ware, Pete               esosun!pete@seismo.CSS.GOV
+[RA11]       Adams, Rick              rick@seismo.CSS.GOV
+[RA17]       Albrightson, Robert      bob@CS.WASHINGTON.EDU
+[RA62]       Aschenbrenner, Rex       Rex%CGIVB%CGI.CSNET@RELAY.CS.NET
+[RA66]       Antonorsi, Richard
+[RA94]       Allison, Roger
+[RAJ3]       Johnson, Richard A.      RAJ@ICS.UCI.EDU
+[RAJ8]       Jones, Richard A.        jones@COLO.COLORADO.EDU
+[RAK12]      Kawin, Richard A.        kawin@MORDOR.S1.GOV
+[RAM57]      Mann, Rex A.
+[RAR22]      Ridder, Robert A.
+[RAR23]      Ragosa, Richard A.
+[RAY4]       Yamin, Raymond A.
+[RB187]      Baxter, Richard          baxter-richard@YALE.ARPA
+[RB217]      Bracho, Rafael           RXB@KL.SRI.COM
+[RB218]      Bentson, Randolph   bentson%colostate.csnet@RELAY.CS.NET
+[RB219]      Bybee, Robert
+[RB221]      Blachley, Rick
+[RB253]      Bjers, Richard    CCONRDB%UCCCVM1.BITNET@CUNYVM.CUNY.EDU
+[RBW]        Wales, Richard B.        WALES@CS.UCLA.EDU
+[RC113]      Collier, Renee
+[RCM9]       McQueen, Robert C.       SIT.MCQUEEN@CU20B.COLUMBIA.EDU
+[RD91]       Dussaulx, Regine
+[RD104]      Dirlewanger, Roland      rd@SUN8.LRI.FR
+[RD108]      Dahlhoff, Randall    GR.RFD%ISUMVS.BITNET@CUNYVM.CUNY.EDU
+[RDG12]      Garvie, Robert D.    garvie%grumpy.dnet@SPOT.COLORADO.EDU
+[RDQ]        Quigley, Roger d.        quigley@SRI-LEWIS.ARPA
+[RDR4]       Rockwell, R. Dennis      DROCKWELL@SH.CS.NET
+[RE22]       Enas, R.                 cdc-ddn@DDN2.ARPA
+[RED22]      Donnelly, Robert  E.
+[RER20]      Rogers, Robert E.
+[RF57]       Fajman, Roger            RAF%NIHCU.BITNET@CUNYVM.CUNY.EDU
+[RFD1]       Donnelly, Robert F.      rfd@ARDEC.ARPA
+[RG92]       Gopstein, Richard        gopstein@RUTGERS.EDU
+[RG94]       Glass, Rick         GLASS%CEBAFVAX.BITNET@CUNYVM.CUNY.EDU
+
+
+
+Romano, Stahl & Recker                                         [Page 59]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+[RGB14]      Bookbinder, Robert G.    lamont!rgb@COLUMBIA.EDU
+[RH5]        Hobby, Russell           RDHOBBY@UCDAVIS.UCDAVIS.EDU
+[RH6]        Hinden, Robert           HINDEN@CCV.BBN.COM
+[RH60]       Hale, Roger              ROGER@LL-SST.ARPA
+[RH164]      Hoffmann, Ron            hoffmann@BITSY.MIT.EDU
+[RHA8]       August, Robert H.  AUGUSTRH%VUCTRVAX.BITNET@CUNYVM.CUNY.EDU
+[RHC3]       Cole, Robert H.          rhc%HPLB.CSNET@RELAY.CS.NET
+[RHM11]      Moreno, Robert H.        rmoreno@MISER.ARPA
+[RHS16]      Sweed, Richard H.        SWEED@RADC-TOPS20.ARPA
+[RJH33]      Hickman, Robert J.
+[RJH37]      Hendley, R.J.    HendleyRJ%CS.BHAM.AC.UK@CUNYVM.CUNY.EDU
+[RJL3]       Liebschutz, Robert J.    rob@PRESTO.IG.COM
+[RK51]       Kisielewski, Richard
+[RK75]       Kocian, Ray              kocian%sdr.slb.com@RELAY.CS.NET
+[RKJ2]       Johnsson, Richard K.     Johnsson@DECWRL.DEC.COM
+[RKS1]       Stodola, Robert K.       STODOLA@RM.FCCC.EDU
+[RL104]      Lynch, Rich             VM10CA%WVNVM.BITNET@CUNYVM.CUNY.EDU
+[RLB3]       Broersma, Ronald L.      ron@NOSC.MIL
+[RLP30]      Paulson, Ray L.
+[RLR23]      Reyenga, Robert L.       REYENGA@WESTPOINT.ARPA
+[RLR36]      Rawlins, Ray L.          ray%USU.BITNET@CUNYVM.CUNY.EDU
+[RLS6]       Smith, Ronald L.         COINS@A.ISI.EDU
+[RLU3]       Ullmann, Robert L.       Ariel@EN-C06.PRIME.COM
+[RM8]        Marantz, Roy             marantz@KLINZHAI.RUTGERS.EDU
+[RM120]      McCarthy, Richard    sp0003%bingvmb.bitnet@CUNYVM.CUNY.EDU
+[RM125]      McCorkle, Ray            NSC-Keyport@DDN2.ARPA
+[RM142]      Michaels, Robert         michaels@HPLABS.HP.COM
+[RM176]      Merry, Rod
+[RM177]      Morrison, Robert         rlm%wyocdc1.bitnet@CUNYVM.CUNY.EDU
+[RM196]      Murphy, Richard      Richard%SWRIMV.SPAN@STAR.STANFORD.EDU
+[RM213]      Mohr, Rupert             UNIDO!RMI!ZENTRALE@UUNET.UU.NET
+[RN25]       Negaret, Roger
+[RN29]       Nomura, Ryo
+                    nomura%nttkb.ntt.junet%ntt-20@SUMEX-AIM.STANFORD.EDU
+[RNB5]       Berlinger, Robert N.     naftoli@AECOM.YU.EDU
+[RNM1]       MacKenzie, R. Neil       cle%rsre.mod.uk@RELAY.MOD.UK
+[RP88]       Perry, Russ              RUSS@CSUFRESNO.EDU
+[RPP]        Pingree, Robert P.       PINGREE@NUSC.ARPA
+[RR2]        Romine, Raleigh F.       ROMINE@NOTE.NSF.GOV
+[RR18]       Reisor, Ron              ron%vax3@LOUIE.UDEL.EDU
+[RR26]       Reilly, William R.       REILLY@COA.ARPA
+[RR33]       Romanelli, Richard       romanell@BRL.ARPA
+[RR97]       Russell, Robb            ROBB%DUVM.BITNET@CUNYVM.CUNY.EDU
+[RS253]      Saccoman, Remi           remi%framentec.FR@UUNET.UU.NET
+[RS255]      Sinnhuber, Roger rogers%cvaxa.sussex.ac.uk@NSS.CS.UCL.AC.UK
+[RSD2]       Dixon, Robert S.      TS0400%OHSTVMA.BITNET@CUNYVM.CUNY.EDU
+[RSH]        Hammel, Randall S.       rsh@SUPER.ORG
+[RSM1]       Miles, Robert S.         rsm@NRTC.NORTHROP.COM
+
+
+
+Romano, Stahl & Recker                                         [Page 60]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+[RT60]       Thigpen, Robert     decvax!savax!thigpen@UCVAX.Berkeley.EDU
+[RTB8]       Baynes, Robert T.
+[RTL]        LaCoss, Richard T.       lacoss@XN.LL.MIT.EDU
+[RV32]       Volk, Ruediger           rv%unido@UUNET.UU.NET
+[RW101]      Witlicki, Randy          witlicki%williams.edu@RELAY.CS.NET
+[RWH5]       Henry, Robert W.         rwh@UCBVAX.Berkeley.EDU
+[RWT2]       Tinker, Robert W.        tinker@DTIX.ARPA
+[SA]         Allen, Scott
+[SA46]       Archer, Stephen          archer@CS.ROCHESTER.EDU
+[SA47]       Ayers, Stephen
+[SAB17]      Baird, Scott A.
+[SAK3]       Kahn, Steven A.          steve@APLVAX.JHUAPL.EDU
+[SB12]       Bertilson, Scott         scott@UMN-REI-UC.ARPA
+[SB28]       Bradner, Scott           SOB@HARVARD.HARVARD.EDU
+[SB90]       Brady, Sean              brady@DCN9.ARPA
+[SB98]       Barber, Stan             SOB@BCM.TMC.EDU
+[SBW4]       Whidden, Samuel B.       sbw@MATH.AMS.COM
+[SC54]       Comer, Scott             wert@RICE.EDU
+[SC59]       Campbell, Stephen        steve%dartmouth.edu@RELAY.CS.NET
+[SC81]       Callahan, Sean           sean@ELXSI.CALTECH.EDU
+[SD1]        Dyer, Stephen            dyer@HARVARD.HARVARD.EDU
+[SD78]       Donegan, Steve
+[SF34]       Fenstermacher, Scott     scott%wmmvs.bitnet@CUNYVM.CUNY.EDU
+[SF41]       Fogel, Steve        SFOGEL!MTCS!MTXINU@UCBARPA.Berkeley.EDU
+[SFJ]        Johnston, Scott F.
+[SG1]        Grandi, Steve            grandi@NOAO.ARPA
+[SG83]       Garwood, Steve
+[SG88]       Gai, Silvano         silvano%itopoli.bitnet@CUNYVM.CUNY.EDU
+[SGC]        Chipman, Stephen G.      CHIPMAN@F.BBN.COM
+[SGR1]       Roediger, Steve G.
+[SH37]       Heker, Sergio            heker@JVNCA.CSC.ORG
+[SH47]       Hallstrom, Steve      STEVEH%UWACDC.BITNET@CUNYVM.CUNY.EDU
+[SH71]       Herber, Steve            herber%andy.bgsu.edu@RELAY.CS.NET
+[SHB]        Blumenthal, Steven H.    BLUMENTHAL@VAX.BBN.COM
+ [SI8]        Ilnicki, Slawomir
+[SJL]        Lucks, Steven J.
+[SJM9]       Mahler, Stephen J.   mahler%usl-pc%usl.csnet@RELAY.CS.NET
+[SJP10]      Piatz, Steven J.         piatz@SP.UNISYS.COM
+[SJS11]      Schroeder, Steven J.     SJS%PSUVM.BITNET@CUNYVM.CUNY.EDU
+[SL10]       Lerner, Sandy            sandy@SPAR-20.ARPA
+[SL47]       Laube, Sheldon           cfisun!shel@HARVARD.HARVARD.EDU
+[SL55]       Leaviseur, Sean          SJL%UKC.AC.UK@CS.UCL.AC.UK
+[SL68]       Langlois, Sylvain        sylvain@CHORUS.FR
+[SLH19]      Howell, Steven L.        showell@NSWC-WO.ARPA
+[SM6]        McLinden, Sean           MCLINDEN@CADRE.DSL.PITTSBURGH.EDU
+[SM62]       Mackey, Sandy            skm@MITRE-OMAHA.ARPA
+[SM67]       Miller, Steve            miller%m2c.org@RELAY.CS.NET
+[SM83]       McPherson, Stew          stew@CSUPWB.COLOSTATE.EDU
+
+
+
+Romano, Stahl & Recker                                         [Page 61]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+[SM96]       Morris, Scooter          scooter@CGL.UCSF.EDU
+[SM111]      Mandell, Stewart         mandell@BN1.ARPA
+[SMF5]       Feldman, Steven M.
+                        hplabs!oliveb!tymix!feldman@UCBVAX.Berkeley.EDU
+[SMK2]       King, Stephen Michael    KING@HQAFSC-VAX.ARPA
+[SMP2]       Polinsky, Steven M.    SMPCU%CUNYVM.BITNET@CUNYVM.CUNY.EDU
+[SMS1]       Schultz, Steve M.        sms@ETN-WLV.EATON.COM
+[SR77]       Rousseau, Susan          susan@NUSC.ARPA
+[SS80]       Schaller, Skip           SKIP@SOLPL.AS.ARIZONA.EDU
+[SS110]      Smith, Stanfield         stan%gcylab.uucp@ITSGW.RPI.EDU
+[SS125]      Stovall, Steven          sstovaall@DAITC.ARPA
+[SS131]      Sutphen, Steven    steve%alberta.cdn%ubc.csnet@RELAY.CS.NET
+[SSW]        Wolff, Stephen S.        STEVE@BRL.ARPA
+[ST13]       Takagi, S.               takagi%icot.jp@RELAY.CS.NET
+[SW78]       Wadle, Steve
+[SWR3]       Rogers, Scott W.         scottr@CSC-LONS.ARPA
+[SWW6]       Weller, Scott W.
+                           rochester!tropics!orion!sww.uucp@UUNET.UU.NET
+[SY8]        Yokota, Shozo
+[TA24]       Asami, Tohru
+[TB4]        Baker, Theodore          TBAKER@AJPO.SEI.CMU.EDU
+[TB64]       Becker, Tony             tony%ucf.edu@RELAY.CS.NET
+[TD40]       Davis, Tom               DAVIS@EGLIN-VAX.ARPA
+[TDM8]       Mudgett, Trish Dailey
+[TE16]       Eldredge, Timothy        g.eldre@SCORE.STANFORD.EDU
+[TEC6]       Chessman, Thomas E.      chessman@LOGNET2.ARPA
+[TES16]      Swazuk, Thomas E.
+[TF6]        Ferrin, Thomas           TEF@CGL.UCSF.EDU
+[TFB3]       Blakely, Thomas F.       ittfb%dcatla.uucp@UUNET.UU.NET
+[TGN]        Norman, T.G.      net-admin!cs.flinders.oz.au@UUNET.UU.NET
+[TGS6]       Sickles, Theodore G.
+[TH15]       Holt, Tracy              Holt%gmuvax.bitnet@CUNYVM.CUNY.EDU
+[TH60]       Hutton, Thomas           hutton@SCUBED.ARPA
+[THD]        Dunigan, Thomas H.       DUNIGAN@MSR.EPM.ORNL.GOV
+[TK43]       Kobayashi, Tsutomu       koba%ntt-20@SUMEX-AIM.STANFORD.EDU
+[TM10]       Mallory, Tracy           tmallory@CCV.BBN.COM
+[TM37]       Lafleur, Tom             LAFLEUR@NET1.UCSD.EDU
+[TM57]       Mead, Theodore           mead@TUT.CC.ROCHESTER.EDU
+[TM86]       MacMillan, Todd          todd%apple.csnet@RELAY.CS.NET
+[TMD6]       Dillon, Theresa M.       tmd@MITRE-BEDFORD.ARPA
+[TMH6]       Herrick, Thomas M.       DCAB600@DDN1.ARPA
+[TML]        Louden, T. Michael       LOUDEN@MITRE.ARPA
+[TN17]       Nijssen, Teun           TEUN%HTIKUB5.BITNET@CUNYVM.CUNY.EDU
+[TO4]        Oishi, Tosaku           oishi%etl.junet%etl.jp@RELAY.CS.NET
+[TONY]       Holland, Anthony R.      TONY@KL.SRI.COM
+[TR38]       Radzykewycz, Tim         calma!radzy@UCBVAX.Berkeley.EDU
+[TRG4]       Giebelhaus, Tim R.       hi-csc!giebelhaus@UMN-CS.ARPA
+[TS9]        Slattery, Terry          tcs@USNA.MIL
+
+
+
+Romano, Stahl & Recker                                         [Page 62]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+[TS14]       Stuckey, Trish           TRISH@TRANTOR.HARRIS-ATD.COM
+[TS31]       Symchych, Tim            symchych@SKL-CRC.ARPA
+[TT35]       Terbush, Terry           tlt%gwuvm.bitnet@CUNYVM.CUNY.EDU
+[TVF1]       Fossum, Timothy V.       fossum@VACS.UWP.WISC.EDU
+[TW51]       Wadlow, Tom A.           taw@MORDOR.S1.GOV
+[UB3]        Bilting, Ulf             BILTING@PURDUE.EDU
+[US2]        Straumann, Ulrich   K538915%CZHRZU1A.BITNET@CUNYVM.CUNY.EDU
+[VBK]        Kava, Victor B.
+[VDC1]       Cone, V. Donald          Cone@SPAM.ISTC.SRI.COM
+[VHB]        Barnes, Vonnie H.        VBARNES@NSWC-OAS.ARPA
+[WA16]       Armitage, William
+                    wja%computer-science.nottingham.ac.uk@CS.UCL.AC.UK
+[WAG5]       Guthmiller, Wayne A.     MKATZ@A.ISI.EDU
+[WAH11]      Hunt, Warren A., Jr.     HUNT@CLI.COM
+[WB53]       Ball, Wayne              wball%umass.bitnet@CUNYVM.CUNY.EDU
+[WCB3]       Bard, William C.         Bard@NGP.UTEXAS.EDU
+[WCW7]       Wells, William C.
+[WCWI]       Ince, W.C.W.       admin_sys%math.waterloo.edu@RELAY.CS.NET
+[WD27]       Dair, Willis             DAIR%SCU.BITNET@JADE.Berkeley.EDU
+[WDL]        Lazear, Walter D.        LAZEAR@MITRE.ARPA
+[WDR7]       Rolph, W.D.
+[WDS11]      Smith, William D.
+[WDW2]       Welch, William D., Jr.   ingr!zaiaz!bill@UUNET.UU.NET
+[WE12]       Edgington, Will     wedgingt%ducair.bitnet@CUNYVM.CUNY.EDU
+[WF3]        Fink, William E.         bill@NRL-LCP.ARPA
+[WG]         Graves, Wayne            WRGRAVES@LBL.ARPA
+[WH64]       Hake, Wolfgang    UHRZS007%DBIUNI11.BITNET@CUNYVM.CUNY.EDU
+[WL31]       Lampeter, William        bill@CS.ROCHESTER.EDU
+[WLB5]       Boyer, William L.        WLB@NCIFCRF.GOV
+[WLG7]       Gordon, Windy L.
+[WM10]       Moore, Wire              wire@INTEL-IWARP.ARPA
+[WM68]       Magnussen, Walt       X048WM%TAMVM1.BITNET@CUNYVM.CUNY.EDU
+[WPJ]        Jones, William Prichard  JONES@AMES.ARPA
+[WRR5]       Ritchie, William R.      DDNWRR@FLTAC-POE.ARPA
+[WS94]       Spirk, Werner     A2824AB%DMOLRZ01.BITNET@BCUNYVM.CUNY.EDU
+[WSC5]       Currie, W.S.      S.Currie%edinburgh.ac.uk@CUNYVM.CUNY.EDU
+[WU1]        Underwood, Walter        wunder@HPLABS.HP.COM
+[WW2]        Wedel, Wally             wedel@NGP.UTEXAS.EDU
+[WWP8]       Plummer, William W.      Plummer@DOCKMASTER.ARPA
+[WWS]        Seemuller, William W.    BILL@ETL.ARPA
+[YD2]        Despond, Yves      despond%clsepf51.bitnet@CUNYVM.CUNY.EDU
+[YN]         Nguyen, Yen              yen@ARINC-GW.ARPA
+[YS10]       Saito, Yaski           yaski%ntt-20@SUMEX-AIM.STANFORD.EDU
+[ZSU]        Su, Zaw-Sing             ZSu@TSCA.ISTC.SRI.COM
+
+
+
+
+
+
+
+Romano, Stahl & Recker                                         [Page 63]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+                               APPENDIX A
+
+The network numbers in class A, B, and C network addresses are allocated
+among Research, Defense, Government (Non-Defense) and Commercial uses.
+
+   Class A (highest-order bit 0)
+
+      Research allocation:             8
+      Defense allocation:             24
+      Government allocation:          24
+      Commercial allocation:          94
+      Reserved Addresses:   (0, 127)
+      Total                          128
+
+   Class B (highest-order bits 1-0)
+
+      Research allocation:          1024
+      Defense allocation:           3072
+      Government allocation:        3072
+      Commercial allocation:       12286
+      Reserved Addresses: (0, 16383)
+      Total                        16384
+
+   Class C (highest-order bits 1-1-0)
+
+      Research allocation:           65536
+      Defense allocation:           458725
+      Government allocation:        458725
+      Commercial allocation:       1572862
+      Reserved Addresses: (0, 2097151)
+      Total                        2097152
+
+   Class D (highest-order bits 1-1-1-0)
+
+      All addresses in this class are allocated for multicast use.
+
+   Class E (highest-order bits 1-1-1-1)
+
+      All addresses in this class are reserved for future use.
+
+Experimental networks which later become operational need not be
+renumbered.  Rather, the identifiers could be moved from Research to
+Defense, Government or Commercial status.  Thus, network identifiers may
+change state among Research, Defense, Government and Commercial, but the
+number of identifiers allocated to each use must remain within the
+limits indicated above.  To make possible this fluid assignment, the
+network identifier spaces are not allocated by simple partition, but
+rather by specific assignment.
+
+
+
+Romano, Stahl & Recker                                         [Page 64]
+
+RFC 1062                    Internet Numbers                 August 1988
+
+
+Also, organizations not currently affiliated with the Internet may be
+assigned numbers for networks for non-connected service.  If at some
+later time such networks are connecteed to the Internet (with
+appropriate prermissions and approvals) the networks need not be
+renumbered.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Romano, Stahl & Recker                                         [Page 65]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1062.txt](<www.ietf.org/rfc/rfc1062.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
