### PR TITLE
Archive rfc1128.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1128.txt
+++ b/www.ietf.org/rfc/rfc1128.txt
@@ -1,0 +1,12 @@
+
+RFC-1128 "Measured Performance of the Network Time Protocol in the
+Internet System"
+
+is available only in PostScript form in the file
+
+RFC1128.PS
+
+To obtain this file via the NIC's automatic mail server SERVICE, use
+the Subject line: SEND RFC:RFCnnnn.PS (where nnnn is the number of
+the RFC you wish to obtain).
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1128.txt](<www.ietf.org/rfc/rfc1128.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
