### PR TITLE
Archive rfc1689.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1689.txt
+++ b/www.ietf.org/rfc/rfc1689.txt
@@ -1,0 +1,12659 @@
+
+
+
+
+
+
+Network Working Group                                  J. Foster, Editor
+Request for Comments: 1689             University of Newcastle upon Tyne
+RARE Technical Report: 13                                    August 1994
+FYI: 25
+Category: Informational
+
+
+                            A Status Report
+                                   on
+           Networked Information Retrieval: Tools and Groups
+
+
+     Produced as a collaborative effort by the Joint IETF/RARE/CNI
+        Networked Information Retrieval - Working Group (NIR-WG)
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  This memo
+   does not specify an Internet standard of any kind.  Distribution of
+   this memo is unlimited.
+
+Abstract
+
+   The purpose of this report is to increase the awareness of Networked
+   Information Retrieval by bringing together in one place information
+   about the various networked information retrieval tools, their
+   developers, interested organisations, and other activities that
+   relate to the production, dissemination, and support of NIR tools.
+   NIR Tools covered include Archie, WAIS, gopher and World Wide Web.
+
+Table of Contents
+
+    1.   Introduction ..............................................   2
+    2.   How the information was collected .........................   3
+    3.   What is covered? ..........................................   3
+    4.   Updating information ......................................   5
+    5.   Overview of the types of NIR Tool .........................   5
+    6.   NIR Tools .................................................   9
+    7.   NIR Groups ................................................ 123
+    8.   Security Considerations ................................... 180
+    9.   Acknowledgements .......................................... 180
+   10.   Author's Address .......................................... 180
+   11.   Appendix A: NIR Tool Template ............................. 181
+   12.   Appendix B: NIR Group Template ............................ 188
+   13.   Appendix C: Email Lists and Newsgroups .................... 192
+   14.   Appendix D: Coming Attractions ............................ 207
+   15.   Appendix E: Extinct Critters (Tools) ...................... 222
+   16.   Appendix F: Extinct Critters (Groups) ..................... 222
+
+
+
+Foster                                                          [Page 1]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+1.   Introduction
+
+   As the network has grown, along with it there has been an increase in
+   the number of software tools and applications to navigate the network
+   and make use of the many, varied resources which are part of the
+   network.  Within the past two and a half years we have seen a
+   widespread adoption of tools such as the archie servers, the Wide
+   Area Information Servers (WAIS), the Internet gopher, and the
+   Worldwide Web (WWW).  In addition to the acceptance of these tools
+   there are also diverse efforts to enhance and customise these tools
+   to meet the needs of particular network communities.
+
+   There are many organisations and associations that are focusing on
+   the proliferating resources and tools for networked information
+   retrieval (NIR).  The Networked Information Retrieval Group is a
+   cooperative effort of three major players in the field of NIR: The
+   Internet Engineering Task Force (IETF), the Association of European
+   Research Networks (RARE) and the Coalition for Networked Information
+   (CNI), specifically tasked to collect and disseminate information
+   about the tools and to discuss and encourage cooperative development
+   of current and future tools.
+
+   The purpose of this report is to increase the awareness of NIR by
+   bringing together in one place information about the various
+   networked information retrieval tools, their developers, interested
+   organisations, and other activities that relate to the production,
+   dissemination, and support of NIR tools.  The intention is to make
+   this a "living document".  It will be held on-line so that each
+   section may be updated separately as appropriate.  In addition, it is
+   intended that the full document will be updated once a year so that
+   it provides a "snapshot" report on activities in this area.
+
+   Whilst the NIR tools in this report are being used on a wide variety
+   of information sources including files and databases there remains
+   much that is currently not accessible by these means.  On the other
+   hand, the majority of the NIR Tools described here are freely
+   available to the networked Research and Education community.  Tools
+   for accessing specialised datasets are often only available at a
+   cost.
+
+   It should be noted that in many ways networked information retrieval
+   is in its infancy compared with traditional information retrieval
+   systems.  Thesaurus construction, boolean searching and
+   classification control are issues which are under discussion for the
+   popular NIR Tools but as yet are not in widespread use.  However it
+   should be said that, with the vast amount of effort that is currently
+   going into the NIR field, rapid progress is being made.  Much work is
+   currently being done on expanding some of the NIR tools to include
+
+
+
+Foster                                                          [Page 2]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+   handling of multimedia information services.  Progress has also been
+   made in the discussions on classifying and cataloguing electronic
+   information resources.
+
+2.  How the information was collected
+
+   The information contained in this report was collected over the
+   network from the contacts for each NIR Tool or Group using two
+   templates:
+
+     - the NIR Tool Template, included in Appendix A;
+     - the NIR Group Template, included in Appendix B.
+
+   The contents of these templates were discussed by the NIR WG in
+   Boston (July, 1992) and subsequently on the email list.  (See the
+   Section on the NIR-WG for details of how to join this mailing list.)
+   The initial draft report was discussed at the NIR Working Group in
+   Washington (November, 1992) and updated and added to at subsequent WG
+   meetings.  Before the final submission as an RFC the individual
+   templates were reviewed by independent reviewers from around the
+   world.  Their efforts are acknowledged in Section 9.
+
+   The NIR Tool template was used to collect the information necessary
+   to identify and track the development of networked information
+   retrieval tools.  This template asked for information such as how and
+   where to get the software for each NIR Tool, documentation,
+   demonstration sites, etc.  The main part of the template has been
+   completed by the main individual responsible for the tool.  Sections
+   of the template (e.g., on clients) may have required completion by
+   others.
+
+   The NIR Group template requested information on the aim and purpose
+   of the group, the current tasks being undertaken, mailing lists,
+   document archives, etc.
+
+3.  What is covered?
+
+   In the current report you will find information on the following NIR
+   tools:
+
+      Alex
+      archie
+      gopher
+      Hytelnet
+      Netfind
+      Prospero
+      Veronica
+      WAIS  (including freeWAIS)
+
+
+
+Foster                                                          [Page 3]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+      WHOIS
+      World Wide Web  (including MOSAIC)
+      X.500 White Pages
+
+      Appendix D covers "Forthcoming Attractions":
+         Hyper-G
+         Soft Pages
+         WHOIS++
+
+ and the following NIR Groups:
+
+      CNI          Coalition for Networked Information (CNI)
+                   Architectures and Standards
+                   Directories and Resource Information Services
+                   TopNode for Networked Information Resources,
+                                                  Services and Tools
+
+      CNIDR        Clearinghouse for Networked Information Discovery
+                                                       and Retrieval
+
+      IETF         Integrated Directory Services (IDS)
+                   Integration of Internet Information Resources (IIIR)
+                   Networked Information Retrieval (NIR)
+                      joint IETF/RARE WG
+                   Network Information Services Infrastructure (NISI)
+                   OSI-Directory Service (OSI-DS)
+                   Uniform Resource Identifiers (URI)
+                   Whois and Network Information Lookup Service (WNILS)
+
+      IRTF         Internet Research Task Force Research Group on
+                     Resource Discovery and Directory Service (IRTF-RD)
+
+      NISO         Z39.50 Implementors Group
+
+      RARE         Information Services and User Support Working Group
+                     (ISUS)
+
+      USMARC/OCLC  USMARC Advisory Group; OCLC Internet Resources
+                        Cataloging Experiment (USMARC/OCLC)
+
+   Appendix C contains a list of the relevant email lists and Appendix D
+   contains information on "Coming Attractions" which are NIR tools not
+   yet in widespread use.
+
+
+
+
+
+
+
+
+Foster                                                          [Page 4]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+4.  Updating Information
+
+   Updates on and additions to the information contained in this report
+   are welcome. CNIDR have agreed to host the report and to accept
+   updates to individual templates from the template maintainers.  Send
+   updates using the appropriate template (from Appendix A or Appendix B
+   of this report) to:
+
+   nir-updates@cnidr.org
+
+   The current templates and this report may be retrieved from the UK
+   Mailbase Server:
+
+   Via anonymous ftp (use your email address as the password):
+
+     URL: ftp://mailbase.ac.uk/pub/lists/nir/files/tool.template
+     URL: ftp://mailbase.ac.uk/pub/lists/nir/files/group.template
+     URL: ftp://mailbase.ac.uk/pub/lists/nir/files/nir.status.report
+
+   or via gopher or World Wide Web to mailbase.ac.uk
+
+   or via email:
+
+     Mail to:  mailbase@mailbase.ac.uk
+
+  Text of the message:
+
+     send nir tool.template
+     send nir group.template
+     send nir nir.status.report
+
+5.  Overview of the types of NIR Tools
+
+   The following is an overview of major networked information retrieval
+   (NIR) tools available on the Internet.  There are many excellent
+   books which discuss the Internet and NIR Tools in detail.  Such books
+   include "The Whole Internet User's Guide and Catalog" by Ed Krol and
+   published by O'Reilly and Associates, Inc and "The Internet Guide for
+   New Users" by Daniel Dearn and published by Meckler.
+
+   The number of these NIR tools is large and growing quickly.  Certain
+   techniques reappear regularly and seemingly different tools may
+   perform similar tasks, allowing a simple classification of projects
+   encompassing most of the existing tools and services.
+
+
+
+
+
+
+
+Foster                                                          [Page 5]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+   The classification presented here is only one possible ordering.  The
+   goal is to define in broad outlines what can be done with particular
+   tools, realizing that users will always find novel unanticipated ways
+   of applying them.
+
+   Interactive Information Delivery Services (Gopher, World Wide Web)
+
+      Basic Internet services such as electronic mail and anonymous FTP
+      can be used to share information across the Internet, but neither
+      allows simple browsing and neither is particularly easy for the
+      newcomer to learn to use.  Gopher and the World Wide Web (W3) are
+      two recent developments that attempt to make it easier to
+      distribute information over the Internet.  Both allow the user to
+      browse information across the network without the necessity of
+      logging in or knowing in advance where to look for information.
+
+      The Gopher project was first developed at the University of
+      Minnesota to provide a simple campus-wide on-line information
+      system.  Gopher represents information as a simple hierarchy of
+      menus and files.  It has limited capability to recognize different
+      types of files, allowing, for example, the display of selected
+      types of image files.  Gateways to other services are provided
+      (usually in a manner that is transparent to the user).  The
+      underlying Gopher protocol is simple, and has facilitated the
+      creation of freely available clients for use on a variety of
+      hardware platforms and operating systems.  The more recent Gopher+
+      protocol adds the ability to provide documents in alternate forms
+      (PDF, PostScript, RTF, Word).  These features and the ease of
+      installing and administering gopher servers has led to an
+      explosive growth of gopher sites since its initial deployment.  As
+      of November 1993, there were over 2200 known servers.
+
+      World Wide Web relies on hypertext; formatted documents are
+      displayed, and hypertext links within the document can be selected
+      to travel from the current document to another.  W3 allows a user
+      to annotate documents (using hypertext links), provides gateways
+      to other services, and has multimedia support (for example, on
+      appropriate hardware platforms it can intermix text and images in
+      a displayed document).  There is a range of free W3 clients,
+      supporting many environments.  World Wide Web was originally
+      developed at CERN for the High Energy Physics Community.
+
+      Gopher and WWW share a maintenance problem in that there is no
+      automated way to update links to other documents when those
+      documents are moved or removed.
+
+
+
+
+
+
+Foster                                                          [Page 6]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+   Directory Services (WHOIS, X.500)
+
+      Directory Service tools are intended to provide a lookup service
+      for locating information about users (often referred to as White
+      Pages), or services and service providers (Yellow Pages).  For
+      example, a White Pages service might be used to locate an
+      electronic mail address, given a name and organization, while a
+      Yellow Pages service could be used to locate an online library
+      catalog or file archive site.
+
+      One of the first directory services deployed on the Internet was
+      WHOIS, a simple White Pages service created to track key network
+      contacts for the early DARPA-sponsored incarnation of the
+      Internet.  A number of sites currently operate WHOIS servers,
+      based on a range of extensions and enhancements to the original
+      model.  WHOIS enjoys the advantages of simplicity and the presence
+      of WHOIS client software on a preponderance of Internet-connected
+      hosts.  Work is underway on a more powerful protocol, known as
+      WHOIS++, which is backwards-compatible with WHOIS.
+
+      The X.500 Directory Service is a much more ambitious Directory
+      project that has been under development for a number of years
+      under the aegis of ISO/OSI.  Implementations, concerned primarily
+      with White pages services, are available in the public domain and
+      from commercial sources.  There are LDAP based X.500 clients
+      available for most major platforms, as well as a LDAP based gopher
+      gateway to X.500.
+
+      Despite years of effort, there is still no single White Pages
+      Directory Service for the entire Internet; Yellow Pages services
+      remain even less well developed and deployed.  The cost of setting
+      up the service is one obstacle; maintaining the required databases
+      is even more daunting.
+
+   Indexing Services (archie, Veronica, online library catalogs)
+
+      There are several Internet-based projects that build indexed
+      catalogs of information to facilitate searching and retrieval.
+      The first such services provided network access to library card
+      catalogs, with more recent projects indexing network-based
+      information.
+
+   archie:
+
+      The archie service began as a simple project to catalog the
+      contents of hundreds of ftp-accessible online file archives.  The
+      archie service gathers location information, name, and other
+      details describing such files and creates an index database.
+
+
+
+Foster                                                          [Page 7]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+      Users can contact an archie server and search this database for
+      files they require.
+
+      The archie service is accessible through a range of access
+      methods, including telnet, stand-alone client programs running on
+      a user's own machine, gopher, WWW, or via electronic mail.  The
+      initial implementation of archie tracks over 2,100,000 filenames
+      on over 1,200 sites around the world (as of November 1993).  There
+      are about 30 (geographically distributed) archie servers.  Both
+      commercial and freely available versions of the archie client
+      software are available.
+
+      Work continues on extending the archie service to provide
+      additional types of information.  The latest version is being used
+      to provide a prototype Yellow Pages service and directories of
+      online library catalogs and electronic mailing lists.
+
+   Veronica:
+
+      Veronica arose as an attempt to do for the world of Gopher what
+      archie did for the world of ftp.  A central server periodically
+      scans the complete menu hierarchies of Gopher servers appearing on
+      an ever-expanding list (over 2000 sites as of November 1993).  The
+      resulting index is provided by a veronica server and can be
+      accessed by any gopher client.
+
+   Online library catalogs:
+
+      A large number of libraries make their computerized library
+      catalogs available over the Internet.  Most are available through
+      telnet sessions in which the user connects to a specific address
+      and logs in using a specific login name.  Some are also available
+      through other tools, such as Gopher.
+
+   Text-based Indexing Services (WAIS)
+
+   WAIS:
+
+      Wide Area Information Servers (WAIS) is a system for indexing and
+      serving information in a network-based environment.  It is
+      distinct from indexing tools such as archie and veronica in that
+      it is used to index text-based target documents on a server, as
+      well as descriptions of the contents of a server.
+
+      A WAIS server allows the administrator to set up an index of the
+      documents (or resources) to be published.  The user employs a WAIS
+      client to attach to a particular WAIS server, and specifies a
+      search pattern which is matched against the server's index.  In
+
+
+
+Foster                                                          [Page 8]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+      early WAIS clients, searches are specified as simple natural-
+      language queries; common ("stop") words are removed, and Boolean
+      "ORs" are implicitly added between the remaining list of words.
+      Matching documents are rank-ordered according to a simple
+      statistical weighting scheme which attempts to indicate likely
+      relevance.  The user may choose to view selected documents, or
+      further refine the search.  The results of one search may be used
+      to successively refine future searches ("relevance feedback").
+      Gopher clients can also access WAIS servers via a transparent
+      gateway.
+
+      Both freely available and commercial versions of WAIS servers and
+      clients are available.  Current work is attempting to add Boolean
+      expressions and proximity and field specifications to queries.
+
+      There are currently (as of November 1993) some 500 registered WAIS
+      databases with an estimated 2000 additional databases that are not
+      yet registered.  There are approximately another 100 commercial
+      WAIS databases.
+
+6.  NIR Tools
+
+   This section contains detailed information about the various NIR
+   Tools.  It is ordered alphabetically.
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+ ALEX
+
+ Date template updated or checked:  19th March, 1994
+ By: Name:             Vincent Cate
+     Email address:    vac@cs.cmu.edu
+
+ ----------------------------------------------------------------------
+
+ NIR Tool Name:      Alex
+
+ Brief Description of Tool:
+
+   OVERVIEW:
+
+      The Alex filesystem provides users and applications transparent
+      read access to files in anonymous FTP sites on the Internet.
+      Today there are thousands of anonymous FTP sites with a total of a
+      few millions of files and roughly a terabyte of data.  The
+      standard approach to accessing these files involves logging in to
+      the remote machine.  This means that an application can not access
+      remote files like local files.  This also means that users do not
+
+
+
+Foster                                                          [Page 9]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+      have any of their aliases or local tools available.  Users who
+      want to use an application on a remote file first have to manually
+      make a local copy of the file.  There is no mechanism for
+      automatically updating this local copy when the remote file
+      changes.  The users must keep track of where they get their files
+      from and check to see if there are updates, and then fetch these.
+      In this approach many different users at the same site may have
+      made copies of the same remote file each using up disk space for
+      the same data.
+
+      Alex addresses the problems with the existing approach while
+      remaining within the existing FTP protocol so that the large
+      collection of currently available files can be used.  To get
+      reasonable performance long term file caching is used.  Thus
+      consistency is an issue.  Traditional solutions to the cache
+      consistency problem do not work in the Internet FTP domain:
+      callbacks are not an option as the FTP protocol has no provisions
+      for this and polling over the Internet is slow.  Therefore, Alex
+      relaxes file cache consistency semantics, on a per file basis, and
+      uses special caching algorithms that take into account the
+      properties of the files and of the network to allow a simple
+      stateless filesystem to scale to the size of the Internet.
+
+   USER'S VIEW:
+
+      To a user or application, Alex is just a normal filesystem.  Any
+      command that works on local files will work on Alex files.  Since
+      Alex is a real filesystem, nothing needs to be recompiled and no
+      libraries are changed.  Thus, users can apply all of their
+      existing skills and tools for using files.
+
+      The user sees a filesystem with a hierarchical name space.  At the
+      top level (/alex) there are top-level Internet domains like "edu",
+      "com", "uk", and "jp".  Each component of the hostname becomes a
+      directory name. Then the remote path is added at the end.  If the
+      user does a "ls /alex/edu/berkeley" he sees some machine names
+      such as "ucbvax" and "sprite" and some directories on
+      berkeley.edu.  From the "ls" it is not clear what is where.  The
+      user may or may not be aware of host boundaries.
+
+   INFORMATION PROVIDER'S VIEW:
+
+      Alex is implemented as a user level NFS server.  NFS was chosen
+      because it makes it easy to add Alex to a wide range of machines.
+      Most machines can simply use the mount command.
+
+
+
+
+
+
+Foster                                                         [Page 10]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+      The model of usage is that there is one Alex server running at
+      each institution (though this is not required in any way).  Users
+      mount the local server which caches files for users at that site.
+
+      Any information put into any anonymous FTP site becomes available
+      via Alex.
+
+ ----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                 Vincent Cate
+
+  Email address:        vac@cs.cmu.edu
+
+  Postal Address:       School of Computer Science
+                        5000 Forbes Ave.
+                        Pittsburgh PA, 15213
+
+  Telephone:            +1-412-268-3077
+
+  Fax:                  +1-412-681-1998
+
+ ----------------------------------------------------------------------
+
+ Help Line:
+
+  At this time Alex is a one person project (Vince).
+
+ ----------------------------------------------------------------------
+
+ Related Working Groups:
+
+  Maybe the FTP working group.
+
+ ----------------------------------------------------------------------
+
+ Sponsoring Organization / Funding source:
+
+  Defense Advanced Research Projects Agency, Information Science and
+  Technology Office, under the title "Research on Parallel Computing,"
+  ARPA Order No.  7330.  Work furnished in connection with this research
+  is provided under prime contract MDA972-90-C-0035 issued by DARPA/CMO
+  to Carnegie Mellon University.  Vincent Cate is supported by an "Intel
+  foundation graduate fellowship".
+
+ ----------------------------------------------------------------------
+
+
+
+
+Foster                                                         [Page 11]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Mailing Lists:
+
+  Address:              alex-servers@cs.cmu.edu
+
+  Administration:       alex-servers-request@cs.cmu.edu
+
+
+  Description:          alex-servers is for people setting up an Alex
+                        fileserver.
+
+  Archive:              alex.sp.cs.cmu.edu (128.2.209.13)
+
+ ----------------------------------------------------------------------
+
+ News groups:
+
+  None.
+
+ ----------------------------------------------------------------------
+
+ Protocols:
+
+  What is supported:   Any machine that can NFS mount a fileserver.
+
+  What it runs over:   Unix machine and FTP
+
+  Other NIR tools this interworks with:
+
+   Uses FTP sites.
+
+   WAIS can be used to index files in Alex
+    (this was done for ftpable-readmes and cs-techreports WAIS servers)
+
+      New versions of archie can output Alex paths.
+
+ Future plans:         Graduate from CMU.
+
+ ----------------------------------------------------------------------
+
+ Servers:
+
+  Date completed or updated:    19 March 1994
+  By: Name:                     Vincent Cate
+
+  Platform:                     UNIX
+
+  Primary Contact:
+  Name:                         Vincent Cate
+
+
+
+Foster                                                         [Page 12]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Email address:                vac@cs.cmu.edu
+  Telephone:                    +1-412-268-3077
+
+  Server software available from:  alex.sp.cs.cmu.edu
+
+  Location of more information:
+   No other place to go to.
+
+  Latest version number:
+   New versions all the time.
+
+  Brief Scope and Characteristics:
+   This software is known to still contain bugs.
+
+  Approximate number of such servers in use:
+   200.
+
+  General comments:
+   You can use lpr, make, grep, more, etc. on files around the world.
+
+ ----------------------------------------------------------------------
+
+ Clients:
+
+  You just do an NFS mount of the server.  No client software
+  is needed.
+
+ ----------------------------------------------------------------------
+
+ Demonstration sites:
+
+  Site name:   alex.sp.cs.cmu.edu
+
+  Access details - do the following as root:
+   mkdir /alex
+   mount -o timeo=30,retrans=300,soft,intr alex.sp.cs.cmu.edu:/ /alex
+
+  Example use:
+   ln -s /alex/edu/cs/cmu/sp/alex/links alexlinks
+   cd alexlinks
+   ls
+   cd cs-tr
+   cd ls
+   cd purdue
+   ls
+   lpr TR758.PS
+
+
+
+
+
+Foster                                                         [Page 13]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  If you like Alex and want to use it regularly please find, or set up,
+  an Alex fileserver at/near your site.
+
+ ----------------------------------------------------------------------
+
+ Documentation:
+
+  ftp://alex.sp.cs.cmu.edu/www/alex.html
+  ftp://alex.sp.cs.cmu.edu/doc/intro.ps
+  ftp://alex.sp.cs.cmu.edu/doc/NIR.Tool
+  ftp://alex.sp.cs.cmu.edu/doc/alex.post
+
+ ----------------------------------------------------------------------
+
+ Bibliography:
+
+  @InProceedings{cate:alex,
+  author =      "Vincent Cate",
+  title =       "Alex - a Global Filesystem",
+  booktitle =   "Proceedings of the Usenix File Systems Workshop",
+  year =        1992,
+  pages =       "1--11",
+  month =       may,
+  place =       "Ann Arbor, MI",
+  keyword =     "distributed file system, wide-area file system"
+
+ ----------------------------------------------------------------------
+
+ Other Information:
+
+  FTP to alex.sp.cs.cmu.edu and "cd to doc".  Get the "README" or
+  anything else there.  A current version of this document may be there
+  and called "NIR.Tool".  In Alex this file is named
+  "/alex/edu/cmu/cs/sp/alex/doc/NIR.Tool".
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                         [Page 14]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ ARCHIE
+
+ Date template updated or checked:       1 March, 1994
+ By: Name:                               Peter Deutsch
+     Email address:                      peterd@bunyip.com
+
+ -----------------------------------------------------------------------
+
+ NIR Tool Name:                  archie
+
+ Brief Description of Tool:
+
+   The archie system is a tool for gathering, indexing and serving
+   information from around the Internet.  The current version serves a
+   collection of filenames found at anonymous FTP sites, as well as a
+   smaller collection of text descriptions for software, data and other
+   information found at anonymous FTP archives.  Additional databases
+   are under development.
+
+   User's View:
+
+      Users run a client program to connect to an archie server and
+      issue search commands to find information in an archie database.
+      In the case of an anonymous FTP filename, this information can
+      then be used to fetch the file directly from the archive site
+      using the `ftp' command.  To the user, archie could be seen as a
+      `secondary source' of information which, because of the high cost
+      of locating and serving, would not otherwise be available.
+
+      The user searches the archie databases through either a telnet
+      session to a machine running an archie server, or by using a
+      stand-alone client program (which uses the Prospero protocol for
+      sending and receiving requests).  There is also an email interface
+      which allows users to send and receive search requests via
+      electronic mail.
+
+      Freely available archie clients exist for most operating systems
+      and can be fetched using anonymous FTP from most of the current
+      archie servers.  There are also gateways to the archie system from
+      many other NIR tools, including Gopher, WAIS and WWW.  An X.500
+      interface to archie is currently under development.
+
+   Information Provider's View:
+
+      There are two types of information providers who would be
+      interested in archie.  Primary information providers are
+      interested in having a summary of the information provided by
+      their service tracked by an archie server.  Secondary service
+
+
+
+Foster                                                         [Page 15]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+      providers, or those sites wishing to provide a "value-added"
+      service for the Internet can elect to run an archie server at
+      their site to provide a useful service to users, to raise the
+      profile of their institution on the Internet, or to provide market
+      differentiation (for commercial service providers).
+
+      The archie system is of particular utility serving information
+      where there are many sites to be searched and/or where the cost of
+      searching each site is high.
+
+      For example, there are currently over 1,200 anonymous FTP sites on
+      the Internet, and the number continues to grow.  Searching for a
+      specific filename at a single site may involve scanning hundreds,
+      or even thousands of filenames.  Thus, most operators of anonymous
+      FTP archives welcome the fact that archie indexes and serves the
+      names of all files available from each site tracked.
+
+   Information Types Supported:
+
+      The archie system allows the gathering and serving of arbitrary
+      information types, although the current system serves only
+      freeform text and a dedicated text format for filename listings.
+      Internally, the archie system now supports a WAIS search engine
+      and frontends for Gopher, WWW and WHOIS++ for accessing archie
+      information through Gopher clients is now being tested.
+      Additional collections of information to be served by the archie
+      software will be announced.
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                   Archie Group, Bunyip Information Systems Inc.
+
+  Email address:          info@bunyip.com
+
+  Postal  Address:        Bunyip Information Systems Inc.,
+                          310 St-Catherine St. West, suite 202,
+                          Montreal, QC
+                          CANADA H2X 2A1
+
+  Telephone:              +1-514-875-8611
+  Fax:                    +1-514-875-8134
+
+ -----------------------------------------------------------------------
+
+ Help Line:       for archie server system and telnet client
+
+
+
+
+Foster                                                         [Page 16]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Name:           Archie Group, Bunyip Information Systems Inc.
+
+  Email address:  info@bunyip.com
+
+  Telephone:      +1-514-875-8611
+
+
+  Level of support offered:
+                  o commercial support for server
+                   (primarily for systems maintainers)
+
+                  o voluntary helpdesk support for freeware clients
+
+                  o volunteer helpdesk support for Internet information
+                   gathering tools in general
+
+  Hours available:        - server system:
+                           email:                24 hour support
+                           phone support:        9-5 EST
+
+                         - helpdesk consultation: as time permits
+
+ ----------------------------------------------------------------------
+
+ Related Working Groups:
+
+  IETF, IIIR, WNILS, URI.
+
+ ----------------------------------------------------------------------
+
+ Sponsoring Organisation / Funding source:
+
+  Bunyip Information Systems Inc.
+
+  Funded by licensing of archie software and development contracts from
+  sponsors.  Additional information services based upon this software
+  are now being tested.
+
+ ----------------------------------------------------------------------
+
+ Mailing Lists:
+
+  Address:              archie-people@bunyip.com
+
+  Administration:       archie-people-request@bunyip.com
+
+  Description:
+
+
+
+
+Foster                                                         [Page 17]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+   This mailing list is for people interested in the archie project and
+   its future developments.  Announcements of upgrades, new services,
+   etc. are made to this list.
+
+  Archive:              none
+
+                        -------------------
+
+  Address:              archie-maint@bunyip.com
+
+  Administration:       archie-maint-request@bunyip.com
+
+  Description:
+
+   This mailing list is for people who operate and maintain archie
+   servers.  Announcements of bug fixes, new releases and discussion of
+   new features are carried out on this list.
+
+  Archive:
+   "archives.cc.mcgill.ca:/pub/mailing-lists/archie-maint"
+
+                        -------------------
+
+  Address:              iafa@bunyip.com
+
+  Administration:       iafa-request@bunyip.com
+
+  Description:
+
+   This mailing list is for people who are involved in the Internet
+   Anonymous FTP Archives Working Group of the IETF.  This group was
+   involved in standardizing the encoding of information at anonymous
+   FTP archives and thus is of interest to operators and users of the
+   archie system.  It came to completion in November, 1992 and produced
+   two documents which have been presented to the IETF as informational
+   RFCs.
+
+  Archive:              "archives.cc.mcgill.ca:/pub/mailing-lists/iafa"
+
+ ----------------------------------------------------------------------
+
+ News groups:
+
+  Name:                 comp.archives.admin
+
+
+
+
+
+
+
+Foster                                                         [Page 18]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Description:
+
+  This newsgroup is for operators and maintainers of Internet archives.
+  Announcements and discussions of issues related to archie are
+  presented here, as well as discussions of more general issues
+  relating to archiving and Internet services.
+
+  Archive:              not known
+
+                        -------------------
+
+  Name:                 alt.internet.services
+
+  Description:
+
+  This newsgroup is for people interested in Internet-related services,
+  with a focus at the user level.  Announcements and discussions of
+  issues related to archie are presented here, as well as discussions
+  of more general issues relating to Internet services.
+
+  Archive:              not known
+
+ ----------------------------------------------------------------------
+
+   Protocols:
+
+   What is supported:
+
+      The current archie system clients use the Prospero protocol for
+      communication with the search engine on the archie server.  Freely
+      available clients are available which include source to perform
+      this communication for those wishing to implement additional
+      clients.
+
+      The archie server is capable of building arbitrary databases,
+      using arbitrary search and access engines and the current release
+      ships with the public domain implementation of WAIS.  We expect
+      future archie servers to serve information using this protocol.
+      The current server system assumes the TCP/IP protocol suite is
+      available, and in particular the ftp protocol for data gathering.
+
+      The archie system can be accessed through systems operating the
+      Gopher, WAIS and WWW (HDDL) protocols.  A gateway from the X.500
+      system is under development.
+
+
+
+
+
+
+
+Foster                                                         [Page 19]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+   What it runs over:
+
+      The Prospero protocol implementation runs over its own
+      implementation of a reliable datagram protocol based upon UDP.
+      Data gathering runs over the TCP/IP protocol suite.
+
+   Other NIR tools this interworks with:
+
+      Prospero, Gopher, WAIS, WWW.
+
+   Future plans:
+
+      The archie system became a commercial product in October, 1992,
+      marketed by Bunyip Information Systems Inc.  The company plans to
+      market additional data gathering modules to allow the server code
+      to build additional types of databases.  Work is also underway to
+      integrate extensions to WHOIS to allow the building and
+      maintaining of White Pages (names) directories.  The company is
+      also working on other Internet information tools that will work
+      with the archie system.
+
+ -----------------------------------------------------------------------
+
+ Servers:
+
+  Date completed or updated:    1 November, 1993
+  By: Name:                     Peter Deutsch
+      Email address:            peterd@bunyip.com
+
+  Platform:                 Sun SPARC running SunOS 4.1 or later.
+                            IBM RS6000 running AIX version 3.2 or later.
+                            for additional UNIX platforms, contact
+                            Bunyip Information Systems details.
+
+  Primary Contact:
+  Name:                         Alan Emtage
+  Email address:                bajan@bunyip.com
+  Telephone:                    +1-514-398-8611
+
+  Server software available from:
+   Bunyip Information Systems Inc.
+   email:  info@bunyip.com
+
+  Location of more information:
+
+  Additional information on the archie product line is available from
+  the anonymous ftp archives on the various archie server sites. Try
+  "archie.ans.net", "archie.sura.net", "archie.au", etc.
+
+
+
+Foster                                                         [Page 20]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Latest version number:          archie 3.1
+
+  Brief Scope and Characteristics:
+
+  This is the  commercial inmplementation of the archie system,
+  replacing a version done as a Masters project at McGill University
+  during the period 1990-1992.  It comes with an archie telnet client
+  that offers a number of minor improvements over earlier versions.
+  Additional releases, with a number of additional improvements, are
+  planned in the coming months.
+
+  Approximate number of such servers in use:
+   Currently about 27 (not all are publicly available)
+
+  General comments:
+
+  Most users access archie through a freeware or public domain client
+  program.  These are available from most archie servers via anonymous
+  FTP.  Check out the archie directory on any of the publicly available
+  archie servers or the banner message when logging into any of the
+  archie telnet clients for more details.
+
+ ----------------------------------------------------------------------
+
+ Clients:
+
+  Date completed or updated:    1 November, 1993
+  By: Name:                     Peter Deutsch
+      Email address:            peterd@bunyip.com
+
+  Platform:                     command line shell, written in C. Works
+                                with both UNIX and MSDOS/OS2 shells.
+
+  Primary Contact:
+  Name:                         Brendan Kehoe
+  Email address:                brendan@cygnus.com
+  Telephone:                    not known
+
+  Client software available from: most archie server hosts and major
+                                  Internet archives. Look for filename
+                                  "c-archie-1.3.2.tar.Z".
+
+  Location of more information:   Packaged with software.
+
+  Latest version number:          1.3.2
+
+
+
+
+
+
+Foster                                                         [Page 21]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Brief Scope and Characteristics:
+
+  This program provides a simple command line interface to the archie
+  server system, using the Prospero protocol.  Written in C, it has
+  been ported to MSDOS and OS2.
+
+  General comments:
+
+  This program should not be confused with the archie system telnet
+  interface, which is a program that runs on the archie server itself.
+
+  Future plans:  Not known
+
+                        -------------------
+
+  Date completed or updated:    1 November, 1993
+  By: Name:                     Peter Deutsch
+      Email address:            peterd@bunyip.com
+
+  Platform:                     command line shell, written in Perl.
+                                Works with both UNIX and MSDOS/OS2
+                                shells.
+
+  Primary Contact:
+  Name:                         Khun Yee Fung
+  Email address:                clipper@csd.uwo.ca
+  Telephone:                    not known
+
+  Client software available from: most archie server hosts and major
+                                  Internet archives. Look for filename
+                                  "perl-archie-3.8.tar.Z".
+
+
+  Location of more information:   Packaged with software.
+
+  Latest version number:          3.8
+
+  Brief Scope and Characteristics:
+
+  This program provides a simple command line interface to the archie
+  server system, using the Prospero protocol.  Written in Perl.
+
+  General comments:
+
+  This program should not be confused with the archie system telnet
+  interface, which is a program that runs on the archie server itself.
+
+  Future plans:  Not known
+
+
+
+Foster                                                         [Page 22]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+                        -------------------
+
+  Date completed or updated:      1 November, 1993
+  By: Name:                       Peter Deutsch
+  Email address:                  peterd@bunyip.com
+
+  Platform:                       archie client program for VMS systems.
+
+  Primary Contact:
+  Name:                           Brendan Kehoe
+  Email address:                  brendan@cygnus.com
+  Telephone:                      not known
+
+  Client software available from: most archie server hosts and major
+                                  Internet archives. Look for filename
+                                  "archie-vms.com".
+
+  Location of more information:   Packaged with software.
+
+  Latest version number:          not known.
+
+  Brief Scope and Characteristics:
+
+  This program provides a simple command line interface to the archie
+  server system for users of VMS.
+
+  General comments:
+
+  This program should not be confused with the archie system telnet
+  interface, which is a program that runs on the archie server itself.
+
+  Future plans:  Not known
+
+                        -------------------
+
+  Date completed or updated:      1 November, 1993
+  By: Name:                       Peter Deutsch
+  Email address:                  peterd@bunyip.com
+
+  Platform:                       Xwindows client (X11R4)
+
+  Primary Contact:
+  Name:                           George Ferguson
+  Email address:                  ferguson@cs.rochester.edu
+  Telephone:                      not known
+
+  Client software available from: cs.rochester.edu, most archie server
+                                  hosts and major Internet archives.
+
+
+
+Foster                                                         [Page 23]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+                                  Look for file "xarchie-1.3.tar.Z".
+
+  Location of more information:   Packaged with software.
+
+  Latest version number:          xarchie-1.3
+
+  Brief Scope and Characteristics:
+
+  This program provides an Xwindows client that allows users to search
+  the archie anonymous FTP database.  Also included is the capability of
+  fetching files (using ftp).
+
+  General comments:               none.
+
+  Future plans:  Not known
+
+                        -------------------
+
+  Date completed or updated:      1 November, 1993
+  By: Name:                       Peter Deutsch
+  Email address:                  peterd@bunyip.com
+
+  Platform:                       NeXTStep client.
+
+  Primary Contact:
+  Name:                          Scott Stark
+  Email address:                 me@superc.che.udel.edu
+  Telephone:                     not known
+
+  Client software available from: most archie server hosts and major
+                                  Internet archives. Look for file
+                                  "NeXTArchie.tar.Z".
+
+  Location of more information:   Packaged with software.
+
+  Latest version number:
+
+  Brief Scope and Characteristics:
+
+  This program provides a NeXTStep client that allows users to search
+  the archie anonymous FTP database.  Also included is the capability
+  of fetching files (using ftp).
+
+  General comments:               none.
+
+  Future plans:  Not known
+
+ ----------------------------------------------------------------------
+
+
+
+Foster                                                         [Page 24]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Demonstration sites:
+
+  Site name:      any one of:
+
+    archie.rutgers.edu   128.6.18.15     (Rutgers University)
+    archie.unl.edu       129.93.1.14     (University of Nebraska in
+                                          Lincoln)
+    archie.sura.net      128.167.254.179 (SURAnet archie server)
+    archie.ans.net       147.225.1.2     (ANS archie server)
+    archie.au            139.130.4.6     (Australian server)
+    archie.funet.fi      128.214.6.100   (European server in Finland)
+    archie.doc.ic.ac.uk  146.169.11.3    (UK/England server)
+    archie.cs.huji.ac.il 132.65.6.15     (Israel server)
+    archie.wide.ad.jp    133.4.3.6       (Japanese server)
+
+  Client software should be supported at all of these sites.
+  Additional sites are available. Use the "sites" command in the archie
+  telnet interface at any of the above sites for a more complete lists.
+
+  Access details:
+                - telnet to any of the above sites
+                - login as user `archie' (no password is required)
+                - type `help' at the prompt to get started.
+
+  Note:  Some people forget and use ftp in place of telnet. This will
+         not work. The hint that this is being done is that they claim
+         that a password is needed, not that the site can't be found.
+
+ ----------------------------------------------------------------------
+
+ Documentation:
+
+  Document Title:         What is archie
+  Location details:       anonymous FTP from archie.ans.net
+  Site:                   archie.ans.net
+  Full file name:         "pub/archie/doc/whatis.archie"
+  Description:            Brief overview of the archie system.
+
+  Document Title:         archie man pages
+  Location details:       anonymous FTP from archie.ans.net
+  Site:                   archie.ans.net
+  Full file name:         "pub/archie/doc/archie.man.*"
+  Description:            Manual pages for the archie system telnet
+                          interface in various formats (raw ASCII,
+                          nroff, compressed, etc.). This document also
+                          explains the various search options and other
+                          features, so is of use to users of the other
+                          archie client programs.
+
+
+
+Foster                                                         [Page 25]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Document Title:         What's New in 3.0
+  Location details:       anonymous FTP from archie.ans.net
+  Site:                   archie.ans.net
+  Full file name:         "pub/archie/doc/whats.new"
+  Description:            Description of the changes to archie for the
+                          first commercial release
+
+ ----------------------------------------------------------------------
+
+ Bibliography:            none
+
+ ----------------------------------------------------------------------
+
+ Other Information:       none
+
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                         [Page 26]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ GOPHER
+
+ Date template updated or checked:  14 March 1994
+ By: Name:   Mark P. McCahill
+     Email address:   mpm@boombox.micro.umn.edu
+
+ -----------------------------------------------------------------------
+
+ NIR Tool Name:  Internet Gopher
+
+ Brief Description of Tool:
+
+   The Internet Gopher protocol is a client/distributed-server document
+   search and retrieval protocol originally developed at the University
+   of Minnesota.  Gopher was originally created as a fast, simple,
+   distributed, campus-wide information search and retrieval system;
+   ease of use and implementation has made Gopher increasingly popular
+   on the Internet.  Since its original release, many folks on the
+   Internet have contributed to its growth, submitting patches, servers,
+   clients, and linking their local servers into the worldwide network
+   of Gopher servers.  Gateways exist to seamlessly access a variety of
+   non-Gopher services such as ftp, WAIS, USENET news, Archie, Z39.50
+   (1992 rev), X.500 directories, Sybase and Oracle SQL servers, etc.
+   In addition, an "archie for gopherspace" called Veronica (very easy
+   rodent-oriented net-wide index to computerized archives) has been
+   developed at the University of Nevada.  Veronica makes it easy to
+   search for items in gopherspace by title.
+
+   The gopher protocol is often described as "fiercely simple"; it is
+   connectionless (stateless), and uses TCP reliable streams.  A client
+   connects to a server using TCP, and sends a one-line text "selector
+   string".  The server responds by returning the item (a file, a
+   directory listing, or a link to some other service) corresponding to
+   the selector string and immediately closing the connection.  Items in
+   directory listings are returned as a series of lines terminated by
+   carriage-return line-feed.  Each item (line) is defined by a one-
+   character tag to specify the item type, a display string or item-name
+   that the client should display to the user, and a number of tab
+   delimited fields to specify the selector string, host domain name and
+   port number.  Because of its simple and connectionless nature, gopher
+   servers make very minimal demands on their host machines and gopher
+   clients are extremely easy to implement.
+
+   The users view the Gopher world as a series of networked hierarchical
+   directories much like a familiar filesystem.  However, the links
+   define a graph rather than a simple rooted tree.  Links in the Gopher
+   graph may define services other than simple files or directories;
+   these include cso (qi) servers, telnet sessions, links to other
+
+
+
+Foster                                                         [Page 27]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+   gopher servers, and links to gateway servers.
+
+   The information provider's simplest view is that files and
+   directories below a certain root directory on their machine are all
+   visible and available for retrieval by gopher clients.  More features
+   like long names, item types, links, and gateway services are
+   available to the more sophisticated information provider.
+
+   Servers and clients run on most popular hardware, including Macs,
+   UNIX boxes, PC-DOS boxes.  The Internet Gopher name is copyright (c)
+   1991-1992 by the University of Minnesota.  The Internet Gopher
+   protocol is described in an informational RFC (1436) available at
+   better RFC archives everywhere.  Extensions to the base gopher
+   protocol allow for associating meta-information with gopher items,
+   alternate views of documents (i.e., text, postscript, rtf, etc.) and
+   electronic forms.  Collectively, these extensions are referred to as
+   Gopher+.  Gopher+ is upward compatible with the orginal gopher
+   protocol.  The gopher software may be retrieved from numerous Gopher
+   or FTP archive sites, including the University of Minnesota Gopher
+   server, the Info-Mac Archive Gopher server, and by anonymous FTP from
+   boombox.micro.umn.edu and sumex-aim.stanford.edu. As of December
+   1993, about 1/3 of the approximately 4800 Gopher servers on the
+   internet support Gopher+.
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                 The Internet Gopher Development Team
+
+  Email address:        gopher@boombox.micro.umn.edu
+
+  Postal Address:       Microcomputer & Workstation Networks Center
+                        152 Shepherd Labs
+                        100 Union Street SE.
+                        University of Minnesota
+                        Minneapolis, MN 55455
+
+  Telephone:            +1-612-625-1300
+
+  Fax:                  +1-612-625-6817
+
+ -----------------------------------------------------------------------
+
+ Help Line:
+
+  Name:                 Microcomputer HelpLine;
+                        ask for The Internet Gopher Development Team
+
+
+
+Foster                                                         [Page 28]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Email address:        gopher@boombox.micro.umn.edu
+
+  Telephone:            USA: 612 MA MICRO (+1-612-626-4276)
+                        Helpline is for general support at the U of M.
+
+  Level of support offered:     all users
+
+  Hours available:      Phone Helpline 9-4 weekdays.
+
+ ----------------------------------------------------------------------
+
+ Related Working Groups:
+
+ ----------------------------------------------------------------------
+
+ Sponsoring Organisation / Funding source:
+
+  The University of Minnesota, Twin Cities.
+
+ ----------------------------------------------------------------------
+
+ Mailing Lists:
+
+  Address:              gopher-news@boombox.micro.umn.edu
+
+  Administration:       gopher-news-request@boombox.micro.umn.edu
+
+  Description:          News and views of all things gopher. Tends to
+                        be a high volume mailing list and technically
+                        oriented.
+
+  Archive:              Via Gopher: University of Minnesota Gopher
+                        Information About Gopher
+
+  Address:              gopher-announce@boombox.micro.umn.edu
+
+  Administration:       gopher-announce-request@boombox.micro.umn.edu
+
+  Description:          A low-volume mailing list of announcements of
+                        new software and servers.
+
+ -----------------------------------------------------------------------
+
+ News groups:
+
+  Name:                 comp.infosystems.gopher
+
+  Description:          Discussion of all things gopher.
+
+
+
+Foster                                                         [Page 29]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Archive:              Available via gopher client; connect to the
+                        gopher server at gopher.tc.umn.edu port 70,
+                        look in the "Information About Gopher" section.
+
+ -----------------------------------------------------------------------
+
+ Protocols:
+
+  What is supported:    Internet Gopher
+
+  What it runs over:    Anything you can run TCP/IP over.
+
+  Other NIR tools this interworks with:
+
+                        Z39.50 WAIS variant via WAIS gateway
+                        FTP via FTP gateway
+                        archie/Prospero via an archie gateway
+                        veronica (an archie for gopherspace)
+                        NNTP via NNTP gateway
+                        Finger (subset of gopher)
+                        X.500 via X.500 gateway
+                        Z39.50 1992 revision variant via Z39.50 gateway
+                        Oracle and Sybase SQL servers via SQL gateway
+                        CSO (Ph/Qi) online phone books
+
+  Future plans:         New user interace metaphor on PowerPC and
+                        Pentium-based clients.
+
+ -----------------------------------------------------------------------
+
+ Servers:
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     UNIX.
+
+  Primary Contact:
+  Name:                         The Internet Gopher Development Team
+  Email address:                gopher@micro.umn.edu
+  Telephone:                    +1-612-625-1300
+
+  Server software available from:
+  Via Gopher:                   U of M Gopher
+                                Information About Gopher
+                                Gopher Software Distribution
+  Via FTP:                      boombox.micro.umn.edu
+
+
+
+Foster                                                         [Page 30]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+                                /pub/gopher/
+
+  Location of more information:
+   As above.
+
+  Latest version number:        (things change fast;
+                                 please check software distribution)
+
+  Brief Scope and Characteristics:
+   Server, index server for WAIS based indices and for NeXT
+   native indexing, tools, gateway code.  Supports Gopher+.
+
+  Approximate number of such servers in use:
+   Over 3000.
+
+  General comments:
+   The defacto standard workhorse Gopher server.
+   Paul Lindner is the architect and keeper of this server.
+
+                         -------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     Macintosh.
+
+  Primary Contact:
+  Name:                         The Internet Gopher Development Team
+  Email address:                gopher@micro.umn.edu
+  Telephone:                    +1-612-625-1300
+
+  Server software available from:
+  Via Gopher:                   U of M Gopher
+                                Information About Gopher
+                                Gopher Software Distribution
+  Via FTP:                      boombox.micro.umn.edu
+                                /pub/gopher/
+
+  Location of more information:
+   As above.
+
+  Latest version number:        (please check software distribution)
+
+  Brief Scope and Characteristics:
+                                Macintosh Gopher Server and tools,
+                                supports Gopher+.
+
+
+
+
+Foster                                                         [Page 31]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Approximate number of such servers in use:
+                                Current estimates between 300 and 400.
+
+  General comments:
+   Runs on any Macintosh with 1MB memory or more.
+   Requires MacTCP.  Can be configured to use Apple Computer's AppleSearch
+   full-text search software as a Gopher-accessible search engine.
+
+                         -------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     PC-DOS.
+
+  Primary Contact:
+  Name:                         The Internet Gopher Development Team
+  Email address:                gopher@micro.umn.edu
+  Telephone:                    +1-612-625-1300
+
+  Additional contacts:
+  Name:                         Dennis Sherman
+  Email address:                Dennis_Sherman@unc.edu
+
+  Name:                         Foteos Macrides
+  Email address:                macrides@sci.wfeb.edu
+
+  Server software available from:
+  Via Gopher:                   U of M Gopher
+                                Information About Gopher
+                                Gopher Software Distribution
+  Via FTP:                      boombox.micro.umn.edu
+                                /pub/gopher/
+
+  Location of more information:
+   As above.
+
+  Latest version number:        0.91b
+
+  Brief Scope and Characteristics:
+                                Basic Gopher server for PC-DOS boxes.
+
+  Approximate number of such servers in use:
+                                Current estimates between 25 and 75.
+
+
+
+
+
+
+Foster                                                         [Page 32]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  General comments:
+   Written by Chris McNeil <cmcneil@mta.ca>, based on Phil Karns net
+   package.  The U of M Gopher team forwards difficult problems to
+   Chris.
+
+                         -------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     VMS
+
+  Primary Contact:
+  Name:                         J. Lance Wilkinson
+  Email address:                jlw@psulias.psu.edu
+  Telephone:                    +1-814-865-1818
+
+  Server software available from:
+  Via Gopher:                   U of M Gopher
+                                Information About Gopher
+                                Gopher Software Distribution
+  Via FTP:                      boombox.micro.umn.edu
+                                /pub/gopher/VMS/
+
+  Location of more information:
+   As above.
+
+  Latest version number:        1.2 VMS-0
+
+  Brief Scope and Characteristics:
+   Basic VMS Server, shares some code with UNIX server.
+
+  Approximate number of such servers in use:
+   35-40 servers in use.
+
+  General comments:
+   The VMS server was written and is maintained by J. Lance Wilkinson,
+   Foteos Macrides, Bruce Tanner and others on the
+   VMSGopher-L@trln.lib.unc.edu mailing list.
+
+                         -------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     VM/CMS
+
+
+
+Foster                                                         [Page 33]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Primary Contact:
+  Name:                         Rick Troth
+  Email address:                TROTH@RICEVM1.RICE.EDU
+  Telephone:
+
+  Server software available from:
+  Via Gopher:                   U of M Gopher
+                                Information About Gopher
+                                Gopher Software Distribution
+  Via FTP:                      boombox.micro.umn.edu:/pub/gopher/
+                                Brazos.IS.Rice.EDU:/pub/vmcms/
+
+  Location of more information:
+   As above.
+
+  Latest version number:        2.4
+
+  Brief Scope and Characteristics:
+   Gopher server for IBM VM/CMS installations.
+
+  Approximate number of such servers in use:
+   Unknown.
+
+  General comments:
+   This server was written and is maintained by Rick Troth.
+   This server is commonly referred to as the Rice VM/CMS server.
+   There is also another VM/CMS server: the Vienna VM/CMS server.
+
+                         -------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     VM/CMS.
+
+  Primary Contact:
+  Name:                         Gerhard Gonter
+  Email address:                Gerhard.Gonter@WU-Wien.ac.at
+  Telephone:
+
+  Server software available from:
+  Via Gopher:                   U of M Gopher
+                                Information About Gopher
+                                Gopher Software Distribution
+  Via FTP:                      boombox.micro.umn.edu:/pub/gopher/
+
+
+
+
+
+Foster                                                         [Page 34]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Location of more information:
+   As above.
+
+  Latest version number:        2.00.00
+
+  Brief Scope and Characteristics:
+   Gopher server for IBM VM/CMS installations.
+
+  Approximate number of such servers in use:
+   Unknown.
+
+  General comments:
+   This server was written and is maintained by Gerhard Gonter.
+   This server is commonly referred to as the Vienna VM/CMS server.
+   There is also another VM/CMS server: the Rice VM/CMS server.
+
+                         -------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     MVS
+
+  Primary Contact:
+  Name:                         Steve Bacher
+  Email address:                seb@draper.com
+  Telephone:
+
+  Server software available from:
+  Via Gopher:                   U of M Gopher
+                                Information About Gopher
+                                Gopher Software Distribution
+  Via FTP:                      boombox.micro.umn.edu:/pub/gopher/
+
+  Location of more information:
+   As above.
+
+  Latest version number:        2.1
+
+  Brief Scope and Characteristics:
+   Gopher server for IBM MVS installations.
+
+  Approximate number of such servers in use:
+   Unknown.
+
+  General comments:
+   This server was written and is maintained by Steve Bacher.
+
+
+
+Foster                                                         [Page 35]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+                         -------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     Unix veronica server
+
+  Primary Contact:
+  Name:                         Steve Foster
+  Email address:                gophadm@futique.scs.unr.edu
+  Telephone:
+
+  Server software available from:
+   Via FTP:                     veronica.scs.unr.edu:/veronica
+
+  Location of more information:
+   As above.
+
+  Latest version number:        (please check software distribution)
+
+  Brief Scope and Characteristics:
+   veronica server software
+
+  Approximate number of such servers in use:
+   Unknown.
+
+  General comments:
+   Written and maintained by Steve Foster at the
+   University of Nevada.
+
+  Future plans: Additional support for searching on Gopher+ attributes
+
+ ----------------------------------------------------------------------
+
+ Clients:
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     Macintosh
+
+  Primary Contact
+  Name:                         The Internet Gopher Development Team
+  Email address:                gopher@micro.umn.edu
+  Telephone:                    +1-612-625-1300
+
+
+
+
+Foster                                                         [Page 36]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Client software available from:
+  Via Gopher:                   U of M Gopher
+                                Information About Gopher
+                                Gopher Software Distribution
+  Via FTP:                      boombox.micro.umn.edu
+                                 /pub/gopher/
+
+  Location of more information:
+   As above.
+
+  Latest version number:        (please check software distribution)
+
+  Brief Scope and Characteristics:
+   One of the many Macintosh Gopher clients.  Requires MacTCP.
+
+  General comments:
+   Macintosh TurboGopher is as of this writing, the fastest
+   Gopher client available for the Mac.  Written by the
+   Minnesota Gopher Development Team.  Supports Gopher+.
+
+                         -------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     Macintosh
+
+  Primary Contact:
+  Name:                         Don Gilbert, Biology, Indiana
+                                University - Bloomington
+  Email address:                Software@Bio.Indiana.Edu
+  Telephone:
+
+  Client software available from:
+  Via Gopher:                   Indiana University Gopher Server
+                                IUBio Software+Data/GopherApp,
+                                Mac Gopher client
+  Via FTP:                      ftp.bio.indiana.edu:/util/gopher/
+                                                     gopherapp/
+
+  Location of more information:
+   As above.
+
+  Latest version number:        (please check software distribution)
+
+  Brief Scope and Characteristics:
+   One of the many Macintosh Gopher clients.  Requires MacTCP.
+
+
+
+Foster                                                         [Page 37]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  General comments:
+   Written and maintained by Don Gilbert.  Supports Gopher+.
+
+  Future plans:
+
+                         -------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     Macintosh
+
+  Primary Contact:
+  Name:                         "Jonzy"
+  Email address:                JONZY@CC.UTAH.EDU
+  Telephone:
+
+  Client software available from:
+  Via Gopher:                   gopher.cc.utah.edu in Testing directory
+
+  Via FTP:                      ftp.cc.utah.edu:/pub/gopher/Macintosh/
+
+  Location of more information:
+   As above.
+
+  Latest version number:        (please check software distribution)
+
+  Brief Scope and Characteristics:
+   One of the many Macintosh Gopher clients.  Requires MacTCP.
+   Has a browser style interface.
+   Uses customized Telnet application.
+
+  General comments:
+   Written and maintained by "Jonzy".
+
+  Future plans:
+
+                         -------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     UNIX (curses/EMACS based client)
+
+  Primary Contact:
+  Name:                         The Internet Gopher Development Team
+
+
+
+Foster                                                         [Page 38]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Email address:                gopher@micro.umn.edu
+  Telephone:                    +1-612-625-1300
+
+  Client software available from:
+  Via Gopher:                   U of M Gopher
+                                Information About Gopher
+                                Gopher Software Distribution
+  Via FTP:                      boombox.micro.umn.edu
+                                /pub/gopher/
+
+  Location of more information:
+   As above.
+
+  Latest version number:        (please check software distribution)
+
+  Brief Scope and Characteristics:
+   The UNIX curses-based client.
+
+  General comments:
+   Written and maintained by Paul Lindner.  Supports Gopher+.
+
+                         -------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     UNIX (simple client does not use CURSES)
+
+  Primary Contact:
+  Name:                         Sean Fuller
+  Email address:                fuller@aedc-vax.af.mil
+  Telephone:
+
+  Client software available from:
+  Via Gopher:                   U of M Gopher
+                                Information About Gopher
+                                Gopher Software Distribution
+  Via FTP:                      boombox.micro.umn.edu
+                                /pub/gopher/
+
+  Location of more information:
+   As above.
+
+  Latest version number:        0.3
+
+  Brief Scope and Characteristics:
+   sgopher is a simple gopher client for inetd/batch/online; it does not
+
+
+
+Foster                                                         [Page 39]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+   require much of the terminal other than it be 80X24 characters.  It
+   can be run stand alone or it can be launched from inetd.  It doesn't
+   use termcap or curses.  Sgopher outputs the \r\n pair at the end of
+   line and requires a <return> after each command to support more
+   terminal types.
+
+  General comments:
+   Runs on VMS, IRIX, Ultrix, AIX, Solaris 2.x, Solaris 1.x
+
+  Future plans:
+
+                         -------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     Xgopher: UNIX XWindows based client
+
+  Primary Contact:
+  Name:                         Allan Tuchman
+  Email address:                tuchman@ux1.cso.uiuc.edu
+  Telephone:
+
+  Client software available from:
+  Via Gopher:                   U of M Gopher
+                                Information About Gopher
+                                Gopher Software Distribution
+  Via FTP:                      boombox.micro.umn.edu
+                                /pub/gopher/
+
+  Location of more information:
+   As above.
+
+  Latest version number:        (please check software distribution)
+
+  Brief Scope and Characteristics:
+   Makes use of the X interface.
+
+  General comments:
+   Written and maintained by Allan Tuchman.
+
+  Future plans:  Gopher+ support planned for the future.
+
+                         -------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+
+
+
+Foster                                                         [Page 40]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     Xgopher: UNIX XWindows based client
+
+  Primary Contact:
+  Name:                         Andrew Scherpbier
+  Email address:                xvgopher@gopher.sdsu.edu
+                                turtle@sciences.sdsu.edu
+  Telephone:
+
+  Client software available from:
+  Via Gopher:                   U of M Gopher
+                                Information About Gopher
+                                Gopher Software Distribution
+  Via FTP:                      boombox.micro.umn.edu
+                                /pub/gopher/
+
+  Location of more information:
+   As above.
+
+  Latest version number:        (please check software distribution)
+
+  Brief Scope and Characteristics:
+   Makes use of the X interface... displays a way cool chewing gopher
+   icon while information is being downloaded.
+
+  General comments:
+   XView based gopher client.
+
+  Future plans:  Gopher+ support.
+
+                         -------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     NeXT: NeXTstep client
+
+  Primary Contact:
+  Name:                         The Internet Gopher Development Team
+  Email address:                gopher@micro.umn.edu
+  Telephone:                    +1-612-625-1300
+
+  Client software available from:
+  Via Gopher:                   U of M Gopher
+                                Information About Gopher
+                                Gopher Software Distribution
+
+
+
+Foster                                                         [Page 41]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Via FTP:                      boombox.micro.umn.edu
+                                /pub/gopher/
+
+  Location of more information:
+   As above.
+
+  Latest version number:        (please check software distribution)
+
+  Brief Scope and Characteristics:
+   Makes full use of the NeXT interface.
+
+  General comments:
+   Initial version written by Max Tardiveau.
+   Now maintained by Paul Lindner.
+
+  Future plans:
+
+                       -------------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     DOS TurboVision w/Clarkson packet
+                                drivers
+
+  Primary Contact:
+  Name:                         The Internet Gopher Development Team
+  Email address:                gopher@micro.umn.edu
+  Telephone:                    +1-612-625-1300
+
+  Client software available from:
+  Via Gopher:                   U of M Gopher
+                                Information About Gopher
+                                Gopher Software Distribution
+  Via FTP:                      boombox.micro.umn.edu
+                                /pub/gopher/
+
+  Location of more information:
+   As above.
+
+  Latest version number:        (please check software distribution)
+
+  Brief Scope and Characteristics:
+   Character-based graphics and windows under DOS. Uses either Clarkson
+   Packet drivers (CRWYN packet drivers) and a built-in TCP/IP protocol
+   stack or Ftp, Inc.'s protocol stack (PC/TCP).
+
+
+
+
+Foster                                                         [Page 42]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  General comments:
+   Gopher+ support.
+
+                         -------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     VMS.
+
+  Primary Contact:
+  Name:                         Mark Van Overbeke
+  Email address:                mark@ummvxm.mrs.umn.edu
+  Telephone:
+
+  Client software available from:
+  Via Gopher:                   U of M Gopher
+                                Information About Gopher
+                                Gopher Software Distribution
+  Via FTP:                      boombox.micro.umn.edu
+                                /pub/gopher/
+
+  Location of more information:
+   As above.
+
+  Latest version number:        0.6
+
+  Brief Scope and Characteristics:
+
+  General comments:
+   The VMS client was written and is maintained by Mark Van Overbeke.
+
+  Future plans:
+
+                         -------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     VMS.
+
+  Primary Contact:
+  Name:                         The Internet Gopher Development Team
+  Email address:                gopher@micro.umn.edu
+  Telephone:                    +1-612-625-1300
+
+
+
+
+Foster                                                         [Page 43]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Client software available from:
+  Via Gopher:                   U of M Gopher
+                                Information About Gopher
+                                Gopher Software Distribution
+  Via FTP:                      boombox.micro.umn.edu
+                                /pub/gopher/
+
+  Location of more information:
+   As above.
+
+  Latest version number:        1.12
+
+  Brief Scope and Characteristics:
+   Identical to Unix gopher1.12. Works on a VMS 5.5-2 system running
+   MultiNet 3.1B.  UCX and Wollongong are also supported.
+
+  General comments:
+   A port of the University of Minnesota Unix client to VMS.
+
+  Future plans:
+
+                         -------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     VM/CMS.
+
+  Primary Contact:
+  Name:                         Rick Troth
+  Email address:                TROTH@RICEVM1.RICE.EDU
+  Telephone:
+
+  Client software available from:
+
+  Via Gopher:                   U of M Gopher
+                                Information About Gopher
+                                Gopher Software Distribution
+  Via FTP:                      boombox.micro.umn.edu
+                                /pub/gopher/
+
+  Location of more information:
+   As above.
+
+  Latest version number:        (please check software distribution)
+
+  Brief Scope and Characteristics:
+
+
+
+Foster                                                         [Page 44]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+   Gopher client for IBM VM/CMS installations.
+
+  General comments:
+   This client was written and is maintained by Rick Troth.
+   This client is commonly referred to as the Rice VM/CMS client.
+   There is also another VM/CMS client: the Vienna VM/CMS client.
+
+  Future plans:
+
+                         -------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     VM/CMS.
+
+  Primary Contact:
+  Name:                         Gerhard Gonter
+  Email address:                Gerhard.Gonter@WU-Wien.ac.at
+  Telephone:
+
+  Client software available from:
+  Via Gopher:                   U of M Gopher
+                                Information About Gopher
+                                Gopher Software Distribution
+  Via FTP:                      boombox.micro.umn.edu
+                                /pub/gopher/
+
+  Location of more information:
+   As above.
+
+  Latest version number:        (please check software distribution)
+
+  Brief Scope and Characteristics:
+   Gopher client for IBM VM/CMS installations.
+
+  General comments:
+   This client was written and is maintained by Gerhard Gonter.
+   This client is commonly referred to as the Vienna VM/CMS client.
+   There is also another VM/CMS client: the  Rice VM/CMS client.
+
+  Future plans:
+
+                         -------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+
+
+
+Foster                                                         [Page 45]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     DOS with PC/TCP.
+
+  Primary Contact:
+  Name:                         Steven E. Newton
+  Email address:                snewton@oac.hsc.uth.tmc.edu
+  Telephone:
+
+  Client software available from:
+  Via FTP:                      oac.hsc.uth.tmc.edu:/public/dos/misc/
+
+  Location of more information:
+   As above.
+
+  Latest version number:        (please check software distribution)
+
+  Brief Scope and Characteristics:
+   Gopher client for DOS with PC/TCP
+
+  General comments:
+   Written and maintained by Steven E. Newton
+
+  Future plans:
+
+                         -------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     DOS with PC-NFS.
+
+  Primary Contact:
+  Name:                         Stan Barber
+  Email address:                sob@TMC.EDU
+  Telephone:
+
+  Client software available from:
+   Via FTP:                     bcm.tmc.edu:/nfs/gopher.exe
+
+  Location of more information:
+   As above.
+
+  Latest version number:        (please check software distribution)
+
+  Brief Scope and Characteristics:
+   Gopher client for DOS with PC-NFS
+
+
+
+Foster                                                         [Page 46]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  General comments:
+   Written and maintained by Stan Barber
+
+  Future plans:
+
+                         -------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     DOS Novell LWP Gopher Client
+
+  Primary Contact:
+  Name:                         Jeremy T. James
+  Email address:                blackp@med.umich.edu
+  Telephone:
+
+  Client software available from:
+  Via FTP:                      lennon.itn.med.umich.edu:pub/gopher
+
+  Location of more information:
+   As above.
+
+  Latest version number:        (please check software distribution)
+
+  Brief Scope and Characteristics:
+   DOS Novell LWP Gopher Client
+
+  General comments:
+   Written and maintained by Jeremy T. James.
+
+  Future plans:
+
+                         -------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     Windows 3.1 with Winsock or PC/NFS.
+
+  Primary Contact:
+  Name:                         Martyn Hampson
+  Email address:                m.hampson@ic.ac.uk
+  Telephone:
+
+  Client software available from:
+
+
+
+Foster                                                         [Page 47]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Via Gopher:                   U of M Gopher
+                                Information About Gopher
+                                Gopher Software Distribution
+  Via FTP:                      lister.cc.ic.ac.uk
+                                /pub/wingopher
+
+  Location of more information:
+   As above.
+
+  Latest version number:        (please check software distribution)
+
+  Brief Scope and Characteristics:
+   Gopher client for Windows; uses either Winsock DLL or PC/NFS network
+   interface.
+
+  General comments:
+   Written and maintained by Martyn Hampson.  Gopher+ support.
+
+  Future plans:
+
+                         -------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     Windows with Winsock and ToolBook.
+
+  Primary Contact:
+  Name:                         Kevin Gamiel
+  Email address:                kgamiel@kudzu.cnidr.org
+  Telephone:
+
+  Client software available from:
+  Via Gopher:                   U of M Gopher
+                                Information About Gopher
+                                Gopher Software Distribution
+  Via FTP:           sunsite.unc.edu
+                     /pub/micro/pc-stuff/ms-windows/winsock/gophbook.zip
+
+  Location of more information:
+   As above.
+
+  Latest version number:         1.0
+
+  Brief Scope and Characteristics:
+   Gopher client for Windows; uses Asymetrix's ToolBook to paint the
+   screen and speaks to the network via a Winsock DLL.
+
+
+
+Foster                                                         [Page 48]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  General comments:
+   Written and maintained by Kevin Gamiel
+
+  Future plans:
+
+                     ------------------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     Air Gopher commercial client for windows
+
+  Primary Contact:
+  Name:                         David Pool, Spry Software, Inc.
+  Email address:                dave@spry.com
+  Telephone:                    +1-206-447-0300
+
+  Client software available from:
+
+  Location of more information:
+
+  Latest version number:
+
+  Brief Scope and Characteristics:
+
+  General Comments:
+
+  Future plans:
+   Gopher+ support planned.
+
+                     ------------------------------
+
+  Date completed or updated:    14 March, 1994
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     Win Gopher
+
+  Primary Contact:
+  Name:                         Bill Easton, Notis, Inc.
+  Telephone:                    +1-708-866-0159
+
+  Client software available from:
+
+  Location of more information:
+
+  Latest version number:
+
+
+
+Foster                                                         [Page 49]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Brief Scope and Characteristics:
+
+  General Comments:
+   Requires Winsock.  Supports gopher.
+
+  Future plans:
+   Gopher+ support planned.
+
+                     ------------------------------
+
+  Date completed or updated:    14 March, 1994
+
+  By: Name:                     Mark McCahill
+      Email address:            mpm@boombox.micro.umn.edu
+
+  Platform:                     GINA
+
+  Primary Contact:
+  Name:                         Mark Resmer, California Technology
+                                Project
+  Email address:                resmer@eis.calstale.edu
+
+  Client software available from:
+
+  Location of more information:
+
+  Latest version number:
+
+  Brief Scope and Characteristics:
+
+  General Comments:
+   Macintosh and windows clients include netnews, email.
+
+  Future plans:
+
+ -----------------------------------------------------------------------
+
+ Demonstration sites:
+
+  List of sites which are willing to act as demonstration
+  sites for this application.
+
+          site name              ip address   login as   serving area
+     ----------------------------------------------------------------
+     consultant.micro.umn.edu  134.84.132.4    gopher    North America
+     gopher.uiuc.edu           128.174.33.160  gopher    North America
+     panda.uiowa.edu           128.255.40.201  panda     North America
+     info.anu.edu.au           150.203.84.20   info      Australia
+
+
+
+Foster                                                         [Page 50]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+     gopher.chalmers.se        129.16.221.40   gopher    Sweden
+     tolten.puc.cl             146.155.1.16    gopher    South America
+
+ -----------------------------------------------------------------------
+
+ Documentation:
+
+  Title:  (1) Gopher Protocol and
+          (2) Gopher+ Proposed Extensions
+  Location details:
+       Via Gopher: U of M Gopher
+                 Information About Gopher
+                      Gopher Software Distribution
+  Via FTP: boombox.micro.umn.edu
+              /pub/gopher/
+
+  Title: RFC 1436   The Internet Gopher Protocol
+                    (a distributed document search and retrieval
+                    protocol)
+  Via FTP: nic.ddn.mil
+              /rfc/rfc1436.txt
+
+ ----------------------------------------------------------------------
+
+ Bibliography:
+
+  The Whole Internet, Ed Kroll, O'Reilly, 1992
+
+  The Internet Gopher, "ConneXions", July 1992, Interop.
+
+  Exploring Internet GopherSpace "The Internet Society News", v1n2 1992
+
+  The Internet Gopher Protocol, Proceedings of the Twenty-Third
+      IETF, CNRI, Section 5.3
+
+  Internet Gopher, Proceedings of Canadian Networking '92
+
+  The Internet Gopher, INTERNET: Getting Started, SRI
+      International, Section 10.5.5
+
+  Tools help Internet users discover on-line treasures, Computerworld,
+      July 20, 1992
+
+  TCP/IP Network Administration, O'Reilly.
+
+  Balakrishan, B. (Oct 1992) "SPIGopher: Making SPIRES databases
+     accessible through the Gopher protocol".  SPIRES Fall '92
+     Workshop, Chapel Hill, North Carolina.
+
+
+
+Foster                                                         [Page 51]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ -----------------------------------------------------------------------
+
+ Other Information:
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                         [Page 52]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ HYTELNET
+
+ Date template updated or checked: 28 February, 1994
+ By: Name:              Peter Scott
+     Email address:     aa375@freenet.carleton.ca
+
+ -----------------------------------------------------------------------
+
+ NIR Tool Name: HYTELNET
+
+ Brief Description of Tool:
+
+   HYTELNET is a terminate-and-stay-resident hypertext browser, which
+   gives a user full instructions for logging into telnet-accessible
+   sites on the Internet i.e., library catalogs, campus-wide information
+   systems, bulletin boards, directory services, gophers, etc.  The
+   browser does not make remote connections.  A Unix/VMS version, which
+   does make remote connections, has been written by Earl Fogel,
+   Computing Services, University of Saskatchewan.  Macintosh and Amiga
+   versions are also available (see ftp site information below).
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                 Peter Scott
+
+  Email address:        aa375@freenet.carleton.ca
+
+  Postal Address:       324 8th Street East
+                        Saskatoon, Sask, Canada S7H 0P5
+
+  Telephone:            +1-306-966-5920
+
+  Fax:                  +1-306-966-6040
+
+ -----------------------------------------------------------------------
+
+ Help Line:
+
+  Name:                 Peter Scott
+
+  Email address:        aa375@freenet.carleton.ca
+
+  Telephone:            +1-306-966-5920
+
+  Level of support offered:
+                        o volunteer
+
+
+
+Foster                                                         [Page 53]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+
+  Hours available:      8:00 a.m - 3:30 p.m CST
+
+ -----------------------------------------------------------------------
+
+ Related Working Groups:
+
+  None
+
+ -----------------------------------------------------------------------
+
+ Sponsoring Organisation / Funding source:
+
+  None
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:         HYTELNET Updates Distribution
+
+  Address:              hytel-l@kentvm.kent.edu
+
+  Administration:       By listowner Peter Scott
+                        aa375@freenet.carleton.ca
+
+  Description:
+
+  To inform members of new versions of the software, and to keep users
+  informed of new/changed/defunct Telnet-accessible sites
+  To subscribe send e-mail message to listserv@kentvm.kent.edu with
+  no subject, and    sub hytel-l firstname lastname  as the body of the
+  message.
+
+  Archive:              None
+
+ -----------------------------------------------------------------------
+
+ News groups:           bit.listserv.hytel-l
+
+ -----------------------------------------------------------------------
+
+ Protocols:
+
+  What is supported:
+
+  What it runs over:
+
+  Other NIR tools this interworks with:
+
+
+
+
+Foster                                                         [Page 54]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Future plans:         Possible translation into gopher format
+
+ -----------------------------------------------------------------------
+
+ Servers:
+
+   None.
+
+ -----------------------------------------------------------------------
+
+ Clients:
+
+  Date completed or updated: 21 December, 1993
+  By: Name:                  Peter Scott
+      Email address:         aa375@freenet.carleton.ca
+
+  Platform:                  DOS
+
+  Primary Contact
+  Name:                      Peter Scott
+  Email address:             aa375@freenet.carleton.ca
+  Telephone:                 +1-306-966-5920
+
+  Client software available from:
+
+   ftp.usask.ca in
+   pub/hytelnet/pc as hytelnXX.zip, where XX = latest version number.
+   pub/hytelnet/{amiga,unix,vms,mac}/* for respective versions
+
+  Location of more information: finger scottp@jester.usask.ca
+
+  Latest version number:     6.6 (Issued October 23, 1993)
+
+  Brief Scope and Characteristics:
+
+  General comments:
+
+  Future plans:
+   To contine to produce updated versions in current form.
+
+ -----------------------------------------------------------------------
+
+ Demonstration sites:
+
+  The Unix/VMS version can be accessed via telnet to access.usask.ca
+  (login: hytelnet)
+
+ -----------------------------------------------------------------------
+
+
+
+Foster                                                         [Page 55]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+
+ Documentation: None
+
+ -----------------------------------------------------------------------
+
+ Bibliography:
+
+  HYTELNET as software for accessing the Internet: a personal
+  perspective on the development of HYTELNET.
+  Electronic Networking, Vol. 2, No. 1 Spring 1992 pp 38-44
+
+  Hypertext...Information at your fingertips.
+  In: Designing Information: new roles for librarians.
+  Graduate School of Library and Information Science, University of
+  Illinois at Urbana-Champaign, 1993
+
+ -----------------------------------------------------------------------
+
+ Other Information:
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                         [Page 56]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ NETFIND
+
+ Date template updated or checked:  1 March, 1994
+ By: Name:              Mike Schwartz
+     Email address:     schwartz@cs.colorado.edu
+
+ -----------------------------------------------------------------------
+
+ NIR Tool Name: Netfind
+
+ Brief Description of Tool:
+
+   Given the name of a person on the Internet and a rough description of
+   where the person works, Netfind attempts to locate information about
+   the person.  People can be specified by first, last, or login name.
+   Their place of work can be described by name and/or the
+   city/state/country.
+
+   Netfind provides textual information about people, when it is able to
+   locate such information.  It is not a directory in the usual sense of
+   the word.  Rather, it searches for people using a number of Internet
+   services and heuristics about how to locate user information.
+   Because of the techniques it uses, Netfind can locate information
+   about more people than any other Internet user directory - over 5
+   million people in over 9,000 domains worldwide when last measured.
+
+   You can use the University of Colorado Netfind server by telnet to
+   bruno.cs.colorado.edu: login as "netfind" (with no password).  Help
+   screens providing more detailed instructions and technical
+   information are available there.  There is currently no way for non-
+   Internet users to access Netfind (e.g., using an email interface).
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                 Mike Schwartz
+
+  Email address:        netfind-dvl@cs.colorado.edu
+
+  Postal Address:       Department of Computer Science
+                        University of Colorado
+                        Boulder, CO  80309-0430
+
+  Telephone:            Declined.  (Note: Netfind is currently a
+                        volunteer service.  We do not have staff
+                        resources to support telephone inquiries.)
+
+
+
+
+Foster                                                         [Page 57]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Fax:                  Declined.
+
+ -----------------------------------------------------------------------
+
+ Help Line:
+
+  There are an increasing number of Netfind servers being set up at
+  various Network Information Centers (including the U.S. Internic).
+  However, since Netfind is provided as a volunteer service at this
+  time, there is no help line.
+
+ -----------------------------------------------------------------------
+
+ Related Working Groups:
+
+  Gopher, NIR, IIIR, IRTF-RD.
+
+ -----------------------------------------------------------------------
+
+ Sponsoring Organisation / Funding source:
+
+  None.  Netfind was originally a research prototype.  It is offered
+  as-is, on an unsupported basis.  From time to time the original
+  developers make improvements, but it is not currently funded.
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+
+  Address:              netfind-users@cs.colorado.edu
+
+  Administration:       netfind-users-request@cs.colorado.edu
+
+  Description:          mailing list for user changes and updates.
+
+  Archive:              None.
+
+                      ----------------------------
+
+  Address:              netfind-servers@cs.colorado.edu
+
+  Administration:       netfind-servers-request@cs.colorado.edu
+
+  Description:          mailing list for sites running Netfind servers.
+
+  Archive:              None.
+
+ -----------------------------------------------------------------------
+
+
+
+Foster                                                         [Page 58]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ News groups:
+
+  None.
+
+ -----------------------------------------------------------------------
+
+ Protocols:
+
+  What is supported:    NVT ASCII.  At present no formal protocol is
+                        used. We are currently implementing a client/
+                        server protocol, which will allow better clients
+                        and more efficient servers.
+
+  What it runs over:    TCP/IP.
+
+  Other NIR tools this interworks with:
+                        Finger, Gopher, PH, SMTP, USENET news, UUCP
+                        maps, Various NIC databases, Various service
+                        logs, WAIS, WHOIS, X.500, DNS
+
+  Future plans:
+
+   Many.  Telnet to the server and see the "Future Directions" menu
+   under the "Frequently Asked Questions" help menu.
+
+   In addition to the above list, we are currently exploring
+   possibilities to integrate the Netfind seed database gathering
+   mechanisms into the Fremont framework, to make the process more
+   scalable, and to support other types of information (e.g., to help
+   with mapping the Internet).
+
+ -----------------------------------------------------------------------
+
+ Servers:
+
+  Date completed or updated:    October 12, 1993
+  By: Name:                     Mike Schwartz
+      Email address:            schwartz@cs.colorado.edu
+
+  Platform:                     SunOS 4.1 or more recent.  Uncertain
+                                whether Netfind will run on Solaris.
+
+  Primary Contact:
+  Name:                         Mike Schwartz
+  Email address:                schwartz@cs.colorado.edu
+  Telephone:                    (not supplied)
+
+  Server software available from: ftp.cs.colorado.edu, in the
+
+
+
+Foster                                                         [Page 59]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+          directory pub/cs/distribs/netfind.
+
+  Location of more information: in above directory.
+
+  Latest version number:        4.4.
+
+  Brief Scope and Characteristics:
+
+     This version of Netfind incorporates the ability for sites to
+     register a set of URLs in their DNS server, pointing Netfind to a
+     variety of different sources for information.  Netfind can now tap
+     information from X.500, WHOIS, and PH, in addition to the previous
+     sources it used (finger, etc.).  For more information see
+     ftp://ftp.cs.colorado.edu/pub/cs/distribs/netfind/Netfind.WP.URLs
+
+   Approximate number of such servers in use:
+
+   17 public servers; hundreds or thousands of private stand-alone
+   clients.
+
+ -----------------------------------------------------------------------
+
+ Clients:
+  The Netfind client is available in the same release as the server.
+  See above.
+
+ -----------------------------------------------------------------------
+
+ Demonstration sites:
+  Site name: bruno.cs.colorado.edu
+  The current list is:
+     archie.au (AARNet, Melbourne, Australia)
+     bruno.cs.colorado.edu (University of Colorado, Boulder)
+     dino.conicit.ve (Nat. Council for Techn. & Scien. Research,
+       Venezuela)
+     ds.internic.net (InterNIC Directory and DB Services,
+       S. Plainfield, NJ)
+     eis.calstate.edu (California State University, Fullerton, CA)
+     lincoln.technet.sg (Technet Unit, Singapore)
+     malloco.ing.puc.cl (Catholic University of Chile, Santiago)
+     monolith.cc.ic.ac.uk (Imperial College, London, England)
+     mudhoney.micro.umn.edu (University of Minnesota, Minneapolis)
+     netfind.anu.edu.au (Australian National University, Canberra)
+     netfind.ee.mcgill.ca (McGill University, Montreal, Quebec, Canada)
+     netfind.if.usp.br (University of Sao Paulo, Sao Paulo, Brazil)
+     netfind.oc.com (OpenConnect Systems, Dallas, Texas)
+     netfind.vslib.cz (Liberec University of Technology, Czech Republic)
+     nic.nm.kr (Korea Network Information Center, Taejon, Korea)
+
+
+
+Foster                                                         [Page 60]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+     nic.uakom.sk (Academy of Sciences, Banska Bystrica, Slovakia)
+     redmont.cis.uab.edu (University of Alabama at Birmingham)
+
+ -----------------------------------------------------------------------
+
+ Documentation:
+
+  There are three primary sets of information available about Netfind.
+  The first is a set of help information, available in the FTP
+  distribution as well as from the help screens available from any
+  Netfind server.  This information includes a fairly complete set of
+  Frequently Asked Questions, as well as user help information and
+  pointers to other related information.  The second is a
+  pre-publication version of a technical paper about Netfind, available
+  in
+
+  ftp://ftp.cs.colorado.edu/pub/cs/techreports/schwartz/PostScript/
+      Netfind.Gathering.ps.Z  (compressed PostScript)
+
+  or
+
+  ftp://ftp.cs.colorado.edu/pub/cs/techreports/schwartz/ASCII/
+      Netfind.Gathering.txt.Z (compressed ASCII).
+
+  An earlier paper is also available in
+
+  ftp://ftp.cs.colorado.edu/pub/cs/techreports/schwartz/PostScript/
+      White.Pages.ps.Z
+  or
+
+  ftp://ftp.cs.colorado.edu/pub/cs/techreports/schwartz/ASCII/
+      White.Pages.txt.Z,
+
+  containing some of the original ideas in Netfind and measurements of
+  the system.  The Netfind.Gathering paper contains an up-to-date
+  description of the data gathering and integration algorithms.
+
+  The third source of information focuses particularly on the URL-based
+  remote site customization mechanism, and is available in
+  ftp://ftp.cs.colorado.edu/pub/cs/distribs/netfind/Netfind.WP.URLs
+
+ -----------------------------------------------------------------------
+
+ Bibliography:
+
+  Netfind is one prototype developed by the Networked Resource Discovery
+  Project, at the University of Colorado - Boulder.  A bibliography and
+  set of project papers is available by anonymous FTP from
+
+
+
+Foster                                                         [Page 61]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  ftp.cs.colorado.edu, in pub/cs/techreports/schwartz.  This directory
+  contains a file called "README" that contains a project overview and
+  bibliography.  The files in this directory are also available via an
+  electronic mail interface.  For more information, send a mail message
+  to infosrv@ftp.cs.colorado.edu, containing the message body (not
+  subject line) "send HELP" (without quotes).
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                         [Page 62]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ PROSPERO
+
+ Date template updated or checked:  1 March, 1994
+ By: Name:                          Steven Augart
+     Email address:                 info-prospero@isi.edu
+
+ -----------------------------------------------------------------------
+
+ NIR Tool Name: Prospero
+
+ Brief Description of Tool:
+
+   The Prospero directory service supports a user centered view of files
+   scattered across the Internet.  It can be used to organize references
+   to files as if they were on your local system, without the need to
+   physically move them.
+
+   Prospero provides access to existing directories and indices that can
+   be used to find files of interest that are available from Internet
+   archive sites.  Among the indices available is the archie database
+   and a gateway to all Gopher menus, files, and searches.  We hope to
+   have WAIS indices and World Wide Web documents online in the near
+   future.
+
+   Prospero also provides a mechanism to make directories and indices
+   available to end-users and applications in a format that allows
+   information from different sources to be integrated into a coherent
+   whole.
+
+   Prospero does not interpret the data that it organizes.  It does
+   provide mechanisms to retrieve the data, but the display and use of
+   the data is up to the user's application.  Prospero is intended to
+   serve as infrastructure that integrates information from a variety of
+   sources and supports a variety of user applications.
+
+   Prospero allows fine grained authorization of requests to all
+   objects, including directories and indices.  Prospero supports the
+   authentication of clients through four mechanisms: (a) simple client
+   assertion of the user's identity; (b) a trusted port mechanism
+   similar to that used by the Berkeley UNIX R commands; (c) a simple
+   cleartext passwording mechanism; (d) Kerberos (version 5).  The
+   maintainer of an ACL chooses which of these mechanisms he or she
+   wishes to accept as proof of the client's identity.
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+
+
+
+Foster                                                         [Page 63]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Name:                 Info Prospero  (preferred contact address)
+
+  Email address:        info-prospero@isi.edu
+
+                       --------------------------
+
+  Name:                 Clifford Neuman
+
+  Email address:        bcn@isi.edu
+
+  Postal Address:       U.S.C. Information Sciences Institute
+                        4676 Admiralty Way
+                        Marina del Rey, CA 90292-6695
+                        U.S.A.
+
+  Telephone:            +1-310-822-1511
+
+                        ------------------------
+
+  Name:                 Steven Augart
+
+  Email address:        swa@isi.edu
+
+  Postal Address:       U.S.C. Information Sciences Institute
+                        4676 Admiralty Way
+                        Marina del Rey, CA 90292-6695
+                        U.S.A.
+
+  Telephone:            +1-310-822-1511
+
+ -----------------------------------------------------------------------
+
+ Help Line:
+
+  Name: Info Prospero
+
+  Email address: info-prospero@isi.edu
+
+ -----------------------------------------------------------------------
+
+ Related Working Groups:
+
+  IETF IAFA WG
+  IETF IIIR WG
+  IETF URI WG
+  IETF NIR WG
+  IRTF Resource Discovery WG
+
+
+
+
+Foster                                                         [Page 64]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ -----------------------------------------------------------------------
+
+ Sponsoring Organisation / Funding source:
+
+  Information Sciences Institute, University of Southern California
+
+  The design and implementation was supported in part by the National
+  Science Foundation (Grant No. CCR-8619663), the Washington Technology
+  Center, Digital Equipment Corporation, and the Advanced Research
+  Projects Agency under NASA Cooperative Agreement NCC-2-539.
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+
+  Address:              info-prospero@ISI.EDU
+
+  Administration:       info-prospero-request@ISI.EDU
+
+  Description:          This mailing list is really two one-way mailing
+                        lists.  Send mail to INFO-PROSPERO to obtain
+                        information about Prospero, papers, or the
+                        release.  Mail to INFO-PROSPERO will not be
+                        passed on to subscribers. INFO-PROSPERO is also
+                        the list to which we will send status updates
+                        and information on how to obtain new releases.
+
+  Archive:              Via anonymous FTP to PROSPERO.ISI.EDU as
+                        /pub/prospero/mail/info-prospero.arc
+
+            Via Prospero in the "#/INET/EDU/ISI/GUEST/prototype" virtual
+            system as /sites/isi.edu/pub/prospero/mail/info-prospero.arc
+
+                       --------------------------
+
+  Address:              prospero@ISI.EDU
+
+  Administration:       prospero-request@ISI.EDU
+
+  Description:          This mailing list is for general discussion of
+                        Prospero, for announcements of new sites that
+                        have come on board, and for announcements of
+                        directories that people have created to organize
+                        the information already accessible.
+
+  Archive:              Via anonymous FTP to PROSPERO.ISI.EDU as
+                        /pub/prospero/mail/prospero.arc
+
+
+
+
+Foster                                                         [Page 65]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+            Via Prospero in the "#/INET/EDU/ISI/GUEST/prototype" virtual
+            system as /sites/isi.edu/pub/prospero/mail/prospero.arc.
+
+ -----------------------------------------------------------------------
+
+ News groups:
+
+  NONE
+
+ -----------------------------------------------------------------------
+
+ Protocols:
+
+  What is supported:
+       Prospero directory service requests are formatted
+       according to the Prospero protocol.
+
+       Prospero does not have its own file retrieval
+       protocol.  Files may be automatically retrieved using
+       FTP, NFS, AFS, and GOPHER.  Loginable services may also be
+       accessed via TELNET.
+
+  What it runs over:
+       Directory service requests are layered on top of
+       UDP, with our own (included) reliable message delivery
+       layer.
+
+  Other NIR tools this interworks with:
+       Archie, Gopher, Wais, WWW
+
+  Future plans:
+
+ -----------------------------------------------------------------------
+
+ Servers:
+
+  Date completed or updated:    1 November, 1993
+
+  Platform:                     UNIX
+
+  Primary Contact:
+  Name:                         Clifford Neuman and Steven Augart
+  Email address:                info-prospero@isi.edu
+  Telephone:                    +1-310-822-1511
+
+  Server software available from:
+
+   Via anonymous FTP: PROSPERO.ISI.EDU, /pub/prospero/prospero.tar.Z
+
+
+
+Foster                                                         [Page 66]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+   Via Prospero: /releases/prospero/prospero.tar.Z, in the
+       "#/INET/EDU/ISI/GUEST/prototype" virtual system.
+
+   Note that the name prospero.tar.Z refers to the most stable release
+   (currently Beta version 5.1).  If you want the latest version of
+   the server (which includes the Gopher gateway), you should retrieve
+   it by version number; the name for the latest version is
+   prospero-alpha.5.2.tar.Z
+
+  Location of more information:
+   Contained within the release.
+
+  Latest version number:
+   Alpha Version 5.3
+
+  Brief Scope and Characteristics:
+
+   The server allows the maintainer to make directory information
+   available about selected portions of the server's filesystem, such as
+   anonymously FTPable files.  The server also is used to publish
+   information from other databases, such as Archie.  The server also
+   allows users and maintainers to store their own customized organizing
+   views of the namespace.  Release Alpha.5.2 of the server includes a
+   gateway feature which treats all Gopher servers as a Prospero
+   database.
+
+  Approximate number of such servers in use:
+
+   50
+
+  General comments:
+
+  Future plans:
+
+   We have a prototype NFS server that makes Prospero queries, but it is
+   not yet ready to release.  We plan to develop a gateway similar to
+   the existing Gopher gateway feature for World Wide Web.  There is
+   also active work being done on exporting WAIS indices through
+   Prospero in a way similar to the way the archie database is exported.
+
+ -----------------------------------------------------------------------
+
+ Clients:
+
+  Date completed or updated:    1st November, 1993
+
+  Platform:                     UNIX
+
+
+
+
+Foster                                                         [Page 67]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Primary Contact
+  Name:                         Clifford Neuman and Steven Augart
+  Email address:                info-prospero@isi.edu
+  Telephone:                    +1-310-822-1511
+
+  Client software available from:
+   Via anonymous FTP: PROSPERO.ISI.EDU, /pub/prospero/prospero.tar.Z
+
+   Via Prospero: /releases/prospero/prospero.tar.Z, in the
+       "#/INET/EDU/ISI/swa" virtual system.
+
+   Note that the name prospero.tar.Z refers to the most stable release
+   (currently Beta version 5.1).  If you want the latest version of
+   the clients (which includes the Prospero menu browser), you should
+   retrieve it by version number; the name for the latest version is
+   prospero-alpha.5.2.tar.Z
+
+  Latest Version number:
+   Alpha Version 5.2
+
+  Brief Scope and Characteristics:
+
+   We provide two client interfaces.  The older one is a command-line
+   client, which can be configured to use the same syntax to navigate
+   through the Prospero namespace that a user uses to navigate through
+   the UNIX filesystem.  ("cd", "ls", etc.) The newer one is a menu-
+   based file and directory browser similar to the UNIX Gopher client.
+
+  General comments:
+
+   Archie clients also make queries in the Prospero namespace, so all
+   Archie clients are Prospero clients too.  They are better described
+   in the Archie report.
+
+  Future plans:
+
+   We are working on enhancing the menu browser client to allow users to
+   remotely customize and update virtual systems.  We plan to develop a
+   Prospero hypertext browser.
+
+ -----------------------------------------------------------------------
+
+ Demonstration sites:
+
+  A guest virtual system is available on PROSPERO.ISI.EDU.  However, to
+  use it, you must compile the Prospero command-line client on your own
+  machine.  Instructions for using it come with the Prospero
+  distribution.
+
+
+
+Foster                                                         [Page 68]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ -----------------------------------------------------------------------
+
+ Documentation:
+
+  All of these papers are available via anonymous FTP from
+  PROSPERO.ISI.EDU.  They may additionally be obtained through
+  Prospero itself by preceding the 'Full file name:' given below with
+  '/sites/isi.edu' and looking in the '#/INET/EDU/ISI/GUEST/prototype'
+  virtual system.
+
+  Document Title: The Prospero Protocol, version 5
+  Location details:
+       Site: PROSPERO.ISI.EDU
+       Full file name: /pub/prospero/doc/prospero-protocol.PS.Z
+
+  Document Title: Prospero User's Manual
+  Location details:
+       Site: PROSPERO.ISI.EDU
+       Full file name: /pub/prospero/doc/prospero-user-manual.PS.Z
+
+  Document Title: Prospero Library Manual
+  Location details:
+       Site: PROSPERO.ISI.EDU
+       Full file name: /pub/prospero/doc/prospero-library-manual.PS.Z
+
+  Document Title: Prospero Menu-based Browser API Manual
+  Location details:
+       Site: PROSPERO.ISI.EDU
+       Full file name: /pub/prospero/doc/prospero-menu-api.PS.Z
+  Document Title: Description of Prospero Documents and Papers
+  Location details:
+       Site: PROSPERO.ISI.EDU
+       Full file name: /pub/prospero/papers/README-prospero-documents
+
+ -----------------------------------------------------------------------
+
+ Bibliography:
+
+  A bibliography listing all publicly available Prospero documents and
+  papers is available via anonymous FTP from PROSPERO.ISI.EDU as
+  /pub/prospero/README-prospero-documents The following papers are also
+  available via anonymous FTP from PROSPERO.ISI.EDU:
+
+
+  Prospero:/papers/subjects/operating-systems/prospero/prospero-bii.ps.Z
+  Anonymous FTP: /pub/papers/prospero/prospero-bii.ps.Z
+  (POSTSCRIPT)
+     @INPROCEEDINGS{prosperobii,
+
+
+
+Foster                                                         [Page 69]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+     AUTHOR      = "Neuman, B. Clifford and Augart, Steven Seger",
+     TITLE       = "Prospero: A Base for Building Information
+                    Infrastructure",
+     BOOKTITLE   = "Proceedings of INET'93",
+     YEAR        = 1993,
+     MONTH       = "August"}
+
+  For the readers of this report, this is the first paper you probably
+  want to read about Prospero.  This paper describes how Prospero can
+  be used to integrate internet information services, including
+  Gopher, WAIS, Archie, and World Wide Web.  The paper was
+  presented at INET'93 in August.
+
+  Prospero:/papers/subjects/operating-systems/prospero/prospero-oir.ps.Z
+  Anonymous FTP: /pub/prospero/papers/prospero-oir.ps.Z
+  (POSTSCRIPT)
+  @ARTICLE{oir,
+  AUTHOR      = "Neuman, B. Clifford",
+  TITLE       = "Prospero: A Tool for Organizing {I}nternet Resources",
+  JOURNAL     = "Electronic Networking: Research, Applications and
+                 Policy",
+  MONTH       = "Spring",
+  YEAR        = 1992,
+  VOLUME      = 2,
+  NUMBER      = 1}
+
+  This is the first paper we give to more general computer science
+  audiences to read.  It's also a good first paper to look at.  It
+  gives a good overview of Prospero and what it does.  It also
+  describes a bit about the Virtual System model, of which Prospero is
+  a prototype implementation.  Describes what Prospero does, not how
+  it does it.
+
+  Anonymous FTP: /pub/prospero/papers/prospero-gfsvsm.ps.Z
+  (POSTSCRIPT)
+     @INPROCEEDINGS{gfsvsm,
+     AUTHOR      = "Neuman, B. Clifford",
+     TITLE       = "The {P}rospero {F}ile {S}ystem: A Global File System
+                    based on the {V}irtual {S}ystem {M}odel",
+     BOOKTITLE   = "Proceedings of the Workshop on File Systems",
+     YEAR        = 1992,
+     MONTH       = "May"}
+
+  This is a good third paper to read about Prospero.  This one is
+  targeted more toward system implementors.  It provides more
+  implementation details than the paper on organizing Internet
+  resources, but less of the vision of how Prospero can be used together
+  with other systems.
+
+
+
+Foster                                                         [Page 70]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Prospero:
+   /papers/subjects/operating-systems/prospero/prospero-smlic.ps.Z
+   Anonymous FTP: /pub/papers/prospero/prospero-smlic.ps.Z
+   (POSTSCRIPT)
+     @INPROCEEDINGS{prosperosmlic,
+     AUTHOR      = "Neuman, B. Clifford and Augart, Steven Seger and
+                    Upasani, Shantaprasad",
+     TITLE       = "Using Prospero to Support Integrated
+                    Location-Independent Computing",
+     BOOKTITLE   = "Proceedings of the Usenix Symposium on Mobile and
+                    Location-Independent Computing",
+     YEAR        = 1993,
+     MONTH       = "August"}
+
+  This paper describes how the Prospero Directory Service can be used to
+  solve the server selection problem and the user location problem.  The
+  paper was presented in August at the Usenix Symposium on Mobile
+  and Location-Independent Computing.
+
+  Anonymous FTP: /pub/prospero/papers/UW-CS-89-01-07.PS.Z
+  (POSTSCRIPT)
+     @TECHREPORT{vsmldos,
+     AUTHOR      = "Neuman, B. Clifford",
+     TITLE       = "The {V}irtual {S}ystem {M}odel for Large Distributed
+                    Operating Systems",
+     INSTITUTION = "Department of Computer Science, University of
+                    Washington",
+     YEAR        = 1989,
+     MONTH       = "April",
+     NUMBER      = "89-01-07"}
+
+  This describes the initial vision for the Virtual System
+  Model, the model on which Prospero is based.  Much of the material in
+  this paper appears in greater detail in other papers.
+
+  Anonymous FTP: /pub/prospero/papers/UW-CSE-90-05-01.PS.Z
+  (POSTSCRIPT)
+     @TECHREPORT{vsmtp,
+     AUTHOR      = "Neuman, B. Clifford",
+     TITLE       = "The {V}irtual {S}ystem {M}odel: A Scalable Approach
+                    to Organizing Large Systems (A Thesis Proposal)",
+     INSTITUTION = "Department of Computer Science and Engineering,
+                    University of Washington",
+     YEAR        = 1990,
+     MONTH       = "May",
+     NUMBER      = "90-05-01"}
+
+  for a long time this was the best description of Prospero, but
+
+
+
+Foster                                                         [Page 71]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  all the information in this document appears in more recent papers and
+  the dissertation itself.
+
+  Anonymous FTP: /pub/prospero/papers/prospero-closure.ps.Z
+  (POSTSCRIPT)
+     @ARTICLE{nfclosure,
+     AUTHOR      = "Neuman, B. Clifford",
+     TITLE       = "The Need for Closure in Large Distributed Systems",
+     JOURNAL     = "Operating Systems Review",
+     MONTH       = "October",
+     YEAR        = 1989,
+     VOLUME      = 23,
+     NUMBER      = 4,
+     PAGES       = "28--30"}
+
+  This paper describes the reasons that operating systems need to
+  support closure, that is they need to make it clear which name space
+  is to be used when resolving names.  While closure is one of the
+  important features of Prospero, the concept should be applied in other
+  operating systems too.
+
+
+  Prospero:
+ /papers/subjects/operating-systems/prospero/prospero-neuman-thesis.ps.Z
+  Anonymous FTP: /pub/prospero/papers/prospero-neuman-thesis.ps.Z
+  (POSTSCRIPT)
+     @PHDTHESIS{phdneuman,
+     AUTHOR      = "Neuman, B. Clifford",
+     TITLE       = "The {V}irtual {S}ystem {M}odel: A Scalable Approach
+                    to Organizing Large Systems",
+     SCHOOL      = "University of Washington",
+     MONTH       = "June",
+     YEAR        = 1992,
+     NOTE        = "Department of Computer Science and Engineering
+                    Technical Report 92-06-04"}
+
+  This is Clifford Neuman's Ph.D. Dissertation.  It is currently the
+  definitive work on Prospero and the Virtual System Model.  Includes
+  an obsolete version of the Prospero User's Manual and of the Prospero
+  Protocol Specification.
+
+ -----------------------------------------------------------------------
+
+ Other Information:
+
+  We provide three documented library interfaces to Prospero in order to
+  make client writing easy.
+
+
+
+
+Foster                                                         [Page 72]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  The PFS and PCOMPAT libraries are documented in the library reference
+  manual.  The PFS library allows one to directly make Prospero requests
+  and parse the results and to manipulate Prospero objects as
+  abstractions.  The PCOMPAT library is an interface to the PFS library
+  which uses the same interface as the UNIX filesystem; one can link
+  many existing programs with the PCOMPAT library in order to get it to
+  resolve names in the Prospero namespace.  It is not as portable as the
+  PFS library and does not provide as much functionality.
+
+  The third library interface is the menu-browser API library.  It is
+  documented in the menu-based browser API manual and is used by our
+  menu-based browser.
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                         [Page 73]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ VERONICA
+
+ Date template updated or checked:      28 February, 1994
+ By: Name:              Steven Foster
+     Email address:     foster@veronica.scs.unr.edu
+
+ -----------------------------------------------------------------------
+
+ NIR Tool Name:  veronica
+
+ Brief Description of Tool:
+
+   veronica: Very Easy Rodent-Oriented Net-wide Index to Computerized
+             Archives.
+
+   veronica is the comprehensive title-index of the world's gopher
+   servers.  Because of veronica, the Gopher web is a search-and-
+   retrieval system as well as a browsing system.  veronica is popular
+   because the ubiquitous Gopher client can both access the search
+   server, and provide immediate access to the discovered resources.
+   Taking advantage of Gopher's linked menus, and of the policy of open
+   access at most gopher sites, veronica finds and indexes almost all
+   items on publicly-accessible gopher servers.
+
+   As of February, 1994, veronica holds indexes to more than 3200 gopher
+   servers on approximately 2500 internet hosts.  In February 1994 the
+   public-access veronica sites served an estimated 1,200,000 queries.
+   Most queries are resolved in less than twenty seconds.  Eight server
+   sites offer searches to the internet community, and several other
+   institutions run servers for internal access.
+
+   veronica is easily accessed via any Gopher client.  It offers various
+   types of searches, ranging from single-keyword searches to boolean
+   queries of indefinite complexity.
+
+   A veronica search originates with a user's request for a search,
+   submitted from a gopher client.  The searches may include boolean
+   operators ( AND, OR, NOT, and parentheses ) and several options to
+   control the number of items returned, and to restrict the search to
+   certain gopher types.  The result of a veronica search is a set of
+   gopher-type data items, which is returned to the gopher client as a
+   gopher menu.  Each item on this menu contains the user's desired
+   keyword or keywords in the item title.
+
+   The user can access any of the gopher items by selecting from the
+   returned menu.  Items on this menu may be drawn from many gopher
+   servers.  Because veronica is accessed through gopher clients, it
+   provides immediate access to all types of data supported by the
+
+
+
+Foster                                                         [Page 74]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+   gopher protocol and the client implementation.
+
+   The veronica service comprises two functions:
+
+   1) Harvesting menu data from gopher servers, and preparing it for
+      use;
+   2) Offering searches of that database to gopher clients.
+
+   These two functions are not necessarily provided by the same host
+   computer.  Currently collection and preparation of data are done at
+   University of Nevada, and datasets are distributed to the other
+   veronica servers.
+
+   The veronica service infrastructure has been fairly stable since
+   July, 1993, with eight server sites offering searches for the
+   internet community (March 1994).  These servers are supported by the
+   participating institutions: NYSERNET, PSI, SERRA, CNIDR, University
+   of Koeln, SUNET, University of Bergen and the University of Nevada
+   System Computing Services.  Several additional servers offer searches
+   with access limited to internal users; in this class are servers at
+   MSU, SUNET, and the Australian University system.
+
+   An auxiliary tool to build a locally held menu of Public available
+   has been created.  Called "maltshop", it has been distributed since
+   January, 1994.  It appears that maltshop is rapidly being accepted,
+   but its long-term effect on loading of the servers may be
+   problematic.
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                 veronica development team
+  Email address:        veronica@veronica.scs.unr.edu
+  Postal Address:       VERONICA development team
+                        SCS Computer Center Building  mailstop 270
+                        University of Nevada, Reno
+                        Reno,
+                        NV  89557-0023
+  Telephone:            +1-702-784-4292  or +1-702-784-6557
+  Fax:                  +1-702-784-1108
+
+  Name:                 Fred Barrie
+  Email address:        barrie@cs.unr.edu
+  Postal Address:       SCS Computer Center Building  mailstop 270
+                        University of Nevada, Reno
+                        Reno,
+                        NV  89557-0023
+
+
+
+Foster                                                         [Page 75]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Telephone:            +1-702-784-4292  or +1-702-784-6557
+  Fax:                  +1-702-784-1108
+
+  Name:                 Steven Foster
+  Email address:        foster@nevada.edu
+  Postal Address:       SCS Computer Center Building  mailstop 270
+                        University of Nevada, Reno
+                        Reno,
+                        NV  89557-0023
+  Telephone:            +1-702-784-4292  or +1-702-784-6557
+  Fax:                  +1-702-784-1108
+
+ -----------------------------------------------------------------------
+
+ Help Line:
+
+  Name:                 veronica development team
+
+  Email address:        veronica@veronica.scs.unr.edu
+
+  Telephone:            no telephone support available
+
+  Level of support offered:  all users
+
+  Hours available:      irregular response latencies to email queries,
+                        based on schedule of developers.
+
+ -----------------------------------------------------------------------
+
+ Related Working Groups:        GOPHER, FACETS
+
+ -----------------------------------------------------------------------
+
+ Sponsoring Organisation / Funding source:
+
+  University and Community College System of Nevada Computer Services,
+  and University of Nevada, Reno.  Additional support has been
+  provided by CNIDR, Pandora Systems, Inc., and Pacific Bell Co.
+  Server hosts have been provided by the sites listed above in
+  the Description section.
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+
+  Address:              gopher-news@boombox.micro.umn.edu
+  Address:              veronica-news@veronica.scs.unr.edu
+
+
+
+
+Foster                                                         [Page 76]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ -----------------------------------------------------------------------
+
+ News groups:
+
+  Name:         veronica discussion happens on comp.infosystems.gopher
+
+ -----------------------------------------------------------------------
+
+ Protocols:
+
+  What is supported:    Gopher protocol, Gopher+ protocol
+
+  What it runs over:    TCP
+
+  Other NIR tools this interworks with:  Gopher, WAIS, ftp
+
+  Future plans:         Implement extensions with Gopher+.
+                        Support for URN/URL standards.
+                        Per-site updates of indexes.
+                        Subject-area-specific indexes.
+                        Indexes for USENET news and LISTSERV articles.
+                        Automated server load-levelling.
+
+ -----------------------------------------------------------------------
+
+ Servers:
+
+  Date completed or updated:    February 28, 1994
+  By: Name:                     Steven Foster
+      Email address:            foster@nevada.edu
+
+  Platform:                     UNIX
+
+  Primary Contact:
+  Name:                         veronica development team
+  Email address:                veronica@veronica.scs.unr.edu
+  Telephone:                    +1-702-784-4292 or +1-702-784-6557
+
+  Server software available from:
+
+        Via ftp:                veronica.scs.unr.edu
+                                  veronica-code/
+                                  veronica-data/
+                                  veronica-data.tar.Z
+
+  Location of more information:
+        Via Gopher:             veronica.scs.unr.edu
+                                  veronica/
+
+
+
+Foster                                                         [Page 77]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+                                    veronica-faq
+                                    how-to-compose-veronica-queries
+
+
+        Via Gopher:             gopher.cnidr.org
+                                   veronica
+                                     veronica-faq
+                                     how-to-compose-veronica-queries
+
+        Via ftp:                veronica.scs.unr.edu
+                                  veronica-code/
+                                  veronica-docs/
+
+  Latest version number:        0.6.5
+  Next planned version:         0.7b   (March 1994)
+
+
+  Brief Scope and Characteristics:
+
+   Two modules:    a data-collection module and a data-server module.
+
+   1.      Data-collector runs on any Unix computer that does TCP
+           and compiles perl.  This has not been distributed yet.
+           Data collection, data preparation, and indexing are being
+           done at veronica.scs.unr.edu.  The harvester "walks" all
+           advertised gopher servers, and any newly-discovered servers.
+           Almost all redundant links are removed, leaving the
+           ( hopefully ) canonical reference for each item.
+           Indexes are built at Nevada, and the indexed dataset is
+           distributed to server sites.
+
+   2.      Server module.
+           Servers run on unix computers and answer to gopher-type-7
+           requests.  Boolean keyword logic is implemented.  See file
+           "how-to-compose-veronica-queries".  Several options allow
+           retrieval of items with specified gopher-types, retrieval
+           of a file of links containing the search results, and
+           override for the default limit on number of results returned,
+           which is 200 items.
+
+           Server software runs on most flavors of unix, requires dbm
+           and perl, and requires about 1.4 GB of data on disk, with
+           considerable /tmp space available.
+
+           Server software is available to any site which wants to run
+           a server.  Server sites are encouraged to offer the service
+           to the net at large.
+
+
+
+
+Foster                                                         [Page 78]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Approximate number of such servers in use:  twelve.
+
+
+  Auxiliary tool:  Maltshop v. 0.2d
+  Maltshop builds a menu of Public Gopher Servers for the local
+  gopher menu.
+
+   Maltshop software available from:
+
+        Via ftp:                veronica.scs.unr.edu
+                                  veronica-code/
+                                  menu-builder-0.2d
+
+        Via Gopher:             veronica.scs.unr.edu, port 70
+                                11/Search ALL of Gopherspace
+                                  12/Script to automate your local
+                                     Veronica menu
+
+  General comments:
+
+   Basic veronica service has been fairly stable since July 1993.
+   Indexing is quite efficient, and most queries are resolved in ten
+   seconds or quicker.  More than 1,000,000 queries were resolved in
+   February, 1994.
+
+   Though veronica is well-accepted at this level of service, we are
+   undertaking significant upgrade efforts during Winter 93-94.
+
+ -----------------------------------------------------------------------
+
+ Clients:
+
+  Date completed or updated:    October 19, 1993
+  By: Name:                     Steven Foster
+      Email address:            foster@nevada.edu
+
+  Platform:                     veronica is accessed through any of the
+                                gopher clients.
+
+  Primary Contact:              As for gopher clients.
+
+  Client software available from:       As for gopher clients.
+
+  Location of more information:
+  Via Gopher:                   gopher.tc.umn.edu, port 70
+                                1/Information About Gopher
+
+  Future plans:                 veronica will interoperate with Gopher+
+
+
+
+Foster                                                         [Page 79]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+                                clients, allowing queries to be
+                                composed by ASK blocks.
+
+ -----------------------------------------------------------------------
+
+ Demonstration sites:
+
+  Site name:            UCCSN veronica server
+  Access details:       gopher to veronica.scs.unr.edu, port 70.
+                        Open "veronica" folder; choose one of
+                        the search types available.
+
+  Site name:            University of Minnesota Gopher server
+  Access details:       gopher to gopher.tc.umn.edu, port 70.
+                        Other Gopher and Information Servers
+                        Search Gopherspace with veronica.
+                        choose one of the search types available.
+
+  Site name:            NYSERNET veronica server
+  Access details:       gopher to nysernet.org, port 70.
+                        Open "Search the Internet" folder;
+                                choose one of veronica searches.
+
+  Site name:            SERRA veronica server
+  Access details:       gopher to gopher.unipi.it, port 70.
+                        Open "University of Pisa - Services"  folder;
+                                choose the veronica search.
+
+ -----------------------------------------------------------------------
+
+ Documentation:
+
+  Document Title:       veronica FAQ:  Common Questions and answers
+                        about veronica, a title search and retrieval
+                        system for use with the internet gopher.
+
+  Location details:
+        Via Gopher:
+        Site:           veronica.scs.unr.edu, port 70.
+                          veronica
+                             veronica FAQ
+                        Full file name: veronica-faq
+
+        Site:           gopher.micro.umn.edu, port 70.
+                          Other Gopher and Information services
+                            Search Gopherspace with veronica
+                              veronica FAQ
+                        Full file name: veronica-faq
+
+
+
+Foster                                                         [Page 80]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+        Site:           gopher.cnidr.org, port 70.
+                          veronica
+                            veronica FAQ
+                        Full file name: veronica-faq
+
+        Via anonymous ftp:
+        Site:           veronica.scs.unr.edu
+                        veronica-docs/veronica-faq
+
+  Document Title:       How to Compose veronica Search Queries.
+
+  Location details:
+        Via Gopher:
+        Site:           veronica.scs.unr.edu, port 70.
+                          veronica
+                             How to Compose veronica Search Queries.
+                        Full file name:  how-to-query-veronica
+
+        Site:           gopher.cnidr.org, port 70.
+                          veronica
+                             How to Compose veronica Search Queries.
+                        Full file name:  how-to-query-veronica
+
+        Via anonymous ftp:
+        Site:           veronica.scs.unr.edu
+                        veronica-docs/how-to-query-veronica
+
+
+  Document Title:       About veronica.
+
+  Location details:
+        Via Gopher:
+        Site:           veronica.scs.unr.edu, port 70.
+                          veronica
+                            About veronica
+                        Full file name: veronica-about
+
+        Site:           gopher.micro.umn.edu, port 70.
+                          Other Gopher and Information services
+                            Search Gopherspace with veronica
+                              About veronica
+                        Full file name: veronica-about
+
+        Site:           gopher.cnidr.org, port 70.
+                          veronica
+                            About veronica
+                        Full file name: veronica-about
+
+
+
+
+Foster                                                         [Page 81]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ -----------------------------------------------------------------------
+
+ Bibliography: none
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                         [Page 82]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ WAIS (WAIS, Inc.)
+
+ Date template updated or checked: 1 March 1994
+ By: Name: Nathaniel Lee
+     Email address: than@wais.com
+
+ freeWAIS (CNIDR)
+
+ Date template updated or checked: 1 March 1994
+ By: Name: Jane Smith and Jim Fullton
+     Email address: Jane.Smith@CNIDR.org and Jim.Fullton@CNIDR.org
+
+ -----------------------------------------------------------------------
+
+ NIR Tool Name:   WAIS
+
+ Brief Description of Tool:
+
+   WAIS - The Wide Area Information Servers system - is an electronic
+   publishing software set which allows you to search out and retrieve
+   multimedia information from databases anywhere in the world.  WAIS
+   databases may be accessed by WAIS, gopher, and WWW clients (such as
+   Mosaic), and via online services such as Delphi and America OnLine.
+   WAIS software includes user interfaces for most platforms, and server
+   software that provides automatic indexing of databases.
+
+   WAIS was developed by Thinking Machines Corporation of Cambridge,
+   Massachusetts in collaboration with Apple Computer, Inc., Dow Jones &
+   Company, and KPMG Peat Marwick.  With over 100 databases and 5,000
+   users worldwide, WAIS is rapidly becoming a standard for information
+   distribution within the Internet environment.
+
+   WAIS is a client-server application.  Most of the clients remain
+   freely available with a few exceptions.  WAIS, Inc.  develops and
+   sells commercial versions of WAIS and the Clearinghouse for Networked
+   Information Discovery and Retrieval (CNIDR) develops freeWAIS, a
+   version free for distribution and use.  A few freely distributable
+   versions remain available from Thinking Machines, Inc.  and other
+   organizations.
+
+   What does WAIS do?
+
+      WAIS allows multimedia information to be stored anywhere on any
+      platform.  Using your interface of choice, WAIS enables you to
+      find personal, corporate and public information.  The information
+      is accessible regardless of format: text, formatted documents,
+      pictures, spreadsheets, graphics, sound, or video.
+
+
+
+
+Foster                                                         [Page 83]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+      WAIS recognizes natural language queries. The search and retrieval
+      of relevant information is made using your native language.  To
+      date, we have used English, French, Italian, and Latin!  The most
+      relevant documents, regardless of size, can be sent back to the
+      server in their entirety to further refine your search (telling
+      the server, "Find me more like this document.") Proven searches
+      can be automatically repeated, monitoring and alerting you to new
+      information as it becomes available.
+
+   How does WAIS work?
+
+      WAIS uses a single computer-to-computer protocol (NISO Z39.50-
+      1988).  Each WAIS server reads your question and based on its
+      words, searches the full text of the database for the most
+      relevant documents, and ranks them using automatic word weighting.
+      Servers need not fully understand your query; the retrieval
+      process is based on a search method called relevance feedback.
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s) (WAIS, Inc.):
+
+  Name:                 Than Lee
+
+  Email address:        info@wais.com
+
+  Postal Address:       1040 Noel Drive, Suite 102, Menlo Park CA 94025
+                        (USA)
+
+  Telephone:            +1-415-617-0444
+
+  Fax:                  +1-415-327-6513
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s) (CNIDR):
+
+  Name:                 George Brett
+
+  Email address:        George.Brett@CNIDR.org
+
+  Postal Address:       3021 Cornwallis Rd., Research Triangle Park
+                        NC 27709 (USA)
+
+  Telephone:            +1-919-248-1499
+
+  Fax:                  +1-919-248-1101
+
+
+
+
+Foster                                                         [Page 84]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ -----------------------------------------------------------------------
+
+ Help Line (WAIS, Inc.):
+
+  Name:
+
+  Email address:        support@wais.com
+
+  Telephone:
+
+  Level of support offered:      commercial customers only
+
+  Hours available:      anytime
+
+ -----------------------------------------------------------------------
+
+ Help Line (CNIDR):
+
+  Name:                 Kevin Gamiel
+
+  Email address:        Kevin.Gamiel@CNIDR.org
+
+  Telephone:            +1-919-248-1499
+
+  Level of support offered:  developers only
+
+  Hours available:      9-5 EST
+
+ -----------------------------------------------------------------------
+
+ Related Working Groups (WAIS, Inc.):
+
+  Z39.50 protocol group
+
+ -----------------------------------------------------------------------
+
+ Related Working Groups (CNIDR):
+
+  NISO: Z39.50 Implementor's Group (ZIG)
+  IETF: IIIR (Integrating Internet Information Resources) Working Group
+        URI (Uniform Resource Identifiers) Working Group
+
+ -----------------------------------------------------------------------
+
+ Sponsoring Organisation / Funding source (WAIS, Inc.):
+
+  WAIS, Inc.
+
+
+
+
+Foster                                                         [Page 85]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ -----------------------------------------------------------------------
+
+ Sponsoring Organisation / Funding source (CNIDR):
+
+  National Science Foundation Cooperative Agreement MCNC University of
+  North Carolina at Chapel Hill Other U.S.  Government agencies
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists (WAIS, Inc. and CNIDR):
+
+  Address:              wais-discussion@wais.com
+
+  Administration:       wais-discussion-request@wais.com
+
+  Description:          Moderated, digested biweekly posting about WAIS
+                        and Electronic publishing subjects.  Please
+                        submit interesting material.
+
+  Archive:     /pub/mail-archives/wais-discussion/issue-*@wais.com
+               and wais-discussion-archive WAIS server
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists (WAIS, Inc. and CNIDR):
+
+  Address:              wais-talk@wais.com
+
+  Administration:       wais-talk-request@wais.com
+
+  Description:          Implementors forum on WAIS/freeWAIS.  This is
+                        for talking about nitty gritty details of
+                        protocols and implementations.
+
+  Archive:              /pub/mail-archives/wais-talk@wais.com
+
+ -----------------------------------------------------------------------
+
+ News groups (WAIS, Inc. and CNIDR):
+
+  Name:                 comp.infosystems.wais
+
+  Description:          Variable quality information on WAIS/freeWAIS.
+
+  Archive:              wais-talk-archive WAIS server
+
+ -----------------------------------------------------------------------
+
+
+
+
+Foster                                                         [Page 86]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Protocols (WAIS, Inc. and CNIDR):
+
+  What is supported:    z39.50-1988
+
+  What it runs over:
+   The freeware runs over tcp/ip.  Production versions have worked
+   over x.25 and modems as well.
+
+  Other NIR tools this interworks with:
+   Gopher and WWW have been used as front ends to WAIS.
+
+  Future plans:
+   freeWAIS: Z39.50-1992 compliance, search engine independence
+
+ -----------------------------------------------------------------------
+
+ Servers (WAIS, Inc.):           Connection Machine WAIS server
+
+  Date completed or updated:     13th December, 1993
+  By: Name:                      Brewster Kahle
+      Email address:             Brewster@wais.com
+
+  Platform:                      Connection Machine Model 2
+
+  Primary Contact:
+  Name:                          Ottavia Bassetti
+  Email address:                 ottavia@wais.com
+  Telephone:                     +1-617-234-1000
+
+  Server software available from: Thinking Machines Corp.
+                                  245 First Street
+                                  Cambridge, MA  02145 Location of more
+                                  information:
+
+  Latest version number:
+
+  Brief Scope and Characteristics:
+   Software that runs on CM2 Connection Machines to make them into WAIS
+   servers.
+
+  Approximate number of such servers in use:
+   10
+
+  General comments:     Requires CM2 super computer.
+
+ -----------------------------------------------------------------------
+
+ Servers (CNIDR):               freeware for most UNIX platforms
+
+
+
+Foster                                                         [Page 87]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Date completed or updated:    13th December, 1993
+  By: Name:                     Jane Smith
+      Email address:            Jane.Smith@CNIDR.org
+
+  Platform:                     Most Unix variations
+
+  Primary Contact:
+  Name:                         George Brett
+  Email address:                George.Brett@CNIDR.org
+  Telephone:                    +1-919-248-1499
+
+  Server software available from:
+        ftp://pub/NIDR.tools/freewais @ftp.cnidr.org
+        gopher://gopher.cnidr.org
+        http://cnidr.org
+
+  Location of more information: info@CNIDR.org
+
+  Latest version number:        freeWAIS 0.202
+
+  Brief Scope and Characteristics:
+   server and client code for freeWAIS.
+
+  Approximate number of such servers in use:
+   Unknown. ~568 databases are registered and freely accessible.
+
+  General comments:
+   Source code freely available for use and modification.  Internet
+   community contributes to the software development, CNIDR incorporates
+   these developments into the freeWAIS releases.
+
+ -----------------------------------------------------------------------
+
+ Clients (CNIDR):               many varied for most platforms
+
+  Date completed or updated:    13th December, 1993
+  By: Name:                     Jane Smith
+      Email address:            Jane.Smith@CNIDR.org
+
+  Platform:                     varied
+
+  Primary Contact:
+  Name:                         Kevin Gamiel
+  Email address:                Kevin.Gamiel@CNIDR.org
+  Telephone:                    +1-919-248-1499
+
+  Client software available from:
+        URL:ftp://pub/NIDR.tools/freewais @ftp.cnidr.org
+
+
+
+Foster                                                         [Page 88]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Location of more information:
+       phone or e-mail CNIDR
+
+  Latest version number:         N/A
+
+  Brief Scope and Characteristics:
+   Many clients of varying capability available for most popular
+   computing platforms
+
+  General comments:
+   Clients developed and updated regularly; check mailing lists or ftp
+   sites for latest information
+
+  Future plans:
+   New clients when freeWAIS 1.0 (Z39.50-1992 version) is released
+
+ -----------------------------------------------------------------------
+
+ Clients:
+
+  Date completed or updated:    13th December, 1993
+  By: Name:                     Brewster Kahle
+      Email address:            brewster@wais.com
+
+  Platform:                     NeXT
+
+  Primary Contact:
+  Name:                         Paul Burchard
+  Email address:                burchard@math.utah.edu
+  Telephone:
+
+  Client software available from:
+         /pub/freeware/next@wais.com via anonymous FTP
+
+  Location of more information:
+
+  Latest version number:        WAIStation-NeXT-1.9.6
+
+  Brief Scope and Characteristics:
+
+  General comments:             NeXT client and server
+
+  Future plans:
+
+                          ------------------
+
+  Date completed or updated:    13th December, 1993
+  By: Name:                     Brewster Kahle
+
+
+
+Foster                                                         [Page 89]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+      Email address:            brewster@wais.com
+
+  Platform:                     EIWAIS 1.55
+
+  Primary Contact:
+  Name:                         Kevin Gourley
+  Email address:                pc-shareware@einet.net
+  Telephone:
+
+  Client software available from:
+         /pub/freeware/windows@wais.com via anonymous FTP
+         /einet/pc@ftp.einet.net via anonymous FTP
+
+  Location of more information:
+
+  Latest version number:        Version 1.55
+
+  Brief Scope and Characteristics:
+         WAIS client for Windows and Windows Sockets
+
+  General comments:  Windows WAIS Client for Windows Sockets
+                     - supporting multiple source queries
+                     - advanced program/viewer launching
+                     - embedded (any file size) text viewer
+                     - auto-keyword highlighting
+                     - graphics viewers included
+                     - auto-browse mode for redirected source queries
+                     - auto-parsing of WAIS catalogs returned by servers
+                     - runs on wide range of winsock TCP/IP stacks
+
+  Future plans:
+
+                       --------------------------
+
+  Date completed or updated:    13th December, 1993
+  By: Name:                     Brewster Kahle
+      Email address:            Brewster@wais.com
+
+  Platform:                     telnet access (vt100)
+
+  Primary Contact:
+  Name:                         John Curran
+  Email address:                jcurran@nnsc.nsf.net
+  Telephone:
+
+  Client software available from:
+       /pub/freeware/unix-src/wais-8-b5.1-swais-patches @wais.com
+
+
+
+
+Foster                                                         [Page 90]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Location of more information:
+       telnet to quake.think.com log in as wais.
+
+  Latest version number:
+
+  Brief Scope and Characteristics:
+
+  General comments:
+
+  Future plans:
+
+                          ------------------
+
+  Date completed or updated:    13th December, 1993
+  By: Name:                     Brewster Kahle
+      Email address:            brewster@wais.com
+
+  Platform:                     MacWAIS 1.28
+
+  Primary Contact:
+  Name:                         John Hardin
+  Email address:                mac-shareware@einet.net
+  Telephone:
+
+  Client software available from:
+       /pub/freeware/mac@wais.com via anonymous FTP
+
+  Location of more information:
+
+  Latest version number:        1.28
+
+  Brief Scope and Characteristics:
+
+  General comments:
+
+  Future plans:
+
+                          ------------------
+
+  Date completed or updated:    13th December, 1993
+  By: Name:                     Brewster Kahle
+      Email address:            Brewster@wais.com
+
+  Platform:                     Mac Hypercard
+
+  Primary Contact:
+  Name:                         Francois Schiettecatte
+  Email address:                francois@wais.com
+
+
+
+Foster                                                         [Page 91]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Telephone:
+
+  Client software available from:
+       /pub/freeware/mac/HyperWais* @wais.com
+
+  Location of more information: contact author
+
+  Latest version number: 1.9
+
+  Brief Scope and Characteristics:
+        HyperWais is a hypercard implementation of a WAIS client.
+        Its main characteristic is that it allows the user to remodel
+        the interface completely to their liking.
+
+  General comments:             Requires approximately 1.7Mb to run
+                                (including Hypercard).
+                                Requires system 7.0 or greater.
+                                Requires Hypercard 2.1
+                                Requires Mac TCP
+
+  Future plans:                 None at present
+
+                          ------------------
+
+  Date completed or updated:    13th December, 1993
+  By: Name:                     Brewster Kahle
+      Email address:            Brewster@wais.com
+
+  Platform:                     VMS
+
+  Primary Contact:
+  Name:                         Jim Fullton
+  Email address:                Jim.Fullton@cnidr.org
+  Telephone:
+
+  Client software available from:
+
+  Location of more information:
+
+  Latest version number:
+
+  Brief Scope and Characteristics:
+
+  General comments:
+
+  Future plans:
+
+                          ------------------
+
+
+
+Foster                                                         [Page 92]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Date completed or updated:    13th December, 1993
+  By: Name:                     Brewster Kahle
+      Email address:            Brewster@wais.com
+
+  Platform:                     DOS
+
+  Primary Contact:
+  Name:                         Jim Fullton
+  Email address:                Jim.Fullton@cnidr.org
+  Telephone:
+
+  Client software available from:  /pub/freeware/dos/pc.wais @wais.com
+
+  Location of more information:
+
+  Latest version number:
+
+  Brief Scope and Characteristics:
+
+  General comments:
+
+  Future plans:
+
+                          ------------------
+
+  Date completed or updated:    13th December, 1993
+  By: Name:                     Brewster Kahle
+      Email address:            Brewster@wais.com
+
+  Platform:                     DOS
+       (Clarkson packet driver and Erick Englke's WATT/TCP)
+
+  Primary Contact:
+  Name:                         Faeiz Hindi
+  Email address:                hindi@eniac.seas.upenn.edu
+  Telephone:
+
+  Client software available from:
+       /pub/tcpip/pcwais.zip@hilbert.wharton.upenn.edu
+
+  Location of more information:
+
+  Latest version number:
+
+  Brief Scope and Characteristics:
+
+  General comments:
+
+
+
+
+Foster                                                         [Page 93]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Future plans:
+
+                          ------------------
+
+  Date completed or updated:    13th December, 1993
+  By: Name:                     Brewster Kahle
+      Email address:            Brewster@wais.com
+
+  Platform:                     AVS
+
+  Primary Contact:
+  Name:                         Steve Thorpe
+  Email address:                thorpe@ncsc.org
+  Telephone:
+
+  Client software available from:
+       avs_modules/data_input/awais/* @avs.ncsc.org
+
+  Location of more information:
+
+  Latest version number:
+
+  Brief Scope and Characteristics:
+
+  General comments:
+
+  Future plans:
+
+                          ------------------
+
+  Date completed or updated:    13th December, 1993
+  By: Name:                     Brewster Kahle
+      Email address:            Brewster@wais.com
+
+  Platform:                     RS6000
+
+  Primary Contact:
+  Name:                         Dennis Shiao
+  Email address:                shiao@ans.net
+  Telephone:
+
+  Client software available from:
+       /pub/freeware/rs6000/wais-8-b3-dist.tar.Z@wais.com
+
+  Location of more information:
+
+  Latest version number:
+
+
+
+
+Foster                                                         [Page 94]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Brief Scope and Characteristics:
+
+  General comments:             client and server
+
+        "The details are correct, but I must point out that this
+        version of WAIS is most outdated.  I'd suggest replacing it
+        with AIX ports of the wais-8-b5 or freeWAIS packages, if
+        anyone's done those (I haven't) .."
+                                -Dennis.
+
+  Future plans:
+
+ -----------------------------------------------------------------------
+
+ Demonstration sites:
+
+  List of sites which are willing to act as demonstration sites for this
+  application.
+
+      Site name:                  quake.think.com
+      Access details:           telnet quake.think.com
+                                        login as wais.
+      Site name:                cnidr.org
+      Access details:           telnet cnidr.org
+                                     login as demo
+                                     select #2 (Demos of NIDR software)
+                                     select #2 (WAIS)
+
+       (this is the worst of all possible interfaces since it is just a
+       dumb terminal interface)
+
+ -----------------------------------------------------------------------
+
+ Documentation:
+
+  o   current overview
+
+  - "WAIS Server, WAIS Workstation, and WAIS Forwarder for UNIX
+     Technical Description", Release 1.1, December, 1993.
+
+  Available via anonymous ftp:
+    /pub/wais-inc-doc/msWord/Tech-description -1.1.sit.hqx @ftp.wais.com
+
+  - "Interfaces for Distributed Systems of Information Servers",
+     Brewster Kahle, Harry Morris, Jonathan Goldman (Thinking Machines
+     Corporation), Thomas Erickson (Apple Computer), John Curran (NSF
+     Network Service Center), March, 1992.  (formally named "Interfaces
+     for Wide Area Information Servers")
+
+
+
+Foster                                                         [Page 95]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Available via anonymous ftp:
+       /pub/wais-inc-doc/txt/Interfaces.txt@ftp.wais.com
+       or WAIS server wais-discussion-archives.src
+
+  o   instructions to information providers
+
+  See the documentation in the release:
+       /pub/freeware/unix-src/wais-8-b5.1.tar.z@wais.com
+       or the wais-docs.src WAIS server.
+
+  o   user manuals
+
+  The Mac interface WAIStation has a user manual.  The unix
+  commands have man pages.
+
+  o   training materials
+       - tutorials
+       - canned demos
+
+  - Macintosh demostration screen-movie: Steve Cisler of Apple put
+    together a short screen-recorder movie for seeing some of what
+    WAIStation does.
+    Available via anonymous FTP:
+    /pub/wais-doc/WAIStation-Canned-Demo.sit.hqx@wais.com
+               - sample session (screen dumps)
+  - "WAIStation, A User Interface for WAIS", February 1991, Thinking
+    Machines technical report TMC-203.
+    User interface documentation with screen shots.
+
+  - videos
+
+  Available in special circumstances. Contact info@wais.com.
+
+ -----------------------------------------------------------------------
+
+ Bibliography:
+
+  - "WAIS Bibliography", WAIS Inc, (last update) September 1993.
+
+  Available via anonymous ftp:
+  /pub/wais-inc-doc/txt/WAIS-bibliography.txt @wais.com or WAIS server
+  wais-discussion-archive.src
+
+
+
+
+
+
+
+
+
+Foster                                                         [Page 96]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ -----------------------------------------------------------------------
+
+ Other Information:
+
+  Check for current information about freeWAIS on CNIDR's gopher and WWW
+  servers: gopher.cnidr.org and www.cnidr.org
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                         [Page 97]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ WHOIS
+
+ Date template updated or checked:       17 March, 1994
+ By: Name:       Joan Gargano
+     Email address:  jcgargano@ucdavis.edu
+
+ -----------------------------------------------------------------------
+
+ NIR Tool Name: Whois
+
+ Brief Description of Tool:
+
+   As currently defined, NICNAME/WHOIS services is a TCP transaction
+   based query/response server, running on a few specific central
+   machines, that provides netwide directory service to internet users.
+   Since the WHOIS service was defined in 1985, it has evolved into a
+   distributed service.
+
+   The InterNIC Registration Services is located at Network Solutions,
+   Inc., Herndon, VA, and is funded by a cooperative agreement from the
+   National Science Foundations to provide assistance in registering
+   networks, domains, asn's, and other entities to the Internet
+   community via telephone, electronic mail, and U.S. postal mail.
+
+   Databases and information servers of interest to network users are
+   provided, including the WHOIS registry of domains, networks, asn's
+   and their associated poc's.  Gopher and Wais interfaces are also
+   available for retrieving information and accessing whois.  Online
+   documents maintained at registration services include registration
+   related rfc's, registration templates, and various netinfo files.
+   Many of the online files are available through our automatic mail
+   service, MAILSERV@RS.INTERNIC.NET.  Whois queries can also be
+   directed to rs.internic.net.  From a host, use the TELNET program to
+   connect to host RS.INTERNIC.NET.  When greeted by the Registration
+   host, type "WHOIS" and press RETURN.
+
+   MAILSERV@RS.INTERNIC.NET is an automated service provided by InterNIC
+   Registration Services.  It allows access to documents and information
+   via ordinary electronic mail.  This is especially useful for users
+   who do not have access to the NIC via a direct Internet link, such as
+   users of BITNET, CSNET and UUCP sites.
+
+   To use the mail service, send a mail message to
+   MAILSERV@RS.INTERNIC.NET.  In the SUBJECT field, request the type of
+   service you wish followed by any needed arguments.  The message body
+   is normally ignored.  Large files will be broken into smaller
+   separate messages.  The information you request will be sent back to
+   you as soon as possible.
+
+
+
+Foster                                                         [Page 98]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+   WHOIS xxx       Returns information about xxx from the WHOIS service.
+                   Use "WHOIS HELP" for information on how to use WHOIS.
+
+   The MILNET Network Information Center, maintains the central NICNAME
+   database and server, providing online look-up of individuals, network
+   organizations, MILNET nodes, and other information of interest to
+   those involved in management of the Internet.  Whois queries can be
+   sent to nic.ddn.mil.
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):    Network Solutions, Inc.
+
+  Name:                 Hostmaster
+
+  Email address:        hostmaster@rs.internic.net
+
+  Postal Address:       Network Solutions
+                        AttN: InterNIC Registration Services
+                        505 Huntmar Park Drive
+                        Herndon, VA 22070
+
+  Telephone:            +1-703-742-4777
+
+ -----------------------------------------------------------------------
+
+ Help Line:
+ (for major center as well as each client)
+
+  Name:                 Hostmaster
+                        Help information available via gopher,
+                        gopher.internic.net
+
+  Email address:        hostmaster@rs.internic.net
+
+  Telephone:            +1-703-742-4777
+
+  Level of support offered:
+        o funded
+        o all users
+
+  Hours available:      24 hours/day, 7 days per week.
+
+ -----------------------------------------------------------------------
+
+ Related Working Groups:
+
+  Whois and Network Information Lookup Service (WNILS)
+
+
+
+Foster                                                         [Page 99]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ -----------------------------------------------------------------------
+
+ Sponsoring Organisation / Funding source:
+
+  National Science Foundations
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+
+  Address:              ietf-wnils@ucdavis.edu
+
+  Administration:       ietf-wnils-request
+
+  Description:          This mailing list is used by the IETF Whois and
+                        Network Information Lookup Service (WNILS)
+                        working group which is defining enhancements
+                        to whois.
+
+  Archive:              ftp.ucdavis.edu:/archive/wnils-archive
+
+ -----------------------------------------------------------------------
+
+ News groups:           None.
+
+ -----------------------------------------------------------------------
+
+ Protocols:
+
+  What is supported:    TCP/whois
+
+  What it runs over:    TCP/IP networks
+
+  Other NIR tools this interworks with:
+
+  Future plans:         Enhancements through Whois++
+                        Enhancements  through Referral Whois.
+
+ -----------------------------------------------------------------------
+
+ Servers:
+
+  Date completed or updated:      4 March, 1994
+  By: Name:                       Joan Gargano
+
+  Platform:                       Unix
+
+  Primary Contact:                Network Solutions, Inc.
+
+
+
+Foster                                                        [Page 100]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Name:                           Hostmaster
+  Email address:                  hostmaster@rs.internic.net
+  Telephone:                      +1-703-742-4777
+
+ -----------------------------------------------------------------------
+
+ Clients:
+
+  Clients are available from the source listed for server software.  VMS
+  clients are available from TVG/Multinet Most TCP/IP networking
+  packages for personal computers include a whois client.
+
+ -----------------------------------------------------------------------
+
+ Demonstration sites:
+
+  Site name:                    rs.internic.net
+    Access details:             Using a whois client,
+                                        whois -h rs.internic.net "name"
+                                where "name" is the name of a person.
+
+ -----------------------------------------------------------------------
+
+ Documentation:
+
+  Document Title:       RFC 954
+  Location details:
+       Site:            nic.ddn.mil:/rfc
+       Full file name:  rfc954.txt
+
+  Document Title:       Specifications for WHOIS Services
+  Location details:
+       Site:            ftp.ucdavis.edu
+       Full file name:  /archive/ietf-wnils/Discussion.Paper
+
+ -----------------------------------------------------------------------
+
+ Bibliography:
+
+        RFC 954
+
+        Internet Drafts:
+        draft-ietf-wnils-whois-01.txt
+        draft-ietf-wnils-whois-02.txt
+        draft-ietf-wnils-whois-lookup-00.txt
+        draft-huitema-solo-00.txt
+
+
+
+
+
+Foster                                                        [Page 101]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+        Please check the 1id-abstracts.txt listing contained in the
+        internet-drafts Shadow Directories on nic.ddn.mil,
+        nnsc.nsf.net, nic.nordu.net, ftp.isi.edu, or munnari.oz.au
+        to learn the current status of any Internet Draft.
+
+ -----------------------------------------------------------------------
+
+ Other Information:
+
+ -----------------------------------------------------------------------
+
+ Evaluation:
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 102]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ World-Wide Web
+
+ Date template updated or checked:      28th January, 1994
+ By: Name:                              Tim Berners-Lee
+     Email address:                     timbl@info.cern.ch
+
+ -----------------------------------------------------------------------
+
+ NIR Tool Name:            World-Wide Web
+
+ Brief Description of Tool:
+
+   The WWW project merges the techniques of networked information and
+   hypertext to make an easy but powerful global information system.  W3
+   uses the concept of a seamless information space (the "web"), in
+   which all objects including those accessed by earlier protocols
+   (wais, gopher, ftp, etc.) exist.
+
+   The project allows information sharing within internationally
+   dispersed teams, and the dissemination of information by support
+   groups.  Originally aimed at the High Energy Physics community, it
+   has spread to other areas and attracted much interest in user
+   support, resource discovery and collaborative work areas.  It is
+   currently the most advanced information system deployed on the
+   Internet.
+
+   READER VIEW
+
+      The WWW world consists of documents, and links.  Indexes are
+      special documents which, rather than being read, may be searched.
+      The result of such a search is another ("virtual") document
+      containing links to the documents found.  A simple protocol ("
+      HTTP ") is used to allow a browser program to request a keyword
+      search by a remote information server.
+
+      The web contains documents in many formats.  Those documents which
+      are hypertext, (real or virtual) contain links to other documents,
+      or places within documents.  All documents, whether real, virtual
+      or indexes, look similar to the reader and are contained within
+      the same addressing scheme.
+
+      To follow a link, a reader clicks with a mouse (or types in a
+      number if he or she has no mouse).  To search and index, a reader
+      gives keywords (or other search criteria).  These are the only
+      operations necessary to access the entire world of data.
+
+
+
+
+
+
+Foster                                                        [Page 103]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+   INFORMATION PROVIDER VIEW
+
+      The WWW browsers can access many existing data systems via
+      existing protocols (FTP, NNTP) or via HTTP and a gateway.  In this
+      way, the critical mass of data is quickly exceeded, and the
+      increasing use of the system by readers and information suppliers
+      encourage each other.
+
+      Providing information is as simple as running the W3 server and
+      pointing it at an existing directory structure.  The server
+      automatically generates the hypertext view of your files to guide
+      the user around.
+
+      To personalize it, you can write a few SGML hypertext files to
+      give an even more friendly view.  Also, any file available by
+      anonymous FTP, or any internet newsgroup can be immediately linked
+      into the web.  The very small start-up effort is designed to allow
+      small contributions.  At the other end of the scale, large
+      information providers may provide an HTTP server with full text or
+      keyword indexing.  This may allow access to a large existing
+      database without changing the way that database is managed.  Such
+      gateways have already been made into Oracle(tm), WAIS, and
+      Digital's VMS/Help systems, to name but a few.
+
+      The WWW model gets over the frustrating incompatibilities of data
+      format between suppliers and reader by allowing negotiation of
+      format between a smart browser and a smart server.  This should
+      provide a basis for extension into multimedia, and allow those who
+      share application standards to make full use of them across the
+      web.
+
+      This summary does not describe the many exciting possibilities
+      opened up by the WWW project, such as efficient document caching.
+      The reduction of redundant out-of-date copies, and the use of
+      knowledge daemons.  There is more information in the online
+      project documentation, including some background on hypertext and
+      many technical notes.
+
+   GETTING STARTED
+
+      You can bootstrap yourself into the web by telnetting to
+      info.cern.ch (no user or password). You can try a full screen
+      interface "Lynx" by telnetting to ukanaix.cc.ukans.edu, login in
+      as "www".  You can also find out more about WWW in this way.
+      These are the least sophisticated browsers -- remember that the
+      window-oriented ones are much smarter!  It is much more efficient
+      to install a browser on your own machine, and you have many more
+      facilities.
+
+
+
+Foster                                                        [Page 104]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+      If you have an X-windows based workstation, PC or Mac just FTP to
+      FTP.NCSA.UIUC.EDU and get the binary of NCSA's "Mosaic" browser in
+      directory /Web/Mosaic-binaries. Download it, uncompress it, set it
+      executable, and run it.  It will tell you all you need to know.
+
+      Mosaic is now available for PCs and Apple Macs.
+
+      If you have an MSDOS machine with Windows, you could try the
+      "Cello" browser from FATTY.LAW.CORNELL.EDU in directory
+      /pub/LII/Cello.
+
+      The line mode browser is currently available in source form by
+      anonymous FTP from node info.cern.ch [currently 128.141.201.74] if
+      you take both files
+
+                /pub/www/src/WWWLibrary_v.vv.tar.Z.
+                /pub/www/src/WWWLineMode_v.vv.tar.Z.
+
+      (v.vv is the version number - take the latest.)
+
+   Also available is a hypertext editor for the NeXT (in
+   /pub/www/bin/next), the MidasWWW and ViolaWWW browsers for X11, an
+   alpha-test Mac browser, and and a basic server
+   (/pub/www/src/WWWDaemon_v.vv.tar.Z).  Documentation, including the
+   latest list of software available , is readable using www.  A plain
+   text version of the installation instructions is included in the tar
+   file!
+
+   Printable (postscript) documentation and articles are in /pub/www/doc
+   on info.cern.ch.
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                 Tim Berners-Lee
+  Email address:        timbl@info.cern.ch
+  Postal Address:       CERN, 1211 Geneva 23, Switzerland
+  Telephone:            +41-22-767-3755
+  Fax:                  +41-22-767-7155
+
+
+  Name:                 Robert Cailliau
+  Email address:        cailliau@cernnext.cern.ch
+  Postal Address:       CERN, 1211 Geneva 23, Switzerland
+  Telephone:            +41-22-767-5005
+  Fax:                  +41-22-767-7155
+
+
+
+
+Foster                                                        [Page 105]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ -------------------------------------------------------------------------
+
+ Help Line:
+ (for www technical or political issues, to report bugs, to register
+  new servers, or new software)
+
+  Name:                 www support
+  Email address:        www-request@info.cern.ch
+
+  Telephone:            none.
+  Telnet:               info.cern.ch for information.
+
+  Level of support offered:
+
+       o funded         for High-Energy Physics users
+
+       o volunteer      for others who have read the online
+                        information already.
+
+  While CERN collaborates with all NIR and W3 development anywhere, CERN
+  cannot provide user support for non-HEP end users.
+
+ -----------------------------------------------------------------------
+
+ Related Working Groups:        NIR, URI, IIIR
+
+ -----------------------------------------------------------------------
+
+ Sponsoring Organisations / Funding source:       NO FUNDING SOURCE
+
+  Bodies providing development effort include
+  HEP labs (CERN, CH; SLAC, CA, USA; FNAL, IL, USA; NIKHEF, NL; etc.),
+  National Center for SuperComputer Applications (NCSA, IL, USA),
+  O'Reilly Associates, (ORA, CA, USA),
+  Clearinghouse for Networked Information Discovery and Retrieval
+  (CNIDR, NC, USA),
+  BSD Inc (BSD, CA, USA) and many others too numerous to mention.
+
+  Other sources welcomed!
+
+ -----------------------------------------------------------------------
+
+ Newsgroup:
+
+  Name:                 comp.infosystems.www
+
+  Description:          General technical discussion, announcements
+                        of new software, etc.
+
+
+
+Foster                                                        [Page 106]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+                        Please mail new server announcements to
+                        www-request@info.cern.ch.
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+
+  1. Address:           www-talk@info.cern.ch for CONTRIBUTIONS ONLY
+
+     Administration:    listserv@info.cern.ch      (robot)
+                        www-talk-request@info.cern.ch (human)
+
+     Description:       Technical discussion, W3 related.
+                        Experts to experts. General questions to
+                        comp.infosystems.www, please.
+
+     Archive:           Not currently served, but kept.
+
+                         -------------------
+
+  2. Address:           www-announce@info.cern.ch
+                        NOT FOR GENERAL USE - serious low-volume
+                                              announcements only
+
+     Administration:    listserv@info.cern.ch             (robot)
+                        www-announce-request@info.cern.ch (human)
+
+     Description:       Low volume summary announcemements
+                        of product releases, etc.
+
+     Archive:           Not currently public
+
+ -----------------------------------------------------------------------
+
+ Protocols:
+
+  What is supported:   HTTP
+                       FTP
+                       anonymous FTP
+                       Gopher
+                       NNTP
+                       WAIS (compile time option)
+                       Local mounted file access
+                       Telnet sessions
+                       Rlogin sessions
+
+  What it runs over:   TCP/IP
+                       DECnet option.
+
+
+
+Foster                                                        [Page 107]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+
+  Other NIR servers W3 clients interworks with:
+                       Techinfo, Hyper-G and X.500 via gateways.
+                       Built-in capability in clients for others above
+                       Archie access via WWW "WARCHIE" archie server
+                       with direct hypertext pointers to FTP sites.
+
+  Resource indexing:   Many browsable and searchable indexes of
+                       available information, by subject (virtual
+                       libraries), and by position (geographical list of
+                       servers).  Many of these point to any form of
+                       data, HTTP or other server. A list of such
+                       indexes is at
+                       http://info.cern.ch/hypertext/DataSources/
+                            bySubject/Virtual_libraries/Overview.html
+
+  Future plans:        Collaborative work features,
+                       Hypertext editors for information organisation
+
+ -----------------------------------------------------------------------
+
+ HTTP Servers:         CERN httpd
+
+  Platform:            unix, VMS, VM/XA, VM/CMS
+
+  Primary Contact:     www-request@info.cern.ch
+
+  Server software available from:
+       ftp://info.cern.ch/pub/www/src
+
+  Location of more information:
+
+       http://info.cern.ch/hypertext/WWW/Daemon/User/Guide.html
+
+  Latest version number:        2.14
+
+  Brief Scope and Characteristics:
+
+       * Fast stateless file server runs over TCP/IP.
+       * Suitable for rapid documentation navigation.
+       * Multimedia server allows multiple file formats to be used.
+       * File format selected for transmission based on client
+         capabilities.
+       * Add special functions using scripts.  Standard CGI interface.
+       * Logging
+
+  Approximate number of such servers in use:   600
+
+
+
+
+Foster                                                        [Page 108]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  General comments:
+
+       Some servers serve many databases.
+
+       Many tools available for serving different sorts
+       of information
+
+               Gnu info
+               teX
+               SGML
+               man pages
+
+       etc., as hypertext.
+
+                    --------------------------------
+
+  Other servers:
+   For more information use WWW to access
+   http://info.cern.ch/hypertext/WWW/Daemon/Overview.html
+
+   Servers include:
+
+    NCSA server    Similar feature set to CERN's httpd, support from
+                   NCSA.
+
+    Plexus         Written in Perl -- many features.  Unix.
+
+    MacHTTPD       Server for the Macintosh
+
+    REXX for VM    A server consisting of a small C program which
+                   passes control to a server written in REXX.
+
+                      ---------------------------
+
+ Mail Server:
+
+  Platform:             unix
+
+  Primary Contact:      www-request@info.cern.ch
+
+  Server software available from:
+
+       ftp://info.cern.ch/pub/www/src/WWWMailRobot_*.tar.Z
+
+  Location of more information:
+       http://info.cern.ch/hypertext/WWW/MailRobot/Overview.html
+
+  Latest version number:        1.0
+
+
+
+Foster                                                        [Page 109]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+
+  Brief Scope and Characteristics:
+
+       Mailing list subscription/unsubscription handling (crude)
+       Return of documents given URL
+
+       Restricts length of data returned.
+       Allows access to ANY document by URL unless restrictions
+       are imposed (FTP, news, etc., included). Quite generic.
+
+       When hypertext messages are retrieved, the links are
+       numbered like [1] and a list of URLs of referenced documents
+       is appended to the document.
+
+       Send message containing HELP to listserv@info.cern.ch for
+       details.
+
+  Approximate number of such servers in use:   1 (-3?)
+
+  General comments
+
+       Extends potential readership of W3 information to anyone
+       with email, so an important step for universal readership.
+
+ -----------------------------------------------------------------------
+
+ NOTE: A full list of client software is kept in
+       http://info.cern.ch/hypertext/WWW/Clients.html
+       and is not repeated here, as the list is constantly
+       changing. Around 20 different clients. Telnet to info.cern.ch
+       to see the list. Only the Line Mode Browser, lynx and
+       Mosaic are covered here.
+
+ -----------------------------------------------------------------------
+
+ Client:                        Line Mode Browser
+
+  Date completed or updated:    28th January, 1994
+  By: Name:                     Tim Berners-Lee
+      Email address:            timbl@info.cern.ch
+
+  Platform:                     Anything.  Even a hard copy terminal.
+                                Written in portable C.
+
+  Primary Contact:
+  Name:                         Tim Berners-Lee
+  Email address:                timbl@info.cern.ch
+
+
+
+
+Foster                                                        [Page 110]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Client software available from:
+       ftp://info.cern.ch/pub/www/src
+
+  Location of more information:
+       http://info.cern.ch./hypertext/WWW/LineMode/Browser.html
+       and linked documents
+
+  Latest version number:        2.14
+
+  Brief Scope and Characteristics:
+
+   The LineMode Browser is suitable for use on dumb terminals, requiring
+   no control sequences except for carriage return and line feed.  It is
+   also of course useable from terminal emulators in workstation windows.
+   It can also be used as a text formatter, as part of a mail server,
+   and as a general information retrieval tool.
+
+   History list, Back/Next/Previous/Home navigation, ability to print or
+   save documents (or pipe to shell commands on unix).
+
+  General comments:
+
+   Very stable product which has many uses apart from interactive use.
+   Generates C .h files from hypertext marked files, etc.
+   Source release requires W3 library product.
+   Public Domain.
+
+  Future plans:
+
+   Future enhancements to include tracing of many links.
+
+  Demonstration sites:
+
+   telnet info.cern.ch or telnet 128.141.201.74 (SWITZERLAND)
+   telnet vms.huji.ac.il or telnet 128.139.4.3 (www) (ISRAEL)
+
+                  -----------------------------------
+
+  Client:                      Lynx
+
+   Date completed or updated:  11 February 1994
+   By: Name:                   Lou Montulli
+   Email address:              montulli@ukanaix.cc.ukans.edu
+
+   Platform:                   Unix + VMS
+
+   Primary Contact(s):
+   Name:                       Lou Montulli, Michael Grobe
+
+
+
+Foster                                                        [Page 111]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+   Email address:              montulli@ukanaix.cc.ukans.edu,
+                               grobe@ukanaix.cc.ukans.edu
+   Postal Address:             Computer Center, University of Kansas,
+                               Lawrence KS, 66045
+   Telephone:                  +1-913-864-0436 (Lou)
+                               +1-913-864-0452 (Michael)
+   Fax:                        +1-913-864-0485
+
+   Client software available from:
+        ftp2.cc.ukans.edu in directory /pub/lynx.
+
+  Location of more information: ftp2.cc.ukans.edu
+
+  Latest version number:       2.2
+
+  Brief Scope and Characteristics:
+
+   Lynx clients provide a user-friendly hypertext interface to
+   all of the major internet protocols for character cell (vt100)
+   terminal users on UNIX and VMS platforms.  Lynx natively
+   understands Gopher, HTTP, WAIS, FTP, NNTP (USENET NEWS) and
+   CSO protocols and can transparently retrieve information using
+   any of them.  Lynx can also launch telnet and tn3270 sessions
+   and has support to run executable programs on the local machine
+   so that it can be used as a menuing system.  Lynx is a part of
+   the World Wide Web (WWW) project and has all of the features
+   of a WWW client including HTML support and HTML+ forms support.
+   Additional resource types such as Archie Techinfo, X.500, and
+   Hytelnet may be also accessed through HTTP and Gopher gateway
+   functions.
+
+  Future plans:
+
+   Development of a DOS (non windows) version.
+
+  Help Line:
+
+   Name:                       Lou Montulli
+   Email address:              montulli@ukanaix.cc.ukans.edu
+   Telephone:                  +1-913-864-0436
+   Level of support offered:   volunteer
+   Hours available:            11-5pm M-F CST
+
+  Demonstration sites:
+
+   Site name:                  ukanaix.cc.ukans.edu
+   Access details:             telnet ukanaix.cc.ukanse.du
+                               login as "www"
+
+
+
+Foster                                                        [Page 112]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Documentation:
+
+    o   current overview
+          http://www.cc.ukans.edu/about_lynx/about_lynx/about_lynx.html
+    o   user manuals
+          http://www.cc.ukans.edu/lynx_help/lynx_help_main.html
+    o   miscellaneous documents
+          tar file of all documentation:
+          ftp://ftp2.cc.ukans.edu/pub/lynx/lynx_help_files.tar.Z
+
+  Sponsoring Organisation / Funding source:
+
+    Academic Computing Services
+    University of Kansas
+
+  Mailing Lists:
+
+    Address:                   lynx-dev@ukanaix.cc.ukans.edu
+    Administration:            listserv@ukanaix.cc.ukans.edu
+
+                  -----------------------------------
+
+  Client:                      NCSA MOSAIC for X
+
+  Date completed or updated:   16th December, 1993
+  By: Name:                    Marc Andreessen
+      Email address:           marca@ncsa.uiuc.edu
+
+  Platform:                    X Window System (Unix)
+                                -- Sun, DEC, IBM, SGI, HP, others.
+
+  Primary Contact:
+  Name:                        Marc Andreessen
+  Email address:               marca@ncsa.uiuc.edu
+  Postal Address:              National Center for Supercomputing
+                                Applications
+                               605 E. Springfield
+                               Champaign, IL 61820
+  Telephone:                   +1-217-244-0765
+
+  Client software available from:
+     ftp.ncsa.uiuc.edu in /Web/Mosaic.
+
+  Location of more information:
+     ftp.ncsa.uiuc.edu in /Web/mosaic, and online, within Mosaic.
+     http://www.ncsa.uiuc.edu/SDG/Software/Mosaic/Docs/help-about.html
+
+
+
+
+
+Foster                                                        [Page 113]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+   o Frequently Asked Questions
+     http://www.ncsa.uiuc.edu/SDG/Software/Mosaic/Docs/mosaic-faq.html
+   o user manuals
+     http://www.ncsa.uiuc.edu/SDG/Software/Mosaic/Docs/mosaic-docs.html
+
+  Latest version number:  1.1
+
+  Brief Scope and Characteristics:
+
+   NCSA Mosaic for the X Window System is a client interface to a wide
+   variety of networked information systems, including World Wide Web,
+   Gopher, WAIS, FTP, Usenet News, Archie, Techinfo, X.500, Hytelnet,
+   Telnet, NCSA Data Management Facility, CSO ph/qi and others.  It
+   offers a Motif-based point-and-click X interface with support for
+   plaintext, formatted text, and embedded images; hyperlinks can also
+   refer to images, video sequences, audio clips, PostScript files, etc.
+
+   Mosaic also offers substantial interaction and collaboration
+   facilities, including global history tracking, text and voice
+   annotations, group/community-wide annotations, and more.
+
+  General comments:
+
+  Sponsoring Organisation:
+   National Center for Supercomputing Applications
+
+  Future plans:
+
+   Enhancement of the NCSA Mosaic environment to support advanced
+   networked information systems and collaboration capabilities;
+   development of clients on other architectures; research and
+   development into intelligent agent-style user assistance mechanisms
+   and novel navigation and representation strategies for dense, dynamic
+   distributed information spaces.  (This is all dependent upon funding,
+   of course.) Beta-test versions of Mac and Microsoft Windows 3.1
+   were released in the fall of 1993.
+
+ -----------------------------------------------------------------------
+
+ Demonstration sites:
+
+   See individual sections on clients.
+
+ -----------------------------------------------------------------------
+
+
+
+
+
+
+
+Foster                                                        [Page 114]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Documentation:
+
+  All the W3 documentation available is in the web.  Some is also dumped
+  off into postscript.  Here are the URLs of entry points into the web
+  for the subjects requested:
+
+  ** To retrieve any document by URL, use WWW (www <url> for example) or
+  ** send mail containing the command "send " followed by the URL to
+  ** listserv@info.cern.ch
+
+    o current overview
+
+       http://info.cern.ch./hypertext/WWW/TheProject.html
+
+       see also
+
+       http://www.ncsa.uiuc.edu/SDG/Software/Mosaic/Docs/help-about.html
+
+    o executive summary
+
+       http://info.cern.ch./hypertext/WWW/Summary.html
+
+    o instructions to information providers
+
+       http://info.cern.ch./hypertext/WWW/Provider/Overview.html
+
+    o Frequently Asked Questions
+
+       http://info.cern.ch./hypertext/WWW/FAQ/List.html
+
+    o user manuals
+       See under individual products.
+
+       ftp://info.cern.ch/pub/www/doc/*.txt
+
+    o training materials
+
+       Illustrated talk on WWW including transparencies: see
+       ftp://info.cern.ch/hypertext/WWW/Talks/General/html
+
+       see also
+
+       http://www.ncsa.uiuc.edu/demoweb/demo.html
+
+ -----------------------------------------------------------------------
+
+
+
+
+
+
+Foster                                                        [Page 115]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ [General WWW bibliography]
+
+ Bibliography:
+
+  o For latest list, see:
+           http://info.cern.ch./hypertext/WWW/Bibliography.html
+
+                  Bibliography for the World Wide Web
+
+                     WORLD-WIDE WEB BIBLIOGRAPHY
+
+   This lists papers and articles about the W3 initiative and related
+   matters which you may want to pick up for background reading or quote
+   as references.  You can of course also quote any page you read with
+   W3 by its document address.  The FTP server info.cern.ch has some of
+   these in /pub/www/doc.
+
+ -----------------------------------------------------------------------
+
+ Other Information:
+
+  All WWW working notes and specs are on the web.  If it is not there
+  somewhere, it may not be anywhere.
+
+  Seek and ye shall find.  And if ye don't, mail someone to fix it.
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 116]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ X.500 White Pages
+
+  Date completed or updated: 10 March, 1994
+  By: Name:          Chris Weider
+      Email address: clw@bunyip.com
+
+ -----------------------------------------------------------------------
+
+ NIR Tool Name: X.500
+
+ Brief Description of Tool:
+
+   X.500 is an international standard designed to provide a distributed
+   global directory service.  It is primarily used today to provide
+   'White Pages' services, although other types of services which have
+   directory components (automated mail aliasing, for example) are
+   beginning to be run over X.500.  In addition to information about
+   people and organizations, the Directory also contains a pilot K-12
+   Directory, pilot Information Resource information, and some other
+   non-White Pages information.  X.500 contains a number of security
+   features, which are implemented on different paradigms in the various
+   servers.
+
+   User's View:
+
+      Users (either human or electronic) run a client program to connect
+      to a local X.500 server.  Since X.500 is distributed, it appears
+      that the entire global X.500 directory is available from the local
+      server.  From this server connection, the user can add, delete, or
+      modify information held by the Directory, or issue powerful search
+      commands to locate individuals or other information.
+
+      The first solid version of the X.500 protocol was released in
+      1988, and has been the subject of much research in the past 5
+      years.  Consequently, there are a large number of clients, for
+      almost every platform, and a healthy number of servers.  There are
+      mail interfaces to some parts of the X.500 directory, and there is
+      a X.500 to Gopher gateway.  An X.500 interface to archie is
+      currently under development, as well as an X.500 to WWW interface.
+
+   Information Provider's View:
+
+      X.500 provides a set of mechanisms to allow distributed location
+      of, maintenance of, and access to a large set of data.  However,
+      current servers force a hierarchical view on the location of the
+      data, so it may not be suitable for all applications.  Also, the
+      X.500 directory is today unable to provide access to information
+      at a rate which would allow 'real-time' applications (such as
+
+
+
+Foster                                                        [Page 117]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+      keeping routing information in the directory).
+
+      Also, there is a great effort underway to reduce the startup costs
+      of X.500 access by providing a lightweight X.500 access protocol
+      for client-server applications.  This work is detailed in RFC
+      1487:
+
+      "Lightweight Directory Access Protocol", by Yeong, Howes, and
+      Kille.  This protocol is expected to make the cost of entry for a
+      service provider much less that it has been.
+
+   Information Types Supported:
+
+      X.500 allows information to be served in an attribute:value
+      paradigm, with related attributes grouped into 'objects'. Each
+      entry in the directory can be described by multiple objects.
+      Attributes can have values which are text strings, dereferenceable
+      file names, or text-encoded photographs, and experimentation is
+      underway to keep digitally encoded sounds in the directory.
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                 The PARADISE Project
+
+  Email address:        helpdesk@paradise.ulcc.ac.uk
+
+
+  Name:                 The White Pages Pilot Project
+
+  Email address:        wpp-manager@psi.com
+
+ -----------------------------------------------------------------------
+
+ Help Line:
+
+  X.500 encompasses a great number of clients and as a distributed
+  system does not have a central help line. Please see the
+  Documentation section for pointers to servers, clients, and associated
+  help lines.
+
+ -----------------------------------------------------------------------
+
+ Related Working Groups:
+
+  IETF's OSI-DS (OSI Directory Services)
+  IETF's IDS (Integrated Directory Services)
+
+
+
+Foster                                                        [Page 118]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  OSI Implementor's Workshop's DS-SIG (Directory Services-SIG)
+  RARE's WG-NAP (Network Application Support)
+
+ -----------------------------------------------------------------------
+
+ Sponsoring Organisation / Funding source:
+
+  Not Applicable
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+
+  Address:              osi-ds@cs.ucl.ac.uk
+
+  Administration:       osi-ds-request@cs.ucl.ac.uk
+
+  Description:          Mail list for OSI-DS working group.
+
+                         -------------------
+
+  Address:              ietf-ids@umich.edu
+
+  Administration:       ietf-ids@umich.edu
+
+  Description:          Mail list for IDS working group.
+
+  Archive:              Anonymous FTP, merit.edu in directory
+                        /pub/ietf-ids-archive.
+
+                         -------------------
+
+  Address:              dssig@ics.uci.edu
+
+  Administration:       dssig-request@ics.uci.edu
+
+  Description:          Mail list for OIW DS-SIG group
+
+                         -------------------
+
+  Address:              wg-nap@rare.nl
+
+  Administration:       mailserver@rare.nl
+
+  Description:          Mail list for RARE working group WG-NAP
+
+  Archive:              Anonymous FTP, ftp.rare.nl, directory
+                        /rare/working-groups/wg-nap/mail/current
+
+
+
+Foster                                                        [Page 119]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ -----------------------------------------------------------------------
+
+ Protocols:
+
+  What is supported:    X.500
+
+  What it runs over:    Applications run on full ISO stack down to
+                        transport over TCP/IP + RFC1006, CONS, CLNS, or
+                        X.25(80)
+
+  Other NIR tools this interworks with: Gateways to Gopher and WWW.
+
+ -----------------------------------------------------------------------
+
+ Servers:
+
+  A full list of servers and clients is available in FYI 11, RFC 1292,
+  "A guide to available X.500 Implementations". See the Documentation
+  section for the location of this document. However, the most widely
+  deployed server is listed here for convenience.
+
+  QUIPU
+
+  Date completed or updated:    21 October, 1993
+  By: Name:                     Chris Weider
+      E-Mail:                   clw@bunyip.com
+
+  Platform:                     BSD 4.2, 4.3; AT&T System V; SunOS; AIX
+
+  Primary Contact:
+  Name:                         Steve Kille
+  E-Mail:                       S.Kille@isode.com
+  Telephone:                    +44-81-332-9091
+  Fax:                          +44-81-332-9019
+
+  Location of more information:
+   RFC 1292
+
+  Latest Version Number:        8.0 (public domain)
+                                IC R1 (ISODE consortium version)
+
+  Approximate number of such servers in use: 400
+
+ -----------------------------------------------------------------------
+
+  Demonstration sites:
+
+   Site name: paradise.ulcc.ac.uk
+
+
+
+Foster                                                        [Page 120]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+   Access details: telnet to paradise.ulcc.ac.uk
+                   login as dua
+
+ -----------------------------------------------------------------------
+
+ Documentation:
+
+  Document Title: FYI 11, RFC 1292, "Catalog of Available X.500
+    Implementations", R. Lang, R. Wright.
+  Location details: Available for anonymous FTP from
+     Site: ds.internic.net
+     Full file name: RFC-1292.txt
+
+  An update of this document is in preparation:
+  Document Title: "A Revised Catalog of Available X.500
+    Implementations", A. Getchell, S. Sataluri.
+  Location details: Available for anonymous FTP from
+     Site: ds.internic.net
+     Full file name: draft-ietf-ids-catalog-00.txt
+
+  Document Title: FYI 13, RFC 1308, "Executive Introduction to directory
+    services using the X.500 protocol", C. Weider, J. K. Reynolds
+  Location details: Available for anonymous FTP from
+     Site: ds.internic.net
+     Full file name: RFC-1308.txt
+
+  Document Title: FYI 14, RFC 1309, "Technical Overview of Directory
+    Services using the X.500 protocol", C. Weider, J. K. Reynolds,
+    S. Heker.
+  Location details: Available for anonymous FTP from
+     Site: ds.internic.net
+     Full file name: RFC-1309.txt
+
+  Document Title: RFC 1430, "A Strategic Plan for Deploying an Internet
+    X.500 Directory Service",
+    S. Kille, E. Huizer, V. Cerf, R. Hobby, S. Kent.
+  Location details: Available for anonymous FTP from
+     Site: ds.internic.net
+     Full file name: RFC-1430.txt
+
+  Document Title: FYI 21, RFC 1491, "A Survey of Advanced Usages of
+    X.500", C. Weider, R. Wright.
+  Location details: Available for anonymous FTP from
+     Site: ds.internic.net
+     Full file name: RFC-1491.txt
+
+  Document Title: RFC 1487, "Lightweight Directory Access Protocol",
+    W. Yeong, T. Howes, and S. Hardcastle-Kille
+
+
+
+Foster                                                        [Page 121]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Location details: Available for anonymous FTP from
+     Site: ds.internic.net
+     Full file name: RFC-1487.txt
+
+  Document Title: RFC 1588, "WHITE PAGES MEETING REPORT",
+    J. Postel, C. Anderson
+  Location details: Available for anonymous FTP from
+     Site: ds.internic.net
+     Full file name: RFC-1588.txt
+
+  These documents contain pointers to the rest of the literature.
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 122]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+7.   NIR Groups
+
+   This section contains information about the various groups working in
+   the area of networked information retrieval.  The groups are listed
+   alphabetically within their overall groupings (CNI, IETF, RARE,
+   etc.).  See Section 3.
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+ CNI Groups
+
+ Date template updated or checked: 1st March, 1994
+ By: Name:          Craig A. Summerhill
+     Email address: craig@cni.org
+
+ ---------------------------------------------------------------------------
+
+ NIR Group Name:          Coalition for Networked Information (CNI)
+
+Sponsoring Organisation: Association of Research Libraries
+                         (ARL), CAUSE, and EDUCOM
+
+ Working subgroups:
+
+  Name of subgroup:       Modernization of Scholarly Publishing
+                          Transformation of Scholarly Communication
+                          Directories and Information Resource Services
+                          Architecture and Standards
+                          Legislation, Codes, Policies and Practices
+                          Access to Public Information
+                          Teaching and Learning
+                          Management and Professional and User Education
+
+  Mailinglist-Address:    cni-announce@cni.org
+
+ Description of main group:
+
+   The Coalition for Networked Information was founded in March 1990 to
+   help realize the promise of high performance networks and computers
+   for the advancement of scholarship and the enrichment of intellectual
+   productivity.  The Coalition is a partnership of the Association of
+   Research Libraries (ARL), CAUSE, and EDUCOM.  ARL is dedicated to
+   equitable access to, and effective use of, recorded knowlege in
+   support of teaching, research, scholarship, and community service,
+   and CAUSE and EDUCOM are dedicated to different aspects of the
+   introduction, use, and management of information technology and
+   related resources in research and education in general and higher
+   education in particular.  The Coalition pursues its mission with the
+
+
+
+Foster                                                        [Page 123]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+   assistance of a task force that provides a common vehicle by which
+   more than 190 institutions and organizations are exploring a shared
+   vision of how information management must change in the 1990s to meet
+   the social and economic opportunities and challenges of the 21st
+   century.  Members of the Coalition Task Force include, among others,
+   higher education institutions, publishers, network service providers,
+   computer hardware, software, and systems companies, library networks
+   and organizations, and public and state libraries. A truly diverse
+   collaboration of institutions and organizations.
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                         Paul Evan Peters
+
+  Email address:                paul@cni.org
+
+  Postal Address:               Coalition for Networked Information
+                                21 Dupont Circle, N.W.
+                                Washington, D.C. 20036
+                                USA
+
+  Telephone:                    +1-202-296-5098
+
+  Fax:                          +1-202-872-0884
+
+                         ---------------------
+
+  Name:                         Joan K. Lippincott
+
+  Email address:                joan@cni.org
+
+  Postal Address:               Coalition for Networked Information
+                                21 Dupont Circle, N.W.
+                                Washington, D.C. 20036
+                                USA
+
+  Telephone:                    +1-202-296-5098
+
+  Fax:                          +1-202-872-0884
+
+                         ---------------------
+
+  Name:                         Craig A. Summerhill
+
+  Email address:                craig@cni.org
+
+
+
+
+Foster                                                        [Page 124]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Postal Address:               Coalition for Networked Information
+                                21 Dupont Circle, N.W.
+                                Washington, D.C. 20036
+                                USA
+
+  Telephone:                    +1-202-296-5098
+
+  Fax:                          +1-202-872-0884
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+
+  Address:         cni-announce@cni.org
+
+  Administration:  listproc@cni.org
+                   subscribe cni-announce <lastname> <firstname>
+
+  Description:     CNI News and Announcements
+
+                      ---------------------------
+
+  Address:         cni-architecture@cni.org
+
+  Administration:  listproc@cni.org
+                   subscribe cni-architecture <lastname> <firstname>
+
+  Description:     CNI Architecture and Standards Working Group Forum
+
+                       --------------------------
+
+  Address:         cni-bigideas@cni.org
+
+  Administration:  listproc@cni.org
+                   subscribe cni-bigideas <lastname> <firstname>
+
+  Description:     CNI Big Ideas Project Forum
+
+                      ----------------------------
+
+  Address:         cni-copyright@cni.org
+
+  Administration:  listproc@cni.org
+                   subscribe cni-copyright <lastname> <firstname>
+
+  Description:     Copyright and Intellectual Property Forum
+
+                        ------------------------
+
+
+
+Foster                                                        [Page 125]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Address:         cni-directories@cni.org
+
+  Administration:  listproc@cni.org
+                   subscribe cni-directories <lastname> <firstname>
+
+  Description:     CNI Directories and Information Resource Services
+                   Working Group Forum
+
+                        ------------------------
+
+  Address:         cni-legislation@cni.org
+
+  Administration:  listproc@cni.org
+                   subscribe cni-legislation <lastname> <firstname>
+
+  Description:     CNI Legislation, Codes, Policies, and Practices
+                   Working Group Forum
+
+                        ------------------------
+
+  Address:         cni-management@cni.org
+
+  Administration:  listproc@cni.org
+                   subscribe cni-management <lastname> <firstname>
+
+  Description:     CNI Management & Professional & User Education
+                   Working Group Forum
+
+                       -------------------------
+
+  Address:         cni-modernization@cni.org
+
+  Administration:  listproc@cni.org
+                   subscribe cni-modernization <lastname> <firstname>
+
+  Description:     CNI Modernization of Scholarly Publication
+                   Working Group Forum
+
+                       -------------------------
+
+  Address:         cni-pubinfo@cni.org
+
+  Administration:  listproc@cni.org
+                   subscribe cni-pubinfo <lastname> <firstname>
+
+  Description:     CNI Access to Public Information Working Group
+                   Forum
+
+
+
+
+Foster                                                        [Page 126]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+                       --------------------------
+
+  Address:         cni-teaching@cni.org
+
+  Administration:  listproc@cni.org
+                   subscribe cni-teaching <lastname> <firstname>
+
+  Description:     CNI Teaching and Learning Working Group Forum
+
+                      ---------------------------
+
+  Address:         cni-transformation@cni.org
+
+  Administration:  listproc@cni.org
+                   subscribe cni-transformation <lastname> <firstname>
+
+  Description:     CNI Transformation of Scholarly Communication
+                   Working Group Forum
+
+ -----------------------------------------------------------------------
+
+ News groups:                   None
+
+ -----------------------------------------------------------------------
+
+ Document Archive:
+
+  URL:ftp://ftp.cni.org/CNI/*
+
+ -----------------------------------------------------------------------
+
+ Official Publications:
+
+  None.  The Coalition relies on the publication programs of its parent
+  organizations (ARL, CAUSE, and EDUCOM) to disseminate printed
+  information on the Coalition's projects and programs.  Information on
+  the Coalition's program is also disseminated via electronic mailing
+  lists on the network.
+
+ -----------------------------------------------------------------------
+
+ Bibliography:                  None
+
+ -----------------------------------------------------------------------
+
+ Other Information:
+
+  URL:gopher://gopher.cni.org 70/CNI Working Group Forums/*
+
+
+
+Foster                                                        [Page 127]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  BRS/SEARCH full-text       telnet a.cni.org
+  information retrieval
+  system:                    login: brsuser
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 128]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Date template updated or checked: 1st March, 1994
+ By: Name:          Craig A. Summerhill
+     Email address: craig@cni.org
+
+ -----------------------------------------------------------------------
+
+ NIR Group Name:              Architecture and Standards Working Group
+
+ Sponsoring Organisation:     Coalition for Networked Information (CNI)
+
+   Working subgroups
+      Name of subgroup:         Z39.50 Interoperability Testbed
+      Mailinglist-Address:
+
+ Description of main group:
+
+   Program priorities are 1) to facilitate a consistent and complete
+   mechanism for linking bibliographic, abstracting, and indexing files
+   to files of their associated source materials; 2) a single standard
+   for the transmission of bitmapped image files; 3) protocols for
+   handling networked requests for delivery of source materials; 4)
+   mechanisms for interorganizational authentication, accounting, and
+   billing; and 5) to integrate lessons drawn from the experience of
+   pilot projects that exercise networked printing utilities and 6) to
+   provide an "interoperability workshop" to specify, implement, and
+   test advanced functions of Z39.50 to accelerate the pace and to
+   ensure the quality of standardization efforts in this area.
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                         Clifford Lynch
+
+  Email address:                calur@uccmvsa.bitnet
+
+  Postal Address:               Office of the President
+                                University of California
+                                300 Lakeside Dr., 8th Floor
+                                Oakland, CA  94612-3350
+                                USA
+
+  Telephone:                    +1-415-987-0522
+
+  Fax:                          +1-415-839-3573
+
+ -----------------------------------------------------------------------
+
+
+
+
+Foster                                                        [Page 129]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Mailing Lists:
+
+  Address:                      cni-architecture@cni.org
+
+  Administration:               listproc@cni.org
+                                SUB cni-architecture Lastname Firstname
+
+  Archive:
+
+    URL:ftp://ftp.cni.org/CNI/forums/cni-architecture/*
+    URL:gopher//gopher.cni.org 70/CNI Working Group Forums/
+        cni-architecture/*
+
+ -----------------------------------------------------------------------
+
+ News groups:                   None
+
+ -----------------------------------------------------------------------
+
+ Document Archive:              None
+
+ -----------------------------------------------------------------------
+
+ Official Publications:         None
+
+ -----------------------------------------------------------------------
+
+ Bibliography:                  None
+
+ -----------------------------------------------------------------------
+
+ Other Information:             None
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 130]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Date template updated or checked: 1st March, 1994
+ By: Name:          Craig A. Summerhill
+     Email address: craig@cni.org
+
+ -----------------------------------------------------------------------
+
+ NIR Group Name:               Directories and Information Resource
+                                 Services Working Group
+
+ Sponsoring Organisation:      Coalition for Networked Information (CNI)
+
+ Working subgroups:
+    Name of subgroup:          TopNode Management Team
+
+    Mailinglist-Address:       cni-directories@cni.org
+
+ Description of main group:
+
+  This group recognizes the need for open systems, standards, and
+  therefore, interoperable products and services based upon a
+  distributed architecture of servers that draw upon a common or at
+  least comparable set of data elements.  It is creating a (printed
+  and networked) directory of directories and resource information
+  services that provide qualitative (consumer) as well as descriptive
+  information.  The group supports the Library of Congress effort to
+  enhance the MARC formats to account for the cataloging requirements of
+  networked resources and services, and the National Science Foundation
+  effort to procure a new NSFNet Network Information Center.
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                         George Brett
+
+  Email address:                George.Brett@cnidr.org
+
+  Postal Address:
+
+   Clearinghouse for Networked Information Discovery and Retrieval
+   Center for Communications at MCNC
+   PO Box 12889, 3021 Cornwallis Road
+   Research Triangle Park, NC  27709-2889
+   USA
+
+  Telephone:                    +1-919-248-1499
+
+  Fax:                          +1-919-248-1101
+
+
+
+Foster                                                        [Page 131]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+                         ---------------------
+
+  Name:                         Peggy Seiden
+
+  Email address:                pseiden@skidmore.edu
+
+  Postal Address:               Scribner Library
+                                Skidmore College
+                                North Broadway
+                                Saratoga Springs, NY 12866
+
+  Telephone:                    +1-518-584-5000 ext. 2126
+
+  Fax:
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+
+  Address:                      cni-directories@cni.org
+
+  Administration:               listproc@cni.org
+                                SUB cni-directories Lastname Firstname
+
+  Archive:
+
+  URL:ftp://ftp.cni.org/CNI/forums/cni-directories/*
+  URL:gopher//gopher.cni.org 70/Coalition Working Groups /
+      WG E-mail Forums/CNI-directories/*
+
+ -----------------------------------------------------------------------
+
+ News groups:                   None
+
+ -----------------------------------------------------------------------
+
+ Document Archive:
+
+  Location details
+       Site:                    ftp.cni.org
+       Directory:               /CNI/forums/cni-directories/*
+
+ -----------------------------------------------------------------------
+
+ Official Publications:         None
+
+ -----------------------------------------------------------------------
+
+
+
+
+Foster                                                        [Page 132]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Bibliography:                  None
+
+ -----------------------------------------------------------------------
+
+ Other Information:             None
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 133]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Date template updated or checked: 1st March, 1994
+ By: Name:          Craig A. Summerhill
+     Email address: craig@cni.org
+
+ -----------------------------------------------------------------------
+
+ NIR Group Name:            TopNode for Networked Information Resources,
+                            Services, and Tools
+
+ Sponsoring Organisation:   Coalition for Networked Information (CNI)
+                            Directories and Information Resource
+                            Services Working Group
+
+ Working subgroups:
+    Name of subgroup:
+    Mailinglist-Address:
+
+ Description of main group:
+
+   (from ARL Newsletter #164 -- September 9, 1992)
+
+      The Coalition's TopNode Project is creating a directory of
+      directories, catalogs and aids of networked information resources,
+      services and tools.  The project is intended to facilitate the
+      network navigational duties, responsibilities and tasks of staff
+      in libraries, computer centers, networking offices and other
+      similar operations.  The primary product of the TopNode project
+      will be a set of records describing these networked information
+      resources, records that can be loaded into a wide range of
+      database management systems.
+
+      Based on their response to a Call for Statements of Interest and
+      Experience, Indiana University and Merit Network, Inc.  were
+      chosen to lead the development effort on the Coalition TopNode
+      project.  Pete Percival, Manager, Academic Information Environment
+      at Indiana University and Craig Summerhill, Coalition Systems
+      Coordinator, have completed the design for the database structure
+      which is being built on the Coalition's Internet fileserver using
+      BRS/SEARCH.  Based on earlier work of the leaders of the
+      Directories and Resource Information Services Working Group,
+      George Brett II of the University of North Carolina General
+      Administration and Peggy Seiden of Skidmore College Library,
+      Percival and Summerhill have developed a data structure that they
+      believe to be both flexible and responsive to the needs of the
+      many interested parties who have been consulted.
+
+      Under the direction of Gary Charbonneau of the Indiana University
+      Libraries, records are being created and prepared for loading.  A
+
+
+
+Foster                                                        [Page 134]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+      thesaurus of added descriptor terms is being maintained.  As of
+      mid-August 1992, close to 200 records had been verified and had
+      received descriptive cataloging.
+
+      When the database is complete, libraries will be alerted and
+      encouraged to mount the TopNode records into their online
+      catalogs.  Records will be available from the Coalition.  In
+      addition, MERIT will use the TopNode database in an experiment to
+      test the viability of the X.500 directory format standard for
+      providing yellow pages-type services (e.g., with subject access).
+      After its initial release, the database will be maintained by
+      Indiana University libraries on the Coalition server; BRS has
+      assisted in the development of procedures for online data entry.
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                         Pete Percival
+
+  Email address:                percival@indiana.edu
+
+  Postal Address:               Indiana State University
+
+  Telephone:                    +1-812-855-9146
+
+  Fax:                          +1-812-855-0299
+
+                           ------------------
+
+  Name:                         Craig Summerhill
+
+  Email address:                craig@cni.org
+
+  Postal Address:               Coalition for Networked Information
+                                21 Dupont Cricle, N.W.
+                                Washington, D.C. 20036
+                                USA
+
+  Telephone:                    +1-202-296-5098
+
+  Fax:                          +1-202-872-0884
+
+                           ------------------
+
+  Name:                         Gary Charbonneau
+
+  Email address:                charbonn@indiana.edu
+
+
+
+Foster                                                        [Page 135]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Postal Address:               Indiana University
+
+  Telephone:
+
+  Fax:
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:                 None
+
+ -----------------------------------------------------------------------
+
+ News groups:                   None
+
+ -----------------------------------------------------------------------
+
+ Document Archive:
+
+  Location details
+       Site:                    ftp.cni.org
+       Directory:               /CNI/projects/topnode/*
+
+ -----------------------------------------------------------------------
+
+ Official Publications:
+
+  Status Report - TopNode Directory of Directories.  Pete Percival.
+  Presented at Coalition's 1992 Fall Task Force meeting, Landsdowne VA
+
+  site: gopher.cni.org/ Coalition FTP archives / Coalition Projects /
+        TopNode / *
+
+ -----------------------------------------------------------------------
+
+ Bibliography:                  None
+
+ -----------------------------------------------------------------------
+
+ Other Information:
+
+  The Coalition has an alpha implementation of Topnode setup using the
+  BRS/SEARCH full text information retrieval software.  This database
+  was created during the data element definition portion of the project,
+  so the data may not be of production-level service quality.
+
+  URL:telnet://brsuser
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+Foster                                                        [Page 136]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ CNIDR
+
+ Date template updated or checked: 1st March, 1994
+ By: Name:          Jane Smith
+     Email address: Jane.Smith@cnidr.org
+
+ -----------------------------------------------------------------------
+
+ NIR Group Name:                 Clearinghouse for Networked Information
+                                                 Discovery and Retrieval
+
+ Sponsoring Organisation:        National Science Foundation,
+                                 Center for Communications at MCNC
+
+ Working subgroups:
+    Name of subgroup:
+    Mailinglist-Address:
+
+ Description of main group:
+
+  Several user-friendly client-server software tools have  been
+  developed recently for locating and retrieving information
+  published on computer platforms reachable over wide-area data
+  communications networks like the Internet. Among them, freeWAIS
+  (freely available wide-area information system), the Internet
+  Gopher, archie, and the WorldWide Web (WWW) have become popular.
+  freeWAIS, archie, and Gopher indicate where information of
+  interest is likely to reside and then assist the user in locating
+  specific information. WWW permits a user to thread a path through
+  the network by selecting tagged hypertext items.
+
+  While focused on the evolution of wide-area information retrieval
+  systems, the Clearinghouse for Networked Information Discovery
+  and Retrieval (CNIDR) works closely with developers of other
+  tools toward providing compatibility, consistency, and, to the
+  extent possible, convergence of the tools.
+
+  Specific activities are to provide a central focus and forum for
+  networked information discovery and retrieval (NIDR) tools and to
+  minimize the divergence of individual implementations by
+  providing a repository for the collection, evaluation, and
+  distribution of protocol-compliant releases and enhanced
+  versions.
+
+  CNIDR participates in standards and policy associations such as
+  the Internet Engineering Task Force and the Coalition for
+  Networked Information, with the goal of increasing consensus
+  among developers and exploring appropriate uses of networked
+
+
+
+Foster                                                        [Page 137]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  information. CNIDR also actively promotes the use of networked
+  information discovery and retrieval tools at many national and
+  international conferences to inform and educate implementors and
+  end users.
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                         George Brett
+
+  Email address:                George.Brett@cnidr.org
+
+  Postal Address:
+
+   Clearinghouse for Networked Information Discovery and Retrieval
+     (CNIDR)
+   Center for Communications at MCNC
+   PO Box 12889, 3021 Cornwallis Road
+   Research Triangle Park, NC  27709-2889 USA
+
+  Telephone:                    +1-919-248-1886
+
+  Fax:                          +1-919-248-1101
+
+                           ------------------
+
+  Name:                         Jane Smith
+
+  Email address:                Jane.Smith@cnidr.org
+
+  Postal Address:
+
+   Clearinghouse for Networked Information Discovery and Retrieval
+     (CNIDR)
+   Center for Communications at MCNC
+   PO Box 12889, 3021 Cornwallis Road
+   Research Triangle Park, NC  27709-2889 USA
+
+  Telephone:                    +1-919-248-9213
+
+  Fax:                          +1-919-248-1101
+
+                           ------------------
+
+  Name:                         Jim Fullton
+
+  Email address:                Jim.Fullton@cnidr.org
+
+
+
+Foster                                                        [Page 138]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Postal Address:
+
+   Clearinghouse for Networked Information Discovery and Retrieval
+    (CNIDR)
+   Center for Communications at MCNC
+   PO Box 12889, 3021 Cornwallis Road
+   Research Triangle Park, NC  27709-2889 USA
+
+  Telephone:                    +1-919-248-9247
+
+  Fax:                          +1-919-248-1101
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+
+  Address:              info@cnidr.org
+
+  Administration:       none.
+
+  Description:          e-mail sent to this address will receive an
+                        automated response containing more information
+                        about current CNIDR activities.
+
+  Archive:              none
+
+                    -------------------------------
+
+ Mailing Lists:         zip@cnidr.org
+
+  Address:              zip@cnidr.org
+
+  Administration:       zip-request@cnidr.org
+                        sub zip Lastname Firstname
+
+  Description:          Technical discussion of Z39.50-92 application
+                        development. Subscribers receive brief overview
+                        of project and information on how to access
+                        archives.
+
+  Archive:
+
+       ftp://ftp.cnidr.org/NIDR.tools/zip
+       gopher://gopher.cnidr.org/NIDR Tools/Discussion/Online Discussion
+
+ -----------------------------------------------------------------------
+
+ News groups:                   None
+
+
+
+Foster                                                        [Page 139]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ -----------------------------------------------------------------------
+
+ Document Archive:              ftp.cnidr.org
+
+ -----------------------------------------------------------------------
+
+ Official Publications:         None
+
+ -----------------------------------------------------------------------
+
+ Bibliography:                  None
+
+ -----------------------------------------------------------------------
+
+ Other Information:             info@cnidr.org
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 140]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ IETF Groups
+
+   The Internet Engineering Task Force (IETF) is the protocol
+   engineering, development and standardisation arm of the Internet.  It
+   has grown to be a large open international community of network
+   designers, operators, vendors and researchers concerned with the
+   evolution of the Internet protocol architecture and the smooth
+   operation of the Internet.
+
+   IETF Information including RFCs and Internet Drafts is available by
+   anonymous FTP from several sites.
+
+   East Coast (US) Address: ds.internic.net
+
+   West Coast (US) Address: ftp.isi.edu
+
+   Europe Address: nic.nordu.net
+
+   Pacific Rim Address: munnari.oz.au
+
+         (The Internet-Drafts on this machine are stored in Unix
+          compressed form (.Z).)
+
+   In addition the information is available via gopher from
+   cnri.reston.va.us under the menu item "Internet Society".
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 141]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ IDS
+
+ Date template updated or checked: 21 October, 1993
+ By: Name:          Chris Weider
+     Email address: clw@bunyip.com
+
+ -----------------------------------------------------------------------
+
+ NIR Group Name:          Integrated Directory Services (IDS)
+
+ Sponsoring Organisation: Internet Engineering Task Force (IETF)
+
+ Working subgroups:       NONE
+
+ Description of main group:
+
+   The Integrated Directory Services Working Group (IDS) is chartered to
+   facilitate the integration and interoperability of current and future
+   directory services into a unified directory service.  This work will
+   unite directory services based on a heterogeneous set of directory
+   services protocols (X.500, WHOIS++, etc.).  In addition to specifying
+   technical requirements for the integration, the IDS group will also
+   contribute to the administrative and maintenance issues of directory
+   service offerings by publishing guidelines on directory data
+   integrity, maintenance, security, and privacy and legal issues for
+   users and administrators of directories.
+
+   Membership is open, and is not limited to IETF attendees.  A full
+   charter for this group is available for anonymous FTP from
+   ds.internic.net as ids-charter.txt in directory ietf/ids.
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                         Chris Weider, Chair
+
+  Email address:                clw@bunyip.com
+
+  Postal Address:               2001 South Huron Parkway 12
+                                Ann Arbor
+                                Michigan
+                                48104, USA
+
+  Telephone:                    +1-313-971-2223
+
+  Fax:                          +1-313-971-2223
+
+
+
+
+Foster                                                        [Page 142]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+
+  Address:                      ietf-ids@umich.edu
+
+  Administration:               ietf-ids-request@umich.edu
+
+  Archive:                      Anonymous FTP to merit.edu, directory
+                                /pub/ietf-ids/archive.
+
+ -----------------------------------------------------------------------
+
+ Document Archive:
+
+  Location details:
+       Site: ds.internic.net or any Internet Draft Server (see
+        sub-section entitled IETF groups)
+       Directory: internet-drafts. All IDS document file names start
+        with either draft-ietf-disi or draft-ietf-ids.
+
+ -----------------------------------------------------------------------
+
+ Official Publications:         None.
+
+ -----------------------------------------------------------------------
+
+ Bibliography:
+
+  Document Title: FYI 11, RFC 1292, "Catalog of Available X.500
+    Implementations", R. Lang, R. Wright.
+  Location details: Available for anonymous FTP from
+     Site: ds.internic.net
+     Full file name: RFC-1292.txt
+
+  An update of this document is in preparation:
+  Document Title: "A Revised Catalog of Available X.500
+    Implementations", A. Getchell, S. Sataluri.
+  Location details: Available for anonymous FTP from
+     Site: ds.internic.net
+     Full file name: draft-ietf-ids-catalog-00.txt
+
+  Document Title: FYI 21, RFC 1491, "A Survey of Advanced Usages of
+    X.500", C. Weider, R. Wright.
+  Location details: Available for anonymous FTP from
+     Site: ds.internic.net
+     Full file name: RFC-1491.txt
+
+
+
+
+Foster                                                        [Page 143]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+   Marine, A, X.500 Pilot Projects, June 1993. Available as
+   draft-ietf-ids-pilots-00.txt from any Internet Draft server.
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 144]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ IIIR
+
+ Date template updated or checked: 14 March, 1994
+ By: Name:          Chris Weider
+     Email address: clw@bunyip.com
+
+ -----------------------------------------------------------------------
+
+ NIR Group Name:  Integration of Internet Information Resources (IIIR)
+
+ Sponsoring Organisation: Internet Engineering Task Forces (IETF)
+
+ Working subgroups:  None
+
+ Description of main group:
+
+   The IIIR group was chartered in September 1992 to facilitate
+   interoperability between and integration of the various Internet
+   information services (Archie, Gopher, WAIS, etc.), just as the IETF
+   was founded to facilitate the integration of various LANs running
+   different protocols. It will develop, specify, and align protocols to
+   integrate the services into a single "virtually unified information
+   service" (VUIS).
+
+   Also, where necessary for interoperability, IIIR will create
+   technical documentation for protocols used for information services
+   in the internet.
+
+   Membership is open, and is not limited to IETF attendees. A full
+   charter for this group is available via anonymous FTP from
+   ds.internic.net as ietf/iiir/iiir-charter.txt
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                         Chris Weider, Chair
+
+  Email address:                clw@bunyip.com
+
+  Postal Address:               2001 South Huron Parkway 12
+                                Ann Arbor
+                                Michigan
+                                48104
+                                USA
+
+  Telephone:                    +1-313-971-2223
+
+
+
+
+Foster                                                        [Page 145]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Fax:                          +1-313-971-2223
+                    -------------------------------
+
+  Address:                      iiir@merit.edu
+
+  Administration:               iiir-request@merit.edu
+
+  Archive:                      Anonymous FTP, iiir/archive
+
+ -----------------------------------------------------------------------
+
+ Document Archive:
+
+  Location details:
+   Site: ds.internic.net or any Internet Draft Server (see sub-section
+    entitled IETF groups).
+   Directory: internet-drafts
+   All IIIR document file names start with the string 'draft-ietf-iiir-'
+
+ -----------------------------------------------------------------------
+
+ Official Publications:         None.
+
+ -----------------------------------------------------------------------
+
+ Bibliography:
+
+   Weider, Chris, and Peter Deutsch, 'A vision of an integrated Internet
+   information service', Internet Draft, March 1993. Available as
+   draft-ietf-iiir-vision-00.txt from any Internet Draft server.
+
+   Weider, Chris, 'Resource Transponders', Internet Draft, March 1993.
+   Available as draft-ietf-iiir-transponder-00.txt from any Internet
+   Draft server.
+
+   Ankelesaria, et al, 'The Internet Gopher Protocol', RFC 1436, March
+   1993. Available from any RFC repository.
+
+   Berners-Lee, Tim. 'Hypertext Markup Language (HTML)', Internet Draft,
+   March 1993. Available as draft-ietf-iiir-html-00.ps from any Internet
+   Draft server.
+
+ -----------------------------------------------------------------------
+
+
+
+
+
+
+
+
+Foster                                                        [Page 146]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Other Information:
+
+  This is a new area, one with lots of interesting open problems and
+  the potential to help shape the future of information services on the
+  Internet. Even if you can't make the IETF meetings, you are
+  strongly encouraged to join the group and contribute.
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 147]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ NIR
+
+  Date template updated or checked: 1st March, 1994
+  By: Name:          Jill Foster
+      Email address: Jill.Foster@newcastle.ac.uk
+
+ -----------------------------------------------------------------------
+
+ NIR Group Name: Networked Information Retrieval Working Group (NIR-WG)
+
+ Sponsoring Organisation: Internet Engineering Task Force (IETF) and
+RARE (Association of European Research Networks)
+
+ Working subgroups:     None
+
+ Description of main group:
+
+   There are many organizations and associations that have begun to
+   focus on the proliferating resources and tools for networked
+   information retrieval (NIR).  The Networked Information Retrieval
+   Group will be a cooperative effort of three major players in the
+   field of NIR: IETF, RARE, and the Coalition for Networked Information
+   (CNI) specifically tasked to collect and disseminate information
+   about the tools and to discuss and encourage cooperative development
+   of current and future tools such as the archie servers, the Wide Area
+   Information Servers (WAIS), the Internet Gopher, and the WorldWide
+   Web (WWW).
+
+   The NIR Working Group intends to increase the useful base of
+   information about networked information retrieval (NIR) tools, their
+   developers, interested organizations, and other activities that
+   relate to the production, dissemination, and support of NIR tools.
+
+   Membership is open and is not limited to attendees of the quarterly
+   IETF meetings; the mailing list is open to all.  The NIR-WG charter
+   is available via anonymous ftp from the various IETF repositories as
+   nir-charter.txt.
+
+ Goals:
+
+   To disseminate information about NIR tools and those groups working
+   on them.  The information in the NIR Status report will be updated
+   and new entries added as appropriate once per year.  This report will
+   be submitted as an RFC.
+
+   Current work includes discussing the criteria for evaluating the
+   major NIR tools available.
+
+
+
+
+Foster                                                        [Page 148]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                 Jill Foster
+
+  Email address:        Jill.Foster@newcastle.ac.uk
+
+  Postal Address:       Computing Service
+                        University of Newcastle upon Tyne
+                        Newcastle upon Tyne
+                        NE1 7RU
+                        U.K.
+
+  Telephone:            +44-91-222-8250
+
+  Fax:                  +44-91-222-8765
+
+                   ---------------------------------
+
+  Name:                 Kevin Gamiel
+
+  Email address:        kevin.gamiel@cnidr.org
+
+  Postal Address:
+
+  Clearinghouse for Networked Information Discovery and Retrieval
+  Center for Communications - MCNC
+  PO Box 12889  3021 Cornwallis Road
+  Research Triangle Park, NC  27709-2889
+  U.S.A.
+
+  Telephone:            +1-919-248-1886
+
+  Fax:                  +1-919-248-1101
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+
+  Address:              nir@mailbase.ac.uk
+
+  Administration:       Auto subscriptions to: mailbase@mailbase.ac.uk
+                        "subscribe nir firstname lastname"
+                        Human admin to: nir-request@mailbase.ac.uk
+
+  Description:
+
+
+
+
+Foster                                                        [Page 149]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Archive:              ftp://mailbase.ac.uk/pub/lists/nir/files/*
+                        or via gopher to mailbase.ac.uk
+
+ -----------------------------------------------------------------------
+
+ News groups:           None
+
+ -----------------------------------------------------------------------
+
+ Document Archive:
+
+  Location details
+       Site: mailbase.ac.uk
+       Directory: /pub/lists/nir/files
+
+  or from any Internet Draft Server (see sub-section entitled IETF
+  groups)
+
+ -----------------------------------------------------------------------
+
+ Bibliography:
+
+ -----------------------------------------------------------------------
+
+ Other Information:
+
+  This Working Group was formed jointly in the User Services and
+  Applications Areas of the Internet Engineering Task Force.
+
+  The RARE (Reseaux Associes pour la Recherche Europeenne) ISUS WG
+  (Information Services and User Support Working Group) is
+  represented by NIR-WG co-chair Jill Foster.  NIR-WG information
+  is also posted to the mailing list for the ISUS WG at
+  "wg-isus@rare.nl".
+
+  More information about CNI (Coalition for Networked Information) may
+  be obtained via anonymous ftp files from ftp.cni.org.
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 150]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ NISI
+
+  Date template updated or checked: 1st March, 1994
+  By: Name:          April Marine
+      Email address: april@atlas.arc.nasa.gov
+
+ -----------------------------------------------------------------------
+
+ NIR Group name: Network Information Services Infrastructure (NISI)
+Working Group
+
+ Sponsoring Organisation: IETF
+
+ Description of main group:
+
+   The NISI Working Group will explore the requirements for common,
+   shared Internet-wide network information services.  The goal is to
+   develop an understanding for what is required to implement an
+   information services "infrastructure" for the Internet.  Membership
+   is open.  Charter is online in the various IETF repositories as
+   nisi-charter.txt.
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                 April Marine
+
+  Email address:        april@atlas.arc.nasa.gov
+
+  Postal Address:       Network Applications and Information Center
+                        NASA Ames Research Center
+                        M/S 204-14
+                        Moffett Field, CA 94035-1000
+                        USA
+
+  Telephone:            +1-415-604-0762
+
+  Fax:                  +1-415-604-0978
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+
+  Address:              nisi@merit.edu
+
+  Administration:       nisi-request@merit.edu
+
+
+
+
+Foster                                                        [Page 151]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ ----------------------------------------------------------------------
+
+ Official Publications: Internet-Drafts and FYI RFCs
+
+ ----------------------------------------------------------------------
+
+ Bibliography:
+
+  RFC 1302:  Building a Network Information Services Infrastructure
+
+  RFC 1355:  Privacy and Accuracy Issues in Network
+             Information Centre Databases
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 152]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ OSI-DS
+
+ Date template updated or checked: 24 February, 1994
+ By: Name:          Chris Weider
+     Email address: clw@bunyip.com
+
+ -----------------------------------------------------------------------
+
+ NIR Group Name: OSI Directory Services (OSI-DS)
+
+ Sponsoring Organisation: Internet Engineering Task Forces (IETF)
+
+ Working subgroups: NONE
+
+ Description of main group:
+
+   The OSI-DS group's mission is to enable building a global Directory
+   Service based on X.500 and to facilitate its deployment on the
+   Internet.  The primary focus is on developing agreements and
+   technical specifications needed to make this happen.  The WG will not
+   be directly concerned with piloting and service activities, but will
+   liaise with such activities.
+
+   Membership is open, and is not limited to IETF attendees.  A full
+   charter for this group is available for anonymous FTP from
+   ds.internic.net as ietf/osids/osids-charter.txt
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                 Steve Kille, Chair
+
+  Email address:        kille@isode.com
+
+  Postal Address:       ISODE Consortium
+                        P.O. Box 505
+                        SW11 1DX London
+                        England
+
+  Telephone:            +44-71-223-4062
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+
+  Address:              ietf-osi-ds@cs.ucl.ac.uk
+
+
+
+
+Foster                                                        [Page 153]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Administration:       ietf-osi-ds-request@cs.ucl.ac.uk
+
+  Archive:              Anonymous FTP, bells.cs.ucl.ac.uk
+
+ -----------------------------------------------------------------------
+
+ Document Archive:
+
+  Location details:
+   Site: bells.cs.ucl.ac.uk
+   Directory:/osi-ds
+
+   Site: ds.internic.net
+   Directory: /ietf/osids
+
+ -----------------------------------------------------------------------
+
+ Official Publications:         None.
+
+ -----------------------------------------------------------------------
+
+ Bibliography:
+
+  The COSINE and Internet X.500 Schema, P. Barker, S. Kille, RFC-1274.
+
+  Replication and Distributed Operations Extensions to Provide an
+   Internet Directory Usign X.500, S. Hardcastle-Kille, RFC-1276
+
+  Requirements to provide an Internet Directory using X.500.
+   S. Hardcastle-Kille, RFC-1275
+
+  A Strategic Plan for Deploying an Internet X.500 Directory Service,
+   S. Hardcastle-Kille et al, RFC-1340
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 154]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ URI
+
+ Date template updated or checked: 14 March, 1994
+ By: Name:          Chris Weider
+     Email address: clw@bunyip.com
+
+ -----------------------------------------------------------------------
+
+ NIR Group Name:    Uniform Resource Identifiers (uri)
+
+ Sponsoring Organisation: Internet Engineering Task Forces (IETF)
+
+ Working subgroups:    NONE
+
+ Description of main group:
+
+   The Uniform Resource Identifiers Archives Working Group is chartered
+   to define a set of standards for the encoding of system independent
+   Resource Location and Identification information for the use of
+   Internet information services.  There are three classes of
+   information being standardized in this group:
+
+
+      1)  Uniform Resource Locators (URLs), which specify a standardized
+          method for encoding location and access information to
+          resources across multiple information systems,
+
+      2)  Uniform Resource Names (URNs), which specify a standardized
+          method for encoding a unique resource identifier for a given
+          content, and
+
+      3)  Uniform Resource Citations (URCs), which specify a
+          standardized method for encoding information about a given
+          instantiation of a content.
+
+   The URLs allow an information service to give a user access and
+   location information for a resource.  The URN allows an information
+   service to determine if the contents of two information resources are
+   the same or not.  The URC allows an information service to select
+   which of a number of different encodings of a resource are
+   appropriate for a given user's retrieval capabilities, and may
+   contain such things as file size and compression techniques.
+
+   Membership is open, and is not limited to IETF attendees.  A full
+   charter for this group is available for anonymous FTP from
+   ds.internic.net as /ietf/uri/uri-charter.txt
+
+ -----------------------------------------------------------------------
+
+
+
+Foster                                                        [Page 155]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Primary Contact(s):
+
+  Name:                 Jim Fullton, co-chair
+
+  Email address:        fullton@concert.net
+
+  Postal Address:       Center for Communications
+                        P.O. Box 12889
+                        3021 Cornwallis Road
+                        Research Triangle Park
+                        North Carolina 27709-2889
+
+  Telephone:            +1-919-248-1499
+
+  Fax:                  +1-919-248-1101
+
+                  -----------------------------------
+
+  Name:                 Alan Emtage, co-chair
+
+  Email address:        bajan@bunyip.com
+
+  Postal Address:       Bunyip Information Systems, Inc.
+                        266 Blvd. Neptune
+                        Dorval QUEBEC H9S 2L4 CANADA
+
+  Telephone:            +1-514-875-8611
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+
+  Address:              uri@bunyip.com
+
+  Administration:       uri-request@bunyip.com
+
+  Archive:              archives.cc.mcgill.ca:~/pub/uri-archive
+
+ -----------------------------------------------------------------------
+
+ Document Archive:
+
+  Location details:
+       Site: ds.internic.net
+       Directory: internet-drafts. All documents will start with the
+         string draft-ietf-uri.
+
+ -----------------------------------------------------------------------
+
+
+
+Foster                                                        [Page 156]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Official Publications:        None
+
+ -----------------------------------------------------------------------
+
+ Bibliography:
+
+   Berners-Lee, Tim, 'Uniform Resource Locators', Internet Draft, March
+   1993.
+   Available as draft-ietf-uri-url-00.ps from any Internet Draft server.
+
+   Weider, Chris and Peter Deutsch, 'Uniform Resource Names', Internet
+   Draft, May 1993. Available as draft-ietf-uri-resource-names-00.txt
+   from any Internet Draft server.
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 157]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ WNILS
+
+  Date template updated or checked: 28 February, 1994
+  By: Name:          Joan Gargano
+      Email address: jcgargano@ucdavis.edu
+
+ -----------------------------------------------------------------------
+
+ NIR Group Name: Whois and Network Information Lookup Service (WNILS)
+
+ Sponsoring Organisation: Internet Engineering Task Force (IETF)
+
+ Working subgroups:
+  Name of subgroup:
+  Mailinglist-Address:  ietf-wnils@ucdavis.edu
+
+ Description of main group:
+
+ This description is the current WNILS-WG charter.
+
+   The Network Information Center (NIC) maintains the central NICNAME
+   database and server, defined in RFC 954, providing online look-up of
+   individuals, network organizations, key nodes, and other information
+   of interest to those who use the Internet.  Other distributed
+   directory information servers and information retrieval tools have
+   been developed and it is anticipated more will be created.  Many
+   sites now maintain local directory servers with information about
+   individuals, departments and services at that specific site.
+   Typically these directory servers are network accessible.  Because
+   these servers are local, there are now wide variations in the type of
+   data stored, access methods, search schemes, and user interfaces.
+   The purpose of the Whois and Network Information Lookup Service
+   (WNILS) working group is to expand and define the standard for WHOIS
+   services, to resolve issues associated with the variations in access
+   and to promote a consistent and predictable service across the
+   network.
+
+ Goals and Milestones:
+
+  Done    Review and approve the charter making any changes deemed
+          necessary. Examine the particular functional needs for
+          expanded whois directory service. Begin work on a framework
+          for recommendations.  Assign writing assignments for first
+          draft of document.
+
+  12/1/93 Submit the Whois and Network Information Lookup Service
+          Recommendations document to the IESG as an Internet Draft.
+
+
+
+
+Foster                                                        [Page 158]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  12/1/93 Submit the WHOIS++ protocol document to the IESG as an
+          Internet Draft.
+
+  12/1/93 Submit the "Architecture of the Whois++ Index Service"
+          document to the IESG as a revised Internet Draft.
+
+  12/1/93 Freeze all work on the Internet Drafts for 6 months for
+          software development.
+
+  Membership is open to attendees of the quarterly IETF meetings; the
+  mailing list is open to all.  The WNILS-WG charter can be obtained via
+  anonymous ftp from the Document Archive sites listed in the Networked
+  Information Retrieval Working Group (WNILS-WG) template.
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                Joan Gargano
+
+  Email address:       jcgargano@ucdavis.edu
+
+  Postal Address:      Distributed Computing Analysis and Support (DCAS)
+                       Information Technology
+                       University of California, Davis
+                       Davis, California  95616
+                       U.S.A
+
+  Telephone:           +1-916-752-2591
+
+  Fax:                 +1-916-752-9158
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+
+  Address:             ietf-wnils@ucdavis.edu
+
+  Administration:      ietf-wnils-request@ucdavis.edu
+
+  Description:
+
+  Archive:             ftp://ftp.ucdavis.edu:/pub/archive
+
+ -----------------------------------------------------------------------
+
+ News groups:          None.
+
+
+
+
+Foster                                                        [Page 159]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ -----------------------------------------------------------------------
+
+ Document Archive:
+
+ Location details:     Gopher: gopher.ucdavis.edu 70
+                       ftp://ftp.ucdavis.edu/archive/wnils-archive
+
+ -----------------------------------------------------------------------
+
+ Other Information:
+
+  This Working Group formed jointly in the User Services and
+  Applications Areas of the Internet Engineering Task Force.
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 160]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ IRTF-RD
+
+ Date template updated or checked: 1st March, 1994
+ By: Name:          Mike Schwartz
+     Email address: schwartz@cs.colorado.edu
+
+ -----------------------------------------------------------------------
+
+ NIR Group Name: Internet Research Task Force Research Group on Resource
+                 Discovery and Directory Service (IRTF-RD)
+
+ Sponsoring Organisation: Internet Society
+
+ Working subgroups: None
+
+ Description of main group:
+
+  The IRTF-RD group is focused on problems of scale that will arise in
+  resource discovery systems in the next 3-5 years.  We divide these
+  scaling problems into three dimensions: volume of information, size of
+  the user base, and information diversity.
+
+  Our goal is to explore techniques for dealing with these problems
+  through a set of interrelated prototypes demonstrating advances in
+  each of these dimensions.  Briefly, our current approaches are:
+     - deal with information diversity through a coordinated set
+       of techniques to gather, transform, and manage entropy of data
+     - deal with user scale through large scale replication
+     - deal with information volume using a combination of
+       views, space efficient indexing, and customization w.r.t.
+       vocabulary, search methods, and personal user history
+  We expect these approaches to evolve significantly over time.
+
+  Membership of this group is closed.  We will consider new members,
+  with two constraints.  First, the group must be kept small and focused
+  to make substantive progress - at most 4 or 5 members seems
+  appropriate at this time.  Second, prospective members must be active
+  resource discovery researchers, who will bring clear strengths to the
+  group.  Prospective members should send a vitae and a one page
+  position paper describing what they propose to do to advance the
+  group's efforts, addressed to the group chair.
+
+  The group currently consists of:
+     Mic Bowman (Transarc, Inc.)
+     Peter Danzig (University of Southern California)
+     Udi Manber (University of Arizona)
+     Mike Schwartz (University of Colorado - Boulder; chair)
+
+
+
+
+Foster                                                        [Page 161]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                 Mike Schwartz
+
+  Email address:        schwartz@cs.colorado.edu
+
+  Postal Address:       Department of Computer Science
+                        University of Colorado
+                        Boulder, CO  80309-0430
+
+  Telephone:            +1-303-492-3902
+
+  Fax:                  Declined.
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+
+  The IRTF-RD group has no formal mailing list or archive.
+
+ -----------------------------------------------------------------------
+
+ News groups:
+
+  The IRTF-RD group has no news groups.
+
+ -----------------------------------------------------------------------
+
+ Document Archive:
+
+  The IRTF-RD group has no document archive, although our paper(s) and
+  prototype(s) are available from the members' FTP archives (see below).
+
+ -----------------------------------------------------------------------
+
+ Official Publications:
+
+  Occasional updates in the Internet Monthly Report.
+
+ -----------------------------------------------------------------------
+
+ Bibliography:
+
+    C. Mic Bowman, Peter B. Danzig and Michael F. Schwartz.
+    Research Problems for Scalable Internet Resource Discovery.
+    Technical Report CU-CS-643-93, Department of Computer Science,
+
+
+
+Foster                                                        [Page 162]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+    University of Colorado, Boulder, March 1993.  To appear,
+    Proceedings of INET '93.  Available by anonymous FTP from
+    ftp.cs.colorado.edu in the file
+    pub/cs/techreports/schwartz/PostScript/RD.ResearchProblems.ps.Z
+    (compressed PostScript) or in the file
+    pub/cs/techreports/schwartz/ASCII/RD.ResearchProblems.txt.Z
+    (compressed ASCII).
+
+    C. Mic Bowman, Peter B. Danzig, Udi Manber and Michael F.
+    Schwartz.  Scalable Internet Resource Discovery: Research
+    Problems and Approaches.  Technical Report CU- CS-679-93,
+
+    Department of Computer Science, University of Colorado, Boulder,
+    October 1993.  To appear, Communications of the ACM, 1994.  A
+    pre-publication version of this paper is available by anonymous
+    FTP and e-mail from ftp.cs.colorado.edu in the file
+    pub/cs/techreports/schwartz/PostScript/RD.ResearchProblems.Jour.ps.Z
+    (compressed PostScript) or in the file
+    pub/cs/techreports/schwartz/ASCII/RD.ResearchProblems.Jour.txt.Z
+    (compressed ASCII).
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 163]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Z39.50 Implementors Group
+
+  Date template updated or checked:  28 February 1994
+  By: Name:          Mark Needleman
+      Email address: mhn@stubbs.ucop.edu
+
+ -----------------------------------------------------------------------
+
+ NIR Group name: Z39.50 Implementors Group
+
+ Description of main group:
+
+   The Z39.50 Implementors group (ZIG) is a volunteer organization
+   consisting of representatives of most of the organizations in the
+   United States and Canada that are actively engaged in implementing
+   the Z39.50 protocol.  This includes the United States Library of
+   Congress, The National Library of Canada, the major bibliographic
+   utilities, many library automation vendors, and other information
+   service providers.  The group is a volunteer effort whose meetings
+   are open at no charge to all.  The group meets about 3 times a year
+   and conducts its activities extensively on its mailing list which is
+   also open to any interested party.
+
+   The group was originally formed to deal with interoperability issues
+   among the Z39.50 implementations that were beginning to emerge in
+   1989 and 1990 but the group has since expanded its role and has now
+   become the primary forum in which new features and versions of the
+   Z39.50 are developed.
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):    Z39.50 Implementors Group
+
+  Name:                 Mark Hinnebusch (Chair)
+
+  Email address:        fclmth@nervm.nerdc.ufl.edu (Internet)
+                        FCLMTH@NERVM  (Bitnet)
+
+  Postal address:       Florida Center For Library Automation
+                        Suite 320
+                        2002 NW 13th Street
+                        Gainesville, FL 32609
+
+  Telephone:            +1-904-392-9020
+
+  Fax:                  +1-904-392-9185
+
+                        ------------------------
+
+
+
+Foster                                                        [Page 164]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Z39.50 Maintenance Agency
+
+  Name:                 Ray Denenberg
+
+  Email address:        RAY@RDEN.loc.gov
+
+  Postal address:       Library of Congress
+                        Network Development and MARC Standards Office
+                        Collections Services
+                        Washington, DC 20540
+
+  Telephone:            +1-202-707-5795
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+
+  Name:                 Z39.50 Implementors Group (ZIG)
+
+  Address:              Z3950IW@nervm.nerdc.ufl.edu
+
+  Administration/Subscriptions:  listserv@nervm.nerdc.ufl.edu
+                        (archives of the mailing list are also
+                        available at this address.)
+
+  Archive:              gopher://sally.fcla.ufl.edu
+                        ftp://sally.fcla.ufl.edu
+                        gopher://marvel.loc.gov/11/services/z3950
+
+ -----------------------------------------------------------------------
+
+ Documentation and References for the Z39.50 Protocol
+
+  American National Standard Information Retrieval Application
+  Service Definition and Protocol Specification for Open Systems
+  Interconnection Version 2, National Information Standards
+  Organization, July 1992
+
+  Mark Hinnebusch "A Primer on Z39.50 Parts 1-8", Academic and
+  Library Computing Volume 9, Numbers 2-9, February-October 1992,
+  Meckler Corporation, Westport CN. (ISSN 1055-4769)
+
+  Mark Hinnebusch "The Z39.50 Explain Service", Campus Wide
+  Information Systems, Volume 10, Number 1, January/February 1993,
+  Meckler Corporation, Westport, CT. (ISSN 1065-0741)
+
+  Michael Buckland and Clifford Lynch. "THE LINKED SYSTEMS PROTOCOL
+  AND THE FUTURE OF BIBLIOGRAPHIC NETWORKS AND SYSTEMS,"
+
+
+
+Foster                                                        [Page 165]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Information Technology and Libraries 6:2 (June 1987), pp. 83-88.
+
+  Michael Buckland and Clifford Lynch. "NATIONAL AND INTERNATIONAL
+  IMPLICATIONS OF THE LINKED SYSTEMS PROTOCOL FOR ONLINE
+  BIBLIOGRAPHICAL SYSTEMS," Cataloging and Classification Quarterly
+  8:3/4 (Spring 1988), pp. 15-33.
+
+  Clifford Lynch. "INTERSYSTEM LINKING AND DISTRIBUTED DATABASE
+  TECHNOLOGY: A COMPARISON OF TWO APPROACHES TO THE CONSTRUCTION OF
+  NETWORK-BASED INFORMATION UTILITIES," Proceedings of the Fourth
+  Integrated Online Library Systems Meeting, New York, New York,
+  May 10-11, 1989. (Medford, NJ: Learned Information, Inc., 1989),
+  pp. 107-112.
+
+  Clifford A. Lynch "LIBRARY AUTOMATION AND THE NATIONAL RESEARCH
+  NETWORK," EDUCOM Review (Fall 1989), pp. 21-28.
+
+  Clifford A. Lynch. "ACCESS TECHNOLOGY FOR NETWORK INFORMATION
+  RESOURCES," CAUSE/EFFECT (Summer 1990), pp. 15-20.
+
+  Clifford A. Lynch; Cecilia M. Preston. "INTERNET ACCESS TO
+  INFORMATION RESOURCES," Annual Review of Information Science and
+  Technology (ARIST) Volume 25. (Westport, CT: Greenwood Press,
+  1990), pp. 264-312.
+
+  Clifford A. Lynch. "THE CLIENT-SERVER MODEL IN INFORMATION
+  RETRIEVAL," Interfaces for Information Retrieval and Online
+  Systems: The State of the Art Martin Dillon, ed. (Westport, CT:
+  Greenwood Press, 1991); pp. 301-318.
+
+  Clifford A. Lynch. "INFORMATION RETRIEVAL AS A NETWORK
+  APPLICATION," Library Hi Tech 8:4, Issue 32 (1990), pp. 59-74.
+
+  Clifford A. Lynch.  "THE Z39.50 INFORMATION RETRIEVAL PROTOCOL:
+  AN OVERVIEW AND STATUS REPORT," Computer Communications Review
+  21:1   (Sigcomm) (January 1991), pp. 58-70.
+
+  Clifford A. Lynch. THE Z39.50 PROTOCOL: QUESTIONS AND ANSWERS.
+  Produced as a pamphlet by Data Research Associates (1991).
+
+  Dennis Lynch "Z39.50 Extended Services" Campus Wide Information
+  Systems Volume 10, Number 3 May/June 1993, Meckler Corporation,
+  Westport, CT  (ISSN 1065 0741)
+
+  Mark H Needleman. "The Z39.50 Protocol: An Implementor's Perspective",
+  Resource Sharing and Information Networks Volume 8 Number 1, 1992, The
+  Haworth Press Inc, Binghamton, NY (ISSN 0737-7797)
+
+
+
+
+Foster                                                        [Page 166]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Kunze, John A.  "Nonbibliographic Applications of Z39.50."  The
+  Public-Access Computer Systems Review 3, no. 5 (1992): 4-30.
+  (Refereed Article.)  To retrieve this article, send the following
+  e-mail message to LISTSERV@UHUPVM1 or LISTSERV@UHUPVM1.UH.EDU:
+  GET KUNZE PRV3N5 F=MAIL.
+
+ -----------------------------------------------------------------------
+
+ Other Information:
+
+ Brief Description of the Z39.50 Protocol
+
+   Z39.50 is a US ANSI standard protocol for information retrieval.  It
+   uses a client server model that allows clients ( or origins in Z39.50
+   terminology) to search servers (targets in Z39.50 usage) and retrieve
+   records from remote databases.  The type and format of the data
+   retrieved is not constrained by the protocol but is agreed to by the
+   origin and the target.  There is a mechanism that allows popular
+   record syntax's to be registered and then referred to by well known
+   identifiers.  Z39.50 is an OSI application layer protocol; that is,
+   it is designed to make use of the OSI presentation layer protocol.
+   It may be used with or without the presentation protocol, and below
+   that, it is irrelevant (to the Z39.50 protocol) what protocols are
+   used.  Most implementations of Z39.50 currently run directly over
+   TCP/IP.
+
+ User's View:
+
+   Users (either human or electronic) run client software to connect
+   with servers to retrieve information using the Z39.50 protocol.  Many
+   clients already exist at least in prototype version today and more
+   are being written.  Most of the major library automation vendors have
+   announced that they will be supporting Z39.50 in either client or
+   server mode or both.  Many of the major information vendors either
+   currently have or are working on implementations of Z39.50 for their
+   systems.  There are also a couple of Z39.50 implementations that are
+   expected to be put in the public domain at some point.  The recently
+   announced FREEWAIS software incorporates Z39.50 Version 2 into it
+   (the older version used a variant of the 1988 version 1 protocol).
+   The Library of Congress acts as the maintenance agency for Z39.50 and
+   can be contacted for a list of registered Implementors.
+
+   Z39.50 provides a protocol mechanism for accessing remote information
+   sources.  It defines the model for the interaction between two sides,
+   a client and a server.  It makes no assumptions or presumptions about
+   how the data is actually organized in the server, nor about how the
+   data is presented to the end user by the client.
+
+
+
+
+Foster                                                        [Page 167]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+   The model postulates one or more databases on the remote system that
+   can be searched using attributes from defined search attribute sets,
+   creating a result set.  Records can be retrieved from the result set
+   using agreed upon record formats.
+
+ Information types supported:
+
+   The Z39.50 protocol was designed as a general purpose search and
+   retrieval mechanism that could be used with a wide variety of data
+   types.  The MARC format (a format used for cataloging library
+   material among other things) and a search attribute set suitable for
+   bibliographic and similar types of data are registered within the
+   current version of the standard.  It is assumed that, as the protocol
+   begins to be used by other communities and for other types of data,
+   other attribute sets and record syntaxes will be developed.  This
+   process has already begun and a generic record syntax and attribute
+   set are already under development, as well as some others,
+   specifically those supporting chemical structures, general science
+   and technology, and business information.  The design philosophy
+   behind Z39.50 is that it will be used with other standards such as
+   Postscript, SGML, ODIF (and others), to communicate a wide variety of
+   data types, including full text, images, and many others.
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 168]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ RARE Groups
+
+  RARE (Reseaux Associes pour la Recherche Europeenne) is the
+  Association of European Networking Organizations and their users.
+  RARE's aim is to overcome national boundaries in research networking
+  by creating a harmonized computer communications infrastructure for
+  the European research community.  At this point in time RARE has over
+  40 members, most of which are national networking organizations
+  providing networking services to their national research and education
+  community.
+
+  RARE's technical programme is carried out by volunteers working in a
+  number of Working Groups.
+
+  For further information on RARE contact:
+
+  RARE Secretariat
+  Singel 466-468
+  NL-1017 AW AMSTERDAM
+
+  Telephone number        +31-20-639-1131
+  Fax number              +31-20-639-3289
+
+  E-mail address RFC8222
+  raresec@rare.nl
+
+  E-mail address X.400
+  C=nl; ADMD=400net; PRMD=surf; O=rare; S=raresec;
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 169]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ RARE ISUS
+
+  Date template updated or checked: 28th February, 1994
+  By: Name:            Jill Foster
+      Email address:   Jill.Foster@newcastle.ac.uk
+
+ -----------------------------------------------------------------------
+
+ NIR Group Name:  RARE Information Services and User Support Working
+                  Group
+
+ Sponsoring Organisation:
+                  RARE (Reseaux Associes pour la Recherche Europeenne)
+
+ Working subgroups (of relevance to nir):
+
+  Name of subgroup:     MMIS Task Force
+  Mailinglist-Address:  mmis@mailbase.ac.uk
+
+  Name of subgroup:     NIR Task Force
+  Mailinglist-Address:  nir@mailbase.ac.uk
+
+  Name of subgroup:     UNITE Task Force
+  Mailinglist-Address:  unite@mailbase.ac.uk
+
+ Description of main group:
+
+  The Information Services and User Support (ISUS) Working Group has
+  been established by the RARE Technical Committee as one of the major
+  working groups in the RARE Technical Programme.  ISUS is concerned
+  with all aspects of networked information services, group
+  communications and network user support.  It is open to all those
+  involved in working in these areas and should include:
+
+  Network User Support Staff: National and European Support Staff
+                              (whether RARE, RIPE, EARN, Eunet etc.)
+                              Site Computing Centre Support Staff
+                              Special subject related User Support Staff
+
+  Library Staff
+  Networked Information Providers
+  Networked Information Service Providers
+  Application Developers
+
+  The ISUS WG mailing list will act both as a forum for discussion
+  amongst experts in this field and as a means for disseminating
+  information to the wider community.
+
+
+
+
+Foster                                                        [Page 170]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  The ISUS Working Group is chartered to have a very broad area of
+  interest which is broken down into several sub-areas:
+               Network User Support
+               Asynchronous Group Communication
+               Networked Information Retrieval and Services
+               Liaison
+
+  Current tasks being worked on in the area of NIR include:
+
+  o    Coordination of NIR services in Europe
+
+  o    Collection of information related to NIR tools and groups.
+       This is a joint effort with the IETF and CNI.
+
+  o    Network Interface to everything (UNITE).  This group is starting
+       to look at the user requirements for a single interface to the
+       network (network information services, email, bulletin boards,
+       etc.).   (unite@mailbase.ac.uk)
+
+  o    Multimedia Information Services task force (MMIS).  This group is
+       a joint task force of the RARE ISUS Working Group and RARE
+       Interactive Multimedia Working Group (mmis@mailbase.ac.uk).
+
+  charter:  anonymous ftp from mailbase.ac.uk
+            file:  /pub/lists/wg-isus/files/isus.charter
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                 Jill Foster
+
+  Email address:        Jill.Foster@newcastle.ac.uk
+
+  Postal Address:       Computing Service
+                        University of Newcastle upon Tyne
+                        Newcastle upon Tyne
+                        NE1 7RU
+                        UK
+
+  Telephone:            +44-91-222-8250
+
+  Fax:                  +44-91-222-8765
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+
+
+
+
+Foster                                                        [Page 171]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Address:              wg-isus@rare.nl
+
+  Administration:       Auto subscriptions to: mailserver@rare.nl
+                        "subscribe wg-isus <firstname> <lastname>"
+
+                        Human admin to: wg-isus-request@rare.nl
+
+  Description:          General purpose mailing list for whole ISUS WG.
+
+  Archive:              Not yet available
+
+ -----------------------------------------------------------------------
+
+ News groups:           None
+
+ -----------------------------------------------------------------------
+
+ Document Archive:
+
+  Location details
+       Site:            raredoc.rare.nl
+       Directory:       /rare/working-groups
+
+  Location details
+       Site:            mailbase.ac.uk
+       Directory:       /pub/lists/wg-isus/files
+                        /pub/lists/nir/files
+
+ -----------------------------------------------------------------------
+
+ Official Publications: RARE Technical Reports
+
+ -----------------------------------------------------------------------
+
+ Bibliography:
+
+  RARE Technical Report 1: User Support and Information Services
+  in the RARE Community - a Status Report.   Jill Foster
+
+  RARE Technical Report 5: A Survey of Distributed Multimedia -
+  Research, Standards and Products.  Chris Adie
+
+ -----------------------------------------------------------------------
+
+ Other Information:
+
+  This group was formed in May 1992 and takes over and expands on the
+  work of the former RARE WG3 USIS Subgroup. The group conducts most
+
+
+
+Foster                                                        [Page 172]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  of its business by email, but meets twice a year before the European
+  Networking Conferences.
+
+  The EARNinfo group has recently joined forces with RARE ISUS WG, they
+  will be working together in the areas of documentation and network
+  training.
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 173]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ USMARC/OCLC
+
+  Date template updated or checked:  10 March 1994
+  By: Name:          Rebecca Guenther
+      Email address: rgue@seq1.loc.gov
+
+ -----------------------------------------------------------------------
+
+ Working Group or Organisation:  USMARC/OCLC
+
+ Name of group: USMARC Advisory Group; OCLC Internet Resources
+                Cataloging Experiment
+
+ Sponsoring Organisations: OCLC, Library of Congress,
+                           USMARC Advisory Group
+
+ Working subgroups:  None
+
+ Description of main group:
+
+  OCLC and the Library of Congress have formed a working group to
+  consider how libraries can create cataloging records for online
+  information resources.  The group initiated a cataloging experiment
+  designed to test and verify the applicability of the cataloging rules
+  and the USMARC format for computer files.  Guidelines have been
+  written for cataloging Internet resources and were considered by the
+  American Library Association committee responsible for maintaining the
+  Anglo- American Cataloging Rules.  Changes to the USMARC format were
+  initiated to accommodate a subset of these materials (electronic data
+  resources, such as software, electronic text, bibliographic and
+  nonbibliographic databases).  USMARC format changes which were
+  approved included an identification of type of file and a field for
+  location and access of the resource (very much like a URL).
+
+  The group is continuing its work by looking at how online systems and
+  services can be accommodated in USMARC.  This work will be done within
+  the USMARC Advisory Group of the American Library Association, which
+  considers changes to the USMARC formats.  Data elements will be
+  defined with mapping to MARC fields; in some cases new fields will be
+  proposed.  This will be accomplished in conjunction with efforts by
+  other working groups (e.g., Government Information Locator Service, or
+  GILS).
+
+  A proposal was presented and approved in February 1994 to the USMARC
+  Advisory Group to add data elements to the Electronic Location and
+  Access Field (USMARC field 856).  Included among these was a subfield
+  for URL (Uniform Resource Locator).  It is intended to be used instead
+  of or in addition to other data identifying location of and access to
+
+
+
+Foster                                                        [Page 174]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  a networked information resource.
+
+  Membership is closed at this point.
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):    Rebecca Guenther rgue@seq1.loc.gov
+
+  Name:                 Rebecca Guenther
+
+  Email address:        rgue@seq1.loc.gov; rebecca@rgue.loc.gov
+
+  Postal address:       Network Development and MARC Standards Office,
+                        Library of Congress,
+                        Washington, DC 20540-4020
+
+  Telephone:            +1-202-707-5092
+
+  Fax:                  +1-202-707-6269
+
+                    -------------------------------
+
+  Name:                 Erik Jul
+
+  Email address:        ekj@oclc.org
+
+  Postal address:       OCLC, Inc.
+                        6565 Franz Rd.
+                        Dublin OH 43017-0702
+
+  Telephone:            +1-614-764-4364
+
+  Fax:                  +1-614-764-2344
+
+                      ----------------------------
+
+  Name:                 Priscilla Caplan
+
+  Email address:        p-caplan@uchicago.edu
+
+  Postal Address:       University of Chicago Library,
+                        1100 E. 57th St.,
+                        Chicago, IL 60637
+
+  Telephone:            +1-312-702-5079
+
+  Fax:                  +1-312-702-6623
+
+
+
+
+Foster                                                        [Page 175]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+                      ----------------------------
+
+  Name:                 William W. Jones, Jr.
+
+  Email Address:        jones@acfcluster.nyu.edu
+
+  Postal Address:       New York University/Elmer Holmes Bobst Library,
+                        Technical and Automated Services Division,
+                        70 Washington Square South,
+                        New York, NY 10012
+
+  Telephone:            +1-212-998-4070
+
+  Fax:                  +1-212-995-4070
+
+                      ---------------------------
+
+  Name:                 Nancy Olson
+
+  Email Address:        nbolson@msus1.msus.edu
+
+  Postal Address:       Memorial Library,
+                        Mankato State University,
+                        Mankato, MN 56001
+
+  Telephone:            +1-507-389-5062
+
+  Fax:                  +1-507-389-5488
+
+                      ----------------------------
+
+  Name:                 Glenn Patton
+
+  Email address:        gep@oclc.org
+
+  Postal address:       OCLC, Inc.
+                        6565 Franz Rd.
+                        Dublin OH 43017-0702
+
+  Telephone:            +1-800-848-5878
+
+  Fax:                  +1-614-764-0155
+
+                    --------------------------------
+
+  Name:                 Martin Dillon
+
+  Email address:        mjd@oclc.org
+
+
+
+Foster                                                        [Page 176]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+
+  Postal address:       OCLC, Inc.
+                        6565 Franz Rd.
+                        Dublin OH 43017-0702
+
+  Telephone:            +1-614-764-6079
+
+  Fax:                  +1-614-764-2344
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:         None.
+
+ -----------------------------------------------------------------------
+
+ News groups:           None.
+
+ -----------------------------------------------------------------------
+
+ Document Archive:
+
+  Archives under USMARC listserv.
+
+  Documents available:
+
+  94-2.doc (Proposal 94-2: Addition of Subfields $g and $3 to Field 856
+            Electronic Location and Access) in the USMARC
+            Holdings/Bibliographic
+            Formats:   Document)
+  94-2.cov (Cover sheet with status information)
+  94-3.doc (Proposal 94-3: Addition of Subfield $u (Uniform
+            Resource Locator) to Field 856 in the USMARC
+            Holdings/Bibliographic
+            Formats: Document)
+  94-3.cov (Cover sheet with status information)
+  93-4.doc (Proposal 93-4: Changes to the USMARC Bibliographic
+            Format (Computer Files) to Accommodate Online Information
+            Resources: Document)
+  93-4.cov (Proposal 93-4: Cover sheet with status information)
+  dp69.doc (Discussion Paper No. 69: Accommodating Online Systems
+            and Services within USMARC: Document)
+  dp69.cov (Discussion Paper No. 69: Cover sheet with status
+            information)
+
+  Location details
+
+   Telnet to: marvel.loc.gov
+   Login: marvel
+
+
+
+Foster                                                        [Page 177]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+   Select: Services to Libraries and Publishers
+   Select: USMARC Standards
+   Select: USMARC Listserv
+   See list of documents
+
+  -or-
+
+   Site: listserv@sun7.loc.gov
+
+  Send email message with
+
+   get usmarc 93-4.doc
+   get usmarc 93-4.cov
+   get usmarc dp69.doc
+   get usmarc dp69.cov
+   etc.
+
+ -----------------------------------------------------------------------
+
+ Official Publications:
+
+  "Assessing Information on the Internet: Toward Providing Library
+   Services for Computer-Mediated Communication". Dublin, OH: OCLC
+   Online Computer Library Center, 1993.  Available in print form
+   from OCLC, Inc. for $20 or electronically from:
+
+   ftp.rsch.oclc.org
+   /pub/internet_resources_project/report
+   Filenames: *.*
+
+ -----------------------------------------------------------------------
+
+ Bibliography:
+
+   Proposal 94-2: Addition of Subfields $g and $3 to Field 856
+   Electronic Location and Access) in the USMARC Holdings/Bibliographic
+   Formats)
+
+   Proposal 94-3: Addition of Subfield $u (Uniform Resource Locator) to
+   Field 856 in the USMARC Holdings/Bibliographic Formats
+
+   Discussion Paper No. 69: Accommodating Online Systems and
+   Services in USMARC  (Washington: Library of Congress, Network
+   Development and MARC Standards Office, Apr. 1993).
+
+   Proposal 93-4:  Changes to the USMARC Bibligraphic Format
+   (Computer Files) to Accommodate Online Information Resources
+   (Washington: Library of Congress, Network Development and MARC
+
+
+
+Foster                                                        [Page 178]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+   Standards Office, Nov. 1992 (rev. Mar. 1993).
+
+ -----------------------------------------------------------------------
+
+  Other Information:             None.
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 179]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+8.  Security Considerations
+
+   Security issues are not discussed in this memo.
+
+9.  Acknowledgements
+
+   The report was very much a collaborative effort of the members of the
+   NIR WG and in particular Peter Deutsch (who contributed the mailing
+   list section and the basis for Section 5), April Marine, Rick
+   Rodgers, Lars-Gunnar Olsson, Farhad Anklesaria, Marsha Perrott, Kevin
+   Gamiel, George Brett, Barbara Thomas and all those who helped review
+   the document.  Special thanks are due to all those contributors who
+   took the time to submit and update descriptions of their NIR tools
+   and groups; their names are included in the templates in Sections 6
+   and 7.
+
+   Before final submission of the report as an RFC, independent
+   reviewers from around the world took two or three templates each and
+   checked them out for accuracy and currency as best they could.  They
+   liaised with the original template authors over the changes they
+   made.  The volunteers were: Larry Masinter, Marilyn Martin, Sinha
+   Velu, Ton Verschuren, Shirley Browne, Alfred Vella, Bert Stals,
+   Yannis Corovesis, Gerard Egan, Robert Janz and Andy Linton.  They
+   provided some very valuable input.
+
+10. Author's Address
+
+   Jill Foster
+   Computing Service
+   University of Newcastle upon Tyne
+   Claremont Road
+   Newcastle upon Tyne
+   NE1 7RU
+   UK
+
+   Phone: +44-91-222-8250
+   Fax:   +44-91-222-8765
+   Email: Jill.Foster@newcastle.ac.uk
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 180]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+APPENDIX A
+
+ NIR TOOL Template (last updated 22.12.93)
+
+
+ Purpose and scope:
+
+  This template is to be used to collect the information necessary to
+  identify and track the development of networked information retrieval
+  tools.  It is intended that the main part of this will be completed by
+  the main individual responsible for the tool.  Sections of the
+  template may require completion by others.
+
+  The NIR tools included are defined by enumeration.  The IETF/RARE/CNI
+  NIR-WG welcome suggestions for others to be included.
+
+ NIR Tools:
+
+      Alex
+      archie
+      gopher
+      Hytelnet
+      Netfind
+      Prospero
+      Veronica
+      WAIS  (including freeWAIS)
+      WHOIS
+      World Wide Web  (including Mosaic)
+      X.500 White Pages
+
+
+ New entries: Please complete this template and return it to
+ Jill.Foster@newcastle.ac.uk (NIR-WG co-chair).  Receipt of your
+ message will be acknowledged.
+
+ Please imbed descriptive text by at least one more column than the
+ heading for that item:
+
+ For example:
+
+ Brief description of tool:
+
+  This is the best application ever seen.  It makes finding information
+  very easy.  This is the decription imbedded one more column.
+
+  Updates: updates to existing information on NIR Tools may be sent by
+  the appropriate contact person at any time to:
+
+
+
+
+Foster                                                        [Page 181]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+        nir-updates@cnidr.org
+
+  The full report will be updated annually and will form the basis of a
+  "snapshot" report on the activities in the area of networked
+  information retrieval (NIR).
+
+ -------------------------x---- cut here ----x--------------------------
+
+ Date template updated or checked: (e.g., 02 November, 1992)
+ By: Name:
+     Email address:
+
+ -----------------------------------------------------------------------
+
+ NIR Tool Name:
+
+ Brief Description of Tool:
+      Note: This should be a maximum of 100 line description which
+      should cover the following:
+      - overview of use, purpose, scope and characteristics
+      - user's view
+      - information provider's view
+      - information types supported (e.g., text, sound, etc.)
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+ [Please duplicate this section for each separate contact]
+
+  Name:
+  [May be the name of a role e.g., nirtool-support or of an
+  individual]
+
+  Email address:
+
+  Postal Address:
+
+  Telephone:
+
+  Fax:
+
+ -----------------------------------------------------------------------
+
+ Help Line:
+ [for major center as well as each client if available]
+
+  Name:
+  [May be the name of a role e.g., nirtool-support or of an
+
+
+
+Foster                                                        [Page 182]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  individual]
+
+  Email address:
+
+  Telephone:
+
+  Level of support offered: [delete as appropriate]
+       o volunteer
+       o funded
+       o for experts only
+       o all users
+
+  Hours available:
+
+ -----------------------------------------------------------------------
+
+ Related Working Groups:
+  [Name only]
+
+ -----------------------------------------------------------------------
+
+ Sponsoring Organisation / Funding source:
+  [Name only]
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+  [Duplicate this section for each list]
+
+  Address:          [Email Address to send contributions]
+
+  Administration:   [<listname>-request etc.]
+
+  Description:
+  [This is optional - if the group has only one mailing list]
+
+  Archive:  [Location of message archive for this list]
+
+ -----------------------------------------------------------------------
+
+ News groups:
+  [Duplicate this section for each news group]
+
+  Name:
+
+  Description:
+  [This is optional - if the group has only one news group]
+
+
+
+
+Foster                                                        [Page 183]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Archive:  [Location of message archive for this news group]
+
+ -----------------------------------------------------------------------
+
+ Protocols:
+
+  What is supported:   [e.g., Z39.50]
+
+  What it runs over:
+
+  Other NIR tools this interworks with:
+
+  Future plans:
+
+ -----------------------------------------------------------------------
+
+ Servers:
+
+  [Duplicate the following for each platform
+  e.g., Unix, VMS, VM/CMS,....]
+
+  [The main contact for this NIR tool should complete at least
+  "platform" and "contact" for each server known to them.]
+
+  Date completed or updated:
+  By: Name:
+      Email address: [If different from that of the Primary
+                     contact listed below]
+
+  Platform:
+
+  Primary Contact:
+  Name:
+  Email address:
+  Telephone:
+
+  Server software available from:
+
+  Location of more information:
+       [Such as installation instructions
+        copyright statements,
+        warnings & bug reports etc.
+
+        Eventually this will be the Unique Resource
+        Identifiers of the documents]
+
+
+  Latest version number:
+
+
+
+Foster                                                        [Page 184]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Brief Scope and Characteristics:
+
+  Approximate number of such servers in use:
+
+  General comments:
+
+ -----------------------------------------------------------------------
+
+ Clients:
+  [Duplicate the following for each platform
+  e.g., MS-DOS PC, MAC, vt100,...]
+
+  [The main contact for this NIR tool should complete
+  "platform" and "contact" for each server known to them.]
+
+  Date completed or updated:
+  By: Name:
+      Email address: [If different from that of the Primary
+                     contact listed below]
+
+  Platform:
+  Primary Contact:
+  Name:
+  Email address:
+  Telephone:
+
+  Client software available from:
+
+  Location of more information:
+       [Such as installation instructions
+        copyright statements,
+        warnings & bug reports etc.
+
+        Eventually this will be the Unique Resource
+        Identifiers of the documents]
+
+  Latest version number:
+
+  Brief Scope and Characteristics:
+
+  General comments:
+
+  Future plans:
+       Items included here could include
+       - optional items to come.
+       - plans for moving to international standards
+       - plans for interoperating with other NIR tools
+       - other functionality to be supported
+
+
+
+Foster                                                        [Page 185]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ ----------------------------------------------------------------------
+
+ Demonstration sites:
+
+  List of sites which are willing to act as demonstration
+  sites for this application.
+  [Duplicate for each site]
+       Site name:
+       Access details:
+           [e.g.,
+                 telnet archie.sura.net
+                 login as archie              ]
+
+ ---------------------------------------------------------------------------
+
+ Documentation:
+
+  The following is a list of suggested items to be found in a
+  document archive. Note that the location pointers below could be
+  replaced in the future by the "Uniform Resource Name".
+
+       o   current overview
+       o   instructions to information providers
+       o   Frequently Asked Questions
+       o   user manuals
+       o   training materials
+               -   tutorials
+               -   canned demos
+               -   sample session (screen dumps)
+               -   videos
+               -   etc.
+       o   miscellaneous documents
+
+  [Duplicate the following for each existing document as
+  necessary]
+
+  Document Title:
+  Location details:
+       Site:
+       Full file name:
+
+ -----------------------------------------------------------------------
+
+ Bibliography:
+  [A list of a maximum of 10 key papers, books etc. on this NIR tool.
+  Optionally a pointer to a fuller bibliography could be given.]
+
+ -----------------------------------------------------------------------
+
+
+
+Foster                                                        [Page 186]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Other Information:
+
+  [Feel free to add other information that you feel is relevant.
+  This will be considered for inclusion in the report.]
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 187]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+APPENDIX B
+
+ NIR Group Template (last updated 22.12.93)
+
+ Purpose and scope:
+
+  This template is to be used to collect the information necessary to
+  identify and track major groups that are working to promote or develop
+  networked information retrieval.  It is intended that this will be
+  completed by the group representative.
+
+  The groups included are defined by enumeration.  The IETF/RARE/CNI
+  NIR-WG welcome suggestions for other groups to be included.
+
+ Groups:
+
+    CNI         Coalition for Networked Information (CNI)
+                Architectures and Standards
+                Directories and Resource Information Services
+                TopNode for Networked Information Resources, Services,
+                                                           and Tools
+
+    CNIDR       Clearing House for Networked Information Discovery
+                                                      and Retrieval
+
+    IETF        Integrated Directory Services (IDS)
+                Integration of Internet Information Resources (IIIR)
+                Networked Information Retrieval (NIR) joint IETF/RARE WG
+                Network Information Services Infrastructure (NISI)
+                OSI-Directory Service (OSI-DS)
+                Uniform Resource Identifiers (URI)
+                Whois and Network Information Lookup Service (WNILS)
+
+    IRTF        Internet Research Task Force Research Group on
+                  Resource Discovery and Directory Service (IRTF-RD)
+
+    NISO        Z39.50 Implementors Group
+
+    RARE        Information Services and User Support Working Group
+                  (ISUS)
+
+    USMARC/OCLC USMARC Advisory Group; OCLC Internet Resources
+                   Cataloging Experiment (USMARC/OCLC)
+
+
+ New Entries: Please complete this template for your group or
+ organisation and return it to Jill.Foster@newcastle.ac.uk (NIR-WG
+ co-chair).  Receipt of your message will be acknowledged.
+
+
+
+Foster                                                        [Page 188]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Please imbed descriptive text by at least one more column than the
+ heading for that item:
+
+ For example:
+
+ Description of main group:
+
+  This is the most active NIR group.  This is the decription imbedded
+  one more column.
+
+ Updates: updates to existing information on NIR Groups may be sent by
+ the appropriate contact person at any time to:
+
+       nir-updates@cnidr.org
+
+ The full report will be updated annually and will form the basis of a
+ "snapshot" report on the activities in the area of networked
+ information retrieval (NIR).
+
+ -----------------------x---- cut here ----x----------------------------
+
+  Date template updated or checked: (e.g., 02 November, 1992)
+  By: Name:
+      Email address:
+
+ -----------------------------------------------------------------------
+
+ NIR Group Name:
+
+ Sponsoring Organisation:
+
+ Working subgroups:
+    Name of subgroup:
+    Mailinglist-Address:
+
+ Description of main group:
+
+      [Description of the scope and purpose of the group and the
+      current tasks being worked on.  (Recommended maximum of
+      100 lines.)  Please indicate whether membership is open or
+      closed.  Include a pointer to an on-line charter if
+      appropriate]
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  [Please duplicate this section for each separate contact]
+
+
+
+Foster                                                        [Page 189]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Name:
+  [May be the name of a role e.g., group-secretariat or of an
+  individual]
+
+  Email address:
+
+  Postal Address:
+
+  Telephone:
+
+  Fax:
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+  [Duplicate this section for each list]
+
+  Address:          [Email Address to send contributions]
+
+  Administration:   [<listname>-request etc.]
+
+  Description:
+  [This is optional - if the group has only one mailing list]
+
+  Archive:  [Location of message archive for this list]
+
+ -----------------------------------------------------------------------
+
+ News groups:
+  [Duplicate this section for each news group]
+
+  Name:
+
+  Description:
+  [This is optional - if the group has only one news group]
+
+  Archive:  [Location of message archive for this news group]
+
+ -----------------------------------------------------------------------
+
+ Document Archive:
+  [Duplicate if necessary]
+
+  Location details:
+       Site:
+       Directory:
+
+ -----------------------------------------------------------------------
+
+
+
+Foster                                                        [Page 190]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Official Publications:
+  [for example: Journal, Newsletter, Report Series]
+
+ -----------------------------------------------------------------------
+
+ Bibliography:
+  [A list of a maximum of 10 key papers, books etc. produced by
+  this group on their NIR work].
+
+ -----------------------------------------------------------------------
+
+ Other Information:
+
+  [Feel free to add other information that you feel is relevant.
+
+  This will be considered for inclusion in the report.]
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 191]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+APPENDIX C
+
+
+  /* A summary of email lists and newsgroups dealing with    */
+  /* various issues in resource discovery and networked      */
+  /* information retrieval.                                  */
+
+ -----------------------------------------------------------------------
+
+ Created-By:             Peter Deutsch
+ Email Address:          peterd@bunyip.com
+ Last Updated:           16 December 1993
+ Comments:               Please send comments, corrections and
+                         additions to the author at the above address.
+
+ -----------------------------------------------------------------------
+
+ /* The following mailing lists are in IAFA format. NIR Groups and   */
+ /* Tool developers are encouraged to make such descriptions         */
+ /* available for their lists.                                       */
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       Alex
+
+ Address:                alex-users@cs.cmu.edu
+
+ Administration:         alex-users-request@cs.cmu.edu
+
+ Address:                alex-servers@cs.cmu.edu
+
+ Administration:         alex-servers-request@cs.cmu.edu
+
+ Description:            alex-servers is for people setting up an Alex
+                         fileserver.  alex-users is for people who just
+                         want to use Alex.
+
+ Archive:                alex.sp.cs.cmu.edu (128.2.209.13)
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       Archie
+
+ Address:                archie-maint@bunyip.com
+
+ Administration:         archie-maint-request@bunyip.com
+
+ Description:            This mailing list is for people who operate and
+
+
+
+Foster                                                        [Page 192]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+                         maintain archie servers.  Announcements of bug
+                         fixes, new releases and discussion of new
+                         features are carried out on this list.
+
+ Archive:          archives.cc.mcgill.ca:/pub/mailing-lists/archie-maint
+
+                   ----------------------------------
+
+ Mailinglist-Name:       The archie People Mailing List
+
+ Address:                archie-people@bunyip.com
+
+ Administration:         archie-people-request@bunyip.com
+
+ Description:            This mailing list is for people interested in
+                         the archie project and its future developments.
+                         Announcements of upgrades, new services, etc.
+                         are made to this list.
+
+ Archive:                None
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name        Gopher
+
+ Address:                gopher-news@boombox.micro.umn.edu
+
+ Administration:         gopher-news-request@boombox.micro.umn.edu
+
+ Description:            News and views of all things gopher.
+
+ Archive: Via gopher:    University of Minnesota Gopher
+                         Information About Gopher
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       HYTELNET Updates Distribution
+
+ Address:                hytel-l@kentvm.kent.edu
+
+ Administration:         By listowner Peter Scott
+                         aa375@freenet.carleton.ca
+
+ Description:            To inform members of new version of the
+                         software, and to keep users informed of
+                         new/changed/defunct Telnet-accessible sites.
+                         To subscribe send email message to
+                         listserv@kentvm.kent.edu with no subject, and
+
+
+
+Foster                                                        [Page 193]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+                         sub hytel-l firstname lastname  as the body of
+                         the message.
+
+ Archive:                None.
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       Netfind
+
+ Address:                netfind-users@cs.colorado.edu
+
+ Administration:         netfind-users-request@cs.colorado.edu
+
+ Description:            Mailing list for user changes and updates.
+
+ Archive:                None.
+
+                      ---------------------------
+
+ Address:                netfind-servers@cs.colorado.edu
+
+ Administration:         schwartz@cs.colorado.edu
+
+ Description:            Mailing list for sites running Netfind servers.
+
+ Archive:                None.
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       Prospero
+
+ Address:                info-prospero@isi.edu
+
+ Administration:         info-prospero-request@isi.edu
+
+ Description:            This mailing list is really two one-way mailing
+                         lists.  Send mail to INFO-PROSPERO to obtain
+                         information about Prospero, papers or the
+                         release. Mail to INFO-PROSPERO will not be
+                         passed on to subscribers.  INFO-PROSPERO is
+                         also the list to which we will send status
+                         updates and information on how to obtain new
+                         releases.
+
+ Archive:                Via anonymous FTP to PROSPERO.ISI.EDU as
+                         /pub/prospero/mail/info-prospero.arc
+
+
+
+
+
+Foster                                                        [Page 194]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+                   Via prospero in the "#/INET/EDU/ISI/GUEST/prototype"
+                   virtual system as
+                   /sites/isi.edu/pub/prospero/mail/info-prospero.arc.
+
+                     -----------------------------
+
+ Address:                prospero@isi.edu
+
+ Administration:         prospero-request@isi.edu
+
+ Description:            This mailing list is for general discussion of
+                         Prospero, for announcements of new sites that
+                         have come on board, and for announcments of
+                         directories that people have created to
+                         organize the information already accessible.
+
+ Archive:                Via anonymous FTP to PROSPERO.ISI.EDU as
+                         /pub/prospero/mail/prospero.arc
+
+                    Via Prospero in the "#/INET/EDU/ISI/GUEST/prototype"
+                    virtual system as
+                    /sites/isi.edu/pub/prospero/mail/prospero.arc.
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       Veronica
+
+ Address:                veronica-news@veronica.scs.unr.edu
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       WAIS
+
+ Address:                wais-discussion@wais.com
+
+ Administration:         wais-discussion-request@wais.com
+
+ Description:            Moderated, digested biweekly posting about WAIS
+                         and Electronic publishing subjects.  Please
+                         submit interesting materials.
+
+ Archive:
+                /pub/wais/mail-archives/wais-discussion/issue-*@wais.com
+                and wais-discussion-archive WAIS server
+
+                     -----------------------------
+
+ Address:                wais-talk@wais.com
+
+
+
+Foster                                                        [Page 195]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Administration:         wais-talk-request@wais.com
+
+ Description:            Implementors forum on WAIS.  This is for
+                         talking about nitty gritty details of protocols
+                         and implementations.
+
+ Archive:                /pub/wais/mail-archives/wais-talk@wais.com
+
+                     -----------------------------
+
+ Mailinglist-Name:       freeWAIS
+
+ Address:                freeWAIS@cnidr.org
+
+ Administration:         not applicable
+
+ Description:            Mailing list for reporting bugs in freeWAIS.
+
+ Archive:                None.
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       WWW
+
+ Address:                www-talk@info.cern.ch for CONTRIBUTIONS ONLY
+
+ Administration:         listserv@info.cern.ch  (robot)
+                         www-talk-request@info.cern.ch (human)
+
+ Description:            Technical discussions, W3 related.  Experts to
+                         experts.  General questions to
+                         comp.infosystems.www please.
+
+ Archive:                Not currently served, but kept.
+
+                      ---------------------------
+
+ Address:                www-announce@info.cern.ch
+                         NOT FOR GENERAL USE - serious low-volume
+                                               announcements only
+
+ Administration:         listserv@info.cern.ch (robot)
+                         www-announce-request@info.cern.ch (human)
+
+ Description:            Low volume summary announcements of product
+                         releases, etc.
+
+ Archive:                Not currently public.
+
+
+
+Foster                                                        [Page 196]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       X.500
+
+ Address:                dssig@ics.uci.edu
+
+ Administration:         dssig-request@ics.uci.edu
+
+ Description:            Mail list for OIW DS-SIG group.
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       CNI Groups
+
+ All of the CNI lists are managed with the Unix-Listprocessor software.
+
+ To join any of them mail to:
+                         listproc@cni.org
+
+                    sub cni-<groupname> Firstname Lastname
+
+ All CNI list archives are available as:
+  URL:ftp://ftp.cni.org/CNI/forums/cni-<groupname>
+  URL:gopher//gopher.cni.org 70/CNI Working Group Forums/
+      cni-<groupname>
+
+                    --------------------------------
+
+ Mailinglist-Name:       CNI News and Announcements
+
+ Address:                cni-announce@cni.org
+
+                    --------------------------------
+
+ Mailinglist-Name:       Architecture and Standards Working Group
+
+ Address:                cni-architecture@cni.org
+
+                    --------------------------------
+
+ Mailinglist-Name:       Copyright and Intellectual Property
+                         Forum
+
+ Address:                cni-copyright@cni.org
+
+                    -------------------------------
+
+
+
+
+
+Foster                                                        [Page 197]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Mailinglist-Name:       Directories and Information Resource Services
+                          Working Group
+
+ Address:                cni-directories@cni.org
+
+                   --------------------------------
+
+ Mailinglist-Name:       CNI Legislation, Codes, Policies and
+                         Practices Working Group Forum
+
+ Address:                cni-legislation@cni.org
+
+                     -----------------------------
+
+ Mailinglist-Name:       CNI Management & Professional & User
+                         Education Working Group Forum
+
+ Address:                cni-management@cni.org
+
+                   ---------------------------------
+
+ Mailinglist-Name:       CNI Modernization of Scholarly
+                         Publication Working Group Forum
+
+ Address:                cni-modernization@cni.org
+
+                    --------------------------------
+
+ Mailinglist-Name:       CNI Access to Public Information
+                         Working Group Forum
+
+ Address:                cni-pubinfo@cni.org
+
+                    -------------------------------
+
+ Mailinglist-Name:       CNI Teaching and Learning Working Group
+                         Forum
+
+ Address:                cni-teaching@cni.org
+
+                    -------------------------------
+
+ Mailinglist-Name:       CNI Transformation of Scholarly
+                         Communication Working Group Forum
+
+ Address:                cni-transformation@cni.org
+
+
+
+
+
+Foster                                                        [Page 198]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+                    -------------------------------
+
+ Mailinglist-Name:       TopNode for Networked Information Resources,
+                           Services and Tools
+
+ Address:                cnidir@cni.org
+                         cni-directories@cni.org
+
+ Administration:         listserv@cni.org
+                         SUB cni-directories Lastname Firstname
+
+ Archive:                ftp.cni.org:/CNI/forums/cni-directories/*
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       CNIDR
+
+ Address:                info@cnidr.org
+
+ Administration:         none
+
+ Description:            Email sent to this address will receive an
+                         automatic response containing more information
+                         about current CNIDR activities.
+
+ Archive:                none
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       zip@cnidr.org
+
+ Address:                zip@cnidr.org
+
+ Administration:         zip-request@cnidr.org
+                         sub zip Lastname Firstname
+
+ Description:            Technical discussion of Z39.50-92 application
+                         development.  Subscribers receive brief
+                         overview of project and information on how to
+                         access archives.
+
+ Archive:
+      ftp://ftp.cnidr.org/NIDR.tools/zip
+      gopher://gopher.cnidr.org/NIDR Tools/Discussion/Online Discussion
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       IDS: Internet Engineering Task Force (IETF) WG
+
+
+
+Foster                                                        [Page 199]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+                         on Integrated Directory Services
+
+ Address:                ietf-ids@merit.edu
+
+ Administration:         ietf-ids-request@merit.edu
+
+ Archive:                Anonymous FTP to merit.edu, ids/archive
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:      IIIR: Internet Engineering Task Force (IETF) WG
+                        on Integration of Internet Information Resources
+
+ Address:                iiir@merit.edu
+
+ Administration:         iiir-request@merit.edu
+
+ Archive:                Anonymous FTP, iiir/archive
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       NIR: Internet Engineering Task Force (IETF) WG
+                         on Network Information Retrieval
+
+ Address:                nir@mailbase.ac.uk
+
+ Administration:         Auto subscriptions to: mailbase@mailbase.ac.uk
+                         "subscribe nir firstname lastname"
+                         Human admin to: nir-request@mailbase.ac.uk
+
+ Description:            This mailing list is intended to act as a
+                         clearing-house for discussions of Networked
+                         Information Retrieval and the active research
+                         projects in this field (eg WAIS, WWW, Gopher).
+
+ Keywords:               IETF, URIs, UDIs, URLs, UDLs, resource
+                         discovery, Internet, Gopher, WAIS, WWW, X.500,
+                         archie
+
+ Archive:                ftp://mailbase.ac.uk/pub/lists/files/nir/*
+                         or via gopher to mailbase.ac.uk
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       NISI: Internet Engineering Task Force (IETF) WG
+                         on Network Information Services Infrastructure
+
+ Address:                nisi@merit.edu
+
+
+
+Foster                                                        [Page 200]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Administration:         nisi-request@merit.edu
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       OSI-DS: Internet Engineering Task Force (IETF)
+                         WG on OSI Directory Services
+
+ Address:                ietf-osi-ds@cs.ucl.ac.uk
+
+ Administration:         ietf-osi-ds-request@cs.ucl.ac.uk
+
+ Archive:                Anonymous FTP, bells.cs.ucl.ac.uk
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       URI: Internet Engineering Task Force (IETF) WG
+                         on Uniform Resource Identifiers
+
+ Address:                uri@bunyip.com
+
+ Administration:         uri-request@bunyip.com
+
+ Archive:                archives.cc.mcgill.ca:~/pub/uri-archive
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       WNILS: Internet Engineering Task Force (IETF)
+                         Whois and Network Information Lookup Service
+
+ Address:                ietf-wnils@ucdavis.edu
+
+ Administration:         ietf-wnils-request@ucdavis.edu
+                         subscribe ietf-wnils Firstname Lastname
+
+ Description:            This mailing list is used by the IETF Whois and
+                         Network Information Lookup Service (WNILS)
+                         working group which is defining enhancements to
+                         whois.
+
+ Archive:                ucdavis.edu:/pub/archive
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       Z39.50 Implementors Group (ZIG)
+
+ Address:                Z3940IW@nervm.nerdc.ufl.edu (Internet)
+                         Z3950IW@NERVM (Bitnet)
+
+
+
+
+Foster                                                        [Page 201]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Administration/         listserv@nervm.nerdc.ufl.edu (Internet)
+ Subscriptions:          LISTSERV@NERVM (Bitnet)
+
+ Archive:                Anonymous FTP and/or Gopher: sally.fcla.ufl.edu
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       RARE Information Services and User Support WG
+
+ Address:                wg-isus@rare.nl
+
+ Administration:         Auto subscriptions to: mailserver@rare.nl
+                         "subscribe wg-isus <firstname> <lastname>
+
+                         Human admin to: wg-isus-request@rare.nl
+
+ Description:            General purpose mailing list for whole ISUS WG.
+
+ Document Archive:       Site: raredoc.rare.nl
+                         Directory: /rare
+
+                     ------------------------------
+
+ Mailinglist-Name:       MMIS: RARE Multimedia Information Services
+                         Task Force
+
+ Address:                mmis@mailbase.ac.uk
+
+ Administration:         Autosubscriptions to: mailbase@mailbase.ac.uk
+                         "subscribe mmis firstname lastname
+                         Human admin to: mmis-request@mailbase.ac.uk
+
+ Archive:                ftp://mailbase.ac.uk/pub/lists/files/mmis/*
+                         or via gopher to mailbase.ac.uk
+
+                     ------------------------------
+
+ Mailinglist-Name:       UNITE: RARE Task Force on "User Network
+                         Interface To Everything"
+
+ Address:                unite@mailbase.ac.uk
+
+ Administration:         Autosubscriptions to: mailbase@mailbase.ac.uk
+                         "subscribe unite firstname lastname
+                         Human admin to: unite-request@mailbase.ac.uk
+
+ Archive:                ftp://mailbase.ac.uk/pub/lists/files/unite/*
+                         or via gopher to mailbase.ac.uk
+
+
+
+Foster                                                        [Page 202]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       Hyper-G
+
+ Address:                uniinfo@mlist.tu-graz.ac.at
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       Soft Pages
+
+ Address:                spp@aic.co.jp
+
+ Administration:         spp-request@aic.co.jp
+
+ Description:            Technical discussion related to representation
+                         of network information in the directory and its
+                         usage is carried out in this group.
+
+ Archive:                Not (yet) available via anonymous FTP.
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       WHOIS++
+
+ Address:                ietf-wnils@ucdavis.edu
+
+ Administration:         ietf-wnils-request@ucdavis.edu
+
+ Archive:                pub/archive/wnils@ucdavis.edu
+
+ -----------------------------------------------------------------------
+
+ Mailinglist-Name:       IAFA: Internet Engineering Task Force (IETF)
+                         Internet Anonymous FTP Archive working group
+
+ Address:                iafa@bunyip.com
+
+ Administration:         iafa-request@bunyip.com
+
+ Description:            This mailing list is for people who are
+                         involved in the Internet Anonymous FTP Archives
+                         Working Group of the IETF.  This group was
+                         involved in standardizing the encoding of
+                         information at anonymous FTP archives and thus
+                         is of interest to operators and users of the
+                         archie system.  It came to completion in
+                         November, 1992 and produced two documents which
+                         have been presented to the IETF as informational
+
+
+
+Foster                                                        [Page 203]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+                         RFCs.
+
+ Archive:                archives.cc.mcgill.ca:/pub/mailing-lists/iafa
+
+ -----------------------------------------------------------------------
+
+ /* The following Usenet newsgroups discuss various issues in */
+ /* resource discovery or specific NIR projects.              */
+
+ Newsgroup-Name:         comp.archives.admin
+
+ Mailinglist-Gate:       <unknown>
+
+ Description:            This group discusses problems in administering
+                         Internet archives. It has also been used as an
+                         informal source of announcements for project
+                         releases, a place for new-comers to ask
+                         questions, etc.
+
+ Keywords:               anonymous FTP, archives, Internet, archie
+
+ Archive:                <unknown>
+
+ -----------------------------------------------------------------------
+
+ Newsgroup-Name:         comp.infosystems.wais
+
+ Mailinglist-Gate:       <unknown>
+
+ Description:            This group was created to host discussions
+                         about the Wide Area Information Server
+                         Also included are information and help with the
+                         public domain release available from Thinking
+                         Machine Corp. and setting up your own WAIS
+                         server.
+
+ Keywords:               WAIS, resource discovery, indexing, Internet
+
+ Archive:                <unknown>
+
+ -----------------------------------------------------------------------
+
+ Newsgroup-Name:         alt.wais
+
+ Mailinglist-Gate:       <unknown>
+
+ Description:            This alt. group was created to host discussions
+                         about the Wide Area Information Service. It has
+
+
+
+Foster                                                        [Page 204]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+                         been superceeded by the group
+                         "comp.infosystems.wais" and its use is
+                         discouraged.
+
+ Keywords:               WAIS, resource discovery, indexing, Internet
+
+ Archive:                <unknown>
+
+ -----------------------------------------------------------------------
+
+ Newsgroup-Name:         comp.infosystems.www
+
+ Mailinglist-Gate:       <unknown>
+
+ Description:            This group was created to host discussions
+                         about the World Wide Web distributed hypertext
+                         information services project based at CERN in
+                         Switzerland, including discussion of the many
+                         public domain implementations of WWW clients
+                         and servers available.
+
+ Keywords:               World Wide Web, campus-wide information
+                         systems, resource discovery, indexing, Internet
+
+ Archive:                <unknown>
+
+ -----------------------------------------------------------------------
+
+ Newsgroup-Name:         alt.gopher
+
+ Mailinglist-Gate:       <unknown>
+
+ Description:            This group was created to host discussions
+                         about the Gopher distributed information
+                         project, based at University of Minnesota,
+                         including discussion of the many public domain
+                         implementations of Gopher clients and servers
+                         available. It has been superceeded by the
+                         group "comp.infosystems.gopher" and its use is
+                         discouraged.
+
+ Keywords:               Gopher, campus-wide information systems,
+                         resource discovery, indexing, Internet
+
+ Archive:                <unknown>
+
+ ----------------------------------------------------------------------
+
+
+
+
+Foster                                                        [Page 205]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Newsgroup-Name:         alt.internet.services
+
+ Description:            This newsgroup is for people interested in
+                         Internet-related services, with a focus at the
+                         user level.  Announcements and discussions of
+                         issues related to archie are presented here, as
+                         well as discussions of more general issues
+                         relating to Internet services.
+
+ Archive:                not known
+
+ -----------------------------------------------------------------------
+
+ Newsgroup-Name:         bit.listserv.hytel-l
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 206]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+APPENDIX D
+
+ COMING ATTRACTIONS
+
+  This section will be used to keep a note of NIR Tools which are
+  considered by the NIR Group to be sufficiently well developed to
+  include here, but that are not yet in widespread use.
+
+  Items currently included here are:
+
+        Hyper-G
+        Soft Pages
+        Whois++
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+ HYPER-G
+
+  Date template updated or checked: 19th October, 1993
+  By: Name:   Frank Kappe
+      Email address:fkappe@iicm.tu-graz.ac.at
+
+ ----------------------------------------------------------------------
+
+ NIR Tool Name: Hyper-G
+
+ Brief Description of Tool:
+
+  Hyper-G is the name of an ambitious hypermedia project currently being
+  developed as a joint effort by a number of institutes of the IIG
+  (Institutes for Information-Processing Graz) and the Computing and
+  Information Services Center of the Graz University of Technology and
+  the Austrian Computer Society.
+
+  Hyper-G is designed as a general-purpose, large-scale, multi-user,
+  distributed hypermedia information system.  As such, it combines
+  concepts of hypermedia, information retrieval systems, documentation
+  systems with aspects of communication and collaboration, and computer
+  supported teaching and learning.  It also provides seamless
+  integration of other systems (e.g., World-Wide Web, Gopher, WAIS) that
+  also operate under the client/server paradigm and allows remote logins
+  to interactive services.
+
+  In addition to hypertext links, Hyper-G allows navigation through
+  hierarchies, queries (including full text), guided tours, and is
+  multilingual.
+
+
+
+
+Foster                                                        [Page 207]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Hyper-G is currently operated at some 10 locations throughout the
+  world, including a University Information System at the Graz Technical
+  University.  Clients and the server are available without fee for
+  educational institutions, and are distributed as binaries for a number
+  of platforms.
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                 Frank Kappe
+
+  Email address:        fkappe@iicm.tu-graz.ac.at
+
+  Postal Address:       Schieszstattg. 4a, A-8010 Graz, AUSTRIA
+
+  Telephone:            +43-316-832551-22
+
+  Fax:                  +43-316-824394
+
+ -----------------------------------------------------------------------
+
+ Help Line:
+  Sorry no help line
+
+ -----------------------------------------------------------------------
+
+ Related Working Groups:
+
+ -----------------------------------------------------------------------
+
+ Sponsoring Organisation / Funding source:
+
+  Austrian Ministry of Science
+  European Space Agency
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+  uniinfo@mlist.tu-graz.ac.at
+
+ -----------------------------------------------------------------------
+
+ News groups:
+  None
+
+ -----------------------------------------------------------------------
+
+
+
+
+Foster                                                        [Page 208]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Protocols:
+
+  What is supported:   RPC
+
+  What it runs over:   TCP/IP
+
+  Other NIR tools this interworks with: gopher, WAIS, World Wide Web
+
+  Future plans: Too numerous to mention.
+
+ -----------------------------------------------------------------------
+
+ Servers:
+
+  Date completed or updated:     12th October, 1993
+  By: Name:                      Gerald Pani
+      Email address:             gpani@iicm.tu-graz.ac.at
+
+  Platform: UNIX
+
+  Primary Contact:
+      Name:           Gerald Pani
+      Email address:  gpani@iicm.tu-graz.ac.at
+      Telephone:      +43-316-832551-34
+
+  Server software available from:  anon-ftp from iicm.tu-graz.ac.at,
+                                   in directory pub/Hyper-G/Server
+
+  Location of more information:    see README in above directory
+
+  Latest version number:
+
+  Brief Scope and Characteristics:
+
+  Approximate number of such servers in use: 13
+
+  General comments:
+
+   Currently available as binary distribution for SUN, DEC, HP,
+   and SGI workstations.
+
+ ----------------------------------------------------------------------
+
+ Clients:
+
+  UNIX curses client (a.k.a. VT100 Client)
+
+  Date completed or updated:    19th October, 1993
+
+
+
+Foster                                                        [Page 209]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  By: Name:                     Frank Kappe
+      Email address:            fkappe@iicm.tu-graz.ac.at
+
+  Platform:  UNIX
+
+  Primary Contact:
+  Name:                         Frank Kappe
+  Email address:                fkappe@iicm.tu-graz.ac.at
+  Telephone:                    +43-316-832551-22
+
+  Client software available from:
+
+      anonymous ftp:  iicm.tu-graz.ac.at:/pub/Hyper-G/UnixClient
+
+  Location of more information:
+
+  Latest version number: 1.41
+
+  Brief Scope and Characteristics:
+
+   Fairly sophisticated terminal viewer with ~50 commands, multi-
+   language user interface, history, authoring capabilities (text
+   documents and links) and the ability to speak to gopher,
+   World-Wide-Web, WAIS and to start telnet sessions.
+
+  General comments:
+
+  Future plans:
+
+   The terminal viewer will probably remain rather stable in the future.
+   Our main effort now goes into the development of clients for
+   X-Windows and MS-Windows.
+
+ -----------------------------------------------------------------------
+
+ MS-Windows Client
+
+  Date completed or updated:    10th October, 1993
+  By: Name:                     Thomas Dietinger
+      Email address:
+
+  Platform:  UNIX
+
+  Primary Contact:
+  Name:                         Thomas Dietinger, Frank Kappe
+  Email address:                tdieting@iicm.tu-graz.ac.at
+  Telephone:                    +43-316-832551-22
+
+
+
+
+Foster                                                        [Page 210]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Client software available from:
+
+      anonymous ftp:  iicm.tu-graz.ac.at:/pub/Hyper-G/pc-client
+
+  Location of more information:
+
+  Latest version number: 1.37
+
+  Brief Scope and Characteristics:
+
+  Preliminary version of a Hyper-G client for MS-Windows 3.1 and Windows
+  NT.  Currently mostly identical to the UNIX curses client.  An
+  exception is its ability to elegantly import and export RTF text files
+  to/from Hyper-G, and its multimedia capabilities.
+
+  General comments:
+
+  Future plans:
+
+  Will become more fancy (menus, icons, buttons...) in the near future.
+
+ -----------------------------------------------------------------------
+
+ Demonstration sites:
+
+  List of sites which are willing to act as demonstration
+  sites for this application.
+
+       Site name: hyperg.tu-graz.ac.at
+       Access details: 'rlogin hyperg.tu-graz.ac.at' or
+                       'telnet hyperg.tu-graz.ac.at', login 'info'
+
+                       (rlogin has the advantage that the terminal size
+                       of xterms is handled correctly (can even be
+                       changed in the middle of a session)
+
+  Note: The same information is available through Gopher and WWW
+        gateways.
+        Gopher: host gopher.tu-graz.ac.at, port 70
+        WWW:    URL=http://www.tu-graz.ac.at:80/ROOT
+
+ -----------------------------------------------------------------------
+
+ Documentation:
+
+
+ Document Title: Most of the documentation is available on-line in the
+                 Graz server. The server distribution include man-pages
+
+
+
+Foster                                                        [Page 211]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+                 of the additional authoring tools and utilities that
+                 are supplied with the server. The ideas behind Hyper-G
+                 are described in a number of research papers (see
+                 Bibliography).
+
+ Location details:
+                 Site:      iicm.tu-graz.ac.at
+                 Full file name: look in directory /pub/Hyper-G/doc
+
+ -----------------------------------------------------------------------
+
+ Bibliography:
+
+  Kappe F.: Aspects of a Modern Multi-Media Information System.  IIG
+  Report 308, IIG, Graz University of Technology, Austria, June 1991.
+  Available by anonymous ftp from
+  iicm.tu-graz.ac.at:/pub/Hyper-G/doc/report308.ps.Z
+
+  Kappe F., Maurer H., Sherbakov N.: Hyper-G - A Universal Hypermedia
+  System. Journal of Educational Multimedia and Hypermedia, Vol. 2,
+  No. 1, pp. 39-66 (1993). Also available by anonymous ftp from
+  iicm.tu-graz.ac.at:/pub/Hyper-G/doc/report333.txt.Z
+
+  Kappe F., Pani G., Schnabel F.: The Architecture of a Massively
+  Distributed Hypermedia System. Internet Research: Electronic
+  Networking Applications and Policy, Vol. 3, No. 1, pp. 10-24; Meckler
+  (Spring 1993)
+
+  Kappe F., Maurer H.: Hyper-G: A Large Universal Hypermedia System and
+  Some Spin-Offs; ACM Computer Graphics, experimental special online
+  issue; available by anonymous ftp from siggraph.org in directory
+  publications/May_93_online/Kappe.Maurer (May 1993)
+
+  Kappe F.: Hyper-G: A Distributed Hypermedia System; Proc. INET '93,
+  San Francisco, California, pp. DCC-1 - DCC-9 (Aug. 1993).
+
+ -----------------------------------------------------------------------
+
+  Other Information:
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 212]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ SOFT PAGES
+
+ Date template updated or checked: 4th November, 1993
+ By: Name:          Glenn Mansfield
+     Email address: glenn@aic.co.jp
+
+ -----------------------------------------------------------------------
+
+ NIR Tool Name:    SoftPages
+
+ Brief Description of Tool:
+
+  A tool to aid users in the efficient retrieval of documents, s/w, and
+  the like from servers ( anonymous FTP, FTAM, ..  ) connected to the
+  network.  In principle, it uses the X.500 Directory framework to store
+  information about the network.  This includes the network
+  configuration, the properties of the links that connect the network
+  elements, location of servers and their contents.  When a user looks
+  for a particular document or s/w the above information is used to
+  search for the object starting from the server that is
+  "nearest" (cheapest) to the user.
+
+  The X.500 directory services is used in several stages
+       get list of file-servers
+       get path to file servers
+       get attributes for computing cost of paths
+       search for file that is being sought
+
+  However, under present circumstances, due to lack of deployment of
+  network information in the directory, when information is unavailable
+  from X.500, alternate sources/methods are used.  [Static-lists of
+  file-servers, or lists of file servers from other clients (e.g.,
+  archie); Paths and/or costs are obtained from static lists or derived
+  by other direct means (e.g., ping, traceroute); file information is
+  sought from other servers (e.g., archie).]
+
+  User's View:
+
+  A "single window" view of the public archives connected to the
+  network.  It locates the server that contains the sought object and is
+  near(/cheap/fast) server.
+
+  Query of files based on incomplete name is supported.  The system also
+  supports queries based on keywords.
+
+  Information Provider's View:
+
+  The information about the server contents have to be updated
+
+
+
+Foster                                                        [Page 213]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  at a single place- namely, the local Directory Service Agent.
+  The Directory Service Agent makes the information globally
+  accessible.
+  It is not necessary to carry out periodic updates on one or
+  more information servers.
+
+  - information types supported (e.g., text, sound, etc.)
+
+  Since the system supports query on name and keywords (not on
+  contents) all kinds of information may be supported.
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:            Manager, SoftPages Project
+  Email address:   spp-manager@aic.co.jp
+  Postal Address:  AIC Sytsems Lab.
+                   Minami Yoshinari 6-6-3
+                   Aoba-ku, Sendai-shi 989-32, Japan
+
+  Telephone:       +81-22-279-3310
+  Fax:             +81-22-279-3640
+
+ -----------------------------------------------------------------------
+
+ Help Line:
+  Name:            SoftPages Project Support Group
+  Email address:   spp-support@aic.co.jp
+  Telephone:       +81-22-279-3310
+
+  Level of support offered:
+       o volunteer
+       o all users             yes
+
+  Hours available: Regular working hours
+
+ -----------------------------------------------------------------------
+
+ Related Working Groups:
+  The SoftPages Project Working Group
+
+ -----------------------------------------------------------------------
+
+ Sponsoring Organisation / Funding source:
+  The project is supported by:
+      AIC Systems Lab., Sendai, Japan
+      Tohoku University, Sendai, Japan
+
+
+
+Foster                                                        [Page 214]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+      The WIDE Project, Japan
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+
+  Address:              spp@aic.co.jp
+  Administration:       spp-request@aic.co.jp
+  Description:          Technical discussion related to representation
+                        of network information in the directory and its
+                        usage is carried out in this group.
+
+  Archive:              Not (yet) available via anonymous FTP.
+
+ -----------------------------------------------------------------------
+
+ News groups:
+  None
+
+ -----------------------------------------------------------------------
+
+ Protocols:
+
+  What is supported:   X.500 DAP
+  What it runs over:   LDAP over IP
+
+  Other NIR tools this interworks with:
+
+  Future plans:
+
+ -----------------------------------------------------------------------
+
+ Servers:
+
+  Date completed or updated:    4th November, 1993
+  By: Name:                     Glenn Mansfield
+      Email address:            glenn@aic.co.jp
+
+  Platform:                     Unix
+
+  Primary Contact:
+  Name:                         Manager, SoftPages Project
+  Email address:                spp-manager@aic.co.jp
+  Telephone:                    +81-22-279-3310
+
+  Server software available from:
+        Any standard X.500 package will do.
+        We are using the QUIPU package that is included
+
+
+
+Foster                                                        [Page 215]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+        in the ISODE system
+
+  Location of more information:
+
+  Latest version number:
+
+  Brief Scope and Characteristics:
+
+  Approximate number of such servers in use:
+
+  General comments:
+          some new oids need to be assigned for
+          SoftPages related objects.
+
+ -----------------------------------------------------------------------
+
+ Clients:
+
+  Date completed or updated:    4th November, 1993
+  By: Name:                     Glenn Mansfield
+      Email address:            glenn@aic.co.jp
+
+  Platform:                     Unix.
+
+  Primary Contact:
+  Name:                         Manager, SoftPages Project
+  Email address:                spp-manager@aic.co.jp
+  Telephone:                    +81-22-279-3310
+
+  Client software available from:
+               will be announced on the mailing list in the
+               near future
+
+  Location of more information:
+
+  Latest version number:
+
+  Brief Scope and Characteristics:
+
+  General comments:
+               The Prototype is under development and testing.
+               It is not (yet) available for public use.
+
+  Future plans:
+
+ -----------------------------------------------------------------------
+
+ Demonstration sites:
+
+
+
+Foster                                                        [Page 216]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ -----------------------------------------------------------------------
+
+ Documentation:
+
+   Document Title: README
+   Location details:
+        Site: ftp.tohoku.ac.jp
+        Full file name:pub/spp/README
+
+ -----------------------------------------------------------------------
+
+ Bibliography:
+
+  "The Soft Pages Project", Th. Johannsen, G.Mansfield,
+  OSI-DS-39, February 1993.
+  Location details:
+       Site: cs.ucl.ac.uk
+       Full file name:osi-ds/osi-ds-39-00.{txt, ps}
+
+ -----------------------------------------------------------------------
+
+ Other Information:
+
+  "Optimized Document Retrieval - Soft Pages Project", Th. Johannsen,
+  G.Mansfield, S.Noguchi, Booklet of Abstracts,
+  The Network Services Conference '92, Pisa, November 1992.
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 217]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ WHOIS++
+
+ Date template updated or checked: 21 October, 1993
+ By: Name:          Chris Weider
+     Email address: clw@bunyip.com
+
+ -----------------------------------------------------------------------
+
+ NIR Tool Name: whois++ and the whois++ index service
+
+ Brief Description of Tool:
+
+  whois++ and the whois++ index service are extensions of the WHOIS
+  protocol.  They are designed to a) subsume in a standardized fashion
+  the many enhancements which have been added to individual WHOIS
+  servers; b) extend the flexibility of WHOIS by enriching the query
+  syntax, and c) provide a distributed indexing system to tie the
+  various whois++ servers into a distributed information lookup service.
+
+  The protocols describe two logically distinct types of servers that an
+  information provider can set up.  The first type is the base-level
+  whois++ server.  This contains primary information, such as entries
+  for individual people or entries describing resources available
+  locally.  For example, if one wished to provide a campus directory
+  through whois++, one would set up a base-level whois++ server that
+  contained entries for each student.  In addition, this base-level
+  server must be able to generate 'forward knowledge' for the
+  information it contains.  The second type of server collects the
+  'forward knowledge' generated by a number of base-level servers, and
+  can take a query sent to it and determine which of the base-level
+  servers it indexes might contain information relevant for the query.
+  A single physical server may contain both primary information and
+  'forward knowledge' for a number of other servers, and an index server
+  can also index 'forward knowledge' for a number of other index
+  servers, allowing a hierarchical mesh of index servers to be built.
+  For more details on the information provider's point of view, see the
+  'Documentation' section of this template.
+
+  The basic information model is centered on the concept of 'templates'.
+  A template is a collection of attribute:value pairs, where the
+  allowable attributes are specified by the template type.  The whois++
+  templates are based on the templates defined by the IAFA working group
+  of the IETF.  The values associated with given attributes are not
+  necessarily limited to text, they can be digitized sound clips, etc.
+
+  Depending on the client she uses, the user will see a connection to
+  the local whois++ base-level server.  The user can ask the server for
+  a list of templates supported by that server, and can then call up a
+
+
+
+Foster                                                        [Page 218]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  blank version of the template so that she can fill in values for the
+  attributes she knows.  Once she has filled in the template as much as
+  she wants, she issues a query to the server to find all the entries
+  which have these attribute:value pairs.  If she is not satisfied with
+  the responses, she can then start traversing the index service to
+  locate a server which can adequately answer her query.  In addition,
+  if a user makes frequent use of the index service, she can set
+  'bookmarks' which can be used later to directly contact servers she's
+  found useful in the past, without having to traverse the index service
+  again.
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                 Chris Weider
+
+  Email address:        clw@bunyip.com
+
+  Postal Address:       2001 South Huron Parkway 12
+                        Ann Arbor
+                        Michigan
+                        48104, USA
+
+  Telephone:                    +1-313-971-2223
+
+  Fax:                          +1-313-971-2223
+                      ----------------------------
+
+  Name:                 Peter Deutsch
+
+  Email address:        peterd@bunyip.com
+
+  Postal Address:       Bunyip Information Systems, Inc.
+                        266 Blvd. Neptune
+                        Dorval QUEBEC H9S 2L4
+                        CANADA
+
+  Telephone:            +1-514-875-8611
+
+ -----------------------------------------------------------------------
+
+ Help Line:
+  Not yet deployed.
+
+ -----------------------------------------------------------------------
+
+ Related Working Groups:
+
+
+
+Foster                                                        [Page 219]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+  Whois Network Information Lookup Service (WNILS) Working Group of the
+  Internet Engineering Task Forces (IETF)
+
+ -----------------------------------------------------------------------
+
+ Sponsoring Organisation / Funding source:
+    None
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+
+  Address:              ietf-wnils@ucdavis.edu
+
+  Administration:       ietf-wnils-request@ucdavis.edu
+
+  Archive:              pub/archive/wnils@ucdavis.edu
+
+ -----------------------------------------------------------------------
+
+ News groups:
+
+   NONE
+
+ -----------------------------------------------------------------------
+
+ Protocols:
+
+  What is supported:    WHOIS, whois++
+
+  What it runs over:    TCP/IP
+
+  Other NIR tools this interworks with: None yet.
+
+  Future plans: Providing resource location services and URN/URL
+   mappings for GOPHER, ARCHIE, WAIS, and WWW.
+
+ -----------------------------------------------------------------------
+
+ Servers:
+
+   Only beta versions available at this time (21 October, 1993). Please
+   contact clw@bunyip.com (Chris Weider) for more information.
+
+ -----------------------------------------------------------------------
+
+ Clients:
+
+
+
+
+Foster                                                        [Page 220]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+   Only beta versions available at this time (21 October, 1993). Please
+   contact clw@bunyip.com (Chris Weider) for more information.
+
+ ----------------------------------------------------------------------
+
+ Demonstration sites:
+
+   NONE at this time (21 October, 1993)
+
+ -----------------------------------------------------------------------
+
+ Documentation:
+
+  Document Title: Architecture of the Whois++ Index Service
+  Location details:
+       Site: gopher.ucdavis.edu
+       Full file name: /pub/IETF/WNILS/Architecture.Index.Service
+
+  Document Title: Architecture of the WHOIS++ Service
+  Location details:
+       Site: gopher.ucdavis.edu
+       Full file name: /pub/IETF/WNILS/Architecture.Overview
+
+  Document Title: Specifications for WHOIS Services
+  Location details:
+       Site: gopher.ucdavis.edu
+       Full file name: /pub/IETF/WNILS/Discussion.Paper
+
+ -----------------------------------------------------------------------
+
+ Bibliography:
+
+   See the documentation section of this template.
+
+ -----------------------------------------------------------------------
+
+ Other Information:
+
+  As this is a coming attraction, we encourage people to get in on the
+  ground floor.  The authors of this protocol see it as potentially
+  being a key player in any integrated Internet information
+  architecture, and we can always use more volunteers who want to
+  beta-test code for us.
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+Foster                                                        [Page 221]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+APPENDIX E
+
+ Extinct Critters (Tools)
+
+ This section will contain information on Tools moved from the main
+ body of the report as the Tool falls out of common usage.
+
+ There are no items currently in this section.
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+APPENDIX F
+
+ Extinct Critters (Groups)
+
+ This section will be used as a historical record of groups which were
+ once in the main body of the report, but which have since been closed.
+
+ Items in this section:
+
+        IAFA
+        Z39.50  Interoperability Testbed
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+ IAFA
+
+ Date template updated or checked:      8th July 1993
+ By: Name:              Peter Deutsch
+     Email Address:     peterd@bunyip.com
+
+ -----------------------------------------------------------------------
+
+ NIR Group Name:       Internet Anonymous File Archive Working Group
+
+ Sponsoring Organisation:  IETF
+
+ Working subgroups:      none.
+
+ Description of main group:
+
+  This working group came to completion during the IETF meeting in
+  November, 1992 and two Internet drafts are are now circulating.  The
+  archive for this mailing list is currently available on
+  "archives.cc.mcgill.ca" via anonymous ftp in the file
+  "pub/mailing-lists/iafa".
+
+ -----------------------------------------------------------------------
+
+
+
+Foster                                                        [Page 222]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Primary Contact(s):
+
+  Name:                 Peter Deutsch
+
+  Email address:        peterd@bunyip.com
+
+  Postal address:       Bunyip Information Systems
+                        266 Blvd Neptune
+                        Dorval, Quebec H9S 2L4
+                        CANADA
+
+  Telephone:            +1-514-398-3709
+
+  Fax:                  +1-514-398-6876
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+
+  Address:              iafa@cc.mcgill.ca
+
+  Administration:       iafa-request@cc.mcgill.ca
+
+  Description:          Discussion list for the IAFA Working Group
+                        concerning the administration of anonymous FTP
+                        archive sites.
+
+  Keywords:             IETF, IAFA, anonymous, FTP, archive, Internet,
+                        archie
+
+  Archive:              The archive for this mailing list is currently
+                        available on "archives.cc.mcgill.ca" via
+                        anonymous FTP in the file
+                        "pub/mailing-lists/iafa".
+
+ -----------------------------------------------------------------------
+
+ News groups:
+
+ -----------------------------------------------------------------------
+
+ Document Archive:
+
+ Location details:
+      Site:             archives.cc.mcgill.ca
+      Directory:        pub/mailing-lists/iafa
+
+ -----------------------------------------------------------------------
+
+
+
+Foster                                                        [Page 223]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Official Publications:
+
+ -----------------------------------------------------------------------
+
+ Bibliography:
+
+ -----------------------------------------------------------------------
+
+ Other Information:
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 224]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ Z39.50
+
+ Date template updated or checked:      8th July 1993
+ By: Name:              Jane Smith
+     Email Address:     Jane.Smith@cnidr.org
+
+ -----------------------------------------------------------------------
+
+ NIR Group Name:               Z39.50 Interoperability Testbed
+
+ Sponsoring Organisation:      Coalition for Networked Information (CNI)
+                               Architectures and Standards Program
+
+ Working subgroups:
+    Name of subgroup:
+    Mailinglist-Address:
+
+ Description of main group:
+
+  Program priorities are 1) to facilitate a consistent and complete
+  mechanism for linking bibliographic, abstracting, and indexing files
+  to files of their associated source materials; 2) a single standard
+  for the transmission of bitmapped image files; 3) protocols for
+  handing networked requests for delivery of source materials; 4)
+  mechanisms for interorganizational authentication, accounting, and
+  billing; and 5) to integrate lessons drawn from the experience of
+  pilot projects that exercise networked printing utilities and 6) to
+  provide an "interoperability workshop" to specify, implement, and test
+  advanced functions of Z39.50 to accelerate the pace and to ensure the
+  quality of standardization efforts in this area.
+
+ -----------------------------------------------------------------------
+
+ Primary Contact(s):
+
+  Name:                 Clifford Lynch
+
+  Email address:        Clifford.Lynch@ucop.edu
+
+  Postal address:       Off. of the President
+                        Unv. of California
+                        300 Lakeside Dr.,
+                        8th Flr. Oakland, CA 94612-3350 USA
+
+  Telephone:            +1-415-987-0522
+
+  Fax:                  +1-415-839-3573
+
+
+
+
+Foster                                                        [Page 225]
+
+RFC 1689   Networked Information Retrieval: Tools and Groups August 1994
+
+
+ -----------------------------------------------------------------------
+
+ Mailing Lists:
+
+  Address:              Z3950iw@NERVM.NERDC.UFL.EDU
+
+  Administration:       LISTSERV@NERVM.NERDC.UFL.EDU
+
+  Description:          Implementors' list for low level discussions
+                        of protocol details.
+
+  Archive:
+
+ -----------------------------------------------------------------------
+
+ News groups:           None
+
+ -----------------------------------------------------------------------
+
+ Document Archive:
+
+  Location details:
+       Site:            ftp.cni.org
+       Directory:       /CNI/projects/
+
+ -----------------------------------------------------------------------
+
+ Official Publications: None
+
+ -----------------------------------------------------------------------
+
+ Bibliography:          None
+
+ -----------------------------------------------------------------------
+
+ Other Information:     None
+
+ =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foster                                                        [Page 226]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1689.txt](<www.ietf.org/rfc/rfc1689.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
