### PR TITLE
Archive rfc1198.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1198.txt
+++ b/www.ietf.org/rfc/rfc1198.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                                       B. Scheifler
+Request for Comments: 1198           MIT Laboratory for Computer Science
+FYI: 6                                                      January 1991
+
+
+                       FYI on the X Window System
+
+Status of this Memo
+
+   This FYI RFC provides pointers to the published standards of the MIT
+   X Consortium.  This memo provides information for the Internet
+   community.  It does not specify any Internet standard.  Distribution
+   of this memo is unlimited.
+
+The following documents are standards of the MIT X Consortium:
+
+      X Window System Protocol
+      X Version 11, Release 4
+      Robert W. Scheifler
+
+      Xlib - C Language X Interface
+      X Version 11, Release 4
+      James Gettys, Robert W. Scheifler, Ron Newman
+
+      X Toolkit Intrinsics - C Language Interface
+      X Version 11, Release 4
+      Joel McCormack, Paul Asente, Ralph R. Swick
+
+      Bitmap Distribution Format
+      Version 2.1
+
+      Inter-Client Communication Conventions Manual
+      Version 1.0
+      David S. H. Rosenthal
+
+      Compound Text Encoding
+      Version 1.1
+      Robert W. Scheifler
+
+      X Logical Font Description Conventions
+      Version 1.3
+      Jim Flowers
+
+      X Display Manager Control Protocol
+      Version 1.0
+      Keith Packard
+
+
+
+
+
+Scheifler                                                       [Page 1]
+
+RFC 1198                 FYI - X Window System              January 1991
+
+
+      X11 Nonrectangular Window Shape Extension
+      Version 1.0
+      Keith Packard
+
+   The following documents are draft standards of the MIT X Consortium.
+   To become standards, further "proof of concept" is required, in the
+   form of working implementations.  The specifications may be subject
+   to incompatible changes if implementation efforts uncover significant
+   problems.
+
+      PEX Protocol Specification
+      Version 4.0P
+      Randi J. Rost (editor)
+
+      Extending X for Double-Buffering, Multi-Buffering, and Stereo
+      Version 3.2
+      Jeffrey Friedberg, Larry Seiler, Jeff Vroom
+
+   Standards and draft standards of the MIT X Consortium are generally
+   included in the MIT X software distribution.  The distribution is
+   usually available via anonymous FTP from a variety of hosts around
+   the world.  Questions about FTP sites for the current release can be
+   sent to xrequest@expo.lcs.mit.edu.  The distribution can also be
+   ordered on tape from MIT for a nominal charge, contact:
+
+      MIT Software Distribution Center
+      Technology Licensing Office
+      Room E32-300
+      77 Massachusetts Avenue
+      Cambridge, MA  02139
+      Phone: (617) 258-8330
+
+   The MIT X Consortium can be reached by writing to the Director:
+
+      Bob Scheifler
+      MIT X Consortium
+      Laboratory for Computer Science
+      545 Technology Square
+      Cambridge, MA 02139
+      EMail: rws@expo.lcs.mit.edu
+
+
+
+
+
+
+
+
+
+
+
+Scheifler                                                       [Page 2]
+
+RFC 1198                 FYI - X Window System              January 1991
+
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Author's Address
+
+   Bob Scheifler
+   MIT X Consortium
+   Laboratory for Computer Science
+   545 Technology Square
+   Cambridge, MA 02139
+
+   Phone: (617) 253-0628
+
+   EMail: rws@expo.lcs.mit.edu
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Scheifler                                                       [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1198.txt](<www.ietf.org/rfc/rfc1198.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
