### PR TITLE
Archive rfc1129.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1129.txt
+++ b/www.ietf.org/rfc/rfc1129.txt
@@ -1,0 +1,9 @@
+
+
+RFC 1129, "Internet Time Synchronization: The Network Time Protocol"
+
+is not available in ASCII format.  It is available in PostScript and
+PDF formats in the files: rfc1129.ps and rfc1129.pdf, respectively.
+
+
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1129.txt](<www.ietf.org/rfc/rfc1129.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
