### PR TITLE
Archive rfc134.txt

### DIFF
--- a/www.ietf.org/rfc/rfc134.txt
+++ b/www.ietf.org/rfc/rfc134.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                           A. Vezza
+Request for Comments: #134                                 29 April 1971
+NIC 6711
+
+                        Network Graphics Meeting
+
+     Project MAC will host a Network Graphics Meeting on the 18th,
+
+19th, and 20th of July 1971.  The meeting will be held at the MIT
+
+Endicott House at 20 Haven Street, Dedham, Massachusetts.  A map
+
+indicating routes and writtem directions to the Endicott House from
+
+Boston's (Logan) airport and from MIT are attached.  Meeting attendees
+
+should plan to arrive at the Endicott House between 4:30 and 6:00 p.m.
+
+on Sunday, July 18th.  The meeting will formally commence at 6:00 p.m.
+
+on the 18th and end after lunch on Tuesday, July 20th.  Attendees are
+
+invited to visit Project MAC for open discussions and/or
+
+demonstrations at the conclusion of the meeting.  Reservations for the
+
+meeting may be made by contacting either Miss Fran Yost or Miss Mary
+
+Bizot by calling 617-864-6900, x1458 or writing to:
+
+
+         Miss Fran Yost or Miss Mary Bizot c/o Mr. A. Vezza
+
+         Project MAC/MIT
+
+         545 Technology Square
+
+         Room 201
+
+         Cambridge, Massachussetts 02139
+
+
+
+
+
+
+
+
+
+
+
+Vezza                                                           [Page 1]
+
+NWGRFC 134
+
+
+NIC 6711
+
+     The ground rules for attendance and topics for discussion are as
+
+outlined in RFC #87.  Basically, each organization represented is
+
+expected to participate by presenting one or more working papers in
+
+one or more of the areas chosen for discussion.  A minimal working
+
+paper is defined to consist of a set of written notes and an oral
+
+presentation.  We suggest that the RFC mechanism be used to
+
+disseminate the written working notes.  I am asking that all attendees
+
+make reservations no later than June 1st and that all RFC's and
+
+working notes which are pertinent to this meeting be in my hand no
+
+later than Tuesday, June 22nd.  We will publish by June 25th a
+
+bibliography of reading material pertinent to this graphic meeting and
+
+a list of prospective attendees.  Authors of working notes not
+
+disseminated through the RFC mechanism are responsible for mailing to
+
+each attendee a copy of his working notes no later than July 1, 1971.
+
+
+     Each attendee making a presentation can expect a telephone call
+
+from me about July 5 to find how much time he wants for his
+
+presentation.  The times will be scaled appropriately to fit the
+
+schedule.
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+        [ into the online RFC archives by Stephane Alnet 4/97 ]
+
+
+
+
+
+
+
+
+Vezza                                                           [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc134.txt](<www.ietf.org/rfc/rfc134.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
