### PR TITLE
Archive rfc1450.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1450.txt
+++ b/www.ietf.org/rfc/rfc1450.txt
@@ -1,0 +1,1593 @@
+
+
+
+          Network Working Group                                  J. Case
+          Request for Comments: 1450                 SNMP Research, Inc.
+                                                           K. McCloghrie
+                                                      Hughes LAN Systems
+                                                                 M. Rose
+                                            Dover Beach Consulting, Inc.
+                                                           S. Waldbusser
+                                              Carnegie Mellon University
+                                                              April 1993
+
+
+                           Management Information Base
+                               for version 2 of the
+                   Simple Network Management Protocol (SNMPv2)
+
+
+          Status of this Memo
+
+          This RFC specifes an IAB standards track protocol for the
+          Internet community, and requests discussion and suggestions
+          for improvements.  Please refer to the current edition of the
+          "IAB Official Protocol Standards" for the standardization
+          state and status of this protocol.  Distribution of this memo
+          is unlimited.
+
+
+          Table of Contents
+
+
+          1 Introduction ..........................................    2
+          1.1 A Note on Terminology ...............................    2
+          2 Definitions ...........................................    3
+          3.1 The SNMPv2 Statistics Group .........................    4
+          3.2 The SNMPv1 Statistics Group .........................    9
+          3.3 The Object Resource Group ...........................   11
+          3.4 The Traps Group .....................................   13
+          3.4.1 Well-known Traps ..................................   16
+          3.5 The Set Group .......................................   18
+          3.6 Conformance Information .............................   19
+          3.6.1 Compliance Statements .............................   19
+          3.6.2 Units of Conformance ..............................   20
+          3 Acknowledgements ......................................   22
+          4 References ............................................   26
+          5 Security Considerations ...............................   27
+          6 Authors' Addresses ....................................   27
+
+
+
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                   [Page 1]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+          1.  Introduction
+
+          A network management system contains: several (potentially
+          many) nodes, each with a processing entity, termed an agent,
+          which has access to management instrumentation; at least one
+          management station; and, a management protocol, used to convey
+          management information between the agents and management
+          stations.  Operations of the protocol are carried out under an
+          administrative framework which defines both authentication and
+          authorization policies.
+
+          Network management stations execute management applications
+          which monitor and control network elements.  Network elements
+          are devices such as hosts, routers, terminal servers, etc.,
+          which are monitored and controlled through access to their
+          management information.
+
+          Management information is viewed as a collection of managed
+          objects, residing in a virtual information store, termed the
+          Management Information Base (MIB).  Collections of related
+          objects are defined in MIB modules.  These modules are written
+          using a subset of OSI's Abstract Syntax Notation One (ASN.1)
+          [1], termed the Structure of Management Information (SMI) [2].
+
+          The management protocol, SNMPv2 [3], provides for the exchange
+          of messages which convey management information between the
+          agents and the management stations.  It is the purpose of this
+          document to define managed objects which describe the behavior
+          of a SNMPv2 entity.
+
+
+          1.1.  A Note on Terminology
+
+          For the purpose of exposition, the original Internet-standard
+          Network Management Framework, as described in RFCs 1155, 1157,
+          and 1212, is termed the SNMP version 1 framework (SNMPv1).
+          The current framework is termed the SNMP version 2 framework
+          (SNMPv2).
+
+
+
+
+
+
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                   [Page 2]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+          2.  Definitions
+
+          SNMPv2-MIB DEFINITIONS ::= BEGIN
+
+          IMPORTS
+              MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE,
+              ObjectName, Integer32, Counter32, snmpModules
+                  FROM SNMPv2-SMI
+              TruthValue, DisplayString, TestAndIncr, TimeStamp
+                  FROM SNMPv2-TC
+              MODULE-COMPLIANCE, OBJECT-GROUP
+                  FROM SNMPv2-CONF
+              system, ifIndex, egpNeighAddr
+                  FROM RFC1213-MIB
+              partyEntry
+                  FROM SNMPv2-PARTY-MIB;
+
+
+          snmpMIB MODULE-IDENTITY
+              LAST-UPDATED "9304010000Z"
+              ORGANIZATION "IETF SNMPv2 Working Group"
+              CONTACT-INFO
+                      "        Marshall T. Rose
+
+                       Postal: Dover Beach Consulting, Inc.
+                               420 Whisman Court
+                               Mountain View, CA  94043-2186
+                               US
+
+                          Tel: +1 415 968 1052
+                          Fax: +1 415 968 2510
+
+                       E-mail: mrose@dbc.mtview.ca.us"
+              DESCRIPTION
+                      "The MIB module for SNMPv2 entities."
+              ::= { snmpModules 1 }
+
+
+          snmpMIBObjects OBJECT IDENTIFIER ::= { snmpMIB 1 }
+
+
+
+
+
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                   [Page 3]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+          -- the SNMPv2 statistics group
+          --
+          -- a collection of objects providing basic instrumentation of
+          -- the SNMPv2 entity.
+
+          -- A Case diagram[4] relating these objects is:
+          --
+          --  \v/   transport service
+          --   |
+          -- ==+==  snmpStatsPackets
+          --   |
+          --   +==> snmpStats30Something
+          --   |
+          --   +==> snmpStatsEncodingErrors
+          --   |
+          --   +==> snmpStatsUnknownDstParties
+          --   |
+          --   +==> snmpStatsDstPartyMismatches
+          --   |
+          --   +==> snmpStatsUnknownSrcParties
+          --   |
+          --   +==> snmpStatsBadAuths
+          --   |
+          --   +==> snmpStatsNotInLifetimes
+          --   |
+          --   +==> snmpStatsWrongDigestValues
+          --   |
+          --   +==> snmpStatsUnknownContexts
+          --   |
+          --   +==> snmpStatsBadOperations
+          --   |
+          --   +==> snmpStatsSilentDrops
+          --   |
+          -- ===== sink
+
+          snmpStats      OBJECT IDENTIFIER ::= { snmpMIBObjects 1 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                   [Page 4]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+          snmpStatsPackets OBJECT-TYPE
+              SYNTAX     Counter32
+              MAX-ACCESS read-only
+              STATUS     current
+              DESCRIPTION
+                      "The total number of packets received by the
+                      SNMPv2 entity from the transport service."
+              REFERENCE
+                      "Derived from RFC1213-MIB.snmpInPkts."
+              ::= { snmpStats 1 }
+
+          snmpStats30Something OBJECT-TYPE
+              SYNTAX     Counter32
+              MAX-ACCESS read-only
+              STATUS     current
+              DESCRIPTION
+                      "The total number of packets which had an initial
+                      octet with a value of 30 hexadecimal received by a
+                      SNMPv2 entity which does not support SNMPv1.
+                      (Such packets are possibly misdirected SNMPv1
+                      Messages.)"
+              REFERENCE
+                      "Derived from RFC1213-MIB.snmpInASNParseErrs."
+              ::= { snmpStats 2 }
+
+          snmpStatsEncodingErrors OBJECT-TYPE
+              SYNTAX     Counter32
+              MAX-ACCESS read-only
+              STATUS     current
+              DESCRIPTION
+                      "The total number of packets received by the
+                      SNMPv2 entity which were improperly encoded or had
+                      invalid syntax."
+              REFERENCE
+                      "Derived from RFC1213-MIB.snmpInASNParseErrs."
+              ::= { snmpStats 3 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                   [Page 5]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+          snmpStatsUnknownDstParties OBJECT-TYPE
+              SYNTAX     Counter32
+              MAX-ACCESS read-only
+              STATUS     current
+              DESCRIPTION
+                      "The total number of SnmpPrivMsgs delivered to the
+                      SNMPv2 entity for which the privDst field was not
+                      a known local party."
+              ::= { snmpStats 4 }
+
+          snmpStatsDstPartyMismatches OBJECT-TYPE
+              SYNTAX     Counter32
+              MAX-ACCESS read-only
+              STATUS     current
+              DESCRIPTION
+                      "The total number of SnmpPrivMsgs delivered to the
+                      SNMPv2 entity which contained a SnmpAuthMsg for
+                      which the authData.dstParty field did not match
+                      the privDst field in the SnmpPrivMsg."
+              ::= { snmpStats 5 }
+
+          snmpStatsUnknownSrcParties OBJECT-TYPE
+              SYNTAX     Counter32
+              MAX-ACCESS read-only
+              STATUS     current
+              DESCRIPTION
+                      "The total number of SnmpAuthMsgs delivered to the
+                      SNMPv2 entity for which the authData.srcParty
+                      field was not a known remote party."
+              ::= { snmpStats 6 }
+
+          snmpStatsBadAuths OBJECT-TYPE
+              SYNTAX     Counter32
+              MAX-ACCESS read-only
+              STATUS     current
+              DESCRIPTION
+                      "The total number of SnmpAuthMsgs delivered to the
+                      SNMPv2 entity which contained an authInfo field
+                      which was inconsistent with the authentication
+                      protocol associated with the source party."
+              ::= { snmpStats 7 }
+
+
+
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                   [Page 6]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+          snmpStatsNotInLifetimes OBJECT-TYPE
+              SYNTAX     Counter32
+              MAX-ACCESS read-only
+              STATUS     current
+              DESCRIPTION
+                      "The total number of SnmpAuthMsgs delivered to the
+                      SNMPv2 entity which were deemed unauthentic due to
+                      their authInfo.authSrcTimestamp field being less
+                      than the source party's clock plus lifetime."
+              ::= { snmpStats 8 }
+
+          snmpStatsWrongDigestValues OBJECT-TYPE
+              SYNTAX     Counter32
+              MAX-ACCESS read-only
+              STATUS     current
+              DESCRIPTION
+                      "The total number of SnmpAuthMsgs delivered to the
+                      SNMPv2 entity which were deemed unauthentic due to
+                      their authInfo.authDigest field being unequal to
+                      the expected digest value."
+              ::= { snmpStats 9 }
+
+          snmpStatsUnknownContexts OBJECT-TYPE
+              SYNTAX     Counter32
+              MAX-ACCESS read-only
+              STATUS     current
+              DESCRIPTION
+                      "The total number of SnmpMgmtComs delivered to the
+                      SNMPv2 entity for which the context field was not
+                      a known SNMPv2 context."
+              ::= { snmpStats 10 }
+
+          snmpStatsBadOperations OBJECT-TYPE
+              SYNTAX     Counter32
+              MAX-ACCESS read-only
+              STATUS     current
+              DESCRIPTION
+                      "The total number of messages delivered to the
+                      SNMPv2 entity which were silently dropped because
+                      the PDU type referred to an operation not allowed
+                      in the aclTable[5]."
+              ::= { snmpStats 11 }
+
+
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                   [Page 7]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+          snmpStatsSilentDrops OBJECT-TYPE
+              SYNTAX     Counter32
+              MAX-ACCESS read-only
+              STATUS     current
+              DESCRIPTION
+                      "The total number of GetRequest-PDUs,
+                      GetNextRequest-PDUs, GetBulkRequest-PDUs,
+                      SetRequest-PDUs, and InformRequest-PDUs delivered
+                      to the SNMPv2 entity which were silently dropped
+                      because the size of an reply containing an
+                      alternate Response-PDU with an empty variable-
+                      bindings field was greater than either a local
+                      constraint or the maximum message size of the
+                      request's source party."
+              ::= { snmpStats 12 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                   [Page 8]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+          -- the SNMPv1 statistics group
+          --
+          -- a collection of objects providing basic instrumentation of
+          -- a SNMPv2 entity which also implements SNMPv1.
+
+          -- A Case diagram[4] relating these objects
+          -- (and those applicable objects in the snmpStats group)
+          -- is:
+          --
+          --  \v/   transport service
+          --   |
+          -- ==+==  snmpStatsPackets
+          --   |
+          --   +==> snmpStatsEncodingErrors
+          --   |
+          --   +==> snmpV1BadCommunityNames
+          --   |
+          --   +==> snmpV1BadCommunityUses
+          --   |
+          -- ===== sink
+
+          snmpV1         OBJECT IDENTIFIER ::= { snmpMIBObjects 2 }
+
+
+          snmpV1BadCommunityNames OBJECT-TYPE
+              SYNTAX     Counter32
+              MAX-ACCESS read-only
+              STATUS     current
+              DESCRIPTION
+                      "The total number of SNMPv1 Messages delivered to
+                      the SNMPv2 entity which used a community name not
+                      known to the SNMPv2 entity."
+              REFERENCE
+                      "Derived from RFC1213-
+                      MIB.snmpInBadCommunityNames."
+              ::= { snmpV1 1 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                   [Page 9]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+          snmpV1BadCommunityUses OBJECT-TYPE
+              SYNTAX     Counter32
+              MAX-ACCESS read-only
+              STATUS     current
+              DESCRIPTION
+                      "The total number of SNMPv1 Messages delivered to
+                      SNMPv2 entity containing an operation which was
+                      not allowed for the community named in the
+                      Message."
+              REFERENCE
+                      "Derived from RFC1213-MIB.snmpInBadCommunityUses."
+              ::= { snmpV1 2 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                  [Page 10]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+          -- the object resource group
+          --
+          -- a collection of objects allowing a SNMPv2 entity acting in
+          -- an agent role to describe its dynamically-configurable
+          -- object resources.
+
+          snmpOR         OBJECT IDENTIFIER ::= { snmpMIBObjects 3 }
+
+
+          snmpORLastChange OBJECT-TYPE
+              SYNTAX     TimeStamp
+              MAX-ACCESS read-only
+              STATUS     current
+              DESCRIPTION
+                      "The value of sysUpTime at the time of the most
+                      recent change in state or value of any instance of
+                      snmpORID."
+              ::= { snmpOR 1 }
+
+          snmpORTable OBJECT-TYPE
+              SYNTAX     SEQUENCE OF SnmpOREntry
+              MAX-ACCESS not-accessible
+              STATUS     current
+              DESCRIPTION
+                      "The (conceptual) table listing the dynamically-
+                      configurable object resources in a SNMPv2 entity
+                      acting in an agent role.  SNMPv2 entities which do
+                      not support dynamically-configurable object
+                      resources will never have any instances of the
+                      columnar objects in this table."
+              ::= { snmpOR 2 }
+
+          snmpOREntry OBJECT-TYPE
+              SYNTAX     SnmpOREntry
+              MAX-ACCESS not-accessible
+              STATUS     current
+              DESCRIPTION
+                      "An entry (conceptual row) in the snmpORTable."
+              INDEX      { snmpORIndex }
+              ::= { snmpORTable 1 }
+
+
+
+
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                  [Page 11]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+          SnmpOREntry ::= SEQUENCE {
+              snmpORIndex                         Integer32,
+              snmpORID                            OBJECT IDENTIFIER,
+              snmpORDescr                         DisplayString
+          }
+
+          snmpORIndex OBJECT-TYPE
+              SYNTAX     Integer32
+              MAX-ACCESS not-accessible
+              STATUS     current
+              DESCRIPTION
+                      "The auxiliary variable used for identifying
+                      instances of the columnar objects in the
+                      snmpORTable."
+              ::= { snmpOREntry 1 }
+
+          snmpORID OBJECT-TYPE
+              SYNTAX     OBJECT IDENTIFIER
+              MAX-ACCESS read-only
+              STATUS     current
+              DESCRIPTION
+                      "An authoritative identification of one of the
+                      dynamically-configurable object resources in a
+                      SNMPv2 entity acting in an agent role.  This is
+                      analogous to the sysObjectID object in MIB-II."
+              ::= { snmpOREntry 2 }
+
+          snmpORDescr OBJECT-TYPE
+              SYNTAX     DisplayString
+              MAX-ACCESS read-only
+              STATUS     current
+              DESCRIPTION
+                      "A textual description of one of the dynamically-
+                      configurable object resources in a SNMPv2 entity
+                      acting in an agent role.  This is analogous to the
+                      sysDescr object in MIB-II."
+              ::= { snmpOREntry 3 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                  [Page 12]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+          -- the traps group
+          --
+          -- a collection of objects which allow the SNMPv2 entity, when
+          -- acting in an agent role, to be configured to generate
+          -- SNMPv2-Trap-PDUs.
+
+          snmpTrap       OBJECT IDENTIFIER ::= { snmpMIBObjects 4 }
+
+
+          snmpTrapOID OBJECT-TYPE
+              SYNTAX     OBJECT IDENTIFIER
+              MAX-ACCESS not-accessible
+              STATUS     current
+              DESCRIPTION
+                      "The authoritative identification of the trap
+                      currently being sent.  This variable occurs as the
+                      second varbind of a SNMPv2-Trap-PDU."
+              ::= { snmpTrap 1 }
+
+          snmpTrapTable OBJECT-TYPE
+              SYNTAX     SEQUENCE OF SnmpTrapEntry
+              MAX-ACCESS not-accessible
+              STATUS     current
+              DESCRIPTION
+                      "A table which keeps track of how many traps have
+                      been sent to each SNMPv2 entity."
+              ::= { snmpTrap 2 }
+
+          snmpTrapEntry OBJECT-TYPE
+              SYNTAX     SnmpTrapEntry
+              MAX-ACCESS not-accessible
+              STATUS     current
+              DESCRIPTION
+                      "An entry which keeps track of how many traps have
+                      been sent to a particular SNMPv2 entity."
+              AUGMENTS   { partyEntry }
+              ::= { snmpTrapTable 1 }
+
+          SnmpTrapEntry ::= SEQUENCE {
+              snmpTrapNumbers                     Counter32
+          }
+
+
+
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                  [Page 13]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+          snmpTrapNumbers OBJECT-TYPE
+              SYNTAX     Counter32
+              MAX-ACCESS read-only
+              STATUS     current
+              DESCRIPTION
+                      "The number of traps which have been sent to a
+                      particular SNMPv2 party, since the last
+                      initialization of the SNMPv2 entity, or the
+                      creation of the SNMPv2 party, whichever occurred
+                      most recently."
+              ::= { snmpTrapEntry 1 }
+
+          snmpTrapEnterprise OBJECT-TYPE
+              SYNTAX     OBJECT IDENTIFIER
+              MAX-ACCESS not-accessible
+              STATUS     current
+              DESCRIPTION
+                      "The authoritative identification of the
+                      enterprise associated with the trap currently
+                      being sent.  When a SNMPv2 proxy agent is mapping
+                      an RFC1157 Trap-PDU into a SNMPv2-Trap-PDU, this
+                      variable occurs as the last varbind."
+              ::= { snmpTrap 3 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                  [Page 14]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+          snmpV2EnableAuthenTraps OBJECT-TYPE
+              SYNTAX     TruthValue
+              MAX-ACCESS read-write
+              STATUS     current
+              DESCRIPTION
+                      "Indicates whether the SNMPv2 entity, when acting
+                      in an agent role, is permitted to generate
+                      authenticationFailure traps.  The value of this
+                      object overrides any configuration information; as
+                      such, it provides a means whereby all
+                      authenticationFailure traps may be disabled.
+
+                      Note that it is strongly recommended that this
+                      object be stored in non-volatile memory so that it
+                      remains constant between re-initializations of the
+                      network management system."
+              REFERENCE
+                      "Derived from RFC1213-MIB.snmpEnableAuthenTraps."
+              ::= { snmpTrap 4 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                  [Page 15]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+          -- well-known traps
+
+          snmpTraps      OBJECT IDENTIFIER ::= { snmpMIBObjects 5 }
+
+
+          coldStart NOTIFICATION-TYPE
+              STATUS  current
+              DESCRIPTION
+                      "A coldStart trap signifies that the SNMPv2
+                      entity, acting in an agent role, is reinitializing
+                      itself such that its configuration may be
+                      altered."
+              ::= { snmpTraps 1 }
+
+          warmStart NOTIFICATION-TYPE
+              STATUS  current
+              DESCRIPTION
+                      "A warmStart trap signifies that the SNMPv2
+                      entity, acting in an agent role, is reinitializing
+                      itself such that its configuration is unaltered."
+              ::= { snmpTraps 2 }
+
+          linkDown NOTIFICATION-TYPE
+              OBJECTS { ifIndex }
+              STATUS  current
+              DESCRIPTION
+                      "A linkDown trap signifies that the SNMPv2 entity,
+                      acting in an agent role, recognizes a failure in
+                      one of the communication links represented in its
+                      configuration."
+              ::= { snmpTraps 3 }
+
+          linkUp NOTIFICATION-TYPE
+              OBJECTS { ifIndex }
+              STATUS  current
+              DESCRIPTION
+                      "A linkUp trap signifies that the SNMPv2 entity,
+                      acting in an agent role, recognizes that one of
+                      the communication links represented in its
+                      configuration has come up."
+              ::= { snmpTraps 4 }
+
+
+
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                  [Page 16]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+          authenticationFailure NOTIFICATION-TYPE
+              STATUS  current
+              DESCRIPTION
+                      "An authenticationFailure trap signifies that the
+                      SNMPv2 entity, acting in an agent role, has
+                      received a protocol message that is not properly
+                      authenticated.  While all implementations of the
+                      SNMPv2 must be capable of generating this trap,
+                      the snmpV2EnableAuthenTraps object indicates
+                      whether this trap will be generated."
+              ::= { snmpTraps 5 }
+
+          egpNeighborLoss NOTIFICATION-TYPE
+              OBJECTS { egpNeighAddr }
+              STATUS  current
+              DESCRIPTION
+                      "An egpNeighborLoss trap signifies that an EGP
+                      neighbor has been marked down and the EGP peer
+                      relationship no longer obtains."
+              ::= { snmpTraps 6 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                  [Page 17]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+          -- the set group
+          --
+          -- a collection of objects which allow several cooperating
+          -- SNMPv2 entities, all acting in a manager role, to
+          -- coordinate their use of the SNMPv2 set operation.
+
+          snmpSet        OBJECT IDENTIFIER ::= { snmpMIBObjects 6 }
+
+
+          snmpSetSerialNo OBJECT-TYPE
+              SYNTAX     TestAndIncr
+              MAX-ACCESS read-write
+              STATUS     current
+              DESCRIPTION
+                      "An advisory lock used to allow several
+                      cooperating SNMPv2 entities, all acting in a
+                      manager role, to coordinate their use of the
+                      SNMPv2 set operation.
+
+                      This object is used for coarse-grain coordination.
+                      To achieve fine-grain coordination, one or more
+                      similar objects might be defined within each MIB
+                      group, as appropriate."
+              ::= { snmpSet 1 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                  [Page 18]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+          -- conformance information
+
+          snmpMIBConformance
+                         OBJECT IDENTIFIER ::= { snmpMIB 2 }
+
+          snmpMIBCompliances
+                         OBJECT IDENTIFIER ::= { snmpMIBConformance 1 }
+          snmpMIBGroups  OBJECT IDENTIFIER ::= { snmpMIBConformance 2 }
+
+
+          -- compliance statements
+
+          snmpMIBCompliance MODULE-COMPLIANCE
+              STATUS  current
+              DESCRIPTION
+                      "The compliance statement for SNMPv2 entities
+                      which implement the SNMPv2 MIB."
+              MODULE  RFC1213-MIB
+                  MANDATORY-GROUPS { system }
+
+              MODULE  -- this module
+                  MANDATORY-GROUPS { snmpStatsGroup, snmpORGroup,
+                                     snmpTrapGroup, snmpSetGroup }
+
+                  GROUP   snmpV1Group
+                  DESCRIPTION
+                      "The snmpV1 group is mandatory only for those
+                       SNMPv2 entities which also implement SNMPv1."
+              ::= { snmpMIBCompliances 1 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                  [Page 19]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+          -- units of conformance
+
+          snmpStatsGroup OBJECT-GROUP
+              OBJECTS { snmpStatsPackets, snmpStats30Something,
+                        snmpStatsEncodingErrors,
+                        snmpStatsUnknownDstParties,
+                        snmpStatsDstPartyMismatches,
+                        snmpStatsUnknownSrcParties, snmpStatsBadAuths,
+                        snmpStatsNotInLifetimes,
+                        snmpStatsWrongDigestValues,
+                        snmpStatsUnknownContexts,
+                        snmpStatsBadOperations,
+                        snmpStatsSilentDrops }
+              STATUS  current
+              DESCRIPTION
+                      "A collection of objects providing basic
+                      instrumentation of the SNMPv2 entity."
+              ::= { snmpMIBGroups 1 }
+
+          snmpV1Group OBJECT-GROUP
+              OBJECTS { snmpV1BadCommunityNames, snmpV1BadCommunityUses }
+              STATUS  current
+              DESCRIPTION
+                      "A collection of objects providing basic
+                      instrumentation of a SNMPv2 entity which also
+                      implements SNMPv1."
+              ::= { snmpMIBGroups 2 }
+
+          snmpORGroup OBJECT-GROUP
+              OBJECTS { snmpORLastChange, snmpORID, snmpORDescr }
+              STATUS  current
+              DESCRIPTION
+                      "A collection of objects allowing a SNMPv2 entity
+                      acting in an agent role to describe its
+                      dynamically-configurable object resources."
+              ::= { snmpMIBGroups 3 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                  [Page 20]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+          snmpTrapGroup OBJECT-GROUP
+              OBJECTS { snmpTrapNumbers, snmpV2EnableAuthenTraps }
+              STATUS  current
+              DESCRIPTION
+                      "A collection of objects which allow the SNMPv2
+                      entity, when acting in an agent role, to be
+                      configured to generate SNMPv2-Trap-PDUs."
+              ::= { snmpMIBGroups 4 }
+
+          snmpSetGroup OBJECT-GROUP
+              OBJECTS { snmpSetSerialNo }
+              STATUS  current
+              DESCRIPTION
+                      "A collection of objects which allow several
+                      cooperating SNMPv2 entities, all acting in a
+                      manager role, to coordinate their use of the
+                      SNMPv2 set operation."
+              ::= { snmpMIBGroups 5 }
+
+
+          END
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                  [Page 21]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+          3.  Acknowledgements
+
+          The objects in the snmpStats and snmpV1 groups are based, in
+          part, on RFC 1213.
+
+          Finally, the comments of the SNMP version 2 working group are
+          gratefully acknowledged:
+
+               Beth Adams, Network Management Forum
+               Steve Alexander, INTERACTIVE Systems Corporation
+               David Arneson, Cabletron Systems
+               Toshiya Asaba
+               Fred Baker, ACC
+               Jim Barnes, Xylogics, Inc.
+               Brian Bataille
+               Andy Bierman, SynOptics Communications, Inc.
+               Uri Blumenthal, IBM Corporation
+               Fred Bohle, Interlink
+               Jack Brown
+               Theodore Brunner, Bellcore
+               Stephen F. Bush, GE Information Services
+               Jeffrey D. Case, University of Tennessee, Knoxville
+               John Chang, IBM Corporation
+               Szusin Chen, Sun Microsystems
+               Robert Ching
+               Chris Chiotasso, Ungermann-Bass
+               Bobby A. Clay, NASA/Boeing
+               John Cooke, Chipcom
+               Tracy Cox, Bellcore
+               Juan Cruz, Datability, Inc.
+               David Cullerot, Cabletron Systems
+               Cathy Cunningham, Microcom
+               James R. (Chuck) Davin, Bellcore
+               Michael Davis, Clearpoint
+               Mike Davison, FiberCom
+               Cynthia DellaTorre, MITRE
+               Taso N. Devetzis, Bellcore
+               Manual Diaz, DAVID Systems, Inc.
+               Jon Dreyer, Sun Microsystems
+               David Engel, Optical Data Systems
+               Mike Erlinger, Lexcel
+               Roger Fajman, NIH
+               Daniel Fauvarque, Sun Microsystems
+               Karen Frisa, CMU
+               Shari Galitzer, MITRE
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                  [Page 22]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+               Shawn Gallagher, Digital Equipment Corporation
+               Richard Graveman, Bellcore
+               Maria Greene, Xyplex, Inc.
+               Michel Guittet, Apple
+               Robert Gutierrez, NASA
+               Bill Hagerty, Cabletron Systems
+               Gary W. Haney, Martin Marietta Energy Systems
+               Patrick Hanil, Nokia Telecommunications
+               Matt Hecht, SNMP Research, Inc.
+               Edward A. Heiner, Jr., Synernetics Inc.
+               Susan E. Hicks, Martin Marietta Energy Systems
+               Geral Holzhauer, Apple
+               John Hopprich, DAVID Systems, Inc.
+               Jeff Hughes, Hewlett-Packard
+               Robin Iddon, Axon Networks, Inc.
+               David Itusak
+               Kevin M. Jackson, Concord Communications, Inc.
+               Ole J. Jacobsen, Interop Company
+               Ronald Jacoby, Silicon Graphics, Inc.
+               Satish Joshi, SynOptics Communications, Inc.
+               Frank Kastenholz, FTP Software
+               Mark Kepke, Hewlett-Packard
+               Ken Key, SNMP Research, Inc.
+               Zbiginew Kielczewski, Eicon
+               Jongyeoi Kim
+               Andrew Knutsen, The Santa Cruz Operation
+               Michael L. Kornegay, VisiSoft
+               Deirdre C. Kostik, Bellcore
+               Cheryl Krupczak, Georgia Tech
+               Mark S. Lewis, Telebit
+               David Lin
+               David Lindemulder, AT&T/NCR
+               Ben Lisowski, Sprint
+               David Liu, Bell-Northern Research
+               John Lunny, The Wollongong Group
+               Robert C. Lushbaugh Martin, Marietta Energy Systems
+               Michael Luufer, BBN
+               Carl Madison, Star-Tek, Inc.
+               Keith McCloghrie, Hughes LAN Systems
+               Evan McGinnis, 3Com Corporation
+               Bill McKenzie, IBM Corporation
+               Donna McMaster, SynOptics Communications, Inc.
+               John Medicke, IBM Corporation
+               Doug Miller, Telebit
+               Dave Minnich, FiberCom
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                  [Page 23]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+               Mohammad Mirhakkak, MITRE
+               Rohit Mital, Protools
+               George Mouradian, AT&T Bell Labs
+               Patrick Mullaney, Cabletron Systems
+               Dan Myers, 3Com Corporation
+               Rina Nathaniel, Rad Network Devices Ltd.
+               Hien V. Nguyen, Sprint
+               Mo Nikain
+               Tom Nisbet
+               William B. Norton, MERIT
+               Steve Onishi, Wellfleet Communications, Inc.
+               David T. Perkins, SynOptics Communications, Inc.
+               Carl Powell, BBN
+               Ilan Raab, SynOptics Communications, Inc.
+               Richard Ramons, AT&T
+               Venkat D. Rangan, Metric Network Systems, Inc.
+               Louise Reingold, Sprint
+               Sam Roberts, Farallon Computing, Inc.
+               Kary Robertson, Concord Communications, Inc.
+               Dan Romascanu, Lannet Data Communications Ltd.
+               Marshall T. Rose, Dover Beach Consulting, Inc.
+               Shawn A. Routhier, Epilogue Technology Corporation
+               Chris Rozman
+               Asaf Rubissa, Fibronics
+               Jon Saperia, Digital Equipment Corporation
+               Michael Sapich
+               Mike Scanlon, Interlan
+               Sam Schaen, MITRE
+               John Seligson, Ultra Network Technologies
+               Paul A. Serice, Corporation for Open Systems
+               Chris Shaw, Banyan Systems
+               Timon Sloane
+               Robert Snyder, Cisco Systems
+               Joo Young Song
+               Roy Spitier, Sprint
+               Einar Stefferud, Network Management Associates
+               John Stephens, Cayman Systems, Inc.
+               Robert L. Stewart, Xyplex, Inc. (chair)
+               Kaj Tesink, Bellcore
+               Dean Throop, Data General
+               Ahmet Tuncay, France Telecom-CNET
+               Maurice Turcotte, Racal Datacom
+               Warren Vik, INTERACTIVE Systems Corporation
+               Yannis Viniotis
+               Steven L. Waldbusser, Carnegie Mellon Universitty
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                  [Page 24]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+               Timothy M. Walden, ACC
+               Alice Wang, Sun Microsystems
+               James Watt, Newbridge
+               Luanne Waul, Timeplex
+               Donald E. Westlake III, Digital Equipment Corporation
+               Gerry White
+               Bert Wijnen, IBM Corporation
+               Peter Wilson, 3Com Corporation
+               Steven Wong, Digital Equipment Corporation
+               Randy Worzella, IBM Corporation
+               Daniel Woycke, MITRE
+               Honda Wu
+               Jeff Yarnell, Protools
+               Chris Young, Cabletron
+               Kiho Yum, 3Com Corporation
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                  [Page 25]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+          4.  References
+
+          [1]  Information processing systems - Open Systems
+               Interconnection - Specification of Abstract Syntax
+               Notation One (ASN.1), International Organization for
+               Standardization.  International Standard 8824, (December,
+               1987).
+
+          [2]  Case, J., McCloghrie, K., Rose, M., and Waldbusser, S.,
+               "Structure of Management Information for version 2 of the
+               Simple Network Management Protocol (SNMPv2)", RFC 1442,
+               SNMP Research, Inc., Hughes LAN Systems, Dover Beach
+               Consulting, Inc., Carnegie Mellon University, April 1993.
+
+          [3]  Case, J., McCloghrie, K., Rose, M., and Waldbusser, S.,
+               "Protocol Operations for version 2 of the Simple Network
+               Management Protocol (SNMPv2)", RFC 1448, SNMP Research,
+               Inc., Hughes LAN Systems, Dover Beach Consulting, Inc.,
+               Carnegie Mellon University, April 1993.
+
+          [4]  J.D. Case, C. Partridge, Case Diagrams: A First Step to
+               Diagramed Management Information Bases.  Computer
+               Communications Review, Volume 19, Number 1, (January,
+               1989).
+
+          [5]  McCloghrie, K., and Galvin, J., "Party MIB for version 2
+               of the Simple Network Management Protocol (SNMPv2)", RFC
+               1447, Hughes LAN Systems, Trusted Information Systems,
+               April 1993.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                  [Page 26]
+
+
+
+
+
+          RFC 1450    Management Information Base for SNMPv2  April 1993
+
+
+          5.  Security Considerations
+
+          Security issues are not discussed in this memo.
+
+
+          6.  Authors' Addresses
+
+               Jeffrey D. Case
+               SNMP Research, Inc.
+               3001 Kimberlin Heights Rd.
+               Knoxville, TN  37920-9716
+               US
+
+               Phone: +1 615 573 1434
+               Email: case@snmp.com
+
+
+               Keith McCloghrie
+               Hughes LAN Systems
+               1225 Charleston Road
+               Mountain View, CA  94043
+               US
+
+               Phone: +1 415 966 7934
+               Email: kzm@hls.com
+
+
+               Marshall T. Rose
+               Dover Beach Consulting, Inc.
+               420 Whisman Court
+               Mountain View, CA  94043-2186
+               US
+
+               Phone: +1 415 968 1052
+               Email: mrose@dbc.mtview.ca.us
+
+               Steven Waldbusser
+               Carnegie Mellon University
+               4910 Forbes Ave
+               Pittsburgh, PA  15213
+               US
+
+               Phone: +1 412 268 6628
+               Email: waldbusser@cmu.edu
+
+
+
+
+
+
+          Case, McCloghrie, Rose & Waldbusser                  [Page 27]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1450.txt](<www.ietf.org/rfc/rfc1450.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
