### PR TITLE
Archive rfc110.txt

### DIFF
--- a/www.ietf.org/rfc/rfc110.txt
+++ b/www.ietf.org/rfc/rfc110.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Network Working Group                                          J. Winett
+Request for Comments: 110                         MIT Lincoln Laboratory
+NIC: 5809                                                  25 March 1971
+
+    Conventions for Using an IBM 2741 Terminal as a User Console for
+                     Access to Network Server Hosts
+
+   Disclaimer
+
+   This material has not been reviewed for public release and is
+   intended only for use with the ARPA network.  It should not be quoted
+   or cited in any publication not related to the ARPA network.
+
+   TO: NIC
+   FROM: Joel M. Winnet (LL)
+   SUBJECT: Conventions for Using an IBM 2741 Terminal as a User
+   Console for Access to Network Server Hosts
+
+   An IBM terminal can be used to key in 92 different codes.  These
+   include 88 graphics plus the 4 controls SP, BS, HT, and NL.  Each of
+   these have defined ASCII codes except the cent graphic ([1]) and the
+   New Line Control (NL).  When the NL character is keyed, the program
+   receiving the keyboard input can translate this signal into the
+   appropriate line end signal for the host which is being used.  That
+   is, to a NL, CR, or LF code whichever is appropriate.  There are 7
+   other ASCII graphic characters ( {, }, [, ], ^, \, `) and 31 other
+   ASCII controls which cannot be keyed on a 2741 terminal.  A
+   convention must be established so that all 128 ASCII codes can be
+   keyed from a 2741 terminal.  This requires that one character be
+   chosen as an escape (or prefix) character which,a together with
+   following characters, can be converted into any desired ASCII code.
+   In addition to this escape character, there are three other functions
+   which are usually indicated by the typing of a single character key.
+   These are:
+
+      a) character delete -- to cause this character and the preceding
+         character in the input line to be deleted.
+
+      b) line delete -- to cause this character and all previous
+         characters in the current input line to be deleted.
+
+      c) logical line end -- to cause all characters keyed after the
+         last logical line end character or last NL character up to this
+         character to be considered as one logical line with this
+         character being treated as if the NL key were entered.
+         Characters following the logical line end character up to
+         another logical line end character or a NL character are used
+         for form another input line.
+
+
+
+Winett                                                          [Page 1]
+
+RFC 110            Conventions for Using an IBM 2741       25 March 1971
+
+
+   Since characters keyed are normally sent to the Server Host, a method
+   must be defined to allow characters keyed to be interpreted by the
+   user program.  A system escape character can be used for this
+   purpose.  On character at a time systems, the characters keyed
+   between two system escape characters can be interpreted by the user
+   program.  On line at a time systems, characters keyed after the
+   system escape character and up to and including a NL character can be
+   interpreted by the user program.  Lines interpreted by the user
+   program are not sent to the Server Host.
+
+   For those host systems which require use of the INS or INR network
+   control commands, a method must be defined for causing these commands
+   to be sent.  These can be sent on a command to the user program
+   either after keying the system escape character or through the use of
+   the 'attention' button on a 2741 terminal.  This choice will depend
+   on the characteristics of the terminal user's operating system.
+
+   Other commands to the user program might be to:
+
+      a) suppress typeout of received messages
+
+      b) restore typeout of received messages
+
+      c) direct received message to a disk file
+
+      d) direct keyed input to a disk file
+
+      e) abort the user program
+
+   The following characters are recommended for the special functions
+   listed above:
+
+      1. character escape $NOT [1]
+      2. system escape     |
+      3. character delete  @
+      4. line delete      $CENT [1]
+      5. logical linend    #
+
+   For the 7 ASCII graphics not on a 2741 terminal, the following
+   character escape and graphic pairs are recommended:
+
+      $NOT <           to translate to         [
+      $NOT >           to translate to         ]
+      $NOT (           to translate to         {
+      $NOT )           to translate to         }
+      $NOT "           to translate to         ^
+      $NOT /           to translate to         \
+      $NOT '           to translate to         `
+
+
+
+Winett                                                          [Page 2]
+
+RFC 110            Conventions for Using an IBM 2741       25 March 1971
+
+
+   To permit the special function characters to be keyed, the following
+   character escape and graphic pairs are recommended:
+
+      $NOT -           to translate to        $NOT
+      $NOT :           to translate to         |
+      $NOT ,           to translate to         @
+      $NOT .           to translate to        $CENT
+      $NOT =           to translate to         #
+
+   To key in the ASCII control codes, it is recommended that the
+   character escape followed by two letters be used to specify a control
+   code.  These two letters are derived from the mnemonic name of the
+   ASCII control function and are as follows:
+
+      $NOT AC          to translate to         ACK             X'06'
+      $NOT BE          to translate to         BEL             X'07'
+      $NOT BS          to translate to         BS              X'08'
+      $NOT CA          to translate to         CAN             X'18'
+      $NOT CR          to translate to         CR              X'0D'
+      $NOT D1          to translate to         DC1             X'11'
+      $NOT D2          to translate to         DC2             X'12'
+      $NOT D3          to translate to         DC3             X'13'
+      $NOT D4          to translate to         DC4             X'14'
+      $NOT DE          to translate to         DEL             X'7F'
+      $NOT DL          to translate to         DLE             X'10'
+      $NOT EM          to translate to         EM              X'19'
+      $NOT EN          to translate to         ENQ             X'05'
+      $NOT EO          to translate to         EOT             X'04'
+      $NOT ES          to translate to         ESC             X'1B'
+      $NOT EB          to translate to         ETB             X'17'
+      $NOT EX          to translate to         ETX             X'03'
+      $NOT FF          to translate to         FF              X'0C'
+      $NOT FS          to translate to         FS              X'1C'
+      $NOT GS          to translate to         GS              X'1D'
+      $NOT HT          to translate to         HT              X'09'
+      $NOT LF          to translate to         LF              X'0A'
+      $NOT NA          to translate to         NAK             X'15'
+      $NOT NU          to translate to         NUL             X'00'
+      $NOT RS          to translate to         RS              X'1E'
+      $NOT SI          to translate to         SI              X'0F'
+      $NOT SO          to translate to         SO              X'0E'
+      $NOT SH          to translate to         SOH             X'01'
+      $NOT SP          to translate to         SP              X'20'
+      $NOT ST          to translate to         STX             X'02'
+      $NOT SU          to translate to         SUB             X'1A'
+      $NOT SY          to translate to         SYN             X'16
+      $NOT US          to translate to         US              X'1F'
+      $NOT VT          to translate to         VT              X'0B'
+
+
+
+Winett                                                          [Page 3]
+
+RFC 110            Conventions for Using an IBM 2741       25 March 1971
+
+
+   Note that the controls SP, BS, and HT can be specified using the
+   character escape character or directly by keying the appropriate key
+   on a 2741 terminal.
+
+Endnote
+
+   [1] The following identifiers are substituted for graphics not in
+       ASCII:
+
+         $CENT   Cent sign
+         $NOT    Logical NOT ("bent bar")
+
+   See the PDF version of this document for graphics that cannot be
+   represented in ASCII format.
+
+
+          [This RFC was put into machine readable form for entry]
+          [into the online RFC archives by Lorrie Shiota, 10/02]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Winett                                                          [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc110.txt](<www.ietf.org/rfc/rfc110.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
