### PR TITLE
Archive rfc170.txt

### DIFF
--- a/www.ietf.org/rfc/rfc170.txt
+++ b/www.ietf.org/rfc/rfc170.txt
@@ -1,0 +1,339 @@
+
+
+
+
+
+
+RFC List by Number        1 June 1971         RFC 170           NIC 6790
+
+
+
+1st Author  Title                               Date          NIC    RFC
+
+Crocker     HOST Software                   7 April 1969      4687    1
+Duvall      HOST Software                   9 April 1969      4688    2
+Crocker     Documentation Conventions       9 April 1969      4689    3
+Shapiro     Network Timetable               24 March 1969     4690    4
+Rulifson    DEL                             2 June 1969       4691    5
+Crocker     Conversation with Rob Kahn      10 April 1969     4692    6
+Deloche     HOST-IMP Interface              May 1969          4693    7
+Deloche     ARPA Network Functional
+            Specifications                  5 May 1969        4694    8
+Deloche     HOST Software                   1 May 1969        4695    9
+Crocker     Documentation Conventions       29 July 1969      4696    10
+Deloche     Implementation of the HOST-HOST
+            Software Procedures In GORDO    1 August 1969     4718    11
+Wingfield   IMP-HOST Interface Flow
+            Diagrams                        26 August 1969    4697    12
+Cerf        Referring to NWG/RFC: 11        20 August 1969    4698    13
+  (No RFC by this number ever issued)                                 14
+Carr        Network Subsystem for
+            Time-sharing HOSTS              26 September 1969 4754    15
+Crocker     M.I.T. (Address)                27 August 1969    4719    16
+Kreznar     Some questions Re: HOST-IMP
+            Protocol                        27 August 1969    4699    17
+Cerf        (Use of links 1 and 2)          September 1969    4720    18
+Kreznar     Two Protocol Suggestions to
+            Reduce Congestion at Swap-
+            Bound Nodes                     7 October 1969    4721    19
+Cerf        AXCII Format for Network
+            Interchange                     16 October 1969   4722    20
+Cerf        /report of Network meeting/     17 October 1969   4723    21
+Cerf        HOST-HOST Control Message
+            Formats                         17 October 1969   4724    22
+Gregg       Transmission of Multiple
+            Control Messages                16 October 1969   4725    23
+Crocker     Documentation Conventions       21 November 1969  4726    24
+Crocker     No High Link Numbers            30 October  1969  4727    25
+   (No RFC by this number ever issued)                                26
+Crocker     Documentation Conventions       9 December 1969   4729    27
+English     Time Standards                  13 January 1970   4730    28
+Kahn        Note in Response to Bill
+            English's Request For Comments  19 January 1970   4731    29
+Crocker     Documentation Conventions       4 February 1970   4732    30
+Bobrow      Binary Message Forms in
+
+
+
+                                                                [Page 1]
+
+RFC List By Number              RFC 170                         NIC 6790
+
+
+            Computer Network                February 1968     4733    31
+Veader      Connecting M.I.T. Computers
+            to the ARPA Computer-to-
+            Computer                        31 January 1969   4734    32
+Crocker     New HOST-HOST Protocol          12 February 1970  4735    33
+English     Some Brief Preliminary Notes
+            on the ARC Clock                26 February 1970  4736    34
+Crocker     Network Meeting                 3 March 1970      4737    35
+Crocker     Protocol Notes                  16 March 1970     4738    36
+Crocker     Network Meeting Epilogue, etc.  20 March 1970     4739    37
+Wolfe       Comments on Network Protocol
+            from NWG/RFC 36.                20 March 1970     4740    38
+Harslem     Comments on Protocol
+            Re: NWG/RFC 36                  25 March 1970     4741    39
+Harslem     More Comments on the Forth-
+            Coming Protocol                 27 March 1970     4742    40
+Melvin      IMP-IMP Teletype Communication  30 March 1970     4743    41
+Ancona      Message Data Types              31 March 1970     4744    42
+Nemeth      Proposed Meeting                8 April 1970      4745    43
+Shoshani    Comments on NWG/RFC 33 and 36   10 April 1970     4746    44
+Postel      New Protocol is Coming          14 April 1970     4747    45
+Meyer       ARPA Network Protocol Notes     17 April 1970     4748    46
+Postel      BBN's Comments on NWG/RFC 33    20 April 1970     4749    47
+Postel      A Possible Protocol Plateau     21 April 1970     4750    48
+Meyer       Conversations with Steve
+            Crocker (UCLA)                  25 April 1970     4728    49
+Harslem     Comments on the Meyer Proposal  30 April 1970     4751    50
+Elie        Proposal for A Network
+            Interchange Language            4 May 1970        4752    51
+Postel      Updated Distribution List       1 July 1970       4753    52
+Crocker     An Official Protocol Mechanism  9 June 1970       4755    53
+Crocker     An official Protocol Proffering 18 June 1970      4756    54
+Newkirk     A Prototypical Implementation
+            of the NCP                      19 June 1970      4757    55
+Belove      Third Level Protocol            June 1970         4758    56
+Kraley      Thoughts and Reflections on
+            NWG/RFC 54                      19 June 1970      4759    57
+Skinner     Logical Message Synchronization 26 June 1970      4760    58
+Meyer       Flow Control - Fixed Versus
+            Demand Allocation               27 June 1970      4761    59
+Kalin       A Simplified NCP Protocol       13 July 1970      4762    60
+Walden      A Note on Interprocess
+            Communication in A Resource
+            Sharing                         17 July 1970      4761    61
+Walden      A System for Interprocess
+            Communication in A Resource
+            Sharing                         3 August 1970     4762    62
+Cerf        Belated Network Meeting Report  31 July 1970      4763    63
+
+
+
+                                                                [Page 2]
+
+RFC List By Number              RFC 170                         NIC 6790
+
+
+Elie        Getting Rid of Marking          (Undated)         4764    64
+Walden      Comments on Host-Host Protocol
+            Document No. 1 (By S. Crocker)  29 August 1970    4765    65
+Crocker     Third Level Ideas and Other
+            Noise                           26 August 1970    5409    66
+Crowther    Proposed Change to Host/IMP
+            Spec to Eliminate Marking       (Undated)         5410    67
+Elie        Comments on Memory Allocation
+            Control Commands (CEASE, ALL,
+            GVB)                            31 August 1970   5411     68
+Bhushan     Distribution List Change For
+            MIT                             22 Sept    1970  5412     69
+Crocker     A Note on Padding               15 October 1970  5413     70
+Schipper    Reallocation in Case of Input
+            Error                           25 Sept     1970 5414     71
+Bressler    Proposed Moratorium on Changes
+            to Network Protocol             26 Sept     1970 5415     72
+Crocker     Response to NWG/RFC 67          25 Sept     1970 5416     73
+White       Specifications for Network Use
+            of the UCSB On-Line Systems     16 October 1970  5417     74
+Crocker     Network Meeting                 14 October 1970  5418     75
+Bouknight   Connection-By Name: User
+            Oriented Protocol               28 October 1970  5180     76
+Grossman    Syntax and Semantics for the
+            Terminal User Control Language
+            for                             (Undated)        5419  ENC76
+Postel      Network Meeting Report          (Undated)        5604     77
+Harslem     NCP Status Report: USCB/RAND    November 1970    5199     78
+Meyer       Logger Protocol Error           16 November 1970 5601     79
+Harslem     Protocols and Data Formats      1 December 1970  5608     80
+Bouknight   Request for Reference
+            Information                     3 December 1970  5609     81
+Meyer       Network Meeting Notes           9 December 1970  5619     82
+Anderson    Language-Machine for Data
+            Reconfiguration                 18 December 1970 5621     83
+North       List of NWG/RFC's 1-80          23 December 1970 5620     84
+Crocker     Network Working Group Meeting   5 January 1971   5624     85
+Crocker     Proposal for a Network Standard
+            Format for Data Streams to      5 January 1971   5631     86
+Vezza       Topic for Discussion at the
+            Next Network Working Group
+            Meeting                         12 January 1971  5632     87
+Braden      NETRJS--A Third Level Protocol
+            for Remote Job Entry            13 January 1971  5668     88
+Metcalfe    Some Historic Moments in
+            Networking                      19 January 1971  5697     89
+Braden      CN As a Network Service Center  25 January 1971  5707     90
+Realy       A Proposed User-User Protocol   27 December 1970 5708     91
+
+
+
+                                                                [Page 3]
+
+RFC List By Number              RFC 170                         NIC 6790
+
+
+         /No RFC By This Number Ever Issued/                          92
+Mckenzie    Initial Connection Protocol     27 January 1971  5721     93
+Harslem     Some Thoughts on Network
+            Graphics                        3 February 1971  5725     94
+Crocker     Distribution of NWG/RFC's
+            Through the NIC                 4 February 1971  5731     95
+Watson      An Interactive Network
+            Experiment ot Study Modes of
+            Access to the                   12 February 1971 5739     96
+Melvin      A First Cut at a Proposed Telnet
+            Protocol                        15 February 1971 5740     97
+Meyer       Logger Protocol Proposol        11 February 1971 5744     98
+Karp        Network Meeting                 22 February 1971 5758     99
+Karp        Categorization and Guide to
+            NWG/RFC's                       26 February 1971 5761    100
+Watson      Notes on the Network Working
+            Group Meeting (Urbana,Illinois) 23 February 1971 5762    101
+Crocker     Output of the Host/Host Protocol
+            Glitch Cleaning Committee       22-23 Feb 1971   5763    102
+Kalin       Implementation of Interrupt
+            Keys                            24 February 1971 5764    103
+Postel      Link 191                        25 February 1971 5768    104
+White       Network Specifications for Remote
+            Job Entry and Remote Job        22 March 1971    5775    105
+O'Sullivan  User/Server Site Protocol       3 March 1971     5776    106
+Bresaler    Output of the Host-Host Protocol
+            Glitch Cleaning Committee       23 March 1971    5806    107
+Watson      Attendance List at the Urbana
+            NWG Meeting, February 17-19,
+            1971                            25 March 1971    5807    108
+Winett      Level III Server Protocol for
+            the Lincoln Laboratory 360/67
+            Host                            24 March 1971    5808    109
+Winett      Conventions for Using an IBM 2741
+            Terminal as a User Console for  25 March 1971    5809    110
+Crocker     Pressure from the Chairman      31 March 1971    5814    111
+O'Sullivan  User/Server Site Protocol;
+            Network Host Questionnaire      1 April 1971     5816    112
+Harslem     Network Activity Report; UCSB--
+            RAND                            5 April 1971     5820    113
+Bnushan     A file Transfer Protocol        16 April 1971    5823    114
+Watson      Some Network Information Center
+            Policies on Handling Documen-
+            tation                          16 April 1971    5822    115
+Crocker     Structure of the May NWG Mtg.   12 April 1971    5825    116
+Wong        Some Comments of the Official
+            Protocol                        7 April 1971     5826    117
+Watson      Recommendations for Facility
+
+
+
+                                                                [Page 4]
+
+RFC List By Number              RFC 170                         NIC 6790
+
+
+            Documentation                   16 April 1971    5830    118
+Krilanovich Network Fortran Subprograms     16 April 1971    5831    119
+Krilanovich Network PLI Subprograms         16 April 1971    5832    120
+Krilanovich Network On-Line Operators       16 April 1971    5833    121
+White       Network Specifications for UCSB's
+            Simple-Minded File System       26 April 1971    5834    122
+Crocker     A proferred Official ICP        20 April 1971    5837    123
+Melvin      Typographical Error in RFC 107  19 April 1971    5840    124
+McConnell   Response to RFC 86, Proposal for
+            Network Standard Format for a   18 April 1971    5841    125
+McConnell   Ames Graphics Facilities at Ames
+            Research Center                 18 April 1971    5842    126
+Postel      Comments on RFC 107             20 April 1971    5843    127
+Postel      Bytes                           21 April 1971    5844    128
+Harslem     A request for Comments on Socket
+            Name Structure                  22 April 1971    5845    129
+Heafner     Response to RFC 111 (Pressure
+            From the Chairman)              22 April 1971    5848    130
+Harslem     Response to RFC 116 (May NWG
+            Meeting)                        22 April 1971    5849    131
+White       Typographical Error in RFC 107  28 April 1971    6708    132
+Sundberg    File Transfer and Recovery      27 April 1971    6710    133
+Vezza       Network Graphics Meeting        29 April 1971    6711    134
+Hathaway    Response to NWG/RFC 110         29 April 1971    6712    135
+Kahn        Host Accounting and Administrative
+            Procedures                      29 April 1971    6713    136
+O'Sullivan  TELNET Protocol -- A Proposed
+            Document                        30 April 1971    6714    137
+O'Sullivan  TELNET Protocol -- A Proposed
+            Document (rev.)                 8 May 1971      6703 rev 137
+Anderson    Status Report on Proposed Data
+            Reconfiguration Service         28 April 1971    6715    138
+Crocker     Agenda for the May NWG Meeting  4 May 1971       6725    140
+Harslem     Comments on RFC 114 ( A File
+            Transfer Protocol)              29 April 1971    6726    141
+Kline       Time-out Mechanism in the Host-
+            Host Protocol                   3 May 1971       6727    142
+Naylor      Regarding Proferred Official
+            ICP                             3 May 1971       6728    143
+Shoshani    Data Sharing on Computer
+            Networks                        30 April 1971    6729    144
+Postel      Initial Connection Protocol
+            Control Commands                4 May 1971       6739    145
+Karp        Views on Issues Relevant to
+            Data Sharing on Computer
+            Networks                        12 May 1971      6742    146
+Winett      The Definition of a Socket      7 May 1971       6750    147
+Bhushan     Comments on RFC 123             10 May 1971      6751    148
+
+
+
+                                                                [Page 5]
+
+RFC List By Number              RFC 170                         NIC 6790
+
+
+Crocker     The best Laid Plans...          10 May 1971      6752    149
+Kalin       The Use of IPC Facilities --
+            A Working Paper                 5 May 1971       6754    150
+Shoshani    Comments on a Proferred Official
+            ICP (RFCs 123, 127)             10 May 1971      6755    151
+Wilber      SRI Artificial Intelligence
+            Status Report                   10 May 1971      6756    152
+Melvin      SRI ARC-NIC Status              15 May 1971      6758    153
+Crocker     Exposition Style                12 May 1971      6759    154
+North       ARPA Network Mailing Lists      May 1971         6760    155
+Bouknight   Status of the Illinois Site
+            (Response to RFC 116)           26 April 1971    6761    156
+Cerf        Invitation to the Second
+            Symposium on Problems in the
+            Optimization                    12 May 1971      6762    157
+O'Sullivan  TELNET Protocol -- A Proposed
+            Document                        19 May 1971      6768    158
+            / not yet issued /                                       159
+            RFC brief List -- Title or Partial
+            Title                           16 May 1971      6771    160
+Shoshani    A Solution to the Race Condition
+            in the ICP                      19 May 1971      6772    161
+Kampe       NETBUGGER3                      22 May 1971      6774    162
+Cerf        Data Tranfer Protocols          19 May 1971      6775    163
+Heafner     Minutes of Network Working Group
+            Meeting, 5/16 through 5/19/71   25 May 1971      6778    164
+Postel      A Proferred Official Initial
+            Connection Protocol             25 May 1971      6779    165
+
+    Items below this point do not appear in other 1 June 1971 listings
+
+Anderson    Data Reconfiguration Service --
+            An Implementation Specification 25 May 1971      6780    166
+Bhushan     Socket Conventions Reconsidered 24 May 1971      6784    167
+            ARPA Network Mailing Lists      26 May 1971      6785    168
+Crocker     Computer Networks -- IEEE
+            Computer Society Workshop       27 May 1971      6789    169
+            RFC LIST BY Number              1 June 1971      6790    170
+
+
+       [ This RFC was put into machine readable form for entry ]
+        [ into the online RFC archives by Jeff McClellan 7/97 ]
+
+
+
+
+
+
+
+
+
+                                                                [Page 6]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc170.txt](<www.ietf.org/rfc/rfc170.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
