### PR TITLE
Archive rfc1089.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1089.txt
+++ b/www.ietf.org/rfc/rfc1089.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                                  M. Schoffstall
+Request for Comments: 1089           Rensselaer Polytechnic Institute
+                                                             C. Davin
+                                  MIT Laboratory for Computer Science
+                                                             M. Fedor
+                                                       NYSERNet, Inc.
+                                                              J. Case
+                                 University of Tennessee at Knoxville
+                                                        February 1989
+
+
+                           SNMP over Ethernet
+
+Status of This Memo
+
+   This memo describes an experimental method by which the Simple
+   Network Management Protocol (SNMP) as specified in [1] can be used
+   over Ethernet MAC layer framing [2] instead of the Internet UDP/IP
+   protocol stack.  This specification is useful for LAN based network
+   elements that support no higher layer protocols beyond the MAC sub-
+   layer.  Distribution of this memo is unlimited.
+
+Overview and Rational
+
+   SNMP has been successful in managing Internet capable network
+   elements which support the protocol stack at least through UDP the
+   connectionless Internet transport layer protocol.  As originally
+   designed, SNMP is capable of running over any reasonable transport
+   mechanism (not necessarily a transport protocol) that supports bi-
+   directional flow and addressability.
+
+   Many non-Internet capable network elements are present in local
+   networks; for example, repeaters and wiring concentrators.  They
+   include both addressability, and programmable intelligence.  These
+   devices are widely used and increasingly important yet, for the most
+   part, invisible except through proprietary mechanisms.
+
+Specification
+
+   Almost all Internet capable network elements use the same mechanism
+   for encapsulation of the Internet protocol stack regardless of
+   conformity with the physical characteristics of Ethernet or 802.3,
+   this mechanism is specified in [3] and [4].  This specification
+   continues that style with the assignment (by XEROX) of 33100
+   (hexadecimal 814C) to the Ethernet Type field for SNMP.  The data
+   portion of the Ethernet frame would then be a standard SNMP message
+   as specified in [1].
+
+
+
+
+Schoffstall, Davin, Fedor & Case                                [Page 1]
+
+RFC 1089                   SNMP over Ethernet              February 1989
+
+
+References
+
+     [1]  Case, J., Fedor, M., Schoffstall, M., and J. Davin, "A Simple
+          Network Management Protocol", RFC-1067, University of
+          Tennessee at Knoxville, NYSERNet, Inc., Rensselaer Polytechnic
+          Institute, and Proteon, Inc., August 1988.
+
+     [2]  DEC, "The Ethernet - A Local Area Network", Version 2.0,
+          Digital Equipment Corporation, Intel Corporation, Xerox
+          Corporation.
+
+     [3]  Hornig, C., "A Standard for the Transmission of IP Datagrams
+          over Ethernet Networks", RFC-894, Symbolics, April 1984.
+
+     [4]  Postel, J., and J. Reynolds, "A Standard for the Transmission
+          of IP Datagrams over IEEE 802 Networks", RFC-1042, USC
+          Information Sciences Institute, February 1988.
+
+Authors' Addresses
+
+   Marty Schoffstall
+   NYSERNET Inc.
+   Rensselaer Technology Park
+   165 Jordan Road
+   Troy, NY 12180
+
+   Phone: (518) 276-2654
+
+   EMail: schoff@stonewall.nyser.net
+
+
+   Chuck Davin
+   MIT Laboratory for Computer Science, NE43-507
+   545 Technology Square
+   Cambridge, MA 02139
+
+   Phone: (617) 253-6020
+
+   EMail: jrd@ptt.lcs.mit.edu
+
+
+
+
+
+
+
+
+
+
+
+
+Schoffstall, Davin, Fedor & Case                                [Page 2]
+
+RFC 1089                   SNMP over Ethernet              February 1989
+
+
+   Mark Fedor
+   Nysernet, Inc.
+   Rensselaer Technology Park
+   125 Jordan Road
+   Troy, NY 12180
+   (518) 283-8860
+
+   Phone: (518) 283-8860
+
+   EMail: fedor@patton.NYSER.NET
+
+
+   Jeff Case
+   University of Tennessee Computing Center
+   Associate Director
+   200 Stokely Management Center
+   Knoxville, TN 37996-0520
+
+   Phone: (615) 974-6721
+
+   EMail: case@UTKUX1.UTK.EDU
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schoffstall, Davin, Fedor & Case                                [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1089.txt](<www.ietf.org/rfc/rfc1089.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
