### PR TITLE
Archive rfc1370.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1370.txt
+++ b/www.ietf.org/rfc/rfc1370.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                          Internet Architecture Board
+Request for Comments: 1370                             Lyman Chapin, Chair
+                                                              October 1992
+
+
+                    Applicability Statement for OSPF
+
+Status of this Memo
+
+   This memo is an IAB standards track Applicability Statement for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "IAB
+   Official Protocol Standards" for the standardization state and status
+   of this specification.  Distribution of this memo is unlimited.
+
+1. INTRODUCTION
+
+   Users and vendors have expressed a strong need for IP routers from
+   different vendors that can interoperate using a common Interior
+   Gateway Protocol (IGP).  There is therefore an urgent requirement for
+   a high-functionality non-proprietary 'open' IGP that will be
+   ubiquitously available from all IP router vendors.
+
+   The Open Shortest Path First (OSPF) routing protocol [1] was
+   developed by the IETF to fill this need.  This Applicability
+   Statement specifies the circumstances under which OSPF must be
+   implemented by router vendors.  The history of OSPF development and
+   the reasoning behind this Applicability Statement will be found in
+   [5].
+
+   This Applicability Statement places a requirement on vendors claiming
+   conformance to this standard, in order to assure that users will have
+   the option of deploying OSPF when they need a multivendor,
+   interoperable IGP in their environment.  Users are of course free to
+   use whatever routing protocol best meets their requirements.
+
+2.  APPLICABILITY OF OSPF
+
+   An IP router that implements any routing protocol (other than static
+   routes) is required to implement OSPF [1] and the OSPF MIB [2].
+   Within OSPF, implementation of all features except TOS (Type-of-
+   Service) routing is required; implementation of TOS routing is
+   recommended.
+
+   This requirement does not prevent a router from implementing other
+   routing protocols in addition to OSPF.  Complete and definitive
+   requirements on all aspects of an IP router will be found in a
+   forthcoming Applicability Statement: "Requirements for IP Routers"
+
+
+
+IAB                                                             [Page 1]
+
+RFC 1370             Applicability Statement: OSPF          October 1992
+
+
+   [4], currently in preparation in the IETF.  "Requirements for IP
+   Routers", when it becomes a Standard, will take precedence if its
+   requirements for OSPF should conflict with this present RFC.
+
+   It should be noted that OSPF is intended for use by routers for
+   exchanging dynamic routing information, and not for use by hosts.  As
+   discussed in Section 3.3.1.4 of STD-2, "Requirements for Internet
+   Hosts -- Communication Layers" [3], 'wiretapping' of routing
+   protocols by hosts is not recommended.  Recommended mechanisms for a
+   host to use for discovering local routers and detecting dead routers
+   will be found in [3].  In particular, the ICMP Router Discovery
+   messages, under development, will provide a standard way for a host
+   to learn the addresses of local routers [6].
+
+3.  REFERENCES
+
+   [1] Moy, J., "OSPF Version 2", RFC 1247, Proteon, Inc., July 1991.
+
+   [2] Baker, F., and R. Coltun, "OSPF Version 2 Management Information
+       Base", RFC 1253, ACC, Computer Science Center, August 1991.
+
+   [3] Braden, R., Editor, "Requirements for Internet Hosts --
+       Communication Layers", IETF, STD 3, RFC 1122, October 1989.
+
+   [4] Almquist, P., Editor, "Requirements for IP Routers", Work in
+       Preparation, IETF.
+
+   [5] Gross, P., Editor, "Choosing a "Common IGP" for the IP Internet
+       (The IESG's Recommendation to the IAB)", RFC 1371, IESG, October
+       1992.
+
+   [6] Deering, S., Editor, "ICMP Router Discovery Messages", RFC 1256,
+       Xerox PARC, September 1991.
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Author's Address
+
+   A. Lyman Chapin
+   BBN Communications Corporation
+   150 Cambridge Park Drive
+   Cambridge, MA  02140
+
+   Phone: 617-873-3133
+   Fax:   617-873-4086
+   Email: Lyman@BBN.COM
+
+
+
+IAB                                                             [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1370.txt](<www.ietf.org/rfc/rfc1370.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
