### PR TITLE
Archive rfc156.txt

### DIFF
--- a/www.ietf.org/rfc/rfc156.txt
+++ b/www.ietf.org/rfc/rfc156.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                      J. Bouknight
+Request for Comments: 156                                 26 April 1971
+Category: G.5                                                  Illinois
+Obsoletes: None
+Updates: None
+
+
+Status of the Illinois Site (Response to RFC 0116)
+
+As of the date of the report, 26 April, the Illinois Site has complete
+operational hardware connecting the PDP-11 system with the IMP.
+
+Due to much trouble with the Burroughs B6500 computer, final checkout
+of the operating system plus the network control program for the
+PDP-11 has been seriously curtailed.  Current expectations are:
+
+     --checkout of the NCP by the latter part of May
+
+     --installation of the PDP-11 system in Paoli, PA (the operating
+       link between Illinois and Burroughs in Paoli) so that the system
+       will be operational during June
+
+
+       [ This RFC was put into machine readable form for entry ]
+          [ into the online RFC archives by Tom McGhan 7/97 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc156.txt](<www.ietf.org/rfc/rfc156.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
