### PR TITLE
Archive rfc132.txt

### DIFF
--- a/www.ietf.org/rfc/rfc132.txt
+++ b/www.ietf.org/rfc/rfc132.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+NETWORK WORKING GROUP                                           Jim White
+Request for Comments #132                                       UCSB
+NIC #6708                                                       April 28, 1971
+
+
+
+
+
+
+                     TYPOGRAPHICAL ERROR IN RFC 107
+                     ______________________________
+
+
+On page 5 of RFC 107, at the end of the section titled 'V.
+Flow Control', the partial sentence:
+
+     Each of these numbers is interpreted as "the number
+     of 128ths of the current allocation" to be returned
+     if it is in the range zero to 128...
+
+should read:
+
+     ...if it is the range of zero to 127,...
+                                      ---
+
+That is, return al the appropriate allocation if and
+only if the high-order of the left-most bit of the corresponding
+fraction is 1.
+
+
+       [ This RFC was put into machine readable form for entry ]
+     [ into the online RFC archives by Mohnish Harisinganey 5/97 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc132.txt](<www.ietf.org/rfc/rfc132.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
