### PR TITLE
Archive rfc1088.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1088.txt
+++ b/www.ietf.org/rfc/rfc1088.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                                  L. McLaughlin III
+Request for Comments: 1088                                           TWG
+                                                           February 1989
+
+
+ A Standard for the Transmission of IP Datagrams over NetBIOS Networks
+
+Status of this Memo
+
+   This document specifies a standard method of encapsulating the
+   Internet Protocol [1] (IP) datagrams on NetBIOS [2] networks.
+   Distribution of this memo is unlimited.
+
+Introduction
+
+   The goal of this specification is to allow compatible and
+   interoperable implementations for transmitting IP datagrams over
+   NetBIOS networks.
+
+   NetBIOS is a standard which specifies a means of creating virtual
+   circuits and of transmitting and receiving point-to-point, multicast,
+   and broadcast datagrams.  This specification uses only the datagram
+   services.
+
+   Previous versions of this memo specified the use of the NetBIOS
+   broadcast datagram services instead of the NetBIOS group name
+   services to implement IP broadcasting.  These versions are now
+   obsolete.
+
+Description
+
+   NetBIOS networks may be used to support IP networks and subnets [3]
+   of any class.  By means of encapsulating IP datagrams within NetBIOS
+   datagrams and assigning IP numbers to the hosts on a NetBIOS network,
+   IP-based applications are supported on these hosts.  The addition of
+   a router capable of encapsulating IP packets within ordinary data-
+   link protocols (such as 802.3 [4]) as well as within NetBIOS
+   datagrams allows these NetBIOS hosts to communicate with the Internet
+   at large.
+
+Address Mappings
+
+   In general, NetBIOS names may be any series of 16 bytes, however, a
+   few values are reserved or used by common networking packages.
+   NetBIOS names for the IP applications on each host are chosen on the
+   basis of the internet number of that host.  Since NetBIOS names are a
+   mapping of IP addresses, no physical address query mechanism (e.g.,
+   ARP [5]) is required.
+
+
+
+McLaughlin                                                      [Page 1]
+
+RFC 1088                IP over NetBIOS networks           February 1989
+
+
+   For these internet protocol applications, IP.XX.XX.XX.XX is the
+   NetBIOS name for any IP over NetBIOS host where XX represents the
+   ascii hexadecimal representation of that byte of the internet
+   address.
+
+   This addressing scheme allows for the multiplexing of standard
+   datagram protocols over NetBIOS as well as easy visual confirmation
+   of the correctness of a given packet's address.
+
+Broadcast and Multicast Addresses
+
+   Broadcast Internet addresses are represented by the NetBIOS group
+   name IP.FF.FF.FF.FF.  Currently, no attempt is made to provide
+   support of IP multicast addresses using NetBIOS group names.
+
+Maximum Transmission Unit
+
+   The maximum data size of a NetBIOS datagram, and therefore the
+   Maximum Transmission Unit (MTU) for IP over NetBIOS networks, is 512
+   bytes.  Therefore, any hosts communicating with a host on a NetBIOS
+   network may be required to reassemble fragmented datagrams.
+
+Implementation
+
+   To support IP on a NetBIOS host for any given IP address the
+   initialization code must:
+
+       1) Add IP.XX.XX.XX.XX to the host's NetBIOS name table.
+
+       2) Add IP.FF.FF.FF.FF to the host's NetBIOS group name table.
+
+       3) Submit a receive datagram request for the reception of NetBIOS
+          datagrams destined for IP.XX.XX.XX.XX.
+
+       4) Submit a receive datagram request for the reception of NetBIOS
+          datagrams destined for IP.FF.FF.FF.FF.
+
+   When a NetBIOS datagram to either address is received, it is
+   processed by the protocol stack and another receive datagram request
+   is submitted.
+
+   When an IP datagram is sent, it is considered to be NetBIOS datagram
+   data and sent by a send datagram request to either IP.XX.XX.XX.XX or
+   IP.FF.FF.FF.FF.
+
+   Optionally, the IP software may desire to make adapter status queries
+   of the NetBIOS network.  As support for SNMP becomes a requirement
+   for IP hosts, these adapter status queries may become mandatory.
+
+
+
+McLaughlin                                                      [Page 2]
+
+RFC 1088                IP over NetBIOS networks           February 1989
+
+
+   Finally, when the IP support for a given NetBIOS host is
+   discontinued, a cancel command request should be submitted for every
+   pending receive datagram, and a delete name request should be
+   submitted for both the IP.XX.XX.XX.XX and IP.FF.FF.FF.FF address
+   added during initialization.
+
+Acknowledgements
+
+   This document would not have been possible without the efforts of
+   John Bartas, James Davidson, and Dan Ladermann in the early design
+   and implementation of IP over NetBIOS.
+
+References
+
+     [1]  Postel, J., "Internet Protocol", RFC-791, September 1981.
+
+     [2]  IBM PC Network Technical Reference, Document Number 6322916,
+          September 1984.
+
+     [3]  Mogul, J., and J. Postel, "Internet Standard Subnetting
+          Procedure", RFC-950, August 1985.
+
+     [4]  Postel, J., and J. Reynolds, "A Standard for the Transmission
+          of IP datagrams over IEEE 802 Networks", RFC-1042,
+          February 1988.
+
+     [5]  Plummer, D., "An Ethernet Address Resolution Protocol",
+          RFC-826, November 1982.
+
+Author's Address:
+
+   Leo J. McLaughlin III
+   The Wollongong Group
+   1129 San antonio Road
+   Palo Alto, CA 94303
+
+   Phone: (415) 962-7100
+
+   EMail: ljm@TWG.COM
+
+
+
+
+
+
+
+
+
+
+
+
+McLaughlin                                                      [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1088.txt](<www.ietf.org/rfc/rfc1088.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
