### PR TITLE
Archive rfc128.txt

### DIFF
--- a/www.ietf.org/rfc/rfc128.txt
+++ b/www.ietf.org/rfc/rfc128.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                          J. Postel
+Request for Comments: 128                                           UCLA
+Category: C.2, D.                                       Computer Science
+NIC #5844                                                     21 April 71
+Obsoletes: none
+Updates: none
+
+
+                                 BYTES
+
+   It is somewhat unclear what to do with the Byte size parameter now
+   allowed by the 2nd level protocol.  I can conceive of an
+   implementation in which the 3rd level programs never see this
+   parameter.  Crocker implies in RFC 123 that control of this parameter
+   is given to the 3rd level programs and that both sender and receiver
+   may specify values of the byte size to the NCP.
+
+   There are at least two interpretations if the sender and receiver
+   specify different byte sizes.
+
+   I.  The first is that the connection is illegal.
+
+   II.  The second is that the NCP must parse the data stream on receipt
+       from the network and into a buffer according to be byte size of
+       the sender, and subsequently parse the data stream on transfer
+       from the buffer to the receiver.  In this second case there are
+       two sub cases.
+
+       A. One is to consider bits as the basic unit.
+
+          For example, if the sender specified byte size = 5 and the
+          receiver specified byte size = 3 then
+
+          Receiver                   NCP                    Sender
+          -+---+---+---+---+      +--------+      +-----+-----+---
+           |000|001|010|011| <--- | Buffer | <--- |00000|10100|11
+          -+---+---+---+---+      +--------+      +-----+-----+---
+
+
+       B. The other is to consider bytes as the significant unit and pad
+          (on the right or left?) or truncate to make things fit, or
+          other transformation.
+
+   At UCLA-Computer Science we are contemplating allowing sender and
+   receiver to specify different byte sizes and consider bits as the
+   basic unit (Case II.A.).  This does not rule out our considering the
+   second subcase (Case II.B.).  We may allow 3rd level programs to
+   specify a library or user supplied routine to perform the
+
+
+
+Postel                                                          [Page 1]
+
+RFC 128                          Bytes                        April 1971
+
+
+   transformation between sender and receiver bytes.  Perhaps these
+   transformation routines would be written in the Data Reconfiguration
+   Language.
+
+         [ This RFC was put into machine readable form for entry ]
+            [ into the online RFC archives by Duncan de Waal 03/98 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Postel                                                          [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc128.txt](<www.ietf.org/rfc/rfc128.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
