### PR TITLE
Archive rfc15.txt

### DIFF
--- a/www.ietf.org/rfc/rfc15.txt
+++ b/www.ietf.org/rfc/rfc15.txt
@@ -1,0 +1,283 @@
+
+
+
+
+
+
+Network Working Group                                   C. Stephen Carr
+Request for Comments: 15                                           UTAH
+                                                      25 September 1969
+
+                Network Subsystem for Time Sharing Hosts
+
+
+Introduction
+
+   A set of network primitives has been defined (Network Working Group
+   Note 11) for inclusion in the monitor systems of the respective
+   HOSTS.  These primitives are at the level of system calls: SPOP's or
+   BRS's on the 940; UUO's on the PDP-10.  Presumably these UUO's are
+   accessible to all user programs when executing for users whose status
+   bits allow network access.
+
+   In addition to user program access, a convenient means for direct
+   network access from the terminal is desirable.  A sub-system called
+   "Telnet" is proposed which is a shell program around the network
+   system primitives, allowing a teletype or similar terminal at a
+   remote host to function as a teletype at the serving host.
+
+System Primitives
+
+   G. Deloche of U.C.L.A. has documented a proposed set of basic network
+   primitives for inclusion in the operating systems of the respective
+   HOSTs (NWG Note:  11).  The primitives are:
+
+      Open primary connection
+
+      Open auxiliary connection
+
+      Transmit over connection
+
+      Close connection.
+
+   The details  and terminology are defined by Deloche and others in
+   previous memos.  The primitives are system calls, available to
+   programmers, and are most likely a part of the resident monitor,
+   rather than the swappable executive.
+
+Basic Terminal Access
+
+   In addition to user programming access, it is desirable to have a
+   subsystem program at each HOST which makes the network immediately
+   accessible from the teletype without special programming.  Subsystems
+   are commonly used system components such as text editors, compilers
+   and interpreters.  The first network-related subsystem should allow
+
+
+
+Carr                                                            [Page 1]
+
+RFC 15          Network Subsystem for Time Sharing Hosts  September 1969
+
+
+   users at HOST A to connect to HOST B and appear as a regular terminal
+   user to HOST B.  It is expected that more sophisticated subsystems
+   will be developed in time, but this basic one will render the early
+   net immediately useful.
+
+    Teletype
+    Terminal        ______                                 ________
+    _________      |      |     ______          ______    |        |
+   |         |     | USER |    |      |        |      |   |SERVING |
+   |         |-----| HOST |----|      |---//---|      |---| HOST   |
+   |_________|     |  A   |    |      |        |      |   |  B     |
+                   |______|    |______|        |______|   |________|
+                  University                               Stanford
+                   of Utah                                 Research
+                                                           Institute
+
+   Figure 1:  User accesses distant serving HOST via shunt
+              subsystem in his own Host computer.
+
+
+Simple Dialogue -- PDP-10 to 940
+
+   A user at Utah is sitting at a teletype dialed into the University's
+   dual PDP-10's.  He wishes to operate the CAL sub-system on the 940 at
+   SRI in Menlo Park, California.
+
+   .LOGIN<CR>                          PDP-10 login
+    ---------
+
+   .R TELNET<CR>                       The PDP-10 run command
+    ------------                       is issued to call and start
+                                       the TELNET subsystem.
+   *ESCAPE CHARACTER IS #<CR>          The user indicates an escape
+    -------------------------          character which TELNET
+                                       will watch for in subsequent
+                                       input from the user.
+
+   *CONNECT TO SRI<CR>                 The TELNET subsystem will make
+    ------------------                 the appropriate system call
+                                       (UUO) to establish a primary
+                                       connection.  The connection
+                                       will be established, provided:
+                                       1.  SRI is willing to accept
+                                       another foreign user;
+                                       2.  The UTAH user is cleared
+                                       for network access at UTAH.
+                                       This is determined by a
+                                       status word kept in the PDP-10
+
+
+
+Carr                                                            [Page 2]
+
+RFC 15          Network Subsystem for Time Sharing Hosts  September 1969
+
+
+                                       monitor for each user.
+
+   @LOGIN CARR.                        The user logs in SRI.
+    --    -----
+
+   Characters typed on the user's teletype are transmitted unaltered
+   through the PDP-10 (user Host) and on to the 940 (serving HOST.)
+   (The exception to this is a possible one-for-one code conversion
+   required between the UCLA Sigma 7 and the PDP-10, for example).
+
+   @CAL.                               The PDP-10 TELNET subsystem
+    -  -                               switches to full duplex,
+                                       character-by-character
+                                       transmission, since this is
+                                       required by 940's.  Characters
+                                       typed by the user are
+                                       underlined. Full duplex
+                                       operation is allowed for by
+                                       the PDP-10, though not used
+                                       by most DEC subsystems.
+
+   The user wishes to load a CAL file into 940 CAL from the file system
+   on his local PDP-10.
+
+   CAL AT YOUR SERVICE
+   >READ FILE FROM NETWRK.             'NETWRK' is a predefined
+    ----------------------             940 name similar to PAPER
+                                       TAPE OR TELETYPE.  The 940
+                                       file opening BRS is set to
+                                       expect an auxiliary connection
+                                       and the file from UTAH.
+
+   #NETWRK: <- DSK:MYFILE.CAL<CR>      The user types the prescribed
+    -----------------------------      escape character, followed by
+                                       the TELNET command, to send
+                                       the desired file to SRI on an
+                                       auxiliary connection.  The
+                                       user's next statement is in
+                                       CAL again.
+
+The Telnet Subsystem
+
+   The Telnet subsystem coding should fit easily into one core page, for
+   it does very little.  It effectively establishes a shunt in the user
+   HOST between the remote user and the serving HOST.  Telnet commands
+   are:
+
+
+
+
+
+Carr                                                            [Page 3]
+
+RFC 15          Network Subsystem for Time Sharing Hosts  September 1969
+
+
+   ESCAPE CHAR IS ___________<CR>      Declares a character which
+                                       Telnet will watch for.
+                                       Subsequent strings typed
+                                       between this character and
+                                       a carriage return are not
+                                       shunted through to the serving
+                                       host, but sent instead to the
+                                       Telnet program in the user's
+                                       local HOST.
+
+   This escape character is not the same as the user's host
+   rubout character.
+
+   CONNECT TO __________________<CR>   The official site name of the
+                                       desired serving HOST is typed
+                                       (i.e.: SRI, UTAH, UCLA, UCSB).
+                                       Telnet attempts to establish a
+                                       connection.  If the attempt is
+                                       successful, the following
+                                       characters are shunted through
+                                       the user's local machine.  The
+                                       connection places the user in
+                                       the pre-logged in state at
+                                       the serving HOST.
+
+   LOGOUT<CR>                          Telnet issues the logout command
+                                       sequence to the serving HOST.
+                                       If the user simply rubs out and
+                                       kills his PDP-10 job, the
+                                       PDP-10 will indicate to the 940
+                                       that the connection is closed.
+                                       The 940 system primitives do
+                                       whatever they do when a normal
+                                       dataphone connection is
+                                       suddenly broken.
+
+   COPY FILE                           A file copying command is
+                                       available in TELNET to
+                                       move data along on auxiliary
+                                       connections from the
+                                       user's HOST file system
+                                       to the serving HOST.
+
+
+
+
+
+
+
+
+
+Carr                                                            [Page 4]
+
+RFC 15          Network Subsystem for Time Sharing Hosts  September 1969
+
+
+        On the 940 this is:
+
+   COPY <file name> TO NETWRK.
+   -                   -     -
+
+        On the PDP-10:
+
+   NETWRK <- DSK: <file name>
+   --------------------------
+
+   These TELNET commands are accepted when the TELNET subsystem is first
+   entered or following the declared escape character.
+
+CONCLUSION
+
+   Given the basic system primitives, the TELNET subsystem at the user
+   host and a manual for the serving host, the network can be
+   profitably employed by a remote user.  TELNET subsystem constitutes a
+   "level 0" network program which will quickly be surpassed.  It is,
+   however, simple enough to be working fairly soon.
+
+   [Editor's note: <CR> has been used in this document to indicate end-
+   of-line, in place of the original handwritten arrows.]
+
+
+
+
+
+         [ This RFC was put into machine readable form for entry ]
+         [ into the online RFC archives by Sergio Kleiman  9/00  ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Carr                                                            [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc15.txt](<www.ietf.org/rfc/rfc15.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
