### PR TITLE
Archive rfc135.txt

### DIFF
--- a/www.ietf.org/rfc/rfc135.txt
+++ b/www.ietf.org/rfc/rfc135.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                                        W. Hathaway
+Request for Comments: 135                                           AMES
+NIC: 6712                                                  29 April 1971
+Updates: 110
+
+
+                        Response to NWG/RFC #110
+   (Conventions for Using an IBM 2741 Terminal as a User Console for
+                    Access to Network Server Hosts)
+
+   I would like to propose the following conventions to replace the ones
+   proposed in RFC #110.  The original conventions suffer from lack of
+   consideration of the correspondence 2741 and what I feel are
+   inconsistencies and considerable difficulty of use.  (The 2741
+   terminal with correspondence keyboard does not have all of the
+   standard characters, notably:
+
+      less than       <
+      greater than    >
+      logical not    [1]
+      vertical bar    |
+
+   Thus we must not use any of these characters in our conventions if we
+   wish to support the correspondence 2741.)
+
+   The dedication of certain characters to special functions involves a
+   trade-off: the convenience of having the function as a single key
+   versus the inconvenience of having to use two keys to enter the
+   character as data.  I believe that only two of the special functions
+   listed in RFC #110 justify the dedication of a key: the "character
+   escape" function and the "character delete" function.  For the
+   "character escape" function I recommend the cent sign [2], as this
+   character is on both the regular and correspondence 2741 terminals
+   and is not in the ASCII character set.  For the "character delete"
+   function I recommend the backspace key for obvious reasons.  While
+   there is some need to be able to enter the character "backspace" (as
+   for underscoring output etc.,) I feel that the trade-off mentioned
+   above clearly indicates a single key "character delete" would be much
+   more valuable than a single key "backspace" and a two key "character
+   delete."
+
+   For the other special functions I recommend two key combinations,
+   consisting of "character escape" [2] and a key to define the
+   function.  These are summarized below:
+
+
+
+
+
+
+
+Hathaway                                                        [Page 1]
+
+RFC 135                 Response to NWG/RFC #110           29 April 1971
+
+
+      character escape        [2]
+      character delete        backspace
+      system delete           [2]$
+      line delete             [2]# or [2]#NL
+      logical line end        [2];
+      line continuation       [2]NL
+      ASCII control           [2]@
+
+   The option in "line delete" is to allow the user to enter a new line
+   (NL) immediately after the "line delete" to line up margins without
+   entering a null line; to enter a null line after a "line delete"
+   would require two NL characters.
+
+   The two new functions defined above, "line continuation" and "ASCII
+   control," are used as follows.  The "line continuation" is used to
+   enter a line which is longer than the 2741 carriage (or the margin
+   placement) will permit.  It can be looked on as the complement of the
+   "logical line end" in that is allows you to enter one logical line on
+   several physical lines.
+
+   The use of the "ASCII control" function requires some background.
+   There are of course many characters in ASCII which are keyed as
+   combinations of "control" and another key.  The "character escape"
+   function may be used to handle these control characters as follows: a
+   "character escape" followed by a letter will be the equivalent of the
+   ASCII "control" "letter", written as Xc (where X is the letter).
+   This will greatly simplify the conventions for users, as they will
+   simply key "[2]A" where they are used to using Ac and so forth.  For
+   completeness, however, there needs to be a way to key the additional
+   control characters which require both "control" and "shift" in
+   addition to a letter (such as ESC, which is SHIFT Mc).  Further it is
+   desirable that a more mnemonic system be provided for the non-
+   Teletype user, who knows he wants a LF but does not know that it is a
+   Jc.  To satisfy both of these needs I recommend the "ASCII control"
+   special function, which is used to enter any of the ASCII control
+   character as "[2]@" followed by the standard two or three character
+   abbreviation.  Thus "escape" would be [2]@ESC, "line feed" would be
+   [2]@LF, and so forth.  The use of the variable length abbreviation
+   does not introduce any ambiguity, although from an implementation
+   standpoint it may be advantageous to use the two character
+   abbreviation proposed in RFC #110.
+
+   Finally we must be able to enter the eight ASCII graphics which do
+   not appear on either 2741 terminal, as well as the "cent sign" and
+   "backspace" themselves (without their special functions).  For these
+   I recommend the following:
+
+
+
+
+
+Hathaway                                                        [Page 2]
+
+RFC 135                 Response to NWG/RFC #110           29 April 1971
+
+
+      [2](            for     [
+      [2])            for     ]
+      [2]6            for     {
+      [2]9            for     }
+      [2]/            for     \
+      [2]'            for     '
+      [2]"            for     ^
+      [2]-            for     ~
+      [2][2]          for     [2]
+      [2]backspace    for     backspace
+
+   Note that the characters "<" and ">" do not appear on the
+   correspondence 2741 and hence should not be used.
+
+Endnotes
+
+   [1] logical not
+
+   [2] cent sign
+
+
+          [This RFC was put into machine readable form for entry]
+          [into the online RFC archives by Lorrie Shiota, 10/02]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hathaway                                                        [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc135.txt](<www.ietf.org/rfc/rfc135.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
