### PR TITLE
Archive rfc160.txt

### DIFF
--- a/www.ietf.org/rfc/rfc160.txt
+++ b/www.ietf.org/rfc/rfc160.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Network Working Group                         Network Information Center
+Request for Comments: 160                    Stanford Research Institute
+NIC: 6771                                                    18 May 1971
+
+      RFC Brief List       18 May 1971     RFC 160       NIC 6771
+
+                    TITLE OR PARTIAL TITLE              NIC    RFC
+
+
+   HOST Software                                         4687    1
+   HOST Software                                         4688    2
+   Documentation Conventions                             4689    3
+   Network Timetable                                     4690    4
+   DEL                                                   4691    5
+   Conversation with Bob Kahn                            4692    6
+   HOST-IMP Interface                                    4693    7
+   ARPA Network Functional Specifications                4694    8
+   HOST Software                                         4695    9
+   Documentation Conventions                             4696   10
+   Implementation of the  HOST-HOST Software             4718   11
+   IMP-HOST Interface Flow Diagrams                      4697   12
+   Referring to NWG/RFC: 11                              4698   13
+   (No RFC issued under this number)                            14
+   Network Subsystem for Time-Sharing HOSTS              4754   15
+   M.I.T. (address)                                      4719   16
+   Some Questions Re: HOST-IMP Protocol                  4699   17
+   (use of links 1 and 2)                                4720   18
+   Two Protocol Suggestions to Reduce Congestion at      4721   19
+   ASCII Format for Network Interchange                  4722   20
+   (report of Network meeting)                           4723   21
+   HOST-HOST Control Message Formats                     4724   22
+   Transmission of Multiple Control Messages             4725   23
+   Documentation Conventions                             4726   24
+   No High Link Numbers                                  4727   25
+   (No RFC issued under this number)                            26
+   Documentation Conventions                             4729   27
+   Time Standards                                        4730   28
+   Note in Response to Bill English's Request for        4731   29
+   Documentation Conventions                             4732   30
+   Binary Message Forms in Computer Network              4733   31
+   Connecting M.I.T. Computers to the ARPA               4734   32
+   New HOST-HOST Protocol                                4735   33
+   Some Brief Preliminary Notes on the ARC Clock         4736   34
+   Network Meeting                                       4737   35
+   Protocol Notes                                        4738   36
+   Network Meeting Epilogue, etc.                        4739   37
+   Comments on Network Protocol from NWG/RFC 36          4740   38
+   Comments on Protocol Re: NWG/RFC 36                   4741   39
+
+
+
+                                                                [Page 1]
+
+RFC 160                      RFC Brief List                     May 1971
+
+
+   More Comments on the Forthcoming Protocol             4742   40
+   IMP-IMP Teletype Communication                        4743   41
+   Message Data Types                                    4744   42
+
+                    TITLE OR PARTIAL TITLE              NIC    RFC
+
+
+   Proposed Meeting                                      4745   43
+   Comments on NWG/RFC 33 and 36                         4746   44
+   New Protocol is Coming                                4747   45
+   ARPA Network Protocol Notes                           4748   46
+   BBN's Comments on NWG/RFC 33                          4749   47
+   A Possible Protocol Plateau                           4750   48
+   Conversations with Steve Crocker (UCLA)               4728   49
+   Comments on the Meyer Proposal                        4751   50
+   Proposal for a Network Interchange Language           4752   51
+   Updated Distribution List                             4753   52
+   An Official Protocol Mechanism                        4755   53
+   An Official Protocol Proffering                       4756   54
+   A Prototypical Implementation of the NCP              4757   55
+   Third Level Protocol                                  4758   56
+   Thoughts and Reflections on NWG/RFC 54                4759   57
+   Logical Message Synchronization                       4760   58
+   Flow Control - Fixed Versus Demand Allocation         4761   59
+   A Simplified NCP Protocol                             4762   60
+   A Note on Interprocess Communication in a             4961   6l
+   A Note on Interprocess Communication in a             4962   62
+   Belated Network Meeting Report                        4963   63
+   Getting Rid of Marking                                4964   64
+   Comments on Host-Host Protocol Document No. 1 (by     4965   65
+   3rd Level Ideas and Other Noise                       5409   66
+   Proposed Change to Host/IMP Spec to Eliminate         5410   67
+   Comments on Memory Allocation Control Commands        5411   68
+   Distribution List Change for MIT                      5412   69
+   A Note on Padding                                     5413   70
+   Reallocation in Case of Input Error                   5414   71
+   Proposed Moratorium on Changes to Network             5415   72
+   Response to NWG/RFC 67                                5416   73
+   Specifications for Network Use of The UCSB            5417   74
+   Network Meeting                                       5418   75
+   Connection-By Name: User-Oriented Protocol            5180   76
+   Syntax and Semantics for the Terminal User            5419  (76encl)
+   Network Meeting Report                                5604   77
+   NCP Status Report: UCSB/RAND                          5199   78
+   Logger Protocol Error                                 5601   79
+   Protocols and Data Formats                            5608   8O
+   Request for Reference Information                     5609   81
+   Network Meeting Notes                                 5619   82
+
+
+
+                                                                [Page 2]
+
+RFC 160                      RFC Brief List                     May 1971
+
+
+   Language-Machine for Data Reconfiguration            5621   83
+   List of NWG/RFC's 1-80                                5620   84
+   Network Working Group Meeting                         5624   85
+   Proposal for a Network Standard Format for a DATA     5631   86
+
+
+                    TITLE OR PARTIAL TITLE              NIC    RFC
+
+   Topic for Discussion at the Next Network Working      5632   87
+   NETRJS--A Third Level Protocol for Remote Job         5668   88
+   Some Historic Moments in Networking                   5697   89
+   CN as a Network Service Center                        5707   90
+   A Proposed User-User Protocol                         5708   91
+   (No RFC issued under this number)                            92
+   Initial Connection Protocol                           5721   93
+   Some Thoughts on Network Graphics                     5725   94
+   Distribution of NWG/RFC's Through the NIC             5731   95
+   An Interactive Network Experiment to Study Modes      5739   96
+   A First Cut at a Proposed Telnet Protocol             5740   97
+   Logger Protocol Proposal                              5744   98
+   Network Meeting                                       5758   99
+   Categorization and Guide to NWG/RFCs                  5761  lO0
+   Notes on the Network Working Group Meeting            5762  101
+   Output of the Host/Host Protocol Glitch Cleaning      5763  102
+   Implementation of Interrupt Keys                      5764  103
+   Link 191                                              5768  104
+
+
+   Items below this point do not appear in 23 March 1971
+      catalog listings.
+
+   Network Specifications for Remote Job Entry...UCSB    5775   105
+   User/Server Site Protocol, Network Host Questionnaire 5776   106
+   Output of the Host-Host Protocol Glitch Comm          5606   107
+   Addendum to NWG Meeting Notes, NIC 5762               5807   108
+   Level III Server Protocol for the Lincoln Lab 360     5806   109
+   Conventions for Using an IBM 2741 Terminal            5809   110
+   Pressure from the Chairman                            5815   111
+   User/Server Site Protocol; HOST Questionnaire         5816   112
+   Network Activity Report: UCSB-RAND                    5820   113
+   A File Transfer Protocol                              5823   114
+   Some NIC Policies on Handling Documents               5822   115
+   Structure of the May NWG Meeting                      5825   116
+   Some Comments on the Official Protocol                5826   117
+   Recommendations for Facility Documentation            5830   118
+   Network Fortran Subprograms                           5831   119
+   Network PL/l Subprograms                              5632   120
+   Network On-line Operators                             5833   121
+
+
+
+                                                                [Page 3]
+
+RFC 160                      RFC Brief List                     May 1971
+
+
+   Network Specifications for UCSB's Simple-Minded       5834   122
+   A Preferred Official ICP                              5837   123
+   Typographical Error in RFC 107                        5640   124
+   Response to RFC 86                                    5841   125
+   Ames Graphics Facilities at Ames Research Center      5842   126
+
+
+                     TITLE OR PARTIAL TITLE              NIC    RFC
+
+   Comments on RFC 123                                   5843   127
+   Bytes                                                 5844   128
+   A Request for Comments on Socket Name Structure       5845   129
+   Response to RFC 111                                   5848   130
+   Response to RFC 116                                   5849   131
+   Typographical Error in RFC 107                        6708   132
+   File Transfer and Error Recovery                      6710   133
+   Network Meeting                                       6711   134
+   Response to NWG/RFC 110                               6712   135
+   Host Accounting and Administrative Procedures         6713   136
+   TELNET Protocol - A Proposed Document                 6714   137
+   Status Report on Proposed Data Reconfiguration        6715   138
+   Discussion of Proposed TELNET                         6717   139
+   Agenda for May NWG Meeting                            6725   140
+   Comments on RFC 114 (A File Transfer Protocol)        6726   141
+   Time-out Mechanism in Host-Host Protocol              6727   142
+   Regarding Proffered Official ICP                      6728   143
+   Data Sharing on Computer Networks                     6729   144
+   Initial Connection Protocol Control Commands          6739   145
+      not yet issued                                     6742   146
+   Definition of a Socket                                6750   147
+   Comments on 123                                       6751   148
+   Best Laid Plans...                                    6752   149
+   Use of IPC Facilities                                 6754   150
+      not yet issued                                     6755   151
+      not yet issued                                     6756   152
+   ARC NIC Status Report                                 6758   153
+   Exposition Style                                      6759   154
+   ARC NIC Mailing Lists                                 6760   155
+      not yet issued                                     6761   156
+   Invitation to 2nd Symposium...                        6762   157
+       not Yet issued                                    6768   158
+       not yet issued                                    6769   159
+   RFC Brief List                                        6771   160
+
+
+       [ This RFC was put into machine readable form for entry ]
+         [ into the online RFC archives by Mark Davidson 1/00 ]
+
+
+
+
+                                                                [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc160.txt](<www.ietf.org/rfc/rfc160.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
