### PR TITLE
Archive rfc1387.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1387.txt
+++ b/www.ietf.org/rfc/rfc1387.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                                          G. Malkin
+Request for Comments: 1387                                Xylogics, Inc.
+                                                            January 1993
+
+
+                    RIP Version 2 Protocol Analysis
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard.  Distribution of this memo is
+   unlimited.
+
+Abstract
+
+   As required by Routing Protocol Criteria (RFC 1264), this report
+   documents the key features of the RIP-2 protocol and the current
+   implementation experience.
+
+Acknowledgements
+
+   The RIP-2 protocol owes much to those who participated in the RIP-2
+   Working Group of the Internet Engineering Task Force (IETF).  A
+   special thanks goes to Fred Baker for his help on the MIB, and to
+   Jeffrey Honig for the implementation experience.
+
+1.  Protocol Documents
+
+   The RIP-2 protocol description is defined in RFC 1388 [1].  This memo
+   suggests an update to the "Routing Information Protocol" (RFC 1058)
+   [3].  The RIP-2 MIB description is defined in RFC 1389 [2].
+
+2.  Key Features
+
+   While RIP-2 shares the same basic algorithms as RIP-1, it supports
+   several new features.  They are: routing domains, external route
+   tags, subnet masks, next hop addresses, and authentication.
+
+2.1  Routing Domains
+
+   Routing domains allow multiple RIP "clouds" to exist over the same
+   physical network.  This is a feature requested by several members of
+   the working group.  It allows simple policies to be constructed by
+   grouping routers into domains which share routing information.
+
+
+
+
+
+
+
+Malkin                                                          [Page 1]
+
+RFC 1387                     RIP-2 Analysis                 January 1993
+
+
+2.2  External Route Tags
+
+   The route tag field may be used to propagate information acquired
+   from an EGP.  The definition of the contents of this field are beyond
+   the scope of this protocol.  However, it may be used, for example, to
+   propagate an EGP AS number.
+
+2.3  Subnet Masks
+
+   Inclusion of subnet masks was the original intent of opening the RIP
+   protocol for improvement.  Subnet mask information makes RIP more
+   useful in a variety of environments and allows the use of variable
+   subnet masks on the network.  Subnet masks are also necessary for
+   implementation of "classless" addressing, as the CIDR work proposes.
+
+2.4  Next Hop Addresses
+
+   Support for next hop addresses allows for optimization of routes in
+   an environment which uses multiple routing protocols.  For example,
+   if RIP-2 were being run on a network along with another IGP, and one
+   router ran both protocols, then that router could indicate to the
+   other RIP-2 routers that a better next hop than itself exists for a
+   given destination.
+
+2.5  Authentication
+
+   One significant improvement RIP-2 offers over RIP-1, is the addition
+   of an authentication mechanism.  Essentially, it is the same
+   extensible mechanism provided by OSPF.  Currently, only a plain-text
+   password is defined for authentication.  However, more sophisticated
+   authentication schemes can easily be incorporated as they are
+   defined.
+
+2.6  Multicasting
+
+   RIP-2 packets may be multicast instead of being broadcast.  The use
+   of an IP multicast address reduces the load on hosts which do not
+   support routing protocols.  It also allows RIP-2 routers to share
+   information which RIP-1 routers cannot hear.  This is useful since a
+   RIP-1 router may misinterpret route information because it cannot
+   apply the supplied subnet mask.
+
+3.  RIP-2 MIB
+
+   The MIB for RIP-2 allows for monitoring and control of RIP's
+   operation within the router.  In addition to global and per-interface
+   counters and controls, there is are per-peer counters which provide
+   the status of RIP-2 "neighbors".
+
+
+
+Malkin                                                          [Page 2]
+
+RFC 1387                     RIP-2 Analysis                 January 1993
+
+
+4.  Implementations
+
+   Currently, there is one nearly complete implementation of RIP-2.  A
+   "gated" implementation is now available with RIP-2, written by
+   Jeffrey Honig at Cornell University.  It may be acquired by anonymous
+   FTP from gated.cornell.edu as pub/gated/gated-alpha.tar.Z.  It
+   implements multicasting, subnet masks, limited authentication, next-
+   hop, and limited routing domain support.  A RIP-2 version of ripquery
+   is also available.  The "gated" implementation does not yet support
+   full subsumption rules, full authentication, full routing domains,
+   and the MIB.  It has been tested against itself and various RIP-1
+   implementations.
+
+   A second, complete implementation is under development by a vendor
+   who's identity cannot be disclosed at this time.
+
+5. References
+
+   [1] Malkin, G., "RIP Version 2 - Carrying Additional Information",
+       RFC 1388, Xylogics, Inc., January 1993.
+
+   [2] Malkin, G., and F. Baker, "RIP Version 2 MIB Extension", RFC
+       1389, Xylogics, Inc., Advanced Computer Communications, January
+       1993.
+
+   [3] Hedrick, C., "Routing Information Protocol", RFC 1058, Rutgers
+       University, June 1988.
+
+6.  Security Considerations
+
+       Security issues are discussed in section 2.5.
+
+7.  Author's Address
+
+       Gary Scott Malkin
+       Xylogics, Inc.
+       53 Third Avenue
+       Burlington, MA 01803
+
+       Phone:  (617) 272-8140
+       EMail:  gmalkin@Xylogics.COM
+
+
+
+
+
+
+
+
+
+
+Malkin                                                          [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1387.txt](<www.ietf.org/rfc/rfc1387.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
