### PR TITLE
Archive rfc155.txt

### DIFF
--- a/www.ietf.org/rfc/rfc155.txt
+++ b/www.ietf.org/rfc/rfc155.txt
@@ -1,0 +1,720 @@
+
+
+
+
+
+
+ARPA NETWORK MAILING LISTS      May 1971        RFC 155         NIC 6760
+
+                        LIST TO RECEIVE RFC'S
+
+Note:  This list includes all Network Liaisons and others who should
+receive initial distribution of formal documents.  It supersedes RFC 95,
+and corresponds to Current Directory of Network Participants, NIC 5799.
+
+
+
+AMES                                    CCA
+
+James A. Jeske                          Richard Winter
+Mail Stop 233-10                        Computer Corporation of America
+NASA Ames Research Center               565 Technology Square
+Moffett Field, Calif. 94035             Cambridge, Mass. 02139
+
+ARC                                     CMU
+
+John T. Melvin                          Harold R. Van Zoeren
+Stanford Research Institute             Carnegie-Mellon University
+Augmentation Research Center            Computer Science Department
+333 Ravenswood Avenue                   Schenley Park
+Menlo Park, Calif. 94025                Pittsburgh, Pa 15213
+
+                                        HARV
+
+Richard W. Watson                       Robert Sundberg
+Stanford Research Institute             Harvard University
+Augmentation Research Center            Aiken Computation Laboratory
+333 Ravenswood Avenue                   33 Oxford Street
+Menlo Park, Calif. 94025                Cambridge, Mass. 02138
+
+                                        ILL
+
+Jeanne B. North                         James Madden
+Stanford Research Institute             University of Illinois
+Augmentation Research Center            Center for Advanced Computation
+333 Ravenswood Avenue                   168 Engineering Research Laboratory
+Menlo Park, Calif. 94025                Urbana, Illinois 61801
+
+ARPA                                    LINC
+
+Dr. Lawrence G. Roberts                 Joel Winett (for the 360)
+Advanced Research Projects Agency       Massachusetts Institute of Technology
+1400 Wilson Boulevard                   Lincoln Laboratory
+Arlington, Virginia 22209               244 Wood Street
+                                        Lexington, Mass. 02173
+
+
+
+
+
+
+
+
+
+
+
+
+<continuation of first page of original document>
+
+BBN-SCI                                 William Kantrowitz (for the TX-2)
+                                        Massachusetts Institute of Technology
+Dan Murphy                              Lincoln Laboratory
+Bolt Beranek and Newman Inc.            244 Wood Street
+50 Moulton Street                       Lexington, Mass 02173
+Cambridge, Mass. 02138
+                                        MAC
+BBN-SYS
+                                        Albert Vezza
+Alex McKenzie                           Massachusetts Institute of Technology
+Bolt Beranek and Newman Inc.            Project MAC
+50 Moulton Street                       545 Technology Square
+Cambridge, Mass. 02138                  Cambridge, Mass. 02139
+
+CASE                                    MITRE
+
+John Barden                             David Wood
+Case Western Reserve University         MITRE Corporation
+Computing and Information Sciences      Information Systems Dept., W140
+Room 222, Crawford Hall                 Westgate Research Park
+10900 Euclid Avenue                     McLean, Va. 22101
+Cleveland, Ohio 44106
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+NETWORK MAILING LISTS   May 1971        RFC 155    NIC 6760
+
+NBS                                     UCLA-NMC
+
+Thomas N Pyke, Jr.                      Ari Ollikainen
+National Bureau of Standards            University of California at Los Angeles
+Center for Computer Sciences and        Computer Science Department
+   Technology                           3732 Boelter Hall
+Washington, D.C. 20234                  Los Angeles, Calif. 90024
+
+RADC                                    Steve Crocker (for ARPA Office Liaison)
+                                        University of California at Los Angeles
+Thomas Lawrence                         Computer Science Department
+Rome Air Development Center (ISIM)      3732 Boelter Hall
+Griffiss Air Force Base                 Los Angeles, Calif. 90024
+Rome, New York  13440
+
+RAND                                    UCSB
+
+John Heafner                            James White
+Rand Corporation                        University of California at Santa
+Computer Science Department                Barbara
+1700 Main Street                        Computer Research Laboratory
+Santa Monica, Calif. 90406              Santa Barbara, Calif. 93106
+
+SDC                                     USC
+
+Abe Landsberg                           Dr. Richard E. Kaplan
+System Development Corporation          University of Southern California
+2500 Colorado Avenue                    School of Engineering
+Santa Monica, Calif. 90406              Los Angeles, Calif. 90007
+
+SRIAI                                   UTAH
+
+Michael Wilber                          Barry D. Wessler
+Stanford Research Institute             University of Utah
+Artificial Intelligence Group           Computer Science/IRL
+333 Ravenswood Avenue                   Salt Lake City, Utah 84112
+Menlo Park, Calif. 94025
+
+SU-AI
+
+James A. (Andy) Moorer
+Stanford University
+Computation Center, AI Project
+Stanford, Calif. 94305
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+SU-HP
+
+Edward A. Feigenbaum
+Stanford University, Heuristic Programming
+Department of Computer Science
+Serra House
+Stanford, Calif. 94305
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<continuation of second page of original document>
+
+UCLA-CCN
+
+Robert Braden
+University of California at Los Angeles
+5306 Math Sciences Building
+Los Angeles, Calif. 90024
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+NETWORK MAILING LISTS   May 1971        RFC 155         NIC 6760
+
+                        Current RFC addressees not sites:
+
+BCC
+
+Charles Simonyi
+Berkeley Computer Corporation
+2131 - 4th Street
+Berkeley, Calif. 94710
+
+CCCTF
+
+C. D. Shepard
+Canadian Computer Communications Task Force
+100 Metcalfe Street
+4th Floor
+Ottawa 2,
+Canada
+
+EDUCOM
+
+John Le Gates
+EDUCOM
+100 Charles River Plaza
+Boston, Mass. 02114
+
+IBMW
+
+Douglas McKay
+IBM Watson Research Center
+P. O. Box 218
+Yorktown Heights, New York 10598
+
+MERIT
+
+Alfred Cocanower
+MERIT Computer Network
+611 Church Street
+Ann Arbor, Michigan 48104
+
+RAY
+
+Thomas O'Sullivan
+Raytheon Data Systems
+1415 Boston-Providence Turnpike
+Norwood, Mass. 02062
+
+
+
+
+
+
+
+
+
+
+
+
+
+WASHU
+
+Marianne Pepper
+Washington University
+Computer Systems Laboratory
+724 South Euclid Avenue
+St. Louis, Mo. 63110
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+NETWORK MAILING LISTS   May 1971        RFC 155         NIC 6760
+
+                     NIC STATION AGENTS:
+
+AMES                                     ILL
+
+Stan Golding                             Nan Brown
+Mail Stop 233-13                         University of Illinois
+NASA Ames Research Center                Center for Advanced Computation
+Moffett Field, Calif. 94035              168 Engineering Research Laboratory
+                                         Urbana, Ill. 61801
+ARC
+                                         LINC
+Cindy Page
+Stanford Research Institute              Carol Mostrom
+Augmentation Research Center             Massachusetts Institute of Technology
+333 Ravenswood Ave.                      Lincoln Laboratory
+Menlo Park, Calif. 94025                 244 Wood Street
+                                         Lexington, Mass. 02173
+ARPA
+                                         MAC
+Margaret Goering
+Advanced Research Projects Agency        Frances L. Yost
+1400 Wilson Boulevard                    Massachusetts Institute of Technology
+Arlington, Va. 22209                     Project MAC
+                                         545 Technology Square
+BBN-SCI                                  Cambridge, Mass. 02139
+
+Steve Chipman                            MITRE
+Bolt Beranek and Newman Inc.
+50 Moulton Street                        David Wood
+Cambridge, Mass. 02138                   Mitre Corporation
+                                         Information Systems Dept. W140
+BBN-SYS                                  Westgate Research Park
+                                         McLean, Va. 22101
+See BBN-SCI
+                                         NBS
+CASE
+                                         Mrs. Shirley Watkins
+John Harden                              National Bureau of Standards
+Case Western Reserve University          Bldg. 255, Room B216
+Computing and Information Sciences       Washington, D.C. 20234
+10900 Euclid Ave.
+Cleveland, Ohio 44106                    RADC
+
+CCA                                      Marcelle Petell
+                                         Rome Air Development Center (ISIM)
+Martha Ginsberg                          Griffiss Air Force Base
+
+
+
+
+
+
+
+
+
+
+
+
+Computer Corporation of America          Rome, New York 13440
+565 Technology Square
+Cambridge, Mass. 02139
+                                         RAND
+CMU
+                                         Linda Connelly
+Carolyn Lisle                            Rand Corporation
+Carnegie-Mellon University               Computer Science Department
+Computer Science Department              1700 Main Street
+Schenley Park                            Santa Monica, Calif. 90406
+Pittsburgh, Pa. 15213
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<continuation of 4th page of original document>
+
+                                         SDC
+HARV
+                                         Judith C. Needham
+Robert Sundberg                          System Development Corporation
+Harvard University                       Information Processing Information
+Aiken Computation Laboratory                Center
+33 Oxford Street                         2500 Colorado Avenue
+Cambridge, MA 02138                      Santa Monica, Calif. 90406
+NETWORK MAILING LISTS   May 1971        RFC 155         NIC 6760
+
+SRAI
+
+Rilla Reynolds
+Stanford Research Institute
+Artificial Intelligence Group
+333 Ravenswood Avenue
+Menlo Park, Calif. 94025
+
+SU-AI
+
+Barbara Barnett
+Stanford University
+Artificial Intelligence Project
+D.C. Power Lab
+Stanford, Calif. 94305
+
+SU-HP
+
+Carol Wilkinson
+Stanford University
+Serra House
+Heuristic Programming Project
+Stanford, Calif. 94305
+
+UCLA-CCN
+
+Imogen Beattie
+University of California at Los Angeles
+3531 Boelter Hall
+Los Angeles, Calif. 90024
+
+UCLA-NMC
+
+Anita Coley
+University of California at Los Angeles
+Computer Science Department
+
+
+
+
+
+
+
+
+
+
+
+
+3732 Boelter Hall
+Los Angeles, Calif. 90024
+
+UCSB
+
+Elizabeth Gibson
+University of California at Santa Barbara
+Computer Research Laboratory
+Santa Barbara, Calif. 93106
+
+USC
+
+Merilee Osterboudt
+University of Southern California
+Olin Hall of Engineering
+Room 340
+Los Angeles, Calif. 90007
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<continuation of 5th page of original document>
+
+UTAH
+
+Nancy Bruderer
+University of Utah
+Computer Science/IRL
+Salt Lake City, Utah 84112
+
+
+
+
+
+
+
+
+
+
+
+
+
+        [ This RFC was put into machine readable form for entry ]
+        [ into the online RFC archives by BBN Corp. under the   ]
+        [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc155.txt](<www.ietf.org/rfc/rfc155.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
