### PR TITLE
Archive rfc1181.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1181.txt
+++ b/www.ietf.org/rfc/rfc1181.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                        R. Blokzijl
+Request for Comments: 1181                                   RIPE/NIKHEF
+                                                          September 1990
+
+
+                        RIPE Terms of Reference
+
+Status of this Memo
+
+   This RFC describes the Terms of Reference of RIPE (Reseaux IP
+   Europeens), the cooperation of European IP networks.  This memo
+   provides information for the Internet community.  It does not specify
+   any standard.
+
+   Distribution of this memo is unlimited.
+
+1. Terms of Reference of RIPE
+
+   Recognising that IP networks are growing beyond the LAN's in Europe,
+   and are extending over national and international WAN's in Europe,
+   the RIPE coordinating body has been created.  RIPE stands for the
+   "Reseaux IP Europeens".
+
+   The objective of RIPE is to ensure the necessary administrative and
+   technical coordination to allow the operation and expansion of a
+   pan-European IP network.
+
+      o RIPE acts as a forum for the exchange of technical information
+        and the creation of expertise on IP networking.
+
+      o The area of relevance for RIPE is Europe.
+
+      o All parties operating wide area IP networks are encouraged to
+        participate.
+
+      o RIPE promotes and coordinates interconnection of IP networks
+        within Europe and to other continents.
+
+      o RIPE establishes agreement on common network management
+        practices and the operational management of the interconnected
+        networks.
+
+      o RIPE serves as a focal point for other common activities of the
+        participants related to IP networking.
+
+      o All documents produced by RIPE will be publicly available.
+
+      o RIPE is not a network service provider.  IP networks
+
+
+
+Blokzijl                                                        [Page 1]
+
+RFC 1181                RIPE Terms of Reference           September 1990
+
+
+        collaborating in RIPE remain under the executive authority of
+        their respective organisations.
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Author's Address
+
+   Rob Blokzijl
+   RIPE
+   c/o NIKHEF
+   P.O.B. 41882
+   NL-1009 DB  Amsterdam
+   the Netherlands
+
+   Phone:  +31 20 5920413
+
+   EMail:  k13@nikhef.nl
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Blokzijl                                                        [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1181.txt](<www.ietf.org/rfc/rfc1181.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
