### PR TITLE
Archive rfc148.txt

### DIFF
--- a/www.ietf.org/rfc/rfc148.txt
+++ b/www.ietf.org/rfc/rfc148.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                             A. Bhushan
+Request for Comments # 148                MIT -- Project MAC
+NIC # 6751                                        7 May 1971
+Categories: D.1
+
+
+                          Comments on RFC #123
+                          --------------------
+
+
+
+        The requirement that byte size 's' be 32-bits for
+the initial connection imposes some severe strains on some of
+the 36-bit machines. For example, in our PDP-10 (DMCG-
+ITS) NCP, we have at present no way of sending or receiving
+exactly 32-bits of data. Data is transmitted either in
+image mode (36-bit bytes) or in ASCII mode (8-bit characters
+with the 8th bit as zero). Perhaps we should permit the
+server to send more than 32-bits (say 72-bits) where the
+remaining bits could be NULL fillers. The byte size
+'s' for the connection may be fixed at 8-bits.
+
+
+
+
+
+
+
+
+  [ This RFC was put into machine readable form for entry ]
+  [ into the online RFC archives by BBN Corp. under the   ]
+  [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc148.txt](<www.ietf.org/rfc/rfc148.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
