### PR TITLE
Archive rfc149.txt

### DIFF
--- a/www.ietf.org/rfc/rfc149.txt
+++ b/www.ietf.org/rfc/rfc149.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                              S. Crocker
+Request for Comments # 149                         UCLA
+NIC # 6752                                         10 May 1971
+Categories:  A.2
+Updates:  #140
+Obsoletes:  None
+
+
+               The Best Laid Plans . . .
+
+
+
+Dr. Roberts informs me that it is now unlikely that he will be
+able to attend the Monday afternoon session of the NWG meeting,
+but that he will be able to attend the Tuesday evening session.
+Accordingly, the topics of "Network Planning" and "other ARPA
+Projects" are moved to Tuesday evening, and on Monday afternoon,
+we will take up as many of the items originally scheduled for
+Tuesday evening as we can.
+
+The relevant reading for Wednesday evening is RFC #131, not #113.
+In general attendees should read all of the RFC's since the last
+NWG meeting.
+
+
+
+   [ This RFC was put into machine readable form for entry ]
+   [ into the online RFC archives by C. Harald Koch  05/97 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc149.txt](<www.ietf.org/rfc/rfc149.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
