### PR TITLE
Archive rfc157.txt

### DIFF
--- a/www.ietf.org/rfc/rfc157.txt
+++ b/www.ietf.org/rfc/rfc157.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                            V. Cerf
+Request for Comments: 157                                           UCLA
+NIC: 6762                                                    12 May 1971
+
+
+           Invitation to the Second Symposium on Problems in
+             the Optimization of Data Communication Systems
+
+   One session of the Symposium on problems in the optimization of data
+   communication networks is to be devoted to software for networks.  I
+   believe that the work on protocols (1st, 2nd, and 3rd level) and file
+   transmission procedures are highly relevant.  NWG participants should
+   welcome the opportunity to inject their ideas into the published
+   literature.  Many NWG/RFC's already are in good enough shape for
+   publication so don't hesitate to submit your drafts.  Time is short,
+   so prompt action is essential.
+
+   ACM IEEE
+
+                              CALL FOR PAPERS
+             SECOND SYMPOSIUM ON PROBLEMS IN THE OPTIMIZATION
+                       OF DATA COMMUNICATION SYSTEMS
+
+   SIGCOMM of ACM and the Technical Committee on Commuter Communications
+   of the IEEE Commuter Society are sponsoring the Second Symposium on
+   Problems in the Optimization of Data Communication Systems to be held
+   at Stanford University on October 20-22, 1971.  The symposium will
+   include the presentation of papers, panel discussions, and workshop
+   sessions.  The purpose is to bring together people engaged in
+   computer communication system design, analysis, and research.  The
+   setting will be one where each participant can engage in a dialogue
+   on problems of interest to him with his colleagues in the computer/
+   communications professional community.
+
+Papers are being sought in the following areas:
+
+   Advances in Data Communication Networks
+   Computer Communication Technology
+   New Applications and Applications Models
+   Software Organization for Communications
+   Systems Modeling, Evaluation, Optimization
+   Interface Problems and Standards
+
+
+
+
+
+
+
+
+
+Cerf                                                            [Page 1]
+
+RFC 157            Invitation to the Second Symposium        12 May 1971
+
+
+Full drafts:
+
+   *may not exceed 5000 words
+   *must include an informative abstract
+   Detailed information will be supplied later concerning
+   the find copy of accepted papers.
+
+   Papers should be mailed to
+
+   V. Cerf
+   3804 Boelter Hall
+   UCLA Engineering Dept.
+   405 Hilgard St.
+   Los Angeles, California
+   90024
+
+   213-825-4864
+       825-2368
+
+   NO LATER THAN JUNE 15, 1971
+
+   Notification of final approval to authors will be given by July 21,
+   1971.  Camera-ready copy of text plus figures must be received by
+   August 21, 1971.
+
+   General information can be obtained by contacting the symposium
+   chairman, P. E. JACKSON 23-434, Bell Telephone Laboratories, Holmdel,
+   New Jersey 87733 telephone (201) 949-2231.
+
+
+         [ This RFC was put into machine readable form for entry ]
+          [ into the online RFC archives by Lorrie Shiota 7/01 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Cerf                                                            [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc157.txt](<www.ietf.org/rfc/rfc157.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
