### PR TITLE
Archive rfc152.txt

### DIFF
--- a/www.ietf.org/rfc/rfc152.txt
+++ b/www.ietf.org/rfc/rfc152.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                            M. Wilber
+Request for Comments #152                                        10 May 71
+NIC #6756                                                        SRAI
+Category: G.3
+Obsoletes: None
+Updates: None
+
+Response to RFC #116
+
+
+                SRI ARTIFICIAL INTELLIGENCE STATUS REPORT
+
+
+     The Stanford Research Institute's Artificial Intelligence Group (SRAI
+in the four-letter abbreviations) expects connection to the ARPA net as a
+research center after conversion this summer to a TENEX from our current
+PDP-10. Our connection will be through the IMP already at SRI for the
+Network Information Center and through a PDP-15 serving our PDP-10 as a
+controller of peripherals. Our hardware interface to the IMP is currently
+in the bidding process, and we intend to use as much as possible of the
+TENEX network software. (Probably all we will need to change is the lowest
+level, most strongly hardware-oriented part of the NCP.)
+
+     The most optimistic estimate we can give for functional connection to
+the network is mid-July 1971. We are currently devoting the energies of
+our system support group to the accomodation of various hardware and design
+changes, and so our contact with the Network Working Group has been only
+minimal and passive. It is entirely conceivable that we may find our par-
+ticipation tending to strength and activeness as we cross our other bridges.
+
+     We can project our participation in the network into the first few
+months of our connection. We can support several simultaneous outside
+users on a system nominally up during the business day and often up at
+other times. Lapses in continuity of system operation are usually due to
+scheduled maintenance or hardware failures and tend to occur at intervals
+of either an hour or several days with remarkable consistency. The prin-
+cipal service we offer to other network participants is the availability
+of various parts of our own research software. The most notable examples
+are QA3.6, a first-order resolution theorem prover;  STRIPS, an extra-
+logical problem solver;  and possibly QA4, a language oriented toward
+problem-solving strategies. The services we can anticipate requesting
+of the network are of two kinds: We could conceivably use other people's
+artificial intelligence programs on a trial basis; and we might use the
+network to make occasional contact with other people in the network.
+
+        [ This RFC was put into machine readable form for entry ]
+        [ into the online RFC archives by BBN Corp. under the   ]
+        [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+Kreznar                                                         [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc152.txt](<www.ietf.org/rfc/rfc152.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
