### PR TITLE
Archive rfc137.txt

### DIFF
--- a/www.ietf.org/rfc/rfc137.txt
+++ b/www.ietf.org/rfc/rfc137.txt
@@ -1,0 +1,619 @@
+
+
+
+
+
+
+Network Working Group                                   T. C. O'Sullivan
+Request for Comments: 137                                       Raytheon
+NIC 6714                                                   30 April 1971
+
+
+                            TELNET Protocol
+
+   This is a request for comment and is being distributed in advance of
+   the Atlantic City meetings for review and comment prior to or during
+   discussions on TELNET in preparation for issuing an official
+   document.
+
+   It is also being distributed so that selected installations planning
+   to implement early versions of TELNET will have a common basis for
+   such implementation.
+
+   The proposed document is the result of the work of the committee.  It
+   represents a TELNET protocol felt to be adequate for initial
+   implementation.  A few recent suggestions by committee members and
+   others have been incorporated where even though not thoroughly
+   cleared with all members, the chairman felt that they clarified the
+   protocol or would tend to simplify implementation but not
+   substantially change the agreed-upon approach.
+
+   Readers are referenced to the following previous releases of
+   information:
+
+   1. Conventions for Using an IBM 2741 Terminal or a User Console for
+      Access to Network Server HOSTS
+         Joel Winett, RFC 110 (NIC #5809)
+
+   2. Level III Server Protocol for the Lincoln Laboratory 360/67 HOST
+         Joel Winett, RFC 109 (NIC #5808)
+
+   3. First Cut at a Proposed TELNET Protocol
+         J. Melvin, D. Watson, RFC 97 (NIC #5740)
+
+   4. ASCII Format for Network Interchange
+         V. Cerf, RFC 20 (NIC# 4722)
+
+   Another RFC will be distributed prior to the Atlantic City Meetings
+   containing many of the arguments supporting the proposal.
+
+
+
+
+
+
+
+
+
+O'Sullivan                                                      [Page 1]
+
+RFC 137                     TELNET Protocol                   April 1971
+
+
+                            TELNET PROTOCOL
+
+
+
+                          A Proposed Document
+
+
+
+                T. O'Sullivan for the TELNET Committee
+
+               Will Crowther                 BBN
+               Bob Long                      SDC
+               John Melvin                   SRI-ARC
+               Bob Metcalf                   Harvard
+               Ed Meyer                      MAC
+               Tom O'Sullivan (Chairman)     Raytheon
+               Joel Winett                   MIT-LL
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+O'Sullivan                                                      [Page 2]
+
+RFC 137                     TELNET Protocol                   April 1971
+
+
+   TELNET is a third-level protocol, the function of which is to make a
+   terminal (or process) at a using site appear to the system or a
+   process at a serving site as logically equivalent to a terminal
+   "directly" connected to the serving site.  In performing this
+   function, the protocol attempts to minimize the amount of information
+   each HOST must keep about the characteristics of other HOSTS.
+
+   Definitions
+
+   Protocol Levels (see Figure 1)
+
+      Level 1
+
+         HOST-IMP protocol specified by BBN in NIC 5735, Specifications
+         for the Interconnection of a HOST, and an IMP (BBN Report 1822)
+
+      Level 2
+
+         HOST-HOST protocol performed by NCPs as described in Document
+         Number 1 (NIC 5413) and subsequent amendments, see RFC 107 (NIC
+         #5806)
+
+            One view of the NCP's function is that it takes information
+            from the net and routes it to receiving processes via
+            mechanisms internal to each HOST; conversely, processes use
+            the NCP, via internal system calls, to have information
+            routed to other processes in the net (via the other
+            processes' NCPs).
+
+      Level 3 (see Figure 2)
+
+         Level 3 is, by definition, the place to which and from which
+         the NCP communicates internally in its own host.
+
+            This level may be equivalent to the user process level in
+            some systems, but this may not be the case in all systems.
+            In using sites, the TELNET process operates at this level.
+            In serving sites, the TELNET server operates at this level.
+
+   Initial Connection Protocol (ICP)
+
+      An agreed-upon sequence of level 3 exchanges between two processes
+      which is, in general, used to synchronize the dialogue between the
+      processes, e.g., RFC 80 (NIC #5608) #1.
+
+
+
+
+
+
+
+O'Sullivan                                                      [Page 3]
+
+RFC 137                     TELNET Protocol                   April 1971
+
+
+   Serving Site
+
+      The HOST into which the TELNET process is directing the user's
+      keyboard input and from which the TELNET process is receiving
+      control information and data effecting the user's terminal.  At
+      the serving site, a TELNET server is executing.
+
+   Using Site
+
+      The HOST in which the TELNET process is executing.
+
+   Sending Site
+
+      The HOST transmitting data, could be either using site or serving
+      site.
+
+   Receiving Site
+
+      Converse of sending site.
+
+   User
+
+      The person or process "driving" the TELNET process.
+
+   In providing services the TELNET protocol will use established
+   network conventions, specifically the Network Control Program, and
+   Initial Connection Protocol referenced in the above definitions.
+
+   The TELNET protocol provides for a Network Virtual Terminal (NVT)
+   through which users may transmit and receive data over connections
+   between the using site and the serving site.
+
+   The code of the NVT will be full ASCII.  The seven-bit code will be
+   transmitted in eight-bit bytes, the high order bit set to zero.
+
+   It will be the responsibility of the using site to provide its users
+   with a means of producing all 128 ASCII codes, as well as a selected
+   set of special TELNET control signals (see Figure 3).
+
+
+
+
+
+
+
+
+
+
+
+
+
+O'Sullivan                                                      [Page 4]
+
+RFC 137                     TELNET Protocol                   April 1971
+
+
+   The ASCII character ESC will be employed by the user as an escape
+   signal indicating that the next character(s) has special meaning.
+   The meaning assigned to escape code will be serving site defined and
+   therefore may not be consistant across the network.
+
+   It will be the responsibility of the serving site to specify for
+   users how the NVT code will be used to represent the codes normally
+   generated by a local terminal.  The serving sites specification of
+   this representation is expected, where reasonable, to map on a one-
+   for-one basis for ASCII graphics and controls that are provided
+   through local terminals.  The serving site will also specify how the
+   escape conventions will be interpreted by the system.
+
+   The end of a line will be represented in the NVT as carriage return
+   followed by line feed.
+
+   The protocol assumes that at initially the serving site will not
+   provide any echo to the using site.
+
+   Each TELNET control signal for which code must be sent over the
+   connection will be represented in the NVT by an eight-bit code, with
+   the high order bit set to one.  Following are the special codes
+   established to date. (U) indicates that in most implementations the
+   user would be expected to have the ability to signal the TELNET
+   process from his terminal to initiate the code.
+
+   Code X'A0'
+
+      Source:  Both Sites (U)
+      Meaning: A DATA TYPE[1] signal indicating that code will be
+               transmitted by NVT, i.e., using the seven-bit ASCII
+               conventions.
+
+   Code X'80'
+
+      Source:  Using Site (U)
+      Meaning: Order using site NCP to send an INS and insert X'80' in
+               data stream.
+
+   Code X'81'
+
+      Source:  Using Site (U)
+      Meaning: Break or Attention
+
+
+
+
+
+
+
+
+O'Sullivan                                                      [Page 5]
+
+RFC 137                     TELNET Protocol                   April 1971
+
+
+   Code X'82'
+
+      Source:  Serving System
+      Meaning: Reverse Break
+
+   Code X'83'
+
+      Source:  Both Sites
+      Meaning: I Echo
+
+   Code X'84'
+
+      Source:  Both Sites
+      Meaning: You Echo
+
+   Code X'85'
+
+      Reserved
+
+   Code X'86'
+
+      Reserved
+
+   Code X'87'
+
+      Source:  Both Sites
+      Meaning: This site has not implemented the following control code.
+
+   Code X'88'
+
+      Source:  Both Sites
+      Meaning: [2]Return to control mode, i.e. next byte will be a
+               control signal, possible a new DATA TYPE.
+
+   Some special TELNET control signals are required to permit the user
+   on some systems to send control information to the using site TELNET
+   process.  These do not require a corresponding control code for
+   transmission.  The local TELNET control signals are:
+
+      1. Transmit all data to this point.
+      2. Suppress transmission of end of line, send all other data.
+
+
+
+
+
+
+
+
+
+
+O'Sullivan                                                      [Page 6]
+
+RFC 137                     TELNET Protocol                   April 1971
+
+
+   Data is to be forwarded to the NCP for transmission as convenient,
+   but at least at the end of line, end of line suppression, and
+   transmit signals.  If the normal line length of the sending site is
+   greater than the allocation given by the receiving site, the sending
+   sites TELNET process or TELNET server will be responsible for
+   breaking the line into convenient lengths and turning them over to
+   the NCP for transmission.
+
+   This document will be revised as necessary to provide conventions for
+   data types, in addition to the NVT ASCII type.
+
+Footnotes:
+
+   [1] A one-byte DATA TYPE signal is sent as the first byte of data
+   over a connection.  A default is employed if the first byte over a
+   connection has the high order bit set to zero, and it is assumed that
+   the seven-bit ASCII NVT convention will be employed.  After initial
+   connection, the DATA TYPE may be changed (see code X'88').  Most
+   implementations and applications may expect the DATA TYPES to be
+   symmetrical at any point in time,(i.e. both using a serving site
+   using the same DATA TYPE.).
+
+   [2] A site receiving a DATA TYPE signal is to respond with a double
+   X'88' if the new DATA TYPE is acceptable.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+O'Sullivan                                                      [Page 7]
+
+RFC 137                     TELNET Protocol                   April 1971
+
+
+|<------- 32 ------->|<-8->|<-8->|<-- 16 -->|<-8->|<---
++--------------------+-----+-----+----------+-----+------------------
+|       leader       |  x  |size |  count   |  x  | TEXT
++--------------------+-----+-----+----------+-----+------------------
+|<---- level 1  ---->|
+    message leader
+
+|<------------------  level 2  ------------------>|
+                  message preamble
+
+                                                         level 3
+                                                  |<- message text..-->
+
+                 Figure 1. Network Message on Link 2-31
+           Indicating Portions of Interest to Various Levels
+
+
+
+
+
+
+       USING HOST                                       Serving HOST
+ -----------------------+                      +----------------------
+                        |                      |
+    \                   |                      |                  /
+     \ -----------------|  +-+            +-+  |-----------------/
+      \           NCP   |  |I|            |I|  |   NCP          /
+       \       ^      <--->|M|---NETWORK--|M|<--->      ^      /
+        \ -----|-----+  |  |P|            |P|  |  +-----|-----/
+         \     v     |  |  +-+            +-+  |  |     v    /
+USER      \          |  |                      |  | TELNET  /  USER
+PROCESSES,  ) TELNET |--|                      |--|Protocol(   PROCESS
+Sub     <===>        |  |                      |  |Routing<--->Sub
+Systems,  /    ^     |  |                      |  |    ^^    \Systems
+ETC      /-----|-----+  |                      |  +----||-----\ETC
+        / TTY  v      <---> Local     Local  <===> TTY vv      \
+       /  Handles       |   Terminals Terminals|   Handles    <===>
+      /-----------------|                      |-----------------\
+     /                  |                      |                  \
+                        |                      |
+ -----------------------+                      +----------------------
+
+<---> Current TELNET paths
+<===> Candidate future TELNET paths
+
+          Figure 2. Current and Candidate Future TELNET Paths
+
+
+
+
+
+O'Sullivan                                                      [Page 8]
+
+RFC 137                     TELNET Protocol                   April 1971
+
+
++---------------------------+----+----+----+----+----+----+----+----+
+|\ b8  ->                   | 0  | 0  | 0  | 0  | 0  | 0  | 0  | 0  |
+| \ b7  ->                  | 0  | 0  | 0  | 0  | 1  | 1  | 1  | 1  |
+|  \ b6  ->                 | 0  | 0  | 1  | 1  | 0  | 0  | 1  | 1  |
+|B  \ b5  ->                | 0  | 1  | 0  | 1  | 0  | 1  | 0  | 1  |
+| I  +---+---+---+---+------+----+----+----+----+----+----+----+----+
++  T | b | b | b | b |\COL->|    |    |    |    |    |    |    |    |
+\   S| 4 | 3 | 2 | 1 | \    |    |    |    |    |    |    |    |    |
+ \   |   |   |   |   | |\   | 0  | 1  | 2  | 3  | 4  | 5  | 6  | 7  |
+  \  | | | | | | | | | v \  |    |    |    |    |    |    |    |    |
+   \ | v | v | v | v |ROW \ |    |    |    |    |    |    |    |    |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 0 | 0 | 0 | 0 |   0  |NUL |DLE | SP | 0  | @  | P  | \  | p  |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 0 | 0 | 0 | 1 |   1  |SOH |DC1 | !  | 1  | A  | Q  | a  | q  |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 0 | 0 | 1 | 0 |   2  |STX |DC2 | "  | 2  | B  | R  | b  | r  |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 0 | 0 | 1 | 1 |   3  |ETX |DC3 | #  | 3  | C  | S  | c  | s  |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 0 | 1 | 0 | 0 |   4  |EOT |DC4 | $  | 4  | D  | T  | d  | t  |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 0 | 1 | 0 | 1 |   5  |ENQ |NAC | %  | 5  | E  | U  | e  | u  |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 0 | 1 | 1 | 0 |   6  |ACK |SYN | &  | 6  | F  | V  | f  | v  |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 0 | 1 | 1 | 1 |   7  |BEL |ETB | '  | 7  | G  | W  | g  | w  |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 1 | 0 | 0 | 0 |   8  | BS |CAN | (  | 8  | H  | X  | h  | x  |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 1 | 0 | 0 | 1 |   9  | HT | EM | )  | 9  | I  | Y  | i  | y  |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 1 | 0 | 1 | 0 |  10  | LF |SUB | *  | :  | J  | Z  | j  | z  |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 1 | 0 | 1 | 1 |  11  | VT |ESC | +  | ;  | K  | [  | k  | {  |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 1 | 1 | 0 | 0 |  12  | FF | FS | ,  | <  | L  | \  | l  | |  |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 1 | 1 | 0 | 1 |  13  | CR | GS | -  | =  | M  | ]  | m  | }  |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 1 | 1 | 1 | 0 |  14  | S0 | RS | .  | >  | N  | ^  | n  | ~  |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 1 | 1 | 1 | 1 |  15  | S1 | US | /  | ?  | O  | _  | o  |DEL |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+         Code Structure      8   7   6   5   4   3   2   1
+                        --- --- --- --- --- --- --- --- --- ---
+
+
+
+
+
+O'Sullivan                                                      [Page 9]
+
+RFC 137                     TELNET Protocol                   April 1971
+
+
++---------------------------+----+----+----+----+----+----+----+----+
+|\ b8  ->                   | 1  | 1  | 1  | 1  | 1  | 1  | 1  | 1  |
+| \ b7  ->                  | 0  | 0  | 0  | 0  | 1  | 1  | 1  | 1  |
+|  \ b6  ->                 | 0  | 0  | 1  | 1  | 0  | 0  | 1  | 1  |
+|B  \ b5  ->                | 0  | 1  | 0  | 1  | 0  | 1  | 0  | 1  |
+| I  +---+---+---+---+------+----+----+----+----+----+----+----+----+
++  T | b | b | b | b |\COL->|    |    |    |    |    |    |    |    |
+\   S| 4 | 3 | 2 | 1 | \    |    |    |    |    |    |    |    |    |
+ \   |   |   |   |   | |\   | 8  | 9  | 10 | 11 | 12 | 13 | 14 | 15 |
+  \  | | | | | | | | | v \  |    |    |    |    |    |    |    |    |
+   \ | v | v | v | v |ROW \ |    |    |    |    |    |    |    |    |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 0 | 0 | 0 | 0 |   0  |'80'|    |'A0'|    |    |    |    |    |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 0 | 0 | 0 | 1 |   1  |'81'|    |    |    |    |    |    |    |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 0 | 0 | 1 | 0 |   2  |'82'|    |    |    |    |    |    |    |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 0 | 0 | 1 | 1 |   3  |'83'|    |    |    |    |    |    |    |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 0 | 1 | 0 | 0 |   4  |'84'|    |    |    |    |    |    |    |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 0 | 1 | 0 | 1 |   5  |'85'|    |    |    |    |    |    |    |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 0 | 1 | 1 | 0 |   6  |'86'|    |    |    |    |    |    |    |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 0 | 1 | 1 | 1 |   7  |'87'|    |    |    |    |    |    |    |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 1 | 0 | 0 | 0 |   8  |'88'|    |    |    |    |    |    |    |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 1 | 0 | 0 | 1 |   9  |    |    |    |    |    |    |    |    |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 1 | 0 | 1 | 0 |  10  |    |    |    |    |    |    |    |    |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 1 | 0 | 1 | 1 |  11  |    |    |    |    |    |    |    |    |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 1 | 1 | 0 | 0 |  12  |    |    |    |    |    |    |    |    |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 1 | 1 | 0 | 1 |  13  |    |    |    |    |    |    |    |    |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 1 | 1 | 1 | 0 |  14  |    |    |    |    |    |    |    |    |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+     | 1 | 1 | 1 | 1 |  15  |    |    |    |    |    |    |    |    |
+     +---+---+---+---+------+----+----+----+----+----+----+----+----+
+
+ 'XX' = HEX designation for codes assigned to TELNET Control Signals.
+
+            Figure 3. Official Network Virtual Terminal Code
+
+
+
+O'Sullivan                                                     [Page 10]
+
+RFC 137                     TELNET Protocol                   April 1971
+
+
+        [This RFC was put into machine readable form for entry]
+         [into the online RFC archives by Sergio Kleiman, 8/01]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+O'Sullivan                                                     [Page 11]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc137.txt](<www.ietf.org/rfc/rfc137.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
