### PR TITLE
Archive rfc1699.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1699.txt
+++ b/www.ietf.org/rfc/rfc1699.txt
@@ -1,0 +1,1179 @@
+
+
+
+
+
+
+Network Working Group                                         J. Elliott
+Request for Comments: 1699                                           ISI
+Category: Informational                                     January 1997
+
+
+                      Request for Comments Summary
+
+                         RFC Numbers 1600-1699
+
+Status of This Memo
+
+   This RFC is a slightly annotated list of the 100 RFCs from RFC 1600
+   through RFCs 1699.  This is a status report on these RFCs.  This memo
+   provides information for the Internet community.  It does not specify
+   an Internet standard of any kind.  Distribution of this memo is
+   unlimited.
+
+Note
+
+   Many RFCs, but not all, are Proposed Standards, Draft Standards, or
+   Standards.  Since the status of these RFCs may change during the
+   standards processing, we note here only that they are on the
+   standards track.  Please see the latest edition of "Internet Official
+   Protocol Standards" for the current state and status of these RFCs.
+   In the following, RFCs on the standards track are marked [STANDARDS-
+   TRACK].
+
+RFC     Author       Date      Title
+---     ------       ----      -----
+
+1699    Elliott      Jan 97   Requests For Comments Summary
+
+This memo.
+
+
+1698    Furniss      Oct 94   Octet Sequences for Upper-Layer OSI
+                              to Support Basic Communications
+                              Applications
+
+This document states particular octet sequences that comprise the OSI
+upper-layer protocols (Session, Presentation and ACSE) when used to
+support applications with "basic communications requirements".  This
+memo provides information for the Internet community.  This memo does
+not specify an Internet standard of any kind.
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 1]
+
+RFC 1699                  Summary of 1600-1699              January 1997
+
+
+1697    Brower       Aug 94   Relational Database Management System
+                              (RDBMS) Management Information Base
+                              (MIB) using SMIv2
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it describes managed objects used for managing relational
+database (RDBMS) implementations.  [STANDARDS-TRACK]
+
+
+1696    Barnes       Aug 94   Modem Management Information Base (MIB)
+                              using SMIv2
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it describes managed objects used for managing dial-up
+modems and similar dial-up devices.  [STANDARDS-TRACK]
+
+
+1695    Ahmed        Aug 94   Definitions of Managed Objects
+                              for ATM Management Version 8.0
+                              using SMIv2
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it describes objects used for managing ATM-based interfaces,
+devices, networks and services.  [STANDARDS-TRACK]
+
+
+1694    Brown        Aug 94   Definitions of Managed Objects
+                              for SMDS Interfaces using SMIv2
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing objects for SMDS access
+interfaces.  [STANDARDS-TRACK]
+
+
+1693    Connolly     Nov 94   An Extension to TCP : Partial Order
+                              Service
+
+This RFC introduces a new transport mechanism for TCP based upon partial
+ordering.  The aim is to present the concepts of partial ordering and
+promote discussions on its usefulness in network communications.  This
+memo defines an Experimental Protocol for the Internet community.
+
+
+
+
+
+
+Elliott                      Informational                      [Page 2]
+
+RFC 1699                  Summary of 1600-1699              January 1997
+
+
+1692    Cameron      Aug 94   Transport Multiplexing Protocol (TMux)
+
+This RFC documents the extended TACACS protocol use by the Cisco Systems
+terminal servers.  This same protocol is used by the University of
+Minnesota's distributed authentication system.  This memo provides
+information for the Internet community.  It does not specify an Internet
+standard.
+
+
+1691    Turner       Aug 94   The Document Architecture for the
+                              Cornell Digital Library
+
+This memo defines an architecture for the storage and retrieval of the
+digital representations for books, journals, photographic images, etc.,
+which are collected in a large organized digital library.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1690    Huston       Aug 94   Introducing the Internet Engineering
+                              and Planning Group (IEPG)
+
+This memo introduces the IEPG to the Internet Community.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1689    Foster       Aug 94   A Status Report on Networked Information
+                              Retrieval: Tools and Groups
+
+The purpose of this report is to increase the awareness of Networked
+Information Retrieval by bringing together in one place information
+about the various networked information retrieval tools, their
+developers, interested organisations, and other activities that relate
+to the production, dissemination, and support of NIR tools.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1688    Simpson      Aug 94   IPng Mobility Considerations
+
+This RFC specifies criteria related to mobility for consideration in
+design and selection of the Next Generation of IP.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+
+
+
+
+Elliott                      Informational                      [Page 3]
+
+RFC 1699                  Summary of 1600-1699              January 1997
+
+
+1687    Fleischman   Aug 94   A Large Corporate User's View of IPng
+
+The goal of this paper is to examine the implications of IPng from the
+point of view of Fortune 100 corporations which have heavily invested in
+TCP/IP technology in order to achieve their (non-computer related)
+business goals.This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+1686    Vecchi       Aug 94   IPng Requirements: A Cable Television
+                              Industry Viewpoint
+
+This paper provides comments on topics related to the IPng requirements
+and selection criteria from a cable television industry viewpoint.  This
+memo provides information for the Internet community.  This memo does
+not specify an Internet standard of any kind.
+
+
+1685    Alvestrand   Aug 94   Writing X.400 O/R Names
+
+There is a need for human beings who use X.400 systems to be able to
+write down O/R names in a uniform way.  This memo is a discussion of
+this topic.  This memo provides information for the Internet Community.
+It does not specify an Internet Standard of any kind.
+
+
+1684    Jurg         Aug 94   Introduction to White Pages Services
+                              based on X.500
+
+The document provides an introduction to the international ITU-T
+(formerly CCITT) X.500 and ISO 9594 standard, which is particularly
+suited for providing an integrated local and global electronic White
+Pages Service.  This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+1683    Clark        Aug 94   Multiprotocol Interoperability In IPng
+
+In this document, we identify several features that affect a protocol's
+ability to operate in a multiprotocol environment and propose the
+incorporation of these features into IPng.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 4]
+
+RFC 1699                  Summary of 1600-1699              January 1997
+
+
+1682    Bound        Aug 94   IPng BSD Host Implementation Analysis
+
+This IPng white paper, IPng BSD Host Implementation Analysis, was
+submitted to the IPng Directorate to provide a BSD host point of
+reference to assist with the engineering considerations during the IETF
+process to select an IPng proposal.  This memo provides information for
+the Internet community.  This memo does not specify an Internet standard
+of any kind.
+
+
+1681    Bellovin     Aug 94   On Many Addresses per Host
+
+This document was submitted to the IETF IPng area in response to RFC
+1550.This memo provides information for the Internet community.  This
+memo does not specify an Internet standard of any kind.
+
+
+1680    Bradziunas   Aug 94   IPng Support for ATM Services
+
+This white paper describes engineering considerations for IPng as
+solicited by RFC 1550 [1]. This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+1679    Green        Aug 94   HPN Working Group Input to the IPng
+                              Requirements Solicitation
+
+The purpose of this document is to provide what the HPN working group
+perceives as requirements for an IPng protocol set.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+1678    Britton      Aug 94   IPng Requirements of Large Corporate
+                              Networks
+
+This draft summarizes some of the requirements of large corporate
+networks for the next generation of the Internet protcol suite.  This
+memo provides information for the Internet community.  This memo does
+not specify an Internet standard of any kind.
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 5]
+
+RFC 1699                  Summary of 1600-1699              January 1997
+
+
+1677    Adamson      Aug 94   Tactical Radio Frequency Communication
+                              Requirments for IPng
+
+This paper describes requirements for Internet Protocol next generation
+(IPng) candidates with respect to their application to military tactical
+radio frequency (RF) communication networks.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+1676    Ghiselli     Aug 94   INFN Requirements for an IPng
+
+ With this paper we would like to emphasize the key points that we would
+to consider if charged with IPng plan.  This memo provides information
+for the Internet community.  This memo does not specify an Internet
+standard of any kind.
+
+
+1675    Bellovin     Aug 94   Security Concerns for IPng
+
+A number of the candidates for IPng have some features that are somewhat
+worrisome from a security perspective.  While it is not necessary that
+IPng be an improvement over IPv4, it is mandatory that it not make
+things worse.  This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+1674    Taylor       Aug 94   A Cellular Industry View of IPng
+
+This is a draft of the requirements for IPng as envisioned by
+representatives of the Cellular Digital Packet Data (CDPD) consortium of
+service providers.  This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+1673    Skelton      Aug 94   Electric Power Research Institute
+                              Comments on IPng
+
+This document was submitted to the IETF IPng area in response to RFC
+1550.  This memo provides information for the Internet community.  This
+memo does not specify an Internet standard of any kind.
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 6]
+
+RFC 1699                  Summary of 1600-1699              January 1997
+
+
+1672    Brownless    Aug 94   Accounting Requirements for IPng
+
+This white paper discusses accounting requirements for IPng. It
+recommends that all IPng packets carry accounting tags, which would vary
+in size.  This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+1671    Carpenter    Aug 94   IPng White Paper on Transition and Other
+                              Considerations
+
+This white paper outlines some general requirements for IPng in selected
+areas.  This memo provides information for the Internet community.  This
+memo does not specify an Internet standard of any kind.
+
+
+1670    Heagerty     Aug 94   Input to IPng Engineering Considerations
+
+This white paper expresses some personal opinions on IPng engineering
+considerations, based on experience with DECnet Phase V transition.  It
+suggests breaking down the IPng decisions and transition tasks into
+smaller parts so they can be tackled early by the relevant experts.
+This memo provides information for the Internet community.  This memo
+does not specify an Internet standard of any kind.
+
+
+1669    Curran       Aug 94   Market Viability as a IPng Criteria
+
+"Viability in the Marketplace" is an important requirement for any IPng
+candidate and this paper is an attempt to summarize some important
+factors in determing market viability of IPng proposals.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1668    Estrin       Aug 94   Unified Routing Requirements for IPng
+
+The document provides requirements on the IPng from the perspective of
+the Unified Routing Architecture, as described in RFC 1322.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 7]
+
+RFC 1699                  Summary of 1600-1699              January 1997
+
+
+1667    Symington    Aug 94   Modeling and Simulation Requirements for
+                              IPng
+
+This white paper summarizes the Distributed Interactive Simulation
+environment that is under development, with regard to its real-time
+nature, scope and magnitude of networking requirements.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1666    Kielczewski  Aug 94   Definitions of Managed Objects
+                              for SNA NAUs using SMIv2
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it defines objects for managing the configuration,
+monitoring and control of Physical Units (PUs) and Logical Units (LUs)
+in an SNA environment.  [STANDARDS-TRACK]
+
+
+1665    Kielczewski  Jul 94   Definitions of Managed Objects
+                              for SNA NAUs using SMIv2
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it defines objects for managing the configuration,
+monitoring and control of Physical Units (PUs) and Logical Units (LUs)
+in an SNA environment.  [STANDARDS-TRACK]
+
+
+1664    Allocchio    Aug 94   Using the Internet DNS to Distribute
+                              RFC1327 Mail Address Mapping Tables
+
+This memo defines how to store in the Internet Domain Name System the
+mapping information needed by e-mail gateways and other tools to map
+RFC822 domain names into X.400 O/R names and vice versa.  This memo
+defines an Experimental Protocol for the Internet community.
+
+
+1663    Rand         Jul 94   PPP Reliable Transmission
+
+This document defines a method for negotiating and using Numbered-Mode,
+as defined by ISO 7776 [2], to provide a reliable serial link.
+[STANDARDS-TRACK]
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 8]
+
+RFC 1699                  Summary of 1600-1699              January 1997
+
+
+1662    Simpson      Jul 94   PPP in HDLC-Like Framing
+
+This document describes the use of HDLC-like framing for PPP
+encapsulated packets.  [STANDARDS-TRACK]
+
+
+1661    Simpson      Jul 94   The Ponit-to-Point Protocol (PPP)
+
+This document defines the PPP organization and methodology, and the PPP
+encapsulation, together with an extensible option negotiation mechanism
+which is able to negotiate a rich assortment of configuration parameters
+and provides additional management functions.  [STANDARDS-TRACK]
+
+
+1660    Stewart      Jul 94   Definitions of Managed Objects for
+                              Parallel-printer-like Hardware Devices
+                              using SMIv2
+
+This memo defines an extension to the Management Information Base (MIB)
+for use with network management protocols in the Internet community.  In
+particular, it defines objects for the management of Parallel-printer-
+like devices.  [STANDARDS-TRACK]
+
+
+1659    Stewart      Jul 94   Definitions of Managed Objects for
+                              RS-232-like Hardware Devices using SMIv2
+
+This memo defines an extension to the Management Information Base (MIB)
+for use with network management protocols in the Internet community.  In
+particular, it defines objects for the management of RS-232-like
+devices. [STANDARDS-TRACK]
+
+
+1658    Stewart      Jul 94   Definitions of Managed Objects for
+                              Character Stream Devices using SMIv2
+
+This memo defines an extension to the Management Information Base (MIB)
+for use with network management protocols in the Internet community.  In
+particular, it defines objects for the management of character stream
+devices.  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 9]
+
+RFC 1699                  Summary of 1600-1699              January 1997
+
+
+1657    Willis       Jul 94   Definitions of Managed Objects for the
+                              Fourth Version of the Border Gateway
+                              Protocol (BGP-4) using SMIv2
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it describes managed objects used for managing the Border
+Gateway Protocol Version 4 or lower [1, 2].  [STANDARDS-TRACK]
+
+
+1656    Traina       Jul 94   BGP-4 Protocol Document Roadmap and
+                              Implementation Experience
+
+Border Gateway Protocol v4 (BGP-4) [1] is an inter-Autonomous System
+routing protocol.  It is built on experience gained with BGP as defined
+in RFC-1267 [2] and BGP usage in the connected Internet as described in
+RFC-1268 [3].  This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+1655    Rekhter      Jul 94   Application of the Border Gateway
+                              Protocol in the Internet
+
+This document, together with its companion document, "A Border Gateway
+Protocol 4 (BGP-4)", define an inter-autonomous system routing protocol
+for the Internet.  [STANDARDS-TRACK]
+
+
+1654    Rekhter      Jul 94   A Border Gateway Protocol 4 (BGP-4)
+
+This document defines an inter-autonomous system routing protocol for
+the Internet.  [STANDARDS-TRACK]
+
+
+1653    Klensin      Jul 94   SMTP Service Extension for Message Size
+                              Declaration
+
+This memo defines an extension to the SMTP service whereby an SMTP
+client and server may interact to give the server an opportunity to
+decline to accept a message (perhaps temporarily) based on the client's
+estimate of the message size.  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 10]
+
+RFC 1699                  Summary of 1600-1699              January 1997
+
+
+1652    Klensin      Jul 94   SMTP Service Extension for
+                              8bit-MIMEtransport
+
+This memo defines an extension to the SMTP service whereby an SMTP
+content body consisting of text containing octets outside of the US-
+ASCII octet range (hex 00-7F) may be relayed using SMTP.  [STANDARDS-
+TRACK]
+
+
+1651    Klensin      Jul 94   SMTP Service Extensions
+
+This memo defines a framework for extending the SMTP service by defining
+a means whereby a server SMTP can inform a client SMTP as to the service
+extensions it supports.  [STANDARDS-TRACK]
+
+
+1650    Kastenholz   Aug 94   Definitions of Managed Objects for the
+                              Ethernet-like Interface Types using
+                              SMIv2
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it defines objects for managing ethernet-like objects.
+[STANDARDS-TRACK]
+
+
+1649    Hagens       Jul 94   Operational Requirements for X.400
+                              Management Domains in the GO-MHS
+                              Community
+
+The goal of this document is to unite regionally operated X.400 services
+on the various continents into one GO-MHS Community (as seen from an
+end-user's point of view).  This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+1648    Cargille     Jul 94   Postmaster Convention for X.400
+                              Operations
+
+This paper extends this concept to X.400 mail domains which have
+registered RFC 1327 mapping rules, and which therefore appear to have
+normal RFC822-style addresses.  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 11]
+
+RFC 1699                  Summary of 1600-1699              January 1997
+
+
+1647    Kelly        Jul 94   TN3270 Enhancements
+
+This document describes a protocol that more fully supports 3270 devices
+than do the existing tn3270 practices.  [STANDARDS-TRACK]
+
+
+1646    Graves       Jul 94   TN3270 Extensions for LUname and
+                              Printer Selection
+
+This document describes protocol extensions to TN3270.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1645    Gwinn        Jul 94   Simple Network Paging Protocol -
+                              Version 2
+
+This RFC suggests a simple way for delivering both alphanumeric and
+numeric pages (one-way) to radio paging terminals.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+1644    Braden       Jul 94   T/TCP -- TCP Extensions for Transactions
+                              Functional Specification
+
+This memo specifies T/TCP, an experimental TCP extension for efficient
+transaction-oriented (request/response) service.  This memo describes an
+Experimental Protocol for the Internet community.
+
+
+1643    Kastenholz   Jul 94   Definitions of Managed Objects for the
+                              Ethernet-like Interface Types
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it defines objects for managing ethernet-like objects.
+[STANDARDS-TRACK]
+
+
+1642    Goldsmith    Jul 94   A Mail-Safe Transformation Format of
+                              Unicode
+
+This document describes a new transformation format of Unicode that
+contains only 7-bit ASCII characters and is intended to be readable by
+humans in the limiting case that the document consists of characters
+from the US-ASCII repertoire.  This memo defines an Experimental
+Protocol for the Internet community.
+
+
+
+Elliott                      Informational                     [Page 12]
+
+RFC 1699                  Summary of 1600-1699              January 1997
+
+
+1641    Goldsmith    Jul 94   Using Unicode with MIME
+
+This document specifies the usage of Unicode within MIME.  This memo
+defines an Experimental Protocol for the Internet community.
+
+
+1640    Crocker      Jun 94   The Process for Organization of Internet
+                              Standards Working Group (POISED)
+
+This report, originally prepared in January 1993 provides a summary of
+the POISED WG, starting from the events leading to the formation of the
+WG to the end of 1992.  This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+1639    Piscitello   Jun 94   FTP Operation Over Big Address Records
+                              (FOOBAR)
+
+This RFC specifies a method for assigning addresses other than 32-bit
+IPv4 addresses to data ports through the specification of a "long Port
+(LPRT)" command and "Long Passive (LPSV)" reply, each having as its
+argument a <long-host-port>, which allows for additional address
+families, variable length network addresses and variable length port
+numbers.  This memo defines an Experimental Protocol for the Internet
+community.
+
+
+1638    Baker        Jun 94   PPP Bridging Control Protocol (BCP)
+
+This document defines the Network Control Protocol for establishing and
+configuring Remote Bridging for PPP links.  [STANDARDS-TRACK]
+
+
+1637    Manning      Jun 94   DNS NSAP Resource Records
+
+This document defines the format of one new Resource Record (RR) for the
+DNS for domain name-to-NSAP mapping.  This memo defines an Experimental
+Protocol for the Internet community.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 13]
+
+RFC 1699                  Summary of 1600-1699              January 1997
+
+
+1636    Braden       Jun 94   Report of IAB Workshop on Security in
+                              the Internet Architecture
+
+This document is a report on an Internet architecture workshop,
+initiated by the IAB and held at USC Information Sciences Institute on
+February 8-10, 1994.  This workshop generally focused on security issues
+in the Internet architecture.  This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+1635    Deutsch      May 94   How to Use Anonymous FTP
+
+This document provides information for the novice Internet user about
+using the File Transfer Protocol (FTP).  It explains what FTP is, what
+anonymous FTP is, and what an anonymous FTP archive site is.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1634    Allen        May 94   Novell IPX Over Various WAN Media
+                              (IPXWAN)
+
+This document describes how Novell IPX operates over various WAN media.
+Specifically, it describes the common "IPX WAN" protocol Novell uses to
+exchange necessary router to router information prior to exchanging
+standard IPX routing information and traffic over WAN datalinks.  This
+memo provides information for the Internet community.  This memo does
+not specify an Internet standard of any kind.
+
+
+1633    Braden       Jun 94   Integrated Services in the Internet
+                              Architecture: an Overview
+
+This memo discusses a proposed extension to the Internet architecture
+and protocols to provide integrated services, i.e., to support real-time
+as well as the current non-real-time service of IP.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 14]
+
+RFC 1699                  Summary of 1600-1699              January 1997
+
+
+1632    Getchell     May 94   A Revised Catalog of Available X.500
+                              Implementations
+
+This document is the result of a survey that gathered new or updated
+descriptions of currently available implementations of X.500, including
+commercial products and openly available offerings. This document is a
+revision of RFC 1292.  This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+1631    Egevang      May 94   The IP Network Address Translator (NAT)
+
+This memo proposes another short-term solution, address reuse, that
+complements CIDR or even makes it unnecessary. The address reuse
+solution is to place Network Address Translators (NAT) at the borders of
+stub domains.  This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+1630    Berners-Lee  Jun 94   Universal Resource Identifiers in WWW
+
+This document defines the syntax used by the World-Wide Web initiative
+to encode the names and addresses of objects on the Internet.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1629    Colella      May 94   Guidelines for OSI NSAP Allocation in
+                              the Internet
+
+This paper provides guidelines for allocating NSAP addresses in the
+Internet.  The guidelines provided in this paper have been the basis for
+initial deployment of CLNP in the Internet, and have proven very
+valuable both as an aid to scaling of CLNP routing, and for address
+administration.  [STANDARDS-TRACK]
+
+
+1628    Case         May 94   UPS Management Information Base
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it defines objects for managing uninterruptible power supply
+(UPS) systems.  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 15]
+
+RFC 1699                  Summary of 1600-1699              January 1997
+
+
+1627    Lear         Jul 94   Network 10 Considered Harmful
+                              (Some Practices Shouldn't be Codified)
+
+This document restates the arguments for maintaining a unique address
+space.  Concerns for Internet architecture and operations, as well as
+IETF procedure, are explored.  This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+1626    Atkinson     May 94   Default IP MTU for use over ATM AAL5
+
+There are a number of good reasons to have a reasonably large default
+MTU value for IP over ATM AAL5.  This paper presents the default IP MIU
+for use over ATM AAL5.  [STANDARDS-TRACK]
+
+
+1625    St. Pierre   Jun 94   WAIS over Z39.50-1988
+
+The purpose of this memo is to initiate a discussion for a migration
+path of the WAIS technology from Z39.50-1988 Information Retrieval
+Service Definitions and Protocol Specification for Library Applications
+[1] to Z39.50-1992 [2] and then to Z39.50-1994 [3].  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+1624    Rijsinghani  May 94   Computation of the Internet Checksum
+                              via Incremental Update
+
+This memo describes an updated technique for incremental computation of
+the standard Internet checksum.  It updates the method described in RFC
+1141.  This memo provides information for the Internet community.  This
+memo does not specify an Internet standard of any kind.
+
+
+1623    Kastenholz   May 94   Definitions of Managed Objects for the
+                              Ethernet-like Interface Types
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it defines objects for managing ethernet-like objects.
+[STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 16]
+
+RFC 1699                  Summary of 1600-1699              January 1997
+
+
+1622    Francis      May 94   Pip Header Processing
+
+The purpose of this RFC and the companion RFC "Pip Near-term
+Architecture" are to record the ideas (good and bad) of Pip.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1621    Francis      May 94   Pip Near-term Architecture
+
+The purpose of this RFC and the companion RFC "Pip Header Processing"
+are to record the ideas (good and bad) of Pip.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+1620    Braden       May 94   Internet Architecture Extensions for
+                              Shared Media
+
+This memo discusses alternative approaches to extending the Internet
+architecture to eliminate some or all unnecessary hops.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1619    Simpson      May 94   PPP over SONET/SDH
+
+This document describes the use of PPP over Synchronous Optical Network
+(SONET) and Synchronous Digital Heirarchy (SDH) circuits.  [STANDARDS-
+TRACK]
+
+
+1618    Simpson      May 94   PPP over ISDN
+
+This document describes the use of PPP over Integrated Services Digital
+Network (ISDN) switched circuits.  [STANDARDS-TRACK]
+
+
+1617    Barker       May 94   Naming and Structuring Guidelines for
+                              X.500 Directory Pilots
+
+This document defines a number of naming and structuring guidelines
+focused on White Pages usage. Alignment to these guidelines is
+recommended for directory pilots.  This memo provides information for
+the Internet community.  This memo does not specify an Internet standard
+of any kind.
+
+
+
+
+
+Elliott                      Informational                     [Page 17]
+
+RFC 1699                  Summary of 1600-1699              January 1997
+
+
+1616    RARE WG-MSG  May 94   A report by the RARE Task Force on
+                              X.400(1988) of the RARE Working Group on
+                              Mail & Messaging
+
+The report documents the results of a task force on X.400(1988)
+deployment of the RARE Mails and Messaging Work Group during the period
+from November 1992 until October 1993.  This memo provides information
+for the Internet community.  This memo does not specify an Internet
+standard of any kind.
+
+
+1615    Houttuin     May 94   Migrating from X.400(84) to X.400(88)
+
+This document compares X.400(88) to X.400(84) and describes what
+problems can be anticipated in the migration, especially considering the
+migration from the existing X.400(84) infrastructure created by the
+COSINE MHS project to an X.400(88) infrastructure.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+1614    Adie         May 94   Network Access to Multimedia Information
+
+This report summarises the requirements of research and academic network
+users for network access to multimedia information.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+1613    Foster       May 94   cisco Systems X.25 over TCP (XOT)
+
+This memo documents a method of sending X.25 packets over IP internets
+by encapsulating the X.25 Packet Level in TCP packets.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1612    Austein      May 94   DNS Resolver MIB Extensions
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it describes a set of extensions which instrument DNS
+resolver functions.  This memo was produced by the DNS working group.
+[STANDARDS-TRACK]
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 18]
+
+RFC 1699                  Summary of 1600-1699              January 1997
+
+
+1611    Austein      May 94   DNS Server MIB Extensions
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it describes a set of extensions which instrument DNS name
+server functions.  This memo was produced by the DNS working group.
+[STANDARDS-TRACK]
+
+
+1610    I.A.B        Jul 94   INTERNET OFFICIAL PROTOCOL STANDARDS
+
+This memo describes the state of standardization of protocols used in
+the Internet as determined by the Internet Architecture Board (IAB).
+[STANDARDS-TRACK]
+
+
+1609    Mansfield    Mar 94   Charting Networks in the X.500 Directory
+
+This document presents a model in which a communication network with all
+its related details and descriptions can be represented in the X.500
+Directory.  This memo defines an Experimental Protocol for the Internet
+community.
+
+
+1608    Johannsen    Mar 94   Representing IP Information in the X.500
+                              Directory
+
+This document describes the objects necessary to include information
+about IP networks and IP numbers in the X.500 Directory. It extends the
+work "Charting networks in the X.500 Directory" [1] where a general
+framework is presented for representing networks in the Directory by
+applying it to IP networks.  This memo defines an Experimental Protocol
+for the Internet community.
+
+
+1607    Cerf         Apr 94   A VIEW FROM THE 21ST CENTURY
+
+This document is a composition of letters discussing a possible future.
+This memo provides information for the Internet community.  This memo
+does not specify an Internet standard of any kind.
+
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 19]
+
+RFC 1699                  Summary of 1600-1699              January 1997
+
+
+1606    Onion        Apr 94   A Historical Perspective On The Usage Of
+                              IP Version 9
+
+This paper reviews the usages of the old IP version protocol. It
+considers some of its successes and its failures.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+1605    Shakespeare  Apr 94   SONET to Sonnet Translation
+
+Because Synchronous Optical Network (SONET) transmits data in frames of
+bytes, it is fairly easy to envision ways to compress SONET frames to
+yield higher bandwidth over a given fiber optic link.  This memo
+describes a particular method, SONET Over Novel English Translation
+(SONNET).  This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+1604    Brown        Mar 94   Definitions of Managed Objects
+                              for Frame Relay Service
+
+This memo defines an extension to the Management Information Base (MIB)
+for use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing the Frame Relay Service.
+[STANDARDS-TRACK]
+
+
+1603    Huizer       Mar 94   IETF Working Group
+                              Guidelines and Procedures
+
+This document describes the guidelines and procedures for formation and
+operation of IETF working groups. It describes the formal relationship
+between IETF participants WG and the Internet Engineering Steering Group
+(IESG).  This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+1602    I.A.B.       Mar 94   The Internet Standards Process --
+                              Revision 2
+
+This document is a revision of RFC 1310, which defined the official
+procedures for creating and documenting Internet Standards.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+
+
+
+
+Elliott                      Informational                     [Page 20]
+
+RFC 1699                  Summary of 1600-1699              January 1997
+
+
+1601    Huitema      Mar 94   Charter of the Internet Architecture
+                              Board (IAB)
+
+This memo documents the composition, selection, roles, and organization
+of the Internet Architecture Board and its subsidiary organizations.
+This memo provides information for the Internet community.  This memo
+does not specify an Internet standard of any kind.
+
+
+1600    I.A.B.       Mar 94   INTERNET OFFICIAL PROTOCOL STANDARDS
+
+This memo describes the state of standardization of protocols used in
+the Internet as determined by the Internet Architecture Board (IAB).
+[STANDARDS-TRACK]
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Author's Address
+
+   Josh Elliott
+   University of Southern California
+   Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone:  (310) 822-1511
+
+   EMail: elliott@isi.edu
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 21]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1699.txt](<www.ietf.org/rfc/rfc1699.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
