### PR TITLE
Archive rfc16.txt

### DIFF
--- a/www.ietf.org/rfc/rfc16.txt
+++ b/www.ietf.org/rfc/rfc16.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                    Steve Crocker
+Request for Comments:  16                                27 August 1969
+
+
+
+
+                                 M.I.T.
+
+M.I.T. is now to receive all Network Working Group memos.  Memos should
+be addressed to:
+
+                         Abhai Bhushan
+                         Room 807 - Project MAC
+                         545 Technology Square
+                         Cambridge, Mass. 02139
+
+Abhai's phone is (617) 864-6900, X 5857.
+
+[This RFC has been restored to on-line status by Walter Pienciak]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc16.txt](<www.ietf.org/rfc/rfc16.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
