### PR TITLE
Archive rfc140.txt

### DIFF
--- a/www.ietf.org/rfc/rfc140.txt
+++ b/www.ietf.org/rfc/rfc140.txt
@@ -1,0 +1,218 @@
+
+
+
+
+
+
+NWG                                                Steve Crocker
+RFC - 140                                          UCLA
+NIC - 6725                                         4 May 71
+
+
+                     AGENDA FOR THE MAY NWG MEETING
+                     ------------------------------
+
+    The NWG meeting will be from 8 p.m., Sunday, May 16 through
+Wednesday evening May 19.  All meetings except Sunday night will take
+place in the Wicker Room of the Dennis Hotel.  The Sunday even- ing
+meeting will take place in the Royal Box Room of the Dennis Hotel.
+Evening meetings will start at 8 p.m.  Afternoon meetings at 1:30 p.m.
+and morning meetings at 9 a.m.  We will meet Sunday evening, all day
+Monday (three sessions), Tuesday morning and evening and Wednesday
+evening.  At times when we are not meeting you are invited to use the
+Wicker Room for private meetings or whatever.  It is reserved thru
+Thursday afternoon.
+
+    Below are the topics to be discussed in each meeting and the list
+of relevant RFC numbers which should be read prior to coming.
+
+
+TIME: Sunday evening
+TITLE: Short Reports                         (RFC's 113, 131, 134)
+
+Each host will give a very short -- five minutes or less -- report on
+their state of development, including hardware, NCP and Telnet and
+including any applications in progress or planned.  In addition, the
+committees will summarize their progress and new sites will introduce
+themselves.  More extended committee reports and discussions will take
+place later.
+
+
+TIME: Monday morning
+TITLE: NIC and Telnet                        (RFC's 103, 106, 112, 109,
+                                              110, 115, 118, 137, 139)
+
+At 9:00 a.m. Dick Watson will talk about the status, plans and policies
+of the NIC.
+
+At 10:00 a.m. Tom O'Sullivan will present the Telnet committee's
+proposed protocol and lead a discussion concerning it.
+
+
+TIME: Monday afternoon
+TITLE: File Transfer, TIP, Network Planning   (RFC's 114, 122, 133, 136)
+       and other ARPA Projects
+
+
+
+                                                                [Page 1]
+
+1) Abhai Bhushan of MAC and Jim White of UCSB will discuss their file
+transfer protocols.
+
+2) BBN representatives will talk about the TIP, including
+specifications, delivery schedules, prices and protocols.
+
+3) Bob Kahn and Larry Roberts will talk about several aspects of the
+Network management and the long-range network planning.  This will be an
+opportunity for questions on who will manage the Network, how it will
+grow and what sites will come on to be directly addressed to Larry.
+
+4) Some other projects are in progress which affect many of the ARPA
+sites and are not centered in any particular site.  These include
+efforts to produce a list-processing system and a speech understanding
+system.
+
+
+TIME: Monday evening
+TITLE: Operating Systems and Networks
+
+The protocols being developed in the Network Working Group are similar
+to interprocesses communication facilities within operating systems.  It
+is not fully understood how these protocols should be built, and what
+the tradeoffs are for alternatives; the same can be said for
+interprocess communication facilities in operating systems.  From time
+to time it is suggested that there would be some payoff in studying
+these matters from an academic point of view, not quite so tied to the
+pressure of producing a particular system.
+
+Professor Art J. Bernstein of SUNY Stonybrook writes:
+
+     "The problem of designing an operating system for a computer which
+     is to be imbedded in a network has received little attention.  In
+     addition to providing those capabilities one normally expects from
+     an advanced multi-programmed system such as file sharing, inter-
+     process communication and a hierarchical process structure, such a
+     system should be structured so that, as nearly as possible, a user
+     process is ig- norant of the actual location in the network of the
+     files and processes with which it is interacting."
+
+He is building an operating system for a PDP-15 based on this philosophy
+and will come to make a short presentation on his system, after which we
+will discuss how to organize interaction among various academic efforts,
+including those not within the ARPA community.
+
+
+
+
+
+
+
+                                                                [Page 2]
+
+TIME: Tuesday morning
+TITLE: Data of Reconfiguration Service and    (RFC's 138 and one yet to come
+       Data Management Systems                 by Shoshani)
+
+At 9:00 a.m. John Heafner of RAND will meet with his committee and
+discuss some of the open issues regarding the proposed data
+reconfiguration service.  This meeting is open to other interested
+parties.
+
+At 10:00 a.m. Arie Shoshani of SDC will chair a meeting on data sharing
+on computer networks.  He writes:
+
+     "The main purpose of the meeting is to discuss the subject of
+     sharing data on Computer Networks.  First, an intro- ductory paper
+     will be presented which will attempt to classify the issues
+     involved, discuss some approaches that one can take to achieve data
+     sharing and to point out some ad- vantages and disadvantages of
+     these approaches.  Then, an open discussion will be conducted.  As
+     a result, recommenda- tions will be attempted as to what approach
+     is best for the ARPA-Network, and possibly set up a commitee of
+     interested people to further investigate the problems.  It is
+     expected that participants will be prepared to discuss briefly data
+     management system they have or plan to have on the ARPA network."
+
+Peggy Karp of MITRE will attend and talk about the data management
+system she is building to use facilities at BBN and UCSB.
+
+
+TIME: Tuesday evening
+TITLE: Remaining Technical Matters        (RFC's 107, 117, 123, 124, 127
+                                           128, 129 and 132)
+
+The issues scheduled for this meeting are discussions of the socket
+numbers, procedures for testing NCP's and Telnets, discussion of ways to
+experiment with protocol, the initial connection protocol and remaining
+glitches in the second level protocol.
+
+
+TIME: Wednesday evening
+TITLE: Non-Technical Matters              (RFC 113)
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 3]
+
+The Network Working Group has grown and changed considerably in the last
+two years.  It now represents a strong voice in network planning but is
+perhaps not optimally organized for technical work. At this meeting we
+will consider what we expect to happen by the end of 1971, what steps
+should be taken to achieve this and, in particular, how the Network
+Working Groups should be organized and managed.
+
+
+       [ This RFC was put into machine readable form for entry ]
+         [ into the online RFC archives by Gert Doering 4/97 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc140.txt](<www.ietf.org/rfc/rfc140.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
