### PR TITLE
Archive rfc1313.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1313.txt
+++ b/www.ietf.org/rfc/rfc1313.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                                       C. Partridge
+Request for Comments: 1313                                           BBN
+                                                            1 April 1992
+
+
+                  Today's Programming for KRFC AM 1313
+                          Internet Talk Radio
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard.  Distribution of this memo is
+   unlimited.
+
+Welcome!
+
+   Hi and welcome to KRFC Internet Talk Radio, your place on the AM dial
+   for lively talk and just-breaking news on internetworking.  Sponsored
+   by the Internet Society, KRFC serves the San Francisco Bay Area.  For
+   those of you outside the Bay Area, copies of program transcripts can
+   be anonymously FTPed from archives.krfc.com the day after the
+   program, or you can listen in via vat.
+
+   Here's today's programming for today, Wednesday, 1 April 1992.
+
+Hacker's Hour with Phil Karn (Midnight)
+
+   Phil's special guest today is Dr. David Mills, who will explain the
+   special problems of correcting for the Doppler effect when trying to
+   properly synchronize the new WWV receiver chip in your PC while
+   flying on the Concorde.
+
+Nighttime News (1AM)
+
+   Award winning Nighttime News gives you a full hour on those key facts
+   you need to know before going to bed.  Be sure to catch our network
+   outage report with Elise Gerich.  (Elise's report is sponsored by
+   ANS).
+
+Late At Night With Ole (2 AM)
+
+   Call in your favorite Internetwork questions to Ole Jacobsen and his
+   guests.  Tonite's featured guests are John Moy, prime author of OSPF,
+   and Milo Medin who will talk about how OSPF is great, but you really
+   need to test it on 1822 networks to understand why.
+
+
+
+
+
+
+Partridge                                                       [Page 1]
+
+RFC 1313          Today's Programming for KRFC AM 13XX      1 April 1991
+
+
+Marty in the Morning (6 AM)
+
+   Join the irrepressable Marty for five hours of eye-opening talk and
+   commentary.  Hear the latest on the commercial state of data
+   networking in the US and who is at fault for limiting its growth.
+   Special guest Kent England plans to drop by the studio today --
+   listen in for the flames!
+
+Education Report (11 AM)
+
+   Gordon Cook solicits advice from Prof. David Farber on good ways to
+   develop a research career.  (In the likely event that Prof. Farber is
+   unavailable at the last minute, Prof.  Farber has arranged for Prof.
+   David Sincoskie to take his place).
+
+Lunch with Lynch (11:30 AM)
+
+   Dan Lynch is on vacation this week and Vint Cerf is taking his place.
+   Today Vint has lunch with Mitch Kapor of the EFF, MacArthur genius
+   Richard Stallman, and Gen. Norman Schwartzkopf.  Don't miss Vint's
+   suggestions for wines to go with today's business lunch! [Lunch with
+   Lynch is sponsored by Interop. Wines are provided by the vineyards in
+   return for promotional considerations].
+
+News (1 PM)
+
+   Join Joyce and Jon as they report on the key networking news of the
+   day.  Don't miss their update on the latest address and port
+   assignments and tips on upcoming RFCs!
+
+Two by Four Time (2 PM)
+
+   Today Marshall Rose will take out his two-by-four and apply it to
+   Phill Gross for violating the Internet Standard Meeting Rules at the
+   last IETF and starting a session before 9 AM.  Additional victims to
+   be announced.  Today's show will be available as a book from Prentice
+   Hall by next Tuesday.
+
+Mike at the Mike (4 PM)
+
+   Listen in to the Marina's favorite local DJ.  Hear why They never
+   listen and Never will!  How come The Book's publishers don't seem to
+   be able to add and why ATM is Another Technical Mistake.  Then join
+   MAP at 7:45 for a wee bit of this week's preferred single malt.
+
+
+
+
+
+
+
+Partridge                                                       [Page 2]
+
+RFC 1313          Today's Programming for KRFC AM 13XX      1 April 1991
+
+
+The Protocol Police (8 PM)
+
+   Liven up your evening with the protocol police.  Join our intrepid
+   team of Stev Knowles and Mike St. Johns as they debug various TCP/IP
+   implementations from the comfort of Mike's hot tub using Stev's
+   water-proof portable PC.  Last week they caught Peter Honeyman
+   hijacking an NFS implementation.  This week they're joined by Yakov
+   Rehkter with his new Roto-Router tool, designed to catch routing
+   anomalies.  Who will our team nab this week?
+
+Family Hour (10 PM)
+
+   As part of this week's special series on children and networking, Bob
+   Morris and Jerry Estrin talk about how much you should teach your
+   young children about networking.
+
+Securely Speaking (11 PM)
+
+   Come eavesdrop as Steve Kent and Steve Crocker give you this week's
+   latest security news (if they're allowed to talk about it).  And
+   remember, just after 11 o'clock Steve and Steve will be reading this
+   week's encrypted message.  If you're the first caller to call in with
+   the right DES key to decrypt the message, you'll win $1,000 and an
+   all expenses paid trip to Ft. Meade!  (US nationals only please).
+
+Security Considerations
+
+   Security issues are discussed in the above section.
+
+Author's Address
+
+   Craig Partridge
+   BBN
+   824 Kipling St
+   Palo Alto, CA  94301
+
+   Phone: 415-325-4541
+   EMail: craig@aland.bbn.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+Partridge                                                       [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1313.txt](<www.ietf.org/rfc/rfc1313.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
