### PR TITLE
Archive rfc108.txt

### DIFF
--- a/www.ietf.org/rfc/rfc108.txt
+++ b/www.ietf.org/rfc/rfc108.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                         R. Watson
+Request for Comments: 108                                       SRI-ARC
+NIC: 5807                                                 25 March 1971
+
+
+               Addendum to NWG Meeting Notes, NIC (5762)
+
+
+Attendance List at the Urbana NWG Meeting
+
+   February 17-19, 1971
+
+   BBN
+      Robert Kahn
+      Ray Tomlinson
+      Alex McKenzie
+
+   Case
+      Patrick Foulk
+
+   CCA
+      Richard Winter
+
+   Harvard
+      Bob Metcalfe
+
+   ILLINOIS
+      Carlton Mills
+      David Grothe
+      Gary R. Grossman
+      Michael S. Sher
+      J. Bouknight
+      J. Madden
+      Stewart Denenberg
+
+   IBM Research
+      Douglas McKay
+      Hans Schlaeppi
+
+   LINCOLN LAB
+      Richard Kalin
+      Joel Winett
+      Tom Barkalow
+
+   MIT
+      Bob Skinner
+
+
+
+
+
+Watson                                                          [Page 1]
+
+RFC 108              Addendum to NWG Meeting Notes            March 1971
+
+
+   MIT-MAC
+      Edwin W. Meyer, Jr.
+      Bob Bressler
+      A. Vezza
+
+   MITRE
+      P. M. Karp
+
+   RADC
+      Tom Lawrence
+      Robt. K. Walker
+
+   RAND
+      John Heafner
+      Raytheon
+      Tom O'Sullivan
+
+   SDC
+      Robert E. Long
+      Jerry Cole
+
+   SRI
+      John Melvin
+      Dick Watson
+
+   UCLA
+      Steve Crocker
+      Jon Postel
+
+   UCSB
+      Jim White
+
+   Utah
+      Barry Wessler
+
+
+          [ This RFC was put into machine readable form for entry ]
+             [ into the online RFC archives by Via Genie 3/99 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+Watson                                                          [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc108.txt](<www.ietf.org/rfc/rfc108.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
