### PR TITLE
Archive rfc1170.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1170.txt
+++ b/www.ietf.org/rfc/rfc1170.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                         R. Fougner
+Request for Comments: 1170                           Public Key Partners
+                                                            January 1991
+
+
+                   Public Key Standards and Licenses
+
+Status of this Memo
+
+   This RFC is a public statement by Public Key Partners regarding
+   Public Key Standards and Licenses.  This memo is for informational
+   use only, and does not constitute an Internet standard.  Distribution
+   of this memo is unlimited.
+
+Public Key Standards and Licenses
+
+   The Massachusetts Institute of Technology and the Board of Trustees
+   of the Leland Stanford Junior University have recently granted Public
+   Key Partners exclusive sublicensing rights to the following patents
+   registered in the United States, and all of their corresponding
+   foreign patents:
+
+      Cryptographic Apparatus and Method
+      ("Diffie-Hellman")............................... No. 4,200,770
+
+      Public Key Cryptographic Apparatus
+      and Method ("Hellman-Merkle").................... No. 4,218,582
+
+      Cryptographic Communications System and
+      Method ("RSA")................................... No. 4,405,829
+
+      Exponential Cryptographic Apparatus
+      and Method ("Hellman-Pohlig").................... No. 4,424,414
+
+   These patents cover all known methods of practicing the art of Public
+   Key, including the variations collectively known as El Gamal.
+
+   Due to the broad acceptance of RSA digital signatures throughout the
+   international community, Public Key Partners strongly endorses its
+   incorporations in a digital signature standard.  We assure the
+   interested parties that Public Key Partners will comply with all of
+   the policies of ANSI and the IEEE concerning the availability of
+   licenses to practice this art.  Specifically, in support of any RSA
+   signature standard which may be adopted, Public Key Partners hereby
+   gives its assurance that licenses to practice RSA signatures will be
+   available under reasonable terms and conditions on a non-
+   discriminatory basis.
+
+
+
+
+Fougner                                                         [Page 1]
+
+RFC 1170           Public Key Standards and Licenses        January 1991
+
+
+   We take this opportunity to thank all of those concerned for their
+   collective efforts in making this technology readily available for
+   commercial implementation.
+
+                                           Public Key Partners
+
+                                           By:  Robert B. Fougner
+                                                Director of Licensing
+
+Security Considerations
+
+   This memo discusses fair access to the use of public key technology
+   to implement security.
+
+Author's Address
+
+   Robert B. Fougner
+   Director of Licensing
+   Public Key Partners
+   130 B Kifer Court
+   Sunnyvale, CA 94086
+
+   Phone:  (408) 735-6779
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fougner                                                         [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1170.txt](<www.ietf.org/rfc/rfc1170.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
