### PR TITLE
Archive rfc1299.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1299.txt
+++ b/www.ietf.org/rfc/rfc1299.txt
@@ -1,0 +1,1123 @@
+
+
+
+
+
+
+Network Working Group                                         M. Kennedy
+Request for Comments: 1299                                           ISI
+Category: Informational                                     January 1997
+
+
+                      Request for Comments Summary
+
+                         RFC Numbers 1200-1299
+
+Status of This Memo
+
+   This RFC is a slightly annotated list of the 100 RFCs from RFC 1200
+   through RFCs 1299.  This is a status report on these RFCs.  This memo
+   provides information for the Internet community.  It does not specify
+   an Internet standard of any kind.  Distribution of this memo is
+   unlimited.
+
+Note
+
+   Many RFCs, but not all, are Proposed Standards, Draft Standards, or
+   Standards.  Since the status of these RFCs may change during the
+   standards processing, we note here only that they are on the
+   standards track.  Please see the latest edition of "Internet Official
+   Protocol Standards" for the current state and status of these RFCs.
+   In the following, RFCs on the standards track are marked [STANDARDS-
+   TRACK].
+
+RFC     Author       Date      Title
+---     ------       ----      -----
+
+1299    Kennedy      Jan 97    Requests For Comments Summary
+
+This memo.
+
+
+1298    Wormley      Feb 92    SNMP over IPX
+
+This memo defines a convention for encapsulating Simple Network
+Management Protocol (SNMP) packets over the transport mechanism provided
+via the Internetwork Packet Exchange (IPX) protocol.  This memo provides
+information for the Internet community.  It does not specify an Internet
+standard.
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 1]
+
+RFC 1299                  Summary of 1200-1299              January 1997
+
+
+1297    Johnson      Jan 92   NOC Internal Integrated Trouble Ticket
+                              System
+                              Functional Specification Wishlist
+
+This document explores competing uses, architectures, and desirable
+features of integrated internal trouble ticket systems for Network and
+other Operations Centers. This memo provides information for the
+Internet community.  It does not specify an Internet standard.
+
+
+1296     Lottor      Jan 92   Internet Growth (1981-1991)
+
+This document illustrates the growth of the Internet by examination of
+entries in the Domain Name System (DNS) and pre-DNS host tables.  This
+memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+
+1295 N.A.D.F.         Jan 92   User Bill of Rights for entries
+                               and listings in the Public Directory
+
+This RFC is a near-verbatim copy of a document, known as NADF-265, which
+has been produced by the North American Directory Forum (NADF).  This
+memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+1294     Bradley      Jan 92   Multiprotocol Interconnect over Frame
+                               Relay
+
+This memo describes an encapsulation method for carrying network
+interconnect traffic over a Frame Relay backbone.  It covers aspects of
+both Bridging and Routing.  [STANDARDS-TRACK]
+
+
+1293    Bradley       Jan 92   Inverse Address Resolution Protocol
+
+This memo describes additions to ARP that will allow a station to
+request a protocol address corresponding to a given hardware address.
+[STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 2]
+
+RFC 1299                  Summary of 1200-1299              January 1997
+
+
+1292    Lang          Jan 92   A Catalog of Available X.500
+                               Implementations
+
+The goal of this document is to provide information regarding the
+availability and capability of implementations of X.500. This memo
+provides information for the Internet community.  It does not specify an
+Internet standard.
+
+
+1291    Aggarwal      Dec 91   Mid-Level Networks Potential
+                               Technical Services
+
+This document proposes a set of technical services that each Internet
+mid-level network can offer within the mid-level network itself and and
+to its peer networks. This RFC provides information for the Internet
+community. It does not specify an Internet standard.
+
+
+1290    Martin        Dec 91   There's Gold in them thar Networks!
+                               or Searching for Treasure in all the
+                               Wrong Places
+
+This paper will present some of the "gold nuggets" of information and
+file repositories on the network that could be of use to end users. This
+RFC provides information for the Internet community. It does not specify
+an Internet standard.
+
+
+1289    Saperia       Dec 91   DECnet Phase IV MIB Extensions
+
+This memo is an extension to the SNMP MIB. This memo defines a set of
+DECnet Phase IV extensions that have been created for the Internet MIB.
+[STANDARDS-TRACK]
+
+
+1288    Zimmerman     Dec 91   The Finger User Informational Protocol
+
+This memo describes the Finger user information protocol.This is a
+simple protocol which provides an interface to a remote user information
+program. [STANDARDS-TRACK]
+
+
+1287    Clark         Dec 91 Towards the Future Internet Architecture
+
+This informational RFC discusses important directions for possible
+future evolution of the Internet architecture, and suggests steps
+towards the desired goals. This memo provides information for the
+Internet community.  It does not specify an Internet standard.
+
+
+
+Kennedy                      Informational                      [Page 3]
+
+RFC 1299                  Summary of 1200-1299              January 1997
+
+
+1286    Decker        Dec 91   Definitions of Managed Objects for
+                               Bridges
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP based internets.  In
+particular it defines objects for managing bridges based on the IEEE
+802.1d draft standard between Local Area Network (LAN) segments. This
+memo is an extension to the SNMP MIB. [STANDARDS-TRACK]
+
+
+1285    Case          Jan 92   FDDI Management Information Base
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing devices which implement the
+FDDI. [STANDARDS-TRACK]
+
+
+1284    Cook          Dec 91   Definitions of Managed Objects for the
+                               Ethernet-like Interface Types
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing ethernet-like objects.
+[STANDARDS-TRACK]
+
+
+1283    Rose          Dec 91   SNMP over OSI
+
+This memo describes mappings from the SNMP onto both the COTS and the
+CLTS. This memo defines an Experimental Protocol for the Internet
+community.  It does not specify an Internet Standard.
+
+
+1282    Kantor        Dec 91   BSD Rlogin
+
+This memo documents an existing protocol and common implementation that
+is extensively used on the Internet.  This memo provides information for
+the Internet community.  It does not specify an Internet standard.
+
+
+1281    Pethia        Nov 91   Guidelines for the Secure Operation of
+                               the Internet
+
+The purpose of this document is to provide a set of guidelines to aid in
+the secure operation of the Internet. This memo provides information for
+the Internet community.  It does not specify an Internet standard.
+
+
+
+
+Kennedy                      Informational                      [Page 4]
+
+RFC 1299                  Summary of 1200-1299              January 1997
+
+
+1280    IAB           Mar 92   IAB Official Protocol Standards
+
+This memo describes the state of standardization of protocols used in
+the Internet as determined by the Internet Activities Board (IAB).  This
+memo provides information for the Internet community. It does not
+specify an Internet standard.
+
+
+1279    Hardcastle-Kille  Nov 91   X.500 and Domains
+
+This RFC considers X.500 in relation to Internet and UK Domains. This
+memo defines an Experimental Protocol for the Internet community.  It
+does not specify an Internet standard.
+
+
+1278    Hardcastle-Kille  Nov 91    A string encoding of Presentation
+                                    Address
+
+There are a number of environments where a simple string encoding of
+Presentation Address is desirable.  This specification defines such a
+representation. This memo provides information for the Internet
+community.  It does not specify an Internet standard.
+
+
+1277    Hardcastle-Kille  Nov 91     Encoding Network Addresses
+                                     to support operation over non-OSI
+                                     lower layers
+
+This document defines a new network address format, and rules for using
+some existing network address formats. [STANDARDS-TRACK]
+
+
+1276    Hardcastle-Kille  Nov 91     Replication and Distributed
+                                     Operations extensions to provide
+                                     an Internet Directory using X.500
+
+Some requirements on extensions to X.500 are described in the
+RFC[HK91b], in order to build an Internet Directory using X.500(1988).
+This document specifies a set of solutions to the problems raised.
+[STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 5]
+
+RFC 1299                  Summary of 1200-1299              January 1997
+
+
+1275    Hardcastle-Kille  Nov 91    Replication Requirements to provide
+                                    an Internet Directory using X.500
+
+This RFC considers certain deficiencies of the 1988 X.500 standard,
+which need to be addressed before an effective open Internet Directory
+can be established using these protocols and services [CCI88]. This memo
+provides information for the Internet community.  It does not specify an
+Internet standard.
+
+
+1274    Barker   Nov 91    The COSINE and Internet X.500 Schema
+
+This document suggests an X.500 Directory Schema, or Naming
+Architecture, for use in the COSINE and Internet X.500 pilots.
+[STANDARDS-TRACK]
+
+
+1273   Schwartz  Nov 91   A Measurement Study of Changes in
+                          Service-Level Reachability in the Global
+                          TCP/IP Internet: Goals, Experimental Design,
+                          Implementation, and Policy Considerations
+
+This memo describes plans to carry out a longitudinal measurement study
+of changes in service-level reachability in the global TCP/IP Internet.
+This memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+1272    Mills    Nov 91   Internet Accounting: Background
+
+This document provides background information for the "Internet
+Accounting Architecture". This memo provides information for the
+Internet community.  It does not specify an Internet standard.
+
+
+1271   Waldbusser  Nov 91   Remote Network Monitoring Management
+                            Information Base
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing remote network monitoring
+devices. [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 6]
+
+RFC 1299                  Summary of 1200-1299              January 1997
+
+
+1270   Kastenholz  Oct 91   SNMP Communications Services
+
+This document discusses various issues to be considered when determining
+the underlying communications services to be used by an SNMP
+implementation. This memo provides information for the Internet
+community.  It does not specify an Internet standard.
+
+
+1269   Willis      Oct 91   Definitions of Managed Objects
+                            for the Border Gateway Protocol (Version 3)
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing the Border Gateway Protocol.
+[STANDARDS-TRACK]
+
+
+1268   Rekhter     Oct 91   Application of the Border Gateway Protocol
+                            in the Internet
+
+This document describes the usage of the BGP in the Internet.
+[STANDARDS-TRACK]
+
+
+1267   Lougheed   Oct 91   A Border Gateway Protocol 3 (BGP-3)
+
+This memo, together with its companion document, "Application of the
+Border Gateway Protocol in the Internet", define an inter-autonomous
+system routing protocol for the Internet. [STANDARDS-TRACK]
+
+
+1266   Rekhter    Oct 91   Experience with the BGP Protocol
+
+The purpose of this memo is to document how the requirements for
+advancing a routing protocol to Draft Standard have been satisfied by
+Border Gateway Protocol (BGP). This memo provides information for the
+Internet community.  It does not specify an Internet standard.
+
+
+1265   Rekhter   Oct 91    BGP Protocol Analysis
+
+This report summarizes the key feature of BGP, and analyzes the protocol
+with respect to scaling and performance. This memo provides information
+for the Internet community. It does not specify an Internet standard.
+
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 7]
+
+RFC 1299                  Summary of 1200-1299              January 1997
+
+
+1264   Hinden    Oct 91   Internet Engineering Task Force
+                          Internet Routing Protocol Standardization
+                          Criteria
+
+This informational RFC presents procedures for creating and documenting
+Internet standards on routing protocols.  These procedures have been
+established by the Internet Activities Board (IAB) in consultation with
+the Internet Engineering Steering Group (IESG). This memo provides
+information for the Internet community. It does not specifiy an Internet
+standard.
+
+
+1263   O'Malley  Oct 91  TCP Extensions Considered Harmful
+
+This RFC comments on recent proposals to extend TCP.  It argues that the
+backward compatible extensions proposed in RFC's 1072 and 1185 should
+not be pursued, and proposes an alternative way to evolve the Internet
+protocol suite. This memo provides information for the Internet
+community.  It does not specify an Internet standard.
+
+
+1262   IAB      Oct 91  Guidelines for Internet Measurement Activities
+
+This RFC represents IAB guidance for researchers considering measurement
+experiments on the Internet. This memo provides information for the
+Internet community.  It does not specify an Internet standard.
+
+
+1261   Williamson  Sept 91   Transition of NIC Services
+
+This memo outlines the transition of NIC Services. This memo provides
+information for the Internet community.  It does not specify an Internet
+standard.
+
+
+1260   Never issued.
+
+
+1259   Kapor      Sept 91  Building The Open Road:
+                           The NREN As Test-Bed For The National
+                           Public Network
+
+This memo discusses the background and importance of NREN. This memo
+provides information for the Internet community.  It does not specify an
+Internet standard.
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 8]
+
+RFC 1299                  Summary of 1200-1299              January 1997
+
+
+1258   Kantor    Sept 91    BSD Rlogin
+
+The rlogin facility provides a remote-echoed, locally flow-controlled
+virtual terminal with proper flushing of output.This memo documents an
+existing protocol and common implementation that is extensively used on
+the Internet.  This memo provides information for the Internet
+community.  It does not specify an Internet standard.
+
+
+1257   Partridge  Sept 91  Isochronous Applications Do Not Require
+                           Jitter-Controlled Networks
+
+This memo argues that jitter control is not required for networks to
+support isochronous applications. This memo provides information for the
+Internet community.  It does not specify an Internet standard.
+
+
+1256   Deering   Sept 91   ICMP Router Discovery Messages
+
+This document specifies an extension of the Internet Control Message
+Protocol (ICMP) to enable hosts attached to multicast or broadcast
+networks to discover the IP addresses of their neighboring routers.
+[STANDARDS-TRACK]
+
+
+1255   N.A.D.F.   Sept 91   A Naming Scheme for c=US
+
+This memo documents the NADF's agreement as to how entries are named in
+the public portions of the North American Directory. This memo provides
+information for the Internet community.  It does not specify an Internet
+standard.
+
+
+1254   Mankin     Aug 91    Gateway Congestion Control Survey
+
+The purpose of this paper is to present a review of the congestion
+control approaches, as a way of encouraging new discussion and
+experimentation.  Included in the survey are Source Quench, Random Drop,
+Congestion Indication (DEC Bit), and Fair Queueing.
+
+
+1253    Baker    Aug 91    OSPF Version 2 Management Information Base
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing OSPF Version 2. [STANDARDS-
+TRACK]
+
+
+
+
+Kennedy                      Informational                      [Page 9]
+
+RFC 1299                  Summary of 1200-1299              January 1997
+
+
+1252    Baker   Aug 91    OSPF Version 2 Management Information Base
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing OSPF Version 2. [STANDARDS-
+TRACK]
+
+
+1251    Malkin  Aug 91   Who's Who in the Internet
+                         Biographies of IAB, IESG and IRSG Members
+
+This FYI RFC contains biographical information about members of the
+Internet Activities Board (IAB), the Internet Engineering Steering Group
+(IESG) of the Internet Engineering Task Force (IETF), and the the
+Internet Research Steering Group (IRSG) of the Internet Research Task
+Force (IRTF). This memo provides information for the Internet community.
+It does not specify an Internet standard. [FYI 9]
+
+
+1250    IAB    Aug 91    IAB Official Protocol Standards
+
+This memo describes the state of standardization of protocols used in
+the Internet as determined by the Internet Activities Board (IAB).  This
+memo provides information for the Internet community. It does not
+specify an Internet standard.
+
+
+1249   Howes   Aug 91    DIXIE Protocol Specification
+
+This RFC defines a mechanism by which TCP/UDP based clients can access
+OSI Directory Service without the overhead of the ISO transport and
+presentation protocols required to implement full-blown DAP.  This memo
+provides information for the Internet community.  It does not specify
+any standard.
+
+
+1248   Baker   Jul 91   OSPF Version 2 Management Information Base
+
+This memo defines an experimental portion of the Management Information
+Base (MIB) for use with network management protocols in TCP/IP-based
+internets.  In particular, it defines objects for managing OSPF Version
+2. [STANDARDS-TRACK]
+
+
+1247   Moy     Jul 91   OSPF Version 2
+
+This memo documents version 2 of the OSPF protocol.  OSPF is a link-
+state based routing protocol. [STANDARDS-TRACK]
+
+
+
+Kennedy                      Informational                     [Page 10]
+
+RFC 1299                  Summary of 1200-1299              January 1997
+
+
+1246   Moy      Jul 91   Experience with the OSPF protocol
+
+This report documents experience with OSPF V2. This includes reports on
+interoperability testing, field experience, simulations and the current
+state of OSPF implementations. This memo provides information for the
+Internet community. It does not specify any Internet standard.
+
+
+1245   Moy      Jul 91    OSPF protocol analysis
+
+This report attempts to summarize the key features of OSPF V2. It also
+attempts to analyze how the protocol will perform and scale in the
+Internet. This memo provides information for the Internet community. It
+does not specify any Internet standard.
+
+
+1244   Holbrook  Jul 91   Site Security Handbook
+
+This FYI RFC is a first attempt at providing Internet users guidance on
+how to deal with security issues in the Internet. This FYI RFC provides
+information for the Internet community.  It does not specify an Internet
+standard. [FYI 8]
+
+
+1243   Waldbusser  Jul 91  AppleTalk Management Information Base
+
+This memo defines objects for managing AppleTalk objects for use with
+the SNMP protocol. [STANDARDS-TRACK]
+
+
+1242   Bradner     Jul 91  Benchmarking Terminology for Network
+                           Interconnection Devices
+
+This memo discusses and defines a number of terms that are used in
+describing performance benchmarking tests and the results of such tests.
+This memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+1241   Woodburn   Jul 91   A Scheme for an Internet Encapsulation
+                           Protocol:  Version 1
+
+This memo defines an Experimental Protocol for the Internet community.
+It does not specify an Internet standard.
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 11]
+
+RFC 1299                  Summary of 1200-1299              January 1997
+
+
+1240   Shue      Jun 91    OSI Connectionless Transport Services
+                           on top of UDP
+                           Version: 1
+
+This document describes a protocol for running OSI Connectionless
+service on UDP. [STANDARDS-TRACK]
+
+
+1239   Reynolds  Jun 91    Reassignment of Experimental MIBs to
+                           Standard MIBs
+
+This memo specifically updates RFC 1229, RFC 1230, RFC 1231, RFC 1232
+and RFC 1233 with new codes. [STANDARDS-TRACK]
+
+
+1238   Satz      Jun 91    CLNS MIB for use with Connectionless
+                           Network Protocol (ISO 8473) and
+                           End System to Intermediate System (ISO 9542)
+
+This memo defines an experimental portion of the Management Information
+Base (MIB) for use with network management protocols in TCP/IP-based
+internets.  This is an Experimental Protocol for the Internet community.
+It does not specify an Internet standard.
+
+
+1237   Colella   Jul 91    Guidelines for OSI NSAP Allocation
+                           in the Internet
+
+This paper provides guidelines for allocating NSAPs in the
+Internet.[STANDARDS-TRACK]
+
+
+1236   Morales   Jun 91    IP to X.121 Address Mapping for DDN
+                           A Model for Routing in the Internet
+
+This memo defines a standard way of converting IP addresses to CCITT
+X.121 addresses and is the recommended standard for use on the Internet,
+specifically for the Defense Data Network (DDN).  This memo provides
+information for the Internet community.  It does not specify an Internet
+standard.
+
+
+1235   Ioannidis  Jun 91   The Coherent File Distribution Protocol
+
+This memo describes the Coherent File Distribution Protocol (CFDP).
+This is an Experimental Protocol for the Internet community. It does not
+specify an Internet standard.
+
+
+
+
+Kennedy                      Informational                     [Page 12]
+
+RFC 1299                  Summary of 1200-1299              January 1997
+
+
+1234   Provan     Jun 91   Tunneling IPX Traffic through IP Networks
+
+This memo describes a method of encapsulating IPX datagrams within UDP
+packets so that IPX traffic can travel across an IP internet.
+[STANDARDS-TRACK]
+
+
+1233   Cox        May 91   Definitions of Managed Objects for the DS3
+                           Interface Type
+
+This memo defines objects for managing DS3 Interface objects for use
+with the SNMP protocol. [STANDARDS-TRACK]
+
+
+1234   Baker     May 91    Definitions of Managed Objects
+                           for the DS1 Interface Type
+
+This memo defines objects for managing DS1 Interface objects for use
+with the SNMP protocol. [STANDARDS-TRACK]
+
+
+1231   McCloghrie  May 91  IEEE 802.5 Token Ring MIB
+
+This memo defines an experimental portion of the Management Information
+Base (MIB) for use with network management protocols in TCP/IP-based
+internets.  In particular, this memo defines managed objects used for
+managing subnetworks which use the IEEE 802.5 Token Ring technology
+described in 802.5 Token Ring Access Method and Physical Layer
+Specifications, IEEE Standard 802.5-1989. [STANDARDS-TRACK]
+
+
+1230   McCloghrie   May 91  IEEE 802.4 Token Bus MIB
+
+This memo defines an experimental portion of the Management Information
+Base (MIB) for use with network management protocols in TCP/IP-based
+internets.  In particular, this memo defines managed objects used for
+managing subnetworks which use the IEEE 802.4 Token Bus technology
+described in 802.4 Token-Passing Bus Access Method and Physical Layer
+Specifications, IEEE Standard 802.4. [STANDARDS-TRACK]
+
+
+1229   McCloghrie   May 91  Extensions to the Generic-Interface MIB
+
+This RFC contains definitions of managed objects used as experimental
+extensions to the generic interfaces structure of MIB-II. [STANDARDS-
+TRACK]
+
+
+
+
+
+Kennedy                      Informational                     [Page 13]
+
+RFC 1299                  Summary of 1200-1299              January 1997
+
+
+1228   Carpenter    May 91  Simple Network Management Protocol
+                            Distributed Program Interface
+
+This RFC describes a protocol that International Business Machines
+Corporation (IBM) has been implementing in most of its SNMP agents to
+allow dynamic extension of supported MIBs. This is an Experimental
+Protocol for the Internet community. It does not specify an Internet
+standard.
+
+
+1227    Rose      May 91   SNMP MUX Protocol and MIB
+
+This memo suggests a mechanism by which a user process may associate
+itself with the local SNMP agent on a host, in order to implement
+portions of the MIB.  This mechanism would be local to the host.This is
+an Experimental Protocol for the Internet community. It does not specify
+an Internet standard.
+
+
+1226   Kantor   May 91   Internet Protocol Encapsulation of AX.25 Frame
+
+This memo describes a method for the encapsulation of AX.25 (the Amateur
+Packet-Radio Link-Layer Protocol) frames within IP packets.  This
+technique is an Experimental Protocol for the Internet community.  It
+does not specify an Internet standard.
+
+
+1225  Rose     May 91   Post Office Protocol - Version 3
+
+This memo suggests a simple method for workstations to dynamically
+access mail from a mailbox server.  [STANDARDS-TRACK]
+
+
+1224  Steinberg  May 91  Techniques for Managing Asynchronously
+                         Generated Alerts
+
+This memo defines common mechanisms for managing asynchronously produced
+alerts in a manner consistent with current network management protocols.
+This memo specifies an Experimental Protocol for the Internet community.
+It does not specify an Internet standard.
+
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 14]
+
+RFC 1299                  Summary of 1200-1299              January 1997
+
+
+1223  Halpern  May 91   OSI CLNS and LLC1 Protocols on Network Systems
+                        HYPERchannel
+
+The intent of this document is to provide a complete discussion of the
+protocols and techniques used to transmit OSI CLNS and LLC1 datagrams
+(and any associated higher level protocols) on Network Systems
+Corporation's HYPERchannel equipment.This memo provides information for
+the Internet community.  It does not specify an Internet standard.
+
+
+1222    Braun         May 91   Advancing the NSFNET Routing Architecture
+
+This RFC suggests improvements in the NSFNET routing architecture to
+accommodate a more flexible interface to the Backbone clients.  This
+memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+1221     Edmond      Apr 91   Host Access Protocol (HAP) Specification
+                              - Version 2
+
+This memo describes the Host Access Protocol implemented in the
+Terrestrial Wideband Network (TWBNET). This memo provides information
+for the Internet community.  It does not specify an Internet standard.
+
+
+1220     Baker       Apr 91   Point-to-Point Protocol Extensions
+                              for Bridging
+
+This document defines an extension of the Internet Point-to-Point
+Protocol (PPP) described in RFC 1171, targeting the use of Point-to-
+Point lines for Remote Bridging. [STANDARDS-TRACK]
+
+
+1219    Tsuchiya     Apr 91   On the Assignment of Subnet Numbers
+
+This memo suggests a new procedure for assigning subnet numbers.  Use of
+this assignment technique within a network would be a purely local
+matter, and would not effect other networks. This memo provides
+information for the Internet community.  It does not specify an Internet
+standard.
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 15]
+
+RFC 1299                  Summary of 1200-1299              January 1997
+
+
+1218    N.A.D.F.    Apr 91  A Naming Scheme for c=US
+
+This RFC is a near-verbatim copy of a document, known as NADF-123, which
+has been produced by the North American Directory Forum (NADF). As a
+part of its charter, the NADF must reach agreement as to how entries are
+named in the public portions of the North American Directory. This memo
+provides information for the Internet community.  It does not specify an
+Internet standard.
+
+
+1217   Cerf        Apr 91   Memo from the Consortium for Slow
+                            Commotion Research (CSCR)
+
+
+This RFC is in response to RFC 1216, "Gigabit Network Economics and
+Paradigm Shifts".  This memo provides information for the Internet
+community. It does not specify an Internet standard.
+
+
+1216  P.R.A.I.     Apr 91  Gigabit Network Economics and Paradigm Shifts
+
+This memo proposes a new standard paradigm for the Internet Activities
+Board (IAB) standardization track. [STANDARDS-TRACK]
+
+
+1215  Rose         Mar 91  A Convention for Defining Traps
+                           for use with the SNMP
+
+This memo suggests a straight-forward approach towards defining traps
+used with the SNMP. This memo provides information for the Internet
+community.  It does not specify any standard.
+
+
+1214  Labarre      Apr 91  OSI Internet Management: Management
+                           Information Base
+
+This RFC documents a MIB for use with CMIP, either over pure OSI stacks
+or with the CMIP over TCP specification.  It redefines objects comprised
+by the second revision of the Management Information Base for Network
+Management of TCP/IP-based internets: MIB-II so as to conform to the OSI
+structure of management information. [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 16]
+
+RFC 1299                  Summary of 1200-1299              January 1997
+
+
+1213   McCloghrie  Mar 91  Management Information Base for Network
+                           Management of TCP/IP-based internets:
+                           MIB-II
+
+This memo defines the second version of the Management Information Base
+(MIB-II) for use with network management protocols in TCP/IP-based
+internets. [STANDARDS-TRACK]
+
+
+1212   Rose       Mar 91   Concise MIB Definitions
+
+This memo describes a straight-forward approach toward producing
+concise, yet descriptive, MIB modules. This memo defines a format for
+producing MIB modules. [STANDARDS-TRACK]
+
+
+1211  Westine     Mar 91    Problems with the Maintenance of Large
+                            Mailing Lists
+
+This RFC discusses problems with maintaining large mailing lists,
+especially the processing of error reports.  This memo provides
+information for the Internet community.  It does not specify an Internet
+standard.
+
+
+1210   Cerf      Mar 91    Network and Infrastructure User
+                           Requirements for Transatlantic Research
+                           Collaboration
+
+This report complements a shorter printed version which appeared in a
+summary report of all the committees which met in Brussels and
+Washington last July, 1990.  This memo provides information for the
+Internet community.  It does not specify an Internet standard.
+
+
+1209   Piscitello   Mar 91  The Transmission of IP Datagrams over the
+                            SMDS Service
+
+This memo defines a protocol for the transmission of IP and ARP packets
+over a Switched Multi-megabit Data Service Network configured as a
+logical IP subnetwork. [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 17]
+
+RFC 1299                  Summary of 1200-1299              January 1997
+
+
+1208   Jacobsen     Mar 91  A Glossary of Networking Terms
+
+This RFC is a glossary adapted from "The INTEROP Pocket Glossary of
+Networking Terms" distributed at Interop '90.  This memo provides
+information for the Internet community.  It does not specify an Internet
+standard.
+
+
+1207   Malkin      Feb 91   FYI on Questions and Answers
+                            Answers to Commonly asked "Experienced
+                            Internet User" Questions
+
+This FYI RFC is one of two FYI's called, "Questions and Answers" (Q/A),
+produced by the User Services Working Group of the Internet Engineering
+Task Force (IETF).  The goal is to document the most commonly asked
+questions and answers in the Internet. This memo provides information
+for the Internet community.  It does not specify any standard.
+
+
+1206   Malkin      Feb 91   FYI on Questions and Answers
+                            Answers to Commonly asked "New
+                            Internet User" Questions
+
+This FYI RFC is one of two FYI's called, "Questions and Answers" (Q/A).
+The goal is to document the most commonly asked questions and answers in
+the Internet. This memo provides information for the Internet community.
+It does not specify any standard. [FYI 4]
+
+
+1205   Chmielewski  Feb 91  5250 Telnet Interface
+
+This RFC is being distributed in order to document the interface to the
+IBM 5250 Telnet implementation. This memo provides information for the
+Internet community.  It does not specify any standard.
+
+
+1204   Yeh         Feb 91   Message Posting Protocol (MPP)
+
+This memo describes a protocol for posting messages from workstations
+(e.g., PCs) to a mail service host.  This RFC specifies an Experimental
+Protocol for the Internet community. It does not specify any standard.
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 18]
+
+RFC 1299                  Summary of 1200-1299              January 1997
+
+
+1203   Rice       Feb 91    Interactive Mail Access Protocol
+                            - Version 3
+
+This RFC suggests a method for workstations to access mail dynamically
+from a mailbox server ("repository"). The following document is a
+modified version of RFC 1064, the definition of the IMAP2 protocol. This
+RFC specifies an Experimental Protocol for the Internet community. It
+does not specify any standard.
+
+
+1202   Rose       Feb 91    Directory Assistance Service
+
+This document defines a mechanism by which a user-interface may access a
+textual DAP-like interface over a TCP/IP connection.  This is a local
+mechanism.  This memo provides information for the Internet community.
+It does not specify any standard.
+
+
+1201   Provan    Feb 91     Transmitting IP Traffic over ARCNET
+                            Networks
+
+This memo defines a protocol for the transmission of IP and ARP packets
+over the ARCnet Local Area Network.This memo specifies a method of
+encapsulating Internet Protocol (IP) and Address Resolution Protocol
+(ARP) datagrams for transmission across ARCNET using the "ARCNET Packet
+Header Definition Standard". [STANDARDS-TRACK]
+
+
+1200   IAB      Apr 91      IAB Official Protocol Standards
+
+This memo describes the state of standardization of protocols used in
+the Internet as determined by the Internet Activities Board (IAB).  An
+overview of the standards procedures is presented first, followed by
+discussions of the standardization process and the RFC document series,
+then the explanation of the terms is presented, the lists of protocols
+in each stage of standardization follows, and finally pointers to
+references and contacts for further information.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 19]
+
+RFC 1299                  Summary of 1200-1299              January 1997
+
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Author's Address
+
+   Mary Kennedy
+   University of Southern California
+   Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone:  (310) 822-1511
+
+   EMail:  MKENNEDY@ISI.EDU
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 20]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1299.txt](<www.ietf.org/rfc/rfc1299.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
