### PR TITLE
Archive rfc1657.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1657.txt
+++ b/www.ietf.org/rfc/rfc1657.txt
@@ -1,0 +1,1179 @@
+
+
+
+
+
+
+Network Working Group                                          S. Willis
+Request for Comments: 1657                                    J. Burruss
+Category: Standards Track                  Wellfleet Communications Inc.
+                                                          J. Chu, Editor
+                                                               IBM Corp.
+                                                               July 1994
+
+
+      Definitions of Managed Objects for the Fourth Version of the
+              Border Gateway Protocol (BGP-4) using SMIv2
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+1. Introduction
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the Internet community.
+   In particular, it describes managed objects used for managing the
+   Border Gateway Protocol Version 4 or lower [1, 2].
+
+2. The SNMPv2 Network Management Framework
+
+   The SNMPv2 Network Management Framework consists of four major
+   components.  They are:
+
+      RFC 1442 which defines the SMI, the mechanisms used for describing
+      and naming objects for the purpose of management.
+
+      STD 17, RFC 1213 defines MIB-II, the core set of managed objects
+      forthe Internet suite of protocols.
+
+      RFC 1445 which defines the administrative and other architectural
+      aspects of the framework.
+
+      RFC 1448 which defines the protocol used for network access to
+      managed objects.
+
+   The Framework permits new objects to be defined for the purpose of
+   experimentation and evaluation.
+
+
+
+
+
+
+Willis, Burruss & Chu                                           [Page 1]
+
+RFC 1657                       BGP-4 MIB                       July 1994
+
+
+3. Object Definitions
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  Objects in the MIB are
+   defined using the subset of Abstract Syntax Notation One (ASN.1)
+   defined in the SMI.  In particular, each object type is named by an
+   OBJECT IDENTIFIER, an administratively assigned name.  The object
+   type together with an object instance serves to uniquely identify a
+   specific instantiation of the object.  For human convenience, we
+   often use a textual string, termed the descriptor, to refer to the
+   object type.
+
+4. Overview
+
+   These objects are used to control and manage a BGP-4 implementation.
+
+   Apart from a few system-wide scalar objects, this MIB is broken into
+   three tables: the BGP Peer Table, the BGP Received Path Attribute
+   Table, and the BGP-4 Received Path Attribute Table. The BGP Peer
+   Table contains information about state and current activity of
+   connections with the BGP peers. The Received Path Attribute Table
+   contains path attributes received from all peers running BGP version
+   3 or less. The BGP-4 Received Path Attribute Table contains path
+   attributes received from all BGP-4 peers.  The actual attributes used
+   in determining a route are a subset of the received attribute tables
+   after local routing policy has been applied.
+
+5. Definitions
+
+BGP4-MIB DEFINITIONS ::= BEGIN
+
+                IMPORTS
+                    MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE,
+                    IpAddress, Integer32, Counter32, Gauge32
+                        FROM SNMPv2-SMI
+                    mib-2
+                        FROM RFC1213-MIB;
+
+                bgp MODULE-IDENTITY
+                    LAST-UPDATED "9405050000Z"
+                    ORGANIZATION "IETF BGP Working Group"
+                    CONTACT-INFO
+                                "   John Chu  (Editor)
+                            Postal: IBM Corp.
+                                    P.O.Box 218
+                                    Yorktown Heights, NY 10598
+                                    US
+
+
+
+
+Willis, Burruss & Chu                                           [Page 2]
+
+RFC 1657                       BGP-4 MIB                       July 1994
+
+
+                               Tel: +1 914 945 3156
+                               Fax: +1 914 945 2141
+                            E-mail: jychu@watson.ibm.com"
+                        DESCRIPTION
+                                "The MIB module for BGP-4."
+                    ::= { mib-2 15 }
+
+                bgpVersion OBJECT-TYPE
+                    SYNTAX     OCTET STRING (SIZE (1..255))
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "Vector of supported BGP protocol version
+                            numbers.  Each peer negotiates the version
+                            from this vector.  Versions are identified
+                            via the string of bits contained within this
+                            object.  The first octet contains bits 0 to
+                            7, the second octet contains bits 8 to 15,
+                            and so on, with the most significant bit
+                            referring to the lowest bit number in the
+                            octet (e.g., the MSB of the first octet
+                            refers to bit 0).  If a bit, i, is present
+                            and set, then the version (i+1) of the BGP
+                            is supported."
+                    ::= { bgp 1 }
+
+                bgpLocalAs OBJECT-TYPE
+                    SYNTAX     INTEGER (0..65535)
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "The local autonomous system number."
+                    ::= { bgp 2 }
+
+
+
+                -- BGP Peer table.  This table contains, one entry per
+                -- BGP peer, information about the BGP peer.
+
+                bgpPeerTable OBJECT-TYPE
+                    SYNTAX     SEQUENCE OF BgpPeerEntry
+                    MAX-ACCESS not-accessible
+                    STATUS     current
+                    DESCRIPTION
+                            "BGP peer table.  This table contains,
+                            one entry per BGP peer, information about
+                            the connections with BGP peers."
+                    ::= { bgp 3 }
+
+
+
+Willis, Burruss & Chu                                           [Page 3]
+
+RFC 1657                       BGP-4 MIB                       July 1994
+
+
+                bgpPeerEntry OBJECT-TYPE
+                    SYNTAX     BgpPeerEntry
+                    MAX-ACCESS not-accessible
+                    STATUS     current
+                    DESCRIPTION
+                            "Entry containing information about the
+                            connection with a BGP peer."
+                    INDEX { bgpPeerRemoteAddr }
+                    ::= { bgpPeerTable 1 }
+
+                BgpPeerEntry ::= SEQUENCE {
+                        bgpPeerIdentifier
+                            IpAddress,
+                        bgpPeerState
+                            INTEGER,
+                        bgpPeerAdminStatus
+                            INTEGER,
+                        bgpPeerNegotiatedVersion
+                            Integer32,
+                        bgpPeerLocalAddr
+                            IpAddress,
+                        bgpPeerLocalPort
+                            INTEGER,
+                        bgpPeerRemoteAddr
+                            IpAddress,
+                        bgpPeerRemotePort
+                            INTEGER,
+                        bgpPeerRemoteAs
+                            INTEGER,
+                        bgpPeerInUpdates
+                            Counter32,
+                        bgpPeerOutUpdates
+                            Counter32,
+                        bgpPeerInTotalMessages
+                            Counter32,
+                        bgpPeerOutTotalMessages
+                            Counter32,
+                        bgpPeerLastError
+                            OCTET STRING,
+                        bgpPeerFsmEstablishedTransitions
+                            Counter32,
+                        bgpPeerFsmEstablishedTime
+                            Gauge32,
+                        bgpPeerConnectRetryInterval
+                            INTEGER,
+                        bgpPeerHoldTime
+                            INTEGER,
+                        bgpPeerKeepAlive
+
+
+
+Willis, Burruss & Chu                                           [Page 4]
+
+RFC 1657                       BGP-4 MIB                       July 1994
+
+
+                            INTEGER,
+                        bgpPeerHoldTimeConfigured
+                            INTEGER,
+                        bgpPeerKeepAliveConfigured
+                            INTEGER,
+                        bgpPeerMinASOriginationInterval
+                            INTEGER,
+                        bgpPeerMinRouteAdvertisementInterval
+                            INTEGER,
+                        bgpPeerInUpdateElapsedTime
+                            Gauge32
+                        }
+
+                bgpPeerIdentifier OBJECT-TYPE
+                    SYNTAX     IpAddress
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "The BGP Identifier of this entry's BGP
+                            peer."
+                    ::= { bgpPeerEntry 1 }
+
+                bgpPeerState OBJECT-TYPE
+                    SYNTAX     INTEGER {
+                                        idle(1),
+                                        connect(2),
+                                        active(3),
+                                        opensent(4),
+                                        openconfirm(5),
+                                        established(6)
+                               }
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "The BGP peer connection state."
+                    ::= { bgpPeerEntry 2 }
+
+                bgpPeerAdminStatus OBJECT-TYPE
+                    SYNTAX     INTEGER {
+                                        stop(1),
+                                        start(2)
+                               }
+                    MAX-ACCESS read-write
+                    STATUS     current
+                    DESCRIPTION
+                            "The desired state of the BGP connection.
+                            A transition from 'stop' to 'start' will
+                            cause the BGP Start Event to be generated.
+
+
+
+Willis, Burruss & Chu                                           [Page 5]
+
+RFC 1657                       BGP-4 MIB                       July 1994
+
+
+                            A transition from 'start' to 'stop' will
+                            cause the BGP Stop Event to be generated.
+                            This parameter can be used to restart BGP
+                            peer connections.  Care should be used in
+                            providing write access to this object
+                            without adequate authentication."
+                    ::= { bgpPeerEntry 3 }
+
+                bgpPeerNegotiatedVersion OBJECT-TYPE
+                    SYNTAX     Integer32
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "The negotiated version of BGP running
+                            between the two peers."
+                    ::= { bgpPeerEntry 4 }
+
+                bgpPeerLocalAddr OBJECT-TYPE
+                    SYNTAX     IpAddress
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "The local IP address of this entry's BGP
+                            connection."
+                    ::= { bgpPeerEntry 5 }
+
+                bgpPeerLocalPort OBJECT-TYPE
+                    SYNTAX     INTEGER (0..65535)
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "The local port for the TCP connection
+                            between the BGP peers."
+                    ::= { bgpPeerEntry 6 }
+
+                bgpPeerRemoteAddr OBJECT-TYPE
+                    SYNTAX     IpAddress
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "The remote IP address of this entry's BGP
+                            peer."
+                    ::= { bgpPeerEntry 7 }
+
+                bgpPeerRemotePort OBJECT-TYPE
+                    SYNTAX     INTEGER (0..65535)
+                    MAX-ACCESS read-only
+                    STATUS     current
+
+
+
+Willis, Burruss & Chu                                           [Page 6]
+
+RFC 1657                       BGP-4 MIB                       July 1994
+
+
+                    DESCRIPTION
+                            "The remote port for the TCP connection
+                            between the BGP peers.  Note that the
+                            objects bgpPeerLocalAddr,
+                            bgpPeerLocalPort, bgpPeerRemoteAddr and
+                            bgpPeerRemotePort provide the appropriate
+                            reference to the standard MIB TCP
+                            connection table."
+                    ::= { bgpPeerEntry 8 }
+
+                bgpPeerRemoteAs OBJECT-TYPE
+                    SYNTAX     INTEGER (0..65535)
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "The remote autonomous system number."
+                    ::= { bgpPeerEntry 9 }
+
+                bgpPeerInUpdates OBJECT-TYPE
+                    SYNTAX     Counter32
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "The number of BGP UPDATE messages
+                            received on this connection.  This object
+                            should be initialized to zero (0) when the
+                            connection is established."
+                    ::= { bgpPeerEntry 10 }
+
+                bgpPeerOutUpdates OBJECT-TYPE
+                    SYNTAX     Counter32
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "The number of BGP UPDATE messages
+                            transmitted on this connection.  This
+                            object should be initialized to zero (0)
+                            when the connection is established."
+                    ::= { bgpPeerEntry 11 }
+
+                bgpPeerInTotalMessages OBJECT-TYPE
+                    SYNTAX     Counter32
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "The total number of messages received
+                            from the remote peer on this connection.
+                            This object should be initialized to zero
+
+
+
+Willis, Burruss & Chu                                           [Page 7]
+
+RFC 1657                       BGP-4 MIB                       July 1994
+
+
+                            when the connection is established."
+                    ::= { bgpPeerEntry 12 }
+
+                bgpPeerOutTotalMessages OBJECT-TYPE
+                    SYNTAX     Counter32
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "The total number of messages transmitted to
+                            the remote peer on this connection.  This
+                            object should be initialized to zero when
+                            the connection is established."
+                    ::= { bgpPeerEntry 13 }
+
+                bgpPeerLastError OBJECT-TYPE
+                    SYNTAX     OCTET STRING (SIZE (2))
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "The last error code and subcode seen by this
+                            peer on this connection.  If no error has
+                            occurred, this field is zero.  Otherwise, the
+                            first byte of this two byte OCTET STRING
+                            contains the error code, and the second byte
+                            contains the subcode."
+                    ::= { bgpPeerEntry 14 }
+
+                bgpPeerFsmEstablishedTransitions OBJECT-TYPE
+                    SYNTAX     Counter32
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "The total number of times the BGP FSM
+                            transitioned into the established state."
+                    ::= { bgpPeerEntry 15 }
+
+                bgpPeerFsmEstablishedTime OBJECT-TYPE
+                    SYNTAX     Gauge32
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "This timer indicates how long (in
+                            seconds) this peer has been in the
+                            Established state or how long
+                            since this peer was last in the
+                            Established state.  It is set to zero when
+                            a new peer is configured or the router is
+                            booted."
+
+
+
+Willis, Burruss & Chu                                           [Page 8]
+
+RFC 1657                       BGP-4 MIB                       July 1994
+
+
+                    ::= { bgpPeerEntry 16 }
+
+                bgpPeerConnectRetryInterval OBJECT-TYPE
+                    SYNTAX     INTEGER (1..65535)
+                    MAX-ACCESS read-write
+                    STATUS     current
+                    DESCRIPTION
+                            "Time interval in seconds for the
+                            ConnectRetry timer.  The suggested value
+                            for this timer is 120 seconds."
+                    ::= { bgpPeerEntry 17 }
+
+                bgpPeerHoldTime OBJECT-TYPE
+                    SYNTAX     INTEGER  ( 0 | 3..65535 )
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "Time interval in seconds for the Hold
+                            Timer established with the peer.  The
+                            value of this object is calculated by this
+                            BGP speaker by using the smaller of the
+                            value in bgpPeerHoldTimeConfigured and the
+                            Hold Time received in the OPEN message.
+                            This value must be at lease three seconds
+                            if it is not zero (0) in which case the
+                            Hold Timer has not been established with
+                            the peer, or, the value of
+                            bgpPeerHoldTimeConfigured is zero (0)."
+                    ::= { bgpPeerEntry 18 }
+
+                bgpPeerKeepAlive OBJECT-TYPE
+                    SYNTAX     INTEGER ( 0 | 1..21845 )
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "Time interval in seconds for the KeepAlive
+                            timer established with the peer.  The value
+                            of this object is calculated by this BGP
+                            speaker such that, when compared with
+                            bgpPeerHoldTime, it has the same
+                            proportion as what
+                            bgpPeerKeepAliveConfigured has when
+                            compared with bgpPeerHoldTimeConfigured.
+                            If the value of this object is zero (0),
+                            it indicates that the KeepAlive timer has
+                            not been established with the peer, or,
+                            the value of bgpPeerKeepAliveConfigured is
+                            zero (0)."
+
+
+
+Willis, Burruss & Chu                                           [Page 9]
+
+RFC 1657                       BGP-4 MIB                       July 1994
+
+
+                    ::= { bgpPeerEntry 19 }
+
+                bgpPeerHoldTimeConfigured OBJECT-TYPE
+                    SYNTAX     INTEGER ( 0 | 3..65535 )
+                    MAX-ACCESS read-write
+                    STATUS     current
+                    DESCRIPTION
+                            "Time interval in seconds for the Hold Time
+                            configured for this BGP speaker with this
+                            peer.  This value is placed in an OPEN
+                            message sent to this peer by this BGP
+                            speaker, and is compared with the Hold
+                            Time field in an OPEN message received
+                            from the peer when determining the Hold
+                            Time (bgpPeerHoldTime) with the peer.
+                            This value must not be less than three
+                            seconds if it is not zero (0) in which
+                            case the Hold Time is NOT to be
+                            established with the peer.  The suggested
+                            value for this timer is 90 seconds."
+                    ::= { bgpPeerEntry 20 }
+
+                bgpPeerKeepAliveConfigured OBJECT-TYPE
+                    SYNTAX     INTEGER ( 0 | 1..21845 )
+                    MAX-ACCESS read-write
+                    STATUS     current
+                    DESCRIPTION
+                            "Time interval in seconds for the
+                            KeepAlive timer configured for this BGP
+                            speaker with this peer.  The value of this
+                            object will only determine the
+                            KEEPALIVE messages' frequency relative to
+                            the value specified in
+                            bgpPeerHoldTimeConfigured; the actual
+                            time interval for the KEEPALIVE messages
+                            is indicated by bgpPeerKeepAlive.  A
+                            reasonable maximum value for this timer
+                            would be configured to be one
+                            third of that of
+                            bgpPeerHoldTimeConfigured.
+                            If the value of this object is zero (0),
+                            no periodical KEEPALIVE messages are sent
+                            to the peer after the BGP connection has
+                            been established.  The suggested value for
+                            this timer is 30 seconds."
+                    ::= { bgpPeerEntry 21 }
+
+
+
+
+
+Willis, Burruss & Chu                                          [Page 10]
+
+RFC 1657                       BGP-4 MIB                       July 1994
+
+
+                bgpPeerMinASOriginationInterval OBJECT-TYPE
+                    SYNTAX     INTEGER (1..65535)
+                    MAX-ACCESS read-write
+                    STATUS     current
+                    DESCRIPTION
+                            "Time interval in seconds for the
+                            MinASOriginationInterval timer.
+                            The suggested value for this timer is 15
+                            seconds."
+                    ::= { bgpPeerEntry 22 }
+
+                bgpPeerMinRouteAdvertisementInterval OBJECT-TYPE
+                    SYNTAX     INTEGER (1..65535)
+                    MAX-ACCESS read-write
+                    STATUS     current
+                    DESCRIPTION
+                            "Time interval in seconds for the
+                            MinRouteAdvertisementInterval timer.
+                            The suggested value for this timer is 30
+                            seconds."
+                    ::= { bgpPeerEntry 23 }
+
+                bgpPeerInUpdateElapsedTime OBJECT-TYPE
+                    SYNTAX     Gauge32
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "Elapsed time in seconds since the last BGP
+                            UPDATE message was received from the peer.
+                            Each time bgpPeerInUpdates is incremented,
+                            the value of this object is set to zero
+                            (0)."
+                    ::= { bgpPeerEntry 24 }
+
+
+
+                bgpIdentifier OBJECT-TYPE
+                    SYNTAX     IpAddress
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "The BGP Identifier of local system."
+                    ::= { bgp 4 }
+
+
+
+
+
+
+
+
+Willis, Burruss & Chu                                          [Page 11]
+
+RFC 1657                       BGP-4 MIB                       July 1994
+
+
+                -- Received Path Attribute Table.  This table contains,
+                -- one entry per path to a network, path attributes
+                -- received from all peers running BGP version 3 or
+                -- less.  This table is deprecated.
+
+                bgpRcvdPathAttrTable OBJECT-TYPE
+                    SYNTAX     SEQUENCE OF BgpPathAttrEntry
+                    MAX-ACCESS not-accessible
+                    STATUS     obsolete
+                    DESCRIPTION
+                            "The BGP Received Path Attribute Table
+                            contains information about paths to
+                            destination networks received from all
+                            peers running BGP version 3 or less."
+                    ::= { bgp 5 }
+
+                bgpPathAttrEntry OBJECT-TYPE
+                    SYNTAX     BgpPathAttrEntry
+                    MAX-ACCESS not-accessible
+                    STATUS     obsolete
+                    DESCRIPTION
+                            "Information about a path to a network."
+                    INDEX { bgpPathAttrDestNetwork,
+                            bgpPathAttrPeer        }
+                    ::= { bgpRcvdPathAttrTable 1 }
+
+                BgpPathAttrEntry ::= SEQUENCE {
+                    bgpPathAttrPeer
+                         IpAddress,
+                    bgpPathAttrDestNetwork
+                         IpAddress,
+                    bgpPathAttrOrigin
+                         INTEGER,
+                    bgpPathAttrASPath
+                         OCTET STRING,
+                    bgpPathAttrNextHop
+                         IpAddress,
+                    bgpPathAttrInterASMetric
+                         Integer32
+                }
+
+                bgpPathAttrPeer OBJECT-TYPE
+                    SYNTAX     IpAddress
+                    MAX-ACCESS read-only
+                    STATUS     obsolete
+                    DESCRIPTION
+                            "The IP address of the peer where the path
+                            information was learned."
+
+
+
+Willis, Burruss & Chu                                          [Page 12]
+
+RFC 1657                       BGP-4 MIB                       July 1994
+
+
+                    ::= { bgpPathAttrEntry 1 }
+
+                bgpPathAttrDestNetwork OBJECT-TYPE
+                    SYNTAX     IpAddress
+                    MAX-ACCESS read-only
+                    STATUS     obsolete
+                    DESCRIPTION
+                            "The address of the destination network."
+                    ::= { bgpPathAttrEntry 2 }
+
+                bgpPathAttrOrigin OBJECT-TYPE
+                    SYNTAX     INTEGER {
+                                   igp(1),-- networks are interior
+                                   egp(2),-- networks learned via EGP
+                                   incomplete(3) -- undetermined
+                               }
+                    MAX-ACCESS read-only
+                    STATUS     obsolete
+                    DESCRIPTION
+                         "The ultimate origin of the path information."
+                    ::= { bgpPathAttrEntry 3 }
+
+                bgpPathAttrASPath OBJECT-TYPE
+                    SYNTAX     OCTET STRING (SIZE (2..255))
+                    MAX-ACCESS read-only
+                    STATUS     obsolete
+                    DESCRIPTION
+                            "The set of ASs that must be traversed to
+                            reach the network.  This object is
+                            probably best represented as SEQUENCE OF
+                            INTEGER.  For SMI compatibility, though,
+                            it is represented as OCTET STRING.  Each
+                            AS is represented as a pair of octets
+                            according to the following algorithm:
+
+                                first-byte-of-pair = ASNumber / 256;
+                                second-byte-of-pair = ASNumber & 255;"
+                    ::= { bgpPathAttrEntry 4 }
+
+                bgpPathAttrNextHop OBJECT-TYPE
+                    SYNTAX     IpAddress
+                    MAX-ACCESS read-only
+                    STATUS     obsolete
+                    DESCRIPTION
+                            "The address of the border router that
+                            should be used for the destination
+                            network."
+                    ::= { bgpPathAttrEntry 5 }
+
+
+
+Willis, Burruss & Chu                                          [Page 13]
+
+RFC 1657                       BGP-4 MIB                       July 1994
+
+
+                bgpPathAttrInterASMetric OBJECT-TYPE
+                    SYNTAX     Integer32
+                    MAX-ACCESS read-only
+                    STATUS     obsolete
+                    DESCRIPTION
+                            "The optional inter-AS metric.  If this
+                            attribute has not been provided for this
+                            route, the value for this object is 0."
+                    ::= { bgpPathAttrEntry 6 }
+
+
+
+                -- BGP-4 Received Path Attribute Table.  This table
+                -- contains, one entry per path to a network, path
+                -- attributes received from all peers running BGP-4.
+
+                bgp4PathAttrTable OBJECT-TYPE
+                    SYNTAX     SEQUENCE OF Bgp4PathAttrEntry
+                    MAX-ACCESS not-accessible
+                    STATUS     current
+                    DESCRIPTION
+                            "The BGP-4 Received Path Attribute Table
+                            contains information about paths to
+                            destination networks received from all
+                            BGP4 peers."
+                    ::= { bgp 6 }
+
+                bgp4PathAttrEntry OBJECT-TYPE
+                    SYNTAX     Bgp4PathAttrEntry
+                    MAX-ACCESS not-accessible
+                    STATUS     current
+                    DESCRIPTION
+                            "Information about a path to a network."
+                    INDEX { bgp4PathAttrIpAddrPrefix,
+                            bgp4PathAttrIpAddrPrefixLen,
+                            bgp4PathAttrPeer            }
+                    ::= { bgp4PathAttrTable 1 }
+
+                Bgp4PathAttrEntry ::= SEQUENCE {
+                    bgp4PathAttrPeer
+                         IpAddress,
+                    bgp4PathAttrIpAddrPrefixLen
+                         INTEGER,
+                    bgp4PathAttrIpAddrPrefix
+                         IpAddress,
+                    bgp4PathAttrOrigin
+                         INTEGER,
+                    bgp4PathAttrASPathSegment
+
+
+
+Willis, Burruss & Chu                                          [Page 14]
+
+RFC 1657                       BGP-4 MIB                       July 1994
+
+
+                         OCTET STRING,
+                    bgp4PathAttrNextHop
+                         IpAddress,
+                    bgp4PathAttrMultiExitDisc
+                         INTEGER,
+                    bgp4PathAttrLocalPref
+                         INTEGER,
+                    bgp4PathAttrAtomicAggregate
+                         INTEGER,
+                    bgp4PathAttrAggregatorAS
+                         INTEGER,
+                    bgp4PathAttrAggregatorAddr
+                         IpAddress,
+                    bgp4PathAttrCalcLocalPref
+                         INTEGER,
+                    bgp4PathAttrBest
+                         INTEGER,
+                    bgp4PathAttrUnknown
+                         OCTET STRING
+
+                }
+
+                bgp4PathAttrPeer OBJECT-TYPE
+                    SYNTAX     IpAddress
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "The IP address of the peer where the path
+                            information was learned."
+                    ::= { bgp4PathAttrEntry 1 }
+
+                bgp4PathAttrIpAddrPrefixLen OBJECT-TYPE
+                    SYNTAX     INTEGER (0..32)
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "Length in bits of the IP address prefix
+                            in the Network Layer Reachability
+                            Information field."
+                    ::= { bgp4PathAttrEntry 2 }
+
+                bgp4PathAttrIpAddrPrefix OBJECT-TYPE
+                    SYNTAX     IpAddress
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "An IP address prefix in the Network Layer
+                            Reachability Information field.  This object
+
+
+
+Willis, Burruss & Chu                                          [Page 15]
+
+RFC 1657                       BGP-4 MIB                       July 1994
+
+
+                            is an IP address containing the prefix with
+                            length specified by
+                            bgp4PathAttrIpAddrPrefixLen.
+                            Any bits beyond the length specified by
+                            bgp4PathAttrIpAddrPrefixLen are zeroed."
+                    ::= { bgp4PathAttrEntry 3 }
+
+                bgp4PathAttrOrigin OBJECT-TYPE
+                    SYNTAX     INTEGER {
+                                         igp(1),-- networks are interior
+                                         egp(2),-- networks learned
+                                                -- via EGP
+                                         incomplete(3) -- undetermined
+                                       }
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "The ultimate origin of the path
+                            information."
+                    ::= { bgp4PathAttrEntry 4 }
+
+                bgp4PathAttrASPathSegment OBJECT-TYPE
+                    SYNTAX     OCTET STRING (SIZE (2..255))
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "The sequence of AS path segments.  Each AS
+                            path segment is represented by a triple
+                            <type, length, value>.
+
+                            The type is a 1-octet field which has two
+                            possible values:
+                                 1      AS_SET: unordered set of ASs a
+                                             route in the UPDATE
+                                             message has traversed
+                                 2      AS_SEQUENCE: ordered set of ASs
+                                             a route in the UPDATE
+                                             message has traversed.
+
+                            The length is a 1-octet field containing the
+                            number of ASs in the value field.
+
+                            The value field contains one or more AS
+                            numbers, each AS is represented in the octet
+                            string as a pair of octets according to the
+                            following algorithm:
+
+
+
+
+
+Willis, Burruss & Chu                                          [Page 16]
+
+RFC 1657                       BGP-4 MIB                       July 1994
+
+
+                                first-byte-of-pair = ASNumber / 256;
+                                second-byte-of-pair = ASNumber & 255;"
+                    ::= { bgp4PathAttrEntry 5 }
+
+                bgp4PathAttrNextHop OBJECT-TYPE
+                    SYNTAX     IpAddress
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "The address of the border router that
+                            should be used for the destination
+                            network."
+                    ::= { bgp4PathAttrEntry 6 }
+
+                bgp4PathAttrMultiExitDisc OBJECT-TYPE
+                    SYNTAX     INTEGER (-1..2147483647)
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "This metric is used to discriminate
+                            between multiple exit points to an
+                            adjacent autonomous system.  A value of -1
+                            indicates the absence of this attribute."
+                    ::= { bgp4PathAttrEntry 7 }
+
+                bgp4PathAttrLocalPref OBJECT-TYPE
+                    SYNTAX     INTEGER (-1..2147483647)
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "The originating BGP4 speaker's degree of
+                            preference for an advertised route.  A
+                            value of -1 indicates the absence of this
+                            attribute."
+                    ::= { bgp4PathAttrEntry 8 }
+
+                bgp4PathAttrAtomicAggregate OBJECT-TYPE
+                    SYNTAX     INTEGER {
+                                   lessSpecificRrouteNotSelected(1),
+                                   lessSpecificRouteSelected(2)
+                               }
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "Whether or not the local system has
+                            selected a less specific route without
+                            selecting a more specific route."
+                    ::= { bgp4PathAttrEntry 9 }
+
+
+
+Willis, Burruss & Chu                                          [Page 17]
+
+RFC 1657                       BGP-4 MIB                       July 1994
+
+
+                bgp4PathAttrAggregatorAS OBJECT-TYPE
+                    SYNTAX     INTEGER (0..65535)
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "The AS number of the last BGP4 speaker that
+                            performed route aggregation.  A value of
+                            zero (0) indicates the absence of this
+                            attribute."
+                    ::= { bgp4PathAttrEntry 10 }
+
+                bgp4PathAttrAggregatorAddr OBJECT-TYPE
+                    SYNTAX     IpAddress
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "The IP address of the last BGP4 speaker
+                            that performed route aggregation.  A value
+                            of 0.0.0.0 indicates the absence of this
+                            attribute."
+                    ::= { bgp4PathAttrEntry 11 }
+
+                bgp4PathAttrCalcLocalPref OBJECT-TYPE
+                    SYNTAX     INTEGER (-1..2147483647)
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "The degree of preference calculated by the
+                            receiving BGP4 speaker for an advertised
+                            route.  A value of -1 indicates the
+                            absence of this attribute."
+                    ::= { bgp4PathAttrEntry 12 }
+
+                bgp4PathAttrBest OBJECT-TYPE
+                    SYNTAX     INTEGER {
+                                   false(1),-- not chosen as best route
+                                   true(2) -- chosen as best route
+                               }
+                    MAX-ACCESS read-only
+                    STATUS     current
+                    DESCRIPTION
+                            "An indication of whether or not this route
+                            was chosen as the best BGP4 route."
+                    ::= { bgp4PathAttrEntry 13 }
+
+               bgp4PathAttrUnknown OBJECT-TYPE
+                    SYNTAX     OCTET STRING (SIZE(0..255))
+                    MAX-ACCESS read-only
+
+
+
+Willis, Burruss & Chu                                          [Page 18]
+
+RFC 1657                       BGP-4 MIB                       July 1994
+
+
+                    STATUS     current
+                    DESCRIPTION
+                            "One or more path attributes not understood
+                             by this BGP4 speaker.  Size zero (0)
+                             indicates the absence of such
+                             attribute(s).  Octets beyond the maximum
+                             size, if any, are not recorded by this
+                             object."
+                    ::= { bgp4PathAttrEntry 14 }
+
+
+                -- Traps.
+
+                bgpTraps                OBJECT IDENTIFIER ::= { bgp 7 }
+
+                bgpEstablished NOTIFICATION-TYPE
+                    OBJECTS { bgpPeerLastError,
+                              bgpPeerState      }
+                    STATUS  current
+                    DESCRIPTION
+                            "The BGP Established event is generated when
+                            the BGP FSM enters the ESTABLISHED state."
+                    ::= { bgpTraps 1 }
+
+                bgpBackwardTransition NOTIFICATION-TYPE
+                    OBJECTS { bgpPeerLastError,
+                              bgpPeerState      }
+                    STATUS  current
+                    DESCRIPTION
+                            "The BGPBackwardTransition Event is generated
+                            when the BGP FSM moves from a higher numbered
+                            state to a lower numbered state."
+                    ::= { bgpTraps 2 }
+
+END
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Willis, Burruss & Chu                                          [Page 19]
+
+RFC 1657                       BGP-4 MIB                       July 1994
+
+
+6. Acknowledgements
+
+   We would like to acknowledge the assistance of all the members of the
+   Interconnectivity Working Group, and particularly the following
+   individuals:
+
+        Yakov Rekhter, IBM
+        Rob Coltun, University of Maryland
+        Guy Almes, ANS
+        Jeff Honig, Cornell Theory Center
+        Marshall T. Rose, Dover Beach Consulting, Inc.
+        Dennis Ferguson, ANS
+        Mike Mathis, PSC
+        John Krawczyk, Wellfleet Communications Inc.
+        Curtis Villamizar, ANS
+        Dave LeRoy, Pencom Systems
+        Paul Traina, cisco Systems
+        Andrew Partan, UUNET
+        Robert Snyder, cisco Systems
+        Dimitry Haskin, Wellfleet Communications Inc.
+        Peder Chr Norgaard, Telebit Communications A/S
+        Joel Halpern, Network Systems Corporation
+
+7. References
+
+   [1] Rekhter, Y., and T. Li, "A Border Gateway Protocol 4 (BGP-4)",
+       RFC 1654,  T.J. Watson Research Center, IBM Corp., cisco Systems,
+       July 1994.
+
+   [2] Rekhter, Y., and P. Gross, Editors, "Application of the Border
+       Gateway Protocol in the Internet", RFC 1655 T.J. Watson Research
+       Center, IBM Corp., MCI, July 1994.
+
+8. Security Considerations
+
+   Security issues are not discussed in this memo.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Willis, Burruss & Chu                                          [Page 20]
+
+RFC 1657                       BGP-4 MIB                       July 1994
+
+
+9.  Authors' Addresses
+
+   Steven Willis
+   Wellfleet Communications Inc.
+   15 Crosby Drive
+   Bedford, MA 01730
+
+   Phone: (617) 275-2400
+   EMail: swillis@wellfleet.com
+
+
+   John Burruss
+   Wellfleet Communications Inc.
+   15 Crosby Drive
+   Bedford, MA 01730
+
+   Phone: (617) 275-2400
+   EMail: jburruss@wellfleet.com
+
+
+   John Chu
+   IBM Corp.
+   P.O.Box 218
+   Yorktown Heights, NY 10598
+
+   Phone: (914) 945-3156
+   EMail: jychu@watson.ibm.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Willis, Burruss & Chu                                          [Page 21]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1657.txt](<www.ietf.org/rfc/rfc1657.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
