### PR TITLE
Archive rfc168.txt

### DIFF
--- a/www.ietf.org/rfc/rfc168.txt
+++ b/www.ietf.org/rfc/rfc168.txt
@@ -1,0 +1,395 @@
+
+
+
+
+
+
+RFC 168                Arpa Network Mailing Lists            26 May 1971
+
+
+The following three lists are those to be used for distribution of
+Network documents. List A should be used by sites when they distribute
+their own documents. to get RFC's to Liaisons as quickly as possible.
+All but local mail should be sent Air Mail. Lists B and C will be used
+by NIC in making distribution of copies to non-site Network Participants
+and to Station Agents. These Lists supercede RPC 95 and RFC 155. For
+phone numbers and lists of names by sites see the Current Directory of
+Network Participants.
+
+                      A. Initial Distribution List
+
+   Note: This list includes all Network Liaisons and others who should
+   receive initial distribution of RFC's, whether sent from NIC or from
+   sites. They will also receive selected catalogs and other formal
+   documents from NIC.
+
+AMES-ILLIAC                        CASE
+   John McConell                      Dr. Patrick W. Foulk
+   NASA Ames Research Center          Jennings Computing Center
+   Mail Stop 233-9                    Room 306, Crawford Hall
+   Moffett Field, California, 94035   Case Western Reserve University
+                                      10900 Euclid Avenue
+                                      Cleveland, Ohio 44106
+
+AMES-CD                            CCA
+   Wayne Hathaway                     Richard Winter
+   Mail Stop 233-9                    Computer Corporation of America
+   NASA Ames Research Center          565 Technology Square
+   Moffett Field, California, 94035   Cambridge, Mass. 02139
+
+ARC                                CMU
+   John T. Melvin                     Harold R. Van Zoeren
+   Stanford Research Institute        Carnegie-Mellon University
+   Augmentation Research Center       Computer Science Department
+   333 Ravenswood Avenue              Schenley Park
+   Menlo Park, Calif. 94025           Pittsburgh, Pa. 15213
+
+                                   HARV
+   Jeanne B. North (for NIC)          Robert Sundberg
+   Stanford Research Institute        Harvard University
+   Augmentation Research Center       Aiken Computer Laboratory
+   333 Ravenswood Avenue              33 Oxford Street
+   Menlo Park, Calif. 94025           Cambridge, Mass. 02138
+
+
+
+
+
+                                                                [Page 1]
+
+ARPA Network Mailing Lists      RFC 168                         NIC 6785
+
+
+ARPA                               IBMW
+   Dr. Lawrence G. Roberts            Douglas McKay
+   Advanced Research Projects Agency  IBM Watson Research Center
+   1400 Wilson Boulevard              P.O. Box 218
+   Arlington, Virginia 22209          Yorktown Heights, N.Y. 10598
+
+BBN-SCI                            ILL
+   Dan Murphy                         James Madden
+   Bolt Beranek and Newman Inc.       University of Illinois
+   50 Moulton Street                  Center for Advanced Computation
+   Cambridge, Mass. 02138             168 Engineering Research Lab.
+                                      Urbana, Illinois 61801
+
+BBN-SYS                            LINC-67
+   Alex McKenzie                      Joel Winett
+   Bolt Beranek and Newman Inc.       Mass. Institute of Technology
+   50 Moulton Street                  Lincoln Laboratory
+   Cambridge, Mass. 02138             244 Wood Street
+                                      Lexington, Mass. 02173
+
+INC-TX2                           SU-AI
+   William Kantrowitz                James A. (Andy) Moorer
+   Mass. Institute of Technology     Stanford University
+   Lincoln Laboratory                Computation Center, AI Project
+   244 Wood Street                   Stanford, Calif. 94305
+   Lexington, Mass. 02173
+
+MAC                               SU-HP
+   Albert Vezza                      Edward A. Feigenbaum
+   Mass. Institute of Technology     Stanford University
+   Project MAC                       Heuristic Programming
+   545 Technology Square             Department of Computer Science
+   Cambridge, Mass. 02139            Serra House
+                                     Stanford, Calif. 94305
+MITRE                             UCLA-CCN
+   David Wood                        Robert Braden
+   MITRE Corporation                 University of California at L.A.
+   Information Systems Dept., W140   5308 Math Sciences Building
+   Westgate Research Park            Los Angeles, Calif. 90024
+   McLean, Va. 22101
+
+NBS                               UCLA-NMC
+   Thomas N. Pyke, Jr.               Ari Ollikainen
+   National Bureau of Standards      University of California at L.A.
+   Center for Computer Sciences and  Computer Science Department
+   Technology                        3732 Boelter Hill
+   Washington, D.C. 20234            Los Angeles, Calif. 90024
+
+
+
+
+                                                                [Page 2]
+
+ARPA Network Mailing Lists      RFC 168                         NIC 6785
+
+
+NIC                                  Steve Crocker (for ARPA Office
+   see ARC                           Liaison)
+                                     University of California at L.A.
+                                     Computer Science Department
+                                     3732 Boelter Hill
+                                     Los Angeles, Calif. 90024
+
+RADC                              UCSB
+   Thomas Lawrence                   James White
+   Rome Air Development Center(ISIM) Univ. of Calif. at St. Barbara
+   Griffiss Air Force Base           Computer Research Laboratory
+   Rome, New York 13440              Santa Barbara, Calif. 93106
+
+RAND                              USC
+   John Heafner                      Dr. Richard E. Kaplan
+   Rand Corporation                  University of Southern Calif.
+   Computer Science Department       School of Engineering
+   Santa Monica, Calif. 90406        Los Angeles, Calif. 90007
+
+RAY                               UTAH
+   Thomas O'Sullivan                 Barry D. Wessler
+   Raytheon Data Systems             University of Utah
+   1415 Boston-Providence Turnpike   Computer Science / IRL
+   Norwood, Mass. 02062              Salt Lake City, Utah 84112
+
+SDC
+   Abe Landsberg
+   System Development Corporation
+   2500 Colorado Avenue
+   Santa Monica, Calif. 90406
+
+SRIAI
+   Michael Weber
+   Stanford Research Institute
+   Artificial Intelligence Group
+   333 Ravenswood Avenue
+   Menlo Park, Calif. 94025
+
+
+                   B. List for Distribution from NIC
+
+   Note: These Network participants will receive all formal
+   Network documents sent from NIC, in the mailing to Liaisons
+   when such is made, otherwise at the time documents are sent
+   to Station Agents.
+
+
+
+
+
+
+                                                                [Page 3]
+
+ARPA Network Mailing Lists      RFC 168                         NIC 6785
+
+
+CCCTF                             WASHU
+   C. D. Shepard                     Marianne Pepper
+   Canadian Computer Communications  Washington University
+   Task Force                        Computer Systems Laboratory
+   100 Metcalfe Street               724 South Euclid Avenue
+   4th Floor                         St. Louis, Mo. 63110
+   Ottawa 2, Canada
+
+DART                              WATERU
+   Prof. Robert F. Hargraves         Prof. Donald Cowan
+   Kiewit Computation Center         Dept. of Computer Science
+   Dartmouth University              University of Waterloo
+   Hanover, New Hampshire 03755      Waterloo, Ontario, Canada
+
+EDUCOM
+   John LeGates
+   EDUCOM
+   100 Charles River Plaza
+   Boston, Mass. 02114
+
+MERIT
+   Alfred Cocanower
+   MERIT Computer Network
+   611 Church Street
+   Ann Arbor, Michigan 48104
+
+NETH
+   Tjaart Schipper
+   13 Marijkestraat
+   Leiderdorp, Netherlands
+
+SUNY
+   Prof Art J. Bernstein
+   SUNY Stoneybrook
+   Dept. of Computer Science
+   Stoneybrook, L.I., N.Y. 11790
+
+UCI
+   Prof. David Farber
+   Dept. of Information and Computer Science
+   University of California
+   Irvine, Calif. 92664
+
+UKICS
+   Prof. Peter Hirstein
+   Institute of Computer Science
+   44 Gordon Square
+   London, W.C.1, England
+
+
+
+                                                                [Page 4]
+
+ARPA Network Mailing Lists      RFC 168                         NIC 6785
+
+
+                         C. NIC Station Agents
+
+   Note: Station Agents receive copies from NIC of all documents
+   distributed to Liaisons, as well as documents sent as part of
+   a Station collection. A mailing is made to Station Agents once
+   a week, or oftener when quantity warrants.
+
+   AMES-ILLIAC                       NARV
+      Stan Golding                      Robert Sundberg
+      Mail Stop 233-13                  Harvard University
+      NASA Ames Research Center         Aiken Computation Laboratory
+      Moffett Field, Calif. 94035       33 Oxford Street
+                                        Cambridge, Mass. 02138
+
+   AMES-CD                           IBMW
+      See AMES-ILLIAC                   Douglas McKay
+                                        IBM Watson Research Center
+                                        P.O. Box 218
+                                        Yorktown Heights, N.Y. 10598
+
+   ARC                               ILL
+      Cindy Page                        Nan Brown
+      Stanford Research Institute       University of Illinois
+      Augmentation Research Center      Center for Advanced Computation
+      333 Ravenswood Ave.               168 Engineering Research Lab.
+      Menlo Park, Calif. 94025          Urbana, Ill. 61801
+
+   ARPA                              LINC-67
+      Margaret Goering                  Carol Mostrom
+      Advanced Research Projects Agency Mass. Institute of Technology
+      1400 Wilson Boulevard             Lincoln Laboratory
+      Arlington, Va. 22209              244 Wood Street
+                                        Lexington, Mass. 02173
+
+   BBN-SCI                           LINC-TX2
+      See BBN-SCI                       See LINC-67
+
+   CASE                              MAC
+      John Barden                       Frances L. Yost
+      Case Western Reserve University   Mass. Institute of Technology
+      Computing and Informat. Sciences  Project MAC
+      10900 Euclid Ave.                 545 Technology Square
+      Cleveland, Ohio 44106             Cambridge, Mass. 02139
+
+
+
+
+
+
+
+
+                                                                [Page 5]
+
+ARPA Network Mailing Lists      RFC 168                         NIC 6785
+
+
+   CCA                               MITRE
+      Martha Ginsberg                   David Wood
+      Computer Corporation of America   Mitre Corporation
+      565 Technology Square             Information Systems Dept. W140
+      Cambridge, Mass. 02139            Westgate Research Park
+                                        McLean, Va. 22101
+
+   CMU                               NBS
+      Carolyn Lisle                     Mrs. Shirley Watkins
+      Carnegie Mellon University        National Bureau of Standards
+      Computer Science Department       Bldg. 225, Room B216
+      Schenley Park                     Washington, D.C. 20234
+      Pittsburgh, Pa. 15213
+
+   NIC                               UCSB
+      See ARC                           Elizabeth Gibson
+                                        Univ. of Calif. at St. Barbara
+                                        Computer Research Laboratory
+                                        Santa Barbara, Calif. 93106
+
+   RADC                              USC
+      Linda Connelly                    Merilee Osterboudt
+      Rand Corporation                  University of Southern Calif.
+      Griffiss Air Force Base           Olin Hall of Engineering
+      Rome, New York 13440              Room 340
+                                        Los Angeles, Calif. 90007
+
+   RAY                               UTAH
+      Laura White                       Nancy Bruderer
+      Raytheon Data Systems             University of Utah
+      1415 Boston-Providence Turnpike   Computer Science / IRL
+      Norwood, Mass. 02062              Salt Lake City, Utah 84112
+
+   SDC
+      Judith C. Needham
+      System Development Corporation
+      Information Porcessing Information Center
+      2500 Colorado Avenue
+      Santa Monica, Calif. 90406
+
+   SRIAI
+      Rilla Reynolds
+      Stanford Research Institute
+      Artificial Intelligence Group
+      333 Ravenswood Avenue
+      Menlo Park, Calif. 94025
+
+
+
+
+
+                                                                [Page 6]
+
+ARPA Network Mailing Lists      RFC 168                         NIC 6785
+
+
+   SU-AI
+      Barbara Barnett
+      Stanford University
+      Artificial Intelligence Group
+      D.C. Power Lab
+      Stanford, Calif. 94305
+
+   SU-HP
+      Carol Wilkinson
+      Stanford University
+      Serra House
+      Heuristic Programming Project
+      Stanford, Calif. 94305
+
+   UCLA-CCN
+      Imogen Beattie
+      University of California at Los Angeles
+      3531 Boelter Hall
+      Los Angeles, Calif. 90024
+
+   UCLA-NMC
+      Anita Coley
+      University of California at Los Angeles
+      3531 Boelter Hall
+      Los Angeles, Calif. 90024
+
+
+         [ This RFC was put into machine readable form for entry ]
+           [ into the online RFC archives by Frank Kaefer 5/97 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 7]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc168.txt](<www.ietf.org/rfc/rfc168.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
