### PR TITLE
Archive rfc1406.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1406.txt
+++ b/www.ietf.org/rfc/rfc1406.txt
@@ -1,0 +1,2803 @@
+
+
+
+
+
+
+Network Working Group                                           F. Baker
+Request for Comments: 1406              Advanced Computer Communications
+Obsoletes: 1232                                                  J. Watt
+                                          Newbridge Networks Corporation
+                                                                 Editors
+                                                            January 1993
+
+
+   Definitions of Managed Objects for the DS1 and E1 Interface Types
+
+Status of this Memo
+
+   This RFC specifies an IAB standards track protocol for the Internet
+   community, and requests discussion and suggestions for improvements.
+   Please refer to the current edition of the "IAB Official Protocol
+   Standards" for the standardization state and status of this protocol.
+   Distribution of this memo is unlimited.
+
+Abstract
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in TCP/IP-based internets.
+   In particular, it defines objects for managing DS1 Interfaces --
+   including both T1 and E1 (a.k.a., CEPT 2 Mbit/s) links.
+
+   This document entirely replaces RFC 1232, which contains a
+   fundamental error: many objects are encoded as Counters that must be
+   encoded as INTEGERs or Gauges.  The magnitude of the change required
+   is sufficient that virtually every object changed.  Therefore, the
+   MIB documented in RFC 1232 should not be implemented.
+
+Table of Contents
+
+   1. The Network Management Framework ......................    2
+   2. Objects ...............................................    2
+   2.1 Format of Definitions ................................    3
+   2.2 Changes from RFC 1232 ................................    3
+   3. Overview ..............................................    4
+   3.1 Binding between ifIndex and DS1 Interfaces ...........    5
+   3.2 Objectives of this MIB Module ........................    7
+   3.3 DS1 Terminology ......................................    7
+   3.3.1 Error Events .......................................    7
+   3.3.2 Performance Defects ................................    8
+   3.3.3 Performance Parameters .............................    9
+   3.3.4 Failure States .....................................   11
+   3.3.5 Other Terms ........................................   13
+   4. Definitions ...........................................   14
+   4.1 DS1 Near End Group ...................................   14
+
+
+
+Trunk MIB Working Group                                         [Page 1]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+   4.1.1 DS1 Configuration Table ............................   14
+   4.1.2 DS1 Current Table ..................................   22
+   4.1.3 DS1 Interval Table .................................   26
+   4.1.4 DS1 Total Table ....................................   30
+   4.2 DS1 Far End Group ....................................   33
+   4.2.1 DS1 Far End Current Table ..........................   34
+   4.2.2 DS1 Far End Interval Table .........................   38
+   4.2.3 DS1 Far End Total Table ............................   41
+   4.3 DS1 Fractional Group .................................   45
+   4.3.1 DS1 Fractional Table ...............................   45
+   5. Acknowledgements ......................................   47
+   6. References ............................................   48
+   7. Security Considerations ...............................   50
+   8. Authors' Addresses ....................................   50
+
+1.  The Network Management Framework
+
+   The Internet-standard Network Management Framework consists of three
+   components.  They are:
+
+      STD 16/RFC 1155 [1] which defines the SMI, the mechanisms used for
+      describing and naming objects for the purpose of management.  STD
+      16/RFC 1212 [2] defines a more concise description mechanism,
+      which is wholly consistent with the SMI.
+
+      RFC 1156 [3] which defines MIB-I, the core set of managed objects
+      for the Internet suite of protocols.  STD 17/RFC 1213 [4] defines
+      MIB-II, an evolution of MIB-I based on implementation experience
+      and new operational requirements.
+
+      STD 15/RFC 1157 [5] which defines the SNMP, the protocol used for
+      network access to managed objects.
+
+   The Framework permits new objects to be defined for the purpose of
+   experimentation and evaluation.
+
+2.  Objects
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  Objects in the MIB are
+   defined using the subset of Abstract Syntax Notation One (ASN.1) [6]
+   defined in the SMI.  In particular, each object has a name, a syntax,
+   and an encoding.  The name is an object identifier, an
+   administratively assigned name, which specifies an object type.  The
+   object type together with an object instance serves to uniquely
+   identify a specific instantiation of the object.  For human
+   convenience, we often use a textual string, termed the OBJECT
+   DESCRIPTOR, to also refer to the object type.
+
+
+
+Trunk MIB Working Group                                         [Page 2]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+   The syntax of an object type defines the abstract data structure
+   corresponding to that object type.  The ASN.1 language is used for
+   this purpose.  However, the SMI [1] purposely restricts the ASN.1
+   constructs which may be used.  These restrictions are explicitly made
+   for simplicity.
+
+   The encoding of an object type is simply how that object type is
+   represented using the object type's syntax.  Implicitly tied to the
+   notion of an object type's syntax and encoding is how the object type
+   is represented when being transmitted on the network.
+
+   The SMI specifies the use of the basic encoding rules of ASN.1 [7],
+   subject to the additional requirements imposed by the SNMP.
+
+2.1.  Format of Definitions
+
+   Section 4 contains contains the specification of all object types
+   contained in this MIB module.  The object types are defined using the
+   conventions defined in the SMI, as amended by the extensions
+   specified in STD 16, RFC 1212 [2].
+
+2.2.  Changes from RFC 1232
+
+   The changes from RFC 1232 are the following:
+
+     (1)  This MIB module contains three groups: DS1 Near End Group
+          which is mandatory, DS1 Far End Group which is optional,
+          and the Fractional Table, which is optional.
+
+     (2)  The Far End Group is a new group and contains statistics
+          that are collected from the far end DS1 interface.  The
+          Far End Group may only be implemented by DS1 systems that
+          use the facilities data link to exchange this information
+          - both T1.403 and PUB 54016 define ways to exchange this
+          information over data links; vendors may use other
+          proprietary means to do this on various link types.
+
+     (3)  ds1CSUIndex has been renamed dsx1LineIndex.  This object
+          is the identifier of a DS1 Interface on a device.  On a
+          CSU, a single DS1 data stream will cross two DS1
+          interfaces, which have separate dsx1LineIndex values.
+
+     (4)  ds1Index has been renamed dsx1IfIndex.  This value for
+          this object is equal to the value of ifIndex from the
+          Interfaces table of MIB II (STD 17, RFC 1213).
+
+     (5)  an object has been added (dsx1TransmitClockSource) to
+          indicate the source of transmit clock.
+
+
+
+Trunk MIB Working Group                                         [Page 3]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+     (6)  The ACCESS for objects in the dsx1ConfigTable has been
+          set to read-write for items that are configurable.
+
+     (7)  Description of test configurations has changed.  A new
+          object has been added called dsx1LoopbackConfig, which
+          better describes the loopback capabilities of a DS1
+          interface on a device.
+
+     (8)  The description of line alarm status has changed.  A new
+          object has been added called dsx1LineStatus.  This object
+          better describes the status (e.g., failure state and
+          loopback state) of a DS1 interface.
+
+     (9)  All Counters have been changed to Gauges.
+
+     (10) Information about how applications might use the zero
+          code suppression have been removed; only the actual line
+          coding algorithm is described.  For clarity the object
+          was thus renamed to dsx1LineCoding.
+
+     (11) A Line Errored Seconds object has been added to all near
+          end tables and the count of Bipolar Violations (BPVs) was
+          changed to a count of Line Code Violations (LCVs).
+
+     (12) Bursty Errored Seconds (a.k.a., Errored Seconds Type B)
+          and Degraded Minutes objects have been added to all near
+          end tables.
+
+     (13) The Coding Violation error event is now referred to as a
+          Path Coding Violation (PCV) Error Event.
+
+3.  Overview
+
+   These objects are used when the particular media being used to
+   realize an interface is a DS1 physical interface.  At present, this
+   applies to these values of the ifType variable in the Internet-
+   standard MIB:
+
+            ds1 (18)
+            e1  (19)
+
+   The definitions contained herein are based on the AT&T T-1 Superframe
+   (a.k.a., D4) and Extended Superframe (ESF) formats [8, 9], the latter
+   of which conforms to ANSI specifications [10], and the CCITT
+   Recommendations [11, 12], referred to as E1 for the rest of this
+   memo.
+
+
+
+
+
+Trunk MIB Working Group                                         [Page 4]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+   The various T1 and E1 line disciplines are similar enough that
+   separate MIBs are unwarranted, although there are some differences.
+   For example, Loss of Frame is defined more rigorously in the ESF
+   specification than in the D4 specification, but it is defined in
+   both.
+
+   Where it is necessary to distinguish between the flavors of E1 with
+   and without CRC, E1-CRC to denotes the "with CRC" form (G.704 Table
+   4b) and E1-noCRC denotes the "without CRC" form (G.704 Table 4a).
+
+3.1.  Binding between ifIndex and DS1 Interfaces
+
+   Different physical configurations for the support of SNMP with DS1
+   equipment exist. To accommodate these scenarios, two different
+   indices for DS1 interfaces are introduced in this MIB.  These indices
+   are dsx1IfIndex and dsx1LineIndex.
+
+   External interface scenario: the SNMP Agent represents all managed
+   DS1 lines as external interfaces (for example, an Agent residing on
+   the device supporting DS1 interfaces directly):
+
+   For this scenario, all interfaces are assigned an integer value equal
+   to ifIndex, and the following applies:
+
+         ifIndex=dsx1IfIndex=dsx1LineIndex for all interfaces.
+
+   The dsx1IfIndex column of the DS1 Configuration table relates each
+   DS1 interface to its corresponding interface (ifIndex) in the
+   Internet-standard MIB (MIB-II STD 17, RFC 1213).
+
+   External & Internal interface scenario: the SNMP Agents resides on an
+   host external from the device supporting DS1 interfaces (e.g., a
+   router).  The Agent represents both the host and the DS1 device.  The
+   index dsx1LineIndex is used to not only represent the DS1 interfaces
+   external from the host/DS1-device combination, but also the DS1
+   interfaces connecting the host and the DS1 device.  The index
+   dsx1IfIndex is always equal to ifIndex.
+
+   Example:
+
+   A shelf full of CSUs connected to a Router.  An SNMP Agent residing
+   on the router proxies for itself and the CSU.  The router has also an
+   Ethernet interface:
+
+
+
+
+
+
+
+
+Trunk MIB Working Group                                         [Page 5]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+           +-----+
+     |     |     |
+     |     |     |               +---------------------+
+     |E    |     |  1.544  MBPS  |              Line#A | DS1 Link
+     |t    |  R  |---------------+ - - - - -  - - -  - +------>
+     |h    |     |               |                     |
+     |e    |  O  |  1.544  MBPS  |              Line#B | DS1 Link
+     |r    |     |---------------+ - - - - - - - - - - +------>
+     |n    |  U  |               |  CSU Shelf          |
+     |e    |     |  1.544  MBPS  |              Line#C | DS1 Link
+     |t    |  T  |---------------+ - - - -- -- - - - - +------>
+     |     |     |               |                     |
+     |-----|  E  |  1.544  MBPS  |              Line#D | DS1 Link
+     |     |     |---------------+ -  - - - -- - - - - +------>
+     |     |  R  |               |_____________________|
+     |     |     |
+     |     +-----+
+
+     The assignment of the index values could for example be:
+
+     ifIndex (= dsx1IfIndex)             dsx1LineIndex
+     1                   NA                  NA (Ethernet)
+     2      Line#A   Router Side             6
+     2      Line#A   Network Side            7
+     3      Line#B   Router Side             8
+     3      Line#B   Network Side            9
+     4      Line#C   Router Side            10
+     4      Line#C   Network Side           11
+     5      Line#D   Router Side            12
+     5      Line#D   Network Side           13
+
+   For this example, ifNumber is equal to 5.  Note the following
+   description of dsx1LineIndex: the dsx1LineIndex identifies a DS1
+   Interface on a managed device.  If there is an ifEntry that is
+   directly associated with this and only this DS1 interface, it should
+   have the same value as ifIndex.  Otherwise, number the
+   dsx1LineIndices with an unique identifier following the rules of
+   choosing a number greater than ifNumber and numbering inside
+   interfaces (e.g., equipment side) with even numbers and outside
+   interfaces (e.g., network side) with odd numbers.
+
+   If the CSU shelf is managed by itself by a local SNMP Agent, the
+   situation would be:
+
+
+
+
+
+
+
+
+Trunk MIB Working Group                                         [Page 6]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+          ifIndex (= dsx1IfIndex)               dsx1LineIndex
+          2      Line#A     Router Side             2
+          1      Line#A     Network Side            1
+          4      Line#B     Router Side             4
+          3      Line#B     Network Side            3
+          6      Line#C     Router Side             6
+          5      Line#C     Network Side            5
+          8      Line#D     Router Side             8
+          7      Line#D     Network Side            7
+
+3.2.  Objectives of this MIB Module
+
+   There are numerous things that could be included in a MIB for DS1
+   signals: the management of multiplexors, CSUs, DSUs, and the like.
+   The intent of this document is to facilitate the common management of
+   all devices with DS1 interfaces.  As such, a design decision was made
+   up front to very closely align the MIB with the set of objects that
+   can generally be read from DS1 devices that are currently deployed.
+
+3.3.  DS1 Terminology
+
+   The terminology used in this document to describe error conditions on
+   a DS1 interface as monitored by a DS1 device are based on the
+   definitions from the ANSI T1M1.3/92-005R1 draft standard [13].  If
+   the definition in this document does not match the definition in the
+   ANSI T1M1.3/92-005R1 draft document, the implementer should follow
+   the definition described in this document.
+
+3.3.1.  Error Events
+
+     Bipolar Violation (BPV) Error Event
+          A BPV error event for an AMI-coded signal is the
+          occurrence of a pulse of the same polarity as the
+          previous pulse.  A BPV error event for a B8ZS- or HDB3-
+          coded signal is the occurrence of a pulse of the same
+          polarity as the previous pulse without being a part of
+          the zero substitution code.
+
+     Excessive Zeroes (EXZ) Error Event
+          An Excessive Zeroes error event for an AMI-coded signal
+          is the occurrence of more than fifteen contiguous zeroes.
+          For a B8ZS coded signal, the defect occurs when more than
+          seven contiguous zeroes are detected.
+
+     Line Coding Violation (LCV) Error Event
+          A Line Coding Violation (LCV) is the occurrence of either
+          a Bipolar Violation (BPV) or Excessive Zeroes (EXZ) Error
+          Event.
+
+
+
+Trunk MIB Working Group                                         [Page 7]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+     Path Coding Violation (PCV) Error Event
+          A Path Coding Violation error event is a frame
+          synchronization bit error in the D4 and E1-noCRC formats,
+          or a CRC error in the ESF and E1-CRC formats.
+
+     Controlled Slip (CS) Error Event
+          A Controlled Slip is the replication or deletion of the
+          payload bits of a DS1 frame.  A Controlled Slip  may be
+          performed when there is a difference between the timing
+          of a synchronous receiving terminal and the received
+          signal.  A Controlled Slip does not cause an Out of Frame
+          defect.
+
+3.3.2.  Performance Defects
+
+     Out Of Frame (OOF) Defect
+          An OOF defect is the occurrence of a particular density
+          of Framing Error events.
+
+          For T1 links, an Out of Frame defect is declared when the
+          receiver detects two or more framing errors within a 3
+          msec period for ESF signals and 0.75 msec for D4 signals,
+          or two or more errors out of five or fewer consecutive
+          framing-bits.
+
+          For E1 links, an Out Of Frame defect is declared when
+          three consecutive frame alignment signals have been
+          received with an error (see G.706 Section 4.1 [17]).
+
+          Once an Out Of Frame Defect is declared, the framer
+          starts searching for a correct framing pattern.  The Out
+          of Frame defect ends when the signal is in frame.
+
+          In-frame occurs when there are fewer than two frame bit
+          errors within 3 msec period for ESF signals and 0.75 msec
+          for D4 signals.
+
+          For E1 links, in-frame occurs when a) in frame N the
+          frame alignment signal is correct and b) in frame N+1 the
+          frame alignment signal is absent (i.e., bit 2 in TS0 is a
+          one) and c) in frame N+2 the frame alignment signal is
+          present and correct.
+
+     Alarm Indication Signal (AIS) Defect
+          For D4 and ESF links, the 'all ones' condition is
+          detected at a DS1 line interface upon observing an
+          unframed signal with a one's density of at least 99.9%
+          present for a time equal to or greater than T, where 3 ms
+
+
+
+Trunk MIB Working Group                                         [Page 8]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+          <= T <= 75 ms.  The AIS is terminated upon observing a
+          signal not meeting the one's density or the unframed
+          signal criteria for a period equal to or greater than
+          than T.
+
+          For E1 links, the 'all-ones' condition is detected at the
+          line interface as a string of 512 bits containing fewer
+          than three zero bits (see O.162 [14] Section 3.3.2).
+
+3.3.3.  Performance Parameters
+
+   All performance parameters are accumulated in fifteen minute
+   intervals and up to 96 intervals (24 hours worth) are kept by an
+   agent.  Fewer than 96 intervals of data will be available if the
+   agent has been restarted within the last 24 hours.  In addition,
+   there is a rolling 24-hour total of each performance parameter.
+
+   There is no requirement for an agent to ensure fixed relationship
+   between the start of a fifteen minute interval and any wall clock;
+   however some agents may align the fifteen minute intervals with
+   quarter hours.
+
+     Line Errored Seconds (LES)
+          A Line Errored Second, according to T1M1.3, is a second
+          in which one or more Line Code Violation error events
+          were detected.
+
+          While many implementations are currently unable to detect
+          the zero strings, it is expected that interface
+          manufacturers will add this capability in deference to
+          ANSI; therefore, it will become available in time.
+
+          In the T1M1.3 specification, near end Line Code
+          Violations and far end Line Errored Seconds are counted.
+          For consistency, we count Line Errored Seconds at both
+          ends.
+
+     Controlled Slip Seconds (CSS)
+          A Controlled Slip Second is a one-second interval
+          containing one or more controlled slips.
+
+     Errored Seconds (ES)
+          For ESF and E1-CRC links an Errored Second is a second
+          with one or more Path Code Violations OR one or more Out
+          of Frame defects OR one or more Controlled Slip events OR
+          a detected AIS defect.
+
+          For D4 and E1-noCRC links, the presence of Bipolar
+
+
+
+Trunk MIB Working Group                                         [Page 9]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+          Violations also triggers an Errored Second.
+
+          This is not incremented during an Unavailable Second.
+
+     Bursty Errored Seconds (BES)
+          A Bursty Errored Second (also known as Errored Second
+          type B) is a second with fewer than 320 and more than 1
+          Path Coding Violation error events, no Severely Errored
+          Frame defects and no detected incoming AIS defects.
+          Controlled slips are not included in this parameter.
+
+          This is not incremented during an Unavailable Second.
+
+     Severely Errored Seconds (SES)
+          A Severely Errored Second for ESF signals is a second
+          with 320 or more Path Code Violation Error Events OR one
+          or more Out of Frame defects OR a detected AIS defect.
+
+          For E1-CRC signals, a Severely Errored Second is a second
+          with 832 or more Path Code Violation error events OR one
+          or more Out of Frame defects.
+
+          For E1-noCRC signals, a Severely Errored Second is a 2048
+          LCVs or more.
+
+          For D4 signals, a Severely Errored Second is a count of
+          one-second intervals with Framing Error events, or an OOF
+          defect, or 1544 LCVs or more.
+
+          Controlled slips are not included in this parameter.
+
+          This is not incremented during an Unavailable Second.
+
+     Severely Errored Framing Second (SEFS)
+          An Severely Errored Framing Second is a second with one
+          or more Out of Frame defects OR a detected AIS defect.
+
+     Degraded Minutes
+          A Degraded Minute is one in which the estimated error
+          rate exceeds 1E-6 but does not exceed 1E-3 (see G.821
+          [15]).
+
+          Degraded Minutes are determined by collecting all of the
+          Available Seconds, removing any Severely Errored Seconds
+          grouping the result in 60-second long groups and counting
+          a 60-second long group (a.k.a., minute) as degraded if the
+          cumulative errors during the seconds present in the group
+          exceed 1E-6.  Available seconds are merely those seconds
+
+
+
+Trunk MIB Working Group                                        [Page 10]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+          which are not Unavailable as described below.
+
+     Unavailable Seconds (UAS)
+          Unavailable Seconds (UAS) are calculated by counting the
+          number of seconds that the interface is unavailable.  The
+          DS1 interface is said to be unavailable from the onset of
+          10 contiguous SESs, or the onset of the condition leading
+          to a failure (see Failure States).  If the condition
+          leading to the failure was immediately preceded by one or
+          more contiguous SESs, then the DS1 interface
+          unavailability starts from the onset of these SESs.  Once
+          unavailable, and if no failure is present, the DS1
+          interface becomes available at the onset of 10 contiguous
+          seconds with no SESs.  Once unavailable, and if a failure
+          is present, the DS1 interface becomes available at the
+          onset of 10 contiguous seconds with no SESs, if the
+          failure clearing time is less than or equal to 10
+          seconds.  If the failure clearing time is more than 10
+          seconds, the DS1 interface becomes available at the onset
+          of 10 contiguous seconds with no SESs, or the onset
+          period leading to the successful clearing condition,
+          whichever occurs later.  With respect to the DS1 error
+          counts, all counters are incremented while the DS1
+          interface is deemed available.  While the interface is
+          deemed unavailable, the only count that is incremented is
+          UASs.
+
+          A special case exists when the 10 or more second period
+          crosses the 900 second statistics window boundary, as the
+          foregoing description implies that the Severely Errored
+          Second and Unavailable Second counters must be adjusted
+          when the Unavailable Signal State is entered.  Clearly,
+          successive GETs of the affected dsx1IntervalSESs and
+          dsx1IntervalUASs objects will return differing values if
+          the first GET occurs during the first few seconds of the
+          window.  This is viewed as an unavoidable side-effect of
+          selecting the presently defined managed objects as a
+          basis for this memo.
+
+3.3.4.  Failure States
+
+   The following failure states are received, or detected failures, that
+   are reported in the dsx1LineStatus object.  When a DS1 interface
+   would, if ever, produce the conditions leading to the failure state
+   is described in the appropriate specification.
+
+
+
+
+
+
+Trunk MIB Working Group                                        [Page 11]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+     Far End Alarm Failure
+          The Far End Alarm failure is also known as "Yellow Alarm"
+          in the T1 case and "Distant Alarm" in the E1 case.
+
+          For D4 links, the Far End Alarm failure is declared when
+          bit 6 of all channels has been zero for at least 335 ms
+          and is cleared when bit 6 of at least one channel is
+          non-zero for a period T, where T is usually less than one
+          second and always less than 5 seconds.  The Far End Alarm
+          failure is not declared for D4 links when a Loss of
+          Signal is detected.
+
+          For ESF links, the Far End Alarm failure is declared if
+          the Yellow Alarm signal pattern occurs in at least seven
+          out of ten contiguous 16-bit pattern intervals and is
+          cleared if the Yellow Alarm signal pattern does not occur
+          in ten contiguous 16-bit signal pattern intervals.
+
+          For E1 links, the Far End Alarm failure is declared when
+          bit 3 of time-slot zero is received set to one on two
+          consecutive occasions.  The Far End Alarm failure is
+          cleared when bit 3 of time-slot zero is received set to
+          zero.
+
+     Alarm Indication Signal (AIS) Failure
+          The Alarm Indication Signal failure is declared when an
+          AIS defect is detected at the input and the  AIS defect
+          still exists after the Loss Of Frame failure (which is
+          caused by the unframed nature of the 'all-ones' signal)
+          is declared. The AIS failure is cleared when the Loss Of
+          Frame failure is cleared.
+
+     Loss Of Frame Failure
+          For T1 links, the Loss Of Frame failure is declared when
+          an OOF or LOS  defect has persisted for T seconds, where
+          2 <= T <= 10.  The Loss Of Frame failure is cleared when
+          there have been no OOF or LOS defects during a period T
+          where 0 <= T <= 20.  Many systems will perform "hit
+          integration" within the period T before declaring or
+          clearing the failure e.g., see TR 62411 [16].
+
+          For E1 links, the Loss Of Frame Failure is declared when
+          an OOF defect is detected.
+
+     Loss Of Signal Failure
+          For T1, the Loss Of Signal failure is declared upon
+          observing 175 +/- 75 contiguous pulse positions with no
+          pulses of either positive or negative polarity.  The LOS
+
+
+
+Trunk MIB Working Group                                        [Page 12]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+          failure is cleared upon observing an average pulse
+          density of at least 12.5% over a period of 175 +/- 75
+          contiguous pulse positions starting with the receipt of a
+          pulse.
+
+          For E1 links, the Loss Of Signal failure is declared when
+          greater than 10 consecutive zeroes are detected (see
+          O.162 Section 3.4.4).
+
+     Loopback Pseudo-Failure
+          The Loopback Pseudo-Failure is declared when the near end
+          equipment has placed a loopback (of any kind) on the DS1.
+          This allows a management entity to determine from one
+          object whether the DS1 can be considered to be in service
+          or not (from the point of view of the near end
+          equipment).
+
+     TS16 Alarm Indication Signal Failure
+          For E1 links, the TS16 Alarm Indication Signal failure is
+          declared when time-slot 16 is received as all ones for
+          all frames of two consecutive multiframes (see G.732
+          Section 4.2.6).  This condition is never declared for T1.
+
+     Loss Of MultiFrame Failure
+          The Loss Of MultiFrame failure is declared when two
+          consecutive multiframe alignment signals (bits 4 through
+          7 of TS16 of frame 0) have been received with an error.
+          The Loss Of Multiframe failure is cleared when the first
+          correct multiframe alignment signal is received.  The
+          Loss Of Multiframe failure can only be declared for E1
+          links operating with G.732 [18] framing (sometimes called
+          "Channel Associated Signalling" mode).
+
+     Far End Loss Of Multiframe Failure
+          The Far End Loss Of Multiframe failure is declared when
+          bit 2 of TS16 of frame 0 is received set to one on two
+          consecutive occasions.  The Far End Loss Of Multiframe
+          failure is cleared when bit 2 of TS16 of frame 0 is
+          received set to zero.  The Far End Loss Of Multiframe
+          failure can only be declared for E1 links operating in
+          "Channel Associated Signalling" mode.
+
+3.3.5.  Other Terms
+
+     Circuit Identifier
+          This is a character string specified by the circuit
+          vendor, and is useful when communicating with the vendor
+          during the troubleshooting process.
+
+
+
+Trunk MIB Working Group                                        [Page 13]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+4.  Definitions
+
+     RFC1406-MIB DEFINITIONS ::= BEGIN
+     IMPORTS
+             Gauge
+                     FROM RFC1155-SMI
+             transmission, DisplayString
+                     FROM RFC1213-MIB
+             OBJECT-TYPE
+                     FROM RFC-1212;
+
+     --  This MIB module uses the extended OBJECT-TYPE macro as
+     --  defined in RFC 1212.
+
+     --  this is the MIB module for the DS1 objects
+
+     ds1 OBJECT IDENTIFIER ::= { transmission 18 }
+
+     -- note that this subsumes cept (19); there is no separate CEPT MIB
+
+
+     -- The DS1 Near End Group
+
+     -- Implementation of this group is mandatory for all systems
+     -- that attach to a DS1 Interface.
+
+     -- The DS1 Near End Group consists of four tables:
+     --    DS1 Configuration
+     --    DS1 Current
+     --    DS1 Interval
+     --    DS1 Total
+
+     -- the DS1 Configuration Table
+
+         dsx1ConfigTable OBJECT-TYPE
+             SYNTAX  SEQUENCE OF Dsx1ConfigEntry
+             ACCESS  not-accessible
+             STATUS  mandatory
+             DESCRIPTION
+                "The DS1 Configuration table."
+            ::= { ds1 6 }
+
+
+         dsx1ConfigEntry OBJECT-TYPE
+             SYNTAX  Dsx1ConfigEntry
+             ACCESS  not-accessible
+             STATUS  mandatory
+             DESCRIPTION
+
+
+
+Trunk MIB Working Group                                        [Page 14]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+                "An entry in the DS1 Configuration table."
+            INDEX   { dsx1LineIndex }
+            ::= { dsx1ConfigTable 1 }
+
+     Dsx1ConfigEntry ::=
+         SEQUENCE {
+             dsx1LineIndex
+                 INTEGER,
+             dsx1IfIndex
+                 INTEGER,
+             dsx1TimeElapsed
+                 INTEGER,
+             dsx1ValidIntervals
+                 INTEGER,
+             dsx1LineType
+                 INTEGER,
+             dsx1LineCoding
+                 INTEGER,
+             dsx1SendCode
+                 INTEGER,
+             dsx1CircuitIdentifier
+                 DisplayString,
+             dsx1LoopbackConfig
+                 INTEGER,
+             dsx1LineStatus
+                 INTEGER,
+             dsx1SignalMode
+                 INTEGER,
+             dsx1TransmitClockSource
+                 INTEGER,
+             dsx1Fdl
+                 INTEGER
+         }
+
+         dsx1LineIndex OBJECT-TYPE
+             SYNTAX  INTEGER (1..'7fffffff'h)
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "This object is the identifier of a DS1  Inter-
+                face on a managed device.  If there is an ifEn-
+                try that is directly associated with  this  and
+                only  this  DS1  interface,  it should have the
+                same value as ifIndex.   Otherwise,  the  value
+                exceeds  ifNumber,  and  is a unique identifier
+                following this rule: inside  interfaces  (e.g.,
+                equipment  side)  with even numbers and outside
+                interfaces  (e.g.,  network   side)   with   odd
+
+
+
+Trunk MIB Working Group                                        [Page 15]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+                numbers."
+            ::= { dsx1ConfigEntry 1 }
+
+
+         dsx1IfIndex OBJECT-TYPE
+             SYNTAX  INTEGER (1..'7fffffff'h)
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "This value for this object  is  equal  to  the
+                value  of  ifIndex from the Interfaces table of
+                MIB II (RFC 1213)."
+            ::= { dsx1ConfigEntry 2 }
+
+
+         dsx1TimeElapsed OBJECT-TYPE
+             SYNTAX  INTEGER (0..899)
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of seconds that have elapsed  since
+                the  beginning of the current error-measurement
+                period."
+            ::= { dsx1ConfigEntry 3 }
+
+
+         dsx1ValidIntervals OBJECT-TYPE
+             SYNTAX  INTEGER (0..96)
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of  previous  intervals  for  which
+                valid data was collected.  The value will be 96
+                unless the interface was brought on-line within
+                the last 24 hours, in which case the value will
+                be the number of complete 15  minute  intervals
+                the since interface has been online."
+            ::= { dsx1ConfigEntry 4 }
+
+
+         dsx1LineType OBJECT-TYPE
+             SYNTAX  INTEGER {
+                         other(1),
+                         dsx1ESF(2),
+                         dsx1D4(3),
+                         dsx1E1(4),
+                         dsx1E1-CRC(5),
+                         dsx1E1-MF(6),
+
+
+
+Trunk MIB Working Group                                        [Page 16]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+                         dsx1E1-CRC-MF(7)
+                     }
+             ACCESS  read-write
+             STATUS  mandatory
+             DESCRIPTION
+                "This variable indicates  the  variety  of  DS1
+                Line  implementing  this  circuit.  The type of
+                circuit affects the number of bits  per  second
+                that  the circuit can reasonably carry, as well
+                as the interpretation of the  usage  and  error
+                statistics.  The values, in sequence, describe:
+
+                TITLE:        SPECIFICATION:
+                dsx1ESF       Extended SuperFrame DS1
+                dsx1D4        AT&T D4 format DS1
+                dsx1E1        CCITT Recommendation G.704
+                                (Table 4a)
+                dsx1E1-CRC    CCITT Recommendation G.704
+                                (Table 4b)
+                dsxE1-MF      G.704 (Table 4a) with TS16
+                                multiframing enabled
+                dsx1E1-CRC-MF G.704 (Table 4b) with TS16
+                                multiframing enabled"
+
+                    ::= { dsx1ConfigEntry 5 }
+
+
+         dsx1LineCoding OBJECT-TYPE
+             SYNTAX  INTEGER {
+                         dsx1JBZS (1),
+                         dsx1B8ZS (2),
+                         dsx1HDB3 (3),
+                         dsx1ZBTSI (4),
+                         dsx1AMI (5),
+                         other(6)
+                     }
+             ACCESS  read-write
+             STATUS  mandatory
+             DESCRIPTION
+                "This variable describes the  variety  of  Zero
+                Code  Suppression  used  on  the link, which in
+                turn affects a number of its characteristics.
+
+                dsx1JBZS refers the Jammed  Bit  Zero  Suppres-
+                sion,  in  which  the  AT&T specification of at
+                least one pulse every 8 bit periods is literal-
+                ly  implemented  by forcing a pulse in bit 8 of
+                each channel.  Thus, only seven bits per  chan-
+
+
+
+Trunk MIB Working Group                                        [Page 17]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+                nel, or 1.344 Mbps, is available for data.
+
+                dsx1B8ZS refers to the use of a specified  pat-
+                tern  of  normal  bits  and  bipolar violations
+                which are used to replace a sequence  of  eight
+                zero bits.
+
+                ANSI Clear Channels may use dsx1ZBTSI, or  Zero
+                Byte Time Slot Interchange.
+
+                E1 links, with or without CRC, use dsx1HDB3  or
+                dsx1AMI.
+
+                dsx1AMI refers to a mode wherein no  zero  code
+                suppression  is  present  and the line encoding
+                does not solve the problem directly.   In  this
+                application, the higher layer must provide data
+                which meets or exceeds the  pulse  density  re-
+                quirements, such as inverting HDLC data."
+            ::= { dsx1ConfigEntry 6 }
+
+
+         dsx1SendCode OBJECT-TYPE
+             SYNTAX  INTEGER {
+                         dsx1SendNoCode(1),
+                         dsx1SendLineCode(2),
+                         dsx1SendPayloadCode(3),
+                         dsx1SendResetCode(4),
+                         dsx1SendQRS(5),
+                         dsx1Send511Pattern(6),
+                         dsx1Send3in24Pattern(7),
+                         dsx1SendOtherTestPattern(8)
+                     }
+             ACCESS  read-write
+             STATUS  mandatory
+             DESCRIPTION
+                "This variable indicates what type of  code  is
+                being sent across the DS1 interface by the dev-
+                ice.  The values mean:
+
+                dsx1SendNoCode
+                     sending looped or normal data
+
+                dsx1SendLineCode
+                     sending a request for a line loopback
+
+                dsx1SendPayloadCode
+                     sending a request for a payload loopback
+
+
+
+Trunk MIB Working Group                                        [Page 18]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+                dsx1SendResetCode
+                     sending a loopback termination request
+
+                dsx1SendQRS
+                     sending a Quasi-Random Signal  (QRS)  test
+                     pattern
+
+                dsx1Send511Pattern
+                     sending a 511 bit fixed test pattern
+
+                dsx1Send3in24Pattern
+                     sending a fixed test pattern of 3 bits set
+                     in 24
+
+                dsx1SendOtherTestPattern
+                     sending a test pattern  other  than  those
+                     described by this object"
+            ::= { dsx1ConfigEntry 7 }
+
+
+         dsx1CircuitIdentifier OBJECT-TYPE
+             SYNTAX  DisplayString (SIZE (0..255))
+             ACCESS  read-write
+             STATUS  mandatory
+             DESCRIPTION
+                "This  variable   contains   the   transmission
+                vendor's circuit identifier, for the purpose of
+                facilitating troubleshooting."
+            ::= { dsx1ConfigEntry 8 }
+
+
+         dsx1LoopbackConfig OBJECT-TYPE
+             SYNTAX  INTEGER {
+                         dsx1NoLoop(1),
+                         dsx1PayloadLoop(2),
+                         dsx1LineLoop(3),
+                         dsx1OtherLoop(4)
+                     }
+             ACCESS  read-write
+             STATUS  mandatory
+             DESCRIPTION
+                "This variable represents the  loopback  confi-
+                guration of the DS1 interface.  Agents support-
+                ing read/write access should return badValue in
+                response to a requested loopback state that the
+                interface does not support.  The values mean:
+
+
+
+
+
+Trunk MIB Working Group                                        [Page 19]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+                dsx1NoLoop
+                     Not in the loopback state.  A device  that
+                     is not capable of performing a loopback on
+                     the interface shall always return this  as
+                     it's value.
+
+                dsx1PayloadLoop
+                     The received signal at this  interface  is
+                     looped  through  the device. Typically the
+                     received signal is  looped  back  for  re-
+                     transmission  after  it has passed through
+                     the device's framing function.
+
+                dsx1LineLoop
+                     The received signal at this interface does
+                     not  go  through the device (minimum pene-
+                     tration) but is looped back out.
+
+                dsx1OtherLoop
+                     Loopbacks that are not defined here."
+            ::= { dsx1ConfigEntry 9 }
+
+
+         dsx1LineStatus OBJECT-TYPE
+             SYNTAX  INTEGER (1..8191)
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "This variable indicates the Line Status of the
+                interface.   It contains loopback, failure, re-
+                ceived 'alarm'  and transmitted 'alarm'  infor-
+                mation.
+
+     The dsx1LineStatus is a bit  map  represented  as  a  sum,
+     therefore, it can represent multiple failures (alarms) and
+     a LoopbackState simultaneously.
+
+     dsx1NoAlarm should be set if and only if no other flag  is
+     set.
+
+     If the dsx1LoopbackState bit is set, the loopback  in  ef-
+     fect can be determined from the dsx1LoopbackConfig object.
+
+     The various bit positions are:
+          1     dsx1NoAlarm           No Alarm Present
+          2     dsx1RcvFarEndLOF      Far end LOF (a.k.a., Yellow Alarm)
+          4     dsx1XmtFarEndLOF      Near end sending LOF Indication
+          8     dsx1RcvAIS            Far end sending AIS
+
+
+
+Trunk MIB Working Group                                        [Page 20]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+         16     dsx1XmtAIS            Near end sending AIS
+         32     dsx1LossOfFrame       Near end LOF (a.k.a., Red Alarm)
+         64     dsx1LossOfSignal      Near end Loss Of Signal
+        128     dsx1LoopbackState     Near end is looped
+        256     dsx1T16AIS            E1 TS16 AIS
+        512     dsx1RcvFarEndLOMF     Far End Sending TS16 LOMF
+       1024     dsx1XmtFarEndLOMF     Near End Sending TS16 LOMF
+       2048     dsx1RcvTestCode       Near End detects a test code
+       4096     dsx1OtherFailure      any line status not defined here"
+         ::= { dsx1ConfigEntry 10 }
+
+
+         dsx1SignalMode OBJECT-TYPE
+             SYNTAX  INTEGER {
+                         none (1),
+                         robbedBit (2),
+                         bitOriented (3),
+                         messageOriented (4)
+                     }
+             ACCESS  read-write
+             STATUS  mandatory
+             DESCRIPTION
+                "'none' indicates that no bits are reserved for
+                signaling on this channel.
+
+                 'robbedBit' indicates that T1 Robbed Bit  Sig-
+                naling is in use.
+
+                 'bitOriented' indicates that E1 Channel  Asso-
+                ciated Signaling is in use.
+
+                 'messageOriented' indicates that Common  Chan-
+                nel Signaling is in use either on channel 16 of
+                an E1 link or channel 24 of a T1."
+            ::= { dsx1ConfigEntry 11 }
+
+
+         dsx1TransmitClockSource OBJECT-TYPE
+             SYNTAX  INTEGER {
+                         loopTiming (1),
+                         localTiming (2),
+                         throughTiming (3)
+                     }
+             ACCESS  read-write
+             STATUS  mandatory
+             DESCRIPTION
+                "The source of Tranmit Clock.
+
+
+
+
+Trunk MIB Working Group                                        [Page 21]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+                 'loopTiming' indicates that the recovered  re-
+                ceive clock is used as the transmit clock.
+
+                 'localTiming' indicates  that  a  local  clock
+                source is used.
+
+                 'throughTiming' indicates that  recovered  re-
+                ceive  clock  from another interface is used as
+                the transmit clock."
+            ::= { dsx1ConfigEntry 12 }
+
+
+         dsx1Fdl OBJECT-TYPE
+             SYNTAX  INTEGER {
+                           other(1),
+                           dsx1Ansi-T1-403(2),
+                           dsx1Att-54016(4),
+                           dsx1Fdl-none(8)
+                     }
+             ACCESS  read-write
+             STATUS  mandatory
+             DESCRIPTION
+                "This bitmap describes the use of  the  facili-
+                ties data link, and is the sum of the capabili-
+                ties:
+
+                 'other' indicates that a protocol  other  than
+                one following is used.
+
+                 'dsx1Ansi-T1-403' refers to the  FDL  exchange
+                recommended by ANSI.
+
+                 'dsx1Att-54016' refers to ESF FDL exchanges.
+
+                 'dsx1Fdl-none' indicates that the device  does
+                not use the FDL."
+            ::= { dsx1ConfigEntry 13 }
+
+
+     -- the DS1 Current Table
+
+     -- The DS1 current table contains various statistics being
+     -- collected for the current 15 minute interval.
+
+         dsx1CurrentTable OBJECT-TYPE
+             SYNTAX  SEQUENCE OF Dsx1CurrentEntry
+             ACCESS  not-accessible
+             STATUS  mandatory
+
+
+
+Trunk MIB Working Group                                        [Page 22]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+             DESCRIPTION
+                "The DS1 Current table."
+            ::= { ds1 7 }
+
+
+         dsx1CurrentEntry OBJECT-TYPE
+             SYNTAX  Dsx1CurrentEntry
+             ACCESS  not-accessible
+             STATUS  mandatory
+             DESCRIPTION
+                "An entry in the DS1 Current table."
+            INDEX   { dsx1CurrentIndex }
+            ::= { dsx1CurrentTable 1 }
+
+     Dsx1CurrentEntry ::=
+         SEQUENCE {
+             dsx1CurrentIndex
+                 INTEGER,
+             dsx1CurrentESs
+                 Gauge,
+             dsx1CurrentSESs
+                 Gauge,
+             dsx1CurrentSEFSs
+                 Gauge,
+             dsx1CurrentUASs
+                 Gauge,
+             dsx1CurrentCSSs
+                 Gauge,
+             dsx1CurrentPCVs
+                 Gauge,
+             dsx1CurrentLESs
+                 Gauge,
+             dsx1CurrentBESs
+                 Gauge,
+             dsx1CurrentDMs
+                 Gauge,
+             dsx1CurrentLCVs
+                 Gauge
+         }
+
+         dsx1CurrentIndex OBJECT-TYPE
+             SYNTAX  INTEGER (1..'7fffffff'h)
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The index value which uniquely identifies  the
+                DS1  interface  to which this entry is applica-
+                ble.  The interface identified by a  particular
+
+
+
+Trunk MIB Working Group                                        [Page 23]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+                value  of  this  index is the same interface as
+                identified by the same value as a dsx1LineIndex
+                object instance."
+            ::= { dsx1CurrentEntry 1 }
+
+
+         dsx1CurrentESs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Errored Seconds, encountered  by
+                a DS1 interface in the current 15 minute inter-
+                val."
+            ::= { dsx1CurrentEntry 2 }
+
+
+         dsx1CurrentSESs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Severely Errored Seconds encoun-
+                tered  by  a  DS1  interface  in the current 15
+                minute interval."
+            ::= { dsx1CurrentEntry 3 }
+
+
+         dsx1CurrentSEFSs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Severely Errored Framing Seconds
+                encountered  by  a DS1 interface in the current
+                15 minute interval."
+            ::= { dsx1CurrentEntry 4 }
+
+
+         dsx1CurrentUASs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Unavailable Seconds  encountered
+                by a DS1 interface in the current 15 minute in-
+                terval."
+            ::= { dsx1CurrentEntry 5 }
+
+
+
+Trunk MIB Working Group                                        [Page 24]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+         dsx1CurrentCSSs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Controlled Slip Seconds  encoun-
+                tered  by  a  DS1  interface  in the current 15
+                minute interval."
+            ::= { dsx1CurrentEntry 6 }
+
+
+         dsx1CurrentPCVs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Path Coding  Violations  encoun-
+                tered  by  a  DS1  interface  in the current 15
+                minute interval."
+            ::= { dsx1CurrentEntry 7 }
+
+
+         dsx1CurrentLESs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Line Errored Seconds encountered
+                by a DS1 interface in the current 15 minute in-
+                terval."
+            ::= { dsx1CurrentEntry 8 }
+
+
+         dsx1CurrentBESs OBJECT-TYPE
+             SYNTAX Gauge
+             ACCESS read-only
+             STATUS mandatory
+             DESCRIPTION
+                "The number of Bursty  Errored  Seconds  (BESs)
+                encountered  by  a DS1 interface in the current
+                15 minute interval."
+            ::= {dsx1CurrentEntry 9 }
+
+
+         dsx1CurrentDMs OBJECT-TYPE
+             SYNTAX Gauge
+             ACCESS read-only
+             STATUS mandatory
+
+
+
+Trunk MIB Working Group                                        [Page 25]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+             DESCRIPTION
+                "The number of Degraded Minutes  (DMs)  encoun-
+                tered  by  a  DS1  interface  in the current 15
+                minute interval."
+            ::= { dsx1CurrentEntry 10 }
+
+
+         dsx1CurrentLCVs OBJECT-TYPE
+             SYNTAX Gauge
+             ACCESS read-only
+             STATUS mandatory
+             DESCRIPTION
+                "The number of Line Code Violations (LCVs)  en-
+                countered  by a DS1 interface in the current 15
+                minute interval."
+         ::= {dsx1CurrentEntry 11 }
+
+
+     -- the DS1 Interval
+
+     -- The DS1 Interval Table contains various statistics
+     -- collected by each DS1 Interface over the previous 24 hours of
+     -- operation.  The past 24 hours are broken into 96 completed
+     -- 15 minute intervals.
+
+         dsx1IntervalTable OBJECT-TYPE
+             SYNTAX  SEQUENCE OF Dsx1IntervalEntry
+             ACCESS  not-accessible
+             STATUS  mandatory
+             DESCRIPTION
+                "The DS1 Interval table."
+            ::= { ds1 8 }
+
+
+         dsx1IntervalEntry OBJECT-TYPE
+             SYNTAX  Dsx1IntervalEntry
+             ACCESS  not-accessible
+             STATUS  mandatory
+             DESCRIPTION
+                "An entry in the DS1 Interval table."
+            INDEX   { dsx1IntervalIndex, dsx1IntervalNumber }
+            ::= { dsx1IntervalTable 1 }
+
+     Dsx1IntervalEntry ::=
+         SEQUENCE {
+             dsx1IntervalIndex
+                 INTEGER,
+             dsx1IntervalNumber
+
+
+
+Trunk MIB Working Group                                        [Page 26]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+                 INTEGER,
+             dsx1IntervalESs
+                 Gauge,
+             dsx1IntervalSESs
+                 Gauge,
+             dsx1IntervalSEFSs
+                 Gauge,
+             dsx1IntervalUASs
+                 Gauge,
+             dsx1IntervalCSSs
+                 Gauge,
+             dsx1IntervalPCVs
+                 Gauge,
+             dsx1IntervalLESs
+                 Gauge,
+             dsx1IntervalBESs
+                 Gauge,
+             dsx1IntervalDMs
+                 Gauge,
+             dsx1IntervalLCVs
+                 Gauge
+         }
+
+         dsx1IntervalIndex OBJECT-TYPE
+             SYNTAX  INTEGER (1..'7fffffff'h)
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The index value which uniquely identifies  the
+                DS1  interface  to which this entry is applica-
+                ble.  The interface identified by a  particular
+                value  of  this  index is the same interface as
+                identified by the same value as a dsx1LineIndex
+                object instance."
+            ::= { dsx1IntervalEntry 1 }
+
+
+         dsx1IntervalNumber OBJECT-TYPE
+             SYNTAX  INTEGER (1..96)
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "A number between 1 and 96, where 1 is the most
+                recently completed 15 minute interval and 96 is
+                the least recently completed 15 minutes  inter-
+                val   (assuming   that  all  96  intervals  are
+                valid)."
+            ::= { dsx1IntervalEntry 2 }
+
+
+
+Trunk MIB Working Group                                        [Page 27]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+         dsx1IntervalESs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Errored Seconds encountered by a
+                DS1  interface in one of the previous 96, indi-
+                vidual 15 minute, intervals."
+            ::= { dsx1IntervalEntry 3 }
+
+
+         dsx1IntervalSESs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Severely Errored Seconds encoun-
+                tered by a DS1 interface in one of the previous
+                96, individual 15 minute, intervals."
+            ::= { dsx1IntervalEntry 4 }
+
+
+         dsx1IntervalSEFSs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Severely Errored Framing Seconds
+                encountered  by  a  DS1 interface in one of the
+                previous 96, individual 15 minute, intervals."
+            ::= { dsx1IntervalEntry 5 }
+
+
+         dsx1IntervalUASs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Unavailable Seconds  encountered
+                by  a  DS1 interface in one of the previous 96,
+                individual 15 minute, intervals."
+            ::= { dsx1IntervalEntry 6 }
+
+
+         dsx1IntervalCSSs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+
+
+
+Trunk MIB Working Group                                        [Page 28]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+             DESCRIPTION
+                "The number of Controlled Slip Seconds  encoun-
+                tered by a DS1 interface in one of the previous
+                96, individual 15 minute, intervals."
+            ::= { dsx1IntervalEntry 7 }
+
+
+         dsx1IntervalPCVs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Path Coding  Violations  encoun-
+                tered by a DS1 interface in one of the previous
+                96, individual 15 minute, intervals."
+            ::= { dsx1IntervalEntry 8 }
+
+
+         dsx1IntervalLESs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Line Errored Seconds encountered
+                by  a  DS1 interface in one of the previous 96,
+                individual 15 minute, intervals."
+            ::= { dsx1IntervalEntry 9 }
+
+
+         dsx1IntervalBESs OBJECT-TYPE
+             SYNTAX Gauge
+             ACCESS read-only
+             STATUS mandatory
+             DESCRIPTION
+                "The number of Bursty  Errored  Seconds  (BESs)
+                encountered  by  a  DS1 interface in one of the
+                previous 96, individual 15 minute, intervals."
+            ::= {dsx1IntervalEntry 10 }
+
+
+         dsx1IntervalDMs OBJECT-TYPE
+             SYNTAX Gauge
+             ACCESS read-only
+             STATUS mandatory
+             DESCRIPTION
+                "The number of Degraded Minutes  (DMs)  encoun-
+                tered by a DS1 interface in one of the previous
+                96, individual 15 minute, intervals."
+
+
+
+Trunk MIB Working Group                                        [Page 29]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+            ::= { dsx1IntervalEntry 11 }
+
+
+         dsx1IntervalLCVs OBJECT-TYPE
+             SYNTAX Gauge
+             ACCESS read-only
+             STATUS mandatory
+             DESCRIPTION
+                "The number of Line Code Violations (LCVs)  en-
+                countered  by a DS1 interface in the current 15
+                minute interval."
+         ::= {dsx1IntervalEntry 12 }
+
+
+     -- the DS1 Total
+
+     -- The DS1 Total Table contains the cumulative sum of the
+     -- various statistics for the 24 hour period preceding the
+     -- current interval.
+
+         dsx1TotalTable OBJECT-TYPE
+             SYNTAX  SEQUENCE OF Dsx1TotalEntry
+             ACCESS  not-accessible
+             STATUS  mandatory
+             DESCRIPTION
+                "The DS1 Total table.  24 hour interval."
+            ::= { ds1 9 }
+
+
+         dsx1TotalEntry OBJECT-TYPE
+             SYNTAX  Dsx1TotalEntry
+             ACCESS  not-accessible
+             STATUS  mandatory
+             DESCRIPTION
+                "An entry in the DS1 Total table."
+            INDEX   { dsx1TotalIndex }
+            ::= { dsx1TotalTable 1 }
+
+     Dsx1TotalEntry ::=
+         SEQUENCE {
+             dsx1TotalIndex
+                 INTEGER,
+             dsx1TotalESs
+                 Gauge,
+             dsx1TotalSESs
+                 Gauge,
+             dsx1TotalSEFSs
+                 Gauge,
+
+
+
+Trunk MIB Working Group                                        [Page 30]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+             dsx1TotalUASs
+                 Gauge,
+             dsx1TotalCSSs
+                 Gauge,
+             dsx1TotalPCVs
+                 Gauge,
+             dsx1TotalLESs
+                 Gauge,
+             dsx1TotalBESs
+                 Gauge,
+             dsx1TotalDMs
+                 Gauge,
+             dsx1TotalLCVs
+                 Gauge
+         }
+
+         dsx1TotalIndex OBJECT-TYPE
+             SYNTAX  INTEGER (1..'7fffffff'h)
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The index value which uniquely identifies  the
+                DS1  interface  to which this entry is applica-
+                ble.  The interface identified by a  particular
+                value  of  this  index is the same interface as
+                identified by the same value as a dsx1LineIndex
+                object instance."
+            ::= { dsx1TotalEntry 1 }
+
+
+         dsx1TotalESs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Errored Seconds encountered by a
+                DS1 interface in the previous 24 hour interval"
+            ::= { dsx1TotalEntry 2 }
+
+
+         dsx1TotalSESs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Severely Errored Seconds encoun-
+                tered  by  a  DS1  interface in the previous 24
+                hour interval."
+
+
+
+Trunk MIB Working Group                                        [Page 31]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+            ::= { dsx1TotalEntry 3 }
+
+
+         dsx1TotalSEFSs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Severely Errored Framing Seconds
+                encountered  by a DS1 interface in the previous
+                24 hour interval."
+            ::= { dsx1TotalEntry 4 }
+
+
+         dsx1TotalUASs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Unavailable Seconds  encountered
+                by  a DS1 interface in the previous 24 hour in-
+                terval."
+            ::= { dsx1TotalEntry 5 }
+
+
+         dsx1TotalCSSs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Controlled Slip Seconds  encoun-
+                tered  by  a  DS1  interface in the previous 24
+                hour interval."
+            ::= { dsx1TotalEntry 6 }
+
+
+         dsx1TotalPCVs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Path Coding  Violations  encoun-
+                tered  by  a  DS1  interface in the previous 24
+                hour interval."
+            ::= { dsx1TotalEntry 7 }
+
+
+
+
+
+
+Trunk MIB Working Group                                        [Page 32]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+         dsx1TotalLESs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Line Errored Seconds encountered
+                by  a DS1 interface in the previous 24 hour in-
+                terval."
+            ::= { dsx1TotalEntry 8 }
+
+
+         dsx1TotalBESs OBJECT-TYPE
+             SYNTAX Gauge
+             ACCESS read-only
+             STATUS mandatory
+             DESCRIPTION
+                "The number of Bursty  Errored  Seconds  (BESs)
+                encountered  by a DS1 interface in the previous
+                24 hour interval."
+            ::= { dsx1TotalEntry 9 }
+
+
+         dsx1TotalDMs OBJECT-TYPE
+             SYNTAX Gauge
+             ACCESS read-only
+             STATUS mandatory
+             DESCRIPTION
+                "The number of Degraded Minutes  (DMs)  encoun-
+                tered  by  a  DS1  interface in the previous 24
+                hour interval."
+            ::= { dsx1TotalEntry 10 }
+
+
+         dsx1TotalLCVs OBJECT-TYPE
+             SYNTAX Gauge
+             ACCESS read-only
+             STATUS mandatory
+             DESCRIPTION
+                "The number of Line Code Violations (LCVs)  en-
+                countered  by a DS1 interface in the current 15
+                minute interval."
+         ::= {dsx1TotalEntry 11 }
+
+
+     -- The DS1 Far End Group
+
+     -- Implementation of this group is optional for all systems
+     -- that attach to a DS1 Interface.
+
+
+
+Trunk MIB Working Group                                        [Page 33]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+     -- The DS1 Far End Group consists of three tables:
+     --   DS1 Far End Current
+     --   DS1 Far End Interval
+     --   DS1 Far End Total
+
+     -- The DS1 Far End Current Table
+
+     -- The DS1 Far End Current table contains various statistics
+     -- being collected for the current 15 minute interval.
+     -- The statistics are collected from the far end messages on the
+     -- Facilities Data Link.  The definitions are the same as
+     -- described for the near-end information.
+
+         dsx1FarEndCurrentTable OBJECT-TYPE
+             SYNTAX  SEQUENCE OF Dsx1FarEndCurrentEntry
+             ACCESS  not-accessible
+             STATUS  mandatory
+             DESCRIPTION
+                "The DS1 Far End Current table."
+            ::= { ds1 10 }
+
+
+         dsx1FarEndCurrentEntry OBJECT-TYPE
+             SYNTAX  Dsx1FarEndCurrentEntry
+             ACCESS  not-accessible
+             STATUS  mandatory
+             DESCRIPTION
+                "An entry in the DS1 Far End Current table."
+            INDEX   { dsx1FarEndCurrentIndex }
+            ::= { dsx1FarEndCurrentTable 1 }
+
+      Dsx1FarEndCurrentEntry ::=
+         SEQUENCE {
+             dsx1FarEndCurrentIndex
+                 INTEGER,
+             dsx1FarEndTimeElapsed
+                 INTEGER,
+             dsx1FarEndValidIntervals
+                 INTEGER,
+             dsx1FarEndCurrentESs
+                 Gauge,
+             dsx1FarEndCurrentSESs
+                 Gauge,
+             dsx1FarEndCurrentSEFSs
+                 Gauge,
+             dsx1FarEndCurrentUASs
+                 Gauge,
+             dsx1FarEndCurrentCSSs
+
+
+
+Trunk MIB Working Group                                        [Page 34]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+                 Gauge,
+             dsx1FarEndCurrentLESs
+                 Gauge,
+             dsx1FarEndCurrentPCVs
+                 Gauge,
+             dsx1FarEndCurrentBESs
+                 Gauge,
+             dsx1FarEndCurrentDMs
+                 Gauge
+         }
+
+         dsx1FarEndCurrentIndex OBJECT-TYPE
+             SYNTAX  INTEGER (1..'7fffffff'h)
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The index value which uniquely identifies  the
+                DS1  interface  to which this entry is applica-
+                ble.  The interface identified by a  particular
+                value  of  this  index is the same interface as
+                identified by the same value  an  dsx1LineIndex
+                object instance."
+            ::= { dsx1FarEndCurrentEntry 1 }
+
+
+         dsx1FarEndTimeElapsed OBJECT-TYPE
+             SYNTAX  INTEGER (0..899)
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                     "The number of seconds that  have  elapsed
+                     since the beginning of the far end current
+                     error-measurement period."
+            ::= { dsx1FarEndCurrentEntry 2 }
+
+
+         dsx1FarEndValidIntervals OBJECT-TYPE
+             SYNTAX  INTEGER (0..96)
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                     "The number of previous far end  intervals
+                     for  which  valid data was collected.  The
+                     value will be 96 unless the interface  was
+                     brought  online  within the last 24 hours,
+                     in which case the value will be the number
+                     of  complete  15  minute far end intervals
+                     since the interface has been online."
+
+
+
+Trunk MIB Working Group                                        [Page 35]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+            ::= { dsx1FarEndCurrentEntry 3 }
+
+
+         dsx1FarEndCurrentESs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Far Far End Errored Seconds  en-
+                countered  by a DS1 interface in the current 15
+                minute interval."
+            ::= { dsx1FarEndCurrentEntry 4 }
+
+
+         dsx1FarEndCurrentSESs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Far End Severely Errored Seconds
+                encountered  by  a DS1 interface in the current
+                15 minute interval."
+            ::= { dsx1FarEndCurrentEntry 5 }
+
+
+         dsx1FarEndCurrentSEFSs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Far End Severely Errored Framing
+                Seconds  encountered  by a DS1 interface in the
+                current 15 minute interval."
+            ::= { dsx1FarEndCurrentEntry 6 }
+
+
+         dsx1FarEndCurrentUASs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Unavailable Seconds  encountered
+                by a DS1 interface in the current 15 minute in-
+                terval."
+            ::= { dsx1FarEndCurrentEntry 7 }
+
+
+
+
+
+
+Trunk MIB Working Group                                        [Page 36]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+         dsx1FarEndCurrentCSSs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Far End Controlled Slip  Seconds
+                encountered  by  a DS1 interface in the current
+                15 minute interval."
+            ::= { dsx1FarEndCurrentEntry 8 }
+
+
+         dsx1FarEndCurrentLESs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Far End Line Errored Seconds en-
+                countered  by a DS1 interface in the current 15
+                minute interval."
+            ::= { dsx1FarEndCurrentEntry 9 }
+
+
+         dsx1FarEndCurrentPCVs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Far End Path  Coding  Violations
+                reported  via the far end block error count en-
+                countered by a DS1 interface in the current  15
+                minute interval."
+            ::= { dsx1FarEndCurrentEntry 10 }
+
+
+         dsx1FarEndCurrentBESs OBJECT-TYPE
+             SYNTAX Gauge
+             ACCESS read-only
+             STATUS mandatory
+             DESCRIPTION
+                "The number of Bursty  Errored  Seconds  (BESs)
+                encountered  by  a DS1 interface in the current
+                15 minute interval."
+            ::= {dsx1FarEndCurrentEntry 11 }
+
+
+         dsx1FarEndCurrentDMs OBJECT-TYPE
+             SYNTAX Gauge
+             ACCESS read-only
+
+
+
+Trunk MIB Working Group                                        [Page 37]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+             STATUS mandatory
+             DESCRIPTION
+                "The number of Degraded Minutes  (DMs)  encoun-
+                tered  by  a  DS1  interface  in the current 15
+                minute interval."
+            ::= { dsx1FarEndCurrentEntry 12 }
+
+
+     -- The DS1 Far End Interval Table
+
+     -- The DS1 Far End Interval Table contains various statistics
+     -- collected by each DS1 interface over the previous 24 hours of
+     -- operation.  The past 24 hours are broken into 96
+     -- completed 15 minute intervals.
+
+         dsx1FarEndIntervalTable OBJECT-TYPE
+             SYNTAX  SEQUENCE OF Dsx1FarEndIntervalEntry
+             ACCESS  not-accessible
+             STATUS  mandatory
+             DESCRIPTION
+                "The DS1 Far End Interval table."
+            ::= { ds1 11 }
+
+
+         dsx1FarEndIntervalEntry OBJECT-TYPE
+             SYNTAX  Dsx1FarEndIntervalEntry
+             ACCESS  not-accessible
+             STATUS  mandatory
+             DESCRIPTION
+                "An entry in the DS1 Far End Interval table."
+            INDEX   { dsx1FarEndIntervalIndex,
+                      dsx1FarEndIntervalNumber }
+            ::= { dsx1FarEndIntervalTable 1 }
+
+     Dsx1FarEndIntervalEntry ::=
+         SEQUENCE {
+             dsx1FarEndIntervalIndex
+                 INTEGER,
+             dsx1FarEndIntervalNumber
+                 INTEGER,
+             dsx1FarEndIntervalESs
+                 Gauge,
+             dsx1FarEndIntervalSESs
+                 Gauge,
+             dsx1FarEndIntervalSEFSs
+                 Gauge,
+             dsx1FarEndIntervalUASs
+                 Gauge,
+
+
+
+Trunk MIB Working Group                                        [Page 38]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+             dsx1FarEndIntervalCSSs
+                 Gauge,
+             dsx1FarEndIntervalLESs
+                 Gauge,
+             dsx1FarEndIntervalPCVs
+                 Gauge,
+             dsx1FarEndIntervalBESs
+                 Gauge,
+             dsx1FarEndIntervalDMs
+                 Gauge
+         }
+
+         dsx1FarEndIntervalIndex OBJECT-TYPE
+             SYNTAX  INTEGER (1..'7fffffff'h)
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The index value which uniquely identifies  the
+                DS1  interface  to which this entry is applica-
+                ble.  The interface identified by a  particular
+                value  of  this  index is the same interface as
+                identified by the same value as a dsx1LineIndex
+                object instance."
+            ::= { dsx1FarEndIntervalEntry 1 }
+
+
+         dsx1FarEndIntervalNumber OBJECT-TYPE
+             SYNTAX  INTEGER (1..96)
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "A number between 1 and 96, where 1 is the most
+                recently completed 15 minute interval and 96 is
+                the least recently completed 15 minutes  inter-
+                val   (assuming   that  all  96  intervals  are
+                valid)."
+            ::= { dsx1FarEndIntervalEntry 2 }
+
+
+         dsx1FarEndIntervalESs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Far End Errored Seconds  encoun-
+                tered by a DS1 interface in one of the previous
+                96, individual 15 minute, intervals."
+            ::= { dsx1FarEndIntervalEntry 3 }
+
+
+
+Trunk MIB Working Group                                        [Page 39]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+         dsx1FarEndIntervalSESs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Far End Severely Errored Seconds
+                encountered  by  a  DS1 interface in one of the
+                previous 96, individual 15 minute, intervals."
+            ::= { dsx1FarEndIntervalEntry 4 }
+
+
+         dsx1FarEndIntervalSEFSs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Far End Severely Errored Framing
+                Seconds  encountered  by a DS1 interface in one
+                of the previous 96, individual 15  minute,  in-
+                tervals."
+            ::= { dsx1FarEndIntervalEntry 5 }
+
+
+         dsx1FarEndIntervalUASs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Unavailable Seconds  encountered
+                by  a  DS1 interface in one of the previous 96,
+                individual 15 minute, intervals."
+            ::= { dsx1FarEndIntervalEntry 6 }
+
+
+         dsx1FarEndIntervalCSSs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Far End Controlled Slip  Seconds
+                encountered  by  a  DS1 interface in one of the
+                previous 96, individual 15 minute, intervals."
+            ::= { dsx1FarEndIntervalEntry 7 }
+
+
+         dsx1FarEndIntervalLESs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+
+
+
+Trunk MIB Working Group                                        [Page 40]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Far End Line Errored Seconds en-
+                countered by a DS1 interface in one of the pre-
+                vious 96, individual 15 minute, intervals."
+            ::= { dsx1FarEndIntervalEntry 8 }
+
+
+         dsx1FarEndIntervalPCVs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Far End Path  Coding  Violations
+                reported  via the far end block error count en-
+                countered by a DS1 interface in one of the pre-
+                vious 96, individual 15 minute, intervals."
+            ::= { dsx1FarEndIntervalEntry 9 }
+
+
+         dsx1FarEndIntervalBESs OBJECT-TYPE
+             SYNTAX Gauge
+             ACCESS read-only
+             STATUS mandatory
+             DESCRIPTION
+                "The number of Bursty  Errored  Seconds  (BESs)
+                encountered  by  a  DS1 interface in one of the
+                previous 96, individual 15 minute, intervals."
+            ::= {dsx1FarEndIntervalEntry 10 }
+
+
+         dsx1FarEndIntervalDMs OBJECT-TYPE
+             SYNTAX Gauge
+             ACCESS read-only
+             STATUS mandatory
+             DESCRIPTION
+                "The number of Degraded Minutes  (DMs)  encoun-
+                tered by a DS1 interface in one of the previous
+                96, individual 15 minute, intervals."
+            ::= { dsx1FarEndIntervalEntry 11 }
+
+
+     -- The DS1 Far End Total Table
+
+     -- The DS1 Far End Total Table contains the cumulative sum of the
+     -- various statistics for the 24 hour period preceding the
+     -- current interval.
+
+
+
+
+Trunk MIB Working Group                                        [Page 41]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+         dsx1FarEndTotalTable OBJECT-TYPE
+             SYNTAX  SEQUENCE OF Dsx1FarEndTotalEntry
+             ACCESS  not-accessible
+             STATUS  mandatory
+             DESCRIPTION
+                "The DS1 Far End Total table."
+            ::= { ds1 12 }
+
+
+         dsx1FarEndTotalEntry OBJECT-TYPE
+             SYNTAX  Dsx1FarEndTotalEntry
+             ACCESS  not-accessible
+             STATUS  mandatory
+             DESCRIPTION
+                "An entry in the DS1 Far End Total table."
+            INDEX   { dsx1FarEndTotalIndex }
+            ::= { dsx1FarEndTotalTable 1 }
+
+     Dsx1FarEndTotalEntry ::=
+         SEQUENCE {
+             dsx1FarEndTotalIndex
+                 INTEGER,
+             dsx1FarEndTotalESs
+                 Gauge,
+             dsx1FarEndTotalSESs
+                 Gauge,
+             dsx1FarEndTotalSEFSs
+                 Gauge,
+             dsx1FarEndTotalUASs
+                 Gauge,
+             dsx1FarEndTotalCSSs
+                 Gauge,
+             dsx1FarEndTotalLESs
+                 Gauge,
+             dsx1FarEndTotalPCVs
+                 Gauge,
+             dsx1FarEndTotalBESs
+                 Gauge,
+             dsx1FarEndTotalDMs
+                 Gauge
+         }
+
+         dsx1FarEndTotalIndex OBJECT-TYPE
+             SYNTAX  INTEGER (1..'7fffffff'h)
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The index value which uniquely identifies  the
+
+
+
+Trunk MIB Working Group                                        [Page 42]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+                DS1  interface  to which this entry is applica-
+                ble.  The interface identified by a  particular
+                value  of  this  index is the same interface as
+                identified by the same value  an  dsx1LineIndex
+                object instance."
+            ::= { dsx1FarEndTotalEntry 1 }
+
+
+         dsx1FarEndTotalESs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Far End Errored Seconds  encoun-
+                tered  by  a  DS1  interface in the previous 24
+                hour interval."
+            ::= { dsx1FarEndTotalEntry 2 }
+
+
+         dsx1FarEndTotalSESs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Far End Severely Errored Seconds
+                encountered  by a DS1 interface in the previous
+                24 hour interval."
+            ::= { dsx1FarEndTotalEntry 3 }
+
+
+         dsx1FarEndTotalSEFSs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Far End Severely Errored Framing
+                Seconds  encountered  by a DS1 interface in the
+                previous 24 hour interval."
+            ::= { dsx1FarEndTotalEntry 4 }
+
+
+         dsx1FarEndTotalUASs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Unavailable Seconds  encountered
+                by  a DS1 interface in the previous 24 hour in-
+
+
+
+Trunk MIB Working Group                                        [Page 43]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+                terval."
+            ::= { dsx1FarEndTotalEntry 5 }
+
+
+         dsx1FarEndTotalCSSs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Far End Controlled Slip  Seconds
+                encountered  by a DS1 interface in the previous
+                24 hour interval."
+            ::= { dsx1FarEndTotalEntry 6 }
+
+
+         dsx1FarEndTotalLESs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Far End Line Errored Seconds en-
+                countered by a DS1 interface in the previous 24
+                hour interval."
+            ::= { dsx1FarEndTotalEntry 7 }
+
+
+         dsx1FarEndTotalPCVs OBJECT-TYPE
+             SYNTAX  Gauge
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The number of Far End Path  Coding  Violations
+                reported  via the far end block error count en-
+                countered by a DS1 interface in the previous 24
+                hour interval."
+            ::= { dsx1FarEndTotalEntry 8 }
+
+
+         dsx1FarEndTotalBESs OBJECT-TYPE
+             SYNTAX Gauge
+             ACCESS read-only
+             STATUS mandatory
+             DESCRIPTION
+                "The number of Bursty  Errored  Seconds  (BESs)
+                encountered  by a DS1 interface in the previous
+                24 hour interval."
+            ::= { dsx1FarEndTotalEntry 9 }
+
+
+
+
+Trunk MIB Working Group                                        [Page 44]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+         dsx1FarEndTotalDMs OBJECT-TYPE
+             SYNTAX Gauge
+             ACCESS read-only
+             STATUS mandatory
+             DESCRIPTION
+                "The number of Degraded Minutes  (DMs)  encoun-
+                tered  by  a  DS1  interface in the previous 24
+                hour interval."
+            ::= { dsx1FarEndTotalEntry 10 }
+
+
+     -- the DS1 Fractional Group
+
+     -- Implementation of this group is mandatory for those
+     -- systems dividing a DS1 into channels containing different
+     -- data streams that are of local interest.  Systems which
+     -- are indifferent to data content, such as CSUs, need not
+     -- implement it.
+
+     -- The DS1 fractional table identifies which DS1 channels
+     -- associated with a CSU are being used to support a
+     -- logical interface, i.e., an entry in the interfaces table
+     -- from the Internet-standard MIB.
+
+     -- For example, consider an application managing a North
+     -- American ISDN Primary Rate link whose division is a 384 kbit/s
+     -- H1 "B" Channel for Video, a second H1 for data to a primary
+     -- routing peer, and 12 64 kbit/s H0 "B" Channels. Consider that
+     -- some subset of the H0 channels are used for voice and the
+     -- remainder are available for dynamic data calls.
+
+     -- we count a total of 14 interfaces multiplexed onto the DS1
+     -- interface. Six DS1 channels (for the sake of the example,
+     -- channels 1..6) are used for Video, six more (7..11 and 13)
+     -- are used for data, and the remaining 12 are are in channels
+     -- 12 and 14..24.
+
+     -- Let us further imagine that ifIndex 2 is of type DS1 and
+     -- refers to the DS1 interface, and that the interfaces layered
+     -- onto it are numbered 3..16.
+
+     -- We might describe the allocation of channels, in the
+     -- dsx1FracTable, as follows:
+
+     -- dsx1FracIfIndex.2. 1 = 3    dsx1FracIfIndex.2.13 = 4
+     -- dsx1FracIfIndex.2. 2 = 3    dsx1FracIfIndex.2.14 = 6
+     -- dsx1FracIfIndex.2. 3 = 3    dsx1FracIfIndex.2.15 = 7
+     -- dsx1FracIfIndex.2. 4 = 3    dsx1FracIfIndex.2.16 = 8
+
+
+
+Trunk MIB Working Group                                        [Page 45]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+     -- dsx1FracIfIndex.2. 5 = 3    dsx1FracIfIndex.2.17 = 9
+     -- dsx1FracIfIndex.2. 6 = 3    dsx1FracIfIndex.2.18 = 10
+     -- dsx1FracIfIndex.2. 7 = 4    dsx1FracIfIndex.2.19 = 11
+     -- dsx1FracIfIndex.2. 8 = 4    dsx1FracIfIndex.2.20 = 12
+     -- dsx1FracIfIndex.2. 9 = 4    dsx1FracIfIndex.2.21 = 13
+     -- dsx1FracIfIndex.2.10 = 4    dsx1FracIfIndex.2.22 = 14
+     -- dsx1FracIfIndex.2.11 = 4    dsx1FracIfIndex.2.23 = 15
+     -- dsx1FracIfIndex.2.12 = 5    dsx1FracIfIndex.2.24 = 16
+
+
+     --      For North American (DS1) interfaces, there are 24 legal
+     --      channels, numbered 1 through 24.
+
+     --      For G.704 interfaces, there are 31 legal channels,
+     --      numbered 1 through 31.  The channels (1..31) correspond
+     --      directly to the equivalently numbered time-slots.
+
+         dsx1FracTable OBJECT-TYPE
+             SYNTAX  SEQUENCE OF Dsx1FracEntry
+             ACCESS  not-accessible
+             STATUS  mandatory
+             DESCRIPTION
+                "The DS1 Fractional table."
+            ::= { ds1 13 }
+
+
+         dsx1FracEntry OBJECT-TYPE
+             SYNTAX  Dsx1FracEntry
+             ACCESS  not-accessible
+             STATUS  mandatory
+             DESCRIPTION
+                "An entry in the DS1 Fractional table."
+            INDEX   { dsx1FracIndex, dsx1FracNumber }
+            ::= { dsx1FracTable 1 }
+
+     Dsx1FracEntry ::=
+         SEQUENCE {
+             dsx1FracIndex
+                 INTEGER,
+             dsx1FracNumber
+                 INTEGER,
+             dsx1FracIfIndex
+                 INTEGER
+         }
+
+
+         dsx1FracIndex OBJECT-TYPE
+             SYNTAX  INTEGER (1..'7fffffff'h)
+
+
+
+Trunk MIB Working Group                                        [Page 46]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The index value which uniquely identifies  the
+                DS1  interface  to which this entry is applica-
+                ble.  The interface identified by a  particular
+                value  of  this  index is the same interface as
+                identified by the same value  an  dsx1LineIndex
+                object instance."
+            ::= { dsx1FracEntry 1 }
+
+
+         dsx1FracNumber OBJECT-TYPE
+             SYNTAX  INTEGER (1..31)
+             ACCESS  read-only
+             STATUS  mandatory
+             DESCRIPTION
+                "The channel number for this entry."
+            ::= { dsx1FracEntry 2 }
+
+
+         dsx1FracIfIndex OBJECT-TYPE
+             SYNTAX  INTEGER (1..'7fffffff'h)
+             ACCESS  read-write
+             STATUS  mandatory
+             DESCRIPTION
+                "An index value that uniquely identifies an in-
+                terface.  The interface identified by a partic-
+                ular value of this index is the same  interface
+                as  identified by the same value an ifIndex ob-
+                ject instance. If no interface is currently us-
+                ing  a channel, the value should be zero.  If a
+                single interface occupies more  than  one  time
+                slot,  that ifIndex value will be found in mul-
+                tiple time slots."
+            ::= { dsx1FracEntry 3 }
+
+     END
+
+5.  Acknowledgements
+
+   This document was produced by the Trunk MIB Working Group:
+
+          Tracy Cox       Bellcore
+          Fred Baker      Advanced Computer Communications
+          James Watt      Newbridge
+          Bill Versteeg   Versteeg Codeworks
+          Steve Buchko    Newbridge
+
+
+
+Trunk MIB Working Group                                        [Page 47]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+          Greg Celmainis  Newbridge
+          Kaj Tesink      Bellcore
+          Al Bryenton     Bell Northern Research
+          Tom Easterday   CIC
+          John Labbe      Merit Corporation
+          Chris Sullivan  Gandalf Ltd
+          Grant Hall      Gandalf Ltd
+          Laurence V. Marks, IBM Corp.
+          Kurt Hall, Clear Communications Corp.
+          Myron Hattig, ADC Kentrox
+
+   Tracy Cox, Bill Versteeg, Myron Hattig, Kurt Hall and Laurence Marks
+   especially worked to make the document what it is.
+
+6.  References
+
+   [1] Rose M., and K. McCloghrie, "Structure and Identification of
+       Management Information for TCP/IP-based internets", STD 16, RFC
+       1155, Performance Systems International, Hughes LAN Systems, May
+       1990.
+
+   [2] Rose, M., and K. McCloghrie, Editors, "Concise MIB Definitions",
+       STD 16, RFC 1212, Performance Systems International, Hughes LAN
+       Systems, March 1991.
+
+   [3] McCloghrie K., and M. Rose, "Management Information Base for
+       Network Management of TCP/IP-based internets", RFC 1156, Hughes
+       LAN Systems, Performance Systems International, May 1990.
+
+   [4] McCloghrie K., and M. Rose, Editors, "Management Information Base
+       for Network Management of TCP/IP-based internets", STD 17, RFC
+       1213, Performance Systems International, March 1991.
+
+   [5] Case, J., Fedor, M., Schoffstall, M., and J. Davin, "Simple
+       Network Management Protocol", STD 15, RFC 1157, SNMP Research,
+       Performance Systems International, Performance Systems
+       International, MIT Laboratory for Computer Science, May 1990.
+
+   [6] Information processing systems - Open Systems Interconnection -
+       Specification of Abstract Syntax Notation One (ASN.1),
+       International Organization for Standardization, International
+       Standard 8824, December 1987.
+
+   [7] Information processing systems - Open Systems Interconnection -
+       Specification of Basic Encoding Rules for Abstract Notation One
+       (ASN.1), International Organization for Standardization,
+       International Standard 8825, December 1987.
+
+
+
+
+Trunk MIB Working Group                                        [Page 48]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+   [8] AT&T Information Systems, AT&T ESF DS1 Channel Service Unit
+       User's Manual, 999-100-305, February 1988.
+
+   [9] AT&T Technical Reference, Requirements for Interfacing Digital
+       Terminal Equipment to Services Employing the Extended Superframe
+       Format, Publication 54016, May 1988.
+
+  [10] American National Standard for Telecommunications -- Carrier-to-
+       Customer Installation - DS1 Metallic Interface, T1.403, February
+       1989.
+
+  [11] CCITT Specifications Volume III, Recommendation G.703,
+       Physical/Electrical Characteristics of Hierarchical Digital
+       Interfaces, July 1988.
+
+  [12] CCITT Specifications Volume III, Recommendation G.704,
+       Synchronous frame structures used at primary and secondary
+       hierarchical levels, July 1988.
+
+  [13] American National Standard for Telecommunications -- Layer 1 In-
+       Service Digital Transmission Performance Monitoring T1M1/92-0xx,
+       T1M1.3/92-005R1, April 1992.
+
+  [14] CCITT Specifications Volume IV, Recommendation O.162, Equipment
+       To Perform In Service Monitoring On 2048 kbit/s Signals, July
+       1988
+
+  [15] CCITT Specifications Volume III, Recommendation G.821, Error
+       Performance Of An International Digital Connection Forming Part
+       Of An Integrated Services Digital Network, July 1988.
+
+  [16] AT&T Technical Reference, Technical Reference 62411, ACCUNET T1.5
+       Service Description And Interface Specification, December 1990.
+
+  [17] CCITT Specifications Volume III, Recommendation G.706, Frame
+       Alignment and Cyclic Redundancy Check (CRC) Procedures Relating
+       to Basic Frame Structures Defined in Recommendation G.704, July
+       1988.
+
+  [18] CCITT Specifications Volume III, Recommendation G.732,
+       Characteristics Of Primary PCM Multiplex Equipment Operating at
+       2048 kbit/s, July 1988.
+
+
+
+
+
+
+
+
+
+Trunk MIB Working Group                                        [Page 49]
+
+RFC 1406                       DS1/E1 MIB                   January 1993
+
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Authors' Addresses
+
+   Fred Baker
+   Advanced Computer Communications
+   315 Bollay Drive
+   Santa Barbara, California 93117
+
+   Phone: (805) 685-4455
+   EMail: fbaker@acc.com
+
+
+   James Watt
+   Newbridge Networks Corporation
+   600 March Road
+   Kanata, Ontario
+   Canada K2K 2E6
+
+   Phone: (613) 591-3600
+   EMail: james@newbridge.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Trunk MIB Working Group                                        [Page 50]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1406.txt](<www.ietf.org/rfc/rfc1406.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
