### PR TITLE
Archive rfc1166.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1166.txt
+++ b/www.ietf.org/rfc/rfc1166.txt
@@ -1,0 +1,10195 @@
+
+
+
+
+
+
+Network Working Group                                     S. Kirkpatrick
+Request for Comments: 1166                                      M. Stahl
+Obsoletes RFCs: 1117, 1020, 997, 990, 960, 943,                M. Recker
+943, 923, 900, 870, 820, 790, 776, 770, 762,                   July 1990
+758, 755, 750, 739, 604, 503, 433, 349
+Obsoletes IENs:  127, 117, 93
+
+
+                            INTERNET NUMBERS
+
+Status of this Memo
+
+   This memo is a status report on the network numbers and autonomous
+   system numbers used in the Internet community.  Distribution of this
+   memo is unlimited.
+
+Table of Contents
+
+   Introduction....................................................   1
+   Network Numbers.................................................   4
+   Class A Networks................................................   7
+   Class B Networks................................................   8
+   Class C Networks................................................  47
+   Other Reserved Internet Addresses............................... 100
+   Network Totals.................................................. 101
+   Autonomous System Numbers....................................... 102
+   Documents....................................................... 111
+   Contacts........................................................ 115
+   Security Considerations......................................... 182
+   Authors' Addresses.............................................. 182
+
+Introduction
+
+   This Network Working Group Request for Comments documents the
+   currently assigned network numbers and gateway autonomous systems.
+   This RFC will be updated periodically, and in any case current
+   information can be obtained from Hostmaster at the DDN Network
+   Information Center (NIC).
+
+         Hostmaster
+         DDN Network Information Center
+         SRI International
+         333 Ravenswood Avenue
+         Menlo Park, California  94025
+
+         Phone: 1-800-235-3155
+
+         Network mail: HOSTMASTER@NIC.DDN.MIL
+
+
+
+Kirkpatrick, Stahl & Recker                                     [Page 1]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   Most of the protocols used in the Internet are documented in the RFC
+   series of notes.  Some of the items listed are undocumented.  Further
+   information on protocols can be found in the memo published by the
+   Internet Activites Board (IAB), "IAB Official Protocol Standards"
+   [52], which describes the state of standardization of protocols used
+   in the Internet.  This document is issued quarterly.  Current copies
+   may be obtained from the DDN Network Information Center.
+
+   The lists below contain the name and network mailbox of the
+   individuals responsible for each registered network or autonomous
+   system.  The bracketed entry, e.g. [nn,iii], at the right hand margin
+   of the page indicates a reference for the listed network or
+   autonomous system, where the number ("nn") cites the document and the
+   letters ("iii") cite the NIC Handle of the responsible person.  The
+   NIC Handle is a unique identifier that is used in the NIC
+   WHOIS/NICNAME service.  People occasionally change electronic
+   mailboxes.  To find out the current network mailbox or phone number
+   for an individual, or to get information about a registered network,
+   use the NIC WHOIS/NICNAME service or contact HOSTMASTER@NIC.DDN.MIL.
+
+   The convention used for the documentation of Internet Protocols is to
+   express numbers in decimal and to picture data in "big-endian" order
+   [39].  That is, fields are described left to right, with the most
+   significant octet on the left and the least significant octet on the
+   right.
+
+   The order of transmission of the header and data described in this
+   document is resolved to the octet level.  Whenever a diagram shows a
+   group of octets, the order of transmission of those octets is the
+   normal order in which they are read in English.  For example, in the
+   following diagram the octets are transmitted in the order they are
+   numbered.
+
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |       1       |       2       |       3       |       4       |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |       5       |       6       |       7       |       8       |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |       9       |      10       |      11       |      12       |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                           Transmission Order of Bytes
+
+
+   Whenever an octet represents a numeric quantity the left most bit in
+   the diagram is the high order or most significant bit.  That is, the
+
+
+
+Kirkpatrick, Stahl & Recker                                     [Page 2]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   bit labeled 0 is the most significant bit.  For example, the
+   following diagram represents the value 170 (decimal).
+
+                               0 1 2 3 4 5 6 7
+                              +-+-+-+-+-+-+-+-+
+                              |1 0 1 0 1 0 1 0|
+                              +-+-+-+-+-+-+-+-+
+
+                              Significance of Bits
+
+   Similarly, whenever a multi-octet field represents a numeric quantity
+   the left most bit of the whole field is the most significant bit.
+   When a multi-octet quantity is transmitted the most significant octet
+   is transmitted first.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kirkpatrick, Stahl & Recker                                     [Page 3]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+NETWORK NUMBERS
+
+   The network numbers listed here are used as internet addresses by the
+   Internet Protocol (IP) [14,26].  The IP uses a 32-bit address field
+   and divides that address into a network part and a "rest" or local
+   address part.  The division takes 4 forms or classes.
+
+      The first type of address, or class A, has a 7-bit network number
+      and a 24-bit local address.  The highest-order bit is set to 0.
+      This allows 128 class A networks.
+
+
+                            1                   2                   3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |0|   NETWORK   |                Local Address                  |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                                 Class A Address
+
+
+      The second type of address, class B, has a 14-bit network number
+      and a 16-bit local address.  The two highest-order bits are set to
+      1-0.  This allows 16,384 class B networks.
+
+
+                            1                   2                   3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |1 0|           NETWORK         |          Local Address        |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                                 Class B Address
+
+
+      The third type of address, class C, has a 21-bit network number
+      and a 8-bit local address.  The three highest-order bits are set
+      to 1-1-0.  This allows 2,097,152 class C networks.
+
+
+                            1                   2                   3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |1 1 0|                    NETWORK              | Local Address |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                                 Class C Address
+
+
+
+
+Kirkpatrick, Stahl & Recker                                     [Page 4]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      The fourth type of address, class D, is used as a multicast
+      address [13].  The four highest-order bits are set to 1-1-1-0.
+
+
+                            1                   2                   3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |1 1 1 0|                  multicast address                    |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                                 Class D Address
+
+
+      Note:  No addresses are allowed with the four highest-order bits
+      set to 1-1-1-1.  These addresses, called "class E", are reserved.
+
+   One commonly used notation for internet host addresses divides the
+   32-bit address into four 8-bit fields and specifies the value of each
+   field as a decimal number with the fields separated by periods.  This
+   is called the "dotted decimal" notation.  For example, the internet
+   address of VENERA.ISI.EDU in dotted decimal is 128.009.000.032, or
+   128.9.0.32.
+
+   The dotted decimal notation will be used in the listing of assigned
+   network numbers.  The class A networks will have nnn.rrr.rrr.rrr, the
+   class B networks will have nnn.nnn.rrr.rrr, and the class C networks
+   will have nnn.nnn.nnn.rrr, where nnn represents part or all of a
+   network number and rrr represents part or all of a local address.
+
+   There are four catagories of users of Internet Addresses: Research,
+   Defense, Government (Non-Defense), and Commercial.  To reflect the
+   allocation of network identifiers among the categories, a one-
+   character code is placed to the left of the network number: R for
+   Research, D for Defense, G for Government, and C for Commercial (see
+   Appendix A for further details on this division of the network
+   identification).
+
+   Network numbers are assigned for networks that are connected to the
+   research Internet and operational Internet, and for independent
+   networks that use the IP family protocols (these are usually
+   commercial).  These independent networks are marked with an asterisk
+   preceding the number.
+
+   The administrators of independent networks must apply separately for
+   permission to interconnect their network with the Internet.
+   Independent networks should not be listed in the working tables of
+   the Internet hosts or gateways.
+
+
+
+
+Kirkpatrick, Stahl & Recker                                     [Page 5]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   For various reasons, the assigned numbers of networks are sometimes
+   changed.  To ease the transition the old number will be listed for a
+   transition period as well.  These "old number" entries will be marked
+   with a "T" following the number and preceding the name, and the
+   network name will be suffixed "-TEMP".
+
+   Special Addresses:
+
+      In certain contexts, it is useful to have fixed addresses with
+      functional significance rather than as identifiers of specific
+      hosts.
+
+         The address zero is to be interpreted as meaning "this", as in
+         "this network".
+
+            For example, the address 0.0.0.37 could be interpreted as
+            meaning host 37 on this network.
+
+         The address of all ones are to be interpreted as meaning "all",
+         as in "all hosts".
+
+            For example, the address 128.9.255.255 could be interpreted
+            as meaning all hosts on the network 128.9.
+
+         The class A network number 127 is assigned the "loopback"
+         function, that is, a datagram sent by a higher level protocol
+         to a network 127 address should loop back inside the host.  No
+         datagram "sent" to a network 127 address should ever appear on
+         any network anywhere.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kirkpatrick, Stahl & Recker                                     [Page 6]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+Class A Networks
+
+      * Internet Address                   Network           Reference
+      - ----------------                   -------           ----------
+       *0.rrr.rrr.rrr                      Reserved          [JBP]
+        1.rrr.rrr.rrr-2.rrr.rrr.rrr        Unassigned        [NIC]
+      C*3.rrr.rrr.rrr                      GE-INTERNET       [JEB50]
+      R 4.rrr.rrr.rrr                      SATNET            [SHB]
+        5.rrr.rrr.rrr                      Unassigned        [NIC]
+      D 6.rrr.rrr.rrr                      YPG-NET           [BWA]
+      D 7.rrr.rrr.rrr                      EDN-TEMP          [EC5]
+      R 8.rrr.rrr.rrr                      BBNCCNET          [SGC]
+      R 9.rrr.rrr.rrr                      IBM               [JP247]
+      R 10.rrr.rrr.rrr                     ARPANET           [JS283]
+      D 11.rrr.rrr.rrr                     DODIIS            [GEG4]
+      C 12.rrr.rrr.rrr                     ATT               [MH82]
+      C 13.rrr.rrr.rrr                     XEROX-NET         [SJ33]
+      C 14.rrr.rrr.rrr                     PDN               [JKR1]
+      R 15.rrr.rrr.rrr                     HP-INTERNET       [WU1]
+      C 16.rrr.rrr.rrr                     DEC-INTERNET      [BKR]
+        17.rrr.rrr.rrr                     Unassigned        [NIC]
+      R 18.rrr.rrr.rrr                     MIT-TEMP          [JIS]
+      C*19.rrr.rrr.rrr                     FINET             [RJB3]
+      D*20.rrr.rrr.rrr                     ANALYTICS         [BD107]
+      D 21.rrr.rrr.rrr                     DDN-RVN           [MLC]
+      D*22.rrr.rrr.rrr                     DSNET1            [GEG4]
+      D 23.rrr.rrr.rrr                     DDN-TC-NET        [DH17]
+        24.rrr.rrr.rrr                     Unassigned        [NIC]
+      R 25.rrr.rrr.rrr                     RSRE-EXP          [DBH11]
+      D 26.rrr.rrr.rrr                     MILNET            [TMH6]
+      R 27.rrr.rrr.rrr                     NOSC-LCCN-TEMP    [RH6]
+      R 28.rrr.rrr.rrr                     WIDEBAND          [CJW2]
+      D 29.rrr.rrr.rrr                     MILX25-TEMP       [TMH6]
+      D 30.rrr.rrr.rrr                     ARPAX25-TEMP      [TMH6]
+      G 31.rrr.rrr.rrr                     UCDLA-NET         [CL64]
+        32.rrr.rrr.rrr-34.rrr.rrr.rrr      Unassigned        [NIC]
+      R 35.rrr.rrr.rrr                     MERIT             [HWB]
+      R 36.rrr.rrr.rrr                     SU-NET-TEMP       [VAF]
+        37.rrr.rrr.rrr-40.rrr.rrr.rrr      Unassigned        [NIC]
+      R 41.rrr.rrr.rrr                     BBN-TEST-A        [RH6]
+      R 42.rrr.rrr.rrr                     CAN-INET          [MV38]
+      R*43.rrr.rrr.rrr                     JAPAN-A           [JM292]
+      R 44.rrr.rrr.rrr                     AMPRNET           [PK28]
+        45.rrr.rrr.rrr                     Reserved          [NIC]
+      C 46.rrr.rrr.rrr                     BBNET             [JSG1]
+      R 47.rrr.rrr.rrr                     BNR               [BM178]
+        48.rrr.rrr.rrr-126.rrr.rrr.rrr     Unassigned        [NIC]
+       *127.rrr.rrr.rrr                    Loopback          [JBP]
+
+
+
+Kirkpatrick, Stahl & Recker                                     [Page 7]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+Class B Networks
+
+      * Internet Address                   Network           Reference
+      - ----------------                   -------           ----------
+        128.0.rrr.rrr                      Reserved          [JBP]
+      R 128.1.rrr.rrr                      BBN-TEST-B        [RH6]
+      R 128.2.rrr.rrr                      CMU-NET           [HDW2]
+      R 128.3.rrr.rrr                      LBL-IP-NET1       [CAL3]
+      R 128.4.rrr.rrr                      DCNET             [DLM1]
+      R 128.5.rrr.rrr                      FORDNET           [FJB3]
+      R 128.6.rrr.rrr                      RUTGERS           [CLH3]
+      R 128.7.rrr.rrr                      KRAUTNET          [GB7]
+      R 128.8.rrr.rrr                      UMDNET            [LAM1]
+      R 128.9.rrr.rrr                      ISI-NET           [VLG]
+      R 128.10.rrr.rrr                     PURDUE-CS-EN      [DT50]
+      R 128.11.rrr.rrr                     BBN-CRONUS        [PK19]
+      R 128.12.rrr.rrr                     SU-NET            [VAF]
+      D 128.13.rrr.rrr                     MATNET            [SHB]
+      R 128.14.rrr.rrr                     BBN-SAT-TEST      [SHB]
+      R 128.15.rrr.rrr                     S1NET             [RAK12]
+      R 128.16.rrr.rrr                     UCL-CS-ETHER      [PK]
+      D 128.17.rrr.rrr                     MATNET-ALT        [SHB]
+      R 128.18.rrr.rrr                     SRINET            [TONY]
+      D 128.19.rrr.rrr                     EDN               [EC5]
+      D 128.20.rrr.rrr                     BRLNET            [TS9]
+      R 128.21.rrr.rrr                     SRI-PR-1          [PEM4]
+      R 128.22.rrr.rrr                     SRI-PR-2          [PEM4]
+      R*128.23.rrr.rrr                     MUSC              [SB228]
+      R 128.24.rrr.rrr                     ROCKWELL-PR       [JCJ1]
+      D 128.25.rrr.rrr                     BRAGG-PR          [LDB3]
+      D 128.26.rrr.rrr                     SAPE-AIRNET       [CAD13]
+      D 128.27.rrr.rrr                     DEMO-PR-1         [DM261]
+      D 128.28.rrr.rrr                     C3-PR-TEMP        [GMR]
+      R 128.29.rrr.rrr                     MITRE             [TML]
+      R 128.30.rrr.rrr                     MIT-NET           [DDC1]
+      R 128.31.rrr.rrr                     MIT-RES           [DDC1]
+      R 128.32.rrr.rrr                     UCB-ETHER         [RWH5]
+      R 128.33.rrr.rrr                     BBN-NET           [SGC]
+      R 128.34.rrr.rrr                     NOSC-LCCN         [RH6]
+      R 128.35.rrr.rrr                     BULLUSANET        [JLM23]
+      R 128.36.rrr.rrr                     YALE-NET          [HML1]
+      D 128.37.rrr.rrr                     YUMA              [RBB2]
+      D 128.38.rrr.rrr                     NSWC-NET          [VHB]
+      R 128.39.rrr.rrr                     NTANET            [PS27]
+      R 128.40.rrr.rrr                     UCL-ETHERNET      [JA168]
+      R 128.41.rrr.rrr                     UCL-CS-SERVICE    [JA168]
+      R 128.42.rrr.rrr                     RICE-NET          [FG50]
+      R 128.43.rrr.rrr                     DRENET            [JS597]
+
+
+
+Kirkpatrick, Stahl & Recker                                     [Page 8]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      D 128.44.rrr.rrr                     WSMR-NET1         [CAS1]
+      C 128.45.rrr.rrr                     DEC-WRL-NET       [BKR]
+      R 128.46.rrr.rrr                     PURDUE-NET        [JRS8]
+      D 128.47.rrr.rrr                     TACTNET           [MB31]
+      G 128.48.rrr.rrr                     UCDLA-NET-B       [CL64]
+      R 128.49.rrr.rrr                     NOSC-ETHER        [RLB3]
+      G 128.50.rrr.rrr                     COINS             [RLS6]
+      G 128.51.rrr.rrr                     COINSTNET         [RLS6]
+      R 128.52.rrr.rrr                     MIT-AI-NET        [CL11]
+      R 128.53.rrr.rrr                     SAC-PR-2          [GMR]
+      R 128.54.rrr.rrr                     UCSD              [GH29]
+      R 128.55.rrr.rrr                     NMFECC            [RJA21]
+      D 128.56.rrr.rrr                     USNA-NET          [RAD15]
+      D 128.57.rrr.rrr                     DEMO-PR-2         [DM261]
+      C 128.58.rrr.rrr                     SLCS              [CG64]
+      R 128.59.rrr.rrr                     CU-NET            [BC14]
+      D 128.60.rrr.rrr                     NRL-ETHER         [WF3]
+      R 128.61.rrr.rrr                     GATECH            [DD11]
+      R 128.62.rrr.rrr                     MCC-NET           [CBD]
+      R 128.63.rrr.rrr                     BRL-SUBNET        [TS9]
+        128.64.rrr.rrr-128.79.rrr.rrr      Unassigned        [NIC]
+      D 128.80.rrr.rrr                     CECOMNET          [PFS2]
+      R 128.81.rrr.rrr                     SYMBOLICS         [SE31]
+      R 128.82.rrr.rrr                     ODU               [CE55]
+      R 128.83.rrr.rrr                     UTAUSTIN          [TLL8]
+      R 128.84.rrr.rrr                     CORNELL-NET       [DK2]
+      C*128.85.rrr.rrr                     DRILL-NET         [DBJ4]
+      R 128.86.rrr.rrr                     JANET             [RHC3]
+      R 128.87.rrr.rrr                     HIRST             [RHC3]
+      R*128.88.rrr.rrr                     HP-NET            [AG67]
+      R 128.89.rrr.rrr                     BBN-ENET          [SGC]
+      C*128.90.rrr.rrr                     SCRIBE            [ERC1]
+      R 128.91.rrr.rrr                     UPENN             [JDH29]
+      R 128.92.rrr.rrr                     INTELLINET        [RJL3]
+      R 128.93.rrr.rrr                     INRIA-NET         [AR41]
+      C*128.94.rrr.rrr                     SYSNET            [EY5]
+      R 128.95.rrr.rrr                     WASHINGTON        [SH162]
+      C 128.96.rrr.rrr                     BELLCORE-NET      [PK28]
+      R 128.97.rrr.rrr                     UCLANET           [ETS4]
+      R 128.98.rrr.rrr                     RSRE-EN2          [JW156]
+      C 128.99.rrr.rrr                     NORTHROP-NET      [RSM1]
+      R 128.100.rrr.rrr                    TORONTO           [BD55]
+      R 128.101.rrr.rrr                    UMN-NET           [PS191]
+      G 128.102.rrr.rrr                    AMES-NET          [MSM1]
+      R 128.103.rrr.rrr                    HARV-FIBER        [SB28]
+      R 128.104.rrr.rrr                    WISC-HERD         [EJN1]
+      R 128.105.rrr.rrr                    WISC              [BAC9]
+      D 128.106.rrr.rrr                    SRI-PSON-1        [ERK3]
+
+
+
+Kirkpatrick, Stahl & Recker                                     [Page 9]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      D 128.107.rrr.rrr                    CISCO-PRNET1      [ERK3]
+      D 128.108.rrr.rrr                    CISCO-PRNET2      [ERK3]
+      R 128.109.rrr.rrr                    NET-CONCERT       [JRR14]
+      R 128.110.rrr.rrr                    UTAH-NET          [JL15]
+      R 128.111.rrr.rrr                    UCSB              [AKS31]
+      R 128.112.rrr.rrr                    PRINCETON         [LRR1]
+      R 128.113.rrr.rrr                    RPINET            [JF78]
+      R 128.114.rrr.rrr                    UCSC              [JHH8]
+      R 128.115.rrr.rrr                    LLNL-LABNET       [LL64]
+      R 128.116.rrr.rrr                    USAN              [JHC12]
+      R 128.117.rrr.rrr                    UCAR              [JHC12]
+      R 128.118.rrr.rrr                    PENN-STATE        [SJS11]
+      R 128.119.rrr.rrr                    UMASS-NET         [GW40]
+      R 128.120.rrr.rrr                    UCDAVIS           [RH5]
+      R 128.121.rrr.rrr                    JVNC-NET          [SH37]
+      R 128.122.rrr.rrr                    NYU-NET           [BJR2]
+      R 128.123.rrr.rrr                    NMSU              [MSP1]
+      R 128.124.rrr.rrr                    NTA-TEMP          [TM10]
+      R 128.125.rrr.rrr                    USCNET            [MAB4]
+      R 128.126.rrr.rrr                    UNISYS-PRC        [JWM3]
+      C 128.127.rrr.rrr                    FTP-SOFTWARE      [JBV2]
+      R 128.128.rrr.rrr                    WHOINET           [ARM5]
+      C*128.129.rrr.rrr                    CGI               [RA62]
+      R*128.130.rrr.rrr                    TUNET-T           [JD238]
+      R*128.131.rrr.rrr                    TUNET-F           [JD238]
+      G 128.132.rrr.rrr                    LNX-ETHER3        [JAM38]
+      G 128.133.rrr.rrr                    AFSC-LONS         [SWR3]
+      R 128.134.rrr.rrr                    SDN               [JEA18]
+      R 128.135.rrr.rrr                    U-CHICAGO         [MC17]
+      R 128.136.rrr.rrr                    TEK-ALLNET        [TE16]
+      R*128.137.rrr.rrr                    GENNET1           [SM96]
+      R 128.138.rrr.rrr                    COLORADO          [RAJ8]
+      R 128.139.rrr.rrr                    ILAN              [DB35]
+      R 128.140.rrr.rrr                    EMORY-INET        [AR60]
+      R 128.141.rrr.rrr                    CERN-LAN          [TB166]
+      R*128.142.rrr.rrr                    CERN-TOKEN        [TB166]
+      R 128.143.rrr.rrr                    VIRGINIA          [JAJ17]
+      R 128.144.rrr.rrr                    ARNET             [TS194]
+      R 128.145.rrr.rrr                    NYSERNET          [MS9]
+      R 128.146.rrr.rrr                    OHIO-STATE        [RSD2]
+      R 128.147.rrr.rrr                    U-PGH-NET         [SM6]
+      R 128.148.rrr.rrr                    BROWN-UNIV        [MR29]
+      G 128.149.rrr.rrr                    JPL-NET           [MSM1]
+      G 128.150.rrr.rrr                    NSF-LAN           [FW17]
+      R 128.151.rrr.rrr                    UR-NET            [TM57]
+      C 128.152.rrr.rrr                    HAC-ENET          [PH45]
+      R 128.153.rrr.rrr                    CLARKSON          [ABS6]
+      G 128.154.rrr.rrr                    WFF-NET           [MSM1]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 10]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      G 128.155.rrr.rrr                    LARC-NET          [MSM1]
+      G 128.156.rrr.rrr                    LERC-NET          [MSM1]
+      G 128.157.rrr.rrr                    JSC-NET           [MSM1]
+      G 128.158.rrr.rrr                    MSFC-NET          [MSM1]
+      G 128.159.rrr.rrr                    KSC-NET           [MSM1]
+      G 128.160.rrr.rrr                    SSCNET            [MG120]
+      G 128.161.rrr.rrr                    NSN-NET           [MSM1]
+      C 128.162.rrr.rrr                    CRAY-NET          [DJD30]
+      R 128.163.rrr.rrr                    UKY               [GB43]
+      R 128.164.rrr.rrr                    GWU-GATE          [TT35]
+      G 128.165.rrr.rrr                    LANL-INET         [PCW]
+      D*128.166.rrr.rrr                    BAC-NET           [JJ48]
+      R 128.167.rrr.rrr                    SURA              [JH92]
+      C 128.168.rrr.rrr                    GOLDHILL          [KR77]
+      R 128.169.rrr.rrr                    UTK               [JDC20]
+      R 128.170.rrr.rrr                    UNISYS-CAM        [DSR]
+      R 128.171.rrr.rrr                    HAWAII            [TN11]
+      R 128.172.rrr.rrr                    VCU-LAN           [JN40]
+      R 128.173.rrr.rrr                    VA-TECH           [PB40]
+      R 128.174.rrr.rrr                    UIUC-CAMPUS-B     [PP14]
+      R 128.175.rrr.rrr                    UDELNET           [DJG2]
+      R*128.176.rrr.rrr                    DMSWWU-ETHER      [GR26]
+      C*128.177.rrr.rrr                    BLI-NET           [EPA]
+      R 128.178.rrr.rrr                    EPFL-EPNET        [YD2]
+      R*128.179.rrr.rrr                    EPF-ETHER2        [YD2]
+      R 128.180.rrr.rrr                    LEHIGH            [MM149]
+      C 128.181.rrr.rrr                    TEKTRONIX         [JB218]
+      R 128.182.rrr.rrr                    PSCNET            [EFH4]
+      R 128.183.rrr.rrr                    GSFC              [JB113]
+      R 128.184.rrr.rrr                    DEAKINET          [JM303]
+      C 128.185.rrr.rrr                    PROTEON-NET       [JS28]
+      R 128.186.rrr.rrr                    FSU               [KMH8]
+      R 128.187.rrr.rrr                    BYU-NET           [KCM2]
+      R 128.188.rrr.rrr                    M2CNET            [SM67]
+      R 128.189.rrr.rrr                    BCNET             [DO26]
+      G 128.190.rrr.rrr                    BELVOIR-NET       [MDS30]
+      C*128.191.rrr.rrr                    NECIS-NET         [DP71]
+      R 128.192.rrr.rrr                    UGA               [EHH4]
+      R 128.193.rrr.rrr                    ORST              [BA26]
+      R 128.194.rrr.rrr                    TAMU-NET          [WM68]
+      R 128.195.rrr.rrr                    UCIICS-NET        [RAJ3]
+      R 128.196.rrr.rrr                    UNIV-ARIZ         [TF30]
+      R 128.197.rrr.rrr                    BU-NET            [KE1]
+      R 128.198.rrr.rrr                    CU-COLOSPGS       [RDG12]
+      R*128.199.rrr.rrr                    STC               [AM54]
+      R 128.200.rrr.rrr                    UCI-NET           [DW96]
+      R*128.201.rrr.rrr                    REUNIR            [RN25]
+      D 128.202.rrr.rrr                    CSOCNET           [JJD12]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 11]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R*128.203.rrr.rrr                    UB-INC            [GC148]
+      R 128.204.rrr.rrr                    ALBNYNET          [BEC1]
+      R 128.205.rrr.rrr                    UBUFFALONET       [CFD4]
+      R 128.206.rrr.rrr                    MONET             [BEC5]
+      C*128.207.rrr.rrr                    BOEING-PSN        [JSY2]
+      R 128.208.rrr.rrr                    WASH-NSF          [SH162]
+      C 128.209.rrr.rrr                    NYNEXSTNET        [MC65]
+      R 128.210.rrr.rrr                    PURDUE-CCNET      [JS81]
+      R 128.211.rrr.rrr                    PURDUE-CS-CYP     [DT50]
+      C 128.212.rrr.rrr                    ISCNET            [DM27]
+      R 128.213.rrr.rrr                    RPICSNET          [CW42]
+      R 128.214.rrr.rrr                    FUNET             [JH141]
+      C 128.215.rrr.rrr                    INTEL             [JR40]
+      D 128.216.rrr.rrr                    CC-PRNET          [GIH]
+      G 128.217.rrr.rrr                    NASA-KSC-OIS      [MSM1]
+      R 128.218.rrr.rrr                    UCSF-NET          [TF6]
+      R 128.219.rrr.rrr                    ORNL-NETB1        [THD]
+      R 128.220.rrr.rrr                    JHU               [RLR46]
+      R 128.221.rrr.rrr                    DGPN1             [PSS1]
+      C 128.222.rrr.rrr                    DGPN2             [PSS1]
+      R 128.223.rrr.rrr                    UONET             [DS85]
+      C*128.224.rrr.rrr                    EPILOGUE          [KA4]
+      C*128.225.rrr.rrr                    BOEING-EN         [JSY2]
+      R 128.226.rrr.rrr                    BINGHAMTON        [RM120]
+      R 128.227.rrr.rrr                    UFNET             [DP173]
+      R 128.228.rrr.rrr                    CUNY              [SMP2]
+      R 128.229.rrr.rrr                    ADSNET            [BJL5]
+      R 128.230.rrr.rrr                    SYR-UNIV-NET      [JW47]
+      G 128.231.rrr.rrr                    NIH-NET           [RF57]
+      R*128.232.rrr.rrr                    CL-CAM-AC-UK      [MAJ1]
+      R*128.233.rrr.rrr                    USASK             [LRC7]
+      R*128.234.rrr.rrr                    COS-NET           [AP25]
+      R 128.235.rrr.rrr                    NJIT              [BM79]
+      D 128.236.rrr.rrr                    USAFA-NET         [GEOFF]
+      R 128.237.rrr.rrr                    CMU-SEI-NET       [TGP3]
+      R 128.238.rrr.rrr                    POLY-U-NET        [AMM14]
+      R 128.239.rrr.rrr                    WM-NET            [SF34]
+      R*128.240.rrr.rrr                    NCL               [CR140]
+      R 128.241.rrr.rrr                    SESQUINET         [GTA]
+      R 128.242.rrr.rrr                    MIDNET            [DF90]
+      R*128.243.rrr.rrr                    NOTT-AC-UK        [WA16]
+      D 128.244.rrr.rrr                    APL-NET           [SFP]
+      R 128.245.rrr.rrr                    SRA-CT-NET        [JSS4]
+      C*128.246.rrr.rrr                    CGCH-WIRZ         [HN3]
+      C 128.247.rrr.rrr                    TI                [DF71]
+      R 128.248.rrr.rrr                    UIC-NET           [EZ3]
+      R 128.249.rrr.rrr                    TMC-NET           [SB98]
+      R 128.250.rrr.rrr                    UNIMELB           [CC89]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 12]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C 128.251.rrr.rrr                    ROCKW-TELEDA      [JCW12]
+      R 128.252.rrr.rrr                    WASHINGTON-U      [MD142]
+      R 128.253.rrr.rrr                    CCS-NET           [DC126]
+      R*128.254.rrr.rrr                    FMC-NOD           [WCW7]
+      R 128.255.rrr.rrr                    UIOWA             [MN54]
+        129.0.rrr.rrr                      Reserved          [NIC]
+      R 129.1.rrr.rrr                      BGSU              [SH71]
+      R 129.2.rrr.rrr                      UMD-BOGON-NET     [LAM1]
+      R 129.3.rrr.rrr                      SUNY-OSWEGO-NET   [PRT2]
+      C 129.4.rrr.rrr                      TRW               [DM348]
+      R 129.5.rrr.rrr                      HGCNET            [GT76]
+      G 129.6.rrr.rrr                      NIST              [CWH3]
+      R 129.7.rrr.rrr                      UH-NET            [APT]
+      R 129.8.rrr.rrr                      CSUFRESNO         [RP88]
+      C*129.9.rrr.rrr                      CHRYSLER-NET      [RER20]
+      R 129.10.rrr.rrr                     NORTHEASTERN-NET  [CJ38]
+      R*129.11.rrr.rrr                     LEEDS             [AJC11]
+      R*129.12.rrr.rrr                     UKC               [SL55]
+      R 129.13.rrr.rrr                     LINK              [BL118]
+      C*129.14.rrr.rrr                     SBINY             [BC72]
+      R 129.15.rrr.rrr                     UOKNOR            [JW136]
+      R 129.16.rrr.rrr                     CTH-NET           [GL41]
+      R*129.17.rrr.rrr                     SSED-NET          [DM147]
+      C 129.18.rrr.rrr                     NEXT-NET          [PFK]
+      R 129.19.rrr.rrr                     WESTNET           [DCMW]
+      R 129.20.rrr.rrr                     VERDUR            [RN25]
+      R 129.21.rrr.rrr                     RIT               [CF35]
+      R 129.22.rrr.rrr                     CWRUNET           [JAG3]
+      R 129.23.rrr.rrr                     SDIO-INTERNET     [KDZ]
+      R 129.24.rrr.rrr                     UNM-CDCN          [SM137]
+      R 129.25.rrr.rrr                     DREXEL            [RR97]
+      R 129.26.rrr.rrr                     GMD-DE            [PM72]
+      R*129.27.rrr.rrr                     TUGNET            [PA43]
+      R*129.28.rrr.rrr                     SPCNET            [AL109]
+      D 129.29.rrr.rrr                     USMANET           [DAS13]
+      C 129.30.rrr.rrr                     HONEYWELL         [DB97]
+      R*129.31.rrr.rrr                     ICNET             [LM88]
+      R 129.32.rrr.rrr                     TEMPLE            [TES16]
+      R 129.33.rrr.rrr                     IBM-ALMADEN       [RC278]
+      R 129.34.rrr.rrr                     IBM-WATSON        [BR92]
+      R 129.35.rrr.rrr                     IBM Research Net  [JP247]
+      R 129.36.rrr.rrr                     IBM-ROCH          [BO3]
+      R 129.37.rrr.rrr-129.39.rrr.rrr      IBM Research Net  [JP247]
+      R 129.40.rrr.rrr                     IBM-KINGSTON      [SD139]
+      R 129.41.rrr.rrr-129.42.rrr.rrr      IBM Research Net  [JP247]
+      R 129.43.rrr.rrr                     NCI-FCRF          [WLB5]
+      C*129.44.rrr.rrr                     NYTEL1095NET      [HT12]
+      C*129.45.rrr.rrr                     NYTELNOCNET1      [JO54]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 13]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C 129.46.rrr.rrr                     QUALNET           [TM37]
+      C 129.47.rrr.rrr                     SYTEK-INC         [RW237]
+      D 129.48.rrr.rrr                     WPAFB-CDS-NET     [SF76]
+      R 129.49.rrr.rrr                     SUNY-SB           [JM414]
+      G*129.50.rrr.rrr                     PSCN              [BRB8]
+      D 129.51.rrr.rrr                     ESMC-LONS         [SWR3]
+      D 129.52.rrr.rrr                     WPAFB-LONS        [SWR3]
+      D 129.53.rrr.rrr                     HANSCOM           [DD63]
+      D 129.54.rrr.rrr                     WSMC-LONS         [SWR3]
+      R 129.55.rrr.rrr                     LINCOLN-MI        [KLS24]
+      D*129.56.rrr.rrr                     AUXNET-PR         [KFS]
+      R 129.57.rrr.rrr                     CEBAF             [RC247]
+      R*129.58.rrr.rrr                     SRPNET            [MJ33]
+      R 129.59.rrr.rrr                     VANDERBILT        [EZ8]
+      R 129.60.rrr.rrr                     NTT-INET          [YS10]
+      D 129.61.rrr.rrr                     ECONET            [CG1]
+      R 129.62.rrr.rrr                     BAYLOR            [BL31]
+      R 129.63.rrr.rrr                     ULOWELL           [RS414]
+      R 129.64.rrr.rrr                     BRANDEIS          [JSM11]
+      R 129.65.rrr.rrr                     CALPOLY           [ML95]
+      R 129.66.rrr.rrr                     ASN-NET           [JRS48]
+      R*129.67.rrr.rrr                     OXFORDNET         [MH118]
+      R*129.68.rrr.rrr                     SJU-NET           [JP147]
+      R 129.69.rrr.rrr                     RUS-NET           [KDM6]
+      R*129.70.rrr.rrr                     UNIBI             [WH64]
+      R 129.71.rrr.rrr                     WVNET             [RL104]
+      R 129.72.rrr.rrr                     UWYO              [RM177]
+      C 129.73.rrr.rrr                     SIEMENS           [MB143]
+      R 129.74.rrr.rrr                     NOTRE-DAME        [MDE3]
+      C 129.75.rrr.rrr                     CCUR-DOM          [PG97]
+      C*129.76.rrr.rrr                     ROSEMOUNT         [JW266]
+      C 129.77.rrr.rrr                     OXFORD-TP         [KRM5]
+      R 129.78.rrr.rrr                     SYDNET            [DP149]
+      R 129.79.rrr.rrr                     INDIANA-NET       [BS69]
+      C*129.80.rrr.rrr                     STORTEK           [DB162]
+      R 129.81.rrr.rrr                     TULANE-NET        [JV41]
+      R 129.82.rrr.rrr                     CSUNET            [SM83]
+      D 129.83.rrr.rrr                     MITRE-B-NETB      [BSW]
+      C 129.84.rrr.rrr                     TWG-NET           [TN29]
+      R 129.85.rrr.rrr                     ROCK              [MK38]
+      C*129.86.rrr.rrr                     SANDERS           [RT60]
+      C 129.87.rrr.rrr                     SLBSDRNET         [RK75]
+      R 129.88.rrr.rrr                     IMAG              [PL37]
+      R 129.89.rrr.rrr                     MILW-IPNET        [JSL9]
+      C*129.90.rrr.rrr                     INTEVEP           [RA66]
+      R 129.91.rrr.rrr                     ENCORE            [PYC]
+      D 129.92.rrr.rrr                     AFIT              [DWD20]
+      R 129.93.rrr.rrr                     HUSKERNET         [MM147]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 14]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R 129.94.rrr.rrr                     UNSW              [PG40]
+      R 129.95.rrr.rrr                     OREGRADNET        [JC235]
+      R 129.96.rrr.rrr                     FLINDERS-UNI      [TGN]
+      R 129.97.rrr.rrr                     UWNET             [WCWI]
+      R*129.98.rrr.rrr                     ALNET             [RNB5]
+      G 129.99.rrr.rrr                     NAS-NET           [JL52]
+      R 129.100.rrr.rrr                    UWO-NET           [PM81]
+      R 129.101.rrr.rrr                    UIDAHO            [WDS11]
+      R*129.102.rrr.rrr                    IRCAM             [MF14]
+      C*129.103.rrr.rrr                    NERV              [RG225]
+      R 129.104.rrr.rrr                    POLY              [GG68]
+      R 129.105.rrr.rrr                    NWUNET            [JPD18]
+      R 129.106.rrr.rrr                    UTHOUSTON         [LN47]
+      R 129.107.rrr.rrr                    UTARLINGTON       [RDC36]
+      R 129.108.rrr.rrr                    OTS-129-108       [DLN12]
+      R 129.109.rrr.rrr                    UTGALVESTON       [MH225]
+      R 129.110.rrr.rrr                    UTDALLAS          [DLL32]
+      R 129.111.rrr.rrr                    UTHSCSA           [CA80]
+      R 129.112.rrr.rrr                    UTSWMED           [VS50]
+      R 129.113.rrr.rrr                    OTS-129-113       [DLN12]
+      R 129.114.rrr.rrr                    UTCCSPRD          [MM352]
+      R 129.115.rrr.rrr                    OTS-129-115       [DLN12]
+      R 129.116.rrr.rrr                    CHPCNET           [WLJ7]
+      R 129.117.rrr.rrr                    THENETMN          [DLN12]
+      R 129.118.rrr.rrr                    TTUNET            [JS450]
+      R 129.119.rrr.rrr                    SOUTHMETHUNIV     [DH23]
+      R 129.120.rrr.rrr                    UNTEXAS           [BB194]
+      R 129.121.rrr.rrr                    NMTECHNET         [IMK1]
+      C 129.122.rrr.rrr                    PRIME             [RLU3]
+      R 129.123.rrr.rrr                    USU               [RLR36]
+      C 129.124.rrr.rrr                    GMRLNET           [LR44]
+      R 129.125.rrr.rrr                    RUGNET            [HH37]
+      C 129.126.rrr.rrr                    KODAK             [DM269]
+      R 129.127.rrr.rrr                    ADELAIDE-UNI      [MP151]
+      R 129.128.rrr.rrr                    U-ALBERTA         [SS131]
+      R 129.129.rrr.rrr                    PSI-ETHER         [HK41]
+      R 129.130.rrr.rrr                    KSUNET            [BAV]
+      D 129.131.rrr.rrr                    NWCNET            [EG17]
+      R 129.132.rrr.rrr                    ETH-ETHER         [FG16]
+      R 129.133.rrr.rrr                    WESNET            [JGD1]
+      C*129.134.rrr.rrr                    HCSD-NET          [DR49]
+      C*129.135.rrr.rrr                    INGR              [GS91]
+      R*129.136.rrr.rrr                    NRCJ              [MS195]
+      R 129.137.rrr.rrr                    UN-OF-CINCI       [JL1]
+      R 129.138.rrr.rrr                    NMTECH            [MJA14]
+      D 129.139.rrr.rrr                    PICANET           [RFD1]
+      R 129.140.rrr.rrr                    NSFNET-BB         [HWB]
+      D 129.141.rrr.rrr                    GAFSNET           [BPW1]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 15]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R 129.142.rrr.rrr                    DENET             [JPS21]
+      R*129.143.rrr.rrr                    BELWUE            [CL80]
+      C 129.144.rrr.rrr-129.159.rrr.rrr    Sun Microsystems  [WM3]
+      R*129.160.rrr.rrr                    SOLARIUM          [JL152]
+      R 129.161.rrr.rrr                    HGCGNET           [GT76]
+      R 129.162.rrr.rrr                    SWRI-NET          [FF20]
+      G*129.163.rrr.rrr                    NASA-JSCSSE       [DGL4]
+      G*129.164.rrr.rrr                    NASA-SSPOSSE      [DGL4]
+      G*129.165.rrr.rrr                    NASA-GSFCSSE      [DGL4]
+      G*129.166.rrr.rrr                    NASA-JFKSSE       [DGL4]
+      G*129.167.rrr.rrr                    NASA-MSFCSSE      [DGL4]
+      G*129.168.rrr.rrr                    NASA-LRCSSE       [DGL4]
+      R*129.169.rrr.rrr                    ENG-CAM-UK        [JMRM]
+      R 129.170.rrr.rrr                    DART-ETHER        [SC59]
+      R 129.171.rrr.rrr                    MIAMI             [HWP2]
+      R 129.172.rrr.rrr                    ROK               [TGS6]
+      R 129.173.rrr.rrr                    DALNET            [JS338]
+      R 129.174.rrr.rrr                    MASONET           [TH15]
+      R 129.175.rrr.rrr                    PARIS-SUD         [RD104]
+      R 129.176.rrr.rrr                    MAYO              [GB125]
+      R 129.177.rrr.rrr                    BERGEN-NET        [PS27]
+      R 129.178.rrr.rrr                    NORWAY-TWO        [PS27]
+      C 129.179.rrr.rrr                    CDC-NET           [JAW34]
+      R 129.180.rrr.rrr                    UNE-CAMPUS        [GS119]
+      C*129.181.rrr.rrr                    LV-BULL           [OD8]
+      C*129.182.rrr.rrr                    CL-BULL           [JPW11]
+      C*129.183.rrr.rrr                    EC-BULL           [JPC17]
+      C*129.184.rrr.rrr                    PR-BULL           [FH35]
+      C*129.185.rrr.rrr                    MY-BULL           [MQ7]
+      R 129.186.rrr.rrr                    CYCLONENET        [RD108]
+      R*129.187.rrr.rrr                    BAVARIAN-NET      [WS94]
+      R 129.188.rrr.rrr                    MOTOROLA          [CC99]
+      R 129.189.rrr.rrr                    ICONET-ORC        [DAVE]
+      D 129.190.rrr.rrr                    ASECC             [RT114]
+      C 129.191.rrr.rrr                    NSCO              [GS123]
+      C 129.192.rrr.rrr                    ACC-NET           [AB20]
+      C 129.193.rrr.rrr                    TRW-TIE-NET       [JB550]
+      R 129.194.rrr.rrr                    UNIGE-CENTER      [AS116]
+      R 129.195.rrr.rrr                    UNIGE-HOP         [AS116]
+      C*129.196.rrr.rrr                    JOHN-FLUKE        [JS210]
+      C*129.197.rrr.rrr                    LMSC-CNU          [DD112]
+      D 129.198.rrr.rrr                    ELAN              [DDK1]
+      R 129.199.rrr.rrr                    ENS-NET           [JV53]
+      D 129.200.rrr.rrr                    DAC-BACK-NET      [RAY4]
+      C*129.201.rrr.rrr-129.204.rrr.rrr    GE-Internet       [JEB50]
+      R*129.205.rrr.rrr                    CDCNET            [JAW34]
+      R 129.206.rrr.rrr                    HD-NET            [LB110]
+      R 129.207.rrr.rrr                    PVAMU-NET         [FE6]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 16]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R*129.208.rrr.rrr                    BIRMINGHAM        [RJH37]
+      D 129.209.rrr.rrr                    BRLNETS           [DET]
+      R*129.210.rrr.rrr                    SCU-NET           [WD27]
+      C*129.211.rrr.rrr                    ISCS-NET          [DS59]
+      R*129.212.rrr.rrr                    AMDAHL-UTS        [KC1]
+      C 129.213.rrr.rrr                    COM-COM-COM       [TB6]
+      C*129.214.rrr.rrr                    PYRAMID-TECH      [CSG]
+      R*129.215.rrr.rrr                    EU-NET            [WSC5]
+      R 129.216.rrr.rrr                    NRC-NET           [IHM]
+      R 129.217.rrr.rrr                    UNIDO-LAN         [RV32]
+      R*129.218.rrr.rrr                    UNISYS-SP         [SJP10]
+      R 129.219.rrr.rrr                    ASU-NET           [AC85]
+      C*129.220.rrr.rrr-129.227.rrr.rrr    UNISYS Nets       [CC129]
+      C*129.228.rrr.rrr                    WESTINGHOUSE      [CWR4]
+      G 129.229.rrr.rrr                    USA-CECER         [DB186]
+      C*129.230.rrr.rrr                    AMOCO             [SG83]
+      C*129.231.rrr.rrr                    DIGICOMM-NET      [WF42]
+      R*129.232.rrr.rrr                    BITNET            [LCV]
+      R 129.233.rrr.rrr                    FHG-STUTTGART     [JW377]
+      R*129.234.rrr.rrr                    DURHAM            [JC288]
+      R 129.235.rrr.rrr                    SRCNET            [CRT4]
+      R 129.236.rrr.rrr                    LDGO-NET          [RGB14]
+      R 129.237.rrr.rrr                    JAYHAWKNET        [DN32]
+      R 129.238.rrr.rrr                    AFWL-NET          [CF57]
+      G 129.239.rrr.rrr                    HI-CFSG           [LP71]
+      R 129.240.rrr.rrr                    UIONET            [JT122]
+      R 129.241.rrr.rrr                    UNITNET           [HE15]
+      R 129.242.rrr.rrr                    UIBNET            [JT122]
+      G 129.243.rrr.rrr                    MMCNET            [DR137]
+      R 129.244.rrr.rrr                    KEHNET            [PLH8]
+      C 129.245.rrr.rrr                    PAC-BELL          [DSP11]
+      D 129.246.rrr.rrr                    IDA               [BS157]
+      R 129.247.rrr.rrr                    DFVRL-NET         [CR24]
+      C 129.248.rrr.rrr                    APOLLO            [NM31]
+      R*129.249.rrr.rrr                    FX-DEV-NET2       [HH45]
+      R 129.250.rrr.rrr                    PRPNET            [BE6]
+      D 129.251.rrr.rrr                    SLAN-BSN          [LA55]
+      R 129.252.rrr.rrr                    SCAROLINA         [AY11]
+      C*129.253.rrr.rrr                    WESDIGCO          [SD78]
+      R 129.254.rrr.rrr                    ETRI              [KH74]
+        129.255.rrr.rrr                    Reserved          [NIC]
+        130.0.rrr.rrr                      Reserved          [NIC]
+      C*130.1.rrr.rrr-130.10.rrr.rrr       Boeing Nets       [DJB34]
+      G 130.11.rrr.rrr                     GEORES            [JRF]
+      R*130.12.rrr.rrr                     ORNET             [DG110]
+      C 130.13.rrr.rrr                     USWEST            [DCM20]
+      G 130.14.rrr.rrr                     NLM-ETHER         [JA1]
+      R 130.15.rrr.rrr                     QUEENSU           [AH81]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 17]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      D 130.16.rrr.rrr                     BCN               [JRC27]
+      R 130.17.rrr.rrr                     CSUSTAN           [TC84]
+      R 130.18.rrr.rrr                     MSSTATE           [MR137]
+      C*130.19.rrr.rrr                     PGE               [AC96]
+      G 130.20.rrr.rrr                     PNLNET            [SCT2]
+      C*130.21.rrr.rrr                     PRIME-CV          [RLU3]
+      D 130.22.rrr.rrr                     DCA-RESTON        [SJ50]
+      C*130.23.rrr.rrr-130.32.rrr.rrr      Hewlett-Packard   [DCL10]
+      R 130.33.rrr.rrr                     SARNOFF           [RJP23]
+      R 130.34.rrr.rrr                     TAINS             [YK3]
+      C 130.35.rrr.rrr                     ORACLE-CORP       [DAA14]
+      C*130.36.rrr.rrr                     ABBOTT            [JES55]
+      R 130.37.rrr.rrr                     VU-NET            [HVS1]
+      C 130.38.rrr.rrr                     MDC-NET           [KRH4]
+      R 130.39.rrr.rrr                     TIGERLAN          [CFB1]
+      G*130.40.rrr.rrr                     JSC-RTDS          [SW114]
+      R 130.41.rrr.rrr                     ATD-NET           [TS14]
+      R 130.42.rrr.rrr                     BOERESNET         [GK44]
+      C 130.43.rrr.rrr                     APPLE-NET         [HK24]
+      R 130.44.rrr.rrr                     AMS               [NK19]
+      C*130.45.rrr.rrr                     RACAL-MILGO       [JC314]
+      D 130.46.rrr.rrr                     DTRC-B1-NET       [RWT2]
+      G*130.47.rrr.rrr                     WISDOT            [JRJ12]
+      C*130.48.rrr.rrr                     ATT-DDO           [CWM17]
+      R 130.49.rrr.rrr                     U-PITT            [DS247]
+      C 130.50.rrr.rrr                     RISC-NET          [WAG5]
+      C*130.51.rrr.rrr                     VIEW-ENG          [CM144]
+      C*130.52.rrr.rrr                     WEARGUARD         [PP62]
+      D 130.53.rrr.rrr                     AFOTECPCNET       [EEL2]
+      R 130.54.rrr.rrr                     KUINS             [JM292]
+      G*130.55.rrr.rrr                     LANL-SINET        [PCW]
+      R 130.56.rrr.rrr                     ANUNET            [GH105]
+      C 130.57.rrr.rrr                     EXCELAN           [TS107]
+      R 130.58.rrr.rrr                     SWARTHMORE        [JB360]
+      R 130.59.rrr.rrr                     SWITCH-LAN        [TL99]
+      R 130.60.rrr.rrr                     UNIZH             [PB145]
+      R*130.61.rrr.rrr                     BBN-SYSENGRB      [DW159]
+      C 130.62.rrr.rrr                     MIPSNET           [DK101]
+      R 130.63.rrr.rrr                     YORKU             [ER61]
+      R*130.64.rrr.rrr                     TUFTSU            [KR69]
+      R*130.65.rrr.rrr                     SJSU-NET          [HB76]
+      R*130.66.rrr.rrr                     RIVE              [CE42]
+      C*130.67.rrr.rrr                     NORSK-DATA        [AH89]
+      R 130.68.rrr.rrr                     MSCNET            [MLT10]
+      R 130.69.rrr.rrr                     UTOKYO-NET        [JM292]
+      R 130.70.rrr.rrr                     USL               [SJM9]
+      R 130.71.rrr.rrr                     STOLAF            [CR127]
+      R*130.72.rrr.rrr                     LSTC-NET          [DC211]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 18]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R*130.73.rrr.rrr                     ZIB               [HB79]
+      R 130.74.rrr.rrr                     OLEMISS           [EFH6]
+      R*130.75.rrr.rrr                     RRZN              [RO44]
+      C*130.76.rrr.rrr                     BE-NET            [KRF5]
+      C*130.77.rrr.rrr                     CH2M              [RR156]
+      C*130.78.rrr.rrr                     BAZIS             [CVG1]
+      R*130.79.rrr.rrr                     OSIRIS            [JP207]
+      C*130.80.rrr.rrr                     CHRON             [JC333]
+      C 130.81.rrr.rrr                     NYTEL-BB-1        [SS110]
+      R 130.82.rrr.rrr                     UNISG             [PG62]
+      R*130.83.rrr.rrr                     THD-NET           [HH50]
+      R 130.84.rrr.rrr                     CIRCE             [CM156]
+      R 130.85.rrr.rrr                     UMBCNET           [KP45]
+      R 130.86.rrr.rrr                     CSUSAC            [MC264]
+      R 130.87.rrr.rrr                     JP-HEPNET         [YB4]
+      R*130.88.rrr.rrr                     MANLAN            [PM115]
+      R 130.89.rrr.rrr                     UTNET             [GAM32]
+      R 130.90.rrr.rrr                     MATHERAFBNET      [SF46]
+      R 130.91.rrr.rrr                     UPENN-SUBNET      [JDH29]
+      R 130.92.rrr.rrr                     UNIBE             [FB61]
+      R 130.93.rrr.rrr                     FERNWOODNET2      [GEOF]
+      R 130.94.rrr.rrr                     JVNCNET           [SH37]
+      R 130.95.rrr.rrr                     UWA-NET           [GH108]
+      C*130.96.rrr.rrr                     SDCAPOL           [RB520]
+      G*130.97.rrr.rrr                     DOERLNET          [DES41]
+      R*130.98.rrr.rrr                     FNET-EDF          [MD127]
+      R 130.99.rrr.rrr                     NET-3M            [BR79]
+      C*130.100.rrr.rrr                    ERICSSON          [BS156]
+      R 130.101.rrr.rrr                    UAKRON            [DK112]
+      R 130.102.rrr.rrr                    UQNET             [LB201]
+      C*130.103.rrr.rrr                    LOTUS             [RMF2]
+      R*130.104.rrr.rrr                    UCLOUVAIN         [ML129]
+      R 130.105.rrr.rrr                    OSF               [MLR1]
+      R*130.106.rrr.rrr                    LLNL-CLOSED       [DW164]
+      R 130.107.rrr.rrr                    SRI-CSL-NET-2     [EH112]
+      R 130.108.rrr.rrr                    WRIGHT-STATE      [SH1]
+      R 130.109.rrr.rrr                    NCSC-NET          [JD130]
+      C*130.110.rrr.rrr                    CENET             [JC347]
+      R 130.111.rrr.rrr                    UMAINE-SYS        [IKA]
+      R*130.112.rrr.rrr                    ECN               [MB203]
+      R 130.113.rrr.rrr                    MCMASTER          [CB162]
+      D 130.114.rrr.rrr                    APGNET            [VC5]
+      R*130.115.rrr.rrr                    EURNET            [IJD1]
+      R 130.116.rrr.rrr                    CSIRO-DMT         [MJ65]
+      R 130.117.rrr.rrr                    NYSER2            [MS9]
+      G 130.118.rrr.rrr                    GEOMEN            [PWM]
+      C*130.119.rrr.rrr                    RTECH             [DA73]
+      R*130.120.rrr.rrr                    UNITOUL           [DI11]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 19]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      D*130.121.rrr.rrr                    BOEING747NET      [GK44]
+      D*130.122.rrr.rrr                    BOEINGAERO        [GK44]
+      R 130.123.rrr.rrr                    MASSEY            [KKS]
+      D 130.124.rrr.rrr                    HI-DSG            [MW135]
+      R 130.125.rrr.rrr                    UNINE             [CW115]
+      R 130.126.rrr.rrr                    UIUC-NCSA         [PP14]
+      R 130.127.rrr.rrr                    CLEMSONU          [MSM3]
+        130.128.rrr.rrr                    Reserved          [NIC]
+        130.129.rrr.rrr                    Reserved          [NIC]
+      R 130.130.rrr.rrr                    UOWNET            [SC143]
+      C*130.131.rrr.rrr                    GTE-CS            [AN32]
+      R 130.132.rrr.rrr                    YALE-SPINE        [ASW3]
+      R*130.133.rrr.rrr                    FUB               [RR163]
+      G 130.134.rrr.rrr                    DFRF-NET          [MSM1]
+      G*130.135.rrr.rrr                    WSTF-NET          [MSM1]
+      R 130.136.rrr.rrr                    BOLOGNA-MATH-CS   [OB]
+      C 130.137.rrr.rrr                    DATAPOINT         [BR87]
+      C*130.138.rrr.rrr-130.143.rrr.rrr    PHILIPS           [OK6]
+      C 130.144.rrr.rrr                    PHILIPS           [OK6]
+      C*130.145.rrr.rrr-130.147.rrr.rrr    PHILIPS           [OK6]
+      C*130.148.rrr.rrr                    GEC-SENSORS       [TD68]
+      R*130.149.rrr.rrr                    TUB               [DK116]
+      R 130.150.rrr.rrr                    CSUNET-IP         [DR161]
+      R 130.151.rrr.rrr                    ROK2              [TGS6]
+      R 130.152.rrr.rrr                    LOS-NETTOS        [WP8]
+      R 130.153.rrr.rrr                    JAPAN-B8          [JM292]
+      R 130.154.rrr.rrr                    RAND-NETB         [JDG]
+      R 130.155.rrr.rrr                    DMS-SYD           [MA88]
+      R*130.156.rrr.rrr                    NJECN             [BM164]
+      R 130.157.rrr.rrr                    SONOMA-STATE      [BB193]
+      R*130.158.rrr.rrr                    UTINS             [NY3]
+      R*130.159.rrr.rrr                    STRATH            [DM259]
+      R 130.160.rrr.rrr                    UANET             [JW337]
+      R 130.161.rrr.rrr                    DUT-LAN           [FD18]
+      C*130.162.rrr.rrr                    TEN-OPS           [DG146]
+      D 130.163.rrr.rrr                    CENTERNET         [JA91]
+      C*130.164.rrr.rrr                    NATINST-NET       [BP42]
+      D 130.165.rrr.rrr                    CESPKED-NET       [JP220]
+      R 130.166.rrr.rrr                    CSUN              [DC316]
+      G 130.167.rrr.rrr                    STSCI-NET         [MSM1]
+      C 130.168.rrr.rrr                    CONVEX            [JT147]
+      C*130.169.rrr.rrr-130.178.rrr.rrr    GM IP Net         [JC365]
+      R*130.179.rrr.rrr                    UMANITOBA         [BR88]
+      C 130.180.rrr.rrr                    DEC-ZK-NET        [SEL10]
+      D 130.181.rrr.rrr                    HONWEL-CLWTR      [MN43]
+      R 130.182.rrr.rrr                    CSULANET          [DTG11]
+      R*130.183.rrr.rrr                    IPPNET            [TH101]
+      R 130.184.rrr.rrr                    UARKNET           [DLM34]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 20]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R 130.185.rrr.rrr                    ONET              [PM81]
+      R 130.186.rrr.rrr                    CINECA-NET        [AA62]
+      C 130.187.rrr.rrr                    ES-NET            [SP81]
+      R 130.188.rrr.rrr                    VTTNET            [JK187]
+      R 130.189.rrr.rrr                    DART-HITCH        [RCD13]
+      R*130.190.rrr.rrr                    GRENET            [JA146]
+      R 130.191.rrr.rrr                    SDSU-NET          [MW180]
+      R 130.192.rrr.rrr                    TORINO-IT-LAN     [SG88]
+      R*130.193.rrr.rrr                    ACONET            [WK56]
+      R 130.194.rrr.rrr                    MONASH-NET        [JM493]
+      R 130.195.rrr.rrr                    VUW               [MN44]
+      G*130.196.rrr.rrr                    STSOC             [RMD26]
+      C*130.197.rrr.rrr                    CECO-NET          [WLR6]
+      C 130.198.rrr.rrr                    PRISMA-ETHER      [JP232]
+      R 130.199.rrr.rrr                    YAPNET            [GR9]
+      C*130.200.rrr.rrr                    LOCUS             [EP53]
+      C 130.201.rrr.rrr                    AOGC              [JH307]
+      G 130.202.rrr.rrr                    ARGONNE           [LW26]
+      R 130.203.rrr.rrr                    PSU-COMPSC        [DRE4]
+      C 130.204.rrr.rrr                    INTERLAN          [DW180]
+      C*130.205.rrr.rrr                    LANIER            [MHW9]
+      R*130.206.rrr.rrr                    IRIS              [IM24]
+      R 130.207.rrr.rrr                    GIT               [DD11]
+      R 130.208.rrr.rrr                    ISNET             [MO33]
+      R*130.209.rrr.rrr                    GLANET            [RAG36]
+      D 130.210.rrr.rrr                    LINKNET           [PR79]
+      C*130.211.rrr.rrr                    EXECU             [DH241]
+      R 130.212.rrr.rrr                    FOGNET            [MCD11]
+      C*130.213.rrr.rrr                    RATNET            [TDG9]
+      C*130.214.rrr.rrr                    SYBASE            [NHC]
+      R 130.215.rrr.rrr                    WPI               [AEJ5]
+      R 130.216.rrr.rrr                    AUKUNI-NET        [AJB20]
+      R 130.217.rrr.rrr                    WAIKATO-LAN-1     [JCH41]
+      R*130.218.rrr.rrr                    NET-KSC           [MC128]
+      R 130.219.rrr.rrr                    UMDNJ             [LPM]
+      R 130.220.rrr.rrr                    SAITEN            [RR181]
+      R 130.221.rrr.rrr                    AERO-NET          [LCN]
+      C 130.222.rrr.rrr                    PRCNE-NET         [SS172]
+      R 130.223.rrr.rrr                    LUNET-ETHER1      [JL247]
+      C 130.224.rrr.rrr                    NET-QUOTRON       [LF58]
+      R 130.225.rrr.rrr                    DENET-1           [JPS21]
+      R*130.226.rrr.rrr-130.229.rrr.rrr    NORDU Nets        [AH94]
+      R 130.230.rrr.rrr                    TAMNET            [JH141]
+      R*130.231.rrr.rrr                    NORDU Nets        [AH94]
+      R 130.232.rrr.rrr                    TURBO             [EA49]
+      R 130.233.rrr.rrr                    HUTNET            [KL66]
+      R*130.234.rrr.rrr                    NORDU Net         [AH94]
+      R 130.235.rrr.rrr                    LUNET             [JE87]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 21]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R 130.236.rrr.rrr                    LIUNET            [LE24]
+      R 130.237.rrr.rrr                    KTH-LAN           [AH94]
+      R 130.238.rrr.rrr                    UU-NET            [BV17]
+      R 130.239.rrr.rrr                    UMUNET            [RH271]
+      R 130.240.rrr.rrr                    LUTHNET           [SW142]
+      R 130.241.rrr.rrr                    GU-NET            [JT167]
+      R*130.242.rrr.rrr-130.244.rrr.rrr    NORDU Nets        [AH94]
+      R 130.245.rrr.rrr                    SUNYSB-CS         [WKT]
+      R*130.246.rrr.rrr                    RAL-IP            [AM129]
+      D*130.247.rrr.rrr                    BOE-TRANS         [GK44]
+      C*130.248.rrr.rrr                    ADOBE             [AIS]
+      R*130.249.rrr.rrr                    FOENET            [FJB3]
+      R*130.250.rrr.rrr                    QU                [BA56]
+      R 130.251.rrr.rrr                    UG-NET            [GAM35]
+      R 130.252.rrr.rrr                    TANDEM-NET        [KR59]
+      R 130.253.rrr.rrr                    DENVERU-NET       [WE12]
+      R*130.254.rrr.rrr                    ASC               [DB296]
+        130.255.rrr.rrr                    Reserved          [NIC]
+        131.0.rrr.rrr                      Reserved          [NIC]
+      C 131.1.rrr.rrr                      ICONET            [JA13]
+      D 131.2.rrr.rrr                      GAFB-NET          [BPW1]
+      D 131.3.rrr.rrr                      MATHERAFB         [SF46]
+      D 131.4.rrr.rrr                      WPAFB-NET         [KEP9]
+      D 131.5.rrr.rrr                      GRIFFISS-NET      [BPW1]
+      D 131.6.rrr.rrr                      LANGLEY-NET       [JJB1]
+      D 131.7.rrr.rrr                      OFFUTT-NET        [PN13]
+      D 131.8.rrr.rrr                      HQUSAF-NET        [BPW1]
+      D 131.9.rrr.rrr                      SCOTTAFB-NET      [FW18]
+      D 131.10.rrr.rrr                     BARKSDALE         [KW75]
+      D 131.11.rrr.rrr                     BOLLING-NET       [SE7]
+      D 131.12.rrr.rrr                     BROOKS-NET        [BDB8]
+      D 131.13.rrr.rrr                     KELLY-NET         [JG268]
+      D 131.14.rrr.rrr                     LOWRYAFB-NET      [BRA2]
+      D 131.15.rrr.rrr                     PETERSON-NET      [MDL1]
+      D 131.16.rrr.rrr                     RAMSTEINNET       [KM103]
+      D 131.17.rrr.rrr                     SHEPPARD          [SR127]
+      D 131.18.rrr.rrr                     TINKERCCSO        [RMD1]
+      D 131.19.rrr.rrr                     BITBURGNET        [MML8]
+      D 131.20.rrr.rrr                     EGLIN-NET         [TM199]
+      D 131.21.rrr.rrr                     HAHNNET           [RM300]
+      D 131.22.rrr.rrr                     KEESLER-NET       [BWS2]
+      D 131.23.rrr.rrr                     KIRTLAND-NET      [OP]
+      D 131.24.rrr.rrr                     MACDILL-NET       [ER90]
+      D 131.25.rrr.rrr                     PATRICK-NET       [MH15]
+      D 131.26.rrr.rrr                     USAFACAD-NET      [JME15]
+      D 131.27.rrr.rrr                     HILLAFB-NET       [JD86]
+      D 131.28.rrr.rrr                     WPAFB-NET2        [BPW1]
+      D 131.29.rrr.rrr                     LAAFB-NET         [JEB45]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 22]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      D 131.30.rrr.rrr                     MCCHORDNET        [BF49]
+      D 131.31.rrr.rrr                     MCCLELLANNET      [JRR6]
+      D 131.32.rrr.rrr                     LACKLANDNET       [DMH20]
+      D 131.33.rrr.rrr                     EDWARDS-NET       [LGB1]
+      D 131.34.rrr.rrr                     MARCH-NET         [CLP18]
+      D 131.35.rrr.rrr                     FAIRCHILD         [GI4]
+      D 131.36.rrr.rrr                     YOKOTA-NET        [JAS8]
+      D 131.37.rrr.rrr                     ELMENDORF         [MD97]
+      D 131.38.rrr.rrr                     HICKAM-NET        [RWJ3]
+      D 131.39.rrr.rrr                     EIELSON           [BPW1]
+      D 131.40.rrr.rrr                     BERGSTROM         [SA42]
+      D 131.41.rrr.rrr                     ANDREWS-NET       [JKB13]
+      D 131.42.rrr.rrr                     HANSCOM-NET       [WJK6]
+      D 131.43.rrr.rrr                     HOMESTEAD         [GLS20]
+      D 131.44.rrr.rrr                     RANDOLPH-NET      [TS149]
+      D 131.45.rrr.rrr                     ROBINS-NET        [NRG4]
+      D 131.46.rrr.rrr                     SHAW              [BPW1]
+      D 131.47.rrr.rrr                     ANDERSEN-NET      [TKH4]
+      D 131.48.rrr.rrr                     AVIANO-NET        [RDB30]
+      D 131.49.rrr.rrr                     CLARK-NET         [GKW3]
+      D 131.50.rrr.rrr                     DAVIS-MONTHAN     [SS130]
+      D 131.51.rrr.rrr                     LAKENHEATH        [RT135]
+      D 131.52.rrr.rrr                     LUKE-NET          [TD91]
+      D 131.53.rrr.rrr                     MALMSTROM         [YC4]
+      D 131.54.rrr.rrr-131.55.rrr.rrr      AF Concentrator   [BPW1]
+      D 131.56.rrr.rrr                     UPPER-HEYFORD     [BPW1]
+      D 131.57.rrr.rrr                     TAEGU             [RWH36]
+      D 131.58.rrr.rrr                     ALCONBURY         [JD274]
+      D 131.59.rrr.rrr                     DYESS             [BPW1]
+      D 131.60.rrr.rrr                     ENGLAND           [BPW1]
+      D 131.61.rrr.rrr                     MCCONNELL         [RCL1]
+      D 131.62.rrr.rrr                     NORTON            [BPW1]
+      D 131.63.rrr.rrr                     GAFB-NET1         [BPW1]
+      D 131.64.rrr.rrr                     HQ-DLA            [CG85]
+      D 131.65.rrr.rrr                     DCRA              [CG85]
+      D 131.66.rrr.rrr                     DCRB              [CG85]
+      D 131.67.rrr.rrr                     DCRI              [CG85]
+      D 131.68.rrr.rrr                     DCRL              [CG85]
+      D 131.69.rrr.rrr                     DCRN              [CG85]
+      D 131.70.rrr.rrr                     DCRO              [CG85]
+      D 131.71.rrr.rrr                     DCRP              [CG85]
+      D 131.72.rrr.rrr                     DCRS              [CG85]
+      D 131.73.rrr.rrr                     DCRT              [CG85]
+      D 131.74.rrr.rrr                     DCSC              [SST]
+      D 131.75.rrr.rrr                     DDMP              [CG85]
+      D 131.76.rrr.rrr                     DDMT              [CG85]
+      D 131.77.rrr.rrr                     DDOU              [CG85]
+      D 131.78.rrr.rrr                     DSAC              [JR276]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 23]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      D 131.79.rrr.rrr                     DDTC              [CG85]
+      D 131.80.rrr.rrr                     DESC              [CG85]
+      D 131.81.rrr.rrr                     DGSC              [CG85]
+      D 131.82.rrr.rrr                     DISC              [CG85]
+      D 131.83.rrr.rrr                     EUROPE-DRMS       [CG85]
+      D 131.84.rrr.rrr                     DTIC-NET          [CG85]
+      D 131.85.rrr.rrr                     DFSC              [CG85]
+      D 131.86.rrr.rrr                     DPSC              [CG85]
+      D 131.87.rrr.rrr                     DRMS              [CG85]
+      D 131.88.rrr.rrr                     PACIFIC-DRMS      [CG85]
+      C*131.89.rrr.rrr-131.90.rrr.rrr      PG&E Net          [AC96]
+      R 131.91.rrr.rrr                     FAU               [RL180]
+      D 131.92.rrr.rrr                     APGEA-SUBNET      [REA3]
+      R 131.93.rrr.rrr                     SJC-NET           [BC130]
+      R 131.94.rrr.rrr                     FIU               [BB208]
+      R 131.95.rrr.rrr                     USM               [DEP17]
+      R*131.96.rrr.rrr                     GSU-NET           [SBH4]
+      C*131.97.rrr.rrr                     AB-VOLVO-NET      [TS141]
+      C*131.98.rrr.rrr                     ESI-PRIM          [WRH20]
+      C*131.99.rrr.rrr                     KONTRONNET        [BS217]
+      C*131.100.rrr.rrr                    BANYAN-HDQTR      [BH144]
+      C*131.101.rrr.rrr                    TERADYNE          [GA45]
+      G*131.102.rrr.rrr                    KOM-BV            [RM306]
+      R 131.103.rrr.rrr                    CICNET            [CA29]
+      R 131.104.rrr.rrr                    UOGUELPH          [KP50]
+      D 131.105.rrr.rrr                    SM-ALC            [RR184]
+      C 131.106.rrr.rrr                    MTXINU-NET        [EG51]
+      C*131.107.rrr.rrr                    MICROSOFT         [WC89]
+      C 131.108.rrr.rrr                    CISCO-SYSTEM      [KSL]
+      R 131.109.rrr.rrr                    BROWN-CFM-CS      [SF59]
+      G*131.110.rrr.rrr                    MAF-NET           [RTD]
+      R*131.111.rrr.rrr                    CAM-AC-UK         [TS146]
+      R 131.112.rrr.rrr                    TITECH-NET        [MO57]
+      R 131.113.rrr.rrr                    KEIO-NET          [TS147]
+      R 131.114.rrr.rrr                    PISA-NET          [GR56]
+      C*131.115.rrr.rrr                    TVTWAN1           [AH96]
+      C*131.116.rrr.rrr                    TVTWAN2           [AH96]
+      C*131.117.rrr.rrr                    NCANET            [WB102]
+      R 131.118.rrr.rrr                    MINCNET           [FAF6]
+      R 131.119.rrr.rrr                    BARRNET           [DLW31]
+      R 131.120.rrr.rrr                    NPSNET            [SW37]
+      G 131.121.rrr.rrr                    NADN              [AF60]
+      G 131.122.rrr.rrr                    NADN2             [AF60]
+      R 131.123.rrr.rrr                    KENT-STATE        [LCH9]
+      C*131.124.rrr.rrr                    TANDEM-MPD        [BC133]
+      R 131.125.rrr.rrr                    KEAN              [AKC5]
+      C*131.126.rrr.rrr                    MTCN              [JCP26]
+      C*131.127.rrr.rrr                    ASGARRETT         [LM176]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 24]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R 131.128.rrr.rrr                    URI               [JB410]
+      C*131.129.rrr.rrr                    DOCUNET           [MR166]
+      R*131.130.rrr.rrr                    UNIVIE            [HS118]
+      C 131.131.rrr.rrr                    CONTEL-WTP        [MJO4]
+      R 131.132.rrr.rrr                    DREVNET           [JS597]
+      R 131.133.rrr.rrr                    DREANET           [JS597]
+      R*131.134.rrr.rrr-131.141.rrr.rrr    Def Rsch Estab    [JS597]
+      R 131.142.rrr.rrr                    CFA-NET           [CM57]
+      C 131.143.rrr.rrr                    CMC               [CNK1]
+      R*131.144.rrr.rrr                    PEACHNET          [JS469]
+      C 131.145.rrr.rrr                    MERIT-TECH        [JRJ18]
+      C 131.146.rrr.rrr                    MDC-SJ-NET        [SMF5]
+      C*131.147.rrr.rrr                    GENESISDND        [SM188]
+      C*131.148.rrr.rrr                    GENESISTOR        [SM188]
+      C*131.149.rrr.rrr                    FAST-TEAM         [SM188]
+      C*131.150.rrr.rrr                    GENESISCSDBS      [SM188]
+      R 131.151.rrr.rrr                    MORNETR           [RWA15]
+      R 131.152.rrr.rrr                    UNIBAS            [RD232]
+      R 131.153.rrr.rrr                    SEMATECH          [RG188]
+      R*131.154.rrr.rrr                    INFNET            [AG113]
+      R 131.155.rrr.rrr                    TUENET1           [JFAS]
+      R 131.156.rrr.rrr                    NIU-NET           [JWN10]
+      C*131.157.rrr.rrr                    LIBRAINC          [WJF1]
+      R 131.158.rrr.rrr                    USUHSNET          [MK124]
+      R*131.159.rrr.rrr                    TUM-INFO-LAN      [HN20]
+      C*131.160.rrr.rrr                    LMFNET            [RS393]
+      C 131.161.rrr.rrr                    WEB-NET           [ML192]
+      R*131.162.rrr.rrr                    AUNET             [BW134]
+      C*131.163.rrr.rrr                    I-CAN             [RW206]
+      R*131.164.rrr.rrr-131.166.rrr.rrr    Danish Net        [SJ28]
+      R 131.167.rrr.rrr                    BMINET            [JA92]
+      C*131.168.rrr.rrr                    PAQNET            [WH110]
+      R*131.169.rrr.rrr                    DESY              [ME57]
+      R 131.170.rrr.rrr                    RMIT              [MS300]
+      R 131.171.rrr.rrr                    UMUC              [RS486]
+      R 131.172.rrr.rrr                    LATROBE           [PC116]
+      R*131.173.rrr.rrr                    UOS               [RN58]
+      R 131.174.rrr.rrr                    NUNET             [JA155]
+      R 131.175.rrr.rrr                    CILEA             [AM134]
+      R*131.176.rrr.rrr                    ESA               [DW195]
+      R 131.177.rrr.rrr                    PTT-TELE          [JT166]
+      R 131.178.rrr.rrr                    ITESM             [HEG6]
+      R 131.179.rrr.rrr                    UCLA-CS           [RBW]
+      R*131.180.rrr.rrr                    DUT-LAN2          [FD18]
+      R 131.181.rrr.rrr                    QUT               [AA70]
+      G 131.182.rrr.rrr                    NASA-HQ-NET       [MSM1]
+      R 131.183.rrr.rrr                    UTOLEDO-NET       [BN38]
+      C*131.184.rrr.rrr                    MCDERMOTT         [TP58]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 25]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      D 131.185.rrr.rrr                    DSTO              [JWB35]
+      R 131.186.rrr.rrr                    WB-TEST           [KS14]
+      R 131.187.rrr.rrr                    OARNET            [MF74]
+      R 131.188.rrr.rrr                    REVUE             [JK198]
+      D*131.189.rrr.rrr                    TRACORNET         [PM140]
+      C*131.190.rrr.rrr                    PGXPRES           [ACL2]
+      G*131.191.rrr.rrr                    TACOMA            [BD89]
+      R 131.192.rrr.rrr                    NEARNET           [DBL1]
+      R 131.193.rrr.rrr                    UIC-ISN-NET       [EZ3]
+      R*131.194.rrr.rrr                    TRINITY           [LHG3]
+      R 131.195.rrr.rrr                    HYDRO-QUEBEC      [CV25]
+      R 131.196.rrr.rrr                    CNUSC             [JLD31]
+      C*131.197.rrr.rrr                    MOTO-SPS          [SO35]
+      C 131.198.rrr.rrr                    ROK3              [TGS6]
+      C 131.199.rrr.rrr                    ROK4              [TGS6]
+      C 131.200.rrr.rrr                    ROK5              [TGS6]
+      C*131.201.rrr.rrr                    HI-RESG-NET       [JG8]
+      R*131.202.rrr.rrr                    UNB-IPNET         [BK76]
+      R 131.203.rrr.rrr                    DSIR              [SW143]
+      R 131.204.rrr.rrr                    AU-NET            [LO28]
+      C*131.205.rrr.rrr                    SLLWAN            [AL16]
+      R*131.206.rrr.rrr                    KIT-NET           [HN21]
+      G*131.207.rrr.rrr                    TIETOTIE          [PI7]
+      C*131.208.rrr.rrr                    MERRILL-LYNCH     [JC394]
+      C*131.209.rrr.rrr                    PW-NET            [EMB]
+      R 131.210.rrr.rrr                    UW-PARKSIDE       [TVF1]
+      R 131.211.rrr.rrr                    RUU               [WPBS]
+      R 131.212.rrr.rrr                    UMNDULNET         [WJM26]
+      C*131.213.rrr.rrr                    NTCRK-MANU        [GJ35]
+      D 131.214.rrr.rrr                    ROMENET           [PV23]
+      R 131.215.rrr.rrr                    CALTECH-NET       [AD22]
+      R 131.216.rrr.rrr                    NEVADA            [RLY1]
+      R 131.217.rrr.rrr                    TASUNI-NET        [RB577]
+      D 131.218.rrr.rrr                    ALADDIN           [CLR16]
+      C*131.219.rrr.rrr                    PPL-NET           [AK70]
+      R*131.220.rrr.rrr                    UNI-BONN          [HG51]
+      R*131.221.rrr.rrr                    FXIS              [SA72]
+      C*131.222.rrr.rrr                    NCR-COMTEN        [RC234]
+      C*131.223.rrr.rrr                    LATA              [JGB17]
+      R*131.224.rrr.rrr                    RIVMNET           [RB578]
+      R 131.225.rrr.rrr                    FERMILAB          [CD75]
+      C 131.226.rrr.rrr                    MEMORY-ALPHA      [JM551]
+      R*131.227.rrr.rrr                    SURREY-NET        [GC122]
+      R 131.228.rrr.rrr                    NOKIA             [AV20]
+      R*131.229.rrr.rrr                    SMITH             [LG91]
+      R 131.230.rrr.rrr                    SIU-NET           [CRC15]
+      R*131.231.rrr.rrr                    LUT-AC-UK         [RT140]
+      R*131.232.rrr.rrr                    ATHABASCA-U       [LN42]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 26]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C*131.233.rrr.rrr                    CIM-NET           [JH342]
+      R*131.234.rrr.rrr                    UNIPADERBORN      [RF130]
+      G 131.235.rrr.rrr                    ALCIDE            [JG266]
+      R 131.236.rrr.rrr                    ADFA-NET          [GC155]
+      G*131.237.rrr.rrr                    RWSNL             [PO16]
+      R*131.238.rrr.rrr                    UNIV-DAYTON       [RT142]
+      C 131.239.rrr.rrr                    THINK-NET         [BJN1]
+      G 131.240.rrr.rrr                    CC                [KMC3]
+      R 131.241.rrr.rrr                    NECAM             [ARS3]
+      G 131.242.rrr.rrr                    CITEC             [TT32]
+      R 131.243.rrr.rrr                    LBL-IP-NET2       [CAL3]
+      R 131.244.rrr.rrr                    BOND-UN1          [EB112]
+      R 131.245.rrr.rrr                    BOND-RP           [EB112]
+      R 131.246.rrr.rrr                    RHRK-LAN          [BGW3]
+      R 131.247.rrr.rrr                    USF               [JG269]
+      C*131.248.rrr.rrr                    CTC-NET           [TS154]
+      R 131.249.rrr.rrr                    FCCC              [RKS1]
+      D 131.250.rrr.rrr                    OCNR-ETHER        [TW3]
+      R*131.251.rrr.rrr                    CARDIFFCOMMA      [RE73]
+      R 131.252.rrr.rrr                    PDX-NET           [FD41]
+      R*131.253.rrr.rrr                    NTCSIS-NET        [JC403]
+      R 131.254.rrr.rrr                    IRISA-NET         [RT144]
+        131.255.rrr.rrr                    Reserved          [NIC]
+        132.0.rrr.rrr                      Reserved          [NIC]
+      D 132.1.rrr.rrr                      VANDENBERG        [BPW1]
+      D 132.2.rrr.rrr                      WESTOVER          [BPW1]
+      D 132.3.rrr.rrr                      NET-WILLIAMS      [BPW1]
+      D 132.4.rrr.rrr                      WURTSMITH         [BPW1]
+      D 132.5.rrr.rrr                      HOLLOMAN          [AJ180]
+      D 132.6.rrr.rrr                      ANKARA            [DWJ6]
+      D 132.7.rrr.rrr                      SANVITO           [BPW1]
+      D 132.8.rrr.rrr                      DOBBINS-NET       [LN4]
+      D 132.9.rrr.rrr                      ELLSWORTH         [SL129]
+      D 132.10.rrr.rrr                     GRAND-FORKS       [TLO]
+      D 132.11.rrr.rrr                     HELLENIKON        [BPW1]
+      D 132.12.rrr.rrr                     MYRTLE-BEACH      [TK86]
+      D 132.13.rrr.rrr                     BENTWATERS        [LS64]
+      D 132.14.rrr.rrr                     AF Concentrator   [BPW1]
+      D 132.15.rrr.rrr                     KADENA            [JEF8]
+      D 132.16.rrr.rrr                     KUNSAN            [RW15]
+      D 132.17.rrr.rrr                     LINDSEY           [SB152]
+      D 132.18.rrr.rrr                     MCGUIRE           [BPW1]
+      D 132.19.rrr.rrr                     MILDENHALL        [DS341]
+      D 132.20.rrr.rrr                     MISAWA            [BPW1]
+      D 132.21.rrr.rrr                     PLATTSBURGH       [BPW1]
+      D 132.22.rrr.rrr                     POPE              [BPW1]
+      D 132.23.rrr.rrr                     SEYMOUR-JOHN      [KS24]
+      D 132.24.rrr.rrr                     AF Concentrator   [BPW1]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 27]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      D 132.25.rrr.rrr                     FAIRFORD          [BPW1]
+      D 132.26.rrr.rrr                     AF Concentrator   [BPW1]
+      D 132.27.rrr.rrr                     INCIRLIK-NET      [KV14]
+      D 132.28.rrr.rrr                     AF Concentrator   [BPW1]
+      D 132.29.rrr.rrr                     IZMIR             [BPW1]
+      D 132.30.rrr.rrr                     LAJES             [BPW1]
+      D 132.31.rrr.rrr                     LORING-NET        [TTO]
+      D 132.32.rrr.rrr                     MINOT             [BPW1]
+      D 132.33.rrr.rrr                     TRAVIS            [RB536]
+      D 132.34.rrr.rrr                     CANNON            [BPW1]
+      D 132.35.rrr.rrr                     ALTUS             [BPW1]
+      D 132.36.rrr.rrr                     EAKER             [BPW1]
+      D 132.37.rrr.rrr                     CARSWELL          [BPW1]
+      D 132.38.rrr.rrr                     AF Concentrator   [BPW1]
+      D 132.39.rrr.rrr                     KISAWYER          [BPW1]
+      D 132.40.rrr.rrr                     MOODY-NET         [BG56]
+      D 132.41.rrr.rrr                     AF Concentrator   [BPW1]
+      D 132.42.rrr.rrr                     SPANGDAHLEM       [BPW1]
+      D 132.43.rrr.rrr                     ZWEIBRUCHEN       [BPW1]
+      D 132.44.rrr.rrr                     GRISSOM           [BPW1]
+      D 132.45.rrr.rrr                     CHANUTE           [BPW1]
+      D 132.46.rrr.rrr                     COLUMBUS          [BPW1]
+      D 132.47.rrr.rrr                     FEWARREN          [BPW1]
+      D 132.48.rrr.rrr                     LAUGHLIN-NET      [JG293]
+      D 132.49.rrr.rrr                     MTNHOME           [BPW1]
+      D 132.50.rrr.rrr                     REESE             [BPW1]
+      D 132.51.rrr.rrr                     AF Concentrator   [BPW1]
+      D 132.52.rrr.rrr                     VANCE             [BPW1]
+      D 132.53.rrr.rrr                     AF Concentrator   [BPW1]
+      D 132.54.rrr.rrr                     ZARAGOZA          [BPW1]
+      D 132.55.rrr.rrr                     TORREJON          [BPW1]
+      D 132.56.rrr.rrr                     BEALE             [BPW1]
+      D 132.57.rrr.rrr                     CASTLE            [BPW1]
+      D 132.58.rrr.rrr                     NELLIS            [BPW1]
+      D 132.59.rrr.rrr                     HOWARD            [BPW1]
+      D 132.60.rrr.rrr                     MAXWELL-NET       [BPW1]
+      D 132.61.rrr.rrr                     OSAN-NET          [TLC28]
+      D 132.62.rrr.rrr                     KIRTLAND2         [BPW1]
+      D 132.63.rrr.rrr                     RANDOLPHMPC       [BPW1]
+      R 132.64.rrr.rrr                     ILAN-HUJI-1       [JM647]
+      R 132.65.rrr.rrr                     ILAN-HUJI-2       [JM647]
+      R 132.66.rrr.rrr                     ILAN-TAU-1        [OC4]
+      R 132.67.rrr.rrr                     ILAN-TAU-2        [OC4]
+      R 132.68.rrr.rrr                     ILAN-TECHNION-1   [GM199]
+      R 132.69.rrr.rrr                     ILAN-TECHNION-2   [GM199]
+      R 132.70.rrr.rrr                     ILAN-BIU-1        [HN7]
+      R 132.71.rrr.rrr                     ILAN-BIU-2        [HN7]
+      R 132.72.rrr.rrr                     ILAN-BGU-1        [SG147]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 28]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R 132.73.rrr.rrr                     ILAN-BGU-2        [SG147]
+      R 132.74.rrr.rrr                     ILAN-HAIFA-1      [MS355]
+      R 132.75.rrr.rrr                     ILAN-HAIFA-2      [MS355]
+      R 132.76.rrr.rrr                     ILAN-WIS-1        [BM211]
+      R 132.77.rrr.rrr                     ILAN-WIS-2        [BM211]
+      R 132.78.rrr.rrr                     ILAN-RESRV        [DB35]
+      D 132.79.rrr.rrr                     VAARNG-NET        [CAP5]
+      D 132.80.rrr.rrr-132.143.rrr.rrr     NG Concentrator   [CAP5]
+      D 132.144.rrr.rrr                    RIA-2             [MMJ1]
+      C*132.145.rrr.rrr                    NET-RESOURCES     [JM561]
+      C*132.146.rrr.rrr                    BTRL-PLANET       [RO58]
+      C*132.147.rrr.rrr                    SCO               [KR35]
+      C*132.148.rrr.rrr                    IAS1              [ND22]
+      R*132.149.rrr.rrr                    CNES              [MP138]
+      G*132.150.rrr.rrr                    STAMNETT          [GG110]
+      R 132.151.rrr.rrr                    NRI-NET           [DKE2]
+      C*132.152.rrr.rrr                    GF                [CN33]
+      G*132.153.rrr.rrr                    AWE-SWAN          [RS409]
+      R 132.154.rrr.rrr                    ROCKWELL-AI       [BMW7]
+      C*132.155.rrr.rrr                    NESTE-NET         [HP44]
+      G*132.156.rrr.rrr                    EMRNET            [DB317]
+      C*132.157.rrr.rrr                    PORTAL-NET        [MR159]
+      C 132.158.rrr.rrr                    HARRIS-SEMI       [JB544]
+      D 132.159.rrr.rrr                    FTLEENET          [TWH19]
+      G 132.160.rrr.rrr                    PACCOM            [TN11]
+      R*132.161.rrr.rrr                    GRIN              [TM169]
+      R 132.162.rrr.rrr                    OBERLIN           [BH161]
+      G 132.163.rrr.rrr                    BLDRDOC           [FMM11]
+      D*132.164.rrr.rrr                    B2TSN             [SM197]
+      R*132.165.rrr.rrr                    CEA-SIEGE         [JP254]
+      R*132.166.rrr.rrr                    CEA-SACLAY        [JD16]
+      R*132.167.rrr.rrr                    CEA-FONTENAY      [JD16]
+      R*132.168.rrr.rrr                    CEA-GRENOBLE      [GB167]
+      R*132.169.rrr.rrr                    CEA-CADARACH      [DC257]
+      R 132.170.rrr.rrr                    UCF               [WTE4]
+      G*132.171.rrr.rrr                    IVOWAN            [TT69]
+      C*132.172.rrr.rrr                    HANDS             [JRA26]
+      D*132.173.rrr.rrr                    CWATCHNET         [GK44]
+      R 132.174.rrr.rrr                    OCLC              [TT70]
+      R 132.175.rrr.rrr                    SNLA-NET          [AB161]
+      R 132.176.rrr.rrr                    FERNUNI-NET       [CR24]
+      R 132.177.rrr.rrr                    UNH               [BR104]
+      R 132.178.rrr.rrr                    IDBSU             [MU7]
+      C*132.179.rrr.rrr                    TPMA-NET          [TS160]
+      R*132.180.rrr.rrr                    UNIBT-LAN         [HT40]
+      R 132.181.rrr.rrr                    CANTERBURY        [BNL1]
+      R*132.182.rrr.rrr                    MEINET            [JY33]
+      R 132.183.rrr.rrr                    MGH-ETHER         [DM75]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 29]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C*132.184.rrr.rrr                    UNX-DEC-NET       [AK75]
+      C*132.185.rrr.rrr                    BBC               [BB231]
+      C 132.186.rrr.rrr                    PYRAMIDOZ         [BK78]
+      R*132.187.rrr.rrr                    UNIWUE-LAN        [MR160]
+      C*132.188.rrr.rrr                    AUTODESK          [DOR]
+      C*132.189.rrr.rrr                    LILLYNET          [FDC2]
+      C*132.190.rrr.rrr                    VARIAN-NET        [DM313]
+      G*132.191.rrr.rrr                    DOERLNET2         [DES41]
+      R 132.192.rrr.rrr                    UTMEM-NET         [EB108]
+      D 132.193.rrr.rrr                    ARO-NET           [BF81]
+      R 132.194.rrr.rrr                    CUDENVER          [RH286]
+      R*132.195.rrr.rrr                    WUPPERNET         [CK96]
+      C*132.196.rrr.rrr                    EUANET            [BO26]
+      R 132.197.rrr.rrr                    GTEL              [MM334]
+      R 132.198.rrr.rrr                    UVM-NET           [GAB36]
+      R*132.199.rrr.rrr                    UNIR-LAN          [KW8]
+      G*132.200.rrr.rrr                    FRB               [RPD5]
+      C 132.201.rrr.rrr                    SBC               [KS133]
+      R 132.202.rrr.rrr                    RISQ              [MV38]
+      R 132.203.rrr.rrr                    ULAVAL            [JG299]
+      R 132.204.rrr.rrr                    UMONTREAL         [RD187]
+      R 132.205.rrr.rrr                    CONCORDIA         [FM83]
+      R 132.206.rrr.rrr                    MCGILL-CA         [CRC9]
+      R 132.207.rrr.rrr                    POLYTECHCA        [JPD]
+      R 132.208.rrr.rrr                    UQAM              [PC138]
+      R 132.209.rrr.rrr-132.221.rrr.rrr    Quebec Research   [MV38]
+      C*132.222.rrr.rrr                    NTT-CAE           [TN40]
+      C*132.223.rrr.rrr                    GENRAD-NET        [RT148]
+      D*132.224.rrr.rrr                    BOE-AS-NET        [GK44]
+      R*132.225.rrr.rrr                    AECL-RCNET        [JP262]
+      R 132.226.rrr.rrr                    ALCOA-NET         [JOG]
+      R 132.227.rrr.rrr                    IBP-NET           [JC414]
+      C 132.228.rrr.rrr                    GRUMMAN           [MT105]
+      R*132.229.rrr.rrr                    RUL-NL            [SL60]
+      R 132.230.rrr.rrr                    FDN               [MW171]
+      R*132.231.rrr.rrr                    PASSAU-LAN        [AK76]
+      C*132.232.rrr.rrr                    BISMACNET         [MAJ14]
+      C*132.233.rrr.rrr                    FM-CIS            [BW142]
+      R 132.234.rrr.rrr                    GUNET             [GW117]
+      R 132.235.rrr.rrr                    OHIOU-NET         [JT149]
+      R 132.236.rrr.rrr                    NYSAES            [BBJ2]
+      C*132.237.rrr.rrr                    WYSE              [BR106]
+      R 132.238.rrr.rrr                    FDUNET            [NMS5]
+      R 132.239.rrr.rrr                    UCSD-SUBNETS      [BK29]
+      C*132.240.rrr.rrr                    VITALINK          [FB77]
+      R 132.241.rrr.rrr                    CSUCHICO          [PT55]
+      C*132.242.rrr.rrr                    NCR-EM-SD         [JS511]
+      C 132.243.rrr.rrr                    NCRWIN            [LL115]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 30]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C*132.244.rrr.rrr                    ROLLS-ROYCE       [CH181]
+      C 132.245.rrr.rrr                    XYLOGICS          [JRL3]
+      R 132.246.rrr.rrr                    NRC               [LB164]
+      R 132.247.rrr.rrr                    RAM               [MA105]
+      R 132.248.rrr.rrr                    REDUNAM           [MA105]
+      R 132.249.rrr.rrr                    SDSCLAN           [GKN1]
+      D 132.250.rrr.rrr                    NRL-NETS          [WF3]
+      R 132.251.rrr.rrr                    ISTS              [EC43]
+      R*132.252.rrr.rrr                    UEGNET            [DN71]
+      C*132.253.rrr.rrr                    RASNA             [TJT1]
+      R 132.254.rrr.rrr                    ITESM-MEXICO      [SZ21]
+        132.255.rrr.rrr                    Reserved          [NIC]
+        133.0.rrr.rrr                      Reserved          [NIC]
+      R 133.1.rrr.rrr                      OSAKAU-NET        [JM292]
+      R 133.2.rrr.rrr                      AGUNET            [JM292]
+      R*133.3.rrr.rrr                      JAPAN-INET        [JM292]
+      R 133.4.rrr.rrr                      WIDE-BB           [JM292]
+      R 133.5.rrr.rrr                      KITE              [JM292]
+      R 133.6.rrr.rrr                      NICE              [JM292]
+      R*133.7.rrr.rrr-133.10.rrr.rrr       JAPAN-INET        [JM292]
+      R 133.11.rrr.rrr                     UTSNET            [JM292]
+      R*133.12.rrr.rrr-133.17.rrr.rrr      JAPAN-INET        [JM292]
+      R 133.18.rrr.rrr                     JAPAN-INET        [JM292]
+      R*133.19.rrr.rrr-133.26.rrr.rrr      JAPAN-INET        [JM292]
+      R 133.27.rrr.rrr                     JAPAN-INET        [JM292]
+      R*133.28.rrr.rrr-133.38.rrr.rrr      JAPAN-INET        [JM292]
+      R 133.39.rrr.rrr                     JAPAN-INET        [JM292]
+      R 133.40.rrr.rrr                     JAPAN-INET        [JM292]
+      R*133.41.rrr.rrr-133.46.rrr.rrr      JAPAN-INET        [JM292]
+      R 133.47.rrr.rrr                     JAPAN-INET        [JM292]
+      R*133.48.rrr.rrr-133.54.rrr.rrr      JAPAN-INET        [JM292]
+      R 133.55.rrr.rrr                     JAPAN-INET        [JM292]
+      R 133.56.rrr.rrr                     JAPAN-INET        [JM292]
+      R*133.57.rrr.rrr-133.136.rrr.rrr     JAPAN-INET        [JM292]
+      R 133.137.rrr.rrr                    JAPAN-INET        [JM292]
+      R 133.138.rrr.rrr                    JAPAN-INET        [JM292]
+      R 133.139.rrr.rrr                    JAPAN-INET        [JM292]
+      R*133.140.rrr.rrr-133.152.rrr.rrr    JAPAN-INET        [JM292]
+      R 133.153.rrr.rrr                    JAPAN-INET        [JM292]
+      R*133.154.rrr.rrr-133.254.rrr.rrr    JAPAN-INET        [JM292]
+        133.255.rrr.rrr                    Reserved          [JBP]
+        134.0.rrr.rrr                      Reserved          [JBP]
+      R*134.1.rrr.rrr                      AWINET            [JMS17]
+      R 134.2.rrr.rrr                      TUENET            [HH68]
+      R 134.3.rrr.rrr                      SSCLAB            [GC118]
+      R 134.4.rrr.rrr                      IPAC-NET          [RE77]
+      C*134.5.rrr.rrr                      LASC              [WM112]
+      C*134.6.rrr.rrr                      MAXTOR            [DP154]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 31]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R*134.7.rrr.rrr                      CUT-NET           [YL14]
+      C*134.8.rrr.rrr                      CADINC            [WN19]
+      R 134.9.rrr.rrr                      OCF-NET           [RAF4]
+      R*134.10.rrr.rrr                     REED              [NG48]
+      D 134.11.rrr.rrr                     PENTNET           [RF50]
+      G 134.12.rrr.rrr                     RIACS-B-NET       [MSM1]
+      C*134.13.rrr.rrr                     CRF               [DJD30]
+      C*134.14.rrr.rrr                     CRG               [DJD30]
+      C*134.15.rrr.rrr                     CRJ               [DJD30]
+      C*134.16.rrr.rrr                     CRUK              [DJD30]
+      R 134.17.rrr.rrr                     BAY-PR-NET        [MSM1]
+      R 134.18.rrr.rrr                     BHP-IP-NET        [IH15]
+      C*134.19.rrr.rrr                     ILAN              [SS253]
+      G 134.20.rrr.rrr                     INEL              [AKP]
+      R 134.21.rrr.rrr                     UNIFR-ETHER1      [MB262]
+      R 134.22.rrr.rrr                     GANDALF-NET       [ML163]
+      C*134.23.rrr.rrr                     MIZARB            [MCL9]
+      R 134.24.rrr.rrr                     CERFNET           [SMA9]
+      C*134.25.rrr.rrr                     RIKSRADION        [KB32]
+      C*134.26.rrr.rrr                     MERCK             [DC272]
+      C*134.27.rrr.rrr                     VLSI              [CG107]
+      R*134.28.rrr.rrr                     TUHH              [PW83]
+      R 134.29.rrr.rrr                     MSUS-NET          [DK142]
+      R*134.30.rrr.rrr                     HMI               [DW212]
+      C*134.31.rrr.rrr                     BOE-CANADA        [GK44]
+      C*134.32.rrr.rrr                     SCR               [SB205]
+      C*134.33.rrr.rrr                     CODEX-CORP        [LB190]
+      R 134.34.rrr.rrr                     KISS              [JB462]
+      C*134.35.rrr.rrr                     NAMSI             [JT181]
+      R*134.36.rrr.rrr                     DUNDEE-UNIV       [MW176]
+      C*134.37.rrr.rrr-134.46.rrr.rrr      Hewlett-Packard   [SI8]
+      G*134.47.rrr.rrr                     NORTELE           [AT79]
+      R 134.48.rrr.rrr                     MARQUENET         [SG68]
+      C*134.49.rrr.rrr                     AHA               [ES144]
+      R 134.50.rrr.rrr                     ISU-NET           [BH167]
+      D*134.51.rrr.rrr                     BOE-MIL           [GK44]
+      G*134.52.rrr.rrr                     BOE-GIS           [GK44]
+      R 134.53.rrr.rrr                     MUOHIO            [JW335]
+      C*134.54.rrr.rrr                     CAMEX             [PM155]
+      G 134.55.rrr.rrr                     ESNET             [AT80]
+      C*134.56.rrr.rrr                     NET               [RP210]
+      C 134.57.rrr.rrr                     ROCKWELL-RKD      [CH191]
+      R*134.58.rrr.rrr                     KULNET            [SB206]
+      R*134.59.rrr.rrr                     ARCHIPEL          [MB32]
+      R 134.60.rrr.rrr                     UDN               [WH2]
+      R*134.61.rrr.rrr                     RWTHPHYS          [CK2]
+      R 134.62.rrr.rrr                     TEKTRONIX1        [MJE]
+      R 134.63.rrr.rrr                     TEKTRONIX2        [MJE]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 32]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R 134.64.rrr.rrr                     TEKTRONIX3        [MJE]
+        134.65.rrr.rrr-134.67.rrr.rrr      Unassigned        [NIC]
+      R 134.68.rrr.rrr                     IUPUI-NET         [DJ24]
+      R 134.69.rrr.rrr                     OXY-NET           [PH73]
+      C*134.70.rrr.rrr                     DESKTALK          [DJK13]
+      R 134.71.rrr.rrr                     CSUPOM            [GCF7]
+      D*134.72.rrr.rrr                     BOE-KSC-NET       [GK44]
+      C*134.73.rrr.rrr                     EHS-NET           [LN1]
+      R 134.74.rrr.rrr                     CITYCOLLEGE       [CPK3]
+      R 134.75.rrr.rrr                     KREONET           [OHB]
+      R*134.76.rrr.rrr                     GWDG              [WJM1]
+      C*134.77.rrr.rrr                     NORTHROP-B2       [DZ]
+      D 134.78.rrr.rrr                     AVTROS-NET        [CAD10]
+      R 134.79.rrr.rrr                     SU-SLAC           [JH40]
+      D 134.80.rrr.rrr                     MONMOUTH-1        [GS12]
+      R*134.81.rrr.rrr                     HOENET            [RL202]
+      R*134.82.rrr.rrr                     BUCKNELL          [GJS13]
+      R*134.83.rrr.rrr                     BRUNEL-NET        [NB39]
+      R*134.84.rrr.rrr                     UMN-GWNET         [CAF13]
+      C 134.85.rrr.rrr                     AMERITECH         [JFG21]
+      C*134.86.rrr.rrr                     SCS               [KM131]
+      R 134.87.rrr.rrr                     BCNET-2           [DO26]
+      R*134.88.rrr.rrr                     SEMASSU-NET       [NJ]
+      R 134.89.rrr.rrr                     MBARI             [HW56]
+      C*134.90.rrr.rrr                     OLY-NET           [JLP6]
+      R*134.91.rrr.rrr                     UNIDUI-LAN        [GS101]
+        134.92.rrr.rrr                     Unassigned        [NIC]
+      R*134.93.rrr.rrr                     UNI-MAINZ         [FN]
+        134.94.rrr.rrr                     Unassigned        [NIC]
+      R 134.95.rrr.rrr                     UNI-KOELN         [CK113]
+      R*134.96.rrr.rrr                     UNISB-LAN         [PK32]
+      R*134.97.rrr.rrr                     TST-HH-LAN        [HK29]
+      C*134.98.rrr.rrr                     PCS-NET           [RW24]
+        134.99.rrr.rrr-134.110.rrr.rrr     Unassigned        [NIC]
+      C 134.111.rrr.rrr                    STRATUS-NET       [WPC]
+      C 134.112.rrr.rrr                    STRATUS-TSTB      [WPC]
+      G*134.113.rrr.rrr                    IMF               [SM10]
+      R 134.114.rrr.rrr                    NAU-NET           [PB1]
+      R 134.115.rrr.rrr                    MURDOCH-UNIV      [RM256]
+      R 134.116.rrr.rrr                    MMLAB             [BK88]
+      R 134.117.rrr.rrr                    CARLETON1         [JS535]
+      G 134.118.rrr.rrr                    JSCFMNET          [EH97]
+      R*134.119.rrr.rrr                    FUNN              [ST22]
+      C*134.120.rrr.rrr                    GENDYNSD          [FAC2]
+      R 134.121.rrr.rrr                    WSUNET            [RW211]
+      C*134.122.rrr.rrr                    PHOENIX           [RS95]
+      G*134.123.rrr.rrr                    OIANET            [SH33]
+      R 134.124.rrr.rrr                    MORNETS           [DVL1]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 33]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R 134.125.rrr.rrr                    TWDB              [TH28]
+      R 134.126.rrr.rrr                    JMU               [CM50]
+      C*134.127.rrr.rrr                    SSDS              [RS49]
+      C*134.128.rrr.rrr                    CYBER-INC         [ST23]
+      R 134.129.rrr.rrr                    NODAK             [TW8]
+      R*134.130.rrr.rrr                    ACHSE             [GS199]
+      D 134.131.rrr.rrr                    WPAFB-AVLAB       [DRY2]
+      R 134.132.rrr.rrr                    LGC-NET           [JA175]
+      C*134.133.rrr.rrr                    COMSAT            [AK78]
+      C*134.134.rrr.rrr                    BIIN-NET          [HH64]
+      D 134.135.rrr.rrr                    GDSS-NET          [RWH29]
+      D 134.136.rrr.rrr                    WPAFB-ASD-NET     [SF76]
+      D*134.137.rrr.rrr                    AEDC-CFD          [JM627]
+      C*134.138.rrr.rrr                    EUANET-2          [BO26]
+      R 134.139.rrr.rrr                    CSULB-IP          [NVT]
+      R 134.140.rrr.rrr                    SIMMONS           [EP70]
+      C 134.141.rrr.rrr                    CABLETRON         [PWB12]
+      C*134.142.rrr.rrr-134.146.rrr.rrr    SHELL-NETS        [FJS2]
+      R*134.147.rrr.rrr                    RUB-INET          [JK213]
+      R 134.148.rrr.rrr                    UNINEWCASTLE      [DM232]
+      R 134.149.rrr.rrr                    APPLE-CAMB        [EF16]
+      C*134.150.rrr.rrr                    NTTNDSTL          [HB7]
+      R*134.151.rrr.rrr                    ASTON             [PF64]
+      D 134.152.rrr.rrr                    OSD-NET           [WSW11]
+      R*134.153.rrr.rrr                    NFRN              [DJ104]
+      R 134.154.rrr.rrr                    CSUHAYWARD        [CDS28]
+      R 134.155.rrr.rrr                    RUMEL             [RW112]
+      C*134.156.rrr.rrr                    MINN-POWER        [KJ4]
+      R*134.157.rrr.rrr                    UPMC-NET          [MTC]
+      R*134.158.rrr.rrr                    PHYNET            [NG15]
+      R 134.159.rrr.rrr                    OTC               [MH233]
+      R 134.160.rrr.rrr                    RIKEN-NET         [TS158]
+      R 134.161.rrr.rrr                    UNI-NET           [SYM2]
+      C*134.162.rrr.rrr                    SHELL1-NET        [DGA]
+      C*134.163.rrr.rrr                    SHELL2-NET        [DGA]
+      D 134.164.rrr.rrr                    USAEWESNET        [SAA]
+      R 134.165.rrr.rrr                    SRIEXPRIGB1       [PEM4]
+        134.166.rrr.rrr-134.167.rrr.rrr    Unassigned        [NIC]
+      C*134.168.rrr.rrr                    INFORMIX-NET      [RE84]
+      R*134.169.rrr.rrr                    TU-BS Network     [DJS7]
+      C*134.170.rrr.rrr                    NORTELRCH         [JP283]
+      R*134.171.rrr.rrr                    ESO-NET           [RH315]
+      R 134.172.rrr.rrr                    IGNET             [EL30]
+      R 134.173.rrr.rrr                    CLAREMONT         [NF13]
+      R 134.174.rrr.rrr                    LMANET            [SB28]
+      C*134.175.rrr.rrr                    AII-NET           [SAJ1]
+      R*134.176.rrr.rrr                    UNIGI-NET         [KA14]
+      C 134.177.rrr.rrr                    SYNOPT-NET        [SCB12]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 34]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      G 134.178.rrr.rrr                    MET-AUST-NET      [BT65]
+      G*134.179.rrr.rrr                    NYSDEC-NET        [FM85]
+      R*134.180.rrr.rrr                    SANYO             [HT44]
+      R*134.181.rrr.rrr                    BATES-NET         [RS348]
+      R*134.182.rrr.rrr                    ORION             [WJS1]
+      C*134.183.rrr.rrr                    TI-EUROPE         [JT185]
+      R*134.184.rrr.rrr                    VUB               [EB129]
+      C 134.185.rrr.rrr                    KODAK-BTC         [HC66]
+      G 134.186.rrr.rrr                    TDCNET            [JS550]
+      G*134.187.rrr.rrr                    TEALE             [JS550]
+      R*134.188.rrr.rrr                    OCE-RD-NL         [MB273]
+      D*134.189.rrr.rrr                    GDFW              [BMV]
+        134.190.rrr.rrr-134.191.rrr.rrr    Unassigned        [NIC]
+      R 134.192.rrr.rrr                    UMAB-NET          [LAM1]
+      R 134.193.rrr.rrr                    UMKC              [BA71]
+      D 134.194.rrr.rrr                    CSTANET           [MH74]
+      C 134.195.rrr.rrr                    CRAYCOS           [BW157]
+      C*134.196.rrr.rrr                    TIMEPLEX-NET      [GP117]
+      R 134.197.rrr.rrr                    UNR-DOM           [MLC34]
+      R 134.198.rrr.rrr                    UOFSCRANTON       [WFG4]
+      C*134.199.rrr.rrr                    MITEL             [DF149]
+      C*134.200.rrr.rrr                    GOODYEAR          [LJE3]
+      G*134.201.rrr.rrr                    LADWP             [BLW2]
+      R 134.202.rrr.rrr                    UPRRNET           [JN12]
+      D*134.203.rrr.rrr                    TNO-HDO-LTD       [RVDA]
+      C*134.204.rrr.rrr                    SEAGATE           [FD44]
+      G 134.205.rrr.rrr                    HQUSAF-LAN        [BP32]
+      R*134.206.rrr.rrr                    LILNET            [GT67]
+      D 134.207.rrr.rrr                    NRL-EXP           [JTS3]
+      R*134.208.rrr.rrr                    ACANET-TWN        [HL65]
+      C*134.209.rrr.rrr                    NELLCOR           [KG12]
+      R*134.210.rrr.rrr                    STOCKTON          [HM80]
+      C 134.211.rrr.rrr                    BULL              [SG146]
+      R*134.212.rrr.rrr                    ONECERT           [PC137]
+      C*134.213.rrr.rrr                    NTGALW            [GO1]
+      R*134.214.rrr.rrr                    ROCAD             [GR85]
+      C*134.215.rrr.rrr                    TDS               [TH131]
+      C*134.216.rrr.rrr                    GULFAERO          [HB14]
+      C*134.217.rrr.rrr                    BECKMAN-DSG       [PA32]
+      G 134.218.rrr.rrr                    SNL-NETA          [AB161]
+      R*134.219.rrr.rrr                    RHBNC             [AM154]
+      R*134.220.rrr.rrr                    WOLVES            [MC280]
+      R*134.221.rrr.rrr                    TNO-NET           [OM1]
+      R*134.222.rrr.rrr                    EUNET-X25         [PB13]
+      C 134.223.rrr.rrr                    GRUMMANLAN        [CPK3]
+      R*134.224.rrr.rrr                    ACNET             [GB184]
+      R*134.225.rrr.rrr                    RDG-UNIV-UK       [AIM4]
+      R*134.226.rrr.rrr                    TCD-NET           [KG16]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 35]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C*134.227.rrr.rrr                    CAM-CNCA          [FB15]
+      C 134.228.rrr.rrr                    SSA-NET           [WJL17]
+      D 134.229.rrr.rrr                    CONCGY-PENS1      [DG163]
+      D 134.230.rrr.rrr                    CONCGY-PENS2      [DG163]
+      R 134.231.rrr.rrr                    GALLAUDET         [DVT]
+      D*134.232.rrr.rrr                    USAREUR           [AH124]
+      D*134.233.rrr.rrr                    TAACOM            [AH124]
+      D*134.234.rrr.rrr                    SETAF             [AH124]
+      D 134.235.rrr.rrr                    WORMS-GW1         [SAS49]
+      R 134.236.rrr.rrr                    LAKE-IPNET        [SGM4]
+      C*134.237.rrr.rrr                    YASKAWA           [MK162]
+      C*134.238.rrr.rrr                    FEDMOGUL-PSN      [TGC1]
+      C*134.239.rrr.rrr                    ICI-CP-NE-RT      [MDF13]
+      D 134.240.rrr.rrr                    USMANET-DDN       [PJM24]
+      R*134.241.rrr.rrr                    HECNET            [PC143]
+      C*134.242.rrr.rrr                    NCUBE-NET         [DR212]
+      R*134.243.rrr.rrr                    CAS               [CB217]
+      C*134.244.rrr.rrr                    MDCME             [JA184]
+      R*134.245.rrr.rrr                    UNI-KIEL          [PW98]
+      R*134.246.rrr.rrr                    IFREMER           [AI2]
+      C*134.247.rrr.rrr                    MUNAIR            [HH71]
+      C*134.248.rrr.rrr                    UNOCAL            [GC138]
+      G*134.249.rrr.rrr                    USDA-AMS          [BG101]
+      R 134.250.rrr.rrr                    SUSCNET           [CW159]
+      C*134.251.rrr.rrr                    GCS               [BB267]
+      G 134.252.rrr.rrr                    SNL-NETC          [AB161]
+      G 134.253.rrr.rrr                    SNL-NETB          [AB161]
+      D 134.254.rrr.rrr                    CONCGWAY-NOLA1    [DG163]
+        134.255.rrr.rrr                    Reserved          [JBP]
+      C*135.0.rrr.rrr-135.255.rrr.rrr      AT&T              [GFW6]
+        136.0.rrr.rrr                      Reserved          [JBP]
+      C*136.1.rrr.rrr-136.140.rrr.rrr      FORD-INTERNET     [FJB3]
+      C*136.141.rrr.rrr                    ROHNET            [JAD16]
+      R 136.142.rrr.rrr                    PITT-SUBNET       [DS247]
+      C*136.143.rrr.rrr                    COASTAL           [SM214]
+      R 136.144.rrr.rrr                    MILLIKIN-NET      [JK228]
+      R 136.145.rrr.rrr                    CUN               [JM476]
+      R*136.146.rrr.rrr                    NTC-MATH          [WD58]
+      R*136.147.rrr.rrr                    NTC-GLOBAL        [JD282]
+      R*136.148.rrr.rrr                    SBANK-POLY        [DC298]
+      D 136.149.rrr.rrr                    AFMPC-LAN         [RLR4]
+      R*136.150.rrr.rrr                    SUNYNET           [TP91]
+        136.151.rrr.rrr-136.155.rrr.rrr    Unassigned        [NIC]
+      R*136.156.rrr.rrr                    EURO-MET-NET      [DD223]
+      C*136.157.rrr.rrr                    NIXDORF-NET       [GRZ1]
+      C*136.158.rrr.rrr                    SAGA-NETTVERK     [LJV4]
+      R 136.159.rrr.rrr                    U-CALGARY         [RK168]
+      R 136.160.rrr.rrr                    COMBNET           [LAM1]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 36]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R 136.161.rrr.rrr                    PSINET1           [CPK3]
+      C*136.162.rrr.rrr                    FPSNET            [DLS20]
+      C*136.163.rrr.rrr                    SAAB-SCANIA       [POJ]
+      C*136.164.rrr.rrr                    HYDRO-NET         [SO42]
+      R*136.165.rrr.rrr                    LOUISVILLE        [DJ115]
+      C*136.166.rrr.rrr                    ZENITHNET         [AB128]
+      R 136.167.rrr.rrr                    BC-NET            [BW164]
+      R 136.168.rrr.rrr                    CSUBNET-IP        [DZ17]
+      R 136.169.rrr.rrr                    SACAENET          [IM33]
+      C*136.170.rrr.rrr                    ACORN             [AI4]
+      C*136.171.rrr.rrr                    CHEVRONLH         [AD106]
+      R*136.172.rrr.rrr                    DKRZ-NET          [GH39]
+      G*136.173.rrr.rrr                    EP-PE-NET         [PHK]
+      G*136.174.rrr.rrr                    PINELLAS          [MAG13]
+      C*136.175.rrr.rrr                    TELESOFT          [JSG2]
+      R 136.176.rrr.rrr                    BRADLEY-NET       [LH124]
+      R 136.177.rrr.rrr                    GEO               [THL3]
+      G 136.178.rrr.rrr                    NASA-RIG-NET      [JM663]
+      C*136.179.rrr.rrr                    NORANDS           [LLZ1]
+      D*136.180.rrr.rrr                    GDLS              [BT78]
+      G*136.181.rrr.rrr                    MICHTRANS-NET     [KJK4]
+      C 136.182.rrr.rrr                    MOT-CELL-NET      [SC193]
+      E*136.183.rrr.rrr                    SUCBUFFALO        [JS583]
+      C*136.184.rrr.rrr                    LIBERTY           [JGG23]
+      C*136.185.rrr.rrr                    AMPEX             [MW196]
+      R*136.186.rrr.rrr                    SWINBURNE         [BT65]
+      R*136.187.rrr.rrr                    NACSIS-NET        [JA180]
+      D 136.188.rrr.rrr-136.197.rrr.rrr    DODIIS            [JV7]
+      R*136.198.rrr.rrr                    JVC               [KS154]
+      R*136.199.rrr.rrr                    UNI-TRIER         [HS116]
+      G 136.200.rrr.rrr                    DWR-NET           [JK233]
+      R*136.201.rrr.rrr                    PARK-NET          [CC252]
+      D*136.202.rrr.rrr                    BOE-REN-NET       [GK44]
+      D*136.203.rrr.rrr                    BOE-AUB-NET       [GK44]
+      R*136.204.rrr.rrr                    SUC-MORRIS        [CB222]
+      D 136.205.rrr.rrr                    REDSTONE-NET      [RT64]
+      R*136.206.rrr.rrr                    DCU-NET           [MC293]
+      D 136.207.rrr.rrr                    WUERZBURG-GW1     [LT75]
+      D 136.208.rrr.rrr                    ASCHAFFENBURG-GW1 [GP129]
+      D 136.209.rrr.rrr                    ANSBACH-GW1       [JS573]
+      D 136.210.rrr.rrr                    AUGSBURG-GW1      [LW137]
+      D 136.211.rrr.rrr                    BURTONWOOD-GW1    [LW138]
+      D 136.212.rrr.rrr                    GEOPPINGEN-GW1    [PO2]
+      D 136.213.rrr.rrr                    GRAFENWOEHR-GW1   [SD131]
+      D 136.214.rrr.rrr                    HEIDELBERG-GW1    [AH130]
+      D 136.215.rrr.rrr                    HEILBRONN-GW1     [MG205]
+      D 136.216.rrr.rrr                    KARLSRUHE-GW1     [OT5]
+      D 136.217.rrr.rrr                    MUNICH-GW1        [RJ127]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 37]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      D 136.218.rrr.rrr                    NUERNBERG-GW1     [SJ65]
+      D 136.219.rrr.rrr                    ULM-GW1           [ML193]
+      D 136.220.rrr.rrr                    SCHWEINFURT-GW1   [WN2]
+      D 136.221.rrr.rrr                    STUTTGART-GW1     [CJC31]
+      D 136.222.rrr.rrr                    BAMBERG-GW1       [DS335]
+      R*136.223.rrr.rrr                    SUC-CERAMICS      [KH128]
+      R*136.224.rrr.rrr                    SUC-TECH-ALF      [TD103]
+      C*136.225.rrr.rrr                    ECN               [BC173]
+      C*136.226.rrr.rrr                    AAI               [TB164]
+      R 136.227.rrr.rrr                    WITTENBERG        [JS591]
+      C*136.228.rrr.rrr                    ALLIANT           [RR77]
+      R 136.229.rrr.rrr                    MMM-GOVT          [BR79]
+      C*136.230.rrr.rrr-136.239.rrr.rrr    Hewlett-Packard   [SI8]
+      C*136.240.rrr.rrr-136.241.rrr.rrr    BOEING-NETS       [GK44]
+      R 136.242.rrr.rrr                    CUAS              [ECM6]
+      C*136.243.rrr.rrr                    SUB-NET           [CS218]
+      R*136.244.rrr.rrr                    CONNCOLLS         [SBB9]
+      G*136.245.rrr.rrr                    ROSEVILLE         [MA119]
+      C 136.246.rrr.rrr                    UCINET            [DA124]
+      R 136.247.rrr.rrr                    MCO               [CLV7]
+      C*136.248.rrr.rrr                    GCA               [LB189]
+      C*136.249.rrr.rrr-136.254.rrr.rrr    HGSNETS           [LH2]
+        136.255.rrr.rrr                    Reserved          [JBP]
+        137.0.rrr.rrr                      Reserved          [JBP]
+      D 137.1.rrr.rrr                      WHITEMAN          [BPW1]
+      D 137.2.rrr.rrr                      GEORGE            [BPW1]
+      D 137.3.rrr.rrr                      LITTLEROCK        [BPW1]
+      D 137.4.rrr.rrr                      CHARLESTON        [AMF2]
+      D 137.5.rrr.rrr-137.14.rrr.rrr       AF Concentrator   [BPW1]
+      G*137.15.rrr.rrr                     METROCMA          [LS224]
+      C*137.16.rrr.rrr                     HI-CFS            [TS193]
+      R*137.17.rrr.rrr                     NLRNET            [FV13]
+      G*137.18.rrr.rrr                     HOUSE             [JS592]
+      C*137.19.rrr.rrr                     ALLIED            [WJL2]
+      C*137.20.rrr.rrr                     PSEG              [JFS37]
+      R*137.21.rrr.rrr                     SUCBROCKPORT      [DS382]
+      R 137.22.rrr.rrr                     CARLETONS         [SB201]
+      C 137.23.rrr.rrr                     MOT-COMM-NET      [SC193]
+      D 137.24.rrr.rrr                     NSWSES-NET        [MJJ1]
+      C*137.25.rrr.rrr-137.27.rrr.rrr      REYNOLDS          [LW134]
+      R 137.28.rrr.rrr                     UWEC              [VS58]
+      D 137.29.rrr.rrr                     BRAGG-MAN         [TN5]
+      R*137.30.rrr.rrr                     UNO-NET-BIG       [DES43]
+      R*137.31.rrr.rrr                     WALLACELABS       [DC304]
+      C*137.32.rrr.rrr                     GDFW-NET          [BSP6]
+      C*137.33.rrr.rrr                     KEMIRA            [EM128]
+      C*137.34.rrr.rrr                     FIRST-BOSTON      [JRF21]
+      C*137.35.rrr.rrr                     MONSANTO          [KNC]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 38]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R*137.36.rrr.rrr                     SUC-COBLE         [RH337]
+      R*137.37.rrr.rrr                     SUC-TECH-CAN      [RH336]
+      C*137.38.rrr.rrr                     CRAY-CF           [DJD30]
+      R 137.39.rrr.rrr                     UUNET-WAN         [AP25]
+      R*137.40.rrr.rrr                     MEINET-US         [JY33]
+      C 137.41.rrr.rrr                     MMCSUBNETS        [DR137]
+      C*137.42.rrr.rrr                     SSI               [JO94]
+      R*137.43.rrr.rrr                     UCD               [TW112]
+      R*137.44.rrr.rrr                     SWANSEA           [TO32]
+      R 137.45.rrr.rrr                     RU-NET            [JS593]
+      C 137.46.rrr.rrr                     ISC-INTEL         [BE46]
+      C*137.47.rrr.rrr                     STAVAFT           [OA4]
+      R 137.48.rrr.rrr                     UNOMAHA           [DH309]
+      R 137.49.rrr.rrr                     HARTFORD          [CPK3]
+        137.50.rrr.rrr-137.51.rrr.rrr      Unassigned        [NIC]
+      R 137.52.rrr.rrr                     NOVANET           [JPO4]
+      R*137.53.rrr.rrr                     OHSU              [MB307]
+      R 137.54.rrr.rrr                     VERNET            [JAJ17]
+      C*137.55.rrr.rrr                     PHILIPS           [MS378]
+        137.56.rrr.rrr-137.64.rrr.rrr      Unassigned        [NIC]
+      R 137.65.rrr.rrr                     NOVELL-NET        [JC481]
+      R 137.66.rrr.rrr                     MN-SUPER-NET      [MKS17]
+      D 137.67.rrr.rrr                     CORONA-GW         [MGR2]
+      R 137.68.rrr.rrr                     PAGODA            [JEA18]
+      C*137.69.rrr.rrr                     LEGATO-NET        [BN4]
+      G*137.70.rrr.rrr                     HCG               [MK132]
+      C*137.71.rrr.rrr                     ANALOG            [RP191]
+      C*137.72.rrr.rrr                     NETCOMMAND        [LK66]
+      R*137.73.rrr.rrr                     KCLNET            [JP301]
+      R*137.74.rrr.rrr                     NTC-LACH          [GC146]
+      G 137.75.rrr.rrr                     NOAA-FSL          [FG15]
+      C*137.76.rrr.rrr                     MIDENET           [PH120]
+      G 137.77.rrr.rrr                     RECNET            [JIMWW]
+      G*137.78.rrr.rrr                     JPL-NET2          [JAW16]
+      G*137.79.rrr.rrr                     JPL-OA            [JAW16]
+      D 137.80.rrr.rrr                     USACEC-NET        [LFM5]
+      R 137.81.rrr.rrr                     SUPER-NET         [PM177]
+      R 137.82.rrr.rrr                     UBC               [DM354]
+      C 137.83.rrr.rrr                     GENCORP           [RLR57]
+      R 137.84.rrr.rrr                     WHECN-CC          [MW200]
+      R 137.85.rrr.rrr                     WHECN-CWC         [MW200]
+      R 137.86.rrr.rrr                     WHECN-EWC         [MW200]
+      R 137.87.rrr.rrr                     WHECN-LCCC        [MW200]
+      R 137.88.rrr.rrr                     WHECN-NWC         [MW200]
+      R 137.89.rrr.rrr                     WHECN-SC          [MW200]
+      R 137.90.rrr.rrr                     WHECN-WWC         [MW200]
+      C*137.91.rrr.rrr                     APS               [RJH66]
+      R*137.92.rrr.rrr                     CANBERRA-UNI      [RT184]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 39]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C*137.93.rrr.rrr                     AALC              [HH77]
+      R*137.94.rrr.rrr                     RMC               [GT73]
+      D 137.95.rrr.rrr                     PATCH-NET         [TTS8]
+      C*137.96.rrr.rrr                     STO-ENERGY        [JL324]
+      C*137.97.rrr.rrr                     GLASGAL           [GMM28]
+      C*137.98.rrr.rrr                     DHLNET            [PSR]
+      R 137.99.rrr.rrr                     UCONN-NET         [JM433]
+      C*137.100.rrr.rrr                    CALSPANATC        [DY28]
+      C*137.101.rrr.rrr                    LOGITEK           [PJV]
+      C*137.102.rrr.rrr                    IWARP-NET         [RLS115]
+      C 137.103.rrr.rrr                    PROSPECT          [JEB84]
+      R 137.104.rrr.rrr                    UWPLATT           [LF70]
+      R*137.105.rrr.rrr                    EDRCNET           [AC154]
+      C*137.106.rrr.rrr                    USRNET-B1         [CC192]
+      C*137.107.rrr.rrr                    USRNET-B2         [CC192]
+      R*137.108.rrr.rrr                    OPEN-UNI          [JS596]
+      C 137.109.rrr.rrr                    LABTAM-NET        [SP116]
+      R 137.110.rrr.rrr                    UCSDMC            [BK29]
+      R 137.111.rrr.rrr                    MACQUARIE         [AVDH1]
+      R*137.112.rrr.rrr                    ROSE-HULMAN       [MM267]
+      R 137.113.rrr.rrr                    WLU               [RWF21]
+      C*137.114.rrr.rrr                    OECO              [JP303]
+      R*137.115.rrr.rrr                    NTC-BVW           [DW239]
+      C*137.116.rrr.rrr                    NTINET-NASH       [RG228]
+      C*137.117.rrr.rrr                    NTINET-RICH       [RG228]
+      C*137.118.rrr.rrr                    NTINET-STMN       [JS598]
+      C*137.119.rrr.rrr                    NTINET-AA         [RD231]
+      R*137.120.rrr.rrr                    MAASNET           [LCVDH]
+      R*137.121.rrr.rrr                    FNET-INRETS       [YK2]
+      R*137.122.rrr.rrr                    UOTTAWA           [JC483]
+      R*137.123.rrr.rrr                    SUC-CORTLAND      [LV6]
+      R*137.124.rrr.rrr                    SUC-TECH-DEL      [DN78]
+      R*137.125.rrr.rrr                    SUC-TECH-FRM      [JA189]
+      D*137.126.rrr.rrr                    USAFMARS          [JHS50]
+      D 137.127.rrr.rrr                    USACAA            [JWB48]
+      D 137.128.rrr.rrr                    TACOM-RDE         [RJ120]
+      G*137.129.rrr.rrr                    METEO-FRANCE      [MG206]
+      D 137.130.rrr.rrr                    JDSSC             [BMW13]
+      R 137.131.rrr.rrr                    SCRIPPSNET-BIG    [SRC16]
+      R*137.132.rrr.rrr                    NUS               [CL134]
+      C*137.133.rrr.rrr                    EBNERA            [RP239]
+      C*137.134.rrr.rrr                    TCS               [RL226]
+      C*137.135.rrr.rrr                    NTMTV             [CY30]
+      D*137.136.rrr.rrr                    BOE-KSCE-NET      [GK44]
+      D*137.137.rrr.rrr                    BOE-SREN-NET      [GK44]
+      R*137.138.rrr.rrr                    CERN-LAN          [TB166]
+      R*137.139.rrr.rrr                    SUC-OLDWEST       [TD104]
+      R*137.140.rrr.rrr                    SUC-NEWPALTZ      [BE47]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 40]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R*137.141.rrr.rrr                    SUC-ONEONTA       [EF55]
+      R*137.142.rrr.rrr                    SUC-PLATT         [TD105]
+      R*137.143.rrr.rrr                    SUC-POTSDAM       [DV36]
+      C*137.144.rrr.rrr                    WAII-NET          [MIW]
+      R 137.145.rrr.rrr                    CALINET           [WP8]
+      R 137.146.rrr.rrr                    COLBY             [DWC32]
+      R*137.147.rrr.rrr                    TRLNET            [RL225]
+      R 137.148.rrr.rrr                    CSUOHIO           [AS198]
+      R*137.149.rrr.rrr                    UPEI              [DC307]
+      R 137.150.rrr.rrr                    HSUNET            [CS276]
+      R 137.151.rrr.rrr                    FULNET            [KB129]
+      R 137.152.rrr.rrr                    GCU               [BC176]
+      C*137.153.rrr.rrr                    SONY-ENG-NET      [TU1]
+        137.154.rrr.rrr                    Unassigned        [NIC]
+      R*137.155.rrr.rrr                    CNC               [SB236]
+      C*137.156.rrr.rrr                    UBS               [MG207]
+      R 137.157.rrr.rrr                    ATOM              [RC306]
+      R*137.158.rrr.rrr                    UCTNET1           [FG51]
+      R*137.159.rrr.rrr                    PEPNET            [JV70]
+      D 137.160.rrr.rrr                    HI-DASD           [TA54]
+        137.161.rrr.rrr                    Unassigned        [NIC]
+      C 137.162.rrr.rrr                    MOT-GEG-NET       [SC193]
+        137.163.rrr.rrr                    Unassigned        [NIC]
+      G 137.164.rrr.rrr                    CALREN            [WP8]
+      R 137.165.rrr.rrr                    WILLIAMS-NET      [MM371]
+      R*137.166.rrr.rrr                    CHASTURT-UNI      [PJ40]
+        137.167.rrr.rrr                    Unassigned        [NIC]
+      C*137.168.rrr.rrr                    HITACH            [SK102]
+      C*137.169.rrr.rrr                    K&E-NET           [JLD42]
+      C*137.170.rrr.rrr                    FNOK              [JFM39]
+      C*137.171.rrr.rrr                    SCI               [MW204]
+      C*137.172.rrr.rrr                    FALNET            [CS277]
+      D*137.173.rrr.rrr                    APOSD             [BD113]
+      C*137.174.rrr.rrr                    EZH-NET           [WS167]
+      C 137.175.rrr.rrr                    MSTAR-NET         [RS487]
+      C*137.176.rrr.rrr-137.185.rrr.rrr    PGXPRESS          [ACL2]
+      C 137.186.rrr.rrr                    NSTN              [JS338]
+      G 137.187.rrr.rrr                    NIH-NETS          [RF57]
+      C*137.188.rrr.rrr                    USWNANET          [JS602]
+      R*137.189.rrr.rrr                    CUHKNET           [CHC7]
+      R 137.190.rrr.rrr                    WEBER-NET         [BC177]
+        137.191.rrr.rrr                    Unassigned        [NIC]
+      R 137.192.rrr.rrr                    MRNET             [JAW34]
+      R*137.193.rrr.rrr                    UNIBWMNET         [VT7]
+      R*137.194.rrr.rrr                    FNET-ESNET        [PD97]
+      R*137.195.rrr.rrr                    HERIOT-WATT       [JH410]
+      C*137.196.rrr.rrr                    STARDENT          [CC185]
+      R 137.197.rrr.rrr                    UNMC              [MRN6]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 41]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R 137.198.rrr.rrr                    HUNET             [TM96]
+      C*137.199.rrr.rrr                    FIDELITYNET       [WRC22]
+      G*137.200.rrr.rrr                    SSA               [TE37]
+      C*137.201.rrr.rrr                    MICRON            [BG112]
+      C*137.202.rrr.rrr                    MENTOR            [MS379]
+      C 137.203.rrr.rrr                    HRINET            [RJB67]
+      R*137.204.rrr.rrr                    BOLOGNA-ALMA-NET  [RD235]
+      R*137.205.rrr.rrr                    WARWICK           [MB310]
+      C*137.206.rrr.rrr                    SHELL-NET         [SD134]
+      R*137.207.rrr.rrr                    UWINDSORNET       [NP24]
+      R*137.208.rrr.rrr                    WU-WIEN           [AN50]
+      D 137.209.rrr.rrr                    SUMNET1           [AJC5]
+      D 137.210.rrr.rrr                    SUMNET2           [AJC5]
+      D 137.211.rrr.rrr                    SUMNET3           [AJC5]
+      D 137.212.rrr.rrr                    SUMNET            [AJC5]
+      C*137.213.rrr.rrr                    BULLUK            [PM180]
+      R*137.214.rrr.rrr                    UNINET-ZA         [VS59]
+        137.215.rrr.rrr                    Unassigned        [NIC]
+      R 137.216.rrr.rrr                    SDSTATE           [PH122]
+      C*137.217.rrr.rrr                    BTNETT            [GK91]
+      G*137.218.rrr.rrr                    USBI              [DC310]
+        137.219.rrr.rrr                    Unassigned        [NIC]
+      R*137.220.rrr.rrr                    BSC               [JB251]
+      C*137.221.rrr.rrr                    GEC-CS-LAN1       [PS216]
+        137.222.rrr.rrr                    Unassigned        [NIC]
+      C*137.223.rrr.rrr                    SIESOFT           [DM357]
+      R*137.224.rrr.rrr                    WAUNET            [AB171]
+      D 137.225.rrr.rrr                    DFRRS-ECAC        [JS522]
+      R*137.226.rrr.rrr                    ACHSES            [GS199]
+      G*137.227.rrr.rrr                    USBM-CCN          [RW128]
+      R 137.228.rrr.rrr                    SFOCLAN           [JAW16]
+      R 137.229.rrr.rrr                    ALAKANET          [JH306]
+      R 137.230.rrr.rrr                    CATNET            [JWB65]
+      D 137.231.rrr.rrr                    ZWEIBKN-GW1       [GEW13]
+      D 137.232.rrr.rrr                    DIMNET1           [FZ]
+      D 137.233.rrr.rrr                    DIMNET2           [FZ]
+      D 137.234.rrr.rrr                    DIMNET3           [FZ]
+      D 137.235.rrr.rrr                    DIMNET4           [FZ]
+      C*137.236.rrr.rrr                    XSI               [DM335]
+      C 137.237.rrr.rrr                    HARRISNET         [RT182]
+      R*137.238.rrr.rrr                    GENESEO           [SEC2]
+      C*137.239.rrr.rrr                    COMMODORE         [GR53]
+      D 137.240.rrr.rrr                    SMALC-1           [SJ55]
+      D 137.241.rrr.rrr                    OOALC-1           [SJ55]
+      D 137.242.rrr.rrr                    SAALC-1           [SJ55]
+      D 137.243.rrr.rrr                    WRALC-1           [SJ55]
+      D 137.244.rrr.rrr                    OCALC-1           [SJ55]
+      D 137.245.rrr.rrr                    WPAFB-1           [SJ55]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 42]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      D 137.246.rrr.rrr                    SEBAT             [MM379]
+      D 137.247.rrr.rrr                    CSSNET            [EKO]
+      R*137.248.rrr.rrr                    UNI-MARBURG       [HH84]
+      C 137.249.rrr.rrr                    FAC-COM           [CEB13]
+      R 137.250.rrr.rrr                    AUX               [SS297]
+      R*137.251.rrr.rrr                    FHGIAO-NET        [JW377]
+      C 137.252.rrr.rrr                    POLANET           [DM358]
+        137.253.rrr.rrr                    Unassigned        [NIC]
+      C 137.254.rrr.rrr                    ORACLE-BBONET     [AC158]
+        137.255.rrr.rrr                    Reserved          [JBP]
+        138.0.rrr.rrr                      Reserved          [JBP]
+      C 138.1.rrr.rrr                      ORACLE-CHIC       [AC158]
+      C 138.2.rrr.rrr                      ORACLE-BETH       [AC158]
+      C 138.3.rrr.rrr                      ORACLE-UK         [LG115]
+      R*138.4.rrr.rrr                      RUNET             [JAM48]
+        138.5.rrr.rrr                      Unassigned        [NIC]
+      G*138.6.rrr.rrr                      UPPSALA-SE        [JS603]
+      R*138.7.rrr.rrr                      AIMSNET           [MM406]
+      C*138.8.rrr.rrr                      GOLDSACHS         [JK237]
+      R 138.9.rrr.rrr                      UOP               [DB380]
+      G*138.10.rrr.rrr                     ONTHYD            [RP241]
+      C*138.11.rrr.rrr                     MATROX            [MR198]
+      C*138.12.rrr.rrr                     MEADDATA          [LS226]
+      D 138.13.rrr.rrr                     SSD-NET           [DD38]
+      D*138.14.rrr.rrr                     NOBEL             [RU1]
+      R 138.15.rrr.rrr                     NEC               [AM175]
+      R 138.16.rrr.rrr                     BROWN-UNIV-2      [AD62]
+      D 138.17.rrr.rrr                     ASNET-NETS        [HF35]
+      D 138.18.rrr.rrr                     ASNET-NET         [HF35]
+      G*138.19.rrr.rrr                     GDWB              [WS168]
+      C*138.20.rrr.rrr                     MORGAN-1          [BP123]
+      C*138.21.rrr.rrr                     RENAULT           [EB134]
+      R*138.22.rrr.rrr                     ZAMGNET-WIEN      [GK92]
+      R 138.23.rrr.rrr                     UCRNET            [LM220]
+      R*138.24.rrr.rrr                     IPS-AUSNET        [CB180]
+      R 138.25.rrr.rrr                     UTSNETS           [AB150]
+      R 138.26.rrr.rrr                     UAB               [LM62]
+      D 138.27.rrr.rrr                     HUACHUCA-NET      [LB24]
+      R 138.28.rrr.rrr                     KENYOUN           [SC196]
+      G 138.29.rrr.rrr                     USCGA             [KC105]
+      R 138.30.rrr.rrr                     HQ                [BO34]
+      C*138.31.rrr.rrr                     EPSON-NET         [PN16]
+      C*138.32.rrr.rrr                     PPCO              [PDC1]
+      G*138.33.rrr.rrr                     GMH-NET           [WA32]
+      C*138.34.rrr.rrr                     ETANET            [KS158]
+      C*138.35.rrr.rrr                     CPQINTL           [DD233]
+      D*138.36.rrr.rrr                     MARI-NET          [AB175]
+      R*138.37.rrr.rrr                     QMW               [TJ40]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 43]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R*138.38.rrr.rrr                     BATH-AC-UK        [PC153]
+      C*138.39.rrr.rrr                     DELMARVA          [JKS23]
+      R*138.40.rrr.rrr                     UKCITY-NET        [IA52]
+      R*138.41.rrr.rrr                     CS-NET            [GG136]
+      C*138.42.rrr.rrr                     INTERLINK1        [FJD4]
+      C*138.43.rrr.rrr                     NCD               [DM280]
+      C 138.44.rrr.rrr                     CSIRO-BM          [SM164]
+      D 138.45.rrr.rrr                     CACNET            [BG25]
+      C*138.46.rrr.rrr                     PRESTOLITE        [TM128]
+      R*138.47.rrr.rrr                     LATECH            [DRH48]
+      R*138.48.rrr.rrr                     FUNDP-AC-BE       [BD117]
+      R 138.49.rrr.rrr                     UWLAX             [DA128]
+      D 138.50.rrr.rrr                     WIESBADN-GW1      [MW213]
+      R*138.51.rrr.rrr                     CA-NET            [DF133]
+      C*138.52.rrr.rrr                     LIANT             [DC303]
+      C*138.53.rrr.rrr-138.58.rrr.rrr      SHELL-NETS        [SD134]
+      R*138.59.rrr.rrr                     CANET             [TM159]
+      D*138.60.rrr.rrr                     NADC-LAN          [TED]
+      C 138.61.rrr.rrr                     MAINZ-GW1         [MM413]
+      R*138.62.rrr.rrr                     NSB-NET           [IS12]
+      R*138.63.rrr.rrr                     CERFACS           [HP50]
+      D*138.64.rrr.rrr                     MSG-NET           [MEG8]
+      D 138.65.rrr.rrr                     FRANKFURT-GW1     [SDM8]
+      R*138.66.rrr.rrr                     TCNO              [VL42]
+      R 138.67.rrr.rrr                     CSM-NET           [KL31]
+      R 138.68.rrr.rrr                     DUPONT-EXSTA      [KR80]
+      C*138.69.rrr.rrr                     LISC              [JLB79]
+      R*138.70.rrr.rrr                     PR-BULL-ITALY     [GP133]
+      R*138.71.rrr.rrr                     MAF               [PW96]
+      C*138.72.rrr.rrr                     PIXAR             [SJK1]
+      R*138.73.rrr.rrr                     MTA-IPNET         [DE80]
+      R 138.74.rrr.rrr                     SNC               [DDK7]
+      R*138.75.rrr.rrr                     LINCOLN-LAN-1     [JB542]
+      G 138.76.rrr.rrr                     NASAHQ-M-NET      [CS279]
+      R*138.77.rrr.rrr                     UCQ               [JV98]
+      R 138.78.rrr.rrr                     ST-MARYS-NET      [SJP18]
+      C*138.79.rrr.rrr                     CPNET             [MC301]
+      R*138.80.rrr.rrr                     NTUNET            [TA61]
+      G*138.81.rrr.rrr                     ISO-CS            [BH196]
+      C*138.82.rrr.rrr                     BELL-CA           [GC158]
+      C*138.83.rrr.rrr                     GTE-TELOPS        [DF180]
+      C*138.84.rrr.rrr                     LOF               [GL88]
+      C*138.85.rrr.rrr                     ERI-RICHARDSON    [DR229]
+      R 138.86.rrr.rrr                     UNC-NET           [JV97]
+        138.87.rrr.rrr-138.252.rrr.rrr     Unassigned        [NIC]
+      R*138.253.rrr.rrr                    LONDON-UNIV       [MK169]
+        138.254.rrr.rrr                    Unassigned        [NIC]
+        138.255.rrr.rrr                    Reserved          [JBP]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 44]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+        139.0.rrr.rrr                      Reserved          [JBP]
+        139.1.rrr.rrr-139.66.rrr.rrr       Unassigned        [NIC]
+      R*139.67.rrr.rrr                     WIU-UCAN-NET      [JW382]
+      C*139.68.rrr.rrr                     BOSENET           [CP130]
+      C*139.69.rrr.rrr                     HARNCO            [CH225]
+      R 139.70.rrr.rrr                     VIMS-NET          [RJL49]
+      C*139.71.rrr.rrr                     AMEX-FTL          [RJ134]
+      C*139.72.rrr.rrr                     NWAIR-NET         [TH147]
+      C*139.73.rrr.rrr                     GMAGT             [MD184]
+      C*139.74.rrr.rrr                     VALNET            [KK104]
+      R*139.75.rrr.rrr                     AWIULTRANET       [JMS17]
+      C*139.76.rrr.rrr                     BELLSOUTH         [DS405]
+      D 139.77.rrr.rrr                     CONCGWY-NEWP1     [SCG]
+      R 139.78.rrr.rrr                     OKSTATE           [KD77]
+      C*139.79.rrr.rrr                     ASCOM             [RO68]
+      R*139.80.rrr.rrr                     OTAGO-LAN1        [IG4]
+      C*139.81.rrr.rrr                     GLI               [BA77]
+      R*139.82.rrr.rrr                     PUC-RIO           [MF148]
+        139.83.rrr.rrr                     Unassigned        [NIC]
+      R 139.84.rrr.rrr                     LASALLE           [SAL27]
+      R*139.85.rrr.rrr                     HNSNET            [JC490]
+      R*139.86.rrr.rrr                     USQ-NET           [RI13]
+      C*139.87.rrr.rrr                     CORP-3COM         [TC96]
+      G 139.88.rrr.rrr                     LERC-OFFCAMPUS    [DC285]
+      C*139.89.rrr.rrr                     UNIWARE-NET       [HB117]
+      C*139.90.rrr.rrr                     NETCS-CUST-B      [CS218]
+      R*139.91.rrr.rrr                     FORTH             [SA94]
+      R 139.92.rrr.rrr                     EASINET-BB        [WP90]
+      C*139.93.rrr.rrr                     ULTRA-COM         [WH54]
+      C 139.94.rrr.rrr                     TAIU-NET          [WM68]
+      C*139.95.rrr.rrr                     AMDNET            [CR129]
+      C*139.96.rrr.rrr                     SAAB-NET          [SN8]
+      C*139.97.rrr.rrr                     CITYNET           [RA145]
+      G*139.98.rrr.rrr                     FYLKOMOEST        [JT222]
+      C*139.99.rrr.rrr                     ES2               [AY21]
+      R*139.100.rrr.rrr                    CNET              [JMR45]
+      C*139.101.rrr.rrr                    MORELLIAUTRO      [PG108]
+      R 139.102.rrr.rrr                    INDSTATE          [CE56]
+      R*139.103.rrr.rrr                    UMONCTON-IPNET    [DP178]
+      C 139.104.rrr.rrr                    DISNEY            [SFW1]
+      G*139.105.rrr.rrr-139.120.rrr.rrr    NO-MULTI-NET      [OS4]
+      C 139.121.rrr.rrr                    SAIC              [SDF5]
+      G*139.122.rrr.rrr                    SCANIAL           [RS502]
+      C*139.123.rrr.rrr                    MYLNET            [EV26]
+      R*139.124.rrr.rrr                    RRM               [MB324]
+      C*139.125.rrr.rrr                    AIT_VINES         [PY17]
+      C*139.126.rrr.rrr                    ADP               [KB134]
+      R 139.127.rrr.rrr                    SUNYHSCSYR        [RLZ3]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 45]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C*139.128.rrr.rrr                    MAELLIAUTRO       [PG108]
+      R*139.129.rrr.rrr                    MAF               [PW96]
+      R*139.130.rrr.rrr                    AARNET            [GH105]
+      R*139.131.rrr.rrr                    SWARE             [PT63]
+        139.132.rrr.rrr                    Unassigned        [NIC]
+      R*139.133.rrr.rrr                    UNIV-ABDN         [JL338]
+      G*139.134.rrr.rrr                    TBSNET            [CH232]
+      R 139.135.rrr.rrr                    EDGEWOOD          [CH233]
+      R 139.136.rrr.rrr                    SKF               [RLZ3]
+      R*139.137.rrr.rrr                    CCFNET            [SG144]
+      C*139.138.rrr.rrr                    DATA-IO-NET       [TR103]
+      D 139.139.rrr.rrr                    GIESSEN-GW1       [BR109]
+      R 139.140.rrr.rrr                    BOWDOIN           [TM200]
+      R 139.141.rrr.rrr                    UKWT-NET          [HBA2]
+      C*139.142.rrr.rrr                    MYRIAS            [DR230]
+      G*139.143.rrr.rrr                    DTINPL            [AS205]
+      G*139.144.rrr.rrr                    ATC               [SM235]
+      C*139.145.rrr.rrr                    AKER-STORD        [OG14]
+      C*139.146.rrr.rrr                    PARS-SERVICE      [RHG]
+      R*139.147.rrr.rrr                    LAFEYETTE         [PK69]
+      R 139.148.rrr.rrr                    SMITHKLINE1       [RLZ3]
+      C*139.149.rrr.rrr                    UBS-LON-PD        [MH269]
+      C*139.150.rrr.rrr                    MOTO-SPS          [RB319]
+        139.151.rrr.rrr-139.160.rrr.rrr    Unassigned        [NIC]
+      D 139.161.rrr.rrr                    FSAMGW1           [SM218]
+      C*139.162.rrr.rrr                    NEDLLOYD          [CT100]
+      C*139.163.rrr.rrr                    GHTOURS           [FC52]
+      G*139.164.rrr.rrr                    BUSK-HELSE        [SB258]
+      R*139.165.rrr.rrr                    OFLIEGE-BE        [AP94]
+      R*139.166.rrr.rrr                    NERC-NET          [GE47]
+      R*139.167.rrr.rrr                    KSR               [JMT1]
+      G*139.168.rrr.rrr                    CORPNET           [GG138]
+      G 139.169.rrr.rrr                    JIN               [JC108]
+        139.170.rrr.rrr-191.54.rrr.rrr     Unassigned        [NIC]
+      C*190.55.rrr.rrr                     FLOW              [DS370]
+        190.56.rrr.rrr-191.254.rrr.rrr     Unassigned        [NIC]
+       *191.255.rrr.rrr                    Reserved          [JBP]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 46]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   Class C Networks
+
+      * Internet Address                   Network           Reference
+      - ----------------                   -------           ----------
+        192.0.0.rrr                        Reserved          [JBP]
+      R 192.0.1.rrr                        BBN-TEST-C        [RH6]
+      R*192.0.2.rrr                        TEST              [JBP]
+        192.0.3.rrr-192.0.255.rrr          Unassigned        [NIC]
+      R 192.1.0.rrr-192.1.1.rrr            BBN Local Nets    [SGC]
+      R 192.1.2.rrr                        BBN-FIBER-NET     [SGC]
+      R 192.1.3.rrr                        BBN-APOLLO-NET    [SGC]
+      R 192.1.4.rrr                        BBN-FIBER-TEST    [SGC]
+      R 192.1.5.rrr                        BBN-SD-ENET       [SGC]
+      R 192.1.6.rrr                        BBN-DGI-ENET      [SGC]
+      R 192.1.7.rrr                        BBN-WASH-ENET     [SGC]
+      R 192.1.8.rrr                        BBN-SCOTLAND-NET  [SGC]
+      R 192.1.9.rrr                        BBN-DGI-APOLLO    [SGC]
+      R 192.1.10.rrr                       BBN-NEWPORT-NET   [SGC]
+      R 192.1.11.rrr                       BBN-TEST-NET      [SGC]
+      R 192.1.12.rrr                       BBN-TEST2-NET     [SGC]
+      R 192.1.13.rrr                       BBN-TEST3-NET     [SGC]
+      R 192.1.14.rrr                       BBN-TEST4-NET     [SGC]
+      R 192.1.15.rrr                       BBNCC-HARDWARE    [SGC]
+      R 192.1.16.rrr                       BBNCC-APOLLO      [SGC]
+      R 192.1.17.rrr                       BBNCC-COLUMBIA    [SGC]
+      R 192.1.18.rrr                       BBNCC-PRO-NET     [SGC]
+      R 192.1.19.rrr                       BBNCC-BILLERICA   [SGC]
+      R 192.1.20.rrr                       BBNACI-MT-VIEW    [SGC]
+      R 192.1.21.rrr                       BBN-DGI-ENET2     [SGC]
+      R 192.1.22.rrr                       BBN-FORT-KNOX     [SGC]
+      R 192.1.23.rrr                       BBN-NEW-LONDON    [SGC]
+      R 192.1.24.rrr                       BBN Local Net     [SGC]
+      R 192.1.25.rrr                       BBN-PCNETSIM      [GL15]
+      R 192.1.26.rrr-192.3.255.rrr         BBN Local Nets    [SGC]
+      R 192.4.0.rrr-192.4.12.rrr           BELLCORE-NET      [PK28]
+      R 192.4.13.rrr                       MRE-MERLOT        [PK28]
+      R 192.4.14.rrr                       MRE-BIRDNET       [PK28]
+      R 192.4.15.rrr-192.4.17.rrr          BELLCORE-NET      [PK28]
+      R 192.4.18.rrr                       MRE-FRAGGLE       [PK28]
+      R 192.4.19.rrr-192.4.31.rrr          BELLCORE-NET      [PK28]
+      R 192.4.32.rrr                       NVC-SHARP         [PK28]
+      R 192.4.33.rrr                       BELLCORE-NET      [PK28]
+      R 192.4.34.rrr                       NVC-BB            [PK28]
+      R 192.4.35.rrr                       NVC-ASPEN         [PK28]
+      R 192.4.36.rrr                       BELLCORE-NET      [PK28]
+      R 192.4.37.rrr                       LCC-APOLLO        [PK28]
+      R 192.4.38.rrr                       PYA-FACS          [PK28]
+      R 192.4.39.rrr-192.4.255.rrr         BELLCORE-NET      [PK28]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 47]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+        192.5.0.rrr                        Reserved          [JBP]
+      R 192.5.1.rrr                        CISLHYPERNET      [JLM23]
+      R*192.5.2.rrr                        UF-NET-A          [AW48]
+      C 192.5.3.rrr                        HP-DESIGN-AIDS    [AG67]
+      C 192.5.4.rrr                        HP-TCG-UNIX       [AG67]
+      R 192.5.5.rrr                        DEC-MRNET         [AF54]
+      R 192.5.6.rrr                        DEC-MRRAD         [AF54]
+      R 192.5.7.rrr                        ASRI              [PK81]
+      R 192.5.8.rrr                        CSEICNET          [SB90]
+      R 192.5.9.rrr                        AERONET           [LCN]
+      R 192.5.10.rrr                       ECLNET            [MAB4]
+      R 192.5.11.rrr                       CSS-RING          [DC115]
+      R 192.5.12.rrr                       UTAH-NET-C        [GW22]
+      R 192.5.13.rrr                       GSWDNET           [FAS]
+      R 192.5.14.rrr                       RAND-NET          [JDG]
+      R*192.5.15.rrr                       AUVM              [JM586]
+      R 192.5.16.rrr                       LANLLAND          [PCW]
+      R 192.5.17.rrr                       NRL-NET           [MPM]
+      R 192.5.18.rrr                       IPTO-NET          [JS283]
+      R 192.5.19.rrr                       UCIICS            [RAJ3]
+      R 192.5.20.rrr                       CISLTTYNET        [JLM23]
+      D 192.5.21.rrr                       BRLNET1           [TS9]
+      D 192.5.22.rrr                       BRLNET2           [MJM2]
+      D 192.5.23.rrr                       BRLNET3           [TS9]
+      D 192.5.24.rrr                       BRLNET4           [TS9]
+      D 192.5.25.rrr                       BRLNET5           [TS9]
+        192.5.26.rrr                       Unassigned        [NIC]
+      D 192.5.27.rrr                       DTNSRDC-NET       [RWT2]
+      R 192.5.28.rrr                       RSRE-NULL         [DBH11]
+      R 192.5.29.rrr                       RSRE-ACC          [DBH11]
+      R 192.5.30.rrr                       RSRE-PR           [DBH11]
+      R*192.5.31.rrr                       SIEMENS-NET       [PN23]
+      R 192.5.32.rrr                       CISLTESTNET2      [JLM23]
+      R 192.5.33.rrr                       CISLTESTNET3      [JLM23]
+      R 192.5.34.rrr                       CISLTESTNET4      [JLM23]
+        192.5.35.rrr-192.5.37.rrr          Unassigned        [NIC]
+      R 192.5.38.rrr                       SRI-C3ETHER       [GMR]
+      C 192.5.39.rrr                       USS               [AV24]
+      R 192.5.40.rrr                       PUCC-NET-A        [JS81]
+      R 192.5.41.rrr                       USNO              [NW33]
+      D 192.5.42.rrr                       HYPER-1ISG        [MCA1]
+      R 192.5.43.rrr                       CUCSNET           [BC14]
+      R 192.5.44.rrr                       FARBER-PC-NET     [DJF]
+        192.5.45.rrr                       Unassigned        [NIC]
+      R 192.5.46.rrr                       NTA-RING          [PS27]
+      R 192.5.47.rrr                       NSRDC             [RWT2]
+      R 192.5.48.rrr                       PURDUE-CS-NET     [DT50]
+      C 192.5.49.rrr                       TISW-NET          [HKO]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 48]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R 192.5.50.rrr                       CTH-CS-NET        [UB3]
+        192.5.51.rrr                       Unassigned        [NIC]
+      R 192.5.52.rrr                       NLM-ETHER-TEMP    [JA1]
+      R 192.5.53.rrr                       UR-CS-ETHER       [LB16]
+      R 192.5.54.rrr                       AERO-A3           [LCN]
+        192.5.55.rrr                       Unassigned        [NIC]
+      C 192.5.56.rrr                       TARTAN-NET        [BM156]
+      R 192.5.57.rrr                       UDEL-CC           [RR18]
+      R 192.5.58.rrr                       CSNET-PDN         [WHN2]
+      R 192.5.59.rrr                       INRIA-A-RING      [AR41]
+      R 192.5.60.rrr                       INRIA-SOPHIA      [AR41]
+      R*192.5.61.rrr                       SM90-X2           [MS171]
+      R*192.5.62.rrr                       LITP-SM90         [MS171]
+      G*192.5.63.rrr                       SVERDRUPMSFC      [JMB64]
+      R 192.5.64.rrr                       AMES-NAS-NET      [MF31]
+      R 192.5.65.rrr                       NPRDC-ETHER       [LRB]
+      R 192.5.66.rrr                       HARV-NET          [SB28]
+      R 192.5.67.rrr                       CECOM-ETHER       [GIH]
+        192.5.68.rrr                       Unassigned        [NIC]
+      R 192.5.69.rrr                       UIUC-NET          [AKC]
+      G 192.5.70.rrr                       CELAN             [RLS6]
+      R*192.5.71.rrr                       WWU-ADMIN-NET     [JSW12]
+      C*192.5.72.rrr                       ABLE              [CWV1]
+      C*192.5.73.rrr                       LVSUN             [GCS8]
+      C*192.5.74.rrr-192.5.81.rrr          MSC Nets          [SL70]
+      R 192.5.82.rrr                       FSUSTAT           [KMH8]
+      C*192.5.83.rrr                       EPOCH-ENGR        [GK32]
+      R*192.5.84.rrr-192.5.87.rrr          UOC Nets          [MC17]
+      R 192.5.88.rrr                       YALE-EE-NET       [AG22]
+      R 192.5.89.rrr                       HARV-APOLLO       [SB28]
+      R 192.5.90.rrr                       SERI-NET          [CK92]
+      R 192.5.91.rrr                       PURDUE-ECN1       [JRS8]
+      R 192.5.92.rrr                       BRAGG-ETHER       [GIH]
+      R 192.5.93.rrr                       SRI-DEMO          [GIH]
+      R*192.5.94.rrr                       SDCRDCF-10MB      [DJV1]
+      R*192.5.95.rrr                       SDCRDCF-3MB       [DJV1]
+      R*192.5.96.rrr                       UBC-CS-NET        [PB67]
+        192.5.97.rrr-192.5.98.rrr          Unassigned        [NIC]
+      R 192.5.99.rrr                       SPACENET          [TW51]
+      R 192.5.100.rrr                      HCSC-NET          [DB322]
+      R 192.5.101.rrr                      PUCC-NET-B        [JS81]
+      R 192.5.102.rrr                      PUCC-RHF-NET      [JS81]
+      C*192.5.103.rrr                      COMCO             [KF55]
+      R 192.5.104.rrr                      THINK-INET        [BJN1]
+      R 192.5.105.rrr                      XAIT-POND         [AL6]
+      C*192.5.106.rrr                      BITSTREAM         [PGA1]
+      R*192.5.107.rrr                      PASC-ETHER        [GAL5]
+      R*192.5.108.rrr                      PASC-BB           [GAL5]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 49]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R 192.5.109.rrr                      CWRUNET-C0        [JAG3]
+      R 192.5.110.rrr                      CWRUNET-C1        [JAG3]
+      R 192.5.111.rrr                      CWRUNET-C2        [JAG3]
+      R 192.5.112.rrr                      CWRUNET-C3        [JAG3]
+      R 192.5.113.rrr                      CWRUNET-C4        [JAG3]
+      C*192.5.114.rrr                      I2-RING-1         [CB42]
+      C*192.5.115.rrr                      I2-ETHER-1        [CB42]
+      R 192.5.116.rrr                      BRAGGNET-1        [LDB3]
+      R 192.5.117.rrr                      BRAGGNET-2        [LDB3]
+      R 192.5.118.rrr                      BRAGGNET-3        [LDB3]
+      R 192.5.119.rrr                      BRAGGNET-4        [LDB3]
+      R 192.5.120.rrr                      BRAGGNET-5        [LDB3]
+      R 192.5.121.rrr                      BRAGGNET-6        [LDB3]
+      R 192.5.122.rrr                      BRAGGNET-7        [LDB3]
+      R 192.5.123.rrr                      BRAGGNET-8        [LDB3]
+      R 192.5.124.rrr                      BRAGGNET-9        [LDB3]
+      R 192.5.125.rrr                      BRAGGNET-10       [LDB3]
+      R 192.5.126.rrr                      BRAGGNET-11       [LDB3]
+      R 192.5.127.rrr                      BRAGGNET-12       [LDB3]
+      R 192.5.128.rrr                      BRAGGNET-13       [LDB3]
+      R 192.5.129.rrr                      BRAGGNET-14       [LDB3]
+      R 192.5.130.rrr                      BRAGGNET-15       [LDB3]
+      R 192.5.131.rrr                      BRAGGNET-16       [LDB3]
+      R 192.5.132.rrr                      BRAGGNET-17       [LDB3]
+      R*192.5.133.rrr                      PERCEPT-AI        [KC8]
+      C*192.5.134.rrr                      I2-ETHER-2        [CB42]
+      R 192.5.135.rrr                      LL-SPEECH-NET     [RH60]
+      R 192.5.136.rrr                      LL43-LEX-BACK     [BC65]
+      R 192.5.137.rrr                      LL43-LEX-SUNA     [BC65]
+      R 192.5.138.rrr                      LL43-LEX-SUNB     [BC65]
+      R 192.5.139.rrr                      LL43-LEX-APO      [BC65]
+      R 192.5.140.rrr                      LL43-TB-BACK      [BC65]
+      R 192.5.141.rrr                      LL43-TB-APO       [BC65]
+      R*192.5.142.rrr                      CCVR              [RD91]
+      R 192.5.143.rrr                      NWU               [AS62]
+      R 192.5.144.rrr                      CRC-ENET          [JS597]
+      R 192.5.145.rrr                      ECRC-SL           [PD39]
+      R 192.5.146.rrr                      CPW-PSC           [ML62]
+      R 192.5.147.rrr                      ALV-ETHER         [LJR5]
+      R 192.5.148.rrr                      DISE              [RHS16]
+      R 192.5.149.rrr                      RDL-ETHER         [MS172]
+      G*192.5.150.rrr                      SP-ACE-NET        [JM304]
+      R 192.5.151.rrr                      PENN-STATE-1      [SJS11]
+      R 192.5.152.rrr                      PENN-STATE-2      [SJS11]
+      R 192.5.153.rrr                      PENN-STATE-3      [SJS11]
+      R 192.5.154.rrr                      PENN-STATE-4      [SJS11]
+      R 192.5.155.rrr                      PENN-STATE-5      [SJS11]
+      R 192.5.156.rrr                      PENN-STATE-6      [SJS11]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 50]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R 192.5.157.rrr                      PENN-STATE-7      [SJS11]
+      R 192.5.158.rrr                      PENN-STATE-8      [SJS11]
+      R 192.5.159.rrr                      PENN-STATE-9      [SJS11]
+      R 192.5.160.rrr                      PENN-STATE-10     [SJS11]
+      R 192.5.161.rrr                      PENN-STATE-11     [SJS11]
+      R 192.5.162.rrr                      PENN-STATE-12     [SJS11]
+      C*192.5.163.rrr                      I2-SPDNET-1       [CB42]
+      C 192.5.164.rrr                      GTEECN            [CH102]
+      R 192.5.165.rrr                      UNISYS-CAM-1      [DSR]
+      G 192.5.166.rrr                      GAT-NET           [DC306]
+      R 192.5.167.rrr                      MCC-ACA6          [CBD]
+      R 192.5.168.rrr                      MCC-CAD2          [CBD]
+      R 192.5.169.rrr                      MCC-CAD3          [CBD]
+      G 192.5.170.rrr                      ANLNET1           [LW26]
+      G 192.5.171.rrr                      ANLNET2           [LW26]
+      G 192.5.172.rrr                      ANLNET3           [LW26]
+      G 192.5.173.rrr                      ANLNET4           [LW26]
+      G 192.5.174.rrr                      ANLNET5           [LW26]
+      G 192.5.175.rrr                      ANLNET6           [LW26]
+      G 192.5.176.rrr                      ANLNET7           [LW26]
+      G 192.5.177.rrr                      ANLNET8           [LW26]
+      G 192.5.178.rrr                      ANLNET9           [LW26]
+      G 192.5.179.rrr                      ANLNET10          [LW26]
+      G 192.5.180.rrr                      ANLNET11          [LW26]
+      G 192.5.181.rrr                      ANLNET12          [LW26]
+      G 192.5.182.rrr                      ANLNET13          [LW26]
+      G 192.5.183.rrr                      ANLNET14          [LW26]
+      G 192.5.184.rrr                      ANLNET15          [LW26]
+      G 192.5.185.rrr                      ANLNET16          [LW26]
+      G 192.5.186.rrr                      ANLNET17          [LW26]
+      G 192.5.187.rrr                      ANLNET18          [LW26]
+      G 192.5.188.rrr                      ANLNET19          [LW26]
+      G 192.5.189.rrr                      ANLNET20          [LW26]
+      G 192.5.190.rrr                      ANLNET21          [LW26]
+      G 192.5.191.rrr                      ANLNET22          [LW26]
+      G 192.5.192.rrr                      ANLNET23          [LW26]
+      G 192.5.193.rrr                      ANLNET24          [LW26]
+      G 192.5.194.rrr                      ANLNET25          [LW26]
+      G 192.5.195.rrr                      ANLNET26          [LW26]
+      G 192.5.196.rrr                      ANLNET27          [LW26]
+      G 192.5.197.rrr                      ANLNET28          [LW26]
+      G 192.5.198.rrr                      ANLNET29          [LW26]
+      G 192.5.199.rrr                      ANLNET30          [LW26]
+      G 192.5.200.rrr                      ANLNET31          [LW26]
+      G 192.5.201.rrr                      ANLNET32          [LW26]
+      R 192.5.202.rrr                      FMC-CTC           [KW2]
+      R*192.5.203.rrr                      OKSTATE-CS        [MV24]
+      R 192.5.204.rrr                      SKL-ENET          [JS597]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 51]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R 192.5.205.rrr                      ARNET2            [TS194]
+      R 192.5.206.rrr                      BU-MATHNET        [BS24]
+      R 192.5.207.rrr                      BU-CHEMNET        [BS24]
+      R 192.5.208.rrr                      BU-CLANET         [BS24]
+      D 192.5.209.rrr                      SSDF-CDCNET       [RE22]
+      G 192.5.210.rrr                      ECSNET            [CAL7]
+      R 192.5.211.rrr                      INTEL-IWARP       [RLS115]
+      R*192.5.212.rrr                      CDC-PCAFAC        [MCB5]
+      R 192.5.213.rrr                      HARRIS            [DAT4]
+      C 192.5.214.rrr                      DECUACNET         [FMA1]
+      R 192.5.215.rrr                      MASONNET          [TH15]
+      R 192.5.216.rrr                      NTT-NET           [YS10]
+        192.5.217.rrr                      Unassigned        [NIC]
+      D 192.5.218.rrr                      ARINC-GW-NET      [YN]
+      R 192.5.219.rrr                      CLEMSON           [CH170]
+      C 192.5.220.rrr                      SCCNET            [MJO4]
+      C 192.5.221.rrr                      CSC-LONS          [SWR3]
+      C 192.5.222.rrr                      CSC-OIS           [SWR3]
+      R*192.5.223.rrr                      HWELL-RE          [PP36]
+      D*192.5.224.rrr                      HAIC-NET          [DMK18]
+      C*192.5.225.rrr-192.5.236.rrr        GE Calma Block    [TR38]
+      R 192.5.237.rrr                      SMITHKLINE        [MS9]
+      R 192.5.238.rrr                      KES-NET           [JK59]
+      R*192.5.239.rrr                      CAM-ORL           [JM588]
+      C*192.5.240.rrr                      EXICOM            [DC305]
+      R 192.5.241.rrr                      USC-CYPRESS       [MAB4]
+      C 192.5.242.rrr                      MOT-242           [MJ91]
+      C 192.5.243.rrr                      MOT-243           [MJ91]
+      C 192.5.244.rrr                      MOT-244           [MJ91]
+      C 192.5.245.rrr                      MOT-245           [MJ91]
+      C 192.5.246.rrr                      MOT-246           [MJ91]
+      C 192.5.247.rrr                      MOT-247           [MJ91]
+      C 192.5.248.rrr                      MOT-248           [MJ91]
+      C 192.5.249.rrr                      MOT-249           [MJ91]
+      C 192.5.250.rrr                      MOT-250           [MJ91]
+      C 192.5.251.rrr                      MOT-251           [MJ91]
+      C 192.5.252.rrr                      MOT-252           [MJ91]
+      C 192.5.253.rrr                      MOT-253           [MJ91]
+      R*192.5.254.rrr                      ANSA              [DO27]
+        192.5.255.rrr                      Reserved          [JBP]
+      C*192.6.0.rrr-192.6.148.rrr          Hewlett-Packard   [AG67]
+      R 192.6.149.rrr                      DBCE              [BW158]
+      C*192.6.150.rrr-192.6.200.rrr        Hewlett-Packard   [AG67]
+      R 192.6.201.rrr                      UTSANANTONIO      [AA73]
+      C*192.6.202.rrr-192.6.255.rrr        Hewlett-Packard   [AG67]
+      C*192.7.0.rrr-192.7.255.rrr          CCI Nets          [RA11]
+      C*192.8.0.rrr-192.8.255.rrr          SPARTACUS         [EK48]
+      C*192.9.0.rrr-192.9.8.rrr            Sun Microsystems  [WM3]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 52]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C 192.9.9.rrr                        SUN-BARRNET       [WM3]
+      C*192.9.10.rrr-192.9.255.rrr         Sun Microsystems  [WM3]
+      C*192.10.0.rrr-192.10.40.rrr         SYMBOLICS         [CH2]
+      C*192.10.41.rrr                      TELLABS-MAIN      [DB273]
+      C*192.10.42.rrr-192.10.255.rrr       SYMBOLICS         [CH2]
+      C*192.11.0.rrr-192.11.51.rrr         AT&T Bell Labs    [MH82]
+      C 192.11.52.rrr                      ATT-NET           [MH82]
+      C*192.11.53.rrr-192.11.255.rrr       AT&T Bell Labs    [MH82]
+        192.12.0.rrr                       Reserved          [JBP]
+      R*192.12.1.rrr                       SUSSEX-CSNET      [RS255]
+      R*192.12.2.rrr                       AMDAHL            [KRS21]
+      C*192.12.3.rrr                       SLCS              [CG64]
+      C*192.12.4.rrr                       SCG-NET           [DBM16]
+      R 192.12.5.rrr                       AIC-LISPMS        [WMT]
+      R 192.12.6.rrr                       NPS-C2            [DW15]
+      D 192.12.7.rrr                       SSSD-NET          [RGH21]
+      D 192.12.8.rrr                       PICANET1          [RFD1]
+      R 192.12.9.rrr                       YALE-EE2-NET      [ASW3]
+      R 192.12.10.rrr                      THENETDFW         [DLN12]
+      R 192.12.11.rrr                      MIT-TEST          [NC3]
+      R 192.12.12.rrr                      SANTAFE           [RKJ]
+      R 192.12.13.rrr                      JHU-NET1          [MJO7]
+      R 192.12.14.rrr                      JHU-NET2          [MJO7]
+      R 192.12.15.rrr                      BROOKNET          [GR9]
+      R 192.12.16.rrr                      PRMNET            [PEM4]
+      G 192.12.17.rrr                      LLL-TIS-NET       [NAL]
+      R 192.12.18.rrr                      CIT-CS-10NET      [AD22]
+      R 192.12.19.rrr                      CIT-NET           [AD22]
+      R 192.12.20.rrr                      CIT-SUN-NET       [AD22]
+      R 192.12.21.rrr                      CIT-PHYSCOMP      [AD22]
+      R 192.12.22.rrr                      UTCSRES           [JSQ1]
+      R 192.12.23.rrr                      UTCSTTY           [JSQ1]
+      R 192.12.24.rrr                      MICANET           [WDL]
+      R 192.12.25.rrr                      CSS-GRAMINAE      [DC115]
+      R*192.12.26.rrr                      UMASS-BOSTON      [RM395]
+      R 192.12.27.rrr                      UR-ESM            [WL31]
+      R*192.12.28.rrr                      RIACS             [DG28]
+      D 192.12.29.rrr                      RF-EVANS          [JEQ1]
+      D 192.12.30.rrr                      RF-HEX-A          [JEQ1]
+      D 192.12.31.rrr                      USNA-ENET         [RAD15]
+      R*192.12.32.rrr                      CMU-VINEYARD      [MK68]
+      R 192.12.33.rrr                      SRI-CSL-NET       [EH112]
+      C*192.12.34.rrr-192.12.40.rrr        SCHLUMBERGER      [CG64]
+      C*192.12.41.rrr                      FAIRCHILD         [CG64]
+      C*192.12.42.rrr                      DARNET            [CG64]
+      C*192.12.43.rrr                      BENSON            [CG64]
+      R 192.12.44.rrr                      NRTC-NET          [RSM1]
+      R 192.12.45.rrr                      ACC-SB-IMP-NET    [AB20]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 53]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R 192.12.46.rrr                      ACC-SB-ETHER      [AB20]
+      R*192.12.47.rrr                      BOLOGNA-EXT1      [OB]
+      G 192.12.48.rrr                      AMES-ED-EXPNET    [MSM1]
+      G 192.12.49.rrr                      AMES-ED-NET       [MSM1]
+      G 192.12.50.rrr                      AMES-HY-NET       [MSM1]
+      R 192.12.51.rrr                      THINK-CHAOS       [BJN1]
+        192.12.52.rrr                      Unassigned        [NIC]
+      R*192.12.53.rrr                      PU-LCA            [CYH]
+      R*192.12.54.rrr                      SURFNET-X25       [EJB]
+      R 192.12.55.rrr                      HAZ-LPR-BETA      [KO11]
+      R 192.12.56.rrr                      UTAH-AP-NET       [JL15]
+      R 192.12.57.rrr                      MCC-CAD1          [CBD]
+      R 192.12.58.rrr                      MCC-ACA7          [CBD]
+      R 192.12.59.rrr                      MCC-ACA8          [CBD]
+      R 192.12.60.rrr                      MCC-ACA9          [CBD]
+      R 192.12.61.rrr                      MCC-SW-NET        [CBD]
+      R 192.12.62.rrr                      DREA-ENET         [GLH5]
+      R 192.12.63.rrr                      CYPRESS           [DT50]
+      D 192.12.64.rrr                      LOGNET            [JR15]
+      D 192.12.65.rrr                      HELNET1           [TS9]
+      D 192.12.66.rrr                      HELNET2           [TS9]
+      D 192.12.67.rrr                      HELNET3           [TS9]
+      G 192.12.68.rrr                      ORNL-MSRNET       [THD]
+      R 192.12.69.rrr                      UA-CS-NET         [PAK6]
+      R 192.12.70.rrr                      NPRDC-IPD         [LRB]
+      R 192.12.71.rrr                      NPRDC-ISG         [LRB]
+      R 192.12.72.rrr                      ULCC              [RHC3]
+      R 192.12.73.rrr                      BTRL              [RHC3]
+      R 192.12.74.rrr                      APPLE-ETHER       [EF16]
+      R*192.12.75.rrr                      PASC-RING         [GAL5]
+      R 192.12.76.rrr                      UQ-NET            [LB201]
+      R*192.12.77.rrr                      BOLOGNA-EXT2      [OB]
+      C*192.12.78.rrr                      GENNET            [SM96]
+      C*192.12.79.rrr                      SLI               [MG58]
+      R 192.12.80.rrr                      CAEN              [HWB]
+        192.12.81.rrr                      Unassigned        [NIC]
+      C 192.12.82.rrr                      CU-CC-NET         [BC14]
+      G 192.12.83.rrr                      UCDLA-EXNET       [CL64]
+      G 192.12.84.rrr                      UCDLA-PCNET       [CL64]
+      G 192.12.85.rrr                      UCDLA-OPNET       [CL64]
+      G 192.12.86.rrr                      UCDLA-RADNET      [CL64]
+      G 192.12.87.rrr                      UCDLA-CSLNET      [CL64]
+      R*192.12.88.rrr                      RUTGERS-NWK       [CLH3]
+      R 192.12.89.rrr                      SBCS-CSDEPT-1     [JS268]
+      R 192.12.90.rrr                      SBCS-CSDEPT-2     [JS268]
+      R 192.12.91.rrr                      RPICSNET0         [MS9]
+      R 192.12.92.rrr                      RPICSNET1         [MS9]
+      C*192.12.93.rrr                      TYMNET-MDC        [TDM8]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 54]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R 192.12.94.rrr                      ROCKWELL-AI-TEMP  [BMW7]
+      C*192.12.95.rrr                      NNWSI             [EJ12]
+      R*192.12.96.rrr                      SUPELEC-GIF       [DC159]
+      R 192.12.97.rrr                      MCRC              [MB288]
+      R 192.12.98.rrr                      SHIRBAY-ENET      [JS597]
+      C*192.12.99.rrr                      FCSL-NET          [SA47]
+      D 192.12.100.rrr                     OOG1              [JD86]
+      R*192.12.101.rrr                     OSU-CGRG          [KS62]
+      G 192.12.102.rrr                     AMES-NAS-HY       [MSM1]
+      R 192.12.103.rrr                     CSU-USC-ETHER     [MM333]
+      R 192.12.104.rrr                     CSU-NREL-ETHER    [MM333]
+        192.12.105.rrr-192.12.108.rrr      Reserved          [NIC]
+      R*192.12.109.rrr-192.12.118.rrr      CSU Nets          [RB218]
+      C 192.12.119.rrr                     XYPLEX            [TS196]
+      D 192.12.120.rrr                     MITRE-B-NET       [BSW]
+      R 192.12.121.rrr                     FSUCS             [DK168]
+      R 192.12.122.rrr                     FSUCS2            [DK168]
+      G 192.12.123.rrr                     AMES-CCF-NET      [MSM1]
+      D 192.12.124.rrr                     ETL-LAN           [WWS]
+      D 192.12.125.rrr                     CRDEC-NET1        [REA3]
+      D 192.12.126.rrr                     CRDEC-NET2        [REA3]
+      R 192.12.127.rrr                     LL-MI-NET         [KLS24]
+      R 192.12.128.rrr                     BRADLEY           [LH124]
+      C*192.12.129.rrr                     SYM-CAN           [MMH5]
+        192.12.130.rrr                     Unassigned        [NIC]
+      R 192.12.131.rrr                     SAC-ADMIN         [KMC3]
+      R 192.12.132.rrr                     LLNL-MON          [LL64]
+      R 192.12.133.rrr                     LLNL-TUES         [LL64]
+      R 192.12.134.rrr                     LLNL-WED          [LL64]
+      R 192.12.135.rrr                     LLNL-THU          [LL64]
+      R 192.12.136.rrr                     LLNL-OUTNET       [LL64]
+      R 192.12.137.rrr                     LLNL-SAT          [LL64]
+      R 192.12.138.rrr                     LLNL-SUN          [LL64]
+      D 192.12.139.rrr                     JTELS-BEN-GW      [RR26]
+      R*192.12.140.rrr                     INFERENCE         [DGT6]
+      R 192.12.141.rrr                     CSS-ETHER         [DC115]
+      C*192.12.142.rrr                     SENTRY            [JB348]
+      C*192.12.143.rrr                     VSHIC-NET         [JB348]
+      R 192.12.144.rrr                     ECRCNET           [PD39]
+      C 192.12.145.rrr                     SMVL-THICK        [RG92]
+      C*192.12.146.rrr-192.12.149.rrr      RCA-CADNET        [RG92]
+      C 192.12.150.rrr                     SMVL-THIN         [RG92]
+      C*192.12.151.rrr                     RCA-CADNET        [RG92]
+      C 192.12.152.rrr                     SMVL-APOLLO       [RG92]
+      C 192.12.153.rrr                     SMVL-153          [RG92]
+      C*192.12.154.rrr                     RCA-CADNET        [RG92]
+      C*192.12.155.rrr-192.12.170.rrr      MTCS-CUST         [SF41]
+      D 192.12.171.rrr                     PICANET2          [RFD1]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 55]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R 192.12.172.rrr                     ROCKWELLENET      [NG]
+      R 192.12.173.rrr                     LBL-EE-NET1       [CAL3]
+      R*192.12.174.rrr-192.12.183.rrr      TORONTO           [BD55]
+      R 192.12.184.rrr                     AGPS-NET          [KDZ]
+      R 192.12.185.rrr                     BOSTONU-NET       [JSOL]
+      R 192.12.186.rrr                     BU-ACCNET         [JSOL]
+      R 192.12.187.rrr                     BU-BROADB         [JSOL]
+      R 192.12.188.rrr                     BU-SCINET         [JSOL]
+      R 192.12.189.rrr                     BU-ENGNET         [JSOL]
+      R 192.12.190.rrr                     BU-DSGNET         [JSOL]
+      R 192.12.191.rrr                     BU-MEDNET         [JSOL]
+      R 192.12.192.rrr                     ITALY-EXTNET      [ABB2]
+      R 192.12.193.rrr                     ITALY-INTNET      [ABB2]
+      R 192.12.194.rrr                     CNUCE-LAN3        [ABB2]
+      R 192.12.195.rrr                     UNISYS-ISF-7      [MS22]
+      R*192.12.196.rrr                     AZMATH            [JC315]
+      D 192.12.197.rrr                     ACATT-ETHER1      [ERK3]
+      D 192.12.198.rrr                     ACATT-ETHER2      [ERK3]
+      D 192.12.199.rrr                     LEWIS-ETHER1      [ERK3]
+      D 192.12.200.rrr                     SRI-PSON-10       [ERK3]
+      D 192.12.201.rrr                     SRI-PSON-11       [ERK3]
+      D 192.12.202.rrr                     SRI-PSON-12       [ERK3]
+      D 192.12.203.rrr                     SRI-PSON-13       [ERK3]
+      D 192.12.204.rrr                     SRI-PSON-14       [ERK3]
+      R 192.12.205.rrr                     OHIO-STATE1       [RSD2]
+      R 192.12.206.rrr                     INDIANA           [BS69]
+      R 192.12.207.rrr                     SUPERCOMP         [GKN1]
+      G*192.12.208.rrr                     AGPS-IPC          [KDZ]
+      R 192.12.209.rrr                     NSF               [FW17]
+      D 192.12.210.rrr                     FSTC              [BB64]
+      R 192.12.211.rrr                     JVNC              [SH37]
+      R 192.12.212.rrr                     RAND-NET2         [JDG]
+      R 192.12.213.rrr                     RAND-NET3         [JDG]
+        192.12.214.rrr                     Unassigned        [NIC]
+      R 192.12.215.rrr                     XDRENET           [JS597]
+      R 192.12.216.rrr                     STEVENS-TECH      [RCM9]
+      C*192.12.217.rrr                     KYFY-CARTO        [WH96]
+      C*192.12.218.rrr                     KYFY-GEOGR        [WH96]
+      C*192.12.219.rrr                     ARIA              [FL27]
+      R 192.12.220.rrr                     WISC-FERD         [EJN1]
+        192.12.221.rrr-192.12.222.rrr      Unassigned        [NIC]
+      R 192.12.223.rrr                     WISC-OZNET        [EJN1]
+      R 192.12.224.rrr                     WISC-OZES         [EJN1]
+        192.12.225.rrr-192.12.234.rrr      Unassigned        [NIC]
+      R*192.12.235.rrr                     IDA-NET           [MSA1]
+      R 192.12.236.rrr                     CITNET            [CBR2]
+      R 192.12.237.rrr                     HCSC-APOLLO       [DB322]
+      R*192.12.238.rrr                     CU-BOULDER        [DCMW]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 56]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R*192.12.239.rrr                     CU-ACS            [DCMW]
+      R*192.12.240.rrr                     CU-ENGINEER       [DCMW]
+      R*192.12.241.rrr                     CU-SUNNET         [DCMW]
+      R*192.12.242.rrr                     CU-CER            [DCMW]
+      R*192.12.243.rrr                     CU-OT             [DCMW]
+      R*192.12.244.rrr                     CU-ENTERPRISE     [DCMW]
+      R*192.12.245.rrr                     CU-LASP           [DCMW]
+      R*192.12.246.rrr                     CU-BOULDER        [DCMW]
+      R*192.12.247.rrr                     TROTTINET         [US2]
+      R 192.12.248.rrr                     ATD1              [TS14]
+      R 192.12.249.rrr                     ATD2              [TS14]
+        192.12.250.rrr                     Unassigned        [NIC]
+      C*192.12.251.rrr                     CDCNET-SDD        [RAM57]
+      R*192.12.252.rrr                     LL-VENET1         [BC65]
+      R*192.12.253.rrr                     LL-VENET2         [BC65]
+      R*192.12.254.rrr                     LL-APOLLO         [BC65]
+      R*192.12.255.rrr                     LL-ENET           [BC65]
+      D 192.13.0.rrr-192.14.255.rrr        DODIIS Subnets    [GEG4]
+      C*192.15.0.rrr-192.15.255.rrr        NBINET            [WW2]
+      G 192.16.0.rrr-192.16.12.rrr         LANLLAN           [PCW]
+      G 192.16.13.rrr                      LANL-SERIAL       [MWS7]
+      G 192.16.14.rrr-192.16.49.rrr        LANLLAN           [PCW]
+      R 192.16.50.rrr-192.16.71.rrr        RPI-LOCALNETS     [MS9]
+      R 192.16.72.rrr                      THENET            [DLN12]
+      R*192.16.73.rrr                      DSU-TOKEN         [GH46]
+      R 192.16.74.rrr                      OTSTOKEN          [DLN12]
+      C*192.16.75.rrr-192.16.122.rrr       CSC Block         [SWR3]
+      R 192.16.123.rrr                     SICSNET           [JW302]
+      R 192.16.124.rrr                     SICS-APOLLORING   [JW302]
+      R*192.16.125.rrr                     SWNET             [BE10]
+      R 192.16.126.rrr                     KTH-ETHER         [AH94]
+      R*192.16.127.rrr-192.16.129.rrr      SWNET             [BE10]
+      R 192.16.130.rrr                     ICU-NET           [AA81]
+      R*192.16.131.rrr-192.16.136.rrr      SWNET             [BE10]
+      R*192.16.137.rrr                     SWNET             [BE10]
+      R 192.16.138.rrr                     LU-SLIP-NET       [JE87]
+      R*192.16.139.rrr                     SWNET             [BE10]
+      R 192.16.140.rrr                     KTH-SICSLINK      [AH94]
+      R 192.16.141.rrr                     NEXUS-NET         [MH246]
+      R 192.16.142.rrr                     LOG-EHTER         [JH87]
+      R*192.16.143.rrr-192.16.145.rrr      SWNET             [BE10]
+      R 192.16.146.rrr                     IMNET             [HB99]
+      R 192.16.147.rrr                     IDEONLUND         [JE87]
+      R*192.16.148.rrr-192.16.151.rrr      SWNET             [BE10]
+      R 192.16.152.rrr                     TVTF-ETHER        [RZ2]
+      R*192.16.153.rrr-192.16.154.rrr      SWNET             [BE10]
+      R*192.16.155.rrr-192.16.166.rrr      CERN-Block        [TB166]
+        192.16.167.rrr                     Unassigned        [NIC]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 57]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      D 192.16.168.rrr                     PICANET3          [RFD1]
+      D 192.16.169.rrr                     NRL-HUBNET        [MPM]
+        192.16.170.rrr                     Reserved          [NIC]
+      R 192.16.171.rrr                     MACOM             [TSC11]
+      C*192.16.172.rrr                     EIK-ENG           [SW78]
+      D 192.16.173.rrr                     NCAD-LAN1         [FJS3]
+      R 192.16.174.rrr                     LL-MICRO-NET      [GLD]
+      R 192.16.175.rrr                     GUACC             [SA]
+      R 192.16.176.rrr                     LSUNET            [CFB1]
+      C*192.16.177.rrr                     FJINET            [CE41]
+      R*192.16.178.rrr                     NTT-Y-ETHER       [RN29]
+      R*192.16.179.rrr                     NTT-Y-APOLLO      [RN29]
+        192.16.180.rrr                     Unassigned        [NIC]
+      R 192.16.181.rrr                     LL-DSN-NET        [KLS24]
+      R*192.16.182.rrr                     GTICS-SUNS        [DD11]
+      R*192.16.183.rrr                     WCW-LAN           [JA]
+      R 192.16.184.rrr                     CWI-ETHER         [PB13]
+      R*192.16.185.rrr-192.16.187.rrr      WCW-LAN           [JA]
+      R 192.16.188.rrr                     NKIS              [JA]
+      R*192.16.189.rrr-192.16.190.rrr      WCW-LAN           [JA]
+      R 192.16.191.rrr                     WCW               [PB13]
+      R*192.16.192.rrr-192.16.200.rrr      WCW-LAN           [JA]
+      R 192.16.201.rrr                     WCWS              [PB13]
+      R 192.16.202.rrr                     CWI-EUNET         [PB13]
+      R 192.16.203.rrr                     HCSC-SUN          [DB322]
+      R 192.16.204.rrr                     IASNET            [KHJ]
+      R 192.16.205.rrr                     DREA-ENET2        [JS597]
+      R 192.16.206.rrr                     DREA-ENET3        [JS597]
+      R 192.16.207.rrr                     DCIEM-CSS         [JS597]
+      R 192.16.208.rrr                     DCIEM-HFD         [JS597]
+      R*192.16.209.rrr-192.16.255.rrr      DREA-LAN          [JS597]
+      R*192.17.0.rrr-192.17.4.rrr          NIBELUNG          [MA24]
+        192.17.5.rrr                       Unassigned        [NIC]
+      R*192.17.6.rrr-192.17.255.rrr        NIBELUNG          [MA24]
+      C*192.18.0.rrr-192.18.255.rrr        Sun Microsystems  [WM3]
+      C*192.19.0.rrr-192.19.255.rrr        SYSNET-2          [EY5]
+      C*192.20.0.rrr-192.20.224.rrr        AT&T Bell Labs    [MH82]
+      R 192.20.225.rrr                     MH-INTER-NET      [BC71]
+      C*192.20.226.rrr-192.20.238.rrr      AT&T Bell Labs    [MH82]
+      C 192.20.239.rrr                     ATT-MD-NET        [MH82]
+      C*192.20.240.rrr-192.20.255.rrr      AT&T Bell Labs    [MH82]
+      C*192.21.0.rrr-192.21.255.rrr        FORMATIVE         [SAB17]
+      C*192.22.0.rrr-192.22.255.rrr        APPLICON          [AS90]
+      C*192.23.0.rrr-192.23.255.rrr        FACTRON           [JCB42]
+      C*192.24.0.rrr-192.24.255.rrr        CHROMATICS        [RB219]
+      R*192.25.0.rrr-192.25.255.rrr        Hewlett-Packard   [SI8]
+      D*192.26.0.rrr                       ACSAD             [SLH19]
+      R 192.26.1.rrr                       MCC-ACA10         [CBD]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 58]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R 192.26.2.rrr                       MCC-ACA11         [CBD]
+      R 192.26.3.rrr                       MCC-ACA12         [CBD]
+      R 192.26.4.rrr                       MCC-ACA13         [CBD]
+      R 192.26.5.rrr                       MCC-ACA14         [CBD]
+      R 192.26.6.rrr                       MCC-ACA15         [CBD]
+      R 192.26.7.rrr                       SPAWAR            [JK7]
+      D 192.26.8.rrr                       SAIC-CPVB         [MAW25]
+      R*192.26.9.rrr                       ICOT              [MY14]
+      R 192.26.10.rrr                      GALLAUDET-TEMP    [KBC]
+      D 192.26.11.rrr                      NRL-HUBNET1       [MPM]
+      D 192.26.12.rrr                      NRL-HUBNET2       [MPM]
+      D 192.26.13.rrr                      NRL-HUBNET3       [MPM]
+      D 192.26.14.rrr                      NRL-HUBNET4       [MPM]
+      D 192.26.15.rrr                      NRL-HUBNET5       [MPM]
+      D 192.26.16.rrr                      NRL-HUBNET6       [MPM]
+      D 192.26.17.rrr                      NRL-HUBNET7       [MPM]
+      D 192.26.18.rrr                      NRL-HUBNET8       [MPM]
+      D 192.26.19.rrr                      NRL-HUBNET9       [MPM]
+      D 192.26.20.rrr                      NSYPTSMH-LAN      [TSD3]
+      R 192.26.21.rrr                      UNISYS-ISF-8      [MS22]
+      R 192.26.22.rrr                      UNISYS-ISF-9      [MS22]
+      R 192.26.23.rrr                      UNISYS-ISF-10     [MS22]
+      R 192.26.24.rrr                      UNISYS-ISF-11     [MS22]
+      R 192.26.25.rrr                      LUCID             [BM68]
+      D 192.26.26.rrr                      NRL-FIBER         [WF3]
+      C 192.26.27.rrr                      ICON-ETHER        [RH227]
+        192.26.28.rrr-192.26.45.rrr        Unassigned        [NIC]
+      R*192.26.46.rrr-192.26.47.rrr        EPFL              [YD2]
+      G*192.26.48.rrr                      FORUM             [MR101]
+      R 192.26.49.rrr                      OTS-192-26-49     [DLN12]
+      R*192.26.50.rrr-192.26.82.rrr        Silcon Graphics   [RB221]
+      R 192.26.83.rrr                      CSM-NET-TEMP      [KL31]
+      R 192.26.84.rrr                      NPRDC-FTC         [LRB]
+      R 192.26.85.rrr                      NUSAN             [JPD18]
+      R 192.26.86.rrr                      PHYSICS-SAC       [JPD18]
+      R 192.26.87.rrr                      MS-SAC            [JPD18]
+      R 192.26.88.rrr                      YALE-ENG-NET      [HML1]
+      D 192.26.89.rrr                      JTELS-BEN1-GW     [RR26]
+      C*192.26.90.rrr                      SYNTELNET-A       [RAR22]
+      R 192.26.91.rrr                      KDD               [TA24]
+      R*192.26.92.rrr                      WRIGHT            [SH1]
+      R 192.26.93.rrr                      AECL-NET          [TK43]
+      R*192.26.94.rrr                      NTT-AP-NET        [HM38]
+      R 192.26.95.rrr                      LL-VLSI-NET       [AHA]
+      R*192.26.96.rrr                      FX-STC-NET2       [SY8]
+      C*192.26.97.rrr                      RCA-SNOOPY        [RAR23]
+      C*192.26.98.rrr                      TASC-CTC-NET      [KDM5]
+      C 192.26.99.rrr                      FAI               [MWS10]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 59]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C 192.26.100.rrr                     PROTEON-EXP1      [JS28]
+      C 192.26.101.rrr                     PROTEON-EXP2      [JS28]
+      C 192.26.102.rrr                     PROTEON-EXP3      [JS28]
+      D 192.26.103.rrr                     EXNET             [MB31]
+      R*192.26.104.rrr-192.26.135.rrr      FINLAND           [JH141]
+      R 192.26.136.rrr                     WASHINGTON-TEMP   [NJB7]
+      R 192.26.137.rrr-192.26.146.rrr      SYR-MH-NET        [JW47]
+      R 192.26.147.rrr                     WLV-ETHER         [SMS1]
+      R 192.26.148.rrr                     UMDNJ-NRAC        [LPM]
+      R 192.26.149.rrr                     LL43-LEX-SUNC     [VBK]
+      R 192.26.150.rrr                     LL43-TB-SUNA      [VBK]
+      C*192.26.151.rrr                     LATICORP          [CC108]
+      R 192.26.152.rrr                     FERNWOODNET1      [GEOF]
+        192.26.153.rrr                     Unassigned        [NIC]
+      C*192.26.154.rrr-192.26.173.rrr      PHILIPS-SERI      [OK6]
+      R*192.26.174.rrr-192.26.193.rrr      UP-NETS           [RF130]
+      G*192.26.194.rrr-192.26.199.rrr      FRB-NETS          [RPD5]
+      G 192.26.200.rrr                     FRB-WS            [RPD5]
+      G*192.26.201.rrr-192.26.209.rrr      FRB-NETS          [RPD5]
+      R 192.26.210.rrr                     CRIM-NET          [MV38]
+        192.26.211.rrr-192.26.239.rrr      Unassigned        [NIC]
+      D 192.26.240.rrr                     BRAGGNET-18       [TN5]
+      D 192.26.241.rrr                     BRAGGNET-19       [TN5]
+      D 192.26.242.rrr                     BRAGGNET-20       [TN5]
+      D 192.26.243.rrr                     BRAGGNET-21       [TN5]
+      D 192.26.244.rrr                     BRAGGNET-22       [TN5]
+      D 192.26.245.rrr                     BRAGGNET-23       [TN5]
+      D 192.26.246.rrr                     BRAGGNET-24       [TN5]
+      D 192.26.247.rrr                     BRAGGNET-25       [TN5]
+      D 192.26.248.rrr                     BRAGGNET-26       [TN5]
+      D 192.26.249.rrr                     BRAGGNET-27       [TN5]
+      R*192.26.250.rrr                     SCRIPPSNET-B      [SRC16]
+      R*192.26.251.rrr                     SCRIPPSNET-C      [SRC16]
+      R*192.26.252.rrr                     SCRIPPSNET-D      [SRC16]
+      R*192.26.253.rrr                     SCRIPPSNET-E      [SRC16]
+      R*192.26.254.rrr                     SCRIPPSNET-F      [SRC16]
+        192.26.255.rrr                     Reserved          [JBP]
+      C*192.27.0.rrr-192.27.255.rrr        HAC-VLSI          [PH45]
+      C*192.28.0.rrr-192.28.99.rrr         3M-NETS           [LS103]
+      R*192.28.100.rrr-192.28.255.rrr      FORD-NETS         [FJB3]
+      C*192.29.0.rrr-192.29.255.rrr        Sun Microsystems  [WM3]
+      C*192.30.0.rrr-192.30.255.rrr        Hewlett-Packard   [SI8]
+      R 192.31.0.rrr                       PURDUE-GEOSC      [DT50]
+      C*192.31.1.rrr                       CSD-GTE-LAN       [MM135]
+      R 192.31.2.rrr                       YCC-SYS-LT        [ASW3]
+      R 192.31.3.rrr                       ALCOA-NET-TEMP    [JOG]
+      C*192.31.4.rrr                       I2-ETHER-3        [CB42]
+      R 192.31.5.rrr                       BOEING-ATC        [PM37]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 60]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C 192.31.6.rrr                       SQ-ETHER          [BG23]
+      C 192.31.7.rrr                       CISCO-NET         [KSL]
+      G 192.31.8.rrr                       USNA-CADNET       [RAD15]
+        192.31.9.rrr                       Unassigned        [NIC]
+      R 192.31.10.rrr                      UTACC-ETHER1      [EK18]
+      R 192.31.11.rrr                      UTACC-ETHER2      [EK18]
+      R 192.31.12.rrr                      UTACC-ETHER3      [EK18]
+      R 192.31.13.rrr                      UTACC-ETHER4      [EK18]
+        192.31.14.rrr                      Unassigned        [NIC]
+      C*192.31.15.rrr                      CASETEK           [PML1]
+      D 192.31.16.rrr                      CC1-ENET          [GIH]
+      D 192.31.17.rrr                      CENTCOM-UNCLAS    [KMC3]
+      D 192.31.18.rrr                      CC3-ENET          [GIH]
+      D 192.31.19.rrr                      CC4-ENET          [GIH]
+      D 192.31.20.rrr                      CC5-ENET          [GIH]
+      R 192.31.21.rrr                      SDSC-APOLLO       [GKN1]
+      C*192.31.22.rrr                      SDCCARY           [DK5]
+      R*192.31.23.rrr                      KULEUVEN-CS       [JH18]
+      D 192.31.24.rrr                      ALBM-NET          [DV42]
+      C*192.31.25.rrr                      NBKNET-AI         [JC272]
+      C*192.31.26.rrr                      ISTNET            [NT12]
+      R 192.31.27.rrr                      ALTAIR-NET        [OG4]
+      R 192.31.28.rrr                      STEWARD-OBS       [SS80]
+      R*192.31.29.rrr                      AMDAHL-TTD        [DR71]
+      R 192.31.30.rrr                      ADS-DC-NET        [WR66]
+      C*192.31.31.rrr                      AXION-NET         [NT13]
+      C*192.31.32.rrr-192.31.36.rrr        NSKK-LAN          [AK36]
+      C*192.31.37.rrr                      SDCAPOLL          [DK5]
+      C*192.31.38.rrr                      TIATSPINE         [WDR7]
+      R 192.31.39.rrr                      UTAH-NSS          [AC98]
+        192.31.40.rrr-192.31.42.rrr        Unassigned        [NIC]
+      R 192.31.43.rrr                      CNSNET            [DC99]
+      C 192.31.44.rrr                      MRC-NET           [WLG7]
+      R 192.31.45.rrr                      WILLIAMS          [DA106]
+      R*192.31.46.rrr                      LFU_ETHER         [MRK14]
+      R 192.31.47.rrr-192.31.61.rrr        BARRNET           [AB71]
+      R*192.31.62.rrr                      SRI-CAM           [AGS5]
+      R 192.31.63.rrr                      SCUBED-BBONE      [TH60]
+      R 192.31.64.rrr                      S3-RESEARCH       [TH60]
+      R 192.31.65.rrr                      S3-FIBER-NET      [TH60]
+      R 192.31.66.rrr                      S3-ABQNET         [TH60]
+      R 192.31.67.rrr                      S3-SLIP-NET       [TH60]
+      R 192.31.68.rrr                      S3-THIN-NET       [TH60]
+      R 192.31.69.rrr                      S3-BBONE2-NET     [TH60]
+      R 192.31.70.rrr                      S3-ETHER2-NET     [TH60]
+      R 192.31.71.rrr                      S3-ETHER3-NET     [TH60]
+      R 192.31.72.rrr                      S3-ETHER4-NET     [TH60]
+      C*192.31.73.rrr                      MTEL-APOLLO       [TSC11]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 61]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C*192.31.74.rrr                      GSD-PCNET         [MDP16]
+      D 192.31.75.rrr                      HQDA-AI           [RAH64]
+      D 192.31.76.rrr                      CSTLNET           [MP20]
+      C*192.31.77.rrr                      MAPNET            [BH80]
+      C*192.31.78.rrr                      WELLSNET-A1       [JN47]
+      C*192.31.79.rrr                      WACHOVIANET-AI    [PMH3]
+        192.31.80.rrr                      Unassigned        [NIC]
+      C*192.31.81.rrr                      ICAD-ETHER        [CJ57]
+      D 192.31.82.rrr                      HQEIS             [SMK2]
+      R 192.31.83.rrr                      OSUNET            [PW37]
+      C*192.31.84.rrr                      CUBI              [SFJ]
+      C 192.31.85.rrr                      CLINET            [WAH11]
+        192.31.86.rrr                      Unassigned        [NIC]
+      R 192.31.87.rrr                      HARC-NET          [JRS67]
+      R 192.31.88.rrr                      BCMTECH-NET       [SB98]
+        192.31.89.rrr                      Unassigned        [NIC]
+      R 192.31.90.rrr                      MORAVIAN          [JPS17]
+      R*192.31.91.rrr                      NECAM-TEMP        [ARS3]
+        192.31.92.rrr                      Unassigned        [NIC]
+      R 192.31.93.rrr                      CIT-SRLNET        [CJL2]
+      C*192.31.94.rrr                      SYNTHESIS         [LL56]
+      R*192.31.95.rrr                      UCCNET            [AC42]
+      G 192.31.96.rrr                      ORNL-OSTINET      [THD]
+      R 192.31.97.rrr                      KSU-NET           [MSM1]
+      D 192.31.98.rrr                      PBAS-BEN2-GW      [RR26]
+      R 192.31.99.rrr                      UTENNK-RES        [JDC20]
+      D 192.31.100.rrr                     GUNTER-LAN-1      [TMD6]
+      R 192.31.101.rrr                     TSU-NET           [AZ]
+      C*192.31.102.rrr                     LEUZENET          [FBR2]
+      R 192.31.103.rrr                     CSNET-NET         [WHN2]
+      R 192.31.104.rrr                     CSNET-ECC         [WHN2]
+      R*192.31.105.rrr                     UCC-PRO-UCB       [AC42]
+      D 192.31.106.rrr                     NSWSES-NAVY       [MJJ1]
+      R*192.31.107.rrr                     ASN428-NET        [JRS48]
+      R*192.31.108.rrr                     UCFCSNET          [TB64]
+      R*192.31.109.rrr                     FREDONIA          [JM278]
+      C*192.31.110.rrr                     ADCAPOLL          [RC113]
+      R 192.31.111.rrr                     AIRMICS           [WES22]
+      R 192.31.112.rrr                     TRINCOLL          [PS173]
+      C 192.31.113.rrr                     ODYSSEY           [JH22]
+      C*192.31.114.rrr                     DRINET            [KB60]
+      C*192.31.115.rrr                     FIRENET-AI        [CO16]
+      R*192.31.116.rrr-192.31.124.rrr      UTOKYO-NETS       [JM292]
+      R*192.31.125.rrr-192.31.144.rrr      DUT-NET           [FD18]
+      R 192.31.145.rrr                     SIGNET            [PGM]
+      R 192.31.146.rrr                     UCR               [JR283]
+      D 192.31.147.rrr                     NUWESNET          [RM125]
+      C*192.31.148.rrr                     AIGNET-AI         [RK51]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 62]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C*192.31.149.rrr                     WACNET-AI         [PMH3]
+      C*192.31.150.rrr                     STPNET-AI         [RLP30]
+      C*192.31.151.rrr                     COGNITIONNET      [DG177]
+      C 192.31.152.rrr                     ROSENET           [SW73]
+      R 192.31.153.rrr                     SALKNET           [JOO]
+      R 192.31.154.rrr                     UNMHC-DEV         [WTC]
+      R 192.31.155.rrr                     GEOLOGY-NWU       [JPD18]
+      R*192.31.156.rrr                     CANISIUS-CS       [MS101]
+      R 192.31.157.rrr                     RTNET             [SC81]
+        192.31.158.rrr                     Unassigned        [NIC]
+      R 192.31.159.rrr                     NYTGCYLAB         [SS110]
+      D 192.31.160.rrr                     NUWES-C-NET       [RM125]
+      R 192.31.161.rrr                     UCB-UCSC-NET      [CF4]
+        192.31.162.rrr                     Unassigned        [NIC]
+      R 192.31.163.rrr                     C3P-NET           [HLW7]
+      D 192.31.164.rrr                     MO-NET            [SM62]
+      R 192.31.165.rrr                     NOAO-TUCSON       [SG1]
+      R*192.31.166.rrr                     EUTEA             [JVE2]
+      R*192.31.167.rrr                     EUTES             [JVE2]
+      R*192.31.168.rrr                     EUTEB             [JVE2]
+      R*192.31.169.rrr                     EUTEEB            [JVE2]
+      R*192.31.170.rrr                     EUTEEA            [JVE2]
+      R*192.31.171.rrr                     EUTEX             [JVE2]
+      D 192.31.172.rrr                     IH-POE-GW         [LK27]
+      R 192.31.173.rrr                     NORTHWESTNET      [GK44]
+      D 192.31.174.rrr                     CORONA-GW-TEMP    [KHJ1]
+      C*192.31.175.rrr                     ZAIAZ             [WDW2]
+      R*192.31.176.rrr                     CADR              [MA56]
+        192.31.177.rrr                     Unassigned        [NIC]
+      R 192.31.178.rrr                     THINK-INET-2      [BJN1]
+        192.31.179.rrr-192.31.180.rrr      Unassigned        [NIC]
+      R 192.31.181.rrr                     THINK-INET-5      [BJN1]
+      R 192.31.182.rrr                     THINK-INET-6      [BJN1]
+      R 192.31.183.rrr                     THINK-INET-7      [BJN1]
+      R 192.31.184.rrr                     THINK-INET-8      [BJN1]
+      R 192.31.185.rrr                     THINK-INET-9      [BJN1]
+      R 192.31.186.rrr                     THINK-INET-10     [BJN1]
+      R 192.31.187.rrr                     THINK-INET-11     [BJN1]
+      R 192.31.188.rrr                     THINK-INET-12     [BJN1]
+      R 192.31.189.rrr                     THINK-INET-13     [BJN1]
+      R 192.31.190.rrr                     THINK-INET-14     [BJN1]
+      R 192.31.191.rrr                     THINK-INET-15     [BJN1]
+      R 192.31.192.rrr                     SUPER             [RSH]
+      R 192.31.193.rrr                     CUA               [ECM6]
+        192.31.194.rrr-192.31.195.rrr      Unassigned        [NIC]
+      R*192.31.196.rrr                     SERC-NET          [DT50]
+      G 192.31.197.rrr                     ETLNET            [TO4]
+      G*192.31.198.rrr-192.31.206.rrr      ETL-LAN           [TO4]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 63]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R 192.31.207.rrr                     HCSC-SUN2         [DB322]
+      D 192.31.208.rrr                     CENTERNET-TEMP    [JA91]
+      C*192.31.209.rrr                     PHRED             [MG95]
+      R 192.31.210.rrr                     STSCI-C-NET       [RK146]
+      R 192.31.211.rrr                     EMSE-INET         [JFC6]
+      C*192.31.212.rrr                     LUCID-ETHER1      [LNZ]
+      C*192.31.213.rrr                     LUCID-APOLLO      [LNZ]
+      R 192.31.214.rrr                     ALASKANET         [GK44]
+      R 192.31.215.rrr                     MONTANANET        [GK44]
+      R 192.31.216.rrr                     WSUNET-TEMP       [RW211]
+      R 192.31.217.rrr                     MCC-ACA1          [CBD]
+      R 192.31.218.rrr                     MCC-ACA2          [CBD]
+      R 192.31.219.rrr                     MCC-ACA3          [CBD]
+      R 192.31.220.rrr                     MCC-ACA4          [CBD]
+      R 192.31.221.rrr                     MCC-ACA5          [CBD]
+      R 192.31.222.rrr                     CAYMAN-IP         [BP52]
+      R 192.31.223.rrr                     UNO-NET           [DES43]
+      C*192.31.224.rrr                     HCR-ETHER         [JR222]
+      D 192.31.225.rrr                     MINSY-POE         [RWC34]
+      D 192.31.226.rrr                     LOGAIRCOMNET      [GT37]
+      C*192.31.227.rrr                     KSR-ETHER-1       [BIM]
+        192.31.228.rrr                     Unassigned        [NIC]
+      R*192.31.229.rrr                     AMDAHL-DAPE       [JFD9]
+      R 192.31.230.rrr                     INCSYS            [JS281]
+      R 192.31.231.rrr                     VUCS-AMS          [HVS1]
+      C*192.31.232.rrr                     CFI-NET           [SL47]
+      C*192.31.233.rrr                     CNT-CORP          [RM176]
+        192.31.234.rrr                     Unassigned        [NIC]
+      R 192.31.235.rrr                     SCA-NET           [HML1]
+      R 192.31.236.rrr                     YALE-CS-NET       [HML1]
+        192.31.237.rrr                     Unassigned        [NIC]
+      D 192.31.238.rrr                     NCP-LAN           [JM246]
+      D 192.31.239.rrr                     SEACOMNET         [JH10]
+      C*192.31.240.rrr                     LEXICON           [MK75]
+      G 192.31.241.rrr                     MSFC-DR-NET       [MSM1]
+      R 192.31.242.rrr                     DIALUP-IP         [WHN2]
+      R*192.31.243.rrr                     WRIGHT-SE         [JLS45]
+        192.31.244.rrr                     Unassigned        [NIC]
+      D 192.31.245.rrr                     BITS-NET          [AM95]
+      C 192.31.246.rrr                     MARBLE-NET        [ME38]
+      C*192.31.247.rrr                     CVBNET            [AC66]
+      R*192.31.248.rrr                     AJTNET            [RJH33]
+      C*192.31.249.rrr                     ADELIE            [BAB7]
+      C*192.31.250.rrr                     THALATTA-NET      [JPB17]
+        192.31.251.rrr                     Unassigned        [NIC]
+      C*192.31.252.rrr                     FTC-ETHER-A       [RS253]
+      R 192.31.253.rrr                     CQENET            [JPD18]
+      R 192.31.254.rrr                     ALFREDNET         [CLB36]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 64]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+        192.31.255.rrr                     Reserved          [JBP]
+      C*192.32.0.rrr-192.32.255.rrr        WELLFLEET         [AW56]
+        192.33.0.rrr                       Reserved          [JBP]
+      R*192.33.1.rrr                       MTHOLYOKE         [WB53]
+      C*192.33.2.rrr                       MRST-NET          [ER42]
+      D 192.33.3.rrr                       DDN-OFFICE        [DM28]
+      R 192.33.4.rrr                       NYSERLAN          [MS9]
+      D 192.33.5.rrr                       CAC-CEN1          [BG25]
+      D 192.33.6.rrr                       CAC-CEN2          [BG25]
+      D 192.33.7.rrr                       CAC-CEN3          [BG25]
+      D 192.33.8.rrr                       CAC-CEN4          [BG25]
+      D 192.33.9.rrr                       CAC-CEN5          [BG25]
+      R 192.33.10.rrr                      NOAO-KPNO         [SG1]
+      R 192.33.11.rrr                      NOAO-ORION        [SG1]
+      R*192.33.12.rrr                      HAMPSHIRE         [PT23]
+      D 192.33.13.rrr                      BRL-CDCNET        [RR33]
+      R 192.33.14.rrr                      CIT-WAG-NET       [RED22]
+      C 192.33.15.rrr                      CHORUS-OPERA      [RD104]
+      R*192.33.16.rrr                      COGS              [RS255]
+      R 192.33.17.rrr                      CALTECH-AMA       [DIM2]
+        192.33.18.rrr                      Unassigned        [NIC]
+      R 192.33.19.rrr                      SERI              [AM92]
+      C*192.33.20.rrr                      AUX-DEFAULT       [HK24]
+      C 192.33.21.rrr                      RISC-ANAHEIM      [WAG5]
+      C*192.33.22.rrr                      PORTAL            [JL115]
+      R 192.33.23.rrr                      ROUTETEST0        [SSW]
+      R 192.33.24.rrr                      ROUTETEST1        [SSW]
+      R 192.33.25.rrr                      ROUTETEST2        [SSW]
+      R 192.33.26.rrr                      ROUTETEST3        [SSW]
+      R 192.33.27.rrr                      ROUTETEST4        [SSW]
+      R 192.33.28.rrr                      ROUTETEST5        [SSW]
+      R 192.33.29.rrr                      ROUTETEST6        [SSW]
+      R 192.33.30.rrr                      ROUTETEST7        [SSW]
+      R 192.33.31.rrr                      ROUTETEST8        [SSW]
+      R 192.33.32.rrr                      ROUTETEST9        [SSW]
+      D 192.33.33.rrr                      NISCNET           [VN]
+        192.33.34.rrr                      Unassigned        [NIC]
+      C*192.33.35.rrr                      MIZAR             [MCL9]
+      R 192.33.36.rrr                      VUPHYS-AMS        [FU1]
+      C*192.33.37.rrr-192.33.86.rrr        BOEING-LOCALNETS  [SGR1]
+      R*192.33.87.rrr-192.33.111.rrr       ETH-NETS          [MA63]
+      C 192.33.112.rrr                     TIS-NET           [DID1]
+      C*192.33.113.rrr                     MYBULL            [CM116]
+      C*192.33.114.rrr                     MYDEMO            [CM116]
+      R 192.33.115.rrr                     NRAO-CV           [DCW9]
+      R 192.33.116.rrr                     NRAO-GB           [NM57]
+      R*192.33.117.rrr                     NRAO-VLA          [BP57]
+      R*192.33.118.rrr-192.33.127.rrr      PSI-NETS          [BH103]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 65]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R 192.33.128.rrr                     BNL-AGS           [SM111]
+        192.33.129.rrr                     Unassigned        [NIC]
+      C*192.33.130.rrr                     SPHINX            [BM106]
+      C*192.33.131.rrr                     PHIL-CE           [HB60]
+      C*192.33.132.rrr                     STEREOLITHO       [EM67]
+        192.33.133.rrr                     Unassigned        [NIC]
+      C*192.33.134.rrr                     ESOSUN            [PW49]
+      G*192.33.135.rrr                     AIST-LAN          [MK79]
+      R 192.33.136.rrr                     KUBNET            [TN17]
+      R*192.33.137.rrr                     CT-ETHER          [CS136]
+      R*192.33.138.rrr                     CT-ATALK          [CS136]
+        192.33.139.rrr                     Unassigned        [NIC]
+      R 192.33.140.rrr                     SAO-NET           [KG35]
+      R 192.33.141.rrr                     SAO1-NET          [KG35]
+      R 192.33.142.rrr                     SAO2-NET          [KG35]
+        192.33.143.rrr                     Unassigned        [NIC]
+      R 192.33.144.rrr                     FNET-CERISI       [AR41]
+      R 192.33.145.rrr                     FNET-LIFO         [AR41]
+      R 192.33.146.rrr                     FNET-LAAS         [AR41]
+      R*192.33.147.rrr                     FNET2             [AR41]
+      R 192.33.148.rrr                     FNET-GRECO        [AR41]
+      R 192.33.149.rrr                     FNET-CMA          [AR41]
+      R*192.33.150.rrr-192.33.152.rrr      FNET-LAN          [AR41]
+      R 192.33.153.rrr                     FNET-ENS-LYON     [AR41]
+      R*192.33.154.rrr-192.33.155.rrr      FNET-LAN          [AR41]
+      R 192.33.156.rrr                     UNIV-PARIS8       [AR41]
+      R*192.33.157.rrr-192.33.158.rrr      FNET-LAN          [AR41]
+      R 192.33.159.rrr                     FNET-CNAM         [AR41]
+      R*192.33.160.rrr-192.33.165.rrr      FNET-LAN          [AR41]
+      R 192.33.166.rrr                     GIPSI             [JMO4]
+      R 192.33.167.rrr                     FNET-CRIN         [AR41]
+      R 192.33.168.rrr                     INRIA-LORR        [AR41]
+      R*192.33.169.rrr                     FNET7             [AR41]
+      R 192.33.170.rrr                     INRIA-FRANCE      [AR41]
+      R*192.33.171.rrr-192.33.177.rrr      FNET-LAN          [AR41]
+      R 192.33.178.rrr                     CNET-PARIS        [AR41]
+      R 192.33.179.rrr                     FNET-EXPO         [AR41]
+      R 192.33.180.rrr                     FNET-DEMO         [AR41]
+      R 192.33.181.rrr                     FNET-IBP          [AR41]
+      R 192.33.182.rrr                     UNIV-PARIS13      [AR41]
+      D 192.33.183.rrr                     SAPE-MOBILE       [CAD13]
+      D 192.33.184.rrr                     SAPE-PRNODE       [CAD13]
+      G 192.33.185.rrr                     SAAD-ARPA         [DRM24]
+      D 192.33.186.rrr                     USACEC-NET-TEMP   [DEA]
+      C*192.33.187.rrr                     INNONET           [JW181]
+      R*192.33.188.rrr                     TG-ETHER          [DC115]
+      C 192.33.189.rrr                     FX-NET            [EJ19]
+      C*192.33.190.rrr                     TCP-SECURE        [AW65]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 66]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C*192.33.191.rrr                     WEST              [BML2]
+      R*192.33.192.rrr                     EPFL-DOMAIN-ME    [YD2]
+      R*192.33.193.rrr                     EPFL-DOMAIN-MA    [YD2]
+      R*192.33.194.rrr                     EPFL-DOMAIN-MX    [YD2]
+      R*192.33.195.rrr                     EPFL-DOMAIN-EL    [YD2]
+      R*192.33.196.rrr                     EPFL-DOMAIN-GC    [YD2]
+      R*192.33.197.rrr                     EPFL-DOMAIN-PH    [YD2]
+      R*192.33.198.rrr                     EPFL-DOMAIN-CH    [YD2]
+      R*192.33.199.rrr                     EPFL-DOMAIN-DA    [YD2]
+      R*192.33.200.rrr                     EPFL-DOMAIN-GR    [YD2]
+      R*192.33.201.rrr                     EPFL-DOMAIN-CC    [YD2]
+      R*192.33.202.rrr                     EPFL-APPLE-ME     [YD2]
+      R*192.33.203.rrr                     EPFL-APPLE-MA     [YD2]
+      R*192.33.204.rrr                     EPFL-APPLE-MX     [YD2]
+      R*192.33.205.rrr                     EPFL-APPLE-EL     [YD2]
+      R*192.33.206.rrr                     EPFL-APPLE-GC     [YD2]
+      R*192.33.207.rrr                     EPFL-APPLE-PH     [YD2]
+      R*192.33.208.rrr                     EPFL-APPLE-CH     [YD2]
+      R*192.33.209.rrr                     EPFL-APPLE-DA     [YD2]
+      R*192.33.210.rrr                     EPFL-APPLE-GR     [YD2]
+      R*192.33.211.rrr                     EPFL-APPLE-CC     [YD2]
+      R 192.33.212.rrr                     C-212             [AS116]
+      R 192.33.213.rrr                     C-213             [AS116]
+      R 192.33.214.rrr                     C-214             [AS116]
+      R 192.33.215.rrr                     C-215             [AS116]
+      R 192.33.216.rrr                     C-216             [AS116]
+      R 192.33.217.rrr                     C-217             [AS116]
+      R 192.33.218.rrr                     C-218             [AS116]
+      R 192.33.219.rrr                     C-219             [AS116]
+      R*192.33.220.rrr-192.33.231.rrr      UNI-GENEVA        [AS116]
+        192.33.232.rrr-192.33.239.rrr      Unassigned        [NIC]
+      R*192.33.240.rrr                     SRHYPER           [MJ33]
+      C*192.33.241.rrr-192.33.250.rrr      SMI-NET           [KD36]
+      C*192.33.251.rrr                     ISA-NET           [CJB15]
+      R 192.33.252.rrr                     CLEMSON-CSD       [CR83]
+      R*192.33.253.rrr                     CANISIUS-CC       [LD46]
+      C*192.33.254.rrr                     RMI-NET           [RM213]
+        192.33.255.rrr                     Reserved          [JBP]
+      C*192.34.0.rrr-192.34.255.rrr        Hewlett-Packard   [SI8]
+      C*192.35.0.rrr-192.35.19.rrr         NIXDORF-NETS      [PD39]
+      C*192.35.20.rrr-192.35.43.rrr        GE-INTERNET       [JEB50]
+      C 192.35.44.rrr                      GECRD-ISONET      [JEB50]
+      C*192.35.45.rrr                      MSDCNET           [PNW]
+      C*192.35.46.rrr                      GMHGATE           [PNW]
+      C*192.35.47.rrr                      GMHNET            [PNW]
+      R 192.35.48.rrr                      VIRGINIA-T1       [JAJ17]
+      R 192.35.49.rrr                      VIRGINIA-T2       [JAJ17]
+      C*192.35.50.rrr                      CLARIS-NET        [CM130]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 67]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+        192.35.51.rrr                      Unassigned        [NIC]
+      C 192.35.52.rrr                      LACHMAN-NET       [SA65]
+      C 192.35.53.rrr                      LAI-TCP           [SA65]
+      C 192.35.54.rrr                      LAI-MAC           [SA65]
+      C 192.35.55.rrr                      LAI-ISDN          [SA65]
+      C 192.35.56.rrr                      LAI-SLIP          [SA65]
+      C 192.35.57.rrr                      LAI-STG           [SA65]
+      R*192.35.58.rrr                      ENSUN             [SC136]
+      R 192.35.59.rrr                      AAII              [DM249]
+      C*192.35.60.rrr                      ASCENT            [EB33]
+        192.35.61.rrr                      Unassigned        [NIC]
+      D 192.35.62.rrr                      NOSL-POE          [DB211]
+      R*192.35.63.rrr-192.35.72.rrr        UNIDO-NETS        [RV32]
+      C*192.35.73.rrr                      OPTICOM           [CJB1]
+      D 192.35.74.rrr                      FOTLANHS          [FJH1]
+      D 192.35.75.rrr                      FOTLANMS          [FJH1]
+      D 192.35.76.rrr                      FOTLANLS          [FJH1]
+      C*192.35.77.rrr                      GM-AES-NET        [DS229]
+      R 192.35.78.rrr                      IRIS-RING         [JFS22]
+      R 192.35.79.rrr                      CCFNET            [SG144]
+      D 192.35.80.rrr                      NUSC-V702M-1      [SR77]
+      R 192.35.81.rrr                      UWP-IPNET         [TVF1]
+      R 192.35.82.rrr                      CORNELL-DMZ       [JCH17]
+      C*192.35.83.rrr                      SDCCARY2          [RC113]
+      C*192.35.84.rrr                      BDM-MCLEAN        [JS167]
+      R*192.35.85.rrr                      MCGILL-TMP01      [MOUSE]
+      R 192.35.86.rrr                      UMN-MORRIS-NET    [MVO1]
+      C*192.35.87.rrr                      CMPNET            [GC89]
+      R 192.35.88.rrr                      ADEL02-NET        [CLR16]
+      R 192.35.89.rrr                      YCC-SYS-TR        [HKG2]
+      C*192.35.90.rrr                      NLCVX-NET         [SN52]
+      C*192.35.91.rrr                      CSR-NET           [HKG2]
+      C*192.35.92.rrr                      UNISYS-HPW-1      [MS22]
+      C*192.35.93.rrr                      UNISYS-HPW-2      [MS22]
+      G*192.35.94.rrr                      RSRE-SLAN         [BO5]
+      R 192.35.95.rrr                      HCSC-APPLE        [DB322]
+      R 192.35.96.rrr                      UOKECNA           [JW136]
+      R 192.35.97.rrr                      UOKECNB           [JW136]
+      R 192.35.98.rrr                      UOKECNC           [JW136]
+      D 192.35.99.rrr                      WSMR-NET3         [RHM11]
+      R 192.35.100.rrr                     HORIZON-NET       [KJS10]
+      R 192.35.101.rrr                     KEYSTONE-NET      [GR11]
+      C*192.35.102.rrr                     IBINET            [KM79]
+      C*192.35.103.rrr                     SONET             [SWW6]
+        192.35.104.rrr                     Unassigned        [NIC]
+      C*192.35.105.rrr                     POCI              [MA56]
+      R*192.35.106.rrr                     LMSC-LAMS         [GMT6]
+      R*192.35.107.rrr                     NOVANET           [JPO4]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 68]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C*192.35.108.rrr                     SGI-UK            [RA94]
+      C*192.35.109.rrr-192.35.126.rrr      APOLLO-NETS       [SJL]
+        192.35.127.rrr                     Unassigned        [NIC]
+      G*192.35.128.rrr                     NESDIS-NET        [MSM1]
+      G 192.35.129.rrr                     WWB-NET           [MSM1]
+      C*192.35.130.rrr                     WANG-CAD          [WWP8]
+      C*192.35.131.rrr                     WANG-TEST         [WWP8]
+      D*192.35.132.rrr                     WANG-TLAN         [WWP8]
+      R*192.35.133.rrr                     WANG-WITA         [WWP8]
+      R*192.35.134.rrr                     LL-DIV7           [BC65]
+      R*192.35.135.rrr                     LL-DIV9           [BC65]
+      R*192.35.136.rrr                     LL-GR47-ADT       [BC65]
+      R*192.35.137.rrr                     LL-GR47-RPV       [BC65]
+      C*192.35.138.rrr                     SPIDER            [AD67]
+        192.35.139.rrr                     Unassigned        [NIC]
+      R 192.35.140.rrr                     WWU-NET           [PAN1]
+      C*192.35.141.rrr                     QUADRON           [HP32]
+      D 192.35.142.rrr                     YKTNPOE-GW        [WRR5]
+      R*192.35.143.rrr                     UHCL              [JCN10]
+      R 192.35.144.rrr                     DREV-ENET         [JS597]
+      G*192.35.145.rrr                     HAWAII-UHCC       [TN11]
+      R*192.35.146.rrr                     ARCO-CNR          [MF96]
+      D 192.35.147.rrr                     WVA-1             [JEG27]
+      D 192.35.148.rrr                     SIMASTL-NET       [LJC2]
+      R*192.35.149.rrr                     GMD-FOKUS         [SW111]
+      R*192.35.150.rrr                     GMD-FIRST         [SW111]
+      R*192.35.151.rrr                     GMD-FOKUS-A       [SW111]
+      R*192.35.152.rrr                     GMD-FOKUS-B       [SW111]
+      R*192.35.153.rrr                     GMD-FIRST-A       [SW111]
+      D 192.35.154.rrr                     RIA-2-NET         [TC72]
+      R*192.35.155.rrr                     ASNCRAY-NET       [JRS48]
+      C 192.35.156.rrr                     QUALNET2          [VH21]
+      R*192.35.157.rrr                     NWNET1            [GK44]
+      R*192.35.158.rrr                     NWNET2            [GK44]
+      R 192.35.159.rrr                     TACTICS-INTA      [GMR]
+      R 192.35.160.rrr                     TACTICS-GRAT      [GMR]
+      R 192.35.161.rrr                     NBB1              [HWB]
+      R 192.35.162.rrr                     NBB2              [HWB]
+      R 192.35.163.rrr                     NBB3              [HWB]
+      R 192.35.164.rrr                     NBB4              [HWB]
+      R 192.35.165.rrr                     NBB5              [HWB]
+      R 192.35.166.rrr                     NBB6              [HWB]
+      R 192.35.167.rrr                     NBB7              [HWB]
+      R 192.35.168.rrr                     NBB8              [HWB]
+      R 192.35.169.rrr                     NBB9              [HWB]
+      R 192.35.170.rrr                     NBB10             [HWB]
+      R 192.35.171.rrr                     MIDNET-NET2       [DF90]
+      R*192.35.172.rrr                     BRISPOLY          [PE25]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 69]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R 192.35.173.rrr                     MCC-CAD4          [CBD]
+      R 192.35.174.rrr                     MCC-CAD5          [CBD]
+      R 192.35.175.rrr                     MCC-CAD6          [CBD]
+      R 192.35.176.rrr                     MCC-CAD7          [CBD]
+      R 192.35.177.rrr                     MCC-CAD8          [CBD]
+      R 192.35.178.rrr                     MCC-CAD9          [CBD]
+      R 192.35.179.rrr                     MCC-CAD10         [CBD]
+      R 192.35.180.rrr                     NWNET3            [GK44]
+      R*192.35.181.rrr                     NWNET4            [GK44]
+      C*192.35.182.rrr                     KCCS-ETHER        [KC40]
+      R*192.35.183.rrr-192.35.192.rrr      VUCS-NETS         [HVS1]
+      G*192.35.193.rrr                     PNL-SNET          [SCT2]
+      C*192.35.194.rrr                     JAR-NET           [PJ29]
+      R 192.35.195.rrr                     ARIZONA-CMI       [JMS56]
+      G 192.35.196.rrr                     NARDAC-NET        [SW69]
+      C*192.35.197.rrr                     ISTCAMNET         [NT12]
+      C*192.35.198.rrr                     ISTREDNET         [NT12]
+        192.35.199.rrr                     Unassigned        [NIC]
+      R 192.35.200.rrr                     NOAO-SUNSPOT      [RM320]
+      R 192.35.201.rrr                     HAWAII-HIG        [TN11]
+      R 192.35.202.rrr                     HAWAII-RIFT       [TN11]
+      R 192.35.203.rrr                     ECE-ARIZ          [CMG9]
+      C*192.35.204.rrr                     AAEC              [TS118]
+      R*192.35.205.rrr                     EAPSNET           [AB115]
+      R*192.35.206.rrr                     APOLLONET         [AB115]
+      R*192.35.207.rrr                     CSTCDIE           [MN36]
+      D 192.35.208.rrr                     LM-HN-MCC         [SJ55]
+      R 192.35.209.rrr                     UCOP-K3RDNET      [CL64]
+      R*192.35.210.rrr                     UCOP-K4THNET      [CL64]
+      R*192.35.211.rrr                     UCOP-K5THNET      [CL64]
+      R*192.35.212.rrr                     UCOP-K6THNET      [CL64]
+      R 192.35.213.rrr                     UCOP-K8THNET      [CL64]
+      R*192.35.214.rrr                     UCOP-PR80NET      [CL64]
+      R*192.35.215.rrr                     UCDLA-FE1NET      [CL64]
+      R*192.35.216.rrr                     UCDLA-FE2NET      [CL64]
+      R*192.35.217.rrr                     UCDLA-UHNET       [CL64]
+      R*192.35.218.rrr                     UCDLA-IINET       [CL64]
+      R*192.35.219.rrr                     UCDLA-SDINET      [CL64]
+      R*192.35.220.rrr                     UCDLA-SCINET      [CL64]
+      R*192.35.221.rrr                     UCDLA-SFINET      [CL64]
+      R*192.35.222.rrr                     UCDLA-SBINET      [CL64]
+      R*192.35.223.rrr                     UCDLA-RINET       [CL64]
+      R*192.35.224.rrr                     UCDLA-SINET       [CL64]
+      R*192.35.225.rrr                     UCDLA-LAINET      [CL64]
+      R 192.35.226.rrr                     UCDLA-DINET       [CL64]
+      R*192.35.227.rrr                     UCDLA-BINET       [CL64]
+      R*192.35.228.rrr                     UCDLA-NLFNET      [CL64]
+      R 192.35.229.rrr                     RWTH-INFO         [GB133]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 70]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+        192.35.230.rrr-192.35.255.rrr      Unassigned        [NIC]
+      R*192.36.0.rrr-192.36.22.0           SWEDISH-NET       [BE10]
+      R 192.36.23.rrr                      IBMCTP-NET        [BGL5]
+      R*192.36.24.rrr-192.36.110.rrr       SWEDISH-NET       [BE10]
+      R 192.36.111.rrr                     CTH-STE-NET       [GL41]
+      R 192.36.112.rrr                     UMDAC-NET         [RH271]
+      R 192.36.113.rrr                     TDB-NET           [RH271]
+      R 192.36.114.rrr                     UMUNET1           [RH271]
+      R*192.36.115.rrr-192.36.119.rrr      SWEDISH-NET       [BE10]
+      R 192.36.120.rrr                     CTH-DTEK-NET      [GL41]
+      R 192.36.121.rrr                     LU-TDE-NET        [JE87]
+      R 192.36.122.rrr                     LU-REGLER-NET     [JE87]
+      R 192.36.123.rrr                     LU-SLIP2          [JE87]
+      R 192.36.124.rrr                     LU-EFD2-NET       [JE87]
+      R 192.36.125.rrr                     SUNET-BACKBONE    [AH94]
+      R*192.36.126.rrr-192.36.132.rrr      SWEDISH-NET       [BE10]
+      R 192.36.133.rrr                     LU-QUARK-NET      [JE87]
+      R 192.36.134.rrr                     LU-LDC-NET        [JE87]
+      R*192.36.135.rrr                     SWEDISH-NET       [BE10]
+      R 192.36.136.rrr                     SISU-NET          [AB125]
+      R*192.36.137.rrr-192.36.142.rrr      SWEDISH-NET       [BE10]
+      R 192.36.143.rrr                     STOCKHOLM-BB      [AH94]
+      R*192.36.144.rrr-192.36.147.rrr      SWEDISH-NET       [BE10]
+      R 192.36.148.rrr                     NORDUNET-BB       [AH94]
+      R*192.36.149.rrr                     SWEDISH-NET       [BE10]
+      R 192.36.150.rrr                     LUTH-NET          [SW142]
+      R 192.36.151.rrr                     LUTH1-NET         [SW142]
+      R*192.36.152.rrr-192.36.154.rrr      SWEDISH-NET       [BE10]
+      R 192.36.155.rrr                     MECE1-NET         [LB181]
+      R*192.36.156.rrr-192.36.167.rrr      SWEDISH-NET       [BE10]
+      R 192.36.168.rrr                     UU1-NET           [AA81]
+      R*192.36.169.rrr-192.36.184.rrr      SWEDISH-NET       [BE10]
+      R 192.36.185.rrr                     CTH-EKO-NET       [GL41]
+      R*192.36.186.rrr-192.36.223.rrr      SWEDISH-NET       [BE10]
+      R 192.36.224.rrr                     GBG-XX-NET        [GL41]
+      R 192.36.225.rrr                     CTH-CTKT-NET      [GL41]
+      R*192.36.226.rrr-192.36.255.rrr      SWEDISH-NET       [BE10]
+      C*192.37.0.rrr-192.37.255.rrr        CIBA-GEIGY        [HN3]
+      R*192.38.0.rrr-192.38.255.rrr        DENET             [JPS21]
+      C*192.39.0.rrr-192.39.10.rrr         UNISYS-NETS       [CC129]
+      R 192.39.11.rrr                      UNISYS-RES1       [KL63]
+      R 192.39.12.rrr                      UNISYS-RES2       [KL63]
+      C*192.39.13.rrr-192.39.255.rrr       UNISYS-NETS       [CC129]
+      C*192.40.0.rrr-192.40.50.rrr.rrr     Hewlett-Packard   [DCL10]
+      D 192.40.51.rrr                      PMS312-NET        [DL164]
+      C*192.40.52.rrr-192.40.255.rrr       Hewlett-Packard   [DCL10]
+      C*192.41.0.rrr-192.41.101.rrr        ICON-ETHER        [RH227]
+      R*192.41.102.rrr-192.41.131.rrr      EU-NETS           [WSC5]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 71]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R*192.41.132.rrr-192.41.136.rrr      UNIZH-BLOCK       [GP88]
+      C*192.41.137.rrr                     VERDIX-NET        [LD4]
+        192.41.138.rrr                     Unassigned        [NIC]
+      R*192.41.139.rrr                     BBN-SYSENGRC      [DW159]
+      R 192.41.140.rrr                     STC-LAN           [JFW]
+      R*192.41.141.rrr-192.41.145.rrr      UNISG-NETS        [PG62]
+      R 192.41.146.rrr                     CSISRING          [SM164]
+      R*192.41.147.rrr                     FBIHH             [RDM25]
+      G*192.41.148.rrr                     CITY-CALGARY      [AK62]
+      R*192.41.149.rrr-192.41.160.rrr      UNIBE-NETS        [FB61]
+      C*192.41.161.rrr                     ACS-DC-NET        [TR62]
+        192.41.162.rrr                     Unassigned        [NIC]
+      C*192.41.163.rrr                     GURUNET           [KDZ]
+      C*192.41.164.rrr-192.41.169.rrr      UNISYS-NETS       [MS22]
+      R*192.41.170.rrr                     AIT-CS-NET        [TK60]
+      R 192.41.171.rrr                     JVNCNET-TEST      [SH37]
+      C*192.41.172.rrr                     CSPI              [GLC18]
+      R 192.41.173.rrr                     PENNLNK           [TES16]
+      R 192.41.174.rrr                     AMBLER            [TES16]
+      R 192.41.175.rrr                     TYLER             [TES16]
+      R 192.41.176.rrr                     TEMPLE-RC         [TES16]
+      R 192.41.177.rrr                     SURA-NOC          [DO66]
+      R*192.41.178.rrr-192.41.191.rrr      UTOKYO-NET        [JM292]
+      R 192.41.192.rrr                     JUNET-JSFNET      [JM292]
+      R*192.41.193.rrr-192.41.196.rrr      UTOKYO-NET        [JM292]
+      R 192.41.197.rrr                     CCUTRDNET         [JM292]
+      C*192.41.198.rrr                     TYMNET-TTE        [JM451]
+      C*192.41.199.rrr                     CONTEX            [SL97]
+      R 192.41.200.rrr                     NIEHS             [SM157]
+      C*192.41.201.rrr                     HSA-SLNET         [SP69]
+      D 192.41.202.rrr                     LBNS-POE-GW       [DC145]
+      C 192.41.203.rrr                     SOFTWAY-NET       [CM153]
+      G 192.41.204.rrr                     EROS-NET          [MSM1]
+      C*192.41.205.rrr                     VERDIX-HQ         [CG24]
+      R*192.41.206.rrr                     UI-NETLAB         [AT62]
+      D 192.41.207.rrr                     NESEA-NET         [DT59]
+      R 192.41.208.rrr                     CIT-SSDP          [TM19]
+      D*192.41.209.rrr                     GSD-APOLONET      [MDP16]
+      C*192.41.210.rrr                     RTS-IOM           [DB263]
+      R 192.41.211.rrr                     APO-GALILEO       [JRF12]
+      C*192.41.212.rrr                     ARINC-LAN-1       [BM168]
+      G 192.41.213.rrr                     GEODEN            [THL3]
+      C*192.41.214.rrr                     INTERCON-NET      [AW90]
+      C*192.41.215.rrr                     ZARDOZ            [NJG6]
+      R 192.41.216.rrr                     KUBNET-A          [TN17]
+      C 192.41.217.rrr                     DSS               [RLP39]
+      R*192.41.218.rrr                     UDSAB             [AN31]
+      R*192.41.219.rrr                     JVNC-ETA10        [SH37]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 72]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      G*192.41.220.rrr                     VERNET            [JR38]
+      G*192.41.221.rrr                     VERNET-GW         [JR38]
+      C*192.41.222.rrr                     QUICK-NET         [SG58]
+      R*192.41.223.rrr                     ENSCO-FL          [EB95]
+      C*192.41.224.rrr                     BWPCC             [DRM31]
+      G 192.41.225.rrr                     AMES-FEI-NET      [MSM1]
+      C*192.41.226.rrr                     ACAD              [JC345]
+      R*192.41.227.rrr                     ISE-NET           [PJ35]
+      C 192.41.228.rrr                     TGV-NET           [KAA]
+      R 192.41.229.rrr                     NBB11             [HWB]
+      R 192.41.230.rrr                     NBB12             [HWB]
+      R 192.41.231.rrr                     NBB13             [HWB]
+      R 192.41.232.rrr                     NBB14             [HWB]
+      R 192.41.233.rrr                     NBB15             [HWB]
+      R 192.41.234.rrr                     NBB16             [HWB]
+      R 192.41.235.rrr                     NBB17             [HWB]
+      R 192.41.236.rrr                     NBB18             [HWB]
+      R 192.41.237.rrr                     NBB19             [HWB]
+      R 192.41.238.rrr                     NBB20             [HWB]
+      R*192.41.239.rrr                     USW-MPLS-DWT      [BRB8]
+      R*192.41.240.rrr                     USW-MPLS-BEE      [BRB8]
+      R*192.41.241.rrr                     USW-MPLS-MAPLE    [BRB8]
+      R*192.41.242.rrr                     USW-MPLS-MNM      [BRB8]
+      R*192.41.243.rrr                     USW-MPLS-BAK      [BRB8]
+      R*192.41.244.rrr                     WRIGHT-CAIA       [MS272]
+      R 192.41.245.rrr                     IIT-NET           [MD119]
+      D 192.41.246.rrr                     ASIFICS           [SC139]
+      C*192.41.247.rrr                     CHIPCOM           [SE49]
+        192.41.248.rrr                     Unassigned        [NIC]
+      D 192.41.249.rrr                     WR-HN-MCC         [SJ55]
+      D*192.41.250.rrr-192.41.255.rrr      DTSA-NET          [BB116]
+        192.42.0.rrr                       Reserved          [JBP]
+      C*192.42.1.rrr                       DATUS             [KFS2]
+      R 192.42.2.rrr                       CSCSAV-NET        [TV]
+      R 192.42.3.rrr                       CLEMSON-ENG       [WGS4]
+      G 192.42.4.rrr                       MSCDPA            [MB204]
+      R 192.42.5.rrr                       MACPHYS           [CB162]
+      R 192.42.6.rrr                       MACENG            [CB162]
+      R 192.42.7.rrr                       MONTANACOE        [JM468]
+      C 192.42.8.rrr                       TELEOS-NET        [NW25]
+      R*192.42.9.rrr-192.42.40.rrr         BOEING-NETS       [GK44]
+      D 192.42.41.rrr                      PUGET-POE-NET     [GC104]
+      R*192.42.42.rrr-192.42.47.rrr        UNINE-BLOCK       [CW115]
+      R 192.42.48.rrr                      CHPCSUNS          [WLJ7]
+      R 192.42.49.rrr                      CHPCAPOLLOS       [WLJ7]
+      R 192.42.50.rrr                      CHPCXMPFEI        [WLJ7]
+      R 192.42.51.rrr                      CHPCXMPOPR        [WLJ7]
+      C*192.42.52.rrr                      ANZNET-AI         [WM96]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 73]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C*192.42.53.rrr                      SUNNET-AI         [PE21]
+      C*192.42.54.rrr                      CBCNET-AI         [BA51]
+      R*192.42.55.rrr                      SBEENET           [JM414]
+      R 192.42.56.rrr                      RAND-NET4         [JDG]
+      R 192.42.57.rrr                      RAND-NET5         [JDG]
+      R 192.42.58.rrr                      RAND-NET6         [JDG]
+      R 192.42.59.rrr                      RAND-NET7         [JDG]
+      R 192.42.60.rrr                      DMS-MELB          [MA88]
+      R 192.42.61.rrr                      DMS-CANB          [MA88]
+      R 192.42.62.rrr                      DMS-PERTH         [MA88]
+        192.42.63.rrr-192.42.64.rrr        Reserved          [NIC]
+      C*192.42.65.rrr                      CINET             [JV69]
+      G 192.42.66.rrr                      WWB-APOLLO-NET    [MSM1]
+      C*192.42.67.rrr                      SOL-ETHER         [NM37]
+      R 192.42.68.rrr                      DREOEWD-ENET      [JS597]
+      R*192.42.69.rrr                      ETHER1            [JV70]
+      G 192.42.70.rrr                      GISS-NET          [MSM1]
+        192.42.71.rrr-192.42.74.rrr        Unassigned        [NIC]
+      G 192.42.75.rrr                      LARC-SNS          [SDD8]
+      G 192.42.76.rrr                      LARCNET2          [SDD8]
+      G 192.42.77.rrr                      LARCNET3          [SDD8]
+      G 192.42.78.rrr                      LARCNET4          [SDD8]
+      G 192.42.79.rrr                      LARCNET5          [SDD8]
+      D 192.42.80.rrr                      SA-HN-MCC         [SJ55]
+      D 192.42.81.rrr                      OC-HN-MCC         [SJ55]
+      R 192.42.82.rrr                      SCRIPPSNET        [SRC16]
+      R*192.42.83.rrr                      IIT-2             [PJF7]
+      C*192.42.84.rrr                      NTTDATA-NET1      [HE12]
+      C*192.42.85.rrr                      NTTDATA-NET2      [HE12]
+      C*192.42.86.rrr                      NTTDATA-NET3      [HE12]
+      R*192.42.87.rrr                      KING-POLY         [SB167]
+      D 192.42.88.rrr                      SHAFTER-NET       [DM35]
+      R*192.42.89.rrr                      WELLESLEY         [SS208]
+      C*192.42.90.rrr                      QUANTIC           [JV74]
+      R 192.42.91.rrr                      FB04              [AJ29]
+      G*192.42.92.rrr                      ACLD-NET          [BS168]
+        192.42.93.rrr                      Unassigned        [NIC]
+      C*192.42.94.rrr                      LILLYNET-TEMP     [FDC2]
+      C 192.42.95.rrr                      PSC               [BV15]
+      R*192.42.96.rrr                      SWIVAX            [HK35]
+      R 192.42.97.rrr                      SOFTWARE          [JLR43]
+      C*192.42.98.rrr                      IEX-NET           [RB548]
+      R*192.42.99.rrr                      RHODENT           [FJG4]
+      R*192.42.100.rrr                     KEELE-CS          [JK186]
+      R*192.42.101.rrr                     UMSMEDCTR         [GAG17]
+      R*192.42.102.rrr                     GRENET            [JA146]
+      R*192.42.103.rrr-192.42.107.rrr      TOHOKU-NET        [YK3]
+      R 192.42.108.rrr                     UMC-NET           [AC98]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 74]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R 192.42.109.rrr                     INCSYS2           [JS281]
+      R 192.42.110.rrr                     SU-ASSOC-NET      [VAF]
+      C*192.42.111.rrr                     ELAN              [JL239]
+        192.42.112.rrr                     Unassigned        [NIC]
+      R*192.42.113.rrr                     SARA-NET          [WVDS]
+      R 192.42.114.rrr                     NKI               [WVDS]
+      R*192.42.115.rrr-192.42.132.rrr      SARA-NET          [WVDS]
+      R*192.42.133.rrr                     ANL-MAN1          [BRB8]
+      R*192.42.134.rrr                     ANL-MAN2          [BRB8]
+      R*192.42.135.rrr                     ANL-MNM           [BRB8]
+      R*192.42.136.rrr                     ANL-BAC           [BRB8]
+      C*192.42.137.rrr                     FIBERCOM          [DM273]
+      C*192.42.138.rrr                     ANSWER-COMP       [RLG36]
+      C*192.42.139.rrr                     SCEARDNET         [MRC13]
+      C*192.42.140.rrr                     ANDERSEN          [BL92]
+      R*192.42.141.rrr                     AFALNET           [HCV1]
+      R 192.42.142.rrr                     ICASE-NET         [LC152]
+      R*192.42.143.rrr                     WSI               [SS218]
+      R 192.42.144.rrr                     UW-ADPNET         [KL40]
+      R 192.42.145.rrr                     UW-ACSNET         [KL40]
+      C*192.42.146.rrr                     VERSATEC          [TT60]
+        192.42.147.rrr                     Unassigned        [NIC]
+      R*192.42.148.rrr                     MONSAN-RCC1       [JRJ16]
+      R*192.42.149.rrr                     MONSAN-RCC2       [JRJ16]
+      R*192.42.150.rrr                     MONSAN-RCC3       [JRJ16]
+      G 192.42.151.rrr                     IPSRADSPACE       [CB180]
+      R 192.42.152.rrr                     UMN-CC-NET        [RG12]
+      R 192.42.153.rrr                     MALONE            [JN91]
+      C*192.42.154.rrr                     NUCLEUS-INTL      [PAG12]
+      R 192.42.155.rrr                     RSRE-BBN-SAT      [MB]
+      R 192.42.156.rrr                     ESD-H3            [NAK2]
+      R*192.42.157.rrr                     NET-SOLUTION      [MAV4]
+      C*192.42.158.rrr                     TRVNET-AI         [NW30]
+      C*192.42.159.rrr                     NMRI              [JB399]
+      R*192.42.160.rrr-192.42.171.rrr      AUSPEX            [BE35]
+      C*192.42.172.rrr                     NEXT-DEFAULT      [PFK]
+        192.42.173.rrr-192.42.177.rrr      Reserved          [NIC]
+      R 192.42.178.rrr                     MICRO-NET         [JAC61]
+      D 192.42.179.rrr                     WSMR-NET2         [RC29]
+      R*192.42.180.rrr-192.42.201.rrr      LUNET             [JL247]
+      C*192.42.202.rrr                     TCR-CAL           [GR67]
+      C*192.42.203.rrr                     TCR-CAL-BG        [GR67]
+      C*192.42.204.rrr                     TCR-BG            [GR67]
+      C*192.42.205.rrr                     TCR-CAL           [GR67]
+      C*192.42.206.rrr                     TCR-EDM           [GR67]
+      D*192.42.207.rrr                     BMA-1             [GK44]
+      D*192.42.208.rrr                     BMA-2             [GK44]
+      D*192.42.209.rrr                     BMA-3             [GK44]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 75]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      D*192.42.210.rrr                     BMA-4             [GK44]
+      D*192.42.211.rrr                     BMA-5             [GK44]
+      D*192.42.212.rrr                     BMA-6             [GK44]
+      D*192.42.213.rrr                     BMA-7             [GK44]
+      D*192.42.214.rrr                     BMA-8             [GK44]
+      D*192.42.215.rrr                     BMA-9             [GK44]
+      D*192.42.216.rrr                     BMA-10            [GK44]
+      D*192.42.217.rrr                     BMA-11            [GK44]
+      D*192.42.218.rrr                     BMA-12            [GK44]
+      D*192.42.219.rrr                     BMA-13            [GK44]
+      D*192.42.220.rrr                     BMA-14            [GK44]
+      D*192.42.221.rrr                     BMA-15            [GK44]
+      D*192.42.222.rrr                     BMA-16            [GK44]
+      D*192.42.223.rrr                     BMA-17            [GK44]
+      D*192.42.224.rrr                     BMA-18            [GK44]
+      D*192.42.225.rrr                     BMA-19            [GK44]
+      D*192.42.226.rrr                     BMA-20            [GK44]
+      D*192.42.227.rrr                     BMA-21            [GK44]
+      D*192.42.228.rrr                     BMA-22            [GK44]
+      D*192.42.229.rrr                     BMA-23            [GK44]
+      D*192.42.230.rrr                     BMA-24            [GK44]
+      D*192.42.231.rrr                     BMA-25            [GK44]
+      D*192.42.232.rrr                     BMA-26            [GK44]
+      D*192.42.233.rrr                     BMA-27            [GK44]
+      D*192.42.234.rrr                     BMA-28            [GK44]
+      D*192.42.235.rrr                     BMA-29            [GK44]
+      D*192.42.236.rrr                     BMA-30            [GK44]
+      R*192.42.237.rrr                     CSCE-NET          [MH198]
+      C*192.42.238.rrr                     ITI-NET           [EU4]
+      R 192.42.239.rrr                     FIT               [MAG16]
+      R*192.42.240.rrr                     ORACODEV          [FH53]
+      C 192.42.241.rrr                     TRZDOR            [SP86]
+      C*192.42.242.rrr                     OBJY              [WC86]
+      C*192.42.243.rrr                     DEV-RING          [RB520]
+      D 192.42.244.rrr                     OBL-LINK-LAN      [TTS8]
+      D 192.42.245.rrr                     CPO-LINK-LAN      [TTS8]
+      D 192.42.246.rrr                     LON-LINK-LAN      [TTS8]
+      D 192.42.247.rrr                     RDM-LINK-LAN      [TTS8]
+      D 192.42.248.rrr                     SM-HN-MCC         [SJ55]
+      C 192.42.249.rrr                     APPLE             [EF16]
+      C*192.42.250.rrr                     IMCLONE           [PG76]
+      R 192.42.251.rrr                     LIGONET           [GH125]
+      C*192.42.252.rrr                     NETWORK-GENL      [VL24]
+      C*192.42.253.rrr                     ITT-SEMICON       [BS196]
+      C*192.42.254.rrr                     MEGASYS           [GMP19]
+        192.42.255.rrr                     Reserved          [JBP]
+        192.43.0.rrr                       Reserved          [JBP]
+      C*192.43.1.rrr-192.43.150.rrr        DEERE-NETS        [DF130]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 76]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C 192.43.151.rrr                     NET-ARDA          [SS226]
+      R 192.43.152.rrr                     RADC-LAN          [CPK3]
+      R*192.43.153.rrr-192.43.160.rrr      NCD-NETS          [DM280]
+      C*192.43.161.rrr                     CYLINK            [CS219]
+      C*192.43.162.rrr-192.43.171.rrr      TVTLAN            [AH96]
+      R 192.43.172.rrr                     PHOTO-NET         [JAC61]
+      G*192.43.173.rrr                     FIRNLAN           [JL256]
+      R*192.43.174.rrr                     SONY-CSL          [FT30]
+      C*192.43.175.rrr-192.43.184.rrr      LUCID             [KDO]
+      C 192.43.185.rrr                     BBYMELB           [GB157]
+      C 192.43.186.rrr                     BBYSYD            [GB157]
+        192.43.187.rrr                     Unassigned        [NIC]
+      R 192.43.188.rrr                     SDIO-WAN          [KDZ]
+      R*192.43.189.rrr                     SONY-WS-NET       [HI7]
+      R 192.43.190.rrr                     BETHEL            [GW107]
+      C*192.43.191.rrr                     CAST-CREW         [CRJ5]
+      R*192.43.192.rrr                     UNIBAS-WWZ        [RD232]
+      R*192.43.193.rrr                     UNIBAS-MATH       [RD232]
+      R*192.43.194.rrr                     UNIBAS-ASTRO      [RD232]
+      R*192.43.195.rrr                     UNIBAS-PHIL1      [RD232]
+      R*192.43.196.rrr                     UNIBAS-IFI        [RD232]
+      D 192.43.197.rrr                     GUNTER-LAN-2      [JCB14]
+      C 192.43.198.rrr                     CXNET             [BA59]
+      R 192.43.199.rrr                     ETSU              [DS303]
+      R*192.43.200.rrr                     LVPD              [ER75]
+      C*192.43.201.rrr                     NELM-NET          [HO13]
+      C*192.43.202.rrr                     NELA-NET          [HO13]
+      R 192.43.203.rrr                     NRAO-CCC          [DCW9]
+      R 192.43.204.rrr                     NRAO-AOC          [BP57]
+      R 192.43.205.rrr                     MCD-UDC-2         [DP7]
+        192.43.206.rrr                     Unassigned        [NIC]
+      R 192.43.207.rrr                     UNIMELB-CS-A      [RE18]
+      R 192.43.208.rrr                     UNIMELB-CS-B      [RE18]
+      R 192.43.209.rrr                     UNIMELB-CS-C      [RE18]
+      C*192.43.210.rrr                     WESTGRP-HOL       [WH108]
+      C*192.43.211.rrr                     SAGPD             [BA60]
+      R*192.43.212.rrr                     IZF-TNO           [TV29]
+      C*192.43.213.rrr                     KELCO             [EMH12]
+      R*192.43.214.rrr                     KEY               [PJS22]
+        192.43.215.rrr                     Unassigned        [NIC]
+      R 192.43.216.rrr                     LHASA             [GIL]
+      G 192.43.217.rrr                     NOAASEL-NET       [JW301]
+      C*192.43.218.rrr                     DATX              [EK55]
+      C*192.43.219.rrr                     EMPRESS           [PH106]
+      C*192.43.220.rrr                     SEDNET            [TPS5]
+      C*192.43.221.rrr                     ACUSTAR-HEDC      [JR262]
+      C*192.43.222.rrr                     STEPSTONE         [AAD6]
+        192.43.223.rrr                     Unassigned        [NIC]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 77]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R*192.43.224.rrr                     CCKU-NET          [MK133]
+      G*192.43.225.rrr                     GSD-DECTCPIP      [MDP16]
+      R 192.43.226.rrr                     UAENG01           [MP151]
+      R 192.43.227.rrr                     UAENG02           [MP151]
+      R 192.43.228.rrr                     UAENG03           [MP151]
+      R 192.43.229.rrr                     UACOMSCI          [MP151]
+        192.43.230.rrr-192.43.233.rrr      Unassigned        [NIC]
+      C*192.43.234.rrr                     LUCNET            [EB110]
+      C*192.43.235.rrr                     HSI               [WRS28]
+      C*192.43.236.rrr                     MEGATEK           [RR193]
+      C*192.43.237.rrr                     PCC-TCP           [FO17]
+        192.43.238.rrr                     Unassigned        [NIC]
+      R 192.43.239.rrr                     RSES-TRING        [HM68]
+      R 192.43.240.rrr                     GSFC2             [RD240]
+      C*192.43.241.rrr                     MEDIANETTE        [RMF17]
+      R*192.43.242.rrr                     UNF-CIS           [TFB3]
+      R 192.43.243.rrr                     HUNKNET           [TH111]
+      R 192.43.244.rrr                     NCAR-NSS          [DM84]
+      G 192.43.245.rrr                     MITRE-CG-NET      [MSM1]
+        192.43.246.rrr                     Unassigned        [NIC]
+      R*192.43.247.rrr                     GTRI-AIB          [SPR1]
+      C*192.43.248.rrr                     DNH               [SB185]
+      R 192.43.249.rrr                     JAXLAB            [LJ58]
+      C 192.43.250.rrr                     TELEMATICS        [TG67]
+      C*192.43.251.rrr                     APLDBIO           [MR152]
+      R 192.43.252.rrr                     CHUB-NET          [EZ3]
+      D 192.43.253.rrr                     AFMPC-NET         [MTF1]
+      R 192.43.254.rrr                     RADFORDU          [JS255]
+        192.43.255.rrr                     Reserved          [JBP]
+        192.44.0.rrr                       Reserved          [JBP]
+      R 192.44.1.rrr                       FRAUNHOFER-NET    [HF30]
+      R*192.44.2.rrr-192.44.40.rrr         FHG-NETS          [HF30]
+      R*192.44.41.rrr-192.44.80.rrr        FNET-NETS         [AR41]
+      R*192.44.81.rrr                      REVUE-81          [JK198]
+      R 192.44.82.rrr                      REVUE-82          [JK198]
+      R 192.44.83.rrr                      REVUE-83          [JK198]
+      R 192.44.84.rrr                      REVUE-84          [JK198]
+      R 192.44.85.rrr                      REVUE-85          [JK198]
+      R*192.44.86.rrr-192.44.90.rrr        REVUE-86          [JK198]
+      C*192.44.91.rrr-192.44.215.rrr       PGXPRES-BLOCK     [ACL2]
+      R 192.44.216.rrr                     VV-NET1           [PP77]
+      R 192.44.217.rrr                     VV-NET2           [PP77]
+      R 192.44.218.rrr                     VV-NET3           [PP77]
+      R 192.44.219.rrr                     VV-NET4           [PP77]
+      R 192.44.220.rrr                     VV-NET5           [PP77]
+      R 192.44.221.rrr                     VV-NET6           [PP77]
+      R 192.44.222.rrr                     VV-NET7           [PP77]
+      R 192.44.223.rrr                     VV-NET8           [PP77]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 78]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R 192.44.224.rrr                     VV-NET9           [PP77]
+      R 192.44.225.rrr                     VV-NET10          [PP77]
+      R 192.44.226.rrr                     VV-NET11          [PP77]
+      R 192.44.227.rrr                     VV-NET12          [PP77]
+      R 192.44.228.rrr                     VV-NET13          [PP77]
+      R 192.44.229.rrr                     VV-NET14          [PP77]
+      R 192.44.230.rrr                     VV-NET15          [PP77]
+      R 192.44.231.rrr                     VV-NET16          [PP77]
+      R 192.44.232.rrr                     VV-NET17          [PP77]
+      R 192.44.233.rrr                     VV-NET18          [PP77]
+      R 192.44.234.rrr                     VV-NET19          [PP77]
+      R 192.44.235.rrr                     VV-NET20          [PP77]
+      R 192.44.236.rrr                     VV-NET21          [PP77]
+      R 192.44.237.rrr                     VV-NET22          [PP77]
+      R 192.44.238.rrr                     VV-NET23          [PP77]
+      R 192.44.239.rrr                     VV-NET24          [PP77]
+      C*192.44.240.rrr-192.44.251.rrr      SLLLAN            [AL16]
+      C*192.44.252.rrr                     ACC-LIMULUS       [JFR24]
+      D 192.44.253.rrr                     NTSC-IELN         [DW198]
+      R 192.44.254.rrr                     JVNC-SATNET       [RA17]
+        192.44.255.rrr                     Reserved          [JBP]
+      C*192.45.0.rrr-192.45.255.rrr        TRW-BB            [MM313]
+      C*192.46.0.rrr-192.46.255.rrr        Hewlett-Packard   [SI8]
+      R*192.47.0.rrr-192.47.241.rrr        KIT-NET           [HN21]
+      R 192.47.242.rrr                     IE-INFERNO        [AM29]
+      R 192.47.243.rrr                     SRI-GEC-NET       [TJF13]
+      R*192.47.244.rrr-192.47.249.rrr      UNIFR-BLOCK       [MB262]
+      C*192.47.250.rrr                     APOLLO-MSP1       [TRG4]
+      C*192.47.251.rrr                     APOLLO-MSP2       [TRG4]
+      C*192.47.252.rrr                     APOLLO-MSP3       [TRG4]
+      C*192.47.253.rrr                     ENVOS             [JMT18]
+      R*192.47.254.rrr                     ROBOTX-VWNET      [DR183]
+        192.47.255.rrr                     Reserved          [JBP]
+      D*192.48.0.rrr-192.48.30.rrr         BOEING-BCAR-NETS  [GK44]
+      C*192.48.31.rrr                      TN-TRNET          [AM139]
+      C*192.48.32.rrr                      NORAND            [LLZ1]
+      R 192.48.33.rrr                      HAC-GATE-NET      [PH45]
+      R*192.48.34.rrr                      SMII              [KS121]
+      C*192.48.35.rrr-192.48.36.rrr        GD-NETS           [SJL]
+      C*192.48.37.rrr                      SIMTEK            [KM2]
+      C*192.48.38.rrr-192.48.77.rrr        GD-NETS           [SJL]
+      R 192.48.78.rrr                      TSB-NET           [TG68]
+        192.48.79.rrr                      Unassigned        [NIC]
+      R 192.48.80.rrr                      SRI-WDC           [RS401]
+      R*192.48.81.rrr                      LOGICON-LAN       [JDM9]
+        192.48.82.rrr-192.48.91.rrr        Unassigned        [NIC]
+      C*192.48.92.rrr                      ACSI              [RH278]
+      C*192.48.93.rrr                      VISTA             [DCN19]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 79]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R*192.48.94.rrr                      MHT-FXEXPERT      [CL115]
+      R*192.48.95.rrr                      LAFAYETT          [PK69]
+      R 192.48.96.rrr                      UUNET-ETHER       [RA11]
+      C*192.48.97.rrr                      GLHNET            [JL268]
+      R*192.48.98.rrr                      POLYCI            [GG68]
+      C*192.48.99.rrr                      ONM-NET           [DSN4]
+      R 192.48.100.rrr                     AAAI              [RS406]
+      R*192.48.101.rrr                     CALCOMP           [TAP15]
+      R*192.48.102.rrr                     AMHERST           [JWM53]
+        192.48.103.rrr                     Unassigned        [NIC]
+      C*192.48.104.rrr                     FRONTIER          [KJ36]
+      R 192.48.105.rrr                     NMSU-ISI-NUL      [MSP1]
+      C*192.48.106.rrr                     FINTRONIC         [JW310]
+      R*192.48.107.rrr                     REGENT            [WT39]
+      C*192.48.108.rrr                     LASC-GANET        [BW4]
+      R 192.48.109.rrr                     BOND-3090         [EB112]
+      R 192.48.110.rrr                     BOND-USLINK       [EB112]
+      R 192.48.111.rrr                     SPARTA-NET        [CFM1]
+      R*192.48.112.rrr                     MANHATTAN         [JPH17]
+      C*192.48.113.rrr                     MURPHNET          [JPH17]
+      R 192.48.114.rrr                     IE-PURGATORIO     [AM29]
+      R 192.48.115.rrr                     IE-PARADISO       [AM29]
+      R 192.48.116.rrr                     IE-COMMUNE        [AM29]
+      R*192.48.117.rrr                     NSCF-NET          [LF61]
+      C 192.48.118.rrr                     INTERSIL          [KEW8]
+      C 192.48.119.rrr                     INTERSIL-APOLLO   [KEW8]
+      C 192.48.120.rrr                     INTERSIL-SING     [KEW8]
+        192.48.121.rrr-192.48.122.rrr      Unassigned        [NIC]
+      C*192.48.123.rrr                     SONY-STEO         [TM166]
+      G*192.48.124.rrr                     USGS-BGRA         [RBP11]
+      G 192.48.125.rrr                     SERI-2            [AM92]
+      R*192.48.126.rrr                     DRURYUNIX         [CE52]
+      C*192.48.127.rrr-192.48.129.rrr      HITACHI-NETS      [SK102]
+      C*192.48.130.rrr-192.48.132.rrr      BURR-BROWN        [JMM50]
+      C*192.48.133.rrr                     ANALOG-TEMP       [RP191]
+      R 192.48.134.rrr                     ARLUTANET0        [VM49]
+      R 192.48.135.rrr                     ARLUTANET1        [VM49]
+        192.48.136.rrr                     Unassigned        [NIC]
+      C*192.48.137.rrr                     CORDIS            [GLS39]
+        192.48.138.rrr                     Unassigned        [NIC]
+      C 192.48.139.rrr                     SQUIBB-NET        [REB50]
+        192.48.140.rrr                     Unassigned        [NIC]
+      G*192.48.141.rrr                     ESMNET            [RC241]
+      R*192.48.142.rrr                     UNOMAHA           [FH59]
+      C 192.48.143.rrr                     CONTEL-SPFLD      [MP139]
+      C*192.48.144.rrr                     UNIPRESS-NET      [MG16]
+      C*192.48.145.rrr                     BERUNET           [AR86]
+      C*192.48.146.rrr-192.48.152.rrr      Silicon Graphics  [VS13]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 80]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C 192.48.153.rrr                     SGI-NET           [VS13]
+      C*192.48.154.rrr-192.48.209.rrr      Silicon Graphics  [VS13]
+        192.48.210.rrr                     Unassigned        [NIC]
+      R*192.48.211.rrr                     SEATTLEU-NET      [FL34]
+      D 192.48.212.rrr                     NARDAC-NET1       [DB]
+      D 192.48.213.rrr                     NARDAC-NET2       [DB]
+      D 192.48.214.rrr                     NARDAC-NET3       [DB]
+      D 192.48.215.rrr                     NARDAC-NET4       [DB]
+      D 192.48.216.rrr                     NARDAC-NET5       [DB]
+      R 192.48.217.rrr                     OACIS-NET         [GK44]
+      R 192.48.218.rrr                     ISTO-NET          [SC3]
+      R 192.48.219.rrr                     DARPA-1555-NET    [SC3]
+      R 192.48.220.rrr                     DARPA-T1-NET      [SC3]
+      C*192.48.221.rrr                     WHITTLE           [LS198]
+      C*192.48.222.rrr                     KLA-INST          [PML1]
+        192.48.223.rrr                     Unassigned        [NIC]
+      R 192.48.224.rrr                     NETCS-NET         [CS218]
+      C*192.48.225.rrr                     NTISC-CIM         [SH160]
+      R*192.48.226.rrr                     HFH-RADNET        [BW138]
+      C*192.48.227.rrr                     MERGETECH         [DAR20]
+      R*192.48.228.rrr                     DF86-HOME-E       [DF86]
+      R*192.48.229.rrr                     DF86-HOME-S       [DF86]
+      R*192.48.230.rrr                     EDRCNET           [LM185]
+      C*192.48.231.rrr                     GUUG-NET          [GB169]
+      R*192.48.232.rrr                     ASYLUM-NET        [JLR4]
+      R 192.48.233.rrr                     VILLANOVA         [NN20]
+      C*192.48.234.rrr                     WIMSEY-NET        [SL122]
+      C*192.48.235.rrr                     BAY-DIGI-NET      [RT147]
+      R*192.48.236.rrr                     U-PGH-MEDNET      [RJY2]
+      R*192.48.237.rrr                     U-PGH-TXSNET      [RJY2]
+      G*192.48.238.rrr                     DOEHQ             [TMR11]
+      C*192.48.239.rrr                     GHB-LAN01         [CB201]
+      C*192.48.240.rrr                     GHB-LAN02         [CB201]
+      C*192.48.241.rrr                     GHB-LAN03         [CB201]
+      D*192.48.242.rrr                     USACRREL          [GD80]
+      D*192.48.243.rrr                     USACRRELAK        [GD80]
+      R*192.48.244.rrr                     HK-VME-NET        [CP108]
+      R*192.48.245.rrr                     HK-ENG-NET        [CP108]
+      C*192.48.246.rrr                     ITP-NET           [QF]
+      C*192.48.247.rrr                     CCNAIBFIR         [PAG14]
+      C*192.48.248.rrr                     CYBER-MELB        [PH111]
+      C*192.48.249.rrr                     TI-DAD1           [WM110]
+      C*192.48.250.rrr                     TI-DAD2           [WM110]
+      C*192.48.251.rrr                     ITT-SEMICON2      [TS144]
+      C*192.48.252.rrr                     ITT-SEMICON3      [TS144]
+      R*192.48.253.rrr                     UCTNET            [FG51]
+      C*192.48.254.rrr                     SAUER1            [BW143]
+        192.48.255.rrr                     Reserved          [JBP]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 81]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      G*192.49.0.rrr-192.49.255.rrr        VTKK-ASIAKKAAT    [PI7]
+      R*192.50.0.rrr-192.50.255.rrr        JAPAN-INET        [JM292]
+      C*192.51.0.rrr-192.51.15.rrr         NORSK-DATA        [AH89]
+      C*192.51.16.rrr-192.51.36.rrr        JAPAN-INET        [JM292]
+      R 192.51.37.rrr                      JAPAN-NET         [JM292]
+      R*192.51.38.rrr-192.51.255.rrr       JAPAN-INET        [JM292]
+      R*192.52.0.rrr-192.52.50.rrr         FDN-NETS          [MW171]
+      C*192.52.51.rrr-192.52.60.rrr        INTEL-NETS        [BW142]
+      R 192.52.61.rrr                      HAYSTACK-1        [AG127]
+      R 192.52.62.rrr                      HAYSTACK-2        [AG127]
+      R 192.52.63.rrr                      HAYSTACK-3        [AG127]
+      R 192.52.64.rrr                      HAYSTACK-4        [AG127]
+      R 192.52.65.rrr                      HAYSTACK-5        [AG127]
+      R 192.52.66.rrr                      HAYSTACK-6        [AG127]
+      C*192.52.67.rrr                      UNIX-RING         [RB520]
+      C*192.52.68.rrr                      PUB-RING          [RB520]
+      C*192.52.69.rrr                      PLUS-FIVE         [HS23]
+      G 192.52.70.rrr                      MEEDIV            [JW326]
+      R 192.52.71.rrr                      BBN-EXT-NET       [DBL1]
+      G*192.52.72.rrr                      COURTSNET         [IR19]
+      G*192.52.73.rrr                      COURTSNET1        [IR19]
+      C*192.52.74.rrr                      SSIWEST           [RES17]
+      G*192.52.75.rrr                      IMIS-NET          [PR99]
+      G*192.52.76.rrr                      DMSTST12          [AD90]
+      G*192.52.77.rrr                      DMSTST16A3        [AD90]
+      G*192.52.78.rrr                      DMSTST37          [AD90]
+      G*192.52.79.rrr                      DMSTSTC           [AD90]
+      G*192.52.80.rrr                      DMSTST15          [AD90]
+      G*192.52.81.rrr                      DMSTST16A4        [AD90]
+      G*192.52.82.rrr                      DMSTST4           [AD90]
+      G*192.52.83.rrr                      DMSTSTD           [AD90]
+      G*192.52.84.rrr                      DMSTST161         [AD90]
+      G*192.52.85.rrr                      DMSTST16A5        [AD90]
+      G*192.52.86.rrr                      DMSTST44          [AD90]
+      G*192.52.87.rrr                      DMSTST162         [AD90]
+      G*192.52.88.rrr                      DMSTST17          [AD90]
+      G*192.52.89.rrr                      DMSTST9           [AD90]
+      G*192.52.90.rrr                      DMSTST16A1        [AD90]
+      G*192.52.91.rrr                      DMSTST32          [AD90]
+      G*192.52.92.rrr                      DMSTSTA           [AD90]
+      G*192.52.93.rrr                      DMSTST36          [AD90]
+      G*192.52.94.rrr                      DMSTSTB           [AD90]
+      G*192.52.95.rrr                      DMSTST16A2        [AD90]
+      G 192.52.96.rrr                      JESTSTI           [ALA6]
+      G 192.52.97.rrr                      JESTSTJ           [ALA6]
+      G 192.52.98.rrr                      JESTSTE           [ALA6]
+      G 192.52.99.rrr                      JESTSTK           [ALA6]
+      G 192.52.100.rrr                     JESTSTL           [ALA6]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 82]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      G 192.52.101.rrr                     JESTSTG           [ALA6]
+      G 192.52.102.rrr                     JESTSTF           [ALA6]
+      G 192.52.103.rrr                     JESTSTM           [ALA6]
+      G 192.52.104.rrr                     JESTSTH           [ALA6]
+      G 192.52.105.rrr                     JESTSTN           [ALA6]
+      R 192.52.106.rrr                     NCAR-HYPER        [DM84]
+      C 192.52.107.rrr                     SIMPACT-NET       [MA107]
+      R*192.52.108.rrr                     BELLQE            [OT3]
+      C*192.52.109.rrr                     MICROWARE         [KK87]
+      C*192.52.110.rrr                     LITTON-DSD        [BR113]
+      D 192.52.111.rrr                     LNX-ETHER1        [JAM38]
+      D 192.52.112.rrr                     LNX-ETHER2        [JAM38]
+      C*192.52.113.rrr                     ZETACO            [DB333]
+        192.52.114.rrr-192.52.115.rrr      Unassigned        [NIC]
+      C*192.52.116.rrr                     OANET             [MM348]
+      G 192.52.117.rrr                     BELVOIR-NET2      [MDS30]
+        192.52.118.rrr                     Unassigned        [NIC]
+      R*192.52.119.rrr-192.52.150.rrr      JAPAN-INFONETS    [MH226]
+      R*192.52.151.rrr                     MSN               [CAC55]
+      G*192.52.152.rrr                     KNMI-NET          [FF30]
+      C*192.52.153.rrr                     PE-NELSON         [DC273]
+      R 192.52.154.rrr                     ESL               [MV25]
+      R 192.52.155.rrr                     UOFH1-NET         [CR157]
+      R 192.52.156.rrr                     UOFH2-NET         [CR157]
+      C*192.52.157.rrr                     TRIANGLE          [VP12]
+        192.52.158.rrr                     Unassigned        [NIC]
+      R 192.52.159.rrr                     HDN1              [WP64]
+      R 192.52.160.rrr                     HDN2              [WP64]
+      C*192.52.161.rrr                     TADNET            [TS171]
+      R 192.52.162.rrr                     NEURONET          [RML28]
+      R 192.52.163.rrr                     NEURONET-1        [RML28]
+      R 192.52.164.rrr                     NEURONET-2        [RML28]
+      R 192.52.165.rrr                     NEURONET-3        [RML28]
+      R 192.52.166.rrr                     NEURONET-4        [RML28]
+      R 192.52.167.rrr                     NEURONET-5        [RML28]
+      R 192.52.168.rrr                     NEURONET-6        [RML28]
+      R 192.52.169.rrr                     NEURONET-7        [RML28]
+      C*192.52.170.rrr                     ANFNET            [TD87]
+      G*192.52.171.rrr                     COURTSNET2        [IR19]
+      G*192.52.172.rrr                     COURTSNET3        [IR19]
+      G*192.52.173.rrr                     COURTSNET4        [IR19]
+      G*192.52.174.rrr                     COURTSNET5        [IR19]
+      G*192.52.175.rrr                     COURTSNET6        [IR19]
+      G*192.52.176.rrr                     COURTSNET7        [IR19]
+      G*192.52.177.rrr                     NYSERDA           [AA76]
+        192.52.178.rrr                     Unassigned        [NIC]
+      R 192.52.179.rrr                     EDUCOM            [JH92]
+      R 192.52.180.rrr                     NYSERWest         [CPK3]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 83]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C*192.52.181.rrr                     SEANET            [TC124]
+      R 192.52.182.rrr                     SKIDMORE          [CPK3]
+      C*192.52.183.rrr                     CDC-DAY-NET       [BDH]
+      C*192.52.184.rrr                     AGELAN1           [JWH39]
+      R*192.52.185.rrr                     FLINDERS-GW       [KM129]
+      C*192.52.186.rrr                     BAKS              [CA84]
+      C*192.52.187.rrr                     ASCI              [RT155]
+      C*192.52.188.rrr                     SOUM-NET          [MT108]
+        192.52.189.rrr                     Unassigned        [NIC]
+      R 192.52.190.rrr                     NSFTRANSIT1       [SA21]
+      R 192.52.191.rrr                     NSFTRANSIT2       [SA21]
+      R 192.52.192.rrr                     NSFTRANSIT3       [SA21]
+      R 192.52.193.rrr                     NSFTRANSIT4       [SA21]
+      R 192.52.194.rrr                     FEBA-EAST         [MB9]
+      R 192.52.195.rrr                     FEBA-WEST         [MSM1]
+      R*192.52.196.rrr                     SAMNET            [BG2]
+      R*192.52.197.rrr                     CFMNET            [BG2]
+      G 192.52.198.rrr                     JSCNETC1          [JC108]
+      G 192.52.199.rrr                     JSCNETC2          [JC108]
+      G 192.52.200.rrr                     JSCNETC3          [JC108]
+      G 192.52.201.rrr                     JSCNETC4          [JC108]
+      G 192.52.202.rrr                     JSCNETC5          [JC108]
+      G 192.52.203.rrr                     JSCNETC6          [JC108]
+      G 192.52.204.rrr                     JSCNETC7          [JC108]
+      G 192.52.205.rrr                     JSCNETC8          [JC108]
+      G 192.52.206.rrr                     JSCNETC9          [JC108]
+      G 192.52.207.rrr                     JSCNETC10         [JC108]
+      G 192.52.208.rrr                     JSCNETC11         [JC108]
+      G 192.52.209.rrr                     JSCNETC12         [JC108]
+      G 192.52.210.rrr                     JSCNETC13         [JC108]
+      G 192.52.211.rrr                     JSCNETC14         [JC108]
+      G 192.52.212.rrr                     JSCNETC15         [JC108]
+      G 192.52.213.rrr                     JSCNETC16         [JC108]
+      G 192.52.214.rrr                     JSCNETC17         [JC108]
+      G 192.52.215.rrr                     JSCNETC18         [JC108]
+      G 192.52.216.rrr                     JSCNETC19         [JC108]
+      G 192.52.217.rrr                     JSCNETC20         [JC108]
+      R 192.52.218.rrr                     UNIONCOLLEGE      [CPK3]
+      R 192.52.219.rrr                     SBU-LAN           [CPK3]
+      R 192.52.220.rrr                     SUNYCT            [CPK3]
+      R*192.52.221.rrr-192.52.223.rrr      OCE-NL-VENLO      [MB273]
+      G*192.52.224.rrr                     GSD-APPLENET      [MDP16]
+      G*192.52.225.rrr                     GSD-MGMTNET       [MDP16]
+      G*192.52.226.rrr                     GSD-LABNET        [MDP16]
+      D 192.52.227.rrr                     SCI-PROC          [GB5]
+        192.52.228.rrr                     Unassigned        [NIC]
+      C*192.52.229.rrr                     HGSNET            [LH2]
+      R*192.52.230.rrr                     HFHINET           [FH2]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 84]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C*192.52.231.rrr                     OCTEL             [TS107]
+      R 192.52.232.rrr                     CNUCE-DARPA       [ABB2]
+      C 192.52.233.rrr                     HARRISNET-1       [RRR1]
+      C 192.52.234.rrr                     HARRISNET-2       [RRR1]
+      C 192.52.235.rrr                     HARRISNET-3       [RRR1]
+      C 192.52.236.rrr                     HARRISNET-4       [RRR1]
+      C*192.52.237.rrr                     GORENET           [JG131]
+      D 192.52.238.rrr                     CNSYD-POE         [MI1]
+      C*192.52.239.rrr                     TSG               [RP211]
+      R*192.52.240.rrr                     ED                [MC261]
+        192.52.241.rrr-192.52.243.rrr      Unassigned        [NIC]
+      G*192.52.244.rrr                     TBESPACEPRGM      [TR3]
+      C 192.52.245.rrr                     SAMSUNG-NET       [WJL17]
+      C*192.52.246.rrr                     HANNABARBERA      [JH84]
+      C 192.52.247.rrr                     STRATUS-C1        [WPC]
+      C 192.52.248.rrr                     STRATUS-C4        [WPC]
+      C 192.52.249.rrr                     STRATUS-C3        [WPC]
+      R*192.52.250.rrr                     NIBR              [MT111]
+        192.52.251.rrr                     Unassigned        [NIC]
+      R*192.52.252.rrr                     IRL               [SO]
+      C*192.52.253.rrr                     AMTHQ             [DB343]
+      C*192.52.254.rrr                     THREECOM-FR       [ML171]
+        192.52.255.rrr                     Reserved          [JBP]
+      C*192.53.0.rrr-192.53.255.rrr        Hewlett-Packard   [SI8]
+      D*192.54.0.rrr-192.54.30.rrr         BOEING-BCAR       [GK44]
+      R*192.54.31.rrr                      SELRCP-LAN-A      [DTH4]
+      R*192.54.32.rrr                      SELCRCP-LAN-B     [DTH4]
+      R 192.54.33.rrr                      TA-NET            [HVKR]
+        192.54.34.rrr-192.54.80.rrr        Unassigned        [NIC]
+      R 192.54.81.rrr                      CARL-NET          [RKS5]
+      C 192.54.82.rrr                      MOT-82            [RB319]
+      C 192.54.83.rrr                      MOT-83            [RB319]
+      C 192.54.84.rrr                      MOT-84            [RB319]
+      C 192.54.85.rrr                      MOT-85            [RB319]
+      C 192.54.86.rrr                      MOT-86            [RB319]
+      C 192.54.87.rrr                      MOT-87            [RB319]
+      C 192.54.88.rrr                      MOT-88            [RB319]
+      C 192.54.89.rrr                      MOT-89            [RB319]
+      C 192.54.90.rrr                      MOT-90            [RB319]
+      C 192.54.91.rrr                      MOT-91            [RB319]
+      R 192.54.92.rrr                      GACNET            [DB346]
+      R 192.54.93.rrr                      CSNET-CYP         [WHN2]
+      R*192.54.94.rrr-192.54.103.rrr       UMD-UNCON         [LAM1]
+      R 192.54.104.rrr                     XLINK             [MR78]
+      R 192.54.105.rrr                     WR-CANB           [KM6]
+      R 192.54.106.rrr                     WR-PERTH          [KM6]
+      C*192.54.107.rrr                     ORA               [JMD6]
+      C*192.54.108.rrr                     SYZYGY            [KJ1]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 85]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C 192.54.109.rrr                     ISR-HAWAII        [TN11]
+      C*192.54.110.rrr                     TRIAD             [BK85]
+      R 192.54.111.rrr                     ARC-HSP-NET       [MSM1]
+      R 192.54.112.rrr                     CHILEAN-NET       [VC]
+      R*192.54.113.rrr                     MPIS-TCPNET       [PW88]
+      C*192.54.114.rrr                     DRD-NET           [LB8]
+      C*192.54.115.rrr-192.54.120.rrr      BK-NETS           [RJ115]
+      R*192.54.121.rrr                     CAL               [GG123]
+      R*192.54.122.rrr                     SFAF              [MS345]
+      C*192.54.123.rrr                     TIMEPLEX          [GP117]
+      C*192.54.124.rrr                     HARRIS-NET        [JKF2]
+      C*192.54.125.rrr-192.54.128.rrr      SYSTEC-NETS       [CB50]
+      D 192.54.129.rrr                     OSI               [LC57]
+      G*192.54.130.rrr                     WCC               [RH310]
+      C*192.54.131.rrr                     LLHS-NYC-NET      [JMH10]
+      R*192.54.132.rrr                     ABB-ZX            [UR]
+      G 192.54.133.rrr                     ACFP-NE-NET       [SS271]
+      G 192.54.134.rrr                     ACFP-IL-NET       [HR43]
+      R*192.54.135.rrr                     ATLANTEK          [WH125]
+      R*192.54.136.rrr                     AWADI             [WH125]
+      R*192.54.137.rrr                     TECHPK            [WH125]
+      R 192.54.138.rrr                     NALNET            [DS348]
+      R*192.54.139.rrr                     UNI-MAINZ         [BR118]
+      R 192.54.140.rrr                     FNET-ESIEE        [AR41]
+      R*192.54.141.rrr-192.54.147.rrr      FNET-NETS         [AR41]
+      R 192.54.148.rrr                     FNET-ENSMP-F      [AR41]
+      R*192.54.149.rrr-192.54.219.rrr      FNET-NETS         [AR41]
+      R*192.54.220.rrr                     IEZ-WIEN          [PB6]
+      R 192.54.221.rrr                     FERNUNI-DVT       [CR24]
+      R 192.54.222.rrr                     MIT-EXT-NET       [JIS]
+      R 192.54.223.rrr                     HARV-EXT-NET      [SB28]
+      R 192.54.224.rrr                     BU-EXT-NET        [KE1]
+      C*192.54.225.rrr                     KOMMHUSET         [SH175]
+      C 192.54.226.rrr                     TRANSARC-NET      [PDB5]
+      R*192.54.227.rrr                     AARNET-WA         [KS32]
+      C*192.54.228.rrr                     CSI               [RP94]
+        192.54.229.rrr                     Unassigned        [NIC]
+      C*192.54.230.rrr-192.54.237.rrr      ERI-ANAHEIM       [JA176]
+      R*192.54.238.rrr                     HUORB             [AJD14]
+      C*192.54.239.rrr                     TSI-NET           [MLR4]
+      D 192.54.240.rrr                     PHILA-POE         [DK60]
+        192.54.241.rrr-192.54.244.rrr      Unassigned        [NIC]
+      C*192.54.245.rrr                     NCR-DUNDEE        [GC132]
+      C*192.54.246.rrr                     FLOW-NET          [DS354]
+      R*192.54.247.rrr                     UOKAYAMA-NET      [TM185]
+      D*192.54.248.rrr                     HI-DSG-NET        [MW135]
+      R*192.54.249.rrr                     CIT-MOC-WEST      [KR72]
+        192.54.250.rrr                     Unassigned        [NIC]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 86]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R*192.54.251.rrr                     QPSX              [AK79]
+      R 192.54.252.rrr                     AARNET            [GH105]
+      D*192.54.253.rrr                     NOSC-SN           [RLB3]
+      G*192.54.254.rrr                     WABOLU            [CH207]
+        192.54.255.rrr                     Reserved          [JBP]
+        192.55.0.rrr                       Reserved          [JBP]
+      C*192.55.1.rrr-192.55.21.rrr         ITINET            [EU4]
+      C*192.55.22.rrr-192.55.31.rrr        MOTOROLA-SPS      [MJ91]
+      C*192.55.32.rrr-192.55.81.rrr        INTEL-CCAD-NET    [EC101]
+        192.55.82.rrr                      Unassigned        [NIC]
+      R*192.55.83.rrr                      TU-CLAUSTHAL      [GL16]
+      C*192.55.84.rrr                      ISANET            [DW139]
+      C*192.55.85.rrr                      ANASAZI           [DM334]
+      C*192.55.86.rrr                      PARASOFT          [JF47]
+      R 192.55.87.rrr                      USD               [AT16]
+      C*192.55.88.rrr                      ATI-IL2           [NS66]
+      C*192.55.89.rrr                      PAC               [ES148]
+      G 192.55.90.rrr                      LERC-CRAYNET      [DC285]
+      G*192.55.91.rrr                      LERC-CRAYNET2     [DC285]
+        192.55.92.rrr-192.55.94.rrr        Unassigned        [NIC]
+      C*192.55.95.rrr                      EREHWON           [JW352]
+      R 192.55.96.rrr                      NOAO-GEMINI       [SG1]
+      R 192.55.97.rrr                      AGOURON-INST      [DLS24]
+      R 192.55.98.rrr                      SUNLAB1-NET       [DH296]
+      C 192.55.99.rrr                      MEGADATA          [AM151]
+      D*192.55.100.rrr                     PERSCOM-KEG       [TAK15]
+      R*192.55.101.rrr                     DIS-NET           [GV23]
+      C*192.55.102.rrr                     INFOTEC           [MM384]
+      D 192.55.103.rrr                     BROOKS-HITS       [JLW49]
+      R*192.55.104.rrr                     MINENG-ETHER      [RK154]
+      D 192.55.105.rrr                     TNO-HDO-FULL      [RVDA]
+      G 192.55.106.rrr                     PPPL              [EW62]
+      C*192.55.107.rrr                     SYMBIO-TECH       [KOP2]
+      G 192.55.108.rrr                     GEOROLLA          [JRF]
+      R 192.55.109.rrr                     RSRE-STC-NUL      [JFW]
+      R*192.55.110.rrr                     NICE              [KK92]
+      C*192.55.111.rrr                     MCSNET            [EDE1]
+      G*192.55.112.rrr                     AUS-SEIS          [SI16]
+      C*192.55.113.rrr                     ALGORISTS         [JK218]
+      R 192.55.114.rrr                     MORNET-SER        [RWA15]
+      C*192.55.115.rrr                     GEVEKE-NET        [RV61]
+      D*192.55.116.rrr                     PAF-IBM           [PHN2]
+      D 192.55.117.rrr                     HDL-WRFSEA        [CHW]
+      R*192.55.118.rrr                     NACSIS-RD         [JA180]
+        192.55.119.rrr                     Unassigned        [NIC]
+      R 192.55.120.rrr                     EI-LAN            [CPK3]
+      C*192.55.121.rrr                     SIGMA             [DCW23]
+      C*192.55.122.rrr-192.55.124.rrr      SC-NETS           [FW51]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 87]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C*192.55.125.rrr-192.55.126.rrr      BITBLOCKS         [JAM69]
+      C*192.55.127.rrr                     MAGIC-BB          [JAM69]
+      C*192.55.128.rrr                     OXFORD-LAN        [WOS]
+      R*192.55.129.rrr                     AHKNET            [MB293]
+      C*192.55.130.rrr                     CCC-NET           [HPD1]
+      C*192.55.131.rrr                     EMTEK             [TS107]
+      D*192.55.132.rrr                     RAEF-MODUK        [DR214]
+      D 192.55.133.rrr                     SEA06NET          [BD105]
+      G 192.55.134.rrr                     PMCDNET           [PJB27]
+      G*192.55.135.rrr                     STDSUN            [WH131]
+      C*192.55.136.rrr                     INDX              [DH303]
+      C*192.55.137.rrr-192.55.186.rrr      FEDMOG-NETS       [TGC1]
+      R 192.55.187.rrr                     SSESCONET         [NL35]
+      R 192.55.188.rrr                     DKFZ              [TR85]
+      C*192.55.189.rrr                     CIPHER            [RH326]
+      R 192.55.190.rrr                     RMITCS1           [ED72]
+      R*192.55.191.rrr                     FRC               [RW96]
+      R*192.55.192.rrr                     UVALRI            [HK35]
+      C*192.55.193.rrr                     7E-COMMS          [KT43]
+      R 192.55.194.rrr                     UOFT-XNET         [LO24]
+      C*192.55.195.rrr                     TELEPRO           [TRW18]
+      C*192.55.196.rrr                     SUNDSTRAND        [PS204]
+      R*192.55.197.rrr                     LIS-NET           [SB221]
+      C*192.55.198.rrr                     MINBNE            [CC241]
+      D*192.55.199.rrr                     JSC-SSE-46        [BS214]
+        192.55.200.rrr                     Unassigned        [NIC]
+      C*192.55.201.rrr                     DANAVICTOR        [WS165]
+      C*192.55.202.rrr                     BWCORTP           [JOH]
+      R*192.55.203.rrr                     AGCNET            [CTJ2]
+        192.55.204.rrr-192.55.205.rrr      Unassigned        [NIC]
+      C*192.55.206.rrr                     CNCP-NET          [IB11]
+      C 192.55.207.rrr                     TRANSARC-INT      [PDB5]
+      R*192.55.208.rrr                     STJUDE            [PE27]
+      C*192.55.209.rrr                     OSIRIS-TECH       [TW102]
+      C*192.55.210.rrr                     GSD-TCPTRUST      [MDP16]
+      C*192.55.211.rrr                     GSD-APPLETP1      [MDP16]
+      C*192.55.212.rrr                     PRAXIS-ETHER      [TR87]
+      C*192.55.213.rrr                     DIGEX-NET         [RES70]
+      R 192.55.214.rrr                     SCTC              [SMM21]
+        192.55.215.rrr                     Unassigned        [NIC]
+      R*192.55.216.rrr                     NTC-MAIR          [RI]
+      R*192.55.217.rrr                     KIT-NET           [YSP3]
+      C*192.55.218.rrr                     FMC-GSD           [DS372]
+      R*192.55.219.rrr                     BIOM-BRIS         [ACC17]
+      R*192.55.220.rrr                     MISHIROSHIMA      [HN27]
+      C*192.55.221.rrr                     NTRLINK-NET       [BH186]
+      C*192.55.222.rrr                     AUTOEX-NET        [GGB2]
+      C*192.55.223.rrr                     TI                [JR206]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 88]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      G*192.55.224.rrr                     BIO-OCEAN         [WWR1]
+      D 192.55.225.rrr                     CONCORD-POE       [SJG2]
+      C*192.55.226.rrr                     FRANKSTON         [RMF2]
+      R 192.55.227.rrr                     JSUNET            [HW59]
+      R 192.55.228.rrr                     COYOTE-NET        [RW247]
+      R 192.55.229.rrr                     USCOLO            [RD225]
+      C 192.55.230.rrr                     ARTEMIS           [JAW34]
+        192.55.231.rrr                     Unassigned        [NIC]
+      R*192.55.232.rrr                     ATMOSNET          [TE35]
+      C*192.55.233.rrr                     DIALOGIC          [DR217]
+      R 192.55.234.rrr                     YSU               [RQ5]
+      C 192.55.235.rrr                     OSA               [MC290]
+      C*192.55.236.rrr                     UPS-RND           [RP230]
+      R*192.55.237.rrr                     STL-MSD           [DD11]
+      C*192.55.238.rrr                     NTTDATA-NET4      [SM217]
+      R 192.55.239.rrr                     WIDENER           [DCW25]
+      G 192.55.240.rrr                     NCEL-NET          [SJG17]
+        192.55.241.rrr                     Unassigned        [NIC]
+      C*192.55.242.rrr                     AURANET           [BD108]
+      C*192.55.243.rrr                     VGH               [DP171]
+      R*192.55.244.rrr                     WICOB             [HAL5]
+      D 192.55.245.rrr                     CDSAR             [LR312]
+      D 192.55.246.rrr                     EDMICS-LAN        [PNP2]
+      C*192.55.247.rrr                     ALTERA            [RH260]
+      C*192.55.248.rrr                     C2S               [CW166]
+      R*192.55.249.rrr                     MSKNET            [JMV7]
+        192.55.250.rrr-192.55.254.rrr      Unassigned        [NIC]
+        192.55.255.rrr                     Reserved          [JBP]
+      C*192.56.0.rrr-192.56.255.rrr        Hewlett-Packard   [SI8]
+      C*192.57.0.rrr-192.57.255.rrr        GM-IPNETS         [JH372]
+        192.58.0.rrr                       Reserved          [JBP]
+      G*192.58.1.rrr                       NOAA-NWS          [HJK4]
+      G 192.58.2.rrr                       NOAA-NWSS11       [HJK4]
+      G 192.58.3.rrr                       NOAA-NWSS1        [HJK4]
+      D*192.58.4.rrr-192.58.18.rrr         APGEA-NETS        [REA3]
+      G*192.58.19.rrr-192.58.27.rrr        JSC-SSE-1         [BS214]
+      C*192.58.28.rrr-192.58.35.rrr        AMBRA-NET         [PHK]
+      G*192.58.36.rrr                      EADS-HC-NET       [RTD]
+      C*192.58.37.rrr-192.58.40.rrr        HGS-NETS          [LH2]
+      C*192.58.41.rrr-192.58.89.rrr        PT-FINLAND        [ET49]
+      R 192.58.90.rrr                      CSNET-WCC         [WHN2]
+      R 192.58.91.rrr                      CSNET-SPR         [WHN2]
+        192.58.92.rrr-192.58.96.rrr        Unassigned        [NIC]
+      C*192.58.97.rrr-192.58.101.rrr       NTTDATA-NET       [SM217]
+      C*192.58.102.rrr                     TISCPACMMSTA      [CH205]
+      C*192.58.103.rrr                     TISCPACLEV3A      [MS400]
+      C*192.58.104.rrr                     TISCPACLEV3B      [MS400]
+      C*192.58.105.rrr                     TISCPACTESTA      [JO93]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 89]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C*192.58.106.rrr                     TISCPACTESTB      [JO93]
+      R 192.58.107.rrr                     SEI-FW-NET        [TGP3]
+      G*192.58.108.rrr                     REMIS             [RL190]
+      R 192.58.109.rrr                     TAMU1             [WM68]
+      R 192.58.110.rrr                     TAMU2             [WM68]
+      R 192.58.111.rrr                     TAMU3             [WM68]
+      R 192.58.112.rrr                     TAMU4             [WM68]
+      R 192.58.113.rrr                     TAMU5             [WM68]
+      R 192.58.114.rrr                     TAMU6             [WM68]
+      R 192.58.115.rrr                     TAMU7             [WM68]
+      R 192.58.116.rrr                     TAMU8             [WM68]
+      R 192.58.117.rrr                     TAMU9             [WM68]
+      R 192.58.118.rrr                     TAMU10            [WM68]
+      G 192.58.119.rrr                     NAS-HTD-NET       [HAW]
+      C*192.58.120.rrr                     LARK              [CBL4]
+      C*192.58.121.rrr                     VOTEK             [RS479]
+      R*192.58.122.rrr                     NCSUARG           [ARG13]
+      C*192.58.123.rrr                     APUNIX            [PHB4]
+      C*192.58.124.rrr                     STATWARE          [MF4]
+      R*192.58.125.rrr                     TTUCF             [GP128]
+      C*192.58.126.rrr                     SGWARBURG         [TJS38]
+      R 192.58.127.rrr                     COOPERUNION       [CPK3]
+      C*192.58.128.rrr                     APPLE             [KS153]
+      C*192.58.129.rrr-192.58.130.rrr      AUSTEK            [CW169]
+      R*192.58.131.rrr-192.58.132.rrr      GSF-NET           [GH42]
+      C*192.58.133.rrr                     LABTAM-NET1       [SP116]
+      C*192.58.134.rrr                     LABTAM-NET2       [SP116]
+      C*192.58.135.rrr                     LABTAM-NET3       [SP116]
+      C*192.58.136.rrr                     LABTAM-NET4       [SP116]
+        192.58.137.rrr-192.58.148.rrr      Unassigned        [NIC]
+      C*192.58.149.rrr                     ATARI             [BH188]
+      R 192.58.150.rrr                     AIP               [MS9]
+      G 192.58.151.rrr                     NOAA-NWS1S        [HJK4]
+      G 192.58.152.rrr                     NOAA-NWS1SS       [HJK4]
+      G 192.58.153.rrr                     NOAA-NWS11        [HJK4]
+      G*192.58.154.rrr                     NOAA-NWS1         [HJK4]
+      D*192.58.155.rrr                     JEWC              [RD227]
+      C*192.58.156.rrr-192.58.179.rrr      LOCKHEED-ESC      [MJL37]
+      C*192.58.180.rrr                     EPIC              [AT87]
+      D 192.58.181.rrr                     PHNSY-POE-GW      [AM164]
+      C 192.58.182.rrr                     ASI-NET           [RMC1]
+      C*192.58.183.rrr-192.58.192.rrr      DEVRING           [RB520]
+      C*192.58.193.rrr                     MSA               [KPK3]
+      R 192.58.194.rrr                     BNR-GATE          [BM178]
+      C*192.58.195.rrr                     DUEICORETECH      [MB308]
+      R*192.58.196.rrr                     ACU               [JB509]
+      C*192.58.197.rrr                     ANALYTIKERNA      [BK98]
+      C*192.58.198.rrr                     LPI               [DC303]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 90]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      D 192.58.199.rrr                     NTSC-NAVAIRHQ     [TR91]
+      G*192.58.200.rrr-192.58.203.rrr      GOVDOJBLS01       [NH36]
+      R 192.58.204.rrr                     GRIDNET           [JAB111]
+      R 192.58.205.rrr                     GRIDNET1          [JAB111]
+      R 192.58.206.rrr                     DEC-AUXNET-1      [BKR]
+      R 192.58.207.rrr                     DEC-AUXNET-2      [BKR]
+      R 192.58.208.rrr                     DEC-AUXNET-3      [BKR]
+      R 192.58.209.rrr                     DEC-AUXNET-4      [BKR]
+      R 192.58.210.rrr                     DEC-AUXNET-5      [BKR]
+      C*192.58.211.rrr                     WEENET            [TD87]
+      D*192.58.212.rrr                     ICUBED            [CF64]
+      R 192.58.213.rrr                     ISTS-XNET         [EC43]
+      R*192.58.214.rrr                     DSUNET            [GH46]
+      C*192.58.215.rrr                     ALCOAVERCIM       [HP49]
+      C*192.58.216.rrr                     LIAS1             [TT84]
+      R*192.58.217.rrr                     PI-TECH           [SO43]
+      R*192.58.218.rrr                     IT-GARR-X25       [ABB2]
+      R 192.58.219.rrr                     MORNET-R-CS       [RWA15]
+      C*192.58.220.rrr                     PELE              [BJORK]
+      R 192.58.221.rrr                     UCB-LOCAL         [CF4]
+      R*192.58.222.rrr                     BANG-NET          [TH60]
+      R 192.58.223.rrr                     NCRDS1            [JRF]
+      R 192.58.224.rrr                     NCRDS2            [JRF]
+      R 192.58.225.rrr                     NCRDS3            [JRF]
+      C*192.58.226.rrr-192.58.229.rrr      WANG-UXCV         [WWP8]
+      D 192.58.230.rrr                     PATCH-GW          [JTM24]
+      R 192.58.231.rrr                     LBL-IPNET-3       [CAL3]
+      G*192.58.232.rrr-192.58.234.rrr      NOAA-NWS-NETS     [HJK4]
+      G 192.58.235.rrr                     NOAA-NWS2         [HJK4]
+      G*192.58.236.rrr-192.58.241.rrr      NOAA-NWS3         [HJK4]
+      R*192.58.242.rrr                     MERRIMACK         [RH338]
+      C*192.58.243.rrr                     BIOGFX            [WKS4]
+      D*192.58.244.rrr                     HDL-TAES          [EBS10]
+      R*192.58.245.rrr                     MDANET            [DF158]
+      G 192.58.246.rrr                     CPLNET            [MN60]
+      R 192.58.247.rrr                     EPA-RTP-NCC       [DW238]
+      C 192.58.248.rrr                     IMATRON           [MT48]
+      C*192.58.249.rrr                     SYNERCOM          [CK117]
+      D*192.58.250.rrr                     MOBILE            [CK116]
+      C*192.58.251.rrr                     CTI-PET           [LD82]
+        192.58.252.rrr                     Unassigned        [NIC]
+      C*192.58.253.rrr                     INMAC             [LC149]
+      C*192.58.254.rrr                     BOHDAN            [PF68]
+        192.58.255.rrr                     Reserved          [JBP]
+      C*192.59.0.rrr-192.63.255.rrr        UNISYS-NET2       [CC249]
+      C*192.64.0.rrr-192.64.67.rrr         Hewlett-Packard   [SI8]
+      C 192.64.68.rrr                      HP-NET            [SI8]
+      C*192.64.69.rrr-192.64.255.rrr       Hewlett-Packard   [SI8]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 91]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+        192.65.0.rrr                       Reserved          [JBP]
+      C*192.65.1.rrr-192.65.49.rrr         TEKTRONIX         [MJE]
+      C 192.65.50.rrr                      SSI-SD            [KS156]
+      R*192.65.51.rrr-192.65.70.rrr        OCE-NL            [MB273]
+      R 192.65.71.rrr                      TST-RGN-47        [DM353]
+      R*192.65.72.rrr                      ATG-NET           [RN67]
+      C*192.65.73.rrr                      NETA-3COM         [TC96]
+      C*192.65.74.rrr                      NETB-3COM         [TC96]
+      C*192.65.75.rrr                      YAEC-NET          [BW168]
+      R*192.65.76.rrr                      CMHC              [PG101]
+      R 192.65.77.rrr                      NMSU-SLIP         [JH204]
+      R 192.65.78.rrr                      NMSU-CAR          [JH204]
+      R*192.65.79.rrr                      MRI-NET           [CCL8]
+      C*192.65.80.rrr                      KEY-SYSTEMS       [SB230]
+      R*192.65.81.rrr                      SIPLAN            [MV41]
+      R*192.65.82.rrr-192.65.91.rrr        ARRBNET           [PH120]
+      R*192.65.92.rrr                      SWITCH-TEST       [TL99]
+      R*192.65.93.rrr                      SWITCH-INTER1     [TL99]
+      R*192.65.94.rrr                      SWITCH-INTER2     [TL99]
+      D 192.65.95.rrr                      CORNETT           [PCW]
+      R*192.65.96.rrr                      SURFNET-HSV       [VR32]
+      R 192.65.97.rrr                      MORNET-REEC       [RWA15]
+      C*192.65.98.rrr                      ALZNET-AI         [RP238]
+      D*192.65.99.rrr-192.65.128.rrr       BOEING-AE-NETS    [GK44]
+      C*192.65.129.rrr                     ISIS              [JFM38]
+      R*192.65.130.rrr                     BIOM-PERTH        [ESD3]
+      R 192.65.131.rrr                     SIAM-LAN1         [DB374]
+      C*192.65.132.rrr                     AMTNET            [DB343]
+        192.65.133.rrr                     Unassigned        [NIC]
+      R*192.65.134.rrr                     CORD              [SG154]
+      C*192.65.135.rrr                     PRC-NET           [SM221]
+      C*192.65.136.rrr                     CHARLESRIVER      [JW375]
+      R 192.65.137.rrr                     SONY-SMSC         [AS196]
+      R*192.65.138.rrr                     SONY-SMSC-1       [AS196]
+      C*192.65.139.rrr                     RADIG-LAN         [PR100]
+      C*192.65.140.rrr                     USRNET-C          [CC192]
+      R 192.65.141.rrr                     NTU               [BS220]
+      C*192.65.142.rrr                     NDL               [GG115]
+      R 192.65.143.rrr                     WYOTECHNET        [RM177]
+      C*192.65.144.rrr                     SLXSYSLAN         [JP302]
+      C*192.65.145.rrr                     SLXSINGLAN        [JP302]
+      C*192.65.146.rrr                     SLXINCLAN         [JP302]
+      D 192.65.147.rrr                     LEAD-NET          [BV4]
+      C*192.65.148.rrr                     CTI-NET           [BY20]
+      C*192.65.149.rrr                     COMBIX            [DL169]
+      C*192.65.150.rrr                     MCI               [ME74]
+      C*192.65.151.rrr                     MICROPROGRAM      [RLH94]
+      R*192.65.152.rrr                     IVIC              [CS275]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 92]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C*192.65.153.rrr                     BT-ITS            [TO33]
+      C*192.65.154.rrr-192.54.170.rrr      GHB-CNETS         [CB201]
+      C*192.65.171.rrr                     ACE-ETHER         [JP232]
+      R*192.65.172.rrr                     SALFORD           [RL224]
+      C*192.65.173.rrr                     MTCN-CNET         [JCP26]
+      R 192.65.174.rrr                     TJHSST            [CY29]
+      C 192.65.175.rrr                     IBM-CAMBRIDG      [JP304]
+      R 192.65.176.rrr                     NAIC              [AV25]
+      C 192.65.177.rrr                     UTC               [CPK3]
+      R*192.65.178.rrr                     NIBR2             [MT111]
+      C*192.65.179.rrr                     USS-NET           [SE8]
+      C*192.65.180.rrr                     ESS               [MJK12]
+      R*192.65.181.rrr                     AHA-NET           [HT48]
+      C*192.65.182.rrr                     CORINET           [RP240]
+      R*192.65.183.rrr-192.65.184.rrr      CERN-BLOCK        [TB166]
+      R 192.65.185.rrr                     CERN-NSS          [OM10]
+      R*192.65.186.rrr-192.65.197.rrr      CERN-BLOCK        [TB166]
+      G*192.65.198.rrr                     APC-NE-NET        [HAW]
+      G*192.65.199.rrr                     APC-SE-NET        [HAW]
+      R*192.65.200.rrr                     SDSC-YMP-ETH      [GKN1]
+      C*192.65.201.rrr                     CRLABS-NET        [CRW12]
+      C 192.65.202.rrr                     DSI               [SSW5]
+      D 192.65.203.rrr                     DFRRS-NAVY        [JS522]
+      C*192.65.204.rrr-192.65.210.rrr      MCDNET            [FW54]
+      C*192.65.211.rrr                     EGSE              [BB277]
+      R*192.65.212.rrr                     SCIN              [SWH8]
+      R*192.65.213.rrr                     HAMLINE           [JS599]
+      C*192.65.214.rrr                     TAMRI             [ST81]
+      G*192.65.215.rrr                     MICHLSB           [WJR17]
+      C*192.65.216.rrr                     HYPERION          [SG140]
+      G*192.65.217.rrr                     FOOTLAN           [DL170]
+      C*192.65.218.rrr                     DRA-STL           [SMD1]
+      C*192.65.219.rrr-192.65.228.rrr      BTNET1            [NT13]
+        192.65.229.rrr                     Unassigned        [NIC]
+      R*192.65.230.rrr-192.65.243.rrr      HFH               [BW138]
+      R 192.65.244.rrr                     NOSC-HAWAII       [EHC3]
+      R 192.65.245.rrr                     MWCNET            [ECA]
+      D 192.65.246.rrr                     NTSC-LINK         [SL135]
+      C*192.65.247.rrr                     OPTIMAGE          [KK87]
+      C*192.65.248.rrr                     PROCOR            [DR217]
+      C*192.65.249.rrr                     ALCOAVERCAD       [HP49]
+      R*192.65.250.rrr                     REGNET            [IR24]
+      C*192.65.251.rrr                     MOT-WDC-RDC       [JV13]
+      C*192.65.252.rrr                     MSAIASIC          [SE15]
+      G*192.65.253.rrr                     NUBPU             [MT123]
+      C*192.65.254.rrr                     MERIDIAN          [RB365]
+        192.65.255.rrr                     Reserved          [JBP]
+      R*192.66.0.rrr-192.66.255.rrr        DKNET-CNETS       [KS125]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 93]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+        192.67.0.rrr                       Reserved          [JBP]
+      G*192.67.1.rrr                       DITR-NET          [AG149]
+      R*192.67.2.rrr                       AUG               [JU14]
+      R*192.67.3.rrr                       SPCM              [DM356]
+      C*192.67.4.rrr                       WESTHAWK          [SL2]
+      C*192.67.5.rrr                       RUSO-AC           [GK89]
+      R 192.67.6.rrr                       PSINET2           [CPK3]
+        192.67.7.rrr                       Unassigned        [NIC]
+      D 192.67.8.rrr                       WSMR-NET5         [SEM18]
+      R 192.67.9.rrr                       BCNET-1           [MP172]
+      R 192.67.10.rrr                      LWC               [JWE12]
+      R 192.67.11.rrr                      ESNET-THENET      [RW9]
+      R*192.67.12.rrr                      CSIROMLT          [PC148]
+      R 192.67.13.rrr                      HARC-GTRI-NET     [WC117]
+      R 192.67.14.rrr                      HARC-TAC-NET      [WC117]
+      C*192.67.15.rrr                      UNISYSTREDY       [AC155]
+      C*192.67.16.rrr                      MACKNIFE          [DW244]
+      C*192.67.17.rrr                      DII               [MT124]
+      R*192.67.18.rrr                      IBSNET            [BF91]
+      C*192.67.19.rrr                      STILLWATER        [PH121]
+      R*192.67.20.rrr                      SDSC-YMP-OWS      [GKN1]
+      R*192.67.21.rrr                      SDSC-YMP-MWS      [GKN1]
+      G*192.67.22.rrr                      OCRWM-NET         [TB172]
+      C*192.67.23.rrr                      KS-FARCOMP        [ME75]
+      G*192.67.24.rrr                      WASH-STATE        [DF162]
+        192.67.25.rrr-192.67.38.rrr        Unassigned        [NIC]
+      C*192.67.39.rrr                      INDEPENDENT       [DAE2]
+        192.67.40.rrr                      Unassigned        [NIC]
+      C*192.67.41.rrr                      FIBERNET1         [JG308]
+      C*192.67.42.rrr                      COAXNET1          [JG308]
+      D 192.67.43.rrr                      RSRE-OPEN-NET     [DBH11]
+      C*192.67.44.rrr                      BSUS              [RS489]
+      R*192.67.45.rrr                      FORNET            [DS387]
+      C*192.67.46.rrr                      PBUSH             [WH136]
+      C*192.67.47.rrr                      BAE-ST            [MH257]
+      C*192.67.48.rrr                      ERE-NET           [CGT2]
+      R*192.67.49.rrr                      CSURICH           [JFK23]
+      C*192.67.50.rrr                      MCDDOUGLAS1       [MD177]
+      C*192.67.51.rrr                      DOCUPRO           [SA99]
+      C*192.67.52.rrr                      HILL-SAMUEL       [AJS24]
+      C 192.67.53.rrr                      XEROX-EPBU        [DS394]
+        192.67.54.rrr                      Unassigned        [NIC]
+      C*192.67.55.rrr                      HP-GRAPHICS       [TO34]
+      C*192.67.56.rrr                      FEDEX             [WD60]
+      R*192.67.57.rrr                      MNSMC             [FS86]
+      R*192.67.58.rrr                      FMV-FP-SE         [AP92]
+      C*192.67.59.rrr                      VTA               [GA69]
+      R*192.67.60.rrr                      STTHOMMN          [PR102]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 94]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C*192.67.61.rrr                      ODI               [BIM]
+      D 192.67.62.rrr                      AFLMC-NET         [HW26]
+      C*192.67.63.rrr                      CIRR              [ES158]
+      R*192.67.64.rrr                      SONY-SMSC-2       [AS196]
+      R*192.67.65.rrr                      SONY-SMSC-3       [AS196]
+      R*192.67.66.rrr                      SONY-SMSC-4       [AS196]
+      D 192.67.67.rrr                      NICNET            [MKL]
+      R*192.67.68.rrr                      SONY-SMSC-5       [AS196]
+      R 192.67.69.rrr                      CIT-NET1          [JAJ17]
+      D 192.67.70.rrr                      ZAMANET           [SLV4]
+      D 192.67.71.rrr                      CVC2NET           [BG14]
+      D 192.67.72.rrr                      BUCKERNET         [BJW8]
+      C*192.67.73.rrr                      DOCUPROS          [SA99]
+      D 192.67.74.rrr                      OPSNET            [LC151]
+        192.67.75.rrr                      Unassigned        [NIC]
+      R*192.67.76.rrr                      PTNET-DI-FCUL     [JL329]
+      R 192.67.77.rrr                      UTOS-NMO          [DD230]
+      C 192.67.78.rrr                      MGINET            [LS227]
+      C*192.67.79.rrr                      TEICENET          [BD115]
+      D 192.67.80.rrr                      NDL-NET           [BHM]
+      R 192.67.81.rrr                      SDSC-ULTRA        [GKN1]
+      R*192.67.82.rrr                      SDSC-UNATIVE      [GKN1]
+      R 192.67.83.rrr                      UARS-GSFC         [JB525]
+      R*192.67.84.rrr                      NMPDNET           [GC151]
+      R*192.67.85.rrr                      NNMDBNET          [GC151]
+      D*192.67.86.rrr                      DSNETLINK1        [KR79]
+      C*192.67.87.rrr                      MAUNET            [HF34]
+        192.67.88.rrr                      Unassigned        [NIC]
+      C*192.67.89.rrr                      INTNET-AI         [BB279]
+      C*192.67.90.rrr                      RMCNET            [TRG8]
+      C*192.67.91.rrr                      WATG              [ES165]
+      C 192.67.92.rrr                      UNISYS-CULV       [GF75]
+      D 192.67.93.rrr                      AMIDS-NET         [MR197]
+      G*192.67.94.rrr                      PKDC-NET          [AB172]
+      C*192.67.95.rrr                      SPSSINC           [GD91]
+      C*192.67.96.rrr                      SCENIC            [PD98]
+      G 192.67.97.rrr                      GFDL              [CK119]
+      C*192.67.98.rrr                      SPECTRADYNE       [CP129]
+      R 192.67.99.rrr                      CLHS              [JT220]
+      C*192.67.100.rrr                     IND-DESIGN        [DAE2]
+      C*192.67.101.rrr                     IND-MAG           [DAE2]
+      C*192.67.102.rrr                     IND-RED           [DAE2]
+      C*192.67.103.rrr                     IND-RSRV1         [DAE2]
+      C*192.67.104.rrr                     IND-RSRV2         [DAE2]
+      R 192.67.105.rrr                     BNR-TEST1         [BM178]
+      R 192.67.106.rrr                     BNR-TEST2         [BM178]
+      G*192.67.107.rrr-192.67.126.rrr      PSCI-NETS         [BS214]
+      D 192.67.127.rrr                     MTMC-NET          [RC309]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 95]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      D 192.67.128.rrr                     UNISYS-RES3       [KL63]
+      C 192.67.129.rrr                     QUORUM-NET        [RMC1]
+      D 192.67.130.rrr                     PC3RANDOLPH       [MTF1]
+      R 192.67.131.rrr                     MBHSNET           [MEV7]
+      R 192.67.132.rrr                     NMSU-SLIP1        [MSP1]
+      R 192.67.133.rrr                     NMSU-MVS          [JH204]
+      G 192.67.134.rrr                     NOAA-NCDC         [EWK4]
+      C*192.67.135.rrr                     GMP-LUTTON        [AP93]
+      C*192.67.136.rrr-192.67.155.rrr      INCA              [BC180]
+      C*192.67.156.rrr                     EXPCIM            [NP34]
+      R*192.67.157.rrr                     CINTIMILATRD      [KW96]
+      C*192.67.158.rrr                     GHSNET            [JY35]
+        192.67.159.rrr-192.67.164.rrr      Unassigned        [NIC]
+      R*192.67.165.rrr                     ASUHYPER          [SMB33]
+      C*192.67.166.rrr                     AHCC              [MJ100]
+      C*192.67.167.rrr                     LEUZE-OPTO        [FBR2]
+      C*192.67.168.rrr                     BCL               [CM226]
+        192.67.169.rrr                     Unassigned        [NIC]
+      C*192.67.170.rrr                     AIC-NET           [GB169]
+      R*192.67.171.rrr                     REMSEN            [PT62]
+        192.67.172.rrr                     Unassigned        [NIC]
+      C*192.67.173.rrr                     DECUS             [CTP1]
+      G 192.67.174.rrr                     NOAAAA            [HJK4]
+      G 192.67.175.rrr                     NOAAA-WET         [HJK4]
+      G 192.67.176.rrr                     NOAAA-WETH        [HJK4]
+      G 192.67.177.rrr                     NOA-WEATHE        [HJK4]
+      G 192.67.178.rrr                     NOAA-WEATHER      [HJK4]
+      G 192.67.179.rrr                     NOA-WEATHER       [HJK4]
+      G 192.67.180.rrr                     NOAAA-WEATHER     [HJK4]
+      G 192.67.181.rrr                     NO-WEAT           [HJK4]
+      G 192.67.182.rrr                     NO-WEATH          [HJK4]
+      G 192.67.183.rrr                     NO-WEATHE         [HJK4]
+      C 192.67.184.rrr                     OMG               [RMS8]
+        192.67.185.rrr                     Unassigned        [NIC]
+      G 192.67.186.rrr                     BSU-HST           [JB525]
+      G 192.67.187.rrr                     USF-MSL           [JB525]
+        192.67.188.rrr                     Unassigned        [NIC]
+      R*192.67.189.rrr-192.67.208.rrr      KLICK-NETS        [BL118]
+      D 192.67.209.rrr                     GDSS-XRSNET       [BB276]
+      D 192.67.210.rrr                     GDSS-21AF         [BB276]
+      D 192.67.211.rrr                     GDSS-22AF         [BB276]
+      D 192.67.212.rrr                     GDSS-23AF         [BB276]
+      D 192.67.213.rrr                     GDSS-322ALD       [BB276]
+      D 192.67.214.rrr                     GDSS-834ALD       [BB276]
+      D 192.67.215.rrr                     GDSS-ANG          [BB276]
+      D 192.67.216.rrr                     HQMAC-ADANS       [BB276]
+        192.67.217.rrr                     Unassigned        [NIC]
+      R*192.67.218.rrr                     MPCNET            [LS228]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 96]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C*192.67.219.rrr                     GANNET            [RHS4]
+      G*192.67.220.rrr                     RIJNMOND          [ERD6]
+      G*192.67.221.rrr                     RIJNMKLAV         [ERD6]
+      C*192.67.222.rrr                     FS                [JM679]
+      R*192.67.223.rrr                     HITACHI-DUB       [NM56]
+      C*192.67.224.rrr                     MBF               [JR311]
+      D 192.67.225.rrr                     SIMNET-RUCKR      [RK174]
+      D 192.67.226.rrr                     SIMNET-DC         [RLC20]
+      D 192.67.227.rrr                     SIMNET-KNOX       [DG152]
+      D 192.67.228.rrr                     SIMNET-LVNW       [JS609]
+      D 192.67.229.rrr                     SIMNET-BNING      [JM678]
+      D 192.67.230.rrr                     SIMNET-GRAF       [GM190]
+      D 192.67.231.rrr                     SIMNET-FRIED      [SC197]
+      D 192.67.232.rrr                     SIMNET-FULDA      [SA87]
+      D 192.67.233.rrr                     SIMNET-SCHWN      [RH300]
+      D 192.67.234.rrr                     SIMNET-MCCAIN     [CH226]
+      D 192.67.235.rrr                     SIMNET-STEW       [RO67]
+      R 192.67.236.rrr                     NET-JVNC-SLIP-A   [RA17]
+      R 192.67.237.rrr                     NET-JVNC-SLIP-B   [RA17]
+      R 192.67.238.rrr                     NET-JVNC-SLIP-C   [RA17]
+      R 192.67.239.rrr                     NET-JVNC-SLIP-D   [RA17]
+      R 192.67.240.rrr                     NET-JVNC-SLIP-E   [RA17]
+      R 192.67.241.rrr                     NET-JVNC-SLIP-F   [RA17]
+      R 192.67.242.rrr                     NET-JVNC-SLIP-G   [RA17]
+      R 192.67.243.rrr                     NET-JVNC-SLIP-H   [RA17]
+      R 192.67.244.rrr                     NET-JVNC-SLIP-I   [RA17]
+      R 192.67.245.rrr                     NET-JVNC-SLIP-J   [RA17]
+      R 192.67.246.rrr                     NET-JVNC-SLIP-K   [RA17]
+      R 192.67.247.rrr                     NET-JVNC-SLIP-L   [RA17]
+      C*192.67.248.rrr                     MOLDFLOW          [DG212]
+      R*192.67.249.rrr                     FORTH-TO-OTHERS   [SA94]
+      C 192.67.250.rrr                     VSG-COM           [MW178]
+      D 192.67.251.rrr                     DAASNET           [MAM71]
+      D 192.67.252.rrr                     DAASNET1          [MAM71]
+      R*192.67.253.rrr                     TSC               [CR159]
+      C*192.67.254.rrr                     SECNET-AI         [MAG37]
+        192.67.255.rrr                     Reserved          [JBP]
+      C*192.68.0.rrr-192.68.17.rrr         NETCS-CUST        [CS218]
+      C*192.68.18.rrr                      CPQ-GER-NET       [ML204]
+      C*192.68.19.rrr                      ALTCE-NET         [MH268]
+      C*192.68.20.rrr                      INTNET-AI1        [BB28]
+      C*192.68.21.rrr                      NTINET            [TP102]
+      C*192.68.22.rrr                      MELATL            [DH322]
+      C*192.68.23.rrr                      ETX-XD            [SW171]
+        192.68.24.rrr                      Unassigned        [NIC]
+      R*192.68.25.rrr                      DOW-CHEM          [JWB65]
+      C 192.68.26.rrr                      HARRIS-NET1       [RRR1]
+      C 192.68.27.rrr                      HARRIS-NET2       [RRR1]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 97]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      C 192.68.28.rrr                      HARRIS-NET3       [RRR1]
+      R 192.68.29.rrr                      LAWRENCENET       [JSA2]
+      R 192.68.30.rrr                      TMC-LIBRARY       [SB98]
+      C*192.68.31.rrr-192.68.50.rrr        PHILIPS-SERI      [OK6]
+      C*192.68.51.rrr                      DRESSLER          [SK119]
+      G 192.68.52.rrr                      NASA-STIF         [JB525]
+      R*192.68.53.rrr-192.68.64.rrr        CAN-1-12          [TM129]
+        192.68.65.rrr-192.68.66.rrr        Unassigned        [NIC]
+      R*192.68.67.rrr-192.68.74.rrr        BCITNET           [HH88]
+      C*192.68.75.rrr                      MAXTOR-ENGR       [TC132]
+      G*192.68.76.rrr-192.68.107.rrr       NO-MULTI-NETS     [OS4]
+      R 192.68.108.rrr                     FSTRFWEST         [DH313]
+      C*192.68.109.rrr                     RDC               [HS119]
+      R*192.68.110.rrr-192.68.111.rrr      CHYKO-SCCS        [HO8]
+      R*192.68.112.rrr                     BCNET             [MC299]
+      C*192.68.113.rrr                     MCNNET-R          [SJC22]
+      C*192.68.114.rrr                     RAYO              [RO70]
+      C*192.68.115.rrr                     CHROMC            [RO70]
+      C*192.68.116.rrr                     WORLDBANK         [LWA8]
+        192.68.117.rrr                     Unassigned        [NIC]
+      C*192.68.118.rrr-192.68.125.rrr      PG&E-NET          [AC96]
+      R*192.68.126.rrr                     SONY-SMSC-6       [AS196]
+      R*192.68.127.rrr                     SONY-SMSC-7       [AS196]
+      R*192.68.128.rrr                     SONY-SMSC-8       [AS196]
+      R*192.68.129.rrr                     SONY-SMSC-9       [AS196]
+      R*192.68.130.rrr                     SONY-SMSC-10      [AS196]
+      C*192.68.131.rrr                     MINDEMOYA         [DE81]
+      R*192.68.132.rrr                     MINPROD           [SY19]
+      R 192.68.133.rrr                     UCS-INDY          [BS69]
+      C*192.68.134.rrr                     NUMIS             [JC497]
+      C*192.68.135.rrr                     AMCADNET          [TG94]
+      C*192.68.136.rrr                     MONTANAPOWER      [RC321]
+      C*192.68.137.rrr                     EIS               [WR88]
+      R*192.68.138.rrr                     RSINET            [MM427]
+      C*192.68.139.rrr                     SGI-MELB          [AD112]
+      C*192.68.140.rrr                     RUST              [OC16]
+      C*192.68.141.rrr                     SD-SYSTEMS        [CP131]
+      C*192.68.142.rrr                     FAXON             [MH267]
+      R 192.68.143.rrr                     DMZ-NET           [TAE1]
+      D 192.68.144.rrr                     WDCNET            [MM158]
+      C*192.68.145.rrr                     BDB-NET           [CJB15]
+      C*192.68.146.rrr                     NCHIP             [DL178]
+      R*192.68.147.rrr                     SCT-NET           [SS310]
+      D*192.68.148.rrr                     NOFS              [JP325]
+        192.68.149.rrr                     Unassigned        [NIC]
+      C*192.68.150.rrr                     FS                [JM679]
+      C*192.68.151.rrr                     CHERNIKEEF        [AW124]
+      C*192.68.152.rrr                     CHERNIKEEFS       [AW124]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 98]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+      R*192.68.153.rrr                     MRC-HGRC-NET      [GG16]
+      D*192.68.154.rrr                     LAFB-NET          [RP251]
+      R 192.68.155.rrr                     RPS               [MP183]
+      D 192.68.156.rrr                     WSMR-NETS         [SEM18]
+      C*192.68.157.rrr                     PICTURETEL        [GP137]
+        192.68.158.rrr                     Unassigned        [NIC]
+      C*192.68.159.rrr                     CLSI              [LC160]
+      C 192.68.160.rrr                     AWARE             [DS53]
+      G 192.68.161.rrr                     NOAA-PMEL         [RB383]
+      C 192.68.162.rrr                     LPARL-SPACE       [DD237]
+      R 192.68.163.rrr                     HAVERFORD         [ED75]
+        192.68.164.rrr                     Unassigned        [NIC]
+      R*192.68.165.rrr-192.68.169.rrr      RHRK-LAN          [BGW3]
+      D*192.68.170.rrr                     SB-HEYFORD        [COV1]
+      C*192.68.171.rrr                     HITECH            [CSS28]
+      C*192.68.172.rrr                     GRAPH-COMP        [DM373]
+      R*192.68.173.rrr                     NSTB              [KL78]
+      C*192.68.174.rrr                     UKIBMPCUGNET      [AJ7]
+      C*192.68.175.rrr                     MARSMCRO          [RH345]
+      R*192.68.176.rrr                     COMBUSTIONE       [AD113]
+      C*192.68.177.rrr                     ARIX              [JD305]
+      R*192.68.178.rrr                     PTUNET-FCTUN1     [SPA]
+      R*192.68.179.rrr                     LEDGENET          [MW225]
+      C*192.68.180.rrr                     INTER-TEL         [TPB1]
+      C*192.68.181.rrr                     DLOGICS           [JH429]
+      C*192.68.182.rrr                     DENKVO            [MVW]
+      C*192.68.183.rrr                     CDSINC            [MW227]
+      G*192.68.184.rrr                     VGH1              [DP171]
+      C*192.68.185.rrr                     ANZUS             [AKW6]
+      R*192.68.186.rrr                     PTNET-LNEC        [AS206]
+      C*192.68.187.rrr                     KEVEX-IPNET       [RB386]
+        192.68.188.rrr                     Unassigned        [NIC]
+      R 192.68.189.rrr                     NRAO-KP           [PPM2]
+      G 192.68.190.rrr                     CTIO              [JB525]
+      R 192.68.191.rrr                     SLAC-DMZ          [JH40]
+      G 192.68.192.rrr                     JCSNETC21         [JC108]
+      G 192.68.193.rrr                     JCSNETC22         [JC108]
+      G 192.68.194.rrr                     JCSNETC23         [JC108]
+      G 192.68.195.rrr                     JCSNETC24         [JC108]
+      G 192.68.196.rrr                     JCSNETC25         [JC108]
+      G 192.68.197.rrr                     JCSNETC26         [JC108]
+      G 192.68.198.rrr                     JCSNETC27         [JC108]
+      G 192.68.199.rrr                     JCSNETC28         [JC108]
+        192.68.200.rrr-192.68.255.rrr      Unassigned        [NIC]
+      C*192.69.0.rrr-192.69.255.rrr        Hewlett-Packard   [SI8]
+        192.70.0.rrr-195.5.67.rrr          Unassigned        [NIC]
+      C*195.5.68.rrr                       DIGITAL           [TM84]
+        195.5.69.rrr-223.255.254.rrr       Unassigned        [NIC]
+
+
+
+Kirkpatrick, Stahl & Recker                                    [Page 99]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+       *223.255.255.rrr                    Reserved          [JBP]
+
+      Other Reserved Internet Addresses
+
+      * Internet Address                   Network           Reference
+      - ----------------                   -------           ----------
+        224.000.000.000-239.255.255.255    Multicast         [JBP]
+        240.000.000.000-255.255.255.255    Reserved          [JBP]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 100]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   Network Totals
+
+         Assigned for the ARPA-Internet and the DDN-Internet
+
+            Class         A         B         C     Total
+
+            Research     15       663      1853      2531
+
+            Defense       8       367       698      1073
+
+            Government    1        58       294       353
+
+            Commercial    5       121       127       253
+
+            Total        29      1209      2972      4210
+
+         Allocated for Internet and Independent Uses
+
+            Class         A         B         C     Total
+
+            Research     16      1197      5191      6404
+
+            Defense      10       393       858      1261
+
+            Government    1       129       722       852
+
+            Commercial    7       814      9443     10264
+
+            Total        34      2533     16214     18781
+
+         Maximum Allowed
+
+            Class         A         B         C     Total
+
+            Research      8      1024     65536     66568
+
+            Defense      24      3072    458752    461848
+
+            Government   24      3072    458752    461848
+
+            Commercial   74      9214   1114137   1123394
+
+            Total       126     16382   2097150   2113658
+
+
+
+
+
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 101]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+AUTONOMOUS SYSTEM NUMBERS
+
+   The Exterior Gateway Protocol (EGP) [41,43] specifies that groups of
+   gateways may form autonomous systems.  The EGP provides a 16-bit
+   field for identifying such systems.  The values of this field are
+   registered here.
+
+      Autonomous System Numbers:
+
+           Number  System Name                        Contact
+           ------  ---------------------------------- -------
+           1       The BBN Core Gateways              [MB]
+           2       DCN-AS                             [DLM1]
+           3       The MIT Gateways                   [RH164]
+           4       ISI-AS                             [JKR1]
+           5       SYMBOLICS                          [SE31]
+           6       HIS-MULTICS                        [JLM23]
+           7       UK-MOD                             [RNM1]
+           8       RICE-AS                            [PGM]
+           9       CMU-ROUTER                         [MA]
+           10      CSNET-EXT-AS                       [WHN2]
+           11      HARVARD                            [SB28]
+           12      NYU-DOMAIN                         [EF5]
+           13      BRL-AS                             [RR33]
+           14      COLUMBIA-GW                        [BC14]
+           15      NET DYNAMICS EXP                   [ZSU]
+           16      LBL                                [WG]
+           17      PURDUE-CS                          [DT50]
+           18      UTEXAS                             [DLN12]
+           19      CSS-DOMAIN                         [RA11]
+           20      UR                                 [LB16]
+           21      RAND                               [JDG]
+           22      NOSC                               [RLB3]
+           23      RIACS-AS                           [DG28]
+           24      AMES-NAS-GW                        [MF31]
+           25      UCB                                [MK17]
+           26      CORNELL                            [JCH17]
+           27      UMDNET                             [MP12]
+           28      DFVLR-SYS                          [GB7]
+           29      YALE-AS                            [HML1]
+           30      SRI-AICNET                         [WMT]
+           31      CIT-CS                             [AD22]
+           32      STANFORD                           [PA5]
+           33      DEC-WRL-AS                         [BKR]
+           34      UDEL-EECIS                         [NMM]
+           35      MICATON                            [WDL]
+           36      EGP-TESTOR                         [PEM4]
+           37      NSWC                               [DAF9]
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 102]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+           38      UIUC                               [AKC]
+           39      NRL-ITD                            [AP]
+           40      MIT-TEST                           [NC3]
+           41      AMES                               [MSM1]
+           42      THINK-AS                           [BJN1]
+           43      BNL-AS                             [GR9]
+           44      S1-DOMAIN                          [RAK12]
+           45      LLL-TIS-AS                         [NAL]
+           46      RUTGERS                            [RM8]
+           47      USC-OBERON                         [DRS4]
+           48      NRL-AS                             [WF3]
+           49      ICST-AS                            [CWH3]
+           50      ORNL-MSRNET                        [THD]
+           51      USAREUR-EM-AS                      [FWD]
+           52      UCLA                               [RBW]
+           53      NORTHROP-AS                        [RSM1]
+           54      COA-FIN-NET-AS                     [RR26]
+           55      UPENN-CIS                          [IW5]
+           56      OPTIMIS-P                          [GPL1]
+           57      UMN-REI-UC                         [TJ]
+           58      DREA-AS                            [GLH5]
+           59      WISC-MADISON-AS                    [EJN1]
+           60      DARPA-BFLY                         [MB]
+           61      DEC-MARLBORO-AS                    [JM60]
+           62      TEKVAXC                            [TE16]
+           63      LL-MI                              [KLS24]
+           64      MITRE-B-AS                         [BSW]
+           65      LOGNET-AS                          [JR15]
+           66      ETL-AI                             [MMM3]
+           67      SDC-PRC-AS                         [MS22]
+           68      LANL-INET-AS                       [PCW]
+           69      WHARTON-AS                         [HK2]
+           70      NLM-GW                             [JA1]
+           71      HP-INTERNET-AS                     [DCL10]
+           72      SCHLUMBERGER-AS                    [CG64]
+           73      WASHINGTON-AS                      [DJ99]
+           74      XDRENET-AS                         [TS31]
+           75      ANL-AS                             [LW26]
+           76      SDC-CAM-AS                         [DSR]
+           77      JHUAPL-AS                          [SFP]
+           78      SSDF-CDC-GW                        [RE22]
+           79      DSPO-HC-AS                         [BT5]
+           80      GE-CRD                             [JC106]
+           81      TUCC-MCNC                          [JRR14]
+           82      TWG-DEMO-AS                        [JS171]
+           83      PICANET-AS                         [RFD1]
+           84      DTNSRDC-AS1                        [RWT2]
+           85      AERO-NET                           [LCN]
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 103]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+           86      SURANET-AS                         [JH92]
+           87      INDIANA-AS                         [BS69]
+           88      PRINCETON-AS                       [LRR1]
+           89      NUSC-CSTLNET-AS                    [MP20]
+           90      SUN-AS                             [WM3]
+           91      RPI-AS                             [MS9]
+           92      CLARKSON-AS                        [ABS6]
+           93      FORD-AS                            [KR9]
+           94      BELVOIR-NET                        [MDS30]
+           95      NUSCLSB1                           [RPP]
+           96      JTELS-BEN1-AS                      [RR26]
+           97      JVNC-AS                            [SH37]
+           98      ROCKEFELLER-AS                     [MK38]
+           99      INTEL-IWARP                        [RLS115]
+           100     FMC-CTC                            [WW82]
+           101     WASH-NSF-AS                        [SH47]
+           102     NSF-HQ-AS                          [FW17]
+           103     NWU-AS                             [JPD18]
+           104     COLORADO-AS                        [DCMW]
+           105     MOT-MCD-AS                         [DP7]
+           106     ETN-WLV-AS                         [SMS1]
+           107     ECSNET-AS                          [CAL7]
+           108     XEROX-AS                           [DCS]
+           109     CISCOSYSTEMS                       [KSL]
+           110     XAIT-AS                            [AL6]
+           111     BOSTONU-AS                         [BS24]
+           112     CMU-SEI-AS                         [PDB5]
+           113     SCCNET-AS                          [MJO4]
+           114     SESQUINET-AS                       [GTA]
+           115     PBAS-BEN2-GW-AS                    [RR26]
+           116     BELLCORE-AS                        [PK28]
+           117     ALBM-NET-AS                        [DV42]
+           118     NSWSES-NAVY-AS                     [DD41]
+           119     AMS-AS                             [SBW4]
+           120     MITRE-OMAHA                        [SM62]
+           121     IH-POE-AS                          [LK27]
+           122     U-PGH-NET-AS                       [SM6]
+           123     LOGAIRCOMNET-AS                    [GT37]
+           124     ENCORE-GW-AS                       [DK70]
+           125     HI-NET-AS                          [DB97]
+           126     MINSY-POE-AS                       [CV14]
+           127     JPL-AS                             [JAW16]
+           128     ADS-AS                             [MB26]
+           129     CDA-AS                             [FJS3]
+           130     CSOCNET-AS                         [JJD12]
+           131     UCSB-NET-AS                        [AKS31]
+           132     WPAFB-CSD-NET-AS                   [KH59]
+           133     AFIT-AS                            [DWD20]
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 104]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+           134     CORONA-GW-AS                       [LM35]
+           135     BRL-CDCNET-GW-AS                   [RR33]
+           136     ECONET-AS                          [TD40]
+           137     ITALY-AS                           [ABB2]
+           138     BRL-CMCGW-AS                       [RR33]
+           139     NUWESNET-AS                        [RM125]
+           140     DAITC-NET-AS                       [CG24]
+           141     NWCNET-AS                          [EG17]
+           142     WESTPOINT                          [RLR23]
+           143     OOG1-AS                            [JD86]
+           144     ATT-INTERNET                       [HT19]
+           145     NSFNET-CORE                        [HWB]
+           146     HQEIS-AS                           [SMK2]
+           147     NAVCAMS-LAN-AS                     [JM246]
+           148     NWSC-GW-AS                         [JA91]
+           149     ADEL-AS                            [CM115]
+           150     SEANET-AS                          [JH10]
+           151     IND-NTC-AS                         [AB98]
+           152     SRI-ACCATT-AS                      [RDQ]
+           153     SAAD-ARPA-AS                       [DRM24]
+           154     USACEC-NET-AS                      [DEA]
+           155     CACNET-AS                          [BG25]
+           156     NORTHEASTERN-GW-AS                 [CJ38]
+           157     INTELLIAUTON                       [RJL3]
+           158     ACC-AS                             [AB20]
+           159     SONNET-AS                          [MF74]
+           160     U-CHICAGO-AS                       [MC17]
+           161     TI-AS                              [DF71]
+           162     NOSL-POE-AS                        [DB211]
+           163     IBM-RESEARCH-AS                    [JP247]
+           164     DDN-MB-AS                          [RH6]
+           165     NESEA-DDN-GW-AS                    [DT59]
+           166     IDA-AS                             [MM227]
+           167     WESLEYAN-AS                        [JGD1]
+           168     UMASS-AMHERST                      [ASG]
+           169     HANSCOM-NET-AS                     [DD63]
+           170     YKTNPOE-GW-AS                      [WRR5]
+           171     NORTHWESTNET-AS                    [GK44]
+           172     CSDA-AS                            [LJC2]
+           173     NTT-AS                             [KM82]
+           174     NYSERNET-AS                        [MF19]
+           175     AFWL-AS                            [BSR]
+           176     BCN-AS                             [JRC27]
+           177     MERIT-AS                           [HWB]
+           178     IBMYORKTOWN-AS                     [HWB]
+           179     IBMMILFORD-AS                      [HWB]
+           180     MCIRESTON-AS                       [HWB]
+           181     NSFNETTEST1-AS                     [HWB]
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 105]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+           182     NSFNETTEST2-AS                     [HWB]
+           183     NSFNETTEST3-AS                     [HWB]
+           184     NSFNETTEST4-AS                     [HWB]
+           185     NSFNETTEST5-AS                     [HWB]
+           186     CUA-AS                             [ECM6]
+           187     MDC-AS                             [KRH4]
+           188     SAIC-AS                            [SDF5]
+           189     BARRNET-AS                         [DLW31]
+           190     NSYPTSMH-POE-AS                    [TSD3]
+           191     NORDA-AS                           [MG120]
+           192     ROCHINSTTECH                       [CF35]
+           193     MIDNET-AS                          [DF90]
+           194     USAN-AS                            [DM84]
+           195     SDSC-AS                            [PGL]
+           196     RISC-SYSTEM                        [WAG5]
+           197     HAC-ENET-AS                        [PH45]
+           198     BRL-SGW1-AS                        [WAW11]
+           199-203 BARRNET-AS                         [DLW31]
+           204     PSCNET-AS                          [EFH4]
+           205     MONTCLAIR-AS                       [MLT10]
+           206     CSC-LONS-GW-AS                     [SWR3]
+           207     CLI-GW-AS                          [WAH11]
+           208     LBNS-POE-AS                        [DC145]
+           209     WESTNET-EAST                       [DCMW]
+           210     WESTNET-WEST                       [DCMW]
+           211     RADC-LONS-GW-AS                    [SWR3]
+           212     HQAFSC-LONS-GW-AS                  [SWR3]
+           213     APGEA-NET1-AS                      [REA3]
+           214     USNA-AS                            [RAD15]
+           215     RIA-2-AUTO-AS                      [TC72]
+           216     LMSC-HOSTNET-AS                    [SJ55]
+           217     UMN-AGS-NET-AS                     [RG12]
+           218     AFOTECPCNET-AS                     [KDA5]
+           219     PUGET-POE-AS                       [GC104]
+           220     OOALC-HOSTNET-AS                   [SJ55]
+           221     WRALC-HOSTNET-AS                   [SJ55]
+           222     SMALC-HOSTNET-AS                   [SJ55]
+           223     TISW-AS                            [KH88]
+           224     UNINETT-AS                         [JT122]
+           225     VIRGINIA-AS                        [JAJ17]
+           226     LOS-NETTOS-AS                      [WP8]
+           227     SHAFTER-AS                         [DM35]
+           228     DC-SUN-NET-AS                      [MC202]
+           229     NSFNETTEST6-AS                     [HWB]
+           230     NSFNETTEST7-AS                     [HWB]
+           231     NSFNETTEST8-AS                     [HWB]
+           232     NSFNETTEST9-AS                     [HWB]
+           233     NSFNETTEST10-AS                    [HWB]
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 106]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+           234     NSFNETTEST11-AS                    [HWB]
+           235     NSFNETTEST12-AS                    [HWB]
+           236     NSFNETTEST13-AS                    [HWB]
+           237     NSFNETTEST14-AS                    [HWB]
+           238     NSFNETTEST15-AS                    [HWB]
+           239     UTORONTO-AS                        [LO24]
+           240     SAALC-HOSTNET-AS                   [SJ55]
+           241     OCALC-HOSTNET-AS                   [SJ55]
+           242     SSSD-AS                            [RGH21]
+           243     HARRIS-ATD-AS                      [TS14]
+           244     ITT-FEC-AS                         [RW45]
+           245     PRC-AS                             [SS172]
+           246     ASIFICS-GW-AS                      [SC139]
+           247     ROMENET-AS                         [PV23]
+           248     OBL-LINK-AS                        [MCB5]
+           249     RDM-LINK-AS                        [MCB5]
+           250     LON-LINK-AS                        [MCB5]
+           251     CPO-LINK-AS                        [MCB5]
+           252     CECOM-A-TACT                       [MB31]
+           253     CIC-NET-AS                         [RG12]
+           254     TWG-NET-AS                         [JS171]
+           255     PATRICK-LONS-GW-AS                 [SWR3]
+           256     NCSC-NET-AS                        [JD130]
+           257     NPS-GATOR-AS                       [SW37]
+           258     BRAGGSRI-EGP-AS                    [TN5]
+           259     SCUBED-AS                          [TH60]
+           260     BBNCC-COL-MD-AS                    [LJK]
+           261     EASINET-AS                         [JLD31]
+           262     JVNC-II-AS                         [JB247]
+           263     JVNC-TEST-AS                       [JB247]
+           264     SRINET-AS                          [DP2]
+           265     WASH-VAX-AS                        [DB310]
+           266     CICNET1-AS                         [JY24]
+           267     CICNET2-AS                         [JY24]
+           268     USUHSNET-AS                        [MK124]
+           269     INCSYS-AS                          [JS281]
+           270     PSCNI-AS                           [BH162]
+           271     BCNET-AS                           [JCD8]
+           272     FTLEENET-AS                        [TWH19]
+           273     DARPA-CISCO-AS                     [SC3]
+           274     SOFT-CON-NTS-AS                    [PP77]
+           275     SESQUI-INTER-AS                    [FG50]
+           276     MCC-NET-AS                         [CBD]
+           277     BBNSTC-KNOX-AS                     [JM113]
+           278     RAM-AS                             [MA105]
+           279     SURANET-AS-2                       [MO48]
+           280     SESQUI-AUX-AS                      [FG50]
+           281     NEARNET-AS                         [DBL1]
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 107]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+           282     MERIT-AUX-AS                       [JRJ18]
+           283     GATED-TEST-AS                      [JCH17]
+           284     UUNET-AS                           [RA11]
+           285     AVTROS-AS                          [CAD10]
+           286     EUNET-AS                           [PB13]
+           287     CNSYD-POE-AS                       [MI1]
+           288     ESA-AS                             [DS342]
+           289     APGNET-AS                          [VC5]
+           290     SHOWNET-AS                         [NIC]
+           291     ESNET-EAST-AS                      [AT80]
+           292     ESNET-CENTRAL-AS                   [AT80]
+           293     ESNET-WEST-AS                      [AT80]
+           294     FRANCE-IP-NET-AS                   [AR41]
+           295     OSI-GW-AS                          [LC57]
+           296     ACFP-NET-TST-AS                    [HR43]
+           297     NSN-UMD-AS                         [MSM1]
+           298     RADC-LONEX-AS                      [JAM38]
+           299     UCINET-AS                          [DW96]
+           300     GUNTER-LAN-AS                      [TMD6]
+           301     C3PO-AS                            [RR184]
+           302     BCM-INFO-NET-AS                    [SB98]
+           303     NPRDC-AS                           [RFS2]
+           304     SRIEXPRIGNET-AS                    [PEM4]
+           305     WALTER-REED-AS                     [BSA2]
+           306-371 NGNET-AS                           [CAP5]
+           372     NSN-AMES-AS                        [MSM1]
+           373     IE-TESTBED-AS                      [GH122]
+           374     BROOKS-AS                          [JLW49]
+           375     TIETOTIE-AS                        [PI7]
+           376     RISQ-AS                            [MV38]
+           377     SNLA-NET-AS                        [AB161]
+           378     ILAN-AS                            [HN7]
+           379-508 AF-CONC-NET-AS                     [DWB2]
+           509     WORMS-GW1-AS                       [SAS49]
+           510     CSNET-INT-AS                       [WHN2]
+           511     CSNET-MIS-AS                       [WHN2]
+           512     NAVDEC-NET1                        [DG163]
+           513     CERN-AS                            [TB]
+           514     EDMICS-POE                         [PWP2]
+           515     PMS312GATE-ASN                     [DL164]
+           516     KODAK-BTC                          [HCL1]
+           517     XLINK-UKA                          [MR78]
+           518     CONCORD-POE-AS                     [SJG2]
+           519     ISCNET                             [DM27]
+           520     COINSDISNET3                       [RLS6]
+           521     FORD-SRL-AS                        [FJB3]
+           522     AFSC-SSD-AS                        [DD38]
+           523     REDSTONE-AS                        [RT64]
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 108]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+           524     BBN-PCNETSIM-AS                    [GL15]
+           525     WUERZBURG-GW1-AS                   [LT70]
+           526     ASCHAFFENBURG-GW1-AS               [GP129]
+           527     ANSBACH-GW1-AS                     [JS573]
+           528     AUGSBURG-GW1-AS                    [LW137]
+           529     BURTONWOOD-GW1-AS                  [LW138]
+           530     GEOPPINGEN-GW1-AS                  [PO2]
+           531     GRAFENWOEHR-GW1-AS                 [SD131]
+           532     HEIDELBERG-GW1-AS                  [AH130]
+           533     HEILBRONN-GW1-AS                   [MG205]
+           534     KARLSRUHE-GW1-AS                   [OT5]
+           535     MUNICH-GW1-AS                      [RJ127]
+           536     NUERNBERG-GW1-AS                   [SJ65]
+           537     ULM-GW1-AS                         [ML193]
+           538     SCHWEINFURT-GW1-AS                 [WN2]
+           539     STUTTGART-GW1-AS                   [CJC31]
+           540     BAMBERG-GW1-AS                     [DS335]
+           541     IGAUTON                            [EL30]
+           542     ARNET                              [TS194]
+           543     CONVEX                             [CG105]
+           544     PTN-FINLAND                        [ET49]
+           545     NRI                                [DKE2]
+           546     SPARTA-AS                          [CFM1]
+           547     TST-RGN-47-AS                      [DM353]
+           548     HQUSAF-AS                          [BP32]
+           549     ONET-AS                            [LO24]
+           550     CORNETT-AS                         [PCW]
+           551     TIS-AS                             [DID1]
+           552     PATCH-AS                           [TTS8]
+           553     BELWUE-AS                          [PM178]
+           554     CALINET-AS                         [WP8]
+           555     MRNET-AS                           [JAW34]
+           556     CALREN-AS                          [WP8]
+           557     UMAINE-SYS-AS                      [IKA]
+           558     OLIVETTI-AS1                       [JA13]
+           559     SWITCH-AS                          [TL99]
+           560     NEARNET-EXT-AS                     [DBL1]
+           561     3COM-A                             [TC96]
+           562     3COM-B                             [TC96]
+           563     3COM-C                             [TC96]
+           564     OPSNET                             [LM237]
+           565     VTTNET-AS                          [JK187]
+           567     DART-AS                            [WP8]
+           568     SUMNET-AS                          [AJC5]
+           569     DIMNET-AS                          [FZ]
+           570     SSD-NET-AS                         [DD38]
+           571     CENTCOM-AS                         [KMC3]
+           572     ZWEIBKN-GW1-AS                     [GEW13]
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 109]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+           573     NAVDEC-NET3-AS                     [DG163]
+           574     PSC-TEST-AS                        [EFH4]
+           576     NAVDAC-NET3-AS                     [DG163]
+           577     CA-NET-AS                          [TM159]
+           578     AS-CA-NET-AS                       [TM159]
+           579     CANET-AS                           [TM159]
+           580     MAINZ-GW1-AS                       [MM413]
+           581     GDSS-XRSNET-AS                     [BB276]
+           582     GDSS-21AF-AS                       [BB276]
+           583     GDSS-22AF-AS                       [BB276]
+           584     GDSS-23AF-AS                       [BB276]
+           585     GDSS-322ALD-AS                     [BB276]
+           586     GDSS-834ALD-AS                     [BB276]
+           587     GDSS-ANG-AS                        [BB276]
+           588     FRANKFRT-GW1-AS                    [SDM8]
+           589     UNT-CAMPUS-AS                      [BB194]
+           590     EASINET-AS1                        [WP90]
+           591     NSTN-AS                            [JS338]
+           592     USNA-NADN-AS                       [AF60]
+           594-598 BARRNET-AS                         [DLW31]
+           599     NISC-AS                            [VN]
+           600     OARNET-AS                          [DW233]
+           601     CANET1-AS                          [DF133]
+           602     CANET2                             [DF133]
+           603     CANET                              [DF133]
+           604     CANET4-AS                          [DF133]
+           605     CANET5-AS                          [DF133]
+           606     CANET6-AS                          [DF133]
+           607     CANET7-AS                          [DF133]
+           608     CANET8-AS                          [DF133]
+           609     CANET9-AS                          [DF133]
+           610     CANET10-AS                         [DF133]
+           611     CANET11-AS                         [DF133]
+           612     CANET12-AS                         [DF133]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 110]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+DOCUMENTS
+
+   [1]    Aerospace, Internal Report, ATM-83(3920-01)-3, 1982.
+
+   [2]    Apollo Computer, Inc., "Managing TCP/IP-Based Communication
+          Products", Order No. 008543, Chelmsford, MA, 01824,
+          March 1986.
+
+   [3]    BBN Proposal No. P83-COM-40, "Packet Switched Overlay to
+          Tactical Multichannel/Satellite Systems".
+
+   [4]    BBN, "Specifications for the Interconnection of a Host
+          and an IMP", Report 1822, Bolt Beranek and Newman
+          Cambridge, Massachusetts, revised, December 1981.
+
+   [5]    CDCNET Network Configuration and Site Administration Guide,
+          CDC Publication Number 60461550.  CDCNET TCP/IP Usage, CDC
+          Publication Number 60000214.
+
+   [6]    Chon, K., et al., "SDN: A Computer Network for Korean
+          Research Community", Proc. of the Pacific Computer
+          Communications Symposium, October 1985, pp. 567-570,
+          Seoul, Korea.
+
+   [7]    Chon, K., et al., "System Development Network", Proc. of
+          TENCON, April 1984, pp. 133-135, Singapore.
+
+   [8]    cisco Systems, "cisco Systems Gateway Server Reference
+          Manual", Revision B, Menlo Park, CA, January 1988.
+
+   [9]    Clark, D., "Revision of DSP Specification", Local Network
+          Note 9, Laboratory for Computer Science, MIT, June 1977.
+
+   [10]   Cohen, D., "On Holy Wars and a Plea for Peace", IEEE
+          Computer Magazine, October 1981.
+
+   [11]   Comer, D., and T. Narten, "The Cypress Multifunction Packet
+          Switch", Technical Report CSD-TR-575, Computer Science
+          Dept., Purdue University, West LaFayette, IN.
+
+   [12]   Comer, D., "Internetworking with TCP/IP:  Principles,
+          Protocols and Architecture", Prentice-Hall, 1988.
+
+   [13]   Croft, W. J., "Unix Networking at Purdue", USENIX
+          Conference, 1980.
+
+   [14]   Deering, S. E., "Host Extensions for IP Multicasting",
+          RFC 988, Stanford University, December 1985.
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 111]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [15]   Digital Equipment Corporation, DELQA User's Guide
+          EK-DELQA-UG-001, Merrimack, NH, 1987.
+
+   [16]   Digital Equipment Corporation, "Ultrix-32 Network Management
+          Guide", Ultrix-32 System, Version 2.0, 1987.
+
+   [17]   Feinler, E., editor, "DDN Protocol Handbook", Network
+          Information Center, SRI International, December 1985.
+
+   [18]   Feinler, E., editor, "Internet Protocol Transition
+          Workbook", Network Information Center, SRI International,
+          March 1982.
+
+   [19]   Feinler, E. and J. Postel, eds., "ARPANET Protocol
+          Handbook", IC 7104, for the Defense Communications Agency by
+          SRI International, Menlo Park, California, Revised
+          January 1978.
+
+   [20]   Harris Corporation, "Harris Ethernet Data Link Reference
+          Manual", Publication No. 0868010-002, Harris Corporation,
+          Computer Systems Divsion, 2101 West Cypress Creek Road,
+          Ft. Lauderdale, FL 33309-1892.
+
+   [21]   Harris Corporation, "Harris TCP/IP Manager's Guide",
+          Publication No. 0868011-100, Harris Corporation,
+          Computer Systems Divsion, 2101 West Cypress Creek Road,
+          Ft. Lauderdale, FL 33309-1892.
+
+   [22]   Honeywell CISL, Internal Document, "AFSDSC Hyperchannel RPQ
+          Project Plan".
+
+   [23]   Honeywell CISL, Internal Document, "Multics MR11 PFS".
+
+   [24]   Hwang, K., W. J. Croft and G. H. Goble, "A Unix-Based Local
+          Computer Network with Load Balancing", IEEE Computer,
+          April 1982.
+
+   [25]   IBM Corporation, "Technical Reference Manual for the IBM PC
+          Network", 6322505, IBM, Boca Raton, Florida, 1984.
+
+   [26]   IEEE Project 802 Local Area Network Standard, "IEEE Standard
+          802.3 CSMA/CD Access Method and Physical Layer
+          Specifications", Approved IEEE 802.3-1985 ISO/DIS 8802/3,
+          July 1983.
+
+   [27]   Korb, J. T., "A Standard for the Transmission of IP
+          Datagrams Over Public Data Networks", RFC 877, Purdue
+          University, September 1983.
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 112]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [28]   Leach, et al., "The Architecture of an Integrated Local
+          Network", IEEE Journal on Selected Areas in Communications,
+          Vol SAC-1, No. 5, November 1983.
+
+   [29]   Leffler, Samuel J., et al., "4.2 BSD Network Implementation
+          Notes", July, 1983, University of California, Berkeley.
+
+   [30]   Leffler, S.J.; Joy, W.N.; Fabry, R.S.; Karels, M.J.
+          "Networking Implementation Notes, 4.3 BSD Edition",
+          CSRG/CSD/EECS, University of California, Berkeley, June
+          1986.
+
+   [31]   Macgregor, W., and D. Tappan, "The CRONUS Virtual Local
+          Network", RFC 824, Bolt Beranek and Newman, August 1982.
+
+   [32]   Mills, D., "Network Time Protocol", RFC 958, M/A-COM
+          Linkabit, September 1985.
+
+   [33]   Postel, J., ed., "Internet Protocol - DARPA Internet Program
+          Protocol Specification", RFC 791, Information Sciences
+          Institute, September 1981.
+
+   [34]   Prime, "Medusa, The Prime Ethernet", PRIME/WS/AI/86/2,
+          July 1986, Framingham, MA.
+
+   [35]   Proteon, "Linkway Software:  Operating System, Release 7.0",
+          SPD 040-013 and "Linkway Software:  IP Packet Forwarder",
+          SPD 040-016.  Proteon, Inc., 4 Tech Circle, Natick, MA.
+
+   [36]   Proteon, "P4200 Gateway User's Guide", 42-040-012.  Proteon,
+          Inc., 4 Tech Circle, Natick, MA 01760.
+
+   [37]   Proteon, ProNET-80 Token Ring Network, Proteon, Inc.,
+          Westborough, MA.
+
+   [38]   Pyramid Technology Corporation, "Networking Software Package
+          Product Description:  Ethernet", 4100-0014-E, April 15,
+          1988.
+
+   [39]   Reed, D., "Protocols for the LCS Network", Local Network
+          Note 3, Laboratory for Computer Science, MIT, November 1976.
+
+   [40]   Reynolds, J. and J. Postel, "Official Internet Protocols",
+          RFC 1011, Information Sciences Institute, May 1987.
+
+   [41]   Rosen, E., "Exterior Gateway Protocol" RFC 827, Bolt Beranek
+          and Newman, October 1982.
+
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 113]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [42]   Saltzer, J. H., "Design of a Ten-megabit/sec Token Ring
+          Network", MIT Laboratory for Computer Science Technical
+          Report.
+
+   [43]   Seamonson, L. J., and E. C. Rosen, "STUB" Exterior Gateway
+          Protocol", RFC 888, BBN Communications Corporation,
+          January 1984.
+
+   [44]   Shuttleworth, B., "A Documentary of MFENet, a National
+          Computer Network", UCRL-52317, Lawrence Livermore Labs,
+          Livermore, California, June 1977.
+
+   [45]   Skelton, A., S. Holmgren, and D. Wood, "The MITRE Cablenet
+          Project", IEN 96, April 1979.
+
+   [46]   Sun Microsystems, "Networking on the Sun Workstation",
+          Part No: 800-1324-03, Revision B of 17 February 1986.
+          Sun Microsystems, Inc., 2550 Garcia Avenue, Mountain
+          View, CA 94043.
+
+   [47]   "The Ethernet, A Local Area Network: Data Link Layer and
+          Physical Layer Specification", AA-K759B-TK, Digital
+          Equipment Corporation, Maynard, MA.  Also as:  "The
+          Ethernet - A Local Area Network", Version 1.0, Digital
+          Equipment Corporation, Intel Corporation, Xerox Corporation,
+          September 1980.  And: "The Ethernet, A Local Area Network:
+          Data Link Layer and Physical Layer Specifications", Digital,
+          Intel and Xerox, November 1982.  And:  XEROX, "The Ethernet,
+          A Local Area Network: Data Link Layer and Physical Layer
+          Specification", X3T51/80-50, Xerox Corporation, Stamford,
+          CT, October 1980.
+
+   [48]   The High Level Protocol Group, "A Network Independent File
+          Transfer Protocol",  INWG Protocol Note 86, December 1977.
+
+   [49]   Wecker, S., "DNA:  The Digital Network Architecture", IEEE
+          Trans., Commun., COM-28, 510-526, April 1980.
+
+   [50]   Whelan, D., "The Caltech Computer Science Department
+          Network", 5052:D F:82, Caltech Computer Science Department,
+          1982.
+
+   [51]   XEROX, "Internet Transport Protocols",  XSIS 028112, Xerox
+          Corporation, Stamford, Connecticut, December 1981.
+
+   [52]   Internet Activities Board, "IAB Official Protocol
+          Standards", RFC 1140, IAB, May 1990.
+
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 114]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+CONTACTS
+
+   HANDLE               NAME                    MAILBOX
+
+   [AA62]          Adrualdi, Annarita
+                   aaa0%icineca2.bitnet@CUNYVM.CUNY.EDU
+   [AA70]          Agnew, Alan
+                   A_AGNEW%QUT.EDU.AU@CUNYVM.CUNY.EDU
+   [AA73]          Ayala, Amador            craxa@UTSA86.SA.UTEXAS.EDU
+   [AA76]          Allopenna, Audrey        ---none---
+   [AA81]          Andersson, Anders        Anders-Andersson@DOCS.UU.SE
+   [AAD6]          Datri, Anthony A.        aad@STEPSTONE.COM
+   [AB115]         Banks, Alan
+                   alanb%cengl%uk.ac.sussex.cvaxa@CUNYVM.CUNY.EDU
+   [AB125]         Bjoernerstedt, Anders    anders@SISUS.SISU.SE
+   [AB128]         Birner, Andrew           ---none---
+   [AB150]         Bray, Allen              ahbray@CTS.UTS.OZ.AU
+   [AB161]         Breckenridge, Arthurine R.ARBRECK@SANDIA.GOV
+   [AB171]         Bosch, Arnold            ARNOLD.BOSCH@RCL.WAU.NL
+   [AB172]         Barr, Alex               ---none---
+   [AB175]         Berni, Alessandro        ab@ITALY.EU.NET
+   [AB20]          Berggreen, Arthur        art@SALT.ACC.COM
+   [AB98]          Beacham, Albert
+                   hpindda!abeacha@HPLABS.HP.COM
+   [ABB2]          Bonito, A. Blasco        BLASCO@CNUCE.CNR.IT
+   [ABS6]          Stine, Arthur B.
+                   abstine@OMNIGATE.CLARKSON.EDU
+   [AC154]         Craig, Alisdair          sysman@UK.AC.EDRC
+   [AC155]         Cataldi, Alan            ---none---
+   [AC158]         Chance, Anthony          achance@US.ORACLE.COM
+   [AC42]          Cohen, Adam              ---none---
+   [AC66]          Crotty, Art              ---none---
+   [AC85]          Cantrall, Arthur
+                   icsadc%asuic.bitnet@CUNYVM.CUNY.EDU
+   [AC96]          Conley, Alan             ---none---
+   [AC98]          Cole, Allen              cole@CC.UTAH.EDU
+   [ACC17]         Colborne, A. C.          ailsa@BIOBRIS.OZ.AU
+   [ACL2]          Lumb, Arthur C.          ---none---
+   [AD106]         Deck, Annabella          ---none---
+   [AD112]         Danne, Andrew            ---none---
+   [AD113]         Di Paolo, Antonio        anto@IRC.NA.CNR.IT
+   [AD22]          DesJardins, Arlene A.    Arlene@VLSI.CALTECH.EDU
+   [AD62]          Diwan, Arif              HOSTMASTER@BROWN.EDU
+   [AD67]          Davis, Andy              andy@SPIDER.CO.UK
+   [AD90]          Dang, Anh                lewton@PRANDTL.NAS.NASA.GOV
+   [AD96]          Decerce, Anthony
+                   ASQM-SWM@MONMOUTH-EMH1.ARMY.MIL
+   [AEJ5]          Johannesen, Allan E.     AEJ@WPI.WPI.EDU
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 115]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [AF54]          Fox, Anthony             lsg-pm@LOGNET2.AF.MIL
+   [AF60]          Fischer, Allan
+                   allan@NADN2.NADN.USNA.NAVY.MIL
+   [AG113]         Ghiselli, Antonia
+                   ghiselli%iboinfn.bitnet@CUNYVM.CUNY.EDU
+   [AG127]         Gorczyca, Anne           ANNE@HYPERION.HAYSTACK.EDU
+   [AG149]         Gourds, Arthur           ---none---
+   [AG22]          Ganz, Alfred             ganz-alfred@YALE.EDU
+   [AG67]          Garg, Atul               ---none---
+   [AGS5]          Smith, Arnold G.         AGSMITH@WARBUCKS.AI.SRI.COM
+   [AH124]         Hildreth, Alan           hildreth@MWUNIX.MITRE.ORG
+   [AH130]         Hubbard, Al
+                   mmdf@HEIDELBERG-EMH1.ARMY.MIL
+   [AH81]          Hooper, Andrew           HOOPER@QUCDN.QUEENSU.CA
+   [AH89]          Hovsto, Asbjorn          ---none---
+   [AH94]          Hillbo, Anders           AHI@NADA.KTH.SE
+   [AH96]          Hellman, Anders
+                   enea!unione!prhla@UUNET.UU.NET
+   [AHA]           Anderson, Allan H.       anderson@VLSI.LL.MIT.EDU
+   [AI2]           Iliou, Alain             ailiou@IFREMER.IFREMER.FR
+   [AI4]           Ingle, Andy              andy@ACORN.CO.UK
+   [AIM4]          Mitchell, Andrew I.
+                   suqaim%cms.am.cc.reading.ac.uk@NSF-RELAY.AC.UK
+   [AIS]           Shore, Andrew I.         shore@ADOBE.COM
+   [AJ180]         Jefferson, Alexis        ---none---
+   [AJ29]          Jha, Ashok               jha@DFTNIC.GSFC.NASA.GOV
+   [AJ7]           Jay, Alan                alanj@IBMPCUG.CO.UK
+   [AJB20]         Blennerhassett, A.J.
+                   postmaster%aukuni.ac.nz@RELAY.CS.NET
+   [AJC11]         Cole, Andrew J.          AJCOLE@AI.LEEDS.AC.UK
+   [AJC5]          Tso, Ann J.              tsoa@IMO-UVAX.DCA.MIL
+   [AJD14]         D'Adamo, Arthur J.       ---none---
+   [AJS24]         Sprott, Alan John        ---none---
+   [AK36]          Kondo, Akio              akondo@ASEVX1.ASE.SLB.COM
+   [AK62]          Kwok, Alex               ---none---
+   [AK70]          King, Art                ---none---
+   [AK75]          Karna, Amitabh           hjuxa!amit@DECVAX.DEC.COM
+   [AK76]          Kornexl, Anton
+                   PARZ00%DERRZE1.BITNET@CUNYVM.CUNY.EDU
+   [AK78]          Kaul, Ajai               ajai%muffin@CVL.UMD.EDU
+   [AK79]          Kennington, Alan         akenning@PICO.QPSX.OZ.AU
+   [AKC]           Cheng, Albert K.         acheng@A.CS.UIUC.EDU
+   [AKC5]          Costanzo, Albert K.      AL@TURBO.KEAN.EDU
+   [AKP]           Powers, Alan K.          akp@INEL.GOV
+   [AKS31]         Stebbens, Alan K.        AKS@HUB.UCSB.EDU
+   [AKW6]          Welch, Arun K.
+                   welch@TUT.CIS.OHIO-STATE.EDU
+   [AL109]         Liwen, Andrew            liwen@SOFTWARE.ORG
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 116]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [AL16]          Liljeberg, Ake           mcvax!hsn!ake@UUNET.UU.NET
+   [AL6]           Layton, Alexis           alex@XAIT.XEROX.COM
+   [ALA6]          Aman, Alice Lewton       lewton@PRANDTL.NAS.NASA.GOV
+   [AM129]         McDermott, Andrew
+                   andrew%informatics.rutherford.ac.uk@NSS.CS.UCL.AC.UK
+   [AM134]         Mattasoglio, Andrea
+                   mattas%imiclvx.bitnet@ICNUCEVM.CNUCE.CNR.IT
+   [AM139]         Moog, Anja               ---none---
+   [AM151]         McRae, Andrew            ANDREW@MEGADATA.MEGA.OZ.AU
+   [AM154]         Morris, Aled             aledm@CS.RHBNC.AC.UK
+   [AM164]         Ma. Allen                ---none---
+   [AM175]         Moschowits, Avi          AVI@RESEARCH.NEC.COM
+   [AM29]          Mankin, Allison          mankin@GATEWAY.MITRE.ORG
+   [AM54]          MacPherson, Andrew       andre@STL.STC.CO.UK
+   [AM92]          Mott, Arch               ---none---
+   [AM95]          Mooney, Andrew F.        NARDACPENSA@NARDACVA.ARPA
+   [AMF2]          Finley, Alvin M.         1968cs-cc@AFCC-OA1.AF.MIL
+   [AMM14]         Monteiro, Antonio M.     monteiro@GRAF.POLY.EDU
+   [AN31]          Negro, Alberto
+                   alberto%udsab.uucp@UUNET.UU.NET
+   [AN32]          Nudo, Al                 ---none---
+   [AN50]          Nagl, Alfred
+                   nagl!awiwuwll.bitnet@CUNYVM.CUNY.EDU
+   [AP]            Palmer, Annie            doim-tcc@SAAD-EMH1.ARMY.MIL
+   [AP25]          Partan, Andrew           asp@UUNET.UU.NET
+   [AP92]          Petersson, Arne          dennis@INMIC.SE
+   [AP93]          Powell, Andrew           ---none---
+   [AP94]          Pirard, Andre            a-pirard@VM1.EARN-ULG.AC.BE
+   [APT]           Pfeiffer-Traum, Alan     APT@UH.EDU
+   [AR41]          Renard, Annie            fr-zone-contact@INRIA.FR
+   [AR60]          Doyle, Dan               OSDJD@EMORYU1.CC.EMORY.EDU
+   [AR86]          Reinhold, Andreas        ---none---
+   [ARG13]         Galland, A. Ronald       ---none---
+   [ARM5]          Maffei, Andrew R.        arm@aqua.whoi.edu
+   [ARS3]          Silverman, Alan R.       ---none---
+   [AS116]         Schindler, Albert        shindler@UNI2A.UNIGE.CH
+   [AS196]         Schneider, Andrew        ajs@SONY.COM
+   [AS198]         Santilli, Angelo
+                   P1783%CSUOHIO.BITNET@CUNYVM.CUNY.EDU
+   [AS205]         Smith, Adrian            ---none---
+   [AS206]         Silva, Antonio           AI@VX8700.LNEC.RCCN.PT
+   [AS62]          Steiner, Albert
+                   AJS001%NUACC.BITNET@CUNYVM.CUNY.EDU
+   [AS90]          Schoener, Anthony        ---none---
+   [ASG]           Gaylord, Arthur S.       ART@UMASS-GW.CS.UMASS.EDU
+   [ASW3]          Watt, Alan S.            watt-alan@CS.YALE.EDU
+   [AT16]          Tsai, Allen              TSAI@USDCSV.ACUSD.EDU
+   [AT62]          Tedja, Andreas           indovax!andreas@UUNET.UU.NET
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 117]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [AT79]          Torkildsen, Arn          ---none---
+   [AT80]          Hain, Anthony            hain@CCC.MFECC.LLNL.GOV
+   [AT87]          Tan, Andy                tan@LEGEND.EPIC.COM
+   [AV20]          Vilavaara, Asko          vilavaar@RC.NOKIA.FI
+   [AV24]          Vassilicos, Achilles     AV@TCMVAX.USS.COM
+   [AV25]          Venkataraman, Arun
+                   arun%naic.bitnet@CUNYVM.CUNY.EDU
+   [AVDH1]         van der Helder, Andrew
+                   cc_helder%vaxa.mqcc.mq.oz.au@UUNET.UU.NET
+   [AW124]         Wilson, Anne             acw@CISCO.COM
+   [AW48]          Wilcox, Andy             ajw%ufl.csnet@RELAY.CS.NET
+   [AW56]          Waldfogel, Asher         ---none---
+   [AW65]          Whiteman, Alan           ---none---
+   [AW90]          Walker, Amanda           AMANDA@INTERCON.COM
+   [AY11]          Yeh, Arthur
+                   C0298%univscvm.bitnet@CUNYVM.CUNY.EDU
+   [AY21]          Alastair, Young          alastair@ES2.CO.UK
+   [AZ]            Zadeh, Ansari
+                   ansariza%tsuunix.uucp@RICE.EDU
+   [BA26]          Ayres, Bill              ayres@UCS.ORST.EDU
+   [BA51]          Au-Yeung, Ben            ---none---
+   [BA56]          Allen, Brad W.           ulmo@SSYX.UCSC.EDU
+   [BA59]          Alting, Burn
+                   munnari!comperex.comperex.oz.au!burn@UUNET.UU.NET
+   [BA60]          Anderson, Bruce
+                   banderso%sagpd1%ncr-sd%ncrlnk.dayton.ncr.com@
+                   RELAY.CS.NET
+   [BA71]          Archer, Barry            archerb@VAX1.UMKC.EDU
+   [BA77]          Abeel, Bruce             ---none---
+   [BAB7]          Burke, Barry A.
+                   barry%adelie@HARVARD.HARVARD.EDU
+   [BAC9]          Cole, Bruce A.           Hostmaster@CS.WISC.EDU
+   [BAV]           Verser, Brick A.         BAV@KSUVM.KSU.EDU
+   [BB116]         Bjorklund, Barbara       dtsa@NEMS.DT.NAVY.MIL
+   [BB193]         Blackburn, Barry         ---none---
+   [BB194]         Barron, Billy            billy@VAXB.ACS.UNT.EDU
+   [BB208]         Branch, Barry
+                   Barry%servax.bitnet@CUNYVM.CUNY.EDU
+   [BB231]         Butterworth, Brandon     brandon@BBC.CO.UK
+   [BB267]         Burroughs, Brian         brian@T2NS1.GCS.CO.NZ
+   [BB276]         Backer, Brian            ---none---
+   [BB277]         Brunner, Brian           ---none---
+   [BB279]         Baker, Bill              ---none---
+   [BB64]          Boyter, Brian
+                   boyter%bimbo.uucp@VIRGINIA.ACC.VIRGINIA.EDU
+   [BBJ2]          Johnson, Bruce B.
+                   BBJ@CORNELLA.CCS.CORNELL.EDU
+   [BC130]         Capouch, Brian           brianc@SAINTJOE.EDU
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 118]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [BC133]         Crews, Bill              crews@EMX.UTEXAS.EDU
+   [BC14]          Cattani, Robert          cattani@CS.COLUMBIA.EDU
+   [BC173]         Carlsson, Berndt         ---none---
+   [BC176]         Carruthers, Bret         BRC@GCU.EDU
+   [BC177]         Chase, Brokke            BCHASE@CC.UTAH.EDU
+   [BC180]         Cocek, Bruce             ---none---
+   [BC65]          Chiarchiaro, Bill        wjc@XN.LL.MIT.EDU
+   [BC71]          Cheswick, Bill           ches@RESEARCH.ATT.COM
+   [BC72]          Carrihill, Brian         carrhill@NYU.EDU
+   [BD105]         Dofner, Bob              BDofner@NUWES-M1.NAVY.MIL
+   [BD107]         Doughty, Bill            ---none---
+   [BD108]         Davis, Bjoren            BKDAVIS@AURATEK.COM
+   [BD113]         Dietz, Bob               ---none---
+   [BD115]         De Vicente, Belen        belen@TEICE.ES
+   [BD117]         Declourt, Bruno          bde@info.fundp.ac.be
+   [BD55]          Down, Brian
+                   bdown%uturing%toronto.csnet@RELAY.CS.NET
+   [BD89]          Davelaar, Brian          ---none---
+   [BDB8]          Buck, Barry D.           BUCK@HQHSD.BROOKS.AF.MIL
+   [BDH]           Hassler, Barry D.
+                   hassler@NAP1.CDS.WPAFB.AF.MIL
+   [BE10]          Eriksen, Bjorn           ber@SUNIC.SUNET.SE
+   [BE35]          Ehrmantraut, Brian       auspex!bae@UUNET.UU.NET
+   [BE46]          Edmark, Bill             bedmark@ISC.INTEL.COM
+   [BE47]          Edison, Bill
+                   edisonwe%snynewba.bitnet@CUNYVM.CUNY.EDU
+   [BE6]           Esposito, Bob            espo@BPA.BELL-ATL.COM
+   [BEC1]          Chi, Benjamin E.         bec@UACSC2.ALBANY.EDU
+   [BEC5]          Colley, Ben E.
+                   TPMAINT%UMVMB.BITNET@CUNYVM.CUNY.EDU
+   [BF49]          Furrow, Buford           NSC-MCCHORD@DDN2.DCA.MIL
+   [BF81]          Fincher, Bobby           FINCHER@ARO-EMH1.ARMY.MIL
+   [BF91]          Freier, Bob              ---none---
+   [BG101]         Griffith, Bruce          ---none---
+   [BG112]         Brooklin, Gore           ---none---
+   [BG14]          Graff, Charles
+                   bud@HEXSUNFS.C3SYS.ARMY.MIL
+   [BG2]           Goodwin, Bernie          ---none---
+   [BG23]          Greasley, Bud            bud@SQ.SQ.COM
+   [BG25]          Gorman, Bryan            GORMAN@CACFS.ARMY.MIL
+   [BG56]          Gerovac, Brian           ---none---
+   [BGL5]          Lindh, Borje G.          lindh@CTP.SE.IBM.COM
+   [BGW3]          Worden, Brian G.
+                   worden%dkluni85.bitnet@RELAY.CS.NET
+   [BH103]         Hale, Bob                HALE@AFCOST.AF.MIL
+   [BH144]         Halsey, Bridget          bah@BANYAN.BANYAN.COM
+   [BH161]         Hulver, Barron           PHULVER@OBERLIN.EDU
+   [BH162]         Hardy, Ben               ---none---
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 119]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [BH167]         Hughes, Brian            HUGHESB@CSC.ISU.EDU
+   [BH186]         Hartsough, Bruce         BAH@INTERLINK.COM
+   [BH188]         Hutson, Bob              ---none---
+   [BH196]         Henigsen, Brian          ---none---
+   [BH80]          Haanstra, Bruce          ---none---
+   [BHM]           Millar, Brian H.         ---none---
+   [BIM]           Margulies, Benson I.
+                   KSR!BENSON@HARVARD.HARVARD.EDU
+   [BJL5]          Lustig, Barry J.         BARRY@ADS.COM
+   [BJN1]          Walker, Bruce            bruce@THINK.COM
+   [BJORK]         Bjork, Steven W.         BJORK@NIC.DDN.MIL
+   [BJR2]          Russell, Bill J.         RUSSELL@NYU.EDU
+   [BJW8]          Ward, Bobby J., Jr.
+                   asqj-sot-amo@BUCKNER-EMH1.ARMY.MIL
+   [BK102]         Kelley, Brian            ---none---
+   [BK29]          Kantor, Brian            brian@UCSD.EDU
+   [BK76]          Kaye, Brian
+                   BDK%UNB.CA@CORNELLC.CCS.CORNELL.EDU
+   [BK78]          Kelton, Bruce
+                   munnari!pta.oz.au!bruce@UUNET.UU.NET
+   [BK85]          Kain, Bill               ---none---
+   [BK88]          Kobler, Ben              ---none---
+   [BK98]          Klebert, Bengt           ---none---
+   [BKR]           Reid, Brian K.           Reid@DECWRL.DEC.COM
+   [BL118]         Lortz, Bruno
+                   lortz@RUS.UNI-STUTTGART.DBP.DE
+   [BL31]          Lemley, Bob
+                   LEMLEYR@BAYLOR.CCIS.BAYLOR.EDU
+   [BL92]          Lord, Bob                lord@ANDERSEN.COM
+   [BLW2]          Wilson, Bennett L.       ---none---
+   [BM106]         Mulligan, Brian
+                   brian%sphinx.co.uk@EDDIE.MIT.EDU
+   [BM156]         Mondics, Brian           MONDICS@TLSUNB0.TARTAN.COM
+   [BM164]         McDougal, Bruce          ---none---
+   [BM168]         Manderville, Bernie      ---none---
+   [BM178]         Murphy, Bernie
+                   BMURPHY%BNR.CA@CORNELLC.CCS.CORNELL.EDU
+   [BM211]         Mizrahi, Benzi
+                   VSBENZI%WEIZMANN.BITNET@CUNYVM.CUNY.EDU
+   [BM230]         Mania, Bill              WJM@HTC.COM
+   [BM68]          Murray, Burton           ---none---
+   [BM79]          Michie, Bob              bob@NJITSC1.NJIT.EDU
+   [BML2]          Liblong, Breen M.
+                   liblong@GAEA.WEST.SYMBOLICS.COM
+   [BMV]           Vance, Bill M.           ---none---
+   [BMW13]         Wallack, Barry M.        DCA-JP@DCA-EMS.DCA.MIL
+   [BMW7]          Wilber, B. Michael       wilber@SCORE.STANFORD.EDU
+   [BN38]          Nelson, Brian            brian@UOFT02.UTOLEDO.EDU
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 120]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [BN4]           Nowicki, Bill            nowicki@Legato.COM
+   [BNL1]          Lawrence, Bryan N.
+                   postmaster@CANTERBURY.AC.NZ
+   [BO26]          Olausson, Bengt
+                   euaunix@EUAS12.ERICSSON.SE
+   [BO3]           Oesterlin, Bob           oester@IBM.COM
+   [BO34]          O'Neil, Bob              ---none---
+   [BO5]           Ogilvy-Morris, Bruce
+                   bom%rsre.mod.uk@RELAY.MOD.UK
+   [BP123]         Pike, Brian              bpike@MORGAN.COM
+   [BP32]          Brightbill, Patricia L.  brightbi@HQ.AF.MIL
+   [BP42]          Powell, Brian Hill       brian@NATINST.COM
+   [BP52]          Parker, Brad             brad@CAYMAN.COM
+   [BP57]          Payne, Bob               bpayne@NRAO.EDU
+   [BPW1]          Wright, Bradley P.
+                   AFDDN.WRIGHT@GUNTER-ADAM.AF.MIL
+   [BR104]         Reinhold, Barry          bbr@UNH.EDU
+   [BR106]         Rainey, Bill             bill@WYSE.COM
+   [BR109]         Ryan, Bobbie             ---none---
+   [BR113]         Rawson, Bryan
+                   cepu!litvax!rawson@SEAS.UCLA.EDU
+   [BR118]         Renk, Burkhard
+                   RENK%DMZNAT51.BITNET@CUNYVM.CUNY.EDU
+   [BR79]          Rhoades, Bradley D.      bdrhoades@MMC.MMMG.COM
+   [BR87]          Ruptash, Brian           bar@DATAPOINT.COM
+   [BR88]          Reid, Bill               Reid@CCM.UMANITOBA.CA
+   [BR92]          Rubin, Bill              RUBIN@IBM.COM
+   [BRA2]          Arnold, Billie R.        OACS-SYS@AFCC-OA2.AF.MIL
+   [BRB8]          Bangaru, Babu R.         ---none---
+   [BS156]         Sandholm, Bo-Erik
+                   enea!erix.ericsson.se!bosse@UUNET.UU.NET
+   [BS157]         Stoltz, Bill             stoltz@IDA.ORG
+   [BS168]         Stewart, Bruce           bruce@BIKINI.CIS.UFL.EDU
+   [BS196]         Schmid, Bernard          ---none---
+   [BS214]         Solomon, Brad            ---none---
+   [BS217]         Schuller, Bernhard
+                   unido!konech!netz@UUNET.UU.NET
+   [BS220]         Stewart, Blake           BLAKE@NTUPUB.NTU.EDU
+   [BS24]          Shein, Barry             BZS@BU-CS.BU.EDU
+   [BS69]          Sweeny, Brent R.         SWEENY@UCS.INDIANA.EDU
+   [BSA2]          Anderson, Brian S.
+                   Andersonb@WRAIR-EMH1.ARMY.MIL
+   [BSP6]          Patel, Bharat S.         ---none---
+   [BSR]           Ridout, Brian S.         RIDOUT@USERVX.AFWL.AF.MIL
+   [BSW]           Seeber-Wagner, Barbara N.bnsw@MBUNIX.MITRE.ORG
+   [BT5]           Tomlinson, Bob           tomlin@HC.DSPO.GOV
+   [BT65]          Tehan, Brian             ---none---
+   [BT78]          Turini, Bill             ---none---
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 121]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [BV15]          Volz, Bernard            VOLZ@PROCESS.COM
+   [BV17]          Victor, Bjorn            victor@DOCS.UU.SE
+   [BV4]           Vagnerini, Beverly
+                   bvagneri@LETTERKENN-EMH1.ARMY.MIL
+   [BW134]         Wilder, Bill             WDW@ACADIAU.CA
+   [BW138]         Wolfe, Brian             brian@HFH.EDU
+   [BW142]         Wrenn, Bill              ---none---
+   [BW143]         Warner, Bill             ---none---
+   [BW157]         Wall, Byron              bwall@CRAYCOS.COM
+   [BW158]         Wilson, Bernard          bernard@PLEIADES.OZ.AU
+   [BW164]         Worobey, Brian
+                   brianw%bcvmcms.bitnet@CUNYVM.CUNY.EDU
+   [BW168]         White, Barry             ---none---
+   [BW4]           Webb, Barry
+                   galbp!gelac!bwebb@GATECH.EDU
+   [BWA]           Allen, Bobby W.          allen@YUMA-EMH1.ARMY.MIL
+   [BWS2]          Schilling, Bruce W.      NSC-Kees@DDN3.DCA.MIL
+   [BY20]          Young, Bradford          ---none---
+   [CA29]          Aronson, Cathy           cja@MERIT.EDU
+   [CA80]          Annable, Conni
+                   annable@THORIN.HSCSA.UTEXAS.EDU
+   [CA84]          Arbaugh, Clinton
+                   cea%pizza@B.CS.WVU.WVNET.EDU
+   [CAC55]         Colona, Chris A.         ---none---
+   [CAD10]         Diak, Christie           Diak@ST-LOUIS-EMH4.ARMY.MIL
+   [CAD13]         DeFranco, Carl A., Jr.   defranco@TOPS20.RADC.AF.MIL
+   [CAF13]         Finseth, Craig A.        fin@UNET.UMN.EDU
+   [CAL3]          Leres, Craig A.          leres@HELIOS.EE.LBL.GOV
+   [CAL7]          Leach, Charles A.        CAL@OKC-UNIX.AF.MIL
+   [CAP5]          Puchon, Charles A.       ---none---
+   [CAS1]          Steffey, Skeet           csteffey@WSMR-EMH05.ARMY.MIL
+   [CB162]         Beame, Carl              beame@MCMASTER.CA
+   [CB180]         Bevins, Craig            craigb@IPSO.IPS.OZ.AU
+   [CB19]          Brooks, Charles E.       brooks@EDN-VAX.DCA.MIL
+   [CB201]         Brigham, Craig           ---none---
+   [CB217]         Bloomfield, Carl         ---none---
+   [CB222]         Brown, Craig
+                   brownca%snymorba@CUNYVM.CUNY.EDU
+   [CB42]          Ball, Charles            cball@INMET.INMET.COM
+   [CB50]          Bode, Carsten            cb@SYSTEC.DE
+   [CBD]           Dawson, Clive B.         Clive@MCC.COM
+   [CBL4]          Lawrence, Charles B.     chas@MBIR.BCM.TMC.EDU
+   [CBR2]          Ray, Charles B.          ---none---
+   [CC108]         Clanton, Charles         ---none---
+   [CC129]         Cline, Carol
+                   s5000!kline%mscunx.sp.unisys.com@RELAY.CS.NET
+   [CC185]         Caldwell, Christopher    CHRIS@STELLAR.STELLAR.COM
+   [CC192]         Campadore, Craig
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 122]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+                   cacampa@VMS2.MNET.USWEST.COM
+   [CC241]         Campbell, Colin          ---none---
+   [CC249]         Cline, Carol             ---none---
+   [CC252]         Collins, Colman
+                   collinsc%itd1.ul.ie@CUNYVM.CUNY.EDU
+   [CC89]          Chaundy, Chris
+                   munnari!ucsvc.ucs.unimelb.edu.au!chris@UUNET.UU.NET
+   [CC99]          Catlett, Charlie         catlett@NCSA.NCSA.UIUC.EDU
+   [CCL8]          LaPlante, Christine C.   ---none---
+   [CD75]          Dowat, Cary              DOWAT@FNNET.FNAL.GOV
+   [CDS28]         da Silva, Chris          ---none---
+   [CE41]          Erickson, Chris          ---none---
+   [CE42]          Erbacher, Claude         ---none---
+   [CE52]          Ess, Charles
+                   dru001d%smsvma.bitnet@UMRVMB.UMR.EDU
+   [CE55]          Echard, Chris            CBE100T@ODUVM.CC.ODU.EDU
+   [CE56]          Edwards, Champe          ---none---
+   [CEB13]         Brooks, Charles E.       CEB@WDL1.FAC.FORD.COM
+   [CF35]          Fung, Charles            cxf@SUNSPOT.RIT.EDU
+   [CF4]           Frost, Cliff
+                   cliff%UCBCMSA.Berkeley.EDU@JADE.Berkeley.EDU
+   [CF57]          Fernandez, Carlos
+                   Fernandez@DDNVX2.AFWL.AF.MIL
+   [CF64]          Frisinger, Chris         cfrisinger@DSAC.DLA.MIL
+   [CFB1]          Brandt, Carl F.
+                   carl%lsumvs.bitnet@CUNYVM.CUNY.EDU
+   [CFD4]          Dunn, Charles F.         CHUCK@UBVM.CC.BUFFALO.EDU
+   [CFM1]          Muckenhirn, Carl F.
+                   Muckenhirn@DOCKMASTER.NCSC.MIL
+   [CG1]           George, Calvin           GEORGE@HQAFSC-VAX.AF.MIL
+   [CG105]         Gibson, Coyne            coyne@CONVEX.COM
+   [CG107]         Gibbs, Charles           chuckg@LUNDY1.VLSI.COM
+   [CG24]          Generous, Curtis         GENEROUS@DEV.DTIC.DLA.MIL
+   [CG64]          Garrigues, Chris         7thSon@SLCS.SLB.COM
+   [CG85]          Grossarth, Clyde         ---none---
+   [CGT2]          Taylor, Clement
+                   CGTAYLO!ERENJ.BITNET@CUNYVM.CUNY.EDU
+   [CH102]         Henderson, Clarence      HENDERSON@GTEWD.AF.MIL
+   [CH170]         Heck, Chuck              CHUCK@PRISM.CLEMSON.EDU
+   [CH181]         Hayward, Chris           ---none---
+   [CH191]         Hwang, Charlie           ---none---
+   [CH2]           Hornig, Charles          Hornig@SYMBOLICS.COM
+   [CH205]         Harden, Cliff            ---none---
+   [CH207]         Hohmann, Christian
+                   HOHMANN%WABOLU.UUCP%TUB.BITNET@MITVMA.MIT.EDU
+   [CH225]         Hemann, Chuck            ---none---
+   [CH226]         Hartness, Clark          chartness@BBN.COM
+   [CH232]         Haigh, Chris             ---none---
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 123]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [CH233]         Hackbart, Chris          hackbart@VMS.MACC.WISC.EDU
+   [CHC7]          Cheng, C. H.
+                   hkucs!cucsc!a563700@UUNET.UU.NET
+   [CHW]           Wilson, Charles H.       cwilson@BRL.MIL
+   [CJ38]          Johnson, Chris           johnson@NORTHEASTERN.EDU
+   [CJ57]          Johnson, Charles         crj@ICAD.COM
+   [CJB1]          Baker, Christopher J.    BAKERC@UV4.EGLIN.AF.MIL
+   [CJB15]         Bedore, Clifford J., III isavax!cliffb@UMD5.UMD.EDU
+   [CJC31]         Copeland, Cecil J.
+                   MMDF@STUTTGART-EMH1.ARMY.MIL
+   [CJL2]          Lydick, Carl J.          carl@CITHEX.CALTECH.EDU
+   [CJW2]          Weinstein, Clifford J.   cjw@SST.LL.MIT.EDU
+   [CK113]         Calle, Claus
+                   A0061!DKORRZKO.BITNET@CUNYVM.CUNY.EDU
+   [CK116]         Kemp, Charlie            ---none---
+   [CK117]         King, Chenghu            ---none---
+   [CK119]         Kranz, Christopher       clk@GFDL.PRINCETON.EDU
+   [CK2]           Kukulies, Christoph
+                   JYJYKUWA%DACTH51.BITNET@CUNYVM.CUNY.EDU
+   [CK92]          Kim, Chankyu
+                   knmc%sorak.kaist.ac.kr@RELAY.CS.NET
+   [CK96]          Kaulfuss, Christoph
+                   WZ00600%DWOURZ0.BITNET@CUNYVM.CUNY.EDU
+   [CL11]          Lindblad, Chris          CJL@AI.AI.MIT.EDU
+   [CL115]         Lee, Chun-mou            ---none---
+   [CL134]         Liem, Chandra
+                   CCECL%NUSVM.BITNET@CUNYVM.CUNY.EDU
+   [CL64]          Lynch, Clifford
+                   lynch@POSTGRES.Berkeley.EDU
+   [CL80]          Leser, Christoph
+                   leser%comvax.rus.uni-stuttgart.dbp.de@RELAY.CS.NET
+   [CLB36]         Beckman, Connie L.
+                   beckman%ceramics.bitnet@CUNYVM.CUNY.EDU
+   [CLH3]          Hedrick, Charles L.      HEDRICK@ARAMIS.RUTGERS.EDU
+   [CLP18]         Peterson, Chris L.       33CGDLNA@SACEMNET.AF.MIL
+   [CLR16]         Rossmark, Carl L.        ddnmgr@ADELPHI-IM2.ARMY.MIL
+   [CLV7]          Vaughan, Clifton L.
+                   vaughan!mcoiarc.bitnet@CUNYVM.CUNY.EDU
+   [CM115]         McDonald, Catherine M.   DDNMGR@ADELPHI-IM2.ARMY.MIL
+   [CM116]         Moret, Christophe
+                   sysgeg%frpoly11.bitnet@CUNYVM.CUNY.EDU
+   [CM130]         Maeckel, Clay            clay@CLARIS.COM
+   [CM144]         Manners, Chris           ---none---
+   [CM153]         Maltby, Chris
+                   chris%softway.sw.oz.au@UUNET.UU.NET
+   [CM156]         Michau, Christian
+                   UCIR059%FRORS31.BITNET@CUNYVM.CUNY.EDU
+   [CM226]         Mackerell, Chris         ---none---
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 124]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [CM50]          Minnick, Connie
+                   acs_connie%jmuvax1.bitnet@CORNELLC.CIT.CORNELL.EDU
+   [CM57]          Maxson, Charles          maxson@CFA.HARVARD.EDU
+   [CMG9]          Glickman, Charles M.
+                   glickman%evax2@RVAX.CCIT.ARIZONA.EDU
+   [CN33]          Nelson, Christopher
+                   daslink!dasnet!dci2cn!chrisn@SUN.COM
+   [CNK1]          Kafai, Corinna N.        cmcvax!corinna@HUB.UCSB.EDU
+   [CO16]          Olson, Chris             ---none---
+   [COV1]          Vargas, Chris O.         VARGASC@GW2.HANSCOM.AF.MIL
+   [CP108]         Peckham, Clarence        ---none---
+   [CP129]         Pellett, Chert
+                   chert!spdyne.uucp@UUNET.UU.NET
+   [CP130]         Palmer, Cam              ---none---
+   [CP131]         Pontzer, Chris           ---none---
+   [CPK3]          Kolb, Christopher P.     KOLB@PSI.COM
+   [CR127]         Rice, Craig              CDR@ACC.STOLAF.EDU
+   [CR129]         Rigney, Carl             cdr@AMDCAD.AMD.COM
+   [CR140]         Ritson, Chris            C.R.Ritson@NEWCASTLE.AC.UK
+   [CR157]         Richards, Charles
+                   charles!hartford.bitnet@CUNYVM.CUNY.EDU
+   [CR159]         Christopher, Riley       ---none---
+   [CR24]          Rokitansky, Carl-Herbert
+                   roki%DHAFEU52.BITNET@CUNYVM.CUNY.EDU
+   [CR83]          Reynolds, Christine      quirk@HUBCAP.CLEMSON.EDU
+   [CRC15]         Campbell, Charles R.
+                   GS0004%SIUCVMB.BITNET@CUNYVM.CUNY.EDU
+   [CRC9]          Craig, C. Robert         ROBERT@VM1.MCGILL.CA
+   [CRJ5]          Jacobsen, Carl R.        pslvax!carl@UCSD.EDU
+   [CRT4]          Tettemer, Clair R., Jr.  tettemer@NOSC.MIL
+   [CRW12]         Wiener, Christopher R.   cwiener@CRLABS.COM
+   [CS136]         Stokely, Celeste         cstokely@COHERENT.COM
+   [CS218]         Schrimpe, Clemens        csch@NETCS.COM
+   [CS219]         Shak, Clifton            ---none---
+   [CS275]         Sevcik, Carlos           ---none---
+   [CS276]         Schall, Cliff
+                   aad002a%calstate.bitnet@CUNYVM.CUNY.EDU
+   [CS277]         Stevens, Craig           ---none---
+   [CS279]         Spell, Charlie           ---none---
+   [CSG]           Gutekunst, Carl S.       csg@PYRAMID.COM
+   [CSS28]         Smith-Stubbs, Clyde      clyde@HITECH.HT.OZ.AU
+   [CT100]         Tadema, C.               ruud@NEDDATA.NL
+   [CTJ2]          Johnson, Christopher T.  ---none---
+   [CTP1]          Poole, Clyde T.          ctp@CS.UTEXAS.EDU
+   [CV14]          Verboom, Charles         ---none---
+   [CV25]          Vaillancourt, Clement    vaillan@IREQ.HYDRO.QC.CA
+   [CVG1]          van Gennip, Chel
+                   gennip%hlerul54.bitnet@CUNYVM.CUNY.EDU
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 125]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [CW115]         Wacker, Claude
+                   CCWACKER%CNEDCU51.BITNET@CUNYVM.CUNY.EDU
+   [CW159]         Whitelaw, Chandler       WHITELAW@CC.SUSC.EDU
+   [CW166]         Wilson, Craig            craig@C2S.MN.ORG
+   [CW169]         Wilson, Chris            cwilson@AUSTEK.OZ.AU
+   [CW42]          Welty, Chris             WELTYC@CS.RPI.EDU
+   [CWH3]          Hunt, Craig W.           Hunt@ENH.NIST.GOV
+   [CWM17]         Moser, C.W.              ---none---
+   [CWR4]          Reece, Carole Warner     ---none---
+   [CWV1]          Vertrees, Charles        CVERTREE@ORION.OAC.UCI.EDU
+   [CY29]          Yuen, Chun               ---none---
+   [CY30]          Yamaoka, Cliff           ---none---
+   [CYH]           Huang, Chien Y.
+                   6026959%PUCC.BITNET@CUNYVM.CUNY.EDU
+   [DA106]         Aebersold, Dennis
+                   DAEBERSO@BIGBIRD.CC.WILLIAMS.EDU
+   [DA124]         Anderson, David          dave@UCI.MN.ORG
+   [DA128]         Abts, Daniel             ABTSACS@LAX.WISC.EDU
+   [DA73]          Alter, Diane             diane@RTECH.COM
+   [DAA14]         Abbajay, David A.
+                   hplabs!oracle!hqsun1!booger!dabbajay@SUN.COM
+   [DAE2]          Ernest, Dwight A.
+                   dwight%independent.uucp@UKC.AC.UK
+   [DAF9]          Futcher, Debbie A.       DFUTCHE@RELAY.NSWC.NAVY.MIL
+   [DAR20]         Roth, Dean A.
+                   lakesys!deanr@CSD1.MILW.WISC.EDU
+   [DAS13]         Sanders, Daun A.
+                   SANDERS@WESTPOINT-EMH1.ARMY.MIL
+   [DAT4]          Thomae, Doug A.          ---none---
+   [DAVE]          Roode, R. David          Roode%orc.uucp@UNIX.SRI.COM
+   [DB]            Brack, Dave              DBRACK@NARDACDC002.NAVY.MIL
+   [DB162]         Black, David             ---none---
+   [DB186]         Brooks, Doug             brooks@CERL.CECER.ARMY.MIL
+   [DB211]         Boss, Don                ---none---
+   [DB263]         Badrick, Dave            ---none---
+   [DB273]         Baker, Darryl            dpb@TELLABS.CHI.IL.US
+   [DB296]         Brown, David             david%pyr@GATECH.EDU
+   [DB310]         Base, David              dbase@WASH-VAX.BBN.COM
+   [DB317]         Bradt, Donna
+                   DBRADT%EMRCAN.BITNET@CORNELLC.CCS.CORNELL.EDU
+   [DB322]         Bergstrom, Darryl        hi-csc!bergstr@UMN-CS.ARPA
+   [DB333]         Balafas, Dino            ---none---
+   [DB343]         Baillie, Duncan          dmb@AMTHQ.CO.UK
+   [DB346]         Boehlke, Dan
+                   dan%gacvax1.bitnet@VM1.NODAK.EDU
+   [DB35]          Braniss, Danny           danny@HUMUS.HUJI.AC.IL
+   [DB374]         Bovio, Daniele           HI@IMISIAM.MI.CNR.IT
+   [DB380]         Bodley, Derrill          dgb@UOP.UOP.EDU
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 126]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [DB97]          Bergum, David I., Jr.
+                   Bergum@CIM-VAX.HONEYWELL.COM
+   [DBH11]         Hearn, David B.          HEARN@CCINT1.RSRE.MOD.UK
+   [DBJ4]          Johnson, David B.        drilltech!dbj@RICE.EDU
+   [DBL1]          Long, Daniel B.          LONG@BBN.COM
+   [DBM16]         Martin, Darrell B.       darrell@HACGATE.SCG.HAC.COM
+   [DC115]         Comay, David S.          dsc@SEISMO.CSS.GOV
+   [DC126]         Cogger, Dick             rhx@CORNELLC.CIT.CORNELL.EDU
+   [DC145]         Crawford, Dennis         crawford@LBNSY.NAVY.MIL
+   [DC159]         Clar, Daniel
+                   CLAR%FRESE51.BITNET@CUNYVM.CUNY.EDU
+   [DC211]         Capshaw, David           Capshaw@AUSTIN.LOCKHEED.COM
+   [DC257]         Carrasco, Denis          ---none---
+   [DC272]         Catalano, Don            ---none---
+   [DC273]         Chandler, Douglas        ---none---
+   [DC285]         Cica, Daniel             XXCICA@EARTH.LERC.NASA.GOV
+   [DC298]         Condon, David            COMMS@UK.AC.SBANK.VAX
+   [DC303]         Clampitt, Dustin         JDC@LIANT.COM
+   [DC304]         Carpe, David             ---none---
+   [DC305]         Comte, David
+                   davelec%exicom.oz@MURTOA.CS.MU.OZ
+   [DC306]         Caruso, David
+                   caruso%GAV.MFENET@CCC.NMFECC.GOV
+   [DC307]         Cairns, David            CAIRNS@UPEI.CA
+   [DC310]         Clark, Don               ---none---
+   [DC316]         Crawford, Dave           DJC@CSUN.EDU
+   [DC99]          Chan, David              chan@BEK-MC.CALTECH.EDU
+   [DCL10]         Loughry, Donald C.
+                   don_loughry%hp6600@HPLABS.HP.COM
+   [DCM20]         Menges, David C.         ---none---
+   [DCMW]          Wood, David CM           DCMWOOD@SPOT.COLORADO.EDU
+   [DCN19]         Nicosia, David C.        dave@VISTA.COM
+   [DCS]           Swinehart, Daniel C.     Swinehart.PA@XEROX.COM
+   [DCW23]         Winegarden, David C.     ---none---
+   [DCW25]         Walls, David C.
+                   pxl!WIDNER!BITNET@CUNYVM.CUNY.EDU
+   [DCW9]          Wells, Donald C.         dwells@NRAO.EDU
+   [DD11]          Deal, Don                don@PYR.GATECH.EDU
+   [DD112]         Deeth, Dave              ---none---
+   [DD223]         Dixon, Dixk
+                   DIXON!UKECMWF.BITNET@CUNYVM.CUNY.EDU
+   [DD230]         DeLarue, Durwin          delarue@UTOS.NM.COM
+   [DD233]         Dixon, Dick              CPQHOU!DIXON@UUNET.UU.NET
+   [DD237]         Datlowe, Dayton
+                   datlowe@LOCKHD.DNET.NASA.GOV
+   [DD38]          Danahy, Daniel J.        DANAHY@AFSC-SSD.AF.MIL
+   [DD41]          DeGrossa, Dan            NSC-Huen@DDN2.DCA.MIL
+   [DD63]          Dorosz, Dave             dorosz@GW2.HANSCOM.AF.MIL
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 127]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [DDC1]          Clark, David D.          ddc@LCS.MIT.EDU
+   [DDK1]          Knight, Donald D.        CC-SI@EDWARDS-2060.AF.MIL
+   [DDK7]          Koch, David D.
+                   KOCHD%LAWRENCE.BITNET@CUNYVM.CUNY.EDU
+   [DE80]          Edgar, Dale
+                   dedgar%mta.bitnet@UGW.UTCS.UTORONTO.CA
+   [DE81]          Eastick, Douglas         eastick@ME.UTORONTO.CA
+   [DEA]           Anselmi, David E.
+                   DANSELMI@HUACHUCA-EMH8.ARMY.MIL
+   [DEP17]         Page, Daniel E.
+                   DEPAGE%USMCP6.BITNET@CORNELLC.CCS.CORNELL.EDU
+   [DES41]         Shafer, Don E.           e41276%rlvax1@LANL.GOV
+   [DES43]         Smith, Daniel E.
+                   des%uno.bitnet@CUNYVM.CUNY.EDU
+   [DET]           Towson, David E.         TOWSON@BRL.MIL
+   [DF130]         Foster, Doug             ---none---
+   [DF133]         Ferguson, Dennis         dennis@UTCS.UTORONTO.CA
+   [DF149]         Fernie, Derek
+                   MITEL!SPOCK!FERNIE@UUNET.UU.NET
+   [DF158]         Floer, Douglas           ---none---
+   [DF162]         De Fries, Dennis         ---none---
+   [DF180]         Farr, Dennis             ---none---
+   [DF71]          Fordyce, David           fordyce@CSC.TI.COM
+   [DF86]          Faunt, Doug              FAUNT@CISCO.COM
+   [DF90]          Finkelson, Dale          dmf@WESTIE.UNL.EDU
+   [DG110]         Galloway, David          DRG@CSRI.TORONTO.EDU
+   [DG146]         Goodman, Dean            ---none---
+   [DG152]         Garvey, Dick             rgarvey@BBN.COM
+   [DG163]         Goodwin, Dave            CODE62@NARDACVA.NAVY.MIL
+   [DG177]         Gallaher, Dale           dale@DANDELION.CI.COM
+   [DG212]         Gawler, Dean             ---none---
+   [DG28]          Gehrt, David L.          ---none---
+   [DGA]           Anderson, Dinah G.       dinah@BCM.TMC.EDU
+   [DGL4]          Loudon, Dennis G.        ---none---
+   [DGT6]          Taylor, David G.         taylor@RAND.ORG
+   [DH17]          Hirsch, Douglas E.       DHIRSCH@BBN.COM
+   [DH23]          Hayes, David S.          hayes@SMU.EDU
+   [DH241]         Henize, Dewey            ---none---
+   [DH296]         Hawking, David
+                   munnari!anucsd.oz.au!dave%rigel@uunet.UU.NET
+   [DH303]         Henning, Doug            ---none---
+   [DH309]         Hoffmann, Dan            SYSADMIN@ZEUS.UNOMAHA.EDU
+   [DH313]         Helda, David
+                   garbo!helda%jimmy@BESS.HARVARD.EDU
+   [DH322]         Harris, Dean             ---none---
+   [DI11]          Incerti, Dominique       ---none---
+   [DID1]          Dalva, David I.          dave@TIS.COM
+   [DIM2]          Meiron, Daniel I.        Meiron@DIPOLE.CALTECH.EDU
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 128]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [DJ104]         Janes, Dave              dave@KEAN.MUN.CA
+   [DJ115]         Jones, Dave
+                   RDJONE01!ULKYVM.BITNET@CUNYVM.CUNY.EDU
+   [DJ24]          Jent, David
+                   idej400%indycms.bitnet@CUNYVM.CUNY.EDU
+   [DJ99]          Jordt, Dan               DANJ@CAC.WASHINGTON.EDU
+   [DJB34]         Banta, Dean J.           ---none---
+   [DJD30]         Dawson, Dana J.          dana@CRAY.COM
+   [DJF]           Farber, David J.         farber@CIS.UPENN.EDU
+   [DJG2]          Grim, Daniel J.          grim@HUEY.UDEL.EDU
+   [DJK13]         Kaufman, David           ---none---
+   [DJS7]          Schmidt, Detlef J.
+                   C0033003%DBSTU1.BITNET@CUNYVM.CUNY.EDU
+   [DJV1]          Van Buer, Darrel J.      VANBUER@ECLA.USC.EDU
+   [DK101]         Koblas, David            koblas@MIPS.COM
+   [DK112]         Keller, Debbie           KELLER@VM1.CC.UAKRON.EDU
+   [DK116]         Kasielke, Dieter
+                   108%db0tuz01.bitnet@CUNYVM.CUNY.EDU
+   [DK142]         Karsten, Dale
+                   dale%msus1.bitnet@CUNYVM.CUNY.EDU
+   [DK168]         Kuncicky, David          KUNCICK@NU.CS.FSU.EDU
+   [DK2]           Krafft, Dean B.          dean@GVAX.CS.CORNELL.EDU
+   [DK5]           Kirby, Diana             ---none---
+   [DK60]          Kain, David              GATE@PHILASHPYD-POE.NAVY.MIL
+   [DK70]          Kirschen, Dave           kirschen@MULTIMAX.ARPA
+   [DKE2]          Ely, David K.            dely@NRI.RESON.VA.US[hko
+   [DL164]         Lewis, Donn              LEWIS@PMS312.NAVSEA.NAVY.MIL
+   [DL169]         Lamb, David              ---none---
+   [DL170]         Lavender, David          ---none---
+   [DL178]         Lang, Dick               ---none---
+   [DLL32]         Lippke, David L.         lippke@UTDALLAS.EDU
+   [DLM1]          Mills, Dave              MILLS@HUEY.UDEL.EDU
+   [DLM34]         Merrifield, David L.     DM06900@UAFSYSB.UARK.EDU
+   [DLN12]         Nash, Donald L.          don@THENIC.THE.NET
+   [DLS20]         Smith, David L.          celerity!dave@UCSD.EDU
+   [DLS24]         Stockdale, Diana L.      diana@KANGA.AGI.ORG
+   [DLW31]         Wasley, David L.         dlw@VIOLET.Berkeley.EDU
+   [DM147]         Morales, Dan             ---none---
+   [DM232]         Morrison, David          sysnet@CC.NU.OZ.AU
+   [DM249]         Morley, David
+                   munarri!aaii.oz.au!morley@UUNET.UU.NET
+   [DM259]         McDonald, D.
+                   D.McDonald%vaxa.strath.ac.uk%ukacrl.bitnet@
+                   CUNYVM.CUNY.EDU
+   [DM261]         Mann, Dale               Mann@SPAM.ISTC.SRI.COM
+   [DM269]         McCrave, Donna           mccrave@KODAKR.KODAK.COM
+   [DM27]          McCallum, Doug           mccallum@ICO.ISC.COM
+   [DM273]         Minnich, David           DWM@FIBERCOM.COM
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 129]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [DM28]          Morris, Dennis           Morrisd@IMO-UVAX.DCA.MIL
+   [DM280]         Mackie, Dave             lupine!djm@UUNET.UU.NET
+   [DM313]         McCord, David
+                   portal!cup.portal.com!david@SUN.COM
+   [DM334]         Morse, Duane             ---none---
+   [DM335]         Mutterer, David          rylos!dave@RUTGERS.EDU
+   [DM348]         Molinelli, Daniel        moline@TRWIND.IND.TRW.COM
+   [DM35]          Millard, David A.
+                   asbp%dmillard@SHAFTER-EMH2.ARMY.MIL
+   [DM353]         Matties, Deborah         matties@IBM.COM
+   [DM354]         McWilliam, Don           mcwillm@CC.UBC.CA
+   [DM356]         Murdock, Dominic         ---none---
+   [DM357]         McEwan, Duncan           postmaster@SIESOFT.CO.UK
+   [DM358]         Margossian, David        margosd@POLAROID.COM
+   [DM373]         Moline, David            drm@GAIA.GCS.OZ.AU
+   [DM75]          Murphy, Dave             murphy@MGHCCC.HARVARD.EDU
+   [DM84]          Morris, Don              morris@NCAR.UCAR.EDU
+   [DMH20]         Herron, David M.
+                   BNM|lackland-aim1@LACKLAND-AIM1.AF.MIL
+   [DMK18]         Keirsey, David M.        Keirsey@ECLA.USC.EDU
+   [DN32]          Nordlund, Dave
+                   NORDLUND%UKANVM.BITNET@CUNYVM.CUNY.EDU
+   [DN71]          Nastoll, Dieter
+                   hrz100%de0hrz1a.bitnet@CUNYVM.CUNY.EDU
+   [DN78]          Nabinger, Dick
+                   nabingrw%snydelba.bitnet@CUNYVM.CUNY.EDU
+   [DO26]          O'Reilly, Dennis         Dennis_O'Reilly@MTSG.UBC.CA
+   [DO27]          Oliver, David
+                   ansa%alvey.uk@NSS.CS.UCL.AC.UK
+   [DO66]          O'leary, David           oleary@NOSC.SURA.NET
+   [DOR]           Rowley, D. Owen          acad!lux!owen@UUNET.UU.NET
+   [DP149]         Phipps, David            davidp@METRO.UCC.SU.OZ.AU
+   [DP154]         Phelps, Duane            phelps@MAXTOR.COM
+   [DP171]         Phillipps, Dan           ---none---
+   [DP173]         Pokorney, Dave           POKE@NERVM.NERDC.UFL.EDU
+   [DP178]         Poirier, Daniel          POIRIED@UMONCTON.CA
+   [DP2]           Pirtle, David A.         PIRTLE@KL.SRI.COM
+   [DP7]           Parter, David            dparter@URBANA.MCD.MOT.COM
+   [DP71]          Palus, David             ---none---
+   [DR137]         Rageth, David            DAVE@MMC.COM
+   [DR161]         Reese, Dave              DAVE@CALSTATE.EDU
+   [DR183]         Ruth, Doug               ruth@ROBOTX.SRI.COM
+   [DR212]         Ruppert, Deborah         nsun1!deborah@CSE.OGC.EDU
+   [DR214]         Reavil, David
+                   D_J_REAVIL%ARE-PN.MOD.UK@RELAY.MOD.UK
+   [DR217]         Rich, Daniel             DRICH@DIALOGIC.COM
+   [DR229]         Ray, David               ---none---
+   [DR230]         Ruiu, Dragos             dr@MYRIAS.COM
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 130]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [DR49]          Reynolds, Dick           hcx1!dick@UUNET.UU.NET
+   [DR71]          Rettig, Duane            ---none---
+   [DRE4]          Ehrlich, Daniel Robert   ehrlich@CS.PSU.EDU
+   [DRH48]         Hudson, Donald R.
+                   drh%latech@REX.CS.TULANE.EDU
+   [DRM24]         Meadows, Don             qncdsin@SAAD-EMH1.ARMY.MIL
+   [DRM31]         Miller, David R.         ---none---
+   [DRS4]          Smith, Dennis R.         SMITH@ECLC.USC.EDU
+   [DRY2]          Yingling, David R., Jr.
+                   YINGLING%AVLAB.DNET@AAGATE.AVLAB.WPAFB.AF.MIL
+   [DS229]         Sabino, David
+                   sundc!sneezy!sabino@SUN.COM
+   [DS247]         Salvin, Don              dss@VMS.CIS.PITTSBURGH.EDU
+   [DS303]         Sturdivant, Darrell
+                   darrell%etsuv2.decnet@UTADNX.CC.UTEXAS.EDU
+   [DS335]         Santos, Don              don@BAMBERG-EMH1.ARMY.MIL
+   [DS341]         Spears, Donna            2176nsc@ANKARA.AF.MIL
+   [DS342]         Stafford, Dave
+                   esc1814%esoc.bitnet@CUNYVM.CUNY.EDU
+   [DS348]         Starr, Dan               ---none---
+   [DS354]         Simmons, David           QUASAR@PANTHER.FLOW.COM
+   [DS370]         Simmons, David           quasar@PANTHER.FLOW.COM
+   [DS372]         Scaletta, Dawn           ---none---
+   [DS382]         Strasenburg, David
+                   straserdr%SNYBROBA.BITNET@CUNYVM.CUNY.EDU
+   [DS387]         St. Jules, Don           dstjules@PNFI.FORESTRY.CA
+   [DS394]         Stokes, David            DAVE@XEROXEP.COM
+   [DS405]         Smith, Dale              ---none---
+   [DS53]          Stefanovic, Dave         daves@AWARE.COM
+   [DS59]          Schmidt, David           DAVIDS@ISC-BR.ISC-BR.COM
+   [DS85]          Smith, Dale C.           dsmith@OREGON.UOREGON.EDU
+   [DSN4]          Notov, Daniel S.         onm3b2!danno@UUNET.UU.NET
+   [DSP11]         St. Pierre, David        david@PACBELL.COM
+   [DSR]           Russell, Dale            dsr@JOVE.CAM.UNISYS.COM
+   [DT50]          Trinkle, Daniel          trinkle@CS.PURDUE.EDU
+   [DT59]          Tetreault, David J.      DJT@NAVELEXNET-STIN.NAVY.MIL
+   [DTG11]         Gregorich, David T.      DTG@CSULA-PS.CALSTATELA.EDU
+   [DTH4]          Henskes, Dieter Th.      dth@RCP.SEL.DE
+   [DV36]          Vining, Dan
+                   viningdp%snypotba.bitnet@CUNYVM.CUNY.EDU
+   [DV42]          Varga, Doug              varga@AUSTIN.LOCKHEED.COM
+   [DVL1]          Lewis, Donald V.
+                   lewis%umslvma.bitnet@UMRVMB.UMR.EDU
+   [DVT]           Torr, Donald V.          DVTORR@GALLUX.GALLAUDET.EDU
+   [DW139]         Woerz, Dieter            woerz@ISAAK.ISA.DE
+   [DW15]          Williams, Doug           WILLIAMSD@A.ISI.EDU
+   [DW159]         Wood, Dan                DWOOD@BBN.COM
+   [DW164]         Wiltzius, Dave           wiltzius@LLL-LCC.LLNL.GOV
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 131]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [DW180]         Weber, Dieter            ---none---
+   [DW195]         Williams, David
+                   ESC1728%ESOC.BITNET@CUNYVM.CUNY.EDU
+   [DW198]         Williams, David W.       SYSTEMDW@NTSC.NAVY.MIL
+   [DW212]         Weidenhammer, Detlef
+                   weidenhammer%vax.hmi.dbp.de@RELAY.CS.NET
+   [DW233]         Wintringham, Dan         DANW@OSC.EDU
+   [DW238]         Weyel, Donald
+                   wdz!epavax.bitnet@CUNYVM.CUNY.EDU
+   [DW239]         Ward, David              ---none---
+   [DW244]         Ware, Donald             ---none---
+   [DW96]          Walker, David            DHWalker@UCI.EDU
+   [DWB2]          Beach, Darrel W.
+                   AFDDN.BEACH@GUNTER-ADAM.AF.MIL
+   [DWC32]         Cooley, David W.         dwcooley@COLBY.EDU
+   [DWD20]         Daniel, David W.
+                   ddaniel@BLACKBIRD.AFIT.AF.MIL
+   [DWJ6]          Johnson, Dennis          2003cgxp@ANKARA.AF.MIL
+   [DY28]          Yearke, David            yearke@CS.BUFFALO.EDU
+   [DZ]            Zabokrtsky, Dianne       ---none---
+   [DZ17]          Zajack, Dennis
+                   azajack@BAD.CSB.CALSTATE.EDU
+   [EA49]          Aarnio, Esa              esa@KONTU.UTU.FI
+   [EB108]         Bibisi, Edmund
+                   ebibisi%utmem1.bitnet@CUNYVM.CUNY.EDU
+   [EB110]         Burrow, Elaine
+                   mcvax!lucifer!elaine@UUNET.UU.NET
+   [EB112]         Brownrigg, Edwin         ---none---
+   [EB129]         Blockeel, Erik           ERIK@MINF.VUB.AC.BE
+   [EB134]         Belpaire, Eric
+                   belpaire!renault.uucp@UUNET.UU.NET
+   [EB33]          Barton, Edward           ---none---
+   [EB95]          Baugh, Earl              baugh@HAL.CSS.GOV
+   [EBS10]         Shine, Elliott B.        ---none---
+   [EC101]         Chan, Eldon              echan@CADEV4.INTEL.COM
+   [EC43]          Carroll, Eric            eric@ISTS.ISTS.CA
+   [EC5]           Cain, Edward A.          Cain@RIGEL.DCA.MIL
+   [ECA]           Ackermaan, Ernest, C.    ---none---
+   [ECM6]          Mulrean, Edward C.
+                   MULREAN%CUA.BITNET@CUNYVM.CUNY.EDU
+   [ED72]          Delios, Erick            ejd@GOANNA.OZ.AU
+   [ED75]          Davies, Eric
+                   E_DAVIES%HVRFORD.BITNET@CUNYVM.CUNY.EDU
+   [EDE1]          Eason, Ernest D.         ---none---
+   [EEL2]          Leyba, Ernest E.         LEYBAEE@AFOTEC.AF.MIL
+   [EF16]          Fair, Erik E.            FAIR@APPLE.COM
+   [EF5]           Franceschini, Edi        FRANCESCHINI@NYU.EDU
+   [EF55]          Formal, Ed
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 132]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+                   formanel%snyoneva.bitnet@CUNYVM.CUNY.EDU
+   [EFH4]          Hastings, Eugene F.
+                   GENE.HASTINGS@BOOLE.ECE.CMU.EDU
+   [EFH6]          Hale, E.F. (Buster), III CCBUSTER@VM.CC.OLEMISS.EDU
+   [EG17]          Guglielmo, Eugene J.     GUGLIELMO@CCF3.NRL.NAVY.MIL
+   [EG51]          Gould, Ed                ed@MTXINU.COM
+   [EH112]         Hogan, Emmett            hogan@CSL.SRI.COM
+   [EH97]          Henry, Ellis
+                   ehenry%nasamail@AMES.ARC.NASA.GOV
+   [EHC3]          Coughran, Ed H.          coughran@NOSC.MIL
+   [EHH4]          Hunter, Eddie H.         ---none---
+   [EJ12]          Jorgensen, Ed            jorg%lvva.span@SDS.SDSC.EDU
+   [EJ19]          James, Ed                edjames@BERKELEY.EDU
+   [EJB]           Bos, Erik-Jan            bos@SURFNET.NL
+   [EJN1]          Norman, Eric J.          ejnorman@MACC.WISC.EDU
+   [EK18]          King, Edwin              King@SPAM.ISTC.SRI.COM
+   [EK48]          Kodinsky, Edward         kodinsk@MITVMA.MIT.EDU
+   [EK55]          Kroeker, Edwin           ---none---
+   [EKO]           Otte, Eric K.            otte@NOSC.MIL
+   [EL30]          Lear, Eliot              lear@TURBO.BIO.NET
+   [EM128]         Manninen, Esa            ---none---
+   [EM67]          Rehm, Eric               REHM@CADSE.DEC.COM
+   [EMB]           Berg, Eric M.            berg@TC.PW.COM
+   [EMH12]         Hayman, Edward M.        ---none---
+   [EP53]          Peterson, Eric           lcc.eric@SEAS.UCLA.EDU
+   [EP70]          Prenowitz, Edward        ep@SIMMONS.EDU
+   [EPA]           Allman, Eric P.          eric@UCBVAX.Berkeley.EDU
+   [ER42]          Rose, Eric               ---none---
+   [ER61]          Rugelis, Eriks           eriks@LIBRA.YORKU.CA
+   [ER75]          Ridenour, Eric           ---none---
+   [ER90]          Rollins, Eugene          ---none---
+   [ERC1]          Crane, Eric R.           Eric.Crane@C.CS.CMU.EDU
+   [ERD6]          de Vreede, E. R.         ---none---
+   [ERK3]          Kozel, Edward R.         Kozel@MILANO.CISCO.COM
+   [ES144]         Schneider, Eric          schneider@SOLOMON.AHA.COM
+   [ES148]         Schnell, Eckhard
+                   ESC%PAC.UUCP%TUB.BITNET@MITVMA.MIT.EDU
+   [ES158]         Schnoebelen, Eric        ERIC@CIRR.COM
+   [ES165]         Silva, Ed                ---none---
+   [ESD3]          De Boer, E.S.            markp@PER.DMS.CSIRO.AU
+   [ET49]          Torri, Eero              ET@AJK.TELE.FI
+   [ETS4]          Sakabu, Edward T.        CSMSETS@OAC.UCLA.EDU
+   [EU4]           Underlee, Everett        ---none---
+   [EV26]          Vesa, Erolainen          ---none---
+   [EW62]          Weisenberger, Edward
+                   WEISENBERGER%PPC.MFENET@CCC.NMFECC.GOV
+   [EWK4]          Kendall, Everitt         ---none---
+   [EY5]           Yamin, Elaine            ---none---
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 133]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [EZ3]           Zawacki, Edward          U17375@UICVM.UIC.EDU
+   [EZ8]           Zafar, Esfandiar         zafar@CTRVX1.VANDERBILT.EDU
+   [FAC2]          Custodio, Fredric A.     ---none---
+   [FAF6]          Feurer, Frederick A., Jr.b8tefeu@MICULX.MINC.UMD.EDU
+   [FAS]           Segovich, Fred A.        fred@URBANA.MCD.MOT.COM
+   [FB15]          Bekka, Farid             bekka@CNCA.CNCA-CAM.FR
+   [FB61]          Buetikofer, Fritz        btkfr@ID.UNIBE.CH
+   [FB77]          Baker, Fred              baker%vitam6@UUNET.UU.NET
+   [FBR2]          Raab, Fritz B.
+                   unido!cosmo!fbraab@UUNET.UU.NET
+   [FC52]          Crawford, Frank          frank@TETI.QHTOURS.OZ.AU
+   [FD18]          de Kruijf, F.
+                   FREEK%DUTRUN.UUCP@UUNET.UU.NET
+   [FD41]          Dayton, Fred
+                   fred%psuorvm.bitnet@CUNYVM.CUNY.EDU
+   [FD44]          DeCastilhos, Flavio      ---none---
+   [FDC2]          Craft, Frankie D.        ---none---
+   [FE6]           Ellis, Frank             ellis@PVAMU.EDU
+   [FF20]          Fore, Frank P., Jr.      FPF@SWRI.EDU
+   [FF30]          Feunekes, Freerk         ---none---
+   [FG15]          Gould, Fred              gould@RDSS.UCAR.EDU
+   [FG16]          Gutzwiller, Florian      mcvax!ethz!flog
+   [FG50]          Gerbode, Farrell         farrell@RICE.EDU
+   [FG51]          Goldstein, Fred          ---none---
+   [FH2]           Thelander, Fredric       ---none---
+   [FH35]          Haag, F.                 ---none---
+   [FH53]          Hanke, Florence          ---none---
+   [FH59]          Hartranft, Frank         ---none---
+   [FJB3]          Ball, Frederick J.       ball@SRLVX0.SRL.FORD.COM
+   [FJD4]          Deboo, Farokh J.         FJD@INTERLINK.COM
+   [FJG4]          Jacot-Guillarmod, Francois---none---
+   [FJH1]          Halloran, Frank J.       FRANK@JPLOPTO.JPL.NASA.GOV
+   [FJS2]          Smans, F.J.              ---none---
+   [FJS3]          Schmidt, F. Jeffery      JSCHMIDT@NCAD-EMH12.ARMY.MIL
+   [FL27]          Labalme, Fen             ---none---
+   [FL34]          Liang, Fanny             ---none---
+   [FM83]          Maselli, Frank           frank@MAXWELL.CONCORDIA.CA
+   [FM85]          McCaffrey, Frank         ---none---
+   [FMA1]          Avolio, Frederick M.     avolio@DCO.DEC.COM
+   [FMM11]         Maish, F. Michael        maish@ALPHA.BLDR.NIST.GOV
+   [FN]            Neugebauer, Friedrich
+                   FN!DMZRZU71.bitnet@CUNYVM.CUNY.EDU
+   [FO17]          Oner, Fatma              ---none---
+   [FS86]          Speck, Francis           ---none---
+   [FT30]          Teraoka, Fumio           tera@CSL.SONY.JP
+   [FU1]           Ullings, Fons            fons@NAT.VU.NL
+   [FV13]          Van den Bosch, Frank     mvdberg@NLR.NL
+   [FW17]          Wendling, Frederic       FWENDLING@NOTE.NSF.GOV
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 134]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [FW18]          Watson, Felix            sds-comm@AFCC-OA1.AF.MIL
+   [FW51]          Wright, Frederick
+                   S.SNELSON@MACBETH.STANFORD.EDU
+   [FW54]          Wolf, Fritz              ---none---
+   [FWD]           Dyner, Wolfgang J.
+                   DYNERW@HEIDELBERG-EMH1.ARMY.MIL
+   [FZ]            Zhang, Frank             zhangf@IMO-UVAX.DCA.MIL
+   [GA45]          Abrahamian, Garnik       ---none---
+   [GA69]          Ansley, Greg             vta!gja@GATECh.EDU
+   [GAB36]         Barbour, Gary A.         gb@UVM.EDU
+   [GAG17]         Gentry, Glenn A.         ---none---
+   [GAL5]          Loyola, Guillermo A.     loyola@IBM.COM
+   [GAM32]         Meijerink, Gert A.
+                   RCGERT%HENUT5.BITNET@CUNYVM.CUNY.EDU
+   [GAM35]         Marino, Giuseppe A.      Joy.Marino@DIST.UNIGE.IT
+   [GB125]         Brunkhorst, Geoffrey     brunkhorst@MAYO.EDU
+   [GB133]         Bunsen, Guido
+                   unido!rwthinf!guido@UUNET.UU.NET
+   [GB157]         Bond, Gregory
+                   munnari!melba.bby.oz.au!gnb@UUNET.UU.NET
+   [GB167]         Bassy, Gerard            ---none---
+   [GB169]         Bartmuss, Gottfried      gob!aicmuc.uucp@UUNET.UU.NET
+   [GB184]         Bass, Guy                ---none---
+   [GB43]          Broomell, George
+                   UKT101%UKCC.BITNET@CUNYVM.CUNY.EDU
+   [GB5]           Bobo, Gary               gbobo@REDSTONE-EMH2.ARMY.MIL
+   [GB7]           Beling, Gerd             GBELING@A.ISI.EDU
+   [GC104]         Cunningham, Gene         ---none---
+   [GC118]         Chartrand, Greg          GREG@SSCVX1.SSC.GOV
+   [GC122]         Carpenter, Graham J.     G.Carpenter@EE.Surrey.Ac.UK
+   [GC132]         Cuthill, Gordon          ---none---
+   [GC138]         Cattelino, Gary          GARY@UNOCAL.COM
+   [GC146]         Coutu, Gino              ---none---
+   [GC148]         Cohn, George             GEO@UB.COM
+   [GC151]         Corfield, Graham         ---none---
+   [GC155]         Collin, Geoff            gco@CCADFA.CC.ADFA.OZ.AU
+   [GC158]         Czirjak, Gary            ---none---
+   [GC89]          Crawford, Geoff          ---none---
+   [GCF7]          Franks, Glenn C.         ---none---
+   [GCS8]          Scott, Glenn C.          glenn@OTTO.LVSUN.COM
+   [GD80]          DeCoff, Gary             ---none---
+   [GD91]          Davis, George            ---none---
+   [GE47]          Evangelides, George      gev@IA.
+   [GEG4]          Guiberson, Gerald E.     DISNETMGR@DDN3.DCA.MIL
+   [GEOF]          Goodfellow, Geoffrey S.  Geoff@fernwood.mpk.ca.us
+   [GEOFF]         Mulligan, Geoffrey C.    geoff@USAFA.AF.MIL
+   [GEW13]         Wright, George E.
+                   ASQEXKZ300@ZWEIBRUCKEN-EMH2.ARMY.MIL
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 135]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [GF75]          Freeman, George          gman@CC.UNISYS.COM
+   [GFW6]          Wetzel, Gregory F.       gfw@PUEBLO.ATT.COM
+   [GG110]         Gullbekk, Gunnar         ---none---
+   [GG115]         Gilley, Greg             Gilley@NDL.COM
+   [GG123]         Green, Gerry             ---none---
+   [GG136]         Gatto, Giuseppe          pippo@CRAI.IT
+   [GG138]         Geronikos, George        ---none---
+   [GG16]          Gibbs, Geoff
+                   G.GIBBS%UK.AC.CRC@NSFNET-RELAY.AC.UK
+   [GG68]          Guillerm, Gerard
+                   sysgeg%frpoly11.bitnet@CUNYVM.CUNY.EDU
+   [GGB2]          Baehr, G. Geoffrey       geoffb@ENG.SUN.COM
+   [GH105]         Huston, Geoff            gih900@CSC.ANU.OZ.AU
+   [GH108]         Huxtable, Glenn
+                   munnari!wacsvax.uwa.oz.au!root@UUNET.UU.NET
+   [GH122]         Hollingsworth, Greg      gregh@GATEWAY.MITRE.ORG
+   [GH125]         Hiscott, Greg            gjh@LIGO.CALTECH.EDU
+   [GH29]          Hidley, Gregory R.       hidley%CS@UCSD.EDU
+   [GH39]          Henken, Gerrit
+                   henken@PASSAT.DKRZ-HAMBURG.DBP.DE
+   [GH42]          Hanoefner, Gerhard
+                   HAN!DMOGSF11.BITNET@CUNYVM.CUNY.EDU
+   [GH46]          Helmer, Guy
+                   HELMER!SDNET.BITNET@CUNYVM.CUNY.EDU
+   [GI4]           Isaackson, Gordon G.     92BMWSCO@SACEMNET.AF.MIL
+   [GIH]           Hastie, Glenn I., II     hastie@SPAM.ISTC.SRI.COM
+   [GIL]           Lotto, Gerald I.         lotto@LHASA.HARVARD.EDU
+   [GJ35]          Johnson, Glenn           ---none---
+   [GJS13]         Smith, Gregory J.        SMITH@BUCKNELL.EDU
+   [GK32]          Kenley, Gregory          ---none---
+   [GK44]          Kunis, Gary              gkunis@BOEING.COM
+   [GK89]          Kreis, Guenter
+                   guenter!ruso.uucp@UUNET.UU.NET
+   [GK91]          Kleiven, Gunnar          ---none---
+   [GK92]          Daindl, Georg            ---none---
+   [GKN1]          Newman, Gerard K.        GKN@SDS.SDSC.EDU
+   [GKW3]          Giles, Wesley            host@CLARK-EMH.AF.MIL
+   [GL15]          Lauer, Gregory           GLAUER@BBN.COM
+   [GL16]          Lange, Gerald            ---none---
+   [GL41]          Lindberg, Gunnar         lindberg@CS.CHALMERS.SE
+   [GL88]          Lapasky, Gwendolyn       ---none---
+   [GLC18]         Cohler, Geoffrey L.      ---none---
+   [GLD]           Durant, Geraldine L.     DURANT@LL.ARPA
+   [GLH5]          Hemphill, Gavin L.       HEMPHILL@XX.DREA.DND.CA
+   [GLS20]         Scherer, Gary L.         NSC-Home@DDN2.DCA.MIL
+   [GLS39]         Schaps, Gary L.          gls@CORDIS.COM
+   [GM190]         Galbraith, Michael       mgalbrai@BBN.COM
+   [GM199]         Mayer, Georges
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 136]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+                   APLGEOR%TECHNION.BITNET@CUNYVM.CUNY.EDU
+   [GMM28]         Marianko, Glen M.        ---none---
+   [GMP19]         Paxinos, Garry M.        PAX@MEGASYS.COM
+   [GMR]           Roemers, Gustaaf M.      roemers@TSCA.ISTC.SRI.COM
+   [GMT6]          Trimble, Gary M.         lams!gmt@AMES.ARC.NASA.GOV
+   [GO1]           O'Carroll, Ger           ---none---
+   [GP117]         Park, Greg               gpark@SUN.TIMEPLEX.COM
+   [GP128]         Plescia, Gary
+                   sngar!TTUVM1.BITNET@CUNYVM.CUNY.EDU
+   [GP129]         Peter, George
+                   mmdf@ASCHAFFENBURG-EMH1.ARMY.MIL
+   [GP133]         Pierluigi, Gianni        Pierluigi.Gianni@EC.BULL.FR
+   [GP137]         Pitkin, Gregg            ---none---
+   [GP88]          Pitteloud, Gerard
+                   K126309%CZHRZU1A.BITNET@CUNYVM.CUNY.EDU
+   [GPL1]          Licona, George P., Jr.   CES433@WPAFB-INFO5.AF.MIL
+   [GR11]          Ricart, Glenn            glenn@MIMSY.UMD.EDU
+   [GR26]          Richter, Georg
+                   urz07%dmswwulc.bitnet@CUNYVM.CUNY.EDU
+   [GR53]          Robbins, George          grr@COMMODORE.COM
+   [GR56]          Romano, Giuseppe         Romano@ICNUCEVM.CNUCE.CNR.IT
+   [GR67]          Roy, Greg                ---none---
+   [GR85]          Rech, Gilles             ---none---
+   [GR9]           Rabinowitz, George       gr@BNL.GOV
+   [GRZ1]          Zarse, Gary R.           ---none---
+   [GS101]         Sander, Gernot
+                   hz203sa%unidui.uucp@UUNET.UU.NET
+   [GS119]         Smith, Gordon            gordon@UNE.OZ.AU
+   [GS12]          Standorf, Gary P.
+                   STANDORF@MONMOUTH-EMH2.ARMY.MIL
+   [GS123]         Stone, Geof              geof@NETWORK.COM
+   [GS199]         Schellbach-Mattay, Gert
+                   ACNET%DACTH51.BITNET@CUNYVM.CUNY.EDU
+   [GS91]          Streeter, Guy            streeter@INGR.COM
+   [GT37]          Tyler, George E.         dstlc@LOGNET2.AF.MIL
+   [GT67]          Temperman, Gerard        ---none---
+   [GT73]          Thomas, Graham           graham@RMC.BITNET.CA
+   [GT76]          Trail, Gary              gary@MSTR.HGC.EDU
+   [GTA]           Almes, Guy T.            Almes@RICE.EDU
+   [GV23]          Ventre, Giorgio          ---none---
+   [GW107]         Wiebe, Glen              wiebe@BETHEL.EDU
+   [GW117]         Watson, Greg             greg@GRIFFIN.ITC.GU.OZ
+   [GW22]          Weiler, Grant            weiler@CS.UTAH.EDU
+   [GW40]          Wallace, Gary            gary@CS.UMASS.EDU
+   [HAL5]          Lindenberg, Hans A.      ---none---
+   [HAW]           Walter, Howard A.        hwalter@NAS.NASA.GOV
+   [HB14]          Bishop, Harold           ---none---
+   [HB60]          Boetzkes, H. A. P. A.
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 137]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+                   mcvax!nlgvax!henkbo@UUNET.UU.NET
+   [HB7]           Brown, Harvey            ---none---
+   [HB76]          Bahmanyar, Hom           sjsumcs!hom@SUN.COM
+   [HB79]          Busch, Hubert            busch@SC.ZIB-BERLIN.DBP.DE
+   [HB99]          Berggren, Hans           hans@INMIC.SE
+   [HBA2]          Al-Sadoun, Humoud B.     AL-SADOUN@UKWT.KW
+   [HC66]          Chuang, Hann-Bin         chuang@BTC.KODAK.COM
+   [HCL1]          Lauer, Hugh C.           lauer@BTC.KODAK.COM
+   [HCV1]          Vander Hyde, Kriss C.    VANDERK@AFAL-EDWARDS.AF.MIL
+   [HDW2]          Wactlar, Howard D.       HDW@CS.CMU.EDU
+   [HE12]          Enjo, Hidekazu           enjo@NTTDPE.NTT.JP
+   [HE15]          Eidnes, Haavard          eidnes@IDT.UNIT.NO
+   [HEG6]          Garcia, Hugo E.
+                   hugo%tecmtyvm.bitnet@UTADNX.CC.UTEXAS.EDU
+   [HF30]          Faerber, Hans-Juergen    fae@IITB.FHG.DE
+   [HF34]          Field, Hugh              ---none---
+   [HF35]          Fry, Hubert              PMUB@MELPAR-EMH1.ARMY.MIL
+   [HG51]          Goehring, Hans-Georg
+                   uzr112%dbnrhrz1.bitnet@CUNYVM.CUNY.EDU
+   [HH37]          Hesseling, Hans
+                   HESSELING%HGRRUG5.BITNET@CUNYVM.CUNY.EDU
+   [HH45]          Hori, Hidehiko           ---none---
+   [HH50]          Honal, Heinrich
+                   XBR1Y013%DDATHD21.BITNET@CUNYVM.CUNY.EDU
+   [HH64]          Hilman, Harlan           hilman@INTELOA.BIIN.COM
+   [HH68]          Hipp, Heinz
+                   zrhi001%dtuzdv5a.bitnet@CUNYVM.CUNY.EDU
+   [HH71]          Hagen, Herr              ---none---
+   [HH77]          Halset, Halvor           ---none---
+   [HH84]          Hahn, Heinz
+                   HAHN%DMRHZ11.BITNET@CUNYVM.CUNY.EDU
+   [HH88]          Han, Hichul              HHAN@BCIT.BC.CA
+   [HI7]           Irie, Hideo
+                   michael%tnkl.ws.sony.junet@RELAY.CS.NET
+   [HJK4]          Kelly, Harold J.         ---none---
+   [HK2]           Kensinger, Hollis        HKENSINGER@RIA-EMH1.ARMY.MIL
+   [HK24]          Knight, Holly            holly@APPLE.COM
+   [HK29]          Kutar, Hormazdyar        ---none---
+   [HK35]          Knops, Huub
+                   mcvax!swivax!huub@UUNET.UU.NET
+   [HK41]          Kneis, Hermann
+                   kneis%cageir5a.bitnet@CUNYVM.CUNY.EDU
+   [HKG2]          Gilbert, Howard K.
+                   gilbert%YALEVM.BITNET@MITVMA.MIT.EDU
+   [HKO]           Orman, Hilarie K.        HO@LA.TIS.COM
+   [HL65]          Liu, Han-Chai
+                   COLOR%TWNMOE10.BITNET@CUNYVM.CUNY.EDU
+   [HLW7]          Lorenz-Wirzba, Heidi     heidi@ELXBSD.CALTECH.EDU
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 138]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [HM38]          Mikami, Hirohide
+                   mikami%ntt-20@SUMEX-AIM.STANFORD.EDU
+   [HM68]          McQueen, Herbert
+                   munnari!csc.anu.oz.au!hsm157@UUNET.UU.ENT
+   [HM80]          Meyers, Herb             ---none---
+   [HML1]          Long, Morrow H.          LONG-MORROW@CS.YALE.EDU
+   [HN20]          Niederle, Herbert
+                   I11C17%DM0TUI1S.BITNET@CUNYVM.CUNY.EDU
+   [HN21]          Nakayama, Hitoshi
+                   iizuka%jpnkisci.bitnet@CUNYVM.CUNY.EDU
+   [HN27]          Nakahara, Hayao          ---none---
+   [HN3]           Naef, Heinz              whna%cgch.uucp@UUNET.UU.NET
+   [HN7]           Nussbacher, Hank
+                   HANK%BARILVM.BITNET@CUNYVM.CUNY.EDU
+   [HO13]          Ohshiba, Hisashi
+                   ohshiba%nttica.ntt.jp@RELAY.CS.NET
+   [HO8]           Ogasawara, Hidemi        HRK@NINCHI.CHUKYO-U.AC.JP
+   [HP32]          Price, Harold            ---none---
+   [HP44]          Parvamo, Heikki          ---none---
+   [HP49]          Preston, Holly           ---none---
+   [HP50]          Prigent, Herve
+                   PRIGENFRTLS12.bitnet@CUNYVM.CUNY.EDU
+   [HPD1]          Dittler, Hans Peter
+                   Dittler%ccc@UNIKA1.IRA.UKA.DE
+   [HR43]          Reddish, Hal             ---none---
+   [HS116]         Steffes, Helmut          steffes@UNI-TRIER.DBP.DE
+   [HS118]         Steinringer, Hermann
+                   z00hsr01%awiunill.bitnet@CUNYVM.CUNY.EDU
+   [HS119]         Suzuki, Haruhisa         ---none---
+   [HS23]          Stenn, Hokey             hokey@PLUS5.COM
+   [HT12]          Tam, Henry
+                   rmay%cornelld.bitnet@JADE.Berkeley.EDU
+   [HT19]          Trickey, Howard          trickey@ARPA.ATT.COM
+   [HT40]          Thurn, Herbert
+                   BTR013%DBTHRZ5.BITNET@CUNYVM.CUNY.EDU
+   [HT44]          Takahashi, Hironobu      ---none---
+   [HT48]          Trompert, Hans           hanst@MAESTRO.HTSA.AHA.NL
+   [HVKR]          Kleist-Retzow, Hans von  hans@ORC.OLIVETTI.COM
+   [HVS1]          van Staveren, Hans       sater@CS.VU.NL
+   [HW26]          Hahn, Willi              ---none---
+   [HW56]          Wright, Hank             hank@HP850.MBARI.ORG
+   [HW59]          Wong, Henry              ---none---
+   [HWB]           Braun, Hans-Werner       HWB@MERIT.EDU
+   [HWP2]          Poor, Henry W. (Hank)    poor@RSMAS.MIAMI.EDU
+   [IA52]          Allen, Ian               I.M.Allen@UK.AC.CITY
+   [IB11]          Bashir, Imran            ---none---
+   [IG4]           Greig, Ian               ian@OTAGO.AC.NZ
+   [IH15]          Hoyle, Ian
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 139]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+                   munnari!merlin.bhpmrl.oz.au!ianh@UUNET.UU.NET
+   [IHM]           Merritt, Ian H.          IHM@NRC.COM
+   [IJD1]          Donkervoort, Ing. J.     ---none---
+   [IKA]           Anderson, Irelann K.     KERRY@MAINE.MAINE.EDU
+   [IM24]          Martinez, Ignacio        martinez@IRIS-DCP.ES
+   [IM33]          McDonald, Ian            mcdonaldi@SACAE.OZ.AU
+   [IMK1]          Kirmer, Irwin M.         kirmer@TECHNET.NM.ORG
+   [IR19]          Rohde, Ian               chris@COMMUNICA.OZ.AU
+   [IR24]          Remnant, Ian             ---none---
+   [IS12]          Stormo, Ivar             ---none---
+   [IW5]           Winston, Ira             ira@CIS.UPENN.EDU
+   [JA]            Akkerhuis, Jaap          ---none---
+   [JA1]           Aronson, Jules P.        ARONSON@MCS.NLM.NIH.GOV
+   [JA13]          Aguirre, Jerry           JERRY@ATC.OLIVETTI.COM
+   [JA146]         Archimbaud, Jean-Luc     ---none---
+   [JA155]         Alsters, Jos             josal@SCI.KUN.NL
+   [JA168]         Andrews, John            ja@ESS.CS.UCL.AC.UK
+   [JA175]         Amason, John             JMA@LGC.COM
+   [JA176]         Andersson, Jan           EUDJAN@ERICSSON.COM
+   [JA180]         Adachi, Jun              adachi@NACSIS.AC.JP
+   [JA184]         Augustine, John          ---none---
+   [JA189]         Amodeo, Jim
+                   AMODEOJB%SNYDELBA.BITNET@CUNYVM.CUNY.EDU
+   [JA91]          Angotti, Joseph J.       jja496@CRANE-POE.NAVY.MIL
+   [JA92]          Anderson, Jack
+                   ANDERSONJ@BCLCL1.IM.BATTELLE.ORG
+   [JAB111]        Berry, Joseph            jab0633@USAV00.GLAXO.COM
+   [JAC61]         Cavallaro, Jeffery A.    Jeffery@SYS.CALTECH.EDU
+   [JAD16]         Danos, John A.           ---none---
+   [JAG3]          Gumpf, Jeffrey A.        Gumpf@INS.CWRU.EDU
+   [JAJ17]         Jokl, James A.           jaj@UVAARPA.VIRGINIA.EDU
+   [JAM38]         Mussman, Joel            jam@LONEX.RADC.AF.MIL
+   [JAM48]         Manas, Jose A.           jmanas@DIT.UPM.ES
+   [JAM69]         Markevitch, James A.     jam@MAGIC.COM
+   [JAS8]          Siegel, Jeffrey A.       HOSTADM@YOKOTA-EMH.AF.MIL
+   [JAW16]         Wieclawek, Joseph A.     jaw@SESUN.JPL.NASA.GOV
+   [JAW34]         Wabik, Jeff A.           jwabik@MSC.UMN.EDU
+   [JB113]         Bennett, Jerome          bennett@DFTNIC.GSFC.NASA.GOV
+   [JB218]         Blondeau, Jim
+                   jbb%tektools.tek.csnet@RELAY.CS.NET
+   [JB247]         Boyle, Joanne            boyle@JVNCB.CSC.ORG
+   [JB251]         Brannon, James
+                   BRANNEN@STEWART-EMH1.ARMY.MIL
+   [JB348]         Bashinski, John
+                   BASHINSKI%SJSCA4@SPAR.SLB.COM
+   [JB360]         Boccio, John
+                   BOCCIO@CAMPUS.SWARTHMORE.EDU
+   [JB399]         Bonn, John               nmri!bonn@UUNET.UU.NET
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 140]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [JB410]         Bradley, Jim
+                   fna104%uriacc.bitnet@MITVMA.MIT.EDU
+   [JB462]         Bruening, Jochen
+                   rzbng%dknkurz1.bitnet@CUNYVM.CUNY.EDU
+   [JB509]         Boothe, Joe
+                   BOOTH!ACUVAX.BITNET@CUNYVM.CUNY.EDU
+   [JB525]         Burgan, Jeffrey          jeff@NSIPO.NASA.GOV
+   [JB542]         Baird, John              j.baird@LINCOLN.AC.NZ
+   [JB544]         Blasik, John             JOHN@SEMI.HARRIS.COM
+   [JB550]         Bien, John               jsb@GUMBY.DSD.TRW.COM
+   [JBP]           Postel, Jon              POSTEL@ISI.EDU
+   [JBV2]          VanBokkelen, James B.    jbvb@VAX.FTP.COM
+   [JC106]         Conklin, Joel            CONKLIN@GE-CRD.ARPA
+   [JC108]         Cox, Jan                 lewton@PRANDTL.NAS.NASA.GOV
+   [JC235]         Crowhurst, Jon           crowhurst@ADMIN.OGI.EDU
+   [JC272]         Cowan, Jack              ---none---
+   [JC288]         Cottrell, Jim
+                   jim%easby.dur.ac.uk@NSS.CS.UCL.AC.UK
+   [JC314]         Cahill, John
+                   cahill%utx1%novavax%codas@MOSS.ATT.COM
+   [JC315]         Cushing, James
+                   cushing@AMETHYST.MA.ARIZONA.EDU
+   [JC333]         Carnicle, John           ---none---
+   [JC345]         Carrington, James        JSC@AUTODESK.COM
+   [JC347]         Curran, John             CEI001@UC.MSC.UMN.EDU
+   [JC365]         Carl, Janice
+                   edsews!carl!janice@UUNET.UU.NET
+   [JC394]         Childs, Jack
+                   jchilds@REDSTONE-EMH2.ARMY.MIL
+   [JC403]         Cole, Jay                ---none---
+   [JC414]         Carlier, Janine          jac@LITP.IBP.FR
+   [JC481]         Christensen, Jon         jchriste@CC.UTAH.EDU
+   [JC483]         Carre, Jean              JXC2F@ACADVM1.UOTTAWA.CA
+   [JC490]         Carlsen, Jerry           ---none---
+   [JC497]         Conant, James            ---none---
+   [JCB14]         Bowling, John C.         LAN@GUNTER-ADAM.AF.MIL
+   [JCB42]         Bergeron, Jay C.         ---none---
+   [JCD8]          Demco, John              demco@EAN.UBC.CA
+   [JCH17]         Honig, Jeffrey C.        jch@DEVVAX.TN.CORNELL.EDU
+   [JCH41]         Houlker, John Charles    j.houlker@WAIKATO.AC.NZ
+   [JCJ1]          Jubin, John C., III      JUBIN@A.ISI.EDU
+   [JCN10]         Nunn, John C.            NUNN@CL.UH.EDU
+   [JCP26]         Person, John C.          ---none---
+   [JCW12]         Woodard, James C.        ---none---
+   [JD130]         DiBella, Joseph          JOE@NCSC.NAVY.MIL
+   [JD16]          Dumas, Jean-Pierre
+                   jphd%frsac11.bitnet@CUNYVM.CUNY.EDU
+
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 141]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [JD238]         Demel, Johannes
+                   z3000jd%awituw01.bitnet@CUNYVM.CUNY.EDU
+   [JD274]         Douglas, James           ---none---
+   [JD282]         Davies, John             ---none---
+   [JD305]         Doyle, John              ---none---
+   [JD86]          Duran, Jose              NSC-HILL@DDN2.DCA.MIL
+   [JDC20]         Case, Jeffrey D.         case@UTKUX1.UTK.EDU
+   [JDG]           Guyton, James D.         guyton@RAND.ORG
+   [JDH29]         Hagan, John Dotts        HAGAN@UPENN.EDU
+   [JDM9]          Makey, Jeffrey D.        Makey@LOGICON.COM
+   [JE87]          Engvald, Jan             xjeldc@LDC.LU.SE
+   [JEA18]         Ahn, Jae Eon             jean@SORAK.KAIST.AC.KR
+   [JEB45]         Butler, Jeffrey E.       UTLERJE@AFSC-SSD.AF.MIL
+   [JEB50]         Bradt, James E.          bradt@CRD.GE.COM
+   [JEB84]         Bogart, James E.         JBOGART@PROSPECT.COM
+   [JEF8]          Fisher, James E.         1962CGLGU@KADENA-EMH.AF.MIL
+   [JEG27]         Garrett, James E.        JGARRETT@RIA-EMH1.ARMY.MIL
+   [JEQ1]          Quigley, John E.
+                   quigley@HEXSUNFS.C3SYS.ARMY.MIL
+   [JES55]         Sitkoski, James E.       ---none---
+   [JF47]          Flower, Jon              JWF@WEGA.CALTECH.EDU
+   [JF78]          Finke, Jon               JFINKE@ITSGW.RPI.EDU
+   [JFAS]          Schillemans, Joop F.A.   rcjoop@URC.TUE.NL
+   [JFC6]          Chambon, J. Francois     ---none---
+   [JFD9]          Detke, John F.           ---none---
+   [JFG21]         Grover, James F.         ---none---
+   [JFK23]         Kent, Joseph F.
+                   kent!urvax.bitnet@CUNYVM.CUNY.EDU
+   [JFM38]         Martin, Joel F.          jfm%ucsdmr@UCSD.EDU
+   [JFM39]         McAloon, John F.         ---none---
+   [JFR24]         Remillard, James F.      ---none---
+   [JFS22]         Scheimer, James F.       jfs@IRIS.CSS.GOV
+   [JFS37]         Scott, John F.           ---none---
+   [JFW]           Wilkes, Jon              wilkes@ISSUN3.STC.NL
+   [JG131]         Gore, Jacob              jacob@gore.com
+   [JG266]         Gagnon, Jean-Francois
+                   aspyjfg%cmeteoc@IRO.UMONTREAL.CA
+   [JG268]         Gasior, Joseph F.        nsc-kelly@DDN2.DCA.MIL
+   [JG269]         Gomes, Joseph            gomes@USF.EDU
+   [JG293]         Gonzales, Jesus          ---none---
+   [JG299]         Gauvin, Jimmy
+                   jim%lavalvx1.bitnet@CUNYVM.CUNY.EDU
+   [JG308]         Greene, Jeremy           GREENE@TAIPAN.PERNIX.COM
+   [JG8]           Grina, Jim               ---none---
+   [JGB17]         Bender, J. Gary          ---none---
+   [JGD1]          Deck, Joseph G.          JDECK@EAGLE.WESLEYAN.EDU
+   [JGG23]         Gallo, Julie             ---none---
+   [JH10]          Hargrove, Jimmy          jimmy@SEAHUB.NAVSEA.NAVY.MIL
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 142]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [JH141]         Heinanen, Juha           fi-technical-contact@tut.fi
+   [JH18]          Huens, Jean
+                   prlb2!kulcs!jean@SEISMO.CSS.GOV
+   [JH204]         Harris, Jeff             jeff@NMSU.EDU
+   [JH22]          Hook, Jim                ---none---
+   [JH306]         Harrison, Jeff           SXJLH@ACAD3.FAI.ALASKA.EDU
+   [JH307]         Horn, John               ---none---
+   [JH342]         Herb, Jeffrey            ---none---
+   [JH372]         Hughes, James            ---none---
+   [JH40]          Halperin, John           jxh@SLACVM.SLAC.STANFORD.EDU
+   [JH410]         Hill, Julia
+                   CENJMH@CLUSTER.HERIOT-WATT.AC.UK
+   [JH429]         Howard, John             JSH@DLOGICS.COM
+   [JH84]          Haskey, John             ---none---
+   [JH87]          Hammar, Johan            johan@UPLOG.SE
+   [JH92]          Hahn, Jack               hahn@UMD5.UMD.EDU
+   [JHC12]         Choy, Joseph H           choy@NCAR.UCAR.EDU
+   [JHH8]          Haynes, James H.         HAYNES@UCSCC.UCSC.EDU
+   [JHS50]         Silva, Jose H.           ---none---
+   [JIMWW]         Wheeler, James W.        JIMWW@SACTO.MP.USBR.GOV
+   [JIS]           Schiller, Jeffrey I.     JIS@BITSY.MIT.EDU
+   [JJ48]          Jongeward, Jeffrey
+                   ssc-vax!root@BEAVER.CS.WASHINGTON.EDU
+   [JJB1]          Batcha, Joseph J.        NSC-Langley@DDN3.DCA.MIL
+   [JJD12]         Diehl, Jeff J.           hq-spcd-xqr@AFCC-OA2.AF.MIL
+   [JK186]         Knight, Jonathan         jonathan@CS.KL.AC.UK
+   [JK187]         Kotovirta, Jukka         ---none---
+   [JK198]         Kleinoeder, Juergen      KLEINOEDER@UNI.ERLANGEN.DE
+   [JK213]         Krieger, Jost
+                   P920012%DBORUB01.BITNET@CUNYVM.CUNY.EDU
+   [JK218]         Kegler, Jeffrey          JEFFREY@ALGOR2.ALGORISTS.COM
+   [JK228]         Kapp, Jeff               KAPP@MILLIKIN.EDU
+   [JK233]         Kwong, James             kwongj@CALDWR.UCDAVIS.EDU
+   [JK237]         Kopitz, John             ---none---
+   [JK59]          Kitson, Jeffrey          JEFF@KESTREL.EDU
+   [JK7]           Koda, Jim                KODA@ISI.EDU
+   [JKB13]         Buehring, Juergen K.     BUEHRING@HQAFSC-VAX.AF.MIL
+   [JKF2]          Freund, Jeff K.          ---none---
+   [JKR1]          Reynolds, Joyce K.       JKREY@ISI.EDU
+   [JKS23]         Scoggin, John K. Jr.     scoggin@DELMARVA.COM
+   [JL1]           Landwehr, Joseph
+                   landwejb%uccc.bitnet@CUNYVM.CUNY.EDU
+   [JL115]         Little, John             portal!jel@SUN.COM
+   [JL15]          Lepreau, Jay             LEPREAU@CS.UTAH.EDU
+   [JL152]         Lange, John
+                   hplabs!sun!texsun!radian!altair!johnl@RUTGERS.EDU
+   [JL239]         Lo, Jeff                 jlo@ELAN.COM
+   [JL247]         Longchamp, Jean-Paul     jlongcha@ULYS.UNIL.CH
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 143]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [JL256]         Lay, Joel
+                   xndrfn0h%servax.bitnet@CUNYVM.CUNY.EDU
+   [JL268]         Laventhol, Jonathan      ---none---
+   [JL324]         Lundberg, Jan            ---none---
+   [JL329]         Legatheaux, Jose
+                   jalm!DI-FCUL.UUCP@UUNET.UU.NET
+   [JL338]         Linn, John               j.linn@ABERDEEN.AC.UK
+   [JL52]          Lekashman, John          lekash@ORVILLE.NAS.NASA.GOV
+   [JLB79]         Boyd, Jerry L.           ---none---
+   [JLD31]         Delhaye, Jean-Loic
+                   delhaye@frmop11.bitnet@CUNYVM.CUNY.EDU
+   [JLD42]         Danrich, Joseph L.       ---none---
+   [JLM23]         Mills, John Luke         Mills@GRANITE.CR.BULL.COM
+   [JLP6]          Peterson, Jan L.
+                   caeco!olyis!sol!jlp@CS.UTAH.EDU
+   [JLR4]          Romkey, John L.          romkey@ASYLUM.SF.CA.US
+   [JLR43]         Russell, James L.        russell@SOFTWARE.ORG
+   [JLS45]         Sloan, John L.
+                   shollen%spots.wright.edu@RELAY.CS.NET
+   [JLW49]         Wilson, Jonathan L.      WILSONJL@HQHSD.BROOKS.AF.MIL
+   [JM113]         McCombie, Jon W.         jmccombie@BBN.COM
+   [JM246]         Moretz, Joseph           rogers@NEMS.DT.NAVY.MIL
+   [JM278]         Mazumdar, Jin
+                   mazumdar%buffalo.csnet@RELAY.CS.NET
+   [JM292]         Murai, Jun               jun@u-tokyo.ac.jp
+   [JM303]         Moorfoot, John
+                   jgm%charlie.oz@seismo.CSS.GOV
+   [JM304]         McClurg, Jim             ---none---
+   [JM414]         Miceli, Joe              JMICELI@CCMAIL.SUNYSB.EDU
+   [JM433]         Marshall, John           john@UCONN.EDU
+   [JM451]         Martell, Javier          ---none---
+   [JM468]         Mathisen, Jaye
+                   icsu6000@CAESAR.CS.MONTANA.EDU
+   [JM476]         Mendez, Jose             J_MENDEZ@UPR1.UPR.CLU.EDU
+   [JM493]         Mann, John               johnm@VAXC.CC.MONASH.EDU.AU
+   [JM551]         Martillo, Joachim
+                   decvax!frog!cpoint!martillo@UCBVAX.Berkeley.EDU
+   [JM561]         Murdock, Joseph          ---none---
+   [JM586]         McIntosh, Jim
+                   jim%auvm.bitnet@CUNYVM.CUNY.EDU
+   [JM588]         Martin, Jenny
+                   mcvax!cam-orl!jm@UUNET.UU.NET
+   [JM60]          McCollum, Jim            MCCOLLUM@TOPS20.DEC.COM
+   [JM627]         McClure, Jim             ---none---
+   [JM647]         Mizrahi, Jacob
+                   JACOB%HUJIVMS.BITNET@CUNYVM.CUNY.EDU
+   [JM663]         McCabe, Jim              jmccabe@NAS.NASA.GOV
+   [JM678]         Morris, Jim              jmorris@BBN.COM
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 144]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [JM679]         Miller, Jeff             STEVE@JHEREG.MN.ORG
+   [JMB64]         Bullington, Joe M.       ---none---
+   [JMD6]          Diaz, Jean Marie         ambar@ORA.COM
+   [JME15]         Elliott, Jeffrey M.
+                   Elliottjm@USAFACDM-AM1.AF.MIL
+   [JMH10]         Hayes, Jordan Michael    jordan@MORGAN.COM
+   [JMM50]         Moe, James M., Jr.       ---none---
+   [JMO4]          Odinot, Jean-Marc        edgard@GIPSI.FR
+   [JMR45]         Roy, Jean Michael        roy@GALAAD.CNET-PAB.FR
+   [JMRM]          Matheson, James M.R.
+                   jmrm%digsys.engineering.cambridge.ac.uk@
+                   NSS.CS.UCL.AC.UK
+   [JMS17]         Schlueter, Jens-M.
+                   schlueter%vax.awi-bremerhaven.dbp.de@RELAY.CS.NET
+   [JMS56]         Snyder, Joel M.          jms@MIS.ARIZONA.EDU
+   [JMT1]          Turner, James M.         turner@KSR.COM
+   [JMT18]         Turner, James M.
+                   envos.com!jmturn%rattler.uucp@XAIT.XEROX.COM
+   [JMV7]          Visovsky, Joseph M.      ---none---
+   [JN12]          Navarro, Joseph
+                   O_MORENO%ACUPR.UPR.CUN.EDU@CORNELLC.CIT.CORNELL.EDU
+   [JN40]          Noble, John              ---none---
+   [JN47]          Nerbovig, Jerry          ---none---
+   [JN91]          Nichols, Jeff            ---none---
+   [JO54]          O'Connor, John           ---none---
+   [JO93]          Oborny, Jim              ---none---
+   [JO94]          Ott, Jim                 ---none---
+   [JOG]           Gartley, John O.         gartley@ALDNCF.ALCOA.COM
+   [JOH]           Hewett, Johnny O.        ---none---
+   [JOO]           Ostlund, James O.        ostlund@SALK-ADM.SDSC.EDU
+   [JP147]         Petragnani, Joseph       petragna@SJUPHIL.SJU.EDU
+   [JP207]         Pansiot, Jean-Jacques    ---none---
+   [JP220]         Pace, Joe                spked!pace@UCDAVIS.EDU
+   [JP232]         Polk, Jeff               polk@PRISMA.COM
+   [JP247]         Powers, Jack             powers@IBM.COM
+   [JP254]         Prevost, Jacques         PREVOST@DPHVX2.DECNET.CERN
+   [JP262]         Poisson, Joe
+                   00839%aeclcr.bitnet@CORNELLCC.CCS.CORNELL.EDU
+   [JP283]         Patoskie, John           ---none---
+   [JP301]         Packer, John             J.Packer@OAK.CC.KCL.AC.UK
+   [JP302]         Pettitt, John            jpp@SPECIALIX.CO.UK
+   [JP303]         Paschal, Janine          ---none---
+   [JP304]         Perchik, Jim             perchik@CAMBRIDGE.IBM.COM
+   [JP325]         Pier, Jeff               ---none---
+   [JPB17]         Bossert, John P.
+                   uw-beaver!uw-entropy!thebes!bossert@RUTGERS.EDU
+   [JPC17]         Chion, J.P.              ---none---
+   [JPD]           Dubois, Jean-Paul
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 145]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+                   JPD%POLYTECA.BITNET@CUNYVM.CUNY.EDU
+   [JPD18]         Draughon, J. Phillip     jpd@ACCUVAX.NWU.EDU
+   [JPH17]         Hanley, John P.          jhanley@ORACLE.COM
+   [JPO4]          O'Brien, John Paul
+                   john%novavax@BIKINI.CIS.UFL.EDU
+   [JPS17]         Stoneback, John P.
+                   allegra!mc70!stonebac@seismo.CSS.GOV
+   [JPS21]         Sorensen, Jan P.         rkujps@VM.UNI-C.DK
+   [JPW11]         Wies, J.P.               ---none---
+   [JR15]          Rhodes, John E.          jrhodes@LOGNET2.AF.MIL
+   [JR206]         Ramey, Joe               ramey@CSC.TI.COM
+   [JR222]         Roberts, Jeffrey         JEFF@HCR.COM
+   [JR262]         Renfro, Jack             ---none---
+   [JR276]         Roth, Jeff               jroth@DSAC.DLA.MIL
+   [JR283]         Richardson, John         JRICH@UCRMATH.UCR.EDU
+   [JR311]         Richardson, John         ---none---
+   [JR38]          Rutemiller, John
+                   Rutemiller@DOCKMASTER.NCSC.MIL
+   [JR40]          Reece, John              jreece@SC.INTEL.COM
+   [JRA26]         Adams, John R.           ---none---
+   [JRC27]         Chappell, Jim R.         jrc@PENTAGON-BCN.ARMY.MIL
+   [JRF]           Fisher, James R.         jfisher@ISDRES.ISD.USGS.GOV
+   [JRF12]         Fowler, James R.
+                   jfowler@GALILEO.APO.NMSU.EDU
+   [JRF21]         Freeman, James           ---none---
+   [JRJ12]         Jaeger, Jay R.           ---none---
+   [JRJ16]         Johnson, Jack R.         ---none---
+   [JRJ18]         Jesson, J. R.            jr@MERIT-TECH.COM
+   [JRL3]          LoVerso, John Robert     loverso@XYLOGICS.COM
+   [JRR14]         Ragland, Joe R.          jrr@NCNOC.CONCERT.NET
+   [JRR6]          Slifko, Gary J.          NSC-McCl@DDN2.DCA.MIL
+   [JRS48]         Shaeffer, James R.       shaeffer@ASNGAT.ASN.NET
+   [JRS67]         Shiflett, James Russell  Shiflett@SXFEP.HARC.EDU
+   [JRS8]          Schwab, Jeffrey R.       jrs@ECN.PURDUE.EDU
+   [JS167]         Shprentz, Joel           shprentz@BDM.COM
+   [JS171]         Scott, Jerry             JERRY@TWG.COM
+   [JS210]         Stearns, Jeff            jeff@TC.FLUKE.COM
+   [JS255]         Setzer, James            ---none---
+   [JS268]         Simonetti, J.            ---none---
+   [JS28]          Shriver, John A.         jas@PROTEON.COM
+   [JS281]         Shultis, Jonathan C.     Jon.Shultis@INCSYS.COM
+   [JS283]         Schwartz, Jack           JSCHWARTZ@A.ISI.EDU
+   [JS338]         Sherwood, John           SHERWOOD@AC.DAL.CA
+   [JS450]         Stalcup, J.              stalcup@TTACS1.TTU.EDU
+   [JS469]         Segers, Jerry
+                   jsegers%uga.bitnet@CUNYVM.CUNY.EDU
+   [JS511]         Shumate, John            jcs@NCR-SD.SANDIEGO.NCR.COM
+   [JS522]         Stone, John              STONE@USNA.MIL
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 146]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [JS535]         Stewart, John            John_Stewart@CARLETON.CA
+   [JS550]         Stadler, Janis           ---none---
+   [JS573]         Sherman, Jan
+                   asqe-y-n-f-ab02@ANSBACH-EMH1.ARMY.MIL
+   [JS583]         Swisher, Joel            ---none---
+   [JS591]         Snyder, Jeff             JCS@WITTENBERG.EDU
+   [JS592]         Schnizlein, John         JOHNS@HOUSE.GOV
+   [JS593]         Setzer, James            JIM_SETZER@MV15.RUNET.EDU
+   [JS596]         Slee, Jamie              J_Slee@VAX.ACS.OPEN.AC.UK
+   [JS597]         Stewart, John            netcoor@NCS.DND.CA
+   [JS598]         Scott, Jack              ---none---
+   [JS599]         Smaby, John              ---none---
+   [JS602]         Spading, John            ---none---
+   [JS603]         Sundman, Jonas           ---none---
+   [JS609]         Stand, John              ---none---
+   [JS81]          Smith, Jeff              JSMITH@CC.PURDUE.EDU
+   [JSA2]          Aldrich, Jeffrey S.
+                   ALDRICHJ%LAWRENCE.BITNET@CUNYVM.CUNY.EDU
+   [JSG1]          Groff, John S.           SGROFF@CCJ.BBN.COM
+   [JSG2]          Goldberg, J. Scott       jgoldberg@TELESOFT.COM
+   [JSL9]          Lowe, James S.           james@UWM.EDU
+   [JSM11]         Miller, James S.         jmiller@CS.BRANDEIS.EDU
+   [JSOL]          Solomon, Jonathan A.     jsol@BU-IT.BU.EDU
+   [JSQ1]          Quarterman, John S.      jsq@LONGWAY.TIC.COM
+   [JSS4]          Sabnis, Jayant S.        SABNIS@CCF3.NRL.NAVY.MIL
+   [JSW12]         Williams, J. Scott       scott@WWU.EDU
+   [JSY2]          Yaplee, Jeffrey S.       ---none---
+   [JT122]         Thomassen, Jens          Jens@IFI.UIO.NO
+   [JT147]         Thompson, James          convex!jthomp@A.CS.UIUC.EDU
+   [JT149]         Tysko, John              tysko@BOSS.CS.OHIOU.EDU
+   [JT166]         Tuomola, Jari            ---none---
+   [JT167]         Tingsell, Jan-Gunnar     jgt@HUM.GU.SE
+   [JT181]         Timlick, John            ---none---
+   [JT185]         Tucker, Jim              ---none---
+   [JT220]         Tarrant, Judith
+                   jtarrant@TCGOULD.TN.CORNELL.EDU
+   [JT222]         Tonnesen, Jan            ---none---
+   [JTM24]         McCartin, Joseph T.      MCCARTIN@UNIX1.EUCOM.MIL
+   [JTS3]          Shirron, John T.         jshirron@CMF.NRL.NAVY.MIL
+   [JU14]          Urbach, James            ---none---
+   [JV13]          Vogel, John              ---none---
+   [JV41]          Voigt, John              SYSBJAV@VM.TCS.TULANE.EDU
+   [JV53]          Vinh, Josianne
+                   mcvax!inria!ens.ens.fr!vinh@UUNET.UU.NET
+   [JV69]          Vaerno, Johan            ---none---
+   [JV70]          Vannoy, John
+                   vannoy%pepvax.bitnet@CUNYVM.CUNY.EDU
+   [JV74]          Vincent, James           ---none---
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 147]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [JV97]          VanGalder, Janette       ---none---
+   [JV98]          Voss, John
+                   j_voss@SHOGUN.CAPRICORNIA.OZ.AU
+   [JVE2]          Eijndhoven, Jos van      ---none---
+   [JW136]         White, James D.          jdw@AARDVARK.UCS.UOKNOR.EDU
+   [JW156]         Wray, John               JCW2%rsre@CS.UCL.AC.UK
+   [JW181]         Washer, James W.         washer@LLL-CRG.LLNL.GOV
+   [JW266]         Westbrock, Jon           jonwest@ROSEMOUNT.COM
+   [JW301]         Winkelman, Jim
+                   jrw%noaasel.gov@HANDIES.UCAR.EDU
+   [JW302]         Widen, Johan             jw@SICS.SE
+   [JW310]         Waters, Jim              waters@POLYA.STANFORD.EDU
+   [JW326]         Whitfill, Jim            whitfill%meediv@LANL.GOV
+   [JW335]         Wolford, James           MWOLFORD@MUSRV.MUOHIO.EDU
+   [JW337]         Watters, John            JWATTERS@UA1VM.UA.EDU
+   [JW352]         Woolverton, John         WOOLSTAR@EREHWON.UUCP
+   [JW375]         Woods, John              ---none---
+   [JW377]         Wagner, Juergen          gandalf@CSLI.STANFORD.EDU
+   [JW382]         Wilman, Jim
+                   CSJAW!ECNCDC.BITNET@CUNYVM.CUNY.EDU
+   [JW47]          Wobus, John              JMWOBUS@SUVM.ACS.SYR.EDU
+   [JWB35]         Bennett, John W.         jwb@DSTOS3.DSTO.OZ.AU
+   [JWB48]         Buchanan, John W.        BUCHNAN@BRL.MIL
+   [JWB65]         Blackmon, Joseph W.      network@NCSA.UIUC.EDU
+   [JWE12]         Erikson, Jon W.          ---none---
+   [JWH39]         Himpel, John W.          ---none---
+   [JWM3]          Meidinger, James W.      jim@BIGBURD.PRC.UNISYS.COM
+   [JWM53]         Manly, John W.
+                   jwmanly%amherst.bitnet@MITVMA.MIT.EDU
+   [JWN10]         Norris, James W.
+                   a02jwn1%niu.bitnet@CUNYVM.CUNY.EDU
+   [JY24]          Yu, Jessica              jyy@MERIT.EDU
+   [JY33]          Yoshida, Jun             ---none---
+   [JY35]          Young, Jeff              ---none---
+   [KA14]          Ackermann, Dr. Kurt      ---none---
+   [KA4]           Auerbach, Karl           auerbach@CSL.SRI.COM
+   [KAA]           Adelman, Kenneth A.      Adelman@TGV.COM
+   [KB129]         Boyer, Kerry
+                   KBOYER%CALSTATE.BITNET@CUNYVM.CUNY.EDU
+   [KB134]         Baker, Ken               ---none---
+   [KB32]          Berggren, Kent           ---none---
+   [KB60]          Braun, Karl              ---none---
+   [KBC]           Casey, Kevin B.
+                   kbcasey@GALLUX.GALLAUDET.EDU
+   [KC1]           Carney, Kevin            kcarney@UTS.AMDAHL.COM
+   [KC105]         Callison, Kelly
+                   K.CALLISON%USCGA.BITNET@CUNYVM.CUNY.EDU
+   [KC40]          Chang, Kelly             kccs!khc@AMES.ARC.NASA.GOV
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 148]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [KC8]           Chen, Ken
+                   SIMNET-PERCEPTRONICS@A.ISI.EDU
+   [KCM2]          McDonald, Kelly C.       KELLY@NOC.BYU.EDU
+   [KD36]          DeJager, Keith           sunatl!ninja!dj@SUN.COM
+   [KD77]          Dalton, Kay              u1906AB@VMS.UCC.OKSTATE.EDU
+   [KDA5]          Augustin, Kurt D.        AUGUSTINKD@AFOTEC2.AF.MIL
+   [KDM5]          Miller, Keith D.         ---none---
+   [KDM6]          Mayer-Spohn, Klaus D.
+                   ZRAM%DS0RUS1I.BITNET@CUNYVM.CUNY.EDU
+   [KDO]           Olum, Ken D.             KDO@LUCID.COM
+   [KDZ]           Zeilenga, Kurt D.        KURT@AGPS.LANL.GOV
+   [KE1]           England, Kent            kwe@BU-IT.BU.EDU
+   [KEP9]          Pickelheimer, Keith E.   PICKELHKE@WPAFB-AMS1.AF.MIL
+   [KEW8]          Wampler, Kurt E.
+                   hplabs!hpda!intersil!wampler@UNIX.SRI.COM
+   [KF55]          Farghaly, Kerim          ---none---
+   [KFS]           Sauer, Kurt F.           Sauer@DOCKMASTER.NCSC.MIL
+   [KFS2]          Schmidt, K. F.           ---none---
+   [KG12]          Gordon, Kenneth          ---none---
+   [KG16]          Gordon, Ken
+                   gordon%vax1.tcd.ie@CUNYVM.CUNY.EDU
+   [KG35]          Gilmore, Kirk
+                   gilmore@GALILEO.AS.ARIZONA.EDU
+   [KH128]         Hannan, Kevin
+                   fhannan!ceramics!bitnet@CUNYVM.CUNY.EDU
+   [KH59]          Hull, Kenneth            HULLKE@ASD.WPAFB.AF.MIL
+   [KH74]          Han, Kisoo
+                   kshan%etrivax.etri.re.kr@RELAY.CS.NET
+   [KH88]          Henriksen, Kyle          kyle@TIS-W.ARPA
+   [KHJ]           Jobes, Karen H.
+                   jobes%iassns.bitnet@CUNYVM.CUNY.EDU
+   [KHJ1]          Jenkins, Karen H.        cd33xkhj@CORONA-PO.NAVY.MIL
+   [KJ1]           Jensen, Kris             jensen@RYE.CS.UNM.EDU
+   [KJ36]          Johnson, Ken             ---none---
+   [KJ4]           Johnson, Kurt            ---none---
+   [KJK4]          Kramer, Kevin J.         ---none---
+   [KJS10]         Sweet, Kevin J.          SWEET@HORIZON.COM
+   [KK104]         Kolari, Klaus            ---none---
+   [KK87]          Kempf, Kim               mcrware!kim@UUNET.UU.NET
+   [KK92]          Kikuchi, Kunihiro        ---none---
+   [KKS]           Spagnolo, Ken            K.SPAGNOLO@MASSEY.AC.NZ
+   [KL31]          Lamb, Kathleen           klamb@MINES.COLORADO.EDU
+   [KL40]          Lowe, Ken                ken@BLAKE.ACS.WASHINGTON.EDU
+   [KL63]          Love, Kim                love@STARS.RESTON.UNISYS.COM
+   [KL66]          Laaksonen, Kimmo         kla@HUT.FI
+   [KL78]          Lockhart, Kent           lockhart@MWUNIX.MITRE.ORG
+   [KLS24]         Smith, Kathryn L.        kathy@XN.LL.MIT.EDU
+   [KM103]         McNees, Kelly            isglgu@RAMSTEIN2-EMH.AF.MIL
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 149]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [KM129]         Maciunas, Kevin          kevin@CS.FLINDERS.OZ.AU
+   [KM131]         Miller, Kevin            caeco!kev@CS.UTAH.EDU
+   [KM2]           Maletsky, Kerry          ---none---
+   [KM6]           Mayo, Kevin
+                   munnari!biomact.oz.au!kevin@UUNET.UU.NET
+   [KM79]          Moran, Kathy             ---none---
+   [KM82]          Murakami, Ken'ichiro
+                   murakami%ntt-20.ntt.jp@RELAY.CS.NET
+   [KMC3]          Crepea, Kenneth M.       Crepea@CCFS.CENTCOM.MIL
+   [KMH8]          Hays, Kenneth M.         hays@gw.scri.fsu.edu
+   [KNC]           Carpenter, Kevin N.      KNCARP@NICSN1.MONSANTO.COM
+   [KO11]          O'Keefe, Kevin           HAZELTINE@A.ISI.EDU
+   [KOP2]          Peasley, Kim O.          symbio!symbio@CS.ORST.EDU
+   [KP45]          Petraska, Karen          KAREN@UMBC3.UMBC.EDU
+   [KP50]          Percival, Kent           PERCIVAL@VM.UOGUELPH.CA
+   [KPK3]          Kleinfelter, Kevin P.    ---none---
+   [KR35]          Reynolds, Keith          keithr@SCO.COM
+   [KR59]          Rowett, Kevin            KEVINR@TANDEM.COM
+   [KR69]          Rabideau, Karen
+                   karen%tufts.bitnet@MITVMA.MIT.EDU
+   [KR72]          Reinholtz, Kirk          KIRK@MOC.JPL.NASA.GOV
+   [KR77]          Rugg, Ken                krugg@GOLDHILL.COM
+   [KR79]          Rossbach, Kim            ---none---
+   [KR80]          Rogers, Karen            rogerskm%esvax@DUPONT.COM
+   [KR9]           Rohan, Kevin             JJKKRR@COS1.FAC.FORD.COM
+   [KRF5]          Fuller, Kevin R.         ---none---
+   [KRH4]          Hacke, Keith R.          Hacke@MDC.COM
+   [KRM5]          Magill, K. Richard       rich@OXTRAP.AA.OX.COM
+   [KRS21]         Stephens, Kris R.        krs@UTS.AMDAHL.COM
+   [KS121]         Simpson, Kenneth         ksimpson@LOIHI.HIG.HAWAII.EDU
+   [KS125]         Simonsen, Keld           keld@dkuug.dk
+   [KS133]         Scully, Kevin            ---none---
+   [KS14]          Seo, Karen S.            KSEO@BBN.COM
+   [KS153]         Sandvik, Kent            ksand@APPLEOZ.OZ.AU
+   [KS154]         Shimizu, Kyoichi         ---none---
+   [KS156]         Sanders, Kevin           ---none---
+   [KS158]         Samec, Kathi             ---none---
+   [KS24]          Kupperion, Brian A.      ---none---
+   [KS32]          Stott, Kaye              K_STOTT@VAXA.UWA.OZ.AU
+   [KS62]          Simpson, Kathy           ---none---
+   [KSL]           Lougheed, Kirk S.        LOUGHEED@CISCO.COM
+   [KT43]          Twidle, Kevin            ---none---
+   [KV14]          Vickers, Kyle            ---none---
+   [KW2]           Wescourt, Keith T.       WESCOURT@CEL.FMC.COM
+   [KW75]          Walker, Katie            NSC-Bark@DDN3.DCA.MIL
+   [KW8]           Wuerfl, Karl
+                   wuerfl%vax1.rz.uni-regensburg.dbp.de@RELAY.CS.NET
+   [KW96]          Wehmeyer, Keith          ---none---
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 150]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [LA55]          Allison, Larry           ---none---
+   [LAM1]          Mamakos, Louis A.        louie@TRANTOR.UMD.EDU
+   [LB110]         Binding, Lothar
+                   $45%dhdurz1.bitnet@CUNYVM.CUNY.EDU
+   [LB16]          Bukys, Liudvikas         bukys@CS.ROCHESTER.EDU
+   [LB164]         Bradley, Larry           larry@VM.NRC.CA
+   [LB181]         Bengtsson, Lars          lars@MECEL.SE
+   [LB189]         Beaulieu, Laurier        ---none---
+   [LB190]         Benjamin, Lee            ---none---
+   [LB201]         Barram, Laurie           ccnetman@BUNYIP.CC.UQ.OZ.AU
+   [LB24]          Burris, Lee
+                   asqnh-nsc@HUACHUCA-EMH2.ARMY.MIL
+   [LB8]           Brown, Lawrence          drd!zlhb0a@UUNET.UU.NET
+   [LC149]         Caylor, Larry            ---none---
+   [LC151]         Coulson, Leilani
+                   lcoulson@NARDACDC002.NARDAC-DC.NAVY.MIL
+   [LC152]         Clancy, Leon             LMCLAN@ICASE.EDU
+   [LC160]         Claiborne, Louvenia
+                   CLAIBORN@PENTAGON-OPTI.ARMY.MIL
+   [LC57]          Claudio, Lester          lclaudio@WNYOSI2.NAVY.MIL
+   [LCH9]          Holmberg, Leo C.         CSERH000@KSUVXA.KENT.EDU
+   [LCN]           Nelson, Louis C.         lou@AEROSPACE.AERO.ORG
+   [LCV]           Varian, Lee C.           lvarian@PUCC.PRINCETON.EDU
+   [LCVDH]         van den Heuvel, L. C.
+                   SYVAXVDH%HMARL5.BITNET@CUNYVM.CUNY.EDU
+   [LD4]           Damon, Lee               NOMAD@CASTLE.ORG
+   [LD46]          Deni, Larry
+                   deni%canisius.bitnet@CUNYVM.CUNY.EDU
+   [LD82]          Davis, Laurie            ---none---
+   [LDB3]          Borchert, L. David
+                   borchert@ARSOCOMVAX.SOCOM.MIL
+   [LE24]          Eriksson, Lars-Anders    larsa@TOTT.LIU.SE
+   [LF58]          Felder, Harry            janus!harry@UUNET.UU.NET
+   [LF61]          Freil, Lawrence          lef@DOGWOOD.ATL.GA.US
+   [LF70]          Fahnoe, Lawrence         FAHNOE@UWPLATT.EDU
+   [LFM5]          Morales, Luis F., Jr.
+                   lmorales@HUACHUCA-EMH8.ARMY.MIL
+   [LG115]         Gasparro, Lou            shooter@UK.ORACLE.COM
+   [LG91]          Goodhue, Lynn
+                   lgoodhue%smith.bitnet@MITVMA.MIT.EDU
+   [LGB1]          Bussard, Lewis G.        BUSSARD@EDWARDS-2060.AF.MIL
+   [LH124]         Hicks, Larry
+                   UIUCDCS!BRADLEY!LARZ@SEAS.UCLA.EDU
+   [LH2]           Hayford, Lloyd           ---none---
+   [LHG3]          Gindler, Lawrence H.
+                   LGINDLER%TRINITY.BITNET@CUNYVM.CUNY.EDU
+   [LJ58]          Jones, Louis             postmaster@JAX.ORG
+   [LJC2]          Crosby, Linda J.
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 151]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+                   LCROSBY@ST-LOUIS-EMH2.ARMY.MIL
+   [LJE3]          Edel, Leander J.         ---none---
+   [LJK]           Kaufman, Lawrence J.     lkaufman@BBN.COM
+   [LJR5]          Romero, Louis J.         ---none---
+   [LJV4]          Vik, Leif Jarle          ---none---
+   [LK27]          Kurtz, Linda J.          KURTZ@EODTC-POE.NAVY.MIL
+   [LK66]          Krystek, Lee             ---none---
+   [LL115]         Lane, Lee                llane@CISS.DAYTON.NCR.COM
+   [LL56]          Lattanzi, Len            len@SYNTHESIS.COM
+   [LL64]          Leedom, Leith (Casey)    casey@LLL-CRG.LLNL.GOV
+   [LLZ1]          Zumbach, Lyle L.         ---none---
+   [LM176]         McDonald, Larry          ---none---
+   [LM185]         McCormick, Linda
+                   L.McCormick@UK.AC.GLA.ENG.CAE
+   [LM220]         Mcgee, Lance             mcgee@UCRAC1.UCR.EDU
+   [LM237]         Morales, Lydia
+                   lmorales@NARDACDC002.NARDAC-DC.NAVY.MIL
+   [LM35]          Michela, Larry J.        ---none---
+   [LM62]          Manderson, Landy
+                   usts034%uabtucc.bitnet@CUNYVM.CUNY.EDU
+   [LM88]          McLoughlin, Lee
+                   lmjm%DOC.IC.AC.UK@CS.UCL.AC.UK
+   [LN1]           Nielsen, Leonard         u16278@UICVM.UIC.EDU
+   [LN4]           Needleman, Lee L.        NSC-Dobb@DDN2.DCA.MIL
+   [LN42]          Nerenberg, Lyndon
+                   lyndon@CS.ATHABASCAU.CA
+   [LN47]          Newton, Lawrence
+                   lnewt@MDA85.CANCER.UTEXAS.EDU
+   [LNZ]           Zubkoff, Leonard N.      edsel!lnz@LABREA.STANFORD.EDU
+   [LO24]          Oattes, Lee              oattes@UTCS.UTORONTO.CA
+   [LO28]          Owen, Larry              OWEN@DUCVAX.AUBURN.EDU
+   [LP71]          Paniccia, Larry          ---none---
+   [LPM]           Michelson, Leslie P.     michelso@JVNCF.CSC.ORG
+   [LR312]         Ragans, Lawrence T. (Larry)---none---
+   [LR44]          Roy, Lynette             roy@GMR.COM
+   [LRB]           Bierma, Larry R.         BIERMA@NPRDC.NAVY.MIL
+   [LRC7]          Custead, Larry R.
+                   CUSTEAD%SASK.BITNET@CUNYVM.CUNY.EDU
+   [LRR1]          Rogers, Lawrence R.      lrr@PRINCETON.EDU
+   [LS103]         Schilmoeller, Leon       ---none---
+   [LS198]         Shipley, Lisa            ---none---
+   [LS224]         Sugar, Laszlo            ---none---
+   [LS226]         Snyder, Larry            ---none---
+   [LS227]         Schoenzeit, Loren        loren@MGI.COM
+   [LS228]         Schafer, Lutz
+                   LUS!DMZMP15P.BITNET@CUNYVM.CUNY.EDU
+   [LS64]          Shumate, Lonnie          ---none---
+   [LT70]          Thomas, Larry
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 152]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+                   EAID-SI-SI@CASEY-EMH1.ARMY.MIL
+   [LT75]          Tillman, Lin             lin @WUERZBURG-EMH1.ARMY.MIL
+   [LV6]           Viswanath, L.
+                   viswanat%snycorba.bitnet@CUNYVM.CUNY.EDU
+   [LW134]         Webb, Larry              ---none---
+   [LW137]         Wolf, Lee                mmdf@AUGSBURG-EMH1.ARMY.MIL
+   [LW138]         Webster, Leslie
+                   mmdf@BURTONWOOD-EMH1.ARMY.MIL
+   [LW26]          Winkler, Linda           b32357@anlvm.ctd.anl.gov
+   [LWA8]          Austin, Larry W.         ---none---
+   [MA]            Accetta, Michael         MIKE.ACCETTA@A.CS.CMU.EDU
+   [MA105]         Ambriz-Maguey, Marco
+                   red%unamvm1.bitnet@CUNYVM.CUNY.EDU
+   [MA107]         Anello, Mike             mja@SIMPACT.COM
+   [MA119]         Allen, Michael           ---none---
+   [MA24]          Anderson, Melanie        m-anderson@UIUC.EDU
+   [MA56]          Alexander, Mark
+                   kma@samson.cadr.dialnet.symbolics.com
+   [MA63]          Allen, Mike              allen@ETHZ.CH
+   [MA88]          Andrews, Mark            marka@SYD.DMS.CSIRO.AU
+   [MAB4]          Brown, Mark A.           Mark@OBERON.USC.EDU
+   [MAG13]         Gadiwalla, Muslim A.     ---none---
+   [MAG16]         Gallo, Michael A.        gallo@ZENO.FIT.EDU
+   [MAG37]         Goldsberry, Michael      ---none---
+   [MAJ1]          Joyce, Marlena A.        ---none---
+   [MAJ14]         Jackson, Michael A.      ---none---
+   [MAM71]         Metzner, Mark A.         ---none---
+   [MAV4]          Verber, Mark A.          VERBER@SOLUTIONS.COM
+   [MAW25]         Waldschmidt, Mark A.     MARKW%CPVB.SPAN@SDS.SDSC.EDU
+   [MB]            Brescia, Michael         BRESCIA@BBN.COM
+   [MB143]         Brichta, Michael         brichta@SIEMENS.SIEMENS.COM
+   [MB203]         Bernards, Marcel         bernards@ECN.NL
+   [MB204]         Bounds, Mitchell         ---none---
+   [MB26]          Brzustowicz, Mike        MAB@ADS.COM
+   [MB262]         Berchier, Marcel
+                   BERCHIER%CFRUNI51.BITNET@CUNYVM.CUNY.EDU
+   [MB273]         Beelen, Marcel
+                   hp4nl!oce.nl!mbee@UUNET.UU.NET
+   [MB288]         Beckerle, Michael        mikeb@MCRC.MOT.COM
+   [MB293]         Betel, Michiel           michiel%cadlab1@UUNET.UU.NET
+   [MB307]         Bushway, Marilyn         MKB@OHSU.EDU
+   [MB308]         Bell, Michael            ---none---
+   [MB31]          Bereschinsky, Michael
+                   beresch@HEXSUNFS.C3SYS.ARMY.MIL
+   [MB310]         Barker, Malcolm          M.Barker@WARWICK.AC.UK
+   [MB32]          Belot, Michel            ---none---
+   [MB324]         Bourguel, Maurice
+                   BOURGUELAFRMRS11.BITNET@CUNYVM.CUNY.EDU
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 153]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [MB9]           Boring, Mike             BORING@GATEWAY.MITRE.ORG
+   [MC128]         Cooper, Mike
+                   PACISMO@HAWAII-EMH1.PACOM.MIL
+   [MC17]          Crawford, Matt           matt@ODDJOB.UCHICAGO.EDU
+   [MC202]         Curran, Mike             MCURRAN@NARDACDC002.NAVY.MIL
+   [MC261]         Cronenweth, Mark         ---none---
+   [MC264]         Cooling, Mike            cooling@CSUS.EDU
+   [MC280]         Caines, Max
+                   M.Caines@SYSA.WOLVERHAMPTON.AC.UK
+   [MC290]         Colburn, Mark            mark@MINNETECH.MN.ORG
+   [MC293]         Connolly, Michael        connollym@DCU.IE
+   [MC299]         Coleman, Michael         ---none---
+   [MC301]         Chesterfield, Mark       mark@BOHRA.CPG.OZ
+   [MC65]          Corn, Michael            ---none---
+   [MCA1]          Akers, Mary
+                   steapqa@APG-EMH3.APG.ARMY.MIL
+   [MCB5]          Berch, Michael C.        mcb@PRESTO.IG.COM
+   [MCD11]         Donahue, Michael         ---none---
+   [MCL9]          Linimon, Mark C.
+                   hpda!sun!central!mizarvme!linimon@UCBVAX.Berkeley.EDU
+   [MD119]         Draughn, Mark            draughn@IITMAX.IIT.EDU
+   [MD127]         Devauze, Michel          ---none---
+   [MD142]         Dubetz, Martin           dubetz@WUGATE.WUSTL.EDU
+   [MD177]         Dew, Martin              mcd!mcdd1.uucp@UUNET.UU.NET
+   [MD184]         Dupont, Michael          ---none---
+   [MD97]          Dunston, Bobby           NSC-Elm@DDN3.DCA.MIL
+   [MDE3]          Eggers, Mark D.
+                   CF4A8X%IRISHMVS.BITNET@CUNYVM.CUNY.EDU
+   [MDF13]         Ferrar, M. D.            ---none---
+   [MDL1]          Lumby, Michael B.        NSC-Peter@DDN2.DCA.MIL
+   [MDP16]         Parker, Michael D.       chip!mparker@NOSC.MIL
+   [MDS30]         Spicer, Marc D.
+                   mspicer@BELVOIR-EMH3.ARMY.MIL
+   [ME38]          Elvy, Marc               ELVY@CARRARA.MARBLE.COM
+   [ME57]          Ernst, Michael
+                   r02ern%dhhdesy3.bitnet@CUNYVM.CUNY.EDU
+   [ME74]          Eastep, Michael          ---none---
+   [ME75]          Epard, Marc              ---none---
+   [MEG8]          Gibbons, Mark E.         ---none---
+   [MEV7]          Verona, Mary Ellen
+                   MHANEY@TCGOULD.TN.CORNELL.EDU
+   [MF14]          Fingerhut, Michael       ircam!mf@UUNET.UU.NET
+   [MF148]         Frutig, Marvello
+                   USERMEFF%LNCC.BITNET@CUNYVM.CUNY.EDU
+   [MF19]          Fedor, Mark              fedor@patton.NYSER.NET
+   [MF31]          Fouts, Martin            FOUTS@AMELIA.ARC.NASA.GOV
+   [MF4]           Federspiel, Mathieu
+                   mcf!STATWARE.UUCP@UUNET.UU.NET
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 154]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [MF74]          Fidler, Michael L.
+                   ts0026@OHSTVMA.IRCC.OHIO-STATE.EDU
+   [MF96]          Furnari, Mario           FURNARI@ARCO.NA.CNR.IT
+   [MG120]         Garcia, Mary
+                   GARCIA@TURNER-JOY.NOARL.NAVY.MIL
+   [MG16]          Gallaher, Michael        gallaher@TOPAZ.RUTGERS.EDU
+   [MG205]         Ganswindt, Helena
+                   helenag@HEILBRONN-EMH1.ARMY.MIL
+   [MG206]         Girard, Michel           ---none---
+   [MG207]         Giger, Max               ---none---
+   [MG58]          Gilbert, Mike            JNG%SLI.COM@UUNET.UU.NET
+   [MG95]          Greisen, Marc            ---none---
+   [MGR2]          Rohren, Mark G.
+                   c3314mgr@DOM1.NWAC.SEA06.NAVY.MIL
+   [MH118]         Harper, Malcom
+                   mkh%sevax.prg.oxford.ac.uk@CS.UCL.AC.UK
+   [MH15]          Harrison, Mark S.        NSC-Patrick@DDN2.DCA.MIL
+   [MH198]         Hirabaru, Masaki         hi@CSCE.KYUSHU-U.AC.JP
+   [MH225]         Hamilton, Molly          system@BEACH.GAL.UTEXAS.EDU
+   [MH226]         Hirose, Masahito         hirose@FURUKAWA.CO.JP
+   [MH233]         Homsey, Mike             msh@OTC.OTCA.OZ.AU
+   [MH246]         Hamberg, Mats            mats@NEXUS.SE
+   [MH257]         Heley, Mike              mheley@STE.DYN.BAE.CO.UK
+   [MH267]         Heavey, Martin           ---none---
+   [MH269]         Haringman, Mark          ---none---
+   [MH74]          Hartmann, Manfred
+                   mhartma@APG-EMH5.APG.ARMY.MIL
+   [MH82]          Horton, Mark             mark@CBLPF.ATT.COM
+   [MHW9]          Warfield, Michael H.     wittsend!mhw@GATECH.EDU
+   [MI1]           Isaacson, Mark           ---none---
+   [MIW]           Whetzel, Mark I.         markw@AIRGUN.WG.WAII.COM
+   [MJ100]         Jacob, Matthew           ---none---
+   [MJ33]          Johnson, Mark            ---none---
+   [MJ65]          Jensen, Murray
+                   mjj%mimir.dmt.oz@UUNET.UU.NET
+   [MJ91]          Jacott, Marc             ---none---
+   [MJA14]         Ames, Michael J.         mike@JUPITER.NMT.EDU
+   [MJE]           Edelman, Michael J.      michaele@TEKTRONIX.TEK.COM
+   [MJJ1]          Jordaan, Martin J.
+                   MJORDAAN@VAXB.NSWSES.NAVY.MIL
+   [MJK12]         Kelly, Marvin J.         ---none---
+   [MJL37]         Lippold, Michael J.      ---none---
+   [MJM2]          Muuss, Michael John      MIKE@BRL.MIL
+   [MJO4]          O'Connor, Michael J.     OCONNOR@SCCGATE.SCC.COM
+   [MJO7]          O'Donnell, Michael J.    ---none---
+   [MK124]         Karas, Michael
+                   KARAS@USUHSB.UCC.USUHS.NNMC.NAVY.MIL
+   [MK132]         Kalscheuer, Michael      ---none---
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 155]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [MK133]         Kawasaki, Masako         ---none---
+   [MK162]         Kawabe, Mitsunori
+                   kawa%yaskawa.co.jp@UUNET.UU.NET
+   [MK169]         Kahn, Michael            M.Kahn@LON.AC.UK
+   [MK17]          Karels, Mike             karels@UCBARPA.BERKELEY.EDU
+   [MK38]          Kowitz, Mark             mark@ROCKY2.ROCKEFELLER.EDU
+   [MK68]          Kazar, Michael           kazar@ANDREW.CMU.EDU
+   [MK75]          Koulopoulos, Mike        well!rk@LLL-LCC.ARPA
+   [MK79]          Kito, Masafumi           ipmaster@ETL.GO.JP
+   [MKL]           Lottor, Mark K.          MKL@NIC.DDN.MIL
+   [MKS17]         Spengler, Michael K.     mks@MSC.UMN.EDU
+   [ML129]         Lobelle, Marc            ml@INFO.UCL.AC.BE
+   [ML163]         Leech, Marcus            ml@GANDALF.CA
+   [ML171]         Legendre, Michel         ---none---
+   [ML192]         Lawrence, Michael
+                   munnari!wcc.oz.au!mike@UUNET.UU.NET
+   [ML193]         Leger, Ms.               mmdf@NEUULM-EMH1.ARMY.MIL
+   [ML62]          Levine, Michael          LEVINE@A.PSY.CMU.EDU
+   [ML95]          Liu, Mei-Ling            mliu@POLYSLO.CALPOLY.EDU
+   [MLC]           Corrigan, Michael        Corrigan@DDN3.DCA.MIL
+   [MLC34]         Carlock, Malcolm L.      malc@UNRVAX.UNR.EDU
+   [MLR1]          Roman, Mark L.
+                   EANC-CP-CL@SEOUL-EMH1.ARMY.MIL
+   [MLR4]          La Rouche, Mark          markl@TWINSUN.COM
+   [MLT10]         Truesdell, M. Lynn       truesdel@PILOT.NJIN.EDU
+   [MM135]         Macbeth, Mary            ---none---
+   [MM147]         Meyer, Mark
+                   mark%unlcdc3.bitnet@CUNYVM.CUNY.EDU
+   [MM149]         Miller, Mark             LUMM@VAX1.CC.LEHIGH.EDU
+   [MM158]         Minsker, Manley          manley@SHARPE-EMH1.ARMY.MIL
+   [MM227]         Mohar, Mike              mohar@IDA.ORG
+   [MM267]         Monnin, Mark
+                   MGRMEM@BITWAY.ROSE-HULMAN.EDU
+   [MM313]         Marcinkevicz, Michael    mdm@GUMBY.DSD.TRW.COM
+   [MM333]         Moravan, Mike            moravan@CSUPWB.COLOSTATE.EDU
+   [MM334]         Murphy, Michael          mm06@GTE.COM
+   [MM348]         McGuire, Michael         ---none---
+   [MM352]         MacLeod, Mike
+                   mmacleod@UTCCSP.SPRD.UTEXAS.EDU
+   [MM371]         Martys, Mike             mmartys@VAX.CC.WILLIAMS.EDU
+   [MM379]         Mastrangeli, Mark        ---none---
+   [MM384]         Mel, Michael             ---none---
+   [MM406]         McKenzie, Malcolm        M_Mckenzie@AMIS.GOV.AU
+   [MM413]         Mailand, Mary
+                   asqexlbm4@mainz-ems1.mainz-emh1.army.mil
+   [MM427]         Mondher, Makni           ---none---
+   [MMH5]          Hayman, Martin M.        ---none---
+   [MMJ1]          Janiczek, Martin         MJANICZEK@RIA-EMH1.ARMY.MIL
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 156]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [MML8]          Lanza, Mario M.          BL-SCL@BITBURG-PIV-1.AF.MIL
+   [MMM3]          McDonnell, Michael M.    MIKE@ETL.ARMY.MIL
+   [MN36]          Nowlan, Michael
+                   mcvax!cs.tcd.ie!michael@UUNET.UU.NET
+   [MN43]          Nusinov, Marc            ---none---
+   [MN44]          Newbery, Michael         newbery@RS1.VUW.AC.NZ
+   [MN54]          Noth, Mike
+                   FMNOTHPB%UIAMVS.BITNET@CUNYVM.CUNY.EDU
+   [MN60]          Nekic, Mark              ---none---
+   [MO33]          Olafsson, Marius
+                   marius%rhi.hi.is@UUNET.UU.NET
+   [MO48]          Oros, Mark               oros@UMD5.UMD.EDU
+   [MO57]          Ohta, Masataka
+                   coordinator@TITECH.AC.JP
+   [MOUSE]         Parker, Mike
+                   mouse@LARRY.MCRCIM.MCGILL.EDU
+   [MP12]          Petry, Michael           petry@TRANTOR.UMD.EDU
+   [MP138]         Portal, M.               ---none---
+   [MP139]         Powell, Michael          powell@ISS.EATON.COM
+   [MP151]         Prior, Mark
+                   hostmaster@UCS.ADELAIDE.EDU.AU
+   [MP172]         Patterson, Mike          Mike_Patterson@MTSG.UBC.CA
+   [MP183]         Puccetti, Matt           PUCCETTI@ROCKY.RPS.NM.COM
+   [MP20]          Perras, Mickey           PERRAS@NUSC-ADA.NAVY.MIL
+   [MPM]           Mullen, M. Preston, Jr.  MULLEN@ITD.NRL.NAVY.MIL
+   [MQ7]           Quipourt, M.             ---none---
+   [MR101]         Roberson, Milton         POSTMASTER@FORUM.VA.GOV
+   [MR137]         Rackley, Mike            Rackley@CC.MSState.EDU
+   [MR152]         Raff, Malcolm            mal@BIOSYS.APLDBIO.COM
+   [MR159]         Reilly, Michael          reilly@NSL.DEC.COM
+   [MR160]         Reichling, Matthias
+                   reichling@VAX.RZ.UNI-WUERZBURG.DBP.DE
+   [MR166]         Roy, Michael             ---none---
+   [MR197]         Rose, Mark               ---none---
+   [MR198]         Rinfret, Marc            mrinfret@MATROX.COM
+   [MR29]          Russell, Mike            russell@CSC.BROWN.EDU
+   [MR78]          Rotert, Michael          Rotert@IRA.UKA.DE
+   [MRC13]         Campbell, Michael R.     ---none---
+   [MRK14]         Kaufmann, Mark R.
+                   wucs1!onemohr!mrk@UUNET.UU.NET
+   [MRN6]          Newcomb, Michael
+                   mnewcomb!unmcvm.bitnet@CUNYVM.CUNY.EDU
+   [MS101]         Szymendera, Michael      mikey@CANISIUS.EDU
+   [MS171]         Shapiro, Marc            Marc.Shapiro@C.CS.CMU.EDU
+   [MS172]         Simonians, Marina        ---none---
+   [MS195]         Shojima, Makoto          ---none---
+   [MS22]          Starner, Mark L.         starner@PRC.UNISYS.COM
+   [MS272]         Sadowski, Mike           sadowski@CAIA.WRIGHT.EDU
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 157]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [MS300]         Scolyer, Mark
+                   munnari!cidam.oz.au!rxxmts@UUNET.UU.NET
+   [MS345]         Schleicher, Marcel       ---none---
+   [MS355]         Snir, Mark
+                   MCCCOMS%HAIFAUVM.BITNET@CUNYVM.CUNY.EDU
+   [MS378]         Seguin, Mark             sysadm@PHILMTL.PHILIPS.CA
+   [MS379]         Silbernagel, Mark        ---none---
+   [MS400]         Smiley, Maria
+                   EAID-DC-IT@CASEY-EMH1.ARMY.MIL
+   [MS9]           Schoffstall, Martin Lee  SCHOFF@PSI.COM
+   [MSA1]          Andersson, Mats S.
+                   enea!liuida!msa@seismo.CSS.GOV
+   [MSM1]          Medin, Milo              MEDIN@NSIPO.NASA.GOV
+   [MSM3]          Marshall, Mike S.        hubcap@HUBCAP.CLEMSON.EDU
+   [MSP1]          St. Paul, Mark           stpaul@NMSU.EDU
+   [MT105]         Tiberia, Marguerite      ---none---
+   [MT108]         Tadamichi, Matsuyama
+                   kddlab!soum.junet!ko@UUNET.UU.NET
+   [MT111]         Timmerman, Marcel        ---none---
+   [MT123]         Thomas, Michael          ---none---
+   [MT124]         Templeton, Marjorie      ---none---
+   [MT48]          Tokunaga, Manabu         SYSADM@IMATRON.COM
+   [MTC]           Champarnaud, M.T.
+                   mtc%frunip62.bitnet@CUNYVM.CUNY.EDU
+   [MTF1]          Franklin, Maurice T.     mfrankl@HAFGW.PC3.AF.MIl
+   [MU7]           Urizar, Mike             dosuriza@IDBSU.IDBSU.EDU
+   [MV24]          Vasoll, Mark             vasoll@A.CS.OKSTATE.EDU
+   [MV25]          Vieler, Mark             MAV@ESL.ARPA
+   [MV38]          Vachon, Mario            vachon@CRIM.CA
+   [MV41]          Vandecappelle, Marijke   cappelle@SURFNET.NL
+   [MVO1]          Van Overbeke, Mark
+                   mark%umnmor.bitnet@CUNYVM.CUNY.EDU
+   [MVW]           van Wolfswinkel, M.      ---none---
+   [MW135]         Widell, Mike             MWIDELL@CIM-VAX.HONEYWELL.COM
+   [MW171]         Walter, Martin
+                   mawa@SUN1.RUF.UNI-FREIBURG.DBP.DE
+   [MW176]         Whitehead, Mike
+                   cs11%primea.dundee.ac.uk@NSS.CS.UCL.AC.UK
+   [MW178]         Witt, Michael            MWITT@CSE.OGI.EDU
+   [MW180]         Wehrmeister, Mark        wehrmeis@SDSU.EDU
+   [MW196]         Willett, Michael         ---none---
+   [MW200]         Walters, Michael         MWalters@CORRAL.UWYO.EDU
+   [MW204]         Wilcox, Michael          ---none---
+   [MW213]         Williams, Maryann
+                   ASQEXLBW@WIESBADN-EMH1.ARMY.MIL
+   [MW225]         Watson, Mark             lemww@LEDGE.CC.MONASH.EDU.AU
+   [MW227]         Wong, Mark               ---none---
+   [MWS10]         Stalnaker, Michael W.    mws@APLVAX.JHUAPL.EDU
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 158]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [MWS7]          Sukalski, Mitchel W.     mws@LANL.GOV
+   [MY14]          Yokotsuka, M.            yokotuka%icot.jp@RELAY.CS.NET
+   [NAK2]          Kuo, Nancy A.            KUOA@GW2.HANSCOM.AF.MIL
+   [NAL]           Lann, Neil               nal@MORDOR.S1.GOV
+   [NB39]          Bonney, Norman           Andrew.Findlay@BRUNEL.AC.UK
+   [NC3]           Chiappa, Noel            JNC@XX.LCS.MIT.EDU
+   [ND22]          Danielson, Nancy         ---none---
+   [NF13]          Freed, Ned               ned@HMCVAX.CLAREMONT.EDU
+   [NG]            Gower, Neil E.           GOWER@A.ISI.EDU
+   [NG15]          Giraud, Noel             ---none---
+   [NG48]          Goetz, Norman
+                   goetz%reed.bitnet@CUNYVM.CUNY.EDU
+   [NH36]          Heiner, Nat              ---none---
+   [NHC]           Cuccia, Nichlos H.       cuccia@LLL-CRG.LLNL.GOV
+   [NJ]            Janakiraman, Narayanan
+                   CCSNJ%SEMASSU.BITNET@CUNYVM.CUNY.EDU
+   [NJB7]          Burr, Nancy Johnson      Burr@CS.WASHINGTON.EDU
+   [NJG6]          Gorsuch, Neil J.         NEIL@CPD.COM
+   [NK19]          Kaull, Nancy             NGK@MATH.AMS.COM
+   [NL35]          Lincoln, Neil            lincoln@SSESCO.COM
+   [NL39]          Lehrer, Nancy            nlehrer@ISX.COM
+   [NM31]          Mishkin, Nat             mishkin@APOLLO.COM
+   [NM37]          McNeill, Neil            neilm@SOLBOURNE.COM
+   [NM56]          Mc Loughlin, N.          mclghlnn%vax1.tcd.ie
+   [NM57]          Maddalena, Nancy         nmaddale@NRAO.EDU
+   [NMM]           Minnich, N. Michael      mminnich@HUEY.UDEL.EDU
+   [NMS5]          Sturm, Neal M.           nsturm@PILOT.NJIN.NET
+   [NN20]          Nadi, Najib              nadi@VILLANOVA.EDU
+   [NP24]          Page, Nancy              PAGEN@INDPLS-ASAFM1.ARMY.MIL
+   [NP34]          Penla, Nick              ---none---
+   [NRG4]          Gardner, Neil R.         NSC-Rob@DDN2.DCA.MIL
+   [NS66]          Swartz, Neil             ---none---
+   [NT12]          Todd, Neil               ist.co.uk!neil@UUNET.UU.NET
+   [NT13]          Titley, Nigel
+                   mcvax!axion.bt.co.uk!ntitley@UUNET.UU.NET
+   [NVT]           Truong, Ninh Van
+                   jgtk496%calstate.bitnet@CUNYVM.CUNY.EDU
+   [NW25]          Wilson, Nathan           nathan@TELEOS.COM
+   [NW30]          White, Nelson            ---none---
+   [NW33]          Withington, F. Neville   FNW@USNO01.UNSO.NAVY.MIL
+   [NY3]           Yamamoto, Nobuhito
+                   yamamoto%jpntsuku.bitnet@CUNYVM.CUNY.EDU
+   [OA4]           Aarreberg, Odd           ---none---
+   [OB]            Babaoglu, Ozalp          ozalp@DM.UNIBO.IT
+   [OC16]          Coggin, Ollie            ---none---
+   [OC4]           Comay, Oded
+                   A19%TAUNIVM.BITNET@CUNYVM.CUNY.EDU
+   [OD8]           Deguine, Olivier
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 159]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+                   mcvax!crg.bull.fr!root@UUNET.UU.NET
+   [OG14]          Grandrud, Ove            ---none---
+   [OG4]           Gremont, Olivier
+                   mcvax!inria!gipaltair-bdblues!root@seismo.CSS.GOV
+   [OHB]           Byeon, Ok Hwan
+                   chlim%gaya.seri.re.kr@RELAY.CS.NET
+   [OK6]           Khan, Osman              khan@SERI.PHILIPS.NL
+   [OM1]           Massar, Onno             NETMAN@TNO.NL
+   [OM10]          Martin, Olivier          martin@CEARN.CERN.CH
+   [OP]            Pugh, Orville            PUGHO@AFOTEC.AF.MIL
+   [OS4]           Seljeseth, Oyvind        ---none---
+   [OT3]           Tanir, Oryal             ---none---
+   [OT5]           Thomas, Odette           mmdf@KARLSRUHE-EMH1.ARMY.MIL
+   [PA32]          Ashton, Paul             ---none---
+   [PA43]          Andreas, Passler
+                   haselbacher@EDVZ.TU-GRAX.ADA.AT
+   [PA5]           Almquist, Philip
+                   Almquist@JESSICA.STANFORD.EDU
+   [PAG12]         Ganschow, Paul A.        ---none---
+   [PAG14]         Greenberg, Peter A.      ---none---
+   [PAK6]          Kaslo, Philip A.         phil@CS.ARIZONA.EDU
+   [PAN1]          Nelson, Philip A.        phil@WWU.EDU
+   [PB1]           Balyoz, Paul
+                   root%naucse.uucp@CS.ARIZONA.EDU
+   [PB13]          Beertema, Piet           piet@CWI.NL
+   [PB145]         Beck, Paul
+                   K029901%CZHRZU1A.BITNET@CUNYVM.CUNY.EDU
+   [PB40]          Bowden, Phillip E.       BOWDENPE@VTVM1.CC.VT.EDU
+   [PB6]           Berger, Peter
+                   Z10BER01%AWIIEZ11.BITNET@CUNYVM.CUNY.EDU
+   [PB67]          Boyle, Pat               boyle%ubc.csnet@RELAY.CS.NET
+   [PC116]         County, Phil
+                   munnari!latvax8.lat.oz.au!ccpc@UUNET.UU.NET
+   [PC137]         Chene, Pierre            chene@TLS-CS.CERT.FR
+   [PC138]         Cormier, Pierre
+                   S602%UQAM.BITNET@CUNYVM.CUNY.EDU
+   [PC143]         Cronin, Patrick
+                   pcronin%rcn.bitnet@MITVMA.MIT.EDU
+   [PC148]         Campbell, Peter          peter@CMLTAS.CML.OZ
+   [PC153]         Powell, Andy             A.Powell@BATH.AC.UK
+   [PCW]           Wood, C. Philip          cpw@LANL.GOV
+   [PD39]          Delaney, Pete
+                   pete%crcvax.uucp%germany.csnet@RELAY.CS.NET
+   [PD97]          Dax, Philippe            dax@ENST.ENST.FR
+   [PD98]          Davis, Paul              pauld@SCENIC.NWNEXUS.WA.COM
+   [PDB5]          Barron, Patrick D.       pat@TRANSARC.COM
+   [PDC1]          Crawford, D. Paul        ---none---
+   [PE21]          Eaton, Paul              ---none---
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 160]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [PE25]          Evans, Phil
+                   lcc100%prime2.bristol-poly.ac.uk@NSS.CS.UCL.AC.UK
+   [PE27]          Eddy, Patricia           EDDY@STJUDE.ORG
+   [PEM4]          McKenney, Paul E.        mckenney@SRI.COM
+   [PF64]          Findon, Phil             FINDONPJ@UK.AC.ASTON
+   [PF68]          Fischer, Paul            ---none---
+   [PFK]           King, Peter F.           peter_king@NEXT.COM
+   [PFS2]          Sass, Paul F.            SASS@FOTLAN5.FOTLAN.ARMY.MIL
+   [PG101]         Goldberg, Phil           ---none---
+   [PG108]         Gouthier, Paole
+                   PGOUTHIER%MARAUT.UUCP@UUNET.UU.NET
+   [PG40]          Gillis, Paul             paulg@USAGE.UNSW.OZ
+   [PG62]          Gloor, Peter
+                   gloor%csghsg5a.bitnet@CUMYVM.CUNY.EDU
+   [PG76]          Greenberg, Peter
+                   hombre!imclone!peter@UUNET.UU.NET
+   [PG97]          Groff, Paul              groff@WESTFORD.CCUR.COM
+   [PGA1]          Apley, Phillip G.        ---none---
+   [PGL]           Love, E. Paul            loveep@SDS.SDSC.EDU
+   [PGM]           Milazzo, Paul G.         MILAZZO@BBN.COM
+   [PH106]         Halsey, Pauline          ---none---
+   [PH111]         Hunter, Peter            ---none---
+   [PH120]         Harrison, Peter
+                   petera%cdcentr.bitnet@CUNYVM.CUNY.EDU
+   [PH121]         Homer, Philip            ---none---
+   [PH122]         Haskett, Philip
+                   CC13%SDSUMUS.BITNET@CUNYVM.CUNY.EDU
+   [PH45]          Ho, Peter                HO@HAC2ARPA.HAC.COM
+   [PH73]          Hubbard, Paul            paul@OXY.EDU
+   [PHB4]          Berens, Peter H.         phb@APUNIX.COM
+   [PHK]           Kamp, Poul-Henning       ---none---
+   [PHN2]          Nguyen, Paul H.          nguyen@MSDDNPENT.AF.MIL
+   [PI7]           Isomaki, Pekka           pisomaki@OPMVAX.KPO.FI
+   [PJ29]          Jensen, Peter            JENSEN@JARSUN1.ZONE1.COM
+   [PJ35]          Jaegle, Peter            peja@ISE.FHG.DE
+   [PJ40]          Jennings, Paul
+                   pjennings@BATHURST.CHASTURT.EDU.AU
+   [PJB27]         Brainard, Philip J.      brainard@DAN.APGEA.ARMY.MIL
+   [PJF7]          Feldner, Patrick J.      feldner@IITMAX.IIT.EDU
+   [PJM24]         McGuinness, Patrick J.
+                   MCGUINNESS@WESTPOINT-EMH1.ARMY.MIL
+   [PJS22]         Sivo, Peter J.           peter@KEY.COM
+   [PJV]           Vickers, Paul J.         paulv@LOGITEK.CO.UK
+   [PK]            Kirstein, Peter T.       KIRSTEIN@CS.UCL.AC.UK
+   [PK19]          Karr, Penny              PKARR@BBN.COM
+   [PK28]          Karn, Phil               KARN@THUMPER.BELLCORE.COM
+   [PK32]          Keller, Paul             pk%sbsvax.uucp@UUNET.UU.NET
+   [PK69]          Kostenbader, Phil
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 161]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+                   kostenba%lafayett.bitnet@CUNYVM.CUNY.EDU
+   [PK81]          Kanaitis, Peter          ---none---
+   [PL37]          Laforgue, Pierre         laforgue@IMAG.FR
+   [PLH8]          Haymon, Paula Langford
+                   apctrc!bigmac!haymon@UUNET.UU.NET
+   [PM115]         Myers, Patrick
+                   p.j.myers%mcc.ac.uk@CUNYVM.CUNY.EDU
+   [PM140]         Manske, Paul             ---none---
+   [PM155]         Mazzarelli, Paul         PM@CAMEX.COM
+   [PM177]         McGillan, Patrick        uwssup@UB.D.UMN.EDU
+   [PM178]         Merdian, Peter
+                   merdian@RUS.UNI-STUTTGART.DBP.DE
+   [PM180]         Moore, Paul
+                   paulm%BULLHM.UUCP@UUNET.UU.NET
+   [PM37]          Melvin, Phyllis          phyllis@BOEING.COM
+   [PM72]          Mies, Paul
+                   unido!gmdzi!mies@seismo.CSS.GOV
+   [PM81]          Marshall, Peter          peter.marshall@UWO.CA
+   [PMH3]          Henderson, P. Marshall   ---none---
+   [PML1]          Lashley, Patrick M.      cohesive!kla!pat@SUN.COM
+   [PN13]          Nunley, Pat              NUNLEY@SACEMNET.AF.MIL
+   [PN16]          Noack, Patricia          ---none---
+   [PN23]          Nellessen, Peter         CRTVAX!PN@SPICE.CS.CMU.EDU
+   [PNP2]          Phair, Pamela W.         ---none---
+   [PNW]           Wan, Peter N.            peter%msdc.uucp@GATECH.EDU
+   [PO16]          O'Regan, Paddy           ---none---
+   [PO2]           O'Brien, Patrick G.
+                   asqe-y-v-kcg@GOEPPINGEN-EMH1.ARMY.MIL
+   [POJ]           Jakobsson, Per-Ove       ---none---
+   [PP14]          Pomes, Paul              paul@UXC.CSO.UIUC.EDU
+   [PP36]          Patton, Paul             ---none---
+   [PP62]          Peccararo, Paul          ---none---
+   [PP77]          Park, Philippe           ppark@BBN.COM
+   [PPM2]          Murphy, Patrick P.       pmurphy@NRAO.EDU
+   [PR100]         Radig, Peter             radig!peter@UUNET.UU.NET
+   [PR102]         Rieckmann, Peter         ---none---
+   [PR79]          Reid, Phil               2D49@LINK.COM
+   [PR99]          Rodrigo, Paul
+                   rodrigo%col01.dec@DECWRL.DEC.COM
+   [PRT2]          Taylor, Paul R.          taylor@OSWEGO.OSWEGO.EDU
+   [PS173]         Sobering, Peter          trin3@VAX1.TRINCOLL.EDU
+   [PS191]         Sharma, Pradeep
+                   sharma@ROHINI.TELECOMM.UMN.EDU
+   [PS204]         St. Clair, Phil          ---none---
+   [PS216]         Stephenson, Paul         ---none---
+   [PS27]          Spilling, Paal           SPILLING@A.ISI.EDU
+   [PSR]           Rarey, Paul S.
+                   prarey@SSF-SYS.GLOBAL-MIS.DHL.COM
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 162]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [PSS1]          Schwarz, Phil S.         PHIL@YODA.CEO.DG.COM
+   [PT23]          Tomb, Peter
+                   ptomb%umass.bitnet@CUNYVM.CUNY.EDU
+   [PT55]          Teegarden, Paul
+                   egtlspr@CCS.CSUSCC.CALSTATE.EDU
+   [PT62]          Turner, Peter            pjt@AMOS.DAR.CSIRO.AU
+   [PT63]          Thublin, Paul            ---none---
+   [PV23]          Valotto, Peter J.        ---none---
+   [PW37]          Woods, Paul              ---none---
+   [PW49]          Ware, Pete               esosun!pete@SEISMO.CSS.GOV
+   [PW83]          Weselmann, Peter
+                   unido!tuhhco!rv-pw@UUNET.UU.NET
+   [PW88]          Winker, Peter
+                   winker%ds0mpi11.bitnet@CUNYVM.CUNY.EDU
+   [PW96]          Wilson, Peter            pjw@FRC.MAF.GOVT.NZ
+   [PW98]          Wick, Peter              wick@RZ.UNI-KIEL.DBP.DE
+   [PWB12]         Bernier, Paul W.         BERNIER@CTRON.COM
+   [PWM]           Murphy, Patrick W.
+                   pmurphy@ISDMNL.MENLO.USGS.GOV
+   [PWP2]          Phillips, Paul W.        PHILLIPS@EDWARDS-2060.AF.MIL
+   [PY17]          Young, Peter             ---none---
+   [PYC]           Chen, Pin-Yee            chen@ENCORE.COM
+   [QF]            Fennessy, Quentin
+                   quentin%hub.umb.edu@RELAY.CS.NET
+   [RA11]          Adams, Rick              rick@UUNET.UU.NET
+   [RA145]         Ahti, Reijo              jjk@TUT.FI
+   [RA17]          Albrightson, Robert      ALBRIGHT@NISC.JVNC.NET
+   [RA62]          Aschenbrenner, Rex       Rex@CGI.COM
+   [RA66]          Antonorsi, Richard       ---none---
+   [RA94]          Allison, Roger           ---none---
+   [RAD15]         Disque, Robert A.        disque@CAD.USNA.MIL
+   [RAF4]          Fischer, Richard         fischer@OCFMAIL.OCF.LLNL.GOV
+   [RAG36]         Gilmour, R. A.
+                   R.Gilmour%vme.glasgow.ac.uk@CUNYVM.CUNY.EDU
+   [RAH64]         Hernandez, Robert A.     Bob@PENTAGON-AI.ARMY.MIL
+   [RAJ3]          Johnson, Richard A.      RAJ@ICS.UCI.EDU
+   [RAJ8]          Jones, Richard A.        jones@COLO.COLORADO.EDU
+   [RAK12]         Kawin, Richard A.        kawin@STAT.BERKELEY.EDU
+   [RAM57]         Mann, Rex A.             ---none---
+   [RAR22]         Ridder, Robert A.        ---none---
+   [RAR23]         Ragosa, Richard A.       ---none---
+   [RAY4]          Yamin, Raymond A.        ---none---
+   [RB218]         Bentson, Randolph
+                   bentson%colostate.csnet@RELAY.CS.NET
+   [RB219]         Bybee, Robert            ---none---
+   [RB221]         Blachley, Rick           ---none---
+   [RB319]         Buchholz, Randy          ---none---
+   [RB365]         Belics, Rob              ---none---
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 163]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [RB383]         Barzel, Ron              barzel@NOAAPMEL.GOV
+   [RB386]         Brown, Randolph          postmaster@KEVEX.COM
+   [RB520]         Bonham, Robert           ---none---
+   [RB536]         Brown, Randall           ---none---
+   [RB548]         Brazile, Robert          BRAZILE@IEX.COM
+   [RB577]         Bilson, Rod
+                   munnari!diemen.cc.utas.oz.au!rod@UUNET.UU.NET
+   [RB578]         Boelma, Rick
+                   mcvax!rivm!ccerick@UUNET.UU.NET
+   [RBB2]          Butler, Robert B.        rbutler@YUMA-EMH1.ARMY.MIL
+   [RBP11]         Park, Robert B.          ---none---
+   [RBW]           Wales, Richard B.        WALES@CS.UCLA.EDU
+   [RC113]         Collier, Renee           ---none---
+   [RC234]         Cape, Robert
+                   r.cape%stpaul.ncr.com@RELAY.CS.NET
+   [RC241]         Cairns, Rob              ---none---
+   [RC247]         Chambers, Rita
+                   CHAMBERS%CEBAFVAX.BITNET@CUNYVM.CUNY.EDU
+   [RC278]         Ching, Robert            rching@IBM.COM
+   [RC29]          French, Ruth E.          rFrench@WSMR-EMH08.ARMY.MIL
+   [RC306]         Cawley, Robert           rjc@ATOM.OZ
+   [RC309]         Cunningham, Robert       ---none---
+   [RC321]         Cannada, Rick            ---none---
+   [RCD13]         Drye, Robert C.          Rob.Drye@DARTMOUTH.EDU
+   [RCL1]          Lang, Ralph C.           2155CSDOA@SACEMNET.AF.MIL
+   [RCM9]          McQueen, Robert C.
+                   SIT.MCQUEEN@CU20B.CC.COLUMBIA.EDU
+   [RD104]         Dirlewanger, Roland      rd@CHORUS.FR
+   [RD108]         Dalhoff, Randal
+                   GR.RFD%ISUMVS.BITNET@CUNYVM.CUNY.EDU
+   [RD187]         Decoste, Ronald          decoste@CC.UMONTREAL.CA
+   [RD225]         Dehn, Ron                ---none---
+   [RD227]         Dinwiddie, Ronald        ---none---
+   [RD231]         Duncan, Robert           ---none---
+   [RD232]         Doelz, Reinhard          doelz@URZ.UNIBAS.CH
+   [RD235]         Davoli, Renzo            renzo@DM.UNIBO.IT
+   [RD240]         Dunbar, Richard
+                   postmaster@DFTSRV.GSFC.NASA.GOV
+   [RD91]          Dussaulx, Regine         ---none---
+   [RDB30]         Bailey, Robert D.        avonsc@ANKARA.AF.MIL
+   [RDC36]         Carr, Robert D.
+                   c130rdc@UTARLG.ARL.UTEXAS.EDU
+   [RDG12]         Garvie, Robert D.
+                   garvie%grumpy.dnet@SPOT.COLORADO.EDU
+   [RDM25]         Marzusch, Ralph-Diether
+                   marzusch%rz.informatik.uni-hamburg.dbp.de@RELAY.CS.NET
+   [RDQ]           Quigley, Roger D.
+                   quigley@SRI-LEWIS.ITSTD.SRI.COM
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 164]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [RE18]          Elz, Robert              kre@MUNNARI.OZ.AU
+   [RE22]          Enas, R.                 cdc-ddn@DDN2.ARPA
+   [RE73]          Evans, Robert
+                   robert%computing-maths.cardiff.ac.uk@NSF.RELAY.AC.UK
+   [RE77]          Ebert, Rick              rick@IPAC.CALTECH.EDU
+   [RE84]          Esqueda, Robert          ---none---
+   [REA3]          Amos, Robert E.          amos@CRDEC3.APGEA.ARMY.MIL
+   [REB50]         Bruccoleri, Robert E.    BRUC@SQUIBB.COM
+   [RED22]         Donnelly, Robert  E.     ---none---
+   [RER20]         Rogers, Robert E.        ---none---
+   [RES17]         Strout, Robert E., II
+                   ssiwest!resii@LLL-LCC.LLNL.GOV
+   [RES70]         Seastrom, Robert E.      RS@EDDIE.MIT.EDU
+   [RF130]         Funke, Rainer
+                   unido!pbinfo!leo.uni-paderborn.de!rainer@UUNET.UU.NET
+   [RF50]          Fry, Roger
+                   MSITD18@PENTAGON-BCN.ARMY.MIL
+   [RF57]          Fajman, Roger            RAF@CU.NIH.GOV
+   [RFD1]          Donnelly, Robert F.      DONNELLY@PICA.ARMY.MIL
+   [RFS2]          Stanonik, Ron F.         STANONIK@NPRDC.NAVY.MIL
+   [RG12]          Gulbranson, Roger        roger@UX.ACSS.UMN.EDU
+   [RG188]         Glowka, Ron              ---none---
+   [RG225]         Glaschick, Rainer
+                   unido!nixpbe!glaschick@UUNET.UU.NET
+   [RG228]         Gill, Rick               ---none---
+   [RG92]          Gopstein, Richard        soleil!gopstein@RUTGERS.EDU
+   [RGB14]         Bookbinder, Robert G.    rgb@LAMONT.LDGO.COLUMBIA.EDU
+   [RGH21]         Hesser, Robert G.        ---none---
+   [RH164]         Hoffmann, Ron            hoffmann@MIT.EDU
+   [RH227]         Holt, Ron                RON@ICONSYS.UU.NET
+   [RH260]         Haddick, Robert          ROBERT@NIC.DDN.MIL
+   [RH271]         Hedberg, Roland          roland@UMU.SE
+   [RH278]         Helbig, Russell          ---none---
+   [RH286]         Hagan, Randy             randy@PIKES.COLORADO.EDU
+   [RH300]         Roberts, Hal             hrobert@FRG.BBN.COM
+   [RH310]         Hardy, Richard D.        33CGXPP@SACEMNET.AF.MIL
+   [RH315]         Hook, Richard            ---none---
+   [RH326]         Harvey, Russ             UCSD!NCR-S
+   [RH336]         Hayden, Robert
+                   haydenrr!snycanba.bitnet@CUNYVM.CUNY.EDU
+   [RH337]         Horton, Randy
+                   hortondr!snycobba.bitnet@CUNYVM.CUNY.EDU
+   [RH338]         Hall, Rand               rand@merrimack.EDU
+   [RH345]         Huber, Rich              ---none---
+   [RH5]           Hobby, Russell           RDHOBBY@UCDAVIS.UCDAVIS.EDU
+   [RH6]           Hinden, Robert           HINDEN@BBN.COM
+   [RH60]          Hale, Roger              ROGER@SST.LL.MIT.EDU
+   [RHC3]          Cole, Robert H.          rhc%otter@HPLABS.HP.COM
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 165]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [RHG]           Gumpertz, Richard H.     rhg@CPS.COM
+   [RHM11]         Moreno, Robert H.        rmoreno@WSMR-EMH82.ARMY.MIL
+   [RHS16]         Sweed, Richard H.        SWEED@TOPS20.RADC.AF.MIL
+   [RHS4]          Schwartz, Ralph H.       ---none---
+   [RI]            Ip, Roque                ---none---
+   [RJ115]         Jul-Hansen, Rene         rjh02@BK.DK
+   [RJ120]         Jacobson, Richard        jacobson@TACOM-EMH2.ARMY.MIL
+   [RJ127]         James, Rita              mmdf@MUNICH-EMH1.ARMY.MIL
+   [RJ134]         Jordak, Russell          techmgr@amex.com
+   [RJA21]         Aiken, Robert J.         AIKEN@NERSC.GOV
+   [RJB3]          Bruce, Richard J.        SAC.42SPS@E.ISI.EDU
+   [RJB67]         Betterini, Raymond J.    ray@HRI.COM
+   [RJH33]         Hickman, Robert J.       ---none---
+   [RJH37]         Hendley, R.J.
+                   HendleyRJ%CS.BHAM.AC.UK@CUNYVM.CUNY.EDU
+   [RJH66]         Henry, Robert J.         ---none---
+   [RJL3]          Liebschutz, Robert J.    ROB@OC.RJL.COM
+   [RJL49]         Lukens, Robert J.        rjl@CHES.CS.VIMS.EDU
+   [RJP23]         Plesset, Robert J.       RJP@SARNOFF.COM
+   [RJY2]          Yount, Russell J.        rjy@MED.PIT.EDU
+   [RK146]         Kidwell, Richard         RKIDWELL@STSCI.EDU
+   [RK154]         Kerpen, Ron
+                   munnari!mineng.oz.au!kerpen@UUNET.UU.NET
+   [RK168]         Kieffer, Rom             Kieffer@UCNET.UCALGARY.CA
+   [RK174]         Kubik, Randy             rkubik@BBN.COM
+   [RK51]          Kisielewski, Richard     ---none---
+   [RK75]          Kocian, Ray              kocian@SDR.SLB.COM
+   [RKJ]           Justice, Robin K.        RKJ@SFI.SANTAFE.EDU
+   [RKS1]          Stodola, Robert K.       STODOLA@FCCC.EDU
+   [RKS5]          Shafer, Robert K.        bshafer@SERVER.CARL.ORG
+   [RL104]         Lynch, Rich
+                   U10CA%WVNVM.BITNET@CUNYVM.CUNY.EDU
+   [RL180]         Levow, Roy
+                   levowrb%servax.bitnet@CUNYVM.CUNY.EDU
+   [RL190]         Lee, Ray                 LEE@REMIS-WP.AF.MIL
+   [RL202]         Lindner, Ralf            ---none---
+   [RL224]         Letts, Richard           R.J.Letts@UK.AC.SALFORD
+   [RL225]         Liu, Richard             liu@CHIVA.TRL.OZ.AU
+   [RL226]         Linton, Richard          rlinton@TCS.COM
+   [RLB3]          Broersma, Ronald L.      ron@NOSC.MIL
+   [RLC20]         Clover, Robert L.        SIMNET-WASHINGTON@A.ISI.EDU
+   [RLG36]         Gifford, Rick L.         ---none---
+   [RLH94]         Harris, Robert L.        ---none---
+   [RLP30]         Paulson, Ray L.          ---none---
+   [RLP39]         Rupp, Richard L., Jr.
+                   rich%dss.med.nyu.edu@CUNYVM.CUNY.EDU
+   [RLR23]         Reyenga, Robert L.
+                   REYENGA@WESTPOINT-EMH1.ARMY.MIL
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 166]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [RLR36]         Rawlins, Ray L.          ray@CC.USU.EDU
+   [RLR4]          Reed, Robert L.          bobr@DBM.MPC.AF.MIL
+   [RLR46]         Ray, Ron L.              rlr@JHUVMS.HCF.JHU.EDU
+   [RLR57]         Riedinger, Randal L.     RIEDINGER@GENCORP.COM
+   [RLS115]        Schwartz, Randal L.      merlyn@IWARP.INTEL.COM
+   [RLS6]          Smith, Ronald L.         COINS@A.ISI.EDU
+   [RLU3]          Ullmann, Robert L.       Ariel@RELAY.PRIME.COM
+   [RLY1]          Young, Ronald L.         ron@UNSVAX.NEVADA.EDU
+   [RLZ3]          Zort, Robert L., Jr.     ZORT@UU.PSI.COM
+   [RM120]         McCarthy, Richard
+                   SP0003@BINGVMB.CC.BINGHAMTON.EDU
+   [RM125]         McCorkle, Ray            ray@NUWES-M1.NAVY.MIL
+   [RM176]         Merry, Rod               ---none---
+   [RM177]         Morrison, Robert         morrison@CORRAL.UWYO.EDU
+   [RM213]         Mohr, Rupert
+                   UNIDO!RMI!ZENTRALE@UUNET.UU.NET
+   [RM256]         Morales, Robert          R_Morales@MAIL.UWA.OZ.AU
+   [RM300]         Moulder, Raymond         hahnnsc@RAMSTEIN2-EMH.AF.MIL
+   [RM306]         Minder, Ruedi            ---none---
+   [RM320]         McGraw, Robert           rmcgraw@SUNSPOT.NOAO.EDU
+   [RM395]         Martin, Rick             rickm@UMB.EDU
+   [RM8]           Marantz, Roy             MARANTZ@KLINZHAI.RUTGERS.EDU
+   [RMC1]          Chavez, R. Martin
+                   chavez@SUMEX-AIM.STANFORD.EDU
+   [RMD1]          Devonshire, Robert M.    DEVONSHIRE@CCSC-VAX.AF.MIL
+   [RMD26]         Deering, Richard M.      ---none---
+   [RMF17]         Fujii, Roger M.
+                   rmf%media@PENTAGON-AI.ARMY.MIL
+   [RMF2]          Frankston, Robert M.     bobf@LOTUS.COM
+   [RML28]         Lofink, Raymond M.
+                   lofink@UNIX.CIS.PITTSBURGH.EDU
+   [RMS8]          Soley, Richard Mark      SOLEY@MC.LCS.MIT.EDU
+   [RN25]          Negaret, Roger           negaret@CICB.FR
+   [RN29]          Nomura, Ryo
+                   nomura%nttkb.ntt.junet%ntt-20@SUMEX-AIM.STANFORD.EDU
+   [RN58]          Nienhueser, Rolf
+                  910003%DOSUNI.BITNET@CUNYVM.CUNY.EDU
+   [RN67]          Newman, Rob              ---none---
+   [RNB5]          Berlinger, Robert N.     naftoli@AECOM.YU.EDU
+   [RNM1]          MacKenzie, R. Neil       cle%rsre.mod.uk@RELAY.MOD.UK
+   [RO44]          Obendorf, Reinhard
+                   ZZOBI%DHVRRZN1.BITNET@CUNYVM.CUNY.EDU
+   [RO58]          O'Brien, Richard
+                   mcvax!planet.bt.co.uk!rob@UUNET.UU.NET
+   [RO67]          Ogden, Richard           rogden@BBN.COM
+   [RO68]          Owen, Robert
+                   owen%hslrswi.uucp@UUNET.UU.NET
+   [RO70]          Obrien, Ray              ---none---
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 167]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [RP191]         Penumalli, Reddy         ---none---
+   [RP210]         Preston, Rick            unet!flp@AMES.ARC.NASA.GOV
+   [RP211]         Paulson, Ragnar          ---none---
+   [RP230]         Pinson, Rick             ---none---
+   [RP238]         Peck, Robert             ---none---
+   [RP239]         Pettersen, Roar          ---none---
+   [RP240]         Perini, Richard
+                   munnari!rilin.ci.oz.au!rl@UUNET.UU.NET
+   [RP241]         Payne, Richard           ---none---
+   [RP251]         Papp, Raymond            ---none---
+   [RP88]          Perry, Russ              RUSS@CSUFRESNO.EDU
+   [RP94]          Peglar, Rob              ---none---
+   [RPD5]          Drzyzgula, Robert P.     rcd@FED.FRB.GOV
+   [RPP]           Pendleton, Ronald P.     PENDLETON@CCF3.NRL.NAVY.MIL
+   [RQ5]           Quigley, Robert          BOB@YSUB.YSU.EDU
+   [RR156]         Rizzio, Rioh             ---none---
+   [RR163]         Ronke, Rainer
+                   steffens%zedat.fu-berlin.dbp.de@RELAY.CS.NET
+   [RR18]          Reisor, Ron              REISOR@UDEL.EDU
+   [RR181]         Ross, Rollo              rollo.ross@SAIT.EDU.AU
+   [RR184]         Robak, Richard           Robak@C3PO.SM-ALC.AF.MIL
+   [RR193]         Rupp, Richard            megatek!rupp@UCSD.EDU
+   [RR26]          Reilly, William R.
+                   REILLY@INDPLS-ASAFM1.ARMY.MIL
+   [RR33]          Romanelli, Richard       tabdd@APG-EMH5.APG.ARMY.MIL
+   [RR77]          Roles, Roger             ---none---
+   [RR97]          Russell, Robb
+                   ROBB%DUVM.BITNET@CUNYVM.CUNY.EDU
+   [RRR1]          Rock, Robert R.          RRRock@X102C.HARRIS-ATD.COM
+   [RS253]         Saccoman, Remi
+                   remi%framentec.FR@UUNET.UU.NET
+   [RS255]         Sinnhuber, Roger
+                   rogers%cogs.sussex.ac.uk@NSS.CS.UCL.AC.UK
+   [RS348]         Spellman, Robert         RSpellman@BAT.BATES.EDU
+   [RS393]         Svartstrom, Ralf         ---none---
+   [RS401]         Sarran, Richard          sarran@TSCA.ISTC.SRI.COM
+   [RS406]         Skalsky, Rick            aaai@KSL.STANFORD.EDU
+   [RS409]         Sassoon, Richard         ---none---
+   [RS414]         St. Pierre, Robert       stpierre@ULOWELL.EDU
+   [RS479]         Siddall, Robert          ---none---
+   [RS486]         Sinnarajah, Ravi         RAVI@UMUC.UMD.EDU
+   [RS487]         Sutterfield, Robert      bob@MORNINGSTAR.COM
+   [RS489]         Stafford, Randy          ---none---
+   [RS49]          Strich, Ronald           SSDS@BLACKBIRD.AFIT.AF.MIL
+   [RS502]         Sondaar, Roelof          ---none---
+   [RS95]          Sherwin, Russ            ---none---
+   [RSD2]          Dixon, Robert S.
+                   ts0400@%OHSTVMA.BITNET@CUNYVM.CUNY.EDU
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 168]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [RSH]           Hammel, Randall S.       rsh@SUPER.ORG
+   [RSM1]          Miles, Robert S.         rsm@NRTC.NORTHROP.COM
+   [RT114]         Toussaint, Riley         TOUSSAINT@NUSC.NAVY.MIL
+   [RT135]         Torres, Robert           HADMIN@LAKEHTH-PIV.AF.MIL
+   [RT140]         Thirlby, Rob
+                   rob%suna.lut.ac.uk@CUNYVM.CUNY.EDU
+   [RT142]         Turner, Robert           ---none---
+   [RT144]         Trepos, Raymond          trepos@IRISA.FR
+   [RT147]         Tribble, Richard         ---none---
+   [RT148]         Thornton, Ronald         thornton@QM7501.GENRAD.COM
+   [RT155]         Tripamer, Raymond
+                   ray%jimi.cs.unlv.edu@RELAY.CS.NET
+   [RT182]         Thibodeaux, Rich         IPCRPT@SUCLA.CORP.HARRIS.COM
+   [RT184]         Thompson, Robert
+                   munnari!cancol.oz.au!rit@UUNET.UU.NET
+   [RT60]          Thigpen, Robert
+                   decvax!savax!thigpen@UCBVAX.Berkeley.EDU
+   [RT64]          Tucker, Ray
+                   RTUCKER@REDSTONE-EMH2.ARMY.MIL
+   [RTD]           Drinkard, Richard T.
+                   Drinkard@GARFLD.MSFC.NASA.GOV
+   [RU1]           Ulrik, Rosen             ---none---
+   [RV32]          Volk, Ruediger           rv%unido@UUNET.UU.NET
+   [RV61]          van der Hauw, Rene       ---none---
+   [RVDA]          van den Assem, Rene      tnofelr6@ET.TUDELFT.NL
+   [RW112]         Winkens, Ralf-Peter
+                   WINKENS%DMARUM8.BITNET@CUNYVM.CUNY.EDU
+   [RW128]         Waldron, Robert W.       ---none---
+   [RW15]          Wahl, Roger A.           datadog@TAEGU-EMH1.ARMY.MIL
+   [RW206]         Wilson, Ric              ---none---
+   [RW211]         Wegner, Rick             rwegner@WSUVMS1.WSU.EDU
+   [RW237]         Woodworth, Robert        sytek!texx@SUN.COM
+   [RW24]          Wildgruber, Rudi         rw@PCSBST.PCS.COM
+   [RW247]         Wood, Robert             RWOOD@CHARLIE.USD.EDU
+   [RW45]          Waffle, Ron              waffle@SM-EDS.AF.MIL
+   [RW9]           Watson, Richard          watson@UTADNX.CC.UTEXAS.EDU
+   [RW96]          Warren, Richard          RWARREN@AAMRL.AF.MIL
+   [RWA15]         Altheide, Richard W.     C0004@UMRVMB.UMR.EDU
+   [RWC34]         Camerer, Robert W.       rwc116@MINSY-POE.ARPA
+   [RWF21]         Floyd, Ruth W.           ruth@P9955.WLU.EDU
+   [RWH29]         Hayes, Rodney W.         HQMACSCO@SCOTT-PIV-3.AF.MIL
+   [RWH36]         Hartle, Robert W.        ---none---
+   [RWH5]          Henry, Robert W.         rwh@UCBVAX.BERKELEY.EDU
+   [RWJ3]          Johnson, Roscoe W.       15NSC@HICKAM-EMH.AF.MIL
+   [RWT2]          Tinker, Robert W.        tinker@DTRC.DT.NAVY.MIL
+   [RZ2]           Zamparo, Roberto         roberto@TVT-F.SE
+   [SA]            Allen, Scott             ---none---
+   [SA21]          Atlas, Stephen           SATLAS@BBN.COM
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 169]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [SA42]          Arnett, Sid              ---none---
+   [SA47]          Ayers, Stephen           ---none---
+   [SA65]          Alexander, Steve         stevea@i88.isc.com
+   [SA72]          Aoshima, Shigeru         ---none---
+   [SA87]          Smisek, Anthony          asmisek@BBN.COM
+   [SA94]          Alexiou, Stergios        alexiou@ARIADNE.GR
+   [SA99]          Amerige, Stephen         ---none---
+   [SAA]           Adamec, Stephen A., Jr.  adamec@BRL.MIL
+   [SAB17]         Baird, Scott A.          ---none---
+   [SAJ1]          Joseph, Samuel A.        SAJ@TARPIT.UUCP
+   [SAL27]         Longo, Stepehn A.        LONGO@ACA.LASALLE.EDU
+   [SAS49]         Smith, Scott A.          netadmin@WORMS-EMH1.ARMY.MIL
+   [SB152]         Boyles, Steve            wingtcf@RAMSTEIN2-EMH.AF.MIL
+   [SB167]         Brown, Syngen            syngen@UX.KINGSTON.AC.UK
+   [SB185]         Bunger, Sam              ---none---
+   [SB201]         Burgess, Steven          sburgess@CARLETON.EDU
+   [SB205]         Barnes, Simon
+                   barnes%scrsu1%sdr.slb.com@RELAY.CS.NET
+   [SB206]         Biesbroeck, Stephan      stephan@CS.KULEUVEN.AC.BE
+   [SB221]         Bamberg, Severin         ---none---
+   [SB228]         Burns, Steve             ---none---
+   [SB230]         Bartram, Scott           SCOTT@KEYSEC.KSE.COM
+   [SB236]         Blandford, Scott         ---none---
+   [SB258]         Bernhardsen, Svein       ---none---
+   [SB28]          Bradner, Scott           SOB@HARVARD.HARVARD.EDU
+   [SB90]          Brady, Sean              brady@DCN9.ARPA
+   [SB98]          Barber, Stan             SOB@BCM.TMC.EDU
+   [SBB9]          Burdick, Scott B.
+                   SBBUR%CONNCOLL.BITNET@MITVMA.MIT.EDU
+   [SBH4]          Heidt, Samuel B.
+                   syssbh%gsuvm1.bitnet@CUNYVM.CUNY.EDU
+   [SBW4]          Whidden, Samuel B.       sbw@MATH.AMS.COM
+   [SC136]         Carter, Sam              carter@ENSUN.CSS.GOV
+   [SC139]         Corbett, Stanley A.      SAC@ASIF1.ARPA
+   [SC143]         Cliffe, Steve
+                   munnari!wolfen.cc.uow.oz.au!steve@UUNET.UU.NET
+   [SC193]         Crumb, Steve             scrumb@CORP.MOT.COM
+   [SC196]         Cory, Sharryn
+                   ts7049@OHSTVMA.IRCC.OHIO-STATE.EDU
+   [SC197]         Campbell, Steve          scampbell@BBN.COM
+   [SC3]           Casner, Steve            CASNER@ISI.EDU
+   [SC59]          Campbell, Stephen        Steve.Campbell@DARTMOUTH.EDU
+   [SC81]          Callahan, Sean           sean@ELXSI.CALTECH.EDU
+   [SCB12]         Blair, Steven C.         sblair@SYNOPTICS.COM
+   [SCG]           Gruenke, Stephen C.      NSC-PENS@DDN3.DCA.MIL
+   [SCT2]          Tollbom, S. Cullen       d39080@PNLG.PNL.GOV
+   [SD131]         Doetterl, Siegfried
+                   mmdf@GRAFENWOEHR-EMH1.ARMY.MIL
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 170]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [SD134]         Dang, Susan              dang%shell.uucp@SUN.COM
+   [SD139]         Decker, Sharan
+                   sharan@MICKEY.NIC.KINGSTON.IBM.COM
+   [SD78]          Donegan, Steve           ---none---
+   [SDD8]          Derry, Stephen D.        sdd@UXV.LARC.NASA.GOV
+   [SDF5]          Freyder, Steven
+                   freyder%cpva.span@SDS.SDSC.EDU
+   [SDM8]          Martin, Scott D.
+                   Martin@FRANKFURT-EMH1.ARMY.MIL
+   [SE15]          Estrich, Scott           ---none---
+   [SE31]          Eldridge, Steve
+                   eldridge@ALDERAAN.SCRC.SYMBOLICS.COM
+   [SE49]          Elias, Steve
+                   spdcc!eli@HARVARD.HARVARD.EDU
+   [SE7]           Ellis, Billy             ---none---
+   [SE8]           Emery, Sean              ---none---
+   [SEC2]          Chichester, Susan E.
+                   SUE%GENESEO.BITNET@CUNYVM.CUNY.EDU
+   [SEL10]         Logcher, Suzanne         logcher@DECVAX.DEC.COM
+   [SEM18]         Mendoza, Sonja E.        mendoza@WSMR-EMH85.ARMY.MIL
+   [SF34]          Fenstermacher, Scott     scott@WMVM1.CC.WM.EDU
+   [SF41]          Fogel, Steve
+                   SFOGEL!MTCS!MTXINU@UCBARPA.Berkeley.EUD
+   [SF46]          Fountain, Steven         stevef@MATHER1.AF.MIL
+   [SF59]          Fulcomer, Sam            sgf@CSC.BROWN.EDU
+   [SF76]          Finch, Scott             FINCHSA@ASD.WPAFB.AF.MIL
+   [SFJ]           Johnston, Scott F.       ---none---
+   [SFP]           Parr, Steven Franklin    sfp@APLCOMM.JHUAPL.EDU
+   [SFW1]          Watson, Scott F.         scott@HEIM.GLENDALE.CA.US
+   [SG1]           Grandi, Steve            grandi@NOAO.EDU
+   [SG140]         Grimm, Steven            koreth@SPUD.HYPERION.COM
+   [SG144]         Gumpf, Shirley           SYSTEM@CCISD2.CCF.ORG
+   [SG146]         Gerraty, Simon
+                   sjg%sun0.melb.bull.oz.au@UUNET.UU.NET
+   [SG147]         Gruber, Shmuel
+                   CLGB100%BGUNVE.BITNET@CUNYVM.CUNY.EDU
+   [SG154]         Gammill, Susan           ---none---
+   [SG58]          Garrett, Spencer         srg@QUICK.COM
+   [SG68]          Goodman, Steve           manager@SPOOL.MU.EDU
+   [SG83]          Garwood, Steve           ---none---
+   [SG88]          Gai, Silvano
+                   silvano%itopoli.bitnet@CUNYVM.CUNY.EDU
+   [SGC]           Chipman, Stephen G.      CHIPMAN@BBN.COM
+   [SGM4]          Goodman, Steven M.       steven@LAKESYS.LAKESYS.COM
+   [SGR1]          Roediger, Steve G.       ---none---
+   [SH1]           Hollenbaugh, Sheila      shollen@SPOTS.WRIGHT.EDU
+   [SH160]         Hung, Saneming           ---none---
+   [SH162]         Hubert, Steve            hubert@CAC.Washington.EDU
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 171]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [SH175]         Hagnell, Staffan         ---none---
+   [SH33]          Henry, S. Lee            master@NEMS.DT.NAVY.MIL
+   [SH37]          Heker, Sergio            HEKER@NISC.JVNC.NET
+   [SH47]          Hallstrom, Steve
+                   SteveH@BLAKE.ACS.WASHINGTON.EDU
+   [SH71]          Herber, Steve            herber@ANDY.BGSU.EDU
+   [SHB]           Blumenthal, Steven H.    BLUMENTHAL@BBN.COM
+   [SI16]          Ingate, Shane            ingate@seismo.CSS.GOV
+   [SI8]           Ilnicki, Slawomir        ---none---
+   [SJ28]          Jensen, Soren            SERGEJ@DIKU.DK
+   [SJ33]          Johnson, Sharon          SJohnson.pa@XEROX.COM
+   [SJ50]          Jacobs, Stephen          jacobss@IMO-UVAX1.DCA.MIL
+   [SJ55]          Jacob, Stephen           sjacob@LOGNET1.AF.MIL
+   [SJ65]          Johnson, Peggy           mmdf@NUERNBERG-EMH1.ARMY.MIL
+   [SJC22]         Corso, Steven J.         ---none---
+   [SJG17]         Gunderson, Steven J.     NCELVAX!STEVE@NOSC.MIL
+   [SJG2]          Gutridge, Steve          ---none---
+   [SJK1]          Kramer, Scott J.
+                   pixar!nil@UCBVAX.BERKELEY.EDU
+   [SJL]           Lucks, Steven J.         ---none---
+   [SJM9]          Mahler, Stephen J.       mahler@USL.EDU
+   [SJP10]         Piatz, Steven J.         piatz@SP.UNISYS.COM
+   [SJP18]         Punnoose, Sunil J.       sunil@OYSTER.SMC.EDU
+   [SJS11]         Schroeder, Steven J.
+                   SJS%PSUVM.BITNET@CUNYVM.CUNY.EDU
+   [SK102]         Kaplan, Scott            ---none---
+   [SK119]         Katerkamp, Stefan
+                   stefan@INFORMATIK.RWTH-AACHEN.DE
+   [SL122]         Lynne, Stuart            sl@WIMSEY.BC.CA
+   [SL129]         Lange, Ssgt              ---none---
+   [SL135]         Legrys, Scott            ---none---
+   [SL2]           Leviseur, Sean           ---none---
+   [SL47]          Laube, Sheldon
+                   cfisun!shel@HARVARD.HARVARD.EDU
+   [SL55]          Leaviseur, Sean          SJL%UKC.AC.UK@CS.UCL.AC.UK
+   [SL60]          Linnemann, Stefan        ---none---
+   [SL70]          Levy, Stuart             slevy@UC.MSC.UMN.EDU
+   [SL97]          Lee, Sang                ---none---
+   [SLH19]         Howell, Steven L.        showell@NSWC-WO.ARPA
+   [SLV4]          Vandenburg, Steven L.
+                   ASQJ-NIC-01@ZAMA-EMH1.ARMY.MIL
+   [SM10]          Morrison, Stuart         ---none---
+   [SM111]         Mandell, Stewart         mandell@BN1.ARPA
+   [SM137]         Morgan, Scott            smorgan@ARIEL.UNM.EDU
+   [SM157]         McBride, Sam
+                   mcbride%niehs.bitnet@CUNYVM.CUNY.EDU
+   [SM164]         Milton, Scott            root@CSIS.OZ.AU
+   [SM188]         Moss, Stephen            ---none---
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 172]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [SM197]         Miller, Scott            ---none---
+   [SM214]         McDonald, Scott          ---none---
+   [SM217]         Matsuda, Shigeyuki       matu@RD.NTTDATA.JP
+   [SM218]         Martinez, Cid            ---none---
+   [SM221]         Momchilovich, Steve      ---none---
+   [SM235]         Mittur, Shyam            ---none---
+   [SM6]           McLinden, Sean
+                   MCLINDEN@CADRE.DSL.PITTSBURGH.EDU
+   [SM62]          Mackey, Sandy            skm@OMAHA.MITRE.ORG
+   [SM67]          Miller, Steve            miller@M2C.ORG
+   [SM83]          McPherson, Stew          stew@CSUPWB.COLOSTATE.EDU
+   [SM96]          Morris, Scooter          scooter@CGL.UCSF.EDU
+   [SMA9]          Arnold, Susan M.         SUSIE@SDS.SDSC.EDU
+   [SMB33]         Brown, Stephen M.        icssmb@ASUVM.INRE.ASU.EDU
+   [SMD1]          Donelan, Sean M.         sean@DRANET.DRA.COM
+   [SMF5]          Feldman, Steven M.       feldman@TYMNET.COM
+   [SMK2]          King, Stephen Michael    KING@HQAFSC-VAX.AF.MIL
+   [SMM21]         Miller, Steven M.        miller@SCTC.COM
+   [SMP2]          Polinsky, Steven M.
+                   SMPCU%CUNYVM.BITNET@CUNYVM.CUNY.EDU
+   [SMS1]          Schultz, Steve M.        sms@WLV.IMSD.CONTEL.COM
+   [SN52]          Naarding, Steven
+                   mcvax!nlcvx.convex.nl!jep@UUNET.UU.NET
+   [SN8]           Silsson, Soren           ---none---
+   [SO]            Oliphant, Steven         oliphant.pa@XEROX.COM
+   [SO35]          Oetinger, Steve          ---none---
+   [SO42]          Odegaard, Sverre         ---none---
+   [SO43]          Overall, Stephen         ---none---
+   [SP116]         Prince, Stephen          sp@LABTAM.OZ.AU
+   [SP69]          Perelgut, Steve          perelgut@TURING.TORONTO.EDU
+   [SP81]          Portner, Stan            escd!stan@DECWRL.DEC.COM
+   [SP86]          Piccardi, Stefano
+                   oliveb!trzdor1.ico.olivetti.com!stefano@SUN.COM
+   [SPA]           Abreu, Salvador Pinto    spa@FCTUN1.RCCN.PT
+   [SPR1]          Roth, Stefan P.          spr%pyr@GATECH.EDU
+   [SR127]         Root, Tsgt.
+                   SHEPPARD-AIM1@SHEPPARD-AIM1.AF.MIL
+   [SR77]          Rousseau, Susan          susan@NUSC.NAVY.MIL
+   [SRC16]         Cary, Stephen R.         cary@RISCSM.SCRIPPS.EDU
+   [SS110]         Smith, Stanfield         stan@H1.GCY.NYTEL.COM
+   [SS130]         Schneidler, Stephan      NSC-DAVM@DDN2.DCA.MIL
+   [SS131]         Sutphen, Steven          steve@CS.UALBERTA.CA
+   [SS172]         Sidner, Steve J.         PRC@SACEMNET.AF.MIL
+   [SS208]         Shurr, Scott             sshurr@WELLESLEY.EDU
+   [SS218]         Seitz, Steffen
+                   iase001%dtuzdv5a.bitnet@CUNYVM.CUNY.EDU
+   [SS226]         Sewall, Scott            sewall@UMN-CS.CS.UMN.EDU
+   [SS253]         Sharkey, Scott
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 173]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+                   sharkey@OSU-20.IRCC.OHIO-STATE.EDU
+   [SS271]         Spencer, Shawn           ---none---
+   [SS297]         Stindl, Siegfried        stindl%uniaug@IRA.UKA.DE
+   [SS310]         Skaar, Steve             ---none---
+   [SS80]          Schaller, Skip           skip@AS.ARIZONA.EDU
+   [SST]           Tabron, Susan S.         stabron@DCSC.DLA.MIL
+   [SSW]           Wolff, Stephen S.        SWOLFF@NOTE.NSF.GOV
+   [SSW5]          Weinstein, Sydney S.     syd@DSI.COM
+   [ST22]          Thung, Sturla            ---none---
+   [ST23]          Toal, Steve              ---none---
+   [ST81]          Tchehrazi, Sissi         ---none---
+   [SW111]         Wasserroth, Stephan
+                   wasserroth%fokus.berlin.gmd.dbp.de@RELAY.CS.NET
+   [SW114]         Weismuller, Steve        ---none---
+   [SW142]         Westberg, Sven-Ove       sow@CAD.LUTH.SE
+   [SW143]         White, Stephen           SRGHSPW@WNV.DSIR.GOVT.NZ
+   [SW171]         Wright, Samuel           pcessw@SWE.ERI.APNDEVA
+   [SW37]          Whalen, Sue              whalen@CS.NPS.NAVY.MIL
+   [SW69]          Winn, Scott F.           SWINN@NARDACDC002.NAVY.MIL
+   [SW73]          Warren, Scott            scott@ROSETTA.COM
+   [SW78]          Wadle, Steve             ---none---
+   [SWH8]          Hoehn, Steven W.         ---none---
+   [SWR3]          Rogers, Scott W.
+                   rogers@OSI540SN.GSFC.NASA.GOV
+   [SWW6]          Weller, Scott W.
+                   rochester!tropics!orion!sww.uucp@UUNET.UU.NET
+   [SY19]          Youl, Shane              shane@DMPMELA.OZ.AU
+   [SY8]           Yokota, Shozo            ---none---
+   [SYM2]          Moon, Steven Y.
+                   moonstni%uiamvs.bitnet@VM1.NODAK.EDU
+   [SZ21]          Zapata, Santiago
+                   szapata%vmtecmex.bitnet@CUNYVM.CUNY.EDU
+   [TA24]          Asami, Tohru             ---none---
+   [TA54]          Andrego, Tom             ---none---
+   [TA61]          Anstey, Terry            t_anstey@UCNT.EDU.AU
+   [TAE1]          Easterday, Thomas A.
+                   TOM@NISCA.IRCC.OHIO-STATE.EDU
+   [TAK15]         Kanka, Terrence A.       KANKA@PENTAGON-OPTI.ARMY.MIL
+   [TAP15]         Pham, Tuan A.            ---none---
+   [TB]            Byrnes, Tim
+                   tbyrnes@APG-EMH5.APG.ARMY.MIL
+   [TB164]         Blankenship, Tom         ---none---
+   [TB166]         Bothner, Tor             bothner@PRIAM.CERN.CH
+   [TB172]         Boarth, Tom              ---none---
+   [TB6]           Baker, Todd              tzb@BRIDGE2.3COM.COM
+   [TB64]          Becker, Tony             ---none---
+   [TC124]         Colegrove, Tod           ---none---
+   [TC132]         Clark, Thomas            ---none---
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 174]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [TC72]          Crouch, Terry            TCROUCH@RIA-EMH1.ARMY.MIL
+   [TC84]          Carter, Tom              tom@ALTAIR.CSUSTAN.EDU
+   [TC96]          Conroy, Tom              trc@ESD.3COM.COM
+   [TD103]         Dawson, Tom
+                   dawsontc!snyalfba!bitnet@CUNYVM.CUNY.EDU
+   [TD104]         D'Angelo, Tony
+                   dangelar%snyoldba.bitnet@CUNYVM.CUNY.EDU
+   [TD105]         Deso, Tom
+                   desotm%snyplava.bitnet@CUNYVM.CUNY.EDU
+   [TD40]          Davis, Tom               DAVIS@UV4.EGLIN.AF.MIL
+   [TD68]          Dunning, Terry           ---none---
+   [TD87]          Davis, Theron            ---none---
+   [TD91]          Dawson, Teddy            NSC-Luke@DDN3.DCA.MIL
+   [TDG9]          Gerrity, Timothy D.      tgerrity@CRVAX.SRI.COM
+   [TDM8]          Mudgett, Trish Dailey    ---none---
+   [TE16]          Eldredge, Timothy        teldredge@UVAX.ISX.COM
+   [TE35]          Eccleston, Tony          aje@ATMOS.DAR.CSIRO.AU
+   [TE37]          Evans, Tim
+                   tkevans!woodb.uucp@UUNET.UU.NET
+   [TED]           Calkins, Ted             TED@NADC.NAVY.MIL
+   [TES16]         Swazuk, Thomas E.        swazuk@FAC.CIS.TEMPLE.EDU
+   [TF30]          Frohling, Ted            tsf@ARIZONA.EDU
+   [TF6]           Ferrin, Thomas           TEF@CGL.UCSF.EDU
+   [TFB3]          Blakely, Thomas F.
+                   tfb%unfvm.bitnet@CUNYVM.CUNY.EDU
+   [TG67]          Goldblatt, Ted           ted@TELEMATICS.COM
+   [TG68]          Gross, Tim               gross@TSB.NRL.NAVY.MIL
+   [TG94]          Gau, Troy                ---none---
+   [TGC1]          Cahoon, Timothy G.       ---none---
+   [TGN]           Norman, T.G.
+                   net-admin!cs.flinders.oz.au@UUNET.UU.NET
+   [TGP3]          Pike, Tod G.             tgp@SEI.CMU.EDU
+   [TGS6]          Sickles, Theodore G.     tgsickle@RISC.COM
+   [TH101]         Hackl, Toni
+                   anh%dgaipp1s.bitnet@CUNYVM.CUNY.EDU
+   [TH111]         Hunkapiller, Tim         tim@HOOD.CALTECH.EDU
+   [TH131]         Handel, Todd             ---none---
+   [TH147]         Halvorson, Tim           ---none---
+   [TH15]          Holt, Tracy              holt@GMUVAX.GMU.EDU
+   [TH28]          Higgins, Thomas          ---none---
+   [TH60]          Hutton, Thomas           hutton@SCUBED.SCUBED.COM
+   [THD]           Dunigan, Thomas H.       DUNIGAN@MSR.EPM.ORNL.GOV
+   [THL3]          Lee, Timothy H.          tlee@ISDDEN.ISD.USGS.GOV
+   [TJ]            Jacobson, Thomas         thomas@UC.MSC.UMN.EDU
+   [TJ40]          Jandu, Tavinder          M.NURSE@UK.AC.GMW
+   [TJF13]         Frivold, Thane J.        frivold@UNIX.SRI.COM
+   [TJS38]         Stone, Timothy J.        TIM@WARBURG.COM
+   [TJT1]          Tessin, Timothy J.       tjt@SAMEDI.LLNL.GOV
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 175]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [TK43]          Kobayashi, Tsutomu
+                   koba%ntt-20@SUMEX-AIM.STANFORD.EDU
+   [TK60]          Kimura, Tomonori         tk%ait.th@UUNET.UU.NET
+   [TK86]          Kelly, Tsgt              ---none---
+   [TKH4]          Hallberg, Theodore K.    ads27lgu@CLARK-EMH.AF.MIL
+   [TL99]          Lenggenhager, Thomas
+                   ch-zone-contact@VERW.SWITCH.CH
+   [TLC28]         Canipe, Todd L.          HOSTADM@OSAN-EMH.AF.MIL
+   [TLL8]          LaQuey, Tracy L.         tracy@EMX.UTEXAS.EDU
+   [TLO]           O'Hara, Thomas L.        SAC.42AD-SCX@E.ISI.EDU
+   [TM10]          Mallory, Tracy           tmallory@CCV.BBN.COM
+   [TM128]         McDowell, Terry          ---none---
+   [TM129]         Minter, Theresa Jean
+                   TMINTER@AEGIS-DAHLGREN.NSWC.NAVY.MIL
+   [TM159]         Molnar, Tom              molnar@GPU.UTCS.TORONTO.EDU
+   [TM166]         Morris, Thomas           ---none---
+   [TM169]         McNeal, Terry
+                   mcneal%grin1.bitnet@CUNYVM.CUNY.EDU
+   [TM185]         Matsuyama, Takashi
+                   TM%OKAYAMA-U.AC.JP@RELAY.CS.NET
+   [TM19]          McGill, Thomas C.        TCM@SSDP.CALTECH.EDU
+   [TM199]         McDermott, Tracy         ---none---
+   [TM200]         Macy, Tad
+                   tmacy%bowdoin.bitnet@MITVMA.MIT.EDU
+   [TM37]          Lafleur, Tom             LAFLEUR@QUALCOMM.COM
+   [TM57]          Mead, Theodore           mead@CC.ROCHESTER.EDU
+   [TM84]          Maegawa, Toshiyuki       ---none---
+   [TM96]          Majithia, Tushar         TM@HAMPTONU.EDU
+   [TMD6]          Dillon, Theresa M.       tmd@MBUNIX.MITRE.ORG
+   [TMH6]          Herrick, Thomas M.       herrickt@IMO-UVAX1.DCA.MIL
+   [TML]           Louden, T. Michael       LOUDEN@MWUNIX.MITRE.ORG
+   [TMR11]         Rowlett, Thomas M.
+                   rowlett#tom%b.mfenet@NMFECC.LLNL.GOV
+   [TN11]          Nielsen, Torben          torben@DORSAI.ICS.HAWAII.EDU
+   [TN17]          Nijssen, Teun
+                   TEUN%HTIKUB5.BITNET@CUNYVM.CUNY.EDU
+   [TN29]          Newell, Tom              Newell@TWG.COM
+   [TN40]          Naito, Takashi
+                   gack%ntt-twins.ntt.jp@RELAY.CS.NET
+   [TN5]           Nolan, Ted               TED@ARSOCOMVAX.SOCOM.MIL
+   [TO32]          Ollier, Tony             ccollier@VAX.SWAN.AC.UK
+   [TO33]          Oldham, Tim              tjo@ITS.BT.CO.UK
+   [TO34]          Oeser, Thomas            ---none---
+   [TO4]           Oishi, Tosaku
+                   oishi%etl.junet%etl.jp@RELAY.CS.NET
+   [TONY]          Holland, Anthony R.      TONY@KL.SRI.COM
+   [TP102]         Pronton, Tim             ---none---
+   [TP58]          Pittari, Tony            ---none---
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 176]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [TP91]          Phelps, Ted
+                   phelps!snycenvm!bitnet@CUNYVM.CUNY.EDU
+   [TPB1]          Berk, Thomas P           BERK@INTER-TEL.COM
+   [TPS5]          Senay, Terence P.        ---none---
+   [TR103]         Rosmus, Tim              TIM@DATA-IO.COM
+   [TR3]           Ridinger, Tom            ---none---
+   [TR38]          Radzykewycz, Tim
+                   calma!radzy@UCBVAX.Berkeley.EDU
+   [TR62]          Reed, Tim                wash08!txr98@UUNET.UU.NET
+   [TR85]          Reber, Tobias
+                   dok235%dhddkfz1.bitnet@CUNYVM.CUNY.EDU
+   [TR87]          Rylance, Tim             tkr@praxis.co.uk
+   [TR91]          Ross, Tom                ---none---
+   [TRG4]          Giebelhaus, Tim R.
+                   hi-csc!apcimsp!tim@UUNET.UU.NET
+   [TRG8]          Grubbs, Thomas R.        ---none---
+   [TRW18]         Walworth, Timothy R.     ---none---
+   [TS107]         Smith, Thorn             ---none---
+   [TS118]         Silva, Tony
+                   tsilva%aaec1.uucp@DSPVAX.MIT.EDU
+   [TS14]          Stuckey, Trish           TRISH@TRANTOR.HARRIS-ATD.COM
+   [TS141]         Schneider, Tom           ---none---
+   [TS144]         Scialdone, Tony          ---none---
+   [TS146]         Stoneley, Tony
+                   ajms%phx.cam.ac.uk@NSS.CS.UCL.AC.UK
+   [TS147]         Sato, Tomomitsu          tomo%keo.junet@RELAY.CS.NET
+   [TS149]         Sutherland, Thomas
+                   NSC|RAN314@RANDOLPH-AIM1.AF.MIL
+   [TS154]         Shimoyama, Tomoaki
+                   tomo%ctc.citoh.jp@UUNET.UU.NET
+   [TS158]         Suzuki, Tomio            r21233@RKNA50.RIKEN.GO.JP
+   [TS160]         Saito, Tetsuya           ---none---
+   [TS171]         Steele, Tim
+                   tjfs%tadtec.uucp@NSS.CS.UCL.AC.UK
+   [TS193]         Sigurdson, Todd          ---none---
+   [TS194]         Tse, Steve               TSE@ARC.AB.CA
+   [TS196]         Stockman, Tony           STOCKMAN@XYPLEX.COM
+   [TS31]          Symchych, Tim            symchych@NCS.DND.CA
+   [TS9]           Slattery, Terry          tcs@BRL.MIL
+   [TSC11]         Collins, Terrance S.     macomw!tcollins@NOSC.MIL
+   [TSD3]          Dunn, Thomas S.          ---none---
+   [TT32]          Thomas, Tony             ---none---
+   [TT35]          Terbush, Terry
+                   tlt%gwuvm.bitnet@CUNYVM.CUNY.EDU
+   [TT60]          Tran, Tony               versatc!tran@SUN.COM
+   [TT69]          Tuomi, Tarmo             ---none---
+   [TT70]          Terrall, Tom             tlt@RSCH.OCLC.OR
+   [TT84]          Thiersch, Tom            ---none---
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 177]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [TTO]           Olson, Timothy T.        SAC.NRCH-LMR@E.ISI.EDU
+   [TTS8]          Spengler, Thomas T.      spengler@TIS.LLNL.GOV
+   [TU1]           Usuki, Takashi           usuki@SONY.CO.JP
+   [TV]            Vollmer, Tom             vollmer@NOSC.MIL
+   [TV29]          Vijlbrief, Tom
+                   mcvax!tnosoes!tom@UUNET.UU.NET
+   [TVF1]          Fossum, Timothy V.       fossum@VACS.UWP.WISC.EDU
+   [TW102]         Wooller, Timothy         ---none---
+   [TW112]         Wade, Tom                t.wade@CC.UCD.IE
+   [TW3]           West, Todd               west@CCF3.NRL.NAVY.MIL
+   [TW51]          Wadlow, Tom A.           taw@MORDOR.S1.GOV
+   [TW8]           Wieland, Terry           nu023467@VM1.NODAK.EDU
+   [TWH19]         Higbe, Thomas W.
+                   ASNBLERP@PENTAGON-OPTI.ARMY.MIL
+   [UB3]           Bilting, Ulf             bilting@CS.CHALMERS.SE
+   [UR]            Ritter, Uwe              ---none---
+   [US2]           Straumann, Ulrich
+                   K538915%CZHRZU1A.BITNET@CUNYVM.CUNY.EDU
+   [VAF]           Fuller, Vince            VAF@STANFORD.EDU
+   [VBK]           Kava, Victor B.          ---none---
+   [VC]            Cid, Victor
+                   vcid%uchcecvm.bitnet@CUNYVM.CUNY.EDU
+   [VC5]           Cericole, Victor, Jr.
+                   vcerico@APG-EMH5.APG.ARMY.MIL
+   [VH21]          Hutchison, Vicki         vicki@QUALCOMM.COM
+   [VHB]           Barnes, Vonnie H.        VBARNES@RELAY.NSWC.NAVY.MIL
+   [VL24]          Lasker, Valerie          ---none---
+   [VL42]          Lagioia, Vincenzo        ---none---
+   [VLG]           Gordon, Vicki L.         VGORDON@ISI.EDU
+   [VM49]          Moore, Virgil            ABC@ARLVS1.ARLUT.UTEXAS.EDU
+   [VN]            Neou, Vivian             VIVIAN@NIC.DDN.MIL
+   [VP12]          Pratt, Vaughan Ronald    pratt@TRIANGLE.COM
+   [VR32]          Reijs, Victor            REIJS@SURFNET.NL
+   [VS13]          Schryver, Vernon         vjs@sgi.com
+   [VS50]          Summerour, Vic
+                   vic%utsw.decnet@UTADNX.CC.UTEXAS.EDU
+   [VS58]          Streif, Vincent
+                   STREIF@UWECVAXA.BITNET@CUNYVM.CUNY.EDU
+   [VS59]          Shaw, Vic
+                   uninet.frd@F4.N494.Z5.FIDONET.ORG
+   [VT7]           Troeltsch, Verena
+                   R41DLRZ!UBW-M.UUCP@UUNET.UU.NET
+   [WA16]          Armitage, William
+                   wja%computer-science.nottingham.ac.uk@CS.UCL.AC.UK
+   [WA32]          Anderson, Walt           ---none---
+   [WAG5]          Guthmiller, Wayne A.     wag@RISC.COM
+   [WAH11]         Hunt, Warren A., Jr.     HUNT@CLI.COM
+   [WAW11]         Winner, Wendy A.         wendy@BRL.MIL
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 178]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [WB102]         Brinkmann, Willi         ---none---
+   [WB53]          Ball, Wayne
+                   wball%umass.bitnet@CUNYVM.CUNY.EDU
+   [WC117]         Colquitt, Walt           C46WALT@HARC.EDU
+   [WC86]          Cheng, Wing              objy!objy1!wing@SUN.COM
+   [WC89]          Chapeskie, Wayne         microsof!waynec@UUNET.UU.NET
+   [WCW7]          Wells, William C.        ---none---
+   [WCWI]          Ince, W.C.W.             wcwince@WATMATH.WATERLOO.EDU
+   [WD27]          Dair, Willis
+                   DAIR%SCU.BITNET@JADE.Berkeley.EDU
+   [WD58]          Davidson, William        ---none---
+   [WD60]          Daniels, William         ---none---
+   [WDL]           Lazear, Walter D.        LAZEAR@GATEWAY.MITRE.ORG
+   [WDR7]          Rolph, W. Don, III       ---none---
+   [WDS11]         Smith, William D.        smith@GROUCHO.MRC.UIDAHO.EDU
+   [WDW2]          Welch, William D., Jr.   ingr!zaiaz!bill@UUNET.UU.NET
+   [WE12]          Edgington, Will          wedgingt@DU.EDU
+   [WES22]         Strickland, Win E., Jr.  win@audiofax.com
+   [WF3]           Fink, William E.         bill@NET.NRL.NAVY.MIL
+   [WF42]          Fulton, William          iswaf@DCATLA.COM
+   [WFG4]          Gunshannon, William F.   WFG702@JAGUAR.UOFS.EDU
+   [WG]            Graves, Wayne            WRGraves@LBL.ARPA
+   [WGS4]          Stefancik, W. Gregg      wstef@ENG.CLEMSON.EDU
+   [WH108]         Helgers, Wim
+                   mcvax!westc!netadm@UUNET.UU.NET
+   [WH110]         Holmes, Walter           ---none---
+   [WH125]         Hosking, Wesley          wes@ATLANTEK.OZ.AU
+   [WH131]         Higgins, William         76420.25@COMPUSERVE.COM
+   [WH136]         Hoover, Bill             ---none---
+   [WH2]           Heinrich, Werner
+                   heinrich%rz.uni-ulm.dbp.de@RELAY.CS.NET
+   [WH54]          Hathaway, Wayne          WAYNE@ULTRA.COM
+   [WH64]          Hake, Wolfgang
+                   UHRZS007%DBIUNI11.BITNET@CUNYVM.CUNY.EDU
+   [WH96]          Hein, W.                 ---none---
+   [WHN2]          Nugent, William H.       whn@CS.NET
+   [WJF1]          Flynn, William J.        ---none---
+   [WJK6]          Kelly, William J., Jr.   KELLY@AFGL-VAX.AF.MIL
+   [WJL17]         Lavallee, Warren J.      warren@PWS.BULL.COM
+   [WJL2]          LaRocca, William J.      ---none---
+   [WJM1]          Moeller, Wolfgang J.
+                   U0012%DGOGWDG5.BITNET@CUNYVM.CUNY.EDU
+   [WJM26]         Marko, William J.        wmarko@UB.D.UMN.EDU
+   [WJR17]         Redmond, William J.      ---none---
+   [WJS1]          Showalter, Weldon Jim    GAMMA@MINTAKA.DCA.MIL
+   [WK56]          Koblitz, Werner
+                   mcvax!egh780!koblitz@UUNET.UU.NET
+   [WKS4]          Smith, Wade              WKS@BIOGFX.COM
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 179]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+   [WKT]           Tong, William K.         Tong@SBCS.SUNYSB.EDU
+   [WL31]          Lampeter, William        bill@CS.ROCHESTER.EDU
+   [WLB5]          Boyer, William L.        WLB@NCIFCRF.GOV
+   [WLG7]          Gordon, Windy L.         ---none---
+   [WLJ7]          Jones, William L.        jones@HERMES.CHPC.UTEXAS.EDU
+   [WLR6]          Riess, William L.        ---none---
+   [WM110]         Manning, William         bmanning@MICRO.TI.COM
+   [WM112]         Mingus, William          ---none---
+   [WM3]           Melohn, William          Melohn@SUN.COM
+   [WM68]          Magnussen, Walt          X048WM@TAMVM1.TAMU.EDU
+   [WM96]          Marty, Walter            ---none---
+   [WMT]           Tyson, William Mabry     TYSON@AI.SRI.COM
+   [WN19]          Nowlin, William          ---none---
+   [WN2]           Nagey, Walter
+                   mmdf@SCHWEINFURT-EMH1.ARMY.MIL
+   [WOS]           Sibert, W. Olin          Sibert@DOCKMASTER.NCSC.MIL
+   [WP64]          Pommerer, Werner
+                   dehnhardt@COMVAX.RUS.UNI-STUTTGART.DBP.DE
+   [WP8]           Prue, Walt               PRUE@ISI.EDU
+   [WP90]          Porten, Willi
+                   grz049%DBNGMD21.BITNET@CORNELLC.CIT.CORNELL.EDU
+   [WPBS]          Sjouw, Wim P.B.
+                   sjouw%hutruu51.bitnet@CUNYVM.CUNY.EDU
+   [WPC]           Caloccia, William P.
+                   caloccia%lectroid.uucp@UUNET.UU.NET
+   [WR66]          Roberts, Wayne           wmr@POTOMAC.ADS.COM
+   [WR88]          Ryder, W.                ---none---
+   [WRC22]         Cronin, W. Robert        ---none---
+   [WRH20]         Harris, Weldon R.
+                   killer!escort!harris@AMES.ARC.NASA.GOV
+   [WRR5]          Ritchie, William R.      DDNWRR@FLTAC-POE.NAVY.MIL
+   [WRS28]         Stevens, W. Richard      stevens@HSI.COM
+   [WS165]         Smith, Warren            ---none---
+   [WS167]         Stolk, Wim               ---none---
+   [WS168]         Stokes, Warren           ---none---
+   [WS94]          Spirk, Werner
+                   A2824AB%DMOLRZ01.BITNET@CUNYVM.CUNY.EDU
+   [WSC1]          Chen, Wen-Sung           ZCHEN@TWNMOE10.BITNET
+   [WSC5]          Currie, W.S.
+                   S.Currie%edinburgh.ac.uk@CUNYVM.CUNY.EDU
+   [WSW11]         Wainner, W. Scott        WAINNER@HQ.AF.MIL
+   [WT39]          Tolle, Werner
+                   wet%tumuc.e-technik.tu-muenchen.dbp.de@RELAY.CS.NET
+   [WTC]           Cyrus, W. Tait           cyrus@PPRG.UNM.EDU
+   [WTE4]          Embach, William T.
+                   bill%ucf1vm.bitnet@CUNYVM.CUNY.EDU
+   [WU1]           Underwood, Walter        wunder@HPLABS.HP.COM
+   [WVDS]          van der Scheun, Willem
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 180]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+                   bssara%sara.nl@CUNYVM.CUNY.EDU
+   [WW2]           Wedel, Wally             wedel@NGP.UTEXAS.EDU
+   [WW82]          White, William           wwhite@CEL.FMC.COM
+   [WWP8]          Plummer, William W.      Plummer@DOCKMASTER.NCSC.MIL
+   [WWR1]          Richard, W. W.           ---none---
+   [WWS]           Seemuller, William W.    BILL@ETL.ARMY.MIL
+   [YB4]           Banno, Yoshiaki
+                   Banno%JPNKEKVM.BITNET@CUNYVM.CUNY.EDU
+   [YC4]           Cruz, Yellixa            sac.341smw-scx@E.ISI.EDU
+   [YD2]           Despond, Yves            despond@SIC.EPFL.CH
+   [YK2]           Karsenti, Yves
+                   karsenti%frirts71.bitnet@CUNYVM.CUNY.EDU
+   [YK3]           Kameyama, Yukiyoshi      kam@SATO.RIEC.TOHOKU.AC.JP
+   [YL14]          Leong, Y.                ---none---
+   [YN]            Nguyen, Yen              yen@ARINC-GW.ARPA
+   [YS10]          Saito, Yaski
+                   yaski%ntt-20@SUMEX-AIM.STANFORD.EDU
+   [YSP3]          Park, Young S.           root@KIT.KIT.AC.KR
+   [ZSU]           Su, Zaw-Sing             Zsu@NISC.SRI.COM
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 181]
+
+RFC 1166                    Internet Numbers                   July 1990
+
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Authors' Addresses
+
+   Sue Kirkpatrick
+   SRI International
+   Network Information Systems Center
+   333 Ravenswood Avenue, EJ217
+   Menlo Park, CA 94025
+
+   Phone: (415) 859-5539
+
+   Email: SUE@NIC.DDN.MIL
+
+
+   Mary Stahl
+   SRI International
+   Network Information Systems Center
+   333 Ravenswood Avenue, EJ296
+   Menlo Park, CA 94025
+
+   Phone: (415) 859-4775
+
+   Email: STAHL@NIC.DDN.MIL
+
+
+
+   Mimi Recker
+   SRI International
+   Network Information Systems Center
+   333 Ravenswood Avenue, EJ268
+   Menlo Park, CA 94025
+
+   Phone: (415) 859-2110
+
+   Email: MIMI@NIC.DDN.MIL
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kirkpatrick, Stahl & Recker                                   [Page 182]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1166.txt](<www.ietf.org/rfc/rfc1166.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
