### PR TITLE
Archive rfc1599.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1599.txt
+++ b/www.ietf.org/rfc/rfc1599.txt
@@ -1,0 +1,1235 @@
+
+
+
+
+
+
+Network Working Group                                         M. Kennedy
+Request for Comments: 1599                                           ISI
+Category: Informational                                     January 1997
+
+
+                      Request for Comments Summary
+
+                        RFC Numbers 1500 - 1599
+
+Status of This Memo
+
+   This RFC is a slightly annotated list of the 100 RFCs from RFC 1500
+   through RFCs 1599.  This is a status report on these RFCs.  This memo
+   provides information for the Internet community.  It does not specify
+   an Internet standard of any kind.  Distribution of this memo is
+   unlimited.
+
+Note
+
+   Many RFCs, but not all, are Proposed Standards, Draft Standards, or
+   Standards.  Since the status of these RFCs may change during the
+   standards processing, we note here only that they are on the
+   standards track.  Please see the latest edition of "Internet Official
+   Protocol Standards" for the current state and status of these RFCs.
+   In the following, RFCs on the standards track are marked [STANDARDS-
+   TRACK].
+
+RFC     Author       Date      Title
+---     ------       ----      -----
+
+1599    Kennedy     Jan 96   Requests For Comments Summary
+
+This memo.
+
+
+1598    Simpson      Mar 94  PPP in X.25
+
+The Point-to-Point Protocol (PPP) provides a standard method for
+transporting multi-protocol datagrams over point-to-point links.  This
+document describes the use of X.25 for framing PPP encapsulated packets.
+[STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 1]
+
+RFC 1599                  Summary of 1500-1599              January 1997
+
+
+1597     Rekhter     Mar 94   Address Allocation for Private Internets
+
+This RFC describes methods to preserve IP address space by not
+allocating globally unique IP addresses to hosts private to an
+enterprise while still permitting full network layer connectivity
+between all hosts inside an enterprise as well as between all public
+hosts of different enterprises. This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+1296     Brown       Mar 94   Definitions of Managed Objects
+                              for Frame Relay Service
+
+This memo defines an extension to the Management Information Base (MIB)
+for use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing the Frame Relay Service.
+[STANDARDS-TRACK]
+
+
+1295     Brown       Mar 94   Definitions of Managed Objects
+                              for the SONET/SDH Interface Type
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing Synchronous Optical
+Network/Synchronous Digital Hierarchy (SONET/SDH) objects.  This
+document is a companion document with Definitions of Managed Objects for
+the DS1/E1 and DS3/E3 Interface Types, RFC1406 and RFC1407.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1594     Marine      Mar 94   FYI on Questions and Answers
+                              Answers to Commonly asked "New Internet
+                              User" Questions
+
+This FYI RFC is one of two FYI's called, "Questions and Answers" (Q/A).
+The goal is to document the most commonly asked questions and answers in
+the Internet. This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind. [FYI 4]
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 2]
+
+RFC 1599                  Summary of 1500-1599              January 1997
+
+
+1593     McKenzie    Mar 94   SNA APPN Node MIB
+
+This RFC describes IBM's SNMP support for SNA Advanced Peer-to-Peer
+Networking (APPN) nodes.  This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+1592      Wijnen     Mar 94   Simple Network Management Protocol
+
+This RFC describes version 2.0 of a protocol that International Business
+Machines Corporation (IBM) has been implementing in most of its SNMP
+agents to allow dynamic extension of supported MIBs. This memo defines
+an Experimental Protocol for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1591     Postel      Mar 94   Domain Name System Structure and
+                              Delegation
+
+This memo provides some information on the structure of the names in the
+Domain Name System (DNS), specifically the top-level domain names; and
+on the administration of domains. This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+1590    Postel      Mar 94   Media Type Registration Procedure
+
+Several questions have been raised about the requirements and
+administrative procedure for registering MIME content-type and subtypes,
+and the use of these Media Types for other applications.  This document
+addresses these issues and specifies a procedure for the registration of
+new Media Types (content-type/subtypes).  It also generalizes the scope
+of use of these Media Types to make it appropriate to use the same
+registrations and specifications with other applications.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+1589    Mills       Mar 94   A Kernel Model for Precision Timekeeping
+
+This memorandum describes an engineering model which implements a
+precision time-of-day function for a generic operating system. The model
+is based on the principles of disciplined oscillators and phase-lock
+loops (PLL) often found in the engineering literature. This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+
+
+Kennedy                      Informational                      [Page 3]
+
+RFC 1599                  Summary of 1500-1599              January 1997
+
+
+1588    Postel     Feb 94   White Pages Meeting Report
+
+This report describes the results of a meeting held at the November IETF
+(Internet Engineering Task Force) in Houston, TX, on November 2, 1993,
+to discuss the future of and approaches to a white pages directory
+services for the Internet. This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+1587     Coltun    Mar 94   The OSPF NSSA Option
+
+This document describes a new optional type of OSPF area, somewhat
+humorously referred to as a "not-so-stubby" area (or NSSA).  NSSAs are
+similar to the existing OSPF stub area configuration option but have the
+additional capability of importing AS external routes in a limited
+fashion. [STANDARDS-TRACK]
+
+
+1586     deSouza   Mar 94   Guidelines for Running OSPF
+                            Over Frame Relay Networks
+
+This memo specifies guidelines for implementors and users of the Open
+Shortest Path First (OSPF) routing protocol to bring about improvements
+in how the protocol runs over frame relay networks. This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+1585     Moy      Mar 94     MOSPF: Analysis and Experience
+
+This memo documents how the MOSPF protocol satisfies the requirements
+imposed on Internet routing protocols by "Internet Engineering Task
+Force internet routing protocol standardization criteria" ([RFC 1264]).
+This memo provides information for the Internet community.  This memo
+does not specify an Internet standard of any kind.
+
+
+1584     Moy       Mar 94           Multicast Extensions to OSPF
+
+This memo documents enhancements to the OSPF protocol enabling the
+routing of IP multicast datagrams. [STANDARDS-TRACK]
+
+
+1583     Moy       Mar 94           OSPF Version 2
+
+This memo documents version 2 of the OSPF protocol.  OSPF is a link-
+state routing protocol. [STANDARDS-TRACK]
+
+
+
+Kennedy                      Informational                      [Page 4]
+
+RFC 1599                  Summary of 1500-1599              January 1997
+
+
+1582     Meyer     Feb 94    Extensions to RIP to Support
+                             Demand Circuits
+
+This memo defines a generalized modification which can be applied to
+Bellman-Ford (or distance vector) algorithm information broadcasting
+protocols. [STANDARDS-TRACK]
+
+
+1581     Meyer     Feb 94    Protocol Analysis for Extensions to RIP
+                             to Support Demand Circuits
+
+As required by Routing Protocol Criteria, this report documents the key
+features of Routing over Demand Circuits on Wide Area Networks - RIP and
+the current implementation experience. This memo provides information
+for the Internet community. This memo does not specify an Internet
+standard of any kind.
+
+
+1580     EARN      Mar 94    Guide to Network Resource Tools
+
+The purpose of this guide is to supply the basic information that anyone
+on the network needs to try out and begin using tools. This memo
+provides information for the Internet community. This memo does not
+specify an Internet standard of any kind. [FYI 23]
+
+
+1579     Bellovin  Feb 94    Firewall-Friendly FTP
+
+This memo describes a suggested change to the behavior of FTP client
+programs. This document provides information for the Internet community.
+This memo provides information for the Internet community.  This memo
+does not specify an Internet standard of any kind.
+
+
+1578     Sellers   Feb 94    FYI on Questions and Answers
+                             Answers to Commonly Asked "Primary and
+                             Secondary School Internet User"
+                             Questions
+
+The goal of this FYI RFC is to document the questions most commonly
+asked about the Internet by those in the primary and secondary school
+community, and to provide pointers to sources which answer those
+questions. This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.  [FYI 22]
+
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 5]
+
+RFC 1599                  Summary of 1500-1599              January 1997
+
+
+1577    Laubach    Jan 94    Classical IP and ARP over ATM
+
+This memo defines an initial application of classical IP and ARP in an
+Asynchronous Transfer Mode (ATM) network environment configured as a
+Logical IP Subnetwork (LIS). [STANDARDS-TRACK]
+
+
+1576    Penner     Jan 94    TN3270 Current Practices
+
+This document describes the existing implementation of transferring 3270
+display terminal data using currently available telnet capabilities.
+The name traditionally associated with this implementation is TN3270.
+This memo provides information for the Internet community.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1575    Hares     Feb 94    An Echo Function for CLNP (ISO 8473)
+
+This memo defines an echo function for the connection-less network layer
+protocol.  The mechanism that is mandated here is in the final process
+of being standardized by ISO as "Amendment X: Addition of an Echo
+function to ISO 8473" an integral part of Version 2 of ISO 8473.
+[STANDARDS-TRACK]
+
+
+1574    Hares    Feb 94    Essential Tools for the OSI Internet
+
+This document specifies the following three necessary tools to debug
+problems in the deployment and maintenance of networks using ISO 8473
+(CLNP): ping or OSI Echo function, traceroute function which uses the
+OSI Echo function, and routing table dump function.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1573    McCloghrie   Jan 94    Evolution of the Interfaces
+                               Group of MIB-II
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it describes managed objects used for managing Network
+Interfaces. [STANARDS-TRACK]
+
+
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 6]
+
+RFC 1599                  Summary of 1500-1599              January 1997
+
+
+1572    Alexander   Jan 94    Telnet Environment Option
+
+This document specifies a mechanism for passing environment information
+between a telnet client and server.  Use of this mechanism enables a
+telnet user to propagate configuration information to a remote host when
+connecting. [STANDARDS-TRACK]
+
+
+1571   Borman      Jan 94    Telnet Environment Option
+                             Interoperability Issues
+
+This document describes a method for allowing implementors to ensure
+that their implementation of the Environment option will be
+interoperable with as many other implementations as possible, by
+providing a set of heuristics that can be used to help identify which
+definitions for VAR and VALUE are being used by the other side of the
+connection. This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+1570    Simpson     Jan 94    PPP LCP Extensions
+
+The Point-to-Point Protocol (PPP) provides a standard method for
+transporting multi-protocol datagrams over point-to-point links.  PPP
+defines an extensible Link Control Protocol (LCP) for establishing,
+configuring, and testing the data-link connection.  This document
+defines several additional LCP features which have been suggested over
+the past few years. [STANDARDS-TRACK]
+
+
+1569    Rose       Jan 94     Principles of Operation for the TPC.INT
+                              Subdomain: Radio Paging
+                              -- Technical Procedures
+
+This memo describes a technique for radio paging using the Internet mail
+infrastructure.  In particular, this memo focuses on the case in which
+radio pagers are identified via the international telephone network.
+This memo provides information for the Internet community.  This memo
+does not specify an Internet standard of any kind.
+
+
+1568    Gwinn     Jan 94     Simple Network Paging Protocol
+                             - Version 1(b)
+
+This RFC suggests a simple way for delivering both alphanumeric and
+numeric pages (one-way) to radio paging terminals. This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+
+Kennedy                      Informational                      [Page 7]
+
+RFC 1599                  Summary of 1500-1599              January 1997
+
+
+1567    Mansfield  Jan 94     X.500 Directory Monitoring MIB
+
+This document defines a portion of the Management Information Base
+(MIB).  It defines the MIB for monitoring Directory System Agents (DSA),
+a component of the OSI Directory. This MIB will be used in conjunction
+with the APPLICATION-MIB for monitoring DSAs. [STANDARDS-TRACK]
+
+
+1566    Kille      Jan 94    Mail Monitoring MIB
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community. In
+particular, this memo extends the basic Network Services Monitoring MIB
+to allow monitoring of Message Transfer Agents (MTAs). It may also be
+used to monitor MTA components within gateways.  [STANDARDS-TRACK]
+
+
+1565    Kille      Jan 94    Network Services Monitoring MIB
+
+This document defines a MIB which contains the elements common to the
+monitoring of any network service application.  This information
+includes a table of all monitorable network service applications, a
+count of the associations (connections) to each application, and basic
+information about the parameters and status of each application-related
+association. [STANDARDS-TRACK]
+
+
+1564    Barker     Jan 94    DSA Metrics (OSI-DS 34 (v3))
+
+This document defines a set of criteria by which a DSA implementation
+may be judged.  Particular issues covered include conformance to
+standards; performance; demonstrated interoperability. This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1563    Borenstein  Jan 94   The text/enriched MIME Content-type
+
+MIME [RFC-1341, RFC-1521] defines a format and general framework for the
+representation of a wide variety of data types in Internet mail.  This
+document defines one particular type of MIME data, the text/enriched
+type, a refinement of the "text/richtext" type defined in RFC 1341.  The
+text/enriched MIME type is intended to facilitate the wider
+interoperation of simple enriched text across a wide variety of hardware
+and software platforms. This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+
+
+
+Kennedy                      Informational                      [Page 8]
+
+RFC 1599                  Summary of 1500-1599              January 1997
+
+
+1562     Michaelson  Dec 93  Naming Guidelines for the AARNet X.500
+                             Directory Service
+
+This document is an AARNet (Australian Academic and Research Network)
+Engineering Note (AEN-001).  AARNet Engineering Notes are engineering
+documents of the AARNet Engineering Working Group, and record current or
+proposed operational practices related to the provision of
+Internetworking services within Australia, and AARNet in particular.
+This memo provides information for the Internet community.  This memo
+does not specify an Internet standard of any kind.
+
+
+1561    Piscitello  Dec 93   Use of ISO CLNP in TUBA Environments
+
+This memo specifies a profile of the ISO/IEC 8473 Connectionless-mode
+Network Layer Protocol for use in conjunction with RFC 1347, TCP/UDP
+over Bigger Addresses.  It describes the use of CLNP to provide the
+lower-level service expected by Transmission Control Protocol and User
+Datagram Protocol.  This memo defines an Experimental Protocol for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+1560    Leiner    Dec 93     The MultiProtocol Internet
+
+There has recently been considerable discussion on two topics:
+MultiProtocol approaches in the Internet and the selection of a next
+generation Internet Protocol. This document suggests a strawman position
+for goals and approaches for the IETF/IESG/IAB in these areas. It takes
+the view that these two topics are related, and proposes directions for
+the IETF/IESG/IAB to pursue. This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+1559   Saperia    Dec 93     DECnet Phase IV MIB Extensions
+
+This memo defines a set of DECnet Phase IV extensions that have been
+created for the Internet MIB.  It reflects changes which are the result
+of operational experience based on RFC 1289. [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 9]
+
+RFC 1599                  Summary of 1500-1599              January 1997
+
+
+1558   Howes      Dec 93     A String Representation of LDAP
+                             Search Filters
+
+The Lightweight Directory Access Protocol (LDAP) defines a network
+representation of a search filter transmitted to an LDAP server.  Some
+applications may find it useful to have a common way of representing
+these search filters in a human-readable form.  This document defines a
+human-readable string format for representing LDAP search filters. This
+memo provides information for the Internet community.  This memo does
+not specify an Internet standard of any kind.
+
+
+1557   Choi       Dec 93     Korean Character Encoding for Internet
+                             Messages
+
+This document describes the encoding method being used to represent
+Korean characters in both header and body part of the Internet mail
+messages [RFC822].  This encoding method was specified in 1991, and has
+since then been used.  It has now widely being used in Korean IP
+networks. This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+1556   Nussbacher  Dec 93   Handling of Bi-directional Texts in MIME
+
+This document describes the format and syntax of the "direction" keyword
+to be used with bi-directional texts in MIME. This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+1555   Nussbacher   Dec 93   Hebrew Character Encoding for Internet
+                             Messages
+
+This document describes the encoding used in electronic mail [RFC822]
+for transferring Hebrew.  The standard devised makes use of MIME
+[RFC1521] and ISO-8859-8. This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 10]
+
+RFC 1599                  Summary of 1500-1599              January 1997
+
+
+1554   Ohta         Dec 93  ISO-2022-JP-2: Multilingual Extension
+                            of ISO-2022-JP
+
+This memo describes a text encoding scheme: "ISO-2022-JP-2", which is
+used experimentally for electronic mail [RFC822] and network news
+[RFC1036] messages in several Japanese networks.  The encoding is a
+multilingual extension of "ISO-2022-JP", the existing encoding for
+Japanese [2022JP].  The encoding is supported by an Emacs based
+multilingual text editor: MULE [MULE]. This memo provides information
+for the Internet community.  This memo does not specify an Internet
+standard of any kind.
+
+
+1553   Mathur     Dec 93   Compressing IPX Headers Over WAN Media (CIPX)
+
+This document describes a method for compressing the headers of IPX
+datagrams (CIPX). [STANDARDS-TRACK]
+
+
+1552   Simpson   Dec 93   The PPP Internetwork Packet Exchange Control
+                          Protocol (IPXCP)
+
+This document defines the Network Control Protocol for establishing and
+configuring the IPX protocol over PPP. [STANDARDS-TRACK]
+
+
+1551   Allen     Dec 93   Novell IPX Over Various WAN Media (IPXWAN)
+
+This document describes how Novell IPX operates over various WAN media.
+Specifically, it describes the common "IPX WAN" protocol Novell uses to
+exchange necessary router to router information prior to exchanging
+standard IPX routing information and traffic over WAN datalinks. This
+memo provides information for the Internet community.  This memo does
+not specify an Internet standard of any kind.
+
+
+1550   Bradner    Dec 93       IP: Next Generation (IPng) White Paper
+                               Solicitation
+
+This memo solicits white papers on topics related to the IPng
+requirements and selection criteria. This memo provides information for
+the Internet community.  This memo does not specify an Internet standard
+of any kind.
+
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 11]
+
+RFC 1599                  Summary of 1500-1599              January 1997
+
+
+1549   Simpson    Dec 93      PPP in HDLC Framing
+
+This document describes the use of HDLC for framing PPP encapsulated
+packets. [STANDARDS-TRACK]
+
+
+1548   Simpson    Dec 93      The Point-to-Point Protocol (PPP)
+
+This document defines the PPP organization and methodology, and the PPP
+encapsulation, together with an extensible option negotiation mechanism
+which is able to negotiate a rich assortment of configuration parameters
+and provides additional management functions. [STANDARDS-TRACK]
+
+
+1547   Perkins    Dec 93      Requirements for an Internet Standard
+                              Point-to-Point Protocol
+
+This document discusses the evaluation criteria for an Internet Standard
+Data Link Layer protocol to be used with point-to-point links. This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1546   Partridge  Nov 93      Host Anycasting Service
+
+This RFC describes an internet anycasting service for IP.  The primary
+purpose of this memo is to establish the semantics of an anycasting
+service within an IP internet. This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+1545   Piscitello  Nov 93     FTP Operation Over Big Address Records
+                              (FOOBAR)
+
+This RFC specifies a method for assigning long addresses in the HOST-
+PORT specification for the data port to be used in establishing a data
+connection for File Transfer Protocol, FTP (STD 9, RFC 959). This is a
+general solution, applicable for all "next generation" IP alternatives,
+and can also be extended to allow FTP operation over transport
+interfaces other than TCP. This memo defines an Experimental Protocol
+for the Internet community.  This memo does not specify an Internet
+standard of any kind.
+
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 12]
+
+RFC 1599                  Summary of 1500-1599              January 1997
+
+
+1544   Rose      Nov 93      The Content-MD5 Header Field
+
+This memo defines the use of an optional header field, Content-MD5,
+which may be used as a message integrity check (MIC), to verify that the
+decoded data are the same data that were initially sent.  [STANDARDS-
+TRACK]
+
+
+1543   Postel    Oct 93      Instructions to RFC Authors
+
+This Request for Comments (RFC) provides information about the
+preparation of RFCs, and certain policies relating to the publication of
+RFCs. This memo provides information for the Internet community.  This
+memo does not specify an Internet standard of any kind.
+
+
+1542   Wimer     Oct 93     Clarifications and Extensions for the
+                            Bootstrap Protocol
+
+Some aspects of the BOOTP protocol were rather loosely defined in its
+original specification.  In particular, only a general description was
+provided for the behavior of "BOOTP relay agents" (originally called
+BOOTP forwarding agents").  The client behavior description also
+suffered in certain ways.  This memo attempts to clarify and strengthen
+the specification in these areas. [STANDARDS-TRACK]
+
+
+1541    Droms    Oct 93    Dynamic Host Configuration Protocol
+
+The Dynamic Host Configuration Protocol (DHCP) provides a framework for
+passing configuration information to hosts on a TCP/IP network.  DHCP is
+based on the Bootstrap Protocol (BOOTP) adding the capability of
+automatic allocation of reusable network addresses and additional
+configuration options. [STANDARDS-TRACK]
+
+
+1540    IAB     Oct 93     Internet Official Protocol Standards
+
+This memo describes the state of standardization of protocols used in
+the Internet as determined by the Internet Activities Board (IAB).
+[STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 13]
+
+RFC 1599                  Summary of 1500-1599              January 1997
+
+
+1539   Malkin   Oct 93    A Guide for New Attendees of the Internet
+                          Engineering Task Force
+
+The purpose of this For Your Information (FYI) RFC is to explain to the
+newcomers how the IETF works. This memo provides information for the
+Internet community.  It does not specify an Internet standard.  [FYI 17]
+
+
+1538   Behl    Oct 93    Advanced SNA/IP : A Simple SNA Transport
+                         Protocol
+
+This RFC provides information for the Internet community about a method
+for establishing and maintaining SNA sessions over an IP internet. This
+memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+1537   Beertema  Oct 93  Common DNS Data File Configuration Errors
+
+This memo describes errors often found in DNS data files. It points out
+common mistakes system administrators tend to make and why they often go
+unnoticed for long periods of time. This memo provides information for
+the Internet community.  It does not specify an Internet standard.
+
+
+1536   Kumar    Oct 93   Common DNS Implementation Errors and
+                         Suggested Fixes
+
+This memo describes common errors seen in DNS implementations and
+suggests some fixes.  This memo provides information for the Internet
+community.  It does not specify an Internet standard.
+
+
+1535   Gavron   Oct 93   A Security Problem and Proposed Correction
+                         With Widely Deployed DNS Software
+
+This document discusses a flaw in some of the currently distributed name
+resolver clients.  The flaw exposes a security weakness related to the
+search heuristic invoked by these same resolvers when users provide a
+partial domain name, and which is easy to exploit.  This document points
+out the flaw, a case in point, and a solution. This memo provides
+information for the Internet community.  It does not specify an Internet
+standard.
+
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 14]
+
+RFC 1599                  Summary of 1500-1599              January 1997
+
+
+1534   Droms    Oct 93   Interoperation Between DHCP and BOOTP
+
+DHCP provides a superset of the functions provided by BOOTP. This
+document describes the interactions between DHCP and BOOTP network
+participants. [STANDARDS-TRACK]
+
+
+1533   Alexander Oct 93  DHCP Options and BOOTP Vendor Extensions
+
+This document specifies the current set of DHCP options. [STANDARDS-
+TRACK]
+
+
+1532  Wimer     Oct 93    Clarifications and Extensions for the
+                          Bootstrap Protocol
+
+Some aspects of the BOOTP protocol were rather loosely defined in its
+original specification.  In particular, only a general description was
+provided for the behavior of "BOOTP relay agents" (originally called
+BOOTP forwarding agents").  The client behavior description also
+suffered in certain ways.  This memo attempts to clarify and strengthen
+the specification in these areas. [STANDARDS-TRACK]
+
+
+1531  Droms    Oct 93     Dynamic Host Configuration Protocol
+
+The Dynamic Host Configuration Protocol (DHCP) provides a framework for
+passing configuration information to hosts on a TCP/IP network.
+[STANDARDS-TRACK]
+
+
+1530  Malamud   Oct 93   Principles of Operation for the TPC.INT
+                         Subdomain: General Principles and Policy
+
+This document defines the initial principles of operation for the
+tpc.int subdomain, a collection of service listings accessible over the
+Internet infrastructure through an administered namespace contained
+within the Domain Name System. This memo provides information for the
+Internet community.  It does not specify an Internet standard.
+
+
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 15]
+
+RFC 1599                  Summary of 1500-1599              January 1997
+
+
+1529  Malamud   Oct 93   Principles of Operation for the TPC.INT
+                         Subdomain:  Remote Printing --
+                         Administrative Policies
+
+This document defines the administrative policies for the operation of
+remote printer facilities within the context of the tpc.int subdomain.
+The document describes different approaches to resource recovery for
+remote printer server sites and includes discussions of issues
+pertaining to auditing, security, and denial of access. This memo
+provides information for the Internet community.  It does not specify an
+Internet standard.
+
+
+1528  Malamud  Oct 93   Principles of Operation for the TPC.INT
+                        Subdomain: Remote Printing -- Technical
+                        Procedures
+
+This memo describes a technique for "remote printing" using the Internet
+mail infrastructure.  In particular, this memo focuses on the case in
+which remote printers are connected to the international telephone
+network. This memo defines an Experimental Protocol for the Internet
+community.  It does not specify an Internet standard.
+
+
+1527  Cook    Sep 93    What Should We Plan Given the
+                        Dilemma of the Network?
+
+The Internet community needs to be asking what the most important policy
+issues facing the network are.  And given agreement on any particular
+set of policy issues, the next thing we should be asking is, what would
+be some of the political choices that would follow for Congress to make?
+This memo is a shortened version of the suggested policy draft. This
+memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+1526   Piscitello     Sep 93  Assignment of System Identifiers for
+                              TUBA/CLNP Hosts
+
+This document describes conventions whereby the system identifier
+portion of an RFC 1237 style NSAP address may be guaranteed uniqueness
+within a routing domain for the purpose of autoconfiguration in
+TUBA/CLNP internets. This memo provides information for the Internet
+community.  It does not specify an Internet standard.
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 16]
+
+RFC 1599                  Summary of 1500-1599              January 1997
+
+
+1525   Decker        Sep 93   Definitions of Managed Objects for
+                              Source Routing Bridges
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP based internets.  In
+particular, it defines objects for managing source routing and source
+routing transparent bridges.  These bridges are also required to
+implement relevant groups in the Bridge MIB. [STANDARDS-TRACK]
+
+
+1524   Borenstein     Sep 93  A User Agent Configuration Mechanism
+                              For Multimedia Mail Format Information
+
+This memo suggests a file format to be used to inform multiple mail
+reading user agent programs about the locally-installed facilities for
+handling mail in various formats. This memo provides information for the
+Internet community.  It does not specify an Internet standard.
+
+
+1523   Borenstein    Sep 93   The text/enriched MIME Content-type
+
+MIME [RFC-1341, RFC-1521] defines a format and general framework for the
+representation of a wide variety of data types in Internet mail.  This
+document defines one particular type of MIME data, the text/enriched
+type, a refinement of the "text/richtext" type defined in RFC 1341. This
+memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+1522    Moore       Sep 93    MIME (Multipurpose Internet Mail
+                              Extensions) Part Two:
+                              Message Header Extensions for Non-ASCII
+                              Text
+
+This memo describes an extension to the message format defined in RFC
+1521,  to allow the representation of character sets other than ASCII in
+RFC 822 (STD 11) message headers.  The extensions described were
+designed to be highly compatible with existing Internet mail handling
+software, and to be easily implemented in mail readers that support RFC
+1521.
+
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 17]
+
+RFC 1599                  Summary of 1500-1599              January 1997
+
+
+1521    Borenstein   Sep 93   MIME (Multipurpose Internet Mail
+                              Extensions) Part One:
+                              Mechanisms for Specifying and Describing
+                              the Format of Internet Message Bodies
+
+This document redefines the format of message bodies to allow multi-part
+textual and non-textual message bodies to be represented and exchanged
+without loss of information.  This is based on earlier work documented
+in RFC 934 and STD 11, RFC 1049, but extends and revises that work.
+[STANDARDS-TRACK]
+
+
+1520    Rekhter      Sep 93    Exchanging Routing Information Across
+                               Provider Boundaries in the CIDR
+                               Environment
+
+The purpose of this document is twofold. First, it describes various
+alternatives for exchanging inter-domain routing information across
+domain boundaries, where one of the peering domain is CIDR-capable and
+another is not.  Second, it addresses the implications of running CIDR-
+capable inter-domain routing protocols (e.g., BGP-4, IDRP) on intra-
+domain routing.  This memo provides information for the Internet
+community.  It does not specify an Internet standard.
+
+
+1519    Fuller      Sep 93     Classless Inter-Domain Routing (CIDR):
+                               an Address Assignment and Aggregation
+                               Strategy
+
+This memo discusses strategies for address assignment of the existing IP
+address space with a view to conserve the address space and stem the
+explosive growth of routing tables in default-route-free routers.
+[STANDARDS-TRACK]
+
+
+1518    Rekhter    Sep 93     An Architecture for IP Address
+                              Allocation with CIDR
+
+This paper provides an architecture and a plan for allocating IP
+addresses in the Internet. This architecture and the plan are intended
+to play an important role in steering the Internet towards the Address
+Assignment and Aggregating Strategy. [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 18]
+
+RFC 1599                  Summary of 1500-1599              January 1997
+
+
+1517    IESG       Sep 93     Applicability Statement for the
+                              Implementation of Classless
+                              Inter-Domain Routing (CIDR)
+
+Classless Inter-Domain Routing (CIDR) defines a mechanism to slow the
+growth of routing tables and reduce the need to allocate new IP network
+numbers. [STANDARDS-TRACK]
+
+
+1516    McMaster    Sep 93    Definitions of Managed Objects
+                              for IEEE 802.3 Repeater Devices
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it defines objects for managing IEEE 802.3 10 Mb/second
+baseband repeaters, sometimes referred to as "hubs." [STANDARDS-TRACK]
+
+
+1515   McMaster    Sep 93    Definitions of Managed Objects
+                             for IEEE 802.3 Medium Attachment Units
+                             (MAUs)
+
+This document defines a portion of the Management Information Base (MIB)
+for use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing IEEE 802.3 Medium Attachment
+Units (MAUs). [STANDARDS-TRACK]
+
+
+1514   Grillo     Sep 93    Host Resources MIB
+
+This memo defines a MIB for use with managing host systems. [STANDARDS-
+TRACK]
+
+
+1513   Waldbusser  Sep 93    Token Ring Extensions to the Remote
+                             Network Monitoring MIB
+
+This memo defines extensions to the Remote Network Monitoring MIB for
+managing 802.5 Token Ring networks. [STANDARDS-TRACK]
+
+
+1512   Case       Sep 93     FDDI Management Information Base
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing devices which implement the
+FDDI based on the ANSI FDDI SMT 7.3 draft standard, which has been
+forwarded for publication by the X3T9.5 committee.
+
+
+
+Kennedy                      Informational                     [Page 19]
+
+RFC 1599                  Summary of 1500-1599              January 1997
+
+
+1511   Linn      Sep 93     Common Authentication Technology Overview
+
+This memo provides information for the Internet community.  It does not
+specify an Internet standard.
+
+
+1510   Kohl     Sep 93     The Kerberos Network Authentication Service
+                           (V5)
+
+This document gives an overview and specification of Version 5 of the
+protocol for the Kerberos network authentication system. [STANDARDS-
+TRACK]
+
+
+1509   Wray     Sep 93     Generic Security Service API : C-bindings
+
+This document specifies C language bindings for the Generic Security
+Service Application Program Interface (GSS-API), which is described at a
+language-independent conceptual level in other documents. [STANDARDS-
+TRACK]
+
+
+1508   Linn    Sep 93     Generic Security Service Application Program
+                          Interface
+
+This Generic Security Service Application Program Interface (GSS-API)
+definition provides security services to callers in a generic fashion,
+supportable with a range of underlying mechanisms and technologies and
+hence allowing source-level portability of applications to different
+environments. [STANDARDS-TRACK]
+
+
+1507   Kaufman  Sep 93    DASS
+                          Distributed Authentication Security Service
+
+The goal of DASS is to provide authentication services in a distributed
+environment which are both more secure and easier to use than existing
+mechanisms. This memo defines an Experimental Protocol for the Internet
+community.  It does not specify an Internet standard.
+
+
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 20]
+
+RFC 1599                  Summary of 1500-1599              January 1997
+
+
+1506   Houttuin  Sep 93   A Tutorial on Gatewaying between X.400 and
+                          Internet Mail
+
+This tutorial was produced especially to help new gateway managers find
+their way into the complicated subject of mail gatewaying according to
+RFC 1327. This memo provides information for the Internet community.  It
+does not specify an Internet standard.
+
+
+1505   Costanzo   Aug 93   Encoding Header Field for Internet Messages
+
+This document expands upon the elective experimental Encoding header
+field which permits the mailing of multi-part, multi-structured
+messages.  It replaces RFC 1154. This memo defines an Experimental
+Protocol for the Internet community.  It does not specify an Internet
+standard.
+
+
+1504   Oppenheimer  Aug 93   Appletalk Update-Based Routing Protocol:
+                             Enhanced Appletalk Routing
+
+This document provides detailed information about the AppleTalk Update-
+based Routing Protocol (AURP) and wide area routing. AURP provides wide
+area routing enhancements to the AppleTalk routing protocols and is
+fully compatible with AppleTalk Phase 2. This memo provides information
+for the Internet community.  It does not specify an Internet standard.
+
+
+1503    McCloghrie Aug 93    Algorithms for Automating Administration
+                             in SNMPv2 Managers
+
+When a user invokes an SNMPv2 management application, it may be
+desirable for the user to specify the minimum amount of information
+necessary to establish and maintain SNMPv2 communications.  This memo
+suggests an approach to achieve this goal. This memo provides
+information for the Internet community.  It does not specify an Internet
+standard.
+
+
+1502   Alvestrand  Aug 93   X.400 Use of Extended Character Sets
+
+This RFC defines a suggested method of using "GeneralText" in order to
+harmonize as much as possible the usage of this body part. [STANDARDS-
+TRACK]
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 21]
+
+RFC 1599                  Summary of 1500-1599              January 1997
+
+
+1501   Brunsen    Aug 93    OS/2 User Group
+
+Memo soliciting reactions to the proposal of a OS/2 User Group. This
+memo provides information for the Internet community.  This memo does
+not specify an IAB standard of any kind.
+
+
+1500   IAB       Aug 93     Internet Official Protocol Standards
+
+This memo describes the state of standardization of protocols used in
+the Internet as determined by the Internet Activities Board (IAB).
+[STANDARDS-TRACK]
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Author's Address
+
+   Mary Kennedy
+   University of Southern California
+   Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone:  (310) 822-1511
+
+   EMail:  MKENNEDY@ISI.EDU
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 22]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1599.txt](<www.ietf.org/rfc/rfc1599.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
