### PR TITLE
Archive rfc136.txt

### DIFF
--- a/www.ietf.org/rfc/rfc136.txt
+++ b/www.ietf.org/rfc/rfc136.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Network Working Group                                            R. Kahn
+Request for Comments: 136                                            BBN
+NIC: 6713                                                  29 April 1971
+
+
+             Host Accounting and Administrative Procedures
+
+   A plan must be formulated and agreed upon for the development of a
+   Host accounting system in the ARPA Network.  Such a plan should take
+   into consideration both current Host accounting practices and new
+   technical contributions.  This document is an early attempt to
+   identify the issues concerning Host accounting.  It is being
+   distributed as a working document on which further discussions may be
+   based and, as such, does not represent, nor is intended to represent,
+   a position on any of these issues.
+
+   The method of network operation and the potential for its growth are
+   relevant factors to be considered in formulating a plan for Host
+   accounting.  For example, the answers to the following questions
+   provide a useful background for reference:
+
+      1.  Who or what operates the Network?
+
+      2.  What is the criteria upon which new sites should be
+          incorporated into the Network?
+
+      3.  What regulations, if any, apply to the connection of non-ARPA
+          sites?
+
+      4.  What is the relation, if any, between the ARPA Network and
+          common carrier services?
+
+      5.  What procedures are required to bring new sites on board and
+          up to speed?
+
+      6.  What is the most effective way to characterize their
+          resources?
+
+      7.  What usage of other Network resources do they anticipate?
+
+      8.  What procedures will be required for a typical user to obtain
+          access to that Host?
+
+      9.  What is their charging policy and for what items?
+
+      10.  Are their rates in accordance with government standards?
+
+
+
+
+
+Kahn                                                            [Page 1]
+
+RFC 136      Host Accounting and Administrative Procedures 29 April 1971
+
+
+Assumptions Regarding the Network
+
+   I have made several assumptions in this presentation that should
+   simplify and, hopefully, clarify the framework in which the
+   accounting issues reside.  Any one of these assumptions may be
+   subject to challenge.
+
+   1. Subnet Considerations
+
+      1.1 That some entity, government or private, will undertake to
+          operate the subnet and will act as a cost center for the
+          subnet.
+
+      1.2 That the total cost of operating the subnet (equipment,
+          development, maintenance, service and other administrative
+          costs) will be assumed by the cost center which will be
+          reimbursed by the Host sites or directly by ARPA on both a
+          connect and usage basis.
+
+      1.3 That the subnet will be initially operated as part of a
+          private government-sponsored resource-sharing network for the
+          use of its participants in obtaining computer services and not
+          as a common carrier for the sale of communication services.
+
+      1.4 That both ARPA and non-ARPA supported contractors will
+          eventually be allowed to connect.  The use of the subnet may
+          be administered to support resource-sharing activities.
+
+   2. Host Considerations
+
+      2.1 That each serving Host will make arrangements for use of its
+          facilities and arrange to obtain payment either from its own
+          ARPA contract, directly from the using Host, or from the using
+          Host via an intermediate mechanism.
+
+      2.2 That each prospective Host site will make available (in some
+          way to be designated) figures on cost of usage for relevant
+          facilities such as cpu, storage, connect time, peripherals,
+          etc.  It will further indicate, where appropriate, the status
+          of equipment (such as government-furnished, leased, or
+          privately owned) and whether the rates are in accord with
+          government standards.
+
+      2.3 That the implementation of standard automated accounting
+          procedures involving the use of the Network will be deferred
+          until non-automated procedures have been understood and
+          stabilized.  Early experimentation in this area is
+          appropriate, however.
+
+
+
+Kahn                                                            [Page 2]
+
+RFC 136      Host Accounting and Administrative Procedures 29 April 1971
+
+
+      2.4 That no major change in current Host accounting procedures
+          should be required initially.
+
+   3. Both Host and Subnet Considerations
+
+      3.1 That two kinds of traffic into the Network will be measured by
+          the network, namely traffic to Hosts at other sites and
+          traffic to Hosts at the same site.
+
+      3.2 The Network cost center will record traffic out of each Host
+          but will not initially keep records of traffic on a Host/Host
+          basis or on a link or socket basis.  Each Host will be
+          responsible for distributing the cost of Network usage among
+          the appropriate users.
+
+      3.3 That some form of duplication, verification, or backup of
+          accounting information may become desirable.
+
+      3.4 Understanding the relationship between service, improvement,
+          reliability and cost should be the responsibility of the
+          Network operator, but that feedback from the Host sites in
+          this area is absolutely essential.
+
+Suggested Topics
+
+   The following set of topics are introduced for discussion among the
+   network community.
+
+   1. Current Practices
+
+      1.1 What constitutes current Host accounting procedures? How is it
+          accomplished and what is accounted for?
+
+   2. Administrative Procedures
+
+      2.1 What access arrangements for network users are either planned
+          or envisioned at each site?
+
+      2.2 Are security or authenticity provisions required for network
+          usage and if so, what is the nature of that requirement?
+
+      2.3 Should Host accounting and network accounting be completely
+          independent of each other or not? If not, in what way should
+          they be made independent?
+
+      2.4 What long range billing procedures are desirable?
+
+
+
+
+
+Kahn                                                            [Page 3]
+
+RFC 136      Host Accounting and Administrative Procedures 29 April 1971
+
+
+   3. Charging Policies
+
+      3.1 What procedures are required for a Host to determine the most
+          cost effective way to run a job on the Network? In this
+          regard, is it helpful to try to categorize resources for
+          costing purposes?
+
+      3.2 Should some classes of Host activity be exempt from
+          accounting?
+
+      3.3 Is it desirable to achieve standardized rates for specific
+          classes of activity, and if so how should those rates be
+          determined?
+
+   4. Technical Aspects
+
+      4.1 Should Host accounting information eventually flow via the
+          Network? Should it be accessible to a user or a Host in real-
+          time? If so, what should flow online?
+
+      4.2 What accounting mechanisms, if any, are needed to deal with
+          events, from which recovery or continuation is not possible
+          that result from use of the Network and lack of proximity to
+          the computer? To what extent are the procedures in current use
+          for remote users from the dial-up network applicable?
+
+      4.3 For what classes of Host Network activity, if any, is
+          conventional logging-in not a desirable long-range strategy?
+
+   This list of topics is not intended to be complete or even very
+   specific.  Suggestions for additional topics are not only welcomed
+   but encouraged.
+
+
+         [ This RFC was put into machine readable form for entry ]
+             [ into the online RFC archives by Sergio Kleiman]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kahn                                                            [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc136.txt](<www.ietf.org/rfc/rfc136.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
