### PR TITLE
Archive rfc165.txt

### DIFF
--- a/www.ietf.org/rfc/rfc165.txt
+++ b/www.ietf.org/rfc/rfc165.txt
@@ -1,0 +1,283 @@
+
+
+
+
+
+
+Network Working Group                                          J. Postel
+Request for Comments: 165                                     UCLA - NMC
+Obsoletes: 123, 143, 145                                    May 25, 1971
+NIC: 6779
+
+
+           A Preferred Official Initial Connection Protocol*
+
+   This document specifies the their level protocol used to connect a
+   user process at one site with a server process at another site.  In
+   one instance, the user process will be a Telnet and the server
+   process will be a Logger, but there will be other cases.
+
+   This document describes a family of Initial Connection Protocols
+   (ICP's) suitable for establishing one pair of connections between any
+   user process and any server process, and further to describe the
+   parameter values for connecting Telnets and Loggers.  The description
+   will be at two levels, the third or user level, and the second or NCP
+   level.
+
+Third Level Description
+
+Notation
+
+   There is no standard notation for describing system calls, which
+   initiate and close connections or cause data to be sent, so the
+   following *ad hoc* notation will be used.
+
+   Init (local = l, foreign = f, size = s)
+
+           Causes the local Host to attempt to establish a connection
+           between socket l at the local Host and socket f, with a byte
+           size of s for the connection.
+
+           l is a 32 bit local socket number,
+           f is a 40 bit foreign socket number, the high-order eight
+             bits of which specify the foreign Host, and
+           s is an eight bit non-zero byte size.
+
+           The sum of l and f must be odd.
+
+   Listen (local = l, size = s)
+
+           Causes the local Host to wait for a request for connection to
+           local socket l with byte size s.  The process will be woken
+           when a connection is established.  The parameters l and s are
+           the same as for Init.
+
+
+
+
+Postel                                                          [Page 1]
+
+RFC 165               Initial Connection Protocol           May 25, 1971
+
+
+   Send  (socket = l, data = d)
+
+           The data named by d is sent over the connection attached to
+           local socket l.  l must be a send socket attached to a
+           connection.  d is the name of a data area.
+
+   Receive (socket = l, data = d)
+
+           The receive side counterpart to send.
+
+   Close (socket = l)
+
+           Any connection currently attached to local socket l is
+           closed.
+
+A Family of ICP's
+
+   Briefly, a server process at a site attaches a well-advertised send
+   socket L and listens.  A user process initiates connection to L from
+   its receive socket U.  The byte size for this connection is 32. The
+   server process then transmits a 32-bit even number S and closes the
+   connection.  The 32-bit number S and its successor, S+1, are the
+   socket numbers the server will use.  The final steps are for sockets
+   S and S+1 at the server site to be connected to sockets U+3 and U+2
+   respectively at the user site.
+
+   Using the notation, the server executes the following sequence:
+
+      Listen (socket = L, size = 32)
+      [Wait until a user connects]
+      Send (socket = L, data = S)
+      Close (socket = L)
+      Init (local = S, Foreign = U+3, size Bu)
+      Init (local = S+1, foreign = U+2, size Bs)
+
+   The user executes the following:
+
+      Init (local = U, foreign = L, size = 32)
+      Receive (socket = U, data = S)
+      Optional Close (socket = U)
+      Listen or Init (local U+3, foreign = S, size = Bu)
+      Listen or Init (local = U+2, foreign = S+1, size = Bs)
+
+   Note that L is a send socket (odd), while S and U are receive sockets
+   (even).  Where L, S, or U are used as values of local, they are 32-
+   bit numbers; where they are values of foreign, they are 40-bit
+   numbers.  The parameters Bs and Bu are the byte sizes to be sent by
+
+
+
+
+Postel                                                          [Page 2]
+
+RFC 165               Initial Connection Protocol           May 25, 1971
+
+
+   the server and user, respectively.  If the user side declines to
+   close socket U, then it must be handled automatically by the second
+   level (see page 4).
+
+   Examination of the above sequences reveals that an ICP is
+   characterized by three numbers L, Bs, and Bu, and must meet the
+   restrictions that
+
+      a) L is a send socket,
+      b) Bs and Bu are legal byte sizes, and
+      c) For each L there is only one pair of associated byte sizes.
+
+   This last restriction prevents two district services from being
+   available through the same socket and distinguished only by the byte
+   sizes.
+
+Second Level Description
+
+Notation
+
+   The following notation will be used for the NCP Control Command used
+   in ICP.
+
+           STR (_ls_, _fs_, _s_)
+                   _ls_ = local send socket
+                   _fs_ = foreign receive socket
+                   _s_ = byte size
+
+           RTS (_ls_, _fs_, _l_)
+                   _ls_ = local receive socket
+                   _fs_ = foreign send socket
+                   _l_ = link
+
+           ALL (_l_, _m_, _b_)
+                   _l_ = link
+                   _m_ = message allocation
+                   _b_ = bit allocation
+
+           CLS (_ls_, _fs_)
+                   _ls_  = local socket
+                   _fs_ = foreign socket
+
+
+
+
+
+
+
+
+
+
+Postel                                                          [Page 3]
+
+RFC 165               Initial Connection Protocol           May 25, 1971
+
+
+   The same family of ICP's is now described again.
+
+   Server                          User
+
+   S1: listening on socket L.      U1: RTS (U, L, _l1_)
+
+   S2: Wait for match.             U2: Wait for match.
+
+   S3: STR (L, U, _s1_)
+
+   S4: Wait for allocation.        U3: All (_l1_, _m1_, _b1_)
+
+   S5: Send data S in_s1_ bit      U4: Receive data S in s1 bit bytes.
+       bytes as allowed by             _s1_ bit bytes.
+       allocation m1_, _b1_).
+
+   S6: CLS (L, U)                  U5: CLS (U, L)
+
+   S7: RTS (S, U+3, _l2_)          U6: STR (U+3, S, _s2_)
+
+   S8: STR (S+1, U+2, _s3_)        U7: RTS (U+2, S+1, _l3_)
+
+   The labels here imply no ordering except that ordering required by
+   the Host-Host Protocol.  Note that steps S7 and S8 can be reversed as
+   can U6 and U7.  Also, notice that at any time after S2 the server
+   could initiate steps S7 and S8 in parallel with steps S3 through S6,
+   and that at any time after U4 the user could initiate steps U6 and U7
+   in parallel with step U5.
+
+   Following the above, exchanges ALL commands would be exchanged and
+   data transfers could begin.
+
+   At this level the parameters of the above ICP family are L, _m1_,
+   _b1_, _s1_, _s2_, _s3_, _l1_, _l2_, _l3_.
+
+   L is a well known socket number and will be specified for each type
+   of service.
+
+   m1 and b1 are allocation quantities for the transfer of a socket
+   number.
+
+      _m1_ is specified to be 1.
+      _b1_ is specified to be 32.
+      _s1_, _s2_, and _s3_ are byte sizes.  Only _s1_ is to be specified
+         as _s2_ and _s3_ are to be left to the process involved.
+      _s1_ is specified to be 32.
+
+      _l1_, _l2_, and _l3_ are links and are not specified.
+
+
+
+Postel                                                          [Page 4]
+
+RFC 165               Initial Connection Protocol           May 25, 1971
+
+
+   Note: Some hosts currently have difficulty sending 32 bit bytes.
+   Thus, it is temporarily allowed to send the socket number S as four 8
+   bit bytes in one message.
+
+   It is legal for the NCP to receive RTS or STR before the
+   corresponding local Init or Listen is issued.  Therefore, it is
+   suggested that requests for connection to idle sockets be queued as
+   allowed by time and space limitations.
+
+Telnet - Logger ICP
+
+   For connecting Telnet and Logger processes, the ICP parameters are
+   L=1, Bu, _s2_, and Bs = _s3_ = 8. (To clarify the socket number
+   required, L = X'00000001').
+
+Formalities
+
+   This proposed official protocol will become official if no serious
+   objections are raised before 2 June 71.  A telephone survey of
+   Network Liaisons will be conducted by Jon Postel before that date.
+   If no objections are raised, this protocol will be declared official
+   by the Working Group chairman.
+
+   * This document is based on RFC 123 by S. Crocker and discussions by
+     the ICP Committee.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Postel                                                          [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc165.txt](<www.ietf.org/rfc/rfc165.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
