### PR TITLE
Archive rfc162.txt

### DIFF
--- a/www.ietf.org/rfc/rfc162.txt
+++ b/www.ietf.org/rfc/rfc162.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                           M. Kampe
+Request for Comments: 162                                       UCLA-NMC
+NIC #6774                                               Computer Science
+Categories: C.2, C.3, D.1, D.2, D.3                          22 May 1971
+Updates: None
+Obsoletes: None
+
+
+                              NETBUGGER3
+
+   NETBUGGER3 is a third level program for the debugging of second and
+   third level programs, experimentation with and simulation of third
+   level protocols.
+
+   We were writing an RJE FILENET to interact with UCLA-CCN, and
+   discovered that they (UCLA-CCN) wouldn't be up for a few months.  We
+   needed a program that would simulate CCN, so that we could interact
+   with it and debug our FILENET.  It occurred to me that all over the
+   network, people had similar problems, i.e., they couldn't debug
+   programs because the intended server wasn't up.  And so I started to
+   write a third level debugger-simulater.
+
+   With NETBUGGER3 the user can easily issue RTSs, STRs, and LISTENs,
+   interrogate the status of connections, receive and display NCP-USER
+   events and transmit and receive data over as many as twelve
+   connections (per copy of program running).  Received data can be
+   displayed in ASCII, EBCDIC on HEX.  The user can, of course,
+   originate data for transmission in the same forms.  NETBUGGER3 can be
+   initiator, receiver and/or intermediate in connections.
+
+   An example of how NETBUGGER3 could be of use to other hosts on the
+   Net follows.
+
+   Host X has a special third level Filenet to debug.  The host they
+   plan to interact with won't be up for several months.  Host X can
+   arrange with us to interact with NETBUGGER3, which will simulate the
+   proposed third level protocol and transactions.
+
+   An alternate possibility is for Host X to use his Telnet to enter our
+   system and start NETBUGGER3 himself.  He can then be running
+   NETBUGGER3 on one console and his filenet on another.
+
+   An alternate possibility is for Host X to use his Telnet to enter our
+   system and start NETBUGGER3 himself.  He can then be running
+   NETBUGGER3 on one console and his filenet on another.
+
+
+
+
+
+
+Kampe                                                           [Page 1]
+
+RFC 162                        NETBUGGER3                       May 1971
+
+
+   Then, later on when the other server Host is up, NETBUGGER3 can be
+   used an intermediate between Host X and his serving host.  Every
+   message from Host X to server and vice versa can be displayed,
+   examined and, if necessary, edited as it passes through the
+   NETBUGGER3 console, thus making possible the debugging and
+   measurements.
+
+   This is only one example.  If you are interested in using, receiving,
+   documentation, making suggestions or anything else regarding
+   NETBUGGER3, please contact the Network liaison at UCLA - NMC.
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alison De La Cruz 12/00]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kampe                                                           [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc162.txt](<www.ietf.org/rfc/rfc162.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
