### PR TITLE
Archive rfc1153.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1153.txt
+++ b/www.ietf.org/rfc/rfc1153.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Network Working Group                                          F. Wancho
+Request for Comments: 1153                                          WSMR
+                                                              April 1990
+
+
+                         Digest Message Format
+
+Status of this Memo
+
+   This memo describes the de facto standard Digest Message Format.
+   This is an elective experimental protocol.  Distribution of this memo
+   is unlimited.
+
+Background
+
+   High traffic volume large mailing lists began to appear on the net in
+   the mid-70s.  The moderators of those lists developed a digest
+   message format to enclose several messages into one composite message
+   for redistribution to the mailing list addressees.  This format
+   reduces the mailer load in proportion to the number of messages
+   contained within a digest message, and conserves network bandwidth by
+   reducing the size of the headers of the enclosed messages.
+
+   This RFC documents the digest message format so that others may
+   follow this format in creating (digestifying) and separating
+   (undigestifying) digest messages to maintain compatibility with the
+   programs expecting this de facto standard.  Any editorial functions
+   performed at the discretion of a digest moderator, such as discarding
+   submissions, editing content to correct spelling and punctuation
+   errors, inserting comments, and reformatting paragraphs to conform to
+   width conventions are beyond the scope of this memo.
+
+   This memo describes the de facto standard Digest Message Format.  It
+   is not meant to supersede nor replace the generic message
+   encapsulation format described in RFC 934.  It merely documents a
+   particular message encapsulation format that existed well before RFC
+   934 was published and continues to be the format of choice for digest
+   messages.
+
+Description
+
+   A digest message is a conventional message consisting of a header and
+   body conforming to RFC 822 as clarified in RFC 1123.  There is no
+   fixed size.  Limitations may exist in intermediate mail gateways
+   which restrict the size.  The typical digest size is 15,000
+   characters.
+
+   The header of a digest message should identify the digest in the
+
+
+
+Wancho                                                          [Page 1]
+
+RFC 1153                 Digest Message Format                April 1990
+
+
+   Subject line by listname, the key word, Digest, the volume number
+   (usually a sequential number either starting at 1 or the last two
+   digits of the year and incremented by one starting with the first
+   issue of the next calendar year), and an issue number starting at one
+   for the first issue of a new calendar year.
+
+   The body of a digest message must consist of a Preamble, one or more
+   enclosed messages, and a Trailer.
+
+   The Preamble usually contains a table of contents consisting of the
+   subject line contents of the enclosed messages, usually indented or
+   centered, and also may contain brief administrative or other
+   announcements.
+
+   The Preamble must be separated from the remainder of the message by a
+   line of 70 hyphens followed by a blank line.
+
+   Each enclosed message is a conventional message consisting of a
+   header and body, separated by a blank line.  If they exist in the
+   original message header, the following lines must be retained as-is
+   in the reconstructed header: Date:, From:, To:, Cc:, Subject:,
+   Message-ID:, and Keywords:, rearranged to appear in that order.
+   Retaining the Summary: line is optional.  Lines include continuation
+   lines as defined in the RFCs.  All other header lines should be
+   discarded, especially Received lines.  All leading and trailing blank
+   lines should be removed from the message body.  The message body may
+   be scanned to replace with a blank the first character of any lines
+   of exactly and only 30 hyphens.
+
+   Each enclosed message must be separated from the the remainder of the
+   digest message by a blank line before and after a line of 30 hyphens.
+
+   The Trailer immediately follows the blank line of message separator
+   following the last enclosed message.  The Trailer consists of two
+   lines.  The first line must begin with the words, End of, followed by
+   the listname a blank and the word Digest which is usually followed by
+   volume and issue number on the same line.  The second and last line
+   of the Trailer and the entire message is a line of asterisks serving
+   to underline the line immediately above it.
+
+Example
+
+   The following example serves as a template for a digest message
+   conforming to this memo.  It contains a header, and a body consisting
+   of a Preamble, two enclosed messages, and a Trailer.  fqhn means
+   Fully Qualified Host Name.  The Date: lines are examples only.
+
+
+
+
+
+Wancho                                                          [Page 2]
+
+RFC 1153                 Digest Message Format                April 1990
+
+
+Date: ddd, dd mmm yy hh:mm:ss zzz
+From: listname-REQUEST@fqhn
+Reply-To: listname@fqhn
+Subject: listname Digest Vyy #nn
+To: listname@fqhn
+
+listname Digest             ddd, dd mmm yy       Volume yy : Issue   nn
+
+Today's Topics:
+                          Message One Subject
+                          Message Two Subject
+
+Administrivia:
+
+Messages from the list moderator or maintainer go here.
+
+----------------------------------------------------------------------
+
+Date: ddd, dd mmm yy hh:mm:ss zzz
+From: Joe User <username@fqhn>
+Subject: Message One Subject
+
+This is the message body of the first message.
+
+Joe
+
+------------------------------
+
+Date: ddd, dd mmm yy hh:mm:ss zzz
+From: Jane User <username@fqhn>
+Subject: Message Two Subject
+
+This is the body of message two.
+
+Jane
+
+------------------------------
+
+End of listname Digest Vyy Issue #nn
+************************************
+
+
+
+
+
+
+
+
+
+
+
+Wancho                                                          [Page 3]
+
+RFC 1153                 Digest Message Format                April 1990
+
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Author's Address
+
+   Frank J. Wancho
+   USAISC-White Sands
+   ASQNC-TWS-SS-C (F. Wancho, Building 1512)
+   White Sands Missile Range, NM 88002-5506
+
+   Phone: (505) 678-3009
+
+   Email: WANCHO@WSMR-SIMTEL20.ARMY.MIL
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Wancho                                                          [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1153.txt](<www.ietf.org/rfc/rfc1153.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
