### PR TITLE
Archive rfc1340.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1340.txt
+++ b/www.ietf.org/rfc/rfc1340.txt
@@ -1,0 +1,7787 @@
+
+
+
+
+
+
+Network	Working	Group					     J.	Reynolds
+Request	for Comments: 1340				       J. Postel
+Obsoletes RFCs:	1060, 1010, 990, 960,				     ISI
+943, 923, 900, 870, 820, 790, 776, 770,			       July 1992
+762, 758,755, 750, 739,	604, 503, 433, 349
+Obsoletes IENs:	127, 117, 93
+
+
+			    ASSIGNED NUMBERS
+
+Status of this Memo
+
+   This	memo is	a status report	on the parameters (i.e., numbers and
+   keywords) used in protocols in the Internet community.  Distribution
+   of this memo	is unlimited.
+
+Table of Contents
+
+   INTRODUCTION...................................................  2
+   Data	Notations.................................................  3
+   Special Addresses..............................................  4
+   VERSION NUMBERS................................................  6
+   PROTOCOL NUMBERS...............................................  7
+   WELL	KNOWN PORT NUMBERS........................................  9
+   REGISTERED PORT NUMBERS........................................ 23
+   INTERNET MULTICAST ADDRESSES................................... 27
+   IANA	ETHERNET ADDRESS BLOCK.................................... 29
+   IP TOS PARAMETERS.............................................. 30
+   IP TIME TO LIVE PARAMETER...................................... 32
+   DOMAIN SYSTEM PARAMETERS....................................... 33
+   BOOTP PARAMETERS............................................... 35
+   NETWORK MANAGEMENT PARAMETERS.................................. 36
+   MILNET LOGICAL ADDRESSES....................................... 49
+   MILNET LINK NUMBERS............................................ 50
+   MILNET X.25 ADDRESS MAPPINGS................................... 51
+   IEEE	802 NUMBERS OF INTEREST................................... 53
+   ETHERNET NUMBERS OF INTEREST................................... 54
+   ETHERNET VENDOR ADDRESS COMPONENTS............................. 57
+   ETHERNET MULTICAST ADDRESSES................................... 60
+   XNS PROTOCOL	TYPES............................................. 62
+   PROTOCOL/TYPE FIELD ASSIGNMENTS................................ 63
+   PRONET 80 TYPE NUMBERS......................................... 64
+   POINT-TO-POINT PROTOCOL FIELD ASSIGNMENTS...................... 65
+   ADDRESS RESOLUTION PROTOCOL PARAMETERS......................... 69
+   REVERSE ADDRESS RESOLUTION PROTOCOL OPERATION CODES............ 70
+   DYNAMIC REVERSE ARP............................................ 70
+   INVERSE ADDRESS RESOULUTION PROTOCOL........................... 70
+   X.25	TYPE NUMBERS.............................................. 71
+
+
+
+Reynolds & Postel					        [Page 1]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   PUBLIC DATA NETWORK NUMBERS.................................... 72
+   TELNET OPTIONS................................................. 75
+   MAIL	ENCRYPTION TYPES.......................................... 76
+   MIME	TYPES..................................................... 77
+   CHARACTER SETS................................................. 79
+   MACHINE NAMES.................................................. 83
+   SYSTEM NAMES................................................... 87
+   PROTOCOL AND	SERVICE	NAMES..................................... 88
+   TERMINAL TYPE NAMES............................................ 92
+   DOCUMENTS...................................................... 96
+   PEOPLE.........................................................109
+   Security Considerations........................................139
+   Authors' Addresses.............................................139
+
+INTRODUCTION
+
+   This	Network	Working	Group Request for Comments documents the
+   currently assigned values from several series of numbers used in
+   network protocol implementations.  This RFC will be updated
+   periodically, and in	any case current information can be obtained from
+   the Internet	Assigned Numbers Authority (IANA).  If you are developing
+   a protocol or application that will require the use of a link, socket,
+   port, protocol, etc., please	contact	the IANA to receive a number
+   assignment.
+
+   Joyce K. Reynolds
+   Internet Assigned Numbers Authority
+   USC - Information Sciences Institute
+   4676	Admiralty Way
+   Marina del Rey, California  90292-6695
+
+   Phone: (310)	822-1511
+
+   Electronic mail: IANA@ISI.EDU
+
+   Most	of the protocols mentioned here	are documented in the RFC series
+   of notes.  Some of the items	listed are undocumented.  Further
+   information on protocols can	be found in the	memo "IAB Official
+   Protocol Standards" [62].
+
+   In the entries below, the name and mailbox of the responsible
+   individual is indicated.  The bracketed entry, e.g.,	[nn,iii], at the
+   right hand margin of	the page indicates a reference for the listed
+   protocol, where the number ("nn") cites the document	and the	letters
+   ("iii") cites the person.  Whenever possible, the letters are a NIC
+   Ident as used in the	WhoIs (NICNAME)	service.
+
+
+
+
+
+Reynolds & Postel					        [Page 2]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+Data Notations
+
+   The convention in the documentation of Internet Protocols is	to
+   express numbers in decimal and to picture data in "big-endian" order
+   [21].  That is, fields are described	left to	right, with the	most
+   significant octet on	the left and the least significant octet on the
+   right.
+
+   The order of	transmission of	the header and data described in this
+   document is resolved	to the octet level.  Whenever a	diagram	shows a
+   group of octets, the	order of transmission of those octets is the
+   normal order	in which they are read in English.  For	example, in the
+   following diagram the octets	are transmitted	in the order they are
+   numbered.
+
+
+       0		   1		       2		   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |	      1	      |	      2	      |	      3	      |	      4	      |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |	      5	      |	      6	      |	      7	      |	      8	      |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |	      9	      |	     10	      |	     11	      |	     12	      |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+			Transmission Order of Bytes
+
+   Whenever an octet represents	a numeric quantity the left most bit in
+   the diagram is the high order or most significant bit.  That	is, the
+   bit labeled 0 is the	most significant bit.  For example, the
+   following diagram represents	the value 170 (decimal).
+
+
+			     0 1 2 3 4 5 6 7
+			    +-+-+-+-+-+-+-+-+
+			    |1 0 1 0 1 0 1 0|
+			    +-+-+-+-+-+-+-+-+
+
+			   Significance	of Bits
+
+   Similarly, whenever a multi-octet field represents a	numeric	quantity
+   the left most bit of	the whole field	is the most significant	bit.
+   When	a multi-octet quantity is transmitted the most significant octet
+   is transmitted first.
+
+
+
+
+
+
+Reynolds & Postel					        [Page 3]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+Special	Addresses:
+
+   There are five classes of IP	addresses: Class A through Class E
+   [119].  Of these, Class E addresses are reserved for	experimental
+   use.	 A gateway which is not	participating in these experiments must
+   ignore all datagrams	with a Class E destination IP address.	ICMP
+   Destination Unreachable or ICMP Redirect messages must not result
+   from	receiving such datagrams.
+
+   There are certain special cases for IP addresses [11].  These special
+   cases can be	concisely summarized using the earlier notation	for an
+   IP address:
+
+	 IP-address ::=	 { <Network-number>, <Host-number> }
+
+	    or
+
+	 IP-address ::=	 { <Network-number>, <Subnet-number>,
+							 <Host-number> }
+
+   if we also use the notation "-1" to mean the	field contains all 1
+   bits.  Some common special cases are	as follows:
+
+	 (a)   {0, 0}
+
+	    This host on this network.	Can only be used as a source
+	    address (see note later).
+
+	 (b)   {0, <Host-number>}
+
+	    Specified host on this network.  Can only be used as a
+	    source address.
+
+	 (c)   { -1, -1}
+
+	    Limited broadcast.	Can only be used as a destination
+	    address, and a datagram with this address must never be
+	    forwarded outside the (sub-)net of the source.
+
+	 (d)   {<Network-number>, -1}
+
+	    Directed broadcast to specified network.  Can only be used
+	    as a destination address.
+
+	 (e)   {<Network-number>, <Subnet-number>, -1}
+
+	    Directed broadcast to specified subnet.  Can only be used as
+	    a destination address.
+
+
+
+Reynolds & Postel					        [Page 4]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+	 (f)   {<Network-number>, -1, -1}
+
+	    Directed broadcast to all subnets of specified subnetted
+	    network.  Can only be used as a destination	address.
+
+	 (g)   {127, <any>}
+
+	    Internal host loopback address.  Should never appear outside
+	    a host.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel					        [Page 5]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+			      VERSION NUMBERS
+
+   In the Internet Protocol (IP) [45,105] there	is a field to identify
+   the version of the internetwork general protocol.  This field is 4
+   bits	in size.
+
+   Assigned Internet Version Numbers
+
+      Decimal	Keyword	   Version			      References
+      -------	-------	   -------			      ----------
+	  0		   Reserved				   [JBP]
+	1-3		   Unassigned				   [JBP]
+	  4	  IP	   Internet Protocol		       [105,JBP]
+	  5	  ST	   ST Datagram Mode			[49,JWF]
+	6-14		   Unassigned				   [JBP]
+	  15		   Reserved				   [JBP]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel					        [Page 6]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+			       PROTOCOL	NUMBERS
+
+   In the Internet Protocol (IP) [45,105] there	is a field, called
+   Protocol, to	identify the the next level protocol.  This is an 8 bit
+   field.
+
+   Assigned Internet Protocol Numbers
+
+      Decimal	 Keyword     Protocol			      References
+      -------	 -------     --------			      ----------
+	   0		     Reserved				   [JBP]
+	   1	 ICMP	     Internet Control Message		[97,JBP]
+	   2	 IGMP	     Internet Group Management		[43,JBP]
+	   3	 GGP	     Gateway-to-Gateway			 [60,MB]
+	   4	 IP	     IP	in IP (encasulation)		   [JBP]
+	   5	 ST	     Stream				[49,JWF]
+	   6	 TCP	     Transmission Control	       [106,JBP]
+	   7	 UCL	     UCL				    [PK]
+	   8	 EGP	     Exterior Gateway Protocol	      [123,DLM1]
+	   9	 IGP	     any private interior gateway	   [JBP]
+	  10	 BBN-RCC-MON BBN RCC Monitoring			   [SGC]
+	  11	 NVP-II	     Network Voice Protocol		[22,SC3]
+	  12	 PUP	     PUP			       [8,XEROX]
+	  13	 ARGUS	     ARGUS				  [RWS4]
+	  14	 EMCON	     EMCON				   [BN7]
+	  15	 XNET	     Cross Net Debugger		       [56,JFH2]
+	  16	 CHAOS	     Chaos				   [NC3]
+	  17	 UDP	     User Datagram		       [104,JBP]
+	  18	 MUX	     Multiplexing			[23,JBP]
+	  19	 DCN-MEAS    DCN Measurement Subsystems		  [DLM1]
+	  20	 HMP	     Host Monitoring			[59,RH6]
+	  21	 PRM	     Packet Radio Measurement		   [ZSU]
+	  22	 XNS-IDP     XEROX NS IDP		     [133,XEROX]
+	  23	 TRUNK-1     Trunk-1				  [BWB6]
+	  24	 TRUNK-2     Trunk-2				  [BWB6]
+	  25	 LEAF-1	     Leaf-1				  [BWB6]
+	  26	 LEAF-2	     Leaf-2				  [BWB6]
+	  27	 RDP	     Reliable Data Protocol	       [138,RH6]
+	  28	 IRTP	     Internet Reliable Transaction	[79,TXM]
+	  29	 ISO-TP4     ISO Transport Protocol Class 4    [63,RC77]
+	  30	 NETBLT	     Bulk Data Transfer	Protocol       [20,DDC1]
+	  31	 MFE-NSP     MFE Network Services Protocol    [124,BCH2]
+	  32	 MERIT-INP   MERIT Internodal Protocol		   [HWB]
+	  33	 SEP	     Sequential	Exchange Protocol	 [JC120]
+	  34	 3PC	     Third Party Connect Protocol	  [SAF3]
+	  35	 IDPR	     Inter-Domain Policy Routing Protocol [MXS1]
+	  36	 XTP	     XTP				   [GXC]
+	  37	 DDP	     Datagram Delivery Protocol		   [WXC]
+
+
+
+Reynolds & Postel					        [Page 7]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+	  38	 IDPR-CMTP   IDPR Control Message Transport Proto [MXS1]
+	  39	 TP++	     TP++ Transport Protocol		   [DXF]
+	  40	 IL	     IL	Transport Protocol		  [DXP2]
+       41-60		     Unassigned				   [JBP]
+	  61		     any host internal protocol		   [JBP]
+	  62	 CFTP	     CFTP			       [50,HCF2]
+	  63		     any local network			   [JBP]
+	  64	 SAT-EXPAK   SATNET and	Backroom EXPAK		   [SHB]
+	  65	 KRYPTOLAN   Kryptolan				  [PXL1]
+	  66	 RVD	     MIT Remote	Virtual	Disk Protocol	   [MBG]
+	  67	 IPPC	     Internet Pluribus Packet Core	   [SHB]
+	  68		     any distributed file system	   [JBP]
+	  69	 SAT-MON     SATNET Monitoring			   [SHB]
+	  70	 VISA	     VISA Protocol			  [GXT1]
+	  71	 IPCV	     Internet Packet Core Utility	   [SHB]
+	  72	 CPNX	     Computer Protocol Network Executive  [DXM2]
+	  73	 CPHB	     Computer Protocol Heart Beat	  [DXM2]
+	  74	 WSN	     Wang Span Network			   [VXD]
+	  75	 PVP	     Packet Video Protocol		   [SC3]
+	  76	 BR-SAT-MON  Backroom SATNET Monitoring		   [SHB]
+	  77	 SUN-ND	     SUN ND PROTOCOL-Temporary		   [WM3]
+	  78	 WB-MON	     WIDEBAND Monitoring		   [SHB]
+	  79	 WB-EXPAK    WIDEBAND EXPAK			   [SHB]
+	  80	 ISO-IP	     ISO Internet Protocol		   [MTR]
+	  81	 VMTP	     VMTP				  [DRC3]
+	  82	 SECURE-VMTP SECURE-VMTP			  [DRC3]
+	  83	 VINES	     VINES				   [BXH]
+	  84	 TTP	     TTP				   [JXS]
+	  85	 NSFNET-IGP  NSFNET-IGP				   [HWB]
+	  86	 DGP	     Dissimilar	Gateway	Protocol      [74,ML109]
+	  87	 TCF	     TCF				  [GAL5]
+	  88	 IGRP	     IGRP				[18,GXS]
+	  89	 OSPFIGP     OSPFIGP			       [83,JTM4]
+	  90	 Sprite-RPC  Sprite RPC	Protocol	       [143,BXW]
+	  91	 LARP	     Locus Address Resolution Protocol	   [BXH]
+	  92	 MTP	     Multicast Transport Protocol	   [SXA]
+	  93	 AX.25	     AX.25 Frames			  [BK29]
+	  94	 IPIP	     IP-within-IP Encapsulation	Protocol  [JXI1]
+	  95	 MICP	     Mobile Internetworking Control Pro.  [JXI1]
+	  96	 AES-SP3-D   AES Security Protocol 3-D		   [HXH]
+	  97	 ETHERIP     Ethernet-within-IP	Encapsulation	  [RXH1]
+	  98	 ENCAP	     Encapsulation Header	      [148,RXB3]
+       99-254		     Unassigned				   [JBP]
+	  255		     Reserved				   [JBP]
+
+
+
+
+
+
+
+Reynolds & Postel					        [Page 8]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+			   WELL	KNOWN PORT NUMBERS
+
+The Well Known Ports are controlled and	assigned by the	IANA and on most
+systems	can only be used by system (or root) processes or by programs
+executed by privileged users.
+
+Ports are used in the TCP [45,106] to name the ends of logical
+connections which carry	long term conversations.  For the purpose of
+providing services to unknown callers, a service contact port is
+defined.  This list specifies the port used by the server process as its
+contact	port.  The contact port	is sometimes called the	"well-known
+port".
+
+To the extent possible,	these same port	assignments are	used with the
+UDP [46,104].
+
+The assigned ports use a small portion of the possible port numbers.
+For many years the assigned ports were in the range 0-255.  Recently,
+the range for assigned ports managed by	the IANA has been expanded to
+the range 0-1023.
+
+Port Assignments:
+
+   Keyword	   Decimal    Description		      References
+   -------	   -------    -----------		      ----------
+		     0/tcp    Reserved				   [JBP]
+		     0/udp    Reserved				   [JBP]
+   tcpmux	     1/tcp    TCP Port Service Multiplexer	   [MKL]
+   tcpmux	     1/udp    TCP Port Service Multiplexer	   [MKL]
+   compressnet	     2/tcp    Management Utility		  [BV15]
+   compressnet	     2/udp    Management Utility		  [BV15]
+   compressnet	     3/tcp    Compression Process		  [BV15]
+   compressnet	     3/udp    Compression Process		  [BV15]
+		     4/tcp    Unassigned			   [JBP]
+		     4/udp    Unassigned			   [JBP]
+   rje		     5/tcp    Remote Job Entry			[12,JBP]
+   rje		     5/udp    Remote Job Entry			[12,JBP]
+		     6/tcp    Unassigned			   [JBP]
+		     6/udp    Unassigned			   [JBP]
+   echo		     7/tcp    Echo				[95,JBP]
+   echo		     7/udp    Echo				[95,JBP]
+		     8/tcp    Unassigned			   [JBP]
+		     8/udp    Unassigned			   [JBP]
+   discard	     9/tcp    Discard				[94,JBP]
+   discard	     9/udp    Discard				[94,JBP]
+		    10/tcp    Unassigned			   [JBP]
+		    10/udp    Unassigned			   [JBP]
+   systat	    11/tcp    Active Users			[89,JBP]
+
+
+
+Reynolds & Postel					        [Page 9]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   systat	    11/udp    Active Users			[89,JBP]
+		    12/tcp    Unassigned			   [JBP]
+		    12/udp    Unassigned			   [JBP]
+   daytime	    13/tcp    Daytime				[93,JBP]
+   daytime	    13/udp    Daytime				[93,JBP]
+		    14/tcp    Unassigned			   [JBP]
+		    14/udp    Unassigned			   [JBP]
+		    15/tcp    Unassigned [was netstat]		   [JBP]
+		    15/udp    Unassigned			   [JBP]
+		    16/tcp    Unassigned			   [JBP]
+		    16/udp    Unassigned			   [JBP]
+   qotd		    17/tcp    Quote of the Day		       [100,JBP]
+   qotd		    17/udp    Quote of the Day		       [100,JBP]
+   msp		    18/tcp    Message Send Protocol		   [RXN]
+   msp		    18/udp    Message Send Protocol		   [RXN]
+   chargen	    19/tcp    Character	Generator		[92,JBP]
+   chargen	    19/udp    Character	Generator		[92,JBP]
+   ftp-data	    20/tcp    File Transfer [Default Data]	[96,JBP]
+   ftp-data	    20/udp    File Transfer [Default Data]	[96,JBP]
+   ftp		    21/tcp    File Transfer [Control]		[96,JBP]
+   ftp		    21/udp    File Transfer [Control]		[96,JBP]
+		    22/tcp    Unassigned			   [JBP]
+		    22/udp    Unassigned			   [JBP]
+   telnet	    23/tcp    Telnet			       [112,JBP]
+   telnet	    23/udp    Telnet			       [112,JBP]
+		    24/tcp    any private mail system		  [RA11]
+		    24/udp    any private mail system		  [RA11]
+   smtp		    25/tcp    Simple Mail Transfer	       [102,JBP]
+   smtp		    25/udp    Simple Mail Transfer	       [102,JBP]
+		    26/tcp    Unassigned			   [JBP]
+		    26/udp    Unassigned			   [JBP]
+   nsw-fe	    27/tcp    NSW User System FE		[24,RHT]
+   nsw-fe	    27/udp    NSW User System FE		[24,RHT]
+		    28/tcp    Unassigned			   [JBP]
+		    28/udp    Unassigned			   [JBP]
+   msg-icp	    29/tcp    MSG ICP				[85,RHT]
+   msg-icp	    29/udp    MSG ICP				[85,RHT]
+		    30/tcp    Unassigned			   [JBP]
+		    30/udp    Unassigned			   [JBP]
+   msg-auth	    31/tcp    MSG Authentication		[85,RHT]
+   msg-auth	    31/udp    MSG Authentication		[85,RHT]
+		    32/tcp    Unassigned			   [JBP]
+		    32/udp    Unassigned			   [JBP]
+   dsp		    33/tcp    Display Support Protocol		   [EXC]
+   dsp		    33/udp    Display Support Protocol		   [EXC]
+		    34/tcp    Unassigned			   [JBP]
+		    34/udp    Unassigned			   [JBP]
+		    35/tcp    any private printer server	   [JBP]
+
+
+
+Reynolds & Postel				               [Page 10]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+		    35/udp    any private printer server	   [JBP]
+		    36/tcp    Unassigned			   [JBP]
+		    36/udp    Unassigned			   [JBP]
+   time		    37/tcp    Time			       [108,JBP]
+   time		    37/udp    Time			       [108,JBP]
+		    38/tcp    Unassigned			   [JBP]
+		    38/udp    Unassigned			   [JBP]
+   rlp		    39/tcp    Resource Location	Protocol	    [MA]
+   rlp		    39/udp    Resource Location	Protocol	    [MA]
+		    40/tcp    Unassigned			   [JBP]
+		    40/udp    Unassigned			   [JBP]
+   graphics	    41/tcp    Graphics			       [129,JBP]
+   graphics	    41/udp    Graphics			       [129,JBP]
+   nameserver	    42/tcp    Host Name	Server			[99,JBP]
+   nameserver	    42/udp    Host Name	Server			[99,JBP]
+   nicname	    43/tcp    Who Is			       [55,ANM2]
+   nicname	    43/udp    Who Is			       [55,ANM2]
+   mpm-flags	    44/tcp    MPM FLAGS	Protocol		   [JBP]
+   mpm-flags	    44/udp    MPM FLAGS	Protocol		   [JBP]
+   mpm		    45/tcp    Message Processing Module	[recv]	[98,JBP]
+   mpm		    45/udp    Message Processing Module	[recv]	[98,JBP]
+   mpm-snd	    46/tcp    MPM [default send]		[98,JBP]
+   mpm-snd	    46/udp    MPM [default send]		[98,JBP]
+   ni-ftp	    47/tcp    NI FTP			       [134,SK8]
+   ni-ftp	    47/udp    NI FTP			       [134,SK8]
+		    48/tcp    Unassigned			   [JBP]
+		    48/udp    Unassigned			   [JBP]
+   login	    49/tcp    Login Host Protocol		  [PHD1]
+   login	    49/udp    Login Host Protocol		  [PHD1]
+   re-mail-ck	    50/tcp    Remote Mail Checking Protocol   [171,SXD1]
+   re-mail-ck	    50/udp    Remote Mail Checking Protocol   [171,SXD1]
+   la-maint	    51/tcp    IMP Logical Address Maintenance	[76,AGM]
+   la-maint	    51/udp    IMP Logical Address Maintenance	[76,AGM]
+   xns-time	    52/tcp    XNS Time Protocol			   [SXA]
+   xns-time	    52/udp    XNS Time Protocol			   [SXA]
+   domain	    53/tcp    Domain Name Server	     [81,95,PM1]
+   domain	    53/udp    Domain Name Server	     [81,95,PM1]
+   xns-ch	    54/tcp    XNS Clearinghouse			   [SXA]
+   xns-ch	    54/udp    XNS Clearinghouse			   [SXA]
+   isi-gl	    55/tcp    ISI Graphics Language		 [7,RB9]
+   isi-gl	    55/udp    ISI Graphics Language		 [7,RB9]
+   xns-auth	    56/tcp    XNS Authentication		   [SXA]
+   xns-auth	    56/udp    XNS Authentication		   [SXA]
+		    57/tcp    any private terminal access	   [JBP]
+		    57/udp    any private terminal access	   [JBP]
+   xns-mail	    58/tcp    XNS Mail				   [SXA]
+   xns-mail	    58/udp    XNS Mail				   [SXA]
+		    59/tcp    any private file service		   [JBP]
+
+
+
+Reynolds & Postel				               [Page 11]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+		    59/udp    any private file service		   [JBP]
+		    60/tcp    Unassigned			   [JBP]
+		    60/udp    Unassigned			   [JBP]
+   ni-mail	    61/tcp    NI MAIL				 [5,SK8]
+   ni-mail	    61/udp    NI MAIL				 [5,SK8]
+   acas		    62/tcp    ACA Services			   [EXW]
+   acas		    62/udp    ACA Services			   [EXW]
+   via-ftp	    63/tcp    VIA Systems - FTP			   [DXD]
+   via-ftp	    63/udp    VIA Systems - FTP			   [DXD]
+   covia	    64/tcp    Communications Integrator	(CI)	   [TXD]
+   covia	    64/udp    Communications Integrator	(CI)	   [TXD]
+   tacacs-ds	    65/tcp    TACACS-Database Service		[3,KH43]
+   tacacs-ds	    65/udp    TACACS-Database Service		[3,KH43]
+   sql*net	    66/tcp    Oracle SQL*NET			  [JFH2]
+   sql*net	    66/udp    Oracle SQL*NET			  [JFH2]
+   bootps	    67/tcp    Bootstrap	Protocol Server	       [36,WJC2]
+   bootps	    67/udp    Bootstrap	Protocol Server	       [36,WJC2]
+   bootpc	    68/tcp    Bootstrap	Protocol Client	       [36,WJC2]
+   bootpc	    68/udp    Bootstrap	Protocol Client	       [36,WJC2]
+   tftp		    69/tcp    Trivial File Transfer	      [126,DDC1]
+   tftp		    69/udp    Trivial File Transfer	      [126,DDC1]
+   gopher	    70/tcp    Gopher				  [MXC1]
+   gopher	    70/udp    Gopher				  [MXC1]
+   netrjs-1	    71/tcp    Remote Job Service	       [10,RTB3]
+   netrjs-1	    71/udp    Remote Job Service	       [10,RTB3]
+   netrjs-2	    72/tcp    Remote Job Service	       [10,RTB3]
+   netrjs-2	    72/udp    Remote Job Service	       [10,RTB3]
+   netrjs-3	    73/tcp    Remote Job Service	       [10,RTB3]
+   netrjs-3	    73/udp    Remote Job Service	       [10,RTB3]
+   netrjs-4	    74/tcp    Remote Job Service	       [10,RTB3]
+   netrjs-4	    74/udp    Remote Job Service	       [10,RTB3]
+		    75/tcp    any private dial out service	   [JBP]
+		    75/udp    any private dial out service	   [JBP]
+		    76/tcp    Unassigned			   [JBP]
+		    76/udp    Unassigned			   [JBP]
+		    77/tcp    any private RJE service		   [JBP]
+		    77/udp    any private RJE service		   [JBP]
+   vettcp	    78/tcp    vettcp				  [CXL1]
+   vettcp	    78/udp    vettcp				  [CXL1]
+   finger	    79/tcp    Finger				[52,KLH]
+   finger	    79/udp    Finger				[52,KLH]
+   www		    80/tcp    World Wide Web HTTP		   [TXL]
+   www		    80/udp    World Wide Web HTTP		   [TXL]
+   hosts2-ns	    81/tcp    HOSTS2 Name Server		  [EAK1]
+   hosts2-ns	    81/udp    HOSTS2 Name Server		  [EAK1]
+   xfer		    82/tcp    XFER Utility			  [TXS2]
+   xfer		    82/udp    XFER Utility			  [TXS2]
+   mit-ml-dev	    83/tcp    MIT ML Device			  [DXR3]
+
+
+
+Reynolds & Postel				               [Page 12]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   mit-ml-dev	    83/udp    MIT ML Device			  [DXR3]
+   ctf		    84/tcp    Common Trace Facility		   [HXT]
+   ctf		    84/udp    Common Trace Facility		   [HXT]
+   mit-ml-dev	    85/tcp    MIT ML Device			  [DXR3]
+   mit-ml-dev	    85/udp    MIT ML Device			  [DXR3]
+   mfcobol	    86/tcp    Micro Focus Cobol			   [SXE]
+   mfcobol	    86/udp    Micro Focus Cobol			   [SXE]
+		    87/tcp    any private terminal link		   [JBP]
+		    87/udp    any private terminal link		   [JBP]
+   kerberos	    88/tcp    Kerberos				   [BCN]
+   kerberos	    88/udp    Kerberos				   [BCN]
+   su-mit-tg	    89/tcp    SU/MIT Telnet Gateway		   [MRC]
+   su-mit-tg	    89/udp    SU/MIT Telnet Gateway		   [MRC]
+   dnsix	    90/tcp    DNSIX Securit Attribute Token Map	  [CXW1]
+   dnsix	    90/udp    DNSIX Securit Attribute Token Map	  [CXW1]
+   mit-dov	    91/tcp    MIT Dover	Spooler			   [EBM]
+   mit-dov	    91/udp    MIT Dover	Spooler			   [EBM]
+   npp		    92/tcp    Network Printing Protocol		   [LXM]
+   npp		    92/udp    Network Printing Protocol		   [LXM]
+   dcp		    93/tcp    Device Control Protocol		  [DT15]
+   dcp		    93/udp    Device Control Protocol		  [DT15]
+   objcall	    94/tcp    Tivoli Object Dispatcher		  [TXB1]
+   objcall	    94/udp    Tivoli Object Dispatcher		  [TXB1]
+   supdup	    95/tcp    SUPDUP				[27,MRC]
+   supdup	    95/udp    SUPDUP				[27,MRC]
+   dixie	    96/tcp    DIXIE Protocol Specification	  [TXH1]
+   dixie	    96/udp    DIXIE Protocol Specification	  [TXH1]
+   swift-rvf	    97/tcp    Swift Remote Vitural File	Protocol   [MXR]
+   swift-rvf	    97/udp    Swift Remote Vitural File	Protocol   [MXR]
+   tacnews	    98/tcp    TAC News				  [ANM2]
+   tacnews	    98/udp    TAC News				  [ANM2]
+   metagram	    99/tcp    Metagram Relay			  [GEOF]
+   metagram	    99/udp    Metagram Relay			  [GEOF]
+   newacct	   100/tcp    [unauthorized use]
+   hostname	   101/tcp    NIC Host Name Server	       [54,ANM2]
+   hostname	   101/udp    NIC Host Name Server	       [54,ANM2]
+   iso-tsap	   102/tcp    ISO-TSAP				[16,MTR]
+   iso-tsap	   102/udp    ISO-TSAP				[16,MTR]
+   gppitnp	   103/tcp    Genesis Point-to-Point Trans Net	  [PXM1]
+   gppitnp	   103/udp    Genesis Point-to-Point Trans Net	  [PXM1]
+   acr-nema	   104/tcp    ACR-NEMA Digital Imag. & Comm. 300  [PXM1]
+   acr-nema	   104/udp    ACR-NEMA Digital Imag. & Comm. 300  [PXM1]
+   csnet-ns	   105/tcp    Mailbox Name Nameserver	      [127,MS56]
+   csnet-ns	   105/udp    Mailbox Name Nameserver	      [127,MS56]
+   3com-tsmux	   106/tcp    3COM-TSMUX			  [JXS5]
+   3com-tsmux	   106/udp    3COM-TSMUX			  [JXS5]
+   rtelnet	   107/tcp    Remote Telnet Service	       [101,JBP]
+   rtelnet	   107/udp    Remote Telnet Service	       [101,JBP]
+
+
+
+Reynolds & Postel				               [Page 13]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   snagas	   108/tcp    SNA Gateway Access Server		   [KXM]
+   snagas	   108/udp    SNA Gateway Access Server		   [KXM]
+   pop2		   109/tcp    Post Office Protocol - Version 2 [14,JKR1]
+   pop2		   109/udp    Post Office Protocol - Version 2 [14,JKR1]
+   pop3		   110/tcp    Post Office Protocol - Version 3 [122,MTR]
+   pop3		   110/udp    Post Office Protocol - Version 3 [122,MTR]
+   sunrpc	   111/tcp    SUN Remote Procedure Call		   [DXG]
+   sunrpc	   111/udp    SUN Remote Procedure Call		   [DXG]
+   mcidas	   112/tcp    McIDAS Data Transmission Protocol	   [GXD]
+   mcidas	   112/udp    McIDAS Data Transmission Protocol	   [GXD]
+   auth		   113/tcp    Authentication Service	      [130,MCSJ]
+   auth		   113/udp    Authentication Service	      [130,MCSJ]
+   audionews	   114/tcp    Audio News Multicast		  [MXF2]
+   audionews	   114/udp    Audio News Multicast		  [MXF2]
+   sftp		   115/tcp    Simple File Transfer Protocol    [73,MKL1]
+   sftp		   115/udp    Simple File Transfer Protocol    [73,MKL1]
+   ansanotify	   116/tcp    ANSA REX Notify			   [NXH]
+   ansanotify	   116/udp    ANSA REX Notify			   [NXH]
+   uucp-path	   117/tcp    UUCP Path	Service			[44,MAE]
+   uucp-path	   117/udp    UUCP Path	Service			[44,MAE]
+   sqlserv	   118/tcp    SQL Services			  [LXB3]
+   sqlserv	   118/udp    SQL Services			  [LXB3]
+   nntp		   119/tcp    Network News Transfer Protocol	[65,PL4]
+   nntp		   119/udp    Network News Transfer Protocol	[65,PL4]
+   cfdptkt	   120/tcp    CFDPTKT				  [JXO3]
+   cfdptkt	   120/udp    CFDPTKT				  [JXO3]
+   erpc		   121/tcp    Encore Expedited Remote Pro.Call [132,JXO]
+   erpc		   121/udp    Encore Expedited Remote Pro.Call [132,JXO]
+   smakynet	   122/tcp    SMAKYNET				   [MXO]
+   smakynet	   122/udp    SMAKYNET				   [MXO]
+   ntp		   123/tcp    Network Time Protocol	       [80,DLM1]
+   ntp		   123/udp    Network Time Protocol	       [80,DLM1]
+   ansatrader	   124/tcp    ANSA REX Trader			   [NXH]
+   ansatrader	   124/udp    ANSA REX Trader			   [NXH]
+   locus-map	   125/tcp    Locus PC-Interface Net Map Ser  [137,EP53]
+   locus-map	   125/udp    Locus PC-Interface Net Map Ser  [137,EP53]
+   unitary	   126/tcp    Unisys Unitary Login		  [FEIL]
+   unitary	   126/udp    Unisys Unitary Login		  [FEIL]
+   locus-con	   127/tcp    Locus PC-Interface Conn Server  [137,EP53]
+   locus-con	   127/udp    Locus PC-Interface Conn Server  [137,EP53]
+   gss-xlicen	   128/tcp    GSS X License Verification	   [JXL]
+   gss-xlicen	   128/udp    GSS X License Verification	   [JXL]
+   pwdgen	   129/tcp    Password Generator Protocol      [141,FJW]
+   pwdgen	   129/udp    Password Generator Protocol      [141,FJW]
+   cisco-fna	   130/tcp    cisco FNATIVE			   [WXB]
+   cisco-fna	   130/udp    cisco FNATIVE			   [WXB]
+   cisco-tna	   131/tcp    cisco TNATIVE			   [WXB]
+   cisco-tna	   131/udp    cisco TNATIVE			   [WXB]
+
+
+
+Reynolds & Postel				               [Page 14]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   cisco-sys	   132/tcp    cisco SYSMAINT			   [WXB]
+   cisco-sys	   132/udp    cisco SYSMAINT			   [WXB]
+   statsrv	   133/tcp    Statistics Service		  [DLM1]
+   statsrv	   133/udp    Statistics Service		  [DLM1]
+   ingres-net	   134/tcp    INGRES-NET Service		   [MXB]
+   ingres-net	   134/udp    INGRES-NET Service		   [MXB]
+   loc-srv	   135/tcp    Location Service			   [JXP]
+   loc-srv	   135/udp    Location Service			   [JXP]
+   profile	   136/tcp    PROFILE Naming System		   [LLP]
+   profile	   136/udp    PROFILE Naming System		   [LLP]
+   netbios-ns	   137/tcp    NETBIOS Name Service		   [JBP]
+   netbios-ns	   137/udp    NETBIOS Name Service		   [JBP]
+   netbios-dgm	   138/tcp    NETBIOS Datagram Service		   [JBP]
+   netbios-dgm	   138/udp    NETBIOS Datagram Service		   [JBP]
+   netbios-ssn	   139/tcp    NETBIOS Session Service		   [JBP]
+   netbios-ssn	   139/udp    NETBIOS Session Service		   [JBP]
+   emfis-data	   140/tcp    EMFIS Data Service		   [GB7]
+   emfis-data	   140/udp    EMFIS Data Service		   [GB7]
+   emfis-cntl	   141/tcp    EMFIS Control Service		   [GB7]
+   emfis-cntl	   141/udp    EMFIS Control Service		   [GB7]
+   bl-idm	   142/tcp    Britton-Lee IDM			  [SXS1]
+   bl-idm	   142/udp    Britton-Lee IDM			  [SXS1]
+   imap2	   143/tcp    Interim Mail Access Protocol v2	   [MRC]
+   imap2	   143/udp    Interim Mail Access Protocol v2	   [MRC]
+   news		   144/tcp    NewS				   [JAG]
+   news		   144/udp    NewS				   [JAG]
+   uaac		   145/tcp    UAAC Protocol			  [DAG4]
+   uaac		   145/udp    UAAC Protocol			  [DAG4]
+   iso-tp0	   146/tcp    ISO-IP0				[86,MTR]
+   iso-tp0	   146/udp    ISO-IP0				[86,MTR]
+   iso-ip	   147/tcp    ISO-IP				   [MTR]
+   iso-ip	   147/udp    ISO-IP				   [MTR]
+   cronus	   148/tcp    CRONUS-SUPPORT		       [135,JXB]
+   cronus	   148/udp    CRONUS-SUPPORT		       [135,JXB]
+   aed-512	   149/tcp    AED 512 Emulation	Service		   [AXB]
+   aed-512	   149/udp    AED 512 Emulation	Service		   [AXB]
+   sql-net	   150/tcp    SQL-NET				   [MXP]
+   sql-net	   150/udp    SQL-NET				   [MXP]
+   hems		   151/tcp    HEMS				[87,CXT]
+   hems		   151/udp    HEMS				[87,CXT]
+   bftp		   152/tcp    Background File Transfer Program	  [AD14]
+   bftp		   152/udp    Background File Transfer Program	  [AD14]
+   sgmp		   153/tcp    SGMP				[37,MS9]
+   sgmp		   153/udp    SGMP				[37,MS9]
+   netsc-prod	   154/tcp    NETSC				  [SH37]
+   netsc-prod	   154/udp    NETSC				  [SH37]
+   netsc-dev	   155/tcp    NETSC				  [SH37]
+   netsc-dev	   155/udp    NETSC				  [SH37]
+
+
+
+Reynolds & Postel				               [Page 15]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   sqlsrv	   156/tcp    SQL Service			   [CMR]
+   sqlsrv	   156/udp    SQL Service			   [CMR]
+   knet-cmp	   157/tcp    KNET/VM Command/Message Protocol[77,GSM11]
+   knet-cmp	   157/udp    KNET/VM Command/Message Protocol[77,GSM11]
+   pcmail-srv	   158/tcp    PCMail Server			[19,MXL]
+   pcmail-srv	   158/udp    PCMail Server			[19,MXL]
+   nss-routing	   159/tcp   NSS-Routing			   [JXR]
+   nss-routing	   159/udp   NSS-Routing			   [JXR]
+   sgmp-traps	   160/tcp    SGMP-TRAPS			[37,MS9]
+   sgmp-traps	   160/udp    SGMP-TRAPS			[37,MS9]
+   snmp		   161/tcp    SNMP				[15,MTR]
+   snmp		   161/udp    SNMP				[15,MTR]
+   snmptrap	   162/tcp    SNMPTRAP				[15,MTR]
+   snmptrap	   162/udp    SNMPTRAP				[15,MTR]
+   cmip-man	   163/tcp    CMIP/TCP Manager			[4,AXB1]
+   cmip-man	   163/udp    CMIP/TCP Manager			[4,AXB1]
+   cmip-agent	   164/tcp    CMIP/TCP Agent			[4,AXB1]
+   smip-agent	   164/udp    CMIP/TCP Agent			[4,AXB1]
+   xns-courier	   165/tcp   Xerox				144,SXA]
+   xns-courier	   165/udp   Xerox			       [144,SXA]
+   s-net	   166/tcp    Sirius Systems			   [BXL]
+   s-net	   166/udp    Sirius Systems			   [BXL]
+   namp		   167/tcp    NAMP				   [MS9]
+   namp		   167/udp    NAMP				   [MS9]
+   rsvd		   168/tcp    RSVD				  [NT12]
+   rsvd		   168/udp    RSVD				  [NT12]
+   send		   169/tcp    SEND				 [WDW11]
+   send		   169/udp    SEND				 [WDW11]
+   print-srv	   170/tcp    Network PostScript		   [BKR]
+   print-srv	   170/udp    Network PostScript		   [BKR]
+   multiplex	   171/tcp    Network Innovations Multiplex	   [KXD]
+   multiplex	   171/udp    Network Innovations Multiplex	   [KXD]
+   cl/1		   172/tcp    Network Innovations CL/1		   [KXD]
+   cl/1		   172/udp    Network Innovations CL/1		   [KXD]
+   xyplex-mux	   173/tcp    Xyplex				   [BXS]
+   xyplex-mux	   173/udp    Xyplex				   [BXS]
+   mailq	   174/tcp    MAILQ				   [RXZ]
+   mailq	   174/udp    MAILQ				   [RXZ]
+   vmnet	   175/tcp    VMNET				   [CXT]
+   vmnet	   175/udp    VMNET				   [CXT]
+   genrad-mux	   176/tcp    GENRAD-MUX			   [RXT]
+   genrad-mux	   176/udp    GENRAD-MUX			   [RXT]
+   xdmcp	   177/tcp    X	Display	Manager	Control	Protocol  [RWS4]
+   xdmcp	   177/udp    X	Display	Manager	Control	Protocol  [RWS4]
+   nextstep	   178/tcp    NextStep Window Server		   [LXH]
+   NextStep	   178/udp    NextStep Window Server		   [LXH]
+   bgp		   179/tcp    Border Gateway Protocol		   [KSL]
+   bgp		   179/udp    Border Gateway Protocol		   [KSL]
+
+
+
+Reynolds & Postel				               [Page 16]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   ris		   180/tcp    Intergraph			   [DXB]
+   ris		   180/udp    Intergraph			   [DXB]
+   unify	   181/tcp    Unify				   [VXS]
+   unify	   181/udp    Unify				   [VXS]
+   audit	   182/tcp    Unisys Audit SITP			   [GXG]
+   audit	   182/udp    Unisys Audit SITP			   [GXG]
+   ocbinder	   183/tcp    OCBinder				  [JXO1]
+   ocbinder	   183/udp    OCBinder				  [JXO1]
+   ocserver	   184/tcp    OCServer				  [JXO1]
+   ocserver	   184/udp    OCServer				  [JXO1]
+   remote-kis	   185/tcp    Remote-KIS			  [RXD1]
+   remote-kis	   185/udp    Remote-KIS			  [RXD1]
+   kis		   186/tcp    KIS Protocol			  [RXD1]
+   kis		   186/udp    KIS Protocol			  [RXD1]
+   aci		   187/tcp    Application Communication	Interface [RXC1]
+   aci		   187/udp    Application Communication	Interface [RXC1]
+   mumps	   188/tcp    Plus Five's MUMPS			  [HS23]
+   mumps	   188/udp    Plus Five's MUMPS			  [HS23]
+   qft		   189/tcp    Queued File Transport		   [WXS]
+   qft		   189/udp    Queued File Transport		   [WXS]
+   gacp		   190/tcp    Gateway Access Control Protocol	   [PCW]
+   cacp		   190/udp    Gateway Access Control Protocol	   [PCW]
+   prospero	   191/tcp    Prospero				   [BCN]
+   prospero	   191/udp    Prospero				   [BCN]
+   osu-nms	   192/tcp    OSU Network Monitoring System	   [DXK]
+   osu-nms	   192/udp    OSU Network Monitoring System	   [DXK]
+   srmp		   193/tcp    Spider Remote Monitoring Protocol	   [TXS]
+   srmp		   193/udp    Spider Remote Monitoring Protocol	   [TXS]
+   irc		   194/tcp    Internet Relay Chat Protocol	  [JXO2]
+   irc		   194/udp    Internet Relay Chat Protocol	  [JXO2]
+   dn6-nlm-aud	   195/tcp    DNSIX Network Level Module Audit	  [LL69]
+   dn6-nlm-aud	   195/udp    DNSIX Network Level Module Audit	  [LL69]
+   dn6-smm-red	   196/tcp    DNSIX Session Mgt	Module Audit Redir[LL69]
+   dn6-smm-red	   196/udp    DNSIX Session Mgt	Module Audit Redir[LL69]
+   dls		   197/tcp    Directory	Location Service	   [SXB]
+   dls		   197/udp    Directory	Location Service	   [SXB]
+   dls-mon	   198/tcp    Directory	Location Service Monitor   [SXB]
+   dls-mon	   198/udp    Directory	Location Service Monitor   [SXB]
+   smux		   199/tcp    SMUX				   [MTR]
+   smux		   199/udp    SMUX				   [MTR]
+   src		   200/tcp    IBM System Resource Controller	   [GXM]
+   src		   200/udp    IBM System Resource Controller	   [GXM]
+   at-rtmp	   201/tcp    AppleTalk	Routing	Maintenance	   [RXC]
+   at-rtmp	   201/udp    AppleTalk	Routing	Maintenance	   [RXC]
+   at-nbp	   202/tcp    AppleTalk	Name Binding		   [RXC]
+   at-nbp	   202/udp    AppleTalk	Name Binding		   [RXC]
+   at-3		   203/tcp    AppleTalk	Unused			   [RXC]
+   at-3		   203/udp    AppleTalk	Unused			   [RXC]
+
+
+
+Reynolds & Postel				               [Page 17]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   at-echo	   204/tcp    AppleTalk	Echo			   [RXC]
+   at-echo	   204/udp    AppleTalk	Echo			   [RXC]
+   at-5		   205/tcp    AppleTalk	Unused			   [RXC]
+   at-5		   205/udp    AppleTalk	Unused			   [RXC]
+   at-zis	   206/tcp    AppleTalk	Zone Information	   [RXC]
+   at-zis	   206/udp    AppleTalk	Zone Information	   [RXC]
+   at-7		   207/tcp    AppleTalk	Unused			   [RXC]
+   at-7		   207/udp    AppleTalk	Unused			   [RXC]
+   at-8		   208/tcp    AppleTalk	Unused			   [RXC]
+   at-8		   208/udp    AppleTalk	Unused			   [RXC]
+   tam		   209/tcp    Trivial Authenticated Mail Protocol [DXB1]
+   tam		   209/udp    Trivial Authenticated Mail Protocol [DXB1]
+   z39.50	   210/tcp    ANSI Z39.50			   [MXN]
+   z39.50	   210/udp    ANSI Z39.50			   [MXN]
+   914c/g	   211/tcp    Texas Instruments	914C/G Terminal	  [BXH1]
+   914c/g	   211/udp    Texas Instruments	914C/G Terminal	  [BXH1]
+   anet		   212/tcp    ATEXSSTR				   [JXT]
+   anet		   212/udp    ATEXSSTR				   [JXT]
+   ipx		   213/tcp    IPX				 [DP666]
+   ipx		   213/udp    IPX				 [DP666]
+   vmpwscs	   214/tcp    VM PWSCS				   [DXS]
+   vmpwscs	   214/udp    VM PWSCS				   [DXS]
+   softpc	   215/tcp    Insignia Solutions		   [MXT]
+   softpc	   215/udp    Insignia Solutions		   [MXT]
+   atls		   216/tcp    Access Technology	License	Server	   [LXD]
+   atls		   216/udp    Access Technology	License	Server	   [LXD]
+   dbase	   217/tcp    dBASE Unix			  [DXG1]
+   dbase	   217/udp    dBASE Unix			  [DXG1]
+   mpp		   218/tcp    Netix Message Posting Protocol	   [STY]
+   mpp		   218/udp    Netix Message Posting Protocol	   [STY]
+   uarps	   219/tcp    Unisys ARPs			  [AXM1]
+   uarps	   219/udp    Unisys ARPs			  [AXM1]
+   imap3	   220/tcp    Interactive Mail Access Protocol v3 [JXR2]
+   imap3	   220/udp    Interactive Mail Access Protocol v3 [JXR2]
+   fln-spx	   221/tcp    Berkeley rlogind with SPX	auth	   [KXA]
+   fln-spx	   221/udp    Berkeley rlogind with SPX	auth	   [KXA]
+   fsh-spx	   222/tcp    Berkeley rshd with SPX auth	   [KXA]
+   fsh-spx	   222/udp    Berkeley rshd with SPX auth	   [KXA]
+   cdc		   223/tcp    Certificate Distribution Center	   [KXA]
+   cdc		   223/udp    Certificate Distribution Center	   [KXA]
+
+		   224-241    Reserved				   [JBP]
+
+   sur-meas	   243/tcp    Survey Measurement		[6,DDC1]
+   sur-meas	   243/udp    Survey Measurement		[6,DDC1]
+   link		   245/tcp    LINK				[1,RDB2]
+   link		   245/udp    LINK				[1,RDB2]
+   dsp3270	   246/tcp    Display Systems Protocol	       [39,WJS1]
+
+
+
+Reynolds & Postel				               [Page 18]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   dsp3270	   246/udp    Display Systems Protocol	       [39,WJS1]
+
+		   247-255    Reserved				   [JBP]
+
+   pawserv	   345/tcp    Perf Analysis Workbench
+   pawserv	   345/udp    Perf Analysis Workbench
+   zserv	   346/tcp    Zebra server
+   zserv	   346/udp    Zebra server
+   fatserv	   347/tcp    Fatmen Server
+   fatserv	   347/udp    Fatmen Server
+   clearcase	   371/tcp    Clearcase				  [DXL1]
+   clearcase	   371/udp    Clearcase				  [DXL1]
+   ulistserv	   372/tcp    Unix Listserv			   [AXK]
+   ulistserv	   372/udp    Unix Listserv			   [AXK]
+   legent-1	   373/tcp    Legent Corporation		   [KXB]
+   legent-1	   373/udp    Legent Corporation		   [KXB]
+   legent-2	   374/tcp    Legent Corporation		   [KXB]
+   legent-2	   374/udp    Legent Corporation		   [KXB]
+   exec		   512/tcp    remote process execution;
+			      authentication performed using
+			      passwords	and UNIX loppgin names
+   biff		   512/udp    used by mail system to notify users
+			      of new mail received; currently
+			      receives messages	only from
+			      processes	on the same machine
+   login	   513/tcp    remote login a la	telnet;
+			      automatic	authentication performed
+			      based on priviledged port	numbers
+			      and distributed data bases which
+			      identify "authentication domains"
+   who		   513/udp    maintains	data bases showing who's
+			      logged in	to machines on a local
+			      net and the load average of the
+			      machine
+   cmd		   514/tcp    like exec, but automatic
+			      authentication is	performed as for
+			      login server
+   syslog	   514/udp
+   printer	   515/tcp    spooler
+   printer	   515/udp    spooler
+   talk		   517/tcp    like tenex link, but across
+			      machine -	unfortunately, doesn't
+			      use link protocol	(this is actually
+			      just a rendezvous	port from which	a
+			      tcp connection is	established)
+   talk		   517/udp    like tenex link, but across
+			      machine -	unfortunately, doesn't
+			      use link protocol	(this is actually
+
+
+
+Reynolds & Postel				               [Page 19]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+			      just a rendezvous	port from which	a
+			      tcp connection is	established)
+   ntalk	   518/tcp
+   ntalk	   518/udp
+   utime	   519/tcp    unixtime
+   utime	   519/udp    unixtime
+   efs		   520/tcp    extended file name server
+   router	   520/udp    local routing process (on	site);
+			      uses variant of Xerox NS routing
+			      information protocol
+   timed	   525/tcp    timeserver
+   timed	   525/udp    timeserver
+   tempo	   526/tcp    newdate
+   tempo	   526/udp    newdate
+   courier	   530/tcp    rpc
+   courier	   530/udp    rpc
+   conference	   531/tcp    chat
+   conference	   531/udp    chat
+   netnews	   532/tcp    readnews
+   netnews	   532/udp    readnews
+   netwall	   533/tcp    for emergency broadcasts
+   netwall	   533/udp    for emergency broadcasts
+   uucp		   540/tcp    uucpd
+   uucp		   540/udp    uucpd
+   klogin	   543/tcp
+   klogin	   543/udp
+   kshell	   544/tcp    krcmd
+   kshell	   544/udp    krcmd
+   new-rwho	   550/tcp    new-who
+   new-rwho	   550/udp    new-who
+   dsf		   555/tcp
+   dsf		   555/udp
+   remotefs	   556/tcp    rfs server
+   remotefs	   556/udp    rfs server
+   rmonitor	   560/tcp    rmonitord
+   rmonitor	   560/udp    rmonitord
+   monitor	   561/tcp
+   monitor	   561/udp
+   chshell	   562/tcp    chcmd
+   chshell	   562/udp    chcmd
+   9pfs		   564/tcp    plan 9 file service
+   9pfs		   564/udp    plan 9 file service
+   whoami	   565/tcp    whoami
+   whoami	   565/udp    whoami
+   meter	   570/tcp    demon
+   meter	   570/udp    demon
+   meter	   571/tcp    udemon
+   meter	   571/udp    udemon
+
+
+
+Reynolds & Postel				               [Page 20]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   ipcserver	   600/tcp    Sun IPC server
+   ipcserver	   600/udp    Sun IPC server
+   nqs		   607/tcp    nqs
+   nqs		   607/udp    nqs
+   mdqs		   666/tcp
+   mdqs		   666/udp
+   elcsd	   704/tcp    errlog copy/server daemon
+   elcsd	   704/udp    errlog copy/server daemon
+   netcp	   740/tcp    NETscout Control Protocol		  [AXS2]
+   netcp	   740/udp    NETscout Control Protocol		  [AXS2]
+   netgw	   741/tcp    netGW				   [OXK]
+   netgw	   741/udp    netGW				   [OXK]
+   netrcs	   742/tcp    Network based Rev. Cont. Sys.	  [GXC2]
+   netrcs	   742/udp    Network based Rev. Cont. Sys.	  [GXC2]
+   flexlm	   744/tcp    Flexible License Manager		  [MXC2]
+   flexlm	   744/udp    Flexible License Manager		  [MXC2]
+   fujitsu-dev	   747/tcp    Fujitsu Device Control
+   fujitsu-dev	   747/udp    Fujitsu Device Control
+   ris-cm	   748/tcp    Russell Info Sci Calendar	Manager
+   ris-cm	   748/udp    Russell Info Sci Calendar	Manager
+   kerberos-adm	   749/tcp    kerberos administration
+   kerberos-adm	   749/udp    kerberos administration
+   rfile	   750/tcp
+   loadav	   750/udp
+   pump		   751/tcp
+   pump		   751/udp
+   qrh		   752/tcp
+   qrh		   752/udp
+   rrh		   753/tcp
+   rrh		   753/udp
+   tell		   754/tcp     send
+   tell		   754/udp     send
+   nlogin	   758/tcp
+   nlogin	   758/udp
+   con		   759/tcp
+   con		   759/udp
+   ns		   760/tcp
+   ns		   760/udp
+   rxe		   761/tcp
+   rxe		   761/udp
+   quotad	   762/tcp
+   quotad	   762/udp
+   cycleserv	   763/tcp
+   cycleserv	   763/udp
+   omserv	   764/tcp
+   omserv	   764/udp
+   webster	   765/tcp
+   webster	   765/udp
+
+
+
+Reynolds & Postel				               [Page 21]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   phonebook	   767/tcp    phone
+   phonebook	   767/udp    phone
+   vid		   769/tcp
+   vid		   769/udp
+   cadlock	   770/tcp
+   cadlock	   770/udp
+   rtip		   771/tcp
+   rtip		   771/udp
+   cycleserv2	   772/tcp
+   cycleserv2	   772/udp
+   submit	   773/tcp
+   notify	   773/udp
+   rpasswd	   774/tcp
+   acmaint_dbd	   774/udp
+   entomb	   775/tcp
+   acmaint_transd  775/udp
+   wpages	   776/tcp
+   wpages	   776/udp
+   wpgs		   780/tcp
+   wpgs		   780/udp
+   hp-collector	   781/tcp	  hp performance data collector
+   hp-collector	   781/udp	  hp performance data collector
+   hp-managed-node 782/tcp	  hp performance data managed node
+   hp-managed-node 782/udp	  hp performance data managed node
+   hp-alarm-mgr	   783/tcp	  hp performance data alarm manager
+   hp-alarm-mgr	   783/udp	  hp performance data alarm manager
+   mdbs_daemon	   800/tcp
+   mdbs_daemon	   800/udp
+   device	   801/tcp
+   device	   801/udp
+   xtreelic	   996/tcp	  XTREE	License	Server
+   xtreelic	   996/udp	  XTREE	License	Server
+   maitrd	   997/tcp
+   maitrd	   997/udp
+   busboy	   998/tcp
+   puparp	   998/udp
+   garcon	   999/tcp
+   applix	   999/udp	  Applix ac
+   puprouter	   999/tcp
+   puprouter	   999/udp
+   cadlock	   1000/tcp
+   ock		   1000/udp
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 22]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+			  REGISTERED PORT NUMBERS
+
+The Registered Ports are not controlled	by the IANA and	on most	systems
+can be used by ordinary	user processes or programs executed by ordinary
+users.
+
+Ports are used in the TCP [45,106] to name the ends of logical
+connections which carry	long term conversations.  For the purpose of
+providing services to unknown callers, a service contact port is
+defined.  This list specifies the port used by the server process as its
+contact	port.  While the IANA can not control uses of these ports it
+does register or list uses of these ports as a convienence to the
+community.
+
+To the extent possible,	these same port	assignments are	used with the
+UDP [46,104].
+
+The Registered Ports are in the	range 1024-65535.
+
+Port Assignments:
+
+   Keyword	   Decimal    Description		      References
+   -------	   -------    -----------		      ----------
+   blackjack	   1025/tcp   network blackjack
+   blackjack	   1025/udp   network blackjack
+   hermes	   1248/tcp
+   hermes	   1248/udp
+   bbn-mmc	   1347/tcp   multi media conferencing
+   bbn-mmc	   1347/udp   multi media conferencing
+   bbn-mmx	   1348/tcp   multi media conferencing
+   bbn-mmx	   1348/udp   multi media conferencing
+   sbook	   1349/tcp   Registration Network Protocol	  [SXS4]
+   sbook	   1349/udp   Registration Network Protocol	  [SXS4]
+   editbench	   1350/tcp   Registration Network Protocol	  [SXS4]
+   editbench	   1350/udp   Registration Network Protocol	  [SXS4]
+   equationbuilder 1351/tcp   Digital Tool Works (MIT)		  [TXT1]
+   equationbuilder 1351/udp   Digital Tool Works (MIT)		  [TXT1]
+   lotusnote	   1352/tcp   Lotus Note			  [GXP1]
+   lotusnote	   1352/udp   Lotus Note			  [GXP1]
+   ingreslock	   1524/tcp   ingres
+   ingreslock	   1524/udp   ingres
+   orasrv	   1525/tcp   oracle
+   orasrv	   1525/udp   oracle
+   prospero-np	   1525/tcp   prospero non-privileged
+   prospero-np	   1525/udp   prospero non-privileged
+   tlisrv	   1527/tcp   oracle
+   tlisrv	   1527/udp   oracle
+   coauthor	   1529/tcp   oracle
+
+
+
+Reynolds & Postel				               [Page 23]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   coauthor	   1529/udp   oracle
+   issd		   1600/tcp
+   issd		   1600/udp
+   nkd		   1650/tcp
+   nkd		   1650/udp
+   callbook	   2000/tcp
+   callbook	   2000/udp
+   dc		   2001/tcp
+   wizard	   2001/udp    curry
+   globe	   2002/tcp
+   globe	   2002/udp
+   mailbox	   2004/tcp
+   emce		   2004/udp    CCWS mm conf
+   berknet	   2005/tcp
+   oracle	   2005/udp
+   invokator	   2006/tcp
+   raid-cc	   2006/udp    raid
+   dectalk	   2007/tcp
+   raid-am	   2007/udp
+   conf		   2008/tcp
+   terminaldb	   2008/udp
+   news		   2009/tcp
+   whosockami	   2009/udp
+   search	   2010/tcp
+   pipe_server	   2010/udp
+   raid-cc	   2011/tcp    raid
+   servserv	   2011/udp
+   ttyinfo	   2012/tcp
+   raid-ac	   2012/udp
+   raid-am	   2013/tcp
+   raid-cd	   2013/udp
+   troff	   2014/tcp
+   raid-sf	   2014/udp
+   cypress	   2015/tcp
+   raid-cs	   2015/udp
+   bootserver	   2016/tcp
+   bootserver	   2016/udp
+   cypress-stat	   2017/tcp
+   bootclient	   2017/udp
+   terminaldb	   2018/tcp
+   rellpack	   2018/udp
+   whosockami	   2019/tcp
+   about	   2019/udp
+   xinupageserver  2020/tcp
+   xinupageserver  2020/udp
+   servexec	   2021/tcp
+   xinuexpansion1  2021/udp
+   down		   2022/tcp
+
+
+
+Reynolds & Postel				               [Page 24]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   xinuexpansion2  2022/udp
+   xinuexpansion3  2023/tcp
+   xinuexpansion3  2023/udp
+   xinuexpansion4  2024/tcp
+   xinuexpansion4  2024/udp
+   ellpack	   2025/tcp
+   xribs	   2025/udp
+   scrabble	   2026/tcp
+   scrabble	   2026/udp
+   shadowserver	   2027/tcp
+   shadowserver	   2027/udp
+   submitserver	   2028/tcp
+   submitserver	   2028/udp
+   device2	   2030/tcp
+   device2	   2030/udp
+   blackboard	   2032/tcp
+   blackboard	   2032/udp
+   glogger	   2033/tcp
+   glogger	   2033/udp
+   scoremgr	   2034/tcp
+   scoremgr	   2034/udp
+   imsldoc	   2035/tcp
+   imsldoc	   2035/udp
+   objectmanager   2038/tcp
+   objectmanager   2038/udp
+   lam		   2040/tcp
+   lam		   2040/udp
+   interbase	   2041/tcp
+   interbase	   2041/udp
+   isis		   2042/tcp
+   isis		   2042/udp
+   isis-bcast	   2043/tcp
+   isis-bcast	   2043/udp
+   rimsl	   2044/tcp
+   rimsl	   2044/udp
+   cdfunc	   2045/tcp
+   cdfunc	   2045/udp
+   sdfunc	   2046/tcp
+   sdfunc	   2046/udp
+   dls		   2047/tcp
+   dls		   2047/udp
+   dls-monitor	   2048/tcp
+   dls-monitor	   2048/udp
+   shilp	   2049/tcp
+   shilp	   2049/udp
+   www-dev	   2784/tcp   world wide web - development
+   www-dev	   2784/udp   world wide web - development
+   NSWS		   3049/tcp
+
+
+
+Reynolds & Postel				               [Page 25]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   NSWS		   3049/ddddp
+   rfa		   4672/tcp   remote file access server
+   rfa		   4672/udp   remote file access server
+   commplex-main   5000/tcp
+   commplex-main   5000/udp
+   commplex-link   5001/tcp
+   commplex-link   5001/udp
+   rfe		   5002/tcp   radio free ethernet
+   rfe		   5002/udp   radio free ethernet
+   rmonitor_secure 5145/tcp
+   rmonitor_secure 5145/udp
+   padl2sim	   5236/tcp
+   padl2sim	   5236/udp
+   sub-process	   6111/tcp   HP SoftBench Sub-Process Control
+   sub-process	   6111/udp   HP SoftBench Sub-Process Control
+   xdsxdm	   6558/udp
+   xdsxdm	   6558/tcp
+   afs3-fileserver 7000/tcp   file server itself
+   afs3-fileserver 7000/udp   file server itself
+   afs3-callback   7001/tcp   callbacks	to cache managers
+   afs3-callback   7001/udp   callbacks	to cache managers
+   afs3-prserver   7002/tcp   users & groups database
+   afs3-prserver   7002/udp   users & groups database
+   afs3-vlserver   7003/tcp   volume location database
+   afs3-vlserver   7003/udp   volume location database
+   afs3-kaserver   7004/tcp   AFS/Kerberos authentication service
+   afs3-kaserver   7004/udp   AFS/Kerberos authentication service
+   afs3-volser	   7005/tcp   volume managment server
+   afs3-volser	   7005/udp   volume managment server
+   afs3-errors	   7006/tcp   error interpretation service
+   afs3-errors	   7006/udp   error interpretation service
+   afs3-bos	   7007/tcp   basic overseer process
+   afs3-bos	   7007/udp   basic overseer process
+   afs3-update	   7008/tcp   server-to-server updater
+   afs3-update	   7008/udp   server-to-server updater
+   afs3-rmtsys	   7009/tcp   remote cache manager service
+   afs3-rmtsys	   7009/udp   remote cache manager service
+   man		   9535/tcp
+   man		   9535/udp
+   isode-dua	   17007/tcp
+   isode-dua	   17007/udp
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 26]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+		       INTERNET	MULTICAST ADDRESSES
+
+   Host	Extensions for IP Multicasting (RFC-1112) [43] specifies the
+   extensions required of a host implementation	of the Internet	Protocol
+   (IP)	to support multicasting.  Current addresses are	listed below.
+
+
+      224.0.0.0	 Reserved					[43,JBP]
+      224.0.0.1	 All Systems on	this Subnet			[43,JBP]
+      224.0.0.2	 All Routers on	this Subnet			   [JBP]
+      224.0.0.3	 Unassigned					   [JBP]
+      224.0.0.4	 DVMRP	  Routers			       [140,JBP]
+      224.0.0.5	 OSPFIGP  OSPFIGP All Routers		       [83,JXM1]
+      224.0.0.6	 OSPFIGP  OSPFIGP Designated Routers	       [83,JXM1]
+      224.0.0.7	 ST Routers					  [KS14]
+      224.0.0.8	 ST Hosts					  [KS14]
+      224.0.0.9	 RIP2 Routers					 [GSM11]
+      224.0.0.10-224.0.0.255 Unassigned				   [JBP]
+
+      224.0.1.0	 VMTP Managers Group			       [17,DRC3]
+      224.0.1.1	 NTP	  Network Time Protocol		       [80,DLM1]
+      224.0.1.2	 SGI-Dogfight					   [AXC]
+      224.0.1.3	 Rwhod						   [SXD]
+      224.0.1.4	 VNP						  [DRC3]
+      224.0.1.5	 Artificial Horizons - Aviator			   [BXF]
+      224.0.1.6	 NSS - Name Service Server			  [BXS2]
+      224.0.1.7	 AUDIONEWS - Audio News	Multicast		  [MXF2]
+      224.0.1.8	 SUN NIS+ Information Service			  [CXM3]
+      224.0.1.9	 MTP Multicast Transport Protocol		   [SXA]
+      224.0.1.10-224.0.1.255  Unassigned			   [JBP]
+
+      224.0.2.1	 "rwho"	Group (BSD) (unofficial)		   [JBP]
+      224.0.2.2	 SUN RPC PMAPPROC_CALLIT			  [BXE1]
+
+      224.0.3.0-224.0.3.255 RFE	Generic	Service			  [DXS3]
+      224.0.4.0-224.0.4.255 RFE	Individual Conferences		  [DXS3]
+
+      224.1.0.0-224.1.255.255  ST Multicast Groups		  [KS14]
+      224.2.0.0-224.2.255.255  Multimedia Conference Calls	   [SC3]
+
+      232.x.x.x	 VMTP transient	groups			       [17,DRC3]
+
+      These addresses are listed in the	Domain Name Service under
+      MCAST.NET	and 224.IN-ADDR.ARPA.
+
+      Note that	when used on an	Ethernet or IEEE 802 network, the 23
+      low-order	bits of	the IP Multicast address are placed in the low-
+      order 23 bits of the Ethernet or IEEE 802	net multicast address
+
+
+
+Reynolds & Postel				               [Page 27]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+      1.0.94.0.0.0.  See the next section on "IANA ETHERNET ADDRESS
+      BLOCK".
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 28]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+			 IANA ETHERNET ADDRESS BLOCK
+
+   The IANA owns an Ethernet address block which may be	used for
+   multicast address asignments	or other special purposes.
+
+   The address block in	IEEE binary is (which is in bit	transmission
+   order):
+
+		       0000 0000 0000 0000 0111	1010
+
+   In the normal Internet dotted decimal notation this is 0.0.94 since
+   the bytes are transmitted higher order first	and bits within	bytes
+   are transmitted lower order first (see "Data	Notation" in the
+   Introduction).
+
+   IEEE	CSMA/CD	and Token Bus bit transmission order: 00 00 5E
+
+   IEEE	Token Ring bit transmission order: 00 00 7A
+
+   Appearance on the wire (bits	transmitted from left to right):
+
+       0			   23				 47
+       |			   |				 |
+       1000 0000 0000 0000 0111	1010 xxxx xxx0 xxxx xxxx xxxx xxxx
+       |				     |
+       Multicast Bit			     0 = Internet Multicast
+					     1 = Assigned by IANA for
+						 other uses
+
+   Appearance in memory	(bits transmitted right-to-left	within octets,
+   octets transmitted left-to-right):
+
+       0			   23				 47
+       |			   |				 |
+       0000 0001 0000 0000 0101	1110 0xxx xxxx xxxx xxxx xxxx xxxx
+	       |		     |
+	       Multicast Bit	     0 = Internet Multicast
+				     1 = Assigned by IANA for other uses
+
+   The latter representation corresponds to the	Internet standard bit-
+   order, and is the format that most programmers have to deal with.
+   Using this representation, the range	of Internet Multicast addresses
+   is:
+
+	  01-00-5E-00-00-00  to	 01-00-5E-7F-FF-FF  in hex, or
+
+	  1.0.94.0.0.0	to  1.0.94.127.255.255	in dotted decimal
+
+
+
+
+Reynolds & Postel				               [Page 29]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+			     IP	TOS PARAMETERS
+
+   This	documents the default Type-of-Service values that are currently
+   recommended for the most important Internet protocols.
+
+   There are four assigned TOS values: low delay, high throughput, high
+   reliability,	and low	cost; in each case, the	TOS value is used to
+   indicate "better".  Only one	TOS value or property can be requested
+   in any one IP datagram.
+
+   Generally, protocols	which are involved in direct interaction with a
+   human should	select low delay, while	data transfers which may involve
+   large blocks	of data	are need high throughput.  Finally, high
+   reliability is most important for datagram-based Internet management
+   functions.
+
+   Application protocols not included in these tables should be	able to
+   make	appropriate choice of low delay	(8 decimal, 1000 binary) or high
+   throughput (4 decimail, 0100	binary).
+
+   The following are recommended values	for TOS:
+
+		  -----	Type-of-Service	Value -----
+
+      Protocol		 TOS Value
+
+      TELNET (1)	 1000		      (minimize	delay)
+
+      FTP
+	Control		 1000		      (minimize	delay)
+	Data (2)	 0100		      (maximize	throughput)
+
+      TFTP		 1000		      (minimize	delay)
+
+      SMTP (3)
+	Command	phase	 1000		      (minimize	delay)
+	DATA phase	 0100		      (maximize	throughput)
+
+      Domain Name Service
+	UDP Query	 1000		      (minimize	delay)
+	TCP Query	 0000
+	Zone Transfer	 0100		      (maximize	throughput)
+
+      NNTP		 0001		      (minimize	monetary cost)
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 30]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+      ICMP
+	Errors		 0000
+	Requests	 0000 (4)
+	Responses	 <same as request> (4)
+
+      Any IGP		 0010		      (maximize	reliability)
+
+      EGP		 0000
+
+      SNMP		 0010		      (maximize	reliability)
+
+      BOOTP		 0000
+
+      Notes:
+
+      (1) Includes all interactive user	protocols (e.g., rlogin).
+
+      (2) Includes all bulk data transfer protocols (e.g., rcp).
+
+      (3) If the implementation	does not support changing the TOS during
+      the lifetime of the connection, then the recommended TOS on
+      opening the connection is	the default TOS	(0000).
+
+      (4) Although ICMP	request	messages are normally sent with	the
+      default TOS, there are sometimes good reasons why	they would be
+      sent with	some other TOS value.  An ICMP response	always uses the
+      same TOS value as	was used in the	corresponding ICMP request
+      message.
+
+   An application may (at the request of the user) substitute 0001
+   (minimize monetary cost) for	any of the above values.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 31]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+			 IP TIME TO LIVE PARAMETER
+
+   The current recommended default time	to live	(TTL) for the Internet
+   Protocol (IP) [45,105] is 64.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 32]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+			 DOMAIN	SYSTEM PARAMETERS
+
+   The Internet	Domain Naming System (DOMAIN) includes several
+   parameters.	These are documented in	RFC-1034, [81] and RFC-1035
+   [82].  The CLASS parameter is listed	here.  The per CLASS parameters
+   are defined in separate RFCs	as indicated.
+
+   Domain System Parameters:
+
+      Decimal	Name					      References
+      --------	----					      ----------
+	     0	Reserved					   [PM1]
+	     1	Internet (IN)					[81,PM1]
+	     2	Unassigned					   [PM1]
+	     3	Chaos (CH)					   [PM1]
+	     4	Hessoid	(HS)					   [PM1]
+       5-65534	Unassigned					   [PM1]
+	 65535	Reserved					   [PM1]
+
+   In the Internet (IN)	class the following TYPEs and QTYPEs are
+   defined:
+
+
+      TYPE	      value and	meaning
+
+      A		      1	a host address				    [82]
+      NS	      2	an authoritative name server		    [82]
+      MD	      3	a mail destination (Obsolete - use MX)	    [82]
+      MF	      4	a mail forwarder (Obsolete - use MX)	    [82]
+      CNAME	      5	the canonical name for an alias		    [82]
+      SOA	      6	marks the start	of a zone of authority	    [82]
+      MB	      7	a mailbox domain name (EXPERIMENTAL)	    [82]
+      MG	      8	a mail group member (EXPERIMENTAL)	    [82]
+      MR	      9	a mail rename domain name (EXPERIMENTAL)    [82]
+      NULL	      10 a null	RR (EXPERIMENTAL)		    [82]
+      WKS	      11 a well	known service description	    [82]
+      PTR	      12 a domain name pointer			    [82]
+      HINFO	      13 host information			    [82]
+      MINFO	      14 mailbox or mail list information	    [82]
+      MX	      15 mail exchange				    [82]
+      TXT	      16 text strings				    [82]
+
+      RP	      17 for Responsible Person			   [172]
+      AFSDB	      18 for AFS Data Base location		   [172]
+      X25	      19 for X.25 PSDN address			   [172]
+      ISDN	      20 for ISDN address			   [172]
+      RT	      21 for Route Through			   [172]
+
+
+
+
+Reynolds & Postel				               [Page 33]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+      NSAP	      22 for NSAP address, NSAP	style A	record	   [174]
+      NSAP-PTR	      23 for domain name pointer, NSAP style	   [174]
+
+      AXFR	      252 transfer of an entire	zone		    [82]
+      MAILB	      253 mailbox-related RRs (MB, MG or MR)	    [82]
+      MAILA	      254 mail agent RRs (Obsolete - see MX)	    [82]
+      *		      255 A request for	all records		    [82]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 34]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+			       BOOTP PARAMETERS
+
+   The Bootstrap Protocol (BOOTP) RFC-951 [36] describes an IP/UDP
+   bootstrap protocol (BOOTP) which allows a diskless client machine to
+   discover its	own IP address,	the address of a server	host, and the
+   name	of a file to be	loaded into memory and executed.  The BOOTP
+   Vendor Information Extensions RFC-1084 [117]	describes an addition to
+   the Bootstrap Protocol (BOOTP).
+
+   Vendor Extensions are listed	below:
+
+      Tag     Name	    Data Length	   Meaning
+      ---     ----	    -----------	   -------
+       0      Pad		0	   None
+       1      Subnet Mask	4	   Subnet Mask Value
+       2      Time Zone		4	   Time	Offset in
+					   Seconds from	UTC
+       3      Gateways		N	   N/4 Gateway addresses
+       4      Time Server	N	   N/4 Timeserver addresses
+       5      Name Server	N	   N/4 IEN-116 Server addresses
+       6      Domain Server	N	   N/4 DNS Server addresses
+       7      Log Server	N	   N/4 Logging Server addresses
+       8      Quotes Server	N	   N/4 Quotes Server addresses
+       9      LPR Server	N	   N/4 Printer Server addresses
+      10      Impress Server	N	   N/4 Impress Server addresses
+      11      RLP Server	N	   N/4 RLP Server addresses
+      12      Hostname		N	   Hostname string
+      13      Boot File	Size	2	   Size	of boot	file in	512 byte
+					   checks
+      14      Merit Dump File		   Client to dump and name
+					   the file to dump it to
+      15-127  Unassigned
+      128-154 Reserved
+      255     End		0	   None
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 35]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+		       NETWORK MANAGEMENT PARAMETERS
+
+   For the management of hosts and gateways on the Internet a data
+   structure for the information has been defined.  This data structure
+   should be used with any of several possible management protocols, such
+   as the "Simple Network Management Protocol" (SNMP) RFC-1157 [15], or
+   the "Common Management Information Protocol over TCP" (CMOT)	[142].
+
+   The data structure is the "Structure	and Indentification of Management
+   Information for TCP/IP-based	Internets" (SMI) RFC-1155 [120], and the
+   "Management Information Base	for Network Management of TCP/IP-based
+   Internets" (MIB-II) [121].
+
+   The SMI includes the	provision for panrameters or codes to indicate
+   experimental	or private data	structures.  These parameter assignments
+   are listed here.
+
+   The older "Simple Gateway Monitoring	Protocol" (SGMP) RFC-1028 [37]
+   also	defined	a data structure.  The parameter assignments used with
+   SGMP	are included here for hist orical completeness.
+
+   The network management object identifiers are under the iso (1), org
+   (3),	dod (6), internet (1), or 1.3.6.1, branch of the name space.
+
+   SMI Network Management Directory Codes:
+
+      Prefix: 1.3.6.1.1.
+
+      Decimal	Name	      Description		      References
+      -------	----	      -----------		      ----------
+	  all	Reserved      Reserved for future use		  [IANA]
+
+   SMI Network Management MGMT Codes:
+
+      Prefix: 1.3.6.1.2.
+
+      Decimal	Name	      Description		      References
+      -------	----	      -----------		      ----------
+	    0	Reserved					  [IANA]
+	    1	MIB					       [149,KZM]
+
+      Prefix: 1.3.6.1.2.1. (mib-2)
+
+      Decimal	Name	      Description		      References
+      -------	----	      -----------		      ----------
+	    0	Reserved      Reserved				  [IANA]
+	    1	system	      System			       [150,KZM]
+	    2	interfaces    Interfaces		       [150,KZM]
+
+
+
+Reynolds & Postel				               [Page 36]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+	    3	at	      Address Translation	       [150,KZM]
+	    4	ip	      Internet Protocol		       [150,KZM]
+	    5	icmp	      Internet Control Message	       [150,KZM]
+	    6	tcp	      Transmission Control Protocol    [150,KZM]
+	    7	udp	      User Datagram Protocol	       [150,KZM]
+	    8	egp	      Exterior Gateway Protocol	       [150,KZM]
+	    9	cmot	      CMIP over	TCP		       [150,KZM]
+	   10	transmission  Transmission		       [150,KZM]
+	   11	snmp	      Simple Network Management	       [150,KZM]
+	   12	GenericIF     Generic Interface	Extensions [151,163,KZM]
+	   13	Appletalk     Appletalk	Networking	       [152,SXW]
+	   14	ospf	      Open Shortest Path First	      [153,FB77]
+	   15	bgp	      Border Gateway Protocol	     [154,SW159]
+	   16	rmon	      Remote Network Monitoring	       [155,SXW]
+	   17	bridge	      Bridge Objects		       [156,EXD]
+	   18	DecnetP4      Decnet Phase 4
+	   19	Character     Character	Streams		     [165,BS221]
+	   20	snmpParties   SNMP Parties		       [177,KZM]
+	   21	snmpSecrets   SNMP Secrets		       [177,KZM]
+
+      Prefix: 1.3.6.1.2.1.10  (transmission)
+
+      Decimal	Name	      Description
+      -------	----	      -----------
+	    7	IEEE802.3     CSMACD--like Objects	       [157,JXC]
+	    8	IEEE802.4     Token Bus-like Objects	   [158,163,KZM]
+	    9	IEEE802.5     Token Ring-like Objects	   [159,163,KZM]
+	   15	FDDI	      FDDI Objects		     [160,JDC20]
+	   18	DS1	      T1 Carrier Objects	  [161,163,FB77]
+	   30	DS3	      DS3 Interface Objects	   [162,163,TXC]
+	   31	SIP	      SMDS Interface Objects	       [164,TXC]
+	   32	FRAME-RELAY   Frame Relay Objects	       [168,CXB]
+	   33	RS-232	      RS-232 Objects		     [166,BS221]
+	   34	Parallel      Parallel Printer Objects	     [167,BS221]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 37]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   SMI Network Management Experimental Codes:
+
+      Prefix: 1.3.6.1.3.
+
+      Decimal	Name	      Description		      References
+      -------	----	      -----------		      ----------
+	    0	Reserved					  [JKR1]
+	    1	CLNS	      ISO CLNS Objects			   [GS2]
+	*   2	T1-Carrier    T1 Carrier Objects		  [FB77]
+	*   3	IEEE802.3     Ethernet-like Objects		   [JXC]
+	*   4	IEEE802.5     Token Ring-like Objects		   [EXD]
+	*   5	DECNet-PHIV   DECNet Phase IV			  [JXS2]
+	*   6	Interface     Generic Interface	Objects		   [KZM]
+	*   7	IEEE802.4     Token Bus-like Objects		   [KZM]
+	*   8	FDDI	      FDDI Objects			 [JDC20]
+	    9	LANMGR-1      LAN Manager V1 Objects		  [JXG1]
+	   10	LANMGR-TRAPS  LAN Manager Trap Objects		  [JXG1]
+	   11	Views	      SNMP View	Objects			   [CXD]
+	   12	SNMP-AUTH     SNMP Authentication Objects	   [KZM]
+	*  13	BGP	      Border Gateway Protocol		 [SW159]
+	*  14	Bridge	      Bridge MIB			  [FB77]
+	*  15	DS3	      DS3 Interface Type		   [TXC]
+	*  16	SIP	      SMDS Interface Protocol		   [TXC]
+	*  17	Appletalk     Appletalk	Networking		   [SXW]
+	   18	PPP	      PPP Objects			  [FJK2]
+	*  19	Character MIB Character	MIB			 [BS221]
+	*  20	RS-232 MIB    RS-232 MIB			 [BS221]
+	*  21	Parallel MIB  Parallel MIB			 [BS221]
+	   22	atsign-proxy  Proxy via	Community		   [RXF]
+	*  23	OSPF	      OSPF MIB				  [FB77]
+	   24	Alert-Man     Alert-Man				   [LS8]
+	   25	FDDI-Synoptics FDDI-Synoptics			  [DXP1]
+	*  26	Frame Relay   Frame Relay MIB			   [CXB]
+	*  27	rmon	      Remote Network Management	MIB	   [SXW]
+	   28	IDPR	      IDPR MIB				 [RAW44]
+	   29	HUBMIB	      IEEE 802.3 Hub MIB		  [DXM5]
+	   30	IPFWDTBLMIB   IP Forwarding Table MIB		  [FB77]
+	   31	LATM MIB					   [TXC]
+	   32	SONET MIB					   [TXC]
+	   33	IDENT						   [MTR]
+	   34	MIME-MHS					   [MTR]
+
+	* = obsoleted
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 38]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   SMI Network Management Private Enterprise Codes:
+
+      Prefix: 1.3.6.1.4.1.
+
+      Decimal	Name					      References
+      -------	----					      ----------
+	    0	Reserved					  [JKR1]
+	    1	Proteon						  [JS28]
+	    2	IBM						   [VXC]
+	    3	CMU						   [SXW]
+	    4	Unix						   [KXS]
+	    5	ACC						  [AB20]
+	    6	TWG						   [KZM]
+	    7	CAYMAN						  [BP52]
+	    8	PSI						   [MS9]
+	    9	cisco						   [GXS]
+	   10	NSC						 [GS123]
+	   11	HP						  [RDXS]
+	   12	Epilogue					   [KA4]
+	   13	U of Tennessee					 [JDC20]
+	   14	BBN						   [RH6]
+	   15	Xylogics, Inc.					  [JRL3]
+	   16	Timeplex					  [LXB1]
+	   17	Canstar						   [SXP]
+	   18	Wellfleet					  [JCB1]
+	   19	TRW						   [HXL]
+	   20	MIT						  [JR35]
+	   21	EON						   [MXW]
+	   22	Spartacus					   [YXK]
+	   23	Excelan						   [RXB]
+	   24	Spider Systems					   [VXW]
+	   25	NSFNET						   [HWB]
+	   26	Hughes LAN Systems				   [KZM]
+	   27	Intergraph					  [GS91]
+	   28	Interlan					   [BXT]
+	   29	Vitalink Communications				   [FXB]
+	   30	Ulana						   [BXA]
+	   31	NSWC						  [SRN1]
+	   32	Santa Cruz Operation				  [KR35]
+	   33	Xyplex						   [BXS]
+	   34	Cray						   [HXE]
+	   35	Bell Northern Research				   [GXW]
+	   36	DEC						  [RXB1]
+	   37	Touch						   [BXB]
+	   38	Network	Research Corp.				   [BXV]
+	   39	Baylor College of Medicine			  [SB98]
+	   40	NMFECC-LLNL					   [SXH]
+	   41	SRI						 [DW181]
+
+
+
+Reynolds & Postel				               [Page 39]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+	   42	Sun Microsystems				   [DXY]
+	   43	3Com						   [TB6]
+	   44	CMC						   [DXP]
+	   45	SynOptics					  [DXP1]
+	   46	Cheyenne Software				   [RXH]
+	   47	Prime Computer					   [MXS]
+	   48	MCNC/North Carolina Data Network		   [KXW]
+	   49	Chipcom						   [JXC]
+	   50	Optical	Data Systems				   [JXF]
+	   51	gated						   [JXH]
+	   52	Cabletron Systems				   [RXD]
+	   53	Apollo Computers				   [JXB]
+	   54	DeskTalk Systems, Inc.				   [DXK]
+	   55	SSDS						   [RXS]
+	   56	Castle Rock Computing				  [JXS1]
+	   57	MIPS Computer Systems				   [CXM]
+	   58	TGV, Inc.					   [KAA]
+	   59	Silicon	Graphics, Inc.				   [RXJ]
+	   60	University of British Columbia			[DXM354]
+	   61	Merit						   [BXN]
+	   62	FiberCom					   [EXR]
+	   63	Apple Computer Inc				  [JXH1]
+	   64	Gandalf						   [HXK]
+	   65	Dartmouth					   [PXK]
+	   66	David Systems					  [KXD1]
+	   67	Reuter						   [BXZ]
+	   68	Cornell						 [DC126]
+	   69	LMS						 [MLS34]
+	   70	Locus Computing	Corp.				   [AXS]
+	   71	NASA						  [SS92]
+	   72	Retix						   [AXM]
+	   73	Boeing						   [JXG]
+	   74	AT&T						  [RXB2]
+	   75	Ungermann-Bass					   [DXM]
+	   76	Digital	Analysis Corp.				   [SXK]
+	   77	LAN Manager					   [DXK]
+	   78	Netlabs						 [JB478]
+	   79	ICL						   [JXI]
+	   80	Auspex Systems					   [BXE]
+	   81	Lannet Company					   [EXR]
+	   82	Network	Computing Devices			 [DM280]
+	   83	Raycom Systems					  [BXW1]
+	   84	Pirelli	Focom Ltd.				   [SXL]
+	   85	Datability Software Systems			   [LXF]
+	   86	Network	Application Technology			   [YXW]
+	   87	LINK (Lokales Informatik-Netz Karlsruhe)	   [GXS]
+	   88	NYU						  [BJR2]
+	   89	RND						   [RXN]
+
+
+
+Reynolds & Postel				               [Page 40]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+	   90	InterCon Systems Corporation			  [AW90]
+	   91	LearningTree Systems				  [JXG2]
+	   92	Webster	Computer Corporation			   [RXE]
+	   93	Frontier Technologies Corporation		   [PXA]
+	   94	Nokia Data Communications			   [DXE]
+	   95	Allen-Bradely Company				   [BXK]
+	   96	CERN						   [JXR]
+	   97	Sigma Network Systems, Inc.			   [KXV]
+	   98	Emerging Technologies, Inc.			  [DXB2]
+	   99	SNMP Research					 [JDC20]
+	  100	Ohio State University				  [SXA1]
+	  101	Ultra Network Technologies			   [JXD]
+	  102	Microcom					   [AXF]
+	  103	Martin Marietta	Astronautic Group		 [DR137]
+	  104	Micro Technology				   [MXE]
+	  105	Process	Software Corporation			  [BV15]
+	  106	Data General Corporation			   [JXK]
+	  107	Bull Company					   [AXB]
+	  108	Emulex Corporation				  [JXF1]
+	  109	Warwick	University Computing Services		   [IXD]
+	  110	Network	General	Corporation			  [JXD1]
+	  111	Oracle						 [JPH17]
+	  112	Control	Data Corporation			   [NXR]
+	  113	Hughes Aircraft	Company				   [KZM]
+	  114	Synernetics, Inc.				  [JXP1]
+	  115	Mitre						  [BM60]
+	  116	Hitachi, Ltd.					   [HXU]
+	  117	Telebit						  [MXL2]
+	  118	Salomon	Technology Services			   [PXM]
+	  119	NEC Corporation					   [YXA]
+	  120	Fibermux					 [KH157]
+	  121	FTP Software Inc.				  [SXK1]
+	  122	Sony						   [TXH]
+	  123	Newbridge Networks Corporation			   [JXW]
+	  124	Racal-Milgo Information	Systems			   [MXR]
+	  125	CR SYSTEMS					  [SXS2]
+	  126	DSET Corporation				   [DXS]
+	  127	Computone					   [BXV]
+	  128	Tektronix, Inc.					 [DT167]
+	  129	Interactive Systems Corporation			  [SXA2]
+	  130	Banyan Systems Inc.				   [DXT]
+	  131	Sintrom	Datanet	Limited				   [SXW]
+	  132	Bell Canada					   [MXF]
+	  133	Crosscomm Corporation				  [RXS1]
+	  134	Rice University					   [CXF]
+	  135	T3Plus Networking, Inc.				   [HXF]
+	  136	Concurrent Computer Corporation			  [JRL3]
+	  137	Basser						   [PXO]
+
+
+
+Reynolds & Postel				               [Page 41]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+	  138	Luxcom						   [RXB]
+	  139	Artel						   [JXZ]
+	  140	Independence Technologies, Inc.	(ITI)		   [GXB]
+	  141	Frontier Software Development			   [NXP]
+	  142	Digital	Computer Limited			   [OXF]
+	  143	Eyring,	Inc.					 [RH227]
+	  144	Case Communications				   [PXK]
+	  145	Penril DataComm, Inc.				  [KXH1]
+	  146	American Airlines				  [BXK1]
+	  147	Sequent	Computer Systems			  [SXH1]
+	  148	Bellcore					   [KXT]
+	  149	Konkord	Communications				   [KXJ]
+	  150	University of Washington			   [CXW]
+	  151	Develcon					   [SXM]
+	  152	Solarix	Systems					  [PXA1]
+	  153	Unifi Communications Corp.			   [YXH]
+	  154	Roadnet						   [DXS]
+	  155	Network	Systems	Corp.				   [NXE]
+	  156	ENE (European Network Engineering)		   [PXC]
+	  157	Dansk Data Elektronik A/S			   [PXH]
+	  158	Morning	Star Technologies			   [KXF]
+	  159	Dupont EOP					   [OXR]
+	  160	Legato Systems,	Inc.				  [JXK1]
+	  161	Motorola SPS					   [VXE]
+	  162	European Space Agency (ESA)			   [EXX]
+	  163	BIM						  [BXL2]
+	  164	Rad Data Communications	Ltd.			   [OXI]
+	  165	Intellicom					   [PXS]
+	  166	Shiva Corporation				   [NXL]
+	  167	Fujikura America				   [DXR]
+	  168	Xlnt Designs INC (XDI)				 [MA108]
+	  169	Tandem Computers				  [RXD3]
+	  170	BICC						  [DXB3]
+	  171	D-Link Systems,	Inc.				   [HXN]
+	  172	AMP, Inc.					  [RXD4]
+	  173	Netlink						   [MXZ]
+	  174	C. Itoh	Electronics				  [LXD1]
+	  175	Sumitomo Electric Industries (SEI)		  [KXT1]
+	  176	DHL Systems, Inc.				  [DXG2]
+	  177	Network	Equipment Technologies			  [MXT1]
+	  178	APTEC Computer Systems				   [LXB]
+	  179	Schneider & Koch & Co.,	Datensysteme GmbH	  [TXR1]
+	  180	Hill Air Force Base				   [RXW]
+	  181	ADC Kentrox					  [BXK2]
+	  182	Japan Radio Co.					   [NXK]
+	  183	Versitron					   [MXH]
+	  184	Telecommunication Systems			  [HXL1]
+	  185	Interphase					  [GXW1]
+
+
+
+Reynolds & Postel				               [Page 42]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+	  186	Toshiba	Corporation				   [MXA]
+	  187	Clearpoint Research Corp.			  [FJK2]
+	  188	Ascom Gfeller Ltd.				  [AXS1]
+	  189	Fujitsu	America					   [CXL]
+	  190	NetCom Solutions, Inc.				   [DXC]
+	  191	NCR						   [CXK]
+	  192	Dr. Materna GmbH				   [TXB]
+	  193	Ericsson Business Communications		   [GXN]
+	  194	Metaphor Computer Systems			   [PXR]
+	  195	Patriot	Partners				   [PXR]
+	  196	The Software Group Limited (TSG)		 [RP211]
+	  197	Kalpana, Inc.					  [AXB3]
+	  198	University of Waterloo				  [RXW1]
+	  199	CCL/ITRI					   [MXC]
+	  200	Coeur Postel					  [PXK2]
+	  201	Mitsubish Cable	Industries, Ltd.		  [MXH1]
+	  202	SMC						   [LXS]
+	  203	Crescendo Communication, Inc.			   [PXJ]
+	  204	Goodall	Software Engineering			 [DG223]
+	  205	Intecom						   [BXP]
+	  206	Victoria University of Wellington		  [JXS3]
+	  207	Allied Telesis,	Inc.				  [SXH2]
+	  208	Dowty Network Systems A/S			  [HXE1]
+	  209	Protools					   [GXA]
+	  210	Nippon Telegraph and Telephone Corp.		  [TXS1]
+	  211	Fujitsu	Limited					   [IXH]
+	  212	Network	Peripherals Inc.			   [CXC]
+	  213	Netronix, Inc.					  [JXR3]
+	  214	University of Wisconsin	- Madison		 [DW328]
+	  215	NetWorth, Inc.					   [CXS]
+	  216	Tandberg Data A/S				   [HXH]
+	  217	Technically Elite Concepts, Inc.		  [RXD5]
+	  218	Labtam Australia Pty. Ltd.			  [MXP1]
+	  219	Republic Telcom	Systems, Inc.			  [SXH3]
+	  220	ADI Systems, Inc.				   [PXL]
+	  221	Microwave Bypass Systems, Inc.			   [TXA]
+	  222	Pyramid	Technology Corp.			   [RXR]
+	  223	Unisys_Corp					  [LXB2]
+	  224	LANOPTICS LTD. Israel				  [IXD1]
+	  225	NKK Corporation					   [JXY]
+	  226	MTrade UK Ltd.					   [PXD]
+	  227	Acals						  [PXC1]
+	  228	ASTEC, Inc.					  [HXF1]
+	  229	Delmarva Power					  [JXS4]
+	  230	Telematics International, Inc.			  [KXS1]
+	  231	Siemens	Nixdorf	Informations Syteme AG		   [GXK]
+	  232	Compaq						   [SXB]
+	  233	NetManage, Inc.					   [WXD]
+
+
+
+Reynolds & Postel				               [Page 43]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+	  234	NCSU Computing Center				   [DXJ]
+	  235	Empirical Tools	and Technologies		   [KA4]
+	  236	Samsung	Group					   [HXP]
+	  237	Takaoka	Electric Mfg. Co., Ltd.			  [HXH2]
+	  238	Netrix Systems Corporation			   [EXM]
+	  239	WINDATA						   [BXR]
+	  240	RC International A/S				  [CXD1]
+	  241	Netexp Research					   [HXB]
+	  242	Internode Systems Pty Ltd			  [SXH4]
+	  243	netCS Informationstechnik GmbH			   [OXK]
+	  244	Lantronix					   [RXL]
+	  245	Avatar Consultants				 [KH157]
+	  246	Furukawa Electoric Co. Ltd.			   [SXF]
+	  247	AEG Electrcom					  [RXN2]
+	  248	Richard	Hirschmann GmbH	& Co.			  [HXN1]
+	  249	G2R Inc.					   [KXH]
+	  250	University of Michigan				  [TXH1]
+	  251	Netcomm, Ltd.					  [WXS2]
+	  252	Sable Technology Corporation			   [RXT]
+	  253	Xerox						  [EXR3]
+	  254	Conware	Computer Consulting GmbH		  [MXS2]
+	  255	Compatible Systems Corp.			 [JG423]
+	  256	Scitec Communications Systems Ltd.		  [SXL1]
+	  257	Transarc Corporation				   [PXB]
+	  258	Matsushita Electric Industrial Co., Ltd.	   [NXM]
+	  259	ACCTON Technology				  [DXR1]
+	  260	Star-Tek, Inc.					  [CXM1]
+	  261	Codenoll Tech. Corp.				   [DXW]
+	  262	Formation, Inc.					  [CXM2]
+	  263	Seiko Instruments, Inc.	(SII)			  [YXW1]
+	  264	RCE (Reseaux de	Communication d'Entreprise S.A.)   [EXB]
+	  265	Xenocom, Inc.					  [SXW2]
+	  266	AEG KABEL					  [HXT1]
+	  267	Systech	Computer Corporation			  [BXP1]
+	  268	Visual						   [BXO]
+	  269	SDD (Scandinavian Airlines Data	Denmark	A/S)	   [PXF]
+	  270	Zenith Electronics Corporation			   [DXL]
+	  271	TELECOM	FINLAND					  [PXJ1]
+	  272	BinTec Computersystems				  [MXS3]
+	  273	EUnet Germany					  [MXS4]
+	  274	PictureTel Corporation				   [OXJ]
+	  275	Michigan State University			   [LXW]
+	  276	GTE Telecom Incorporated			   [LXO]
+	  277	Cascade	Communications Corp.			   [CS1]
+	  278	Hitachi	Cable, Ltd.				  [TXA1]
+	  279	Olivetti					  [MXF1]
+	  280	Vitacom	Corporation				  [PXR1]
+	  281	INMOS						   [GXH]
+
+
+
+Reynolds & Postel				               [Page 44]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+	  282	AIC Systems Laboratories Ltd.			  [GXM1]
+	  283	Cameo Communications, Inc.			  [AXB4]
+	  284	Diab Data AB					  [MXL1]
+	  285	Olicom A/S					   [LXP]
+	  286	Digital-Kienzle	Computersystems			   [HXD]
+	  287	CSELT(Centro Studi E Laboratori	Telecomunicazioni)[PXC2]
+	  288	Electronic Data	Systems				  [MXH2]
+	  289	McData Corporation				   [GXL]
+	  290	Harris Computer	Systems	Division (HCSD)		  [DXR2]
+	  291	Technology Dynamics, Inc.			  [CXS1]
+	  292	DATAHOUSE Information Systems Ltd.		   [KXL]
+	  293	DSIR Network Group				   [TXP]
+	  294	Texas Instruments				  [BXS1]
+	  295	PlainTree Systems Inc.				  [PXC3]
+	  296	Hedemann Software Development			  [SXH5]
+	  297	Fuji Xerox Co.,	Ltd.				  [HXK1]
+	  298	Asante Technology				   [HXM]
+	  299	Stanford University				   [BXM]
+	  300	Digital	Link					  [JXT1]
+	  301	Raylan Corporation				  [MXL2]
+	  302	Datacraft					   [AXL]
+	  303	Hughes						   [KZM]
+	  304	Farallon Computing, Inc.			  [SXS3]
+	  305	GE Information Services				  [SXB2]
+	  306	Gambit Computer	Communications			   [ZXS]
+	  307	Livingston Enterprises,	Inc.			  [SXW3]
+	  308	Star Technologies				  [JXM1]
+	  309	Micronics Computers Inc.			  [DXC1]
+	  310	Basis, Inc.					   [HXS]
+	  311	Microsoft					  [JXB1]
+	  312	US West	Advance	Technologies			   [DXH]
+	  313	University College London			   [SXC]
+	  314	Eastman	Kodak Company				  [WXC1]
+	  315	Network	Resources Corporation			  [KXW1]
+	  316	Atlas Telecom					  [BXK2]
+	  317	Bridgeway					   [UXV]
+	  318	American Power Conversion Corp.			   [PXY]
+	  319	DOE Atmospheric	Radiation Measurement Project	  [PXK3]
+	  320	VerSteeg CodeWorks				   [BXV]
+	  321	Verilink Corp					   [BXV]
+	  322	Sybus Corportation				  [MXB2]
+	  323	Tekelec						   [BXG]
+	  324	NASA Ames Research Center			   [NXC]
+	  325	Simon Fraser University				   [RXU]
+	  326	Fore Systems, Inc.				  [EXC1]
+	  327	Centrum	Communications,	Inc.			   [VXL]
+	  328	NeXT Computer, Inc.				   [LXL]
+	  329	Netcore, Inc.					  [SXM1]
+
+
+
+Reynolds & Postel				               [Page 45]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+	  330	Northwest Digital Systems			   [BXD]
+	  331	Andrew Corporation				   [TXT]
+	  332	DigiBoard					  [DXK2]
+	  333	Computer Network Technology Corp.		  [BXM1]
+	  334	Lotus Development Corp.				  [BXF1]
+	  335	MICOM Communication Corporation			  [DXB4]
+	  336	ASCII Corporation				   [TXO]
+	  337	PUREDATA Research/USA				  [BXF2]
+	  338	NTT DATA					  [YXK1]
+	  339	Empros Systems International			  [DXT1]
+	  340	Kendall	Square Research	(KSR)			  [DXH1]
+	  341	Martin Marietta	Energy Systems			  [GXH1]
+	  342	Network	Innovations				   [PXG]
+	  343	Intel Corporation				  [CXT1]
+	  344	Proxar						   [CXH]
+	  345	Epson Research Center				  [RXS2]
+	  346	Fibernet					  [GXS1]
+	  347	Box Hill Systems Corporation			   [TXJ]
+	  348	American Express Travel	Related	Services	  [JXC1]
+	  349	Compu-Shack					   [TXV]
+	  350	Parallan Computer, Inc.				  [CXD2]
+	  351	Stratacom					   [CXI]
+	  352	Open Networks Engineering, Inc.			  [RXB4]
+	  353	ATM Forum					   [KZM]
+	  354	SSD Management,	Inc.				  [BXR1]
+	  355	Automated Network Management, Inc.		   [CXV]
+	  356	Magnalink Communications Corporation		  [DXK3]
+	  357	TIL Systems, Ltd.				  [GXM2]
+	  358	Skyline	Technology, Inc.			  [DXW1]
+	  359	Nu-Mega	Technologies, Inc.			  [DXS4]
+	  360	Morgan Stanley & Co. Inc.			   [VXK]
+	  361	Integrated Business Network			  [MXB3]
+	  362	L & N Technologies, Ltd.			  [SXL2]
+	  363	Cincinnati Bell	Information Systems, Inc.	  [DXM4]
+	  364	OSCOM International				   [FXF]
+	  365	MICROGNOSIS					  [PXA2]
+	  366	Datapoint Corporation				  [LZ15]
+	  367	RICOH Co. Ltd.					   [TXW]
+	  368	Axis Communications AB				 [MG277]
+	  369	Pacer Software					   [WXT]
+	  370	Axon Networks Inc.				   [RXI]
+	  371	Brixton	Systems, Inc.				   [PXE]
+	  372	GSI						  [PXB1]
+	  373	Tatung Co., Ltd.				  [CXC1]
+	  374	DIS Research LTD				  [RXC2]
+	  375	Quotron	Systems, Inc.				  [RXS3]
+	  376	Dassault Electronique				   [OXC]
+	  377	Corollary, Inc.					  [JXG3]
+
+
+
+Reynolds & Postel				               [Page 46]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+	  378	SEEL, Ltd.					   [KXR]
+	  379	Lexcel						   [MXE]
+	  380	W.J. Parducci &	Associates, Inc.		   [WXP]
+	  381	OST						  [AXP1]
+	  382	Megadata Pty Ltd.				  [AXM2]
+	  383	LLNL Livermore Computer	Center			   [DXN]
+	  384	Dynatech Communications				  [GXW2]
+	  385	Symplex	Communications Corp.			   [CXA]
+	  386	Tribe Computer Works				  [KXF1]
+	  387	Taligent, Inc.					   [LXA]
+	  388	Symbol Technology, Inc.				  [JXC2]
+	  389	Lancert						  [MXH3]
+	  390	Alantec						   [PXV]
+	  391	Ridgeback Solutions				   [EXG]
+	  392	Metrix,	Inc.					   [DXV]
+	  393	Excutive Systems/XTree Company			  [DXC2]
+	  394	NRL Communication Systems Branch		  [RXR1]
+	  395	I.D.E. Corporation				  [RXS4]
+	  396	Matsushita Electric Works, Ltd.			  [CXH1]
+	  397	MegaPAC						   [IXG]
+	  398	Pilkington Communication Systems		   [DXA]
+	  440	Amnet, Inc.					   [RM1]
+	  441	Chase Research					   [KXG]
+	  442	PEER Networks					 [TS566]
+	  443	Gateway	Communications,	Inc.			   [EXF]
+	  444	Peregrine Systems				   [EXO]
+	  445	Daewoo Telecom					   [SXO]
+	  446	Norwegian Telecom Research			  [PXY1]
+	  447	WilTel						   [AXP]
+	  448	Ericsson-Camtec					  [SXP1]
+	  449	Codex						  [TXM1]
+	  450	Basis						   [HXS]
+	  451	AGE Logic					  [SXL3]
+	  452	INDE Electronics				  [GXD1]
+	  453	ISODE Consortium				 [SH284]
+	  454	J.I. Case					  [MXO1]
+	  455	Trillium Digital Systems			  [CXC2]
+	  456	Bacchus	Inc.					   [EXG]
+	  457	MCC						  [DR48]
+	  458	Stratus	Computer				   [KXC]
+	  459	Quotron						  [RXS3]
+	  460	Beame &	Whiteside				  [CXB1]
+	  461	Cellular Technical Servuces			  [GXH2]
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 47]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   SGMP	Vendor Specific	Codes: [obsolete]
+
+      Prefix: 1,255,
+
+      Decimal	Name					      References
+      -------	----					      ----------
+	    0	Reserved					  [JKR1]
+	    1	Proteon						  [JS18]
+	    2	IBM						   [JXR]
+	    3	CMU						   [SXW]
+	    4	Unix						   [MS9]
+	    5	ACC						  [AB20]
+	    6	TWG						   [MTR]
+	    7	CAYMAN						  [BP52]
+	    8	NYSERNET					   [MS9]
+	    9	cisco						   [GS2]
+	   10	BBN						   [RH6]
+	   11	Unassigned					  [JKR1]
+	   12	MIT						  [JR35]
+       13-254	Unassigned					  [JKR1]
+	  255	Reserved					  [JKR1]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 48]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+			   MILNET LOGICAL ADDRESSES
+
+   The MILNET facility for "logical addressing"	is described in	RFC-878
+   [57]	and RFC-1005 [109].  A portion of the possible logical addresses
+   are reserved	for standard uses.
+
+   There are 49,152 possible logical host addresses.  Of these,	256 are
+   reserved for	assignment to well-known functions.  Assignments for
+   well-known functions	are made by the	IANA.  Assignments for other
+   logical host	addresses are made by the NIC.
+
+   Logical Address Assignments:
+
+      Decimal	 Description				      References
+      -------	 -----------				      ----------
+      0		 Reserved					   [JBP]
+      1		 The BBN Core Gateways				    [MB]
+      2-254	 Unassigned					   [JBP]
+      255	 Reserved					   [JBP]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 49]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+			     MILNET LINK NUMBERS
+
+   The word "link" here	refers to a field in the original MILNET
+   Host/IMP interface leader.  The link	was originally defined as an 8-
+   bit field.  Later specifications defined this field as the "message-
+   id" with a length of	12 bits.  The name link	now refers to the high
+   order 8 bits	of this	12-bit message-id field.  The Host/IMP interface
+   is defined in BBN Report 1822 [2].
+
+   The low-order 4 bits	of the message-id field	are called the sub-link.
+   Unless explicitly specified otherwise for a particular protocol,
+   there is no sender to receiver significance to the sub-link.	 The
+   sender may use the sub-link in any way he chooses (it is returned in
+   the RFNM by the destination IMP), the receiver should ignore	the
+   sub-link.
+
+   Link	Assignments:
+
+      Decimal	Description				      References
+      -------	-----------				      ----------
+      0-63	BBNCC Monitoring				    [MB]
+      64-149	Unassigned					   [JBP]
+      150	Xerox NS IDP				     [133,XEROX]
+      151	Unassigned					   [JBP]
+      152	PARC Universal Protocol			       [8,XEROX]
+      153	TIP Status Reporting				   [JGH]
+      154	TIP Accounting					   [JGH]
+      155	Internet Protocol [regular]		       [105,JBP]
+      156-158	Internet Protocol [experimental]	       [105,JBP]
+      159	Figleaf	Link					  [JBW1]
+      160	Blacker	Local Network Protocol			  [DM28]
+      161-194	Unassigned					   [JBP]
+      195	ISO-IP						[64,RXM]
+      196-247	Experimental Protocols				   [JBP]
+      248-255	Network	Maintenance				   [JGH]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 50]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+			 MILNET	X.25 ADDRESS MAPPINGS
+
+   All MILNET hosts are	assigned addresses by the Defense Data Network
+   (DDN).  The address of a MILNET host	may be obtained	from the Network
+   Information Center (NIC), represented as an ASCII text string in what
+   is called "host table format".  This	section	describes the process by
+   which MILNET	X.25 addresses may be derived from addresses in	the NIC
+   host	table format.
+
+   A NIC host table address consists of	the ASCII text string
+   representations of four decimal numbers separated by	periods,
+   corresponding to the	four octeted of	a thirty-two bit Internet
+   address.  The four decimal numbers are referred to in this section as
+   "n",	"h' "l", and "i".  Thus, a host	table address may be represented
+   as: "n.h.l.i".  Each	of these four numbers will have	either one, two,
+   or three decimal digits and will never have a value greater than 255.
+   For example,	in the host table, address: "10.2.0.124", n=10,	h=2,
+   l=0,	and i=124.  To convert a host table address to a MILNET	X.25
+   address:
+
+      1.  If h < 64, the host table address corresponds	to the X.25
+      physical address:
+
+			     ZZZZ F IIIHHZZ (SS)
+
+      where:
+
+	   ZZZZ	= 0000	  as required
+
+	   F = 0	  because the address is a physical address;
+
+	   III		  is a three decimal digit respresentation of
+			  "i", right-adjusted and padded with leading
+			  zeros	if required;
+
+	   HH		  is a two decimal digit representation	of "h",
+			  right-adjusted and padded with leading zeros
+			  if required;
+
+	   ZZ =	00	  and
+
+	   (SS)		  is optional
+
+      In the example given above, the host table address 10.2.0.124
+      corresponds to the X.25 physical address 000001240200.
+
+
+
+
+
+
+Reynolds & Postel				               [Page 51]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   2.  If h > 64 or h =	64, the	host table address corresponds to the
+   X.25	logical	address
+
+			    ZZZZ F RRRRRZZ (SS)
+
+   where:
+
+	ZZZZ = 0000    as required
+
+	F = 1	       because the address is a	logical	address;
+
+	RRRRR	       is a five decimal digit representation of
+		       the result "r" of the calculation
+
+				r = h *	256 + i
+
+		       (Note that the decimal representation of
+		       "r" will	always require five digits);
+
+	ZZ = 00	       and
+
+	(SS)	       is optional
+
+      Thus, the	host table address 10.83.0.207 corresponds to the X.25
+      logical address 000012145500.
+
+   In both cases, the "n" and "l" fields of the	host table address are
+   not used.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 52]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+		       IEEE 802	NUMBERS	OF INTEREST
+
+   Some	of the networks	of all classes are IEEE	802 Networks.  These
+   systems may use a Link Service Access Point (LSAP) field in much the
+   same	way the	MILNET uses the	"link" field.  Further,	there is an
+   extension of	the LSAP header	called the Sub-Network Access Protocol
+   (SNAP).
+
+   The IEEE likes to describe numbers in binary	in bit transmission
+   order, which	is the opposite	of the big-endian order	used throughout
+   the Internet	protocol documentation.
+
+   Assignments:
+
+      Link Service Access Point	  Description		     References
+      -------------------------	  -----------		     ----------
+      IEEE     Internet
+      binary   binary	 decimal
+      00000000 00000000	       0   Null	LSAP			  [IEEE]
+      01000000 00000010	       2   Indiv LLC Sublayer Mgt	  [IEEE]
+      11000000 00000011	       3   Group LLC Sublayer Mgt	  [IEEE]
+      00100000 00000100	       4   SNA Path Control		  [IEEE]
+      01100000 00000110	       6   Reserved (DOD IP)	       [104,JBP]
+      01110000 00001110	      14   PROWAY-LAN			  [IEEE]
+      01110010 01001110	      78   EIA-RS 511			  [IEEE]
+      01111010 01011110	      94   ISI IP			   [JBP]
+      01110001 10001110	     142   PROWAY-LAN			  [IEEE]
+      01010101 10101010	     170   SNAP				  [IEEE]
+      01111111 11111110	     254   ISO CLNS IS 8473		[64,JXJ]
+      11111111 11111111	     255   Global DSAP			  [IEEE]
+
+   These numbers (and others) are assigned by the IEEE Standards Office.
+   The address is: IEEE	Standards Office, 345 East 47th	Street,	New
+   York, N.Y. 10017, Attn: Vince Condello.  Phone: (212) 705-7092.
+
+   At an ad hoc	special	session	on "IEEE 802 Networks and ARP",	held
+   during the TCP Vendors Workshop (August 1986), an approach to a
+   consistent way to send DoD-IP datagrams and other IP	related
+   protocols (such as the Address Resolution Protocol (ARP)) on	802
+   networks was	developed, using the SNAP extension (see RFC-1042 [90]).
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 53]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+		       ETHERNET	NUMBERS	OF INTEREST
+
+   Many	of the networks	of all classes are Ethernets (10Mb) or
+   Experimental	Ethernets (3Mb).  These	systems	use a message "type"
+   field in much the same way the ARPANET uses the "link" field.
+
+   If you need an Ethernet type, contact the Xerox Corporation,	Xerox
+   Systems Institute, 475 Oakmead Parkway, Sunnyvale, CA 94086,	Attn:
+   Ms. Fonda Pallone, (415) 813-7164.
+
+   The following list is contributed unverified	information from various
+   sources.
+
+   Assignments:
+
+      Ethernet		Exp. Ethernet	 Description	      References
+      -------------	-------------	-----------	      ----------
+      decimal  Hex	decimal	 octal
+	 000   0000-05DC   -	   -	IEEE802.3 Length Field	 [XEROX]
+	 257   0101-01FF   -	   -	Experimental		 [XEROX]
+	 512   0200	   512	 1000	XEROX PUP (see 0A00)   [8,XEROX]
+	 513   0201	   -	  -	PUP Addr Trans (see 0A01)[XEROX]
+	1536   0600	  1536	 3000	XEROX NS IDP	     [133,XEROX]
+	2048   0800	   513	 1001	DOD IP		       [105,JBP]
+	2049   0801	   -	  -	X.75 Internet		 [XEROX]
+	2050   0802	   -	  -	NBS Internet		 [XEROX]
+	2051   0803	   -	  -	ECMA Internet		 [XEROX]
+	2052   0804	   -	  -	Chaosnet		 [XEROX]
+	2053   0805	   -	  -	X.25 Level 3		 [XEROX]
+	2054   0806	   -	  -	ARP			[88,JBP]
+	2055   0807	   -	  -	XNS Compatability	 [XEROX]
+	2076   081C	   -	  -	Symbolics Private	  [DCP1]
+	2184   0888-088A   -	  -	Xyplex			 [XEROX]
+	2304   0900	   -	  -	Ungermann-Bass net debugr[XEROX]
+	2560   0A00	   -	  -	Xerox IEEE802.3	PUP	 [XEROX]
+	2561   0A01	   -	  -	PUP Addr Trans		 [XEROX]
+	2989   0BAD	   -	  -	Banyan Systems		 [XEROX]
+	4096   1000	   -	  -	Berkeley Trailer nego	 [XEROX]
+	4097   1001-100F   -	  -	Berkeley Trailer encap/IP[XEROX]
+	5632   1600	   -	  -	Valid Systems		 [XEROX]
+       16962   4242	   -	  -	PCS Basic Block	Protocol [XEROX]
+       21000   5208	   -	  -	BBN Simnet		 [XEROX]
+       24576   6000	   -	  -	DEC Unassigned (Exp.)	 [XEROX]
+       24577   6001	   -	  -	DEC MOP	Dump/Load	 [XEROX]
+       24578   6002	   -	  -	DEC MOP	Remote Console	 [XEROX]
+       24579   6003	   -	  -	DEC DECNET Phase IV Route[XEROX]
+       24580   6004	   -	  -	DEC LAT			 [XEROX]
+       24581   6005	   -	  -	DEC Diagnostic Protocol	 [XEROX]
+
+
+
+Reynolds & Postel				               [Page 54]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+       24582   6006	   -	  -	DEC Customer Protocol	 [XEROX]
+       24583   6007	   -	  -	DEC LAVC, SCA		 [XEROX]
+       24584   6008-6009   -	  -	DEC Unassigned		 [XEROX]
+       24586   6010-6014   -	  -	3Com Corporation	 [XEROX]
+       28672   7000	   -	  -	Ungermann-Bass download	 [XEROX]
+       28674   7002	   -	  -	Ungermann-Bass dia/loop	 [XEROX]
+       28704   7020-7029   -	  -	LRT			 [XEROX]
+       28720   7030	   -	  -	Proteon			 [XEROX]
+       28724   7034	   -	  -	Cabletron		 [XEROX]
+       32771   8003	   -	  -	Cronus VLN	      [131,DT15]
+       32772   8004	   -	  -	Cronus Direct	      [131,DT15]
+       32773   8005	   -	  -	HP Probe		 [XEROX]
+       32774   8006	   -	  -	Nestar			 [XEROX]
+       32776   8008	   -	  -	AT&T			 [XEROX]
+       32784   8010	   -	  -	Excelan			 [XEROX]
+       32787   8013	   -	  -	SGI diagnostics		   [AXC]
+       32788   8014	   -	  -	SGI network games	   [AXC]
+       32789   8015	   -	  -	SGI reserved		   [AXC]
+       32790   8016	   -	  -	SGI bounce server	   [AXC]
+       32793   8019	   -	  -	Apollo Computers	 [XEROX]
+       32815   802E	   -	  -	Tymshare		 [XEROX]
+       32816   802F	   -	  -	Tigan, Inc.		 [XEROX]
+       32821   8035	   -	  -	Reverse	ARP		[48,JXM]
+       32822   8036	   -	  -	Aeonic Systems		 [XEROX]
+       32824   8038	   -	  -	DEC LANBridge		 [XEROX]
+       32825   8039-803C   -	  -	DEC Unassigned		 [XEROX]
+       32829   803D	   -	  -	DEC Ethernet Encryption	 [XEROX]
+       32830   803E	   -	  -	DEC Unassigned		 [XEROX]
+       32831   803F	   -	  -	DEC LAN	Traffic	Monitor	 [XEROX]
+       32832   8040-8042   -	  -	DEC Unassigned		 [XEROX]
+       32836   8044	   -	  -	Planning Research Corp.	 [XEROX]
+       32838   8046	   -	  -	AT&T			 [XEROX]
+       32839   8047	   -	  -	AT&T			 [XEROX]
+       32841   8049	   -	  -	ExperData		 [XEROX]
+       32859   805B	   -	  -	Stanford V Kernel exp.	 [XEROX]
+       32860   805C	   -	  -	Stanford V Kernel prod.	 [XEROX]
+       32861   805D	   -	  -	Evans &	Sutherland	 [XEROX]
+       32864   8060	   -	  -	Little Machines		 [XEROX]
+       32866   8062	   -	  -	Counterpoint Computers	 [XEROX]
+       32869   8065-8066   -	  -	Univ. of Mass. @ Amherst [XEROX]
+       32871   8067	   -	  -	Veeco Integrated Auto.	 [XEROX]
+       32872   8068	   -	  -	General	Dynamics	 [XEROX]
+       32873   8069	   -	  -	AT&T			 [XEROX]
+       32874   806A	   -	  -	Autophon		 [XEROX]
+       32876   806C	   -	  -	ComDesign		 [XEROX]
+       32877   806D	   -	  -	Computgraphic Corp.	 [XEROX]
+       32878   806E-8077   -	  -	Landmark Graphics Corp.	 [XEROX]
+       32890   807A	   -	  -	Matra			 [XEROX]
+
+
+
+Reynolds & Postel				               [Page 55]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+       32891   807B	   -	  -	Dansk Data Elektronik	 [XEROX]
+       32892   807C	   -	  -	Merit Internodal	   [HWB]
+       32893   807D-807F   -	  -	Vitalink Communications	 [XEROX]
+       32896   8080	   -	  -	Vitalink TransLAN III	 [XEROX]
+       32897   8081-8083   -	  -	Counterpoint Computers	 [XEROX]
+       32923   809B	   -	  -	Appletalk		 [XEROX]
+       32924   809C-809E   -	  -	Datability		 [XEROX]
+       32927   809F	   -	  -	Spider Systems Ltd.	 [XEROX]
+       32931   80A3	   -	  -	Nixdorf	Computers	 [XEROX]
+       32932   80A4-80B3   -	  -	Siemens	Gammasonics Inc. [XEROX]
+       32960   80C0-80C3   -	  -	DCA Data Exchange Cluster[XEROX]
+       32966   80C6	   -	  -	Pacer Software		 [XEROX]
+       32967   80C7	   -	  -	Applitek Corporation	 [XEROX]
+       32968   80C8-80CC   -	  -	Intergraph Corporation	 [XEROX]
+       32973   80CD-80CE   -	  -	Harris Corporation	 [XEROX]
+       32974   80CF-80D2   -	  -	Taylor Instrument	 [XEROX]
+       32979   80D3-80D4   -	  -	Rosemount Corporation	 [XEROX]
+       32981   80D5	   -	  -	IBM SNA	Service	on Ether [XEROX]
+       32989   80DD	   -	  -	Varian Associates	 [XEROX]
+       32990   80DE-80DF   -	  -	Integrated Solutions TRFS[XEROX]
+       32992   80E0-80E3   -	  -	Allen-Bradley		 [XEROX]
+       32996   80E4-80F0   -	  -	Datability		 [XEROX]
+       33010   80F2	   -	  -	Retix			 [XEROX]
+       33011   80F3	   -	  -	AppleTalk AARP (Kinetics)[XEROX]
+       33012   80F4-80F5   -	  -	Kinetics		 [XEROX]
+       33015   80F7	   -	  -	Apollo Computer		 [XEROX]
+       33023   80FF-8103   -	  -	Wellfleet Communications [XEROX]
+       33031   8107-8109   -	  -	Symbolics Private	 [XEROX]
+       33072   8130	   -	  -	Waterloo Microsystems	 [XEROX]
+       33073   8131	   -	  -	VG Laboratory Systems	 [XEROX]
+       33079   8137-8138   -	  -	Novell,	Inc.		 [XEROX]
+       33081   8139-813D   -	  -	KTI			 [XEROX]
+       33100   814C	   -	  -	SNMP			  [JKR1]
+       36864   9000	   -	  -	Loopback		 [XEROX]
+       36865   9001	   -	  -	3Com(Bridge) XNS Sys Mgmt[XEROX]
+       36866   9002	   -	  -	3Com(Bridge) TCP-IP Sys	 [XEROX]
+       36867   9003	   -	  -	3Com(Bridge) loop detect [XEROX]
+       65280   FF00	   -	  -	BBN VITAL-LanBridge cache[XEROX]
+
+   The standard	for transmission of IP datagrams over Ethernets	and
+   Experimental	Ethernets is specified in RFC-894 [61] and RFC-895 [91]
+   respectively.
+
+   NOTE:  Ethernet 48-bit address blocks are assigned by the IEEE.
+
+   IEEE	Standards Office, 345 East 47th	Street,	New York, N.Y. 10017,
+   Attn: Vince Condello.  Phone: (212) 705-7092.
+
+
+
+
+Reynolds & Postel				               [Page 56]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+		    ETHERNET VENDOR ADDRESS COMPONENTS
+
+   Ethernet hardware addresses are 48 bits, expressed as 12 hexadecimal
+   digits (0-9,	plus A-F, capitalized).	 These 12 hex digits consist of
+   the first/left 6 digits (which should match the vendor of the
+   Ethernet interface within the station) and the last/right 6 digits
+   which specify the interface serial number for that interface	vendor.
+
+   Ethernet addresses might be written unhyphenated (e.g.,
+   123456789ABC), or with one hyphen (e.g., 123456-789ABC), but	should
+   be written hyphenated by octets (e.g., 12-34-56-78-9A-BC).
+
+   These addresses are physical	station	addresses, not multicast nor
+   broadcast, so the second hex	digit (reading from the	left) will be
+   even, not odd.
+
+   At present, it is not clear how the IEEE assigns Ethernet block
+   addresses.  Whether in blocks of 2**24 or 2**25, and	whether
+   multicasts are assigned with	that block or separately.  A portion of
+   the vendor block address is reportedly assigned serially, with the
+   other portion intentionally assigned	randomly.  If there is a global
+   algorithm for which addresses are designated	to be physical (in a
+   chipset) versus logical (assigned in	software), or globally-assigned
+   versus locally-assigned addresses, some of the known	addresses do not
+   follow the scheme (e.g., AA0003; 02xxxx).
+
+   00000C  Cisco
+   00000F  NeXT
+   000010  Sytek
+   00001D  Cabletron
+   000020  DIAB	(Data Intdustrier AB)
+   000022  Visual Technology
+   00002A  TRW
+   00005A  S & Koch
+   00005E  IANA
+   000065  Network General
+   00006B  MIPS
+   000077  MIPS
+   00007A  Ardent
+   000089  Cayman Systems  Gatorbox
+   000093  Proteon
+   00009F  Ameristar Technology
+   0000A2  Wellfleet
+   0000A3  Network Application Technology
+   0000A6  Network General (internal assignment, not for products)
+   0000A7  NCD		   X-terminals
+   0000A9  Network Systems
+   0000AA  Xerox	   Xerox machines
+
+
+
+Reynolds & Postel				               [Page 57]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   0000B3  CIMLinc
+   0000B7  Dove		   Fastnet
+   0000BC  Allen-Bradley
+   0000C0  Western Digital
+   0000C6  HP Intelligent Networks Operation (formerly Eon Systems)
+   0000C8  Altos
+   0000C9  Emulex	   Terminal Servers
+   0000D7  Dartmouth College (NED Router)
+   0000D8  3Com? Novell?   PS/2
+   0000DD  Gould
+   0000DE  Unigraph
+   0000E2  Acer	Counterpoint
+   0000EF  Alantec
+   0000FD  High	Level Hardvare (Orion, UK)
+   000102  BBN		   BBN internal	usage (not registered)
+   001700  Kabel
+   00802D  Xylogics, Inc.  Annex terminal servers
+   00808C  Frontier Software Development
+   0080C2  IEEE	802.1 Committee
+   0080D3  Shiva
+   00AA00  Intel
+   00DD00  Ungermann-Bass
+   00DD01  Ungermann-Bass
+   020701  Racal InterLan
+   020406  BBN		   BBN internal	usage (not registered)
+   026086  Satelcom MegaPac (UK)
+   02608C  3Com		   IBM PC; Imagen; Valid; Cisco
+   02CF1F  CMC		   Masscomp; Silicon Graphics; Prime EXL
+   080002  3Com	(Formerly Bridge)
+   080003  ACC (Advanced Computer Communications)
+   080005  Symbolics	   Symbolics LISP machines
+   080008  BBN
+   080009  Hewlett-Packard
+   08000A  Nestar Systems
+   08000B  Unisys
+   080011  Tektronix, Inc.
+   080014  Excelan	   BBN Butterfly, Masscomp, Silicon Graphics
+   080017  NSC
+   08001A  Data	General
+   08001B  Data	General
+   08001E  Apollo
+   080020  Sun		   Sun machines
+   080022  NBI
+   080025  CDC
+   080026  Norsk Data (Nord)
+   080027  PCS Computer	Systems	GmbH
+   080028  TI		   Explorer
+   08002B  DEC
+
+
+
+Reynolds & Postel				               [Page 58]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   08002E  Metaphor
+   08002F  Prime Computer  Prime 50-Series LHC300
+   080036  Intergraph	   CAE stations
+   080037  Fujitsu-Xerox
+   080038  Bull
+   080039  Spider Systems
+   080041  DCA Digital Comm. Assoc.
+   080045  ????	(maybe Xylogics, but they claim	not to know this number)
+   080046  Sony
+   080047  Sequent
+   080049  Univation
+   08004C  Encore
+   08004E  BICC
+   080056  Stanford University
+   080058  ???		   DECsystem-20
+   08005A  IBM
+   080067  Comdesign
+   080068  Ridge
+   080069  Silicon Graphics
+   08006E  Excelan
+   080075  DDE (Danish Data Elektronik A/S)
+   08007C  Vitalink	   TransLAN III
+   080080  XIOS
+   080086  Imagen/QMS
+   080087  Xyplex	   terminal servers
+   080089  Kinetics	   AppleTalk-Ethernet interface
+   08008B  Pyramid
+   08008D  XyVision	   XyVision machines
+   080090  Retix Inc	   Bridges
+   484453  HDS ???
+   800010  AT&T
+   AA0000  DEC		   obsolete
+   AA0001  DEC		   obsolete
+   AA0002  DEC		   obsolete
+   AA0003  DEC		   Global physical address for some DEC	machines
+   AA0004  DEC		   Local logical address for systems running
+			   DECNET
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 59]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+		       ETHERNET	MULTICAST ADDRESSES
+
+   Ethernet		   Type
+   Address		   Field   Usage
+
+   Multicast Addresses:
+
+   01-00-5E-00-00-00-	   0800	   Internet Multicast (RFC-1112) [43]
+   01-00-5E-7F-FF-FF
+   01-00-5E-80-00-00-	   ????	   Internet reserved by	IANA
+   01-00-5E-FF-FF-FF
+   01-80-C2-00-00-00	   -802-   Spanning tree (for bridges)
+   09-00-02-04-00-01?	   8080?   Vitalink printer
+   09-00-02-04-00-02?	   8080?   Vitalink management
+   09-00-09-00-00-01	   8005	   HP Probe
+   09-00-09-00-00-01	   -802-   HP Probe
+   09-00-09-00-00-04	   8005?   HP DTC
+   09-00-1E-00-00-00	   8019?   Apollo DOMAIN
+   09-00-2B-00-00-00	   6009?   DEC MUMPS?
+   09-00-2B-00-00-01	   8039?   DEC DSM/DTP?
+   09-00-2B-00-00-02	   803B?   DEC VAXELN?
+   09-00-2B-00-00-03	   8038	   DEC Lanbridge Traffic Monitor (LTM)
+   09-00-2B-00-00-04	   ????	   DEC MAP End System Hello
+   09-00-2B-00-00-05	   ????	   DEC MAP Intermediate	System Hello
+   09-00-2B-00-00-06	   803D?   DEC CSMA/CD Encryption?
+   09-00-2B-00-00-07	   8040?   DEC NetBios Emulator?
+   09-00-2B-00-00-0F	   6004	   DEC Local Area Transport (LAT)
+   09-00-2B-00-00-1x	   ????	   DEC Experimental
+   09-00-2B-01-00-00	   8038	   DEC LanBridge Copy packets
+				   (All	bridges)
+   09-00-2B-01-00-01	   8038	   DEC LanBridge Hello packets
+				   (All	local bridges)
+				   1 packet per	second,	sent by	the
+				   designated LanBridge
+   09-00-2B-02-00-00	   ????	   DEC DNA Lev.	2 Routing Layer	routers?
+   09-00-2B-02-01-00	   803C?   DEC DNA Naming Service Advertisement?
+   09-00-2B-02-01-01	   803C?   DEC DNA Naming Service Solicitation?
+   09-00-2B-02-01-02	   803E?   DEC DNA Time	Service?
+   09-00-2B-03-xx-xx	   ????	   DEC default filtering by bridges?
+   09-00-2B-04-00-00	   8041?   DEC Local Area Sys. Transport (LAST)?
+   09-00-2B-23-00-00	   803A?   DEC Argonaut	Console?
+   09-00-4E-00-00-02?	   8137?   Novell IPX
+   09-00-56-00-00-00-	   ????	   Stanford reserved
+   09-00-56-FE-FF-FF
+   09-00-56-FF-00-00-	   805C	   Stanford V Kernel, version 6.0
+   09-00-56-FF-FF-FF
+   09-00-77-00-00-01	   ????	   Retix spanning tree bridges
+   09-00-7C-02-00-05	   8080?   Vitalink diagnostics
+
+
+
+Reynolds & Postel				               [Page 60]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   09-00-7C-05-00-01	   8080?   Vitalink gateway?
+   0D-1E-15-BA-DD-06	   ????	   HP
+   AB-00-00-01-00-00	   6001	   DEC Maintenance Operation Protocol
+				   (MOP) Dump/Load Assistance
+   AB-00-00-02-00-00	   6002	   DEC Maintenance Operation Protocol
+				   (MOP) Remote	Console
+				   1 System ID packet every 8-10 minutes,
+				   by every:
+				   DEC LanBridge
+				   DEC DEUNA interface
+				   DEC DELUA interface
+				   DEC DEQNA interface
+				   (in a certain mode)
+   AB-00-00-03-00-00	   6003	   DECNET Phase	IV end node Hello
+				   packets 1 packet every 15 seconds,
+				   sent	by each	DECNET host
+   AB-00-00-04-00-00	   6003	   DECNET Phase	IV Router Hello	packets
+				   1 packet every 15 seconds, sent by
+				   the DECNET router
+   AB-00-00-05-00-00	   ????	   Reserved DEC	through
+   AB-00-03-FF-FF-FF
+   AB-00-03-00-00-00	   6004	   DEC Local Area Transport (LAT) - old
+   AB-00-04-00-xx-xx	   ????	   Reserved DEC	customer private use
+   AB-00-04-01-xx-yy	   6007	   DEC Local Area VAX Cluster groups
+				   Sys.	Communication Architecture (SCA)
+   CF-00-00-00-00-00	   9000	   Ethernet Configuration Test protocol
+				   (Loopback)
+
+   Broadcast Address:
+
+   FF-FF-FF-FF-FF-FF	   0600	   XNS packets,	Hello or gateway search?
+				   6 packets every 15 seconds, per XNS
+				   station
+   FF-FF-FF-FF-FF-FF	   0800	   IP (e.g. RWHOD via UDP) as needed
+   FF-FF-FF-FF-FF-FF	   0804	   CHAOS
+   FF-FF-FF-FF-FF-FF	   0806	   ARP (for IP and CHAOS) as needed
+   FF-FF-FF-FF-FF-FF	   0BAD	   Banyan
+   FF-FF-FF-FF-FF-FF	   1600	   VALID packets, Hello	or gateway
+				   search?
+				   1 packets every 30 seconds, per VALID
+				   station
+   FF-FF-FF-FF-FF-FF	   8035	   Reverse ARP
+   FF-FF-FF-FF-FF-FF	   807C	   Merit Internodal (INP)
+   FF-FF-FF-FF-FF-FF	   809B	   EtherTalk
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 61]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+			    XNS	PROTOCOL TYPES
+
+   Assigned well-known socket numbers
+
+	   Routing Information		   1
+	   Echo				   2
+	   Router Error			   3
+	   Experimental		       40-77
+
+   Assigned internet packet types
+
+	   Routing Information		   1
+	   Echo				   2
+	   Error			   3
+	   Packet Exchange		   4
+	   Sequenced Packet		   5
+	   PUP				  12
+	   DoD IP			  13
+	   Experimental		       20-37
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 62]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+		      PROTOCOL/TYPE FIELD ASSIGNMENTS
+
+   Below are two tables	describing the arrangement of protocol fields or
+   type	field assignments so that one could send NS Datagrams on the
+   MILNET or Internet Datagrams	on 10Mb	Ethernet, and also protocol and
+   type	fields so one could encapsulate	each kind of Datagram in the
+   other.
+
+	      \	  upper| DoD IP	|  PUP	 | NS IP  |
+	 lower \       |	|	 |	  |
+	 --------------|--------|--------|--------|
+		       |  Type	|  Type	 |  Type  |
+	 3Mb Ethernet  |  1001	|  1000	 |  3000  |
+		       |  octal	|  octal |  octal |
+	 --------------|--------|--------|--------|
+		       |  Type	|  Type	 |  Type  |
+	 10 Mb Ethernet|  0800	|  0200	 |  0600  |
+		       |   hex	|   hex	 |   hex  |
+	 --------------|--------|--------|--------|
+		       |  Link	|  Link	 |  Link  |
+	 MILNET	       |  155	|  152	 |  150	  |
+		       | decimal| decimal| decimal|
+	 --------------|--------|--------|--------|
+
+
+
+	      \	  upper| DoD IP	|  PUP	 | NS IP  |
+	 lower \       |	|	 |	  |
+	 --------------|--------|--------|--------|
+		       |	|Protocol|Protocol|
+	 DoD IP	       |   X	|   12	 |   22	  |
+		       |	| decimal| decimal|
+	 --------------|--------|--------|--------|
+		       |	|	 |	  |
+	 PUP	       |   ?	|   X	 |   ?	  |
+		       |	|	 |	  |
+	 --------------|--------|--------|--------|
+		       |  Type	|  Type	 |	  |
+	 NS IP	       |   13	|   12	 |   X	  |
+		       | decimal| decimal|	  |
+	 --------------|--------|--------|--------|
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 63]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+			     PRONET 80 TYPE NUMBERS
+
+   Below is the	current	list of	PRONET 80 Type Numbers.	 Note: a
+   protocol that is on this list does not necessarily mean that	there is
+   any implementation of it on ProNET.
+
+   Of these, protocols 1, 14, and 20 are the only ones that have ever
+   been	seen in	ARP packets.
+
+   For reference, the header is	(one byte/line):
+
+	   destination hardware	address
+	   source hardware address
+	   data	link header version (2)
+	   data	link header protocol number
+	   data	link header reserved (0)
+	   data	link header reserved (0)
+
+   Some	protocols have been known to tuck stuff	in the reserved	fields.
+
+   Those who need a protocol number on ProNET-10/80 should contact John
+   Shriver (jas@proteon.com).
+
+      1	      IP
+      2	      IP with trailing headers
+      3	      Address Resolution Protocol
+      4	      Proteon HDLC
+      5	      VAX Debugging Protocol (MIT)
+      10      Novell NetWare (IPX and pre-IPX) (old format,
+	      3	byte trailer)
+      11      Vianetix
+      12      PUP
+      13      Watstar protocol (University of Waterloo)
+      14      XNS
+      15      Diganostics
+      16      Echo protocol (link level)
+      17      Banyan Vines
+      20      DECnet (DEUNA Emulation)
+      21      Chaosnet
+      23      IEEE 802.2 or ISO	8802/2 Data Link
+      24      Reverse Address Resolution Protocol
+      29      TokenVIEW-10
+      31      AppleTalk	LAP Data Packet
+      33      Cornell Boot Server Location Protocol
+      34      Novell NetWare IPX (new format, no trailer,
+	      new XOR checksum)
+
+
+
+
+
+Reynolds & Postel				               [Page 64]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+		  POINT-TO-POINT PROTOCOL FIELD	ASSIGNMENTS
+
+PPP DLL	PROTOCOL NUMBERS
+
+   The Point-to-Point Protocol (PPP) Data Link Layer [146,147,175]
+   contains a 16 bit Protocol field to identify	the the	encapsulated
+   protocol.  The Protocol field is consistent with the	ISO 3309 (HDLC)
+   extension mechanism for Address fields.  All	Protocols MUST be
+   assigned such that the least	significant bit	of the most significant
+   octet equals	"0", and the least significant bit of the least
+   significant octet equals "1".
+
+Assigned PPP DLL Protocol Numbers
+
+   Value (in hex)  Protocol Name
+
+   0001	to 001f	   reserved (transparency inefficient)
+   0021		   Internet Protocol
+   0023		   OSI Network Layer
+   0025		   Xerox NS IDP
+   0027		   DECnet Phase	IV
+   0029		   Appletalk
+   002b		   Novell IPX
+   002d		   Van Jacobson	Compressed TCP/IP
+   002f		   Van Jacobson	Uncompressed TCP/IP
+   0031		   Bridging PDU
+   0033		   Stream Protocol (ST-II)
+   0035		   Banyan Vines
+   0037		   reserved (until 1993)
+   00ff		   reserved (compression inefficient)
+
+   0201		   802.1d Hello	Packets
+   0231		   Luxcom
+   0233		   Sigma Network Systems
+
+   8021		   Internet Protocol Control Protocol
+   8023		   OSI Network Layer Control Protocol
+   8025		   Xerox NS IDP	Control	Protocol
+   8027		   DECnet Phase	IV Control Protocol
+   8029		   Appletalk Control Protocol
+   802b		   Novell IPX Control Protocol
+   802d		   Reserved
+   802f		   Reserved
+   8031		   Bridging NCP
+   8033		   Stream Protocol Control Protocol
+   8035		   Banyan Vines	Control	Protocol
+   8037		   reserved till 1993
+   80ff		   reserved (compression inefficient
+
+
+
+Reynolds & Postel				               [Page 65]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   c021		   Link	Control	Protocol
+   c023		   Password Authentication Protocol
+   c025		   Link	Quality	Report
+   c223		   Challenge Handshake Authentication Protocol
+
+   Protocol field values in the	"0---" to "3---" range identify	the
+   network-layer protocol of specific datagrams, and values in the "8--
+   -" to "b---"	range identify datagrams belonging to the associated
+   Network Control Protocol (NCP), if any.
+
+   It is recommended that values in the	"02--" to "1e--" and "--01" to
+   "--1f" ranges not be	assigned, as they are compression inefficient.
+
+   Protocol field values in the	"4---" to "7---" range are used	for
+   protocols with low volume traffic which have	no associated NCP.
+
+   Protocol field values in the	"c---" to "e---" range identify
+   datagrams as	Control	Protocols (such	as LCP).
+
+PPP LCP	AND IPCP CODES
+
+   The Point-to-Point Protocol (PPP) Link Control Protocol (LCP) [146]
+   and Internet	Protocol Control Protocol (IPCP) [147] contain an 8 bit
+   Code	field which identifies the type	of packet.  These Codes	are
+   assigned as follows:
+
+   Code	      Packet Type
+   ----	      -----------
+      1	      Configure-Request
+      2	      Configure-Ack
+      3	      Configure-Nak
+      4	      Configure-Reject
+      5	      Terminate-Request
+      6	      Terminate-Ack
+      7	      Code-Reject
+      8	    * Protocol-Reject
+      9	    * Echo-Request
+     10	    * Echo-Reply
+     11	    * Discard-Request
+     12	    * RESERVED
+
+   * LCP Only
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 66]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+PPP LCP	CONFIGURATION OPTION TYPES
+
+   The Point-to-Point Protocol (PPP) Link Control Protocol (LCP)
+   specifies a number of Configuration Options [146] which are
+   distinguished by an 8 bit Type field.  These	Types are assigned as
+   follows:
+
+   Type	      Configuration Option
+   ----	      --------------------
+      1	      Maximum-Receive-Unit
+      2	      Async-Control-Character-Map
+      3	      Authentication-Protocol
+      4	      Quality-Protocol
+      5	      Magic-Number
+      6	      RESERVED
+      7	      Protocol-Field-Compression
+      8	      Address-and-Control-Field-Compression
+      9	      FCS-Alternatives
+
+PPP IPCP CONFIGURATION OPTION TYPES
+
+   The Point-to-Point Protocol (PPP) Internet Protocol Control Protocol
+   (IPCP) specifies a number of	Configuration Options [147] which are
+   distinguished by an 8 bit Type field.  These	Types are assigned as
+   follows:
+
+   Type	      Configuration Option
+   ----	      --------------------
+      1	      IP-Addresses (deprecated)
+      2	      IP-Compression-Protocol
+      3	      IP-Address
+
+PPP BRIDGING CONFIGURATION OPTION TYPES
+
+   The Point-to-Point Protocol (PPP) Extensions	for Bridging specifies a
+   number of Configuration Options [176] which are distinguished by an 8
+   bit Type field.  These Types	are assigned as	follows:
+
+   Type	      Configuration Option
+   ----	      --------------------
+      1	      Remote Ring Identification
+      2	      Line Identification
+      3	      MAC Type Selection
+      4	      Tinygram Compression
+      5	      LAN Identification
+
+
+
+
+
+
+Reynolds & Postel				               [Page 67]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+PPP BRIDGING MAC TYPES
+
+   The Point-to-Point Protocol (PPP) Extensions	for Bridging [176]
+   contains an 8 bit MAC Type field which identifies the MAC
+   encapsulated.  These	Types are assigned as follows:
+
+   Type	      MAC
+   ----	      -----------
+      0	      Reserved
+      1	      IEEE 802.3/Ethernet
+      2	      IEEE 802.4
+      3	      IEEE 802.5
+      4	      FDDI
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 68]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+		  ADDRESS RESOLUTION PROTOCOL PARAMETERS
+
+   The Address Resolution Protocol (ARP) specified in RFC-826 [88] has
+   several parameters.	The assigned values for	these parameters are
+   listed here.
+
+   Assignments:
+
+   Operation Code (op)
+
+	    1	REQUEST
+	    2	REPLY
+
+   Hardware Type (hrd)
+
+      Type   Description				   References
+      ----   -----------				   ----------
+	1    Ethernet (10Mb)					[JBP]
+	2    Experimental Ethernet (3Mb)			[JBP]
+	3    Amateur Radio AX.25				[PXK]
+	4    Proteon ProNET Token Ring				[JBP]
+	5    Chaos						[GXP]
+	6    IEEE 802 Networks					[JBP]
+	7    ARCNET						[JBP]
+	8    Hyperchannel					[JBP]
+	9    Lanstar						 [TU]
+       10    Autonet Short Address			       [MXB1]
+       11    LocalTalk					       [JKR1]
+       12    LocalNet (IBM PCNet or SYTEK LocalNET)		[JXM]
+       13    Ultra link					       [RXD2]
+       14    SMDS					       [GXC1]
+       15    Frame Relay					[AGM]
+       16    Asynchronous Transmission Mode (ATM)	       [JXB2]
+
+   Protocol Type (pro)
+
+      Use the same codes as listed in the section called "Ethernet
+      Numbers of Interest" (all	hardware types use this	code set for the
+      protocol type).
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 69]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+	     REVERSE ADDRESS RESOLUTION	PROTOCOL OPERATION CODES
+
+   The Reverse Address Resolution Protocol (RARP) specified in RFC-903
+   [48]	has the	following operation codes:
+
+   Assignments:
+
+   Operation Code (op)
+
+	    3  request Reverse
+	    4  reply Reverse
+
+
+			    DYNAMIC REVERSE ARP
+
+   Assignments:
+
+   Operation Code (op)
+
+	    5  DRARP-Request
+	    6  DRARP-Reply
+	    7  DRARP-Error
+
+   For further information, contact: David Brownell
+   (suneast!helium!db@Sun.COM).
+
+
+		   INVERSE ADDRESS RESOULUTION PROTOCOL
+
+   The Inverse Address Resolution Protocol (IARP) specified in RFC-1293
+   [173] has the following operation codes:
+
+   Assignments:
+
+   Operation Code (op)
+
+	    8  InARP-Request
+	    9  InARP-Reply
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 70]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+			     X.25 TYPE NUMBERS
+
+   CCITT defines the high order	two bits of the	first octet of call user
+   data	as follows:
+
+      00 - Used	for other CCITT	recomendations (such as	X.29)
+      01 - Reserved for	use by "national" administrative
+	   authorities
+      10 - Reserved for	use by international administrative authoorities
+      11 - Reserved for	arbitrary use between consenting DTEs
+
+      Call User	Data (hex)     Protocol			     Reference
+      -------------------      --------			     ---------
+
+      01		       PAD				 [GS2]
+      C5		       Blacker front-end descr dev	 [AGM]
+      CC		       IP			      [69,AGM]*
+      CD		       ISO-IP				 [AGM]
+      DD		       Network Monitoring		 [AGM]
+
+      *NOTE: ISO SC6/WG2 approved assignment in	ISO 9577 (January 1990).
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 71]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+			 PUBLIC	DATA NETWORK NUMBERS
+
+One of the Internet Class A Networks is	the international system of
+Public Data Networks.  This section lists the mapping between the
+Internet Addresses and the Public Data Network Addresses (X.121).
+
+Assignments:
+
+	Internet	   Public Data Net    Description     References
+	--------------	 -----------------   -----------      ----------
+       014.000.000.000			     Reserved		   [JBP]
+       014.000.000.001	 3110-317-00035	00   PURDUE-TN		    [TN]
+       014.000.000.002	 3110-608-00027	00   UWISC-TN		    [TN]
+       014.000.000.003	 3110-302-00024	00   UDEL-TN		    [TN]
+       014.000.000.004	 2342-192-00149	23   UCL-VTEST		    [PK]
+       014.000.000.005	 2342-192-00300	23   UCL-TG		    [PK]
+       014.000.000.006	 2342-192-00300	25   UK-SATNET		    [PK]
+       014.000.000.007	 3110-608-00024	00   UWISC-IBM		  [MS56]
+       014.000.000.008	 3110-213-00045	00   RAND-TN		   [MO2]
+       014.000.000.009	 2342-192-00300	23   UCL-CS		    [PK]
+       014.000.000.010	 3110-617-00025	00   BBN-VAN-GW		  [JD21]
+       014.000.000.011	 2405-015-50300	00   CHALMERS		   [UXB]
+       014.000.000.012	 3110-713-00165	00   RICE		  [PAM6]
+       014.000.000.013	 3110-415-00261	00   DECWRL		  [PAM6]
+       014.000.000.014	 3110-408-00051	00   IBM-SJ		  [SXA3]
+       014.000.000.015	 2041-117-01000	00   SHAPE		   [JFW]
+       014.000.000.016	 2628-153-90075	00   DFVLR4-X25		   [GB7]
+       014.000.000.017	 3110-213-00032	00   ISI-VAN-GW		  [JD21]
+       014.000.000.018	 2624-522-80900	52   FGAN-SIEMENS-X25	   [GB7]
+       014.000.000.019	 2041-170-10000	00   SHAPE-X25		   [JFW]
+       014.000.000.020	 5052-737-20000	50   UQNET		   [AXH]
+       014.000.000.021	 3020-801-00057	50   DMC-CRC1		   [VXT]
+       014.000.000.022	 2624-522-80329	02   FGAN-FGANFFMVAX-X25   [GB7]
+       014.000.000.023	 2624-589-00908	01   ECRC-X25		   [PXD]
+       014.000.000.024	 2342-905-24242	83   UK-MOD-RSRE	  [JXE2]
+       014.000.000.025	 2342-905-24242	82   UK-VAN-RSRE	   [AXM]
+       014.000.000.026	 2624-522-80329	05   DFVLRSUN-X25	   [GB7]
+       014.000.000.027	 2624-457-11015	90   SELETFMSUN-X25	   [BXD]
+       014.000.000.028	 3110-408-00146	00   CDC-SVL		 [RAM57]
+       014.000.000.029	 2222-551-04400	00   SUN-CNUCE		  [ABB2]
+       014.000.000.030	 2222-551-04500	00   ICNUCEVM-CNUCE	  [ABB2]
+       014.000.000.031	 2222-551-04600	00   SPARE-CNUCE	  [ABB2]
+       014.000.000.032	 2222-551-04700	00   ICNUCEVX-CNUCE	  [ABB2]
+       014.000.000.033	 2222-551-04524	00   CISCO-CNUCE	  [ABB2]
+       014.000.000.034	 2342-313-00260	90   SPIDER-GW		  [AD67]
+       014.000.000.035	 2342-313-00260	91   SPIDER-EXP		  [AD67]
+       014.000.000.036	 2342-225-00101	22   PRAXIS-X25A	   [TXR]
+       014.000.000.037	 2342-225-00101	23   PRAXIS-X25B	   [TXR]
+
+
+
+Reynolds & Postel				               [Page 72]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+       014.000.000.038	 2403-712-30250	00   DIAB-TABY-GW	   [FXB]
+       014.000.000.039	 2403-715-30100	00   DIAB-LKP-GW	   [FXB]
+       014.000.000.040	 2401-881-24038	00   DIAB-TABY1-GW	   [FXB]
+       014.000.000.041	 2041-170-10060	00   STC		  [TC27]
+       014.000.000.042	 2222-551-00652	60   CNUCE		  [TC27]
+       014.000.000.043	 2422-510-05900	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.044	 2422-670-08900	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.045	 2422-516-01000	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.046	 2422-450-00800	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.047	 2422-610-00200	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.048	 2422-310-00300	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.049	 2422-470-08800	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.050	 2422-210-04600	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.051	 2422-130-28900	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.052	 2422-310-27200	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.053	 2422-250-05800	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.054	 2422-634-05900	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.055	 2422-670-08800	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.056	 2422-430-07400	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.057	 2422-674-07800	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.058	 2422-230-16900	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.059	 2422-518-02900	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.060	 2422-370-03100	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.061	 2422-516-03400	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.062	 2422-616-04400	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.063	 2422-650-23500	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.064	 2422-330-02500	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.065	 2422-350-01900	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.066	 2422-410-00700	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.067	 2422-539-06200	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.068	 2422-630-07200	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.069	 2422-470-12300	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.070	 2422-470-13000	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.071	 2422-170-04600	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.072	 2422-516-04300	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.073	 2422-530-00700	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.074	 2422-650-18800	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.075	 2422-450-24500	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.076	 2062-243-15631	00   DPT-BXL-DDC	  [LZ15]
+       014.000.000.077	 2062-243-15651	00   DPT-BXL-DDC2	  [LZ15]
+       014.000.000.078	 3110-312-00431	00   DPT-CHI		  [LZ15]
+       014.000.000.079	 3110-512-00135	00   DPT-SAT-ENG	  [LZ15]
+       014.000.000.080	 2080-941-90550	00   DPT-PAR		  [LZ15]
+       014.000.000.081	 4545-511-30600	00   DPT-PBSC		  [LZ15]
+       014.000.000.082	 4545-513-30900	00   DPT-HONGKONG	  [LZ15]
+       014.000.000.083	 4872-203-55000	00   UECI-TAIPEI	  [LZ15]
+       014.000.000.084	 2624-551-10400	20   DPT-HANOVR		  [LZ15]
+       014.000.000.085	 2624-569-00401	99   DPT-FNKFRT		  [LZ15]
+
+
+
+Reynolds & Postel				               [Page 73]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+       014.000.000.086	 3110-512-00134	00   DPT-SAT-SUPT	  [LZ15]
+       014.000.000.087	 4602-3010-0103	20   DU-X25A		  [JK64]
+       014.000.000.088	 4602-3010-0103	21   FDU-X25B		  [JK64]
+       014.000.000.089	 2422-150-33700	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.090	 2422-271-07100	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.091	 2422-516-00100	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.092	 2422-650-18800	00   Norsk Informas.	   [OXG]
+       014.000.000.093	 2422-250-30400	00   Tollpost-Globe AS	   [OXG]
+       014.000.000.094-014.255.255.254	     Unassigned		   [JBP]
+       014.255.255.255			     Reserved		   [JBP]
+
+      The standard for transmission of IP datagrams over the Public Data
+      Network is specified in RFC-877 [69].
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 74]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+				TELNET OPTIONS
+
+The Telnet Protocol has	a number of options that may be	negotiated.
+These options are listed here.	"IAB Official Protocol Standards" [62]
+provides more detailed information.
+
+   Options  Name					      References
+   -------  -----------------------			      ----------
+      0	    Binary Transmission				       [110,JBP]
+      1	    Echo					       [111,JBP]
+      2	    Reconnection					[42,JBP]
+      3	    Suppress Go	Ahead				       [114,JBP]
+      4	    Approx Message Size	Negotiation		       [133,JBP]
+      5	    Status					       [113,JBP]
+      6	    Timing Mark					       [115,JBP]
+      7	    Remote Controlled Trans and	Echo		       [107,JBP]
+      8	    Output Line	Width					[40,JBP]
+      9	    Output Page	Size					[41,JBP]
+     10	    Output Carriage-Return Disposition			[28,JBP]
+     11	    Output Horizontal Tab Stops				[32,JBP]
+     12	    Output Horizontal Tab Disposition			[31,JBP]
+     13	    Output Formfeed Disposition				[29,JBP]
+     14	    Output Vertical Tabstops				[34,JBP]
+     15	    Output Vertical Tab	Disposition			[33,JBP]
+     16	    Output Linefeed Disposition				[30,JBP]
+     17	    Extended ASCII				       [136,JBP]
+     18	    Logout						[25,MRC]
+     19	    Byte Macro						[35,JBP]
+     20	    Data Entry Terminal				    [145,38,JBP]
+     22	    SUPDUP					     [26,27,MRC]
+     22	    SUPDUP Output					[51,MRC]
+     23	    Send Location				       [68,EAK1]
+     24	    Terminal Type				      [128,MS56]
+     25	    End	of Record				       [103,JBP]
+     26	    TACACS User	Identification				 [1,BA4]
+     27	    Output Marking				       [125,SXS]
+     28	    Terminal Location Number				[84,RN6]
+     29	    Telnet 3270	Regime				       [116,JXR]
+     30	    X.3	PAD					       [70,SL70]
+     31	    Negotiate About Window Size			     [139,DW183]
+     32	    Terminal Speed				       [57,CLH3]
+     33	    Remote Flow	Control				       [58,CLH3]
+     34	    Linemode						[9,DB14]
+     35	    X Display Location				       [75,GM23]
+     36	    Environment	Option					  [DB14]
+     37	    Authentication Option				  [DB14]
+     38	    Encryption Option					  [DB14]
+    255	    Extended-Options-List			       [109,JBP]
+
+
+
+Reynolds & Postel				               [Page 75]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+			   MAIL	ENCRYPTION TYPES
+
+   RFC-822 specifies that Encryption Types for mail may	be assigned.
+   There are currently no RFC-822 encryption types assigned.  Please use
+   instead the Mail Privacy procedures defined in [71,72,66].
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 76]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+				MIME TYPES
+
+RFC-1341 [169] specifies that Content Types, Content Subtypes, Character
+Sets, Access Types, and	Conversion values for MIME mail	will be	assigned
+and listed by the IANA.
+
+   Content Types and Subtypes
+   --------------------------
+
+   Type		   Subtype	   Description		       Reference
+   ----		   -------	   -----------		       ---------
+   text		   plain				       [169,NSB]
+		   richtext
+
+   multipart	   mixed				       [169,NSB]
+		   alternative
+		   digest
+		   parallel
+
+   message	   rfc822				       [169,NSB]
+		   partial
+		   external-body
+
+   application	   octet-stream				       [169,NSB]
+		   postscript
+		   oda
+
+   image	   jpeg					       [169,NSB]
+		   gif
+
+   audio	   basic				       [169,NSB]
+
+   video	   mpeg					       [169,NSB]
+
+
+   Character Sets
+   --------------
+
+   Type		  Description				       Reference
+   ----		  -----------				       ---------
+   US-ASCII	  the default character	set		       [169,NSB]
+   ISO-8859-1	  see ISO_8859-1:1987 below		       [169,NSB]
+   ISO-8859-2	  see ISO_8859-2:1987 below		       [169,NSB]
+   ISO-8859-3	  see ISO_8859-3:1988 below		       [169,NSB]
+   ISO-8859-4	  see ISO_8859-4:1988 below		       [169,NSB]
+   ISO-8859-5	  see ISO_8859-5:1988 below		       [169,NSB]
+   ISO-8859-6	  see ISO_8859-6:1987 below		       [169,NSB]
+   ISO-8859-7	  see ISO_8859-7:1987 below		       [169,NSB]
+
+
+
+Reynolds & Postel				               [Page 77]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   ISO-8859-8	  see ISO_8859-8:1988 below		       [169,NSB]
+   ISO-8859-9	  see ISO_8859-9:1989 below		       [169,NSB]
+
+   Access Types
+   ------------
+
+   Type		  Description				       Reference
+   ----		  -----------				       ---------
+   FTP							       [169,NSB]
+   ANON-FTP						       [169,NSB]
+   TFTP							       [169,NSB]
+   AFS							       [169,NSB]
+   LOCAL-FILE						       [169,NSB]
+   MAIL-SERVER						       [169,NSB]
+
+
+
+   Conversion Values
+   -----------------
+
+   Conversion values or	Content	Transfer Encodings.
+
+   Type		  Description				       Reference
+   ----		  -----------				       ---------
+   7BIT							       [169,NSB]
+   8BIT							       [169,NSB]
+   BASE64						       [169,NSB]
+   BINARY						       [169,NSB]
+   QUOTED-PRINTABLE					       [169,NSB]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 78]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+			      CHARACTER	SETS
+
+   Character Set					       Reference
+   -------------					       ---------
+   ISO_646.basic:1983					      [170,KXS2]
+   INVARIANT						      [170,KXS2]
+   ISO_646.irv:1983					      [170,KXS2]
+   BS_4730						      [170,KXS2]
+   ANSI_X3.4-1968					      [170,KXS2]
+   NATS-SEFI						      [170,KXS2]
+   NATS-SEFI-ADD					      [170,KXS2]
+   NATS-DANO						      [170,KXS2]
+   NATS-DANO-ADD					      [170,KXS2]
+   SEN_850200_B						      [170,KXS2]
+   SEN_850200_C						      [170,KXS2]
+   JIS_C6220-1969-jp					      [170,KXS2]
+   JIS_C6220-1969-ro					      [170,KXS2]
+   IT							      [170,KXS2]
+   PT							      [170,KXS2]
+   ES							      [170,KXS2]
+   greek7-old						      [170,KXS2]
+   latin-greek						      [170,KXS2]
+   DIN_66003						      [170,KXS2]
+   NF_Z_62-010_(1973)					      [170,KXS2]
+   Latin-greek-1					      [170,KXS2]
+   ISO_5427						      [170,KXS2]
+   JIS_C6226-1978					      [170,KXS2]
+   BS_viewdata						      [170,KXS2]
+   INIS							      [170,KXS2]
+   INIS-8						      [170,KXS2]
+   INIS-cyrillic					      [170,KXS2]
+   ISO_5427:1981					      [170,KXS2]
+   ISO_5428:1980					      [170,KXS2]
+   GB_1988-80						      [170,KXS2]
+   GB_2312-80						      [170,KXS2]
+   NS_4551-1						      [170,KXS2]
+   NS_4551-2						      [170,KXS2]
+   NF_Z_62-010						      [170,KXS2]
+   videotex-suppl					      [170,KXS2]
+   PT2							      [170,KXS2]
+   ES2							      [170,KXS2]
+   MSZ_7795.3						      [170,KXS2]
+   JIS_C6226-1983					      [170,KXS2]
+   greek7						      [170,KXS2]
+   ASMO_449						      [170,KXS2]
+   iso-ir-90						      [170,KXS2]
+   JIS_C6229-1984-a					      [170,KXS2]
+   JIS_C6229-1984-b					      [170,KXS2]
+
+
+
+Reynolds & Postel				               [Page 79]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   JIS_C6229-1984-b-add					      [170,KXS2]
+   JIS_C6229-1984-hand					      [170,KXS2]
+   JIS_C6229-1984-hand-add				      [170,KXS2]
+   JIS_C6229-1984-kana					      [170,KXS2]
+   ISO_2033-1983					      [170,KXS2]
+   ANSI_X3.110-1983					      [170,KXS2]
+   ISO_8859-1:1987					      [170,KXS2]
+   ISO_8859-2:1987					      [170,KXS2]
+   T.61-7bit						      [170,KXS2]
+   T.61-8bit						      [170,KXS2]
+   ISO_8859-3:1988					      [170,KXS2]
+   ISO_8859-4:1988					      [170,KXS2]
+   ECMA-cyrillic					      [170,KXS2]
+   CSA_Z243.4-1985-1					      [170,KXS2]
+   CSA_Z243.4-1985-2					      [170,KXS2]
+   CSA_Z243.4-1985-gr					      [170,KXS2]
+   ISO_8859-7:1987					      [170,KXS2]
+   ISO_8859-6:1987					      [170,KXS2]
+   T.101-G2						      [170,KXS2]
+   ISO_8859-8:1988					      [170,KXS2]
+   CSN_369103						      [170,KXS2]
+   JUS_I.B1.002						      [170,KXS2]
+   ISO_6937-2-add					      [170,KXS2]
+   IEC_P27-1						      [170,KXS2]
+   ISO_8859-5:1988					      [170,KXS2]
+   JUS_I.B1.003-serb					      [170,KXS2]
+   JUS_I.B1.003-mac					      [170,KXS2]
+   ISO_8859-9:1989					      [170,KXS2]
+   KS_C_5601-1987					      [170,KXS2]
+   greek-ccitt						      [170,KXS2]
+   NC_NC00-10:81					      [170,KXS2]
+   ISO_6937-2-25					      [170,KXS2]
+   GOST_19768-74					      [170,KXS2]
+   ISO_8859-supp					      [170,KXS2]
+   ISO_10367-box					      [170,KXS2]
+   latin6						      [170,KXS2]
+   latin-lap						      [170,KXS2]
+   JIS_X0212-1990					      [170,KXS2]
+   DS_2089						      [170,KXS2]
+   us-dk						      [170,KXS2]
+   dk-us						      [170,KXS2]
+   JIS_X0201						      [170,KXS2]
+   KSC5636						      [170,KXS2]
+   DEC-MCS						      [170,KXS2]
+   hp-roman8						      [170,KXS2]
+   macintosh						      [170,KXS2]
+   IBM037						      [170,KXS2]
+   IBM038						      [170,KXS2]
+
+
+
+Reynolds & Postel				               [Page 80]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   IBM273						      [170,KXS2]
+   IBM274						      [170,KXS2]
+   IBM275						      [170,KXS2]
+   IBM277						      [170,KXS2]
+   IBM278						      [170,KXS2]
+   IBM280						      [170,KXS2]
+   IBM281						      [170,KXS2]
+   IBM284						      [170,KXS2]
+   IBM285						      [170,KXS2]
+   IBM290						      [170,KXS2]
+   IBM297						      [170,KXS2]
+   IBM420						      [170,KXS2]
+   IBM423						      [170,KXS2]
+   IBM424						      [170,KXS2]
+   IBM437						      [170,KXS2]
+   IBM500						      [170,KXS2]
+   IBM850						      [170,KXS2]
+   IBM851						      [170,KXS2]
+   IBM852						      [170,KXS2]
+   IBM855						      [170,KXS2]
+   IBM857						      [170,KXS2]
+   IBM860						      [170,KXS2]
+   IBM861						      [170,KXS2]
+   IBM862						      [170,KXS2]
+   IBM863						      [170,KXS2]
+   IBM864						      [170,KXS2]
+   IBM865						      [170,KXS2]
+   IBM868						      [170,KXS2]
+   IBM869						      [170,KXS2]
+   IBM870						      [170,KXS2]
+   IBM871						      [170,KXS2]
+   IBM880						      [170,KXS2]
+   IBM891						      [170,KXS2]
+   IBM903						      [170,KXS2]
+   IBM904						      [170,KXS2]
+   IBM905						      [170,KXS2]
+   IBM918						      [170,KXS2]
+   IBM1026						      [170,KXS2]
+   EBCDIC-AT-DE						      [170,KXS2]
+   EBCDIC-AT-DE-A					      [170,KXS2]
+   EBCDIC-CA-FR						      [170,KXS2]
+   EBCDIC-DK-NO						      [170,KXS2]
+   EBCDIC-DK-NO-A					      [170,KXS2]
+   EBCDIC-FI-SE						      [170,KXS2]
+   EBCDIC-FI-SE-A					      [170,KXS2]
+   EBCDIC-FR						      [170,KXS2]
+   EBCDIC-IT						      [170,KXS2]
+   EBCDIC-PT						      [170,KXS2]
+
+
+
+Reynolds & Postel				               [Page 81]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   EBCDIC-ES						      [170,KXS2]
+   EBCDIC-ES-A						      [170,KXS2]
+   EBCDIC-ES-S						      [170,KXS2]
+   EBCDIC-UK						      [170,KXS2]
+   EBCDIC-US						      [170,KXS2]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 82]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+			       MACHINE NAMES
+
+   These are the Official Machine Names	as they	appear in the Domain Name
+   System HINFO	records	and the	NIC Host Table.	 Their use is described	in
+   RFC-952 [53].
+
+   A machine name or CPU type may be up	to 40 characters taken from the
+   set of uppercase letters, digits, and the two punctuation characters
+   hyphen and slash.  It must start with a letter, and end with	a letter
+   or digit.
+
+
+
+
+
+      ALTO				    DEC-1080
+      ALTOS-6800			    DEC-1090
+      AMDAHL-V7				    DEC-1090B
+      APOLLO				    DEC-1090T
+      ATARI-104ST			    DEC-2020T
+      ATT-3B1				    DEC-2040
+      ATT-3B2				    DEC-2040T
+      ATT-3B20				    DEC-2050T
+      ATT-7300				    DEC-2060
+      BBN-C/60				    DEC-2060T
+      BURROUGHS-B/29			    DEC-2065
+      BURROUGHS-B/4800			    DEC-FALCON
+      BUTTERFLY				    DEC-KS10
+      C/30				    DEC-VAX-11730
+      C/70				    DORADO
+      CADLINC				    DPS8/70M
+      CADR				    ELXSI-6400
+      CDC-170				    EVEREX-386
+      CDC-170/750			    FOONLY-F2
+      CDC-173				    FOONLY-F3
+      CELERITY-1200			    FOONLY-F4
+      CLUB-386				    GOULD
+      COMPAQ-386/20			    GOULD-6050
+      COMTEN-3690			    GOULD-6080
+      CP8040				    GOULD-9050
+      CRAY-1				    GOULD-9080
+      CRAY-X/MP				    H-316
+      CRAY-2				    H-60/68
+      CTIWS-117				    H-68
+      DANDELION				    H-68/80
+      DEC-10				    H-89
+      DEC-1050				    HONEYWELL-DPS-6
+      DEC-1077				    HONEYWELL-DPS-8/70
+
+
+
+Reynolds & Postel				               [Page 83]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+      HP3000				    ONYX-Z8000
+      HP3000/64				    PDP-11
+      IBM-158				    PDP-11/3
+      IBM-360/67			    PDP-11/23
+      IBM-370/3033			    PDP-11/24
+      IBM-3081				    PDP-11/34
+      IBM-3084QX			    PDP-11/40
+      IBM-3101				    PDP-11/44
+      IBM-4331				    PDP-11/45
+      IBM-4341				    PDP-11/50
+      IBM-4361				    PDP-11/70
+      IBM-4381				    PDP-11/73
+      IBM-4956				    PE-7/32
+      IBM-6152				    PE-3205
+      IBM-PC				    PERQ
+      IBM-PC/AT				    PLEXUS-P/60
+      IBM-PC/RT				    PLI
+      IBM-PC/XT				    PLURIBUS
+      IBM-SERIES/1			    PRIME-2350
+      IMAGEN				    PRIME-2450
+      IMAGEN-8/300			    PRIME-2755
+      IMSAI				    PRIME-9655
+      INTEGRATED-SOLUTIONS		    PRIME-9755
+      INTEGRATED-SOLUTIONS-68K		    PRIME-9955II
+      INTEGRATED-SOLUTIONS-CREATOR	    PRIME-2250
+      INTEGRATED-SOLUTIONS-CREATOR-8	    PRIME-2655
+      INTEL-386				    PRIME-9955
+      INTEL-IPSC			    PRIME-9950
+      IS-1				    PRIME-9650
+      IS-68010				    PRIME-9750
+      LMI				    PRIME-2250
+      LSI-11				    PRIME-750
+      LSI-11/2				    PRIME-850
+      LSI-11/23				    PRIME-550II
+      LSI-11/73				    PYRAMID-90
+      M68000				    PYRAMID-90MX
+      MAC-II				    PYRAMID-90X
+      MASSCOMP				    RIDGE
+      MC500				    RIDGE-32
+      MC68000				    RIDGE-32C
+      MICROPORT				    ROLM-1666
+      MICROVAX				    S1-MKIIA
+      MICROVAX-I			    SMI
+      MV/8000				    SEQUENT-BALANCE-8000
+      NAS3-5				    SIEMENS
+      NCR-COMTEN-3690			    SILICON-GRAPHICS
+      NEXT/N1000-316			    SILICON-GRAPHICS-IRIS
+      NOW				    SGI-IRIS-2400
+
+
+
+Reynolds & Postel				               [Page 84]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+      SGI-IRIS-2500			    SUN-3/50
+      SGI-IRIS-3010			    SUN-3/60
+      SGI-IRIS-3020			    SUN-3/75
+      SGI-IRIS-3030			    SUN-3/80
+      SGI-IRIS-3110			    SUN-3/110
+      SGI-IRIS-3115			    SUN-3/140
+      SGI-IRIS-3120			    SUN-3/150
+      SGI-IRIS-3130			    SUN-3/160
+      SGI-IRIS-4D/20			    SUN-3/180
+      SGI-IRIS-4D/20G			    SUN-3/200
+      SGI-IRIS-4D/25			    SUN-3/260
+      SGI-IRIS-4D/25G			    SUN-3/280
+      SGI-IRIS-4D/25S			    SUN-3/470
+      SGI-IRIS-4D/50			    SUN-3/480
+      SGI-IRIS-4D/50G			    SUN-4/60
+      SGI-IRIS-4D/50GT			    SUN-4/110
+      SGI-IRIS-4D/60			    SUN-4/150
+      SGI-IRIS-4D/60G			    SUN-4/200
+      SGI-IRIS-4D/60T			    SUN-4/260
+      SGI-IRIS-4D/60GT			    SUN-4/280
+      SGI-IRIS-4D/70			    SUN-4/330
+      SGI-IRIS-4D/70G			    SUN-4/370
+      SGI-IRIS-4D/70GT			    SUN-4/390
+      SGI-IRIS-4D/80GT			    SUN-50
+      SGI-IRIS-4D/80S			    SUN-100
+      SGI-IRIS-4D/120GTX		    SUN-120
+      SGI-IRIS-4D/120S			    SUN-130
+      SGI-IRIS-4D/210GTX		    SUN-150
+      SGI-IRIS-4D/210S			    SUN-170
+      SGI-IRIS-4D/220GTX		    SUN-386i/250
+      SGI-IRIS-4D/220S			    SUN-68000
+      SGI-IRIS-4D/240GTX		    SYMBOLICS-3600
+      SGI-IRIS-4D/240S			    SYMBOLICS-3670
+      SGI-IRIS-4D/280GTX		    SYMMETRIC-375
+      SGI-IRIS-4D/280S			    SYMULT
+      SGI-IRIS-CS/12			    TANDEM-TXP
+      SGI-IRIS-4SERVER-8		    TANDY-6000
+      SPERRY-DCP/10			    TEK-6130
+      SUN				    TI-EXPLORER
+      SUN-2				    TP-4000
+      SUN-2/50				    TRS-80
+      SUN-2/100				    UNIVAC-1100
+      SUN-2/120				    UNIVAC-1100/60
+      SUN-2/130				    UNIVAC-1100/62
+      SUN-2/140				    UNIVAC-1100/63
+      SUN-2/150				    UNIVAC-1100/64
+      SUN-2/160				    UNIVAC-1100/70
+      SUN-2/170				    UNIVAC-1160
+
+
+
+Reynolds & Postel				               [Page 85]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+      UNKNOWN
+      VAX-11/725
+      VAX-11/730
+      VAX-11/750
+      VAX-11/780
+      VAX-11/785
+      VAX-11/790
+      VAX-11/8600
+      VAX-8600
+      WANG-PC002
+      WANG-VS100
+      WANG-VS400
+      WYSE-386
+      XEROX-1108
+      XEROX-8010
+      ZENITH-148
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 86]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+			       SYSTEM NAMES
+
+   These are the Official System Names as they appear in the Domain Name
+   System HINFO	records	and the	NIC Host Table.	 Their use is described
+   in RFC-952 [53].
+
+   A system name may be	up to 40 characters taken from the set of upper-
+   case	letters, digits, and the three punctuation characters hyphen,
+   period, and slash.  It must start with a letter, and	end with a
+   letter or digit.
+
+   AEGIS		     LISP		       SUN OS 3.5
+   APOLLO		     LISPM		       SUN OS 4.0
+   AIX/370		     LOCUS		       SWIFT
+   AIX-PS/2		     MACOS		       TAC
+   BS-2000		     MINOS		       TANDEM
+   CEDAR		     MOS		       TENEX
+   CGW			     MPE5		       TOPS10
+   CHORUS		     MSDOS		       TOPS20
+   CHRYSALIS		     MULTICS		       TOS
+   CMOS			     MUSIC		       TP3010
+   CMS			     MUSIC/SP		       TRSDOS
+   COS			     MVS		       ULTRIX
+   CPIX			     MVS/SP		       UNIX
+   CTOS			     NEXUS		       UNIX-BSD
+   CTSS			     NMS		       UNIX-V1AT
+   DCN			     NONSTOP		       UNIX-V
+   DDNOS		     NOS-2		       UNIX-V.1
+   DOMAIN		     NTOS		       UNIX-V.2
+   DOS			     OS/DDP		       UNIX-V.3
+   EDX			     OS/2		       UNIX-PC
+   ELF			     OS4		       UNKNOWN
+   EMBOS		     OS86		       UT2D
+   EMMOS		     OSX		       V
+   EPOS			     PCDOS		       VM
+   FOONEX		     PERQ/OS		       VM/370
+   FUZZ			     PLI		       VM/CMS
+   GCOS			     PSDOS/MIT		       VM/SP
+   GPOS			     PRIMOS		       VMS
+   HDOS			     RMX/RDOS		       VMS/EUNICE
+   IMAGEN		     ROS		       VRTX
+   INTERCOM		     RSX11M		       WAITS
+   IMPRESS		     RTE-A		       WANG
+   INTERLISP		     SATOPS		       WIN32
+   IOS			     SCO-XENIX/386	       X11R3
+   IRIX			     SCS		       XDE
+   ISI-68020		     SIMP		       XENIX
+   ITS			     SUN
+
+
+
+Reynolds & Postel				               [Page 87]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+			PROTOCOL AND SERVICE NAMES
+
+   These are the Official Protocol Names as they appear	in the Domain
+   Name	System WKS records and the NIC Host Table.  Their use is
+   described in	RFC-952	[53].
+
+   A protocol or service may be	up to 40 characters taken from the set
+   of uppercase	letters, digits, and the punctuation character hyphen.
+   It must start with a	letter,	and end	with a letter or digit.
+
+   ARGUS	       - ARGUS Protocol
+   ARP		       - Address Resolution Protocol
+   AUTH		       - Authentication	Service
+   BBN-RCC-MON	       - BBN RCC Monitoring
+   BL-IDM	       - Britton Lee Intelligent Database Machine
+   BOOTP	       - Bootstrap Protocol
+   BOOTPC	       - Bootstrap Protocol Client
+   BOOTPS	       - Bootstrap Protocol Server
+   BR-SAT-MON	       - Backroom SATNET Monitoring
+   CFTP		       - CFTP
+   CHAOS	       - CHAOS Protocol
+   CHARGEN	       - Character Generator Protocol
+   CISCO-FNA	       - CISCO FNATIVE
+   CISCO-TNA	       - CISCO TNATIVE
+   CISCO-SYS	       - CISCO SYSMAINT
+   CLOCK	       - DCNET Time Server Protocol
+   CMOT		       - Common	Mgmnt Info Ser and Prot	over TCP/IP
+   COOKIE-JAR	       - Authentication	Scheme
+   CSNET-NS	       - CSNET Mailbox Nameserver Protocol
+   DAYTIME	       - Daytime Protocol
+   DCN-MEAS	       - DCN Measurement Subsystems Protocol
+   DCP		       - Device	Control	Protocol
+   DGP		       - Dissimilar Gateway Protocol
+   DISCARD	       - Discard Protocol
+   DMF-MAIL	       - Digest	Message	Format for Mail
+   DOMAIN	       - Domain	Name System
+   ECHO		       - Echo Protocol
+   EGP		       - Exterior Gateway Protocol
+   EHF-MAIL	       - Encoding Header Field for Mail
+   EMCON	       - Emission Control Protocol
+   EMFIS-CNTL	       - EMFIS Control Service
+   EMFIS-DATA	       - EMFIS Data Service
+   FINGER	       - Finger	Protocol
+   FTP		       - File Transfer Protocol
+   FTP-DATA	       - File Transfer Protocol	Data
+   GGP		       - Gateway Gateway Protocol
+   GRAPHICS	       - Graphics Protocol
+   HMP		       - Host Monitoring Protocol
+
+
+
+Reynolds & Postel				               [Page 88]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   HOST2-NS	       - Host2 Name Server
+   HOSTNAME	       - Hostname Protocol
+   ICMP		       - Internet Control Message Protocol
+   IGMP		       - Internet Group	Management Protocol
+   IGP		       - Interior Gateway Protocol
+   IMAP2	       - Interim Mail Access Protocol version 2
+   INGRES-NET	       - INGRES-NET Service
+   IP		       - Internet Protocol
+   IPCU		       - Internet Packet Core Utility
+   IPPC		       - Internet Pluribus Packet Core
+   IP-ARC	       - Internet Protocol on ARCNET
+   IP-ARPA	       - Internet Protocol on ARPANET
+   IP-CMPRS	       - Compressing TCP/IP Headers
+   IP-DC	       - Internet Protocol on DC Networks
+   IP-DVMRP	       - Distance Vector Multicast Routing Protocol
+   IP-E		       - Internet Protocol on Ethernet Networks
+   IP-EE	       - Internet Protocol on Exp. Ethernet Nets
+   IP-FDDI	       - Transmission of IP over FDDI
+   IP-HC	       - Internet Protocol on Hyperchannnel
+   IP-IEEE	       - Internet Protocol on IEEE 802
+   IP-IPX	       - Transmission of 802.2 over IPX	Networks
+   IP-MTU	       - IP MTU	Discovery Options
+   IP-NETBIOS	       - Internet Protocol over	NetBIOS	Networks
+   IP-SLIP	       - Transmission of IP over Serial	Lines
+   IP-WB	       - Internet Protocol on Wideband Network
+   IP-X25	       - Internet Protocol on X.25 Networks
+   IRTP		       - Internet Reliable Transaction Protocol
+   ISI-GL	       - ISI Graphics Language Protocol
+   ISO-TP4	       - ISO Transport Protocol	Class 4
+   ISO-TSAP	       - ISO TSAP
+   LA-MAINT	       - IMP Logical Address Maintenance
+   LARP		       - Locus Address Resoultion Protocol
+   LDP		       - Loader	Debugger Protocol
+   LEAF-1	       - Leaf-1	Protocol
+   LEAF-2	       - Leaf-2	Protocol
+   LINK		       - Link Protocol
+   LOC-SRV	       - Location Service
+   LOGIN	       - Login Host Protocol
+   MAIL		       - Format	of Electronic Mail Messages
+   MERIT-INP	       - MERIT Internodal Protocol
+   METAGRAM	       - Metagram Relay
+   MIB		       - Management Information	Base
+   MIT-ML-DEV	       - MIT ML	Device
+   MFE-NSP	       - MFE Network Services Protocol
+   MIT-SUBNET	       - MIT Subnet Support
+   MIT-DOV	       - MIT Dover Spooler
+   MPM		       - Internet Message Protocol (Multimedia Mail)
+   MPM-FLAGS	       - MPM Flags Protocol
+
+
+
+Reynolds & Postel				               [Page 89]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   MPM-SND	       - MPM Send Protocol
+   MSG-AUTH	       - MSG Authentication Protocol
+   MSG-ICP	       - MSG ICP Protocol
+   MUX		       - Multiplexing Protocol
+   NAMESERVER	       - Host Name Server
+   NETBIOS-DGM	       - NETBIOS Datagram Service
+   NETBIOS-NS	       - NETBIOS Name Service
+   NETBIOS-SSN	       - NETBIOS Session Service
+   NETBLT	       - Bulk Data Transfer Protocol
+   NETED	       - Network Standard Text Editor
+   NETRJS	       - Remote	Job Service
+   NI-FTP	       - NI File Transfer Protocol
+   NI-MAIL	       - NI Mail Protocol
+   NICNAME	       - Who Is	Protocol
+   NFILE	       - A File	Access Protocol
+   NNTP		       - Network News Transfer Protocol
+   NSW-FE	       - NSW User System Front End
+   NTP		       - Network Time Protocol
+   NVP-II	       - Network Voice Protocol
+   OSPF		       - Open Shortest Path First Interior GW Protocol
+   PCMAIL	       - Pcmail	Transport Protocol
+   POP2		       - Post Office Protocol -	Version	2
+   POP3		       - Post Office Protocol -	Version	3
+   PPP		       - Point-to-Point	Protocol
+   PRM		       - Packet	Radio Measurement
+   PUP		       - PUP Protocol
+   PWDGEN	       - Password Generator Protocol
+   QUOTE	       - Quote of the Day Protocol
+   RARP		       - A Reverse Address Resolution Protocol
+   RATP		       - Reliable Asynchronous Transfer	Protocol
+   RE-MAIL-CK	       - Remote	Mail Checking Protocol
+   RDP		       - Reliable Data Protocol
+   RIP		       - Routing Information Protocol
+   RJE		       - Remote	Job Entry
+   RLP		       - Resource Location Protocol
+   RTELNET	       - Remote	Telnet Service
+   RVD		       - Remote	Virtual	Disk Protocol
+   SAT-EXPAK	       - Satnet	and Backroom EXPAK
+   SAT-MON	       - SATNET	Monitoring
+   SEP		       - Sequential Exchange Protocol
+   SFTP		       - Simple	File Transfer Protocol
+   SGMP		       - Simple	Gateway	Monitoring Protocol
+   SNMP		       - Simple	Network	Management Protocol
+   SMI		       - Structure of Management Information
+   SMTP		       - Simple	Mail Transfer Protocol
+   SQLSRV	       - SQL Service
+   ST		       - Stream	Protocol
+   STATSRV	       - Statistics Service
+
+
+
+Reynolds & Postel				               [Page 90]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   SU-MIT-TG	       - SU/MIT	Telnet Gateway Protocol
+   SUN-RPC	       - SUN Remote Procedure Call
+   SUPDUP	       - SUPDUP	Protocol
+   SUR-MEAS	       - Survey	Measurement
+   SWIFT-RVF	       - Remote	Virtual	File Protocol
+   TACACS-DS	       - TACACS-Database Service
+   TACNEWS	       - TAC News
+   TCP		       - Transmission Control Protocol
+   TCP-ACO	       - TCP Alternate Checksum	Option
+   TELNET	       - Telnet	Protocol
+   TFTP		       - Trivial File Transfer Protocol
+   THINWIRE	       - Thinwire Protocol
+   TIME		       - Time Server Protocol
+   TP-TCP	       - ISO Transport Service on top of the TCP
+   TRUNK-1	       - Trunk-1 Protocol
+   TRUNK-2	       - Trunk-2 Protocol
+   UCL		       - University College London Protocol
+   UDP		       - User Datagram Protocol
+   NNTP		       - Network News Transfer Protocol
+   USERS	       - Active	Users Protocol
+   UUCP-PATH	       - UUCP Path Service
+   VIA-FTP	       - VIA Systems-File Transfer Protocol
+   VISA		       - VISA Protocol
+   VMTP		       - Versatile Message Transaction Protocol
+   WB-EXPAK	       - Wideband EXPAK
+   WB-MON	       - Wideband Monitoring
+   XNET		       - Cross Net Debugger
+   XNS-IDP	       - Xerox NS IDP
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 91]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+			    TERMINAL TYPE NAMES
+
+These are the Official Terminal	Type Names.  Their use is described in
+RFC-930	[128].	The maximum length of a	name is	40 characters.
+
+A terminal names may be	up to 40 characters taken from the set of upper-
+case letters, digits, and the two punctuation characters hyphen	and
+slash.	It must	start with a letter, and end with a letter or digit.
+
+   ADDS-CONSUL-980			 DATAMEDIA-1521
+   ADDS-REGENT-100			 DATAMEDIA-2500
+   ADDS-REGENT-20			 DATAMEDIA-3025
+   ADDS-REGENT-200			 DATAMEDIA-3025A
+   ADDS-REGENT-25			 DATAMEDIA-3045
+   ADDS-REGENT-40			 DATAMEDIA-3045A
+   ADDS-REGENT-60			 DATAMEDIA-DT80/1
+   ADDS-VIEWPOINT			 DATAPOINT-2200
+   ADDS-VIEWPOINT-60			 DATAPOINT-3000
+   AED-512				 DATAPOINT-3300
+   AMPEX-DIALOGUE-210			 DATAPOINT-3360
+   AMPEX-DIALOGUE-80			 DEC-DECWRITER-I
+   AMPEX-210				 DEC-DECWRITER-II
+   AMPEX-230				 DEC-GIGI
+   ANDERSON-JACOBSON-510		 DEC-GT40
+   ANDERSON-JACOBSON-630		 DEC-GT40A
+   ANDERSON-JACOBSON-832		 DEC-GT42
+   ANDERSON-JACOBSON-841		 DEC-LA120
+   ANN-ARBOR-AMBASSADOR			 DEC-LA30
+   ANSI					 DEC-LA36
+   ARDS					 DEC-LA38
+   BITGRAPH				 DEC-VT05
+   BUSSIPLEXER				 DEC-VT100
+   CALCOMP-565				 DEC-VT101
+   CDC-456				 DEC-VT102
+   CDI-1030				 DEC-VT125
+   CDI-1203				 DEC-VT131
+   C-ITOH-101				 DEC-VT132
+   C-ITOH-50				 DEC-VT200
+   C-ITOH-80				 DEC-VT220
+   CLNZ					 DEC-VT240
+   COMPUCOLOR-II			 DEC-VT241
+   CONCEPT-100				 DEC-VT300
+   CONCEPT-104				 DEC-VT320
+   CONCEPT-108				 DEC-VT340
+   DATA-100				 DEC-VT50
+   DATA-GENERAL-6053			 DEC-VT50H
+   DATAGRAPHIX-132A			 DEC-VT52
+   DATAMEDIA-1520			 DEC-VT55
+
+
+
+Reynolds & Postel				               [Page 92]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   DEC-VT61				 HP-2626
+   DEC-VT62				 HP-2626A
+   DELTA-DATA-5000			 HP-2626P
+   DELTA-DATA-NIH-7000			 HP-2627
+   DELTA-TELTERM-2			 HP-2640
+   DIABLO-1620				 HP-2640A
+   DIABLO-1640				 HP-2640B
+   DIGILOG-333				 HP-2645
+   DTC-300S				 HP-2645A
+   DTC-382				 HP-2648
+   EDT-1200				 HP-2648A
+   EXECUPORT-4000			 HP-2649
+   EXECUPORT-4080			 HP-2649A
+   FACIT-TWIST-4440			 IBM-1050
+   FREEDOM-100				 IBM-2741
+   FREEDOM-110				 IBM-3101
+   FREEDOM-200				 IBM-3101-10
+   GENERAL-TERMINAL-100A		 IBM-3151
+   GENERAL-TERMINAL-101			 IBM-3179-2
+   GIPSI-TX-M				 IBM-3180-2
+   GIPSI-TX-ME				 IBM-3196-A1
+   GIPSI-TX-C4				 IBM-3275-2
+   GIPSI-TX-C8				 IBM-3276-2
+   GSI					 IBM-3276-3
+   HAZELTINE-1420			 IBM-3276-4
+   HAZELTINE-1500			 IBM-3277-2
+   HAZELTINE-1510			 IBM-3278-2
+   HAZELTINE-1520			 IBM-3278-3
+   HAZELTINE-1552			 IBM-3278-4
+   HAZELTINE-2000			 IBM-3278-5
+   HAZELTINE-ESPRIT			 IBM-3279-2
+   HITACHI-5601				 IBM-3279-3
+   HITACHI-5603				 IBM-3477-FC
+   HITACHI-5603E			 IBM-3477-FG
+   HITACHI-5603EA			 IBM-5081
+   HITACHI-560X				 IBM-5151
+   HITACHI-560XE			 IBM-5154
+   HITACHI-560XEA			 IBM-5251-11
+   HITACHI-560PR			 IBM-5291-1
+   HITACHI-HOAP1			 IBM-5292-2
+   HITACHI-HOAP2			 IBM-5555-B01
+   HITACHI-HOAP3			 IBM-5555-C01
+   HITACHI-HOAP4			 IBM-6153
+   HP-2392				 IBM-6154
+   HP-2621				 IBM-6155
+   HP-2621A				 IBM-AED
+   HP-2621P				 IBM-3278-2-E
+   HP-2623				 IBM-3278-3-E
+
+
+
+Reynolds & Postel				               [Page 93]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   IBM-3278-4-E				 TEC
+   IBM-3278-5-E				 TEKTRONIX-4006
+   IBM-3279-2-E				 TEKTRONIX-4010
+   IBM-3279-3-E				 TEKTRONIX-4012
+   IMLAC				 TEKTRONIX-4013
+   INFOTON-100				 TEKTRONIX-4014
+   INFOTON-400				 TEKTRONIX-4023
+   INFOTONKAS				 TEKTRONIX-4024
+   ISC-8001				 TEKTRONIX-4025
+   LSI-ADM-1				 TEKTRONIX-4027
+   LSI-ADM-11				 TEKTRONIX-4105
+   LSI-ADM-12				 TEKTRONIX-4107
+   LSI-ADM-2				 TEKTRONIX-4110
+   LSI-ADM-20				 TEKTRONIX-4112
+   LSI-ADM-22				 TEKTRONIX-4113
+   LSI-ADM-220				 TEKTRONIX-4114
+   LSI-ADM-3				 TEKTRONIX-4115
+   LSI-ADM-31				 TEKTRONIX-4125
+   LSI-ADM-3A				 TEKTRONIX-4404
+   LSI-ADM-42				 TELERAY-1061
+   LSI-ADM-5				 TELERAY-3700
+   MEMOREX-1240				 TELERAY-3800
+   MICROBEE				 TELETEC-DATASCREEN
+   MICROTERM-ACT-IV			 TELETERM-1030
+   MICROTERM-ACT-V			 TELETYPE-33
+   MICROTERM-ERGO-301			 TELETYPE-35
+   MICROTERM-MIME-1			 TELETYPE-37
+   MICROTERM-MIME-2			 TELETYPE-38
+   MICROTERM-ACT-5A			 TELETYPE-40
+   MICROTERM-TWIST			 TELETYPE-43
+   NEC-5520				 TELEVIDEO-910
+   NETRONICS				 TELEVIDEO-912
+   NETWORK-VIRTUAL-TERMINAL		 TELEVIDEO-920
+   OMRON-8025AG				 TELEVIDEO-920B
+   PERKIN-ELMER-550			 TELEVIDEO-920C
+   PERKIN-ELMER-1100			 TELEVIDEO-925
+   PERKIN-ELMER-1200			 TELEVIDEO-955
+   PERQ					 TELEVIDEO-950
+   PLASMA-PANEL				 TELEVIDEO-970
+   QUME-SPRINT-5			 TELEVIDEO-975
+   QUME-101				 TERMINET-1200
+   QUME-102				 TERMINET-300
+   SOROC				 TI-700
+   SOROC-120				 TI-733
+   SOUTHWEST-TECHNICAL-PRODUCTS-CT82	 TI-735
+   SUN					 TI-743
+   SUPERBEE				 TI-745
+   SUPERBEE-III-M			 TI-800
+
+
+
+Reynolds & Postel				               [Page 94]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   TYCOM
+   UNIVAC-DCT-500
+   VIDEO-SYSTEMS-1200
+   VIDEO-SYSTEMS-5000
+   VOLKER-CRAIG-303
+   VOLKER-CRAIG-303A
+   VOLKER-CRAIG-404
+   VISUAL-200
+   VISUAL-55
+   WYSE-30
+   WYSE-50
+   WYSE-60
+   WYSE-75
+   WYSE-85
+   XEROX-1720
+   XTERM
+   ZENITH-H19
+   ZENITH-Z29
+   ZENTEC-30
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				               [Page 95]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+				 DOCUMENTS
+
+
+   [1]	  Anderson, B.,	"TACACS	User Identification Telnet Option",
+	  RFC-927, BBN,	December 1984.
+
+   [2]	  BBN, "Specifications for the Interconnection of a Host and an
+	  IMP",	Report 1822, Bolt Beranek and Newman, Cambridge,
+	  Massachusetts, revised, December 1981.
+
+   [3]	  BBN, "User Manual for	TAC User Database Tool", Bolt Beranek
+	  and Newman, September	1984.
+
+   [4]	  Ben-Artzi, Amatzia, "Network Management for TCP/IP Network: An
+	  Overview", 3Com, May 1988.
+
+   [5]	  Bennett, C., "A Simple NIFTP-Based Mail System", IEN 169,
+	  University College, London, January 1981.
+
+   [6]	  Bhushan, A., "A Report on the	Survey Project", RFC-530,
+	  NIC 17375, June 1973.
+
+   [7]	  Bisbey, R., D. Hollingworth, and B. Britt, "Graphics Language
+	  (version 2.1)", ISI/TM-80-18,	Information Sciences Institute,
+	  July 1980.
+
+   [8]	  Boggs, D., J.	Shoch, E. Taft,	and R. Metcalfe, "PUP: An
+	  Internetwork Architecture", XEROX Palo Alto Research Center,
+	  CSL-79-10, July 1979;	also in	IEEE Transactions on
+	  Communication, Volume	COM-28,	Number 4, April	1980.
+
+   [9]	  Borman, D., Editor, "Telnet Linemode Option",
+	  RFC 1116, Cray Research, Inc., August	1989.
+
+   [10]	  Braden, R., "NETRJS Protocol", RFC-740, NIC 42423,
+	  Information Sciences Institute, November 1977.
+
+   [11]	  Braden, R., and J. Postel, "Requirements for Internet
+	  Gateways", RFC-1009, Obsoletes RFC-985, Information Sciences
+	  Institute, June 1987.
+
+   [12]	  Bressler, B.,	"Remote	Job Entry Protocol",  RFC-407,
+	  NIC 12112, October 1972.
+
+   [13]	  Bressler, R.,	"Inter-Entity Communication -- An Experiment",
+	  RFC-441, NIC 13773, January 1973.
+
+   [14]	  Butler, M., J. Postel, D. Chase, J. Goldberger, and
+
+
+
+Reynolds & Postel				               [Page 96]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+	  J. K.	Reynolds, "Post	Office Protocol	- Version 2", RFC-937,
+	  Information Sciences Institute, February 1985.
+
+   [15]	  Case,	J., M. Fedor, M. Schoffstall, and J. Davin,
+	  "A Simple Network Management Protocol", RFC-1157,
+	  (Obsoletes RFC-1067, RFC-1098), SNMP Research,
+	  Performance Systems International, Performance Systems
+	  International, MIT Laboratory	for Computer Science,
+	  May 1990.
+
+   [16]	  Cass,	D., and	M. Rose, "ISO Transport	Services on Top	of
+	  the TCP", RFC-983, NTRC, April 1986.
+
+   [17]	  Cheriton, D.,	"VMTP: Versatile Message Transaction
+	  Protocol Specification", RFC-1045, pgs 103 & 104,
+	  Stanford University, February	1988.
+
+   [18]	  Cisco	Systems, "Gateway Server Reference Manual", Manual
+	  Revision B, January 10, 1988.
+
+   [19]	  Clark, D., "PCMAIL: A	Distributed Mail System	for Personal
+	  Computers", RFC-984, MIT, May	1986.
+
+   [20]	  Clark, D., M.	Lambert, and L.	Zhang, "NETBLT:	A Bulk Data
+	  Transfer Protocol", RFC-969, MIT Laboratory for Computer
+	  Science, December 1985.
+
+   [21]	  Cohen, D., "On Holy Wars and a Plea for Peace", IEEE Computer
+	  Magazine, October 1981.
+
+   [22]	  Cohen, D., "Specifications for the Network Voice Protocol",
+	  RFC-741, ISI/RR 7539,	Information Sciences Institute,
+	  March	1976.
+
+   [23]	  Cohen, D. and	J. Postel, "Multiplexing Protocol", IEN	90,
+	  Information Sciences Institute, May 1979.
+
+   [24]	  COMPASS, "Semi-Annual	Technical Report", CADD-7603-0411,
+	  Massachusetts	Computer Associates, 4 March 1976. Also	as,
+	  "National Software Works, Status Report No. 1,"
+	  RADC-TR-76-276, Volume 1, September 1976. And	COMPASS. "Second
+	  Semi-Annual Report," CADD-7608-1611, Massachusetts Computer
+	  Associates, August 1976.
+
+   [25]	  Crispin, M., "Telnet Logout Option", Stanford	University-AI,
+	  RFC-727, April 1977.
+
+   [26]	  Crispin, M., "Telnet SUPDUP Option", Stanford	University-AI,
+
+
+
+Reynolds & Postel				               [Page 97]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+	  RFC-736, October 1977.
+
+   [27]	  Crispin, M., "SUPDUP Protocol", RFC-734, NIC 41953,
+	  October 1977.
+
+   [28]	  Crocker, D., "Telnet Output Carriage-Return Disposition
+	  Option", RFC-652, October 1974.
+
+   [29]	  Crocker, D., "Telnet Output Formfeed Disposition Option",
+	  RFC-655, October 1974.
+
+   [30]	  Crocker, D., "Telnet Output Linefeed Disposition", RFC-658,
+	  October 1974.
+
+   [31]	  Crocker, D., "Telnet Output Horizontal Tab Disposition
+	  Option", RFC-654, October 1974.
+
+   [32]	  Crocker, D., "Telnet Output Horizontal Tabstops Option",
+	  RFC-653, October 1974.
+
+   [33]	  Crocker, D., "Telnet Output Vertical Tab Disposition Option",
+	  RFC-657, October 1974.
+
+   [34]	  Crocker, D., "Telnet Output Vertical Tabstops	Option",
+	  RFC-656, October 1974.
+
+   [35]	  Crocker, D. and R. Gumpertz, "Revised	Telnet Byte Marco
+	  Option", RFC-735, November 1977.
+
+   [36]	  Croft, B., and J. Gilmore, "BOOTSTRAP	Protocol (BOOTP)",
+	  RFC-951, Stanford and	SUN Microsytems, September 1985.
+
+   [37]	  Davin, J., J.	Case, M. Fedor,	and M. Schoffstall, "A Simple
+	  Gateway Monitoring Protocol",	RFC-1028, November 1987.
+
+   [38]	  Day, J., "Telnet Data	Entry Terminal Option",	RFC-732,
+	  September 1977.
+
+   [39]	  DCA, "3270 Display System Protocol", #1981-08.
+
+   [40]	  DDN Protocol Handbook, "Telnet Output	Line Width Option",
+	  NIC 50005, December 1985.
+
+   [41]	  DDN Protocol Handbook, "Telnet Output	Page Size Option",
+	  NIC 50005, December 1985.
+
+   [42]	  DDN Protocol Handbook, "Telnet Reconnection Option",
+	  NIC 50005, December 1985.
+
+
+
+Reynolds & Postel				               [Page 98]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [43]	  Deering, S., "Host Extensions	for IP Multicasting",
+	  RFC-1112, Obsoletes RFC-988, RFC-1054, Stanford University,
+	  August 1989.
+
+   [44]	  Elvy,	M., and	R. Nedved, "Network Mail Path Service",	RFC-915,
+	  Harvard and CMU, July	1986.
+
+   [45]	  Feinler, E., editor, "DDN Protocol Handbook",	Network
+	  Information Center, SRI International, December 1985.
+
+   [46]	  Feinler, E., editor, "Internet Protocol Transition Workbook",
+	  Network Information Center, SRI International, March 1982.
+
+   [47]	  Feinler, E. and J. Postel, eds., "ARPANET Protocol Handbook",
+	  NIC 7104, for	the Defense Communications Agency by SRI
+	  International, Menlo Park, California, Revised January 1978.
+
+   [48]	  Finlayson, R., T. Mann, J. Mogul, and	M. Theimer, "A Reverse
+	  Address Resolution Protocol",	RFC-903, Stanford University,
+	  June 1984.
+
+   [49]	  Forgie, J., "ST - A Proposed Internet	Stream Protocol",
+	  IEN 119, MIT Lincoln Laboratory, September 1979.
+
+   [50]	  Forsdick, H.,	"CFTP",	Network	Message, Bolt Beranek and
+	  Newman, January 1982.
+
+   [51]	  Greenberg, B., "Telnet SUPDUP-OUTPUT Option",	RFC-749,
+	  MIT-Multics, September 1978.
+
+   [52]	  Harrenstien, K., "Name/Finger", RFC-742, NIC 42758,
+	  SRI International,  December 1977.
+
+   [53]	  Harrenstien, K., M. Stahl, and E. Feinler, "DOD Internet Host
+	  Table	Specification",	RFC-952, Obsoletes RFC-810,
+	  October 1985.
+
+   [54]	  Harrenstien, K., V. White, and E. Feinler, "Hostnames	Server",
+	  RFC-811, SRI International, March 1982.
+
+   [55]	  Harrenstien, K., and V. White, "Nicname/Whois", RFC-812,
+	  SRI International, March 1982.
+
+   [56]	  Haverty, J., "XNET Formats for Internet Protocol Version 4",
+	  IEN 158, October 1980.
+
+   [57]	  Hedrick, C., "Telnet Terminal	Speed Option", RFC-1079,
+	  Rutgers University, December 1988.
+
+
+
+Reynolds & Postel				               [Page 99]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [58]	  Hedrick, C., "Telnet Remote Flow Control Option",
+	  RFC-1080, Rutgers University,	December 1988.
+
+   [59]	  Hinden, R., "A Host Monitoring Protocol", RFC-869,
+	  Bolt Beranek and Newman, December 1983.
+
+   [60]	  Hinden, R., and A. Sheltzer, "The DARPA Internet Gateway",
+	  RFC-823, September 1982.
+
+   [61]	  Hornig, C., "A Standard for the Transmission of IP Datagrams
+	  over Ethernet	Networks, RFC-894, Symbolics, April 1984.
+
+   [62]	  Internet Activities Board, J.	Postel,	Editor,	"IAB Official
+	  Protocol Standards", RFC-1280, Internet Activities
+	  March	1992.
+
+   [63]	  International	Standards Organization,	"ISO Transport Protocol
+	  Specification	- ISO DP 8073",	RFC-905, April 1984.
+
+   [64]	  International	Standards Organization,	"Protocol for Providing
+	  the Connectionless-Mode Network Services", RFC-926, ISO,
+	  December 1984.
+
+   [65]	  Kantor, B., and P. Lapsley, "Network News Transfer Protocol",
+	  RFC-977, UC San Diego	& UC Berkeley, February	1986.
+
+   [66]	  Kent,	S., and	J. Linn, "Privacy Enhancement for Internet
+	  Electronic Mail: Part	II -- Certificate-Based	Key Management",
+	  BBNCC	and DEC, August	1989.
+
+   [67]	  Khanna, A., and A. Malis, "The ARPANET AHIP-E	Host Access
+	  Protocol (Enhanced AHIP)", RFC-1005, BBN Communications
+	  Corporation, May 1987.
+
+   [68]	  Killian, E., "Telnet Send-Location Option", RFC-779,
+	  April	1981.
+
+   [69]	  Korb,	J., "A Standard	for the	Transmission of	IP Datagrams
+	  Over Public Data Networks", RFC-877, Purdue University,
+	  September 1983.
+
+   [70]	  Levy,	S., and	T. Jacobson, "Telnet X.3 PAD Option", RFC-1053,
+	  Minnesota Supercomputer Center, April	1988.
+
+   [71]	  Linn,	J., "Privacy Enhancement for Internet Electronic
+	  Mail:	Part I:	Message	Encipherment and Authentication
+	  Procedures", RFC-1113, Obsoletes RFC-989 and RFC-1040, DEC,
+	  August 1989.
+
+
+
+Reynolds & Postel				              [Page 100]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [72]	  Linn,	J., "Privacy Enhancement for Internet Electronic
+	  Mail:	Part III -- Algorithms,	Modes, and Identifiers",
+	  RFC-1115, DEC, August	1989.
+
+   [73]	  Lottor, M., "Simple File Transfer Protocol", RFC-913,	MIT,
+	  September 1984.
+
+   [74]	  M/A-COM Government Systems, "Dissimilar Gateway Protocol
+	  Specification, Draft Version", Contract no. CS901145,
+	  November 16, 1987.
+
+   [75]	  Marcy, G., "Telnet X Display Location	Option", RFC-1096,
+	  Carnegie Mellon University, March 1989.
+
+   [76]	  Malis, A., "Logical Addressing Implementation	Specification",
+	  BBN Report 5256, pp 31-36, May 1983.
+
+   [77]	  Malkin, G., "KNET/VM Command Message Protocol	Functional
+	  Overview", Spartacus,	Inc., January 4, 1988.
+
+   [78]	  Metcalfe, R. M. and D. R. Boggs, "Ethernet: Distributed Packet
+	  Switching for	Local Computer Networks", Communications of the
+	  ACM, 19 (7), pp 395-402, July	1976.
+
+   [79]	  Miller, T., "Internet	Reliable Transaction Protocol",	RFC-938,
+	  ACC, February	1985.
+
+   [80]	  Mills, D., "Network Time Protocol (Version 1), Specification
+	  and Implementation", RFC-1059, University of Delaware,
+	  July 1988.
+
+   [81]	  Mockapetris, P., "Domain Names - Concepts and
+	  Facilities", RFC-1034, Obsoletes RFCs	882, 883, and
+	  973, Information Sciences Institute, November	1987.
+
+   [82]	  Mockapetris, P., "Domain Names - Implementation and
+	  Specification", RFC-1035, Obsoletes RFCs 882,	883, and
+	  973, Information Sciences Institute, November	1987.
+
+   [83]	  Moy, J., "The	OSPF Specification", RFC 1131, Proteon,
+	  October 1989.
+
+   [84]	  Nedved, R., "Telnet Terminal Location	Number Option",	RFC-946,
+	  Carnegie-Mellon University, May 1985.
+
+   [85]	  NSW Protocol Committee, "MSG:	The Interprocess Communication
+	  Facility for the National Software Works", CADD-7612-2411,
+	  Massachusetts	Computer Associates, BBN 3237, Bolt Beranek and
+
+
+
+Reynolds & Postel				              [Page 101]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+	  Newman, Revised December 1976.
+
+   [86]	  Onions, J., and M. Rose, "ISO-TP0 bridge between TCP
+	  and X.25", RFC-1086, Nottingham, TWG,	December 1988.
+
+   [87]	  Partridge, C.	and G. Trewitt,	The High-Level Entity Management
+	  System (HEMS), RFCs 1021, 1022, 1023,	and 1024, BBN/NNSC,
+	  Stanford, October, 1987.
+
+   [88]	  Plummer, D., "An Ethernet Address Resolution Protocol	or
+	  Converting Network Protocol Addresses	to 48-bit Ethernet
+	  Addresses for	Transmission on	Ethernet Hardware", RFC-826,
+	  MIT-LCS, November 1982.
+
+   [89]	  Postel, J., "Active Users", RFC-866, Information
+	  Sciences Institute, May 1983.
+
+   [90]	  Postel, J., and J. Reynolds, "A Standard for the Transmission
+	  of IP	Datagrams over IEEE 802	Networks", RFC-1042,
+	  USC/Information Sciences Institute, February 1988.
+
+   [91]	  Postel, J., "A Standard for the Transmission of IP Datagrams
+	  over Experimental Ethernet Networks, RFC-895,	Information
+	  Sciences Institute, April 1984.
+
+   [92]	  Postel, J., "Character Generator Protocol", RFC-864,
+	  Information Sciences Institute, May 1983.
+
+   [93]	  Postel, J., "Daytime Protocol", RFC-867, Information Sciences
+	  Institute, May 1983.
+
+   [94]	  Postel, J., "Discard Protocol", RFC-863, Information Sciences
+	  Institute, May 1983.
+
+   [95]	  Postel, J., "Echo Protocol", RFC-862,	Information Sciences
+	  Institute, May 1983.
+
+   [96]	  Postel, J. and J. Reynolds, "File Transfer Protocol",	RFC-959,
+	  Information Sciences Institute, October 1985.
+
+   [97]	  Postel, J., "Internet	Control	Message	Protocol - DARPA
+	  Internet Program Protocol Specification", RFC-792,
+	  Information Sciences Institute, September 1981.
+
+   [98]	  Postel, J., "Internet	Message	Protocol", RFC-759, IEN	113,
+	  Information Sciences Institute, August 1980.
+
+   [99]	  Postel, J., "Name Server", IEN 116, Information Sciences
+
+
+
+Reynolds & Postel				              [Page 102]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+	  Institute, August 1979.
+
+   [100]  Postel, J., "Quote of	the Day	Protocol", RFC-865,
+	  Information Sciences Institute, May 1983.
+
+   [101]  Postel, J., "Remote Telnet Service", RFC-818,
+	  Information Sciences Institute, November 1982.
+
+   [102]  Postel, J., "Simple Mail Transfer Protocol", RFC-821,
+	  Information Sciences Institute, August 1982.
+
+   [103]  Postel, J., "Telnet End of Record Option", RFC-885,
+	  Information Sciences Institute, December 1983.
+
+   [104]  Postel, J., "User Datagram Protocol",	RFC-768
+	  Information Sciences Institute, August 1980.
+
+   [105]  Postel, J., ed., "Internet Protocol -	DARPA Internet Program
+	  Protocol Specification", RFC-791, Information	Sciences
+	  Institute, September 1981.
+
+   [106]  Postel, J., ed., "Transmission Control Protocol - DARPA
+	  Internet Program Protocol Specification", RFC-793,
+	  Information Sciences Institute, September 1981.
+
+   [107]  Postel, J. and D. Crocker, "Remote Controlled	Transmission and
+	  Echoing Telnet Option", RFC-726, March 1977.
+
+   [108]  Postel, J., and K. Harrenstien, "Time	Protocol", RFC-868,
+	  Information Sciences Institute, May 1983.
+
+   [109]  Postel, J. and J. Reynolds, "Telnet Extended Options - List
+	  Option", RFC-861, Information	Sciences Institute, May	1983.
+
+   [110]  Postel, J. and J. Reynolds, "Telnet Binary Transmission",
+	  RFC-856, Information Sciences	Institute, May 1983.
+
+   [111]  Postel, J. and J. Reynolds, "Telnet Echo Option", RFC-857,
+	  Information Sciences Institute, May 1983.
+
+   [112]  Postel, J., and J. Reynolds, "Telnet Protocol	Specification",
+	  RFC-854, Information Sciences	Institute, May 1983.
+
+   [113]  Postel, J. and J. Reynolds, "Telnet Status Option", RFC-859,
+	  Information Sciences Institute, May 1983.
+
+   [114]  Postel, J. and J. Reynolds, "Telnet Suppress Go Ahead	Option",
+	  RFC-858, Information Sciences	Institute, May 1983.
+
+
+
+Reynolds & Postel				              [Page 103]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [115]  Postel, J. and J. Reynolds, "Telnet Timing Mark Option",
+	  RFC-860, Information Sciences	Institute, May 1983.
+
+   [116]  Rekhter, J., "Telnet 3270 Regime Option", RFC-1041,
+	  IBM, January 1988.
+
+   [117]  Reynolds, J.,	"BOOTP Vendor Information Extensions",
+	  RFC 1084, Information	Sciences Institute, December 1988.
+
+   [118]  Reynolds, J. and J. Postel, "Official	Internet Protocols",
+	  RFC-1011, USC/Information Sciences Institute,	May 1987.
+	  [NOTE: This document is replaced by "IAB Official Protocol
+	  Standards" [62].]
+
+   [119]  Romano, S., M. Stahl,	and M. Recker, "Internet Numbers",
+	  RFC-1166, SRI-NIC, May 1990.
+
+   [120]  Rose,	M., and	K. McCloghrie, "Structure and Identification of
+	  Management Information for TCP/IP-based internets", RFC-1155,
+	  Performance Systems International, Hughes LAN	Systems,
+	  May 1990.
+
+   [121]  McCloghrie, K., and M. Rose, "Management Information Base for
+	  Network Management of	TCP/IP-based internets:	MIB-II",
+	  RFC-1213, Hughes LAN Systems,	Performance Systems
+	  International, March 1991.
+
+   [122]  Rose,	M., "Post Office Protocol - Version 3",	RFC 1225,
+	  PSI, May 1991.
+
+   [123]  Seamonson, L.	J., and	E. C. Rosen, "STUB" Exterior Gateway
+	  Protocol", RFC-888, BBN Communications Corporation,
+	  January 1984.
+
+   [124]  Shuttleworth,	B., "A Documentary of MFENet, a	National
+	  Computer Network", UCRL-52317, Lawrence Livermore Labs,
+	  Livermore, California, June 1977.
+
+   [125]  Silverman, S., "Output Marking Telnet	Option", RFC-933, MITRE,
+	  January 1985.
+
+   [126]  Sollins, K., "The TFTP Protocol (Revision 2)", RFC-783,
+	  MIT/LCS, June	1981.
+
+   [127]  Solomon, M., L. Landweber, and D. Neuhengen, "The CSNET Name
+	  Server", Computer Networks, v.6, n.3,	pp. 161-172, July 1982.
+
+   [128]  Solomon, M., and E. Wimmers, "Telnet Terminal	Type Option",
+
+
+
+Reynolds & Postel				              [Page 104]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+	  RFC-930, Supercedes RFC-884, University of Wisconsin,	Madison,
+	  January 1985.
+
+   [129]  Sproull, R., and E. Thomas, "A Networks Graphics Protocol",
+	  NIC 24308, August 1974.
+
+   [130]  St. Johns, M., "Authentication Service", RFC-931, TPSC,
+	  January 1985.
+
+   [131]  Tappan, D., "The CRONUS Virtual Local	Network", RFC-824,
+	  Bolt Beranek and Newman, August 1982.
+
+   [132]  Taylor, J., "ERPC Functional Specification", Version 1.04,
+	  HYDRA	Computer Systems, Inc.,	July 1984.
+
+   [133]  "The Ethernet, A Local Area Network: Data Link Layer and
+	  Physical Layer Specification", AA-K759B-TK, Digital Equipment
+	  Corporation, Maynard,	MA.  Also as:  "The Ethernet - A Local
+	  Area Network", Version 1.0, Digital Equipment	Corporation,
+	  Intel	Corporation, Xerox Corporation,	September 1980.	 And:
+	  "The Ethernet, A Local Area Network: Data Link Layer and
+	  Physical Layer Specifications", Digital, Intel and Xerox,
+	  November 1982.  And:	XEROX, "The Ethernet, A	Local Area
+	  Network: Data	Link Layer and Physical	Layer Specification",
+	  X3T51/80-50, Xerox Corporation, Stamford, CT., October 1980.
+
+   [134]  The High Level Protocol Group, "A Network Independent	File
+	  Transfer Protocol",  INWG Protocol Note 86, December 1977.
+
+   [135]  Thomas, Bob, "The Interhost Protocol to Support CRONUS/DIAMOND
+	  Interprocess Communication", BBN, September 1983.
+
+   [136]  Tovar, "Telnet Extended ASCII	Option", RFC-698, Stanford
+	  University-AI, July 1975.
+
+   [137]  Uttal, J., J.	Rothschild, and	C. Kline, "Transparent
+	  Integration of UNIX and MS-DOS", Locus Computing Corporation.
+
+   [138]  Velten, D., R. Hinden, and J.	Sax, "Reliable Data Protocol",
+	  RFC-908, BBN Communications Corporation, July	1984.
+
+   [139]  Waitzman, D.,	"Telnet	Window Size Option", RFC-1073,
+	  BBN STC, October, 1988.
+
+   [140]  Waitzman, D.,	C. Partridge, and S. Deering
+	  "Distance Vector Multicast Routing Protocol",	RFC-1075,
+	  BBN STC and Stanford University, November 1988.
+
+
+
+
+Reynolds & Postel				              [Page 105]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [141]  Wancho, F., "Password	Generator Protocol",  RFC-972, WSMR,
+	  January 1986.
+
+   [142]  Warrier, U., and L. Besaw, "The Common Management
+	  Information Services and Protocol over TCP/IP	(CMOT)",
+	  RFC-1095, Unisys Corp. and Hewlett-Packard, April 1989.
+
+   [143]  Welch, B., "The Sprite Remote	Procedure Call System",
+	  Technical Report, UCB/Computer Science Dept.,	86/302,
+	  University of	California at Berkeley,	June 1986.
+
+   [144]  Xerox, "Courier: The Remote Procedure	Protocol", XSIS	038112,
+	  December 1981.
+
+   [145]  Yasuda, A., and T. Thompson, "TELNET Data Entry Terminal
+	  Option DODIIS	Implementation", RFC 1043, DIA,	February 1988.
+
+   [146]  Simpson, W., "The Point-to-Point Protocol (PPP) for the
+	  Transmission of Multi-Protocol Datagrams Over	Point-to-Point
+	  Links", RFC 1331, Daydreamer,	May 1992.
+
+   [147]  McGregor, G.,	"The (PPP) Internet Protocol Control Protocol
+	  (IPCP)", RFC 1332, Merit, May	1992.
+
+   [148]  Woodburn, W.,	and D. Mills, "	A Scheme for an	Internet
+	  Encapsulation	Protocol: Version 1", RFC 1241,	SAIC,
+	  University of	Delaware, July 1991.
+
+   [149]  McCloghrie, K., and M. Rose, "Management Information Base for
+	  Network Management of	TCP/IP-based internets", Hughes	LAN
+	  Systems,  Performance	Systems	International, May 1990.
+
+   [150]  McCloghrie, K., and M. Rose, "Management Information Base for
+	  Network Management of	TCP/IP-based internets:	MIB-II",
+	  RFC 1213, Hughes LAN Systems,	 Performance Systems
+	  International, March 1991.
+
+   [151]  McCloghrie, K., Editor, "Extensions to the Generic-Interface
+	  MIB",	RFC 1229, Hughes LAN Systems, May 1991.
+
+   [152]  Waldbusser, S., Editor, "AppleTalk Management	Information
+	  Base", RFC 1243, Carnegie Mellon University, July 1991.
+
+   [153]  Baker, F., and R. Coltun, "OSPF Version 2 Management
+	  Information Base", RFC 1253, ACC, Computer Science Center,
+	  August 1991.
+
+   [154]  Willis, S, and J. Burruss, "Definitions of Managed Objects
+
+
+
+Reynolds & Postel				              [Page 106]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+	  for the Border Gateway Protocol (Version 3)",	RFC 1269,
+	  Wellfleet Communications Inc., October 1991.
+
+   [155]  Waldbusser, S., "Remote Network Monitoring Management
+	  Information Base", RFC 1271, Carnegie	Mellon University,
+	  November 1991.
+
+   [156]  Decker, E., Langille,	P., Rijsinghani, A., and K. McCloghrie,
+	  "Definitions of Managed Objects for Bridges",	RFC 1286,
+	  cisco	Systems, Inc., DEC,  Hughes LAN	Systems, Inc.,
+	  December 1991.
+
+   [157]  Cook,	J., Editor, Definitions	of Managed Objects for the
+	  Ethernet-like	Interface Types", RFC 1284, Chipcom Corporation,
+	  December 1991.
+
+   [158]  McCloghrie, K., and R. Fox, "IEEE 802.4 Token	Bus MIB",
+	  RFC 1230, Hughes LAN Systems,	Inc., Synoptics, Inc.,
+	  May 1991.
+
+   [159]  McCloghrie, K., Fox, R., and E. Decker, "IEEE	802.5 Token
+	  Ring MIB", RFC 1231, Hughes LAN Systems, Inc., Synoptics,
+	  Inc.,	cisco Systems, Inc., May 1991.
+
+   [160]  Case,	J., "FDDI Management Information Base",	RFC 1285,
+	  SNMP Research, Incorporated, January 1992.
+
+   [161]  Baker, F., and C. Kolb, Editors, "Definitions	of Managed
+	  Objects for the DS1 Interface	Type", RFC 1232, ACC,
+	  Performance Systems International, Inc., May 1991.
+
+   [162]  Cox, T., and K. Tesink, Editors, "Definitions	of Managed
+	  Objects for the DS3 Interface	Type", RFC 1233, Bell
+	  Communications Research, May 1991.
+
+   [163]  Reynolds, J.,	"Reassignment of Experimental MIBs to
+	  Standard MIBs", RFC 1239, ISI, June 1991.
+
+   [164]  Cox, T., and K. Tesnik, Editors, "Definitions	of Managed
+	  Objects for the SIP Interface	Type", RFC 1304, Bell
+	  Communications Research, February 1992.
+
+   [165]  Stewart, B., Editor, "Definitions of Managed Objects
+	  for Character	Stream Devices", RFC 1316, Xyplex, Inc.,
+	  April	1992.
+
+   [166]  Stewart, B., Editor, "Definitions of Managed Objects for
+	  RS-232-like Hardware Devices", RFC 1317, Xyplex, Inc.,
+
+
+
+Reynolds & Postel				              [Page 107]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+	  April	1992.
+
+   [167]  Stewart, B., Editor, "Definitions of Managed Objects
+	  for Parallel-printer-like Hardware Devices", RFC 1318,
+	  Xyplex, Inc.,	April 1992.
+
+   [168]  Brown, C., Baker, F.,	and C. Carvalho, "Management
+	  Information Base for Frame Relay DTEs", RFC 1315,
+	  Wellfleet Communications, Inc., Advanced Computer
+	  Communications, April	1992.
+
+   [169]  Borenstein, N., and N. Freed,	"MIME (Multipurpose Internet
+	  Mail Extensions): Mechanisms for Specifying and Describing
+	  the Format of	Internet Message Bodies", RFC 1341, Bellcore,
+	  Innosoft, June 1992.
+
+   [170]  Simonsen, K.,	"Character Mnemonics & Character Sets",
+	  RFC 1345, Rationel Almen Planlaegning, June 1992.
+
+   [171]  Dorner, S., and P. Resnick, "Remote Mail Checking Protocol",
+	  RFC 1339, U. of Illinois at Urbana-Champaign,	June 1992.
+
+   [172]  Everhart, C.,	Mamakos, L., Ullmann, R., and P. Mockapetris,
+	  Editors, "New	DNS RR Definitions", RFC 1183, Transarc,
+	  University of	Maryland, Prime	Computer, ISI, October 1990.
+
+   [173]  Bradley, T., and C. Brown, "Inverse Address Resolution
+	  Protocol", RFC 1293, Wellfleet Communications, Inc.,
+	  January 1992.
+
+   [174]  Manning, B. "DNS NSAP	RRs", RFC 1348,	Rice University,
+	  July 1992.
+
+   [175]  Simpson, W., "PPP Link Quality Monitoring", RFC 1333,
+	  Daydreamer, May 1992.
+
+   [176]  Baker, F., Editor, "Point-to-Point Protocol Extensions for
+	  Bridging", RFC 1220, ACC, April 1991.
+
+   [177]  McCloghrie, K., Davin, J., and J. Galvin, "Definitions of
+	  Managed Objects for Administration of	SNMP Parties",
+	  RFC 1353, Hughes LAN Systems,	Inc., MIT Laboratory for
+	  Computer Science, Trusted Information	Systems, Inc.,
+	  July 1992.
+
+
+
+
+
+
+
+Reynolds & Postel				              [Page 108]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+				  PEOPLE
+
+
+   [AB20]    Art Berggreen	 ACC	   art@SALT.ACC.COM
+
+   [ABB2]    A.	Blasco Bonito	 CNUCE	   blasco@ICNUCEVM.CNUCE.CNR.IT
+
+   [AD14]    Annette DeSchon	 ISI	   DESCHON@ISI.EDU
+
+   [AGM]     Andy Malis		 BBN	   Malis@BBN.COM
+
+   [AKH5]    Arthur Hartwig	 UQNET
+		   munnari!wombat.decnet.uq.oz.au!ccarthur@UUNET.UU.NET
+
+   [ANM2]    April N. Marine	 SRI	   april@nisc.sri.com
+
+   [AW90]    Amanda Walker	 Intercon  AMANDA@INTERCON.COM
+
+   [AXB]     Albert G. Broscius	 UPENN	   broscius@DSL.CIS.UPENN.EDU
+
+   [AXB1]    Amatzia Ben-Artzi		   ---none---
+
+   [AXB2]    Andre Baux		 Bull	   baux@ec.bull.fr
+
+   [AXB3]    Anil Bhavnani	 Kalpana, Inc.	 ---none---
+
+   [AXB4]    Alan Brind		 Cameo Communications, Inc.
+					   ---none---
+
+   [AXC]     Andrew Cherenson	 SGI	   arc@SGI.COM
+
+   [AXC1]    Anthony Chung	 Sytek
+				    sytek!syteka!anthony@HPLABS.HP.COM
+
+   [AXF]     Annmarie Freitas	 Microcom  ---none---
+
+   [AXH]     Arthur Harvey	DEC	   harvey@gah.enet.dec.com
+
+   [AXK]     Anastasios	Kotsikonas  Boston University
+					   tasos@cs.bu.edu
+
+   [AXL]     Alan Lloyd		Datacraft  alan@datacraft.oz
+
+   [AXM]     Alex Martin	Retix	   ---none---
+
+   [AXM1]    Ashok Marwaha	Unisys	   ---none---
+
+
+
+
+
+Reynolds & Postel				              [Page 109]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [AXM2]    Andrew McRae	Megadata Pty Ltd.
+					   andrew@megadata.mega.oz.au
+
+   [AXP]     Anil Prasad	WilTel	   wiltel!aprasad@uunet.UU.NET
+
+   [AXP1]    A.	Pele		OST	   ---none---
+
+   [AXS]     Arthur Salazar	Locus	   lcc.arthur@SEAS.UCLA.EDU
+
+   [AXS1]    Andrew Smith	Ascom	   andrew@hasler.ascom.ch
+
+   [AXS2]    Anil Singhal	Frontier   ---none---
+
+   [BA4]     Brian Anderson	 BBN	   baanders@CCQ.BBN.COM
+
+   [BCH2]    Barry Howard	 LLNL	   Howard@NMFECC.LLNL.GOV
+
+   [BCN]     B.	Clifford Neuman	 ISI	   bcn@isi.edu
+
+   [BD70]    Bernd Doleschal	 SEL	   Doleschal@A.ISI.EDU
+
+   [BH144]   Bridget Halsey	 Banyan	   bah@BANYAN.BANYAN.COM
+
+   [BJR2]    Bill Russell	 NYU	   russell@cmcl2.NYU.EDU
+
+   [BK29]    Brian Kantor	 UCSD	   brian@UCSD.EDU
+
+   [BKR]     Brian Reid		 DEC	   reid@DECWRL.DEC.COM
+
+   [BM60]    Bede McCall	 Mitre	   bede@mitre.org
+
+   [BP52]    Brad Parker	 CAYMAN	   brad@cayman.Cayman.COM
+
+   [BS221]   Bob Stewart	 Xyplex	   STEWART@XYPLEX.COM
+
+   [BV15]    Bernie Volz	 PSC	   VOLZ@PROCESS.COM
+
+   [BWB6]    Barry Boehm	 DARPA	   boehm@DARPA.MIL
+
+   [BXA]     Bill Anderson	 MITRE	   wda@MITRE-BEDFORD.ORG
+
+   [BXB]     Brad Benson	 Touch	   ---none---
+
+   [BXD]     Brian Dockter	 Northwest Digital Systems
+					   ---none---
+
+   [BXE]     Brian A. Ehrmantraut Auspex Systems bae@auspex.com
+
+
+
+
+Reynolds & Postel				              [Page 110]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [BXE1]    Brendan Eich	 SGI	   brendan@illyria.wpd.sgi.com
+
+   [BXF]     Bruce Factor	 Artificial Horizons, Inc.
+				     ahi!bigapple!bruce@uunet.UU.NET
+
+   [BXF1]    Bill Flanagan	 Lotus Development Corp.
+				     bflanagan@lotus.com
+
+   [BXF2]    Bob Friesenhahn	 PUREDATA Research/USA
+					    pdrusa!bob@uunet.UU.NET
+
+   [BXG]     Bob Grady		 Tekelec   ---none---
+
+   [BXH]     Brian Horn		 Locus	   ---none---
+
+   [BXH1]    Bill Harrell	 TI	   ---none---
+
+   [BXK]     Bill King		 Allen-Bradley Co.
+			       abvax!calvin.icd.ab.com!wrk@uunet.UU.NET
+
+   [BXK1]    Bill Keatley	 American Airlines ---none---
+
+   [BXK2]    Bruce Kropp	 ADC Kentrox
+						ktxc8!bruce@uunet.UU.NET
+
+   [BXL]     Brian Lloyd	 SIRIUS	   ---none---
+
+   [BXL1]    Brian Lloyd	 Telebit   brian@robin.telebit.com
+
+   [BXL2]    Bernard Lemercier	 BIM	   bl@sunbim.be
+
+   [BXM]     RL	"Bob" Morgan	 Stanford University
+					   morgan@jessica.stanford.edu
+
+   [BXM1]    Bob Meierhofer	 Computer Network Technology Corp.
+					   ---none---
+
+   [BXN]     Bill Norton	 Merit	   wbn@MERIT.EDU
+
+   [BXO]     Brian O'Shea	 Visual	   bos@visual.com
+
+   [BXP]     Brad Parke		 Intecom   ---none---
+
+   [BXP1]    Brian Petry	 Systech Computer Corporation
+					systech!bpetry@uunet.UU.NET
+
+   [BXR]     Bob Rosenbaum	 WINDATA   ---none---
+
+
+
+
+Reynolds & Postel				              [Page 111]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [BXR1]    Bill Rose		 SSD Management, Inc.  --none---
+
+   [BXS]     Bill Simpson	 ACS	   bsimpson@vela.acs.oakland.edu
+
+   [BXS1]    Blair Sanders	 Texas Instruments
+					   Blair_Sanders@mcimail.com
+
+   [BXS2]    Bill Schilit	 Xerox PARC  schilit@parc.xerox.com
+
+   [BXT]     Bruce Taber	 Interlan  taber@europa.InterLan.COM
+
+   [BXV]     Bill Versteeg	 NCR	   bvs@NCR.COM
+
+   [BXW]     Brent Welch	 Sprite
+			brent%sprite.berkeley.edu@GINGER.BERKELEY.EDU
+
+   [BXW1]    Bruce Willins	 Raycom	   ---none---
+
+   [BXZ]     Bob Zaniolo	 Reuter	   ---none---
+
+   [CLH3]    Charles Hedrick	 RUTGERS   HEDRICK@ARAMIS.RUTGERS.EDU
+
+   [CMR]     Craig Rogers	 ISI	   Rogers@ISI.EDU
+
+   [CS1]     Chikong Shue	 Cascade Communications	Corp.
+				     alpo!chi@uunet.uu.net
+
+   [CWL]     Charles W.	Lynn, Jr. BBN	   CLYNN@BBN.COM
+
+   [CXA]     Cyrus Azar		  Symplex Communications Corp.
+					   ---none---
+
+   [CXB]     Caralyn Brown	 Wellfleet
+		     cbrown%wellfleet.com@talcott.harvard.edu
+
+   [CXB1]    Carl Beame		 Beame & Whiteside
+					   beame@ns.bws.com
+
+   [CXC]     Creighton Chong	 Network Peripherals Inc.
+					cchong@fastnet.com
+
+   [CXC1]    Chih-Yi Chen	 Tatung	Co., Ltd.
+			     TCCISM1%TWNTTIT.BITNET@pucc.Princeton.EDU
+
+   [CXC2]    Chuck Chriss	 Trillium Digital Systems
+					 76675.1372@compuserve.com
+
+   [CXD]     Chuck Davin	 MIT	   jrd@ptt.lcs.mit.edu
+
+
+
+Reynolds & Postel				              [Page 112]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [CXD1]    Carl H. Dreyer	 RC International A/S
+						    chd@rci.dk
+
+   [CXD2]    Charles Dulin	 Parallan Computer, Inc. ---none---
+
+   [CXF]     Catherine Foulston	 RICE	   cathyf@rice.edu
+
+   [CXH]     Ching-Fa Hwang	 Proxar	   cfh@proxar.com
+
+   [CXH1]    Claude Huss	 Matsushita Tokyo Research Labs
+					   claude@trc.mew.mei.co.jp
+
+   [CXI1]    Clyde Iwamoto	 Stratacom cki@strata.com
+
+   [CXL]     Chung Lam		 Fujitsu   ---none---
+
+   [CXL1]    Christopher Leong	 DEC	  leong@kolmod.mlo.dec.com
+
+   [CXM]     Charles Marker II	 MIPS	  marker@MIPS.COM
+
+   [CXM1]    Carl Madison	 Star-Tek, Inc.	 carl@startek.com
+
+   [CXM2]    Carl Marcinik	 Formation, Inc.  ---none---
+
+   [CXM3]    Chuck McManis	 Sun	  Chuck.McManis@Eng.Sun.COM
+
+   [CXR]     Cheryl Krupczak	 NCR
+				 clefor@secola.columbia.ncr.com
+
+   [CXS]     Craig Scott	 NetWorth, Inc.	 ---none---
+
+   [CXS1]    Chip Standifer	 Technology Dynamics, Inc.
+					   TDYNAMICS@MCIMAIL.COM
+
+   [CXT]     Christopher Tengi	 Princeton tengi@Princeton.EDU
+
+   [CXT1]    Chris Thomas	 Intel Corporation
+						 ---none--
+
+   [CXV]     Carl Vanderbeek	 Automated Network Management, Inc.
+						 ---none--
+
+   [CXW]     Christopher Wheeler UW  cwheeler@cac.washignton.edu
+
+   [CXW1]    Charles Watt	 SecureWare  watt@sware.com
+
+   [DAG4]    David A. Gomberg	 MITRE	   gomberg@GATEWAY.MITRE.ORG
+
+
+
+
+Reynolds & Postel				              [Page 113]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [DB14]    Dave Borman	 Cray	   dab@CRAY.COM
+
+   [DC126]   Dick Cogger	 Cornell   rhx@CORNELLC.CIT.CORNELL.EDU
+
+   [DCP1]    David Plummer	 MIT	   DCP@SCRC-QUABBIN.ARPA
+
+   [DDC1]    David Clark	 MIT	   ddc@LCS.MIT.EDU
+
+   [DG223]   Doug Goodall	 Goodall Software
+				 goodall!doug@uunet.uu.net
+
+   [DJK13]   David Kaufman	 DeskTalk  ---none---
+
+   [DLM1]    David Mills	 LINKABIT  Mills@HUEY.UDEL.EDU
+
+   [DM28]    Dennis Morris	 DCA	   Morrisd@IMO-UVAX.DCA.MIL
+
+   [DM280]   Dave Mackie	 NCD	   lupine!djm@UUNET.UU.NET
+
+   [DM354]   Don McWilliam	 UBC	   mcwillm@CC.UBC.CA
+
+   [DP4Q]    Drew Perkins	 InterStream
+					  Drew.Perkins@ANDREW.CMU.EDU
+
+   [DP666]   Don Provan		 Novell	   donp@xlnvax.novell.com
+
+   [DR48]    Doug Rosenthal	 MCC	   rosenthal@mcc.com
+
+   [DR137]   David Rageth	 Martin	Marietta  DAVE@MMC.COM
+
+   [DRC3]    Dave Cheriton	 STANFORD
+				 cheriton@PESCADERO.STANFORD.EDU
+
+   [DT15]    Daniel Tappan	 BBN	   Tappan@BBN.COM
+
+   [DT167]   Dennis Thomas	 Tektronics dennist@tektronix.TEK.COM
+
+   [DW181]   David Wolfe	 SRI	   ctabka@TSCA.ISTC.SRI.COM
+
+   [DW183]   David Waitzman	 BBN	   dwaitzman@BBN.COM
+
+   [DW238]   Dave Windorski	 UWisc
+			     DAVID.WINDORSKI@MAIL.ADMIN.WISC.EDU
+
+   [DXA]     Dave Atkinson	 Kinmel	Park	---none---
+
+   [DXB]     Dave Buehmann	 Intergraph ingr!daveb@UUNET.UU.NET
+
+
+
+
+Reynolds & Postel				              [Page 114]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [DXB1]    Dan Bernstein	 NYU	   brnstnd@stealth.acf.nyu.edu
+
+   [DXB2]    Dennis E. Baasch	 Emerging Technologies,	Inc.
+				       etinc!dennis@uu.psi.com
+
+   [DXB3]    David A. Brown	 BICC	   fzbicdb@uk.ac.ucl
+
+   [DXB4]    Donna Beatty	 MICOM Communication Corporation
+					      SYSAD@prime.micom.com
+
+   [DXC]     Dale Cabell	 NetCom	   ---none---
+
+   [DXC1]    Darren Croke	 Micronics Computers Inc.
+					   dc@micronics.com
+
+   [DXC2]    Dale Cabell	XTree	  cabell@smtp.xtree.com
+
+   [DXD]     Dennis J.W. Dube	 VIA SYSTEMS ---none---
+
+   [DXE]     Douglas Egan	 Nokia	   ---none---
+
+   [DXF]     Dave Feldmeier	 Bellcore  dcf@thumper.bellcore.com
+
+   [DXG]     David Goldberg	 SMI	   sun!dg@UCBARPA.BERKELEY.EDU
+
+   [DXG1]     Don Gibson	  Aston-Tate
+		sequent!aero!twinsun!ashtate.A-T.COM!dong@uunet.UU.NET
+
+   [DXG2]    David B. Gurevich	 DHL Systems
+				      dgurevic@rhubarb.ssf-sys.dhl.com
+
+   [DXH]     Donna Hopkins	 US West Advance Technologies
+					    dmhopki@uswat.uswest.com
+
+   [DXH1]    Dave Hudson	 Kendall Square	Research (KSR)
+						    tdh@uunet.UU.NET
+
+   [DXJ]     David Joyner	 NCSU Computing	Center
+				      david@unity.ncsu.edu
+
+   [DXK]     Doug Karl		 OSU
+				     KARL-D@OSU-20.IRCC.OHIO-STATE.EDU
+
+   [DXK1]    Dwain Kinghorn	 Microsoft
+				     microsoft!dwaink@cs.washington.edu
+
+   [DXK2]    Dror Kessler	 DigiBoard  dror@digibd.com
+
+
+
+
+Reynolds & Postel				              [Page 115]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [DXK3]    David E. Kaufman	 Magnalink Communications Corporation
+					  ---none---
+
+   [DXL]     David Lin		 Zenith	  ---none---
+
+   [DXL1]    Dave LeBlang	 Atria Software	 leglang@atria.com
+
+   [DXM]     Didier Moretti	 Ungermann-Bass	---none---
+
+   [DXM2]    David Mittnacht	 Computer Protocol ---none---
+
+   [DXM3]    Danny Mitzel	 Hughes	   dmitzel@whitney.hac.com
+
+   [DXM4]    Deron Meranda	 Cincinnati Bell Info. Systems,	Inc.
+					 bem56094@ucunix.san.uc.EDU
+
+   [DXM5]    Donna McMaster	 SynOptics  mcmaster@synoptics.com
+
+   [DXN]     Danny Nessett	 LLNL Livermore	Computer Center
+					    nessett@ocfmail.ocf.llnl.gov
+
+   [DXP]     Dave Preston	 CMC	   ---none---
+
+   [DXP1]    David Perkins	 Synoptics  dperkins@synoptics.com
+
+   [DXP2]    Dave Presotto	 AT&T	   presotto@reseach.att.com
+
+   [DXR]     Debbie Reed	 Fujikura  ---none---
+
+   [DXR1]    Don Rooney		 ACCTON	   ---none---
+
+   [DXR2]    David Rhein	 HCSD	   davidr@ssd.csd.harris.com
+
+   [DXR3]    David Reed		 MIT-LCS   ---none---
+
+   [DXS]     Dan Shia		 DSET	   dset!shia@uunet.UU.NET
+
+   [DXS1]    Daisy Shen		 IBM	   ---none---
+
+   [DXS2]    Dale Shelton	 Roadnet   ---none---
+
+   [DXS3]    Daniel Steinber	 SUN	   Daniel.Steinberg@Eng.Sun.COM
+
+   [DXS4]    Dirk Smith		 Nu-Mega Technologies, Inc.
+					   ---none---
+
+   [DXT]     Deepak Taneja	 Banyan
+			    Deepak=Taneja%Eng%Banyan@Thing.banyan.com
+
+
+
+Reynolds & Postel				              [Page 116]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [DXT1]    David Taylor	 Empros	Systems	International
+						    dtaylor@ems.cdc.com
+
+   [DXV]     D.	Venkatrangan	 Metrix	   venkat@metrix.com
+
+   [DXW]     Dan Willie		 Codenoll Tech.	Corp.  ---none---
+
+   [DXW1]    Don Weir		 Skyline Technology, Inc.  --none---
+
+   [DY26]    Dennis Yaro	 SUN	   yaro@SUN.COM
+
+   [EAK4]    Earl Killian	 LLL	   EAK@MORDOR.S1.GOV
+
+   [EBM]     Eliot Moss		 MIT	   EBM@XX.LCS.MIT.EDU
+
+   [EP53]    Eric Peterson	 Locus	   lcc.eric@SEAS.UCLA.EDU
+
+   [EXB]     Etienne Baudras-Chardigny	 RCE   ---none---
+
+   [EXC]     Ed	Cain		 DCA	   cain@edn-unix.dca.mil
+
+   [EXC1]    Eric Cooper	 Fore Systems, Inc.  ecc@fore.com
+
+   [EXD]     Eric Decker	 cisco	   cire@cisco.com
+
+   [EXF]     Ed	Fudurich	 Gateway Communications, Inc.
+					   ---none---
+
+   [EXG]    Errol Ginsberg	 Ridgeback Solutions
+				     bacchus!zulu!errol@uu2.psi.com
+
+   [EXM]     Eldon S. Mast	 Netrix	Systems	Corporation
+				     esm@netrix.com
+
+   [EXO]     Eric Olinger	 Peregrine Systems    eric@peregrine.com
+
+   [EXR]     Eric Rubin		 FiberCom  err@FIBERCOM.COM
+
+   [EXR1]    Efrat Ramati	 Lannet	Co. ---none---
+
+   [EXR2]    Edwards E.	Reed	 Xerox	    ipcontact.cin_ops@xerox.com
+
+   [EXW]     E.	Wald		 DEC	    ewald@via.enet.dec.com
+
+   [EXX]     Eduardo		 ESA
+				     EDUATO%ESOC.BITNET@CUNYVM.CUNY.EDU
+
+   [FB77]    Fred Baker		 ACC	   fbaker@acc.com
+
+
+
+Reynolds & Postel				              [Page 117]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [FEIL]			 Unisys
+				     feil@kronos.nisd.cam.unisys.com
+
+   [FJW]     Frank J. Wancho	 WSMR	   WANCHO@WSMR-SIMTEL20.ARMY.MIL
+
+   [FXB1]    Felix Burton	 DIAB	   FB@DIAB.SE
+
+   [FXF]     Farhad Fozdar	 OSCOM International
+				       f_fozdar@fennel.cc.uwa.edu.au
+
+
+   [GAL5]    Guillermo A. Loyola IBM	   LOYOLA@IBM.COM
+
+   [GB7]     Gerd Beling	 FGAN	   GBELING@ISI.EDU
+
+   [GEOF]    Geoff Goodfellow	 OSD	   Geoff@FERNWOOD.MPK.CA.US
+
+   [GM23]    Glenn Marcy	 CMU	   Glenn.Marcy@A.CS.CMU.EDU
+
+   [GS2]     Greg Satz		 cisco	   satz@CISCO.COM
+
+   [GS91]    Guy Streeter	 Intergraph guy@guy.bll.ingr.com
+
+   [GS123]   Geof Stone		 NSC	   geof@NETWORK.COM
+
+   [GSM11]   Gary S. Malkin	 Xylogics  GMALKIN@XYLOGICS.COM
+
+   [GXA]     Glen Arp		 Protools  ---none---
+
+   [GXB]     Gerard Berthet	 Independence Technologies
+					   gerard@indetech.com
+
+   [GXC]     Greg Chesson	 SGI	   Greg@SGI.COM
+
+   [GXC1]    George Clapp	 Bellcore
+				  meritec!clapp@bellcore.bellcore.com
+
+   [GXC2]    Gordon C. Galligher	   gorpong@ping.chi.il.us
+
+   [GXD]     Glenn Davis	 Unidata   davis@unidata.ucar.edu
+
+   [GXD1]    Gordon Day		 INDE Electronics  gday@cs.ubc.ca
+
+   [GXG]     Gil Greenbaum	 Unisys	   gcole@nisd.cam.unisys.com
+
+   [GXH]     Graham Hudspith	 INMOS	   gwh@inmos.co.uk
+
+
+
+
+
+Reynolds & Postel				              [Page 118]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [GXH1]    Gary Haney		 Martin	Marietta Energy	Systems
+					   haneyg@ornl.gov
+
+   [GXH2]     Greg Hummel	  Cellular Technical Servuces
+					   ---none---
+
+   [GXK]     Gunther Kroenert	 Siemens Nixdorf Informationssyteme AG
+					   ---none---
+
+   [GXL]     Glenn Levitt	 McData	Corporation
+					   gpl0363@mcmail.mcdata.com
+
+   [GXM]     Gerald McBrearty	 IBM	   ---none---
+
+   [GXM1]    Glenn Mansfield	 AIC Systems Laboratories Ltd.
+					   glenn@aic.co.jp
+
+   [GXM2]    Garry McCracken	 TIL Systems, Ltd.   ---none---
+
+   [GXN]     Gunnar Nilsson	 Ericsson  ---none---
+
+   [GXP]     Gill Pratt		 MIT	   gill%mit-ccc@MC.LCS.MIT.EDU
+
+   [GXP1]    Greg Pflaum	 IRIS
+				     iris.com!Greg_Pflaum@uunet.uu.net
+
+   [GXS]     Guenther Schreiner	 LINK
+				      snmp-admin@ira.uka.de
+
+   [GXS1]    George Sandoval	 Fibernet  ---none---
+
+   [GXT]     Glenn Trewitt	 STANFORD  trewitt@AMADEUS.STANFORD.EDU
+
+   [GXT1]    Gene Tsudik	 USC	   tsudik@USC.EDU
+
+   [GXW]     Glenn Waters	 Bell Northern gwaters@BNR.CA
+
+   [GXW1]    Gil Widdowson	 Interphase  ---none---
+
+   [GXW2]    Graham Welling	 Dynatech Communications
+					   s8000!gcw@uunet.uu.net
+
+   [HCF2]    Harry Forsdick	 BBN	   Forsdick@BBN.COM
+
+   [HS23]    Hokey Stenn	 Plus5	   hokey@PLUS5.COM
+
+   [HWB]     Hans-Werner Braun	 MICHIGAN  HWB@MCR.UMICH.EDU
+
+
+
+
+Reynolds & Postel				              [Page 119]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [HXB]     Henk Boetzkes	 Netexp	Research   ---none---
+
+   [HXD]     Hans Jurgen Dorr	 Digital-Kienzle Computersystems
+						   ---none---
+
+   [HXE]     Hunaid Engineer	 Cray	   hunaid@OPUS.CRAY.COM
+
+   [HXE1]    Hartvig Ekner	 Dowty Network Systems A/S
+						      hj@dowtyns.dk
+
+   [HXF]     Harley Frazee	 T3Plus	   harley@io.t3plus.com
+
+   [HXF1]    Hiroshi Fujii	 ASTEC,	Inc.  fujii@astec.co.jp
+
+   [HXH]     Harald Hoeg	 Tandberg Data A/S
+					   haho%huldra.uucp@nac.no
+
+   [HXH1]    Howard C. Herbert	 AES	   ---none---
+
+   [HXH2]    Hidekazu Hagiwara	 Takaoka Electric Mfg. Co., Ltd.
+				hagiwara@takaoka.takaoka-electric.co.jp
+
+   [HXK]     Henry Kaijak	 Gandalf   ---none---
+
+   [HXK1]    Hiroshi Kume	 Fuji Xerox Co., Ltd.
+		    Kume%KSPB%Fuji_Xerox@tcpgw.netg.ksp.fujixerox.co.jp
+
+   [HXL]     Henry Lee		 TRW	   henry@trwind.ind.trw.com
+
+   [HXL1]    Hugh Lockhart	 Telecommunication Systems
+					   ---none---
+
+   [HXM]     Hsiang Ming Ma	 Asante	Technology   ---none---
+
+   [HXN]     Henry P. Nagai	 D-Link	   ---none---
+
+   [HXN1]    Heinz Nisi		 Richard Hirschmann GmbH & Co.
+				      mia@intsun.rus.uni-stuttgart.de
+
+   [HXP]     Hong K. Paik	 Samsung   paik@samsung.com
+
+   [HXS]     Heidi Stettner	 Basis,	Inc.  heidi@mtxinu.COM
+
+   [HXT]     Hugh Thomas	 DEC	   thomas@oils.enet.dec.com
+
+   [HXT1]    Hubert Theissen	 AEG KABEL ---none---
+
+   [HXU]     Hirotaka Usuda	 Hitachi   ---none---
+
+
+
+Reynolds & Postel				              [Page 120]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [IEEE]    Vince Condello	 IEEE	   ---none---
+
+   [IXD]     Ian Dickinson	 WUCS	   vato@cu.warwick.ac.uk
+
+   [IXD1]    Israel Drori	 LANOPTICS LTD.	Israel
+					  raanan@techunix.technion.ac.il
+
+   [IXG]     Ian George		 MegaPAC    ---none---
+
+   [IXH]     Ippei Hayashi	 Fujitsu Limited
+				      hayashi@sysrap.cs.fujitsu.co.jp
+
+   [JAG]     James Gosling	 SUN	   JAG@SUN.COM
+
+   [JB478]   Jonathan Biggar	 Netlabs   jon@netlabs.com
+
+   [JBP]     Jon Postel		 ISI	   Postel@ISI.EDU
+
+   [JBW1]    Joseph Walters, Jr. BBN	   JWalters@BBN.COM
+
+   [JCB1]    John Burruss	 BBN	   JBurruss@VAX.BBN.COM
+
+   [JCM48]   Jeff Mogul		 DEC	   mogul@DECWRL.DEC.COM
+
+   [JD21]    Jonathan Dreyer	 BBN	   Dreyer@CCV.BBN.COM
+
+   [JDC20]   Jeffrey Case	 UTK	   case@UTKUX1.UTK.EDU
+
+   [JFH2]    Jack Haverty	 Oracle	Corporation
+					   jhaverty@ORACLE.COM
+
+   [JFW]     Jon F. Wilkes	 STC	   Wilkes@CCINT1.RSRE.MOD.UK
+
+   [JGH]     Jim Herman		 BBN	   Herman@CCJ.BBN.COM
+
+   [JG423]   John Gawf		 Compatible Systems Corporation
+					gawf@compatible.com
+
+   [JJB25]   John Bowe		 BBN	   jbowe@PINEAPPLE.BBN.COM
+
+   [JPH17]   John Hanley	 Oracle	   jhanley@oracle.com
+
+   [JKR1]    Joyce K. Reynolds	 ISI	   JKRey@ISI.EDU
+
+   [JR35]    Jon Rochlis	 MIT	   jon@ATHENA.MIT.EDU
+
+   [JRL3]    John R. LoVerso	 CCUR	   loverso@westford.ccur.com
+
+
+
+
+Reynolds & Postel				              [Page 121]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [JS28]    John A. Shriver	 Proteon   jas@PROTEON.COM
+
+   [JTM4]    John Moy		 Proteon   jmoy@PROTEON.COM
+
+   [JWF]     Jim Forgie		 MIT/LL	   FORGIE@XN.LL.MIT.EDU
+
+   [JXB]     Jeffrey Buffun	 Apollo	   jbuffum@APOLLO.COM
+
+   [JXB1]    John M. Ballard	 Microsoft jballard@microsoft.com
+
+   [JXB2]    John Burnett	 ATM	   ---none---
+
+   [JXC]     John Cook		 Chipcom   cook@chipcom.com
+
+   [JXC1]    Jeff Carton	 American Express Travel Rel. Ser.
+					   jcarton@amex-trs.com
+
+   [JXC2]    Joseph Chen	 Symbol	Technology, Inc.  ---none---
+
+   [JXD]     Julie Dmytryk	 Ultra
+				       Julie_Dmytryk.MKT@usun.ultra.com
+
+   [JXD1]    James Davidson	 NGC	   ngc!james@uunet.UU.NET
+
+   [JXE2]    Jeanne Evans	 UKMOD	   JME%RSRE.MOD.UK@CS.UCL.AC.UK
+
+   [JXF]     Josh Fielk		 Optical Data Systems  ---none---
+
+   [JXF1]    Jeff Freeman	 Emulex	   ---none---
+
+   [JXG]     Jerry Geisler	 Boeing	   ---none---
+
+   [JXG1]    Jim Greuel		 HP	   jimg%hpcndpc@hplabs.hp.com
+
+   [JXG2]    Jeremy Greene	 LearningTree taipan!greene@uunet.UU.NET
+
+   [JXG3]    James L. Gula	 Corollary, Inc.  gula@corollary.com
+
+   [JXH]     Jeffrey C.	Honig	 Cornell   jch@gated.cornell.edu
+
+   [JXH1]    Jim Hayes		 Apple	   Hayes@APPLE.COM
+
+   [JXI]     Jon Infante	 ICL	   ---none---
+
+   [JXI1]    John Ioannidis	 Columbia  ji@close.cs.columbia.edu
+
+   [JXK]     Joanna Karwowska	 DGC	   karwowska@dg-rtp.dg.com
+
+
+
+
+Reynolds & Postel				              [Page 122]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [JXK1]    Jon Kepecs		 Legato	   kepecs@Legato.COM
+
+   [JXL]     John Light		 GSS	   johnl@gssc.gss.com
+
+   [JXM]     Joseph Murdock	 Network Resources Corporation
+					   ---none---
+
+   [JXM1]    Jim Miner		 Star Technologies  miner@star.com
+
+   [JXO]     Jack O'Neil	 ENCORE	   ---none---
+
+   [JXO1]    Jerrilynn Okamura	 Ontologic ---none---
+
+   [JXO2]    Jarkko Oikarinen	 Tolsun	   jto@TOLSUN.OULU.FI
+
+   [JXO3]    John Ioannidis	 Columbia  ji@close.cs.columbia.edu
+
+   [JXP]     Joe Pato		 Apollo	   apollo!pato@EDDIE.MIT.EDU
+
+   [JXP1]    Jas Parmar		 Synernetics jas@synnet.com
+
+   [JXP2]    John Pickens	 3Com	   jrp@3Com.com
+
+   [JXR]     Jacob Rekhter	 IBM	   Yakov@IBM.COM
+
+   [JXR1]    Jens T. Rasmussen	 CERN
+				 jenst%cernvax.cern.ch@CUNYVM.CUNY.EDU
+
+   [JXR2]    James Rice		 Stanford  RICE@SUMEX-AIM.STANFORD.EDU
+
+   [JXR3]    Jacques Roth	 Netronix, Inc.	---none---
+
+   [JXS]     Jim Stevens	 Rockwell  Stevens@ISI.EDU
+
+   [JXS1]    John Sancho	 CastleRock ---none---
+
+   [JXS2]    Jon Saperia	 DEC	   saperia@tcpjon.enet.dec.com
+
+   [JXS3]    Jonathan Stone	 Victoria University
+					       jonathan@isor.vuw.ac.nz
+
+   [JXS4]    John K. Scoggin, Jr.  Delmarva Power  scoggin@delmarva.com
+
+   [JXS5]    Jeremy Siegel	 3COM	   jzs@NSD.3Com.COM
+
+   [JXT]     Jim Taylor		 Kodak	   taylor@heart.epps.kodak.com
+
+   [JXT1]    Jimmy Tu		 Digital Link	jimmy@dl.com
+
+
+
+Reynolds & Postel				              [Page 123]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [JXW]     James Watt		 NNC	   ---none---
+
+   [JXY]     J.	Yoshida		 NKK Corp. ---none---
+
+   [JXZ]     Jon Ziegler	 Artel	   Ziegler@Artel.com
+
+   [KAA]     Ken Adelman	 TGV, Inc. Adelman@TGV.COM
+
+   [KA4]     Karl Auerbach	 Empirical Tools and Technologies
+					   karl@empirical.com
+
+   [KH43]    Kathy Huber	 BBN	   khuber@bbn.com
+
+   [KH157]   Kory Hamzeh	 Fibermux
+			      ames!avatar.com!kory@harvard.harvard.edu
+
+   [KLH]     Ken Harrenstien	 SRI	   KLH@nisc.sri.com
+
+   [KR35]    Keith Reynolds	 SCO	   keithr@SCO.COM
+
+   [KSL]     Kirk Lougheed	 cisco	   LOUGHEED@MATHOM.CISCO.COM
+
+   [KXA]     Kannan Alagappan	 DEC	   kannan@sejour.enet.dec.comp
+
+   [KXB]     Keith Boyce	Legent	   ---none---
+
+   [KXC]    Ken	Chapman	       Stratus Computer
+					   Ken_Chapman@vos.stratus.com
+
+   [KXD]     Kevin DeVault	 NI	   ---none---
+
+   [KXD1]    Kathryn de	Graaf	 David Systems	degraaf@davidsys.com
+
+   [KXF]     Karl Fox		 MST	   karl@MorningStar.Com
+
+   [KXF1]    Ken Fujimoto	 Tribe Computer	Works  fuji@tribe.com
+
+   [KXG]     Kevin Gage		 Chase Research
+
+   [KXH]     Khalid Hireche	 G2R Inc.  ---none---
+
+   [KXH1]    Keith Hogan	 Penril	   keith%penril@uunet.uu.net
+
+   [KXJ]     Ken Jones		 KonKord   konkord!ksj@uunet.uu.net
+
+   [KXL]     Kim Le		 DATAHOUSE Information Systems Ltd.
+					   ---none---
+
+
+
+
+Reynolds & Postel				              [Page 124]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [KXM]     Kevin Murphy	 DEC	   murphy@sevens.lkg.dec.com
+
+   [KXR]     Ken Ritchie	 SEEL	   ---none---
+
+   [KXS]     Keith Sklower	 Berkeley  sklower@okeeffe.berkeley.edu
+
+   [KXS1]    Kevin Smith	 Telematics International, Inc.
+					   ---none---
+
+   [KXS2]    Keld Simonsen	 RAP	   Keld.Simonsen@dkuug.dk
+
+   [KXT]     Kaj Tesink		 Bellcore  kaj@nvuxr.cc.bellcore.com
+
+   [KXT1]    Kent Tsuno		 SEI	   tsuno@sumitomo.com
+
+   [KXV]     Ken Virgile	 Sigma Net. Sys. signet!ken@xylogics.COM
+
+   [KXW]     Ken Whitfield	 MCNC	   ken@MCNC.ORG
+
+   [KXW1]    Kathy Weninger	 Network Resources Corporation
+					   ---none---
+
+   [KZM]     Keith McCloghrie	 HLS	   KZM@HLS.COM
+
+   [LL69]    Lawrence Lebahn	 DIA	   DIA3@PAXRV-NES.NAVY.MIL
+
+   [LLP]     Larry Peterson	 ARIZONA   llp@ARIZONA.EDU
+
+   [LS8]     Louis Steinberg	 Rutgers   lou@ARAMIS.RUTGERS.EDU
+
+   [LXA]     Lorenzo Aguilar	 Taligent  lorenzo@taligent.com
+
+   [LXB]     Larry Burton	 APTEC Computer	Systems
+						ssds!larryb@uunet.UU.NET
+
+   [LXB1]    Laura Bridge	 Timeplex  laura@uunet.UU.NET
+
+   [LXB2]    Lawrence Brown	 Unisys	   ---none---
+
+   [LXB3]    Larry Barnes	 DEC	   barnes@broke.enet.dec.com
+
+   [LXD]     Larry DeLuca	 AT	   henrik@EDDIE.MIT.EDU
+
+   [LXD1]    Larry Davis	 C. Itoh Electronics   ---none---
+
+   [LXE]     Len Edmondson	 SUN	   len@TOPS.SUN.COM
+
+   [LXF]     Larry Fischer	 DSS	   lfischer@dss.com
+
+
+
+Reynolds & Postel				              [Page 125]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [LXH]     Leo Hourvitz	 NeXt	   leo@NEXT.COM
+
+   [LXL]     Lennart Lovstrand	 NeXT Computer,	Inc.
+					   Lennart_Lovstrand@NeXT.COM
+
+   [LXM]     Louis Mamakos	 UMD	   louie@sayshell.umd.edu
+
+   [LXO]     Larry Osterman	 GTE Telecom   larryo@gtetele.com
+
+   [LXP]     Lars Povlsen	 Olicom	A/S  krus@olicom.dk
+
+   [LXS]     Lance Sprung	 SMC	   ---none---
+
+   [LXW]     Lih-Er Wey		 MSU	   WEYLE@msu.edu
+
+   [LZ15]    Lee Ziegenhals	 Datapoint  lcz@sat.datapoint.com
+
+   [MA]	     Mike Accetta	 CMU	   MIKE.ACCETTA@CMU-CS-A.EDU
+
+   [MA108]   Mike Anello	 XDI	   mike@xlnt.com
+
+   [MAR10]   Mark A. Rosenstein	 MIT	   mar@ATHENA.MIT.EDU
+
+   [MB]	     Michael Brescia	 BBN	   Brescia@CCV.BBN.COM
+
+   [MBG]     Michael Greenwald	 SYMBOLICS
+		      Greenwald@SCRC-STONY-BROOK.SYMBOLICS.COM
+
+   [MCSJ]    Mike StJohns	 TPSC	   stjohns@UMD5.UMD.EDU
+
+   [ME38]    Marc A. Elvy	 Marble	   ELVY@CARRARA.MARBLE.COM
+
+   [MG277]   Martin Gren	 Axis Communications AB	 martin@axis.se
+
+   [MKL]     Mark Lottor	 SRI	   MKL@nisc.sri.com
+
+   [ML109]   Mike Little	 MACOM	   little@MACOM4.ARPA
+
+   [MLS34]   L.	Michael	Sabo	 TMAC	   Sabo@DOCKMASTER.NCSC.MIL
+
+   [MO2]     Michael O'Brien	 AEROSPACE obrien@AEROSPACE.AERO.ORG
+
+   [MRC]     Mark Crispin	 Simtel	   MRC@WSMR-SIMTEL20.ARMY.MIL
+
+   [MS9]     Marty Schoffstahl	 Nysernet  schoff@NISC.NYSER.NET
+
+   [MS56]    Marvin Solomon	 WISC	   solomon@CS.WISC.EDU
+
+
+
+
+Reynolds & Postel				              [Page 126]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [MTR]     Marshall T. Rose	 PSI	   mrose@PSI.COM
+
+   [MXA]     Mike Asagami	 Toshiba   toshiba@mothra.nts.uci.edu
+
+   [MXB]     Mike Berrow	 Relational Technology	---none---
+
+   [MXB1]    Mike Burrows	 DEC	   burrows@SRC.DEC.COM
+
+   [MXB2]    Mark T. Dauscher	 Sybus Corportation
+					      mdauscher@sybus.com
+
+   [MXB3]    Michael Bell	 Integrated Business Network
+					      ---none---
+
+   [MXC]     Ming-Perng	Chen	 CCL/ITRI
+			       N100CMP0%TWNITRI1.BITNET@CUNYVM.CUNY.EDU
+
+   [MXC1]    Mark McCahill	 UMN	     mpm@boombox.micro.umn.edu
+
+   [MXC2]    Matt Christiano	 Olivettti
+				    globes@matt@oliveb.atc.olivetti.com
+
+   [MXE]     Mike Erlinger	 Lexel	     mike@lexcel.com
+
+   [MXF]     Mark Fabbi		 Bell Canada markf@gpu.utcs.utoronto.ca
+
+   [MXF1]    Marco Framba	 Olivetti   framba@orc.olivetti.com
+
+   [MXF2]    Martin Forssen	 Chalmers   maf@dtek.chalmers.se
+
+   [MXH]     Matt Harris	 Versitron  ---none---
+
+   [MXH1]    Masahiko Hori	 Mitsubishi Cable Industries, Ltd.
+					    ---none---
+
+   [MXH2]    Mark Holobach	 Electronic Data Systems
+					   holobach@tis.eds.com
+
+   [MXH3]    Mark Hankin	 Lancert   ---none---
+
+   [MXL]     Mark L. Lambert	 MIT	   markl@PTT.LCS.MIT.EDU
+
+   [MXL1]    Mats Lindstrom	 Diab Data AB  mli@diab.se
+
+   [MXL2]    Mark S. Lewis	 Telebit   mlewis@telebit.com
+
+   [MXN]     Mark Needleman	 UCDLA
+			 mhnur%uccmvsa.bitnet@cornell.cit.cornell.edu
+
+
+
+Reynolds & Postel				              [Page 127]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [MXL2]    Mark Lenney	 Raylan	Corporation  ---none---
+
+   [MXO]     Mike O'Dowd	 EPFL	   odowd@ltisun8.epfl.ch
+
+   [MXO1]    Mike Oswald	 J.I. Case mike@helios.uwsp.edu
+
+   [MXP]     Martin Picard	 Oracle	   ---none---
+
+   [MXP1]    Michael Podhorodecki  Labtam Australia Pty. Ltd.
+					     michael@labtam.oz.au
+
+   [MXR]     Maurice R.	Turcotte RMIS
+			mailrus!uflorida!rm1!dnmrt%rmatl@uunet.UU.NET
+
+   [MXS]     Mike Spina		 Prime
+				  WIZARD%enr.prime.com@RELAY.CS.NET
+
+   [MXS1]    Martha Steenstrup	 BBN	   MSteenst@BBN.COM
+
+   [MXS2]    Michael Sapich	 CCCBS	   sapich@conware.de
+
+   [MXS3]    Marc Sheldon	 BinTec	   ms@BinTec.DE
+
+   [MXS4]    Marc Sheldon	 EUnet Germany	  ms@Germany.EU.net
+
+   [MXT]     Martyn Thomas	 Insignia Solutions  ---none---
+
+   [MXT1]    Mark Tom		 NET	   marktom@tom.net.com
+
+   [MXW]     Michael Waters	 EON	   ---none---
+
+   [MXZ]     Mauro Zallocco	 Netlink   ---none---
+
+   [NC3]     J.	Noel Chiappa	 MIT	   JNC@XX.LCS.MIT.EDU
+
+   [NT12]    Neil Todd		 IST
+				    mcvax!ist.co.uk!neil@UUNET.UU.NET
+
+   [NXC]     Nick Cuccia	 NASA Ames Research Center
+					      cuccia@nas.nasa.gov
+
+   [NXE]     Nadya K. El-Afandi	 NSC	   nadya@khara.network.com
+
+   [NXH]     Nicola J. Howarth	 ANSA	   njh@ansa.co.uk
+
+   [NXK]     Nagayuki Kojima	 Japan Radio Co.
+				   nkojima@lab.nihonmusen.co.jp
+
+
+
+
+Reynolds & Postel				              [Page 128]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [NXL]     Nik Langrind	 Shiva Corp.  nik@Shiva.COM
+
+   [NXM]     Nob Mizuno		 Matsushita Electric Industrial	Co.,
+				 Ltd.	   mizuno@isl.mei.co.jp
+
+   [NXP]     Narendra Popat	 FSD	   ---none---
+
+   [NXR]     Nelluri L.	Reddy	 CDC	   reddy@uc.msc.umn.edu
+
+   [OXC]     Olivier J.	Caleff	 Dassault  caleff@dassault-elec.fr
+
+   [OXF]     Osamu Fujiki	 DCL	   ---none---
+
+   [OXG]     Oyvind Gjerstad	 Tollpost-Globe	AS
+				  ogj%tglobe2.UUCP@nac.no
+
+   [OXI]     Oft Israel		 Rad	   ---none---
+
+   [OXJ]     Oliver Jones	 PictureTel Corporation	 oj@pictel.com
+
+   [OXK]     Oliver Korfmacher	 netCS Informationstechnik GmbH
+					    okorf@bunt.netcs.com
+
+   [OXR]     Oscar Rodriguez	 Dupont	   ---none---
+
+   [PAM6]    Paul McNabb	 RICE	   pam@PURDUE.EDU
+
+   [PCW]     C.	Philip Wood	 LANL	   cpw@LANL.GOV
+
+   [PD39]    Pete Delaney	 ECRC
+			pete%crcvax.uucp%germany.csnet@RELAY.CS.NET
+
+   [PHD1]    Pieter Ditmars	 BBN	   pditmars@BBN.COM
+
+   [PK]	     Peter Kirstein	 UCL	   Kirstein@NSS.CS.UCL.AC.UK
+
+   [PL4]     Phil Lapsley	 BERKELEY  phil@UCBARPA.BERKELEY.EDU
+
+   [PM1]     Paul Mockapetris	 ISI	   PVM@ISI.EDU
+
+   [PXA]     Prakash Ambegaonkar FTC	   ---none---
+
+   [PXA1]    Paul Afshar	 Solarix Systems
+					paul@solar1.portal.com
+
+   [PXA2]    Paul Andon		 MICROGNOSIS  pandon@micrognosis.co.uk
+
+
+
+
+
+Reynolds & Postel				              [Page 129]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [PXB]     Pat Barron		 Transarc Corporation
+					     Pat_Barron@TRANSARC.COM
+
+   [PXB1]    Pascal Bataille	 GSI	    pascal.bataille@gsi.fr
+
+   [PXC]     Peter Cox		 ENE	    ---none---
+
+   [PXC1]    Patrick Cheng	 TRW	    pcheng@dill.ind.trw.com
+
+   [PXC2]    Paolo Coppo	 CSELT	    coppo@cz8700.cselt.stet.it
+
+   [PXC3]    Paul Chefurka	 PlainTree Systems Inc.
+					    chefurka@plntree.UUCP
+
+   [PXD]     Peter Delchiappo	 MTrade	UK Ltd.	 ---none---
+
+   [PXE]     Peter S. Easton	 Brixton Systems, Inc.
+					    easton@brixton.com
+
+   [PXF]     Per Futtrup	 SDD (Scandinavian Airlines Data
+				 Denmark A/S)	---none---
+
+   [PXG]     Pete Grillo	 Network Innovations
+					    pl0143@mail.psi.net
+
+   [PXH]     Per Bech Hansen	 DDE	    pbh@dde.dk
+
+   [PXJ]     Prem Jain		 Crescendo  prem@cres.com
+
+   [PXJ1]    Petri Jokela	 Telecom Finland  ---none---
+
+   [PXK]     Philip Koch	 Dartmouth Philip.Koch@DARTMOUTH.EDU
+
+   [PXK1]    Peter Kumik	 Case Comm. ---none---
+
+   [PXK2]    Professor Kynikos	 Special Consultant  ---none---
+
+   [PXK3]    Paul Krystosek	 DOE Atmospheric Radiation
+				 Measurement Project
+					      krystosk@eid.anl.gov
+
+   [PXL]     Paul Liu		 ADI Systems, Inc.  ---none---
+
+   [PXL1]    Reter de Laval	 SECTRA		  pdl@sectra.se
+
+   [PXM]     Paul Maurer II	 STS	   ---none---
+
+   [PXM1]    Patrick McNamee	 GE	   ---none---
+
+
+
+Reynolds & Postel				              [Page 130]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [PXO]     Paul O'Donnell	 Basser	   paulod@cs.su.oz.au
+
+   [PXR]     Paul Rodwick	 Metaphor  ---none---
+
+   [PXR1]    Parag Rastogi	 Vitacom Corporation
+					   parag@cup.portal.com
+
+   [PXS]     Paul Singh		 Intellicom ---none---
+
+   [PXV]     Paul V. Fries	 Alantec    pvf@alantec.com
+
+   [PXY]     Peter C. Yoest	 American Power	Conversion Corp.
+					    apc!yoest@uunet.uu.net
+
+   [PXY1]    Paul Hoff		 Norwegian Telecom Research
+					   paalh@brage.nta.no
+
+   [RA11]    Rick Adams		 UUNET	   rick@UUNET.UU.NET
+
+   [RAM57]   Rex Mann		 CDC	   ---none---
+
+   [RAW44]   Robert A. Woodburn	 Sparta	   WOODY@SPARTA.COM
+
+   [RDXS]    R.	Dwight Schettler HP	   rds%hpcndm@HPLABS.HP.COM
+
+   [RH6]     Robert Hinden	 BBN	   Hinden@CCV.BBN.COM
+
+   [RH227]   Ron Holt		 Eyring, Inc.  ron@Eyring.COM
+
+   [RHT]     Robert Thomas	 BBN	   BThomas@F.BBN.COM
+
+   [RM1]     Richard Mak	 Amnet,	Inc.   mak@amnet.COM
+
+   [RN6]     Rudy Nedved	 CMU	   Rudy.Nedved@CMU-CS-A.EDU
+
+   [RP211]   Ragnar Paulson	 TSG	   tsgfred!ragnar@uunet.UU.NET
+
+   [RTB3]    Bob Braden		 ISI	   Braden@ISI.EDU
+
+   [RWS4]    Robert W. Scheifler ARGUS	   RWS@XX.LCS.MIT.EDU
+
+   [RXB]     Ramesh Babu	 Luxcom	   krbabu@btr.com
+
+   [RXB1]    Ron Bhanukitsiri	 DEC	   rbhank@DECVAX.DEC.COM
+
+   [RXB2]    Rich Bantel	 AT&T	   rgb@mtung.att.com
+
+   [RXB3]    Robert Woodburn	 SAIC	   woody@cseic.saic.com
+
+
+
+Reynolds & Postel				              [Page 131]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [RXB4]    Russ Blaesing	 Open Networks Engineering, Inc.
+					   rrb@one.com
+
+   [RXC]     Rob Chandhok	 CMU	   chandhok@gnome.cs.cmu.edu
+
+   [RXC1]    Rick Carlos	 TI	   rick.ticipa.csc.ti.com
+
+   [RXC2]    Ray Compton	 DIS Research LTD  rayc@command.com
+
+   [RXD]     Roger Dev		 Cabletron ---none---
+
+   [RXD1]    Ralph Droms	 NRI	   rdroms@NRI.RESTON.VA.US
+
+   [RXD2]    Rajiv Dhingra	 Ultranet  rajiv@ULTRA.COM
+
+   [RXD3]    Rex Davis		 Tandem	   ---none---
+
+   [RXD4]    Rick Downs		 AMP	   ---none---
+
+   [RXD5]    Russell S.	Dietz	 Technically Elite Concepts, Inc.
+					    Russell_Dietz@Mcimail.com
+
+   [RXE]     Robert R. Elz	 Webster Computer kre@munnari.oz.au
+
+   [RXF]     Richard Fox	 Synoptics rfox@synoptics.com
+
+   [RXH]     Reijane Huai	 Cheyenne  sibal@CSD2.NYU.EDU
+
+   [RXH1]    Russ Housley	 Xerox
+				 Russ_Housley.McLean_CSD@xerox.com
+
+   [RXI]     Robin Iddon	 Axon Networks Inc.
+					   axon@cix.clink.co.uk
+
+   [RXJ]     Ronald Jacoby	 SGI	   rj@SGI.COM
+
+   [RXL]     Rich Lyman		 Lantronix  rich@alecto.gordian.com
+
+   [RXM]     Robert Myhill	 BBN	   Myhill@CCS.BBN.COM
+
+   [RXN]     Rina Nethaniel	 RND	   ---none---
+
+   [RXN1]    Russ Nelson	 Clarkson  nelson@clutx.clarkson.edu
+
+   [RXN2]    R.	Nurnberg	 AEG Electrcom	 ---none---
+
+   [RXR]     Richard Rein	 Pyramid Technology Corp.
+					    rein@pyramid.com
+
+
+
+Reynolds & Postel				              [Page 132]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [RXR1]    R.	K. Nair		 NRL	   nair@itd.nrl.navy.mil
+
+   [RXS]     Ron Strich		 SSDS	   ---none---
+
+   [RXS1]    Reuben Sivan	 Crosscomm crossc!rsivan@uunet.UU.NET
+
+   [RXS2]    Richard Schneider	 Epson Research	Center
+					   rschneid@epson.com
+
+   [RXS3]    Richard P.	Stubbs	 Quotron Systems, Inc.
+					   richard@atd.quotron.com
+
+   [RXS4]    Rob Spade		 I.D.E.	Corporation ---none---
+
+   [RXT]     Ron Thornton	 GenRad	   thornton@qm7501.genrad.com
+
+   [RXT1]    Rodney Thayer	 Sable	   ---none---
+
+   [RXU]     Robert Urquhart	 Simon Fraser University
+							 quipu@sfu.ca
+
+   [RXW]     Russell G.	Wilson	 Hill AFB  rwilson@oodis01.af.mil
+
+   [RXW1]    R.	J. White	 Univ. of Waterloo
+					 snmp-tech@watmath.waterloo.edu
+
+   [RXZ]     Rayan Zachariassen	 Toronto   rayan@AI.TORONTO.EDU
+
+   [SAF3]    Stuart A. Friedberg UWISC	   stuart@CS.WISC.EDU
+
+   [SB98]    Stan Barber	 BCM	   SOB@BCM.TMC.EDU
+
+   [SC3]     Steve Casner	 ISI	   Casner@ISI.EDU
+
+   [SGC]     Steve Chipman	 BBN	   Chipman@F.BBN.COM
+
+   [SH284]   Steve Hardcastle-Kille ISODE Consortium  S.Kille@isode.com
+
+   [SHB]     Steven Blumenthal	 BBN	   BLUMENTHAL@VAX.BBN.COM
+
+   [SH37]    Sergio Heker	 JVNC	   heker@JVNCC.CSC.ORG
+
+   [SL70]    Stuart Levy	 UMN	   slevy@UC.MSC.UMN.EDU
+
+   [SMB]     Scott Bellew	 Purdue	   smb@cs.purdue.edu
+
+   [SRN1]    Stephen Northcutt	 NSWC	   SNORTHC@RELAY-NSWC.NAVY.MIL
+
+
+
+
+Reynolds & Postel				              [Page 133]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [SS92]    Steve Schoch	 NASA	   SCHOCH@AMES.ARC.NASA.GOV
+
+   [STY]     Shannon Yeh	 Netix	   yeh@netix.com
+
+   [SW159]   Steven Willis	 Wellfleet swillis@WELLFLEET.COM
+
+   [SXA]     Susie Armstrong	 XEROX	   Armstrong.wbst128@XEROX.COM
+
+   [SXA1]    Shamim Ahmed	 OSU
+				   ahmed@nisca.ircc.ohio-state.edu
+
+   [SXA2]    Steve Alexander	 ISC	   stevea@i88.isc.com
+
+   [SXA3]    Sten Andler	 IBM	   ---none---
+
+   [SXB]     Steve Briggs	 Compaq	   steveb@se.hou.compaq.com
+
+   [SXB2]    Steve Bush		 GEIS	   sfb@ncoast.org
+
+   [SXC]     Shaw C. Chuang	 University College London
+					       S.Chuang@cs.ucl.ac.uk
+
+   [SXD]     Steve Deering	 Stanford deering@PECASERO.STANFORD.EDU
+
+   [SXD1]    Steve Dorner	 U. of Illinois	 s-dorner@UIUC.EDU
+
+   [SXE]     Simon Edwards	 Micro Focus UK	 ---none---
+
+   [SXF]     Shoji Fukutomi	 Furukawa Electoric Co.	Ltd.
+			    kddlab!polo.furukawa.co.jp!fuku@uunet.UU.NET
+
+   [SXH]     Steven Hunter	 LLNL	   hunter@CCC.MFECC.LLNL.GOV
+
+   [SXH1]    Scott Hahn		 Sequent   sdh@sequent.com
+
+   [SXH2]    Scott Holley  Allied Telesis, Inc.
+				    SCOTT_CLINTON_HOLLEY@cup.portal.com
+
+   [SXH3]    Steve Harris	 Republic Telcom Systems, Inc.
+				    rtsc!harris@boulder.Colorado.edu
+
+   [SXH4]    Simon Hackett	 Internode Systems Pty Ltd
+					     simon@ucs.adelaide.edu.au
+
+   [SXH5]    Stefan Hedemann	 Hedemann Software Development
+					   100015.2504@compuserve.com
+
+   [SXK]     Skip Koppenhaver	 DAC	   stubby!skip@uunet.UU.NET
+
+
+
+Reynolds & Postel				              [Page 134]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [SXK1]    Stev Knowles	 FTP	   stev@vax.ftp.com
+
+   [SXL]     Sam Lau		 Pirelli/Focom ---none---
+
+   [SXL1]    Stephen Lewis	 Scitec	   ---none---
+
+   [SXL2]    Steve Loring	 L & N Technologies, Ltd.
+					   ---none---
+
+   [SXL3]    Syd Logan		 AGE Logic  syd@age.com
+
+   [SXM]     Sheri Mayhew	 Develcon
+					zaphod!sherim@herald.usask.ca
+
+   [SXM1]    Skip Morton	 Netcore, Inc.	 ---none---
+
+   [SXO]     SeeYoung Oh	 Daewoo	Telecom	   oco@scorpio.dwt.co.kr
+
+   [SXP]     Sanand Patel	 Canstar   sanand@HUB.TORONTO.EDU
+
+   [SXP1]    Satish Popat	 Ericsson-Camtec  ---none---
+
+   [SXS]     Steve Silverman	 MITRE	   Blankert@MITRE-GATEWAY.ORG
+
+   [SXS1]    Susie Snitzer	 Britton-Lee ---none---
+
+   [SXS2]    Soren H. Sorensen	 CR SYSTEMS ---none---
+
+   [SXS3]    Steven Sweeney	 Farallon Computing, Inc.  ---none---
+
+   [SXS4]    Simson L. Garfinkel NeXt	   simsong@next.cambridge.ma.us
+
+   [SXW]     Steve Waldbusser	 CMU	   sw01+@andrew.cmu.edu
+
+   [SXW1]    Simon van Winkelen	 SDL	   ---none---
+
+   [SXW2]    Sean Welch		 Xenocom, Inc.	welch@raven.ulowell.edu
+
+   [SXW3]    Steve Willens	 Livingston Enterprises, Inc.
+						steve@livingston.com
+
+   [TC27]    Thomas Calderwood	 BBN	   TCALDERW@BBN.COM
+
+   [TN]	     Thomas Narten	 Purdue	   narten@PURDUE.EDU
+
+   [TS566]   Timon Sloane	 PeerNet
+				     peernet!timon@uunet.UU.NET
+
+
+
+
+Reynolds & Postel				              [Page 135]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [TU]	     Tom Unger		 UMich	   tom@CITI.UMICH.EDU
+
+   [TXA]     Tad Artis		 Microwave Bypass Systems, Inc.
+					   ---none---
+
+   [TXA1]    Takahiro Asai	 Hitachi Cable,	Ltd.   ---none---
+
+   [TXB]     Torsten Beyer	 Dr. Materna GmbH  tb@Materna.de
+
+   [TXB1]    Tom Bereiter	 Tiviloi   ---none---
+
+   [TXC]     Tracy Cox		 Bellcore  tacox@sabre.bellcore.com
+
+   [TXD]     "Tundra" Tim Daneliuk  Covia
+				  tundraix!tundra@clout.chi.il.us
+
+   [TXH]     Takashi Hagiwara	 Sony	   Hagiwara@Sm.Sony.Co.Jp
+
+   [TXH1]    Tim Howes		 UMich
+				  Tim.Howes@terminator.cc.umich.edu
+
+   [TXJ]     Tim Jones		 Box Hill Systems Corporation
+					   tim@boxhill.com
+
+   [TXL]     Tim Berners-Lee	 CERN	   timbl@nxoc01.cern.ch
+
+   [TXM]     Trudy Miller	 ACC	   Trudy@ACC.COM
+
+   [TXM1]    Thomas McGinty	 Codex	   ---none---
+
+   [TXO]     Toshiharu Ohno	 ASCII Corporation  tony-o@ascii.co.jp
+
+   [TXP]     Tony van der Peet	 DSIR Network Group
+					   srghtvp@grv.dsir.govt.nz
+
+   [TXR]     Tim Rylance	 Praxis	   praxis!tkr@UUNET.UU.NET
+
+   [TXR1]    Thomas Ruf		 Schneider & Koch   tom@rsp.de
+
+   [TXS]     Ted J. Socolofsky	 Spider	   Teds@SPIDER.CO.UK
+
+   [TXS1]    Toshiharu Sugawara	 NTTC
+				     sugawara%wink.ntt.jp@RELAY.CS.NET
+
+   [TXS2]    Thomas M. Smith	 GE Aerospace  tmsmith@esc.syr.ge.com
+
+   [TXT]     Ted Tran		 Andrew	Corporation   ---none---
+
+
+
+
+Reynolds & Postel				              [Page 136]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [TXT1]    Terrence J. Talbot	 BU	    lexcube!tjt@bu.edu
+
+   [TXV]     Tomas Vocetka	 Compu-Shack
+				     OPLER%CSEARN.bitnet@CUNYVM.CUNY.EDU
+
+   [TXW]     Toshio Watanabe	 RICOH Co. Ltd.
+				 watanabe@godzilla.rsc.spdd.ricoh.co.jp
+
+   [UB3]     Ulf Bilting	 CHALMERS  bilting@PURDUE.EDU
+
+   [UXV]     Umberto Vizcaino	 Bridgeway  ---none---
+
+   [UW2]     Unni Warrier	 Netlabs   unni@NETLABS.COM
+
+   [VJ]	     Van Jacobson	 LBL	   van@CSAM.LBL.GOV
+
+   [VXC]     Vik Chandra	 IBM	   vc@ralvm6.vnet.ibm.com
+
+   [VXD]     Victor Dafoulas	 Wang Labs ---none---
+
+   [VXE]     Vince Enriquez	 Motorola  enriquez@sps.mot.com
+
+   [VXK]     Victor Kazdoba	 Morgan	Stanley	& Co. Inc.
+					   vsk@katana.is.morgan.com
+
+   [VXL]     Vince Liu		 Centrum Communications, Inc.
+					   ---none---
+
+   [VXS]     Vinod Singh	 Unify	   ---none---
+
+   [VXT]     V.	Taylor		 CANADA	   vktaylor@NCS.DND.CA
+
+   [WDW11]   William D.	Wisner		   wisner@HAYES.FAI.ALASKA.EDU
+
+   [WJC2]    Bill Croft		 STANFORD  Croft@SUMEX-AIM.STANFORD.EDU
+
+   [WJS1]    Weldon J. Showalter DCA	   Gamma@MINTAKA.DCA.MIL
+
+   [WLB8]    William L.	Biagi	 Advintech
+				     CSS002.BLBIAGI@ADVINTECH-MVS.ARPA
+
+   [WM3]     William Melohn	 SUN	   Melohn@SUN.COM
+
+   [WXC]     Wesley Craig	 UMICH
+				   Wesley.Craig@terminator.cc.umich.edu
+
+   [WXC1]    W.	James Colosky	 Eastman Kodak Company
+					       wjc@tornado.kodak.com
+
+
+
+Reynolds & Postel				              [Page 137]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+   [WXD]     William Dunn	 NetManage, Inc.
+					       netmanage@cup.portal.com
+
+   [WXP]     W.J. Parducci & Associates, Inc.  Bill Parducci
+					   70262.1267@compuserve.com
+
+   [WXS]     Wayne Schroeder	 SDSC	   schroeder@SDS.SDSC.EDU
+
+   [WXS2]    W.R. Maynard-Smith	 Netcomm, Ltd.	---none---
+
+   [WXT]     Wayne Tackabury	 Pacer Software	wft@pacersoft.com
+
+   [VXW]     Val Wilson		 Spider	   val@spider.co.uk
+
+   [YXA]     Yoshiyuki Akiyama	 NEC
+		    kddlab!ccs.mt.nec.co.jp!y-akiyam@uunet.uu.net
+
+   [YXH]     Yigal Hochberg	 Unifi	   yigal@unifi.com
+
+   [YXK]     Yoav Kluger	 Spartacus ykluger@HAWK.ULOWELL.EDU
+
+   [YXK1]    Yasuhiro Kohata	 NTT DATA  kohata@rd.nttdata.jp
+
+   [YXW]     Y.C. Wang		 Network Application Technology
+					   ---none---
+
+   [YXW1]    Yasuyoshi Watanabe	 Seiko Instruments, Inc. (SII)
+					   ---none---
+
+   [XEROX]   Fonda Pallone	 Xerox	   ---none---
+
+   [ZSU]     Zaw-Sing Su	 SRI	   ZSu@TSCA.ISTC.SRI.COM
+
+   [ZXS]     Zohar Seigal	 Gambit	Computer ---none---
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				              [Page 138]
+
+RFC 1340		    Assigned Numbers		       July 1992
+
+
+Security Considerations
+
+   Security issues are not discussed in	this memo.
+
+Authors' Addresses
+
+   Joyce K. Reynolds
+   Information Sciences	Institute
+   University of Southern California
+   4676	Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone: (310)	822-1511
+
+   Email: JKREY@ISI.EDU
+
+
+   Jon Postel
+   Information Sciences	Institute
+   University of Southern California
+   4676	Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone: (310)	822-1511
+
+   Email: POSTEL@ISI.EDU
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel				              [Page 139]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1340.txt](<www.ietf.org/rfc/rfc1340.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
