### PR TITLE
Archive rfc124.txt

### DIFF
--- a/www.ietf.org/rfc/rfc124.txt
+++ b/www.ietf.org/rfc/rfc124.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+NETWORK WORKING GROUP                           J. Melvin
+Request for Comments #124                       NIC
+NIC #5840                                       19 April 1971
+
+
+                     Typographical Error in RFC 107
+
+
+
+Catagories:  C
+RFCs Obsoleted:  none
+RFCs Updated:  106
+
+
+          On page 7 of RFC 107, the RTS (1.) should be an STR.
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc124.txt](<www.ietf.org/rfc/rfc124.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
