### PR TITLE
Archive rfc1606.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1606.txt
+++ b/www.ietf.org/rfc/rfc1606.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Network Working Group                                         J. Onions
+Request for Comments: 1606                                   Nexor Ltd.
+Category: Informational                                    1 April 1994
+
+
+         A Historical Perspective On The Usage Of IP Version 9
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  This memo
+   does not specify an Internet standard of any kind.  Distribution of
+   this memo is unlimited.
+
+Abstract
+
+   This paper reviews the usages of the old IP version protocol. It
+   considers some of its successes and its failures.
+
+Introduction
+
+   The take-up of the network protocol TCP/IPv9 has been phenomenal over
+   the last few years. Gone are the days when there were just a few
+   million hosts, and the network was understood. As the IP version 9
+   protocol comes to the end of its useful life, once again due to
+   address space exhaustion, we look back at some of the success of the
+   protocol.
+
+Routing
+
+   The up to 42 deep hierarchy of routing levels built into IPv9 must
+   have been one of the key features for its wide deployment. The
+   ability to assign a whole network, or group of networks to an
+   electronic component must be seen as one of the reasons for its
+   takeup. The use of the Compact Disk Hologram units is typical of the
+   usage. They typically have a level 37 network number assigned to each
+   logical part, and a level 36 network number assigned to the whole
+   device. This allows the CDH management protocol to control the unit
+   as a whole, and the high-street vendor to do remote diagnostics on
+   discreet elements of the device. This still allows sub-chip routing
+   to be done using the 38th level addressing to download new nanocode.
+   As yet, no requirement has been found for levels 40-42, with level 39
+   still being used for experimental interrogation of atomic structure
+   of components where required.
+
+
+
+
+
+
+
+
+Onions                                                          [Page 1]
+
+RFC 1606         Historical Perspective Usage of IP V9      1 April 1994
+
+
+Allocation
+
+   The vast number space of the IPv9 protocol has also allowed
+   allocation to be done in a straight forward manner. Typically, most
+   high street commercial internet providers issue a range of 1 billion
+   addresses to each house. The addresses are then dynamically
+   partitioned into subnet hierarchies allowing groups of a million
+   addresses to be allocated for each discreet unit (e.g., room/floor
+   etc.) The allocation of sub groups then to controllers such as light
+   switches, mains sockets and similar is then done from each pool.
+
+   The allocation process is again done in a hierarchical zoned way,
+   with each major application requesting a block of addresses from its
+   controller. In this way the light bulb requests an address block from
+   the light switch, the light switch in turn from the electrical system
+   which in turn requests one from the room/floor controller. This has
+   been found to be successful due to the enormous range of addresses
+   available, and contention for the address space being without
+   problems typically.
+
+   Whilst there are still many addresses unallocated the available space
+   has been sharply decreased. The discovery of intelligent life on
+   other solar systems with the parallel discovery of a faster-than-
+   light transport stack is the main cause. This enables real time
+   communication with them, and has made the allocation of world-size
+   address spaces necessary, at the level 3 routing hierarchy. There is
+   still only 1 global (spatial) level 2 galaxy wide network required
+   for this galaxy, although the establishment of permanent space
+   stations in deep space may start to exhaust this. This allows level 1
+   to be used for inter-galaxy routing. The most pressing problem now is
+   the case of parallel universes.  Of course there is the danger of
+   assuming that there is no higher extrapolation than parallel
+   universes...
+
+   Up to now, the hacking into, and setting of holo-recorder devices to
+   the wrong channel from remote galaxies, has not been confirmed, and
+   appears to be attributable to finger problem with the remote control
+   whilst travelling home from the office.
+
+Applications
+
+   The introduction of body monitors as IPv9 addresseable units injected
+   into the blood stream has been rated as inconclusive. Whilst being
+   able to have devices lodged in the heart, kidneys, brain, etc.,
+   sending out SNMPv9 trap messages at critical events has been a useful
+   monitoring tool for doctors, the use of the blood stream as both a
+   delivery and a communication highway, has been problematic. The
+   crosstalk between the signals moving through the blood stream and the
+
+
+
+Onions                                                          [Page 2]
+
+RFC 1606         Historical Perspective Usage of IP V9      1 April 1994
+
+
+   close proximity of nerves has meant that patients suffering multiple
+   events at once, can go into violent spasm. This, coupled with early
+   problems with broadcasts storms tending to make patients blood boil,
+   have led to a rethink on this whole procedure. Also, the requirement
+   to wear the silly satellite dish hat has led to feelings of
+   embarrassment except in California, where it is now the latest trend.
+
+   The usage of IPv9 addresseable consumer packaging has been a topic of
+   hot debate. The marketing people see it as a godsend, being able to
+   get feedback on how products are actually used. Similarly, the
+   recycling is much improved by use of directed broadcast, "All those
+   packages composed of cardboard respond please." Consumers are not so
+   keen on this seeing it as an invasion of privacy. The introduction of
+   the handy-dandy directed stack zapper (which is also rumoured to be
+   IPv9 aware) sending directed broadcasts on the local food package net
+   effectively resetting the network mask to all 1's has made this an
+   area of choice.
+
+   The advent of the IPv9 magazine was universally approved of. Being
+   able to ask a magazine where its contents page was the most useful of
+   the features. However combined with the networked newspaper/magazine
+   rack, the ability to find out where you left the magazine with the
+   article that was concerned with something about useage of lawn mowers
+   in outer space is obvious. The ability to download reading habits
+   automatically into the house controller and therefore alert the
+   reader of articles of similar ilk is seen as marginal. Alleged
+   querying of this information to discover "deviant" behaviour in
+   persons within political office by members of contending parties is
+   suspected
+
+   Sneakernet, as pioneered by shoe specialists skholl is seen to be a
+   failure. The market was just not ready for shoes that could forward
+   detailed analysis of foot odour to manufacturers...
+
+Manufacture
+
+   Of course, cost is one of the issues that was not considered when
+   IPv9 was designed. It took a leap of imagination to believe that one
+   day anything that wished to be could be IPv9 addresseable. It was
+   assumed that IPv9 protocol machines would drop in price as with
+   general chip technology. Few people would have forseen the advance in
+   genetic manipulation that allowed viruses to be instructed to build
+   nano-technology IPv9 protocol machines by the billion for the price
+   or a grain of sugar. Or similarly, the nano-robots that could insert
+   and wire these in place.
+
+
+
+
+
+
+Onions                                                          [Page 3]
+
+RFC 1606         Historical Perspective Usage of IP V9      1 April 1994
+
+
+   The recent research in quark-quark transistors, shows some promise
+   and may allow specially built atoms to be used as switches. The
+   manufacture of these will be so expensive (maybe up to 10cent an IPv9
+   stack) as to be prohibitive except for the most highly demanding
+   niches.
+
+Conclusions
+
+   Those who do not study history, are doomed to repeat it.
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Author's Address
+
+   Julian Onions
+   Nexor Ltd.
+   PO Box 132
+   Nottingham NG7 2UU, ENGLAND
+
+   Phone: +44 602 520580
+   EMail: j.onions@nexor.co.uk
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Onions                                                          [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1606.txt](<www.ietf.org/rfc/rfc1606.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
