### PR TITLE
Archive rfc1399.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1399.txt
+++ b/www.ietf.org/rfc/rfc1399.txt
@@ -1,0 +1,1235 @@
+
+
+
+
+
+
+Network Working Group                                         J. Elliott
+Request for Comments: 1399                                           ISI
+Category: Informational                                     January 1997
+
+
+                      Request for Comments Summary
+
+                         RFC Numbers 1300-1399
+
+Status of This Memo
+
+   This RFC is a slightly annotated list of the 100 RFCs from RFC 1300
+   through RFCs 1399.  This is a status report on these RFCs.  This memo
+   provides information for the Internet community.  It does not specify
+   an Internet standard of any kind.  Distribution of this memo is
+   unlimited.
+
+Note
+
+   Many RFCs, but not all, are Proposed Standards, Draft Standards, or
+   Standards.  Since the status of these RFCs may change during the
+   standards processing, we note here only that they are on the
+   standards track.  Please see the latest edition of "Internet Official
+   Protocol Standards" for the current state and status of these RFCs.
+   In the following, RFCs on the standards track are marked [STANDARDS-
+   TRACK].
+
+RFC     Author       Date      Title
+---     ------       ----      -----
+
+1399    Elliott      Jan 97   Requests For Comments Summary
+
+This memo.
+
+
+1398    Kastenholz   Jan 93   Definitions of Managed Objects for the
+                              Ethernet-like Interface Types
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing ehternet-like objects.
+[STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 1]
+
+RFC 1399                  Summary of 1300-1399              January 1997
+
+
+1397    Haskin       Jan 93   Default Route Advertisement In BGP2 and
+                              BGP3 Versions of the Border Gateway
+                              Protocol
+
+This document speficies the recommendation of the BGP Working Group on
+default route advertisement support in BGP2 [1] and BGP3 [2] versions of
+the Border Gateway Protocol.  [STANDARDS-TRACK]
+
+
+1396    Crocker      Jan 93   The Process for Organization of Internet
+                              Standards
+
+This report provides a summary of the POISED Working Group (WG),
+starting from the events leading to the formation of the WG to the end
+of 1992.  This memo provides information for the Internet community.  It
+does not specify an Internet standard.
+
+
+1395    Reynolds     Jan 93   BOOTP Vendor Information Extensions
+
+This RFC is a slight revision and extension of RFC-1048 by Philip
+Prindeville, who should be credited with the original work in this memo.
+This memo will be updated as additional tags are defined.  This edition
+introduces Tag 14 for Merit Dump File, Tag 15 for Domain Name, Tag 16
+for Swap Server and Tag 17 for Root Path.  This memo is a status report
+on the vendor information extensions used int the Bootstrap Protocol
+(BOOTP).
+
+
+1394    Robinson     Jan 93   Relationship of Telex Answerback Codes
+                              to Internet Domains
+
+This RFC gives the list, as best known, of all common Internet domains
+and the conversion between specific country telex answerback codes and
+Internet country domain identifiers.  It also lists the telex code and
+international dialing code, wherever it is available.  It will also list
+major Internet "Public" E-Mail addresses.  This memo provides
+information for the Internet community.  It does not specify an Internet
+standard.
+
+
+1393    Malkin       Jan 93   Traceroute Using an IP Option
+
+This document specifies a new IP option and ICMP message type which
+duplicates the functionality of the existing traceroute method while
+generating fewer packets and completing in a shorter time.  This memo
+defines an Experimental Protocol for the Internet community.
+
+
+
+
+Elliott                      Informational                      [Page 2]
+
+RFC 1399                  Summary of 1300-1399              January 1997
+
+
+1392    Malkin       Jan 93   Internet Users' Glossary
+
+There are many networking glossaries in existence.  This glossary
+concentrates on terms which are specific to the Internet.  This memo
+provides information for the Internet community.  It does not specify an
+Internet standard.
+
+
+1391    Malkin       Jan 93   The Tao of IETF
+                              A Guide for New Attendees of the
+                              Internet Engineering Task Force
+
+The purpose of this For Your Information (FYI) RFC is to explain to the
+newcomers how the IETF works.  This will give them a warm, fuzzy feeling
+and enable them to make the meeting more productive for everyone.  This
+memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+1390    Katz         Jan 93   Transmission of IP and ARP over FDDI
+                              Networks
+
+This memo defines a method of encapsulating the Internet Protocol (IP)
+datagrams and Address Resolution Protocol (ARP) requests and replies on
+Fiber Distributed Data Interface (FDDI) Networks.  [STANDARDS-TRACK]
+
+
+1389    Malkin       Jan 93   RIP Version 2 MIB Extension
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.
+[STANDARDS-TRACK]
+
+
+1388    Malkin       Jan 93   RIP Version 2
+                              Carrying Additional Information
+
+This document specifies an extension of the Routing Information Protocol
+(RIP), as defined in [1], to expand the amount of useful information
+carried in RIP packets and to add a measure of security.  [STANDARDS-
+TRACK]
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 3]
+
+RFC 1399                  Summary of 1300-1399              January 1997
+
+
+1387    Malkin       Jan 93   RIP Version 2 Protocol Analysis
+
+As required by Routing Protocol Criteria (RFC 1264), this report
+documents the key features of the RIP-2 protocol and the current
+implementation experience.  This memo provides information for the
+Internet community.  It does not specify an Internet standard.
+
+
+1386    Cooper       Dec 92   The US Domain
+
+This is a description of the US Top Level Domains on the Internet.  This
+memo provides information for the Internet community. It does not
+specify an Internet standard.
+
+
+1385    Wang         Nov 92   EIP: The Extended Internet Protocol
+                              A Framework for Maintaining Backward
+                              Compatibility
+
+EIP can substantially reduce the amount of modifications needed to the
+current Internet systems and greatly ease the difficulties of
+transition. This is an "idea" paper and discussion is strongly
+encouraged on Big-Internet@munnari.oz.au.  This memo provides
+information for the Internet community. It does not specify an Internet
+standard.
+
+
+1384    Barker       Jan 93   Naming Guidelines for Directory Pilots
+
+This document defines a number of naming guidelines.  Alignment to these
+guidelines is recommended for directory pilots.  This memo provides
+information for the Internet community. It does not specify an Internet
+standard.
+
+
+1383    Huitema      Dec 92   An Experiment in DNS Based IP Routing
+
+Potential solutions to the routing explosion.  This memo defines an
+Experimental Protocol for the Internet community.
+
+
+1382    Throop       Nov 92   SNMP MIB Extension for the X.25 Packet
+                              Layer
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.
+[STANDARDS-TRACK]
+
+
+
+
+Elliott                      Informational                      [Page 4]
+
+RFC 1399                  Summary of 1300-1399              January 1997
+
+
+1381    Throop       Nov 92   SNMP MIB Extension for X.25 LAPB
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing the Link Layer of X.25,
+LAPB.  [STANDARDS-TRACK]
+
+
+1380    Gross        Nov 92    IESG Deliberations on Routing and
+                               Addressing
+
+This memo summarizes issues surrounding the routing and addressing
+scaling problems in the IP architecture, and it provides a brief
+background of the ROAD group and related activities in the Internet
+Engineering Task Force (IETF).  This memo provides information for the
+Internet community.  It does not specify an Internet standard.
+
+
+1379    Braden       Nov 92    Extending TCP for Transactions --
+                               Concepts
+
+This memo discusses extension of TCP to provide transaction-oriented
+service, without altering its virtual-circuit operation.  This memo
+provides information for the Internet community.  It does not specify an
+Internet standard.
+
+
+1378    Parker       Nov 92    The PPP AppleTalk Control Protocol
+                               (ATCP)
+
+This document defines the NCP for establishing and configuring the
+AppleTalk Protocol [3] over PPP.  [STANDARDS-TRACK]
+
+
+1377     Katz        Nov 92    The PPP OSI Network Layer Control
+                               Protocol (OSINLCP)
+
+This document defines the NCP for establishing and configuring OSI
+Network Layer Protocols.  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 5]
+
+RFC 1399                  Summary of 1300-1399              January 1997
+
+
+1376    Senum         Nov 92   The PPP DECnet Phase IV Control
+                               Protocol (DNCP)
+
+This document defines the NCP for establishing and configuring Digital's
+DNA Phase IV Routing protocol (DECnet Phase IV) over PPP.  This document
+applies only to DNA Phase IV Routing messages (both data and control),
+and not to other DNA Phase IV protocols (MOP, LAT, etc.).  [STANDARDS-
+TRACK]
+
+
+1375    Robinson      Oct 92   Suggestion for New Classes of IP
+                               Addresses
+
+This RFC suggests a change in the method of specifying the IP address to
+add new classes of networks to be called F, G, H, and K, to reduce the
+amount of wasted address space, and to increase the available IP address
+number space, especially for smaller organizations or classes of
+connectors that do not need or do not want a full Class C IP address.
+This memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+1374    Renwick       Oct 92   IP and ARP on HIPPI
+
+The ANSI X3T9.3 committee has drafted a proposal for the encapsulation
+of IEEE 802.2 LLC PDUs and, by implication, IP on HIPPI.  Another X3T9.3
+draft describes the operation of HIPPI physical switches.  X3T9.3 chose
+to leave HIPPI networking issues largely outside the scope of their
+standards; this document discusses methods of using of ANSI standard
+HIPPI hardware and protocols in the context of the Internet, including
+the use of HIPPI switches as LANs and interoperation with other
+networks.  This memo is intended to become an Internet Standard.
+[STANDARDS-TRACK]
+
+
+1373    Tignor        Oct 92   PORTABLE DUAs
+
+This document comes in two parts. The first part is for regular people
+who wish to set up their own DUAs (Directory User Interfaces) to access
+the Directory.  The second part is for ISODE-maintainers wishing to
+provide portable DUAs to users. This part gives instructions in a
+similar but longer, step-by-step format.  This memo provides information
+for the Internet community.  It does not specify an Internet standard.
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 6]
+
+RFC 1399                  Summary of 1300-1399              January 1997
+
+
+1372    Hedrick       Oct 92   Telnet Remote Flow Control Option
+
+This document specifies an extended version of the Telnet Remote Flow
+Control Option, RFC 1080, with the addition of the RESTART-ANY and
+RESTART-XON suboptions.  [STANDARDS-TRACK]
+
+
+1371    Gross         Oct 92   Choosing a "Common IGP" for the IP
+                               Internet
+                               (The IESG's Recommendation to the IAB)
+
+This memo presents motivation, rationale and other surrounding
+background information leading to the IESG's recommendation to the IAB
+for a single "common IGP" for the IP portions of the Internet.  This
+memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+1370    I.A.B.        Oct 92   Applicability Statement for OSPF
+
+This Applicability Statement places a requirement on vendors claiming
+conformance to this standard, in order to assure that users will have
+the option of deploying OSPF when they need a multivendor, interoperable
+IGP in their environment.  [STANDARDS-TRACK]
+
+
+1369    Kastenholz    Oct 92   Implementation Notes and Experience for
+                               The Internet Ethernet MIB
+
+This document reflects the currently known status of 11 different
+implementations of the MIB by 7 different vendors on 7 different
+Ethernet interface chips.  This memo provides information for the
+Internet community.  It does not specify an Internet standard.
+
+
+1368    McMaster      Oct 92   Definitions of Managed Objects for IEEE
+                               802.3 Repeater Devices
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing IEEE 802.3 10 Mb/second
+baseband repeaters, sometimes referred to as "hubs".  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 7]
+
+RFC 1399                  Summary of 1300-1399              January 1997
+
+
+1367    Topolcic      Oct 92   Schedule for IP Address Space
+                               Management Guidelines
+
+This memo suggests a schedule for the implementation of the IP network
+number allocation plan described in RFC 1366.  This memo provides
+information for the Internet community.  It does not specify an Internet
+standard.
+
+
+1366    Gerich        Oct 92   Guidelines for Management of IP Address
+                               Space
+
+This document has been reviewed by the Federal Engineering Task Force
+(FEPG) on behalf of the Federal Networking Council (FNC), the co-chairs
+of the International Engineering Planning Group (IEPG), and the Reseaux
+IP Europeens (RIPE).  There was general consensus by those groups to
+support the recommendations proposed in this document for management of
+the IP address space.  This memo provides information for the Internet
+community.  It does not specify an Internet standard.
+
+
+1365    Siyan         Spt 92   An IP Address Extension Proposal
+
+This RFC suggests an extension to the IP protocol to solve the shortage
+of IP address problem, and requests discussion and suggestions for
+improvements.  This memo provides information for the Internet
+community.  It does not specify an Internet standard.
+
+
+1364    Varadhan      Spt 92   BGP OSPF Interaction
+
+This memo defines the various criteria to be used when designing
+Autonomous System Border Routers (ASBR) that will run BGP with other
+ASBRs external to the AS and OSPF as its IGP.  [STANDARDS-TRACK]
+
+
+1363    Partridge     Spt 92   A Proposed Flow Specification
+
+The flow specification defined in this memo is intended for information
+and possible experimentation (i.e., experimental use by consenting
+routers and applications only).  This RFC is a product of the Internet
+Research Task Force (IRTF).  This memo provides information for the
+Internet community.  It does not specify an Internet standard.
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 8]
+
+RFC 1399                  Summary of 1300-1399              January 1997
+
+
+1362    Allen         Spt 92   Novell IPX Over Various WAN Media
+                               (IPXWAN)
+
+This document describes how Novell IPX operates over various WAN media.
+Specifically, it describes the common "IPX WAN" protocol Novell uses to
+exchange necessary router to router information prior to exchanging
+standard IPX routing information and traffic over WAN datalinks.  This
+memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+1361    Mills         Aug 92   Simple Network Time Protocol (SNTP)
+
+This memorandum describes the Simple Network Time Protocol (SNTP), which
+is an adaptation of the Network Time Protocol (NTP) used to synchronize
+computer clocks in the Internet.  This memorandum does not obsolete or
+update any RFC.  This memo provides information for the Internet
+community.  It does not specify an Internet standard.
+
+
+1360    I.A.B.        Spt 92   IAB OFFICIAL PROTOCOL STANDARDS
+
+Discussion of the standardization process and the RFC document series is
+presented first, followed by an explanation of the terms.  Sections 6.2
+- 6.9 contain the lists of protocols in each stage of standardization.
+Finally come pointers to references and contacts for further
+information.  [STANDARDS-TRACK]
+
+
+1359    ACM SIGUCCS   Aug 92   Connecting to the Internet
+                               What Connecting Institutions Should
+                               Anticipate
+
+This FYI RFC outlines the major issues an institution should consider in
+the decision and implementation of a campus connection to the Internet.
+This memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+1358    Chapin        Aug 92   Charter of the Internet Architecture
+                               Board (IAB)
+
+The Internet Architecture Board (IAB) shall be constituted and shall
+operate as a technical advisory group of the Internet Society.  This
+memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+
+
+
+Elliott                      Informational                      [Page 9]
+
+RFC 1399                  Summary of 1300-1399              January 1997
+
+
+1357    Cohen         Jul 92   A Format for E-mailing Bibliographic
+                               Records
+
+This memo defines a format for E-mailing bibliographic records of
+technical reports.  It is intended to accelerate the dissemination of
+information about new Computer Science Technical Reports (CS-TR).  This
+memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+1356    Malis         Aug 92   Multiprotocol Interconnect
+                               on X.25 and ISDN in the Packet Mode
+
+This document specifies the encapsulation of IP and other network layer
+protocols over X.25 networks, in accordance and alignment with ISO/IEC
+and CCITT standards.  It is a replacement for RFC 877, "A Standard for
+the Transmission of IP Datagrams Over Public Data Networks" [1].
+[STANDARDS-TRACK]
+
+
+1355    Curran        Aug 92   Privacy and Accuracy Issues in Network
+                               Information Center Databases
+
+This document provides a set of guidelines for the administration and
+operation of public Network Information Center (NIC) databases.  This
+memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+1354    Baker         Jul 92   IP Forwarding Table MIB
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing routes in the IP Internet.
+[STANDARDS-TRACK]
+
+
+1353    McCloghrie    Jul 92   Definitions of Managed Objects
+                               for Administration of SNMP Parties
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it describes a representation of the SNMP parties defined in
+[8] as objects defined according to the Internet Standard SMI [1].
+[STANDARDS-TRACK]
+
+
+
+
+
+
+Elliott                      Informational                     [Page 10]
+
+RFC 1399                  Summary of 1300-1399              January 1997
+
+
+1352    Galvin        Jul 92   SNMP Security Protocols
+
+The Simple Network Management Protocol (SNMP) specification [1] allows
+for the protection of network management operations by a variety of
+security protocols.  The SNMP administrative model described in [2]
+provides a framework for securing SNMP network management. In the
+context of that framework, this memo defines protocols to support the
+following three security services: data integrity, data origin
+authentication and data confidentiality.  [STANDARDS-TRACK]
+
+
+1351    Davin         Jul 92   SNMP Administrative Model
+
+This memo presents an elaboration of the SNMP administrative model set
+forth in [1]. This model provides a unified conceptual basis for
+administering SNMP protocol entities to support: authenticaiton and
+integrity, privacy, access control, and cooperation of protocol
+entities.  [STANDARDS-TRACK]
+
+
+1350    Sollins       Jul 92   THE TFTP PROTOCOL (REVISION 2)
+
+TFTP is a very simple protocol used to transfer files.  It is from this
+that its name comes, Trivial File Transfer Protocol or TFTP.  Each
+nonterminal packet is acknowledged separately.  This document describes
+the protocol and its types of packets.  The document also explains the
+reasons behind some of the design decisions.  [STANDARDS-TRACK]
+
+
+1349   Almquist       Jul 92   Type of Service in the Internet
+                               Protocol Suite
+
+This memo changes and clarifies some aspects of the semantics of the
+Type of Service octet in the Internet Protocol (IP) header.
+[STANDARDS-TRACK]
+
+
+1348    Manning       Jul 92   DNS NSAP RRs
+
+This RFC defines the format of two new Resource Records (RRs) for the
+Domain Name System (DNS), and reserves corresponding DNS type mnemonic
+and numerical codes.  This memo defines an Experimental Protocol for the
+Internet community.
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 11]
+
+RFC 1399                  Summary of 1300-1399              January 1997
+
+
+1347    Callon        Jun 92   TCP and UDP with bigger Addresses
+                               (TUBA), A Simple Proposal for Internet
+                               Addressing and Routing
+
+This paper describes a simple proposal which provides a long-term
+solution to Internet addressing, routing, and scaling.  This memo
+provides information for the Internet community. It does not specify an
+Internet standard.
+
+
+1346    Jones         Jun 92   Resource Allocation, Control, and
+                               Accounting for the Use of Network
+                               Resources
+
+The purpose of this RFC is to focus discussion on particular challenges
+in large service networks in general, and the International IP Internet
+in particular.  No solution discussed in this document is intended as a
+standard.  Rather, it is hoped that a general consensus will emerge as
+to the appropriate solutions, leading eventually to the adoption of
+standards.  This memo provides information for the Internet community.
+It does not specify an Internet standard.
+
+
+1345    Simonsen      Jun 92   Character Mnemonics & Character Sets
+
+This memo lists a selection of characters and their presence in some
+coded character sets.  This memo provides information for the Internet
+community.  It does not specify an Internet standard.
+
+
+1344   Borenstein     Jun 92   Implicaitons of MIME for Internet Mail
+                               Gateways
+
+While MIME was carefully designed so that it does not require any
+changes to Internet electronic message transport facilities, there are
+several ways in which message transport systems may want to take
+advantage of MIME.  These opportunities are the subject of this memo.
+This memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+1343    Borenstein     Jun 92   A User Agent Configuration Mechanism
+                                For Multimedia Mial Format Information
+
+This memo suggests a file format to be used to inform multiple mail
+reading user agent programs about the locally-installed facilities for
+handling mail in various formats.  This memo provides information for
+the Internet community.  It does not specify an Internet standard.
+
+
+
+Elliott                      Informational                     [Page 12]
+
+RFC 1399                  Summary of 1300-1399              January 1997
+
+
+1342    Moore          Jun 92   Representation of Non-ASCII Text in
+                                Internet Message Headers
+
+This memo describes an extension to the message format defined in [1]
+(known to the IETF Mail Extensions Working Group as "RFC 1341"), to
+allow the representation of character sets other than ASCII in RFC 822
+message headers.  [STANDARDS-TRACK]
+
+
+1341    Borenstein     Jun 92   MIME: Mechanisms for Specifying and
+                                Describing the Format of Internet
+                                Message Bodies
+
+This document redefines the format of message bodies to allow multi-part
+textual and non-textual message bodies to be represented and exchanged
+without loss of information.  [STANDARDS-TRACK]
+
+
+1340    Reynolds       Jul 92   ASSIGNED NUMBERS
+
+This Network Working Group Request for Comments documents the currently
+assigned values from several series of numbers used in network protocol
+implementations. This memo is a status report on the parameters (i.e.,
+numbers and keywords) used in protocols in the Internet community.
+
+
+1339    Dorner         Jun 92   Remote Mail Checking Protocol
+
+This RFC defines a protocol to provide a mail checking service to be
+used between a client and server pair. Typically, a small program on a
+client workstation would use the protocol to query a server in order to
+find out whether new mail has arrived for a specified user.  This memo
+defines an Experimental Protocol for the Internet community.
+
+
+1338    Fuller         Jun 92   Supernetting: an Address Assignment
+                                and Aggregation Strategy
+
+This memo discusses strategies for address assignment of the existing IP
+address space with a view to conserve the address space and stem the
+explosive growth of routing tables in default-route-free routers run by
+transit routing domain providers.  This memo provides information for
+the Internet community. It does not specify an Internet standard.
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 13]
+
+RFC 1399                  Summary of 1300-1399              January 1997
+
+
+1337    Braden         May 92   TIME-WAIT Assassination Hazards in TCP
+
+This note describes some theoretically-possible failure modes for TCP
+connections and discusses possible remedies.  In particular, one very
+simple fix is identified.  This memo provides information for the
+Internet community.  It does not specify an Internet standard.
+
+
+1336    Malkin         May 92   Who's Who in the Internet
+                                Biographies of IAB, IESG and
+                                IRSG Members
+
+This FYI RFC contains biographical information about members of the
+Internet Activities Board (IAB), the Internet Engineering Steering Group
+(IESG) of the Internet Engineering Task Force (IETF), and the the
+Internet Research Steering Group (IRSG) of the Internet Research Task
+Force (IRTF).  This memo provides information for the Internet
+community.  It does not specify any standard.
+
+
+1335    Wang           May 92   A Two-Tier Address Structure for the
+                                Internet:  A Solution to the Problem
+                                of Address Space Exhaustion
+
+This RFC presents a solution to problem of address space exhaustion in
+the Internet.  It proposes a two-tier address structure for the
+Internet.  This is an "idea" paper and discussion is strongly
+encouraged.  This memo provides information for the Internet community.
+It does not specify an Internet standard.
+
+
+1334    Lloyd          Oct 92   PPP Authentication Protocols
+
+This document defines two protocols for Authentication: the Password
+Authentication Protocol and the Challenge-Handshake Authentication
+Protocol.  [STANDARDS-TRACK]
+
+
+1333    Simpson        May 92   PPP Link Quality Monitoring
+
+The Point-to-Point Protocol (PPP) [1] provides a standard method of
+encapsulating Network Layer protocol information over point-to-point
+links.  PPP also defines an extensible Link Control Protocol, which
+allows negotiation of a Quality Protocol for continuous monitoring of
+the viability of the link.  [STANDARDS-TRACK]
+
+
+
+
+
+
+Elliott                      Informational                     [Page 14]
+
+RFC 1399                  Summary of 1300-1399              January 1997
+
+
+1332    McGregor       May 92   The PPP Internet Protocol Control
+                                Protocol (IPCP)
+
+The Point-to-Point Protocol (PPP) [1] provides a standard method of
+encapsulating Network Layer protocol information over point-to-point
+links.  PPP also defines an extensible Link Control Protocol, and
+proposes a family of Network Control Protocols (NCPs) for establishing
+and configuring different network-layer protocols.  [STANDARDS-TRACK]
+
+
+1331    Simpson        May 92   The Point-to-Point Protocol (PPP>
+                                for the Transmission of Multi-protocol
+                                Datagrams over Point-to-Point Links
+
+This document defines the PPP encapsulation scheme, together with the
+PPP Link Control Protocol (LCP), an extensible option negotiation
+protocol which is able to negotiate a rich assortment of configuration
+parameters and provides additional management functions.  [STANDARDS-
+TRACK]
+
+
+1330    E.S.C.C.       May 92   Recommendations for the Phase I
+                                Deployment of OSI Directory Services
+                                (X.500) and OSI Message Handling
+                                Services <X.400) within the ESnet
+                                Community
+
+This RFC is a near verbatim copy of the whitepaper produced by the ESnet
+Site Coordinating Committee's X.500/X.400 Task Force.  This memo
+provides information for the Internet community.  It does not specify an
+Internet standard.
+
+
+1329    Kuehn          May 92   Thoughts on Address Resolution for
+                                Dual MAC FDDI Networks
+
+In this document an idea is submitted how IP and ARP can be used on
+inhomogeneous FDDI networks (FDDI networks with single MAC and dual MAC
+stations) by introducing a new protocol layer in the protocol suite of
+the dual MAC stations.  This memo provides information for the Internet
+community.  It does not specify an Internet standard.
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 15]
+
+RFC 1399                  Summary of 1300-1399              January 1997
+
+
+1328    Kille          May 92   X.400 1988 to 1984 downgrading
+
+This document considers issues of downgrading from X.400(1988) to
+X.400(1984) [MHS88a, MHS84].  Annexe B of X.419 specifies some
+downgrading rules [MHS88b], but these are not sufficient for provision
+of service in an environment containing both 1984 and 1988 components.
+This document defines a number of extensions to this annexe.
+[STANDARDS-TRACK]
+
+
+1327    Kille          May 92   Mapping between X.400(1988) / ISO
+                                10021 and RFC 822
+
+This document specifies a mapping between two protocols.  This
+specification should be used when this mapping is performed on the DARPA
+Internet or in the UK Academic Community.  This specification may be
+modified in the light of implementation experience, but no substantial
+changes are expected.  [STANDARDS-TRACK]
+
+
+1326    Tsuchiya       May 92   Mutual Encapsulation Considered
+                                Dangerous
+
+This memo describes a packet explosion problem that can occur with
+mutual encapsulation of protocols (A encapsulates B and B encapsulates
+A).  This memo provides information for the Internet community.  It does
+not specify an Internet standard.
+
+
+1325    Malkin         May 92   FYI on Questions and Answers
+                                Answers to Commonly asked "New
+                                Internet User" Questions
+
+This FYI RFC is one of two FYI's called, "Questions and Answers" (Q/A),
+produced by the User Services Working Group of the Internet Engineering
+Task Force (IETF).  The goal is to document the most commonly asked
+questions and answers in the Internet.  This memo provides information
+for the Internet community.  It does not specify an Internet standard.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 16]
+
+RFC 1399                  Summary of 1300-1399              January 1997
+
+
+1324    Reed           May 92   A Discussion on Computer Network
+                                Conferencing
+
+This memo is intended to make more people aware of the present
+developments in the Computer Conferencing field as well as put forward
+ideas on what should be done to formalize this work so that there is a
+common standard for programmers and others who are involved in this
+field to work with.  This memo provides information for the Internet
+community.  It does not specify an Internet standard.
+
+
+1323    Jacobson       May 92   TCP Extensions for High Performance
+
+This memo presents a set of TCP extensions to improve performance over
+large bandwidth*delay product paths and to provide reliable operation
+over very high-speed paths.  It defines new TCP options for scaled
+windows and timestamps, which are designed to provide compatible
+interworking with TCP's that do not implement the extensions.
+[STANDARDS-TRACK]
+
+
+1322    Estrin         May 92   A Unified Approach to Inter-Domain
+                                Routing
+
+This memo is an informational RFC which outlines one potential approach
+for inter-domain routing in future global internets.  This memo provides
+information for the Internet community.  It does not specify an Internet
+standard.
+
+
+1321    Rivest         Apr 92   The MD5 Message-Digest Algorithm
+
+This document describes the MD5 message-digest algorithm. The algorithm
+takes as input a message of arbitrary length and produces as output a
+128-bit "fingerprint" or "message digest" of the input.  This memo
+provides information for the Internet community.  It does not specify an
+Internet standard.
+
+
+1320    Rivest         Apr 92   The MD4 Message-Digest Algorithm
+
+This document describes the MD4 message-digest algorithm [1]. The
+algorithm takes as input a message of arbitrary length and produces as
+output a 128-bit "fingerprint" or "message digest" of the input.  This
+memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+
+
+
+Elliott                      Informational                     [Page 17]
+
+RFC 1399                  Summary of 1300-1399              January 1997
+
+
+1319    Kaliski        Apr 92   The MD2 Message-Digest Algorithm
+
+This document describes the MD2 message-digest algorithm. The algorithm
+takes as input a message of arbitrary length and produces as output a
+128-bit "fingerprint" or "message digest" of the input.  This memo
+provides information for the Internet community.  It does not specify an
+Internet standard.
+
+
+1318    Stewart        Apr 92   Definitions of Managed Objects
+                                for Parallel-printer-like Hardware
+                                Devices
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP based internets.  In
+particular, it defines objects for the management of parallel-printer-
+like devices.  [STANDARDS-TRACK]
+
+
+1317    Stewart        Apr 92   Definitions of Managed Objects for
+                                RS-232-like Hardware Devices
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP based internets.  In
+particular, it defines objects for the management of RS-232-like
+devices.  [STANDARDS-TRACK]
+
+
+1316    Stewart        Apr 92   Definitions of Managed Objects
+                                for Character Stream Devices
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP based internets.  In
+particular it defines objects for the management of character stream
+devices. [STANDARDS-TRACK]
+
+
+1315    Brown          Apr 92   Management Information Base for Frame
+                                Relay DTEs
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing Frame Relay.  [STANDARDS-
+TRACK]
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 18]
+
+RFC 1399                  Summary of 1300-1399              January 1997
+
+
+1314    Katz           Apr 92   A File Format for the Exchange of
+                                Images in the Internet
+
+This document defines a standard file format for the exchange of fax-
+like black and white images within the Internet.  [STANDARDS-TRACK]
+
+
+1313    Partridge      Apr 92   Today's Programming for KRFC AM 1313
+                                Internet Talk Radio
+
+Hi and welcome to KRFC Internet Talk Radio, your place on the AM dial
+for lively talk and just-breaking news on internetworking.  This memo
+provides information for the Internet community.  It does not specify an
+Internet standard.
+
+
+1312    Nelson         Apr 92   Message Send Protocol 2
+
+The Message Send Protocol is used to send a short message to a given
+user on a given terminal on a given host.  This memo defines an
+Experimental Protocol for the Internet community.
+
+
+1311    Postel         Mar 92   Introduction to the STD Notes
+
+The STDs are a subseries of notes within the RFC series that are the
+Internet standards.  The intent is to identify clearly for the Internet
+community those RFCs which document Internet standards.  [STANDARDS-
+TRACK]
+
+
+1310    I.A.B.         Mar 92   The Internet Standards Process
+
+This memo documents the process currently used for the standardization
+of Internet protocols and procedures.  [STANDARDS-TRACK]
+
+
+1309    Weider         Mar 92   Technical Overview of Directory
+                                Services Using the X.500 Protocol
+
+This document is an overview of the X.500 standard for people not
+familiar with the technology. It compares and contrasts Directory
+Services based on X.500 with several of the other Directory services
+currently in use in the Internet. This paper also describes the status
+of the standard and provides references for further information on X.500
+implementations and technical information.  This memo provides
+information for the Internet community. It does not specify an Internet
+standard.
+
+
+
+Elliott                      Informational                     [Page 19]
+
+RFC 1399                  Summary of 1300-1399              January 1997
+
+
+1308    Weider         Mar 92   Executive Introduction to Directory
+                                Services Using the X.500 Protocol
+
+This document is an Executive Introduction to Directory Services using
+the X.500 protocol. It briefly discusses the deficiencies in currently
+deployed Internet Directory Services, and then illustrates the solutions
+provided by X.500.  This memo provides information for the Internet
+community. It does not specify an Internet standard.
+
+
+1307    Young          Mar 92   Dynamically Switched Link Control
+                                Protocol
+
+This memo describes an experimental protocol developed by a project team
+at Cray Research, Inc., in implementing support for circuit-switched T3
+services.  The protocol is used for the control of network connections
+external to a host, but known to the host.  This memo defines an
+Experimental Protocol for the Internet community.
+
+
+1306    Nicholson      Mar 92   Experiences Supporting By-Request
+                                Circuit-Switched T3 Networks
+
+This memo describes the experiences of a project team at Cray Research,
+Inc., in implementing support for circuit-switched T3 services.  While
+the issues discussed may not be directly relevant to the research
+problems of the Internet, they may be interesting to a number of
+researchers and implementers.  This RFC provides information for the
+Internet community.  It does not specify an Internet standard.
+
+
+1305   Mills           Mar 92   Network Time Protocol (Version 3):
+                                Specification, Implementation and
+                                Analysis
+
+This document describes the Network Time Protocol (NTP), specifies its
+formal structure and summarizes information useful for its
+implementation.  [STANDARDS-TRACK]
+
+
+1304    Cox            Feb 92   Definitions of Managed Objects for the
+                                SIP Interface Type
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing SIP (SMDS Interface
+Protocol) objects.  [STANDARDS-TRACK]
+
+
+
+
+Elliott                      Informational                     [Page 20]
+
+RFC 1399                  Summary of 1300-1399              January 1997
+
+
+1303    McCloghrie     Feb 92   A Convention for Describing SNMP-based
+                                Agents
+
+This memo suggests a straight-forward approach towards describing SNMP-
+based agents.  This memo provides information for the Internet
+community.  It does not specify an Internet standard.
+
+
+1302    Sitzler        Feb 92   Building a Network Information
+                                Services Infrastructure
+
+This FYI RFC document is intended for existing Internet Network
+Information Center (NIC) personnel, people interested in establishing a
+new NIC, Internet Network Operations Centers (NOCs), and funding
+agencies interested in contributing to user support facilities.  This
+memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+1301    Armstrong      Feb 92   Multicast Transport Protocol
+
+This memo describes a protocol for reliable transport that utilizes the
+multicast capability of applicable lower layer networking architectures.
+The transport definition permits an arbitrary number of transport
+providers to perform realtime collaborations without requiring
+networking clients (aka, applications) to possess detailed knowledge of
+the population or geographical dispersion of the participating members.
+It is not network architectural specific, but does implicitly require
+some form of multicasting (or broadcasting) at the data link level, as
+well as some means of communicating that capability up through the
+layers to the transport.  This memo provides information for the
+Internet community.  It does not specify an Internet standard.
+
+
+1300    Greenfield     Feb 92   Remembrances of Things Past
+
+Poem.  This memo provides information for the Internet community.  It
+does not specify an Internet standard.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 21]
+
+RFC 1399                  Summary of 1300-1399              January 1997
+
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Author's Address
+
+   Josh Elliott
+   University of Southern California
+   Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone:  (310) 822-1511
+
+   EMail: elliott@isi.edu
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 22]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1399.txt](<www.ietf.org/rfc/rfc1399.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
