### PR TITLE
Archive rfc127.txt

### DIFF
--- a/www.ietf.org/rfc/rfc127.txt
+++ b/www.ietf.org/rfc/rfc127.txt
@@ -1,0 +1,112 @@
+
+
+
+
+
+
+Network Working Group                             J. Postel
+Request for Comments # 127                        20 April 71
+NIC #5843                                         UCLA
+[Category D.1                                     Computer Science
+Updates 123]
+
+                          Comments on RFC 123
+
+The following is my interpretation of the exchange between NCP's which
+would be necessary to carry out the Initial Connection Protocol of RFC
+123.
+
+     Server NCP                                User NCP
+     ----------                                --------
+
+     Listen for Connection on L                RTS, U, L, l
+     STR, L, U, 32                                         A
+
+     Send 32 bits of data
+     in 1 message on link l
+                           A
+     (value is S)                              Receive 32 bits of data
+                                               from link l (value is S)
+                                                          A
+
+     CLS, L, U                                 CLS, U, L
+
+     STR, S+1, U, B                            STR, U+1, S, B
+                   s                                         u
+
+     RTS, S, U+1, l                            RTS, U, S+1, l
+                   B                                         c
+
+     wait for connection                       wait for connection
+
+     ALL, l , m , b                            ALL, l , m , b
+           B   B   B                                 c   c   c
+
+     data sent on link l                       data sent on link l
+                        c                                         B
+
+     data received on link l                   data received on link l
+                            B                                         c
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+
+l , l , and l  are links, m  and m  are message allocations, b
+ A   B       c             B      c                           B
+and b  are bit allocations, and all other symbols are as defined in
+     c
+RFC 123.
+
+
+       [ This RFC was put into machine readable form for entry ]
+         [ into the online RFC archives by Gert Doering 4/97 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc127.txt](<www.ietf.org/rfc/rfc127.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
