### PR TITLE
Archive rfc1160.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1160.txt
+++ b/www.ietf.org/rfc/rfc1160.txt
@@ -1,0 +1,619 @@
+
+
+
+
+
+
+Network Working Group                                            V. Cerf
+Request for Comments:  1160                                          NRI
+Obsoletes: RFC 1120                                             May 1990
+
+
+                     The Internet Activities Board
+
+Status of this Memo
+
+   This RFC provides a history and description of the Internet
+   Activities Board (IAB) and its subsidiary organizations.  This memo
+   is for informational use and does not constitute a standard.  This is
+   a revision of RFC 1120.  Distribution of this memo is unlimited.
+
+1. Introduction
+
+   In 1968, the U.S. Defense Advanced Research Projects Agency (DARPA)
+   initiated an effort to develop a technology which is now known as
+   packet switching.  This technology had its roots in message switching
+   methods, but was strongly influenced by the development of low-cost
+   minicomputers and digital telecommunications techniques during the
+   mid-1960's [BARAN 64, ROBERTS 70, HEART 70, ROBERTS 78].  A very
+   useful survey of this technology can be found in [IEEE 78].
+
+   During the early 1970's, DARPA initiated a number of programs to
+   explore the use of packet switching methods in alternative media
+   including mobile radio, satellite and cable [IEEE 78].  Concurrently,
+   Xerox Palo Alto Research Center (PARC) began an exploration of packet
+   switching on coaxial cable which ultimately led to the development of
+   Ethernet local area networks [METCALFE 76].
+
+   The successful implementation of packet radio and packet satellite
+   technology raised the question of interconnecting ARPANET with other
+   types of packet nets.  A possible solution to this problem was
+   proposed by Cerf and Kahn [CERF 74] in the form of an internetwork
+   protocol and a set of gateways to connect the different networks.
+   This solution was further developed as part of a research program in
+   internetting sponsored by DARPA and resulted in a collection of
+   computer communications protocols based on the original Transmission
+   Control Protocol (TCP) and its lower level counterpart, Internet
+   Protocol (IP).  Together, these protocols, along with many others
+   developed during the course of the research, are referred to as the
+   TCP/IP Protocol Suite [RFC 1140, LEINER 85, POSTEL 85, CERF 82, CLARK
+   86].
+
+   In the early stages of the Internet research program, only a few
+   researchers worked to develop and test versions of the internet
+   protocols.  Over time, the size of this activity increased until, in
+
+
+
+Cerf                                                           [Page 1]
+
+RFC 1160                        The IAB                        May 1990
+
+
+   1979, it was necessary to form an informal committee to guide the
+   technical evolution of the protocol suite.  This group was called the
+   Internet Configuration Control Board (ICCB) and was established by
+   Dr. Vinton Cerf who was then the DARPA program manager for the
+   effort. Dr. David C. Clark of the Laboratory for Computer Science at
+   Massachusetts Institute of Technology was named the chairman of this
+   committee.
+
+   In January, 1983, the Defense Communications Agency, then responsible
+   for the operation of the ARPANET, declared the TCP/IP protocol suite
+   to be standard for the ARPANET and all systems on the network
+   converted from the earlier Network Control Program (NCP) to TCP/IP.
+   Late that year, the ICCB was reorganized by Dr. Barry Leiner, Cerf's
+   successor at DARPA, around a series of task forces considering
+   different technical aspects of internetting.  The re-organized group
+   was named the Internet Activities Board.
+
+   As the Internet expanded, it drew support from U.S. Government
+   organizations including DARPA, the National Science Foundation (NSF),
+   the Department of Energy (DOE) and the National Aeronautics and Space
+   Administration (NASA).  Key managers in these organizations,
+   responsible for computer networking research and development, formed
+   an informal Federal Research Internet Coordinating Committee (FRICC)
+   to coordinate U.S. Government support for and development and use of
+   the Internet system.  The FRICC sponsored most of the U.S. research
+   on internetting, including support for the Internet Activities Board
+   and its subsidiary organizations.
+
+   In 1990, the FRICC was reorganized as part of a larger initiative
+   sponsored by the networking subcommittee of the Federal Coordinating
+   Committee on Science, Engineering and Technology (FCCSET).  The
+   reorganization created the Federal Networking Council (FNC) and its
+   Working Groups.  The membership of the FNC included all the former
+   FRICC members and many other U.S. Government representatives.  The
+   first chairman of the FNC is Dr. Charles Brownstein of the National
+   Science Foundation.  The FNC is the Federal Government's body for
+   coordinating the agencies that support the Internet.  It provides
+   liaison to the Office of Science and Technology Policy (headed by the
+   President's Science Advisor) which is responsible for setting science
+   and technology policy affecting the Internet.  It endorses and
+   employs the existing planning and operational activities of the
+   community-based bodies that have grown up to manage the Internet in
+   the United States.  The FNC plans to involve user and supplier
+   communities through creation of an external advisory board and will
+   coordinate Internet activities with other Federal initiatives ranging
+   from the Human Genome and Global Change programs to educational
+   applications.  The FNC has also participated in planning for the
+   creation of a National Research and Education Network in the United
+
+
+
+Cerf                                                           [Page 2]
+
+RFC 1160                        The IAB                        May 1990
+
+
+   States.
+
+   At the international level, a Coordinating Committee for
+   Intercontinental Research Networks (CCIRN) has been formed which
+   includes the U.S. FNC and its counterparts in North America and
+   Europe.  Co-chaired by the executive directors of the FNC and the
+   European Association of Research Networks (RARE), the CCIRN provides
+   a forum for cooperative planning among the principal North American
+   and European research networking bodies.
+
+2. Internet Activities Board
+
+   The Internet Activities Board (IAB) is the coordinating committee for
+   Internet design, engineering and management.  The Internet is a
+   collection of over two thousand of packet switched networks located
+   principally in the U.S., but also in many other parts of the world,
+   all interlinked and operating using the protocols of the TCP/IP
+   protocol suite.  The IAB is an independent committee of researchers
+   and professionals with a technical interest in the health and
+   evolution of the Internet system.  Membership changes with time to
+   adjust to the current realities of the research interests of the
+   participants, the needs of the Internet system and the concerns of
+   constituent members of the Internet.
+
+   IAB members are deeply committed to making the Internet function
+   effectively and evolve to meet a large scale, high speed future.  New
+   members are appointed by the chairman of the IAB, with the advice and
+   consent of the remaining members.  The chairman serves a term of two
+   years and is elected by the members of the IAB.  The IAB focuses on
+   the TCP/IP protocol suite, and extensions to the Internet system to
+   support multiple protocol suites.
+
+   The IAB has two principal subsidiary task forces:
+
+      1)  Internet Engineering Task Force (IETF)
+
+      2)  Internet Research Task Force (IRTF)
+
+   Each of these Task Forces is led by a chairman and guided by a
+   Steering Group which reports to the IAB through its chairman.  Each
+   task force is organized, by the chairman, as required, to carry out
+   its charter.  For the most part, a collection of Working Groups
+   carries out the work program of each Task Force.
+
+   All decisions of the IAB are made public.  The principal vehicle by
+   which IAB decisions are propagated to the parties interested in the
+   Internet and its TCP/IP protocol suite is the Request for Comment
+   (RFC) note series.  The archival RFC series was initiated in 1969 by
+
+
+
+Cerf                                                           [Page 3]
+
+RFC 1160                        The IAB                        May 1990
+
+
+   Dr. Stephen D. Crocker as a means of documenting the development of
+   the original ARPANET protocol suite [RFC 1000].  The editor-in-chief
+   of this series, Dr. Jonathan B. Postel, has maintained the quality of
+   and managed the archiving of this series since its inception.  A
+   small proportion of the RFCs document Internet standards.  Most of
+   them are intended to stimulate comment and discussion.  The small
+   number which document standards are especially marked in a "status"
+   section to indicate the special status of the document.  An RFC
+   summarizing the status of all standard RFCs is published regularly
+   [RFC 1140].
+
+   RFCs describing experimental protocols, along with other submissions
+   whose intent is merely to inform, are typically submitted directly to
+   the RFC editor.  A Standard Protocol starts out as a Proposed
+   Standard and may be promoted to Draft Standard and finally Standard
+   after suitable review, comment, implementation and testing.
+
+   Prior to publication of a Proposed Standard RFC, it is made available
+   for comment through an on-line Internet-Draft directory.  Typically,
+   these Internet-Drafts are working documents of the IAB or of the
+   working groups of the Internet Engineering and Research Task Forces.
+   Internet-Drafts are either submitted to the RFC editor for
+   publication or discarded within 3-6 months.  Prior to promotion to
+   Draft Standard or Standard, an Internet-Draft publication and review
+   cycle may be initiated if significant changes to the RFC are
+   contemplated.
+
+   The IAB performs the following functions:
+
+      1)   Sets Internet Standards,
+
+      2)   Manages the RFC publication process,
+
+      3)   Reviews the operation of the IETF and IRTF,
+
+      4)   Performs strategic planning for the Internet, identifying
+           long-range problems and opportunities,
+
+      5)   Acts as an international technical policy liaison and
+           representative for the Internet community, and
+
+      6)   Resolves technical issues which cannot be treated within
+           the IETF or IRTF frameworks.
+
+   To supplement its work via electronic mail, the IAB meets quarterly
+   to review the condition of the Internet, to review and approve
+   proposed changes or additions to the TCP/IP suite of protocols, to
+   set technical development priorities, to discuss policy matters which
+
+
+
+Cerf                                                           [Page 4]
+
+RFC 1160                        The IAB                        May 1990
+
+
+   may need the attention of the Internet sponsors, and to agree on the
+   addition or retirement of IAB members and on the addition or
+   retirement of task forces reporting to the IAB.  Typically, two of
+   the quarterly meetings are by means of video teleconferencing
+   (provided, when possible, through the experimental Internet packet
+   video-conferencing system).  The minutes of the IAB meetings are
+   published in the Internet Monthly on-line report.
+
+   The IAB membership is currently as follows:
+
+            Vinton Cerf/CNRI              Chairman
+            Robert Braden/USC-ISI         Executive Director
+            David Clark/MIT-LCS           IRTF Chairman
+            Phillip Gross/CNRI            IETF Chairman
+            Jonathan Postel/USC-ISI       RFC Editor
+            Hans-Werner Braun/Merit       Member
+            Lyman Chapin/DG               Member
+            Stephen Kent/BBN              Member
+            Anthony Lauck/Digital         Member
+            Barry Leiner/RIACS            Member
+            Daniel Lynch/Interop, Inc.    Member
+
+3.  The Internet Engineering Task Force
+
+   The Internet has grown to encompass a large number of widely
+   geographically dispersed networks in academic and research
+   communities.  It now provides an infrastructure for a broad community
+   with various interests.  Moreover, the family of Internet protocols
+   and system components has moved from experimental to commercial
+   development.  To help coordinate the operation, management and
+   evolution of the Internet, the IAB established the Internet
+   Engineering Task Force (IETF).  The IETF is chaired by Mr. Phillip
+   Gross and managed by its Internet Engineering Steering Group (IESG).
+   The IAB has delegated to the IESG the general responsibility for
+   making the Internet work and for the resolution of all short- and
+   mid-range protocol and architectural issues required to make the
+   Internet function effectively.
+
+   The charter of the IETF includes:
+
+      1) Responsibility for specifying the short and mid-term
+         Internet protocols and architecture and recommending
+         standards for IAB approval.
+
+      2) Provision of a forum for the exchange of information within
+         the Internet community.
+
+      3) Identification of pressing and relevant short- to mid-range
+
+
+
+Cerf                                                           [Page 5]
+
+RFC 1160                        The IAB                        May 1990
+
+
+         operational and technical problem areas and convening of
+         Working Groups to explore solutions.
+
+   The Internet Engineering Task Force is a large open community of
+   network designers, operators, vendors, and researchers concerned with
+   the Internet and the Internet protocol suite.  It is organized around
+   a set of eight technical areas, each managed by a technical area
+   director.  In addition to the IETF Chairman, the area directors make
+   up the IESG membership.  Each area director has primary
+   responsibility for one area of Internet engineering activity, and
+   hence for a subset of the IETF Working Groups.  The area directors
+   have jobs of critical importance and difficulty and are selected not
+   only for their technical expertise but also for their managerial
+   skills and judgment.  At present, the eight technical areas and
+   chairs are:
+
+            1) Applications             -  Russ Hobby/UC-Davis
+            2) Host and User Services   -  Craig Partridge/BBN
+            3) Internet Services        -  Noel Chiappa/Consultant
+            4) Routing                  -  Robert Hinden/BBN
+            5) Network Management       -  David Crocker/DEC
+            6) OSI Integration          -  Ross Callon/DEC and
+                                           Robert Hagens/UWisc.
+            7) Operations               -  Phill Gross/CNRI (Acting)
+            8) Security                 -  Steve Crocker/TIS
+
+   The work of the IETF is performed by subcommittees known as Working
+   Groups.  There are currently more than 40 of these.  Working Groups
+   tend to have a narrow focus and a lifetime bounded by completion of a
+   specific task, although there are exceptions.  The IETF is a major
+   source of proposed protocol standards, for final approval by the IAB.
+   The IETF meets quarterly and extensive minutes of the plenary
+   proceedings as well as reports from each of the working groups are
+   issued by the IAB Secretariat at the Corporation for National
+   Research Initiatives.
+
+4.  The Internet Research Task Force
+
+   To promote research in networking and the development of new
+   technology, the IAB established the Internet Research Task Force
+   (IRTF).
+
+   In the area of network protocols, the distinction between research
+   and engineering is not always clear, so there will sometimes be
+   overlap between activities of the IETF and the IRTF.  There is, in
+   fact, considerable overlap in membership between the two groups.
+   This overlap is regarded as vital for cross-fertilization and
+   technology transfer.  In general, the distinction between research
+
+
+
+Cerf                                                           [Page 6]
+
+RFC 1160                        The IAB                        May 1990
+
+
+   and engineering is one of viewpoint and sometimes (but not always)
+   time-frame.  The IRTF is generally more concerned with understanding
+   than with products or standard protocols, although specific
+   experimental protocols may have to be developed, implemented and
+   tested in order to gain understanding.
+
+   The IRTF is a community of network researchers, generally with an
+   Internet focus.  The work of the IRTF is governed by its Internet
+   Research Steering Group (IRSG).  The chairman of the IRTF and IRSG is
+   David Clark.  The IRTF is organized into a number of Research Groups
+   (RGs) whose chairs of these are appointed by the chairman of the
+   IRSG. The RG chairs and others selected by the IRSG chairman serve on
+   the IRSG.  These groups typically have 10 to 20 members, and each
+   covers a broad area of research, pursuing specific topics, determined
+   at least in part by the interests of the members and by
+   recommendations of the IAB.
+
+   The current members of the IRSG are as follows:
+
+            David Clark/MIT LCS     -   Chairman
+            Robert Braden/USC-ISI   -   End-to-End Services
+            Douglas Comer/PURDUE    -   Member-at-Large
+            Deborah Estrin/USC      -   Autonomous Networks
+            Stephen Kent/BBN        -   Privacy and Security
+            Keith Lantz/Consultant  -   Collaboration Technology
+            David Mills/UDEL        -   Member-at-Large
+
+5.  The Near-term Agenda of the IAB
+
+   There are seven principal foci of IAB attention for the period 1989 -
+   1990:
+
+      1) Operational Stability
+      2) User Services
+      3) OSI Coexistence
+      4) Testbed Facilities
+      5) Security
+      6) Getting Big
+      7) Getting Fast
+
+   Operational stability of the Internet is a critical concern for all
+   of its users.  Better tools are needed for gathering operational
+   data, to assist in fault isolation at all levels and to analyze the
+   performance of the system.  Opportunities abound for increased
+   cooperation among the operators of the various Internet components
+   [RFC 1109].  Specific, known problems should be dealt with, such as
+   implementation deficiencies in some versions of the BIND domain name
+   service resolver software.  To the extent that the existing Exterior
+
+
+
+Cerf                                                           [Page 7]
+
+RFC 1160                        The IAB                        May 1990
+
+
+   Gateway Protocol (EGP) is only able to support limited topologies,
+   constraints on topological linkages and allowed transit paths should
+   be enforced until a more general Inter-Autonomous System routing
+   protocol can be specified.  Flexiblity for Internet implementation
+   would be enhanced by the adoption of a common internal gateway
+   routing protocol by all vendors of internet routers.  A major effort
+   is recommended to achieve conformance to the Host Requirements RFCs
+   which were published in the fourth quarter of calendar 1989.
+
+   Among the most needed user services, the White Pages (electronic
+   mailbox directory service) seems the most pressing.  Efforts should
+   be focused on widespread deployment of these capabilities in the
+   Internet by mid-1990.  The IAB recommends that existing white pages
+   facilities and newer ones, such as X.500, be populated with up-to-
+   date user information and made accessible to Internet users and users
+   of other systems (e.g., commercial email carriers) linked to the
+   Internet. Connectivity with commercial electronic mail carriers
+   should be vigorously pursued, as well as links to other network
+   research communities in Europe and the rest of the world.
+
+   Development and deployment of privacy-enhanced electronic mail
+   software should be accelerated in 1990 after release of public domain
+   software implementing the private electronic mail standards [RFC
+   1113, RFC 1114 and RFC 1115].  Finally, support for new or enhanced
+   applications such as computer-based conferencing, multi-media
+   messaging and collaboration support systems should be developed.
+
+   The National Network Testbed (NNT) resources planned by the FRICC
+   should be applied to support conferencing and collaboration protocol
+   development and application experiments and to support multi-vendor
+   router interoperability testing (e.g., interior and exterior routing,
+   network management, multi-protocol routing and forwarding).
+
+   With respect to growth in the Internet, architectural attention
+   should be focused on scaling the system to hundreds of millions of
+   users and hundreds of thousands of networks.  The naming, addressing,
+   routing and navigation problems occasioned by such growth should be
+   analyzed.  Similarly, research should be carried out on analyzing the
+   limits to the existing Internet architecture, including the ability
+   of the present protocol suite to cope with speeds in the gigabit
+   range and latencies varying from microseconds to seconds in duration.
+
+   The Internet should be positioned to support the use of OSI protocols
+   by the end of 1990 or sooner, if possible.  Provision for multi-
+   protocol routing and forwarding among diverse vendor routes is one
+   important goal.  Introduction of X.400 electronic mail services and
+   interoperation with RFC 822/SMTP [RFC 822, RFC 821, RFC 987, RFC
+   1026, and RFC 1148] should be targeted for 1990 as well.  These
+
+
+
+Cerf                                                           [Page 8]
+
+RFC 1160                        The IAB                        May 1990
+
+
+   efforts will need to work in conjunction with the White Pages
+   services mentioned above.  The IETF, in particular, should establish
+   liaison with various OSI working groups (e.g., at NIST, RARE, Network
+   Management Forum) to coordinate planning for OSI introduction into
+   the Internet and to facilitate registration of information pertinent
+   to the Internet with the various authorities responsible for OSI
+   standards in the United States.
+
+   Finally, with respect to security, a concerted effort should be made
+   to develop guidance and documentation for Internet host managers
+   concerning configuration management, known security problems (and
+   their solutions) and software and technologies available to provide
+   enhanced security and privacy to the users of the Internet.
+
+REFERENCES
+
+       [BARAN 64]  Baran, P., et al, "On Distributed Communications",
+       Volumes I-XI, RAND Corporation Research Documents, August 1964.
+
+       [CERF 74]  Cerf V., and R. Kahn, "A Protocol for Packet Network
+       Interconnection", IEEE Trans. on Communications, Vol. COM-22,
+       No. 5, pp. 637-648, May 1974.
+
+       [CERF 82]  Cerf V., and E. Cain, "The DoD Internet Protocol
+       Architecture", Proceedings of the SHAPE Technology Center
+       Symposium on Interoperability of Automated Data Systems,
+       November 1982.  Also in Computer Networks and ISDN,
+       Vol. 17, No. 5, October 1983.
+
+       [CLARK 86]  Clark, D., "The Design Philosophy of the DARPA
+       Internet protocols", Proceedings of the SIGCOMM '88 Symposium,
+       Computer Communications Review, Vol. 18, No. 4, pp. 106-114,
+       August 1988.
+
+       [HEART 70]  Heart, F., Kahn, R., Ornstein, S., Crowther, W.,
+       and D. Walden, "The Interface Message Processor for the ARPA
+       Computer Network", AFIPS Conf. Proc. 36, pp. 551-567,
+       June 1970.
+
+       [IEEE 78]  Kahn, R. (Guest Editor), Uncapher, K. and
+       H. Van Trees (Associate Guest Editors), Proceedings of the
+       IEEE, Special Issue on Packet Communication Networks,
+       Volume 66, No. 11, pp. 1303-1576, November 1978.
+
+       [IEEE 87]  Leiner, B. (Guest Editor), Nielson, D., and
+       F. Tobagi (Associate Guest Editors), Proceedings of the
+       IEEE, Special Issue on Packet Radio Networks, Volume 75,
+       No. 1, pp. 1-272, January 1987.
+
+
+
+Cerf                                                           [Page 9]
+
+RFC 1160                        The IAB                        May 1990
+
+
+
+       [LEINER 85]  Leiner, B., Cole, R., Postel, J., and D. Mills,
+       "The DARPA Protocol Suite", IEEE INFOCOM 85, Washington, D.C.,
+       March 1985.  Also in IEEE Communications Magazine, March 1985.
+
+       [METCALFE 76]  Metcalfe, R., and D. Boggs, "Ethernet:
+       Distributed Packet for Local Computer Networks", Communications
+       of the ACM, Vol. 19, No. 7, pp. 395-404, July 1976.
+
+       [POSTEL 85]  Postel, J., "Internetwork Applications Using the
+       DARPA Protocol Suite", IEEE INFOCOM 85, Washington, D.C.,
+       March 1985.
+
+       [RFC 821]  Postel, J., "Simple Mail Transfer Protocol", RFC 821,
+       USC/Information Sciences Institute, August 1982.
+
+       [RFC 822]  Crocker, D., "Standard for the Format of ARPA Internet
+       Text Messages", RFC 822, University of Delaware, August 1982.
+
+       [RFC 987]  Kille, S., "Mapping between X.400 and RFC 822",
+       University College London, June 1986.
+
+       [RFC 1000]  Reynolds, J., and J. Postel, "The Request for
+       Comments Reference Guide", RFC 1000, USC/Information Sciences
+       Institute, August 1987.
+
+       [RFC 1026]  Kille, S., "Addendum to RFC 987: (Mapping between
+       X.400 and RFC 822)", RFC 1026, University College London,
+       September 1987.
+
+       [RFC 1109]  Cerf, V., "Report of the Second Ad Hoc Network
+       Management Review Group", RFC 1109, NRI, August 1989.
+
+       [RFC 1113]  Linn, J., "Privacy Enhancement for Internet
+       Electronic Mail: Part I -- Message Encipherment and
+       Authentication Procedures", RFC 1113, IAB Privacy Task
+       Force, August 1989.
+
+       [RFC 1114]  Kent, S.,  and J. Linn, "Privacy Enhancement for
+       Internet Electronic Mail: Part II -- Certificate-based Key
+       Management", RFC 1114, IAB Privacy Task Force, August 1989.
+
+       [RFC 1115]  Linn, J., "Privacy Enhancement for Internet
+       Electronic Mail: Part III -- Algorithms, Modes and Identifiers",
+       RFC 1115, IAB Privacy Task Force, August 1989.
+
+       [RFC 1140]  Postel, J., Editor, "IAB Official Protocol
+       Standards", RFC 1140, Internet Activities Board, May 1990.
+
+
+
+Cerf                                                          [Page 10]
+
+RFC 1160                        The IAB                        May 1990
+
+
+
+       [RFC 1148]  Kille, S., "Mapping between X.400(1988) / ISO 10021
+       and RFC 822", RFC 1048, UCL, March 1990.
+
+       [ROBERTS 70]  Roberts, L., and B. Wessler, "Computer Network
+       Development to Achieve Resource Sharing", pp. 543-549,
+       Proc. SJCC 1970.
+
+       [ROBERTS 78]  Roberts, L., "Evolution of Packet Switching",
+       Proc.  IEEE, Vol. 66, No. 11, pp. 1307-1313, November 1978.
+
+   Note:  RFCs are available from the Network Information Center at SRI
+   International, 333 Ravenswood Ave., Menlo Park, CA 94025, (1-800-
+   235-3155), or on-line via anonymous file transfer from NIC.DDN.MIL.
+
+Author's Address
+
+   Vinton G. Cerf
+   Corporation for National Research Initiatives
+   1895 Preston White Drive, Suite 100
+   Reston, VA 22091
+
+   Phone: (703) 620-8990
+
+   EMail: VCERF@NRI.RESTON.VA.US
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Cerf                                                          [Page 11]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1160.txt](<www.ietf.org/rfc/rfc1160.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
