### PR TITLE
Archive rfc1690.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1690.txt
+++ b/www.ietf.org/rfc/rfc1690.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                          G. Huston
+Request for Comments: 1690                                        AARNet
+Category: Informational                                      August 1994
+
+
+                  Introducing the Internet Engineering
+                       and Planning Group (IEPG)
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  This memo
+   does not specify an Internet standard of any kind.  Distribution of
+   this memo is unlimited.
+
+Abstract
+
+   This memo introduces the IEPG to the Internet Community.  The IEPG is
+   an Internet Service Operators' forum, intended to assist Service
+   Operators to coordinate in operational aspects of managing Internet
+   services.
+
+1.  Charter of the Internet Engineering and Planning Group
+
+   Domain of Activity
+
+      The Internet Engineering and Planning Group (IEPG) is a group
+      principally comprised of Internet Service Operators.
+
+   Goal
+
+      The common objective of the group is to promote a technically
+      coordinated operational environment of the Global Internet.
+
+   Activities
+
+      The activities of the IEPG will be within the following areas:
+
+     -  To facilitate the operations and management of Global Internet
+        services,
+
+     -  To promote the introduction of new Internet services within the
+        Global Internet, and
+
+     -  Liaison with related Internet Operations groups and liaison with
+        technical development groups.
+
+      Explicitly the IEPG is not a group which will conduct activities
+      of a technical developmental nature.
+
+
+
+Huston                                                          [Page 1]
+
+RFC 1690      The Internet Engineering and Planning Group    August 1994
+
+
+   Constituency
+
+      Membership of the IEPG shall be open. Any individual may subscribe
+      to the IEPG mailing list, and all meeting announcements, meeting
+      agenda, meetings and meeting reports shall be made openly
+      available.
+
+   Reporting
+
+      The IEPG will maintain an archive of material available using
+      World Wide Web (WWW) access tools. The location of this WWW
+      archive, and this charter will be disseminated to the Internet
+      community through an Informational RFC.
+
+2. IEPG membership and IEPG mailing list
+
+   Membership of the IEPG is open. Any member of the Internet community
+   may join the IEPG mailing list. The mailing list is "iepg@iepg.org".
+   Anyone may join the list by subscribing to "iepg-request@iepg.org".
+
+3. Archive of IEPG material
+
+   All IEPG material is archived at "http://iepg.org/iepg".
+
+4. Security Considerations
+
+   Security issues are not discussed in this memo.
+
+5. Author's Address
+
+   Geoff Huston
+   Australian Academic and Research Network
+   GPO Box 1142
+   Canberra  ACT  2601
+   Australia
+
+   Phone: +61 6 249 3385
+   Fax: +61 6 249 1369
+   EMail: Geoff.Huston@aarnet.edu.au
+
+
+
+
+
+
+
+
+
+
+
+
+Huston                                                          [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1690.txt](<www.ietf.org/rfc/rfc1690.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
