### PR TITLE
Archive rfc1367.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1367.txt
+++ b/www.ietf.org/rfc/rfc1367.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                                        C. Topolcic
+Request for Comments: 1367                                          CNRI
+                                                            October 1992
+
+
+          Schedule for IP Address Space Management Guidelines
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard.  Distribution of this memo is
+   unlimited.
+
+Introduction
+
+   This memo suggests a schedule for the implementation of the IP
+   network number allocation plan described in RFC 1366.  This schedule
+   is meant to support the implementation and deployment of an address
+   aggregation mechanism for the Internet by proposing an achievable
+   target for which we can all aim.  The timely deployment of that
+   aggregation mechanism and the IP addressing plan will help the the
+   size of the Internet router forwarding tables and management of the
+   IP address space.  By doing so, it will help the current Internet
+   addressing and routing technology operate during the interim period
+   until the next generation technology is deployed. This interim
+   solution in no way constrains the selection of the next generation
+   addressing and routing technology.
+
+   This draft schedule was put together by the FNC Engineering and
+   Planning Group (FEPG) based on the IP addressing plan BOF of the July
+   1992 IETF meeting, as well as discussions with a number (though, of
+   course, not all) of knowledgeable and interested parties, including
+   the IANA and IR.  This draft schedule assumes that the address
+   aggregation mechanism will be available in the Internet by mid-1993.
+   The activities described in this schedule are the precursors to that
+   deployment, and will promote the efficient operation of that
+   mechanism.  We feel that our assumptions are realistic and that this
+   schedule can be met.  We encourage its open discussion as we move
+   toward community consensus.
+
+      Please send comments to topolcic@nri.reston.va.us, or to the
+      mailing list ipalloc@nri.reston.va.us.  To be added to this
+      mailing list, send a request to ipalloc-request@nri.reston.va.us.
+
+   Note that the references below to an addressing plan and to criteria
+   for regional address registries refer to RFC 1366.
+
+
+
+
+
+Topolcic                                                        [Page 1]
+
+RFC 1367        Schedule for IP Address Space Guidelines    October 1992
+
+
+Draft Implementation Schedule for IP Network Number Allocation Plan:
+
+      1) 31 October 92:
+
+         The following address allocation procedures are continued:
+
+         a) Initial set of criteria for selecting regional address
+            registries will be put into place, and requests from
+            prospective regional registries will be accepted by the
+            IANA.
+
+         b) Class A network numbers are practically impossible to
+            obtain.
+
+         c) Class B network numbers will continue to be issued only when
+            reasonably justified.  If possible, a block of C's will be
+            issued rather than a B. The requirements for allocating a
+            Class B will become progressively more constrained until the
+            date in step (3).
+
+         d) Class C network numbers will be allocated according to the
+            addressing plan.  Allocation will be performed by the
+            Internet Registry (IR) if an appropriate regional registry
+            has not yet been designated by the IANA.
+
+      2) 14 February 93:
+
+         Re-evaluate and readjust the schedule if necessary.
+
+      3) 15 April 93:
+
+         a) The IR begins to allocate all networks according to the
+            addressing plan in appropriately sized blocks of Class C
+            numbers.
+
+         b) Class B network numbers will be difficult to obtain,
+            following the recommendation of the addressing plan and only
+            issued when justified.
+
+      4) 6 June 93:
+
+         Expected date that an address aggregation mechanism is
+         available in the Internet.
+
+References
+
+   [1] Gerich, E., "Guidelines for Management of IP Address Space", RFC
+       1366, Merit, October 1992.
+
+
+
+Topolcic                                                        [Page 2]
+
+RFC 1367        Schedule for IP Address Space Guidelines    October 1992
+
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Author's Address
+
+   Claudio Topolcic
+   Corporation for National Research Initiatives
+   895 Preston White Drive
+   Suite 100
+   Reston, VA  22091
+
+   Phone: (703) 620-8990
+   EMail: topolcic@NRI.Reston.VA.US
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Topolcic                                                        [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1367.txt](<www.ietf.org/rfc/rfc1367.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
