### PR TITLE
Archive rfc1199.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1199.txt
+++ b/www.ietf.org/rfc/rfc1199.txt
@@ -1,0 +1,1235 @@
+
+
+
+
+
+
+Network Working Group                                        J. Reynolds
+Request for Comments: 1199                                           ISI
+                                                           December 1991
+
+
+                      Request for Comments Summary
+
+                         RFC Numbers 1100-1199
+
+Status of This Memo
+
+   This RFC is a slightly annotated list of the 100 RFCs from RFC 1100
+   through RFCs 1199.  This is a status report on these RFCs.  This memo
+   provides information for the Internet community.  It does not specify
+   an Internet standard.  Distribution of this memo is unlimited.
+
+Note
+
+   Many RFCs, but not all, are Proposed Standards, Draft Standards, or
+   Standards.  Since the status of these RFCs may change during the
+   standards processing, we note here only that they are on the
+   standards track.  Please see the latest edition of "IAB Official
+   Protocol Standards" for the current state and status of these RFCs.
+   In the following, RFCs on the standards track are marked [STANDARDS-
+   TRACK].
+
+RFC     Author       Date      Title
+---     ------       ----      -----
+
+1199    Reynolds     Dec 91   Requests For Comments Summary
+
+This memo.
+
+
+1198    Scheifler    Jan 91   FYI on the X Window System
+
+This FYI RFC provides pointers to the published standards of the MIT X
+Consortium.  This memo provides information for the Internet community.
+It does not specify any Internet standard.
+
+
+1197    Sherman      Dec 90   Using ODA for Translating Multimedia
+                              Information
+
+The purpose of this RFC is to inform implementors of multimedia systems
+about our experiences using ISO 8613: Office Document Architecture
+(ODA).  Because ODA is being proposed as an encoding format for use in
+multimedia mail and file exchange, implementors wishing to use ODA in an
+
+
+
+Reynolds                                                        [Page 1]
+
+RFC 1199                  Summary of 1100-1199             December 1991
+
+
+open systems environment may profit from our experiences.  This memo
+provides information for the Internet community.  It does not specify
+any standard.
+
+
+1196    Zimmerman    Dec 90   The Finger User Information Protocol
+
+This memo describes the Finger User Information Protocol.  This is a
+simple protocol which provides an interface to a remote user information
+program.  Based on RFC 742, a description of the original Finger
+protocol, this memo attempts to clarify the expected communication
+between the two ends of a Finger connection.  It also tries not to
+invalidate the many existing implementations or add unnecessary
+restrictions to the original protocol definition.  This edition corrects
+and clarifies in a minor way, RFC 1194.  [STANDARDS-TRACK]
+
+
+1195    Callon       Dec 90   Use of OSI IS-IS for Routing in TCP/IP
+                              and Dual Environments
+
+This memo specifies an integrated routing protocol, based on the OSI
+Intra-Domain IS-IS Routing Protocol, which may be used as an interior
+gateway protocol (IGP) to support TCP/IP as well as OSI.  This allows a
+single routing protocol to be used to support pure IP environments, pure
+OSI environments, and dual environments.  This specification was
+developed by the IS-IS working group of the Internet Engineering Task
+Force.  [STANDARDS-TRACK]
+
+
+1194    Zimmerman    Nov 90   The Finger User Information Protocol
+
+This memo describes the Finger User Information Protocol.  This is a
+simple protocol which provides an interface to a remote user information
+program.  Based on RFC 742, a description of the original Finger
+protocol, this memo attempts to clarify the expected communication
+between the two ends of a Finger connection.  It also tries not to
+invalidate the many existing implementations or add unnecessary
+restrictions to the original protocol definition.  [STANDARDS-TRACK]
+
+
+1193    Ferrari      Nov 90   Client Requirements for Real-Time
+                              Communication Services
+
+This memo describes client requirements for real-time communication
+services.  This memo provides information for the Internet community,
+and requests discussion and suggestions for improvements.  It does not
+specify any standard.
+
+
+
+
+Reynolds                                                        [Page 2]
+
+RFC 1199                  Summary of 1100-1199             December 1991
+
+
+1192    Kahin        Nov 90   Commercialization of the Internet
+                              Summary Repor
+
+This memo is based on a workshop held by the Science, Technology and
+Public Policy Program of the John F. Kennedy School of Government,
+Harvard University, March 1-3, 1990.  This memo provides information for
+the Internet community.  It does not specify any standard.
+
+
+1191    Mogul        Nov 90   Path MTU Discovery
+
+This memo describes a technique for dynamically discovering the maximum
+transmission unit (MTU) of an arbitrary internet path.  It specifies a
+small change to the way routers generate one type of ICMP message.  For
+a path that passes through a router that has not been so changed, this
+technique might not discover the correct Path MTU, but it will always
+choose a Path MTU as accurate as, and in many cases more accurate than,
+the Path MTU that would be chosen by current practice.  [STANDARDS-
+TRACK]
+
+
+1190    Topolcic     Oct 90   Experimental Internet Stream Protocol,
+                              Version 2 (ST-II)
+
+This memo defines a revised version of the Internet Stream Protocol,
+originally defined in IEN-119 [8], based on results from experiments
+with the original version, and subsequent requests, discussion, and
+suggestions for improvements.  This is a Limited-Use Experimental
+Protocol.  Please refer to the current edition of the "IAB Official
+Protocol Standards" for the standardization state and status of this
+protocol.
+
+
+1189    Warrier      Oct 90   The Common Management Information
+                              Services and Protocols for the Internet
+
+This memo defines a network management architecture that uses the
+International Organization for Standardization's (ISO) Common Management
+Information Services/Common Management Information Protocol (CMIS/CMIP)
+in the Internet.  [STANDARDS-TRACK]
+
+
+1188    Katz         Oct 90   A Proposed Standard for the
+                              Transmission of IP Datagrams over
+                              FDDI Networks
+
+This memo defines a method of encapsulating the Internet Protocol (IP)
+datagrams and Address Resolution Protocol (ARP) requests and replies on
+
+
+
+Reynolds                                                        [Page 3]
+
+RFC 1199                  Summary of 1100-1199             December 1991
+
+
+Fiber Distributed Data Interface (FDDI) Networks.  [STANDARDS-TRACK]
+
+
+1187    Rose         Oct 90   Bulk Table Retrieval with the SNMP
+
+This memo reports an interesting family of algorithms for bulk table
+retrieval using the Simple Network Management Protocol (SNMP).  This
+memo describes an Experimental Protocol for the Internet community, and
+requests discussion and suggestions for improvements.  This memo does
+not specify a standard for the Internet community.  Please refer to the
+current edition of the "IAB Official Protocol Standards" for the
+standardization state and status of this protocol.
+
+
+1186    Rivest       Oct 90   The MD4 Message Digest Algorithm
+
+This RFC is the specification of the MD4 Digest Algorithm.  If you are
+going to implement MD4, it is suggested you do it this way.  This memo
+is for informational use and does not constitute a standard.
+
+
+1185    Jacobson     Oct 90   TCP Extension for High-Speed Paths
+
+This memo describes an Experimental Protocol extension to TCP for the
+Internet community, and requests discussion and suggestions for
+improvements.  Please refer to the current edition of the "IAB Official
+Protocol Standards" for the standardization state and status of this
+protocol.
+
+
+1184    Borman       Oct 90   Telnet Linemode Option
+
+This RFC specifies a procedure for line at a time terminal interaction
+based on the Telnet Protocol.  It obsoletes RFC 1116.  [STANDARDS-TRACK]
+
+
+1183    Everhart     Oct 90   New DNS RR Definitions
+
+This memo defines five new DNS types for experimental purposes.  This
+RFC describes an Experimental Protocol for the Internet community, and
+requests discussion and suggestions for improvements.
+
+
+1182    Never issued.
+
+
+
+
+
+
+
+Reynolds                                                        [Page 4]
+
+RFC 1199                  Summary of 1100-1199             December 1991
+
+
+1181    Blokzijl     Sep 90   RIPE Terms of Reference
+
+This RFC describes the Terms of Reference of RIPE (Reseaux IP
+Europeens), the cooperation of European IP networks.  This memo provides
+information for the Internet community.  It does not specify any
+standard.
+
+
+1180    Socolofsky   Jan 91   A TCP/IP Tutorial
+
+This RFC is a tutorial on the TCP-IP protocol suite, focusing
+particularly on the steps in forwarding an IP datagram from source host
+to destination host through a router.  It does not specify an Internet
+standard.
+
+
+1179    McLaughlin   Aug 90   Line Printer Daemon Protocol
+
+This RFC describes an existing print server protocol widely used on the
+Internet for communicating between line printer daemons (both clients
+and servers).  This memo is for informational purposes only, and does
+not specify an Internet standard.  Please refer to the current edition
+of the "IAB Official Protocol Standards" for the standardization state
+and status of this protocol.
+
+
+1178    Libes        Aug 90   Choosing a Name for Your Computer
+
+This FYI RFC is a republication of a Communications of the ACM article
+on guidelines on what to do and what not to do when naming your
+computer.  This memo provides information for the Internet community.
+It does not specify any standard.  [Also FYI 5.]
+
+
+1177    Malkin       Aug 90   FYI on Questions and Answers
+                              Answers to Commonly asked "New
+                              Internet User" Questions
+
+This FYI RFC is one of three FYI's called, "Questions and Answers"
+(Q/A), produced by the User Services Working Group (USWG) of the
+Internet Engineering Task Force (IETF).  The goal is to document the
+most commonly asked questions and answers in the Internet.  This memo
+provides information for the Internet community.  It does not specify
+any standard.  [Also FYI 4.]
+
+
+
+
+
+
+
+Reynolds                                                        [Page 5]
+
+RFC 1199                  Summary of 1100-1199             December 1991
+
+
+1176    Crispin      Aug 90   Interactive Mail Access Protocol -
+                              Version 2
+
+This RFC suggests a method for personal computers and workstations to
+dynamically access mail from a mailbox server ("repository").  It
+obosoletes RFC 1064.  This RFC specifies an Experimental Protocol for
+the Internet community.  Discussion and suggestions for improvement are
+requested.  Please refer to the current edition of the "IAB Official
+Protocol Standards" for the standardization state and status of this
+protocol.
+
+
+1175    Bowers       Aug 90   FYI on Where to Start - A Bibliography
+                              of Internetworking Information
+
+This FYI RFC is a bibliography of information about TCP/IP
+internetworking, prepared by the User Services Working Group (USWG) of
+the Internet Engineering Task Force (IETF).  This memo provides
+information for the Internet community.  It does not specify any
+standard.  [Also FYI 3.]
+
+
+1174    Cerf         Aug 90   IAB Recommended Policy on Distributing
+                              Internet Identifier Assignment and
+                              IAB Recommended Policy
+                              Change to Internet "Connected" Status
+
+This informational RFC represents the official view of the Internet
+Activities Board (IAB), and describes the recommended policies and
+procedures on distributing Internet identifier assignments and dropping
+the connected status requirement.  This RFC does not specify a standard.
+
+
+1173    Van Bokkelen Aug 90   Responsibilities of Host and Network
+                              Managers: A Summary of the "Oral
+                              Tradition" of the Internet
+
+This informational RFC describes the conventions to be followed by those
+in charge of networks and hosts in the Internet.  It is a summary of the
+"oral tradition" of the Internet on this subject.  [RFC Editor's note:
+This memo is a contribution by the author of his view of these
+conventions.  It is expected that this RFC will provide a basis for the
+development of official policies in the future.] These conventions may
+be supplemented or amended by the policies of specific local and
+regional components of the Internet.  This RFC does not specify a
+standard, or a policy of the IAB.
+
+
+
+
+
+Reynolds                                                        [Page 6]
+
+RFC 1199                  Summary of 1100-1199             December 1991
+
+
+1172    Perkins      Jul 90   The Point-to-Point Protocol (PPP)
+                              Initial Configuration Options
+
+This memo specifies the Point-to-Point Protocol (PPP) Initial
+Configuration Options as a Proposed Standard Protocol for the Internet
+community.  When it becomes a full Standard, this protocol will be
+recommended for all TCP/IP implementations that communicate over serial
+links.
+
+
+1171    Perkins      Jul 90   The Point-to-Point Protocol for the
+                              Transmission of Multi-Protocol Datagrams
+                              Over Point-to-Point Links
+
+This memo specifies the Point-to-Point Protocol (PPP) as a Draft
+Standard Protocol for the Internet community.  When it becomes a full
+Standard, this protocol will be recommended for all TCP/IP
+implementations that communicate over serial links.
+
+
+1170    Fougner      Jan 91   Public Key Standards and Licenses
+
+This RFC is a public statement by Public Key Partners regarding Public
+Key Standards and Licenses.  This memo is for informational use only,
+and does not constitute an Internet standard.
+
+
+1169    Cerf         Aug 90   Explaining the Role of GOSIP
+
+This informational RFC represents the official view of the Internet
+Activities Board (IAB), after coordination with the Federal Networking
+Council (FNC).  This RFC does not specify a standard.
+
+
+1168    Westine      Jul 90   Intermail and Commercial Mail
+                              Relay Services
+
+This RFC discusses the history and evolution of the Intermail and
+Commercial mail systems.  The problems encountered in operating a
+store-and-forward mail relay between commercial systems such as
+Telemail, MCI Mail and Dialcom are also discussed.  This RFC provides
+information for the Internet community, and does not specify any
+standard.
+
+
+
+
+
+
+
+
+Reynolds                                                        [Page 7]
+
+RFC 1199                  Summary of 1100-1199             December 1991
+
+
+1167    Cerf         Jul 90   Thoughts on the National Research and
+                              Education Network
+
+The memo provides a brief outline of a National Research and Education
+Network (NREN).  This memo provides information for the Internet
+community.  It does not specify any standard.  It is not a statement of
+IAB policy or recommendations.
+
+
+1166    Kirkpatrick  Jul 90   Internet Numbers
+
+This memo is a status report on the network numbers and autonomous
+system numbers used in the Internet community.
+
+
+1165    Crowcrowft   Jun 90   Network Time Protocol (NTP)
+                              over the OSI Remote Operations Service
+
+This memo suggests an Experimental Protocol for the OSI and Internet
+communities.  Hosts in either community, and in particular those on both
+are encouraged to experiment with this mechanism.
+
+
+1164    Honig         Jun 90  Application of the Border Gateway
+                              Protocol in the Internet
+
+This RFC, together with its companion RFC-1163, "A Border Gateway
+Protocol (BGP)", specify an inter-autonomous system routing protocol for
+the Internet.  [STANDARDS-TRACK]
+
+
+1163    Lougheed     Jun 90   A Border Gateway Protocol (BGP)
+
+This RFC, together with its companion RFC-1164, "Application of the
+Border Gateway Protocol in the Internet", specify an inter-autonomous
+system routing protocol for the Internet.  [STANDARDS-TRACK]
+
+
+1162    Satz         Jun 90   Connectionless Network Protocol
+                              (ISO 8473) and End System to
+                              Intermediate System (ISO 9542)
+                              Management Information Base
+
+This memo defines an experimental portion of the Management Information
+Base (MIB) for use with network management protocols in TCP/IP-based
+internets.  This memo does not specify a standard for the Internet
+community.
+
+
+
+
+Reynolds                                                        [Page 8]
+
+RFC 1199                  Summary of 1100-1199             December 1991
+
+
+1161    Rose         Jun 90   SNMP over OSI
+
+This memo defines an experimental means for running the Simple Network
+Management Protocol (SNMP) over OSI transports.  This memo does not
+specify a standard for the Internet community,
+
+
+1160    Cerf         May 90   The Internet Activities Board
+
+This RFC provides a history and description of the Internet Activities
+Board (IAB) and its subsidiary organizations.  This memo is for
+informational use and does not constitute a standard.  This is a
+revision of RFC 1120.
+
+
+1159    Nelson       Jun 90   Message Send Protocol
+
+This RFC suggests an Experimental Protocol for the Internet community.
+Hosts on the Internet that choose to implement a Message Send Protocol
+may experiment with this protocol.
+
+
+1158    Rose         May 90   Management Information Base for
+                              Network Management of TCP/IP-based
+                              internets:  MIB-II
+
+This memo defines the second version of the Management Information Base
+(MIB-II) for use with network management protocols in TCP/IP- based
+internets.  In particular, together with its companion memos which
+describe the structure of management information (RFC 1155) along with
+the network management protocol (RFC 1157) for TCP/IP- based internets,
+these documents provide a simple, workable architecture and system for
+managing TCP/IP-based internets and in particular the Internet
+community.
+
+This document on MIB-II incorporates all of the technical content of RFC
+1156 on MIB-I and extends it, without loss of compatibilty.
+[STANDARDS-TRACK]
+
+
+1157    Case         May 90   A Simple Network Management
+                              Protocol (SNMP)
+
+This RFC is a re-release of RFC 1098, with a changed "Status of this
+Memo" section plus a few minor typographical corrections.  This memo
+defines a simple protocol by which management information for a network
+element may be inspected or altered by logically remote users.
+[STANDARDS-TRACK]
+
+
+
+Reynolds                                                        [Page 9]
+
+RFC 1199                  Summary of 1100-1199             December 1991
+
+
+1156    McCloghrie   May 90   Management Information Base for
+                              Network Management of
+                              TCP/IP-based internets
+
+This RFC is a re-release of RFC 1066, with a changed "Status of this
+Memo", "IAB Policy Statement", and "Introduction" sections plus a few
+minor typographical corrections.  The technical content of the document
+is unchanged from RFC 1066.  [STANDARDS-TRACK]
+
+
+1155    Rose         May 90   Structure and Identification of
+                              Management Information for
+                              TCP/IP-based Internets
+
+This RFC is a re-release of RFC 1065, with a changed "Status of this
+Memo", plus a few minor typographical corrections.  The technical
+content of the document is unchanged from RFC 1065.  [STANDARDS-TRACK]
+
+
+1154    Robinson     Apr 90   Encoding Header Field for
+                              Internet Messages
+
+This RFC proposes an elective experimental Encoding header field to
+permit the mailing of multi-part, multi-structured messages.
+
+The use of Encoding updates RFC 1049 (Content-Type), and is a suggested
+update to RFCs 1113, 1114, and 1115 (Privacy Enhancement).
+
+
+1153    Wancho       Apr 90   Digest Message Format
+
+This memo describes the de facto standard Digest Message Format.  This
+is an elective experimental protocol.
+
+
+1152    Partridge    Apr 90   Workshop Report: Internet Research
+                              Steering GroupWorkshop on
+                              Very-High-Speed Networks
+
+This memo is a report on a workshop sponsored by the Internet Research
+Steering Group.  This memo is for information only.  This RFC does not
+specify an Internet standard.
+
+
+1151    Partridge    Apr 90   Version 2 of the Reliable Data
+                              Protocol (RDP)
+
+This RFC suggests several updates to the specification of the Reliable
+
+
+
+Reynolds                                                       [Page 10]
+
+RFC 1199                  Summary of 1100-1199             December 1991
+
+
+Data Protocol (RDP) in RFC-908 based on experience with the protocol.
+This revised version of the protocol is experimental.
+
+
+1150    Malkin       Mar 90   F.Y.I on F.Y.I:
+                              Introduction to the F.Y.I. Notes
+
+This memo is the first in a new sub-series of RFCs called FYIs (For Your
+Information).  This memo provides information for the Internet
+community.  It does not specify any standard.  [Also FYI 1.]
+
+
+1149    Waitzman     Apr 90   A Standard for the Transmission of
+                              IP Datagrams on Avian Carriers
+
+This memo describes an experimental method for the encapsulation of IP
+datagrams in avian carriers.  This specification is primarily useful in
+Metropolitan Area Networks.  This is an experimental, not recommended
+standard.
+
+
+1148    Kille        Mar 90   Mapping between X.400(1988) /
+                              ISO 10021 and RFC 822
+
+This RFC suggests an electronic mail protocol mapping for the Internet
+community and UK Academic Community, and requests discussion and
+suggestions for improvements.  This memo does not specify an Internet
+standard.  This edition includes material lost in editing.
+
+
+1147    Stine        Apr 90   FYI on a Network Management Tool
+                              Catalog: Tools for Monitoring and
+                              Debugging TCP/IP Internets
+                              and Interconnected Devices
+
+The goal of this FYI memo is to provide practical information to site
+administrators and network managers.  This memo provides information for
+the Internet community.  It does not specify any standard.  It is not a
+statement of IAB policy or recommendations.  [Also FYI 2.] This catalog
+contains descriptions of several tools available to assist network
+managers in debugging and maintaining TCP/IP internets and
+interconnected communications resources.  Entries in the catalog tell
+what a tool does, how it works, and how it can be obtained.
+
+
+
+
+
+
+
+
+Reynolds                                                       [Page 11]
+
+RFC 1199                  Summary of 1100-1199             December 1991
+
+
+1146    Zweig        Mar 90   TCP Alternate Checksum Options
+
+This memo is suggests a pair of TCP options to allow use of alternate
+data checksum algorithms in the TCP header.  The use of these options is
+experimental, and not recommended for production use.  Note: This RFC
+corrects errors introduced in the editing process in RFC 1145.
+
+
+1145    Zweig        Feb 90   TCP Alternate Checksum Options
+
+This memo is suggests a pair of TCP options to allow use of alternate
+data checksum algorithms in the TCP header.  The use of these options is
+experimental, and not recommended for production use.
+
+
+1144    Jacobson     Feb 90   Compressing TCP/IP Headers for
+                              Low-Speed Serial Links
+
+This RFC describes a method for compressing the headers of TCP/IP
+datagrams to improve performance over low speed serial links.  The
+motivation, implementation and performance of the method are described.
+C code for a sample implementation is given for reference.  [STANDARDS-
+TRACK]
+
+
+1143    Bernstein    Feb 90   The Q Method of Implementing TELNET
+                              Option Negotiation
+
+This is RFC discusses an implementation approach to option negotiation
+in the Telnet protocol (RFC 854).  It does not propose any changes to
+the TELNET protocol.  Rather, it discusses the implementation of the
+protocol of one feature, only.  This is not a protocol specification.
+This is an experimental method of implementing a protocol.
+
+
+1142    Oran         Feb 90   OSI IS-IS Intra-domain Routing Protocol
+
+This RFC is a republication of ISO DP 10589 as a service to the
+Internet community.  This is not an Internet standard.
+
+
+1141    Mallory      Jan 90   Incremental Updating of the
+                              Internet Checksum
+
+This memo correctly describes the incremental update procedure for use
+with the standard Internet checksum.  It is intended to replace the
+description of Incremental Update in RFC 1071.  This is not a standard
+but rather, an implementation technique.
+
+
+
+Reynolds                                                       [Page 12]
+
+RFC 1199                  Summary of 1100-1199             December 1991
+
+
+1140    Postel       May 90   IAB Official Protocol Standards
+
+This memo describes the state of standardization of protocols used in
+the Internet as determined by the Internet Activities Board (IAB).
+
+This memo is issued quarterly, please be sure the copy you are reading
+is dated within the last three months.  Current copies may be obtained
+from the Network Information Center or from the Internet Assigned
+Numbers Authority.  Do not use this edition after 31-Aug-90.
+
+
+1139    Hagens       Jan 90   An Echo Function for ISO 8473
+
+This memo defines an echo function for the connection-less network layer
+protocol.  Two mechanisms are introduced that may be used to implement
+the echo function.  The first mechanism is recommended as an interim
+solution for the Internet community.  The second mechanism will be
+progressed to the ANSI X3S3.3 working group for consideration as a work
+item.
+
+When an ISO standard is adopted that provides functionality similar to
+that described by this memo, then this memo will become obsolete and
+superceded by the ISO standard.  This memo is not intended to compete
+with an ISO standard.  [STANDARDS-TRACK]
+
+
+1138    Kille        Dec 89   Mapping between X.400(1988) / ISO 10021
+                              and RFC 822
+
+Ths RFC suggests an electronic mail protocol mapping for the Internet
+community and UK Academic Community, and requests discussion and
+suggestions for improvements.  This memo does not specify an Internet
+standard.  This memo updates RFCs 822, 987, and 1026.
+
+
+1137    Kille        Dec 89   Mapping Between Full RFC 822 and
+                              RFC 822 with Restricted Encoding
+
+This RFC suggests an electronic mail protocol mapping for the Internet
+community and UK Academic Community, and requests discussion and
+suggestions for improvements.  This memo does not specify an Internet
+standard.
+
+
+1136    Hares        Dec 89   Administrative Domains and Routing Domains
+                              A Model for Routing in the Internet
+
+This RFC proposes a model for describing routing within the Internet.
+
+
+
+Reynolds                                                       [Page 13]
+
+RFC 1199                  Summary of 1100-1199             December 1991
+
+
+The model is an adaptation of the "OSI Routeing Framework".  This memo
+does not specify an Internet standard.
+
+
+1135    Reynolds     Dec 89   The Helminthiasis of the Internet
+
+This memo takes a look back at the helminthiasis (infestation with, or
+disease caused by parasitic worms) of the Internet that was unleashed
+the evening of 2 November 1988.  This RFC provides information about an
+event that occurred in the life of the Internet.  This memo does not
+specify any standard.
+
+This document provides a glimpse at the infection, its festering, and
+cure.  The impact of the worm on the Internet community, ethics
+statements, the role of the news media, crime in the computer world, and
+future prevention is discussed.  A documentation review presents four
+publications that describe in detail this particular parasitic computer
+program.  Reference and bibliography sections are also included.
+
+
+1134    Perkins      Nov 89   The Point-to-Point Protocol: A Proposal
+                              for Multi-Protocol Transmission of
+                              Datagrams Over Point-to-Point Links
+
+This proposal is the product of the Point-to-Point Protocol Working
+Group of the Internet Engineering Task Force (IETF).  Comments on this
+memo should be submitted to the IETF Point-to-Point Protocol Working
+Group chair by January 15, 1990.  Comments will be reviewed at the
+February 1990 IETF meeting, with the goal of advancing PPP to draft
+standard status.  [STANDARDS-TRACK]
+
+
+1133    Yu           Nov 89   Routing between the NSFNET and the DDN
+
+This document is a case study of the implementation of routing between
+the NSFNET and the DDN components (the MILNET and the ARPANET).  We hope
+that it can be used to expand towards interconnection of other
+Administrative Domains.  We would welcome discussion and suggestions
+about the methods employed for the interconnections.  No standards are
+specified in this memo.
+
+
+1132    McLaughlin   Nov 89   A Standard for the Transmission of
+                              802.2 Packets over IPX Networks
+
+This document specifies a standard method of encapsulating 802.2 packets
+on networks supporting Novell's Internet Packet Exchange Protocol (IPX).
+It obsoletes earlier documents detailing the transmission of Internet
+
+
+
+Reynolds                                                       [Page 14]
+
+RFC 1199                  Summary of 1100-1199             December 1991
+
+
+packets over IPX networks.  It differs from these earlier documents in
+that it allows for the transmission of multiple network protocols over
+IPX and for the transmission of packets through IPX bridges.
+
+
+1131    Moy          Oct 89   The OSPF Specification
+
+This RFC is the specification of the Open Shortest Path First (OSPF)
+Internet routing protocol.  OSPF is in the class of Internal Gateway
+Protocols (IGPs) for distributing routing information between gateways
+of a single Autonomous System.  This routing protocol is based on the
+link-state approach (in contrast to the distance-vector approach).  This
+specification was developed by the OSPF Working Group of the Internet
+Engineering Task Force.  [STANDARDS-TRACK]
+
+
+1130    Postel       Oct 89   IAB Official Protocol Standards
+
+This memo describes the state of standardization of protocols used in
+the Internet as determined by the Internet Activities Board (IAB).
+
+
+1129    Mills        Oct 89   Internet Time Synchronization:
+                              the Network Time Protocol
+
+This memo describes the Network Time Protocol (NTP) designed to
+distribute time information in a large, diverse internet system
+operating at speeds from mundane to lightwave.  It uses a returnable-
+time architecture in which a distributed subnet of time servers
+operating in a self-organizing, hierarchical, master-slave configuration
+synchronizes local clocks within the subnet and to national time
+standards via wire or radio.  The servers can also redistribute time
+information within a network via local routing algorithms and time
+daemons.
+
+The architectures, algorithms and protocols which have evolved to NTP
+over several years of implementation and refinement are described in
+this paper.  The synchronization subnet which has been in regular
+operation in the Internet for the last several years is described along
+with performance data which shows that timekeeping accuracy throughout
+most portions of the Internet can be ordinarily maintained to within a
+few tens of milliseconds, even in cases of failure or disruption of
+clocks, time servers or networks.
+
+This memo describes the Network Time Protocol in RFC-1119.
+
+
+
+
+
+
+Reynolds                                                       [Page 15]
+
+RFC 1199                  Summary of 1100-1199             December 1991
+
+
+1128    Mills        Oct 89   Measured Performance of the Network Time
+                              Protocol in the Internet System
+
+This paper describes a series of experiments involving over 100,000
+hosts of the Internet system and located in the U.S., Europe and the
+Pacific.  The experiments are designed to evaluate the availability,
+accuracy and reliability of international standard time distribution
+using the DARPA/NSF Internet and the Network Time Protocol (NTP), which
+is specified in RFC-1119.  NTP is designed specifically for use in a
+large, diverse internet system operating at speeds from mundane to
+lightwave.  In NTP a distributed subnet of time servers operating in a
+self-organizing, hierarchical, master-slave configuration exchange
+precision timestamps in order to synchronize subnet clocks to each other
+and national time standards via wire or radio.
+
+The experiments are designed to locate Internet hosts and gateways that
+provide time by one of three time distribution protocols and evaluate
+the accuracy of their indications.  For those hosts that support NTP,
+the experiments determine the distribution of errors and other
+statistics over paths spanning major portions of the globe.  Finally,
+the experiments evaluate the accuracy and reliability of precision
+timekeeping using NTP and typical Internet paths involving DARPA, NSFNET
+and other agency networks.  The experiments demonstrate that timekeeping
+accuracy throughout most portions of the Internet can be ordinarily
+maintained to within a few tens of milliseconds, even in cases of
+failure or disruption of clocks, time servers or networks.
+
+This memo does not specify a standard.
+
+
+1127    Braden       Oct 89   Perspective on Host Requirements
+
+This RFC is for information only; it does not constitute a standard,
+draft standard, or proposed standard, and it does not define a protocol.
+
+
+1126    Little       Oct 89   Goals and Functional Requirements for
+                              Inter-Autonomous System Routing
+
+This document describes the functional requirements for a routing
+protocol to be used between autonomous systems.  This document is
+intended as a necessary precursor to the design of a new inter-
+autonomous system routing protocol and specifies requirements for the
+Internet applicable for use with the current DoD IP, the ISO IP, and
+future Internet Protocols.  It is intended that these requirements will
+form the basis for the future development of a new inter-autonomous
+systems routing architecture and protocol. This memo does not specify a
+standard.
+
+
+
+Reynolds                                                       [Page 16]
+
+RFC 1199                  Summary of 1100-1199             December 1991
+
+
+1125    Estrin       Nov 89   Policy Requirements for Inter
+                              Administrative Domain Routing
+
+The purpose of this memo is to focus discussion on particular problems
+in the Internet and possible methods of solution.  No proposed solutions
+in this document are intended as standards for the Internet.  Rather, it
+is hoped that a general consensus will emerge as to the appropriate
+solution to such problems, leading eventually to the development and
+adoption of standards.
+
+
+1124    Leiner       Sep 89   Policy Issues in Interconnecting Networks
+
+To support the activities of the Federal Research Internet Coordinating
+Committee (FRICC) in creating an interconnected set of networks to serve
+the research community, two workshops were held to address the technical
+support of policy issues that arise when interconnecting such networks.
+Held under the suspices of the Internet Activities Board at the request
+of the FRICC, and sponsored by NASA through RIACS, the workshops
+addressed the required and feasible technologies and architectures that
+could be used to satisfy the desired policies for interconnection.  The
+purpose of this RFC is to report the results of these workshops.
+
+
+1123    Braden       Oct 89   Requirements for Internet Hosts --
+                              Application and Support
+
+This RFC is an official specification for the Internet community.  It
+incorporates by reference, amends, corrects, and supplements the primary
+protocol standards documents relating to hosts.  [STANDARDS-TRACK]
+
+
+1122    Braden       Oct 89   Requirements for Internet Hosts --
+                              Communication Layers
+
+This RFC is an official specification for the Internet community.  It
+incorporates by reference, amends, corrects, and supplements the primary
+protocol standards documents relating to hosts.  [STANDARDS-TRACK]
+
+
+1121    Postel       Sep 89   Act One - The Poems
+
+This RFC presents a collection of poems that were presented at "Act
+One", a symposium held partially in celebration of the 20th anniversary
+of the ARPANET.
+
+
+
+
+
+
+Reynolds                                                       [Page 17]
+
+RFC 1199                  Summary of 1100-1199             December 1991
+
+
+1120    Cerf         Sep 89   The Internet Activities Board
+
+This RFC provides a history and description of the Internet Activities
+Board (IAB) and its subsidiary organizations.  This memo is for
+informational use and does not constitute a standard.
+
+
+1119    Mills        Sep 89   Network Time Protocol (Version 2)
+                              Specification and Implementation
+
+This document describes the Network Time Protocol (NTP), specifies its
+formal structure and summarizes information useful for its
+implementation.  NTP provides the mechanisms to synchronize time and
+coordinate time distribution in a large, diverse internet operating at
+rates from mundane to lightwave.  It uses a returnable-time design in
+which a distributed subnet of time servers operating in a self-
+organizing, hierarchical-master-slave configuration synchronizes local
+clocks within the subnet and to national time standards via wire or
+radio.  The servers can also redistribute reference time via local
+routing algorithms and time daemons.  [STANDARDS-TRACK]
+
+
+1118    Krol         Sep 89   The Hitchhikers Guide to the Internet
+
+This RFC is being distributed to members of the Internet community in
+order to make available some "hints" which will allow new network
+participants to understand how the direction of the Internet is set, how
+to acquire online information and how to be a good Internet neighbor.
+While the information discussed may not be relevant to the research
+problems of the Internet, it may be interesting to a number of
+researchers and implementors.  No standards are defined or specified in
+this memo.
+
+
+1117    Romano       Aug 89   Internet Numbers
+
+This memo is an official status report on the network numbers and the
+autonomous system numbers used in the Internet community.
+
+
+1116    Borman       Aug 89   Telnet Linemode Option
+
+Hosts on the Internet that support Linemode within the Telnet protocol
+are expected to adopt and implement this protocol.  Obsoleted by RFC
+1184.  [STANDARDS-TRACK]
+
+
+
+
+
+
+Reynolds                                                       [Page 18]
+
+RFC 1199                  Summary of 1100-1199             December 1991
+
+
+1115    Linn         Aug 89   Privacy Enhancement for Internet
+                              Electronic Mail: Part III --
+                              Algorithms, Modes, and Identifiers
+
+This RFC provides definitions, references, and citations for
+algorithms, usage modes, and associated identifiers used in RFC-1113
+and RFC-1114 in support of privacy-enhanced electronic mail.
+[STANDARDS-TRACK]
+
+
+1114    Kent         Aug 89   Privacy Enhancement for Internet
+                              Electronic Mail: Part II --
+                              Certificate-Based Key Management
+
+This RFC specifies the key management aspects of Privacy Enhanced Mail.
+[STANDARDS-TRACK]
+
+
+1113    Linn         Aug 89   Privacy Enhancement for Internet
+                              Electronic Mail: Part I -- Message
+                              Encipherment and Authentication
+                              Procedures
+
+This RFC specifies features for private electronic mail based on
+encryption technology.  [STANDARDS-TRACK]
+
+
+1112    Deering      Aug 89   Host Extensions for IP Multicasting
+
+This memo specifies the extensions required of a host implementation of
+the Internet Protocol (IP) to support multicasting.  Recommended
+procedure for IP multicasting in the Internet.  This RFC obsoletes RFCs
+998 and 1054.  [STANDARDS-TRACK]
+
+
+1111    Postel       Aug 89   Request for Comments on Request for
+                              Comments - Instructions to
+                              RFC Authors
+
+This RFC specifies a standard for the Internet community.  Authors of
+RFCs are expected to adopt and implement this standard.
+
+
+1110    McKenzie     Aug 89   A Problem with the TCP Big Window
+                              Option
+
+This memo comments on the TCP Big Window option described in RFC 1106.
+
+
+
+
+Reynolds                                                       [Page 19]
+
+RFC 1199                  Summary of 1100-1199             December 1991
+
+
+1109    Cerf         Aug 89   Report of the Second Ad Hoc
+                              Network Management Review Group
+
+This RFC reports an official Internet Activities Board (IAB) policy
+position on the treatment of Network Management in the Internet.  This
+RFC presents the results and recommendations of the second Ad Hoc
+Network Management Review on June 12, 1989.  The results of the first
+such meeting were reported in RFC 1052.
+
+
+1108    Kent         Nov 91   U.S. Department of Defense Security
+                              Options for the Internet Protocol
+
+This RFC specifies the U.S. Department of Defense Basic Security
+Option and the top-level description of the Extended Security Option
+for use with the Internet Protocol.  This RFC obsoletes RFC 1038,
+"Revised IP Security Option", dated January 1988.  [STANDARDS-TRACK]
+
+
+1107    Sollins      Jul 89   A Plan for Internet Directory Services
+
+This memo proposes a program to develop a directory service for the
+Internet.  It reports the results of a meeting held in February 1989,
+which was convened to review requirements and options for such a
+service.  This proposal is offered for comment, and does not represent a
+committed research activity of the Internet community.
+
+
+1106    Fox          Jun 89   TCP Big Window and Nak Options
+
+This memo discusses two extensions to the TCP protocol to provide a more
+efficient operation over a network with a high bandwidth*delay product.
+The extensions described in this document have been implemented and
+shown to work using resources at NASA.  This memo describes an
+Experimental Protocol, these extensions are not proposed as an Internet
+standard, but as a starting point for further research.
+
+
+1105    Lougheed     Jun 89   A Border Gateway Protocol (BGP)
+
+This RFC outlines a specific approach for the exchange of network
+reachability information between Autonomous Systems.  Updated by RFCs
+1163 and 1164.  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+Reynolds                                                       [Page 20]
+
+RFC 1199                  Summary of 1100-1199             December 1991
+
+
+1104    Braun        Jun 89   Models of Policy Based Routing
+
+The purpose of this RFC is to outline a variety of models for policy
+based routing.  The relative benefits of the different approaches are
+reviewed.  Discussions and comments are explicitly encouraged to move
+toward the best policy based routing model that scales well within a
+large internetworking environment.
+
+
+1103    Katz         Jun 89   A Proposed Standard for the Transmission
+                              of IP Datagrams over FDDI Networks
+
+This RFC specifies a method of encapsulating the Internet Protocol (IP)
+datagrams and Address Resolution Protocol (ARP) requests and replies on
+Fiber Distributed Data Interface (FDDI) Networks.  [STANDARDS-TRACK]
+
+
+1102    Clark        May 89   Policy Routing in Internet Protocols
+
+The purpose of this RFC is to focus discussion on particular problems in
+the Internet and possible methods of solution.  No proposed solutions in
+this document are intended as standards for the Internet.
+
+
+1101    Mockapetris  Apr 89   DNS Encoding of Network Names and
+                              Other Types
+
+This RFC proposes two extensions to the Domain Name System:
+
+   - A specific method for entering and retrieving RRs which map
+     between network names and numbers.
+
+   - Ideas for a general method for describing mappings between
+     arbitrary identifiers and numbers.
+
+The method for mapping between network names and addresses is a proposed
+standard, the ideas for a general method are experimental.
+
+
+1100    IAB          Apr 89   IAB Official Protocol Standards
+
+This memo describes the state of standardization of protocols used in
+the Internet as determined by the Internet Activities Board (IAB).  An
+overview of the standards procedures is presented first, followed by
+discussions of the standardization process and the RFC document series,
+then the explanation of the terms is presented, the lists of protocols
+in each stage of standardization follows, and finally pointers to
+references and contacts for further information.
+
+
+
+Reynolds                                                       [Page 21]
+
+RFC 1199                  Summary of 1100-1199             December 1991
+
+
+This memo is issued quarterly, please be sure the copy you are reading
+is dated within the last three months.  Current copies may be obtained
+from the Network Information Center or from the Internet Assigned
+Numbers Authority (see the contact information at the end of this memo).
+Do not use this memo after 31-July-89.
+
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Author's Address
+
+   Joyce K. Reynolds
+   University of Southern California
+   Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone:  (310) 822-1511
+
+   EMail:  JKREY@ISI.EDU
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds                                                       [Page 22]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1199.txt](<www.ietf.org/rfc/rfc1199.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
