### PR TITLE
Archive rfc1295.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1295.txt
+++ b/www.ietf.org/rfc/rfc1295.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                 The North American Directory Forum
+Request for Comments: 1295                                  January 1992
+
+
+                          User Bill of Rights
+                        for entries and listings
+                        in the Public Directory
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard.  Distribution of this memo is
+   unlimited.
+
+Abstract
+
+   This RFC is a near-verbatim copy of a document, known as NADF-265,
+   which has been produced by the North American Directory Forum (NADF).
+
+                            User Bill of Rights
+                         for entries and listings
+                          in the Public Directory
+
+   The mission of the North American Directory Forum is to provide
+   interconnected electronic directories which empower users with
+   unprecedented access to public information.  To address significant
+   security and privacy issues, the North American Directory Forum
+   introduces the following "User Bill of Rights" for entries in the
+   Public Directory.  As a user, you have:
+
+        I. The right not to be listed.
+
+       II. The right to have you or your agent informed when
+           your entry is created.
+
+      III. The right to examine your entry.
+
+       IV. The right to correct inaccurate information in your
+           entry.
+
+        V. The right to remove specific information from your
+           entry.
+
+       VI. The right to be assured that your listing in the
+           Public Directory will comply with US or Canadian law
+           regulating privacy or access information.
+
+      VII. The right to expect timely fulfillment of these rights.
+
+
+
+NADF                                                            [Page 1]
+
+RFC 1295                  User Bill of Rights               January 1992
+
+
+Scope of Intent - User Bill of Rights
+
+   The North American Directory Forum is a collection of service
+   providers that plan to offer a cooperative directory service in North
+   America.  This is achieved by interconnecting electronic directories
+   using a set of internationally developed standards known as the CCITT
+   X.500 series.
+
+   In this context, the "Directory" represents the collection of
+   electronic directories administered by both service providers and
+   private operators.  When an entry containing information about a user
+   is listed in the Directory, that information can be accessed unless
+   restricted by security and privacy controls.
+
+   A portion of the Directory -- The Public Directory -- contains
+   information for public dissemination.  In contrast, other portions of
+   the Directory may contain information not intended for public access.
+   A user or user's agent may elect to list information in the Public
+   Directory, a private directory, or some combination.  For example, a
+   user might publicly list a telephone number or an electronic mail
+   address, and might designate other information for specific private
+   use.
+
+   The User Bill of Rights pertains to the Public Directory.
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Author's Address
+
+   North American Directory Forum
+   c/o Theodore H. Myer
+   Rapport Communication
+   3055 Q Street NW
+   Washington, DC  20007
+
+   Phone: +1 202-342-2727
+
+   EMail: 0004454742@mcimail.com
+
+
+
+
+
+
+
+
+
+
+
+NADF                                                            [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1295.txt](<www.ietf.org/rfc/rfc1295.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
