### PR TITLE
Archive rfc111.txt

### DIFF
--- a/www.ietf.org/rfc/rfc111.txt
+++ b/www.ietf.org/rfc/rfc111.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                           S. Crocker
+Request for Comments #111                       UCLA
+NIC #5815                                       31 March 71
+
+                       Pressure from the Chairman
+
+[Categories:  A.5;
+ RFC's obsoleted:  none;
+ RFC's updated:  107]
+
+It is time to set serious schedules for the implementation of NCP's  and
+Telnets.   To  facilitate  matters,  John  Heafner of Rand has agreed to
+monitor each site's progress and test its implementation.
+
+Network Liaison Contacts are hereby responsible for preparing a schedule
+for  implementation  and  informing  John.  Such a schedule must include
+dates of
+
+   (a)  implementation of an NCP according to the specifications
+        in Document #1 as modified by RFC #107;
+
+   (b)  implementation of a user-Telnet which enables local users to
+        login to foreign Hosts;
+
+   (c)  implementation of a server-Telnet which enables foreign users to
+        login on your Host;
+
+   (d)  documentation of the mechanism for connecting to and logging in
+        to your Host;
+
+   (e)  documentation of the mechanism for obtaining job numbers,
+        passwords, etc. to your Host;
+
+   (f)  documentation of the services available on your Host; and
+
+   (e) regular operation at advertised hours.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+
+RFC 111
+
+
+John is hereby responsible  for  prodding  Host  teams  to  prodcue  the
+requisite  schedule,  software  and  documentation;  for testing out the
+advertised  implementations;  and  for  probing  and  understanding  the
+reasons  for  unseemly  delays.   Concomitantly,  John  is now the right
+person  to  complain   to   about   ambiguities,   insufficiencies   and
+misunderstandings of the protocols.
+
+   Thank you for your cooperation.
+
+
+
+               Steve Crocker
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+         [ into the online RFC archives by Josh Elliott 1/98 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc111.txt](<www.ietf.org/rfc/rfc111.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
