### PR TITLE
Archive rfc1239.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1239.txt
+++ b/www.ietf.org/rfc/rfc1239.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                       J. Reynolds
+Request for Comments: 1239                                          ISI
+Updates: RFCs 1229, 1230, 1231, 1232, 1233                    June 1991
+
+
+           Reassignment of Experimental MIBs to Standard MIBs
+
+Status of this Memo
+
+   This RFC specifies an IAB standards track protocol for the Internet
+   community, and requests discussion and suggestions for improvements.
+   Please refer to the current edition of the "IAB Official Protocol
+   Standards" for the standardization state and status of this protocol.
+   Distribution of this memo is unlimited.
+
+Statement
+
+   In the past, MIBs have been assigned arcs in the experimental MIB
+   namespace early in their development and then were not assigned arcs
+   in the standard MIB namespace until they reached Full Standard
+   status.  This practice required vendors to revise their
+   implementations when a MIB went from Draft to Full Standard status,
+   even though there was probably no substantive technical change in the
+   definitions.  This practice could also engender operational problems
+   in the field at an undesirably late stage of the standardization
+   process.  It was also observed that this practice could discourage
+   implementation until the Full Standard stage and that this, too,
+   would be undesirable.  So, a preferable practice is to assign arcs in
+   the standard MIB namespace at the earliest phase of standardization
+   and to preserve these assignments as the standard progresses.
+
+   This memo specifically updates:
+
+      RFC 1229 - "Extensions to the Generic-Interface MIB"
+
+      RFC 1230 - "IEEE 802.4 Token Bus MIB"
+
+      RFC 1231 - "IEEE 802.5 Token Ring MIB"
+
+      RFC 1232 - "Definitions of Managed Objects for the DS1 Interface
+                  Type"
+
+      RFC 1233 - "Definitions of Managed Objects for the DS3 Interface
+                  Type"
+
+   with new codes.  In the future, consult each MIB publication for new
+   code assignments.
+
+
+
+
+Reynolds                                                        [Page 1]
+
+RFC 1239          Reassignment of Exp MIBs to Std MIBs         June 1991
+
+
+SMI Network Management Old Experimental Codes
+
+      Prefix: 1.3.6.1.3       (experimental)
+
+      Decimal   Name          Description
+      -------   ----          -----------
+            2   T1-Carrier    T1 Carrier Objects
+            4   IEEE802.5     Token Ring-like Objects
+            6   Interface     Generic Interface Extension Objects
+            7   IEEE802.4     Token Bus-like Objects
+           15   DS3           DS3 Interface Type
+
+SMI Network Management New Standard Codes
+
+      Prefix: 1.3.6.1.2.1     (standard-mib)
+
+      Decimal   Name          Description
+      -------   ----          -----------
+           12   Generic IF    Generic Interface Extension Objects
+
+      Prefix: 1.3.6.1.2.1.10  (transmission)
+
+      Decimal   Name          Description
+      -------   ----          -----------
+            8   IEEE802.4     Token Bus-like Objects
+            9   IEEE802.5     Token Ring-like Objects
+           18   DS1           T1 Carrier Objects
+           30   DS3           DS3 Interface Type
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Author's Address
+
+   Joyce K. Reynolds
+   USC/Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA  90292-6695
+
+   Phone:  (213) 822-1511
+
+   EMail:  jkrey@isi.edu
+
+
+
+
+
+
+
+
+Reynolds                                                        [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1239.txt](<www.ietf.org/rfc/rfc1239.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
