### PR TITLE
Archive rfc1438.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1438.txt
+++ b/www.ietf.org/rfc/rfc1438.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                         L. Chapin
+Request for Comments: 1438                                          BBN
+                                                             C. Huitema
+                                                                  INRIA
+                                                           1 April 1993
+
+
+                    Internet Engineering Task Force
+                      Statements Of Boredom (SOBs)
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard.  Distribution of this memo is
+   unlimited.
+
+Discussion
+
+   The current IETF process has two types of RFCs: standards track
+   documents and other RFCs (e.g., informational, experimental, FYIs).
+   The intent of the standards track documents is clear, and culminates
+   in an official Internet Standard.  Informational RFCs can be
+   published on a less formal basis, subject to the reasonable
+   constraints of the RFC Editor.  Informational RFCs are not subject to
+   peer review and carry no significance whatsoever within the IETF
+   process.
+
+   The IETF currently has no mechanism or means of publishing documents
+   that express its deep concern about something important, but
+   otherwise contain absolutely no useful information whatsoever.  This
+   document creates a new subseries of RFCs, entitled, IETF Statements
+   Of Boredom (SOBs).  The SOB process is similar to that of the normal
+   standards track.  The SOB is submitted to the IAB, the IRSG, the
+   IESG, the SOB Editor (Morpheus), and the Academie Francais for
+   review, analysis, reproduction in triplicate, translation into ASN.1,
+   and distribution to Internet insomniacs.  However, once everyone has
+   approved the document by falling asleep over it, the process ends and
+   the document is discarded.  The resulting vacuum is viewed as having
+   the technical approval of the IETF, but it is not, and cannot become,
+   an official Internet Standard.
+
+
+
+
+
+
+
+
+
+
+
+Chapin & Huitema                                                [Page 1]
+
+RFC 1438                       IETF SOBs                    1 April 1993
+
+
+References
+
+   [1] Internet Activities Board, "The Internet Standards Process", RFC
+       1310, IAB, March 1992.
+
+   [2] Postel, J., Editor, "IAB OFFICIAL PROTOCOL STANDARDS", RFC 1410,
+       IAB, March 1993.
+
+Security Considerations
+
+   Security issues are not discussed in this memo, but then again, no
+   other issues of any importance are discussed in this memo either.
+
+Authors' Addresses
+
+   A. Lyman Chapin
+   Bolt, Beranek & Newman
+   Mail Stop 20/5b
+   150 Cambridge Park Drive
+   Cambridge, MA 02140
+   USA
+
+   Phone: 1 617 873 3133
+   EMail: Lyman@BBN.COM
+
+
+   Christian Huitema
+   INRIA, Sophia-Antipolis
+   2004 Route des Lucioles
+   BP 109
+   F-06561 Valbonne Cedex
+   France
+
+   Phone: +33 93 65 77 15
+   EMail: Christian.Huitema@MIRSA.INRIA.FR
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Chapin & Huitema                                                [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1438.txt](<www.ietf.org/rfc/rfc1438.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
