### PR TITLE
Archive rfc145.txt

### DIFF
--- a/www.ietf.org/rfc/rfc145.txt
+++ b/www.ietf.org/rfc/rfc145.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                          J. Postel
+Request for Comments: 145                                     UCLA - NMC
+NIC: 6739                                                     4 May 1971
+Updates: 123
+Obsoletes: 127
+
+              Initial Connection Protocol Control Commands
+
+     The following is my interpretation of the exchange between NCP's
+   which would be necessary to carry out the Initial Connection Protocol
+   of RFC #123.  (This note corrects an error pointed out by Eric
+   Harslem of RAND).
+
+      Server NCP                      User NCP
+      __________                      ________
+
+      Listen for Connection L         RTS, U, L, l
+                                                  A
+
+      STR, L, U, 32                   ALL, l  , 1, 32
+                                            A
+
+      Send 32 bits of data
+      in 1 message on link l
+                            A
+
+      (value is S)                    Receive 32 bits of data
+                                      from link l  (value is S)
+                                                 A
+
+      CLS, L, U                       CLS, U, L
+
+      STR, S+1, U+1, B                STR, U+1, S, B
+                      s                             u
+
+      RTS, S, U+1, l                  RTS, U, S+1, l
+                    B                               C
+
+      wait for connection             wait for connection
+      ALL, l , m , b                  ALL, l , m , b
+            B   B   B                       C   C   C
+
+      data sent to link l             data sent on link l
+                         C                               B
+
+      data received on link           data received on link l
+                           B                                 C
+
+
+
+
+Postel                                                          [Page 1]
+
+RFC 145               Initial Connection Protocol             4 May 1971
+
+
+      l , l , and l , are links, m  and m  are messages allocations, b
+       A   B       C              B      C                            B
+      and b  are bit allocations, and all other symbols are defined in
+           C
+      RFC #123.
+
+      [This RFC is also available in .PS and. PDF format.]
+
+          [ This RFC was put into machine readable form for entry ]
+               [ into the online RFC archives by Lorrie Shiota]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Postel                                                          [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc145.txt](<www.ietf.org/rfc/rfc145.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
