### PR TITLE
Archive rfc1099.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1099.txt
+++ b/www.ietf.org/rfc/rfc1099.txt
@@ -1,0 +1,1235 @@
+
+
+
+
+
+
+Network Working Group                                        J. Reynolds
+Request for Comments: 1099                                           ISI
+                                                           December 1991
+
+
+                      Request for Comments Summary
+
+                         RFC Numbers 1000-1099
+
+Status of This Memo
+
+   This memo is a slightly annotated list of the 100 RFCs from RFC 1000
+   through RFCs 1099.  This is a status report on these RFCs.  This memo
+   provides information for the Internet community.  It does not specify
+   an Internet standard.  Distribution of this memo is unlimited.
+
+RFC     Author       Date      Title
+---     ------       ----      -----
+
+1099    Reynolds     Dec 91    Requests For Comments Summary
+
+This memo.
+
+
+1098    Case         Apr 89    A Simple Network Management
+                               Protocol (SNMP)
+
+This RFC is a re-release of RFC 1067, with a changed "Status of this
+Memo" section.  This memo defines a simple protocol by which management
+information for a network element may be inspected or altered by
+logically remote users.  In particular, together with its companion
+memos which describe the structure of management information along with
+the initial management information base, these documents provide a
+simple, workable architecture and system for managing TCP/IP-based
+internets and in particular the Internet.
+
+
+1097    Miller       Apr 89    Telnet Subliminal-Message Option
+
+This RFC specifies a standard for the Internet community.  Hosts on the
+Internet that display subliminal messages within the Telnet protocol are
+expected to adopt and implement this standard.
+
+
+1096    Marcy        Mar 89    Telnet X Display Location Option
+
+This RFC specifies a standard for the Internet community.  Hosts on the
+Internet that transmit the X display location within the Telnet protocol
+
+
+
+Reynolds                                                        [Page 1]
+
+RFC 1099                  Summary of 1000-1099             December 1991
+
+
+are expected to adopt and implement this standard.
+
+
+1095    Warrier      Apr 89    The Common Management Information
+                               Services and Protocol over TCP/IP
+                               (CMOT)
+
+This memo defines a network management architecture that uses the
+International Organization for Standardization's (ISO) Common Management
+Information Services/Common Management Information Protocol (CMIS/CMIP)
+in a TCP/IP environment.  This architecture provides a means by which
+control and monitoring information can be exchanged between a manager
+and a remote network element.  In particular, this memo defines the
+means for implementing the Draft International Standard (DIS) version of
+CMIS/CMIP on top of Internet transport protocols for the purpose of
+carrying management information defined in the Internet-standard
+management information base.  DIS CMIS/CMIP is suitable for deployment
+in TCP/IP networks while CMIS/CMIP moves toward becoming an
+International Standard.  Together with the relevant ISO standards and
+the companion RFCs that describe the initial structure of management
+information and management information base, these documents provide the
+basis for a comprehensive architecture and system for managing TCP/IP-
+based internets, and in particular the Internet.
+
+
+1094    Sun          Mar 89    NFS: Network File System
+                               Protocol Specification
+
+This RFC describes a protocol that Sun Microsystems, Inc., and others
+are using.  A new version of the protocol is under development, but
+others may benefit from the descriptions of the current protocol, and
+discussion of some of the design issues.
+
+
+1093    Braun        Feb 89    The NSFNET Routing Architecture
+
+This document describes the routing architecture for the NSFNET centered
+around the new NSFNET Backbone, with specific emphasis on the interface
+between the backbone and its attached networks.
+
+
+1092    Rekhter      Feb 89    EGP and Policy Based Routing
+                               in the New NSFNET Backbone
+
+This memo discusses implementation decisions for routing issues in the
+NSFNET, especially in the NSFNET Backbone.  Of special concern is the
+restriction of routing information to advertize the best route as
+established by a policy decision.
+
+
+
+Reynolds                                                        [Page 2]
+
+RFC 1099                  Summary of 1000-1099             December 1991
+
+
+1091    VanBokkelen  Feb 89    Telnet Terminal-Type Option
+
+This RFC specifies a standard for the Internet community.  Hosts on the
+Internet that exchange terminal type information within the Telnet
+protocol are expected to adopt and implement this standard.
+
+This standard supersedes RFC 930.  A change is made to permit cycling
+through a list of possible terminal types and selecting the most
+appropriate
+
+
+1090    Ullmann      Feb 89    SMTP on X.25
+
+This memo proposes a standard for SMTP on the virtual circuit facility
+provided by the X.25 standard of the CCITT.
+
+
+1089    Schoffstall  Feb 89    SNMP over Ethernet
+
+This memo describes an experimental method by which the Simple Network
+Management Protocol (SNMP) can be used over Ethernet MAC layer framing
+instead of the Internet UDP/IP protocol stack.  This specification is
+useful for LAN based network elements that support no higher layer
+protocols beyond the MAC sub-layer.
+
+
+1088    McLaughlin   Feb 89    A Standard for the Transmission of IP
+                               Datagrams over NetBIOS Networks
+
+This document specifies a standard method of encapsulating the Internet
+Protocol (IP) datagrams on NetBIOS networks.
+
+
+1087    IAB          Jan 89    Ethics and the Internet
+
+This memo is a statement of policy by the Internet Activities Board
+(IAB) concerning the proper use of the resources of the Internet.
+
+
+1086    Onions       Dec 88    ISO-TP0 bridge between TCP and X.25
+
+This memo proposes a standard for the Internet community.  Hosts on the
+Internet that choose to implement ISO TP0 transport connectivity between
+TCP and X.25 based hosts are expected to experiment with this proposal.
+TCP port 146 is reserved for this proposal.
+
+
+
+
+
+
+Reynolds                                                        [Page 3]
+
+RFC 1099                  Summary of 1000-1099             December 1991
+
+
+1085    Rose         Dec 88    ISO Presentation Services
+                               on top of TCP/IP-based internets
+
+RFC 1006 describes a mechanism for providing the ISO transport service
+on top of TCP/IP.  Once this method is applied, one may implement "real"
+ISO applications on top of TCP/IP-based internets, by simply
+implementing OSI session, presentation, and application services on top
+of the transport service access point which is provided on top of the
+TCP.  Although straight-forward, there are some environments in which
+the richness provided by the OSI application layer is desired, but it is
+nonetheless impractical to implement the underlying OSI infrastructure
+(i.e., the presentation, session, and transport services on top of the
+TCP).
+
+This memo describes an approach for providing "stream-lined" support of
+OSI application services on top of TCP/IP-based internets for such
+constrained environments.  This memo proposes a standard for the
+Internet community.
+
+
+1084    Reynolds     Dec 88      BOOTP Vendor Information Extensions
+
+This RFC is a slight revision and extension of RFC-1048 by Philip
+Prindeville.  This memo will be updated as additional tags are are
+defined.  This edition introduces Tag 13 for Boot File Size.  Comments
+and suggestions for improvements are sought.
+
+
+1083    IAB          Dec 88      IAB Official Protocol Standards
+
+This memo describes the state of standardization of protocols used in
+the Internet as determined by the Internet Activities Board (IAB).  An
+overview of the standards procedures is presented first, followed by
+discussions of the standardization process and the RFC document series,
+then the explanation of the terms is presented, the lists of protocols
+in each stage of standardization follows, and finally pointers to
+references and contacts for further information.
+
+This memo is issued quarterly, please be sure the copy you are reading
+is dated within the last three months.
+
+
+1082    Rose         Nov 88      Post Office Protocol - Version 3
+                                 Extended Service Offerings
+
+This memo suggests a simple method for workstations to dynamically
+access mail from a discussion group server, as an extension to an
+earlier memo which dealt with dynamically accessing mail from a mailbox
+
+
+
+Reynolds                                                        [Page 4]
+
+RFC 1099                  Summary of 1000-1099             December 1991
+
+
+server using the Post Office Protocol - Version 3 (POP3).  This RFC
+specifies a proposed protocol for the Internet community, and requests
+discussion and suggestions for improvements.  All of the extensions
+described in this memo to the POP3 are OPTIONAL.
+
+
+1081    Rose         Nov 88      Post Office Protocol - Version 3
+
+This memo suggests a simple method for workstations to dynamically
+access mail from a mailbox server.  This RFC specifies a proposed
+protocol for the Internet community, and requests discussion and
+suggestions for improvements.
+
+
+1080    Hedrick      Dec 88      Telnet Remote Flow Control Option
+
+This RFC specifies a standard for the Internet community.  Hosts on the
+Internet that do remote flow control within the Telnet protocol are
+expected to adopt and implement this standard.
+
+
+1079    Hedrick      Dec 88      Telnet Terminal Speed Option
+
+This RFC specifies a standard for the Internet community.  Hosts on the
+Internet that exchange terminal speed information within the Telnet
+protocol are expected to adopt and implement this standard.
+
+
+1078    Lottor       Nov 88      TCP Port Service Multiplexer (TCPMUX)
+
+This RFC proposes an Internet standard which can be used by future TCP
+services instead of using 'well-known ports'.
+
+
+1077    Leiner       Nov 88      Critical Issues in High Bandwidth
+                                 Networking
+
+This memo presents the results of a working group on High Bandwidth
+Networking.  This RFC is for your information and you are encouraged to
+comment on the issues presented.
+
+
+1076    Trewitt      Nov 88      HEMS Monitoring and Control Language
+
+This RFC specifies a query language for monitoring and control of
+network entities.  This RFC supercedes RFC 1023, extending the query
+language and providing more discussion of the underlying issues.
+
+
+
+
+Reynolds                                                        [Page 5]
+
+RFC 1099                  Summary of 1000-1099             December 1991
+
+
+This language is a component of the High-Level Entity Monitoring System
+(HEMS) described in RFC 1021 and RFC 1022.  Readers may wish to consult
+these RFCs when reading this memo.  RFC 1024 contains detailed
+assignments of numbers and structures used in this system.  Portions of
+RFC 1024 that define query language structures are superceded by
+definitions in this memo.  This memo assumes a knowledge of the ISO data
+encoding standard, ASN.1.
+
+
+1075    Waitzman     Nov 88      Distance Vector Multicast Routing
+                                 Protocol
+
+This RFC describes a distance-vector-style routing protocol for routing
+multicast datagrams through an internet.  It is derived from the Routing
+Information Protocol (RIP), and implements multicasting as described in
+RFC-1054.  This is an experimental protocol, and its implementation is
+not recommended at this time.
+
+
+1074    Rekhter      Oct 88      The NSFNET Backbone SPF based Interior
+                                 Gateway Protocol
+
+This RFC is an implementation description of the standard ANSI IS-IS and
+ISO ES-IS routing protocols within the NSFNET backbone network.
+
+
+1073    Waitzman     Oct 88      Telnet Window Size Option
+
+This RFC describes a proposed Telnet option to allow a client to convey
+window size to a Telnet server.
+
+
+1072    Jacobson     Oct 88      TCP Extensions for Long-Delay Paths
+
+This RFC proposes a set of extensions to the TCP protocol to provide
+efficient operation over a path with a high bandwidth*delay product.
+These extensions are not proposed as an Internet standard at this time.
+Instead, they are intended as a basis for further experimentation and
+research on transport protocol performance.
+
+
+1071    Braden       Aug 88      Computing the Internet Checksum
+
+This RFC summarizes techniques and algorithms for efficiently computing
+the Internet checksum.  It is not a standard, but a set of useful
+implementation techniques.
+
+
+
+
+
+Reynolds                                                        [Page 6]
+
+RFC 1099                  Summary of 1000-1099             December 1991
+
+
+1070    Hagens       Feb 89      Use of the Internet as a Subnetwork
+                                 for Experimentation with the OSI
+                                 Network Layer
+
+This RFC proposes a scenario for experimentation with the International
+Organization for Standardization (ISO) Open Systems Interconnection
+(OSI) network layer protocols over the Internet and requests discussion
+and suggestions for improvements to this scenario.  This RFC also
+proposes the creation of an experimental OSI internet.  To participate
+in the experimental OSI internet, a system must abide by the agreements
+set forth in this RFC.
+
+
+1069    Callon       Feb 89      Guidelines for the use of Internet-IP
+                                 addresses in the ISO Connectionless-
+                                 Mode Network Protocol
+
+This RFC suggests an addressing scheme for use with the ISO
+Connectionless Network Protocol (CLNP) in the Internet.  This is a
+solution to one of the problems inherent in the use of "ISO-grams" in
+the Internet.  This memo is a revision of RFC 986.  This RFC suggests a
+proposed protocol for the Internet community, and requests discussion
+and suggestions for improvements.
+
+
+1068    DeSchon      Aug 88      Background File Transfer Program
+                                 (BFTP)
+
+This RFC describes an Internet background file transfer service that is
+built upon the third-party transfer model of FTP.  No new protocols are
+involved.  The purpose of this memo is to stimulate discussions on new
+Internet service modes.
+
+
+1067    Case         Aug 88      A Simple Network Management Protocol
+
+This RFC defines a simple protocol by which management information for a
+network element may be inspected or altered by logically remote users.
+In particular, together with its companion memos which describe the
+structure of management information along with the initial management
+information base, these documents provide a simple, workable
+architecture and system for managing TCP/IP-based internets and in
+particular, the Internet.
+
+This memo specifies a draft standard for the Internet community. TCP/IP
+implementations in the Internet which are network manageable are
+expected to adopt and implement this specification.
+
+
+
+
+Reynolds                                                        [Page 7]
+
+RFC 1099                  Summary of 1000-1099             December 1991
+
+
+1066    McCloghrie    Aug 88      Management Information Base for Network
+                                  Management of TCP/IP-based internets
+
+This RFC provides the initial version of the Management Information Base
+(MIB) for use with network management protocols in TCP/IP-based
+internets in the short-term.  In particular, together with its companion
+memos which describe the structure of management information along with
+the initial network management protocol, these documents provide a
+simple, workable architecture and system for managing TCP/IP-based
+internets, and in particular, the Internet.
+
+This memo specifies a draft standard for the Internet community.  TCP/IP
+implementations in the Internet which are network manageable are
+expected to adopt and implement this specification.
+
+
+1065    Rose          Aug 88      Structure and Identification of
+                                  Management Information for
+                                  TCP/IP-based internets
+
+This RFC provides the common definitions for the structure and
+identification of management information for TCP/IP-based internets.  In
+particular, together with its companion memos, which describe the
+initial management information base along with the initial network
+management protocol, these documents provide a simple, working
+architecture and system for managing TCP/IP-based internets and in
+particular, the Internet.
+
+This memo specifies a draft standard for the Internet community.  TCP/IP
+implementation in the Internet which are network manageable are expected
+to adopt and implement this specification.
+
+
+1064    Crispin       Jul 88      Interactive Mail Access Protocol -
+                                  Version 2
+
+This memo suggests a method for workstations to dynamically access mail
+from a mailbox server ("respository").  This RFC specifies a standard
+for the SUMEX-AIM community and a proposed experimental protocol for the
+Internet community.  Discussion and suggestions for improvement are
+requested.
+
+
+1063    Mogul         Jul 88      IP MTU Discovery Options
+
+A pair of IP options that can be used to learn the minimum MTU of a path
+through an internet is described, along with its possible uses.  This is
+a proposal for an Experimental protocol.
+
+
+
+Reynolds                                                        [Page 8]
+
+RFC 1099                  Summary of 1000-1099             December 1991
+
+
+1062    Romano        Aug 88      Internet Numbers
+
+This memo is an official status report on the network numbers and
+gateway autonomous system numbers used in the Internet community.
+
+
+1061    Never issued.
+
+
+1060    Reynolds      Mar 90      Assigned Numbers
+
+This memo is a status report on the parameters (i.e., numbers and
+keywords) used in protocols in the Internet community.  Distribution of
+this memo is unlimited.
+
+
+1059    Mills         Jul 88      Network Time Protocol (Version 1)
+                                  Specification and Implementation
+
+This memo describes the Network Time Protocol (NTP), specifies its
+formal structure and summarizes information useful for its
+implementation.  NTP provides the mechanisms to synchronize time and
+coordinate time distribution in a large, diverse internet operating at
+rates from mundane to lightwave.  It uses a returnable-time design in
+which a distributed subnet of time servers operating in a self-
+organizing, hierarchical master-slave configuration synchronizes logical
+clocks within the subnet and to national time standards via wire or
+radio.  The servers can also redistribute reference time via local
+routing algorithms and time daemons.
+
+The NTP architectures, algorithms and protocols which have evolved over
+several years of implementation and refinement are described in this
+document.  The prototype system, which has been in regular operation in
+the Internet for the last two years, is described in an Appendix along
+with performance data which shows that timekeeping accuracy throughout
+most portions of the Internet can be ordinarily maintained to within a
+few tens of milliseconds, even the cases of failure or disruption of
+clocks, time servers or nets. This is a Draft Standard for an Elective
+protocol.
+
+
+1058    Hedrick       Jun 88      Routing Information Protocol
+
+This RFC describes an existing protocol for exchanging routing
+information among gateways and other hosts.  It is intended to be used
+as a basis for developing gateway software for use in the Internet
+community.
+
+
+
+
+Reynolds                                                        [Page 9]
+
+RFC 1099                  Summary of 1000-1099             December 1991
+
+
+1057    Sun           Jun 88       RPC: Remote Procedure Call Protocol
+                                   Specification Version 2
+
+This RFC describes a standard that Sun Microsystems and others are
+using, and is one we wish to propose for the Internet's consideration.
+This memo is not an Internet standard at this time.
+
+
+1056    Lambert       Jun 88   PCMAIL: A Distributed Mail System
+                               for Personal Computers
+
+This memo is a discussion of the Pcmail workstation based distributed
+mail system.  It is identical to the discussion in RFC-993, save that a
+new, much simpler mail transport protocol is described.  The new
+transport protocol is the result of continued research into ease of
+protocol implementation and use issues.
+
+
+1055    Romkey         Jun 88    A Nonstandard for Transmission of
+                                 IP Datagrams over Serial Lines: SLIP
+
+The TCP/IP protocol family runs over a variety of network media: IEEE
+802.3 (ethernet) and 802.5 (token ring) LAN's, X.25 lines, satellite
+links, and serial lines.  There are standard encapsulations for IP
+packets defined for many of these networks, but there is no standard for
+serial lines.  SLIP, Serial Line IP, is a currently a de facto standard,
+commonly used for point-to-point serial connections running TCP/IP.  It
+is not an Internet standard.
+
+
+1054    Deering        May 88      Host Extensions for IP Multicasting
+
+This memo specifies the extensions required of a host implementation of
+the Internet Protocol (IP) to support multicasting.  IP multicasting is
+the transmission of an IP datagram to a "host group", a set hosts
+identified by a single IP destination address.  A multicast datagram is
+delivered to all members of its destination host group with the same
+"best-efforts" reliability as regular unicast IP datagrams.  It is
+proposed as a standard for IP multicasting in the Internet.  This
+specification is a major revision of RFC-988.
+
+
+1053    Levy           Apr 88       Telnet X.3 PAD Option
+
+This RFC proposes a new option to Telnet for the Internet community, and
+requests discussion and suggestions for improvements.
+
+
+
+
+
+Reynolds                                                       [Page 10]
+
+RFC 1099                  Summary of 1000-1099             December 1991
+
+
+1052    Cerf           Apr 88      IAB Recommendations for the
+                                   Development of Internet Network
+                                   Management Standards
+
+This RFC is intended to convey to the Internet community and other
+interested parties the recommendations of the Internet Activities Board
+(IAB) for the development of network management protocols for use in the
+TCP/IP environment.  This memo does NOT, in and of itself, define or
+propose an Official Internet Protocol.  It does reflect, however, the
+policy of the IAB with respect to further network management development
+in the short and long term.
+
+
+1051    Prindeville     Mar 88     A Standard for the Transmission of IP
+                                   Datagrams and ARP Packets over ARCNET
+                                   Networks
+
+This memo specifies a standard method of encapsulating Internet Protocol
+(IP) and Address Resolution Protocol (ARP) datagrams on an ARCNET.  This
+RFC is a standard protocol for the Internet community.
+
+
+1050    Sun             Apr 88      RPC: Remote Procedure Call
+                                    Protocol Specification
+
+This memo specifies a message protocol used in implementing Sun's Remote
+Procedure Call (RPC) package.  This RFC describes a standard that Sun
+Microsystems and others are using and is one they wish to propose for
+the Internet's consideration.  It is not an Internet standard at this
+time.
+
+
+1049    Sirbu           Mar 88      A Content-Type Header Field for
+                                    Internet Messages
+
+This memo suggests proposed additions to the Internet Mail Protocol,
+RFC-822, for the Internet community, and requests discussion and
+suggestions for improvements.
+
+
+1048    Prindeville     Feb 88      BOOTP Vendor Information Extensions
+
+This memo proposes an addition to the Bootstrap Protocol (BOOTP).
+Comments and suggestions for improvements are sought.
+
+
+
+
+
+
+
+Reynolds                                                       [Page 11]
+
+RFC 1099                  Summary of 1000-1099             December 1991
+
+
+1047    Partridge       Feb 88      Duplicate Messages and SMTP
+
+An examination of a synchronization problem in the Simple Mail Transfer
+Protocol (SMTP) is presented.  This synchronization problem can cause a
+message to be delivered multiple times.  A method for avoiding this
+problem is suggested.  Nodding familiarity with the SMTP specification,
+RFC-821, is required.
+
+
+1046    Prue            Feb 88      A Queuing Algorithm to Provide
+                                    Type-of-Service for IP Links
+
+This memo is intended to explore how Type-of-Service might be
+implemented in the Internet.  The proposal describes a method of queuing
+which can provide the different classes of service.  The technique also
+prohibits one class of service from consuming excessive resources or
+excluding other classes of service.  This is an "idea paper" and
+discussion is strongly encouraged.
+
+
+1045    Cheriton        Feb 88      VMTP: Versatile Message Transaction
+                                    Protocol Protocol Specification
+
+This memo specifies the Versatile Message Transaction Protocol (VMTP)
+[Version 0.7 of 19-Feb-88], a transport protocol specifically designed
+to support the transaction model of communication, as exemplified by
+remote procedure call (RPC).  The full function of VMTP, including
+support for security, real-time, asynchronous message exchanges,
+streaming, multicast and idempotency, provides a rich selection to the
+VMTP user level.  Subsettability allows the VMTP module for particular
+clients and servers to be specialized and simplified to the services
+actually required.  Examples of such simple clients and servers include
+PROM network bootload programs, network boot servers, data sensors and
+simple controllers, to mention but a few examples.  This RFC describes a
+protocol proposed as a standard for the Internet community.
+
+
+1044    Hardwick        Feb 88      Internet Protocol on Network Systems
+                                    HYPERchannel Protocol Specification
+
+This memo intends to provide a complete discussion of the protocols and
+techniques used to embed DoD standard Internet Protocol datagrams (and
+its associated higher level protocols) on Network Systems Corporation's
+HYPERchannel equipment.  This document is directed toward network
+planners and implementors who are already familiar with the TCP/IP
+protocol suite and the techniques used to carry TCP/IP traffic on common
+networks such as the DDN or the Ethernet.  No great familiarity with NSC
+products is assumed; an appendix is devoted to a review of NSC
+
+
+
+Reynolds                                                       [Page 12]
+
+RFC 1099                  Summary of 1000-1099             December 1991
+
+
+technologies and protocols.
+
+
+1043    Yasuda          Feb 88      TELNET Data Entry Terminal Option
+                                    DODIIS Implementation
+
+This RFC suggests a proposed protocol on the TELNET Data Entry Terminal
+(DET) Option - DODIIS Implementation for the Internet community.  It is
+intended that this specification be capatible with the specification of
+DET Option in RFC-732.  Discussion and suggests for improvements are
+encouraged.
+
+
+1042    Postel          Feb 88      A Standard for the Transmission of
+                                    IP Datagrams over IEEE 802 Networks
+
+This RFC specifies a standard method of encapsulating the Internet
+Protocol (IP) datagrams and Address Resolution Protocol (ARP) requests
+and replies on IEEE 802 Networks to allow compatible and interoperable
+implementations.  This RFC specifies a protocol standard for the
+Internet community.
+
+
+1041    Rekhter         Jan 88      Telnet 3270 Regime Option
+
+This RFC specifies a proposed standard for the Internet community.
+Hosts on the Internet that want to support 3270 data stream within the
+Telnet protocol, are expected to adopt and implement this standard.
+
+
+1040    Linn            Jan 88      Privacy Enhancement for Internet
+                                    Electronic Mail:  Part I Message
+                                    Encipherment and Authentication
+                                    Procedures
+
+This RFC is the Outgrowth of a series of IAB Privacy Task Force meetings
+and of internal working papers distributed for those meetings.  This
+memo defines message encipherment and authentication procedures, as the
+initial phase of an effort to provide privacy enhancement services for
+electronic mail transfer in the Internet.  Detailed key management
+mechanisms to support these procedures will be defined in a subsequent
+RFC.  As a goal of this initial phase, it is intended that the
+procedures defined here be compatible with a wide range of key
+management approaches, including both conventional (symmetric) and
+public-key (asymmetric) approaches for encryption of data encrypting
+keys.  Use of conventional cryptography for message text encryption
+and/or integrity check computation is anticipated.
+
+
+
+
+Reynolds                                                       [Page 13]
+
+RFC 1099                  Summary of 1000-1099             December 1991
+
+
+1039    Latham          Jan 88      A DoD Statement on Open Systems
+                                    Interconnection Protocols
+
+This RFC reproduces a memorandum issued on 2-JUL-87 from the Assistant
+Secretary of Defense for Command, Control, Communications, and
+Intelligence (ASDC31) to the Director of the Defense Communications
+Agency (DCA).  This memo is distributed for information only.
+
+
+1038    St. Johns       Jan 88       Draft Revised IP Security Option
+
+This memo is a pre-publication draft of the revised Internet Protocol
+Security Option.  This RFC reflects the version as approved by the
+Protocol Standards Steering group, and is provided for informational
+purposes only.  The final version of this document will be available
+from Navy publications and should not differ from this document in any
+major fashion.  This document will be published as a change to the MIL-
+STD 1777, "Internet Protocol".
+
+
+1037    Greenberg       Dec 87        NFILE - A File Access Protocol
+
+This document includes a specification of the NFILE file access protocol
+and its underlying levels of protocol, the Token List Transport Layer
+and Byte Stream with Mark.  The goal of this specification is to promote
+discussion of the ideas described here, and to encourage designers of
+future file protocols to take advantage of these ideas.  A secondary
+goal is to make the specification available to sites that might benefit
+from implementing NFILE.
+
+
+1036    Horton          Dec 87        Standard for Interchange of
+                                      USENET Messages
+
+This RFC defines the standard format for the interchange of network News
+messages among USENET hosts.  It updates and replaces RFC-850,
+reflecting version B2.11 of the News program.  This memo is distributed
+as an RFC to make this information easily accessible to the Internet
+community.  It does not specify an Internet standard.
+
+
+1035    Mockapetris     Nov 87      Domain Names - Implementation
+                                    Specification
+
+This RFC is the revised specification of the protocol and format used in
+the implementation of the Domain Name System.  It obsoletes RFC-883.
+This memo documents the details of the domain name client - server
+communication.
+
+
+
+Reynolds                                                       [Page 14]
+
+RFC 1099                  Summary of 1000-1099             December 1991
+
+
+1034    Mockapetris     Nov 87      Domain Names - Concepts and
+                                    Facilities
+
+This RFC is the revised basic definition of The Domain Name System.  It
+obsoletes RFC-882.  This memo describes the domain style names and their
+used for host address look up and electronic mail forwarding.  It
+discusses the clients and servers in the domain name system and the
+protocol used between them.
+
+
+1033    Lottor          Nov 87     Domain Administrators Operations
+                                   Guide
+
+This RFC provides guidelines for domain administrators in operating a
+domain server and maintaining their portion of the hierarchical
+database.  Familiarity with the domain system is assumed (see RFCs 1031,
+1032, 1034, and 1035).
+
+
+1032    Stahl           Nov 87     Domain Administrators Guide
+
+Domains are administrative entities that provide decentralized
+management of host naming and addressing.  The domain-naming system is
+distributed and hierarchical.
+
+This memo describes procedures for registering a domain with the Network
+Information Center (NIC) of Defense Data Network (DDN), and offers
+guidelines on the establishment and administration of a domain in
+accordance with the requirements specified in RFC-920. It is recommended
+that the guidelines described in this document be used by domain
+administrators in the establishment and control of second-level domains.
+The role of the domain administrator (DA) is that of coordinator,
+manager, and technician.  If his domain is established at the second
+level or lower in the tree, the domain administrator must register by
+interacting with the management of the domain directly above this.
+
+
+1031    Lazear          Nov 87     Milnet Name Domain Transition
+
+This RFC consolidates information necessary for the implementation of
+domain style names throughout the DDN/MILNET Internet community.  The
+introduction of domain style names will impact all hosts in the
+DDN/MILNET Internet.  This RFC is designed as an aid to implementors and
+administrators by providing: 1) an overview of the transition process
+from host tables to domains, 2) a timetable for the transition, and 3)
+references to documentation and software relating to the domain system.
+
+
+
+
+
+Reynolds                                                       [Page 15]
+
+RFC 1099                  Summary of 1000-1099             December 1991
+
+
+1030    Lambert         Nov 87     On Testing the NETBLT Protocol over
+                                   Divers Networks
+
+This memo describes the results gathered from testing NETBLT over three
+networks of different bandwidths and round-trip delays.  The results are
+not complete, but the information gathered so far has not been
+promising.  The NETBLT protocol is specified in RFC-998; this document
+assumes an understanding of the specification as described in RFC-998.
+
+
+1029    Parr            May 88     A More Tolerant Approach to Address
+                                   Resolution  for Multi-Lan system of
+                                   Ethernets
+
+This memo discusses an extension to a Bridge Protocol to detect and
+disclose changes in heighbouring host address parameters in a Multi-Lan
+system of Ethernets.  The problem is one which is appearing more and
+more regularly as the interconnected systems grow larger on Campuses and
+in Commercial Institutions.  This RFC suggests a protocol enhancement
+for the Internet community, and requests discussion and suggestions for
+improvements.
+
+
+1028    Davin           Nov 87     A Simple Gateway Monitoring Protocol
+
+This memo defines a simple application-layer protocol by which
+management information for a gateway may be inspected or altered by
+remote users.  This proposal is intended only as an interim response to
+immediate gateway monitoring needs.
+
+
+1027    Carl-Mitchell   Oct 87     Using ARP to Implement Transparent
+                                   Subnet Gateways
+
+This RFC describes the use of the Address Resolution Protocol (ARP) by
+subnet gateways to permit hosts on the connected subnets to communicate
+without being aware of the existence of subnets, using the technique of
+"Proxy ARP".
+
+
+1026    Kille           Sep 87     Addendum to RFC-987 (Mapping between
+                                   X.400 and RFC-882)
+
+This memo suggest a proposed protocol for the Internet community, and
+request discussion and suggestions for improvements.
+
+
+
+
+
+
+Reynolds                                                       [Page 16]
+
+RFC 1099                  Summary of 1000-1099             December 1991
+
+
+1025    Postel          Sep 87     TCP and IP Bake Off
+
+This memo describes some of the procedures, scoring and tests used in
+the TCP and IP bake offs held in the early development of these
+protocols.  These procedures and tests may still be of use in testing
+newly implemented TCP and IP modules.
+
+
+1024    Partridge       Oct 87     HEMS Variable Definitions
+
+This memo assigns instruction codes, defines object formats and object
+semantics for use with the High-Level Monitoring and Control Language,
+defined in RFC-1023.  A general system has been described in previous
+memos (RFC-1021, RFC-1022).  This system is called the High-Level Entity
+Management System (HEMS).  This memo is provisional and the definitions
+are subject to change.  Readers should confirm with the authors that
+they have the most recent version.  This RFC assumes a working knowledge
+of the ISO data encoding standard, ASN.1, and a general understanding of
+the IP protocol suite.
+
+
+1023    Partridge       Oct 87     HEMS Monitoring and Control Language
+
+This RFC specifies the High-Level Entity Management System (HEMS)
+Monitoring and Control Language.  This language defines the requests and
+replies used in HEMS.  This memo assumes knowledge of the HEMS system
+described in RFC-1021, and of the ISO data encoding standard, ASN.1.
+
+
+1022    Partridge       Oct 87     The High-Level Entity Management
+                                   Protocol (HEMP)
+
+This memo presents an application protocol for managing network entities
+such as hosts, gateways, and front end machines.  This protocol is a
+component of the High-level Entity Management System HEMS), described is
+RFC-1021.  This memo also assumes a knowledge of the ISO data encoding
+standard, ASN.1.
+
+
+1021    Partridge       Oct 87     The High-Level Entity Management
+                                   System (HEMS)
+
+This memo provides a general overview of the High-level Entity
+management system (HEMS).  This system is experimental, and is currently
+being tested in portions of the Internet.
+
+
+
+
+
+
+Reynolds                                                       [Page 17]
+
+RFC 1099                  Summary of 1000-1099             December 1991
+
+
+1020    Romano          Nov 87     Internet Numbers
+
+This RFC is a list of the Assigned IP Network Numbers and EGP Autonomous
+System Numbers.  This RFC obsoletes RFC-997.
+
+
+1019    Arnon           Sep 87     Report of the Workshop on
+                                   Environments for Computational
+                                   Mathematics
+
+This memo is a report on the discussion of the representation of
+equations in a workshop at the ACM SIGGRAPH Conference held in Anaheim,
+California on 30 July 1987.
+
+
+1018    McKenzie        Aug 87     Some Comments on SQuID
+
+This memo is a discussion of some of the ideas expressed in RFC-1016 on
+Source Quench.  This memo introduces the distinction of the cause of
+congestion in a gateway between the effects of "Funneling" and
+Mismatch".  It is offered in the same spirit as RFC-1016; to stimulate
+discussion.  The opinions offered are personal, not corporate, opinions.
+
+
+1017    Leiner          Aug 87     Network Requirements for Scientific
+                                   Research
+
+This RFC identifies the requirements on communication networks for
+supporting scientific research.  It proposes some specific areas for
+near term work, as well as some long term goals.  This is an "idea"
+paper and discussion is strongly encouraged.
+
+
+1016    Prue            July 87    Something a Host Could Do with Source
+                                   Quench:  The Source Quench Introduced
+                                   Delay (SQuID)
+
+The memo is intended to explore the issue of what a host could do with a
+source quench.  The proposal is for each source host IP module to
+introduce some delay between datagrams sent to the same destination
+host.  This is a "crazy idea paper" and discussion is essential.
+
+
+1015    Leiner          July 87    Implementation Plan for Interagency
+                                   Research Internet
+
+This RFC proposes an Interagency Research Internet as the natural
+outgrowth of the current Internet.  This is an "idea paper" and
+
+
+
+Reynolds                                                       [Page 18]
+
+RFC 1099                  Summary of 1000-1099             December 1991
+
+
+discussion is strongly encouraged.
+
+
+1014    Sun             Jun 87     XDR: External Data Representation
+                                   Standard
+
+XDR is a standard for the description and encoding of data.  It is
+useful for transferring data between different computer architectures.
+XDR fits into ISO presentation layer, and is roughly analogous in
+purpose to X.409, ISO Abstract Syntax Notation.  The major difference
+between these two is that XDR uses implicit typing, while X.409 uses
+explicit typing.  This RFC is distributed for information only, it does
+not establish a Internet standard.
+
+
+1013    Scheifler       Jun 87     X Window System Protocol,
+                                   Version 11-Beta
+
+This RFC is distributed to the Internet community for information only.
+It does not establish an Internet standard.  The X window system has
+been widely reviewed and tested.  The Internet community is encouraged
+to experiment with it.
+
+
+1012    Reynolds        Jun 87     Bibliography of Requests for
+                                   Comments 1-999
+
+This RFC is a reference guide for the Internet community which provides
+a bibliographic summary of the Request for Comments numbers 1 through
+999 issued between the years 1969-1987.
+
+
+1011    Reynolds        May 87     Official Internet Protocols
+
+This memo is an official status report on the protocols used in the
+Internet community.  It identifies the documents specifying the official
+protocols used in the Internet.  Comments indicate any revisions or
+changes planned.
+
+
+1010    Reynolds        May 87     Assigned Numbers
+
+This memo is an official status report on the numbers used in protocols
+in the Internet community.  It documents the currently assigned values
+from several series of numbers including link, socket, port, and
+protocol, used in network protocol implementations.
+
+
+
+
+
+Reynolds                                                       [Page 19]
+
+RFC 1099                  Summary of 1000-1099             December 1991
+
+
+1009     Braden         Jun 87     Requirements for Internet Gateways
+
+This RFC summarizes the requirements for gateways to be used between
+networks supporting the Internet protocols.  This document is a formal
+statement of the requirements to be met by gateways used in the Internet
+system.  As such, it is an official specification for the Internet
+community.
+
+
+1008     McCoy          Jun 87     Implementation Guide for the ISO
+                                   Transport Protocol
+
+This RFC is being distributed to members of the Internet community in
+order to solicit comments on the Implementors Guide.  While this
+document may not be directly relevant to the research problems of the
+Internet, it may be of some interest to a number of researchers and
+implementors.
+
+
+1007     McCoy          Jun 87     Military Supplement to the ISO
+                                   Transport Protocol
+
+This document supplements the Transport Service and Protocol of the
+International Standards Organization (ISO), IS 8072 and IS 8073,
+respectively, and their formal descriptions by providing conventions,
+option selections and parameter values.  This RFC is being distributed
+to members of the Internet community in order to solicit comments on the
+Draft Military Supplement.  While this document may not be directly
+relevant to the research problems of the Internet, it may be of some
+interest to a number of researchers and implementors.
+
+
+1006     Rose           May 87     ISO Transport Services on top of
+                                   the TCP Version: 3
+
+This memo specifies a standard for the Internet community.  Hosts on the
+Internet that choose to implement ISO transport services on top of the
+TCP are expected to adopt and implement this standard.  TCP port 102 is
+reserved for hosts which implement this standard.  This memo specifies
+version 3 of the protocol and supersedes RFC-983.  Changes between the
+protocol is described in RFC-983 and this memo are minor, but
+unfortunately incompatible.
+
+
+1005     Khanna         May 87     The ARPANET AHIP-E Host Access
+                                   Protocol (Enhanced AHIP)
+
+This RFC is a proposed specification for the encoding of Class A IP
+
+
+
+Reynolds                                                       [Page 20]
+
+RFC 1099                  Summary of 1000-1099             December 1991
+
+
+addresses for use on ARPANET-style networks such as the Milnet and
+Arpanet, and for enhancements to the ARPANET AHIP Host Access Protocol
+(AHIP; formerly known as 1822).  These enhancements increase the size of
+the PSN field, allow ARPANET hosts to use logical names to address each
+other, allow for the communication of type-of-service information from
+the host to the PSN and enable the PSN to provide congestion feedback to
+the host on a connection basis.
+
+
+1004     Mills          Apr 87     A Distributed-Protocol
+                                   Authentication Scheme
+
+The purpose of this RFC is to focus discussion on authentication
+problems in the Internet and possible methods of solution.  The proposed
+solutions this document are not intended as standards for the Internet
+at this time.  Rather, it is hoped that a general consensus will emerge
+as to the appropriate solution to authentication problems, leading
+eventually to the adoption of standards.  This document suggests
+mediated access-control and authentication procedures suitable for those
+cases when an association is to be set up between users belonging to
+different trust environments.
+
+
+1003     Katz           Mar 87     Issues in Defining an Equations
+                                   Representation Standard
+
+This memo is intended to identify and explore issues in defining a
+standard for the exchange of mathematical equations.  No attempt is made
+at a complete definition and more questions are asked than are answered.
+Questions about the user interface are only addressed to the extent that
+they affect interchange issues.
+
+
+1002    NETBIOS         Mar 87     Protocol Standard for A NetBIOS
+                                   Service on a TCP/UDP Transport:
+                                   Detailed Specifications
+
+This RFC defines a proposed standard protocol to support NetBIOS
+services in a TCP/IP environment.  Both local network and internet
+operation are supported.  Various node types are defined to accommodate
+local and internet topologies and to allow operation with or without the
+use of IP broadcast.  This RFC gives the detailed specifications of the
+netBIOS-over-TCP packets, protocols, and defined constants and
+variables.  A more general overview is found in a companion RFC,
+"Protocol Standard For NetBIOS Service on TCP/UDP Transport: Concepts
+and Methods".
+
+
+
+
+
+Reynolds                                                       [Page 21]
+
+RFC 1099                  Summary of 1000-1099             December 1991
+
+
+1001    NETBIOS         Mar 87     Protocol Standard for A NetBIOS
+                                   Service on a TCP/UDP Transport:
+                                   Concepts and Methods
+
+This RFC defines a proposed standard protocol to support NetBIOS
+services in a TCP/IP environment.  Both local network and internet
+operation are supported.  Various node types are defined to accommodate
+local and internet topologies and to allow operation with or without the
+use of IP broadcast.  This RFC describes the NetBIOS-over-TCP protocols
+in a general manner, emphasizing the underlying ideas and techniques.
+Detailed specifications are found in a companion RFC, "Protocol Standard
+For a NetBIOS Service on a TCP/UDP Transport: Detailed Specifications".
+
+
+1000    Reynolds        Aug 87     The Request for Comments Reference
+                                   Guide
+
+This RFC Reference Guide is intended to provide a historical account by
+categorizing and summarizing of the Request for Comments numbers 1
+through 999 issued between the years 1969-1987.  These documents have
+been crossed referenced to indicate which RFCs are current, obsolete, or
+revised.
+
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Author's Address
+
+   Joyce K. Reynolds
+   University of Southern California
+   Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone:  (310) 822-1511
+
+   EMail:  JKREY@ISI.EDU
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds                                                       [Page 22]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1099.txt](<www.ietf.org/rfc/rfc1099.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
