### PR TITLE
Archive rfc1499.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1499.txt
+++ b/www.ietf.org/rfc/rfc1499.txt
@@ -1,0 +1,1179 @@
+
+
+
+
+
+
+Network Working Group                                         J. Elliott
+Request for Comments: 1499                                           ISI
+Category: Informational                                     January 1997
+
+
+                      Request for Comments Summary
+
+                         RFC Numbers 1400-1499
+
+Status of This Memo
+
+   This RFC is a slightly annotated list of the 100 RFCs from RFC 1400
+   through RFCs 1499.  This is a status report on these RFCs.  This memo
+   provides information for the Internet community.  It does not specify
+   an Internet standard of any kind.  Distribution of this memo is
+   unlimited.
+
+Note
+
+   Many RFCs, but not all, are Proposed Standards, Draft Standards, or
+   Standards.  Since the status of these RFCs may change during the
+   standards processing, we note here only that they are on the
+   standards track.  Please see the latest edition of "Internet Official
+   Protocol Standards" for the current state and status of these RFCs.
+   In the following, RFCs on the standards track are marked [STANDARDS-
+   TRACK].
+
+RFC     Author       Date      Title
+---     ------       ----      -----
+
+1499    Elliott      Jan 97   Requests For Comments Summary
+
+This memo.
+
+
+1498    Saltzer      Aug 93   On the Naming and Binding of Network
+                              Destinations
+
+This brief paper offers a perspective on the subject of names of
+destinations in data communication networks. It suggests two ideas:
+First, it is helpful to distinguish among four different kinds of
+objects that may be named as the destination of a packet in a network.
+Second, the operating system concept of binding is a useful way to
+describe the relations among the four kinds of objects.  This memo
+provides information for the Internet community.  It does not specify an
+Internet standard.
+
+
+
+
+
+Elliott                      Informational                      [Page 1]
+
+RFC 1499                  Summary of 1400-1499              January 1997
+
+
+1497    Reynolds     Aug 93   BOOTP Vendor Information Extensions
+
+This RFC is a slight revision and extension of RFC-1048 by Philip
+Prindeville, who should be credited with the original work in this memo.
+This memo is a status report on the vendor information extensions used
+in the Bootstrap Protocol (BOOTP).
+
+
+1496    Alverstrand  Aug 93   Rules for Downgrading Messages from
+                              X.400/88 to X.400/84 When MIME
+                              Content-Types are Present in the
+                              Messages
+
+This document describes how RFC-1328 must be modified in order to
+provide adequate support for the scenarios:
+
+                    SMTP(MIME) -> X.400(84)
+                    X.400(84) -> SMTP(MIME)
+
+It replaces chapter 6 of RFC-1328. The rest of RFC-1328 is NOT
+obsoleted.  [STANDARDS-TRACK]
+
+
+1495    Alverstrand  Aug 93   Mapping between X.400 and RFC-822
+                              Message Bodies
+
+Since the introduction of X.400(84), there has been work ongoing for
+defining mappings between MHS and RFC-822.  The most recent work in this
+area is RFC-1327 [3], which focuses primarily on translation of envelope
+and headers.  This document is complimentary to RFC-1327 as it focuses
+on translation of the message body.  [STANDARDS-TRACK]
+
+
+1494    Alverstrand  Aug 93   Equivalences between 1988 X.400 and
+                              RFC-822 Message Bodies
+
+This document describes the content of the "IANA MHS/MIME Equivalence
+table", and defines the initial configuration of this table.  Mappings
+for new MIME content-types and/or X.400 body part types should be
+registered with the IANA to minimize redundancy and promote
+interoperability. [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 2]
+
+RFC 1499                  Summary of 1400-1499              January 1997
+
+
+1493    Decker       Jul 93   Definitions of Managed Objects
+                              for Bridges
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP based internets.  In
+particular it defines objects for managing MAC bridges based on the IEEE
+802.1D-1990 standard between Local Area Network (LAN) segments.
+[STANDARDS-TRACK]
+
+
+1492    Finseth      Jul 93   An Access Control Protocol, Sometimes
+                              Called TACACS
+
+This RFC documents the extended TACACS protocol use by the Cisco Systems
+terminal servers.  This same protocol is used by the University of
+Minnesota's distributed authentication system.  This memo provides
+information for the Internet community.  It does not specify an Internet
+standard.
+
+
+1491    Weider       Jul 93   A Survey of Advanced Usages of X.500
+
+This document is the result of a survey asking people to detail their
+advanced usages of X.500. It is intended to show how various
+organizations are using X.500 in ways which extend the view of X.500 as
+a "White Pages" service.  This RFC is a product of the Integrated
+Directory Services Working Group of the Application and User Services
+Areas of the IETF.  This memo provides information for the Internet
+community.  It does not specify an Internet standard.
+
+
+1490    Bradley      Jul 93   Multiprotocol Interconnect over Frame
+                              Relay
+
+This memo describes an encapsulation method for carrying network
+interconnect traffic over a Frame Relay backbone.  It covers aspects of
+both Bridging and Routing.  Additionally, it describes a simple
+fragmentation procedure for carrying large frames over a frame relay
+network with a smaller MTU.  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 3]
+
+RFC 1499                  Summary of 1400-1499              January 1997
+
+
+1489    Chernov      Jul 93   Registration of a Cyrillic Character Set
+
+Though the proposed character set "koi8-r" is not currently an
+international standard, there is very large user community (including
+Relcom Net) supporting it.  Factually, "koi8-r" is de-facto standard for
+Unix and global network applications in the former Soviet Union.  This
+is the reason the Society of Unix User Groups (SUUG) believes "koi8-r"
+should be registered.  This memo provides information for the Internet
+community.  It does not specify an Internet standard.
+
+
+1488    Howes        Jul 93   The X.500 String Representation of
+                              Standard Attribute Syntaxes
+
+This document defines the requirements that must be satisfied by
+encoding rules used to render Directory attribute syntaxes into a form
+suitable for use in the LDAP, then goes on to define the encoding rules
+for the standard set of attribute syntaxes defined in [1,2] and [3].
+[STANDARDS-TRACK]
+
+
+1487    Yeong        Jul 93   X.500 Lightweight Directory Access
+                              Protocol
+
+The protocol described in this document is designed to provide access to
+the Directory while not incurring the resource requirements of the
+Directory Access Protocol (DAP).  [STANDARDS-TRACK]
+
+
+1486    Rose         Jul 93   An Experiment in Remote Printing
+
+This memo describes a technique for "remote printing" using the Internet
+mail infrastructure.  In particular, this memo focuses on the case in
+which remote printers are connected to the international telephone
+network.  This memo defines an Experimental Protocol for the Internet
+community.  It does not specify an Internet standard.
+
+
+1485    Kille        Jul 93   A String Representation of Distinguished
+                              Names (OSI-DS 23 (v5))
+
+When a distinguished name is communicated between to users not using a
+directory protocol (e.g., in a mail message), there is a need to have a
+user-oriented string representation of distinguished name.  [STANDARDS-
+TRACK]
+
+
+
+
+
+
+Elliott                      Informational                      [Page 4]
+
+RFC 1499                  Summary of 1400-1499              January 1997
+
+
+1484    Kille        Jul 93   Using the OSI Directory to achieve
+                              User Friendly Naming (OSI-DS 24 (v1.2))
+
+This proposal sets out some conventions for representing names in a
+friendly manner, and shows how this can be used to achieve really
+friendly naming.  This memo defines an Experimental Protocol for the
+Internet community.  It does not specify an Internet standard.
+
+
+1483    Heinanen     Jul 93   Multiprotocol Encapsulation over ATM
+                              Adaptation Layer 5
+
+This memo describes two encapsulations methods for carrying network
+interconnect traffic over ATM AAL5.  [STANDARDS-TRACK]
+
+
+1482    Knopper      Jun 93   Aggregation Support in the NSFNET
+                              Policy-Based Routing Database
+
+This document describes plans for support of route aggregation, as
+specified in the descriptions of Classless Inter-Domain Routing (CIDR)
+[1] and the BGP-4 protocol [2], by the NSFNET Backbone Network Service.
+This memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+1481    Huitema      Jul 93   IAB Recommendation for an Intermediate
+                              Strategy to Address the Issue of Scaling
+
+CIDR is proposed as an immediate term strategy to extend the life of the
+current 32 bit IP address space.  This memo provides information for the
+Internet community.  It does not specify an Internet standard.
+
+
+1480    Cooper       Jun 93   The US Domain
+
+This is a description of the US Top Level Domains on the Internet.  This
+memo provides information for the Internet community. It does not
+specify an Internet standard.
+
+
+1479    Steenstrup   Jul 93   Inter-Domain Policy Routing Protocol
+                              Specification: Version 1
+
+We present the set of protocols and procedures that constitute Inter-
+Domain Policy Routing (IDPR).  [STANDARDS-TRACK]
+
+
+
+
+
+Elliott                      Informational                      [Page 5]
+
+RFC 1499                  Summary of 1400-1499              January 1997
+
+
+1478    Steenstrup   Jul 93   An Architecture for Inter-Domain Policy
+                              Routing
+
+We present an architecture for inter-domain policy routing (IDPR).
+[STANDARDS-TRACK]
+
+
+1477    Steenstrup   Jul 93   IDPR as a Proposed Standard
+
+This document contains a discussion of inter-domain policy routing
+(IDPR), including an overview of functionality and a discussion of
+experiments.  This memo provides information for the Internet community.
+It does not specify an Internet standard.
+
+
+1476    Ullman       Jun 93   RAP: Internet Route Access Protocol
+
+This RFC describes an open distance vector routing protocol for use at
+all levels of the internet, from isolated LANs to the major routers of
+an international commercial network provider.  This memo defines an
+Experimental Protocol for the Internet community.  It does not specify
+an Internet standard.
+
+
+1475    Ullman       Jun 93   TP/IX: The Next Internet
+
+This memo presents the specification for version 7 of the Internet
+Protocol, as well as version 7 of the TCP and the user datagram
+protocol.  This memo defines an Experimental Protocol for the Internet
+community.  It does not specify an Internet standard.
+
+
+1474    Kastrenholz  Jun 93   The Definitions of Managed Objects for
+                              the Bridge Network Control Protocol of
+                              the Point-to-Point Protocol
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it describes managed objects used for managing the bridge
+Network Control Protocol [10] on subnetwork interfaces using the family
+of Point-to-Point Protocols.  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 6]
+
+RFC 1499                  Summary of 1400-1499              January 1997
+
+
+1473    Kastrenholz  Jun 93   The Definitions of Managed Objects for
+                              the IP Network Control Protocol of
+                              the Point-to-Point Protocol
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it describes managed objects used for managing the IP
+Network Control Protocol on subnetwork interfaces using the family of
+Point-to-Point Protocols [8, 9, 10, 11, & 12].  [STANDARDS-TRACK]
+
+
+1472    Kastrenholz  Jun 93   The Definitions of Managed Objects for
+                              the Security Protocols of
+                              the Point-to-Point Protocol
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it describes managed objects used for managing the Security
+Protocols on subnetwork interfaces using the family of Point-to-Point
+Protocols [8, 9, 10, 11, & 12].  [STANDARDS-TRACK]
+
+
+1471    Kastrenholz  Jun 93   The Definitions of Managed Objects for
+                              the Link Control Protocol of
+                              the Point-to-Point Protocol
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it describes managed objects used for managing the Link
+Control Protocol and Link Quality Monitoring on subnetwork interfaces
+that use the family of Point-to-Point Protocols [8, 9, 10, 11, & 12].
+[STANDARDS-TRACK]
+
+
+1470    Enger        Jun 93   FYI on a Network Management Tool
+                              Catalog: Tools for Monitoring and
+                              Debugging TCP/IP Internets and
+                              Interconnected Devices
+
+The goal of this FYI memo is to provide an update to FYI 2, RFC 1147
+[1], which provided practical information to site administrators and
+network managers.  This memo provides information for the Internet
+community.  It does not specify an Internet standard.
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 7]
+
+RFC 1499                  Summary of 1400-1499              January 1997
+
+
+1469    Pusateri     Jun 93   IP Multicast over Token-Ring Local Area
+                              Networks
+
+This document specifies a method for the transmission of IP multicast
+datagrams over Token-Ring Local Area Networks.  [STANDARDS-TRACK]
+
+
+1468    Murai        Jun 93   Japanese Character Encoding for Internet
+                              Messages
+
+This document describes the encoding used in electronic mail [RFC822]
+and network news [RFC1036] messages in several Japanese networks.  This
+memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+1467    Topolcic     Aug 93   Status of CIDR Deployment in the
+                              Internet
+
+This document describes the current status of the development and
+deployment of CIDR technology into the Internet. This document replaces
+RFC 1367, which was a schedule for the deployment of IP address space
+management procedures to support route aggregation.  This memo provides
+information for the Internet community.  It does not specify an Internet
+standard.
+
+
+1466    Gerich       May 93   Guidelines for Management of IP Address
+                              Space
+
+This document proposes a plan which will forward the implementation of
+RFC 1174 and which defines the allocation and assignment of the network
+number space.  This memo provides information for the Internet
+community.  It does not specify an Internet standard.
+
+
+1465    Eppenberger  May 93   Routing Coordination for X.400 MHS
+                              Services Within a Multi Protocol / Multi
+                              Network Environment Table Format V3 for
+                              Static Routing
+
+This document proposes short term solutions for maintaining and
+distributing routing information and shows how messages can travel over
+different networks by using multi stack MTAs as relays.  This memo
+defines an Experimental Protocol for the Internet community.
+
+
+
+
+
+
+Elliott                      Informational                      [Page 8]
+
+RFC 1499                  Summary of 1400-1499              January 1997
+
+
+1464    Rosenbaum    May 93   Using the Domain Name System
+                              To Store Arbitrary String Attributes
+
+This paper describes a simple means to associate arbitrary string
+information (ASCII text) with attributes that have not been defined by
+the DNS.  This memo defines an Experimental Protocol for the Internet
+community.
+
+
+1463    Hoffman      May 93   FYI on Introducing the Internet--
+                              A Short Bibliography of Introductory
+                              Internetworking Readings for the Network
+                              Novice
+
+This bibliography offers a short list of recent information resources
+that will help the network novice become familiar with the Internet,
+including its associated networks, resources, protocols, and history.
+This memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+1462    Krol         May 93   FYI on "What is the Internet?"
+
+This FYI RFC answers the question, "What is the Internet?"  and is
+produced by the User Services Working Group of the Internet Engineering
+Task Force (IETF).  This memo provides information for the Internet
+community.  It does not specify an Internet standard.
+
+
+1461    Throop       May 93   SNMP MIB extension for Multiprotocol
+                              Interconnect over X.25
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing Multiprotocol Interconnect
+(including IP) traffic carried over X.25.  [STANDARDS-TRACK]
+
+
+1460    Rose         Jun 93   Post Office Protocol - Version 3
+
+This memo is a revision to RFC 1225, a Draft Standard.  [STANDARDS-
+TRACK]
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 9]
+
+RFC 1499                  Summary of 1400-1499              January 1997
+
+
+1459    Oikarinen    May 93   Internet Relay Chat Protocol
+
+The IRC protocol is a text-based protocol, with the simplest client
+being any socket program capable of connecting to the server.  This memo
+defines an Experimental Protocol for the Internet community.
+
+
+1458    Braudes      May 93   Requirements for Multicast Protocols
+
+This memo discusses some of these unresolved issues, and provides a
+high-level design for a new multicast transport protocol, group address
+and membership authority, and modifications to existing routing
+protocols.  This memo provides information for the Internet community.
+It does not specify an Internet standard.
+
+
+1457    Housley      May 93   Security Label Framework for the
+                              Internet
+
+This memo presents a security labeling framework for the Internet.  The
+framework is intended to help protocol designers determine what, if any,
+security labeling should be supported by their protocols.  This memo
+provides information for the Internet community.  It does not specify an
+Internet standard.
+
+
+1456    V.S.W.G.     May 93   Conventions for Encoding the Vietnamese
+                              Language VISCII: VIetnamese Standard
+                              Code for Information Interchange VIQR:
+                              Vietnamese Quoted-Readable Specification
+                              Revision 1.1
+
+This document provides information to the Internet community on the
+currently used conventions for encoding Vietnamese characters into 7-bit
+US ASCII and in an 8-bit form.  This memo provides information for the
+Internet community.  It does not specify an Internet standard.
+
+
+1455    Eastlake     May 93   Physical Link Security Type of Service
+
+This RFC documents an experimental protocol providing a Type of Service
+(TOS) to request maximum physical link security.  This is an addition to
+the types of service enumerated in RFC 1349: Type of Service in the
+Internet Protocol Suite.  This memo defines an Experimental Protocol for
+the Internet community.
+
+
+
+
+
+
+Elliott                      Informational                     [Page 10]
+
+RFC 1499                  Summary of 1400-1499              January 1997
+
+
+1454    Dixon        May 93   Comparison of Proposals for Next Version
+                              of IP
+
+This is a slightly edited reprint of RARE Technical Report (RTC(93)004).
+This memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+1453    Chimiak      Apr 93   A Comment on Packet Video Remote
+                              Conferencing and the Transport/Network
+                              Layers
+
+This RFC is a vehicle to inform the Internet community about XTP as it
+benefits from past Internet activity and targets general-purpose
+applications and multimedia applications with the emerging ATM networks
+in mind.  This memo provides information for the Internet community.  It
+does not specify an Internet standard.
+
+
+1452    Case         Apr 93   Coexistence between version 1 and
+                              version 2 of the Internet-standard
+                              Network Management Framework
+
+The purpose of this document is to describe coexistence between version
+2 of the Internet-standard Network Management Framework, termed the SNMP
+version 2 framework (SNMPv2) [1], and the original Internet-standard
+Network Management Framework (SNMPv1).  [STANDARDS-TRACK]
+
+
+1451    Case         Apr 93   Manager-to-Manager
+                              Management Information Base
+
+It is the purpose of this document to define managed objects which
+describe the behavior of a SNMPv2 entity acting in both a manager role
+and an agent role.  [STANDARDS-TRACK]
+
+
+1450    Case         Apr 93   Management Information Base for version
+                              2 of the Simple Network Management
+                              Protocol (SNMPv2)
+
+It is the purpose of this document to define managed objects which
+describe the behavior of a SNMPv2 entity.  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 11]
+
+RFC 1499                  Summary of 1400-1499              January 1997
+
+
+1449    Case         Apr 93   Transport Mapplings for version 2 of the
+                              Simple Network Management Protocol
+                              (SNMPv2)
+
+It is the purpose of this document to define how the SNMPv2 maps onto an
+initial set of transport domains.  [STANDARDS-TRACK]
+
+
+1448    Case         Apr 93   Protocol Operations for version 2 of the
+                              Simple Network Management Protocol
+                              (SNMPv2)
+
+It is the purpose of this document, Protocol Operations for SNMPv2, to
+define the operations of the protocol with respect to the sending and
+receiving of the PDUs.  [STANDARDS-TRACK]
+
+
+1447    McCloghrie   Apr 93   Party MIB for version 2 of the Simple
+                              Network Management Protocol (SNMPv2)
+
+The Administrative Model for SNMPv2 document [3] defines the properties
+associated with SNMPv2 parties, SNMPv2 contexts, and access control
+policies.  It is the purpose of this document, the Party MIB for SNMPv2,
+to define managed objects which correspond to these properties.
+[STANDARDS-TRACK]
+
+
+1446    Galvin       Apr 93   Security Protocols for version 2 of the
+                              Simple Network Management Protocol
+                              (SNMPv2)
+
+It is the purpose of this document, Security Protocols for SNMPv2, to
+define one such authentication and one such privacy protocol.
+[STANDARDS-TRACK]
+
+
+1445    Galvin       Apr 93   Administrative Model for version 2 of
+                              the Simple Network Management Protocol
+                              (SNMPv2)
+
+It is the purpose of this document, the Administrative Model for SNMPv2,
+to define how the administrative framework is applied to realize
+effective network management in a variety of configurations and
+environments.  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 12]
+
+RFC 1499                  Summary of 1400-1499              January 1997
+
+
+1444    Case         Apr 93   Conformance Statements for version 2 of
+                              the Simple Network Management Protocol
+                              (SNMPv2)
+
+It may be useful to define the acceptable lower-bounds of
+implementation, along with the actual level of implementation achieved.
+It is the purpose of this document to define the notation used for these
+purposes.  [STANDARDS-TRACK]
+
+
+1443    Case         Apr 93   Textual Conventions for version 2 of the
+                              Simple Network Management Protocol
+                              (SNMPv2)
+
+It is the purpose of this document to define the initial set of textual
+conventions available to all MIB modules.  [STANDARDS-TRACK]
+
+
+1442    Case         Apr 93   Structure of Management Information for
+                              version 2 of the Simple Network
+                              Management Protocol (SNMPv2)
+
+Management information is viewed as a collection of managed objects,
+residing in a virtual information store, termed the Management
+Information Base (MIB).  Collections of related objects are defined in
+MIB modules.  These modules are written using a subset of OSI's Abstract
+Syntax Notation One (ASN.1) [1].  It is the purpose of this document,
+the Structure of Management Information (SMI), to define that subset.
+[STANDARDS-TRACK]
+
+
+1441    Case         Apr 93   Introduction to version 2 of the
+                              Internet-standard Network Management
+                              Framework
+
+The purpose of this document is to provide an overview of version 2 of
+the Internet-standard Network Management Framework, termed the SNMP
+version 2 framework (SNMPv2).  [STANDARDS-TRACK]
+
+
+1440    Troth        Jul 93   SIFT/UFT: Sender-Initiated/Unsolicited
+                              File Transfer
+
+This document describes a Sender-Initiated File Transfer (SIFT)
+protocol, also commonly called Unsolicited File Transfer (UFT) protocol.
+This memo defines an Experimental Protocol for the Internet community.
+
+
+
+
+
+Elliott                      Informational                     [Page 13]
+
+RFC 1499                  Summary of 1400-1499              January 1997
+
+
+1439    Finseth      Mar 93   The Uniqueness of Unique Identifiers
+
+This RFC provides information that may be useful when selecting a method
+to use for assigning unique identifiers to people.  This memo provides
+information for the Internet community.  It does not specify an Internet
+standard.
+
+
+1438    Chapin       Apr 93   IETF Statements Of Boredom (SOB)s
+
+This document creates a new subseries of RFCs, entitled, IETF Statements
+Of Boredom (SOBs).  This memo provides information for the Internet
+community.  It does not specify an Internet standard.
+
+
+1437    Borenstein   Apr 93   The Extension of MIME Content-Types to a
+                              New Medium
+
+This document defines one particular type of MIME data, the matter-
+transport/sentient-life-form type.  This memo provides information for
+the Internet community.  It does not specify an Internet standard.
+
+
+1436    Anklesaria   Mar 93   The Internet Gopher Protocol
+
+This document describes the protocol, lists some of the implementations
+currently available, and has an overview of how to implement new client
+and server applications.  This memo provides information for the
+Internet community.  It does not specify an Internet standard.
+
+
+1435    Knowles      Mar 93   IESG Advice from Experience with Path
+                              MTU Discovery
+
+In the course of reviewing the MTU Discovery protocol for possible
+elevation to Draft Standard, a specific operational problem was
+uncovered.  The problem results from the optional suppression of ICMP
+messages implemented in some routers.  This memo outlines a modification
+to this practice to allow the correct functioning of MTU Discovery.
+This memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 14]
+
+RFC 1499                  Summary of 1400-1499              January 1997
+
+
+1434    Dixon        Mar 93   Data Link Switching: Switch-to-Switch
+                              Protocol
+
+This RFC describes IBM's support of Data Link Switching over TCP/IP.
+This memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+1433    Garrett      Mar 93   Directed ARP
+
+Directed ARP is a dynamic address resolution procedure that enables
+hosts and routers to resolve advertised potential next-hop IP addresses
+on foreign IP networks to their associated link level addresses.  This
+memo defines an Experimental Protocol for the Internet community.
+
+
+1432    Quarterman   Mar 93   Recent Internet Books
+
+Here is a list of books related to using the Internet.  This memo
+provides information for the Internet community.  It does not specify an
+Internet standard.
+
+
+1431    Barker       Feb 93   DUA Metrics
+
+This document defines a set of criteria by which a DUA implementation,
+or more precisely a Directory user interface, may be judged.  This memo
+provides information for the Internet community.  It does not specify an
+Internet standard.
+
+
+1430    Kille        Feb 93   A Strategic Plan for Deploying an
+                              Internet X.500 Directory Service
+
+This document describes an overall strategy for deploying a Directory
+Service on the Internet, based on the OSI X.500 Directory Service.  This
+memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+1429    Thomas       Feb 93   Listserv Distribute Protocol
+
+This memo specifies a subset of the distribution protocol used by the
+BITNET LISTSERV to deliver mail messages to large amounts of recipients.
+This memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+
+
+
+Elliott                      Informational                     [Page 15]
+
+RFC 1499                  Summary of 1400-1499              January 1997
+
+
+1428    Vaudreuil    Feb 93   Transition of Internet Mail from
+                              Just-Send-8 to 8bit-SMTP/MIME
+
+This document outlines the problems in this environment and an approach
+to minimizing the cost of transition from current usage of non-MIME 8bit
+messages to MIME.  This RFC provides information for the Internet
+community.  It does not specify an Internet standard.
+
+
+1427    Klensin      Feb 93   SMTP Service Extension
+                              for Message Size Declaration
+
+This memo defines an extension to the SMTP service whereby an SMTP
+client and server may interact to give the server an opportunity to
+decline to accept a message (perhaps temporarily) based on the client's
+estimate of the message size.  [STANDARDS-TRACK]
+
+
+1426    Klensin      Feb 93   SMTP Service Extension
+                              for 8bit-MIMEtransport
+
+This memo defines an extension to the SMTP service whereby an SMTP
+content body containing octets outside of the US ASCII octet range (hex
+00-7F) may be relayed using SMTP.  [STANDARDS-TRACK]
+
+
+1425    Klensin      Feb 93   SMTP Service Extensions
+
+This memo defines a framework for extending the SMTP service by defining
+a means whereby a server SMTP can inform a client SMTP as to the service
+extensions it supports.  [STANDARDS-TRACK]
+
+
+1424    Kaliski       Feb 93   Privacy Enhancement for Internet
+                               Electronic Mail:  Part IV: Key
+                               Certification and Related Services
+
+This document describes three types of service in support of Internet
+Privacy-Enhanced Mail (PEM) [1-3]: key certification, certificate-
+revocation list (CRL) storage, and CRL retrieval.  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 16]
+
+RFC 1499                  Summary of 1400-1499              January 1997
+
+
+1423    Balenson      Feb 93   Privacy Enhancement for Internet
+                               Electronic Mail:  Part III: Algorithms,
+                               Modes, and Identifiers
+
+This document provides definitions, formats, references, and citations
+for cryptographic algorithms, usage modes, and associated identifiers
+and parameters used in support of Privacy Enhanced Mail (PEM) in the
+Internet community.  [STANDARDS-TRACK]
+
+
+1422    Kent          Feb 93   Privacy Enhancement for Internet
+                               Electronic Mail:  Part II:
+                               Certificate-Based Key Management
+
+This is one of a series of documents defining privacy enhancement
+mechanisms for electronic mail transferred using Internet mail
+protocols.  [STANDARDS-TRACK]
+
+
+1421    Linn          Feb 93   Privacy Enhancement for Internet
+                               Electronic Mail:  Part I: Message
+                               Encryption and Authentication
+                               Procedures
+
+This document defines message encryption and authentication procedures,
+in order to provide privacy-enhanced mail (PEM) services for electronic
+mail transfer in the Internet.  [STANDARDS-TRACK]
+
+
+1420    Bostock       Mar 93   SNMP over IPX
+
+This document defines a convention for encapsulating Simple Network
+Management Protocol (SNMP) [1] packets over the transport mechanism
+provided via the Internetwork Packet Exchange (IPX) protocol [2].
+[STANDARDS-TRACK]
+
+
+1419    Minshall      Mar 93   SNMP over AppleTalk
+
+This memo describes the method by which the Simple Network Management
+Protocol (SNMP) as specified in [1] can be used over AppleTalk protocols
+[2] instead of the Internet UDP/IP protocol stack.  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 17]
+
+RFC 1499                  Summary of 1400-1499              January 1997
+
+
+1418    Rose          Mar 93   SNMP over OSI
+
+This memo addresses some concerns by defining a framework for running
+the SNMP in an environment which supports the OSI connectionless-mode
+transport service.  [STANDARDS-TRACK]
+
+
+1417    N.A.D.F.      Feb 93   NADF Standing Documents:
+                               A Brief Overview
+
+The purpose of this document is to provide a brief overview of the
+NADF's Standing Document series.  This memo provides information for the
+Internet community.  It does not specify an Internet standard.
+
+
+1416    Borman        Feb 93   Telnet Authentication Option
+
+This RFC 1416 replaces RFC 1409, which has an important typographical
+error in the example on page 6 (one occurance of "REPLY" should be
+"IS").  This memo defines an Experimental Protocol for the Internet
+community.
+
+
+1415    Mindel        Jan 93   FTP-FTAM Gateway Specification
+
+This memo describes a dual protocol stack application layer gateway that
+performs protocol translation, in an interactive environment, between
+the FTP and FTAM file transfer protocols.  [STANDARDS-TRACK]
+
+
+1414    St. Johns     Feb 93   Identification MIB
+
+This memo defines a MIB for use with identifying the users associated
+with TCP connections.  It provides functionality approximately
+equivalent to that provided by the protocol defined in RFC 1413 [1].
+[STANDARDS-TRACK]
+
+
+1413    St. Johns     Feb 93   Identification Protocol
+
+The Identification Protocol was formerly called the Authentication
+Server Protocol.  It has been renamed to better reflect its function.
+[STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 18]
+
+RFC 1499                  Summary of 1400-1499              January 1997
+
+
+1412    Alagappan     Jan 93   Telnet Authentication: SPX
+
+This memo defines an Experimental Protocol for the Internet community.
+
+
+1411    Borman        Jan 93   Telnet Authentication:
+                               Kerberos Version 4
+
+This memo defines an Experimental Protocol for the Internet community.
+
+
+1410    I.A.B         Mar 93   IAB OFFICIAL PROTOCOL STANDARDS
+
+This memo describes the state of standardization of protocols used in
+the Internet as determined by the Internet Architecture Board (IAB).
+
+
+1409    Borman        Jan 93   Telnet Authentication Option
+
+This memo defines an Experimental Protocol for the Internet community.
+
+
+1408    Borman        Jan 93   Telnet Environment Option
+
+This document specifies a mechanism for passing environment information
+between a telnet client and server.  [STANDARDS-TRACK]
+
+
+1407    Cox           Jan 93   Definitions of Managed Objects for the
+                               DS3/E3 Interface Type
+
+This memo defines an extension to the Management Information Base (MIB)
+for use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing DS3 and E3 Interfaces.
+[STANDARDS-TRACK]
+
+
+1406    Basker        Jan 93   Definitions of Managed Objects for the
+                               DS1 and E1 Interface Types
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing DS1 Interfaces -- including
+both T1 and E1 (a.k.a., CEPT 2 Mbit/s) links.  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 19]
+
+RFC 1499                  Summary of 1400-1499              January 1997
+
+
+1405    Allocchio     Jan 93   Mapping between X.400(1984/1988) and
+                               Mail-11 (DECnet mail)
+
+This document describes a set of mappings which will enable inter
+working between systems operating the CCITT X.400 ( 1984 / 1988 )
+Recommendations on Message Handling Systems, and systems running the
+Mail-11 (also known as DECnet mail) protocol.  This memo defines an
+Experimental Protocol for the Internet community.
+
+
+1404    Stockman      Jan 93   A Model for Common Operational
+                               Statistics
+
+This memo describes a model for operational statistics in the Internet.
+It gives recommendations for metrics, measurements, polling periods,
+storage formats and presentation formats.  This memo provides
+information for the Internet community.  It does not specify an Internet
+standard.
+
+
+1403    Varadhan      Jan 93   BGP OSPF Interaction
+
+This memo defines the various criteria to be used when designing an
+Autonomous System Border Routers (ASBR) that will run BGP with other
+ASBRs external to the AS and OSPF as its IGP.  [STANDARDS-TRACK]
+
+
+1402    Martin        Jan 93   There's Gold in them thar Networks!
+                               Searching for Treasure in all the Wrong
+                               Places
+
+The ultimate goal is to make the route to these sources of information
+invisible to you.  At present, this is not easy to do.  I will explain
+some of the techniques that can be used to make these nuggets easier to
+pick up so that we all can be richer.  This RFC provides information for
+the Internet community.  It does not specify an Internet standard.
+
+
+1401    I.A.B.        Jan 93   Correspondence between the IAB and DISA
+                               on the use of DNS throughout the
+                               Internet
+
+This memo reproduces three letters exchanged between the Internet
+Activities Board (IAB) and the Defense Information Systems Agency (DISA)
+regarding the importance of using the Domain Name System (DNS)
+throughout the Internet, and phasing out the use of older host name to
+address tables, such as "hosts.txt".  This memo provides information for
+the Internet community.  It does not specify an Internet standard.
+
+
+
+Elliott                      Informational                     [Page 20]
+
+RFC 1499                  Summary of 1400-1499              January 1997
+
+
+1400    Williamson    Mar 93   Transition and Modernization
+                               of the Internet Registration Service
+
+As a result of the NREN NIS award by National Science Foundation, non-
+DDN registration services will soon be transferred from the DDN NIC to
+the new Internet Registration Service, which is a part of an entity
+referred to as the InterNIC.  This memo provides information for the
+Internet community.  It does not specify an Internet standard.
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Author's Address
+
+   Josh Elliott
+   University of Southern California
+   Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone:  (310) 822-1511
+
+   EMail: elliott@isi.edu
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 21]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1499.txt](<www.ietf.org/rfc/rfc1499.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
