### PR TITLE
Archive rfc112.txt

### DIFF
--- a/www.ietf.org/rfc/rfc112.txt
+++ b/www.ietf.org/rfc/rfc112.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                      T. O'Sullivan
+Request for Comments: 112                  Raytheon Data Systems Company
+NIC: 5816                                                  April 1, 1971
+
+          User/Server Site Protocol Network HOST Questionnaire
+                  (Reference RFC #106, NIC Note 5776)
+
+   Attached is a summary of the responses to the referenced
+   questionnaires.
+
+   The questions involving terminal support were of interest to members
+   of the User/Service Site Protocol Committee in its considerations of
+   TELNET.
+
+   The summary points out some of the key differences between line-at-
+   a-time and character-at-a-time (or both) in handling terminal
+   support, especially with respect to control characters.  The
+   information may prove useful as background information to TELNET
+   implementers.
+
+   If errors of interpretation of any sites' answer have occurred,
+   please advise me at the following address so that I may update the
+   chart.
+
+                                         Tom O'Sullivan
+                                         Raytheon Data Systems
+                                         1415 Boston-Providence Turnpike
+                                         Norwood, Massachusetts 02062
+
+   [chart: ARPA Network User Terminal Support.  Please view the PDF
+   version of this RFC.]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+O'Sullivan                                                      [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc112.txt](<www.ietf.org/rfc/rfc112.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
