### PR TITLE
Archive rfc116.txt

### DIFF
--- a/www.ietf.org/rfc/rfc116.txt
+++ b/www.ietf.org/rfc/rfc116.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                   S. Crocker
+Request for Comments #116                               12 April 71
+NIC #5825                                               UCLA
+Categories: A.2
+Obsoletes: None
+Updates: 99
+
+                     STRUCTURE OF THE MAY NWG MTG.
+
+In order to use our time in Atlantic City more effectively, I would
+like to organize the meetings around discussions of advertised topics,
+with published status reports and position papers.  I envision our
+time being divided into three phases.
+
+Phase one is for status reports from each of the sites and for the
+introductions of new sites or agencies.  Each existing site should
+plan to report on its state of software and hardware development, and
+on its use of the network.  New sites will introduce themselves and
+present their plans for attachment to and use of the network.  In
+addition, work on the ILLIAC IV, the List machine, and the terminal
+IMP will be reviewed.  I will assume that each site needs 5-10 minutes
+unless I am notified otherwise.  A short written status report is also
+explected.
+
+Phase two is for discussion of current network-wide topics such as the
+NIC, the Form Machine Telnet, and Logger Protocol.  Suggestions for
+these topics should be made to me.  Committees should plan to prepare
+these reports and discuss their work.  Points of view not represented
+by existing committees should be explicated in position papers.
+
+Phase three is consideration of new topcs.  Som eof the topics I have
+in mind are what the long range goals of the NWG should be, what
+operational goals the NWG should set for the next six months, and
+neither the NWG should have more or less structure.  Suggestions for
+new topics are particularly encouraged, and these are best opened up
+with an introductory position paper.
+
+A major factor in the effiectiveness of this meeting will be the
+written material available before the meeting.  As far as possible,
+reports and position papers should be published in RFC form by 1 May 71.
+
+The agenda will be composed from suggestions made to me; please call
+me at (213) 825-2368.  I will publish an agenda and schedule of
+meetings about 1 May.
+
+       [ This RFC was put into machine readable form for entry ]
+         [ into the online RFC archives by Josh Elliott 1/98 ]
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc116.txt](<www.ietf.org/rfc/rfc116.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
