### PR TITLE
Archive rfc13.txt

### DIFF
--- a/www.ietf.org/rfc/rfc13.txt
+++ b/www.ietf.org/rfc/rfc13.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                          Vint Cerf
+Request for Comments: 13                                       UCLA
+                                                          20 August 1969
+
+
+
+
+Referring to NWG/RFC: 11, it appears that file transmissions over
+auxiliary connections will require some mechanism to specify "END-OF-
+FILE."  It is proposed that a length 0 (zero) message be used for this
+purpose.  Figure 1 shows the format:
+
+
+
+
+
+
+|<---32 bits--->|<---32 bits--->|<----16 bits---->|<------?------>|
++---------------+---------------+-----------------+---------------+
+|    leader     |    marking    |    checksum     |    padding    |
++---------------+---------------+-----------------+---------------+
+
+
+
+                                Figure 1
+
+                      Zero Text Length EOF Message
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+      [ into the online RFC archives by Michael Brunnbauer 1/97 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc13.txt](<www.ietf.org/rfc/rfc13.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
