### PR TITLE
Archive rfc1619.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1619.txt
+++ b/www.ietf.org/rfc/rfc1619.txt
@@ -1,0 +1,334 @@
+
+
+
+
+
+
+Network Working Group                                         W. Simpson
+Request for Comments: 1619                                    Daydreamer
+Category: Standards Track                                       May 1994
+
+
+                           PPP over SONET/SDH
+
+
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+
+
+Abstract
+
+   The Point-to-Point Protocol (PPP) [1] provides a standard method for
+   transporting multi-protocol datagrams over point-to-point links.
+   This document describes the use of PPP over Synchronous Optical
+   Network (SONET) and Synchronous Digital Heirarchy (SDH) circuits.
+
+   This document is the product of the Point-to-Point Protocol Working
+   Group of the Internet Engineering Task Force (IETF).  Comments should
+   be submitted to the ietf-ppp@merit.edu mailing list.
+
+
+
+Applicability
+
+   This specification is intended for those implementations which desire
+   to use the PPP encapsulation over high speed private point-to-point
+   links, such as intra-campus single-mode fiber which may already be
+   installed and unused.  Because the PPP encapsulation has relatively
+   low overhead, it is anticipated that significantly higher throughput
+   can be attained compared to other SONET/SDH payload mappings, at a
+   significantly lower cost for line termination equipment.
+
+
+
+
+
+
+
+
+
+
+Simpson                                                         [Page i]
+RFC 1619                   PPP over SONET/SDH                   May 1994
+
+
+                           Table of Contents
+
+
+     1.     Introduction ..........................................    1
+
+     2.     Physical Layer Requirements ...........................    1
+
+     3.     Framing ...............................................    2
+
+     4.     Configuration Details .................................    3
+
+     SECURITY CONSIDERATIONS ......................................    3
+
+     REFERENCES ...................................................    3
+
+     ACKNOWLEDGEMENTS .............................................    3
+
+     CHAIR'S ADDRESS ..............................................    4
+
+     AUTHOR'S ADDRESS .............................................    4
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Simpson                                                        [Page ii]
+RFC 1619                   PPP over SONET/SDH                   May 1994
+
+
+1.  Introduction
+
+   PPP was designed as a standard method of communicating over point-
+   to-point links.  Initial deployment has been over short local lines,
+   leased lines, and plain-old-telephone-service (POTS) using modems.
+   As new packet services and higher speed lines are introduced, PPP is
+   easily deployed in these environments as well.
+
+   This specification is primarily concerned with the use of the PPP
+   encapsulation over SONET/SDH links.  Since SONET/SDH is by definition
+   a point-to-point circuit, PPP is well suited to use over these links.
+
+   The Synchronous Optical Network (SONET) [3] is an octet-synchronous
+   multiplex scheme that defines a family of standard rates and formats.
+   Despite the name, it is not limited to optical links.  Electrical
+   specifications have been defined for single-mode fiber, multi-mode
+   fiber, and CATV 75 ohm coaxial cable.  The transmission rates are
+   integral multiples of 51.840 Mbps, which may be used to carry T3/E3
+   bit-synchronous signals.  The allowed multiples are currently
+   specified as
+
+           STS-1    51.840         STS-18    933.120
+           STS-3   155.520         STS-24  1,244.160
+           STS-9   466.560         STS-36  1,866.240
+           STS-12  622.080         STS-48  2,488.320
+
+
+   The CCITT Synchronous Digital Heirarchy (SDH) defines a subset of
+   SONET transmission rates beginning at 155.520 Mbps [5].
+
+           SONET           SDH equivalent
+           STS-3c          STM-1
+           STS-12c         STM-4
+           STS-48c         STM-16
+
+
+
+
+2.  Physical Layer Requirements
+
+   PPP treats SONET/SDH transport as octet oriented synchronous links.
+   SONET/SDH links are full-duplex by definition.
+
+   Interface Format
+
+      PPP presents an octet interface to the physical layer.  There is
+      no provision for sub-octets to be supplied or accepted.
+
+
+
+
+Simpson                                                         [Page 1]
+RFC 1619                   PPP over SONET/SDH                   May 1994
+
+
+      The octet stream is mapped into the SONET/SDH Synchronous Payload
+      Envelope (SPE), with the octet boundaries aligned with the SPE
+      octet boundaries.
+
+      No scrambling is needed during insertion into the SPE.
+
+      The Path Signal Label (C2) is intended to indicate the contents of
+      the SPE.  The experimental value of 207 (cf hex) is used to
+      indicate PPP.
+
+      The Multiframe Indicator (H4) is currently unused, and MUST be
+      zero.
+
+   Transmission Rate
+
+      The basic rate for PPP over SONET/SDH is that of STS-3c/STM-1 at
+      155.520 Mbps.  The available information bandwidth is 149.760
+      Mbps, which is the STS-3c/STM-1 SPE with section, line and path
+      overhead removed.  This is the same super-rate mapping that is
+      used for ATM and FDDI [4].
+
+      Lower signal rates MUST use the Virtual Tributary (VT) mechanism
+      of SONET/SDH.  This maps existing signals up to T3/E3 rates
+      asynchronously into the SPE, or uses available clocks for bit-
+      synchronous and byte-synchronous mapping.
+
+      Higher signal rates SHOULD conform to the SDH STM series, rather
+      than the SONET STS series, as equipment becomes available.  The
+      STM series progresses in powers of 4 (instead of 3), and employs
+      fewer steps, which is likely to simplify multiplexing and
+      integration.
+
+   Control Signals
+
+      PPP does not require the use of control signals.  When available,
+      using such signals can allow greater functionality and
+      performance.  Implications are discussed in [2].
+
+
+
+3.  Framing
+
+   The framing for octet-synchronous links is described in "PPP in HDLC
+   Framing" [2].
+
+   The PPP frames are located by row within the SPE payload.  Because
+   frames are variable in length, the frames are allowed to cross SPE
+   boundaries.
+
+
+
+Simpson                                                         [Page 2]
+RFC 1619                   PPP over SONET/SDH                   May 1994
+
+
+4.  Configuration Details
+
+   The standard LCP sync configuration defaults apply to SONET/SDH
+   links.
+
+   The following Configuration Options are recommended:
+
+      Magic Number
+      No Address and Control Field Compression
+      No Protocol Field Compression
+      32-bit FCS
+
+
+
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+
+
+References
+
+   [1]   Simpson, W., Editor, "The Point-to-Point Protocol (PPP)", RFC
+         1548, Daydreamer, December 1993.
+
+   [2]   Simpson, W., Editor, "PPP in HDLC Framing", RFC 1549, 
+         Daydreamer, December 1993.
+
+   [3]   "American National Standard for Telecommunications - Digital
+         Hierarchy - Optical Interface Rates and Formats Specification",
+         ANSI T1.105-1991.
+
+   [4]   "American National Standard for Telecommunications -
+         Synchronous Optical Network (SONET) Payload Mappings", ANSI
+         T1.105.02-1993 draft.
+
+   [5]   CCITT Recommendation G.707, "Synchronous Digital Hierarchy Bit
+         Rates", June 1992.
+
+
+
+
+
+
+
+
+
+
+
+
+Simpson                                                         [Page 3]
+RFC 1619                   PPP over SONET/SDH                   May 1994
+
+
+Acknowledgments
+
+   PPP over SONET was first proposed by Craig Partridge (BBN).  Some
+   information was obtained from the good folks at Bellcore.
+
+   Technical assistance and information was also provided by Victor
+   Demjanenko (SUNY Buffalo).
+
+   Special thanks to Morning Star Technologies for providing computing
+   resources and network access support for writing this specification.
+
+
+
+Chair's Address
+
+   The working group can be contacted via the current chair:
+
+      Fred Baker
+      Advanced Computer Communications
+      315 Bollay Drive
+      Santa Barbara, California  93117
+
+      EMail: fbaker@acc.com
+
+
+
+Author's Address
+
+   Questions about this memo can also be directed to:
+
+      William Allen Simpson
+      Daydreamer
+      Computer Systems Consulting Services
+      1384 Fontaine
+      Madison Heights, Michigan  48071
+
+      EMail: Bill.Simpson@um.cc.umich.edu
+             bsimpson@MorningStar.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+Simpson                                                         [Page 4]
+
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1619.txt](<www.ietf.org/rfc/rfc1619.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
