### PR TITLE
Archive rfc1150.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1150.txt
+++ b/www.ietf.org/rfc/rfc1150.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Network Working Group                                          G. Malkin
+Request for Comments: 1150                                       Proteon
+FYI: 1                                                       J. Reynolds
+                                                                     ISI
+                                                              March 1990
+
+
+                            F.Y.I. on F.Y.I.
+
+                    Introduction to the F.Y.I. Notes
+
+Status of this Memo
+
+   This RFC is the first in a new sub-series of RFCs called FYIs (For
+   Your Information).  This memo provides information for the Internet
+   community.  It does not specify any standard.  Distribution of this
+   memo is unlimited.
+
+1.  Introduction
+
+   The FYI series of notes is designed to provide Internet users with a
+   central repository of information about any topics which relate to
+   the Internet.  FYIs topics may range from historical memos on "Why it
+   was was done this way" to answers to commonly asked operational
+   questions.
+
+   The FYIs are intended for a wide audience.  Some FYIs will cater to
+   beginners, while others will discuss more advanced topics.  An FYI
+   may be submitted by anyone who has something to contribute and has
+   the time to do so.
+
+2.  Why RFCs
+
+   There are several reasons why the FYIs are part of the larger RFC
+   series of notes.  The formost reason is that the distribution
+   mechanisms for RFCs are tried and true.  Anyone who can get an RFC,
+   can automatically get an FYI.  More importantly, anyone who knows of
+   the RFC series, can easily find out about the FYIs.
+
+   Another reason for making FYIs part of the RFC series is that the
+   maintainance mechanisms for RFCs are already in place and funded.  It
+   makes sense to maintain similar documents is a similar way.  After
+   all, there have been informational RFCs before.
+
+   Finally, the name RFC has come to carry a meaning with it.  There is
+   credibility associated memos carrying the RFC label.  FYIs should
+   share that respect.
+
+
+
+
+Malkin & Reynolds                                               [Page 1]
+
+RFC 1150                    F.Y.I. on F.Y.I.                  March 1990
+
+
+3.  Format Rules
+
+   Since the FYIs are a part of the RFC series, they must conform to
+   RFC-1111 (Request for Comments on Request for Comments: Instructions
+   to RFC Authors) with respect to format.  Ideally, they should be
+   submitted in ASCII format, as described by section 2a, of RFC-1111.
+
+4.  Status Statement
+
+   Each RFC must include on its first page the "Status of this Memo"
+   section which contains a paragraph describing the intention of the
+   RFC.  This section is meant to convey the status granted by the RFC
+   Editor and the Internet Activities Board (IAB).  There are several
+   reasons for publishing a memo as an RFC, for example, to make
+   available some information for interested people, or to begin or
+   continue a discussion of an interesting idea, or to make available
+   the specification of a protocol.
+
+   For example:
+
+   This RFC is the first in a new sub-series of RFCs called FYIs (For
+   Your Information).  This memo provides information for the Internet
+   community.  It does not specify any standard.  Distribution of this
+   memo is unlimited.
+
+5.  Distribution Statement
+
+   Each FYI is to also include a "distribution statement".  As the
+   purpose of the FYI series is to disseminate information, there is no
+   reason for the distribution to be anything other than "unlimited".
+
+   Typically, the distribution statement will simply be the sentence
+   "Distribution of this memo is unlimited." appended to the "Status of
+   this Memo" section.
+
+6. Security Considerations
+
+   All FYIs must contain a section that discusses the security
+   considerations of the procedures that are the main topic of the RFC.
+
+7.  Author's Address
+
+   Each FYI must have at the very end a section giving the author's
+   address, including the name and postal address, the telephone number,
+   and the Internet email address.
+
+
+
+
+
+
+Malkin & Reynolds                                               [Page 2]
+
+RFC 1150                    F.Y.I. on F.Y.I.                  March 1990
+
+
+8.  Relation to other FYIs
+
+   Sometimes an FYI adds information on a topic discussed in a previous
+   FYI or completely replaces an earlier FYI.  There are two terms used
+   for these cases respectively, UPDATES and OBSOLETES.  A document that
+   obsoletes an earlier document can stand on its own.  A document that
+   merely updates an earlier document cannot stand on its own; it is
+   something that must be added to or inserted into the existing
+   document, and has limited usefulness independently.
+
+   UPDATES
+
+      To be used as a reference from a new item that cannot be used
+      alone (i.e., one that supplements a previous document), to refer
+      to the previous document.  The newer publication is a part that
+      will supplement or be added on to the existing document; e.g., an
+      addendum, or separate, extra information that is to be added to
+      the original document.
+
+   OBSOLETES
+
+      To be used to refer to an earlier document that is replaced by
+      this document.  This document contains either revised information,
+      or else all of the same information plus some new information,
+      however extensive or brief that new information is; i.e., this
+      document can be used alone, without reference to the older
+      document.
+
+   OBSOLETED-BY
+
+      To be used to refer to the newer document that replaces the older
+      document.
+
+   UPDATED-BY
+
+      To be used to refer to the newer document that adds information to
+      the existing, still useful, document.
+
+9. The FYI Editors
+
+   All FYIs are submitted to the IETF User Services Working Group for
+   review prior to their submission to the RFC Editor.
+
+   Submissions may be made to:
+
+
+
+
+
+
+
+Malkin & Reynolds                                               [Page 3]
+
+RFC 1150                    F.Y.I. on F.Y.I.                  March 1990
+
+
+         Joyce K. Reynolds
+         Chair, User Services Working Group
+         USC - Information Sciences Institute
+         4676 Admiralty Way
+         Marina del Rey, California  90292-6695
+
+         Phone: (213) 822-1511
+
+         Electronic mail: JKREY@ISI.EDU
+
+10.  The FYI Announcement List
+
+   New FYIs are announced to the RFC distribution list maintained by the
+   SRI Network Information Center (NIC).  Contact the SRI-NIC to be
+   added or deleted from this mailing list by sending an email message
+   to RFC-REQUEST@NIC.DDN.MIL.
+
+11.  Obtaining FYIs
+
+   FYIs can be obtained via FTP from NIC.DDN.MIL, with the pathname
+   FYI:mm.TXT, or RFC:RFCnnnn.TXT (where "mm" refers to the number of
+   the FYI and "nnnn" refers to the number of the RFC).  Login with FTP,
+   username ANONYMOUS and password GUEST.  The NIC also provides an
+   automatic mail service for those sites which cannot use FTP.  Address
+   the request to SERVICE@NIC.DDN.MIL and in the subject field of the
+   message indicate the FYI or RFC number, as in "Subject: FYI mm" or
+   "Subject: RFC nnnn".
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Authors' Addresses
+
+   Gary Scott Malkin
+   Proteon, Inc.
+   2 Technology Drive
+   Westborough, MA  01581-5008
+   Phone:  (508) 898-2800
+   EMail:  gmalkin@proteon.com
+
+   Joyce K. Reynolds
+   USC/Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA  90292-6695
+   Phone:  (213) 822-1511
+   EMail:  jkrey@isi.edu
+
+
+
+
+Malkin & Reynolds                                               [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1150.txt](<www.ietf.org/rfc/rfc1150.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
