### PR TITLE
Archive rfc1700.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1700.txt
+++ b/www.ietf.org/rfc/rfc1700.txt
@@ -1,0 +1,12883 @@
+
+
+
+
+
+
+Network Working Group                                        J. Reynolds
+Request for Comments: 1700                                     J. Postel
+STD: 2                                                               ISI
+Obsoletes RFCs: 1340, 1060, 1010, 990, 960,                 October 1994
+943, 923, 900, 870, 820, 790, 776, 770,
+762, 758,755, 750, 739, 604, 503, 433, 349
+Obsoletes IENs: 127, 117, 93
+Category: Standards Track
+
+
+                            ASSIGNED NUMBERS
+
+Status of this Memo
+
+   This memo is a status report on the parameters (i.e., numbers and
+   keywords) used in protocols in the Internet community.  Distribution
+   of this memo is unlimited.
+
+OVERVIEW
+
+This RFC is a snapshot of the ongoing process of the assignment of
+protocol parameters for the Internet protocol suite.  To make the
+current information readily available the assignments are kept up-to-
+date in a set of online text files.  This RFC has been assembled by
+catinating these files together with a minimum of formatting "glue".
+The authors appologize for the somewhat rougher formatting and style
+than is typical of most RFCs.
+
+We expect that various readers will notice specific items that should be
+corrected.  Please send any specific corrections via email to
+<iana@isi.edu>.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                               [Page 1]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+INTRODUCTION
+
+The files in this directory document the currently assigned values for
+several series of numbers used in network protocol implementations.
+
+        ftp://ftp.isi.edu/in-notes/iana/assignments
+
+The Internet Assigned Numbers Authority (IANA) is the central
+coordinator for the assignment of unique parameter values for Internet
+protocols.  The IANA is chartered by the Internet Society (ISOC) and
+the Federal Network Council (FNC) to act as the clearinghouse to
+assign and coordinate the use of numerous Internet protocol
+parameters.
+
+The Internet protocol suite, as defined by the Internet Engineering
+Task Force (IETF) and its steering group (the IESG), contains numerous
+parameters, such as internet addresses, domain names, autonomous
+system numbers (used in some routing protocols), protocol numbers,
+port numbers, management information base object identifiers,
+including private enterprise numbers, and many others.
+
+The common use of the Internet protocols by the Internet community
+requires that the particular values used in these parameter fields be
+assigned uniquely.  It is the task of the IANA to make those unique
+assignments as requested and to maintain a registry of the currently
+assigned values.
+
+Requests for parameter assignments (protocols, ports, etc.) should be
+sent to <iana@isi.edu>.
+
+Requests for SNMP network management private enterprise number
+assignments should be sent to <iana-mib@isi.edu>.
+
+The IANA is located at and operated by the Information Sciences
+Institute (ISI) of the University of Southern California (USC).
+
+If you are developing a protocol or application that will require the
+use of a link, socket, port, protocol, etc., please contact the IANA
+to receive a number assignment.
+
+        Joyce K. Reynolds
+        Internet Assigned Numbers Authority
+        USC - Information Sciences Institute
+        4676 Admiralty Way
+        Marina del Rey, California  90292-6695
+
+        Electronic mail: IANA@ISI.EDU
+        Phone: +1 310-822-1511
+
+
+
+Reynolds & Postel                                               [Page 2]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+Most of the protocols are documented in the RFC series of notes.  Some
+of the items listed are undocumented.  Further information on
+protocols can be found in the memo, "Internet Official Protocol
+Standards" (STD 1).
+
+Data Notations
+
+The convention in the documentation of Internet Protocols is to
+express numbers in decimal and to picture data in "big-endian" order
+[COHEN].  That is, fields are described left to right, with the most
+significant octet on the left and the least significant octet on the
+right.
+
+The order of transmission of the header and data described in this
+document is resolved to the octet level.  Whenever a diagram shows a
+group of octets, the order of transmission of those octets is the
+normal order in which they are read in English.  For example, in the
+following diagram the octets are transmitted in the order they are
+numbered.
+
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |       1       |       2       |       3       |       4       |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |       5       |       6       |       7       |       8       |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |       9       |      10       |      11       |      12       |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                       Transmission Order of Bytes
+
+Whenever an octet represents a numeric quantity the left most bit in the
+diagram is the high order or most significant bit.  That is, the bit
+labeled 0 is the most significant bit.  For example, the following
+diagram represents the value 170 (decimal).
+
+
+                          0 1 2 3 4 5 6 7
+                         +-+-+-+-+-+-+-+-+
+                         |1 0 1 0 1 0 1 0|
+                         +-+-+-+-+-+-+-+-+
+
+                        Significance of Bits
+
+Similarly, whenever a multi-octet field represents a numeric quantity
+the left most bit of the whole field is the most significant bit.  When
+
+
+
+Reynolds & Postel                                               [Page 3]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+a multi-octet quantity is transmitted the most significant octet is
+transmitted first.
+
+Special Addresses
+
+There are five classes of IP addresses: Class A through Class E.  Of
+these, Classes A, B, and C are used for unicast addresses, Class D is
+used for multicast addresses, and Class E addresses are reserved for
+future use.
+
+With the advent of classless addressing [CIDR1, CIDR2], the
+network-number part of an address may be of any length, and the whole
+notion of address classes becomes less important.
+
+There are certain special cases for IP addresses.  These special cases
+can be concisely summarized using the earlier notation for an IP
+address:
+
+      IP-address ::=  { <Network-number>, <Host-number> }
+
+         or
+
+      IP-address ::=  { <Network-number>, <Subnet-number>,
+                                                      <Host-number> }
+
+if we also use the notation "-1" to mean the field contains all 1
+bits.  Some common special cases are as follows:
+
+      (a)   {0, 0}
+
+         This host on this network.  Can only be used as a source
+         address (see note later).
+
+      (b)   {0, <Host-number>}
+
+         Specified host on this network.  Can only be used as a
+         source address.
+
+      (c)   { -1, -1}
+
+         Limited broadcast.  Can only be used as a destination
+         address, and a datagram with this address must never be
+         forwarded outside the (sub-)net of the source.
+
+      (d)   {<Network-number>, -1}
+
+         Directed broadcast to specified network.  Can only be used
+         as a destination address.
+
+
+
+Reynolds & Postel                                               [Page 4]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+      (e)   {<Network-number>, <Subnet-number>, -1}
+
+         Directed broadcast to specified subnet.  Can only be used as
+         a destination address.
+
+      (f)   {<Network-number>, -1, -1}
+
+         Directed broadcast to all subnets of specified subnetted
+         network.  Can only be used as a destination address.
+
+      (g)   {127, <any>}
+
+         Internal host loopback address.  Should never appear outside
+         a host.
+
+
+REFERENCES
+
+[COHEN]   Cohen, D., "On Holy Wars and a Plea for Peace", IEEE Computer
+          Magazine, October 1981.
+
+[CIDR1]   Fuller, V., T. Li, J. Yu, and K. Varadhan, "Classless
+          Inter-Domain Routing (CIDR): an Address Assignment and
+          Aggregation Strategy", RFC 1519, September 1993.
+
+[CIDR2]   Rekhter, Y., and T. Li, "An Architecture for IP Address
+          Allocation with CIDR", RFC 1518, September 1993.
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/introduction
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                               [Page 5]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+VERSION NUMBERS
+
+In the Internet Protocol (IP) [RFC791] there is a field to identify
+the version of the internetwork general protocol.  This field is 4
+bits in size.
+
+Assigned Internet Version Numbers
+
+Decimal   Keyword    Version                            References
+-------   -------    -------                            ----------
+    0                Reserved                                [JBP]
+  1-3                Unassigned                              [JBP]
+    4       IP       Internet Protocol                [RFC791,JBP]
+    5       ST       ST Datagram Mode                [RFC1190,JWF]
+    6       SIP      Simple Internet Protocol                [RH6]
+    7       TP/IX    TP/IX: The Next Internet                [RXU]
+    8       PIP      The P Internet Protocol                 [PXF]
+    9       TUBA     TUBA                                    [RXC]
+10-14                Unassigned                              [JBP]
+   15                Reserved                                [JBP]
+
+REFERENCES
+
+[RFC791] Postel, J., ed., "Internet Protocol - DARPA Internet Program
+         Protocol Specification", STD 5, RFC 791, USC/Information
+         Sciences Institute, September 1981.
+
+[RFC1190] Topolcic, C., Editor, "Experimental Internet Stream
+          Protocol, Version 2 (ST-II)", RFC 1190, CIP Working Group,
+          October 1990.
+
+PEOPLE
+
+[JPB] Jon Postel <postel@isi.edu>
+
+[JWF] Jim Forgie <FORGIE@XN.LL.MIT.ED>
+
+[RH6] Robert Hinden <Hinden@ENG.SUN.COM>
+
+[RXU] Robert Ullmann <ariel@world.std.com>
+
+[PXF] Paul Francis <francis@cactus.ntt.jp>
+
+[RXC] Ross Callon <callon@wellfleet.com>
+
+[]
+
+
+
+
+
+Reynolds & Postel                                               [Page 6]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/version-numbers
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                               [Page 7]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+PROTOCOL NUMBERS
+
+
+In the Internet Protocol (IP) [DDN], [RFC791] there is a field, called
+Protocol, to identify the next level protocol.  This is an 8 bit
+field.
+
+
+Assigned Internet Protocol Numbers
+
+Decimal    Keyword     Protocol                         References
+-------    -------     --------                         ----------
+     0                 Reserved                              [JBP]
+     1     ICMP        Internet Control Message       [RFC792,JBP]
+     2     IGMP        Internet Group Management     [RFC1112,JBP]
+     3     GGP         Gateway-to-Gateway              [RFC823,MB]
+     4     IP          IP in IP (encasulation)               [JBP]
+     5     ST          Stream                 [RFC1190,IEN119,JWF]
+     6     TCP         Transmission Control           [RFC793,JBP]
+     7     UCL         UCL                                    [PK]
+     8     EGP         Exterior Gateway Protocol     [RFC888,DLM1]
+     9     IGP         any private interior gateway          [JBP]
+    10     BBN-RCC-MON BBN RCC Monitoring                    [SGC]
+    11     NVP-II      Network Voice Protocol         [RFC741,SC3]
+    12     PUP         PUP                             [PUP,XEROX]
+    13     ARGUS       ARGUS                                [RWS4]
+    14     EMCON       EMCON                                 [BN7]
+    15     XNET        Cross Net Debugger            [IEN158,JFH2]
+    16     CHAOS       Chaos                                 [NC3]
+    17     UDP         User Datagram                  [RFC768,JBP]
+    18     MUX         Multiplexing                    [IEN90,JBP]
+    19     DCN-MEAS    DCN Measurement Subsystems           [DLM1]
+    20     HMP         Host Monitoring                [RFC869,RH6]
+    21     PRM         Packet Radio Measurement              [ZSU]
+    22     XNS-IDP     XEROX NS IDP               [ETHERNET,XEROX]
+    23     TRUNK-1     Trunk-1                              [BWB6]
+    24     TRUNK-2     Trunk-2                              [BWB6]
+    25     LEAF-1      Leaf-1                               [BWB6]
+    26     LEAF-2      Leaf-2                               [BWB6]
+    27     RDP         Reliable Data Protocol         [RFC908,RH6]
+    28     IRTP        Internet Reliable Transaction  [RFC938,TXM]
+    29     ISO-TP4     ISO Transport Protocol Class 4 [RFC905,RC77]
+    30     NETBLT      Bulk Data Transfer Protocol    [RFC969,DDC1]
+    31     MFE-NSP     MFE Network Services Protocol  [MFENET,BCH2]
+    32     MERIT-INP   MERIT Internodal Protocol             [HWB]
+    33     SEP         Sequential Exchange Protocol        [JC120]
+    34     3PC         Third Party Connect Protocol         [SAF3]
+    35     IDPR        Inter-Domain Policy Routing Protocol [MXS1]
+
+
+
+Reynolds & Postel                                               [Page 8]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+    36     XTP         XTP                                   [GXC]
+    37     DDP         Datagram Delivery Protocol            [WXC]
+    38     IDPR-CMTP   IDPR Control Message Transport Proto [MXS1]
+    39     TP++        TP++ Transport Protocol               [DXF]
+    40     IL          IL Transport Protocol                [DXP2]
+    41     SIP         Simple Internet Protocol              [SXD]
+    42     SDRP        Source Demand Routing Protocol       [DXE1]
+    43     SIP-SR      SIP Source Route                      [SXD]
+    44     SIP-FRAG    SIP Fragment                          [SXD]
+    45     IDRP        Inter-Domain Routing Protocol   [Sue Hares]
+    46     RSVP        Reservation Protocol           [Bob Braden]
+    47     GRE         General Routing Encapsulation     [Tony Li]
+    48     MHRP        Mobile Host Routing Protocol[David Johnson]
+    49     BNA         BNA                          [Gary Salamon]
+    50     SIPP-ESP    SIPP Encap Security Payload [Steve Deering]
+    51     SIPP-AH     SIPP Authentication Header  [Steve Deering]
+    52     I-NLSP      Integrated Net Layer Security  TUBA [GLENN]
+    53     SWIPE       IP with Encryption                    [JI6]
+    54     NHRP        NBMA Next Hop Resolution Protocol
+ 55-60                 Unassigned                            [JBP]
+    61                 any host internal protocol            [JBP]
+    62     CFTP        CFTP                            [CFTP,HCF2]
+    63                 any local network                     [JBP]
+    64     SAT-EXPAK   SATNET and Backroom EXPAK             [SHB]
+    65     KRYPTOLAN   Kryptolan                            [PXL1]
+    66     RVD         MIT Remote Virtual Disk Protocol      [MBG]
+    67     IPPC        Internet Pluribus Packet Core         [SHB]
+    68                 any distributed file system           [JBP]
+    69     SAT-MON     SATNET Monitoring                     [SHB]
+    70     VISA        VISA Protocol                        [GXT1]
+    71     IPCV        Internet Packet Core Utility          [SHB]
+    72     CPNX        Computer Protocol Network Executive  [DXM2]
+    73     CPHB        Computer Protocol Heart Beat         [DXM2]
+    74     WSN         Wang Span Network                     [VXD]
+    75     PVP         Packet Video Protocol                 [SC3]
+    76     BR-SAT-MON  Backroom SATNET Monitoring            [SHB]
+    77     SUN-ND      SUN ND PROTOCOL-Temporary             [WM3]
+    78     WB-MON      WIDEBAND Monitoring                   [SHB]
+    79     WB-EXPAK    WIDEBAND EXPAK                        [SHB]
+    80     ISO-IP      ISO Internet Protocol                 [MTR]
+    81     VMTP        VMTP                                 [DRC3]
+    82     SECURE-VMTP SECURE-VMTP                          [DRC3]
+    83     VINES       VINES                                 [BXH]
+    84     TTP         TTP                                   [JXS]
+    85     NSFNET-IGP  NSFNET-IGP                            [HWB]
+    86     DGP         Dissimilar Gateway Protocol     [DGP,ML109]
+    87     TCF         TCF                                  [GAL5]
+    88     IGRP        IGRP                            [CISCO,GXS]
+
+
+
+Reynolds & Postel                                               [Page 9]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+    89     OSPFIGP     OSPFIGP                      [RFC1583,JTM4]
+    90     Sprite-RPC  Sprite RPC Protocol            [SPRITE,BXW]
+    91     LARP        Locus Address Resolution Protocol     [BXH]
+    92     MTP         Multicast Transport Protocol          [SXA]
+    93     AX.25       AX.25 Frames                         [BK29]
+    94     IPIP        IP-within-IP Encapsulation Protocol   [JI6]
+    95     MICP        Mobile Internetworking Control Pro.   [JI6]
+    96     SCC-SP      Semaphore Communications Sec. Pro.    [HXH]
+    97     ETHERIP     Ethernet-within-IP Encapsulation     [RXH1]
+    98     ENCAP       Encapsulation Header         [RFC1241,RXB3]
+    99                 any private encryption scheme         [JBP]
+   100     GMTP        GMTP                                 [RXB5]
+101-254                Unassigned                            [JBP]
+    255                Reserved                              [JBP]
+
+
+REFERENCES
+
+[CFTP] Forsdick, H., "CFTP", Network Message, Bolt Beranek and
+       Newman, January 1982.
+
+[CISCO] Cisco Systems, "Gateway Server Reference Manual", Manual
+        Revision B, January 10, 1988.
+
+[DDN] Feinler, E., Editor, "DDN Protocol Handbook", Network
+      Information Center, SRI International, December 1985.
+
+[DGP] M/A-COM Government Systems, "Dissimilar Gateway Protocol
+      Specification, Draft Version", Contract no. CS901145,
+      November 16, 1987.
+
+[ETHERNET]  "The Ethernet, A Local Area Network: Data Link Layer and
+            Physical Layer Specification", AA-K759B-TK, Digital
+            Equipment Corporation, Maynard, MA.  Also as: "The
+            Ethernet - A Local Area Network", Version 1.0, Digital
+            Equipment Corporation, Intel Corporation, Xerox
+            Corporation, September 1980.  And: "The Ethernet, A Local
+            Area Network: Data Link Layer and Physical Layer
+            Specifications", Digital, Intel and Xerox, November 1982.
+            And: XEROX, "The Ethernet, A Local Area Network: Data Link
+            Layer and Physical Layer Specification", X3T51/80-50,
+            Xerox Corporation, Stamford, CT., October 1980.
+
+[IEN90] Cohen, D. and J. Postel, "Multiplexing Protocol", IEN 90,
+        USC/Information Sciences Institute, May 1979.
+
+[IEN119] Forgie, J., "ST - A Proposed Internet Stream Protocol",
+         IEN 119, MIT Lincoln Laboratory, September 1979.
+
+
+
+Reynolds & Postel                                              [Page 10]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[IEN158] Haverty, J., "XNET Formats for Internet Protocol Version 4",
+         IEN 158, October 1980.
+
+[MFENET] Shuttleworth, B., "A Documentary of MFENet, a National
+         Computer Network", UCRL-52317, Lawrence Livermore Labs,
+         Livermore, California, June 1977.
+
+[PUP] Boggs, D., J. Shoch, E. Taft, and R. Metcalfe, "PUP: An
+      Internetwork Architecture", XEROX Palo Alto Research Center,
+      CSL-79-10, July 1979; also in IEEE Transactions on
+      Communication, Volume COM-28, Number 4, April 1980.
+
+[SPRITE] Welch, B., "The Sprite Remote Procedure Call System",
+         Technical Report, UCB/Computer Science Dept., 86/302,
+         University of California at Berkeley, June 1986.
+
+[RFC741] Cohen, D., "Specifications for the Network Voice Protocol",
+         RFC 741, ISI/RR 7539, USC/Information Sciences Institute,
+         March 1976.
+
+[RFC768] Postel, J., "User Datagram Protocol", STD 6, RFC 768,
+         USC/Information Sciences Institute, August 1980.
+
+[RFC791] Postel, J., "Internet Protocol - DARPA Internet Program
+         Protocol Specification", STD 5, RFC 791, DARPA, September
+         1981.
+
+[RFC792] Postel, J., "Internet Control Message Protocol - DARPA
+         Internet Program Protocol Specification", STD 5, RFC 792,
+         USC/Information Sciences Institute, September 1981.
+
+[RFC793] Postel, J., "Transmission Control Protocol - DARPA
+         Internet Program Protocol Specification", STD 7, RFC 793,
+         USC/Information Sciences Institute, September 1981.
+
+[RFC823] Hinden, R., and A. Sheltzer, "The DARPA Internet Gateway",
+         RFC 823, BBN, September 1982.
+
+[RFC869] Hinden, R., "A Host Monitoring Protocol", RFC 869,
+         Bolt Beranek and Newman, December 1983.
+
+[RFC888] Seamonson, L., and E. Rosen, "STUB" Exterior Gateway
+         Protocol", RFC 888, BBN Communications Corporation,
+         January 1984.
+
+[RFC905] International Standards Organization, "ISO Transport Protocol
+         Specification - ISO DP 8073", RFC 905, April 1984.
+
+
+
+
+Reynolds & Postel                                              [Page 11]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[RFC908] Velten, D., R. Hinden, and J. Sax, "Reliable Data Protocol",
+         RFC 908, BBN Communications Corporation, July 1984.
+
+[RFC938] Miller, T., "Internet Reliable Transaction Protocol", RFC 938,
+         ACC, February 1985.
+
+[RFC969] Clark, D., M. Lambert, and L. Zhang, "NETBLT: A Bulk Data
+         Transfer Protocol", RFC 969, MIT Laboratory for Computer
+         Science, December 1985.
+
+[RFC1112] Deering, S., "Host Extensions for IP Multicasting",
+          STD 5, RFC 1112, Stanford University, August 1989.
+
+[RFC1190] Topolcic, C., Editor, "Experimental Internet Stream
+          Protocol, Version 2 (ST-II)", RFC 1190, CIP Working Group,
+          October 1990.
+
+[RFC1241] Woodburn, W., and D. Mills, " A Scheme for an Internet
+          Encapsulation Protocol: Version 1", RFC 1241, SAIC,
+          University of Delaware, July 1991.
+
+[RFC1583] Moy, J., "The OSPF Specification", RFC 1583, Proteon,
+          March 1994.
+
+
+PEOPLE
+
+[BCH2] Barry Howard  <Howard@NMFECC.LLNL.GOV>
+
+[BK29] Brian Kantor  <brian@UCSD.EDU>
+
+[BN7] <mystery contact>
+
+[BWB6] Barry Boehm  <boehm@ARPA.MIL>
+
+[BXH] Brian Horn  <---none--->
+
+[BXW] Bruce Willins <---none--->
+
+[DDC1] David Clark  <ddc@LCS.MIT.EDU>
+
+[DLM1] David Mills  <Mills@HUEY.UDEL.EDU>
+
+[DRC3] Dave Cheriton  <cheriton@PESCADERO.STANFORD.EDU>
+
+[DXE1] Deborah Estrin  <estrin@usc.edu>
+
+[DXF] Dirk Fromhein  <df@watershed.com>
+
+
+
+Reynolds & Postel                                              [Page 12]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[DXM2] David Mittnacht  <---none--->
+
+[DXP2] Dave Presotto  <presotto@reseach.att.co
+
+[David Johnson] <mystery contact>
+
+[GAL5] Guillermo A. Loyola  <LOYOLA@IBM.COM>
+
+[GLENN]  K. Robert Glenn  <glenn@osi.ncsl.nist.gov>
+
+[GXC] Greg Chesson  <Greg@SGI.COM>
+
+[GXS] Guenther Schreiner  <snmp-admin@ira.uka.de>
+
+[GXT1] Gene Tsudik  <tsudik@USC.EDU>
+
+[HCF2] Harry Forsdick  <Forsdick@BBN.COM>
+
+[HWB] Hans-Werner Braun  <HWB@MCR.UMICH.EDU>
+
+[HXH] Howard Hart  <hch@hybrid.com>
+
+[JBP]   Jon Postel <postel@isi.edu>
+
+[JC120] <mystery contact>
+
+[JFH2] Jack Haverty <jhaverty@ORACLE.COM>
+
+[JI6] John Ioannidis  <ji@CS.COLUMBIA.EDU>
+
+[JTM4] John Moy  <jmoy@PROTEON.COM>
+
+[JWF] Jim Forgie  <FORGIE@XN.LL.MIT.EDU>
+
+[JXS] Jim Stevens  <Stevens@ISI.EDU>
+
+[KATZ]  Dave Katz <dkatz@cisco.com>
+
+[MB] Mike Brescia  <Brescia@CCV.BBN.COM>
+
+[MBG] Michael Greenwald  <Greenwald@SCRC-STONY-BROOK.SYMBOLICS.COM>
+
+[ML109] Mike Little  <little@MACOM4.ARPA>
+
+[MTR] Marshall T. Rose  <mrose@dbc.mtview.ca.us>
+
+[MXS1] Martha Steenstrup  <MSteenst@BBN.COM>
+
+
+
+
+Reynolds & Postel                                              [Page 13]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[NC3] J. Noel Chiappa  <JNC@XX.LCS.MIT.EDU>
+
+[PK] Peter Kirstein <Kirstein@NSS.CS.UCL.AC.UK>
+
+[PXL1] Paul Liu  <---none--->
+
+[RH6] Robert Hinden  <Hinden@ENG.SUN.COM>
+
+[RTB3]  Bob Braden <braden@isi.edu>
+
+[RC77] <mystery contact>
+
+[RWS4] Robert W. Scheifler  <RWS@XX.LCS.MIT.EDU>
+
+[RXB3] Robert Woodburn <woody@cseic.saic.com>
+
+[RXH1] Russ Housley  <Russ_Housley.McLean_CSD@xerox.com>
+
+[SAF3] Stuart A. Friedberg  <stuart@CS.WISC.EDU>
+
+[SC3] Steve Casner  <casner@isi.edu
+
+[SGC] Steve Chipman  <Chipman@F.BBN.COM>
+
+[SHB] Steven Blumenthal  <BLUMENTHAL@VAX.BBN.COM>
+
+[Sue Hares]  Sue Hares <skh@merit.edu>
+
+[SXA] Susie Armstrong  <Armstrong.wbst128@XEROX.COM>
+
+[SXD] Steve Deering  <deering@PARC.XEROX.COM>
+
+[Tony Li] Tony Li  <tli@cisco.com>
+
+[TXM] Trudy Miller  <Trudy@ACC.COM>
+
+[VXD] Victor Dafoulas  <---none--->
+
+[WM3] William Melohn  <Melohn@SUN.COM>
+
+[WXC] Wesley Craig   <Wesley.Craig@terminator.cc.umich.edu>
+
+[ZSU] Zaw-Sing Su  <ZSu@TSCA.ISTC.SRI.>
+
+
+[]
+
+
+
+
+
+Reynolds & Postel                                              [Page 14]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/protocol-numbers
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 15]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+
+WELL KNOWN PORT NUMBERS
+
+The Well Known Ports are controlled and assigned by the IANA and on
+most systems can only be used by system (or root) processes or by
+programs executed by privileged users.
+
+Ports are used in the TCP [RFC793] to name the ends of logical
+connections which carry long term conversations.  For the purpose of
+providing services to unknown callers, a service contact port is
+defined.  This list specifies the port used by the server process as
+its contact port.  The contact port is sometimes called the
+"well-known port".
+
+To the extent possible, these same port assignments are used with the
+UDP [RFC768].
+
+The assigned ports use a small portion of the possible port numbers.
+For many years the assigned ports were in the range 0-255.  Recently,
+the range for assigned ports managed by the IANA has been expanded to
+the range 0-1023.
+
+Port Assignments:
+
+Keyword         Decimal    Description                     References
+-------         -------    -----------                     ----------
+                  0/tcp    Reserved
+                  0/udp    Reserved
+#                          Jon Postel <postel@isi.edu>
+tcpmux            1/tcp    TCP Port Service Multiplexer
+tcpmux            1/udp    TCP Port Service Multiplexer
+#                          Mark Lottor <MKL@nisc.sri.com>
+compressnet       2/tcp    Management Utility
+compressnet       2/udp    Management Utility
+compressnet       3/tcp    Compression Process
+compressnet       3/udp    Compression Process
+#                          Bernie Volz <VOLZ@PROCESS.COM>
+#                 4/tcp    Unassigned
+#                 4/udp    Unassigned
+rje               5/tcp    Remote Job Entry
+rje               5/udp    Remote Job Entry
+#                          Jon Postel <postel@isi.edu>
+#                 6/tcp    Unassigned
+#                 6/udp    Unassigned
+echo              7/tcp    Echo
+echo              7/udp    Echo
+#                          Jon Postel <postel@isi.edu>
+#                 8/tcp    Unassigned
+
+
+
+Reynolds & Postel                                              [Page 16]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+#                 8/udp    Unassigned
+discard           9/tcp    Discard
+discard           9/udp    Discard
+#                          Jon Postel <postel@isi.edu>
+#                10/tcp    Unassigned
+#                10/udp    Unassigned
+systat           11/tcp    Active Users
+systat           11/udp    Active Users
+#                          Jon Postel <postel@isi.edu>
+#                12/tcp    Unassigned
+#                12/udp    Unassigned
+daytime          13/tcp    Daytime
+daytime          13/udp    Daytime
+#                          Jon Postel <postel@isi.edu>
+#                14/tcp    Unassigned
+#                14/udp    Unassigned
+#                15/tcp    Unassigned [was netstat]
+#                15/udp    Unassigned
+#                16/tcp    Unassigned
+#                16/udp    Unassigned
+qotd             17/tcp    Quote of the Day
+qotd             17/udp    Quote of the Day
+#                          Jon Postel <postel@isi.edu>
+msp              18/tcp    Message Send Protocol
+msp              18/udp    Message Send Protocol
+#                          Rina Nethaniel <---none--->
+chargen          19/tcp    Character Generator
+chargen          19/udp    Character Generator
+ftp-data         20/tcp    File Transfer [Default Data]
+ftp-data         20/udp    File Transfer [Default Data]
+ftp              21/tcp    File Transfer [Control]
+ftp              21/udp    File Transfer [Control]
+#                          Jon Postel <postel@isi.edu>
+#                22/tcp    Unassigned
+#                22/udp    Unassigned
+telnet           23/tcp    Telnet
+telnet           23/udp    Telnet
+#                          Jon Postel <postel@isi.edu>
+                 24/tcp    any private mail system
+                 24/udp    any private mail system
+#                          Rick Adam <rick@UUNET.UU.NET>
+smtp             25/tcp    Simple Mail Transfer
+smtp             25/udp    Simple Mail Transfer
+#                          Jon Postel <postel@isi.edu>
+#                26/tcp    Unassigned
+#                26/udp    Unassigned
+nsw-fe           27/tcp    NSW User System FE
+nsw-fe           27/udp    NSW User System FE
+
+
+
+Reynolds & Postel                                              [Page 17]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+#                          Robert Thomas <BThomas@F.BBN.COM>
+#                28/tcp    Unassigned
+#                28/udp    Unassigned
+msg-icp          29/tcp    MSG ICP
+msg-icp          29/udp    MSG ICP
+#                          Robert Thomas <BThomas@F.BBN.COM>
+#                30/tcp    Unassigned
+#                30/udp    Unassigned
+msg-auth         31/tcp    MSG Authentication
+msg-auth         31/udp    MSG Authentication
+#                          Robert Thomas <BThomas@F.BBN.COM>
+#                32/tcp    Unassigned
+#                32/udp    Unassigned
+dsp              33/tcp    Display Support Protocol
+dsp              33/udp    Display Support Protocol
+#                          Ed Cain <cain@edn-unix.dca.mil>
+#                34/tcp    Unassigned
+#                34/udp    Unassigned
+                 35/tcp    any private printer server
+                 35/udp    any private printer server
+#                          Jon Postel <postel@isi.edu>
+#                36/tcp    Unassigned
+#                36/udp    Unassigned
+time             37/tcp    Time
+time             37/udp    Time
+#                          Jon Postel <postel@isi.edu>
+rap              38/tcp    Route Access Protocol
+rap              38/udp    Route Access Protocol
+#                          Robert Ullmann <ariel@world.std.com>
+rlp              39/tcp    Resource Location Protocol
+rlp              39/udp    Resource Location Protocol
+#                          Mike Accetta <MIKE.ACCETTA@CMU-CS-A.EDU>
+#                40/tcp    Unassigned
+#                40/udp    Unassigned
+graphics         41/tcp    Graphics
+graphics         41/udp    Graphics
+nameserver       42/tcp    Host Name Server
+nameserver       42/udp    Host Name Server
+nicname          43/tcp    Who Is
+nicname          43/udp    Who Is
+mpm-flags        44/tcp    MPM FLAGS Protocol
+mpm-flags        44/udp    MPM FLAGS Protocol
+mpm              45/tcp    Message Processing Module [recv]
+mpm              45/udp    Message Processing Module [recv]
+mpm-snd          46/tcp    MPM [default send]
+mpm-snd          46/udp    MPM [default send]
+#                          Jon Postel <postel@isi.edu>
+ni-ftp           47/tcp    NI FTP
+
+
+
+Reynolds & Postel                                              [Page 18]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+ni-ftp           47/udp    NI FTP
+#                          Steve Kille <S.Kille@isode.com>
+auditd           48/tcp    Digital Audit Daemon
+auditd           48/udp    Digital Audit Daemon
+#                          Larry Scott <scott@zk3.dec.com>
+login            49/tcp    Login Host Protocol
+login            49/udp    Login Host Protocol
+#                          Pieter Ditmars <pditmars@BBN.COM>
+re-mail-ck       50/tcp    Remote Mail Checking Protocol
+re-mail-ck       50/udp    Remote Mail Checking Protocol
+#                          Steve Dorner <s-dorner@UIUC.EDU>
+la-maint         51/tcp    IMP Logical Address Maintenance
+la-maint         51/udp    IMP Logical Address Maintenance
+#                          Andy Malis <malis_a@timeplex.com>
+xns-time         52/tcp    XNS Time Protocol
+xns-time         52/udp    XNS Time Protocol
+#                          Susie Armstrong <Armstrong.wbst128@XEROX>
+domain           53/tcp    Domain Name Server
+domain           53/udp    Domain Name Server
+#                          Paul Mockapetris <PVM@ISI.EDU>
+xns-ch           54/tcp    XNS Clearinghouse
+xns-ch           54/udp    XNS Clearinghouse
+#                          Susie Armstrong <Armstrong.wbst128@XEROX>
+isi-gl           55/tcp    ISI Graphics Language
+isi-gl           55/udp    ISI Graphics Language
+xns-auth         56/tcp    XNS Authentication
+xns-auth         56/udp    XNS Authentication
+#                          Susie Armstrong <Armstrong.wbst128@XEROX>
+                 57/tcp    any private terminal access
+                 57/udp    any private terminal access
+#                          Jon Postel <postel@isi.edu>
+xns-mail         58/tcp    XNS Mail
+xns-mail         58/udp    XNS Mail
+#                          Susie Armstrong <Armstrong.wbst128@XEROX>
+                 59/tcp    any private file service
+                 59/udp    any private file service
+#                          Jon Postel <postel@isi.edu>
+                 60/tcp    Unassigned
+                 60/udp    Unassigned
+ni-mail          61/tcp    NI MAIL
+ni-mail          61/udp    NI MAIL
+#                          Steve Kille <S.Kille@isode.com>
+acas             62/tcp    ACA Services
+acas             62/udp    ACA Services
+#                          E. Wald <ewald@via.enet.dec.com>
+#                63/tcp    Unassigned
+#                63/udp    Unassigned
+covia            64/tcp    Communications Integrator (CI)
+
+
+
+Reynolds & Postel                                              [Page 19]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+covia            64/udp    Communications Integrator (CI)
+#                          "Tundra" Tim Daneliuk
+#                          <tundraix!tundra@clout.chi.il.us>
+tacacs-ds        65/tcp    TACACS-Database Service
+tacacs-ds        65/udp    TACACS-Database Service
+#                          Kathy Huber <khuber@bbn.com>
+sql*net          66/tcp    Oracle SQL*NET
+sql*net          66/udp    Oracle SQL*NET
+#                          Jack Haverty <jhaverty@ORACLE.COM>
+bootps           67/tcp    Bootstrap Protocol Server
+bootps           67/udp    Bootstrap Protocol Server
+bootpc           68/tcp    Bootstrap Protocol Client
+bootpc           68/udp    Bootstrap Protocol Client
+#                          Bill Croft <Croft@SUMEX-AIM.STANFORD.EDU>
+tftp             69/tcp    Trivial File Transfer
+tftp             69/udp    Trivial File Transfer
+#                          David Clark <ddc@LCS.MIT.EDU>
+gopher           70/tcp    Gopher
+gopher           70/udp    Gopher
+#                          Mark McCahill <mpm@boombox.micro.umn.edu>
+netrjs-1         71/tcp    Remote Job Service
+netrjs-1         71/udp    Remote Job Service
+netrjs-2         72/tcp    Remote Job Service
+netrjs-2         72/udp    Remote Job Service
+netrjs-3         73/tcp    Remote Job Service
+netrjs-3         73/udp    Remote Job Service
+netrjs-4         74/tcp    Remote Job Service
+netrjs-4         74/udp    Remote Job Service
+#                          Bob Braden <Braden@ISI.EDU>
+                 75/tcp    any private dial out service
+                 75/udp    any private dial out service
+#                          Jon Postel <postel@isi.edu>
+deos             76/tcp    Distributed External Object Store
+deos             76/udp    Distributed External Object Store
+#                          Robert Ullmann <ariel@world.std.com>
+                 77/tcp    any private RJE service
+                 77/udp    any private RJE service
+#                          Jon Postel <postel@isi.edu>
+vettcp           78/tcp    vettcp
+vettcp           78/udp    vettcp
+#                          Christopher Leong <leong@kolmod.mlo.dec.com>
+finger           79/tcp    Finger
+finger           79/udp    Finger
+#                          David Zimmerman <dpz@RUTGERS.EDU>
+www-http         80/tcp    World Wide Web HTTP
+www-http         80/udp    World Wide Web HTTP
+#                          Tim Berners-Lee <timbl@nxoc01.cern.ch>
+hosts2-ns        81/tcp    HOSTS2 Name Server
+
+
+
+Reynolds & Postel                                              [Page 20]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+hosts2-ns        81/udp    HOSTS2 Name Server
+#                          Earl Killian <EAK@MORDOR.S1.GOV>
+xfer             82/tcp    XFER Utility
+xfer             82/udp    XFER Utility
+#                          Thomas M. Smith <tmsmith@esc.syr.ge.com>
+mit-ml-dev       83/tcp    MIT ML Device
+mit-ml-dev       83/udp    MIT ML Device
+#                          David Reed <--none--->
+ctf              84/tcp    Common Trace Facility
+ctf              84/udp    Common Trace Facility
+#                          Hugh Thomas <thomas@oils.enet.dec.com>
+mit-ml-dev       85/tcp    MIT ML Device
+mit-ml-dev       85/udp    MIT ML Device
+#                          David Reed <--none--->
+mfcobol          86/tcp    Micro Focus Cobol
+mfcobol          86/udp    Micro Focus Cobol
+#                          Simon Edwards <--none--->
+                 87/tcp    any private terminal link
+                 87/udp    any private terminal link
+#                          Jon Postel <postel@isi.edu>
+kerberos         88/tcp    Kerberos
+kerberos         88/udp    Kerberos
+#                          B. Clifford Neuman <bcn@isi.edu>
+su-mit-tg        89/tcp    SU/MIT Telnet Gateway
+su-mit-tg        89/udp    SU/MIT Telnet Gateway
+#                          Mark Crispin <MRC@PANDA.COM>
+dnsix            90/tcp    DNSIX Securit Attribute Token Map
+dnsix            90/udp    DNSIX Securit Attribute Token Map
+#                          Charles Watt <watt@sware.com>
+mit-dov          91/tcp    MIT Dover Spooler
+mit-dov          91/udp    MIT Dover Spooler
+#                          Eliot Moss <EBM@XX.LCS.MIT.EDU>
+npp              92/tcp    Network Printing Protocol
+npp              92/udp    Network Printing Protocol
+#                          Louis Mamakos <louie@sayshell.umd.edu>
+dcp              93/tcp    Device Control Protocol
+dcp              93/udp    Device Control Protocol
+#                          Daniel Tappan <Tappan@BBN.COM>
+objcall          94/tcp    Tivoli Object Dispatcher
+objcall          94/udp    Tivoli Object Dispatcher
+#                          Tom Bereiter <--none--->
+supdup           95/tcp    SUPDUP
+supdup           95/udp    SUPDUP
+#                          Mark Crispin <MRC@PANDA.COM>
+dixie            96/tcp    DIXIE Protocol Specification
+dixie            96/udp    DIXIE Protocol Specification
+#                Tim Howes <Tim.Howes@terminator.cc.umich.edu>
+swift-rvf        97/tcp    Swift Remote Vitural File Protocol
+
+
+
+Reynolds & Postel                                              [Page 21]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+swift-rvf        97/udp    Swift Remote Vitural File Protocol
+#                          Maurice R. Turcotte
+#                <mailrus!uflorida!rm1!dnmrt%rmatl@uunet.UU.NET>
+tacnews          98/tcp    TAC News
+tacnews          98/udp    TAC News
+#                          Jon Postel <postel@isi.edu>
+metagram         99/tcp    Metagram Relay
+metagram         99/udp    Metagram Relay
+#                          Geoff Goodfellow <Geoff@FERNWOOD.MPK.CA.U>
+newacct         100/tcp    [unauthorized use]
+hostname        101/tcp    NIC Host Name Server
+hostname        101/udp    NIC Host Name Server
+#                          Jon Postel <postel@isi.edu>
+iso-tsap        102/tcp    ISO-TSAP
+iso-tsap        102/udp    ISO-TSAP
+#                          Marshall Rose <mrose@dbc.mtview.ca.us>
+gppitnp         103/tcp    Genesis Point-to-Point Trans Net
+gppitnp         103/udp    Genesis Point-to-Point Trans Net
+acr-nema        104/tcp    ACR-NEMA Digital Imag. & Comm. 300
+acr-nema        104/udp    ACR-NEMA Digital Imag. & Comm. 300
+#                          Patrick McNamee <--none--->
+csnet-ns        105/tcp    Mailbox Name Nameserver
+csnet-ns        105/udp    Mailbox Name Nameserver
+#                          Marvin Solomon <solomon@CS.WISC.EDU>
+3com-tsmux      106/tcp    3COM-TSMUX
+3com-tsmux      106/udp    3COM-TSMUX
+#                          Jeremy Siegel <jzs@NSD.3Com.COM>
+rtelnet         107/tcp    Remote Telnet Service
+rtelnet         107/udp    Remote Telnet Service
+#                          Jon Postel <postel@isi.edu>
+snagas          108/tcp    SNA Gateway Access Server
+snagas          108/udp    SNA Gateway Access Server
+#                          Kevin Murphy <murphy@sevens.lkg.dec.com>
+pop2            109/tcp    Post Office Protocol - Version 2
+pop2            109/udp    Post Office Protocol - Version 2
+#                          Joyce K. Reynolds <jkrey@isi.edu>
+pop3            110/tcp    Post Office Protocol - Version 3
+pop3            110/udp    Post Office Protocol - Version 3
+#                          Marshall Rose <mrose@dbc.mtview.ca.us>
+sunrpc          111/tcp    SUN Remote Procedure Call
+sunrpc          111/udp    SUN Remote Procedure Call
+#                          Chuck McManis <cmcmanis@sun.com>
+mcidas          112/tcp    McIDAS Data Transmission Protocol
+mcidas          112/udp    McIDAS Data Transmission Protocol
+#                          Glenn Davis <davis@unidata.ucar.edu>
+auth            113/tcp    Authentication Service
+auth            113/udp    Authentication Service
+#                          Mike St. Johns <stjohns@arpa.mil>
+
+
+
+Reynolds & Postel                                              [Page 22]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+audionews       114/tcp    Audio News Multicast
+audionews       114/udp    Audio News Multicast
+#                          Martin Forssen <maf@dtek.chalmers.se>
+sftp            115/tcp    Simple File Transfer Protocol
+sftp            115/udp    Simple File Transfer Protocol
+#                          Mark Lottor <MKL@nisc.sri.com>
+ansanotify      116/tcp    ANSA REX Notify
+ansanotify      116/udp    ANSA REX Notify
+#                          Nicola J. Howarth <njh@ansa.co.uk>
+uucp-path       117/tcp    UUCP Path Service
+uucp-path       117/udp    UUCP Path Service
+sqlserv         118/tcp    SQL Services
+sqlserv         118/udp    SQL Services
+#                          Larry Barnes <barnes@broke.enet.dec.com>
+nntp            119/tcp    Network News Transfer Protocol
+nntp            119/udp    Network News Transfer Protocol
+#                          Phil Lapsley <phil@UCBARPA.BERKELEY.EDU>
+cfdptkt         120/tcp    CFDPTKT
+cfdptkt         120/udp    CFDPTKT
+#                          John Ioannidis <ji@close.cs.columbia.ed>
+erpc            121/tcp    Encore Expedited Remote Pro.Call
+erpc            121/udp    Encore Expedited Remote Pro.Call
+#                          Jack O'Neil <---none--->
+smakynet        122/tcp    SMAKYNET
+smakynet        122/udp    SMAKYNET
+#                          Mike O'Dowd <odowd@ltisun8.epfl.ch>
+ntp             123/tcp    Network Time Protocol
+ntp             123/udp    Network Time Protocol
+#                          Dave Mills <Mills@HUEY.UDEL.EDU>
+ansatrader      124/tcp    ANSA REX Trader
+ansatrader      124/udp    ANSA REX Trader
+#                          Nicola J. Howarth <njh@ansa.co.uk>
+locus-map       125/tcp    Locus PC-Interface Net Map Ser
+locus-map       125/udp    Locus PC-Interface Net Map Ser
+#                          Eric Peterson <lcc.eric@SEAS.UCLA.EDU>
+unitary         126/tcp    Unisys Unitary Login
+unitary         126/udp    Unisys Unitary Login
+#                          <feil@kronos.nisd.cam.unisys.com>
+locus-con       127/tcp    Locus PC-Interface Conn Server
+locus-con       127/udp    Locus PC-Interface Conn Server
+#                          Eric Peterson <lcc.eric@SEAS.UCLA.EDU>
+gss-xlicen      128/tcp    GSS X License Verification
+gss-xlicen      128/udp    GSS X License Verification
+#                          John Light <johnl@gssc.gss.com>
+pwdgen          129/tcp    Password Generator Protocol
+pwdgen          129/udp    Password Generator Protocol
+#               Frank J. Wacho <WANCHO@WSMR-SIMTEL20.ARMY.MIL>
+cisco-fna       130/tcp    cisco FNATIVE
+
+
+
+Reynolds & Postel                                              [Page 23]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+cisco-fna       130/udp    cisco FNATIVE
+cisco-tna       131/tcp    cisco TNATIVE
+cisco-tna       131/udp    cisco TNATIVE
+cisco-sys       132/tcp    cisco SYSMAINT
+cisco-sys       132/udp    cisco SYSMAINT
+statsrv         133/tcp    Statistics Service
+statsrv         133/udp    Statistics Service
+#                          Dave Mills <Mills@HUEY.UDEL.EDU>
+ingres-net      134/tcp    INGRES-NET Service
+ingres-net      134/udp    INGRES-NET Service
+#                          Mike Berrow <---none--->
+loc-srv         135/tcp    Location Service
+loc-srv         135/udp    Location Service
+#                          Joe Pato <apollo!pato@EDDIE.MIT.EDU>
+profile         136/tcp    PROFILE Naming System
+profile         136/udp    PROFILE Naming System
+#                          Larry Peterson <llp@ARIZONA.EDU>
+netbios-ns      137/tcp    NETBIOS Name Service
+netbios-ns      137/udp    NETBIOS Name Service
+netbios-dgm     138/tcp    NETBIOS Datagram Service
+netbios-dgm     138/udp    NETBIOS Datagram Service
+netbios-ssn     139/tcp    NETBIOS Session Service
+netbios-ssn     139/udp    NETBIOS Session Service
+#                          Jon Postel <postel@isi.edu>
+emfis-data      140/tcp    EMFIS Data Service
+emfis-data      140/udp    EMFIS Data Service
+emfis-cntl      141/tcp    EMFIS Control Service
+emfis-cntl      141/udp    EMFIS Control Service
+#                          Gerd Beling <GBELING@ISI.EDU>
+bl-idm          142/tcp    Britton-Lee IDM
+bl-idm          142/udp    Britton-Lee IDM
+#                          Susie Snitzer <---none--->
+imap2           143/tcp    Interim Mail Access Protocol v2
+imap2           143/udp    Interim Mail Access Protocol v2
+#                          Mark Crispin <MRC@PANDA.COM>
+news            144/tcp    NewS
+news            144/udp    NewS
+#                          James Gosling <JAG@SUN.COM>
+uaac            145/tcp    UAAC Protocol
+uaac            145/udp    UAAC Protocol
+#               David A. Gomberg <gomberg@GATEWAY.MITRE.ORG>
+iso-tp0         146/tcp    ISO-IP0
+iso-tp0         146/udp    ISO-IP0
+iso-ip          147/tcp    ISO-IP
+iso-ip          147/udp    ISO-IP
+#                          Marshall Rose <mrose@dbc.mtview.ca.us>
+cronus          148/tcp    CRONUS-SUPPORT
+cronus          148/udp    CRONUS-SUPPORT
+
+
+
+Reynolds & Postel                                              [Page 24]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+#                          Jeffrey Buffun <jbuffum@APOLLO.COM>
+aed-512         149/tcp    AED 512 Emulation Service
+aed-512         149/udp    AED 512 Emulation Service
+#               Albert G. Broscius <broscius@DSL.CIS.UPENN.EDU>
+sql-net         150/tcp    SQL-NET
+sql-net         150/udp    SQL-NET
+#                          Martin Picard <<---none--->
+hems            151/tcp    HEMS
+hems            151/udp    HEMS
+#                          Christopher Tengi <tengi@Princeton.EDU>
+bftp            152/tcp    Background File Transfer Program
+bftp            152/udp    Background File Transfer Program
+#                          Annette DeSchon <DESCHON@ISI.EDU>
+sgmp            153/tcp    SGMP
+sgmp            153/udp    SGMP
+#                          Marty Schoffstahl <schoff@NISC.NYSER.NET>
+netsc-prod      154/tcp    NETSC
+netsc-prod      154/udp    NETSC
+netsc-dev       155/tcp    NETSC
+netsc-dev       155/udp    NETSC
+#                          Sergio Heker <heker@JVNCC.CSC.ORG>
+sqlsrv          156/tcp    SQL Service
+sqlsrv          156/udp    SQL Service
+#                          Craig Rogers <Rogers@ISI.EDU>
+knet-cmp        157/tcp    KNET/VM Command/Message Protocol
+knet-cmp        157/udp    KNET/VM Command/Message Protocol
+#                          Gary S. Malkin <GMALKIN@XYLOGICS.COM>
+pcmail-srv      158/tcp    PCMail Server
+pcmail-srv      158/udp    PCMail Server
+#                          Mark L. Lambert <markl@PTT.LCS.MIT.EDU>
+nss-routing     159/tcp    NSS-Routing
+nss-routing     159/udp    NSS-Routing
+#                          Yakov Rekhter <Yakov@IBM.COM>
+sgmp-traps      160/tcp    SGMP-TRAPS
+sgmp-traps      160/udp    SGMP-TRAPS
+#                          Marty Schoffstahl <schoff@NISC.NYSER.NET>
+snmp            161/tcp    SNMP
+snmp            161/udp    SNMP
+snmptrap        162/tcp    SNMPTRAP
+snmptrap        162/udp    SNMPTRAP
+#                          Marshall Rose <mrose@dbc.mtview.ca.us>
+cmip-man        163/tcp    CMIP/TCP Manager
+cmip-man        163/udp    CMIP/TCP Manager
+cmip-agent      164/tcp    CMIP/TCP Agent
+smip-agent      164/udp    CMIP/TCP Agent
+#                          Amatzia Ben-Artzi <---none--->
+xns-courier     165/tcp    Xerox
+xns-courier     165/udp    Xerox
+
+
+
+Reynolds & Postel                                              [Page 25]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+#                          Susie Armstrong <Armstrong.wbst128@XEROX.COM>
+s-net           166/tcp    Sirius Systems
+s-net           166/udp    Sirius Systems
+#                          Brian Lloyd <---none--->
+namp            167/tcp    NAMP
+namp            167/udp    NAMP
+#                          Marty Schoffstahl <schoff@NISC.NYSER.NET>
+rsvd            168/tcp    RSVD
+rsvd            168/udp    RSVD
+#                          Neil Todd <mcvax!ist.co.uk!neil@UUNET.UU.NET>
+send            169/tcp    SEND
+send            169/udp    SEND
+#               William D. Wisner <wisner@HAYES.FAI.ALASKA.EDU>
+print-srv       170/tcp    Network PostScript
+print-srv       170/udp    Network PostScript
+#                          Brian Reid <reid@DECWRL.DEC.COM>
+multiplex       171/tcp    Network Innovations Multiplex
+multiplex       171/udp    Network Innovations Multiplex
+cl/1            172/tcp    Network Innovations CL/1
+cl/1            172/udp    Network Innovations CL/1
+#                          Kevin DeVault <<---none--->
+xyplex-mux      173/tcp    Xyplex
+xyplex-mux      173/udp    Xyplex
+#                          Bob Stewart <STEWART@XYPLEX.COM>
+mailq           174/tcp    MAILQ
+mailq           174/udp    MAILQ
+#                          Rayan Zachariassen <rayan@AI.TORONTO.EDU>
+vmnet           175/tcp    VMNET
+vmnet           175/udp    VMNET
+#                          Christopher Tengi <tengi@Princeton.EDU>
+genrad-mux      176/tcp    GENRAD-MUX
+genrad-mux      176/udp    GENRAD-MUX
+#                          Ron Thornton <thornton@qm7501.genrad.com>
+xdmcp           177/tcp    X Display Manager Control Protocol
+xdmcp           177/udp    X Display Manager Control Protocol
+#                          Robert W. Scheifler <RWS@XX.LCS.MIT.EDU>
+nextstep        178/tcp    NextStep Window Server
+NextStep        178/udp    NextStep Window Server
+#                          Leo Hourvitz <leo@NEXT.COM>
+bgp             179/tcp    Border Gateway Protocol
+bgp             179/udp    Border Gateway Protocol
+#                          Kirk Lougheed <LOUGHEED@MATHOM.CISCO.COM>
+ris             180/tcp    Intergraph
+ris             180/udp    Intergraph
+#                          Dave Buehmann <ingr!daveb@UUNET.UU.NET>
+unify           181/tcp    Unify
+unify           181/udp    Unify
+#                          Vinod Singh <--none--->
+
+
+
+Reynolds & Postel                                              [Page 26]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+audit           182/tcp    Unisys Audit SITP
+audit           182/udp    Unisys Audit SITP
+#                          Gil Greenbaum <gcole@nisd.cam.unisys.com>
+ocbinder        183/tcp    OCBinder
+ocbinder        183/udp    OCBinder
+ocserver        184/tcp    OCServer
+ocserver        184/udp    OCServer
+#                          Jerrilynn Okamura <--none--->
+remote-kis      185/tcp    Remote-KIS
+remote-kis      185/udp    Remote-KIS
+kis             186/tcp    KIS Protocol
+kis             186/udp    KIS Protocol
+#                          Ralph Droms <rdroms@NRI.RESTON.VA.US>
+aci             187/tcp    Application Communication Interface
+aci             187/udp    Application Communication Interface
+#                          Rick Carlos <rick.ticipa.csc.ti.com>
+mumps           188/tcp    Plus Five's MUMPS
+mumps           188/udp    Plus Five's MUMPS
+#                          Hokey Stenn <hokey@PLUS5.COM>
+qft             189/tcp    Queued File Transport
+qft             189/udp    Queued File Transport
+#                          Wayne Schroeder <schroeder@SDS.SDSC.EDU>
+gacp            190/tcp    Gateway Access Control Protocol
+cacp            190/udp    Gateway Access Control Protocol
+#                          C. Philip Wood <cpw@LANL.GOV>
+prospero        191/tcp    Prospero Directory Service
+prospero        191/udp    Prospero Directory Service
+#                          B. Clifford Neuman <bcn@isi.edu>
+osu-nms         192/tcp    OSU Network Monitoring System
+osu-nms         192/udp    OSU Network Monitoring System
+#               Doug Karl <KARL-D@OSU-20.IRCC.OHIO-STATE.EDU>
+srmp            193/tcp    Spider Remote Monitoring Protocol
+srmp            193/udp    Spider Remote Monitoring Protocol
+#                          Ted J. Socolofsky <Teds@SPIDER.CO.UK>
+irc             194/tcp    Internet Relay Chat Protocol
+irc             194/udp    Internet Relay Chat Protocol
+#                          Jarkko Oikarinen <jto@TOLSUN.OULU.FI>
+dn6-nlm-aud     195/tcp    DNSIX Network Level Module Audit
+dn6-nlm-aud     195/udp    DNSIX Network Level Module Audit
+dn6-smm-red     196/tcp    DNSIX Session Mgt Module Audit Redir
+dn6-smm-red     196/udp    DNSIX Session Mgt Module Audit Redir
+#                          Lawrence Lebahn <DIA3@PAXRV-NES.NAVY.MIL>
+dls             197/tcp    Directory Location Service
+dls             197/udp    Directory Location Service
+dls-mon         198/tcp    Directory Location Service Monitor
+dls-mon         198/udp    Directory Location Service Monitor
+#                          Scott Bellew <smb@cs.purdue.edu>
+smux            199/tcp    SMUX
+
+
+
+Reynolds & Postel                                              [Page 27]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+smux            199/udp    SMUX
+#                          Marshall Rose <mrose@dbc.mtview.ca.us>
+src             200/tcp    IBM System Resource Controller
+src             200/udp    IBM System Resource Controller
+#                          Gerald McBrearty <---none--->
+at-rtmp         201/tcp    AppleTalk Routing Maintenance
+at-rtmp         201/udp    AppleTalk Routing Maintenance
+at-nbp          202/tcp    AppleTalk Name Binding
+at-nbp          202/udp    AppleTalk Name Binding
+at-3            203/tcp    AppleTalk Unused
+at-3            203/udp    AppleTalk Unused
+at-echo         204/tcp    AppleTalk Echo
+at-echo         204/udp    AppleTalk Echo
+at-5            205/tcp    AppleTalk Unused
+at-5            205/udp    AppleTalk Unused
+at-zis          206/tcp    AppleTalk Zone Information
+at-zis          206/udp    AppleTalk Zone Information
+at-7            207/tcp    AppleTalk Unused
+at-7            207/udp    AppleTalk Unused
+at-8            208/tcp    AppleTalk Unused
+at-8            208/udp    AppleTalk Unused
+#                          Rob Chandhok <chandhok@gnome.cs.cmu.edu>
+tam             209/tcp    Trivial Authenticated Mail Protocol
+tam             209/udp    Trivial Authenticated Mail Protocol
+#                          Dan Bernstein <brnstnd@stealth.acf.nyu.edu>
+z39.50          210/tcp    ANSI Z39.50
+z39.50          210/udp    ANSI Z39.50
+#                          Mark Needleman
+#                         <mhnur%uccmvsa.bitnet@cornell.cit.cornell.edu>
+914c/g          211/tcp    Texas Instruments 914C/G Terminal
+914c/g          211/udp    Texas Instruments 914C/G Terminal
+#                          Bill Harrell <---none--->
+anet            212/tcp    ATEXSSTR
+anet            212/udp    ATEXSSTR
+#                          Jim Taylor <taylor@heart.epps.kodak.com>
+ipx             213/tcp    IPX
+ipx             213/udp    IPX
+#                          Don Provan <donp@xlnvax.novell.com>
+vmpwscs         214/tcp    VM PWSCS
+vmpwscs         214/udp    VM PWSCS
+#                          Dan Shia <dset!shia@uunet.UU.NET>
+softpc          215/tcp    Insignia Solutions
+softpc          215/udp    Insignia Solutions
+#                          Martyn Thomas <---none--->
+atls            216/tcp    Access Technology License Server
+atls            216/udp    Access Technology License Server
+#                          Larry DeLuca <henrik@EDDIE.MIT.EDU>
+dbase           217/tcp    dBASE Unix
+
+
+
+Reynolds & Postel                                              [Page 28]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+dbase           217/udp    dBASE Unix
+#                          Don Gibson
+#            <sequent!aero!twinsun!ashtate.A-T.COM!dong@uunet.UU.NET>
+mpp             218/tcp    Netix Message Posting Protocol
+mpp             218/udp    Netix Message Posting Protocol
+#                          Shannon Yeh <yeh@netix.com>
+uarps           219/tcp    Unisys ARPs
+uarps           219/udp    Unisys ARPs
+#                          Ashok Marwaha <---none--->
+imap3           220/tcp    Interactive Mail Access Protocol v3
+imap3           220/udp    Interactive Mail Access Protocol v3
+#                          James Rice <RICE@SUMEX-AIM.STANFORD.EDU>
+fln-spx         221/tcp    Berkeley rlogind with SPX auth
+fln-spx         221/udp    Berkeley rlogind with SPX auth
+rsh-spx         222/tcp    Berkeley rshd with SPX auth
+rsh-spx         222/udp    Berkeley rshd with SPX auth
+cdc             223/tcp    Certificate Distribution Center
+cdc             223/udp    Certificate Distribution Center
+#               Kannan Alagappan <kannan@sejour.enet.dec.com>
+#               224-241    Reserved
+#                          Jon Postel <postel@isi.edu>
+#               242/tcp    Unassigned
+#               242/udp    Unassigned
+sur-meas        243/tcp    Survey Measurement
+sur-meas        243/udp    Survey Measurement
+#                          Dave Clark <ddc@LCS.MIT.EDU>
+#               244/tcp    Unassigned
+#               244/udp    Unassigned
+link            245/tcp    LINK
+link            245/udp    LINK
+dsp3270         246/tcp    Display Systems Protocol
+dsp3270         246/udp    Display Systems Protocol
+#                          Weldon J. Showalter <Gamma@MINTAKA.DCA.MIL>
+#               247-255    Reserved
+#                          Jon Postel <postel@isi.edu>
+#               256-343    Unassigned
+pdap            344/tcp    Prospero Data Access Protocol
+pdap            344/udp    Prospero Data Access Protocol
+#                          B. Clifford Neuman <bcn@isi.edu>
+pawserv         345/tcp    Perf Analysis Workbench
+pawserv         345/udp    Perf Analysis Workbench
+zserv           346/tcp    Zebra server
+zserv           346/udp    Zebra server
+fatserv         347/tcp    Fatmen Server
+fatserv         347/udp    Fatmen Server
+csi-sgwp        348/tcp    Cabletron Management Protocol
+csi-sgwp        348/udp    Cabletron Management Protocol
+#               349-370    Unassigned
+
+
+
+Reynolds & Postel                                              [Page 29]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+clearcase       371/tcp    Clearcase
+clearcase       371/udp    Clearcase
+#                          Dave LeBlang <leglang@atria.com>
+ulistserv       372/tcp    Unix Listserv
+ulistserv       372/udp    Unix Listserv
+#                          Anastasios Kotsikonas <tasos@cs.bu.edu>
+legent-1        373/tcp    Legent Corporation
+legent-1        373/udp    Legent Corporation
+legent-2        374/tcp    Legent Corporation
+legent-2        374/udp    Legent Corporation
+#                          Keith Boyce <---none--->
+hassle          375/tcp    Hassle
+hassle          375/udp    Hassle
+#                          Reinhard Doelz <doelz@comp.bioz.unibas.ch>
+nip             376/tcp    Amiga Envoy Network Inquiry Proto
+nip             376/udp    Amiga Envoy Network Inquiry Proto
+#                          Kenneth Dyke <kcd@cbmvax.cbm.commodore.com>
+tnETOS          377/tcp    NEC Corporation
+tnETOS          377/udp    NEC Corporation
+dsETOS          378/tcp    NEC Corporation
+dsETOS          378/udp    NEC Corporation
+#                          Tomoo Fujita <tf@arc.bs1.fc.nec.co.jp>
+is99c           379/tcp    TIA/EIA/IS-99 modem client
+is99c           379/udp    TIA/EIA/IS-99 modem client
+is99s           380/tcp    TIA/EIA/IS-99 modem server
+is99s           380/udp    TIA/EIA/IS-99 modem server
+#                          Frank Quick <fquick@qualcomm.com>
+hp-collector    381/tcp    hp performance data collector
+hp-collector    381/udp    hp performance data collector
+hp-managed-node 382/tcp    hp performance data managed node
+hp-managed-node 382/udp    hp performance data managed node
+hp-alarm-mgr    383/tcp    hp performance data alarm manager
+hp-alarm-mgr    383/udp    hp performance data alarm manager
+#                          Frank Blakely <frankb@hpptc16.rose.hp.com>
+arns            384/tcp    A Remote Network Server System
+arns            384/udp    A Remote Network Server System
+#                          David Hornsby <djh@munnari.OZ.AU>
+ibm-app         385/tcp    IBM Application
+ibm-app         385/tcp    IBM Application
+#                          Lisa Tomita <---none--->
+asa             386/tcp    ASA Message Router Object Def.
+asa             386/udp    ASA Message Router Object Def.
+#                          Steve Laitinen <laitinen@brutus.aa.ab.com>
+aurp            387/tcp    Appletalk Update-Based Routing Pro.
+aurp            387/udp    Appletalk Update-Based Routing Pro.
+#                          Chris Ranch <cranch@novell.com>
+unidata-ldm     388/tcp    Unidata LDM Version 4
+unidata-ldm     388/udp    Unidata LDM Version 4
+
+
+
+Reynolds & Postel                                              [Page 30]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+#                          Glenn Davis <davis@unidata.ucar.edu>
+ldap            389/tcp    Lightweight Directory Access Protocol
+ldap            389/udp    Lightweight Directory Access Protocol
+#                          Tim Howes <Tim.Howes@terminator.cc.umich.edu>
+uis             390/tcp    UIS
+uis             390/udp    UIS
+#                          Ed Barron <---none--->
+synotics-relay  391/tcp    SynOptics SNMP Relay Port
+synotics-relay  391/udp    SynOptics SNMP Relay Port
+synotics-broker 392/tcp    SynOptics Port Broker Port
+synotics-broker 392/udp    SynOptics Port Broker Port
+#                          Illan Raab <iraab@synoptics.com>
+dis             393/tcp    Data Interpretation System
+dis             393/udp    Data Interpretation System
+#                          Paul Stevens <pstevens@chinacat.Metaphor.COM>
+embl-ndt        394/tcp    EMBL Nucleic Data Transfer
+embl-ndt        394/udp    EMBL Nucleic Data Transfer
+#                          Peter Gad <peter@bmc.uu.se>
+netcp           395/tcp    NETscout Control Protocol
+netcp           395/udp    NETscout Control Protocol
+#                          Anil Singhal <---none--->
+netware-ip      396/tcp    Novell Netware over IP
+netware-ip      396/udp    Novell Netware over IP
+mptn            397/tcp    Multi Protocol Trans. Net.
+mptn            397/udp    Multi Protocol Trans. Net.
+#                          Soumitra Sarkar <sarkar@vnet.ibm.com>
+kryptolan       398/tcp    Kryptolan
+kryptolan       398/udp    Kryptolan
+#                          Peter de Laval <pdl@sectra.se>
+#               399/tcp    Unassigned
+#               399/udp    Unassigned
+work-sol        400/tcp    Workstation Solutions
+work-sol        400/udp    Workstation Solutions
+#                          Jim Ward <jimw@worksta.com>
+ups             401/tcp    Uninterruptible Power Supply
+ups             401/udp    Uninterruptible Power Supply
+#                          Guenther Seybold <gs@hrz.th-darmstadt.de>
+genie           402/tcp    Genie Protocol
+genie           402/udp    Genie Protocol
+#                          Mark Hankin <---none--->
+decap           403/tcp    decap
+decap           403/udp    decap
+nced            404/tcp    nced
+nced            404/udp    nced
+ncld            405/tcp    ncld
+ncld            405/udp    ncld
+#                          Richard Jones <---none--->
+imsp            406/tcp    Interactive Mail Support Protocol
+
+
+
+Reynolds & Postel                                              [Page 31]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+imsp            406/udp    Interactive Mail Support Protocol
+#                          John Myers <jgm+@cmu.edu>
+timbuktu        407/tcp    Timbuktu
+timbuktu        407/udp    Timbuktu
+#                          Marc Epard <marc@waygate.farallon.com>
+prm-sm          408/tcp    Prospero Resource Manager Sys. Man.
+prm-sm          408/udp    Prospero Resource Manager Sys. Man.
+prm-nm          409/tcp    Prospero Resource Manager Node Man.
+prm-nm          409/udp    Prospero Resource Manager Node Man.
+#                          B. Clifford Neuman <bcn@isi.edu>
+decladebug      410/tcp    DECLadebug Remote Debug Protocol
+decladebug      410/udp    DECLadebug Remote Debug Protocol
+#                          Anthony Berent <berent@rdgeng.enet.dec.com>
+rmt             411/tcp    Remote MT Protocol
+rmt             411/udp    Remote MT Protocol
+#                          Peter Eriksson <pen@lysator.liu.se>
+synoptics-trap  412/tcp    Trap Convention Port
+synoptics-trap  412/udp    Trap Convention Port
+#                          Illan Raab <iraab@synoptics.com>
+smsp            413/tcp    SMSP
+smsp            413/udp    SMSP
+infoseek        414/tcp    InfoSeek
+infoseek        414/udp    InfoSeek
+#                          Steve Kirsch <stk@frame.com>
+bnet            415/tcp    BNet
+bnet            415/udp    BNet
+#                          Jim Mertz <JMertz+RV09@rvdc.unisys.com>
+silverplatter   416/tcp    Silverplatter
+silverplatter   416/udp    Silverplatter
+#                          Peter Ciuffetti <petec@silverplatter.com>
+onmux           417/tcp    Onmux
+onmux           417/udp    Onmux
+#                          Stephen Hanna <hanna@world.std.com>
+hyper-g         418/tcp    Hyper-G
+hyper-g         418/udp    Hyper-G
+#                          Frank Kappe <fkappe@iicm.tu-graz.ac.at>
+ariel1          419/tcp    Ariel
+ariel1          419/udp    Ariel
+#                          Jonathan Lavigne <BL.JPL@RLG.Stanford.EDU>
+smpte           420/tcp    SMPTE
+smpte           420/udp    SMPTE
+#                          Si Becker <71362.22@CompuServe.COM>
+ariel2          421/tcp    Ariel
+ariel2          421/udp    Ariel
+ariel3          422/tcp    Ariel
+ariel3          422/udp    Ariel
+#                          Jonathan Lavigne  <BL.JPL@RLG.Stanford.EDU>
+opc-job-start   423/tcp    IBM Operations Planning and Control Start
+
+
+
+Reynolds & Postel                                              [Page 32]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+opc-job-start   423/udp    IBM Operations Planning and Control Start
+opc-job-track   424/tcp    IBM Operations Planning and Control Track
+opc-job-track   424/udp    IBM Operations Planning and Control Track
+#                          Conny Larsson  <cocke@VNET.IBM.COM>
+icad-el         425/tcp    ICAD
+icad-el         425/udp    ICAD
+#                          Larry Stone  <lcs@icad.com>
+smartsdp        426/tcp    smartsdp
+smartsdp        426/udp    smartsdp
+#                          Alexander Dupuy <dupuy@smarts.com>
+svrloc          427/tcp    Server Location
+svrloc          427/udp    Server Location
+#                          <veizades@ftp.com>
+ocs_cmu         428/tcp    OCS_CMU
+ocs_cmu         428/udp    OCS_CMU
+ocs_amu         429/tcp    OCS_AMU
+ocs_amu         429/udp    OCS_AMU
+#                          Florence Wyman <wyman@peabody.plk.af.mil>
+utmpsd          430/tcp    UTMPSD
+utmpsd          430/udp    UTMPSD
+utmpcd          431/tcp    UTMPCD
+utmpcd          431/udp    UTMPCD
+iasd            432/tcp    IASD
+iasd            432/udp    IASD
+#                          Nir Baroz <nbaroz@encore.com>
+nnsp            433/tcp    NNSP
+nnsp            433/udp    NNSP
+#                          Rob Robertson <rob@gangrene.berkeley.edu>
+mobileip-agent  434/tcp    MobileIP-Agent
+mobileip-agent  434/udp    MobileIP-Agent
+mobilip-mn      435/tcp    MobilIP-MN
+mobilip-mn      435/udp    MobilIP-MN
+#                          Kannan Alagappan <kannan@sejour.lkg.dec.com>
+dna-cml         436/tcp    DNA-CML
+dna-cml         436/udp    DNA-CML
+#                          Dan Flowers <flowers@smaug.lkg.dec.com>
+comscm          437/tcp    comscm
+comscm          437/udp    comscm
+#                          Jim Teague <teague@zso.dec.com>
+dsfgw           438/tcp    dsfgw
+dsfgw           438/udp    dsfgw
+#                          Andy McKeen <mckeen@osf.org>
+dasp            439/tcp    dasp      Thomas Obermair
+dasp            439/udp    dasp      tommy@inlab.m.eunet.de
+#                          Thomas Obermair <tommy@inlab.m.eunet.de>
+sgcp            440/tcp    sgcp
+sgcp            440/udp    sgcp
+#                          Marshall Rose <mrose@dbc.mtview.ca.us>
+
+
+
+Reynolds & Postel                                              [Page 33]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+decvms-sysmgt   441/tcp    decvms-sysmgt
+decvms-sysmgt   441/udp    decvms-sysmgt
+#                          Lee Barton <barton@star.enet.dec.com>
+cvc_hostd       442/tcp    cvc_hostd
+cvc_hostd       442/udp    cvc_hostd
+#                          Bill Davidson <billd@equalizer.cray.com>
+https           443/tcp    https  MCom
+https           443/udp    https  MCom
+#                          Kipp E.B. Hickman <kipp@mcom.com>
+snpp            444/tcp    Simple Network Paging Protocol
+snpp            444/udp    Simple Network Paging Protocol
+#                          [RFC1568]
+microsoft-ds    445/tcp    Microsoft-DS
+microsoft-ds    445/udp    Microsoft-DS
+#                          Arnold Miller <arnoldm@microsoft.com>
+ddm-rdb         446/tcp    DDM-RDB
+ddm-rdb         446/udp    DDM-RDB
+ddm-dfm         447/tcp    DDM-RFM
+ddm-dfm         447/udp    DDM-RFM
+ddm-byte        448/tcp    DDM-BYTE
+ddm-byte        448/udp    DDM-BYTE
+#                          Jan David Fisher <jdfisher@VNET.IBM.COM>
+as-servermap    449/tcp    AS Server Mapper
+as-servermap    449/udp    AS Server Mapper
+#                          Barbara Foss <BGFOSS@rchvmv.vnet.ibm.com>
+tserver         450/tcp    TServer
+tserver         450/udp    TServer
+#                          Harvey S. Schultz <hss@mtgzfs3.mt.att.com>
+#               451-511    Unassigned
+exec            512/tcp    remote process execution;
+#                          authentication performed using
+#                          passwords and UNIX loppgin names
+biff            512/udp    used by mail system to notify users
+#                          of new mail received; currently
+#                          receives messages only from
+#                          processes on the same machine
+login           513/tcp    remote login a la telnet;
+#                          automatic authentication performed
+#                          based on priviledged port numbers
+#                          and distributed data bases which
+#                          identify "authentication domains"
+who             513/udp    maintains data bases showing who's
+#                          logged in to machines on a local
+#                          net and the load average of the
+#                          machine
+cmd             514/tcp    like exec, but automatic
+#                          authentication is performed as for
+#                          login server
+
+
+
+Reynolds & Postel                                              [Page 34]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+syslog          514/udp
+printer         515/tcp    spooler
+printer         515/udp    spooler
+#               516/tcp    Unassigned
+#               516/udp    Unassigned
+talk            517/tcp    like tenex link, but across
+#                          machine - unfortunately, doesn't
+#                          use link protocol (this is actually
+#                          just a rendezvous port from which a
+#                          tcp connection is established)
+talk            517/udp    like tenex link, but across
+#                          machine - unfortunately, doesn't
+#                          use link protocol (this is actually
+#                          just a rendezvous port from which a
+                           tcp connection is established)
+ntalk           518/tcp
+ntalk           518/udp
+utime           519/tcp    unixtime
+utime           519/udp    unixtime
+efs             520/tcp    extended file name server
+router          520/udp    local routing process (on site);
+#                          uses variant of Xerox NS routing
+#                          information protocol
+#               521-524    Unassigned
+timed           525/tcp    timeserver
+timed           525/udp    timeserver
+tempo           526/tcp    newdate
+tempo           526/udp    newdate
+#               527-529    Unassigned
+courier         530/tcp    rpc
+courier         530/udp    rpc
+conference      531/tcp    chat
+conference      531/udp    chat
+netnews         532/tcp    readnews
+netnews         532/udp    readnews
+netwall         533/tcp    for emergency broadcasts
+netwall         533/udp    for emergency broadcasts
+#               534-538    Unassigned
+apertus-ldp     539/tcp    Apertus Technologies Load Determination
+apertus-ldp     539/udp    Apertus Technologies Load Determination
+uucp            540/tcp    uucpd
+uucp            540/udp    uucpd
+uucp-rlogin     541/tcp    uucp-rlogin  Stuart Lynne
+uucp-rlogin     541/udp    uucp-rlogin  sl@wimsey.com
+#               542/tcp    Unassigned
+#               542/udp    Unassigned
+klogin          543/tcp
+klogin          543/udp
+
+
+
+Reynolds & Postel                                              [Page 35]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+kshell          544/tcp    krcmd
+kshell          544/udp    krcmd
+#               545-549    Unassigned
+new-rwho        550/tcp    new-who
+new-rwho        550/udp    new-who
+#               551-555    Unassigned
+dsf             555/tcp
+dsf             555/udp
+remotefs        556/tcp    rfs server
+remotefs        556/udp    rfs server
+#               557-559    Unassigned
+rmonitor        560/tcp    rmonitord
+rmonitor        560/udp    rmonitord
+monitor         561/tcp
+monitor         561/udp
+chshell         562/tcp    chcmd
+chshell         562/udp    chcmd
+#               563/tcp    Unassigned
+#               563/udp    Unassigned
+9pfs            564/tcp    plan 9 file service
+9pfs            564/udp    plan 9 file service
+whoami          565/tcp    whoami
+whoami          565/udp    whoami
+#               566-569    Unassigned
+meter           570/tcp    demon
+meter           570/udp    demon
+meter           571/tcp    udemon
+meter           571/udp    udemon
+#               572-599    Unassigned
+ipcserver       600/tcp    Sun IPC server
+ipcserver       600/udp    Sun IPC server
+nqs             607/tcp    nqs
+nqs             607/udp    nqs
+urm             606/tcp    Cray Unified Resource Manager
+urm             606/udp    Cray Unified Resource Manager
+#                          Bill Schiefelbein <schief@aspen.cray.com>
+sift-uft        608/tcp    Sender-Initiated/Unsolicited File Transfer
+sift-uft        608/udp    Sender-Initiated/Unsolicited File Transfer
+#                          Rick Troth <troth@rice.edu>
+npmp-trap       609/tcp    npmp-trap
+npmp-trap       609/udp    npmp-trap
+npmp-local      610/tcp    npmp-local
+npmp-local      610/udp    npmp-local
+npmp-gui        611/tcp    npmp-gui
+npmp-gui        611/udp    npmp-gui
+#                          John Barnes <jbarnes@crl.com>
+ginad           634/tcp    ginad
+ginad           634/udp    ginad
+
+
+
+Reynolds & Postel                                              [Page 36]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+#                          Mark Crother <mark@eis.calstate.edu>
+mdqs            666/tcp
+mdqs            666/udp
+doom            666/tcp    doom Id Software
+doom            666/tcp    doom Id Software
+#                          <ddt@idcube.idsoftware.com>
+elcsd           704/tcp    errlog copy/server daemon
+elcsd           704/udp    errlog copy/server daemon
+
+entrustmanager  709/tcp    EntrustManager
+entrustmanager  709/udp    EntrustManager
+#                          Peter Whittaker <pww@bnr.ca>
+netviewdm1      729/tcp    IBM NetView DM/6000 Server/Client
+netviewdm1      729/udp    IBM NetView DM/6000 Server/Client
+netviewdm2      730/tcp    IBM NetView DM/6000 send/tcp
+netviewdm2      730/udp    IBM NetView DM/6000 send/tcp
+netviewdm3      731/tcp    IBM NetView DM/6000 receive/tcp
+netviewdm3      731/udp    IBM NetView DM/6000 receive/tcp
+#                          Philippe Binet  (phbinet@vnet.IBM.COM)
+netgw           741/tcp    netGW
+netgw           741/udp    netGW
+netrcs          742/tcp    Network based Rev. Cont. Sys.
+netrcs          742/udp    Network based Rev. Cont. Sys.
+#                          Gordon C. Galligher <gorpong@ping.chi.il.us>
+flexlm          744/tcp    Flexible License Manager
+flexlm          744/udp    Flexible License Manager
+#                          Matt Christiano
+#                          <globes@matt@oliveb.atc.olivetti.com>
+fujitsu-dev     747/tcp    Fujitsu Device Control
+fujitsu-dev     747/udp    Fujitsu Device Control
+ris-cm          748/tcp    Russell Info Sci Calendar Manager
+ris-cm          748/udp    Russell Info Sci Calendar Manager
+kerberos-adm    749/tcp    kerberos administration
+kerberos-adm    749/udp    kerberos administration
+rfile           750/tcp
+loadav          750/udp
+pump            751/tcp
+pump            751/udp
+qrh             752/tcp
+qrh             752/udp
+rrh             753/tcp
+rrh             753/udp
+tell            754/tcp     send
+tell            754/udp     send
+nlogin          758/tcp
+nlogin          758/udp
+con             759/tcp
+con             759/udp
+
+
+
+Reynolds & Postel                                              [Page 37]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+ns              760/tcp
+ns              760/udp
+rxe             761/tcp
+rxe             761/udp
+quotad          762/tcp
+quotad          762/udp
+cycleserv       763/tcp
+cycleserv       763/udp
+omserv          764/tcp
+omserv          764/udp
+webster         765/tcp
+webster         765/udp
+phonebook       767/tcp    phone
+phonebook       767/udp    phone
+vid             769/tcp
+vid             769/udp
+cadlock         770/tcp
+cadlock         770/udp
+rtip            771/tcp
+rtip            771/udp
+cycleserv2      772/tcp
+cycleserv2      772/udp
+submit          773/tcp
+notify          773/udp
+rpasswd         774/tcp
+acmaint_dbd     774/udp
+entomb          775/tcp
+acmaint_transd  775/udp
+wpages          776/tcp
+wpages          776/udp
+wpgs            780/tcp
+wpgs            780/udp
+concert         786/tcp       Concert
+concert         786/udp       Concert
+#                             Josyula R. Rao <jrrao@watson.ibm.com>
+mdbs_daemon     800/tcp
+mdbs_daemon     800/udp
+device          801/tcp
+device          801/udp
+xtreelic        996/tcp        Central Point Software
+xtreelic        996/udp        Central Point Software
+#                              Dale Cabell <dacabell@smtp.xtree.com>
+maitrd          997/tcp
+maitrd          997/udp
+busboy          998/tcp
+puparp          998/udp
+garcon          999/tcp
+applix          999/udp        Applix ac
+
+
+
+Reynolds & Postel                                              [Page 38]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+puprouter       999/tcp
+puprouter       999/udp
+cadlock         1000/tcp
+ock             1000/udp
+                1023/tcp       Reserved
+                1024/udp       Reserved
+#                              IANA <iana@isi.edu>
+
+
+
+REGISTERED PORT NUMBERS
+
+The Registered Ports are not controlled by the IANA and on most
+systems can be used by ordinary user processes or programs executed by
+ordinary users.
+
+Ports are used in the TCP [RFC793] to name the ends of logical
+connections which carry long term conversations.  For the purpose of
+providing services to unknown callers, a service contact port is
+defined.  This list specifies the port used by the server process as
+its contact port.  While the IANA can not control uses of these ports
+it does register or list uses of these ports as a convienence to the
+community.
+
+To the extent possible, these same port assignments are used with the
+UDP [RFC768].
+
+The Registered Ports are in the range 1024-65535.
+
+Port Assignments:
+
+Keyword         Decimal    Description                     References
+-------         -------    -----------                     ----------
+                1024/tcp   Reserved
+                1024/udp   Reserved
+#                          IANA <iana@isi.edu>
+blackjack       1025/tcp   network blackjack
+blackjack       1025/udp   network blackjack
+iad1            1030/tcp   BBN IAD
+iad1            1030/udp   BBN IAD
+iad2            1031/tcp   BBN IAD
+iad2            1031/udp   BBN IAD
+iad3            1032/tcp   BBN IAD
+iad3            1032/udp   BBN IAD
+#                          Andy Malis <malis_a@timeplex.com>
+instl_boots     1067/tcp   Installation Bootstrap Proto. Serv.
+instl_boots     1067/udp   Installation Bootstrap Proto. Serv.
+instl_bootc     1068/tcp   Installation Bootstrap Proto. Cli.
+
+
+
+Reynolds & Postel                                              [Page 39]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+instl_bootc     1068/udp   Installation Bootstrap Proto. Cli.
+#                          David Arko <<darko@hpfcrn.fc.hp.com>
+socks           1080/tcp   Socks
+socks           1080/udp   Socks
+#                          Ying-Da Lee <ylee@syl.dl.nec.com
+ansoft-lm-1     1083/tcp   Anasoft License Manager
+ansoft-lm-1     1083/udp   Anasoft License Manager
+ansoft-lm-2     1084/tcp   Anasoft License Manager
+ansoft-lm-2     1084/udp   Anasoft License Manager
+nfa             1155/tcp   Network File Access
+nfa             1155/udp   Network File Access
+#                          James Powell <james@mailhost.unidata.com>
+nerv            1222/tcp   SNI R&D network
+nerv            1222/udp   SNI R&D network
+#                          Martin Freiss <freiss.pad@sni.de>
+hermes          1248/tcp
+hermes          1248/udp
+alta-ana-lm     1346/tcp   Alta Analytics License Manager
+alta-ana-lm     1346/udp   Alta Analytics License Manager
+bbn-mmc         1347/tcp   multi media conferencing
+bbn-mmc         1347/udp   multi media conferencing
+bbn-mmx         1348/tcp   multi media conferencing
+bbn-mmx         1348/udp   multi media conferencing
+sbook           1349/tcp   Registration Network Protocol
+sbook           1349/udp   Registration Network Protocol
+editbench       1350/tcp   Registration Network Protocol
+editbench       1350/udp   Registration Network Protocol
+#               Simson L. Garfinkel <simsong@next.cambridge.ma.us>
+equationbuilder 1351/tcp   Digital Tool Works (MIT)
+equationbuilder 1351/udp   Digital Tool Works (MIT)
+#                          Terrence J. Talbot <lexcube!tjt@bu.edu>
+lotusnote       1352/tcp   Lotus Note
+lotusnote       1352/udp   Lotus Note
+#               Greg Pflaum <iris.com!Greg_Pflaum@uunet.uu.net>
+relief          1353/tcp   Relief Consulting
+relief          1353/udp   Relief Consulting
+#                          John Feiler <relief!jjfeiler@uu2.psi.com>
+rightbrain      1354/tcp   RightBrain Software
+rightbrain      1354/udp   RightBrain Software
+#                          Glenn Reid <glann@rightbrain.com>
+intuitive edge  1355/tcp   Intuitive Edge
+intuitive edge  1355/udp   Intuitive Edge
+#                          Montgomery Zukowski
+#                          <monty@nextnorth.acs.ohio-state.edu>
+cuillamartin    1356/tcp   CuillaMartin Company
+cuillamartin    1356/udp   CuillaMartin Company
+pegboard        1357/tcp   Electronic PegBoard
+pegboard        1357/udp   Electronic PegBoard
+
+
+
+Reynolds & Postel                                              [Page 40]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+#                          Chris Cuilla
+#                          <balr!vpnet!cuilla!chris@clout.chi.il.us>
+connlcli        1358/tcp   CONNLCLI
+connlcli        1358/udp   CONNLCLI
+ftsrv           1359/tcp   FTSRV
+ftsrv           1359/udp   FTSRV
+#                          Ines Homem de Melo <sidinf@brfapesp.bitnet>
+mimer           1360/tcp   MIMER
+mimer           1360/udp   MIMER
+#                          Per Schroeder  <Per.Schroder@mimer.se>
+linx            1361/tcp   LinX
+linx            1361/udp   LinX
+#                          Steffen Schilke <---none--->
+timeflies       1362/tcp   TimeFlies
+timeflies       1362/udp   TimeFlies
+#                          Doug Kent <mouthers@slugg@nwnexus.wa.com>
+ndm-requester   1363/tcp   Network DataMover Requester
+ndm-requester   1363/udp   Network DataMover Requester
+ndm-server      1364/tcp   Network DataMover Server
+ndm-server      1364/udp   Network DataMover Server
+#                          Toshio Watanabe
+#                          <watanabe@godzilla.rsc.spdd.ricoh.co.j>
+adapt-sna       1365/tcp   Network Software Associates
+adapt-sna       1365/udp   Network Software Associates
+#                          Jeffery Chiao <714-768-401>
+netware-csp     1366/tcp   Novell NetWare Comm Service Platform
+netware-csp     1366/udp   Novell NetWare Comm Service Platform
+#                          Laurie Lindsey <llindsey@novell.com>
+dcs             1367/tcp   DCS
+dcs             1367/udp   DCS
+#                          Stefan Siebert <ssiebert@dcs.de>
+screencast      1368/tcp   ScreenCast
+screencast      1368/udp   ScreenCast
+#                          Bill Tschumy <other!bill@uunet.UU.NET>
+gv-us           1369/tcp   GlobalView to Unix Shell
+gv-us           1369/udp   GlobalView to Unix Shell
+us-gv           1370/tcp   Unix Shell to GlobalView
+us-gv           1370/udp   Unix Shell to GlobalView
+#               Makoto Mita <mita@ssdev.ksp.fujixerox.co.jp>
+fc-cli          1371/tcp   Fujitsu Config Protocol
+fc-cli          1371/udp   Fujitsu Config Protocol
+fc-ser          1372/tcp   Fujitsu Config Protocol
+fc-ser          1372/udp   Fujitsu Config Protocol
+#               Ryuichi Horie <horie@spad.sysrap.cs.fujitsu.co.jp>
+chromagrafx     1373/tcp   Chromagrafx
+chromagrafx     1373/udp   Chromagrafx
+#                          Mike Barthelemy <msb@chromagrafx.com>
+molly           1374/tcp   EPI Software Systems
+
+
+
+Reynolds & Postel                                              [Page 41]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+molly           1374/udp   EPI Software Systems
+#                          Jim Vlcek <vlcek@epimbe.com>
+bytex           1375/tcp   Bytex
+bytex           1375/udp   Bytex
+#               Mary Ann Burt <bytex!ws054!maryann@uunet.UU.NET>
+ibm-pps         1376/tcp   IBM Person to Person Software
+ibm-pps         1376/udp   IBM Person to Person Software
+#                          Simon Phipps <sphipps@vnet.ibm.com>
+cichlid         1377/tcp   Cichlid License Manager
+cichlid         1377/udp   Cichlid License Manager
+#                          Andy Burgess <aab@cichlid.com>
+elan            1378/tcp   Elan License Manager
+elan            1378/udp   Elan License Manager
+#                          Ken Greer <kg@elan.com>
+dbreporter      1379/tcp   Integrity Solutions
+dbreporter      1379/udp   Integrity Solutions
+#                          Tim Dawson <tdawson%mspboss@uunet.UU.NET>
+telesis-licman  1380/tcp   Telesis Network License Manager
+telesis-licman  1380/udp   Telesis Network License Manager
+#                          Karl Schendel, Jr. <wiz@telesis.com>
+apple-licman    1381/tcp   Apple Network License Manager
+apple-licman    1381/udp   Apple Network License Manager
+#                          Earl Wallace <earlw@apple.com>
+udt_os          1382/tcp
+udt_os          1382/udp
+gwha            1383/tcp   GW Hannaway Network License Manager
+gwha            1383/udp   GW Hannaway Network License Manager
+#                          J. Gabriel Foster <fop@gwha.com>
+os-licman       1384/tcp   Objective Solutions License Manager
+os-licman       1384/udp   Objective Solutions License Manager
+#               Donald Cornwell <don.cornwell@objective.com>
+atex_elmd       1385/tcp   Atex Publishing License Manager
+atex_elmd       1385/udp   Atex Publishing License Manager
+#                          Brett Sorenson <bcs@atex.com>
+checksum        1386/tcp   CheckSum License Manager
+checksum        1386/udp   CheckSum License Manager
+#                          Andreas Glocker <glocker@sirius.com>
+cadsi-lm        1387/tcp   Computer Aided Design Software Inc LM
+cadsi-lm        1387/udp   Computer Aided Design Software Inc LM
+#                          Sulistio Muljadi
+objective-dbc   1388/tcp   Objective Solutions DataBase Cache
+objective-dbc   1388/udp   Objective Solutions DataBase Cache
+#                          Donald Cornwell
+iclpv-dm        1389/tcp   Document Manager
+iclpv-dm        1389/udp   Document Manager
+iclpv-sc        1390/tcp   Storage Controller
+iclpv-sc        1390/udp   Storage Controller
+iclpv-sas       1391/tcp   Storage Access Server
+
+
+
+Reynolds & Postel                                              [Page 42]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+iclpv-sas       1391/udp   Storage Access Server
+iclpv-pm        1392/tcp   Print Manager
+iclpv-pm        1392/udp   Print Manager
+iclpv-nls       1393/tcp   Network Log Server
+iclpv-nls       1393/udp   Network Log Server
+iclpv-nlc       1394/tcp   Network Log Client
+iclpv-nlc       1394/udp   Network Log Client
+iclpv-wsm       1395/tcp   PC Workstation Manager software
+iclpv-wsm       1395/udp   PC Workstation Manager software
+#               A.P. Hobson <A.P.Hobson@bra0112.wins.icl.co.uk>
+dvl-activemail  1396/tcp   DVL Active Mail
+dvl-activemail  1396/udp   DVL Active Mail
+audio-activmail 1397/tcp   Audio Active Mail
+audio-activmail 1397/udp   Audio Active Mail
+video-activmail 1398/tcp   Video Active Mail
+video-activmail 1398/udp   Video Active Mail
+#                          Ehud Shapiro <udi@wisdon.weizmann.ac.il>
+cadkey-licman   1399/tcp   Cadkey License Manager
+cadkey-licman   1399/udp   Cadkey License Manager
+cadkey-tablet   1400/tcp   Cadkey Tablet Daemon
+cadkey-tablet   1400/udp   Cadkey Tablet Daemon
+#                          Joe McCollough <joe@cadkey.com>
+goldleaf-licman 1401/tcp   Goldleaf License Manager
+goldleaf-licman 1401/udp   Goldleaf License Manager
+#                          John Fox <---none--->
+prm-sm-np       1402/tcp   Prospero Resource Manager
+prm-sm-np       1402/udp   Prospero Resource Manager
+prm-nm-np       1403/tcp   Prospero Resource Manager
+prm-nm-np       1403/udp   Prospero Resource Manager
+#                          B. Clifford Neuman <bcn@isi.edu>
+igi-lm          1404/tcp   Infinite Graphics License Manager
+igi-lm          1404/udp   Infinite Graphics License Manager
+ibm-res         1405/tcp   IBM Remote Execution Starter
+ibm-res         1405/udp   IBM Remote Execution Starter
+netlabs-lm      1406/tcp   NetLabs License Manager
+netlabs-lm      1406/udp   NetLabs License Manager
+dbsa-lm         1407/tcp   DBSA License Manager
+dbsa-lm         1407/udp   DBSA License Manager
+#                          Scott Shattuck <ss@dbsa.com>
+sophia-lm       1408/tcp   Sophia License Manager
+sophia-lm       1408/udp   Sophia License Manager
+#                          Eric Brown <sst!emerald!eric@uunet.UU.net>
+here-lm         1409/tcp   Here License Manager
+here-lm         1409/udp   Here License Manager
+#                          David Ison  <here@dialup.oar.net>
+hiq             1410/tcp   HiQ License Manager
+hiq             1410/udp   HiQ License Manager
+#                          Rick Pugh <rick@bilmillennium.com>
+
+
+
+Reynolds & Postel                                              [Page 43]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+af              1411/tcp   AudioFile
+af              1411/udp   AudioFile
+#                          Jim Gettys <jg@crl.dec.com>
+innosys         1412/tcp   InnoSys
+innosys         1412/udp   InnoSys
+innosys-acl     1413/tcp   Innosys-ACL
+innosys-acl     1413/udp   Innosys-ACL
+#                          Eric Welch <--none--->
+ibm-mqseries    1414/tcp   IBM MQSeries
+ibm-mqseries    1414/udp   IBM MQSeries
+#                          Roger Meli <rmmeli%winvmd@vnet.ibm.com>
+dbstar          1415/tcp   DBStar
+dbstar          1415/udp   DBStar
+#                          Jeffrey Millman <jcm@dbstar.com>
+novell-lu6.2    1416/tcp   Novell LU6.2
+novell-lu6.2    1416/udp   Novell LU6.2
+#                          Peter Liu <--none--->
+timbuktu-srv1   1417/tcp   Timbuktu Service 1 Port
+timbuktu-srv1   1417/tcp   Timbuktu Service 1 Port
+timbuktu-srv2   1418/tcp   Timbuktu Service 2 Port
+timbuktu-srv2   1418/udp   Timbuktu Service 2 Port
+timbuktu-srv3   1419/tcp   Timbuktu Service 3 Port
+timbuktu-srv3   1419/udp   Timbuktu Service 3 Port
+timbuktu-srv4   1420/tcp   Timbuktu Service 4 Port
+timbuktu-srv4   1420/udp   Timbuktu Service 4 Port
+#                          Marc Epard <marc@waygate.farallon.com>
+gandalf-lm      1421/tcp   Gandalf License Manager
+gandalf-lm      1421/udp   Gandalf License Manager
+#                          gilmer@gandalf.ca
+autodesk-lm     1422/tcp   Autodesk License Manager
+autodesk-lm     1422/udp   Autodesk License Manager
+#                          David Ko <dko@autodesk.com>
+essbase         1423/tcp   Essbase Arbor Software
+essbase         1423/udp   Essbase Arbor Software
+hybrid          1424/tcp   Hybrid Encryption Protocol
+hybrid          1424/udp   Hybrid Encryption Protocol
+#                          Howard Hart <hch@hybrid.com>
+zion-lm         1425/tcp   Zion Software License Manager
+zion-lm         1425/udp   Zion Software License Manager
+#                          David Ferrero <david@zion.com>
+sas-1           1426/tcp   Satellite-data Acquisition System 1
+sas-1           1426/udp   Satellite-data Acquisition System 1
+#                          Bill Taylor <sais@ssec.wisc.edu>
+mloadd          1427/tcp   mloadd monitoring tool
+mloadd          1427/udp   mloadd monitoring tool
+#                          Bob Braden <braden@isi.edu>
+informatik-lm   1428/tcp   Informatik License Manager
+informatik-lm   1428/udp   Informatik License Manager
+
+
+
+Reynolds & Postel                                              [Page 44]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+#                          Harald Schlangmann
+#                          <schlangm@informatik.uni-muenchen.de>
+nms             1429/tcp   Hypercom NMS
+nms             1429/udp   Hypercom NMS
+tpdu            1430/tcp   Hypercom TPDU
+tpdu            1430/udp   Hypercom TPDU
+#                          Noor Chowdhury <noor@hypercom.com>
+rgtp            1431/tcp   Reverse Gosip Transport
+rgtp            1431/udp   Reverse Gosip Transport
+#                          <iwj10@cl.cam-orl.co.uk>
+blueberry-lm    1432/tcp   Blueberry Software License Manager
+blueberry-lm    1432/udp   Blueberry Software License Manager
+#                          Steve Beigel <ublueb!steve@uunet.uu.net>
+ms-sql-s        1433/tcp   Microsoft-SQL-Server
+ms-sql-s        1433/udp   Microsoft-SQL-Server
+ms-sql-m        1434/tcp   Microsoft-SQL-Monitor
+ms-sql-m        1434/udp   Microsoft-SQL-Monitor
+#                          Peter Hussey <peterhus@microsoft.com>
+ibm-cics        1435/tcp   IBM CISC
+ibm-cics        1435/udp   IBM CISC
+#                          Geoff Meacock <gbibmswl@ibmmail.COM>
+sas-2           1436/tcp   Satellite-data Acquisition System 2
+sas-2           1436/udp   Satellite-data Acquisition System 2
+#                          Bill Taylor <sais@ssec.wisc.edu>
+tabula          1437/tcp   Tabula
+tabula          1437/udp   Tabula
+#                          Marcelo Einhorn
+#                          <KGUNE%HUJIVM1.bitnet@taunivm.tau.ac.il>
+eicon-server    1438/tcp   Eicon Security Agent/Server
+eicon-server    1438/udp   Eicon Security Agent/Server
+eicon-x25       1439/tcp   Eicon X25/SNA Gateway
+eicon-x25       1439/udp   Eicon X25/SNA Gateway
+eicon-slp       1440/tcp   Eicon Service Location Protocol
+eicon-slp       1440/udp   Eicon Service Location Protocol
+#                          Pat Calhoun <CALHOUN@admin.eicon.qc.ca>
+cadis-1         1441/tcp   Cadis License Management
+cadis-1         1441/udp   Cadis License Management
+cadis-2         1442/tcp   Cadis License Management
+cadis-2         1442/udp   Cadis License Management
+#                          Todd Wichers <twichers@csn.org>
+ies-lm          1443/tcp   Integrated Engineering Software
+ies-lm          1443/udp   Integrated Engineering Software
+#                          David Tong <David_Tong@integrated.mb.ca>
+marcam-lm       1444/tcp   Marcam  License Management
+marcam-lm       1444/udp   Marcam  License Management
+#                          Therese Hunt <hunt@marcam.com>
+proxima-lm      1445/tcp   Proxima License Manager
+proxima-lm      1445/udp   Proxima License Manager
+
+
+
+Reynolds & Postel                                              [Page 45]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+ora-lm          1446/tcp   Optical Research Associates License Manager
+ora-lm          1446/udp   Optical Research Associates License Manager
+apri-lm         1447/tcp   Applied Parallel Research LM
+apri-lm         1447/udp   Applied Parallel Research LM
+#                          Jim Dillon <jed@apri.com>
+oc-lm           1448/tcp   OpenConnect License Manager
+oc-lm           1448/udp   OpenConnect License Manager
+#                          Sue Barnhill <snb@oc.com>
+peport          1449/tcp   PEport
+peport          1449/udp   PEport
+#                          Qentin Neill <quentin@ColumbiaSC.NCR.COM>
+dwf             1450/tcp   Tandem Distributed Workbench Facility
+dwf             1450/udp   Tandem Distributed Workbench Facility
+#                          Mike Bert <BERG_MIKE@tandem.com>
+infoman         1451/tcp   IBM Information Management
+infoman         1451/udp   IBM Information Management
+#                          Karen Burns <---none--->
+gtegsc-lm       1452/tcp   GTE Government Systems License Man
+gtegsc-lm       1452/udp   GTE Government Systems License Man
+#               Mike Gregory <Gregory_Mike@msmail.iipo.gtegsc.com>
+genie-lm        1453/tcp   Genie License Manager
+genie-lm        1453/udp   Genie License Manager
+#                          Paul Applegate <p.applegate2@genie.geis.com>
+interhdl_elmd   1454/tcp   interHDL License Manager
+interhdl_elmd   1454/tcp   interHDL License Manager
+#                          Eli Sternheim eli@interhdl.com
+esl-lm          1455/tcp   ESL License Manager
+esl-lm          1455/udp   ESL License Manager
+#                          Abel Chou <abel@willy.esl.com>
+dca             1456/tcp   DCA
+dca             1456/udp   DCA
+#                          Jeff Garbers <jgarbers@netcom.com>
+valisys-lm      1457/tcp    Valisys License Manager
+valisys-lm      1457/udp    Valisys License Manager
+#               Leslie Lincoln <leslie_lincoln@valisys.com>
+nrcabq-lm       1458/tcp    Nichols Research Corp.
+nrcabq-lm       1458/udp    Nichols Research Corp.
+#                           Howard Cole <hcole@tumbleweed.nrcabq.com>
+proshare1       1459/tcp    Proshare Notebook Application
+proshare1       1459/udp    Proshare Notebook Application
+proshare2       1460/tcp    Proshare Notebook Application
+proshare2       1460/udp    Proshare Notebook Application
+#                           Robin Kar <Robin_Kar@ccm.hf.intel.com>
+ibm_wrless_lan  1461/tcp    IBM Wireless LAN
+ibm_wrless_lan  1461/udp    IBM Wireless LAN
+#                           <flanne@vnet.IBM.COM>
+world-lm        1462/tcp    World License Manager
+world-lm        1462/udp    World License Manager
+
+
+
+Reynolds & Postel                                              [Page 46]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+#                           Michael S Amirault <ambi@world.std.com>
+nucleus         1463/tcp    Nucleus
+nucleus         1463/udp    Nucleus
+#                           Venky Nagar <venky@fafner.Stanford.EDU>
+msl_lmd         1464/tcp    MSL License Manager
+msl_lmd         1464/udp    MSL License Manager
+#                           Matt Timmermans
+pipes           1465/tcp    Pipes Platform
+pipes           1465/udp    Pipes Platform  mfarlin@peerlogic.com
+#                           Mark Farlin <mfarlin@peerlogic.com>
+oceansoft-lm    1466/tcp    Ocean Software License Manager
+oceansoft-lm    1466/udp    Ocean Software License Manager
+#                           Randy Leonard <randy@oceansoft.com>
+csdmbase        1467/tcp    CSDMBASE
+csdmbase        1467/udp    CSDMBASE
+csdm            1468/tcp    CSDM
+csdm            1468/udp    CSDM
+#               Robert Stabl <stabl@informatik.uni-muenchen.de>
+aal-lm          1469/tcp    Active Analysis Limited License Manager
+aal-lm          1469/udp    Active Analysis Limited License Manager
+#                           David Snocken  +44 (71)437-7009
+uaiact          1470/tcp    Universal Analytics
+uaiact          1470/udp    Universal Analytics
+#                           Mark R. Ludwig <Mark-Ludwig@uai.com>
+csdmbase        1471/tcp    csdmbase
+csdmbase        1471/udp    csdmbase
+csdm            1472/tcp    csdm
+csdm            1472/udp    csdm
+#               Robert Stabl <stabl@informatik.uni-muenchen.de>
+openmath        1473/tcp    OpenMath
+openmath        1473/udp    OpenMath
+#                           Garth Mayville <mayville@maplesoft.on.ca>
+telefinder      1474/tcp    Telefinder
+telefinder      1474/udp    Telefinder
+#                           Jim White <Jim_White@spiderisland.com>
+taligent-lm     1475/tcp    Taligent License Manager
+taligent-lm     1475/udp    Taligent License Manager
+#               Mark Sapsford <Mark_Sapsford@@taligent.com>
+clvm-cfg        1476/tcp    clvm-cfg
+clvm-cfg        1476/udp    clvm-cfg
+#                           Eric Soderberg <seric@cup.hp.com>
+ms-sna-server   1477/tcp    ms-sna-server
+ms-sna-server   1477/udp    ms-sna-server
+ms-sna-base     1478/tcp    ms-sna-base
+ms-sna-base     1478/udp    ms-sna-base
+#                           Gordon Mangione <gordm@microsoft.com>
+dberegister     1479/tcp    dberegister
+dberegister     1479/udp    dberegister
+
+
+
+Reynolds & Postel                                              [Page 47]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+#                           Brian Griswold <brian@dancingbear.com>
+pacerforum      1480/tcp    PacerForum
+pacerforum      1480/udp    PacerForum
+#                           Peter Caswell <pfc@pacvax.pacersoft.com>
+airs            1481/tcp    AIRS
+airs            1481/udp    AIRS
+#                           Bruce Wilson, 905-771-6161
+miteksys-lm     1482/tcp    Miteksys License Manager
+miteksys-lm     1482/udp    Miteksys License Manager
+#                           Shane McRoberts <mcroberts@miteksys.com>
+afs             1483/tcp    AFS License Manager
+afs             1483/udp    AFS License Manager
+#                           Michael R. Pizolato <michael@afs.com>
+confluent       1484/tcp    Confluent License Manager
+confluent       1484/udp    Confluent License Manager
+#                           James Greenfiel <jim@pa.confluent.com>
+lansource       1485/tcp    LANSource
+lansource       1485/udp    LANSource
+#                           Doug Scott <lansourc@hookup.net>
+nms_topo_serv   1486/tcp    nms_topo_serv
+nms_topo_serv   1486/udp    nms_topo_serv
+#                           Sylvia Siu <Sylvia_Siu@Novell.CO>
+localinfosrvr   1487/tcp    LocalInfoSrvr
+localinfosrvr   1487/udp    LocalInfoSrvr
+#               Brian Matthews <brian_matthews@ibist.ibis.com>
+docstor         1488/tcp    DocStor
+docstor         1488/udp    DocStor
+#                           Brian Spears <bspears@salix.com>
+dmdocbroker     1489/tcp    dmdocbroker
+dmdocbroker     1489/udp    dmdocbroker
+#                           Razmik Abnous <abnous@documentum.com>
+insitu-conf     1490/tcp    insitu-conf
+insitu-conf     1490/udp    insitu-conf
+#                           Paul Blacknell <paul@insitu.com>
+anynetgateway   1491/tcp    anynetgateway
+anynetgateway   1491/udp    anynetgateway
+#                           Dan Poirier <poirier@VNET.IBM.COM>
+stone-design-1  1492/tcp    stone-design-1
+stone-design-1  1492/udp    stone-design-1
+#                           Andrew Stone <andrew@stone.com>
+netmap_lm       1493/tcp    netmap_lm
+netmap_lm       1493/udp    netmap_lm
+#                           Phillip Magson <philm@extro.ucc.su.OZ.AU>
+ica             1494/tcp    ica
+ica             1494/udp    ica
+#                           John Richardson, Citrix Systems
+cvc             1495/tcp    cvc
+cvc             1495/udp    cvc
+
+
+
+Reynolds & Postel                                              [Page 48]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+#                           Bill Davidson <billd@equalizer.cray.com>
+liberty-lm      1496/tcp    liberty-lm
+liberty-lm      1496/udp    liberty-lm
+#                           Jim Rogers <trane!jimbo@pacbell.com>
+rfx-lm          1497/tcp    rfx-lm
+rfx-lm          1497/udp    rfx-lm
+#                           Bill Bishop <bil@rfx.rfx.com>
+watcom-sql      1498/tcp    Watcom-SQL
+watcom-sql      1498/udp    Watcom-SQL
+#                           Rog Skubowius <rwskubow@ccnga.uwaterloo.ca>
+fhc             1499/tcp    Federico Heinz Consultora
+fhc             1499/udp    Federico Heinz Consultora
+#                           Federico Heinz <federico@heinz.com>
+vlsi-lm         1500/tcp    VLSI License Manager
+vlsi-lm         1500/udp    VLSI License Manager
+#                           Shue-Lin Kuo <shuelin@mdk.sanjose.vlsi.com>
+sas-3           1501/tcp    Satellite-data Acquisition System 3
+sas-3           1501/udp    Satellite-data Acquisition System 3
+#                           Bill Taylor <sais@ssec.wisc.edu>
+shivadiscovery  1502/tcp    Shiva
+shivadiscovery  1502/udp    Shiva
+#                           Jonathan Wenocur <jhw@Shiva.COM>
+imtc-mcs        1503/tcp    Databeam
+imtc-mcs        1503/udp    Databeam
+#                           Jim Johnstone <jjohnstone@databeam.com>
+evb-elm         1504/tcp    EVB Software Engineering License Manager
+evb-elm         1504/udp    EVB Software Engineering License Manager
+#                           B.G. Mahesh < mahesh@sett.com>
+funkproxy       1505/tcp    Funk Software, Inc.
+funkproxy       1505/udp    Funk Software, Inc.
+#                           Robert D. Vincent <bert@willowpond.com>
+#               1506-1523   Unassigned
+ingreslock      1524/tcp    ingres
+ingreslock      1524/udp    ingres
+orasrv          1525/tcp    oracle
+orasrv          1525/udp    oracle
+prospero-np     1525/tcp    Prospero Directory Service non-priv
+prospero-np     1525/udp    Prospero Directory Service non-priv
+pdap-np         1526/tcp    Prospero Data Access Prot non-priv
+pdap-np         1526/udp    Prospero Data Access Prot non-priv
+#                           B. Clifford Neuman <bcn@isi.edu>
+tlisrv          1527/tcp    oracle
+tlisrv          1527/udp    oracle
+coauthor        1529/tcp    oracle
+coauthor        1529/udp    oracle
+issd            1600/tcp
+issd            1600/udp
+nkd             1650/tcp
+
+
+
+Reynolds & Postel                                              [Page 49]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+nkd             1650/udp
+proshareaudio   1651/tcp   proshare conf audio
+proshareaudio   1651/udp   proshare conf audio
+prosharevideo   1652/tcp   proshare conf video
+prosharevideo   1652/udp   proshare conf video
+prosharedata    1653/tcp   proshare conf data
+prosharedata    1653/udp   proshare conf data
+prosharerequest 1654/tcp   proshare conf request
+prosharerequest 1654/udp   proshare conf request
+prosharenotify  1655/tcp   proshare conf notify
+prosharenotify  1655/udp   proshare conf notify
+#                          <gunner@ibeam.intel.com>
+netview-aix-1   1661/tcp   netview-aix-1
+netview-aix-1   1661/udp   netview-aix-1
+netview-aix-2   1662/tcp   netview-aix-2
+netview-aix-2   1662/udp   netview-aix-2
+netview-aix-3   1663/tcp   netview-aix-3
+netview-aix-3   1663/udp   netview-aix-3
+netview-aix-4   1664/tcp   netview-aix-4
+netview-aix-4   1664/udp   netview-aix-4
+netview-aix-5   1665/tcp   netview-aix-5
+netview-aix-5   1665/udp   netview-aix-5
+netview-aix-6   1666/tcp   netview-aix-6
+netview-aix-6   1666/udp   netview-aix-6
+#               Martha Crisson <CRISSON@ralvm12.vnet.ibm.com>
+licensedaemon   1986/tcp   cisco license management
+licensedaemon   1986/udp   cisco license management
+tr-rsrb-p1      1987/tcp   cisco RSRB Priority 1 port
+tr-rsrb-p1      1987/udp   cisco RSRB Priority 1 port
+tr-rsrb-p2      1988/tcp   cisco RSRB Priority 2 port
+tr-rsrb-p2      1988/udp   cisco RSRB Priority 2 port
+tr-rsrb-p3      1989/tcp   cisco RSRB Priority 3 port
+tr-rsrb-p3      1989/udp   cisco RSRB Priority 3 port
+#PROBLEMS!===================================================
+mshnet          1989/tcp   MHSnet system
+mshnet          1989/udp   MHSnet system
+#               Bob Kummerfeld <bob@sarad.cs.su.oz.au>
+#PROBLEMS!===================================================
+stun-p1         1990/tcp   cisco STUN Priority 1 port
+stun-p1         1990/udp   cisco STUN Priority 1 port
+stun-p2         1991/tcp   cisco STUN Priority 2 port
+stun-p2         1991/udp   cisco STUN Priority 2 port
+stun-p3         1992/tcp   cisco STUN Priority 3 port
+stun-p3         1992/udp   cisco STUN Priority 3 port
+#PROBLEMS!===================================================
+ipsendmsg       1992/tcp   IPsendmsg
+ipsendmsg       1992/udp   IPsendmsg
+#               Bob Kummerfeld <bob@sarad.cs.su.oz.au>
+
+
+
+Reynolds & Postel                                              [Page 50]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+#PROBLEMS!===================================================
+snmp-tcp-port   1993/tcp   cisco SNMP TCP port
+snmp-tcp-port   1993/udp   cisco SNMP TCP port
+stun-port       1994/tcp   cisco serial tunnel port
+stun-port       1994/udp   cisco serial tunnel port
+perf-port       1995/tcp   cisco perf port
+perf-port       1995/udp   cisco perf port
+tr-rsrb-port    1996/tcp   cisco Remote SRB port
+tr-rsrb-port    1996/udp   cisco Remote SRB port
+gdp-port        1997/tcp   cisco Gateway Discovery Protocol
+gdp-port        1997/udp   cisco Gateway Discovery Protocol
+x25-svc-port    1998/tcp   cisco X.25 service (XOT)
+x25-svc-port    1998/udp   cisco X.25 service (XOT)
+tcp-id-port     1999/tcp   cisco identification port
+tcp-id-port     1999/udp   cisco identification port
+callbook        2000/tcp
+callbook        2000/udp
+dc              2001/tcp
+wizard          2001/udp    curry
+globe           2002/tcp
+globe           2002/udp
+mailbox         2004/tcp
+emce            2004/udp    CCWS mm conf
+berknet         2005/tcp
+oracle          2005/udp
+invokator       2006/tcp
+raid-cc         2006/udp    raid
+dectalk         2007/tcp
+raid-am         2007/udp
+conf            2008/tcp
+terminaldb      2008/udp
+news            2009/tcp
+whosockami      2009/udp
+search          2010/tcp
+pipe_server     2010/udp
+raid-cc         2011/tcp    raid
+servserv        2011/udp
+ttyinfo         2012/tcp
+raid-ac         2012/udp
+raid-am         2013/tcp
+raid-cd         2013/udp
+troff           2014/tcp
+raid-sf         2014/udp
+cypress         2015/tcp
+raid-cs         2015/udp
+bootserver      2016/tcp
+bootserver      2016/udp
+cypress-stat    2017/tcp
+
+
+
+Reynolds & Postel                                              [Page 51]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+bootclient      2017/udp
+terminaldb      2018/tcp
+rellpack        2018/udp
+whosockami      2019/tcp
+about           2019/udp
+xinupageserver  2020/tcp
+xinupageserver  2020/udp
+servexec        2021/tcp
+xinuexpansion1  2021/udp
+down            2022/tcp
+xinuexpansion2  2022/udp
+xinuexpansion3  2023/tcp
+xinuexpansion3  2023/udp
+xinuexpansion4  2024/tcp
+xinuexpansion4  2024/udp
+ellpack         2025/tcp
+xribs           2025/udp
+scrabble        2026/tcp
+scrabble        2026/udp
+shadowserver    2027/tcp
+shadowserver    2027/udp
+submitserver    2028/tcp
+submitserver    2028/udp
+device2         2030/tcp
+device2         2030/udp
+blackboard      2032/tcp
+blackboard      2032/udp
+glogger         2033/tcp
+glogger         2033/udp
+scoremgr        2034/tcp
+scoremgr        2034/udp
+imsldoc         2035/tcp
+imsldoc         2035/udp
+objectmanager   2038/tcp
+objectmanager   2038/udp
+lam             2040/tcp
+lam             2040/udp
+interbase       2041/tcp
+interbase       2041/udp
+isis            2042/tcp
+isis            2042/udp
+isis-bcast      2043/tcp
+isis-bcast      2043/udp
+rimsl           2044/tcp
+rimsl           2044/udp
+cdfunc          2045/tcp
+cdfunc          2045/udp
+sdfunc          2046/tcp
+
+
+
+Reynolds & Postel                                              [Page 52]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+sdfunc          2046/udp
+dls             2047/tcp
+dls             2047/udp
+dls-monitor     2048/tcp
+dls-monitor     2048/udp
+shilp           2049/tcp
+shilp           2049/udp
+dlsrpn          2065/tcp   Data Link Switch Read Port Number
+dlsrpn          2065/udp   Data Link Switch Read Port Number
+dlswpn          2067/tcp   Data Link Switch Write Port Number
+dlswpn          2067/udp   Data Link Switch Write Port Number
+ats             2201/tcp   Advanced Training System Program
+ats             2201/udp   Advanced Training System Program
+rtsserv         2500/tcp   Resource Tracking system server
+rtsserv         2500/udp   Resource Tracking system server
+rtsclient       2501/tcp   Resource Tracking system client
+rtsclient       2501/udp   Resource Tracking system client
+#                          Aubrey Turner
+#               <S95525ta%etsuacad.bitnet@ETSUADMN.ETSU.EDU>
+hp-3000-telnet  2564/tcp   HP 3000 NS/VT block mode telnet
+www-dev         2784/tcp   world wide web - development
+www-dev         2784/udp   world wide web - development
+NSWS            3049/tcp
+NSWS            3049/udp
+ccmail          3264/tcp   cc:mail/lotus
+ccmail          3264/udp   cc:mail/lotus
+dec-notes       3333/tcp   DEC Notes
+dec-notes       3333/udp   DEC Notes
+#                          Kim Moraros <moraros@via.enet.dec.com>
+mapper-nodemgr    3984/tcp     MAPPER network node manager
+mapper-nodemgr    3984/udp     MAPPER network node manager
+mapper-mapethd    3985/tcp     MAPPER TCP/IP server
+mapper-mapethd    3985/udp     MAPPER TCP/IP server
+mapper-ws_ethd    3986/tcp     MAPPER workstation server
+mapper-ws_ethd    3986/udp     MAPPER workstation server
+#                 John C. Horton <jch@unirsvl.rsvl.unisys.com>
+bmap            3421/tcp   Bull Apprise portmapper
+bmap            3421/udp   Bull Apprise portmapper
+#                          Jeremy Gilbert <J.Gilbert@ma30.bull.com>
+udt_os          3900/tcp   Unidata UDT OS
+udt_os          3900/udp   Unidata UDT OS
+#                          James Powell <james@mailhost.unidata.com>
+nuts_dem        4132/tcp   NUTS Daemon
+nuts_dem        4132/udp   NUTS Daemon
+nuts_bootp      4133/tcp   NUTS Bootp Server
+nuts_bootp      4133/udp   NUTS Bootp Server
+#                          Martin Freiss <freiss.pad@sni.>
+unicall         4343/tcp   UNICALL
+
+
+
+Reynolds & Postel                                              [Page 53]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+unicall         4343/udp   UNICALL
+#                          James Powell <james@enghp.unidata.comp>
+krb524          4444/tcp   KRB524
+krb524          4444/udp   KRB524
+#                          B. Clifford Neuman <bcn@isi.edu>
+rfa             4672/tcp   remote file access server
+rfa             4672/udp   remote file access server
+commplex-main   5000/tcp
+commplex-main   5000/udp
+commplex-link   5001/tcp
+commplex-link   5001/udp
+rfe             5002/tcp   radio free ethernet
+rfe             5002/udp   radio free ethernet
+telelpathstart  5010/tcp   TelepathStart
+telelpathstart  5010/udp   TelepathStart
+telelpathattack 5011/tcp   TelepathAttack
+telelpathattack 5011/udp   TelepathAttack
+#               Helmuth Breitenfellner <hbreitenf@vnet.imb.com>
+mmcc            5050/tcp   multimedia conference control tool
+mmcc            5050/udp   multimedia conference control tool
+rmonitor_secure 5145/tcp
+rmonitor_secure 5145/udp
+aol             5190/tcp   America-Online
+aol             5190/udp   America-Online
+#                          Marty Lyons <marty@aol.com>
+padl2sim        5236/tcp
+padl2sim        5236/udp
+hacl-hb         5300/tcp        # HA cluster heartbeat
+hacl-hb         5300/udp        # HA cluster heartbeat
+hacl-gs         5301/tcp        # HA cluster general services
+hacl-gs         5301/udp        # HA cluster general services
+hacl-cfg        5302/tcp        # HA cluster configuration
+hacl-cfg        5302/udp        # HA cluster configuration
+hacl-probe      5303/tcp        # HA cluster probing
+hacl-probe      5303/udp        # HA cluster probing
+hacl-local      5304/tcp
+hacl-local      5304/udp
+hacl-test       5305/tcp
+hacl-test       5305/udp
+#                               Eric Soderberg <seric@hposl102.cup.hp>
+x11             6000-6063/tcp   X Window System
+x11             6000-6063/udp   X Window System
+#               Stephen Gildea <gildea@expo.lcs.mit.edu>
+sub-process     6111/tcp   HP SoftBench Sub-Process Control
+sub-process     6111/udp   HP SoftBench Sub-Process Control
+meta-corp       6141/tcp   Meta Corporation License Manager
+meta-corp       6141/udp   Meta Corporation License Manager
+#                          Osamu Masuda <--none--->
+
+
+
+Reynolds & Postel                                              [Page 54]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+aspentec-lm     6142/tcp   Aspen Technology License Manager
+aspentec-lm     6142/udp   Aspen Technology License Manager
+#                          Kevin Massey <massey@aspentec.com>
+watershed-lm    6143/tcp   Watershed License Manager
+watershed-lm    6143/udp   Watershed License Manager
+#                          David Ferrero <david@zion.com>
+statsci1-lm     6144/tcp   StatSci License Manager - 1
+statsci1-lm     6144/udp   StatSci License Manager - 1
+statsci2-lm     6145/tcp   StatSci License Manager - 2
+statsci2-lm     6145/udp   StatSci License Manager - 2
+#                          Scott Blachowicz <scott@statsci.com>
+lonewolf-lm     6146/tcp   Lone Wolf Systems License Manager
+lonewolf-lm     6146/udp   Lone Wolf Systems License Manager
+#                          Dan Klein <dvk@lonewolf.com>
+montage-lm      6147/tcp   Montage License Manager
+montage-lm      6147/udp   Montage License Manager
+#                          Michael Ubell <michael@montage.com>
+xdsxdm          6558/udp
+xdsxdm          6558/tcp
+afs3-fileserver 7000/tcp   file server itself
+afs3-fileserver 7000/udp   file server itself
+afs3-callback   7001/tcp   callbacks to cache managers
+afs3-callback   7001/udp   callbacks to cache managers
+afs3-prserver   7002/tcp   users & groups database
+afs3-prserver   7002/udp   users & groups database
+afs3-vlserver   7003/tcp   volume location database
+afs3-vlserver   7003/udp   volume location database
+afs3-kaserver   7004/tcp   AFS/Kerberos authentication service
+afs3-kaserver   7004/udp   AFS/Kerberos authentication service
+afs3-volser     7005/tcp   volume managment server
+afs3-volser     7005/udp   volume managment server
+afs3-errors     7006/tcp   error interpretation service
+afs3-errors     7006/udp   error interpretation service
+afs3-bos        7007/tcp   basic overseer process
+afs3-bos        7007/udp   basic overseer process
+afs3-update     7008/tcp   server-to-server updater
+afs3-update     7008/udp   server-to-server updater
+afs3-rmtsys     7009/tcp   remote cache manager service
+afs3-rmtsys     7009/udp   remote cache manager service
+ups-onlinet     7010/tcp   onlinet uninterruptable power supplies
+ups-onlinet     7010/udp   onlinet uninterruptable power supplies
+#                          Brian Hammill <hamill@dolphin.exide.com>
+font-service    7100/tcp   X Font Service
+font-service    7100/udp   X Font Service
+#                          Stephen Gildea <gildea@expo.lcs.mit.edu>
+fodms           7200/tcp   FODMS FLIP
+fodms           7200/udp   FODMS FLIP
+#           David Anthony <anthony@power.amasd.anatcp.rockwell.com>
+
+
+
+Reynolds & Postel                                              [Page 55]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+man             9535/tcp
+man             9535/udp
+isode-dua       17007/tcp
+isode-dua       17007/udp
+
+REFERENCES
+
+[RFC768] Postel, J., "User Datagram Protocol", STD 6, RFC 768,
+         USC/Information Sciences Institute, August 1980.
+
+[RFC793] Postel, J., ed., "Transmission Control Protocol - DARPA
+         Internet Program Protocol Specification", STD 7, RFC 793,
+         USC/Information Sciences Institute, September 1981.
+
+
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/port-numbers
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 56]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+INTERNET MULTICAST ADDRESSES
+
+Host Extensions for IP Multicasting [RFC1112] specifies the
+extensions required of a host implementation of the Internet Protocol
+(IP) to support multicasting.  Current addresses are listed below.
+
+224.0.0.0  Base Address (Reserved)                   [RFC1112,JBP]
+224.0.0.1  All Systems on this Subnet                [RFC1112,JBP]
+224.0.0.2  All Routers on this Subnet                        [JBP]
+224.0.0.3  Unassigned                                        [JBP]
+224.0.0.4  DVMRP    Routers                          [RFC1075,JBP]
+224.0.0.5  OSPFIGP  OSPFIGP All Routers             [RFC1583,JXM1]
+224.0.0.6  OSPFIGP  OSPFIGP Designated Routers      [RFC1583,JXM1]
+224.0.0.7  ST Routers                               [RFC1190,KS14]
+224.0.0.8  ST Hosts                                 [RFC1190,KS14]
+224.0.0.9  RIP2 Routers                                    [GSM11]
+224.0.0.10 IGRP Routers                           [Dino Farinacci]
+224.0.0.11 Mobile-Agents                            [Bill Simpson]
+224.0.0.12-224.0.0.255 Unassigned                            [JBP]
+
+224.0.1.0  VMTP Managers Group                      [RFC1045,DRC3]
+224.0.1.1  NTP      Network Time Protocol           [RFC1119,DLM1]
+224.0.1.2  SGI-Dogfight                                      [AXC]
+224.0.1.3  Rwhod                                             [SXD]
+224.0.1.4  VNP                                              [DRC3]
+224.0.1.5  Artificial Horizons - Aviator                     [BXF]
+224.0.1.6  NSS - Name Service Server                        [BXS2]
+224.0.1.7  AUDIONEWS - Audio News Multicast                 [MXF2]
+224.0.1.8  SUN NIS+ Information Service                     [CXM3]
+224.0.1.9  MTP Multicast Transport Protocol                  [SXA]
+224.0.1.10 IETF-1-LOW-AUDIO                                  [SC3]
+224.0.1.11 IETF-1-AUDIO                                      [SC3]
+224.0.1.12 IETF-1-VIDEO                                      [SC3]
+224.0.1.13 IETF-2-LOW-AUDIO                                  [SC3]
+224.0.1.14 IETF-2-AUDIO                                      [SC3]
+224.0.1.15 IETF-2-VIDEO                                      [SC3]
+224.0.1.16 MUSIC-SERVICE                        [Guido van Rossum]
+224.0.1.17 SEANET-TELEMETRY                        [Andrew Maffei]
+224.0.1.18 SEANET-IMAGE                            [Andrew Maffei]
+224.0.1.19 MLOADD                                         [Braden]
+224.0.1.20 any private experiment                            [JBP]
+224.0.1.21 DVMRP on MOSPF                               [John Moy]
+224.0.1.22 SVRLOC                               <veizades@ftp.com>
+224.0.1.23 XINGTV                                 <hgxing@aol.com>
+224.0.1.24 microsoft-ds                    <arnoldm@microsoft.com>
+224.0.1.25 nbc-pro                      <bloomer@birch.crd.ge.com>
+224.0.1.26 nbc-pfn                      <bloomer@birch.crd.ge.com>
+224.0.1.27-224.0.1.255  Unassigned                           [JBP]
+
+
+
+Reynolds & Postel                                              [Page 57]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+224.0.2.1  "rwho" Group (BSD) (unofficial)                   [JBP]
+224.0.2.2  SUN RPC PMAPPROC_CALLIT                          [BXE1]
+
+224.0.3.000-224.0.3.255 RFE Generic Service                 [DXS3]
+224.0.4.000-224.0.4.255 RFE Individual Conferences          [DXS3]
+224.0.5.000-224.0.5.127 CDPD Groups                  [Bob Brenner]
+224.0.5.128-224.0.5.255 Unassigned                          [IANA]
+224.0.6.000-224.0.6.127 Cornell ISIS Project           [Tim Clark]
+224.0.6.128-224.0.6.255 Unassigned                          [IANA]
+
+224.1.0.0-224.1.255.255  ST Multicast Groups        [RFC1190,KS14]
+224.2.0.0-224.2.255.255  Multimedia Conference Calls         [SC3]
+
+224.252.0.0-224.255.255.255 DIS transient groups     [Joel Snyder]
+
+232.0.0.0-232.255.255.255  VMTP transient groups    [RFC1045,DRC3]
+
+These addresses are listed in the Domain Name Service under MCAST.NET
+and 224.IN-ADDR.ARPA.
+
+Note that when used on an Ethernet or IEEE 802 network, the 23
+low-order bits of the IP Multicast address are placed in the low-order
+23 bits of the Ethernet or IEEE 802 net multicast address
+1.0.94.0.0.0.  See the next section on "IANA ETHERNET ADDRESS BLOCK".
+
+REFERENCES
+
+[RFC1045] Cheriton, D., "VMTP: Versatile Message Transaction
+          Protocol Specification", RFC 1045, Stanford University,
+          February 1988.
+
+[RFC1075] Waitzman, D., C. Partridge, and S. Deering "Distance Vector
+          Multicast Routing Protocol", RFC-1075, BBN STC, Stanford
+          University, November 1988.
+
+[RFC1112] Deering, S., "Host Extensions for IP Multicasting",
+          STD 5, RFC 1112, Stanford University, August 1989.
+
+[RFC1119] Mills, D., "Network Time Protocol (Version 1), Specification
+          and Implementation", STD 12, RFC 1119, University of
+          Delaware, July 1988.
+
+[RFC1190] Topolcic, C., Editor, "Experimental Internet Stream
+          Protocol, Version 2 (ST-II)", RFC 1190, CIP Working Group,
+          October 1990.
+
+[RFC1583] Moy, J., "The OSPF Specification", RFC 1583, Proteon,
+          March 1994.
+
+
+
+Reynolds & Postel                                              [Page 58]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+PEOPLE
+
+<arnoldm@microsoft.com>
+
+[AXC] Andrew Cherenson <arc@SGI.COM>
+
+[Bob Brenner]
+
+<bloomer@birch.crd.ge.com>
+
+[Braden] Bob Braden <braden@isi.edu
+
+[BXE1] Brendan Eic <brendan@illyria.wpd.sgi.com>
+
+[BXF] Bruce Factor <ahi!bigapple!bruce@uunet.UU.NET>
+
+[BXS2] Bill Schilit <schilit@parc.xerox.com>
+
+[CXM3] Chuck McManis <cmcmanis@sun.com>
+
+[Tim Clark]
+
+[DLM1] David Mills <Mills@HUEY.UDEL.EDU>
+
+[DRC3] Dave Cheriton <cheriton@PESCADERO.STANFORD.EDU>
+
+[DXS3] Daniel Steinber <Daniel.Steinberg@Eng.Sun.COM>
+
+[Dino Farinacci]
+
+[GSM11] Gary S. Malkin <GMALKIN@XYLOGICS.COM>
+
+<hgxing@aol.com>
+
+[IANA] IANA <iana@isi.edu>
+
+[JBP] Jon Postel <postel@isi.edu>
+
+[JXM1] Jim Miner <miner@star.com>
+
+[KS14] <mystery contact>
+
+[Andrew Maffei]
+
+[John Moy] John Moy <jmoy@PROTEON.COM>
+
+[MXF2] Martin Forssen <maf@dtek.chalmers.se>
+
+
+
+
+Reynolds & Postel                                              [Page 59]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[Guido van Rossum]
+
+[SC3] Steve Casner <casner@isi.edu>
+
+[Joel Snyder]
+
+[SXA] Susie Armstrong <Armstrong.wbst128@XEROX.COM>
+
+[SXD] Steve Deering <deering@PARC.XEROX.COM>
+
+<veizades@ftp.com>
+
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/multicast-addresses
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 60]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+SUN RPC NUMBERS
+
+
+To obtain SUN Remote Procedure Call (RPC) numbers send an e-mail
+request to "rpc@sun.com".
+
+The RPC port management service ('portmap' in SunOS versions less than
+5.0 and 'rpcbind' in SunOS versions greater than 5.0) "registers" the
+IP port number that is allocated to a particular service when that
+service is created. It does not allocate ports on behalf of those
+services.
+
+For an exact specification of the semantics refer to the source code
+of svcudp_create() and svctcp_create() in the archives.  In short
+however is that these interfaces, and svc_tli_create their Transport
+Independent RPC equivalent, take either a user specified port number
+or RPC_ANY (-1) which effectively means "I don't care."  In the "I
+don't care" case the create code simply calls socket(2) or t_open(3n)
+which allocates an IP port based on the rules:
+
+        if euid of the requesting process is 0 (i.e., root)
+                allocate the next available port number in the
+                reserved port range.
+        else
+                allocate the next available port in the non-reserved
+                range.
+
+Port numbers count up sequentially.
+
+Can a port that is "assigned" can be used when the assignee's service
+is not present?  Say port 501 is assigned to the "jeans" service.  On
+a machine that does not have the "jeans" service, nor has any clients
+that might be expecting to use it, is port 501 available for other
+uses?  Any dynamic allocation process, like the portmapper, that
+chooses the next unused port might allocate port 501 dynamically to a
+process that asked for a "I don't care" port.  So any dynamic
+allocation scheme may pick an unused port that happened to correspond
+to a port number that had been "assigned" but was currently unused.
+
+While it might be desirable, it is impossible to guarantee that any
+unused port, even though officially assigned to a service, is not
+picked by a dynamic allocator since such an assignment might occur
+long after the delivery of the system into a site that doesn't watch
+for the latest list.
+
+There is the restriction that only "superuser" on BSD derived systems
+such as SunOS can bind to a port number that is less than 1024.  So
+programs have used this information in the past to identify whether or
+
+
+
+Reynolds & Postel                                              [Page 61]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+not the service they were talking to was started by the superuser on
+the remote system.  Making this assumption is dangerous because not
+all system enforce this restriction.
+
+Sun RPC services use ports that are currently unused.  If someone
+noted that an RPC service was using port 781, it would be just as
+happy using port 891, or 951.  The service doesn't care what port it
+gets, remote clients will query the portmapper to ask it what port
+number was assigned to the service when it was started.  The key is
+that the port was not currently in use.  The only port that ONC/RPC
+must have is 111 its assigned port for the portmap service.
+
+The most common complaint comes when people put a new service on their
+system.  When they configure their systems they put the new service
+configuration commands at the end of their system startup scripts.
+During startup, several network services may be started. Those
+services that are ONC/RPC based just pick the next available port,
+those that have pre-assigned ports bind to their pre-assigned port.
+Clearly the correct sequence is to have all services that need a
+particular port to be started first (or if they are "latent" services
+that are started by inetd, to have inetd started).  Finally, the RPC
+services should be started as they will be assigned unused ports. (In
+the BSD networking code (which we use) the algorithm for picking
+ports is in the file in_pcb.c, function in_pcbbind().)
+
+Services should be started in this order:
+
+   a) Services that will "run" continuously and have an assigned
+      port. Note that this includes rpcbind (nee portmap) that has
+      port 111 assigned to it.
+
+   b) inetd - which will automatically create sockets for those
+      services that have reserved ports but only run on demand
+      (like finger)
+
+   c) RPC services - which will automatically pick unused ports and
+      maximize efficiency of the "IP Port" namespace.
+
+The include file /usr/include/netinet/in.h defines a constant
+IPPORT_RESERVED to be 1024.  The relevant text is:
+
+   /*
+    * Ports < IPPORT_RESERVED are reserved for
+    * privileged processes (e.g. root).
+    * Ports > IPPORT_USERRESERVED are reserved
+    * for servers, not necessarily privileged.
+    */
+   #define IPPORT_RESERVED         1024
+
+
+
+Reynolds & Postel                                              [Page 62]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+   #define IPPORT_USERRESERVED     5000
+
+Portmap does not allocate ports, the kernel allocates ports.  The code
+that does this is part of nearly every UNIX system in the world (and
+since the BSD code is 'free' it is often the same code).  RPC services
+ask the kernel to allocate them a port by calling the "bind()" system
+call.  The parameter they pass is "INADDR_ANY" which means "allocate
+me any IP port you want".  The kernel does that by looking at all of
+the ports that are currently in use and picking one that is not
+currently used.  The number picked is either less that 1024 if the
+process is privledged, or greater than 1024 if the process is not
+privledged.  After the kernel has allocated a port, the service
+registers this allocation with portmap.  The portmapper is merely a
+registry of previously allocated ports.  Note "allocated" here is
+being used in the sense that they are used by an open socket, not
+assigned a well known name.
+
+The role of /etc/services is to provide an idea to people who are
+looking at network traffic as to where a packet may have originated
+from or is headed to.  For services like finger that have assigned
+ports, they can just hard code the port they want into their
+executable. (it isn't like it will change, and if they read it from
+/etc/services and someone had mistyped the port number it won't
+interoperate with clients anyway!)
+
+It is not practical to read the /etc/services file into the kernel to
+prevent it from giving out port numbers that are "pre-assigned", nor
+is it generally desirable since with the correct ordering of startup
+it is completely unneccesary.
+
+Editors Note: This information was supplied by Chuck McManis of Sun.
+
+[]
+
+
+
+
+
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/sun-rpc-numbers
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 63]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+IP OPTION NUMBERS
+
+The Internet Protocol (IP) has provision for optional header fields
+identified by an option type field.  Options 0 and 1 are exactly one
+octet which is their type field.  All other options have their one
+octet type field, followed by a one octet length field, followed by
+length-2 octets of option data.  The option type field is sub-divided
+into a one bit copied flag, a two bit class field, and a five bit
+option number.  These taken together form an eight bit value for the
+option type field.  IP options are commonly refered to by this value.
+
+
+Copy Class Number Value Name                            Reference
+---- ----- ------ ----- ------------------------------- ---------
+   0     0      0     0 EOOL   - End of Options List    [RFC791,JBP]
+   0     0      1     1 NOP    - No Operation           [RFC791,JBP]
+   1     0      2   130 SEC    - Security                  [RFC1108]
+   1     0      3   131 LSR    - Loose Source Route     [RFC791,JBP]
+   0     2      4    68 TS     - Time Stamp             [RFC791,JBP]
+   1     0      5   133 E-SEC  - Extended Security         [RFC1108]
+   1     0      6   134 CIPSO  - Commercial Security           [???]
+   0     0      7     7 RR     - Record Route           [RFC791,JBP]
+   1     0      8   136 SID    - Stream ID              [RFC791,JBP]
+   1     0      9   137 SSR    - Strict Source Route    [RFC791,JBP]
+   0     0     10    10 ZSU    - Experimental Measurement      [ZSu]
+   0     0     11    11 MTUP   - MTU Probe                 [RFC1191]
+   0     0     12    12 MTUR   - MTU Reply                 [RFC1191]
+   1     2     13   205 FINN   - Experimental Flow Control    [Finn]
+   1     0     14   142 VISA   - Expermental Access Control [Estrin]
+   0     0     15    15 ENCODE - ???                      [VerSteeg]
+   1     0     16   144 IMITD  - IMI Traffic Descriptor        [Lee]
+   1     0     17   145 EIP    - ???                       [RFC1358]
+   0     2     18    82 TR     - Traceroute                [RFC1393]
+   1     0     19   147 ADDEXT - Address Extension    [Ullmann IPv7]
+
+
+
+IP TIME TO LIVE PARAMETER
+
+The current recommended default time to live (TTL) for the
+Internet Protocol (IP) [45,105] is 64.
+
+
+IP TOS PARAMETERS
+
+This documents the default Type-of-Service values that are currently
+recommended for the most important Internet protocols.
+
+
+
+
+Reynolds & Postel                                              [Page 64]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+TOS Value       Description                             Reference
+---------       --------------------------              ---------
+  0000          Default                                 [RFC1349]
+  0001          Minimize Monetary Cost                  [RFC1349]
+  0010          Maximize Reliability                    [RFC1349]
+  0100          Maximize Throughput                     [RFC1349]
+  1000          Minimize Delay                          [RFC1349]
+  1111          Maximize Security                       [RFC1455]
+
+The TOS value is used to indicate "better".  Only one TOS value or
+property can be requested in any one IP datagram.
+
+Generally, protocols which are involved in direct interaction with a
+human should select low delay, while data transfers which may involve
+large blocks of data are need high throughput.  Finally, high reliability
+is most important for datagram-based Internet management functions.
+
+Application protocols not included in these tables should be able to
+make appropriate choice of low delay (8 decimal, 1000 binary) or high
+throughput (4 decimal, 0100 binary).
+
+The following are recommended values for TOS:
+
+
+            ----- Type-of-Service Value -----
+
+Protocol           TOS Value
+
+TELNET (1)         1000                 (minimize delay)
+
+FTP
+  Control          1000                 (minimize delay)
+  Data (2)         0100                 (maximize throughput)
+
+TFTP               1000                 (minimize delay)
+
+SMTP (3)
+  Command phase    1000                 (minimize delay)
+  DATA phase       0100                 (maximize throughput)
+
+Domain Name Service
+  UDP Query        1000                 (minimize delay)
+  TCP Query        0000
+  Zone Transfer    0100                 (maximize throughput)
+
+NNTP               0001                 (minimize monetary cost)
+
+ICMP
+
+
+
+Reynolds & Postel                                              [Page 65]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+  Errors           0000
+  Requests         0000 (4)
+  Responses        <same as request> (4)
+
+Any IGP            0010                 (maximize reliability)
+
+EGP                0000
+
+SNMP               0010                 (maximize reliability)
+
+BOOTP              0000
+
+Notes:
+
+(1) Includes all interactive user protocols (e.g., rlogin).
+
+(2) Includes all bulk data transfer protocols (e.g., rcp).
+
+(3) If the implementation does not support changing the TOS
+during the lifetime of the connection, then the
+recommended TOS on opening the connection is the default
+TOS (0000).
+
+(4) Although ICMP request messages are normally sent with
+the default TOS, there are sometimes good reasons why they
+would be sent with some other TOS value.  An ICMP
+response always uses the same TOS value as was used in the
+corresponding ICMP request message.
+
+An application may (at the request of the user) substitute
+0001 (minimize monetary cost) for any of the above values.
+
+
+REFERENCES
+
+[RFC791] Postel, J., "Internet Protocol - DARPA Internet Program
+         Protocol Specification", STD 5, RFC 791, DARPA, September
+         1981.
+
+[RFC1108] Kent, S., "U.S. Department of Defense Security Options for
+          the Internet Protocol", RFC 1108, BBN Communications,
+          November 1991.
+
+[RFC1191] Mogul, J., and S. Deering, "Path MTU Discovery", RFC 1191,
+          DECWRL, Stanford University, November 1990.
+
+[RFC1349] Almquist, P., "Type of Service in the Internet Protocol
+          Suite", RFC 1349, Consultant, July 1992.
+
+
+
+Reynolds & Postel                                              [Page 66]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[RFC1358] Chapin, L., Chair, "Charter of the Internet Architecture
+          Board (IAB)", RFC 1358, Internet Architecture Board, August
+          1992.
+
+[RFC1393] Malkin, G., "Traceroute Using an IP Option", RFC 1393,
+          Xylogics, Inc., January 1993.
+
+[RFC1455] Eastlake, D., "Physical Link Security Type of Service",
+          RFC 1455, Digital Equipment Corporation, May 1993.
+
+[Ullmann IPv7]
+
+
+PEOPLE
+
+[Estrin] Deborah Estrin <Estrin@usc.edu>
+
+[Finn] Greg Finn <Finn@isi.edu>
+
+[JBP] Jon Postel <postel@isi.edu>
+
+[Ullmann] Robert Ullmann <ariel@world.std.com>
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/ip-parameters
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 67]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+ICMP TYPE NUMBERS
+
+The Internet Control Message Protocol (ICMP) has many messages that
+are identified by a "type" field.
+
+Type    Name                                    Reference
+----    -------------------------               ---------
+  0     Echo Reply                               [RFC792]
+  1     Unassigned                                  [JBP]
+  2     Unassigned                                  [JBP]
+  3     Destination Unreachable                  [RFC792]
+  4     Source Quench                            [RFC792]
+  5     Redirect                                 [RFC792]
+  6     Alternate Host Address                      [JBP]
+  7     Unassigned                                  [JBP]
+  8     Echo                                     [RFC792]
+  9     Router Advertisement                    [RFC1256]
+ 10     Router Selection                        [RFC1256]
+ 11     Time Exceeded                            [RFC792]
+ 12     Parameter Problem                        [RFC792]
+ 13     Timestamp                                [RFC792]
+ 14     Timestamp Reply                          [RFC792]
+ 15     Information Request                      [RFC792]
+ 16     Information Reply                        [RFC792]
+ 17     Address Mask Request                     [RFC950]
+ 18     Address Mask Reply                       [RFC950]
+ 19     Reserved (for Security)                    [Solo]
+ 20-29  Reserved (for Robustness Experiment)        [ZSu]
+ 30     Traceroute                              [RFC1393]
+ 31     Datagram Conversion Error               [RFC1475]
+ 32     Mobile Host Redirect              [David Johnson]
+ 33     IPv6 Where-Are-You                 [Bill Simpson]
+ 34     IPv6 I-Am-Here                     [Bill Simpson]
+ 35     Mobile Registration Request        [Bill Simpson]
+ 36     Mobile Registration Reply          [Bill Simpson]
+ 37-255 Reserved                                    [JBP]
+
+Many of these ICMP types have a "code" field.  Here we list the types
+again with their assigned code fields.
+
+Type    Name                                    Reference
+----    -------------------------               ---------
+  0     Echo Reply                               [RFC792]
+
+        Codes
+            0  No Code
+
+  1     Unassigned                                  [JBP]
+
+
+
+Reynolds & Postel                                              [Page 68]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+  2     Unassigned                                  [JBP]
+
+  3     Destination Unreachable                  [RFC792]
+
+        Codes
+            0  Net Unreachable
+            1  Host Unreachable
+            2  Protocol Unreachable
+            3  Port Unreachable
+            4  Fragmentation Needed and Don't Fragment was Set
+            5  Source Route Failed
+            6  Destination Network Unknown
+            7  Destination Host Unknown
+            8  Source Host Isolated
+            9  Communication with Destination Network is
+               Administratively Prohibited
+           10  Communication with Destination Host is
+               Administratively Prohibited
+           11  Destination Network Unreachable for Type of Service
+           12  Destination Host Unreachable for Type of Service
+
+  4     Source Quench                            [RFC792]
+        Codes
+            0  No Code
+
+  5     Redirect                                 [RFC792]
+
+        Codes
+            0  Redirect Datagram for the Network (or subnet)
+            1  Redirect Datagram for the Host
+            2  Redirect Datagram for the Type of Service and Network
+            3  Redirect Datagram for the Type of Service and Host
+
+  6     Alternate Host Address                      [JBP]
+
+        Codes
+            0  Alternate Address for Host
+
+  7     Unassigned                                  [JBP]
+
+  8     Echo                                     [RFC792]
+
+        Codes
+            0  No Code
+
+  9     Router Advertisement                    [RFC1256]
+
+        Codes
+
+
+
+Reynolds & Postel                                              [Page 69]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+            0  No Code
+
+ 10     Router Selection                        [RFC1256]
+
+        Codes
+            0  No Code
+
+ 11     Time Exceeded                            [RFC792]
+
+        Codes
+            0  Time to Live exceeded in Transit
+            1  Fragment Reassembly Time Exceeded
+
+ 12     Parameter Problem                        [RFC792]
+
+        Codes
+            0  Pointer indicates the error
+            1  Missing a Required Option        [RFC1108]
+            2  Bad Length
+
+
+ 13     Timestamp                                [RFC792]
+
+        Codes
+            0  No Code
+
+ 14     Timestamp Reply                          [RFC792]
+
+        Codes
+            0  No Code
+
+ 15     Information Request                      [RFC792]
+
+        Codes
+            0  No Code
+
+ 16     Information Reply                        [RFC792]
+
+        Codes
+            0  No Code
+
+ 17     Address Mask Request                     [RFC950]
+
+        Codes
+            0  No Code
+
+ 18     Address Mask Reply                       [RFC950]
+
+
+
+
+Reynolds & Postel                                              [Page 70]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+        Codes
+            0  No Code
+
+ 19     Reserved (for Security)                    [Solo]
+
+ 20-29  Reserved (for Robustness Experiment)        [ZSu]
+
+ 30     Traceroute                              [RFC1393]
+
+ 31     Datagram Conversion Error               [RFC1475]
+
+ 32     Mobile Host Redirect              [David Johnson]
+
+ 33     IPv6 Where-Are-You                 [Bill Simpson]
+
+ 34     IPv6 I-Am-Here                     [Bill Simpson]
+
+ 35     Mobile Registration Request        [Bill Simpson]
+
+ 36     Mobile Registration Reply          [Bill Simpson]
+
+REFERENCES
+
+[RFC792] Postel, J., "Internet Control Message Protocol", STD 5,
+         RFC 792, USC/Information Sciences Institute, September 1981.
+
+[RFC950] Mogul, J., and J. Postel, "Internet Standard Subnetting
+         Procedure", STD 5, RFC 950, Stanford, USC/Information
+         Sciences Institute, August 1985.
+
+[RFC1108] Kent, S., "U.S. Department of Defense Security Options for
+          the Internet Protocol", RFC 1108, November 1991.
+
+[RFC1256] Deering, S., Editor, "ICMP Router Discovery Messages", RFC
+          1256, Xerox PARC, September 1991.
+
+[RFC1393] Malkin, G., "Traceroute Using an IP Option", RFC 1393,
+          Xylogics, Inc., January 1993.
+
+[RFC1475] Ullmann, R., "TP/IX: The Next Internet", RFC 1475, Process
+          Software Corporation, June 1993.
+
+
+PEOPLE
+
+[JBP] Jon Postel <postel@isi.edu>
+
+[David Johnson]
+
+
+
+Reynolds & Postel                                              [Page 71]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[Bill Simpson]  <Bill.Simpson@um.cc.umich.edu> September, 1994.
+
+[Solo]
+
+[ZSu] Zaw-Sing Su <ZSu@TSCA.ISTC.SRI.COM>
+
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/icmp-parameters
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 72]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+TCP OPTION NUMBERS
+
+The Transmission Control Protocol (TCP) has provision for optional
+header fields identified by an option kind field.  Options 0 and 1 are
+exactly one octet which is their kind field.  All other options have
+their one octet kind field, followed by a one octet length field,
+followed by length-2 octets of option data.
+
+Kind   Length   Meaning                           Reference
+----   ------   -------------------------------   ---------
+  0        -    End of Option List                 [RFC793]
+  1        -    No-Operation                       [RFC793]
+  2        4    Maximum Segment Lifetime           [RFC793]
+  3        3    WSOPT - Window Scale              [RFC1323]
+  4        2    SACK Permitted                    [RFC1072]
+  5        N    SACK                              [RFC1072]
+  6        6    Echo (obsoleted by option 8)      [RFC1072]
+  7        6    Echo Reply (obsoleted by option 8)[RFC1072]
+  8       10    TSOPT - Time Stamp Option         [RFC1323]
+  9        2    Partial Order Connection Permitted[RFC1693]
+ 10        5    Partial Order Service Profile     [RFC1693]
+ 11             CC                                 [Braden]
+ 12             CC.NEW                             [Braden]
+ 13             CC.ECHO                            [Braden]
+ 14         3   TCP Alternate Checksum Request    [RFC1146]
+ 15         N   TCP Alternate Checksum Data       [RFC1146]
+ 16             Skeeter                           [Knowles]
+ 17             Bubba                             [Knowles]
+ 18         3   Trailer Checksum Option    [Subbu & Monroe]
+
+
+TCP ALTERNATE CHECKSUM NUMBERS
+
+
+Number  Description                     Reference
+------- ------------------------------- ----------
+   0    TCP Checksum                    [RFC-1146]
+   1    8-bit Fletchers's algorithm     [RFC-1146]
+   2    16-bit Fletchers's algorithm    [RFC-1146]
+   3    Redundant Checksum Avoidance    [Kay]
+
+
+REFERENCES
+
+[KAY] Kay, J. and Pasquale, J., "Measurement, Analysis, and
+      Improvement of UDP/IP Throughput for the DECstation 5000,"
+      Proceedings of the Winter 1993 Usenix Conference, January 1993
+      (available for anonymous FTP in
+
+
+
+Reynolds & Postel                                              [Page 73]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+      ucsd.edu:/pub/csl/fastnet/fastnet.tar.Z). <jkay@ucsd.edu>
+
+[RFC793] Postel, J., "Transmission Control Protocol - DARPA Internet
+         Program Protocol Specification", STD 7, RFC 793, DARPA,
+         September 1981.
+
+[RFC1323] Jacobson, V., Braden, R., and D. Borman, "TCP Extensions for
+          High Performance", RFC 1323, LBL, ISI, Cray Research, May
+          1992.
+
+[RFC1072] Jacobson, V., and R. Braden, "TCP Extensions for Long-Delay
+          Paths", RFC 1072, LBL, ISI, October 1988.
+
+[RFC1693]  ?????
+
+[RFC1146] Zweig, J., and C. Partridge, "TCP Alternate Checksum
+          Options", RFC 1146, UIUC, BBN, March 1990.
+
+PEOPLE
+
+[Braden]  Bob Braden <braden@isi.edu>
+
+[Knowles] Stev Knowles <stev@ftp.com>
+
+[Kay] J. Kay <jkay@ucsd.edu>
+
+[Subbu & Monroe] <mystery contact>
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/tcp-parameters
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 74]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+TELNET OPTIONS
+
+The Telnet Protocol has a number of options that may be negotiated.
+These options are listed here.  "Internet Official Protocol Standards"
+(STD 1) provides more detailed information.
+
+Options  Name                                              References
+-------  -----------------------                           ----------
+   0     Binary Transmission                             [RFC856,JBP]
+   1     Echo                                            [RFC857,JBP]
+   2     Reconnection                                  [NIC50005,JBP]
+   3     Suppress Go Ahead                               [RFC858,JBP]
+   4     Approx Message Size Negotiation               [ETHERNET,JBP]
+   5     Status                                          [RFC859,JBP]
+   6     Timing Mark                                     [RFC860,JBP]
+   7     Remote Controlled Trans and Echo                [RFC726,JBP]
+   8     Output Line Width                             [NIC50005,JBP]
+   9     Output Page Size                              [NIC50005,JBP]
+  10     Output Carriage-Return Disposition              [RFC652,JBP]
+  11     Output Horizontal Tab Stops                     [RFC653,JBP]
+  12     Output Horizontal Tab Disposition               [RFC654,JBP]
+  13     Output Formfeed Disposition                     [RFC655,JBP]
+  14     Output Vertical Tabstops                        [RFC656,JBP]
+  15     Output Vertical Tab Disposition                 [RFC657,JBP]
+  16     Output Linefeed Disposition                     [RFC657,JBP]
+  17     Extended ASCII                                  [RFC698,JBP]
+  18     Logout                                          [RFC727,MRC]
+  19     Byte Macro                                      [RFC735,JBP]
+  20     Data Entry Terminal                     [RFC1043,RFC732,JBP]
+  22     SUPDUP                                   [RFC736,RFC734,MRC]
+  22     SUPDUP Output                                   [RFC749,MRC]
+  23     Send Location                                  [RFC779,EAK1]
+  24     Terminal Type                                 [RFC1091,MS56]
+  25     End of Record                                   [RFC885,JBP]
+  26     TACACS User Identification                      [RFC927,BA4]
+  27     Output Marking                                  [RFC933,SXS]
+  28     Terminal Location Number                        [RFC946,RN6]
+  29     Telnet 3270 Regime                             [RFC1041,JXR]
+  30     X.3 PAD                                       [RFC1053,SL70]
+  31     Negotiate About Window Size                  [RFC1073,DW183]
+  32     Terminal Speed                                [RFC1079,CLH3]
+  33     Remote Flow Control                           [RFC1372,CLH3]
+  34     Linemode                                      [RFC1184,DB14]
+  35     X Display Location                            [RFC1096,GM23]
+  36     Environment Option                            [RFC1408,DB14]
+  37     Authentication Option                         [RFC1409,DB14]
+  38     Encryption Option                                     [DB14]
+  39     New Environment Option                        [RFC1572,DB14]
+
+
+
+Reynolds & Postel                                              [Page 75]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+  40     TN3270E                                            [RFC1647]
+ 255     Extended-Options-List                           [RFC861,JBP]
+
+Telnet Authentication Types
+
+In [RFC1409], a list of authentication types is introduced.  Additions
+to the list are registerd by the IANA and documented here.
+
+Type       Description                  Reference
+  0        NULL                         [RFC1409]
+  1        KERBEROS_V4                  [RFC1409]
+  2        KERBEROS_V5                  [RFC1409]
+  3        SPX                          [RFC1409]
+  4-5      Unassigned
+  6        RSA                          [RFC1409]
+  7-9      Unassigned
+ 10        LOKI                         [RFC1409]
+ 11        SSA                          [Schoch]
+
+REFERENCES
+
+[ETHERNET] "The Ethernet, A Local Area Network: Data Link Layer and
+           Physical Layer Specification", AA-K759B-TK, Digital
+           Equipment Corporation, Maynard, MA.  Also as: "The
+           Ethernet - A Local Area Network", Version 1.0, Digital
+           Equipment Corporation, Intel Corporation, Xerox
+           Corporation, September 1980.  And: "The Ethernet, A Local
+           Area Network: Data Link Layer and Physical Layer
+           Specifications", Digital, Intel and Xerox, November 1982.
+           And: XEROX, "The Ethernet, A Local Area Network: Data Link
+           Layer and Physical Layer Specification", X3T51/80-50, Xerox
+           Corporation, Stamford, CT., October 1980.
+
+[NIC50005] DDN Protocol Handbook, "Telnet Reconnection Option",
+           "Telnet Output Line Width Option", "Telnet Output Page Size
+           Option", NIC 50005, December 1985.
+
+[RFC652] Crocker, D., "Telnet Output Carriage-Return Disposition
+         Option", RFC 652, UCLA-NMC, October 1974.
+
+[RFC653] Crocker, D., "Telnet Output Horizontal Tabstops Option",
+         RFC 653, UCLA-NMC, October 1974.
+
+[RFC654] Crocker, D., "Telnet Output Horizontal Tab Disposition
+         Option", RFC 654, UCLA-NMC, October 1974.
+
+[RFC655] Crocker, D., "Telnet Output Formfeed Disposition Option",
+         RFC 655, UCLA-NMC, October 1974.
+
+
+
+Reynolds & Postel                                              [Page 76]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[RFC656] Crocker, D., "Telnet Output Vertical Tabstops Option",
+         RFC 656, UCLA-NMC, October 1974.
+
+[RFC657] Crocker, D., "Telnet Output Vertical Tab Disposition Option",
+         RFC 657, UCLA-NMC, October 1974.
+
+[RFC658] Crocker, D., "Telnet Output Linefeed Disposition", RFC 658,
+         UCLA-NMC, October 1974.
+
+[RFC698] Tovar, "Telnet Extended ASCII Option", RFC 698, Stanford
+         University-AI, July 1975.
+
+[RFC726] Postel, J. and D. Crocker, "Remote Controlled Transmission
+         and Echoing Telnet Option", RFC 726, SRI-ARC, UC Irvine,
+         March 1977.
+
+[RFC727] Crispin, M., "Telnet Logout Option", RFC 727, Stanford
+         University-AI, April 1977.
+
+[RFC734] Crispin, M., "SUPDUP Protocol", RFC 734, Stanford,
+         October 1977.
+
+[RFC735] Crocker, D. and R. Gumpertz, "Revised Telnet Byte Marco
+         Option", RFC 735, Rand, CMU, November 1977.
+
+[RFC736] Crispin, M., "Telnet SUPDUP Option", Stanford University-AI,
+         RFC 736, Stanford, October 1977.
+
+[RFC749] Greenberg, B., "Telnet SUPDUP-OUTPUT Option", RFC 749,
+         MIT-Multics, September 1978.
+
+[RFC779] Killian, E., "Telnet Send-Location Option", RFC 779,
+         LLL, April 1981.
+
+[RFC856] Postel, J. and J. Reynolds, "Telnet Binary Transmission",
+         STD 27, RFC 856, USC/Information Sciences Institute, May
+         1983.
+
+[RFC857] Postel, J. and J. Reynolds, "Telnet Echo Option", STD 28, RFC
+         857, USC/Information Sciences Institute, May 1983.
+
+[RFC858] Postel, J. and J. Reynolds, "Telnet Suppress Go Ahead
+         Option", STD 29, RFC 858, USC/Information Sciences Institute,
+         May 1983.
+
+[RFC859] Postel, J. and J. Reynolds, "Telnet Status Option", STD 30,
+         RFC 859, USC/Information Sciences Institute, May 1983.
+
+
+
+
+Reynolds & Postel                                              [Page 77]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[RFC860] Postel, J. and J. Reynolds, "Telnet Timing Mark Option",
+         STD 31, RFC 860, USC/Information Sciences Institute, May
+         1983.
+
+[RFC861] Postel, J. and J. Reynolds, "Telnet Extended Options - List
+         Option", STD 32, RFC 861, USC/Information Sciences Institute,
+         May 1983.
+
+[RFC885] Postel, J., "Telnet End of Record Option", RFC 885,
+         USC/Information Sciences Institute, December 1983.
+
+[RFC927] Anderson, B., "TACACS User Identification Telnet Option",
+         RFC 927, BBN, December 1984.
+
+[RFC933] Silverman, S., "Output Marking Telnet Option", RFC 933,
+         MITRE, January 1985.
+
+[RFC946] Nedved, R., "Telnet Terminal Location Number Option",
+         RFC 946, Carnegie-Mellon University, May 1985.
+
+[RDC1041] Rekhter, J., "Telnet 3270 Regime Option", RFC 1041,
+          IBM, January 1988.
+
+[RFC1043] Yasuda, A., and T. Thompson, "TELNET Data Entry Terminal
+          Option DODIIS Implementation", RFC 1043, DIA, February 1988.
+
+[RFC1053] Levy, S., and T. Jacobson, "Telnet X.3 PAD Option",
+          RFC 1053, Minnesota Supercomputer Center, April 1988.
+
+[RFC1073] Waitzman, D., "Telnet Window Size Option", RFC 1073,
+          BBN STC, October, 1988.
+
+[RFC1079] Hedrick, C., "Telnet Terminal Speed Option", RFC 1079,
+          Rutgers University, December 1988.
+
+[RFC1091] VanBokkelen, J., "Telnet Terminal Type Option",
+          RFC 1091, FTP Software, Inc., February 1989.
+
+[RFC1096] Marcy, G., "Telnet X Display Location Option", RFC 1096,
+          Carnegie Mellon University, March 1989.
+
+[RFC1184] Borman, D., Editor, "Telnet Linemode Option",
+          RFC 1184, Cray Research, Inc., October 1990.
+
+[RFC1372] Hedrick, C., and D. Borman, "Telnet Remote Flow Control
+         Option", RFC 1372, Rutgers University, Cray Research, Inc.,
+         October 1992.
+
+
+
+
+Reynolds & Postel                                              [Page 78]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[RFC1408] Borman, D., Editor, "Telnet Environment Option", RFC 1408,
+          Cray Research, Inc., January 1993.
+
+[RFC1409] Borman, D., Editor, "Telnet Authentication Option", RFC
+          1409, Cray Research, Inc., January 1993.
+
+[RFC1572] Alexander, S., Editor, "Telnet Environment Option", RFC1572,
+          Lachman Technology, Inc., January 1994.
+
+[RFC1647] Kelly, B., "TN3270 Enhancements", RFC1647, Auburn
+          University, July 1994.
+
+
+PEOPLE
+
+[BA4] Brian Anderson <baanders@CCQ.BBN.CO>
+
+[CLH3] Charles Hedrick  <HEDRICK@ARAMIS.RUTGERS.EDU>
+
+[DB14] Dave Borman <dab@CRAY.COM>
+
+[DW183] David Waitzman <dwaitzman@BBN.COM>
+
+[EAK4] Earl Kill <EAK@MORDOR.S1.GOV>
+
+[GM23] Glenn Marcy  <Glenn.Marcy@A.CS.CMU.EDU>
+
+[JBP] Jon Postel <postel@isi.edu>
+
+[MRC] Mark Crispin <MRC@WSMR-SIMTEL20.ARMY.MIL>
+
+[MS56] Marvin Solomon <solomon@CS.WISC.EDU>
+
+[RN6] Rudy Nedved <Rudy.Nedved@CMU-CS-A.>
+
+[Schoch]  Steven Schoch <schoch@sheba.arc.nasa.gov>
+
+[SL70] Stuart Levy <slevy@UC.MSC.UMN.EDU>
+
+[SXS] Steve Silverman <Blankert@MITRE-GATEWAY.ORG>
+
+[YXR] Yakov Rekhter  <Yakov@IBM.COM>
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/telnet-options
+
+
+
+
+Reynolds & Postel                                              [Page 79]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+DOMAIN NAME SYSTEM PARAMETERS
+
+The Internet Domain Naming System (DOMAIN) includes several
+parameters.  These are documented in [RFC1034] and [RFC1035].  The
+CLASS parameter is listed here.  The per CLASS parameters are defined
+in separate RFCs as indicated.
+
+Domain System Parameters:
+
+Decimal   Name                                          References
+--------  ----                                          ----------
+       0  Reserved                                           [PM1]
+       1  Internet (IN)                              [RFC1034,PM1]
+       2  Unassigned                                         [PM1]
+       3  Chaos (CH)                                         [PM1]
+       4  Hessoid (HS)                                       [PM1]
+ 5-65534  Unassigned                                         [PM1]
+   65535  Reserved                                           [PM1]
+
+In the Internet (IN) class the following TYPEs and QTYPEs are defined:
+
+TYPE            value and meaning
+
+A               1 a host address                         [RFC1035]
+NS              2 an authoritative name server           [RFC1035]
+MD              3 a mail destination (Obsolete - use MX) [RFC1035]
+MF              4 a mail forwarder (Obsolete - use MX)   [RFC1035]
+CNAME           5 the canonical name for an alias        [RFC1035]
+SOA             6 marks the start of a zone of authority [RFC1035]
+MB              7 a mailbox domain name (EXPERIMENTAL)   [RFC1035]
+MG              8 a mail group member (EXPERIMENTAL)     [RFC1035]
+MR              9 a mail rename domain name (EXPERIMENTAL)[RFC1035]
+NULL            10 a null RR (EXPERIMENTAL)              [RFC1035]
+WKS             11 a well known service description      [RFC1035]
+PTR             12 a domain name pointer                 [RFC1035]
+HINFO           13 host information                      [RFC1035]
+MINFO           14 mailbox or mail list information      [RFC1035]
+MX              15 mail exchange                         [RFC1035]
+TXT             16 text strings                          [RFC1035]
+
+RP              17 for Responsible Person                [RFC1183]
+AFSDB           18 for AFS Data Base location            [RFC1183]
+X25             19 for X.25 PSDN address                 [RFC1183]
+ISDN            20 for ISDN address                      [RFC1183]
+RT              21 for Route Through                     [RFC1183]
+
+NSAP            22 for NSAP address, NSAP style A record [RFC1348]
+NSAP-PTR        23 for domain name pointer, NSAP style   [RFC1348]
+
+
+
+Reynolds & Postel                                              [Page 80]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+SIG             24 for security signature        [Donald Eastlake]
+KEY             25 for security key              [Donald Eastlake]
+
+PX              26 X.400 mail mapping information        [RFC1664]
+
+GPOS            27 Geographical Position           [Craig Farrell]
+
+AAAA            28 IP6 Address                     [Susan Thomson]
+
+AXFR            252 transfer of an entire zone           [RFC1035]
+MAILB           253 mailbox-related RRs (MB, MG or MR)   [RFC1035]
+MAILA           254 mail agent RRs (Obsolete - see MX)   [RFC1035]
+*               255 A request for all records            [RFC1035]
+
+
+REFERENCES
+
+[RFC1034] Mockapetris, P., "Domain Names - Concepts and
+          Facilities", STD 13, RFC 1034, USC/Information Sciences
+          Institute, November 1987.
+
+[RFC1035] Mockapetris, P., "Domain Names - Implementation and
+          Specification", STD 13, RFC 1035, USC/Information Sciences
+          Institute, November 1987.
+
+[RFC1183] Everhart, C., Mamakos, L., Ullmann, R., and P. Mockapetris,
+          Editors, "New DNS RR Definitions", RFC 1183, Transarc,
+          University of Maryland, Prime Computer, USC/Information
+          Sciences Institute, October 1990.
+
+[RFC1348] Manning, B., "DNS NSAP RRs", RFC 1348, Rice University,
+          July 1992.
+
+[RFC1664] Allocchio, C., Bonito, A., Cole, B., Giordano, S., and R.
+          Hagens, "Using the Internet DNS to Distribute RFC1327 Mail
+          Address Mapping Tables", GARR-Italy, Cisco Systems Inc.,
+          Centro Svizzero Calcolo Scientifico, Advanced Network &
+          Services, August 1994.
+
+
+PEOPLE
+
+[Susan Thomson] Susan Thomson <set@swift.bellcore.com>
+
+[PM1] Paul Mockapetris <pvm@isi.edu>
+
+[Donald Eastlake] Donald E. Eastlake, III <dee@ranger.enet.dec.com>
+
+
+
+
+Reynolds & Postel                                              [Page 81]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[Craig Farrell]
+
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/dns-parameters
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 82]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+MAIL ENCODING HEADER FIELD KEYWORDS
+
+
+[RFC1505] specifies an initial list of keywords for the experimental
+encoding header field (EHF-MAIL), and provides that additional
+keywords may be registered with the IANA.
+
+
+Keyword         Description                             Reference
+_______         ___________                          ____________
+
+EDIFACT         EDIFACT format                          [RFC1505]
+EDI-X12         EDI X12 format                         [ANSI-X12]
+EVFU            FORTRAN format                          [RFC1505]
+FS              File System format                      [RFC1505]
+Hex             Hex binary format                       [RFC1505]
+LZJU90          LZJU90 format                           [RFC1505]
+LZW             LZW format                              [RFC1505]
+Message         Encapsulated Message                     [RFC822]
+PEM, PEM-Clear  Privacy Enhanced Mail                   [RFC1421]
+PGP             Pretty Good Privacy                     [RFC1505]
+Postscript      Postscript format                    [POSTSCRIPT]
+Shar            Shell Archive format                    [RFC1505]
+Signature       Signature                               [RFC1505]
+Tar             Tar format                              [RFC1505]
+Text            Text                                   [IS-10646]
+uuencode        uuencode format                         [RFC1505]
+URL             external URL-reference                  [RFC1505]
+
+
+
+MAIL ENCRYPTION TYPES
+
+
+[RFC822] specifies that Encryption Types for mail may be assigned.
+There are currently no RFC 822 encryption types assigned.  Please use
+instead the Mail Privacy procedures defined in [RFC1421, RFC1422,
+RFC1423].
+
+
+ESMTP MAIL KEYWORDS
+
+
+[RFC1651] specifies that extension to SMTP can be identified with
+keywords.
+
+
+Keywords        Description                              Reference
+
+
+
+Reynolds & Postel                                              [Page 83]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+------------    --------------------------------         ---------
+SEND            Send as mail                              [RFC821]
+SOML            Send as mail or terminal                  [RFC821]
+SAML            Send as mail and terminal                 [RFC821]
+EXPN            Expand the mailing list                   [RFC821]
+HELP            Supply helpful information                [RFC821]
+TURN            Turn the operation around                 [RFC821]
+8BITMIME        Use 8-bit data                           [RFC1652]
+SIZE            Message size declaration                 [RFC1653]
+VERB            Verbose                              [Eric Allman]
+ONEX            One message transaction only         [Eric Allman]
+
+
+
+MAIL EXTENSION TYPES
+
+
+The Simple Mail Transfer Protocol [RFC821] specifies a set of
+commands or services for mail transfer.  A general procedure for
+extending the set of services is defined in [RFC1651].  The set of
+service extensions is listed here.
+
+
+Service Ext   EHLO Keyword Parameters Verb       Reference
+-----------   ------------ ---------- ---------- ---------
+Send             SEND         none       SEND     [RFC821]
+Send or Mail     SOML         none       SOML     [RFC821]
+Send and Mail    SAML         none       SAML     [RFC821]
+Expand           EXPN         none       EXPN     [RFC821]
+Help             HELP         none       HELP     [RFC821]
+Turn             TURN         none       TURN     [RFC821]
+8 Bit MIME       8BITMIME     none       none    [RFC1652]
+Size             SIZE         number     none    [RFC1653]
+
+
+
+MAIL SYSTEM NAMES
+
+
+In some places, an identification of other mail systems is used.
+
+One of these is in "The COSINE and Internet X.500 Schema" (section
+9.3.18) [RFC1274].  The mail system names listed here are used as the
+legal values in that schema under the "otherMailbox" attribute
+"mailboxType" type (which must be a PrintableString).
+
+Another place is in "Mapping between X.400(1988) / ISO 10021 and RFC
+822" (section 4.2.2) [RFC1327].  The names listed here are used as
+
+
+
+Reynolds & Postel                                              [Page 84]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+the legal values in that schema under the "std-or-address" attribute
+"registered-dd-type" type (which must be a "key-string").
+
+Note that key-string = <a-z, A-Z, 0-9, and "-" >.
+
+
+Mail System Name        Description                     Reference
+----------------        ------------------------------- ---------
+mcimail                 MCI Mail
+
+
+
+MAIL TRANSMISSION TYPES
+
+
+The Simple Mail Transfer Protocol [RFC821] and the Standard for the
+Format of ARPA Internet Text Messages [RFC822] specify that a set of
+"Received" lines will be prepended to the headers of electronic mail
+messages as they are transported through the Internet.  These received
+line may optionally include either or both a "via" phrase and/or a
+"with" phrase.  The legal values for the phrases are listed here.  The
+via phrase is intended to indicate the link or physical medium over
+which the message was transferred.  The with phrase is intended to
+indicate the protocol or logical process that was used to transfer the
+message.
+
+
+VIA link types  Description                             Reference
+--------------  ----------------------------            ---------
+UUCP            Unix-to-Unix Copy Program                   [???]
+
+
+WITH protocol types  Description                        Reference
+-------------------  ----------------------------       ---------
+SMTP                 Simple Mail Transfer Protocol       [RFC821]
+ESMTP                SMTP with Service Extensions       [RFC1651]
+
+
+REFERENCES
+
+
+[ANSI-X12]
+
+[POSTSCRIPT] Adobe Systems Inc., "PostScript Langpuage Reference
+Manual", 2nd Edition, 2nd Printing, January 1991.
+
+[IS-10646]
+
+
+
+
+Reynolds & Postel                                              [Page 85]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[RFC821] Postel, J., "Simple Mail Transfer Protocol", STD 10, RFC 821,
+         USC/Information Sciences Institute, August 1982.
+
+[RFC822] Crocker, D., "Standard for the Format of ARPA-Internet Text
+         Messages", STD 11, RFC 822, UDEL, August 1982.
+
+[RFC1274] Barker, P., and S. Kille, "The COSINE and Internet X.500
+          Schema", RFC 1274, University College London, November 1991.
+
+[RFC1327] Hardcastle-Kille, S., "Mapping between X.400(1988) / ISO
+          10021 and RFC 822", RFC 1327, University College London,
+          May 1992.
+
+[RFC1421] Linn, J., "Privacy Enhancement for Internet Electronic
+          Mail: Part I: Message Encipherment and Authentication
+          Procedures", RFC 1421, IAB IRTF PSRG, IETF PEM WG,
+          February 1993.
+
+[RFC1422] Kent, S., "Privacy Enhancement for Internet
+          Electronic Mail: Part II -- Certificate-Based Key
+          Management", BBN, IAB IRTF PSRG, IETF PEM, February 1993.
+
+[RFC1423] Balenson, D., "Privacy Enhancement for Internet Electronic
+          Mail: Part III -- Algorithms, Modes, and Identifiers",
+          RFC 1423, TIS, IAB IRTF PSRG, IETF PEM WG, February 1993.
+
+[RFC1505] Costanzo, A., Robinson, D., and R. Ullmann, "Encoding Header
+          Field for Internet Messages", RFC 1505, AKC Consulting,
+          Computervision Corporation, August 1993.
+
+[RFC1651] Klensin, J., Freed, N., Rose, M., Stefferud, E., and D.
+          Crocker, "SMTP Service Extensions", RFC 1651, MCI, Innosoft,
+          Dover Beach Consulting, Inc., Network Management Associates,
+          Inc., Silicon Graphics, Inc., July 1994.
+
+[RFC1652] Klensin, J., Freed, N., Rose, M., Stefferud, E., and D.
+          Crocker, "SMTP Service Extension for 8bit-MIMEtransport",
+          RFC 1652, MCI, Innosoft, Dover Beach Consulting, Inc.,
+          Network Management Associates, Inc., Silicon Graphics, Inc.,
+          July 1994.
+
+[RFC1653] Klensin, J., Freed, N., and K. Moore, "SMTP Service
+          Extension for Message Size Declaration", RFC 1653,
+          MCI, Innosoft, University of Tennessee, July 1994.
+
+
+PEOPLE
+
+
+
+
+Reynolds & Postel                                              [Page 86]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[Eric Allman]
+
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/mail-parameters
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 87]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+BOOTP AND DHCP PARAMETERS
+
+The Bootstrap Protocol (BOOTP) [RFC951] describes an IP/UDP
+bootstrap protocol (BOOTP) which allows a diskless client machine to
+discover its own IP address, the address of a server host, and the
+name of a file to be loaded into memory and executed.  The Dynamic
+Host Configuration Protocol (DHCP) [RFC1531] provides a framework for
+automatic configuration of IP hosts.  The "DHCP Options and BOOTP
+Vendor Information Extensions" [RFC1533] describes the additions to the
+Bootstrap Protocol (BOOTP) which can also be used as options with the
+Dynamic Host Configuration Protocol (DHCP).
+
+BOOTP Vendor Extensions and DHCP Options are listed below:
+
+
+   Tag     Name          Data Length    Meaning
+   ---     ----          -----------    -------
+    0      Pad               0          None
+    1      Subnet Mask       4          Subnet Mask Value
+    2      Time Offset       4          Time Offset in
+                                        Seconds from UTC
+    3      Gateways          N          N/4 Gateway addresses
+    4      Time Server       N          N/4 Timeserver addresses
+    5      Name Server       N          N/4 IEN-116 Server addresses
+    6      Domain Server     N          N/4 DNS Server addresses
+    7      Log Server        N          N/4 Logging Server addresses
+    8      Quotes Server     N          N/4 Quotes Server addresses
+    9      LPR Server        N          N/4 Printer Server addresses
+   10      Impress Server    N          N/4 Impress Server addresses
+   11      RLP Server        N          N/4 RLP Server addresses
+   12      Hostname          N          Hostname string
+   13      Boot File Size    2          Size of boot file in 512 byte
+                                        chunks
+   14      Merit Dump File              Client to dump and name
+                                        the file to dump it to
+   15      Domain Name       N          The DNS domain name of the
+                                        client
+   16      Swap Server       N          Swap Server addeess
+   17      Root Path         N          Path name for root disk
+   18      Extension File    N          Path name for more BOOTP info
+
+   19      Forward On/Off    1          Enable/Disable IP Forwarding
+   20      SrcRte On/Off     1          Enable/Disable Source Routing
+   21      Policy Filter     N          Routing Policy Filters
+   22      Max DG Assembly   2          Max Datagram Reassembly Size
+   23      Default IP TTL    1          Default IP Time to Live
+   24      MTU Timeout       4          Path MTU Aging Timeout
+   25      MTU Plateau       N          Path MTU  Plateau Table
+
+
+
+Reynolds & Postel                                              [Page 88]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+   26      MTU Interface     2          Interface MTU Size
+   27      MTU Subnet        1          All Subnets are Local
+   28      Broadcast Address 4          Broadcast Address
+   29      Mask Discovery    1          Perform Mask Discovery
+   30      Mask Supplier     1          Provide Mask to Others
+   31      Router Discovery  1          Perform Router Discovery
+   32      Router Request    4          Router Solicitation Address
+   33      Static Route      N          Static Routing Table
+   34      Trailers          1          Trailer Encapsulation
+   35      ARP Timeout       4          ARP Cache Timeout
+   36      Ethernet          1          Ethernet Encapsulation
+   37      Default TCP TTL   1          Default TCP Time to Live
+   38      Keepalive Time    4          TCP Keepalive Interval
+   39      Keepalive Data    1          TCP Keepalive Garbage
+   40      NIS Domain        N          NIS Domain Name
+   41      NIS Servers       N          NIS Server Addresses
+   42      NTP Servers       N          NTP Server Addresses
+   43      Vendor Specific   N          Vendor Specific Information
+   44      NETBIOS Name Srv  N          NETBIOS Name Servers
+   45      NETBIOS Dist Srv  N          NETBIOS Datagram Distribution
+   46      NETBIOS Note Type 1          NETBIOS Note Type
+   47      NETBIOS Scope     N          NETBIOS Scope
+   48      X Window Font     N          X Window Font Server
+   49      X Window Manmager N          X Window Display Manager
+   50      Address Request   4          Requested IP Address
+   51      Address Time      4          IP Address Lease Time
+   52      Overload          1          Overloaf "sname" or "file"
+   53      DHCP Msg Type     1          DHCP Message Type
+   54      DHCP Server Id    4          DHCP Server Identification
+   55      Parameter List    N          Parameter Request List
+   56      DHCP Message      N          DHCP Error Message
+   57      DHCP Max Msg Size 2          DHCP Maximum Message Size
+   58      Renewal Time      4          DHCP Renewal (T1) Time
+   59      Rebinding Time    4          DHCP Rebinding (T2) Time
+   60      Class Id          N          Class Identifier
+   61      Client Id         N          Client Identifier
+   62      Netware/IP Domain N          Netware/IP Domain Name
+   63      Netware/IP Option N          Netware/IP sub Options
+
+
+   64-127  Unassigned
+   128-154 Reserved
+
+   255     End               0          None
+
+
+REFERENCES
+
+
+
+
+Reynolds & Postel                                              [Page 89]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[RFC951]  Croft, B., and J. Gilmore, "BOOTSTRAP Protocol (BOOTP)",
+          RFC-951, Stanford and SUN Microsytems, September 1985.
+
+[RFC1531]  Droms, R., "Dynamic Host Configuration Protocol", Bucknell
+           University, October 1993.
+
+[RFC1533]  Alexander, S., and R. Droms, "DHCP Options and BOOTP Vendor
+           Extensions", Lachman Technology, Inc., Bucknell University,
+           October 1993.
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/bootp-and-dhcp-
+parameters
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 90]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+ADDRESS FAMILY NUMBERS
+
+Several protocols deal with multiple address families.  The 16-bit
+assignments are listed here.
+
+
+Number    Description                                          Reference
+------    ---------------------------------------------------- ---------
+     0    Reserved
+     1    IP (IP version 4)
+     2    IP6 (IP version 6)
+     3    NSAP
+     4    HDLC (8-bit multidrop)
+     5    BBN 1822
+     6    802 (includes all 802 media plus Ethernet "canonical format")
+     7    E.163
+     8    E.164 (SMDS, Frame Relay, ATM)
+     9    F.69 (Telex)
+    10    X.121 (X.25, Frame Relay)
+    11    IPX
+    12    Appletalk
+    13    Decnet IV
+    14    Banyan Vines
+ 65535    Reserved
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/address-family-numbers
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 91]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+FOOBAR AF NUMBERS
+
+
+In the FTP Operation Over Big Address Records (FOOBAR) Protocol
+[RFC1639] there is a field, called "address family" or "af", to
+identify the lower level protocol addresses in use.  This is an 8 bit
+field.  The first 16 assignments (0-15) of the af value are exactly
+the same as the IP Version number.  The assignment for values 16-255
+are listed here.
+
+Assigned FOOBAR Address Families
+
+Decimal   Keyword    Address Family                     References
+-------   -------    --------------                     ----------
+    16    IPX        Novell IPX
+17-254               Unassigned
+   255               Reserved
+
+
+REFERENCES
+
+[RFC1639] Piscitello, D., "FTP Operation Over Big Address Records
+          (FOOBAR)", Core Competence, Inc., June 1994.
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/foobar-af-numbers
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 92]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+DIRECTORY SYSTEM NAMES
+
+
+In the representation of distinquished names (and possibly other
+contexts) of the X.500 Directory system, several unique keywords may
+be necessary.  For example, in the string representation of
+distinguished names [RFC1485].
+
+Keyword  Attribute (X.520 keys)
+-------  ---------------------------------
+ CN       CommonName
+ L        LocalityName
+ ST       StateOrProvinceName
+ O        OrganizationName
+ OU       OrganizationalUnitName
+ C        CountryName
+
+
+REFERENCES
+
+[RFC1485]  Hardcastle-Kille, S., "A String Representation of
+           Distinguished Names (OSI-DS 23 (v5))", RFC1485, ISODE
+           Consortium, July 1993.
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/directory-system-names
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 93]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+PUBLISHER IDENTIFICATION CODE
+
+The RFC "A Format for E-Mailing Bibliographic Records" [RFC1357]
+establishs a "publisher-ID" code.  The IANA registry of these codes is
+listed here.
+
+
+Code   Publisher                                               Reference
+------ ------------------------------------------------------- ---------
+DUMMY  for testing only                                         [RFC1357]
+TEST   for testing only                                         [RFC1357]
+ISI    Information Sciences Institute                               [JBP]
+          of the University of Southern California
+UMCS   University of Manchester Computer Science Department         [TXC]
+
+
+REFERENCES
+
+[RFC1357] Cohen, D., Editor, "A Format for E-mailing Bibliographic
+          Records", RFC 1357, USC/Information Sciences Institute,
+          July 1992.
+
+PEOPLE
+
+[JBP] Jon Postel <postel@isi.edu>
+
+[TXC] Tim Clement <timc@cs.man.ac.uk>
+
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/publisher-id
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 94]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+OSPF AUTHENTICATION CODES
+
+
+The Open Shotrest Path First (OSPF) protocols has a provision for
+authentication, and the type of authentication can me indicated by a
+code number.  The following are the registered authentication codes.
+
+
+Code    Authentication Method                             Reference
+----    ---------------------                             ---------
+   0    No Authentication                                 [RFC1583]
+   1    Simple Password Authentication                    [RFC1583]
+2-65535 Reserved
+
+
+REFERENCES
+
+[RFC1583] Moy, J., "OSPF Version 2", RFC 1583, Proteon, Inc., March
+          1994.
+
+[RFC1584] Moy, J., "Multicast Extensions to OSPF", RFC 1584, Proteon,
+          Inc., March 1994.
+
+[RFC1585] Moy, J., "MOSPF: Analysis and Experience", RFC 1585,
+          Proteon, Inc., March 1994.
+
+[RFC1586] deSouza, O., and M. Rodrigues, "Guidelines for Running OSPF
+          Over Frame Relay Networks", RFC 1586, AT&T Bell
+          Laboratories, March 1994.
+
+[RFC1587] Coltun, R., and V. Fuller, "The OSPF NSSA Option", RFC 1587,
+          RainbowBridge Communications, BARRNet, March 1994.
+
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/ospf-authentication-
+codes
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                              [Page 95]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+MEDIA TYPES
+
+
+[RFC1521] specifies that Content Types, Content Subtypes, Character
+Sets, Access Types, and Conversion values for MIME mail will be
+assigned and listed by the IANA.
+
+
+Content Types and Subtypes
+--------------------------
+
+Type            Subtype         Description                 Reference
+----            -------         -----------                 ---------
+text            plain                                   [RFC1521,NSB]
+                richtext                                [RFC1521,NSB]
+                tab-separated-values                   [Paul Lindner]
+
+multipart       mixed                                   [RFC1521,NSB]
+                alternative                             [RFC1521,NSB]
+                digest                                  [RFC1521,NSB]
+                parallel                                [RFC1521,NSB]
+                appledouble                [MacMime,Patrik Faltstrom]
+                header-set                             [Dave Crocker]
+
+message         rfc822                                  [RFC1521,NSB]
+                partial                                 [RFC1521,NSB]
+                external-body                           [RFC1521,NSB]
+                news                        [RFC 1036, Henry Spencer]
+
+application     octet-stream                            [RFC1521,NSB]
+                postscript                              [RFC1521,NSB]
+                oda                                     [RFC1521,NSB]
+                atomicmail                           [atomicmail,NSB]
+                andrew-inset                       [andrew-inset,NSB]
+                slate                           [slate,terry crowley]
+                wita              [Wang Info Transfer,Larry Campbell]
+                dec-dx            [Digital Doc Trans, Larry Campbell]
+                dca-rft        [IBM Doc Content Arch, Larry Campbell]
+                activemessage                          [Ehud Shapiro]
+                rtf                                    [Paul Lindner]
+                applefile                  [MacMime,Patrik Faltstrom]
+                mac-binhex40               [MacMime,Patrik Faltstrom]
+                news-message-id              [RFC1036, Henry Spencer]
+                news-transmission            [RFC1036, Henry Spencer]
+                wordperfect5.1                         [Paul Lindner]
+                pdf                                    [Paul Lindner]
+                zip                                    [Paul Lindner]
+                macwriteii                             [Paul Lindner]
+
+
+
+Reynolds & Postel                                              [Page 96]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+                msword                                 [Paul Lindner]
+                remote-printing                         [RFC1486,MTR]
+
+image           jpeg                                    [RFC1521,NSB]
+                gif                                     [RFC1521,NSB]
+                ief             Image Exchange Format       [RFC1314]
+                tiff            Tag Image File Format           [MTR]
+
+audio           basic                                   [RFC1521,NSB]
+
+video           mpeg                                    [RFC1521,NSB]
+                quicktime                              [Paul Lindner]
+
+The "media-types" directory contains a subdirectory for each content
+type and each of those directories contains a file for each content
+subtype.
+
+                               |-application-
+                               |-audio-------
+                               |-image-------
+                 |-media-types-|-message-----
+                               |-multipart---
+                               |-text--------
+                               |-video-------
+
+   URL = ftp://ftp.isi.edu/in-notes/iana/assignments/media-types
+
+
+Character Sets
+--------------
+
+All of the character sets listed the section on Character Sets are
+registered for use with MIME as MIME Character Sets.  The
+correspondance between the few character sets listed in the MIME
+specification [RFC1521] and the list in that section are:
+
+Type           Description                                  Reference
+----           -----------                                  ---------
+US-ASCII       see ANSI_X3.4-1968 below                 [RFC1521,NSB]
+ISO-8859-1     see ISO_8859-1:1987 below                [RFC1521,NSB]
+ISO-8859-2     see ISO_8859-2:1987 below                [RFC1521,NSB]
+ISO-8859-3     see ISO_8859-3:1988 below                [RFC1521,NSB]
+ISO-8859-4     see ISO_8859-4:1988 below                [RFC1521,NSB]
+ISO-8859-5     see ISO_8859-5:1988 below                [RFC1521,NSB]
+ISO-8859-6     see ISO_8859-6:1987 below                [RFC1521,NSB]
+ISO-8859-7     see ISO_8859-7:1987 below                [RFC1521,NSB]
+ISO-8859-8     see ISO_8859-8:1988 below                [RFC1521,NSB]
+ISO-8859-9     see ISO_8859-9:1989 below                [RFC1521,NSB]
+
+
+
+Reynolds & Postel                                              [Page 97]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+Access Types
+------------
+
+Type           Description                                  Reference
+----           -----------                                  ---------
+FTP                                                     [RFC1521,NSB]
+ANON-FTP                                                [RFC1521,NSB]
+TFTP                                                    [RFC1521,NSB]
+AFS                                                     [RFC1521,NSB]
+LOCAL-FILE                                              [RFC1521,NSB]
+MAIL-SERVER                                             [RFC1521,NSB]
+
+
+
+Conversion Values
+-----------------
+
+Conversion values or Content Transfer Encodings.
+
+Type           Description                                  Reference
+----           -----------                                  ---------
+7BIT                                                    [RFC1521,NSB]
+8BIT                                                    [RFC1521,NSB]
+BASE64                                                  [RFC1521,NSB]
+BINARY                                                  [RFC1521,NSB]
+QUOTED-PRINTABLE                                        [RFC1521,NSB]
+
+
+MIME / X.400 MAPPING TABLES
+
+MIME to X.400 Table
+
+    MIME content-type          X.400 Body Part             Reference
+    -----------------          ------------------          ---------
+    text/plain
+      charset=us-ascii         ia5-text                     [RFC1494]
+      charset=iso-8859-x       EBP - GeneralText            [RFC1494]
+    text/richtext              no mapping defined           [RFC1494]
+    application/oda            EBP - ODA                    [RFC1494]
+    application/octet-stream   bilaterally-defined          [RFC1494]
+    application/postscript     EBP - mime-postscript-body   [RFC1494]
+    image/g3fax                g3-facsimile                 [RFC1494]
+    image/jpeg                 EBP - mime-jpeg-body         [RFC1494]
+    image/gif                  EBP - mime-gif-body          [RFC1494]
+    audio/basic                no mapping defined           [RFC1494]
+    video/mpeg                 no mapping defined           [RFC1494]
+
+    Abbreviation: EBP - Extended Body Part
+
+
+
+Reynolds & Postel                                              [Page 98]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+X.400 to MIME Table
+
+
+                             Basic Body Parts
+
+    X.400 Basic Body Part      MIME content-type           Reference
+    ---------------------      --------------------        ---------
+    ia5-text                   text/plain;charset=us-ascii [RFC1494]
+    voice                      No Mapping Defined          [RFC1494]
+    g3-facsimile               image/g3fax                 [RFC1494]
+    g4-class1                  no mapping defined          [RFC1494]
+    teletex                    no mapping defined          [RFC1494]
+    videotex                   no mapping defined          [RFC1494]
+    encrypted                  no mapping defined          [RFC1494]
+    bilaterally-defined        application/octet-stream    [RFC1494]
+    nationally-defined         no mapping defined          [RFC1494]
+    externally-defined         See Extended Body Parts     [RFC1494]
+
+    X.400 Extended Body Part  MIME content-type            Reference
+    ------------------------- --------------------         ---------
+    GeneralText               text/plain;charset=iso-8859-x[RFC1494]
+    ODA                       application/oda              [RFC1494]
+    mime-postscript-body      application/postscript       [RFC1494]
+    mime-jpeg-body            image/jpeg                   [RFC1494]
+    mime-gif-body             image/gif                    [RFC1494]
+
+REFERENCES
+
+[MacMime] Work in Progress.
+
+[RFC1036] Horton, M., and R. Adams, "Standard for Interchange of
+          USENET Messages", RFC 1036, AT&T Bell Laboratories,
+          Center for Seismic Studies, December 1987.
+
+[RFC1494] Alvestrand, H., and S. Thompson, "Equivalences between 1988
+          X.400 and RFC-822 Message Bodies", RFC 1494, SINTEF DELAB,
+          Soft*Switch, Inc., August 1993.
+
+[RFC1521] Borenstien, N., and N. Freed, "MIME (Multipurpose Internet
+          Mail Extensions) Part One: Mechanisms for Specifying and
+          Describing the Format of Internet Message Bodies", RFC 1521,
+          Bellcore, Innosoft, September 1993.
+
+PEOPLE
+
+[Larry Campbell]
+
+[Dave Crocker]  Dave Crocker <dcrocker@mordor.stanford.edu>
+
+
+
+Reynolds & Postel                                              [Page 99]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[Terry Crowley]
+
+[NSB] Nathaniel Borenstein <nsb@bellcore.com>
+
+[MTR] Marshall Rose <mrose@dbc.mtview.ca.us>
+
+[Paul Lindner]
+
+[PXF] Patrik Faltstrom <paf@nada.kth.se>
+
+[Ehud Shapiro]
+
+[Henry Spencer]
+
+[]
+
+
+
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/media-types/media-
+types
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                             [Page 100]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+CHARACTER SETS
+
+These are the official names for character sets that may be used in
+the Internet and may be referred to in Internet documentation.  These
+names are expressed in ANSI_X3.4-1968 which is commonly called
+US-ASCII or simply ASCII.  The character set most commonly use in the
+Internet and used especially in protocol standards is US-ASCII, this
+is strongly encouraged.  The use of the name US-ASCII is also
+encouraged.
+
+The character set names may be up to 40 characters taken from the
+printable characters of US-ASCII.  However, no distinction is made
+between use of upper and lower case letters.
+
+
+Character Set                                               Reference
+-------------                                               ---------
+
+Name: ANSI_X3.4-1968                                   [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-6
+Alias: ANSI_X3.4-1986
+Alias: ISO_646.irv:1991
+Alias: ASCII
+Alias: ISO646-US
+Alias: US-ASCII
+Alias: us
+Alias: IBM367
+Alias: cp367
+
+Name: ISO-10646-UCS-2
+Source: the 2-octet Basic Multilingual Plane, aka Unicode
+        this needs to specify network byte order: the standard
+        does not specify (it is a 16-bit integer space)
+
+Name: ISO-10646-UCS-4
+Source: the full code space. (same comment about byte order,
+        these are 31-bit numbers.
+
+Name: ISO-10646-UTF-1
+Source: Universal Transfer Format (1), this is the multibyte
+        encoding, that subsets ASCII-7. It does not have byte
+        ordering issues.
+
+Name: ISO_646.basic:1983                                [RFC1345,KXS2]
+Source: ECMA registry
+Alias: ref
+
+
+
+
+Reynolds & Postel                                             [Page 101]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+Name: INVARIANT                                         [RFC1345,KXS2]
+
+Name: ISO_646.irv:1983                                  [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-2
+Alias: irv
+
+Name: BS_4730                                           [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-4
+Alias: ISO646-GB
+Alias: gb
+Alias: uk
+
+Name: NATS-SEFI                                         [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-8-1
+
+Name: NATS-SEFI-ADD                                     [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-8-2
+
+Name: NATS-DANO                                         [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-9-1
+
+Name: NATS-DANO-ADD                                     [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-9-2
+
+Name: SEN_850200_B                                      [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-10
+Alias: FI
+Alias: ISO646-FI
+Alias: ISO646-SE
+Alias: se
+
+Name: SEN_850200_C                                      [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-11
+Alias: ISO646-SE2
+Alias: se2
+
+Name: KS_C_5601-1987                                    [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-149
+Alias: KS_C_5601-1989
+
+
+
+Reynolds & Postel                                             [Page 102]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+Alias: KSC_5601
+Alias: korean
+
+Name: ISO-2022-KR                                       [RFC1557,Choi]
+Source: RFC-1557 (see also KS_C_5601-1987)
+
+Name: EUC-KR                                            [RFC1557,Choi]
+Source: RFC-1557 (see also KS_C_5861-1992)
+
+Name: ISO-2022-JP                                      [RFC1468,Murai]
+Source: RFC-1468
+
+Name: ISO-2022-JP-2                                     [RFC1554,Ohta]
+Source: RFC-1554
+
+Name: JIS_C6220-1969-jp                                 [RFC1345,KXS2]
+Source: ECMA registry
+Alias: JIS_C6220-1969
+Alias: iso-ir-13
+Alias: katakana
+Alias: x0201-7
+
+Name: JIS_C6220-1969-ro                                 [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-14
+Alias: jp
+Alias: ISO646-JP
+
+Name: IT                                                [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-15
+Alias: ISO646-IT
+
+Name: PT                                                [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-16
+Alias: ISO646-PT
+
+Name: ES                                                [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-17
+Alias: ISO646-ES
+
+Name: greek7-old                                        [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-18
+
+Name: latin-greek                                       [RFC1345,KXS2]
+
+
+
+Reynolds & Postel                                             [Page 103]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+Source: ECMA registry
+Alias: iso-ir-19
+
+Name: DIN_66003                                         [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-21
+Alias: de
+Alias: ISO646-DE
+
+Name: NF_Z_62-010_(1973)                                [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-25
+Alias: ISO646-FR1
+
+Name: Latin-greek-1                                     [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-27
+
+Name: ISO_5427                                          [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-37
+
+Name: JIS_C6226-1978                                    [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-42
+
+Name: BS_viewdata                                       [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-47
+
+Name: INIS                                              [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-49
+
+Name: INIS-8                                            [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-50
+
+Name: INIS-cyrillic                                     [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-51
+
+Name: ISO_5427:1981                                     [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-54
+
+Name: ISO_5428:1980                                     [RFC1345,KXS2]
+Source: ECMA registry
+
+
+
+Reynolds & Postel                                             [Page 104]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+Alias: iso-ir-55
+
+Name: GB_1988-80                                        [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-57
+Alias: cn
+Alias: ISO646-CN
+
+Name: GB_2312-80                                        [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-58
+Alias: chinese
+
+Name: NS_4551-1                                         [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-60
+Alias: ISO646-NO
+Alias: no
+
+Name: NS_4551-2                                          [RFC1345,KXS2]
+Source: ECMA registry
+Alias: ISO646-NO2
+Alias: iso-ir-61
+Alias: no2
+
+Name: NF_Z_62-010                                        [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-69
+Alias: ISO646-FR
+Alias: fr
+
+Name: videotex-suppl                                     [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-70
+
+Name: PT2                                                [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-84
+Alias: ISO646-PT2
+
+Name: ES2                                                [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-85
+Alias: ISO646-ES2
+
+Name: MSZ_7795.3                                         [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-86
+
+
+
+Reynolds & Postel                                             [Page 105]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+Alias: ISO646-HU
+Alias: hu
+
+Name: JIS_C6226-1983                                     [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-87
+Alias: x0208
+Alias: JIS_X0208-1983
+
+Name: greek7                                             [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-88
+
+Name: ASMO_449                                           [RFC1345,KXS2]
+Source: ECMA registry
+Alias: ISO_9036
+Alias: arabic7
+Alias: iso-ir-89
+
+Name: iso-ir-90                                          [RFC1345,KXS2]
+Source: ECMA registry
+
+Name: JIS_C6229-1984-a                                   [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-91
+Alias: jp-ocr-a
+
+Name: JIS_C6229-1984-b                                   [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-92
+Alias: ISO646-JP-OCR-B
+Alias: jp-ocr-b
+
+Name: JIS_C6229-1984-b-add                               [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-93
+Alias: jp-ocr-b-add
+
+Name: JIS_C6229-1984-hand                                [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-94
+Alias: jp-ocr-hand
+
+Name: JIS_C6229-1984-hand-add                            [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-95
+Alias: jp-ocr-hand-add
+
+
+
+
+Reynolds & Postel                                             [Page 106]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+Name: JIS_C6229-1984-kana                                [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-96
+
+Name: ISO_2033-1983                                      [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-98
+Alias: e13b
+
+Name: ANSI_X3.110-1983                                   [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-99
+Alias: CSA_T500-1983
+Alias: NAPLPS
+
+Name: ISO_8859-1:1987                                    [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-100
+Alias: ISO_8859-1
+Alias: ISO-8859-1
+Alias: latin1
+Alias: l1
+Alias: IBM819
+Alias: CP819
+
+Name: ISO_8859-2:1987                                    [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-101
+Alias: ISO_8859-2
+Alias: ISO-8859-2
+Alias: latin2
+Alias: l2
+
+Name: T.61-7bit                                          [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-102
+
+Name: T.61-8bit                                          [RFC1345,KXS2]
+Alias: T.61
+Source: ECMA registry
+Alias: iso-ir-103
+
+Name: ISO_8859-3:1988                                    [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-109
+Alias: ISO_8859-3
+Alias: ISO-8859-3
+Alias: latin3
+
+
+
+Reynolds & Postel                                             [Page 107]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+Alias: l3
+
+Name: ISO_8859-4:1988                                    [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-110
+Alias: ISO_8859-4
+Alias: ISO-8859-4
+Alias: latin4
+Alias: l4
+
+Name: ECMA-cyrillic                                      [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-111
+
+Name: CSA_Z243.4-1985-1                                  [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-121
+Alias: ISO646-CA
+Alias: csa7-1
+Alias: ca
+
+Name: CSA_Z243.4-1985-2                                  [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-122
+Alias: ISO646-CA2
+Alias: csa7-2
+
+Name: CSA_Z243.4-1985-gr                                 [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-123
+
+Name: ISO_8859-6:1987                                    [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-127
+Alias: ISO_8859-6
+Alias: ISO-8859-6
+Alias: ECMA-114
+Alias: ASMO-708
+Alias: arabic
+
+Name: ISO_8859-6-E                                       [RFC1556,IANA]
+Source: RFC-1556
+
+Name: ISO_8859-6-I                                       [RFC1556,IANA]
+Source: RFC-1556
+
+Name: ISO_8859-7:1987                                    [RFC1345,KXS2]
+Source: ECMA registry
+
+
+
+Reynolds & Postel                                             [Page 108]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+Alias: iso-ir-126
+Alias: ISO_8859-7
+Alias: ISO-8859-7
+Alias: ELOT_928
+Alias: ECMA-118
+Alias: greek
+Alias: greek8
+
+Name: T.101-G2                                            [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-128
+
+Name: ISO_8859-8:1988                                     [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-138
+Alias: ISO_8859-8
+Alias: ISO-8859-8
+Alias: hebrew
+
+Name: ISO_8859-8-E                                  [RFC1556,Nussbacher]
+Source: RFC-1556
+
+Name: ISO_8859-8-I                                  [RFC1556,Nussbacher]
+Source: RFC-1556
+
+Name: CSN_369103                                          [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-139
+
+Name: JUS_I.B1.002                                        [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-141
+Alias: ISO646-YU
+Alias: js
+Alias: yu
+
+Name: ISO_6937-2-add                                      [RFC1345,KXS2]
+Source: ECMA registry and ISO 6937-2:1983
+Alias: iso-ir-142
+
+Name: IEC_P27-1                                           [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-143
+
+Name: ISO_8859-5:1988                                     [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-144
+Alias: ISO_8859-5
+
+
+
+Reynolds & Postel                                             [Page 109]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+Alias: ISO-8859-5
+Alias: cyrillic
+
+Name: JUS_I.B1.003-serb                                   [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-146
+Alias: serbian
+
+Name: JUS_I.B1.003-mac                                    [RFC1345,KXS2]
+Source: ECMA registry
+Alias: macedonian
+Alias: iso-ir-147
+
+Name: ISO_8859-9:1989                                     [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-148
+Alias: ISO_8859-9
+Alias: ISO-8859-9
+Alias: latin5
+Alias: l5
+
+Name: greek-ccitt                                         [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-150
+
+Name: NC_NC00-10:81                                       [RFC1345,KXS2]
+Source: ECMA registry
+Alias: cuba
+Alias: iso-ir-151
+Alias: ISO646-CU
+
+Name: ISO_6937-2-25                                       [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-152
+
+Name: GOST_19768-74                                       [RFC1345,KXS2]
+Source: ECMA registry
+Alias: ST_SEV_358-88
+Alias: iso-ir-153
+
+Name: ISO_8859-supp                                       [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-154
+Alias: latin1-2-5
+
+Name: ISO_10367-box                                       [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-155
+
+
+
+Reynolds & Postel                                             [Page 110]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+Name: latin6                                              [RFC1345,KXS2]
+Source: ECMA registry
+Alias: iso-ir-157
+Alias: l6
+
+Name: latin-lap                                           [RFC1345,KXS2]
+Source: ECMA registry
+Alias: lap
+Alias: iso-ir-158
+
+Name: JIS_X0212-1990                                      [RFC1345,KXS2]
+Source: ECMA registry
+Alias: x0212
+Alias: iso-ir-159
+
+Name: DS_2089                                             [RFC1345,KXS2]
+Source: Danish Standard, DS 2089, February 1974
+Alias: DS2089
+Alias: ISO646-DK
+Alias: dk
+
+Name: us-dk                                               [RFC1345,KXS2]
+
+Name: dk-us                                               [RFC1345,KXS2]
+
+Name: JIS_X0201                                           [RFC1345,KXS2]
+Alias: X0201
+
+Name: KSC5636                                             [RFC1345,KXS2]
+Alias: ISO646-KR
+
+Name: DEC-MCS                                             [RFC1345,KXS2]
+Source: VAX/VMS User's Manual,
+        Order Number: AI-Y517A-TE, April 1986.
+Alias: dec
+
+Name: hp-roman8                                           [RFC1345,KXS2]
+Source: LaserJet IIP Printer User's Manual,
+        HP part no 33471-90901, Hewlet-Packard, June 1989.
+Alias: roman8
+Alias: r8
+
+Name: macintosh                                           [RFC1345,KXS2]
+Source: The Unicode Standard ver1.0, ISBN 0-201-56788-1, Oct 1991
+Alias: mac
+
+Name: IBM037                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+
+
+
+Reynolds & Postel                                             [Page 111]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+Alias: cp037
+Alias: ebcdic-cp-us
+Alias: ebcdic-cp-ca
+Alias: ebcdic-cp-wt
+Alias: ebcdic-cp-nl
+
+Name: IBM038                                              [RFC1345,KXS2]
+Source: IBM 3174 Character Set Ref, GA27-3831-02, March 1990
+Alias: EBCDIC-INT
+Alias: cp038
+
+Name: IBM273                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: CP273
+
+Name: IBM274                                              [RFC1345,KXS2]
+Source: IBM 3174 Character Set Ref, GA27-3831-02, March 1990
+Alias: EBCDIC-BE
+Alias: CP274
+
+Name: IBM275                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: EBCDIC-BR
+Alias: cp275
+
+Name: IBM277                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: EBCDIC-CP-DK
+Alias: EBCDIC-CP-NO
+
+Name: IBM278                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: CP278
+Alias: ebcdic-cp-fi
+Alias: ebcdic-cp-se
+
+Name: IBM280                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: CP280
+Alias: ebcdic-cp-it
+
+Name: IBM281                                              [RFC1345,KXS2]
+Source: IBM 3174 Character Set Ref, GA27-3831-02, March 1990
+Alias: EBCDIC-JP-E
+Alias: cp281
+
+Name: IBM284                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+
+
+
+Reynolds & Postel                                             [Page 112]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+Alias: CP284
+Alias: ebcdic-cp-es
+
+Name: IBM285                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: CP285
+Alias: ebcdic-cp-gb
+
+Name: IBM290                                              [RFC1345,KXS2]
+Source: IBM 3174 Character Set Ref, GA27-3831-02, March 1990
+Alias: cp290
+Alias: EBCDIC-JP-kana
+
+Name: IBM297                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: cp297
+Alias: ebcdic-cp-fr
+
+Name: IBM420                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990,
+        IBM NLS RM p 11-11
+Alias: cp420
+Alias: ebcdic-cp-ar1
+
+Name: IBM423                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: cp423
+Alias: ebcdic-cp-gr
+
+Name: IBM424                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: cp424
+Alias: ebcdic-cp-he
+
+Name: IBM437                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: cp437
+Alias: 437
+
+Name: IBM500                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: CP500
+Alias: ebcdic-cp-be
+Alias: ebcdic-cp-ch
+
+Name: IBM850                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: cp850
+
+
+
+Reynolds & Postel                                             [Page 113]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+Alias: 850
+
+Name: IBM851                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: cp851
+Alias: 851
+
+Name: IBM852                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: cp852
+Alias: 852
+
+Name: IBM855                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: cp855
+Alias: 855
+
+Name: IBM857                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: cp857
+Alias: 857
+
+Name: IBM860                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: cp860
+Alias: 860
+
+Name: IBM861                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: cp861
+Alias: 861
+Alias: cp-is
+
+Name: IBM862                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: cp862
+Alias: 862
+
+Name: IBM863                                              [RFC1345,KXS2]
+Source: IBM Keyboard layouts and code pages, PN 07G4586 June 1991
+Alias: cp863
+Alias: 863
+
+Name: IBM864                                              [RFC1345,KXS2]
+Source: IBM Keyboard layouts and code pages, PN 07G4586 June 1991
+Alias: cp864
+
+Name: IBM865                                              [RFC1345,KXS2]
+
+
+
+Reynolds & Postel                                             [Page 114]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+Source: IBM DOS 3.3 Ref (Abridged), 94X9575 (Feb 1987)
+Alias: cp865
+Alias: 865
+
+Name: IBM868                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: CP868
+Alias: cp-ar
+
+Name: IBM869                                              [RFC1345,KXS2]
+Source: IBM Keyboard layouts and code pages, PN 07G4586 June 1991
+Alias: cp869
+Alias: 869
+Alias: cp-gr
+
+Name: IBM870                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: CP870
+Alias: ebcdic-cp-roece
+Alias: ebcdic-cp-yu
+
+Name: IBM871                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: CP871
+Alias: ebcdic-cp-is
+
+Name: IBM880                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: cp880
+Alias: EBCDIC-Cyrillic
+
+Name: IBM891                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: cp891
+
+Name: IBM903                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: cp903
+
+Name: IBM904                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: cp904
+Alias: 904
+
+Name: IBM905                                              [RFC1345,KXS2]
+Source: IBM 3174 Character Set Ref, GA27-3831-02, March 1990
+Alias: CP905
+Alias: ebcdic-cp-tr
+
+
+
+Reynolds & Postel                                             [Page 115]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+Name: IBM918                                              [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: CP918
+Alias: ebcdic-cp-ar2
+
+Name: IBM1026                                             [RFC1345,KXS2]
+Source: IBM NLS RM Vol2 SE09-8002-01, March 1990
+Alias: CP1026
+
+Name: EBCDIC-AT-DE                                        [RFC1345,KXS2]
+Source: IBM 3270 Char Set Ref Ch 10, GA27-2837-9, April 1987
+
+Name: EBCDIC-AT-DE-A                                      [RFC1345,KXS2]
+Source: IBM 3270 Char Set Ref Ch 10, GA27-2837-9, April 1987
+
+Name: EBCDIC-CA-FR                                        [RFC1345,KXS2]
+Source: IBM 3270 Char Set Ref Ch 10, GA27-2837-9, April 1987
+
+Name: EBCDIC-DK-NO                                        [RFC1345,KXS2]
+Source: IBM 3270 Char Set Ref Ch 10, GA27-2837-9, April 1987
+
+Name: EBCDIC-DK-NO-A                                      [RFC1345,KXS2]
+Source: IBM 3270 Char Set Ref Ch 10, GA27-2837-9, April 1987
+
+Name: EBCDIC-FI-SE                                        [RFC1345,KXS2]
+Source: IBM 3270 Char Set Ref Ch 10, GA27-2837-9, April 1987
+
+Name: EBCDIC-FI-SE-A                                      [RFC1345,KXS2]
+Source: IBM 3270 Char Set Ref Ch 10, GA27-2837-9, April 1987
+
+Name: EBCDIC-FR                                           [RFC1345,KXS2]
+Source: IBM 3270 Char Set Ref Ch 10, GA27-2837-9, April 1987
+
+Name: EBCDIC-IT                                           [RFC1345,KXS2]
+Source: IBM 3270 Char Set Ref Ch 10, GA27-2837-9, April 1987
+
+Name: EBCDIC-PT                                           [RFC1345,KXS2]
+Source: IBM 3270 Char Set Ref Ch 10, GA27-2837-9, April 1987
+
+Name: EBCDIC-ES                                           [RFC1345,KXS2]
+Source: IBM 3270 Char Set Ref Ch 10, GA27-2837-9, April 1987
+
+Name: EBCDIC-ES-A                                         [RFC1345,KXS2]
+Source: IBM 3270 Char Set Ref Ch 10, GA27-2837-9, April 1987
+
+Name: EBCDIC-ES-S                                         [RFC1345,KXS2]
+Source: IBM 3270 Char Set Ref Ch 10, GA27-2837-9, April 1987
+
+
+
+
+Reynolds & Postel                                             [Page 116]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+Name: EBCDIC-UK                                           [RFC1345,KXS2]
+Source: IBM 3270 Char Set Ref Ch 10, GA27-2837-9, April 1987
+
+Name: EBCDIC-US                                           [RFC1345,KXS2]
+Source: IBM 3270 Char Set Ref Ch 10, GA27-2837-9, April 1987
+
+Name: UNKNOWN-8BIT                                             [RFC1428]
+
+Name: MNEMONIC                                            [RFC1345,KXS2]
+Source: RFC 1345, also known as "mnemonic+ascii+38"
+
+Name: MNEM                                                [RFC1345,KXS2]
+Source: RFC 1345, also known as "mnemonic+ascii+8200"
+
+Name: VISCII                                                   [RFC1456]
+Source: RFC 1456
+
+Name: VIQR                                                     [RFC1456]
+Source: RFC 1456
+
+Name: KOI8-R                                                   [RFC1489]
+Source: RFC 1489, based on GOST-19768-74, ISO-6937/8,
+        INIS-Cyrillic, ISO-5427.
+
+Name: UNICODE-1-1                                              [RFC1641]
+Source: RFC 1641
+
+Name: UNICODE-1-1-UTF-7                                        [RFC1642]
+Source: RFC 1642
+
+REFERENCES
+
+[RFC1345]  Simonsen, K., "Character Mnemonics & Character Sets",
+           RFC 1345, Rationel Almen Planlaegning, Rationel Almen
+           Planlaegning, June 1992.
+
+[RFC1428]  Vaudreuil, G., "Transition of Internet Mail from
+           Just-Send-8 to 8bit-SMTP/MIME", RFC1428, CNRI, February
+           1993.
+
+[RFC1456]  Vietnamese Standardization Working Group, "Conventions for
+           Encoding the Vietnamese Language VISCII: VIetnamese
+           Standard Code for Information Interchange VIQR: VIetnamese
+           Quoted-Readable Specification Revision 1.1", RFC 1456, May
+           1993.
+
+[RFC1468]  Murai, J., Crispin, M., and E. van der Poel, "Japanese
+           Character Encoding for Internet Messages", RFC 1468,
+
+
+
+Reynolds & Postel                                             [Page 117]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+           Keio University, Panda Programming, June 1993.
+
+[RFC1489]  Chernov, A., "Registration of a Cyrillic Character Set",
+           RFC1489, RELCOM Development Team, July 1993.
+
+[RFC1554]  Ohta, M., and K. Handa, "ISO-2022-JP-2: Multilingual
+           Extension of ISO-2022-JP", RFC1554, Tokyo Institute of
+           Technology, ETL, December 1993.
+
+[RFC1556]  Nussbacher, H., "Handling of Bi-directional Texts in MIME",
+           RFC1556, Israeli Inter-University, December 1993.
+
+[RFC1557]  Choi, U., Chon, K., and H. Park, "Korean Character Encoding
+           for Internet Messages", KAIST, Solvit Chosun Media,
+           December 1993.
+
+[RFC1641]  Goldsmith, D., and M. Davis, "Using Unicode with MIME",
+           RFC1641, Taligent, Inc., July 1994.
+
+[RFC1642]  Goldsmith, D., and M. Davis, "UTF-7", RFC1642, Taligent,
+           Inc., July 1994.
+
+PEOPLE
+
+[KXS2] Keld Simonsen <Keld.Simonsen@dkuug.dk>
+
+[Choi] Uhhyung Choi <uhhyung@kaist.ac.kr>
+
+[Murai] Jun Murai <jun@wide.ad.jp>
+
+[Ohta] Masataka Ohta <mohta@cc.titech.ac.jp>
+
+[Nussbacher] Hank Nussbacher <hank@vm.tau.ac.il>
+
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/character-sets
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                             [Page 118]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+NETWORK MANAGEMENT PARAMETERS
+
+For the management of hosts and gateways on the Internet a data
+structure for the information has been defined.  This data structure
+should be used with any of several possible management protocols, such
+as the "Simple Network Management Protocol" (SNMP) [RFC1157], or the
+"Common Management Information Protocol over TCP" (CMOT) [RFC1095].
+
+The data structure is the "Structure and Indentification of Management
+Information for TCP/IP-based Internets" (SMI) [RFC1155], and the
+"Management Information Base for Network Management of TCP/IP-based
+Internets" (MIB-II) [RFC1213].
+
+The SMI includes the provision for panrameters or codes to indicate
+experimental or private data structures.  These parameter assignments
+are listed here.
+
+The older "Simple Gateway Monitoring Protocol" (SGMP) [RFC1028] also
+defined a data structure.  The parameter assignments used with SGMP
+are included here for historical completeness.
+
+The network management object identifiers are under the iso (1), org
+(3), dod (6), internet (1), or 1.3.6.1, branch of the name space.
+
+The major branches are:
+
+1                   iso
+1.3                 org
+1.3.6               dod
+1.3.6.1             internet
+1.3.6.1.1           directory
+1.3.6.1.2           mgmt
+1.3.6.1.2.1         mib-2
+1.3.6.1.2.1.2.2.1.3 ifType
+1.3.6.1.2.1.10      transmission
+1.3.6.1.2.1.10.23   transmission.ppp
+1.3.6.1.2.1.27      application
+1.3.6.1.2.1.28      mta
+1.3.6.1.3           experimental
+1.3.6.1.4           private
+1.3.6.1.4.1         enterprise
+1.3.6.1.5           security
+1.3.6.1.6           SNMPv2
+1.3.6.1.7           mail
+
+SMI Network Management Directory Codes:
+
+Prefix: iso.org.dod.internet.directory (1.3.6.1.1.)
+
+
+
+Reynolds & Postel                                             [Page 119]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+Decimal   Name          Description                     References
+-------   ----          -----------                     ----------
+    all   Reserved      Reserved for future use             [IANA]
+
+SMI Network Management MGMT Codes:
+
+Prefix: iso.org.dod.internet.mgmt (1.3.6.1.2.)
+
+Decimal   Name          Description                     References
+-------   ----          -----------                     ----------
+      0   Reserved                                          [IANA]
+      1   MIB                                                [KZM]
+
+Prefix: iso.org.dod.internet.mgmt.mib-2 (1.3.6.1.2.1)
+
+Decimal   Name          Description                     References
+-------   ----          -----------                     ----------
+      0   Reserved      Reserved                            [IANA]
+      1   system        System                       [RFC1213,KZM]
+      2   interfaces    Interfaces                   [RFC1213,KZM]
+      3   at            Address Translation          [RFC1213,KZM]
+      4   ip            Internet Protocol            [RFC1213,KZM]
+      5   icmp          Internet Control Message     [RFC1213,KZM]
+      6   tcp           Transmission Control Protocol[RFC1213,KZM]
+      7   udp           User Datagram Protocol       [RFC1213,KZM]
+      8   egp           Exterior Gateway Protocol    [RFC1213,KZM]
+      9   cmot          CMIP over TCP                [RFC1213,KZM]
+     10   transmission  Transmission                 [RFC1213,KZM]
+     11   snmp          Simple Network Management    [RFC1213,KZM]
+     12   GenericIF     Generic Interface Extensions
+--                                           [RFC1229,RFC1239,KZM]
+     13   Appletalk     Appletalk Networking         [RFC1243,SXW]
+     14   ospf          Open Shortest Path First    [RFC1253,FB77]
+     15   bgp           Border Gateway Protocol          [RFC1657]
+     16   rmon          Remote Network Monitoring    [RFC1271,SXW]
+     17   bridge        Bridge Objects               [RFC1286,EXD]
+     18   DecnetP4      Decnet Phase 4          [RFC1559, Saperia]
+     19   Character     Character Streams                [RFC1658]
+     20   snmpParties   SNMP Parties                 [RFC1353,KZM]
+     21   snmpSecrets   SNMP Secrets                 [RFC1353,KZM]
+     22   snmpDot3RptrMgt                                [RFC1516]
+     23   rip-2         Routing Information Protocol     [RFC1389]
+     24   ident         Identification Protocol          [RFC1414]
+     25   host          Host Resources                   [RFC1514]
+     26   snmpDot3MauMgt 802.3 Medium Attachment Units   [RFC1515]
+     27   application   Network Services Monitoring      [RFC1565]
+     28   mta           Mail Monitoring                  [RFC1566]
+     29   dsa           X.500 Directory Monitoring       [RFC1567]
+
+
+
+Reynolds & Postel                                             [Page 120]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+     30   IANAifType    Interface Types                  [RFC1573]
+     31   ifMIB         Interface Types                  [RFC1573]
+     32   dns           Domain Name System               [RFC1611]
+     33   upsMIB        Uninterruptible Power Supplies   [RFC1628]
+     34   sannauMIB     SNA NAU MIB                      [RFC1665]
+     35   etherMIB      Ethernet-like generic objects    [RFC1650]
+     36   sipMIB        SMDS inteface objects            [RFC1694]
+     37   atmMIB        ATM objects                      [RFC1695]
+     38   mdmMIB        Dial-up modem objects            [RFC1696]
+     39   rdbmsMIB      relational database objects      [RFC1697]
+
+Prefix: iso.org.dod.internet.mgmt.mib-2.interface (1.3.6.1.2.1.2)
+
+(1.3.6.1.2.1.2.2.1.3)
+
+ifType definitions
+
+Decimal   Name          Description
+-------   ----          -----------
+      1   other         none of the following            [RFC1213]
+      2   regular1822   BBN Report 1822                  [RFC1213]
+      3   hdh1822       BBN Report 1822                  [RFC1213]
+      4   ddn-x25       BBN Report 1822                  [RFC1213]
+      5   x25           X.25                             [RFC1382]
+      6   ethernet-csmacd                                [RFC1213]
+      7   IEEE802.3     CSMACD--like Objects          [RF1284,JXC]
+      8   IEEE802.4     Token Bus-like Objects
+--                                           [RFC1230,RFC1239,KZM]
+      9   IEEE802.5     Token Ring-like Objects
+--                                           [RFC1231,RFC1239,KZM]
+     10   iso88026-man                                   [RFC1213]
+     11   starLan                                        [RFC1213]
+     12   proteon-10Mbit                                 [RFC1213]
+     13   proteon-80Mbit                                 [RFC1213]
+     14   hyperchannel                                   [RFC1213]
+     15   FDDI          FDDI Objects               [RFC1285,JDC20]
+     16   lapb          LAP B                            [RFC1381]
+     17   sdlc                                           [RFC1213]
+     18   ds1           T1/E1 Carrier Objects            [RFC1406]
+     19   e1            obsolete
+     20   basicISDN                                      [RFC1213]
+     21   primaryISDN                                    [RFC1213]
+     22   propPointToPointSerial                         [RFC1213]
+     23   ppp           Point-to-Point Protocol          [RFC1471]
+     24   softwareLoopback                               [RFC1213]
+     25   eon                                            [RFC1213]
+     26   ethernet-3Mbit                                 [RFC1213]
+     27   nsip                                           [RFC1213]
+
+
+
+Reynolds & Postel                                             [Page 121]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+     28   slip                                           [RFC1213]
+     29   ultra                                          [RFC1213]
+     30   ds3           DS3/E3 Interface Objects         [RFC1407]
+     31   sip           SMDS Interface Objects       [RFC1304,TXC]
+     32   frame-relay   Frame Relay Objects          [RFC1315,CXB]
+     33   RS-232        RS-232 Objects                   [RFC1659]
+     34   Parallel      Parallel Printer Objects         [RFC1660]
+     35   arcnet        ARC network
+     36   arcnet-plus   ARC network plus
+     37   atm           ATM
+     38   MIOX25        MIOX25                           [RFC1461]
+     39   SONET         SONET or SDH
+     40   x25ple        X.25 packet level                [RFC1382]
+     41   iso88022llc   802.2 LLC
+     42   localTalk
+     43   smds-dxi      SMDS DXI
+     44   frameRelayService Frame Relay DCE
+     45   v35           V.35
+     46   hssi          HSSI
+     47   hippi         HIPPI
+     48   modem         generic modem
+     49   aal5          AAL5 over ATM
+     50   sonetPath
+     51   sonetVT
+     52   smds-icip     SMDS Inter-Carrier Interface Protocol
+     53   propVirtual   proprietary vitural/internal interface
+     54   propMultiLink proprietary multi-link multiplexing
+     55   IEEE802.12    100BaseVG
+     56   fibre-channel Fibre Channel
+
+Prefix: iso.org.dod.internet.mgmt.mib-2.transmission (1.3.6.1.2.1.10)
+
+Decimal   Name          Description
+-------   ----          -----------
+      5   x25           X.25                             [RFC1382]
+      7   IEEE802.3     CSMACD--like Objects             [RFC1650]
+      8   IEEE802.4     Token Bus-like Objects
+--                                           [RFC1230,RFC1239,KZM]
+      9   IEEE802.5     Token Ring-like Objects
+--                                           [RFC1231,RFC1239,KZM]
+     15   FDDI          FDDI Objects               [RFC1285,JDC20]
+     16   lapb          LAP B                            [RFC1381]
+     18   ds1           T1 Carrier Objects               [RFC1406]
+     19   e1            E1 Carrier Objects               [RFC1406]
+     23   ppp           Point-to-Point Protocol          [RFC1471]
+     30   ds3           DS3/E3 Interface Objects         [RFC1407]
+     31   sip           SMDS Interface Objects           [RFC1694]
+     32   frame-relay   Frame Relay Objects          [RFC1315,CXB]
+
+
+
+Reynolds & Postel                                             [Page 122]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+     33   RS-232        RS-232 Objects                   [RFC1659]
+     34   Parallel      Parallel Printer Objects         [RFC1660]
+     35   arcnet        ARC network
+     36   arcnet-plus   ARC network plus
+     37   atm           ATM
+     38   MIOX25        MIOX25                           [RFC1461]
+     39   sonetMIB      SONET MIB                        [RFC1595]
+     44   frnetservMIB  Frame Relay Service MIB for DCE  [RFC1596]
+
+Prefix: iso.org.dod.internet.mgmt.mib-2.transmission (1.3.6.1.2.1.10)
+
+(1.3.6.1.2.1.10.23)
+
+Decimal   Name          Description                     References
+-------   ----          -----------                     ----------
+      1   pppLcp        ppp link control                [RFC1471]
+      2   pppSecurity   ppp security                    [RFC1472]
+      3   pppIp         ppp IP network control          [RFC1473]
+      4   pppBridge     ppp bridge networl control      [RFC1474]
+
+Prefix: iso.org.dod.internet.mgmt.mib-2.application (1.3.6.1.2.1.27)
+
+(1.3.6.1.2.1.27.2.1.3)
+
+   assocApplicationProtocol OBJECT-TYPE
+       SYNTAX OBJECT IDENTIFIER
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+         "An identification of the protocol being used for the
+          application.  For an OSI Application, this will be the
+          Application Context.  For Internet applications, the IANA
+          maintains a registry of the OIDs which correspond to
+          well-known applications.  If the application protocol is
+          not listed in the registry, an OID value of the form
+          {applTCPProtoID port} or {applUDProtoID port} are used for
+          TCP-based and UDP-based protocols, respectively. In either
+          case 'port' corresponds to the primary port number being
+          used by the protocol."
+       ::= {assocEntry 3}
+
+Decimal   Name          Description
+-------   ----          -----------
+     0    Reserved
+
+(1.3.6.1.2.1.27.3)
+
+(1.3.6.1.2.1.27.4)
+
+
+
+Reynolds & Postel                                             [Page 123]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+   -- OIDs of the form {applTCPProtoID port} are intended to be used
+   -- for TCP-based protocols that don't have OIDs assigned by other
+   -- means. {applUDPProtoID port} serves the same purpose for
+   -- UDP-based protocols. In either case 'port' corresponds to
+   -- the primary port number being used by the protocol. For example,
+   -- assuming no other OID is assigned for SMTP, an OID of
+   -- {applTCPProtoID 25} could be used, since SMTP is a TCP-based
+   -- protocol that uses port 25 as its primary port.
+
+Prefix: iso.org.dod.internet.mgmt.mib-2.mta (1.3.6.1.2.1.28)
+
+(1.3.6.1.2.1.28.2.1.24)
+
+   mtaGroupMailProtocol OBJECT-TYPE
+       SYNTAX OBJECT IDENTIFIER
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+         "An identification of the protocol being used by this group.
+         For an group employing OSI protocols, this will be the
+         Application Context.  For Internet applications, the IANA
+         maintains a registry of the OIDs which correspond to
+         well-known message transfer protocols.  If the application
+         protocol is not listed in the registry, an OID value of the
+         form {applTCPProtoID port} or {applUDProtoID port} are used
+         for TCP-based and UDP-based protocols, respectively.  In
+         either case 'port' corresponds to the primary port number
+         being used by the group.  applTCPProtoID and applUDPProtoID
+         are defined in [5]."
+       ::= {mtaGroupEntry 24}
+
+Decimal   Name          Description
+-------   ----          -----------
+     0    Reserved
+
+SMI Network Management Experimental Codes:
+
+Prefix: iso.org.dod.internet.experimental (1.3.6.1.3.)
+
+Decimal   Name          Description                     References
+-------   ----          -----------                     ----------
+      0   Reserved                                          [JKR1]
+      1   CLNS          ISO CLNS Objects                     [GS2]
+  *   2   T1-Carrier    T1 Carrier Objects                  [FB77]
+  *   3   IEEE802.3     Ethernet-like Objects                [JXC]
+  *   4   IEEE802.5     Token Ring-like Objects              [EXD]
+  *   5   DECNet-PHIV   DECNet Phase IV                     [JXS2]
+  *   6   Interface     Generic Interface Objects            [KZM]
+
+
+
+Reynolds & Postel                                             [Page 124]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+  *   7   IEEE802.4     Token Bus-like Objects               [KZM]
+  *   8   FDDI          FDDI Objects                       [JDC20]
+      9   LANMGR-1      LAN Manager V1 Objects              [JXG1]
+     10   LANMGR-TRAPS  LAN Manager Trap Objects            [JXG1]
+     11   Views         SNMP View Objects                    [CXD]
+     12   SNMP-AUTH     SNMP Authentication Objects          [KZM]
+  *  13   BGP           Border Gateway Protocol            [SW159]
+  *  14   Bridge        Bridge MIB                          [FB77]
+  *  15   DS3           DS3 Interface Type                   [TXB]
+  *  16   SIP           SMDS Interface Protocol              [TXB]
+  *  17   Appletalk     Appletalk Networking                 [SXW]
+  *  18   PPP           PPP Objects                         [FJK2]
+  *  19   Character MIB Character MIB                      [BS221]
+  *  20   RS-232 MIB    RS-232 MIB                         [BS221]
+  *  21   Parallel MIB  Parallel MIB                       [BS221]
+     22   atsign-proxy  Proxy via Community                  [RXF]
+  *  23   OSPF          OSPF MIB                            [FB77]
+     24   Alert-Man     Alert-Man                            [LS8]
+     25   FDDI-Synoptics FDDI-Synoptics                     [DXP1]
+  *  26   Frame Relay   Frame Relay MIB                      [CXB]
+  *  27   rmon          Remote Network Management MIB        [SXW]
+     28   IDPR          IDPR MIB                           [RAW44]
+     29   HUBMIB        IEEE 802.3 Hub MIB                  [DXM5]
+     30   IPFWDTBLMIB   IP Forwarding Table MIB             [FB77]
+     31   LATM MIB                                           [TXB]
+     32   SONET MIB                                          [TXB]
+     33   IDENT                                              [MTR]
+     34   MIME-MHS                                           [MTR]
+     35   MAUMIB        IEEE 802.3 Mau MIB                  [DXM5]
+     36   Host Resources Host Resources MIB                  [SXW]
+     37   ISIS-MIB      Integrated ISIS protocol MIB         [CXG]
+     38   Chassis       Chassis MIB                        [JDC20]
+     39   ups           ups                                [JDC20]
+     40   App-Mon       Application Monitoring MIB           [TXK]
+     41   ATM UNI       ATM                                 [MXA1]
+     42   FC            Fibre Channel                       [JXC4]
+*    43   DNS           Domain Name Service          [Rob Austein]
+     44   X.25          X.25 MIB                     [Dean Throop]
+     45   Frame Relay Serv.  Frame Relay Service MIB   [Tracy Cox]
+     46   Madman-Applications                          [Ned Freed]
+     47   Madman-MTA                                   [Ned Freed]
+     48   Madman-DSA                                   [Ned Freed]
+     49   Modem                                 [Steve Waldbusser]
+     50   SNA NAU                                [Deirdre Kostick]
+     51   SDLC          SDLC                       [Jeff Hilgeman]
+     52   DNS           Domain Name Service          [Jon Saperia]
+     53   network-objects IP info ix X.500             [Johannsen]
+     54   printmib                               [Joel Gyllenskog]
+
+
+
+Reynolds & Postel                                             [Page 125]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+     55   rdbmsmib                                 [Robert Purvey]
+     56   sipMIB                                     [Tracy Brown]
+     57   stIImib       ST-II protocol MIB        [Hartmut Wittig]
+     58   802.5 SSR MIB 802.5 Station Source Routing MIB     [KZM]
+
+  * = obsoleted
+
+SMI Private Codes:
+
+Prefix: iso.org.dod.internet.private (1.3.6.1.4)
+
+Decimal   Name          Description                     References
+-------   ----          -----------                     ----------
+      0   Reserved                                          [JKR1]
+      1   enterprise    private enterprises                 [JKR1]
+
+SMI Private Enterprise Codes:
+
+Prefix: iso.org.dod.internet.private.enterprise (1.3.6.1.4.1)
+
+See the file "enterprise-numbers".
+
+SMI Security Codes:
+
+Prefix: iso.org.dod.internet.security (1.3.6.1.5)
+
+Decimal   Name          Description                     References
+-------   ----          -----------                     ----------
+      0   Reserved                                          [JKR1]
+      1   kerberosV4    Kerberos version 4 objects         [1,BCN]
+      2   kerberosV5    Kerberos version 5 objects         [2,BCN]
+
+SMI SNMPv2 Codes:
+
+Prefix: iso.org.dod.internet.snmpv2 (1.3.6.1.6)
+
+SMI mail Codes:
+
+Prefix: iso.org.dod.internet.mail (1.3.6.1.7)
+
+   1     mime-mhs
+
+
+REFERENCES
+
+[1]       Miller, S.P., B.C. Neuman, J.I. Schiller, and J.H. Saltzer,
+          "Project Athena Technical Plan Section E.2.1: Kerberos
+          Authentication and Authorization System", Project Athena,
+
+
+
+Reynolds & Postel                                             [Page 126]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+          MIT, December 1987.
+
+[2]       Kohl, J., and B.C. Neuman, "The Kerberos Network
+          Authentication Service (V5)" work in progress, September
+          1992.
+
+[RFC1028] Davin, J., J. Case, M. Fedor, and M. Schoffstall, "A Simple
+          Gateway Monitoring Protocol", RFC 1028, Proteon, Inc.,
+          University of Tennessee at Knoxville, Cornell University,
+          Rensselaer Polytechnic Institute, November 1987.
+
+[RFC1095] Warrier, U., and L. Besaw, "The Common Management
+          Information Services and Protocol over TCP/IP (CMOT)",
+          RFC 1095, Unisys Corp., Hewlett-Packard, April 1989.
+
+[RFC1155] Rose, M., and K. McCloghrie, "Structure and Identification
+          of Management Information for TCP/IP-based internets",
+          STD 16, RFC 1155, Performance Systems International, Hughes
+          LAN Systems, May 1990.
+
+[RFC1157] Case, J., M. Fedor, M. Schoffstall, and J. Davin,
+          "A Simple Network Management Protocol", STD 15, RFC 1157,
+          SNMP Research, Performance Systems International,
+          Performance Systems International, MIT Laboratory for
+          Computer Science, May 1990.
+
+[RFC1213] McCloghrie, K., and M. Rose, "Management Information Base
+          for Network Management of TCP/IP-based internets: MIB-II",
+          STD 17, RFC 1213, Hughes LAN Systems, Performance Systems
+          International, March 1991.
+
+[RFC1229] McCloghrie, K., Editor, "Extensions to the Generic-Interface
+          MIB", RFC 1229, Hughes LAN Systems, Inc., May 1991.
+
+[RFC1230] McCloghrie, K., and R. Fox, "IEEE 802.4 Token Bus MIB",
+          RFC 1230, Hughes LAN Systems, Inc., Synoptics, Inc.,
+          May 1991.
+
+[RFC1231] McCloghrie, K., Fox, R., and E. Decker, "IEEE 802.5 Token
+          Ring MIB", RFC 1231, Hughes LAN Systems, Inc., Synoptics,
+          Inc., cisco Systems, Inc., May 1991.
+
+[RFC1239] Reynolds, J., "Reassignment of Experimental MIBs to
+          Standard MIBs", RFC 1239, USC/Information Sciences
+          Institute, ISI, June 1991.
+
+[RFC1243] Waldbusser, S., Editor, "AppleTalk Management Information
+          Base", RFC 1243, Carnegie Mellon University, July 1991.
+
+
+
+Reynolds & Postel                                             [Page 127]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[RFC1253] Baker, F., and R. Coltun, "OSPF Version 2 Management
+          Information Base", RFC 1253, ACC, Computer Science Center,
+          August 1991.
+
+[RFC1271] Waldbusser, S., "Remote Network Monitoring Management
+          Information Base", RFC 1271, Carnegie Mellon University,
+          November 1991.
+
+[RFC1284] Cook, J., Editor, "Definitions of Managed Objects
+          for the Ethernet-like Interface Types", RFC 1284, Chipcom
+          Corporation, December 1991.
+
+[RFC1285] Case, J., "FDDI Management Information Base", RFC 1285,
+          SNMP Research, Incorporated, January 1992.
+
+[RFC1286] Decker, E., Langille, P., Rijsinghani, A., and K.
+          McCloghrie, "Definitions of Managed Objects for Bridges",
+          RFC 1286, cisco Systems, Inc., DEC, Hughes LAN Systems,
+          Inc., December 1991.
+
+[RFC1304] Cox, T., and K. Tesnik, Editors, "Definitions of Managed
+          Objects for the SIP Interface Type", RFC 1304, Bell
+          Communications Research, February 1992.
+
+[RFC1315] Brown, C., Baker, F., and C. Carvalho, "Management
+          Information Base for Frame Relay DTEs", RFC 1315, Wellfleet
+          Communications, Inc., Advanced Computer Communications,
+          April 1992.
+
+[RFC1353] McCloghrie, K., Davin, J., and J. Galvin, "Definitions of
+          Managed Objects for Administration of SNMP Parties",
+          RFC 1353, Hughes LAN Systems, Inc., MIT Laboratory for
+          Computer Science, Trusted Information Systems, Inc.,
+          July 1992.
+
+[RFC1381] Throop, D., and F. Baker, "SNMP MIB Extension for X.25
+          LAPB", RFC 1381, Data General Corporation, Advanced Computer
+          Communications, November 1992.
+
+[RFC1382] Throop, D., Editor, "SNMP MIB Extension for the X.25 Packet
+          Layer", RFC 1382, Data General Corporation, November 1992.
+
+[RFC1389] Malkin, G., and F. Baker, "RIP Version 2 MIB Extension", RFC
+          1389, Xylogics, Inc., Advanced Computer Communications,
+          January 1993.
+
+[RFC1406] Baker, F., and J. Watt, Editors, "Definitions of Managed
+          Objects for the DS1 and E1 Interface Types", RFC 1406,
+
+
+
+Reynolds & Postel                                             [Page 128]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+          Advanced Computer Communications, Newbridge Networks
+          Corporation, January 1993.
+
+[RFC1407] Cox, T., and K. Tesink, "Definitions of Managed Objects
+          for the DS3/E3 Interface Type", RFC 1407, Bell
+          Communications Research, January 1993.
+
+[RFC1414] St. Johns, M., and M. Rose, "Identification MIB", RFC 1414,
+          US Department of Defense, Dover Beach Consulting, Inc.,
+          February 1993.
+
+[RFC1461] Throop, D., "SNMP MIB extension for Multiprotocol
+          Interconnect over X.25", RFC 1461, Data General Corporation,
+          May 1993.
+
+[RFC1471] Kastenholz, F., "The Definitions of Managed Objects for
+          the Link Control Protocol of the Point-to-Point Protocol",
+          RFC 1471, FTP Software, Inc., June 1993.
+
+[RFC1472] Kastenholz, F., "The Definitions of Managed Objects for
+          the Security Protocols of the Point-to-Point Protocol", RFC
+          1472, FTP Software, Inc., June 1993.
+
+[RFC1473] Kastenholz, F., "The Definitions of Managed Objects for
+          the IP Network Control Protocol of the Point-to-Point
+          Protocol", RFC 1473, FTP Software, Inc., June 1993.
+
+[RFC1474] Kastenholz, F., "The Definitions of Managed Objects for
+          the Bridge Network Control Protocol of the Point-to-Point
+          Protocol" RFC 1474, FTP Software, Inc., June 1993.
+
+[RFC1514] Grillo, P., and S. Waldbusser, "Host Resources MIB", RFC
+          1514, Network Innovations, Intel Corporation, Carnegie
+          Mellon University, September 1993.
+
+[RFC1515] McMaster, D., McCloghrie, K., and S. Roberts, "Definitions
+          of Managed Objects for IEEE 802.3 Medium Attachment Units
+          (MAUs)", RFC 1515, SynOptics Communications, Inc., Hughes
+          LAN Systems, Inc., Farallon Computing, Inc., September 1993.
+
+[RFC1516] McMaster, D., and K. McCloghrie, "Definitions of Managed
+          Objects for IEEE 802.3 Repeater Devices", RFC 1516,
+          SynOptics Communications, Inc., Hughes LAN Systems, Inc.,
+          September 1993.
+
+[RFC1559] Saperia, J., "DECnet Phase IV MIB Extensions", RFC 1559,
+          Digital Equipment Corporation, December 1993.
+
+
+
+
+Reynolds & Postel                                             [Page 129]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[RFC1565] Kille, S., WG Chair, and N. Freed, Editor, "Network Services
+          Monitoring MIB", RFC 1565, ISODE Consortium and Innosoft,
+          January 1994.
+
+[RFC1566] Kille, S., WG Chair, and N. Freed, Editor, "Mail Monitoring
+          MIB", RFC 1566, ISODE Consortium, Innosoft, January 1994.
+
+[RFC1567] Mansfield, G., and S. Kille, "X.500 Directory Monitoring
+          MIB", RFC 1567, AIC Systems Laboratory, ISODE Consortium,
+          January 1994.
+
+[RFC1573] McCloghrie, K., and F. Kastenholz, "Evolution of the
+          Interfaces Group of MIB-II", RFC 1573, Hughes LAN Systems,
+          FTP Software, January 1994.
+
+[RFC1595] Brown, T., and K. Tesink, Editors, "Definitions of Managed
+          Objects for the SONET/SDH Interface Type", RFC 1595,
+          Bell Communications Research, March 1994.
+
+[RFC1596] Brown, T., Editor, Definitions of Managed Objects for Frame
+          Relay Service", RFC 1596, Bell Communications Research,
+          March 1994.
+
+[RFC1611] Austein, R., and J. Saperia, "DNS Server MIB Extensions",
+          RFC 1611, Epilogue Technology Corporation, Digital Equipment
+          Corporation, May 1994.
+
+[RFC1628] Case, J., Editor, "UPS Management Information Base", RFC
+          1628, SNMP Research, Incorporated, May 1994.
+
+[RFC1650] Kastenholz, F., "Definitions of Managed Objects for
+          the Ethernet-like Interface Types using SMIv2", RFC 1650,
+          FTP Software, Inc., August 1994.
+
+[RFC1657] Willis, S., Burruss, J., and J. Chu, Editor, "Definitions of
+          Managed Objects for the Fourth Version of the Border Gateway
+          Protocol (BGP-4) using SMIv2", RFC 1657, Wellfleet
+          Communications Inc., IBM Corp., July 1994.
+
+[RFC1658] Stewart, B., "Definitions of Managed Objects for Character
+          Stream Devices using SMIv2", RFC 1658, Xyplex, Inc., July
+          1994.
+
+[RFC1659] Stewart, B., "Definitions of Managed Objects for RS-232-like
+          Hardware Devices using SMIv2", RFC 1659, Xyplex, Inc., July
+          1994.
+
+[RFC1660] Stewart, B., "Definitions of Managed Objects for
+
+
+
+Reynolds & Postel                                             [Page 130]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+          Parallel-printer-like Hardware Devices using SMIv2", RFC
+          1660, Xyplex, Inc., July
+          1994.
+
+[RFC1665] Kielczewski, Z., Kostick, D., and K. Shih, Editors,
+          "Definitions of Managed Objects for SNA NAUs using SMIv2",
+          RFC 1665, Eicon Technology Corporation, Bell Communications
+          Research, Novell, July 1994.
+
+[RFC1694] Brown, T., and K. Tesink, Editors, "Definitions of Managed
+          Objects for SMDS Interfaces using SMIv2", RFC 1694, Bell
+          Communications Research, August 1994.
+
+[RFC1695] Ahmed, M., and K. Tesink, Editors, "Definitions of Managed
+          Objects for ATM Management Version 8.0 using SMIv2", RFC
+          1695, Bell Communications Research, August 1994.
+
+[RFC1696] Barnes, J., Brown, L., Royston, R., and S. Waldbusser,
+          "Modem Management Information Base (MIB) using SMIv2", RFC
+          1696, Xylogics, Inc., Motorola, US Robotics, Inc., Carnegie
+          Mellon University, August 1994.
+
+[RFC1697] Brower, D., Editor, Purvy, B., RDBMSMIB Working Group Chair,
+          Daniel, A., Sinykin, M., and J. Smith, "Relational Database
+          Management System (RDBMS) Management Information Base (MIB)
+          using SMIv2", RFC 1697, The ASK Group, INGRES DBMS
+          Development, Oracle Corporation, Informix Software, Inc.,
+          Oracle Corporation, August 1994.
+
+PEOPLE
+
+[Rob Austein]
+
+[BCN] B. Clifford Neuman <bcn@isi.edu>
+
+[BS221] Bob Stewart <STEWART@XYPLEX.COM>
+
+[CXB]  Caralyn Brown <cbrown%wellfleet.com@talcott.harvard.edu>
+
+[CXD] Chuck Davin <jrd@ptt.lcs.mit.edu>
+
+[CXG] Chris Gunner <gunner@dsmail.lkg.dec.com>
+
+[Dean Throop]
+
+[DXM5] Donna McMaster <mcmaster@synoptics.com>
+
+[DXP1] David Perkins <dperkins@synoptics.com>
+
+
+
+Reynolds & Postel                                             [Page 131]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[EXD] Eric Decker <cire@cisco.com>
+
+[FB77] Fred Baker <fbaker@acc.com>
+
+[FJK2]
+
+[GS2] Greg Satz  <satz@CISCO.COM>
+
+[IANA] IANA <iana@isi.edu>
+
+[JDC20] Jeffrey Case <case@UTKUX1.UTK.EDU>
+
+[JKR1] Joyce K. Reynolds <jkrey@isi.edu>
+
+[JXC] John Cook <cook@chipcom.com>
+
+[JXG1] Jim Greuel <jimg%hpcndpc@hplabs.hp.com>
+
+[JXS2] Jon Saperia <saperia@tcpjon.enet.dec.com>
+
+[Jeff Hilgeman]
+
+[Johannsen]
+
+[KZM] Keith McCloghrie <KZM@HLS.COM>
+
+[LS8] Louis Steinberg <lou@ARAMIS.RUTGERS.EDU>
+
+[MXA1] Masuma Ahmed <mxa@mail.bellcore.com>
+
+[MTR] Marshall Rose <mrose@dbc.mtview.ca.us>
+
+[RAW44] Robert A. Woodburn <WOODY@SPARTA.COM>
+
+[JXC4] John Chu <jychu@watson.ibm.com>
+
+[Ned Freed]
+
+[Deirdre Kostick]
+
+[Joel Gyllenskog] Joel Gyllenskog <jgyllens@hpdmd48.boi.hp.com>
+
+[Robert Purvey] Robert Purvey <bpurvy@us.oracle.com>
+
+[RXF] Richard Fox <rfox@synoptics.com>
+
+[Jon Saperia] Jon Saperia <saperia@tcpjon.enet.dec.com>
+
+
+
+
+Reynolds & Postel                                             [Page 132]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[SW159] Steven Willis <swillis@WELLFLEET.COM>
+
+[SXW] Steve Waldbusser <sw01+@andrew.cmu.edu>
+
+[TXB] Tracy Brown <tacox@mail.bellcore.com>
+
+[TXK] Teemu Kurki <grus@funet.fi>
+
+[Hartmut Wittig]
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/smi-numbers
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                             [Page 133]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+PRIVATE ENTERPRISE NUMBERS
+
+SMI Network Management Private Enterprise Codes:
+
+Prefix: iso.org.dod.internet.private.enterprise (1.3.6.1.4.1)
+
+This file is
+
+          ftp://ftp.isi.edu/in-notes/iana/assignments/enterprise-numbers
+
+Decimal   Name                                                References
+-------   ----                                                ----------
+      0   Reserved                     Joyce K. Reynolds <jkrey@isi.edu>
+      1   Proteon                     John A. Shriver  <jas@PROTEON.COM>
+      2   IBM                      Vik Chandra  <vc@ralvm6.vnet.ibm.com>
+      3   CMU                    Steve Waldbusser <sw01+@andrew.cmu.edu>
+      4   Unix             Keith Sklower  <sklower@okeeffe.berkeley.edu>
+      5   ACC                          Art Berggreen  <art@SALT.ACC.COM>
+      6   TWG           John Lunny  <jlunny@eco.twg.com>  (703) 847-4500
+      7   CAYMAN                          Beth Miaoulis  beth@cayman.com
+      8   PSI                   Marty Schoffstahl  schoff@NISC.NYSER.NET
+      9   cisco                                Greg Satz  satz@CISCO.COM
+     10   NSC                               Geof Stone  geof@NETWORK.COM
+     11   HP               R. Dwight Schettler  rds%hpcndm@HPLABS.HP.COM
+     12   Epilogue                      Karl Auerbac  karl@empirical.com
+     13   U of Tennessee              Jeffrey Case   case@UTKUX1.UTK.EDU
+     14   BBN                         Robert Hinden <hinden@ENG.SUN.COM>
+     15   Xylogics, Inc.      John R. LoVerso  loverso@westford.ccur.com
+     16   Timeplex                      Laura Bridge  laura@uunet.UU.NET
+     17   Canstar                   Sanand Patel  sanand@HUB.TORONTO.EDU
+     18   Wellfleet                   Caralyn Brown cbrown@wellfleet.com
+     19   TRW                 Jay Frederking  jayf@blackhole.ind.TRW.COM
+     20   MIT                            Jon Rochlis  jon@ATHENA.MIT.EDU
+     21   EON                                 Michael Waters  ---none---
+     22   Spartacus                Yoav Kluger  ykluger@HAWK.ULOWELL.EDU
+     23   Novell                        Steve Bostock  steveb@novell.com
+     24   Spider Systems                  Peter Reid  peter@spider.co.uk
+     25   NSFNET                    Hans-Werner Braun  HWB@MCR.UMICH.EDU
+     26   Hughes LAN Systems               Keith McCloghrie  KZM@HLS.COM
+     27   Intergraph                  Guy Streeter  guy@guy.bll.ingr.com
+     28   Interlan                Bruce Taber  taber@europa.InterLan.COM
+     29   Vitalink Communications
+     30   Ulana                     Bill Anderson  wda@MITRE-BEDFORD.ORG
+     31   NSWC            Stephen Northcutt  SNORTHC@RELAY-NSWC.NAVY.MIL
+     32   Santa Cruz Operation            Keith Reynolds  keithr@SCO.COM
+     33   Xyplex                          Bob Stewart STEWART@XYPLEX.COM
+     34   Cray                     Hunaid Engineer  hunaid@OPUS.CRAY.COM
+     35   Bell Northern Research            Glenn Waters  gwaters@BNR.CA
+
+
+
+Reynolds & Postel                                             [Page 134]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+     36   DEC                    Ron Bhanukitsiri  rbhank@DECVAX.DEC.COM
+     37   Touch                                  Brad Benson  ---none---
+     38   Network Research Corp.              Bill Versteeg  bvs@NCR.COM
+     39   Baylor College of Medicine        Stan Barber  SOB@BCM.TMC.EDU
+     40   NMFECC-LLNL           Steven Hunter  hunter@CCC.MFECC.LLNL.GOV
+     41   SRI                      David Wolfe  ctabka@TSCA.ISTC.SRI.COM
+     42   Sun Microsystems                     Dennis Yaro  yaro@SUN.COM
+     43   3Com                           Jeremy Siegel  jzs@NSD.3Com.COM
+     44   CMC                                   Dave Preston  ---none---
+     45   SynOptics                David Perkins  dperkins@synoptics.com
+     46   Cheyenne Software             Reijane Huai  sibal@CSD2.NYU.EDU
+     47   Prime Computer   Mike Spina  WIZARD%enr.prime.com@RELAY.CS.NET
+     48   MCNC/North Carolina   Data Network Ken Whitfield  ken@MCNC.ORG
+     49   Chipcom                            John Cook  cook@chipcom.com
+     50   Optical Data Systems                    Josh Fielk  ---none---
+     51   gated                  Jeffrey C. Honig  jch@gated.cornell.edu
+     52   Cabletron Systems                        Roger Dev  ---none---
+     53   Apollo Computers            Jeffrey Buffun  jbuffum@APOLLO.COM
+     54   DeskTalk Systems, Inc.               David Kaufman  ---none---
+     55   SSDS                                   Ron Strich   ---none---
+     56   Castle Rock Computing                  John Sancho  ---none---
+     57   MIPS Computer Systems       Charles Marker II  marker@MIPS.COM
+     58   TGV, Inc.                         Ken Adelman  Adelman@TGV.COM
+     59   Silicon Graphics, Inc.               Ronald Jacoby  rj@SGI.COM
+     60   University of British Columbia Don McWilliam mcwillm@CC.UBC.CA
+     61   Merit                               Bill Norton  wbn@MERIT.EDU
+     62   FiberCom                          Eric Rubin  err@FIBERCOM.COM
+     63   Apple Computer Inc                  Jim Hayes  Hayes@APPLE.COM
+     64   Gandalf                               Henry Kaijak  ---none---
+     65   Dartmouth              Philip Koch   Philip.Koch@DARTMOUTH.EDU
+     66   David Systems           Kathryn de Graaf  degraaf@davidsys.com
+     67   Reuter                                 Bob Zaniolo  ---none---
+     68   Cornell                  Laurie Collinsworth  ljc1@cornell.edu
+     69   LMS                  L. Michael Sabo  Sabo@DOCKMASTER.NCSC.MIL
+     70   Locus Computing Corp.  Arthur Salazar lcc.arthur@SEAS.UCLA.EDU
+     71   NASA                   Steve Schoch   SCHOCH@AMES.ARC.NASA.GOV
+     72   Retix                                  Alex Martin  ---none---
+     73   Boeing                               Jerry Geisler  ---none---
+     74   AT&T                            Rich Bantel  rgb@mtung.att.com
+     75   Ungermann-Bass                      Didier Moretti  ---none---
+     76   Digital Analysis Corporation
+                               Skip Koppenhaver stubby!skip@uunet.UU.NET
+     77   LAN Manager        Doug Karl KARL-D@OSU-20.IRCC.OHIO-STATE.EDU
+     78   Netlabs                       Jonathan Biggar  jon@netlabs.com
+     79   ICL                                    Jon Infante  ---none---
+     80   Auspex Systems            Brian A. Ehrmantraut  bae@auspex.com
+     81   Lannet Company                        Efrat Ramati  ---none---
+     82   Network Computing Devices  Dave Mackie lupine!djm@UUNET.UU.NET
+
+
+
+Reynolds & Postel                                             [Page 135]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+     83   Raycom Systems                        Bruce Willins ---none---
+     84   Pirelli Focom Ltd.                         Sam Lau  ---none---
+     85   Datability Software Systems     Larry Fischer lfischer@dss.com
+     86   Network Application Technology           Y.C. Wang  ---none---
+     87   LINK (Lokales Informatik-Netz Karlsruhe)
+                                Guenther Schreiner snmp-admin@ira.uka.de
+     88   NYU                        Bill Russell  russell@cmcl2.NYU.EDU
+     89   RND                                Rina Nethaniel   ---none---
+     90   InterCon Systems Corporation Amanda Walker AMANDA@INTERCON.COM
+     91   Coral Network Corporation      Jason Perreault jason@coral.com
+     92   Webster Computer Corporation  Robert R. Elz  kre@munnari.oz.au
+     93   Frontier Technologies Corporation
+                                          Prakash Ambegaonkar ---none---
+     94   Nokia Data Communications              Douglas Egan ---none---
+     95   Allen-Bradely Company
+                      Bill King abvax!calvin.icd.ab.com!wrk@uunet.UU.NET
+     96   CERN
+                 Jens T. Rasmussen jenst%cernvax.cern.ch@CUNYVM.CUNY.EDU
+     97   Sigma Network Systems, Inc.
+                                     Ken Virgile signet!ken@xylogics.COM
+     98   Emerging Technologies, Inc.
+                                Dennis E. Baasch etinc!dennis@uu.psi.com
+     99   SNMP Research                Jeffrey Case  case@UTKUX1.UTK.EDU
+    100 Ohio State University
+                            Shamim Ahmed ahmed@nisca.ircc.ohio-state.edu
+    101 Ultra Network Technologies Julie Dmytryk
+                                        Julie_Dmytryk.MKT@usun.ultra.com
+    102   Microcom                           Annmarie Freitas ---none---
+    103   Martin Marietta Astronautic Group    David Rageth DAVE@MMC.COM
+    104   Micro Technology                Mike Erlinger  mike@lexcel.com
+    105   Process Software Corporation      Bernie Volz VOLZ@PROCESS.COM
+    106   Data General Corporation
+                                Joanna Karwowska karwowska@dg-rtp.dg.com
+    107   Bull Company         Anthony Berent berent@rdgeng.enet.dec.com
+    108   Emulex Corporation                     Jeff Freeman ---none---
+    109   Warwick University Computing Services
+                             Israel Drori raanan@techunix.technion.ac.il
+    110   Network General Corporation
+                                   James Davidson ngc!james@uunet.UU.NET
+    111   Oracle                          John Hanley jhanley@oracle.com
+    112   Control Data Corporation Nelluri L. Reddy reddy@uc.msc.umn.edu
+    113   Hughes Aircraft Company           Keith McCloghrie KZM@HLS.COM
+    114   Synernetics, Inc.                    Jas Parmar jas@synnet.com
+    115   Mitre                               Bede McCall bede@mitre.org
+    116   Hitachi, Ltd.                        Hirotaka Usuda ---none---
+    117   Telebit                       Mark S. Lewis mlewis@telebit.com
+    118   Salomon Technology Services          Paul Maurer II ---none---
+    119   NEC Corporation                              Yoshiyuki Akiyama
+
+
+
+Reynolds & Postel                                             [Page 136]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+                           kddlab!ccs.mt.nec.co.jp!y-akiyam@uunet.uu.net
+    120   Fibermux               Michael Sung msung@ccrelay.fibermux.com
+    121   FTP Software Inc.                Stev Knowles stev@vax.ftp.com
+    122   Sony                   Takashi Hagiwara Hagiwara@Sm.Sony.Co.Jp
+    123   Newbridge Networks Corporation           James Watt ---none---
+    124   Racal-Milgo Information Systems            Maurice R. Turcotte
+                           mailrus!uflorida!rm1!dnmrt%rmatl@uunet.UU.NET
+    125   CR SYSTEMS                        Soren H. Sorensen ---none---
+    126   DSET Corporation               Dan Shia dset!shia@uunet.UU.NET
+    127   Computone                            Bill Versteeg bvs@NCR.COM
+    128   Tektronix, Inc.        Dennis Thomas dennist@tektronix.TEK.COM
+    129   Interactive Systems Corporation
+                                      Steve Alexander stevea@i88.isc.com
+    130 Banyan Systems Inc.
+                  Deepak Taneja eepak=Taneja%Eng%Banyan@Thing.banyan.com
+    131   Sintrom Datanet Limited
+    132   Bell Canada              Mark Fabbi markf@gpu.utcs.utoronto.ca
+    133   Crosscomm Corporation  Reuben Sivan crossc!rsivan@uunet.UU.NET
+    134   Rice University             Catherine Foulston cathyf@rice.edu
+    135   T3Plus Networking, Inc.     Harley Frazee harley@io.t3plus.com
+    136   Concurrent Computer Corporation
+                               John R. LoVerso loverso@westford.ccur.com
+    137   Basser                       Paul O'Donnell paulod@cs.su.oz.au
+    138   Luxcom
+    139   Artel                            Jon Ziegler Ziegler@Artel.com
+    140   Independence Technologies, Inc. (ITI)
+                                      Gerard Berthet gerard@indetech.com
+    141   Frontier Software Development        Narendra Popat ---none---
+    142   Digital Computer Limited               Osamu Fujiki ---none---
+    143   Eyring, Inc.                           Ron Holt ron@Eyring.COM
+    144   Case Communications                     Peter Kumik ---none---
+    145   Penril DataComm, Inc.    Keith Hogan keith%penril@uunet.uu.net
+    146   American Airlines                     Bill Keatley  ---none---
+    147   Sequent Computer Systems           Scott Hahn  sdh@sequent.com
+    148   Bellcore                 Kaj Tesink  kaj@nvuxr.cc.bellcore.com
+    149   Konkord Communications      Ken Jones konkord!ksj@uunet.uu.net
+    150   University of Washington
+                         Christopher Wheeler cwheeler@cac.washignton.edu
+    151   Develcon            Sheri Mayhew zaphod!sherim@herald.usask.ca
+    152   Solarix Systems             Paul Afshar paul@solar1.portal.com
+    153   Unifi Communications Corp.      Yigal Hochberg yigal@unifi.com
+    154   Roadnet                                Dale Shelton ---none---
+    155   Network Systems Corp.
+                              Nadya K. El-Afandi nadya@khara.network.com
+    156   ENE (European Network Engineering)        Peter Cox ---none---
+    157   Dansk Data Elektronik A/S           Per Bech Hansen pbh@dde.dk
+    158   Morning Star Technologies        Karl Fox karl@MorningStar.Com
+    159   Dupont EOP                          Oscar Rodriguez ---none---
+
+
+
+Reynolds & Postel                                             [Page 137]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+    160   Legato Systems, Inc.             Jon Kepecs  kepecs@Legato.COM
+    161   Motorola SPS               Vince Enriquez enriquez@sps.mot.com
+    162   European Space Agency (ESA)
+                              Eduardo EDUATO%ESOC.BITNET@CUNYVM.CUNY.EDU
+    163   BIM                             Bernard Lemercier bl@sunbim.be
+    164   Rad Data Communications Ltd.             Oft Israel ---none---
+    165   Intellicom                               Paul Singh ---none---
+    166   Shiva Corporation                    Phil Budne phil@Shiva.COM
+    167   Fujikura America                        Debbie Reed ---none---
+    168   Xlnt Designs INC (XDI)               Mike Anello mike@xlnt.com
+    169   Tandem Computers                          Rex Davis ---none---
+    170   BICC                          David A. Brown fzbicdb@uk.ac.ucl
+    171   D-Link Systems, Inc.                Henry P. Nagai  ---none---
+    172   AMP, Inc.                                Rick Downs ---none---
+    173   Netlink                              Mauro Zallocco ---none---
+    174   C. Itoh Electronics                     Larry Davis ---none---
+    175   Sumitomo Electric Industries (SEI)
+                                           Kent Tsuno tsuno@sumitomo.com
+    176   DHL Systems, Inc.
+                      David B. Gurevich dgurevic@rhubarb.ssf-sys.dhl.com
+    177   Network Equipment Technologies    Mark Tom marktom@tom.net.com
+    178   APTEC Computer Systems   Larry Burton ssds!larryb@uunet.UU.NET
+    179   Schneider & Koch & Co, Datensysteme GmbH Thomas Ruf tom@rsp.de
+    180   Hill Air Force Base   Russell G. Wilson rwilson@oodis01.af.mil
+    181   ADC Kentrox               Bruce Kropp ktxc8!bruce@uunet.UU.NET
+    182   Japan Radio Co.   Nagayuki Kojima nkojima@lab.nihonmusen.co.jp
+    183   Versitron                               Matt Harris ---none---
+    184   Telecommunication Systems             Hugh Lockhart ---none---
+    185   Interphase                            Gil Widdowson ---none---
+    186   Toshiba Corporation    Mike Asagami toshiba@mothra.nts.uci.edu
+    187   Clearpoint Research Corp.
+    188   Ascom                      Andrew Smith andrew@hasler.ascom.ch
+    189   Fujitsu America                           Chung Lam ---none---
+    190   NetCom Solutions, Inc.                   Dale Cabell---none---
+    191   NCR             Cheryl Krupczak clefor@secola.columbia.ncr.com
+    192   Dr. Materna GmbH                   Torsten Beyer tb@Materna.de
+    193   Ericsson Business Communications     Gunnar Nilsson ---none---
+    194   Metaphor Computer Systems              Paul Rodwick ---none---
+    195   Patriot Partners                       Paul Rodwick ---none---
+    196   The Software Group Limited (TSG)
+                              Ragnar Paulson tsgfred!ragnar@uunet.UU.NET
+    197   Kalpana, Inc.                         Anil Bhavnani ---none---
+    198   University of Waterloo
+                              R. J. White snmp-tech@watmath.waterloo.edu
+    199   CCL/ITRI
+                Ming-Perng Chen N100CMP0%TWNITRI1.BITNET@CUNYVM.CUNY.EDU
+    200   Coeur Postel            Professor Kynikos   Special Consultant
+    201   Mitsubish Cable Industries, Ltd.      Masahiko Hori ---none---
+
+
+
+Reynolds & Postel                                             [Page 138]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+    202   SMC                                   Lance Sprung  ---none---
+    203   Crescendo Communication, Inc.         Prem Jain  prem@cres.com
+    204   Goodall Software Engineering    Doug Goodall   goodall@crl.com
+    205   Intecom                                 Brad Parke  ---none---
+    206   Victoria University of Wellington
+                                  Jonathan Stone jonathan@isor.vuw.ac.nz
+    207   Allied Telesis, Inc.
+                        Scott Holley SCOTT_CLINTON_HOLLEY@cup.portal.com
+    208   Dowty Network Systems A/S         Hartvig Ekner  hj@dowtyns.dk
+    209   Protools                                   Glen Arp ---none---
+    210   Nippon Telegraph and Telephone Corp.
+                    Toshiharu Sugawara sugawara%wink.ntt.jp@RELAY.CS.NET
+    211   Fujitsu Limited  Ippei Hayashi hayashi@sysrap.cs.fujitsu.co.jp
+    212   Network Peripherals Inc.    Creighton Chong cchong@fastnet.com
+    213   Netronix, Inc.                         Jacques Roth ---none---
+    214   University of Wisconsin - Madison
+                      Dave Windorski DAVID.WINDORSKI@MAIL.ADMIN.WISC.EDU
+    215   NetWorth, Inc.                         Craig Scott  ---none---
+    216   Tandberg Data A/S          Harald Hoeg haho%huldra.uucp@nac.no
+    217   Technically Elite Concepts, Inc.
+                              Russell S. Dietz Russell_Dietz@Mcimail.com
+    218   Labtam Australia Pty. Ltd.
+                               Michael Podhorodecki michael@labtam.oz.au
+    219   Republic Telcom Systems, Inc.
+                           Steve Harris rtsc!harris@boulder.Colorado.edu
+    220   ADI Systems, Inc.                          Paul Liu ---none---
+    221   Microwave Bypass Systems, Inc.           Tad Artis  ---none---
+    222   Pyramid Technology Corp.         Richard Rein rein@pyramid.com
+    223   Unisys_Corp                           Lawrence Brow ---none---
+    224   LANOPTICS LTD., Israel
+                             Israel Drori raanan@techunix.technion.ac.il
+    225   NKK Corporation                         J. Yoshida  ---none---
+    226   MTrade UK Ltd.                     Peter Delchiappo ---none---
+    227   Acals                    Patrick Cheng pcheng@dill.ind.trw.com
+    228   ASTEC, Inc.                    Hiroshi Fujii fujii@astec.co.jp
+    229   Delmarva Power       John K. Scoggin, Jr. scoggin@delmarva.com
+    230   Telematics International, Inc.          Kevin Smith ---none---
+    231   Siemens Nixdorf Informations Syteme AG
+                                             Gunther Kroenert ---none---
+    232   Compaq
+    233   NetManage, Inc.          William Dunn netmanage@cup.portal.com
+    234   NCSU Computing Center        David Joyner david@unity.ncsu.edu
+    235   Empirical Tools and Technologies
+                                        Karl Auerbach karl@empirical.com
+    236   Samsung Group                    Hong K. Paik paik@samsung.com
+    237   Takaoka Electric Mfg. Co., Ltd.
+               Hidekazu Hagiwara hagiwara@takaoka.takaoka-electric.co.jp
+    238   Netrix Systems Corporation        Eldon S. Mast esm@netrix.com
+
+
+
+Reynolds & Postel                                             [Page 139]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+    239   WINDATA                               Bob Rosenbaum ---none---
+    240   RC International A/S                 Carl H. Dreyer chd@rci.dk
+    241   Netexp Research                       Henk Boetzkes ---none---
+    242   Internode Systems Pty Ltd
+                                 Simon Hackett simon@ucs.adelaide.edu.au
+    243   netCS Informationstechnik GmbH
+                                  Oliver Korfmacher okorf@bunt.netcs.com
+    244   Lantronix                  Rich Lyman  rich@alecto.gordian.com
+    245   Avatar Consultants
+                    Kory Hamzeh ames!avatar.com!kory@harvard.harvard.edu
+    246   Furukawa Electoric Co. Ltd.
+             Shoji Fukutomi kddlab!polo.furukawa.co.jp!fuku@uunet.UU.NET
+    247   AEG Electrcom                           R. Nurnberg ---none---
+    248   Richard Hirschmann GmbH & Co.
+                              Heinz Nisi mia@intsun.rus.uni-stuttgart.de
+    249   G2R Inc.                             Khalid Hireche ---none---
+    250   University of Michigan
+                             Tim Howes Tim.Howes@terminator.cc.umich.edu
+    251   Netcomm, Ltd.                    W.R. Maynard-Smith ---none---
+    252   Sable Technology Corporation         Rodney Thayer  ---none---
+    253   Xerox              Edwards E. Reed ipcontact.cin_ops@xerox.com
+    254   Conware Computer Consulting GmbH
+                                        Michael Sapich sapich@conware.de
+    255   Compatible Systems Corp.        John Gawf  gawf@compatible.com
+    256   Scitec Communications Systems Ltd.    Stephen Lewis ---none---
+    257   Transarc Corporation        Pat Barron Pat_Barron@TRANSARC.COM
+    258   Matsushita Electric Industrial Co., Ltd.
+                                         Nob Mizuno mizuno@isl.mei.co.jp
+    259   ACCTON Technology                        Don Rooney ---none---
+    260   Star-Tek, Inc.                   Carl Madison carl@startek.com
+    261   Codenoll Tech. Corp.                     Dan Willie ---none---
+    262   Formation, Inc.                       Carl Marcinik ---none---
+    263   Seiko Instruments, Inc. (SII)    Yasuyoshi Watanabe ---none---
+    264   RCE (Reseaux de Communication d'Entreprise S.A.)
+                                   Etienne Baudras-Chardigny  ---none---
+    265   Xenocom, Inc.               Sean Welch welch@raven.ulowell.edu
+    266   KABELRHEYDT                         Hubert Theissen ---none---
+    267   Systech Computer Corporation
+                                 Brian Petry systech!bpetry@uunet.UU.NET
+    268   Visual                             Brian O'Shea bos@visual.com
+    269   SDD (Scandinavian Airlines Data Denmark A/S)
+                                                  Per Futtrup ---none---
+    270   Zenith Electronics Corporation            David Lin ---none---
+    271   TELECOM FINLAND                        Petri Jokela ---none---
+    272   BinTec Computersystems               Marc Sheldon ms@BinTec.DE
+    273   EUnet Germany                   Marc Sheldon ms@Germany.EU.net
+    274   PictureTel Corporation              Oliver Jones oj@pictel.com
+    275   Michigan State University             Lih-Er Wey WEYLE@msu.edu
+
+
+
+Reynolds & Postel                                             [Page 140]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+    276   GTE Telecom Incorporated              Grant Gifford ---none---
+    277   Cascade Communications Corp.
+                                      Chikong Shue alpo!chi@uunet.uu.net
+    278   Hitachi Cable, Ltd.                   Takahiro Asai ---none---
+    279   Olivetti                 Marco Framba  framba@orc.olivetti.com
+    280   Vitacom Corporation         Parag Rastogi parag@cup.portal.com
+    281   INMOS                         Graham Hudspith  gwh@inmos.co.uk
+    282   AIC Systems Laboratories Ltd.  Glenn Mansfield glenn@aic.co.jp
+    283   Cameo Communications, Inc.               Alan Brind ---none---
+    284   Diab Data AB                        Mats Lindstrom mli@diab.se
+    285   Olicom A/S                         Lars Povlsen krus@olicom.dk
+    286   Digital-Kienzle Computersystems    Hans Jurgen Dorr ---none---
+    287   CSELT(Centro Studi E Laboratori Telecomunicazioni)
+                                  Paolo Coppo coppo@cz8700.cselt.stet.it
+    288   Electronic Data Systems     Mark Holobach holobach@tis.eds.com
+    289   McData Corporation      Glenn Levitt gpl0363@mcmail.mcdata.com
+    290   Harris Corporation       David Rhein davidr@ssd.csd.harris.com
+    291   Technology Dynamics, Inc. Chip Standifer TDYNAMICS@MCIMAIL.COM
+    292   DATAHOUSE Information Systems Ltd.           Kim Le ---none---
+    293   DSIR Network Group  Tony van der Peet srghtvp@grv.dsir.govt.nz
+    294   Texas Instruments      Blair Sanders Blair_Sanders@mcimail.com
+    295   PlainTree Systems Inc.     Paul Chefurka chefurka@plntree.UUCP
+    296   Hedemann Software Development
+                              Stefan Hedemann 100015.2504@compuserve.com
+    297   Fuji Xerox Co., Ltd.                              Hiroshi Kume
+                     Kume%KSPB%Fuji_Xerox@tcpgw.netg.ksp.fujixerox.co.jp
+    298   Asante Technology                    Hsiang Ming Ma ---none---
+    299   Stanford University
+                             RL "Bob" Morgan morgan@jessica.stanford.edu
+    300   Digital Link                            Jimmy Tu  jimmy@dl.com
+    301   Raylan Corporation            Mark S. Lewis mlewis@telebit.com
+    302   Datacraft                         Alan Lloyd alan@datacraft.oz
+    303   Hughes                            Keith McCloghrie KZM@HLS.COM
+    304   Farallon Computing, Inc.             Steven Sweeney ---none---
+    305   GE Information Services              Steve Bush sfb@ncoast.org
+    306   Gambit Computer Communications         Zohar Seigal ---none---
+    307   Livingston Enterprises, Inc.
+                                      Steve Willens steve@livingston.com
+    308   Star Technologies                     Jim Miner miner@star.com
+    309   Micronics Computers Inc.         Darren Croke dc@micronics.com
+    310   Basis, Inc.                    Heidi Stettner heidi@mtxinu.COM
+    311   Microsoft               John M. Ballard jballard@microsoft.com
+    312   US West Advance Technologies
+                                  Donna Hopkins dmhopki@uswat.uswest.com
+    313   University College London Shaw C. Chuang S.Chuang@cs.ucl.ac.uk
+    314   Eastman Kodak Company   W. James Colosky wjc@tornado.kodak.com
+    315   Network Resources Corporation       Kathy Weninger  ---none---
+    316   Atlas Telecom             Bruce Kropp ktxc8!bruce@uunet.UU.NET
+
+
+
+Reynolds & Postel                                             [Page 141]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+    317   Bridgeway                          Umberto Vizcaino ---none---
+    318   American Power Conversion Corp.
+                                   Peter C. Yoest apc!yoest@uunet.uu.net
+    319   DOE Atmospheric Radiation Measurement Project
+                                     Paul Krystosek krystosk@eid.anl.gov
+    320   VerSteeg CodeWorks                   Bill Versteeg bvs@NCR.COM
+    321   Verilink Corp                        Bill Versteeg bvs@NCR.COM
+    322   Sybus Corportation        Mark T. Dauscher mdauscher@sybus.com
+    323   Tekelec                                  Bob Grady  ---none---
+    324   NASA Ames Research Cente       Nick Cuccia cuccia@nas.nasa.gov
+    325   Simon Fraser University           Robert Urquhart quipu@sfu.ca
+    326   Fore Systems, Inc.                    Eric Cooper ecc@fore.com
+    327   Centrum Communications, Inc.             Vince Liu  ---none---
+    328   NeXT Computer, Inc.
+                            Lennart Lovstrand Lennart_Lovstrand@NeXT.COM
+    329   Netcore, Inc.                           Skip Morton ---none---
+    330   Northwest Digital Systems             Brian Dockter ---none---
+    331   Andrew Corporation                         Ted Tran ---none---
+    332   DigiBoard                        Dror Kessler  dror@digibd.com
+    333   Computer Network Technology Corp.   Bob Meierhofer  ---none---
+    334   Lotus Development Corp.      Bill Flanagan bflanagan@lotus.com
+    335   MICOM Communication Corporation
+                                      Donna Beatty SYSAD@prime.micom.com
+    336   ASCII Corporation            Toshiharu Ohno tony-o@ascii.co.jp
+    337   PUREDATA Research                Tony Baxter tony@puredata.com
+    338   NTT DATA               Yasuhiro Kohata    kohata@rd.nttdata.jp
+    339   Empros Systems International   David Taylor dtaylor@ems.cdc.ca
+    340   Kendall Square Research (KSR)     Dave Hudson tdh@uunet.UU.NET
+    341   Martin Marietta Energy Systems     Gary Haney  haneyg@ornl.gov
+    342   Network Innovations            Pete Grillo pl0143@mail.psi.net
+    343   Intel Corporation          Brady Orand borand@pcocd2.intel.com
+    344   Proxar                           Ching-Fa Hwang cfh@proxar.com
+    345   Epson Research Center    Richard Schneider  rschneid@epson.com
+    346   Fibernet                            George Sandoval ---none---
+    347   Box Hill Systems Corporation        Tim Jones  tim@boxhill.com
+    348   American Express Travel Related Services
+                                        Jeff Carton jcarton@amex-trs.com
+    349   Compu-Shack  Tomas Vocetka OPLER%CSEARN.bitnet@CUNYVM.CUNY.EDU
+    350   Parallan Computer, Inc.               Charles Dulin ---none---
+    351   Stratacom                         Clyde Iwamoto cki@strata.com
+    352   Open Networks Engineering, Inc.      Russ Blaesing rrb@one.com
+    353   ATM Forum                         Keith McCloghrie KZM@HLS.COM
+    354   SSD Management, Inc.                      Bill Rose ---none---
+    355   Automated Network Management, Inc.   Carl Vanderbeek ---none--
+    356   Magnalink Communications Corporation
+                                            David E. Kaufman  ---none---
+    357   TIL Systems, Ltd.                   Garry McCracken ---none---
+    358   Skyline Technology, Inc.                   Don Weir ---none---
+
+
+
+Reynolds & Postel                                             [Page 142]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+    359   Nu-Mega Technologies, Inc.              Dirk Smith  ---none---
+    360   Morgan Stanley & Co. Inc.
+                                 Victor Kazdoba vsk@katana.is.morgan.com
+    361   Integrated Business Network            Michael Bell ---none---
+    362   L & N Technologies, Ltd.               Steve Loring ---none---
+    363   Cincinnati Bell Information Systems, Inc.
+                                         Deron Meranda dmeranda@cbis.COM
+    364   OSCOM International
+                             Farhad Fozdar f_fozdar@fennel.cc.uwa.edu.au
+    365   MICROGNOSIS                Paul Andon pandon@micrognosis.co.uk
+    366   Datapoint Corporation     Lee Ziegenhals lcz@sat.datapoint.com
+    367   RICOH Co. Ltd.
+                  Toshio Watanabe watanabe@godzilla.rsc.spdd.ricoh.co.jp
+    368   Axis Communications AB              Martin Gren martin@axis.se
+    369   Pacer Software               Wayne Tackabury wft@pacersoft.com
+    370   Axon Networks Inc.            Robin Iddon axon@cix.clink.co.uk
+    371   Brixton Systems, Inc.       Peter S. Easton easton@brixton.com
+    372   GSI                   Etienne Demailly etienne.demailly@gsi.fr
+    373   Tatung Co., Ltd.
+                  Chih-Yi Chen TCCISM1%TWNTTIT.BITNET@pucc.Princeton.EDU
+    374   DIS Research LTD.                 Ray Compton rayc@command.com
+    375   Quotron Systems, Inc.
+                               Richard P. Stubbs richard@atd.quotron.com
+    376   Dassault Electronique
+                               Olivier J. Caleff caleff@dassault-elec.fr
+    377   Corollary, Inc.               James L. Gula gula@corollary.com
+    378   SEEL, Ltd.                              Ken Ritchie ---none---
+    379   Lexcel                           Mike Erlinger mike@lexcel.com
+    380   Sophisticated Technologies, Inc.
+                                 Bill Parducci 70262.1267@compuserve.com
+    381   OST                                         A. Pele ---none---
+    382   Megadata Pty Ltd.      Andrew McRae andrew@megadata.mega.oz.au
+    383   LLNL Livermore Computer Center
+                                Dan Nessett nessett@ocfmail.ocf.llnl.gov
+    384   Dynatech Communications  Graham Welling s8000!gcw@uunet.uu.net
+    385   Symplex Communications Corp.             Cyrus Azar ---none---
+    386   Tribe Computer Works               Ken Fujimoto fuji@tribe.com
+    387   Taligent, Inc.            Lorenzo Aguilar lorenzo@taligent.com
+    388   Symbol Technologies, Inc.
+                      John Kramer +1-408-369-2679 jkramer@psd.symbol.com
+    389   Lancert                                 Mark Hankin ---none---
+    390   Alantec                          Paul V. Fries pvf@alantec.com
+    391   Ridgeback Solutions
+                           Errol Ginsberg bacchus!zulu!errol@uu2.psi.com
+    392   Metrix, Inc.                 D. Venkatrangan venkat@metrix.com
+    393   Excutive Systems/XTree Company
+                                       Dale Cabell cabell@smtp.xtree.com
+    394   NRL Communication Systems Branch
+
+
+
+Reynolds & Postel                                             [Page 143]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+                                        R. K. Nair nair@itd.nrl.navy.mil
+    395   I.D.E. Corporation                        Rob Spade ---none---
+    396   Matsushita Electric Works, Ltd.
+                                    Claude Huss claude@trc.mew.mei.co.jp
+    397   MegaPAC                                  Ian George ---none---
+    398   Pilkington Communication Systems      Dave Atkinson ---none---
+    399   Hitachi Computer Products (America), Inc.
+                                    Masha Golosovker masha@hicomb.hi.com
+    400   METEO FRANCE                 Remy Giraud  Remy.Giraud@meteo.fr
+    401   PRC Inc.                          Jim Noble  noble_jim@prc.com
+    402   Wal*Mart Stores, Inc.     Mike Fitzgerel  mlfitzg@wal-mart.com
+    403   Nissin Electric Company, Ltd.   Aki Komatsuzaki (408) 737-0274
+    404   Distributed Support Information Standard
+                                            Mike Migliano <mike@uwm.edu>
+    405   SMDS Interest Group (SIG)
+                                Elysia C. Tan <ecmt1@sword.bellcore.com>
+    406   SolCom Systems Ltd.                    Hugh Evans  0506 873855
+    407   Bell Atlantic  Colin deSa socrates!bm5ld15@bagout.BELL-ATL.COM
+    408   Advanced Multiuser Technologies Corporation
+    409   Mitsubishi Electric Corporation
+                            Yoshitaka Ogawa <ogawa@nkai.cow.melco.co.jp>
+    410   C.O.L. Systems, Inc.         Frank Castellucci  (914) 277-4312
+    411   University of Auckland
+                               Nevil Brownlee < n.brownlee@aukuni.ac.nz>
+    412   Desktop Management Task Force (DMTF)
+                                   Dave Perkins <dperkins@synoptics.com>
+    413   Klever Computers, Inc.  Tom Su  408-735-7723    kci@netcom.com
+    414   Amdahl Corporation              Steve Young  sy@uts.admahl.com
+    415   JTEC Pty, Ltd.                       Jan Bartel  (02) 809 6933
+    416   Matra Communcation         Hong-Loc Nguyen  (33.1) 34.60.85.25
+    417   HAL Computer Systems       Michael A. Petonic  petonic@hal.com
+    418   Lawrence Berkeley Laboratory       Russ Wright  wright@lbl.gov
+    419   Dale Computer Corporation          Dean Craven  1-800-336-7483
+    420 IPTC, Universitaet of Tuebingen
+                   Andreas J. Haug <ahaug@mailserv.zdv.uni-tuebingen.de>
+    421   Bytex Corporation
+                        Mary Ann Burt <bytex!ws054!maryann@uunet.UU.NET>
+    422   Cogwheel, Inc.                   Brian Ellis  bri@Cogwheel.COM
+    423   Lanwan Technologies                 Thomas Liu  (408) 986-8899
+    424   Thomas-Conrad Corporation             Karen Boyd  512-836-1935
+    425   TxPort                              Bill VerSteeg  bvs@ver.com
+    426   Compex, Inc.             Andrew Corlett  BDA@ORION.OAC.UCI.EDU
+    427   Evergreen Systems, Inc.             Bill Grace  (415) 897-8888
+    428   HNV, Inc.                 James R. Simons  jrs@denver.ssds.COM
+    429   U.S. Robotics, Inc.               Chris Rozman  chrisr@usr.com
+    430   Canada Post Corporation          Walter Brown  +1 613 722-8843
+    431   Open Systems Solutions, Inc.         David Ko  davidk@ossi.com
+    432   Toronto Stock Exchange               Paul Kwan  (416) 947-4284
+
+
+
+Reynolds & Postel                                             [Page 144]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+    433   MamakosTransSys Consulting
+                                   Louis A. Mamakos   louie@transsys.com
+    434   EICON                      Vartan Narikian  vartan@eicon.qc.ca
+    435   Jupiter Systems                Russell Leefer  rml@jupiter.com
+    436   SSTI                             Philip Calas (33) 61 44 19 51
+    437   Grand Junction Networks  Randy Ryals  randyr@grandjunction.com
+    438   Anasazi, Inc.                   Chad Larson (chad@anasazi.com)
+    439   Edward D. Jones and Company        John Caruso  (314) 851-3422
+    440   Amnet, Inc.                          Richard Mak mak@amnet.COM
+    441   Chase Research                           Kevin Gage ---none---
+    442   PEER Networks                    Randy Presuhn  randy@peer.com
+    443   Gateway Communications, Inc.            Ed Fudurich ---none---
+    444   Peregrine Systems              Eric Olinger eric@peregrine.com
+    445   Daewoo Telecom               SeeYoung Oh oco@scorpio.dwt.co.kr
+    446   Norwegian Telecom Research        Paul Hoff paalh@brage.nta.no
+    447   WilTel  Anil Prasad                     anil_prasad@wiltel.com
+    448   Ericsson-Camtec                        Satish Popat ---none---
+    449   Codex                                Thomas McGinty ---none---
+    450   Basis                          Heidi Stettner heidi@mtxinu.COM
+    451   AGE Logic                                Syd Logan syd@age.com
+    452   INDE Electronics                   Gordon Day gday@inde.ubc.ca
+    453   ISODE Consortium                 Steve Kille S.Kille@isode.com
+    454   J.I. Case                     Mike Oswald mike@helios.uwsp.edu
+    455   Trillium                 Jeff Lawrence j_lawrence@trillium.com
+    456   Bacchus Inc.     Errol Ginsberg bacchus!zulu!errol@uu2.psi.com
+    457   MCC                           Doug Rosenthal rosenthal@mcc.com
+    458   Stratus Computer                 Dave Snay  dks@sw.stratus.com
+    459   Quotron              Richard P. Stubbs richard@atd.quotron.com
+    460   Beame & Whiteside                  Carl Beame beame@ns.bws.com
+    461   Cellular Technical Services             Greg Hummel ---none---
+    462   Shore Microsystems, Inc.           Gordon Elam  (309) 229-3009
+    463   Telecommunications Techniques Corp.  Tom Nisbet  nisbet@tt.com
+    464   DNPAP (Technical University Delft)
+                   Jan van Oorschot <bJan.vOorschot@dnpap.et.tudelft.nl>
+    465   Plexcom, Inc.                     Bruce Miller  (805) 522-3333
+    466   Tylink                         Stavros Mohlulis (508) 285-0033
+    467   Brookhaven National Laboratory
+                                        Dave Stampf drs@bach.ccd.bnl.gov
+    468   Computer Communication Systems
+                            Gerard Laborde <Gerard.Laborde@sp1.y-net.fr>
+    469   Norand Corp.                         Rose Gorrell 319-269-3100
+    470   MUX-LAP                        Philippe Labrosse  514-735-2741
+    471   Premisys Communications, Inc
+                        Mike MacFaden <premisys!mike@fernwood.mpk.ca.us>
+    472   Bell South Telecommunications       Johnny Walker 205-988-7105
+    473   J. Stainsbury PLC                 Steve Parker  44-71-921-7550
+    474   Ki Research Inc                Toni Barckley  410-290-0355x220
+    475 Wandel and Goltermann Technologies
+
+
+
+Reynolds & Postel                                             [Page 145]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+                         David Walters 919-941-5730x4203 <walter@wg.com>
+    476   Emerson Computer Power
+                            Roger Draper  714-457-3638  rdraper@cerf.net
+    477   Network Software Associates        Jeffery Chiao  714-768-4013
+    478   Procter and Gamble           Peter Marshall  513-983-1100x5988
+    479 Meridian Technology Corporation
+                        Kenneth B. Denson <kdenson@magic.meridiantc.com>
+    480   QMS, Inc.                           Bill Lott  lott@imagen.com
+    481   Network Express        Tom Jarema  313-761-5051  ITOH@MSEN.COM
+    482   LANcity Corporation               Pam Yassini  pam@lancity.com
+    483   Dayna Communications, Inc.
+                                  Sanchaita Datta  datta@signus.utah.edu
+    484   kn-X Ltd.                               Sam Lau  44 943 467007
+    485   Sync Research, Inc.                Alan Bartky  (714) 588-2070
+    486   PremNet                  Ken Huang  HuangK@rimail.interlan.com
+    487   SIAC                               Peter Ripp   (212) 383-9061
+    488   New York Stock Exchange            Peter Ripp   (212) 383-9061
+    489   American Stock Exchange            Peter Ripp   (212) 383-9061
+    490   FCR Software, Inc.                   Brad Parker  brad@fcr.com
+    491   National Medical Care, Inc.      Robert Phelan  (617) 466-9850
+    492   Dialogue Communication Systemes, S.A.
+                                       Klaus Handke   +(49) 30 802 24 97
+    493   NorTele                            Bjorn Kvile  +47 2 48 89 90
+    494   Madge Networks, Inc.
+                      Duncan Greatwood dgreatwo@madge.mhs.compuserve.com
+    495   Memotec Communications   Graham Higgins ghiggins@teleglobe.com
+    496   CTON  Nick Hennenfent                        nicholas@cton.com
+    497   Leap Technology, Inc.         George Economou  george@leap.com
+    498   General DataComm, Inc.       William Meltzer   meltzer@gdc.com
+    499   ACE Communications, Ltd.              Danny On  972-3-570-1423
+    500   Automatic Data Processing (ADP)      Alex Rosin (201) 714-3982
+    501   Programa SPRITEL                              Alberto Martinez
+                              Martinez_Alberto_SPRITEL@euskom.spritel.es
+    502   Adacom                              Aial Haorch  972-4-899-899
+    503   Metrodata Ltd            Nick Brown  100022.767@compuserve.com
+    504   Ellemtel Telecommunication Systems Laboratories
+                        Richard G Bruvik  Richard.Bruvik@eua.ericsson.se
+    505   Arizona Public Service          Duane Booher  DBOOHER@APSC.COM
+    506   NETWIZ, Ltd.,    Emanuel Wind  eumzvir@techunix.technion.ac.il
+    507   Science and Engineering Research Council (SERC)    Paul Kummer
+                                                P.Kummer@daresbury.ac.uk
+    508   The First Boston Corporation                        Kevin Chou
+                                       csfb1!dbadmin4!kchou@uunet.UU.NET
+    509   Hadax Electronics Inc.                       Marian Kramarczyk
+                                               73477.2731@compuserve.com
+    510   VTKK            Markku Lamminluoto  lamminluoto@vtkes1.vtkk.fi
+    511   North Hills Israel Ltd.   Carmi Cohen  carmi@north.hellnet.org
+    512   TECSIEL                       R. Burlon   sr@teculx.tecsiel.it
+
+
+
+Reynolds & Postel                                             [Page 146]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+    513   Bayerische Motoren Werke (BMW) AG             Michael Connolly
+                                                    mconnolly@net.bmw.de
+    514   CNET Technologies                       Nelson Su 408-954-8000
+    515   MCI   Kurt Robohm                          krobohm@mcimail.com
+    516   Human Engineering AG (HEAG)                        Urs Brunner
+                                              ubrunner@clients.switch.ch
+    517   FileNet Corporation                 Joe Raby  raby@filenet.com
+    518   NFT-Ericsson                    Kjetil Donasen  +47 2 84 24 00
+    519   Dun & Bradstreet                    Vic Smagovic  908-464-2079
+    520   Intercomputer Communications      Brian Kean  513-745-0500x244
+    521   Defense Intelligence Agency
+                              Barry Atkinson   DIA-DMS@DDN-CONUS.DDN.MIL
+    522   Telesystems SLW Inc.                   Joe Magony 416-441-9966
+    523   APT Communications                  David Kloper  301-831-1182
+    524   Delta Airlines                           Jim Guy  404-715-2948
+    525   California Microwave                 Kevin Braun  408-720-6520
+    526   Avid Technology Inc                 Steve Olynyk  508-640-3328
+    527   Integro Advanced Computer Systems
+                                         Pascal Turbiez  +33-20-08-00-40
+    528   RPTI                                Chris Shin  886-2-918-3006
+    529   Ascend Communications Inc.            Marc Hyman  510-769-6001
+    530   Eden Computer Systems Inc.          Louis Brando  305-591-7752
+    531   Kawasaki-Steel Corp
+                           Tomoo Watanabe  nrd@info.kawasaki-steel.co.jp
+    532   Barclays                     Malcolm Houghton  +44 202 671 212
+    533   B.U.G., Inc.                 Isao Tateishi  tateishi@bug.co.jp
+    534   Exide Electronics      Brian Hammill  hamill@dolphin.exide.com
+    535   Superconducting Supercollider Lab.
+                           Carl W. Kalbfleisch    cwk@irrational.ssc.gov
+    536   Triticom                             Jim Bales  (612) 937-0772
+    537   Universal Instruments Corp.
+                    Tom Dinnel   BA06791%BINGVAXA.bitnet@CUNYVM.CUNY.EDU
+    538   Information Resources, Inc.         Jeff Gear  jjg@infores.com
+    539   Applied Innovation, Inc.   Dean Dayton  dean@aicorp.cmhnet.org
+    540   Crypto AG                      Roland Luthi  luthi@iis.ethz.ch
+    541   Infinite Networks, Ltd.          Sean Harding  +44 923 710 277
+    542   Rabbit Software                     Bill Kwan  kwan@rabbit.com
+    543   Apertus Technologies       Stuart Stanley  stuarts@apertus.com
+    544   Equinox Systems, Inc.       Monty Norwood  1-800-275-3500 x293
+    545   Hayes Microcomputer Products
+                     Chris Roussel hayes!hayes.com!croussel@uunet.UU.NET
+    546   Empire Technologies Inc. Cheryl Krupczak  cheryl@cc.gatech.edu
+    547   Glaxochem, Ltd.                     Andy Wilson  0229 52261547
+    548   KPY Network Partners, Corp.
+                                  Gordon Vickers   sccs@pizza.netcom.com
+    549   Agent Technology, Inc.  Ibi Dhilla  idhilla@genesis.nred.ma.us
+    550   Dornier GMBH                Arens Heinrech  49-7545-8 ext 9337
+    551   Telxon Corporation      Frank Ciotti  frankc@teleng.telxon.com
+
+
+
+Reynolds & Postel                                             [Page 147]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+    552   Entergy Corporation                 Louis Cureau  504-364-7630
+    553   Garrett Communications Inc.        Igor Khasin  (408) 980-9752
+    554   Agile Networks, Inc.          Dave Donegan  ddonegan@agile.com
+    555   Larscom                           Sameer Jayakar  415-969-7572
+    556   Stock Equipment                    Karl Klebenow  216-543-6000
+    557   ITT Corporation      Kevin M. McCauley  kmm@vaxf.acdnj.itt.com
+    558   Universal Data Systems, Inc.
+                           Howard Cunningham   70400.3671@compuserve.com
+    559   Sonix Communications, Ltd.      David Webster  +44 285 641 651
+    560   Paul Freeman Associates, Inc.
+                                      Pete Wilson  pwilson@world.std.com
+    561   John S. Barnes, Corp.              Michael Lynch  704-878-4107
+    562   Northern Telecom, Ltd.
+                             Glenn Waters  613-763-3933 <gwaters@bnr.ca>
+    563   CAP Debris       Patrick Preuss  ppr@lfs.hamburg.cap-debris.de
+    564   Telco Systems NAC            Harry Hirani  Harry@telco-nac.com
+    565   Tosco Refining Co                 Fred Sanderson  510-602-4358
+    566   Russell Info Sys                      Atul Desai  714-362-4040
+    567   University of Salford   Richard Letts  R.J.Letts@salford.ac.uk
+    568   NetQuest Corp.         Jerry Jacobus  netquest@tigger.jvnc.net
+    569   Armon Networking Ltd.    Yigal Jacoby  yigal@armon.hellnet.org
+    570   IA Corporation                Didier Fort  Didier.Fort@lia.com
+    571   AU-System Communicaton AB           Torbjorn Ryding  8-7267572
+    572   GoldStar Information & Communications, Ltd.
+                                      Soo N. Kim  ksn@giconet.gsic.co.kr
+    573   SECTRA AB                        Tommy Pedersen  tcp@sectra.se
+    574   ONEAC Corporation                Bill Elliot  ONEACWRE@AOL.COM
+    575   Tree Technologies           Michael Demjanenko  (716) 688-4640
+    576   GTE Government Systems         Henry Hernandez  (617) 455-2942
+    577   Denmac Systems, Inc.            Andy Denenberg  (708) 291-7760
+    578   Interlink Computer Sciences, Inc.
+                                         Mike Mazurek  mfm@interlink.com
+    579   Bridge Information Systems, Inc. Stephen Harvey (314) 567-8482
+    580   Leeds and Northrup Australia (LNA) Nigel Cook nigelc@lna.oz.au
+    581   BHA Computer                       David Hislop  rob@bha.oz.au
+    582   Newport Systems Solutions, Inc.
+                                       Pauline Chen  paulinec@netcom.com
+    583   Atrium Technologies     Narender Reddy Vangati  vnr@atrium.com
+    584   ROBOTIKER                 Maribel Narganes  maribel@teletek.es
+    585   PeerLogic Inc.          Ratinder Ahuja  ratinder@peerlogic.com
+    586   Digital Transmittion Systems        Bill VerSteeg  bvs@ver.com
+    587   Far Point Communications            Bill VerSteeg  bvs@ver.com
+    588   Xircom                              Bill VerSteeg  bvs@ver.com
+    589   Mead Data Central         Stephanie Bowman  steph@meaddata.com
+    590   Royal Bank of Canada                    N. Lim  (416) 348-5197
+    591   Advantis, Inc.                       Janet Brehm  813 878-4298
+    592   Chemical Banking Corp.  Paul McDonnell  pmcdonnl@world.std.com
+    593   Eagle Technology                    Ted Haynes  (408) 441-4043
+
+
+
+Reynolds & Postel                                             [Page 148]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+    594   British Telecom               Ray Smyth  rsmyth@bfsec.bt.co.uk
+    595   Radix BV                     P. Groenendaal  project2@radix.nl
+    596   TAINET Communication System Corp.
+                                    Joseph Chen  +886-2-6583000 (R.O.C.)
+    597   Comtek Services Inc.              Steve Harris  (703) 506-9556
+    598   Fair Issac   Steve Pasadis  apple.com!fico!sxp  (415) 472-2211
+    599   AST Research Inc.                      Bob Beard  bobb@ast.com
+    600   Soft*Star s.r.l. Ing. Enrico Badella softstar@pol88a.polito.it
+    601   Bancomm                            Joe Fontes  jwf@bancomm.com
+    602   Trusted Information Systems, Inc.
+                                         James M. Galvin  galvin@tis.com
+    603   Harris & Jeffries, Inc.         Deepak Shahane  hjinc@CERF.NET
+    604   Axel Technology Corp.               Henry Ngai  (714) 455-1688
+    605   GN Navtel, Inc.                       Joe Magony  416-479-8090
+    606   CAP debis                    Patrick Preuss  +49 40 527 28 366
+    607   Lachman Technology, Inc.  Steve Alexander   stevea@lachman.com
+    608   Galcom Networking Ltd.
+                             Zeev Greenblatt  galnet@vax.trendline.co.il
+    609   BAZIS                            M. van Luijt  martin@bazis.nl
+    610   SYNAPTEL                       Eric Remond  remond@synaptel.fr
+    611   Investment Management Services, Inc.
+                                J. Laurens Troost  rens@stimpys.imsi.com
+    612   Taiwan Telecommunication Lab
+                 Dennis Tseng   LOUIS%TWNMOCTL.BITNET@pucc.Princeton.EDU
+    613   Anagram Corporation        Michael Demjanenko   (716) 688-4640
+    614   Univel                      John Nunneley  jnunnele@univel.com
+    615   University of California, San Diego
+                                        Arthur Bierer   abierer@ucsd.edu
+    616   CompuServe   Ed Isaacs, Brian Biggs  SYSADM@csi.compuserve.com
+    617   Telstra - OTC Australia
+                  Peter Hanselmann    peterhan@turin.research.otc.com.au
+    618   Westinghouse Electric Corp.
+                                Ananth Kupanna   ananth@access.digex.com
+    619   DGA Ltd.              Tom L. Willis  twillis@pintu.demon.co.uk
+    620   Elegant Communications Inc.
+                                  Robert Story  Robert.Story@Elegant.COM
+    621   Experdata                  Claude Lubin  clubin@expdat.gna.org
+    622   Unisource Business Networks Sweden AB
+                                               Goran Sterner gsr@tip.net
+    623   Molex, Inc.                    Steven Joffe  molex@mcimail.com
+    624   Quay Financial Software            Mick Fleming  mickf@quay.ie
+    625   VMX Inc.                     Joga Ryali  joga@vmxi.cerfnet.com
+    626   Hypercom, Inc.                  Noor Chowdhury  (602) 548-2113
+    627   University of Guelph   Kent Percival  Percival@CCS.UoGuelph.CA
+    628   DIaLOGIKa                  Juergen Jungfleisch  0 68 97 9 35-0
+    629   NBASE Switch Communication
+                            Sergiu Rotenstein  75250.1477@compuserve.com
+    630   Anchor Datacomm B.V.      Erik Snoek  sdrierik@diamond.sara.nl
+
+
+
+Reynolds & Postel                                             [Page 149]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+    631   PACDATA                     John Reed  johnr@hagar.pacdata.com
+    632   University of Colorado         Evi Nemeth  evi@cs.colorado.edu
+    633   Tricom Communications Limited
+                                  Robert Barrett  0005114429@mcimail.com
+    634   Santix Software GmbH
+                       Michael Santifaller   santi%mozart@santix.guug.de
+    635   FastComm Communications Corp.
+                               Bill Flanagan   70632.1446@compuserve.com
+    636   The Georgia Institute of Technology
+                      Michael Mealling   michael.mealling@oit.gatech.edu
+    637   Alcatel Data Networks
+                        Douglas E. Johnson doug.e.johnson@adn.sprint.com
+    638   GTECH                             Brian Ruptash  bar@gtech.com
+    639   UNOCAL Corporation                     Peter Ho  ho@unocal.com
+    640   First Pacific Network             Randy Hamilton  408-703-2763
+    641   Lexmark International              Don Wright  don@lexmark.com
+    642   Qnix Computer             Sang Weon, Yoo  swyoo@qns.qnix.co.kr
+    643   Jigsaw Software Concepts (Pty) Ltd.
+                                   Willem van Biljon  wvb@itu2.sun.ac.za
+    644   VIR, Inc.                          Mark Cotton  (215) 364-7955
+    645   SFA Datacomm Inc.           Don Lechthaler  lech@world.std.com
+    646   SEIKO Telecommunication Systems, Inc.
+                                        Lyn T. Robertson  (503) 526-5638
+    647   Unified Management              Andy Barnhouse  (612) 561-4944
+    648   RADLINX Ltd.                Ady Lifshes  ady%rndi@uunet.uu.net
+    649   Microplex Systems Ltd.            Henry Lee  hyl@microplex.com
+    650   Objecta Elektronik & Data AB      Johan Finnved  jf@objecta.se
+    651   Phoenix Microsystems                Bill VerSteeg  bvs@ver.com
+    652   Distributed Systems International, Inc.
+                                              Ron Mackey  rem@dsiinc.com
+    653   Evolving Systems, Inc.   Judith C. Bettinger judy@evolving.com
+    654   SAT GmbH           Walter Eichelburg  100063.74@compuserve.com
+    655   CeLAN Technology, Inc.                Mark Liu  886--35-772780
+    656   Landmark Systems Corp.
+                               Steve Sonnenberg  steves@socrates.umd.edu
+    657   Netone Systems Co., Ltd.
+                                 YongKui Shao  syk@new-news.netone.co.jp
+    658   Loral Data Systems     Jeff Price  jprice@cps070.lds.loral.com
+    659   Cellware Broadband Technology   Michael Roth  mike@cellware.de
+    660   Mu-Systems                Gaylord Miyata  miyata@world.std.com
+    661   IMC Networks Corp.                  Jerry Roby  (714) 724-1070
+    662   Octel Communications Corp.         Alan Newman  (408) 321-5182
+    663   RIT Technologies LTD.      Ghiora Drori  drori@dcl.hellnet.org
+    664   Adtran                                Jeff Wells  205-971-8000
+    665   PowerPlay Technologies, Inc.        Ray Caruso  rayman@csn.org
+    666   Oki Electric Industry Co., Ltd.
+                                Shigeru Urushibara  uru@cs1.cs.oki.co.jp
+    667   Specialix International  Jeremy Rolls  jeremyr@specialix.co.uk
+
+
+
+Reynolds & Postel                                             [Page 150]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+    668   INESC (Instituto de Engenharia de Sistemas e Computadores)
+                                      Pedro Ramalho Carlos  prc@inesc.pt
+    669   Globalnet Communications         Real Barriere  (514) 651-6164
+    670   Product Line Engineer SVEC Computer Corp.
+                                  Rich Huang   msumgr@enya.cc.fcu.edu.tw
+    671   Printer Systems Corp.              Bill Babson  bill@prsys.com
+    672   Contec Micro Electronics USA       David Sheih  (408) 434-6767
+    673   Unix Integration Services         Chris Howard   chris@uis.com
+    674   Dell Computer Corporation        Steven Blair  sblair@dell.com
+    675   Whittaker Electronic Systems   Michael McCune  mccune@cerf.net
+    676   QPSX Communications          David Pascoe    davidp@qpsx.oz.au
+    677   Loral WDl      Mike Aronson  Mike_Aronson@msgate.wdl.loral.com
+    678   Federal Express Corp.             Randy Hale    (901) 369-2152
+    679   E-COMMS Inc.                    Harvey Teale    (206) 857-3399
+    680   Software Clearing House                 Tom Caris   ca@sch.com
+    681   Antlow Computers LTD.               C. R. Bates  44-635-871829
+    682   Emcom Corp.                       Mike Swartz   emcom@cerf.net
+    683   Extended Systems, Inc.
+                               Al Youngwerth alberty@tommy.extendsys.com
+    684   Sola Electric                     Mike Paulsen  (708) 439-2800
+    685   Esix Systems, Inc.           Anthony Chung  esix@esix.tony.com
+    686   3M/MMM                           Chris Amley   ccamley@mmm.com
+    687   Cylink Corp.                          Ed Chou    ed@cylink.com
+    688   Znyx Advanced Systems Division, Inc.
+                                          Alan Deikman  aland@netcom.com
+    689   Texaco, Inc.                      Jeff Lin     linj@Texaco.com
+    690   McCaw Cellular Communication Corp. Tri Phan tri.phan@mccaw.com
+    691   ASP Computer Product Inc. Elise Moss 71053.1066@compuserve.com
+    692   HiPerformance Systems              Mike Brien  +27-11-806-1000
+    693   Regionales Rechenzentrum
+                   Sibylle Schweizer  unrz54@daphne.rrze.uni-erlangen.de
+    694   SAP AG                          Dr. Uwe Hommel  +49 62 27 34 0
+    695   ElectroSpace System Inc.
+                               Dr. Joseph Cleveland e03353@esitx.esi.org
+    696   ( Unassigned )
+    697   MultiPort Software     Reuben Sivan  72302.3262@compuserve.com
+    698   Combinet, Inc.               Samir Sawhney  samir@combinet.com
+    699   TSCC                               Carl Wist    carlw@tscc.com
+    700   Teleos Communications Inc.    Bill Nayavich  wln@teleoscom.com
+    701   Alta Research                   Amy Saperstein  (305) 428-8535
+    702   Independence Blue Cross              Bill Eshbach  esh@ibx.com
+    703   ADACOM Station Interconnectivity LTD.
+                                            Itay Kariv  +9 72 48 99 89 9
+    704   MIROR Systems                     Frank Kloes  +27 12 911 0003
+    705   Merlin Gerin               Adam Stolinski  (714) 557-1637 x249
+    706   Owen-Corning Fiberglas     Tom Mann mann.td@ocf.compuserve.com
+    707   Talking Networks Inc.          Terry Braun  tab@lwt.mtxinu.com
+    708   Cubix Corporation             Rebekah Marshall  (702) 883-7611
+
+
+
+Reynolds & Postel                                             [Page 151]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+    709   Formation Inc.          Bob Millis  bobm@formail.formation.com
+    710   Lannair Ltd.                    Pablo Brenner pablo@lannet.com
+    711   LightStream Corp.       Chris Chiotasso  chris@lightstream.com
+    712   LANart Corp.                Doron I. Gartner  doron@lanart.com
+    713   University of Stellenbosch   Graham Phillips phil@cs.sun.ac.za
+    714   Wyse Technology                     Bill Rainey  bill@wyse.com
+    715   DSC Communications Corp.        Colm Bergin  cbergin@cpdsc.com
+    716   NetEc                      Thomas Krichel  netec@uts.mcc.ac.uk
+    717   Breltenbach Software Engineering Hilmar Tuneke +02 92 49 70 00
+    718   Victor Company of Japan,Limited
+                           Atsushi Sakamoto   101176.2703@compuserve.com
+    719   Japan Direx Corporation        Teruo Tomiyama  +81 3 3498 5050
+    720   NECSY Network Control Systems S.p.A. Piero Fiozzo fip@necsy.it
+    721   ISDN Systems Corp.             Jeff Milloy  p00633@psilink.com
+    722   Zero-One Technologies, LTD.     Curt Chen  + 88 62 56 52 32 33
+    723   Radix Technologies, Inc.        Steve Giles  giless@delphi.com
+    724   National Institute of Standards and Technology
+                                     Jim West   west@mgmt3.ncsl.nist.gov
+    725   Digital Technology Inc.     Chris Gianattasio  gto@lanhawk.com
+    726   Castelle Corp.                   Waiming Mok  wmm@castelle.com
+    727   Presticom Inc.          Martin Dube  76270.2672@compuserve.com
+    728   Showa Electric Wire & Cable Co., Ltd.
+                                  Robert O'Grady  kfn@tanuki.twics.co.jp
+    729   SpectraGraphics                Jack Hinkle  hinkle@spectra.com
+    730   Connectware Inc.                 Rick Downs  rxd4@acsysinc.com
+    731   Wind River Systems                     Emily Hipp hipp@wrs.com
+    732   RADWAY International Ltd. Doron Kolton  0005367977@mcimail.com
+    733   System Management ARTS, Inc. Alexander Dupuy  dupuy@smarts.com
+    734   Persoft, Inc.      Steven M. Entine  entine@pervax.persoft.com
+    735   Xnet Technology Inc.      Esther Chung  estchung@xnet-tech.com
+    736   Unison-Tymlabs                    Dean Andrews  ada@unison.com
+    737   Micro-Matic Research   Patrick Lemli 73677.2373@compuserve.com
+    738   B.A.T.M. Advance Technologies
+                                      Nahum Killim bcrystal@actcom.co.il
+    739   University of Copenhagen         Kim H|glund  shotokan@diku.dk
+    740   Network Security Systems, Inc.
+                                      Carleton Smith  rpitt@nic.cerf.net
+    741   JNA Telecommunications             Sean Cody  seanc@jna.com.au
+    742   Encore Computer Corporation    Tony Shafer  tshafer@encore.com
+    743   Central Intelligent Agency         Carol Jobusch  703 242-2485
+    744   ISC (GB) Limited      Mike Townsend  miket@cix.compulink.co.uk
+    745   Digital Communication Associates Ravi Shankar shankarr@dca.com
+    746   CyberMedia Inc.                Unni Warrier   unni@cs.ucla.edu
+    747   Distributed Systems International, Inc.
+                                               Ron Mackey rem@dsiinc.com
+    748   Peter Radig EDP-Consulting       Peter Radig  +49 69 9757 6100
+    749   Vicorp Interactive Systems           Phil Romine  phil@vis.com
+    750   Inet Inc.                        Bennie Lopez  brl@inetinc.com
+
+
+
+Reynolds & Postel                                             [Page 152]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+    751   Argonne National Laboratory  Michael Shaffer mashaffer@anl.gov
+    752   Tek Logix                          Peter Palsall  905 625-4121
+    753   North Western University            Phil Draughon  jpd@nwu.edu
+    754   Astarte Fiber Networks     James Garnett  garnett@catbelly.com
+    755   Diederich & Associates, Inc.
+                                  Douglas Capitano dlcapitano@delphi.com
+    756   Florida Power Corporation        Bob England  rengland@fpc.com
+    757   ASK/INGRES                  Howard Dernehl   howard@ingres.com
+    758   Open Network Enterprise         Spada Stefano  +39 39 245-8101
+    759   The Home Depot               Keith Porter  ktp01@homedepot.com
+    760   Pan Dacom Telekommunikations   Jens Andresen  +49 40 644 09 71
+    761   NetTek                          Steve Kennedy  steve@gbnet.com
+    762   Karlnet Corp.                       Doug Kall  kbridge@osu.edu
+    763   Efficient Networks, Inc.          Thirl Johnson (214) 991-3884
+    764   Fiberdata                          Jan Fernquist  +46 828 8383
+    765   Lanser                           Emil Smilovici (514) 485-7104
+    766   Telebit Communications A/S     Peder Chr. Norgaard pcn@tbit.dk
+    767   HILAN GmbH           Markus Pestinger  markus@lahar.ka.sub.org
+    768   Network Computing Inc.
+                           Fredrik Noon fnoon@ncimail.mhs.compuserve.com
+    769   Walgreens Company                 Denis Renaud  (708) 818-4662
+    770   Internet Initiative Japan Inc. Toshiharu Ohno tony-o@iij.ad.jp
+    771   GP van Niekerk Ondernemings
+                        Gerrit van Niekerk  gvanniek@dos-lan.cs.up.ac.za
+    772   DSP & Telecoms Research Group
+                  Patrick McGleenon  p.mcgleenon@ee.queens-belfast.ac.uk
+    773   Securities Industry Automation Corporation
+                                       Chiu Szeto  cszeto@prism.poly.edu
+    774   SYNaPTICS                       David Gray  david@synaptics.ie
+    775   Data Switch Corporation         Joe Welfeld  jwelfeld@dasw.com
+    776   Telindus Distribution  Karel Van den Bogaert  kava@telindus.be
+    777   MAXM Systems Corporation  Gary Greathouse ggreathouse@maxm.com
+    778   Fraunhofer Gesellschaft
+                               Jan Gottschick jan.gottschick@isst.fhg.de
+    779   EQS Business Services           Ken Roberts   kroberts@esq.com
+    780   CNet Technology Inc.     Repus Hsiung  idps17@shts.seed.net.tw
+    781   Datentechnik GmbH           Thomas Pischinger  +43 1 50100 266
+    782   Network Solutions Inc.          Dave Putman   davep@netsol.com
+    783   Viaman Software                Vikram Duvvoori  info@viman.com
+    784   Schweizerische Bankgesellschaft Zuerich
+                           Roland Bernet  Roland.Bernet@zh014.ubs.ubs.ch
+    785   University of Twente - TIOS      Aiko Pras  pras@cs.utwente.nl
+    786   Simplesoft Inc.               Sudhir Pendse  sudhir@netcom.com
+    787   Stony Brook, Inc.               Ken Packert p01006@psilink.com
+    788   Unified Systems Solutions, Inc.
+                              Steven Morgenthal  smorgenthal@attmail.com
+    789   Network Appliance Corporation
+                                     Varun Mehta  varun@butch.netapp.com
+
+
+
+Reynolds & Postel                                             [Page 153]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+    790   Ornet Data Communication Technologies Ltd.
+                                              Haim Kurz haim@ornet.co.il
+    791   Computer Associates International
+                                  Glenn Gianino giagl01@usildaca.cai.com
+    792   Multipoint Network Inc.    Michael Nguyen  mike@multipoint.com
+    793   NYNEX Science & Technology          Lily Lau  llau@nynexst.com
+    794   Commercial Link Systems    Wiljo Heinen  wiljo@freeside.cls.de
+    795   Adaptec Inc.                    Tom Battle  tab@lwt.mtxinu.com
+    796   Softswitch                       Charles Springer  cjs@ssw.com
+    797   Link Technologies, Inc.                 Roy Chu  royc@wyse.com
+    798   IIS                      Olry Rappaport   iishaifa@attmail.com
+    799   Mobile Solutions Inc.    Dale Shelton  dshelton@srg.srg.af.mil
+    800   Xylan Corp.                        Burt Cyr     burt@xylan.com
+    801   Airtech Software Forge Limited
+                                 Callum Paterson tsf@cix.compulink.co.uk
+    802   National Semiconductor Maurice Turcotte  mturc@atlanta.nsc.com
+    803   Video Lottery Technologies     Angelo Lovisa  ange@awd.cdc.com
+    804   National Semiconductor Corp   Waychi Doo   wcd@berlioz.nsc.com
+    805   Applications Management Corp
+                         Terril (Terry) Steichen tjs@washington.ssds.com
+    806   Travelers Insurance Company   Eric Miner  ustrv67v@ibmmail.com
+    807   Taiwan International Standard Electronics Ltd.
+                                        B. J. Chen  bjchen@taisel.com.tw
+    808   US Patent and Trademark Office Rick Randall  randall@uspto.gov
+    809   Hynet, LTD.                    Amir Fuhrmann  amf@teleop.co.il
+    810   Aydin, Corp.                   Rick Veher       (215) 657-8600
+    811   ADDTRON Technology Co., LTD.       Tommy Tasi  +8 86-2-4514507
+    812   Fannie Mae                        David King   s4ujdk@fnma.com
+    813   MultiNET Services         Hubert Martens   martens@multinet.de
+    814   GECKO mbH                          Holger Dopp    hdo@gecko.de
+    815   Memorex Telex                Mike Hill     hill@raleng.mtc.com
+    816   Advanced Communications Networks (ACN) SA
+                                              Antoine Boss +41 38 247434
+    817   Telekurs AG         Jeremy Brookfield  bkj@iris.F2.telekurs.ch
+    818   Victron bv                    Jack Stiekema    jack@victron.nl
+    819   CF6 Company                   Francois Caron    +331 4696 0060
+    820   Walker Richer and Quinn Inc.
+                                  Rebecca Higgins  rebecca@elmer.wrq.com
+    821   Saturn Systems  Paul Parker  paul_parker@parker.fac.cs.cmu.edu
+    822   Mitsui Marine and Fire Insurance Co. LTD.
+                                             Kijuro Ikeda +813 5389 8111
+    823   Loop Telecommunication International, Inc.
+                                          Charng-Show Li +886 35 787 696
+    824   Telenex Corporation                 James Krug  (609) 866-1100
+    825   Bus-Tech, Inc.      Charlie Zhang   chun@eecs.cory.berkley.edu
+    826   ATRIE             Fred B.R. Tuang    cmp@fddi3.ccl.itri.org.tw
+    827   Gallagher & Robertson A/S         Arild Braathen  arild@gar.no
+    828   Networks Northwest, Inc. John J. Hansen jhansen@networksnw.com
+
+
+
+Reynolds & Postel                                             [Page 154]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+    829   Conner Peripherials  Richard Boyd  rboyd@mailserver.conner.com
+    830   Elf Antar France                 P. Noblanc  +33 1 47 44 45 46
+    831   Lloyd Internetworking          Glenn McGregor  glenn@lloyd.com
+    832   Datatec Industries, Inc.     Chris Wiener  cwiener@datatec.com
+    833   TAICOM   Scott Tseng                 cmp@fddi3.ccl.itri.org.tw
+    834   Brown's Operating System Services Ltd.
+                             Alistair Bell  alistair@ichthya.demon.co.uk
+    835   MiLAN Technology Corp.            Gopal Hegde  gopal@milan.com
+    836   NetEdge Systems, Inc.  Dave Minnich   Dave_Minnich@netedge.com
+    837   NetFrame Systems   George Mathew    george_mathew@netframe.com
+    838   Xedia Corporation     Colin Kincaid  colin%madway.uucp@dmc.com
+    839   Pepsi                          Niraj Katwala  niraj@netcom.com
+    840   Tricord Systems, Inc.      Mark Dillon  mdillon@tricord.mn.org
+    841   Proxim Inc.                   Russ Reynolds  proxim@netcom.com
+    842   Applications Plus, Inc.     Joel Estes  joele@hp827.applus.com
+    843   Pacific Bell                Aijaz Asif  saasif@srv.PacBell.COM
+    844   Supernet                    Sharon Barkai  sharon@supernet.com
+    845   TPS-Teleprocessing Systems    Manfred Gorr  gorr@tpscad.tps.de
+    846   Technology Solutions Company   Niraj Katwala  niraj@netcom.com
+    847   Computer Site Technologies           Tim Hayes  (805) 967-3494
+    848   NetPort Software             John Bartas  jbartas@sunlight.com
+    849   Alon Systems          Menachem Szus  70571.1350@compuserve.com
+    850   Tripp Lite             Lawren Markle  72170.460@compuserve.com
+    851   NetComm Limited
+                         Paul Ripamonti paulri@msmail.netcomm.pronet.com
+    852   Precision Systems, Inc. (PSI)
+                                     Fred Griffin  cheryl@empiretech.com
+    853   Objective Systems Integrators     Ed Reeder  Ed.Reeder@osi.com
+    854   Simpact Associates Inc.
+                            Robert Patterson  bpatterson@dcs.simpact.com
+    855   Systems Enhancement Corporation
+                                    Steve Held 71165.2156@compuserve.com
+    856   Information Integration, Inc.        Gina Sun  iiii@netcom.com
+    857   CETREL S.C.                    Louis Reinard  ssc-re@cetrel.lu
+    858   ViaTech Development
+                        Theodore J. Collins III ted.collins@vtdev.mn.org
+    859   Olivetti North America  Tom Purcell tomp@mail.spk.olivetti.com
+    860   WILMA      Nikolaus Schaller  hns@ldv.e-technik.tu-muenchen.de
+    861   ILX Systems Inc.                   Peter Mezey  peterm@ilx.com
+    862   Total Peripherals Inc.              Mark Ustik  (508) 393-1777
+    863   SunNetworks Consultant John Brady  jbrady@fedeast.east.sun.com
+    864   Arkhon Technologies, Inc.         Joe Wang  rkhon@nic.cerf.net
+    865   Computer Sciences Corporation
+                                      George M. Dands  dands@sed.csc.com
+    866   Philips.TRT                   Thibault Muchery  +33 14128 7000
+    867   Katron Technologies Inc.           Robert Kao  +88 627 991 064
+    868   Transition Engineering Inc.
+                                   Hemant Trivedi  hemant@transition.com
+
+
+
+Reynolds & Postel                                             [Page 155]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+    869   Altos Engineering Applications, Inc.
+                           Wes Weber or Dave Erhart  altoseng@netcom.com
+    870   Nicecom Ltd.                 Arik Ramon  arik@nicecom.nice.com
+    871   Fiskars/Deltec                     Carl Smith   (619) 291-2973
+    872   AVM GmbH              Andreas Stockmeier  stocki@avm-berlin.de
+    873   Comm Vision               Richard Havens    (408) 923 0301 x22
+    874   Institute for Information Industry
+                                       Peter Pan peterpan@pdd.iii.org.tw
+    875   Legent Corporation             Gary Strohm  gstrohm@legent.com
+    876   Network Automation                Doug Jackson  +64 6 285 1711
+    877   NetTech                 Marshall Sprague  marshall@nettech.com
+    878   Coman Data Communications Ltd.
+                                      Zvi Sasson coman@nms.cc.huji.ac.il
+    879   Skattedirektoratet           Karl Olav Wroldsen  +47 2207 7162
+    880   Client-Server Technologies       Timo Metsaportti  timo@itf.fi
+    881   Societe Internationale de Telecommunications Aeronautiques
+                                Chuck Noren  chuck.noren@es.atl.sita.int
+    882   Maximum Strategy Inc.        Paul Stolle  pstolle@maxstrat.com
+    883   Integrated Systems, Inc.             Michael Zheng  mz@isi.com
+    884   E-Systems, Melpar         Rick Silton  rsilton@melpar.esys.com
+    885   Reliance Comm/Tec        Mark Scott  73422.1740@compuserve.com
+    886   Summa Four Inc.                    Paul Nelson  (603) 625-4050
+    887   J & L Information Systems          Rex Jackson  (818) 709-1778
+    888   Forest Computer Inc.               Dave Black  dave@forest.com
+    889   Palindrome Corp.   Jim Gast  jgast@palindro.mhs.compuserve.com
+    890   ZyXEL Communications Corp.  Harry Chou  howie@csie.nctu.edu.tw
+    891   Network Managers (UK) Ltd,   Mark D Dooley  mark@netmgrs.co.uk
+    892   Sensible Office Systems Inc.      Pat Townsend  (712) 276-0034
+    893   Informix Software         Anthony Daniel  anthony@informix.com
+    894   Dynatek Communications           Howard Linton  (703) 490-7205
+    895   Versalynx Corp.                    Dave Fisler  (619) 536-8023
+    896   Potomac Scheduling Communications Company
+                                    David Labovitz  del@access.digex.net
+    897   Sybase Inc.                   Dave Meldrum  meldrum@sybase.com
+    898   DiviCom Inc.                         Eyal Opher  eyal@divi.com
+    899   Datus elektronische Informationssysteme GmbH
+                                        Hubert Mertens marcus@datus.uucp
+    900   Matrox Electronic Systems Limited
+                           Marc-Andre Joyal  marc-andre.joyal@matrox.com
+    901   Digital Products, Inc.        Ross Dreyer  rdreyer@digprod.com
+    902   Scitex Corp. Ltd.          Yoav Chalfon  yoav_h@ird.scitex.com
+    903   RAD Vision          Oleg Pogorelik  radvis@vax.trendline.co.il
+    904   Tran Network Systems            Paul Winkeler  paulw@revco.com
+    905   Scorpion Logic                     Sean Harding  +09 2324 5672
+    906   Inotech Inc.                       Eric Jacobs  (703) 641-0469
+    907   Controlled Power Co.        Yu Chin  76500,3160@compuserve.com
+    908   Elsag Bailey Incorporate Derek McKearney  mckearney@bailey.com
+    909   J.P. Morgan              Chung Szeto  szeto_chung@jpmorgan.com
+
+
+
+Reynolds & Postel                                             [Page 156]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+    910   Clear Communications Corp.          Kurt Hall  khall@clear.com
+    911   General Technology Inc.         Perry Rockwell  (407) 242-2733
+    912   Adax Inc.                          Jory Gessow   jory@adax.com
+    913   Mtel Technologies, Inc.     Jon Robinson  552-3355@mcimail.com
+    914   Underscore, Inc.            Jeff Schnitzer  jds@underscore.com
+    915   SerComm Corp.                        Ben Lin   +8 862-577-5400
+    916   Baxter Healthcare Corporation
+                      Joseph Sturonas  sturonaj@mpg.mcgawpark.baxter.com
+    917   Tellus Technology               Ron Cimorelli   (510) 498-8500
+    918   Continuous Electron Beam Accelerator Facility
+                                             Paul Banta  banta@cebaf.gov
+    919   Canoga Perkins                   Margret Siska  (818) 718-6300
+    920   R.I.S Technologies              Fabrice Lacroix  +33 7884 6400
+    921   INFONEX Corp.            Kazuhiro Watanabe  kazu@infonex.co.jp
+    922   WordPerfect Corp.           Douglas Eddy  eddy@wordperfect.com
+    923   NRaD                          Russ Carleton  roccor@netcom.com
+    924   Hong Kong Telecommunications Ltd.     K. S. Luk +8 52 883 3183
+    925   Signature Systems               Doug Goodall   goodall@crl.com
+    926   Alpha Technologies LTD.          Guy Pothiboon  (604) 430-8908
+    927   PairGain Technologies, Inc.       Ken Huang  kenh@pairgain.com
+    928   Sonic Systems             Sudhakar Ravi  sudhakar@sonicsys.com
+    929   Steinbrecher Corp.       Kary Robertson  krobertson@delphi.com
+    930   Centillion Networks, Inc.     Derek Pitcher   derek@lanspd.com
+    931   Network Communication Corp.
+                     Tracy Clark  ncc!central!tracyc@netcomm.attmail.com
+    932   Sysnet A.S.                   Carstein Seeberg  case@sysnet.no
+    933   Telecommunication Systems Lab Gerald Maguire maguire@it.kth.se
+    934   QMI                             Scott Brickner  (410) 573-0013
+    935   Phoenixtec Power Co., LTD.       An-Hsiang Tu  +8 862 646 3311
+    936   Hirakawa Hewtech Corp.     H. Ukaji  lde02513@niftyserve.or.jp
+    937   No Wires Needed B.V.       Arnoud Zwemmer  roana@cs.utwente.nl
+    938   Primary Access               Kerstin Lodman  lodman@priacc.com
+    939   Enterprises.FDSW            Dag Framstad  dag.framstad@fdsw.no
+    940   Grabner & Kapfer GnbR          Vinzenz Grabner  zen@wsr.ac.att
+    941   Nemesys Research Ltd.         Michael Dixon  mjd@nemesys.co.uk
+    942   Pacific Communication Sciences, Inc. (PSCI)
+                                      Yvonne Kammer mib-contact@pcsi.com
+    943   Level One Communications, Inc.
+                                      Moshe Kochinski  moshek@level1.com
+    944   Fast Track, Inc.     Andrew H. Dimmick  adimmick@world.std.com
+    945   Andersen Consulting, OM/NI Practice
+                                         Greg Tilford p00919@psilink.com
+    946   Bay Technologies Pty Ltd.   Paul Simpson  pauls@baytech.com.au
+    947   Integrated Network Corp.      Daniel Joffe wandan@integnet.com
+    948   Epoch, Inc.                       David Haskell  deh@epoch.com
+    949   Wang Laboratories Inc.         Pete Reilley  pvr@wiis.wang.com
+    950   Polaroid Corp.       Sari Germanos  sari@temerity.polaroid.com
+    951   Sunrise Sierra                    Gerald Olson  (510) 443-1133
+
+
+
+Reynolds & Postel                                             [Page 157]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+    952   Silcon Group                   Bjarne Bonvang  +45 75 54 22 55
+    953   Coastcom                  Donald Pickerel  dpickere@netcom.com
+    954   4th DIMENSION SOFTWARE LTD.
+                       Thomas Segev/Ely Hofner autumn@zeus.datasrv.co.il
+    955   SEIKO SYSTEMS Inc.              Kiyoshi Ishida  ishi@ssi.co.jp
+    956   PERFORM                    Jean-Hugues Robert  +33 42 27 29 32
+    957   TV/COM International              Jean Tellier  (619) 675-1376
+    958   Network Integration, Inc.
+                           Scott C. Lemon  slemon@nii.mhs.compuserve.com
+    959   Sola Electric, A Unit of General Signal
+                                  Bruce Rhodes 72360,2436@compuserve.com
+    960   Gradient Technologies, Inc.  Geoff Charron  geoff@gradient.com
+    961   Tokyo Electric Co., Ltd.           A. Akiyama  +81 558 76 9606
+    962   Codonics, Inc.                     Joe Kulig  jjk@codonics.com
+    963   Delft Technical University Mark Schenk m.schenk@ced.tudelft.nl
+    964   Carrier Access Corp.        Roger Koenig  tomquick@carrier.com
+    965   eoncorp                           Barb Wilson  wilsonb@eon.com
+    966   Naval Undersea Warfare Center
+                           Mark Lovelace  lovelace@mp34.nl.nuwc.navy.mil
+    967   AWA Limited                   Mike Williams    +61 28 87 71 11
+    968   Distinct Corp.           Tarcisio Pedrotti  tarci@distinct.com
+    969   National Technical University of Athens
+                             Theodoros Karounos karounos@phgasos.ntua.gr
+    970   BGS Systems, Inc.                       Amr Hafez  amr@bgs.com
+    971   McCaw Wireless Data Inc.     Brian Bailey  bbailey@airdata.com
+    972   Bekaert                  Koen De Vleeschauwer  kdv@bekaert.com
+    973   Epic Data Inc.        Vincent Lim  vincent_lim@epic.wimsey.com
+    974   Prodigy Services Co.              Ed Ravin  elr@wp.prodigy.com
+    975   First Pacific Networks (FPN)     Randy Hamilton  randy@fpn.com
+    976   Xylink Ltd.         Bahman Rafatjoo  100117.665@compuserve.com
+    977   Relia Technologies Corp.  Fred Chen  fredc@relia1.relia.com.tw
+    978   Legacy Storage Systems Inc.
+                            James Hayes james@lss-chq.mhs.compuserve.com
+    979   Digicom, SPA                   Claudio Biotti  +39 3312 0 0122
+    980   Ark Telecom                       Alan DeMars  alan@arktel.com
+    981   National Security Agency (NSA)
+                                Cynthia Stewart maedeen@romulus.ncsc.mil
+    982  Southwestern Bell Corporation
+                                      Brian Bearden bb8840@swuts.sbc.com
+    983  Virtual Design Group, Inc.
+                                Chip Standifer 70650.3316@compuserve.com
+    984  Rhone Poulenc                Olivier Pignault   +33 1348 2 4053
+    985  Swiss Bank Corporation        Neil Todd  toddn@gb.swissbank.com
+    986  ATEA N.V.             Walter van Brussel  p81710@banyan.atea.be
+    987  Computer Communications Specialists, Inc.
+                                        Carolyn Zimmer  cczimmer@crl.com
+    988  Object Quest, Inc.             Michael L. Kornegay  mlk@bir.com
+    989  DCL System International, Ltd.   Gady Amit gady-a@dcl-see.co.il
+
+
+
+Reynolds & Postel                                             [Page 158]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+    990  SOLITON SYSTEMS K.K.             Masayuki Yamai  +81 33356 6091
+    991  U S Software                       Don Dunstan  ussw@netcom.com
+    992  Systems Research and Applications Corporation
+                                        Todd Herr herrt@smtplink.sra.com
+    993  University of Florida           Todd Hester  todd@circa.ufl.edu
+    994  Dantel, Inc.                       John Litster  (209) 292-1111
+    995  Multi-Tech Systems, Inc.    Dale Martenson  (612) 785-3500 x519
+    996  Softlink Ltd.     Moshe Leibovitch  softlink@zeus.datasrv.co.il
+    997  ProSum                        Christian Bucari  +33.1.4590.6231
+    998  March Systems Consultancy, Ltd.
+                                     Ross Wakelin  r.wakelin@march.co.uk
+    999  Hong Technology, Inc.            Walt Milnor  brent@oceania.com
+   1000  Internet Assigned Numbers Authority                iana@isi.edu
+   1001  PECO Energy Co.                  Rick Rioboli  u002rdr@peco.com
+   1002  United Parcel Service        Steve Pollini  nrd1sjp@nrd.ups.com
+   1003  Storage Dimensions, Inc.     Michael Torhan  miketorh@xstor.com
+   1004  ITV Technologies, Inc.               Jacob Chen  itv@netcom.com
+   1005  TCPSI             Victor San Jose   Victor.Sanjose@sp1.y-net.es
+   1006  Promptus Communications, Inc.     Paul Fredette  (401) 683-6100
+   1007  Norman Data Defense Systems
+                                   Kristian A. Bognaes  norman@norman.no
+   1008  Pilot Network Services, Inc.     Rob Carrade  carrade@pilot.net
+   1009  Integrated Systems Solutions Corporation
+                                           Chris Cowan cc@austin.ibm.com
+   1010  SISRO                 Kamp Alexandre  100074.344@compuserve.com
+   1011  NetVantage                       Kevin Bailey  speed@kaiwan.com
+   1012  Marconi S.p.A.             Giuseppe Grasso  gg@relay.marconi.it
+   1013  SURECOM                         Mike S. T. Hsieh  +886.25.92232
+   1014  Royal Hong Kong Jockey Club
+                                   Edmond Lee 100267.3660@compuserve.com
+   1015  Gupta                            Howard Cohen  hcohen@gupta.com
+   1016  Tone Software Corporation       Neil P. Harkins  (714) 991-9460
+   1017  Opus Telecom                     Pace Willisson  pace@blitz.com
+   1018  Cogsys Ltd.          Niall Teasdale  niall@hedgehog.demon.co.uk
+   1019  Komatsu, Ltd.              Akifumi Katsushima  +81 463.22.84.30
+   1020  ROI Systems, Inc                   Michael Wong  (801) 942-1752
+   1021  Lightning Instrumentation SA    Mike O'Dowd  odowd@lightning.ch
+   1022  TimeStep Corp.          Stephane Lacelle slacelle@newbridge.com
+   1023  INTELSAT                       Ivan Giron  i.giron@intelsat.int
+   1024  Network Research Corporation Japan, Ltd.
+                                Tsukasa Ueda  100156.2712@compuserve.com
+   1025  Relational Development, Inc.  Steven Smith  rdi@ins.infonet.net
+   1026  Emerald Systems, Corp. Robert A. Evans Jr. (619) 673-2161 x5120
+   1027  Mitel, Corp.                    Tom Quan  tq@software.mitel.com
+   1028  Software AG                        Peter Cohen  sagpc@sagus.com
+   1029  MillenNet, Inc.                       Manh Do    (510) 770-9390
+   1030  NK-EXA Corp.           Ken'ichi Hayami  hayami@dst.nk-exa.co.jp
+   1031  BMC Software                     Chris Sharp  csharp@patrol.com
+
+
+
+Reynolds & Postel                                             [Page 159]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+   1032  StarFire Enterprises, Inc.          Lew Gaiter  lg@starfire.com
+   1033  Hybrid Networks, Inc.           Doug Muirhead  dougm@hybrid.com
+   1034  Quantum Software GmbH          Thomas Omerzu  omerzu@quantum.de
+   1035  Openvision Technologies Limited
+                             Andrew Lockhart  alockhart@openvision.co.uk
+   1036  Healthcare Communications, Inc. (HCI)
+                                    Larry Streepy streepy@healthcare.com
+   1037  SAIT Systems                          Hai Dotu    +3223.7053.11
+   1038  SAT                              Mleczko Alain  +33.1.4077.1156
+   1039  CompuSci Inc.,                   Bob Berry  bberry@compusci.com
+   1040  Aim Technology                 Ganesh Rajappan  ganeshr@aim.com
+   1041  CIESIN                      Kalpesh Unadkat  kalpesh@ciesin.org
+   1042  Systems & Technologies International
+                                            Howard Smith  ghamex@aol.com
+   1043  Israeli Electric Company (IEC) Yoram Harlev yoram@yor.iec.co.il
+   1044  Phoenix Wireless Group, Inc.
+                                  Gregory M. Buchanan  buchanan@pwgi.com
+   1045  SWL                  Bill Kight  wkightgrci.com  (410) 290.7245
+   1046  nCUBE                            Greg Thompson  gregt@ncube.com
+   1047  Cerner, Corp.             Dennis Avondet  (816) 221.1024  X2432
+   1048  Andersen Consulting        Mark Lindberg  mlindber@andersen.com
+   1049  Lincoln Telephone Company     Bob Morrill  root@si6000.ltec.com
+   1050  Acer                                    Jay Tao  jtao@Altos.COM
+   1051  Cedros                        Juergen Haakert  +49.2241.9701.80
+   1052  AirAccess                  Ido Ophir  100274.365@compuserve.com
+   1053  Expersoft Corporation        David Curtis  curtis@expersoft.com
+   1054  Eskom                    Sanjay Lakhani h00161@duvi.eskom.co.za
+   1055  SBE, Inc.                         Vimal Vaidya   vimal@sbei.com
+   1056  EBS, Inc.                        Emre Gundogan  baroque@ebs.com
+   1057  American Computer and Electronics, Corp.
+                                               Tom Abraham  tha@acec.com
+   1058  Syndesis Limited                 Wil Macaulay  wil@syndesis.com
+   1059  Isis Distributed Systems, Inc.   Ken Chapman  kchapman@isis.com
+   1060  Priority Call Management   Greg Schumacher  gregs@world.std.com
+   1061  Koelsch & Altmann GmbH
+                           Christian Schreyer  100142.154@compuserve.com
+   1062  WIPRO INFOTECH LTD. Chandrashekar Kapse  kapse@wipinfo.soft.net
+   1063  Controlware                          Uli Blatz  ublatz@cware.de
+   1064  Mosaic Software                W.van Biljon willem@mosaic.co.za
+   1065  Canon Information Systems
+                            Victor Villalpando  vvillalp@cisoc.canon.com
+   1066  AmericaOnline               Andrew R. Scholnick  andrew@aol.net
+   1067  Whitetree Network Technologies, Inc.
+                                           Carl Yang cyang@whitetree.com
+   1068  Xetron Corp.                    Dave Alverson  davea@xetron.com
+   1069  Target Concepts, Inc.               Bill Price  bprice@tamu.edu
+   1070  DMH Software          Yigal Hochberg  72144.3704@compuserve.com
+   1071  Innosoft International, Inc.    Jeff Allison  jeff@innosoft.com
+
+
+
+Reynolds & Postel                                             [Page 160]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+   1072  Controlware GmbH                     Uli Blatz  ublatz@cware.de
+   1073  Telecommunications Industry Association (TIA)
+                                      Mike Youngberg   mikey@synacom.com
+   1074  Boole & Babbage                      Rami Rubin  rami@boole.com
+   1075  System Engineering Support, Ltd.  Vince Taylor  +44 454.614.638
+   1076  SURFnet               Ton Verschuren  Ton.Verschuren@surfnet.nl
+   1077  OpenConnect Systems, Inc.        Mark Rensmeyer  mrensme@oc.com
+   1078  PDTS (Process Data Technology and Systems)
+                        Martin Gutenbrunner  GUT@pdts.mhs.compuserve.com
+   1079  Cornet, Inc.                          Nat Kumar  (703) 658-3400
+   1080  NetStar, Inc.                  John K. Renwick  jkr@netstar.com
+   1081  Semaphore Communications, Corp.  Jimmy Soetarman (408) 980-7766
+   1082  Casio Computer Co., Ltd.      Shouzo Ohdate  ohdate@casio.co.jp
+   1083  CSIR            Frikkie Strecker fstreck@marge.mikom.csir.co.za
+   1084  APOGEE Communications      Olivier Caleff  caleff@apogee-com.fr
+   1085  Information Management Company   Michael D. Liss  mliss@imc.com
+   1086  Wordlink, Inc.                    Mike Aleckson  (314) 878-1422
+   1087  PEER                            Avinash S. Rao  arao@cranel.com
+   1088  Telstra Corp.  Michael Scollay        michaels@ind.tansu.com.au
+   1089  Net X, Inc.  Sridhar Kodela  techsupp@netx.unicomp.net
+   1090  PNC PLC     Gordon Tees        +44 716.061.200
+
+To request an assignment of an Enterprise Number send the complete
+company name, address, and phone number; and the contact's person
+complete name, address, phone number, and email mailbox in an email
+message to <iana-mib@isi.edu>.
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/enterprise-numbers
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                             [Page 161]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+SGMP Vendor Specific Codes: [obsolete]
+
+
+Prefix: 1,255,
+
+Decimal   Name                                          References
+-------   ----                                          ----------
+      0   Reserved                                          [JKR1]
+      1   Proteon                                           [JS18]
+      2   IBM                                                [JXR]
+      3   CMU                                                [SXW]
+      4   Unix                                               [MS9]
+      5   ACC                                               [AB20]
+      6   TWG                                                [MTR]
+      7   CAYMAN                                            [BXM2]
+      8   NYSERNET                                           [MS9]
+      9   cisco                                              [GS2]
+     10   BBN                                                [RH6]
+     11   Unassigned                                        [JKR1]
+     12   MIT                                               [JR35]
+ 13-254   Unassigned                                        [JKR1]
+    255   Reserved                                          [JKR1]
+
+
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/sgmp-vendor-specific-
+codes
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                             [Page 162]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+ADDRESS RESOLUTION PROTOCOL PARAMETERS
+
+The Address Resolution Protocol (ARP) specified in [RFC826] has
+several parameters.  The assigned values for these parameters are
+listed here.
+
+REVERSE ADDRESS RESOLUTION PROTOCOL OPERATION CODES
+
+The Reverse Address Resolution Protocol (RARP) specified in [RFC903]
+uses the "Reverse" codes below.
+
+DYNAMIC REVERSE ARP
+
+The Dynamic Reverse Address Resolution Protocol (DRARP) uses the
+"DRARP" codes below.  For further information, contact: David Brownell
+(suneast!helium!db@Sun.COM).
+
+INVERSE ADDRESS RESOULUTION PROTOCOL
+
+The Inverse Address Resolution Protocol (IARP) specified in [RFC1293]
+uses the "InARP" codes below.
+
+Assignments:
+
+Number Operation Code (op)                       Reference
+------ --------------------------                ---------
+     1  REQUEST                                  [RFC826]
+     2  REPLY                                    [RFC826]
+     3  request Reverse                          [RFC903]
+     4  reply Reverse                            [RFC903]
+     5  DRARP-Request                    [David Brownell]
+     6  DRARP-Reply                      [David Brownell]
+     7  DRARP-Error                      [David Brownell]
+     8  InARP-Request                           [RFC1293]
+     9  InARP-Reply                             [RFC1293]
+    10  ARP-NAK                            [Mark Laubach]
+
+Number Hardware Type (hrd)                           References
+------ -----------------------------------           ----------
+     1 Ethernet (10Mb)                                    [JBP]
+     2 Experimental Ethernet (3Mb)                        [JBP]
+     3 Amateur Radio AX.25                                [PXK]
+     4 Proteon ProNET Token Ring                          [JBP]
+     5 Chaos                                              [GXP]
+     6 IEEE 802 Networks                                  [JBP]
+     7 ARCNET                                             [JBP]
+     8 Hyperchannel                                       [JBP]
+     9 Lanstar                                             [TU]
+
+
+
+Reynolds & Postel                                             [Page 163]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+    10 Autonet Short Address                             [MXB1]
+    11 LocalTalk                                         [JKR1]
+    12 LocalNet (IBM PCNet or SYTEK LocalNET)             [JXM]
+    13 Ultra link                                        [RXD2]
+    14 SMDS                                              [GXC1]
+    15 Frame Relay                                        [AGM]
+    16 Asynchronous Transmission Mode (ATM)              [JXB2]
+    17 HDLC                                               [JBP]
+    18 Fibre Channel                            [Yakov Rekhter]
+    19 Asynchronous Transmission Mode (ATM)      [Mark Laubach]
+    20 Serial Line                                        [JBP]
+    21 Asynchronous Transmission Mode (ATM)              [MXB1]
+
+Protocol Type (pro)
+
+Use the same codes as listed in the section called "Ethernet Numbers
+of Interest" (all hardware types use this code set for the protocol
+type).
+
+
+REFERENCES
+
+[RFC826] Plummer, D., "An Ethernet Address Resolution Protocol or
+         Converting Network Protocol Addresses to 48-bit Ethernet
+         Addresses for Transmission on Ethernet Hardware", STD 37, RFC
+         826, MIT-LCS, November 1982.
+
+[RFC903] Finlayson, R., Mann, T., Mogul, J., and M. Theimer, "A
+         Reverse Address Resolution Protocol", STD 38, RFC 903,
+         Stanford University, June 1984.
+
+[RFC1293] Bradley, T., and C. Brown, "Inverse Address Resolution
+          Protocol", RFC 1293, Wellfleet Communications, Inc.,
+          January 1992.
+
+
+PEOPLE
+
+[AGM] Andy Malis <malis_a@timeplex.com>
+
+[GXC1] George Clapp <meritec!clapp@bellcore.bellcore.com>
+
+[GXP] Gill Pratt <gill%mit-ccc@MC.LCS.MIT.EDU>
+
+[JBP] Jon Postel <postel@isi.edu>
+
+[JKR1] Joyce K. Reynolds <jkrey@isi.edu>
+
+
+
+
+Reynolds & Postel                                             [Page 164]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[JXM] Joseph Murdock <---none--->
+
+[MXB1] Mike Burrows <burrows@SRC.DEC.COM>
+
+[PXK] Philip Koch <Philip.Koch@DARTMOUTH.EDU>
+
+[RXD2] Rajiv Dhingra <rajiv@ULTRA.COM>
+
+[TU] Tom Unger <tom@CITI.UMICH>
+
+[David Brownell]
+
+[Mark Laubach]
+
+[Yakov Rekhter] <Yakov@IBM.COM>
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/arp-parameters
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                             [Page 165]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+IEEE 802 NUMBERS OF INTEREST
+
+Some of the networks of all classes are IEEE 802 Networks.  These
+systems may use a Link Service Access Point (LSAP) field in much the
+same way the MILNET uses the "link" field.  Further, there is an
+extension of the LSAP header called the Sub-Network Access Protocol
+(SNAP).
+
+The IEEE likes to describe numbers in binary in bit transmission
+order, which is the opposite of the big-endian order used throughout
+the Internet protocol documentation.
+
+
+Assignments:
+
+   Link Service Access Point   Description                References
+   -------------------------   -----------                ----------
+   IEEE     Internet
+   binary   binary    decimal
+   00000000 00000000        0   Null LSAP                      [IEEE]
+   01000000 00000010        2   Indiv LLC Sublayer Mgt         [IEEE]
+   11000000 00000011        3   Group LLC Sublayer Mgt         [IEEE]
+   00100000 00000100        4   SNA Path Control               [IEEE]
+   01100000 00000110        6   Reserved (DOD IP)        [RFC768,JBP]
+   01110000 00001110       14   PROWAY-LAN                     [IEEE]
+   01110010 01001110       78   EIA-RS 511                     [IEEE]
+   01111010 01011110       94   ISI IP                          [JBP]
+   01110001 10001110      142   PROWAY-LAN                     [IEEE]
+   01010101 10101010      170   SNAP                           [IEEE]
+   01111111 11111110      254   ISO CLNS IS 8473         [RFC926,JXJ]
+   11111111 11111111      255   Global DSAP                    [IEEE]
+
+These numbers (and others) are assigned by the IEEE Standards Office.
+The address is:
+
+IEEE Registration Authority
+c/o Iris Ringel
+IEEE Standards Dept
+445 Hoes Lane, P.O. Box 1331
+Piscataway, NJ 08855-1331
+Phone +1 908 562 3813
+Fax: +1 908 562 1571
+
+The fee is $1000 and it takes 10 working days after receipt of the
+request form and fee.  They will not do anything via fax or phone.
+
+At an ad hoc special session on "IEEE 802 Networks and ARP", held
+during the TCP Vendors Workshop (August 1986), an approach to a
+
+
+
+Reynolds & Postel                                             [Page 166]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+consistent way to send DoD-IP datagrams and other IP related protocols
+(such as the Address Resolution Protocol (ARP)) on 802 networks was
+developed, using the SNAP extension (see [RFC1042]).
+
+REFERENCES
+
+[RFC768] Postel, J., "User Datagram Protocol", STD 6, RFC 768,
+         USC/Information Sciences Institute, August 1980.
+
+[RFC926] International Standards Organization, "Protocol for Providing
+         the Connectionless-Mode Network Services", RFC 926, ISO,
+         December 1984.
+
+[RFC1042] Postel, J., and J. Reynolds, "A Standard for the
+          Transmission of IP Datagrams over IEEE 802 Networks", STD
+          43, RFC 1042, USC/Information Sciences Institute, February
+          1988.
+
+PEOPLE
+
+[JBP] Jon Postel <postel@isi.edu>
+
+[JXJ] <mystery contact>
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/ieee-802-numbers
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                             [Page 167]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+ETHER TYPES
+
+Many of the networks of all classes are Ethernets (10Mb) or
+Experimental Ethernets (3Mb).  These systems use a message "type"
+field in much the same way the ARPANET uses the "link" field.
+
+If you need an Ether Type, contact:
+
+Xerox Systems Institute
+3400 Hillview Ave.
+PO BOX 10034
+Palo Alto, CA 94303
+
+Phone: 415-813-7164
+Contact: Fonda Lix Pallone
+
+The following list of EtherTypes is contributed unverified information
+from various sources.
+
+Assignments:
+
+Ethernet          Exp. Ethernet    Description          References
+-------------     -------------   -----------           ----------
+decimal  Hex      decimal  octal
+   000   0000-05DC   -       -    IEEE802.3 Length Field   [XEROX]
+   257   0101-01FF   -       -    Experimental             [XEROX]
+   512   0200        512   1000   XEROX PUP (see 0A00)   [8,XEROX]
+   513   0201        -      -     PUP Addr Trans (see 0A01)[XEROX]
+         0400                     Nixdorf                  [XEROX]
+  1536   0600       1536   3000   XEROX NS IDP         [133,XEROX]
+         0660                     DLOG                     [XEROX]
+         0661                     DLOG                     [XEROX]
+  2048   0800        513   1001   Internet IP (IPv4)     [105,JBP]
+  2049   0801        -      -     X.75 Internet            [XEROX]
+  2050   0802        -      -     NBS Internet             [XEROX]
+  2051   0803        -      -     ECMA Internet            [XEROX]
+  2052   0804        -      -     Chaosnet                 [XEROX]
+  2053   0805        -      -     X.25 Level 3             [XEROX]
+  2054   0806        -      -     ARP                     [88,JBP]
+  2055   0807        -      -     XNS Compatability        [XEROX]
+  2076   081C        -      -     Symbolics Private         [DCP1]
+  2184   0888-088A   -      -     Xyplex                   [XEROX]
+  2304   0900        -      -     Ungermann-Bass net debugr[XEROX]
+  2560   0A00        -      -     Xerox IEEE802.3 PUP      [XEROX]
+  2561   0A01        -      -     PUP Addr Trans           [XEROX]
+  2989   0BAD        -      -     Banyan Systems           [XEROX]
+  4096   1000        -      -     Berkeley Trailer nego    [XEROX]
+  4097   1001-100F   -      -     Berkeley Trailer encap/IP[XEROX]
+
+
+
+Reynolds & Postel                                             [Page 168]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+  5632   1600        -      -     Valid Systems            [XEROX]
+ 16962   4242        -      -     PCS Basic Block Protocol [XEROX]
+ 21000   5208        -      -     BBN Simnet               [XEROX]
+ 24576   6000        -      -     DEC Unassigned (Exp.)    [XEROX]
+ 24577   6001        -      -     DEC MOP Dump/Load        [XEROX]
+ 24578   6002        -      -     DEC MOP Remote Console   [XEROX]
+ 24579   6003        -      -     DEC DECNET Phase IV Route[XEROX]
+ 24580   6004        -      -     DEC LAT                  [XEROX]
+ 24581   6005        -      -     DEC Diagnostic Protocol  [XEROX]
+ 24582   6006        -      -     DEC Customer Protocol    [XEROX]
+ 24583   6007        -      -     DEC LAVC, SCA            [XEROX]
+ 24584   6008-6009   -      -     DEC Unassigned           [XEROX]
+ 24586   6010-6014   -      -     3Com Corporation         [XEROX]
+ 28672   7000        -      -     Ungermann-Bass download  [XEROX]
+ 28674   7002        -      -     Ungermann-Bass dia/loop  [XEROX]
+ 28704   7020-7029   -      -     LRT                      [XEROX]
+ 28720   7030        -      -     Proteon                  [XEROX]
+ 28724   7034        -      -     Cabletron                [XEROX]
+ 32771   8003        -      -     Cronus VLN            [131,DT15]
+ 32772   8004        -      -     Cronus Direct         [131,DT15]
+ 32773   8005        -      -     HP Probe                 [XEROX]
+ 32774   8006        -      -     Nestar                   [XEROX]
+ 32776   8008        -      -     AT&T                     [XEROX]
+ 32784   8010        -      -     Excelan                  [XEROX]
+ 32787   8013        -      -     SGI diagnostics            [AXC]
+ 32788   8014        -      -     SGI network games          [AXC]
+ 32789   8015        -      -     SGI reserved               [AXC]
+ 32790   8016        -      -     SGI bounce server          [AXC]
+ 32793   8019        -      -     Apollo Computers         [XEROX]
+ 32815   802E        -      -     Tymshare                 [XEROX]
+ 32816   802F        -      -     Tigan, Inc.              [XEROX]
+ 32821   8035        -      -     Reverse ARP             [48,JXM]
+ 32822   8036        -      -     Aeonic Systems           [XEROX]
+ 32824   8038        -      -     DEC LANBridge            [XEROX]
+ 32825   8039-803C   -      -     DEC Unassigned           [XEROX]
+ 32829   803D        -      -     DEC Ethernet Encryption  [XEROX]
+ 32830   803E        -      -     DEC Unassigned           [XEROX]
+ 32831   803F        -      -     DEC LAN Traffic Monitor  [XEROX]
+ 32832   8040-8042   -      -     DEC Unassigned           [XEROX]
+ 32836   8044        -      -     Planning Research Corp.  [XEROX]
+ 32838   8046        -      -     AT&T                     [XEROX]
+ 32839   8047        -      -     AT&T                     [XEROX]
+ 32841   8049        -      -     ExperData                [XEROX]
+ 32859   805B        -      -     Stanford V Kernel exp.   [XEROX]
+ 32860   805C        -      -     Stanford V Kernel prod.  [XEROX]
+ 32861   805D        -      -     Evans & Sutherland       [XEROX]
+ 32864   8060        -      -     Little Machines          [XEROX]
+ 32866   8062        -      -     Counterpoint Computers   [XEROX]
+
+
+
+Reynolds & Postel                                             [Page 169]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+ 32869   8065        -      -     Univ. of Mass. @ Amherst [XEROX]
+ 32870   8066        -      -     Univ. of Mass. @ Amherst [XEROX]
+ 32871   8067        -      -     Veeco Integrated Auto.   [XEROX]
+ 32872   8068        -      -     General Dynamics         [XEROX]
+ 32873   8069        -      -     AT&T                     [XEROX]
+ 32874   806A        -      -     Autophon                 [XEROX]
+ 32876   806C        -      -     ComDesign                [XEROX]
+ 32877   806D        -      -     Computgraphic Corp.      [XEROX]
+ 32878   806E-8077   -      -     Landmark Graphics Corp.  [XEROX]
+ 32890   807A        -      -     Matra                    [XEROX]
+ 32891   807B        -      -     Dansk Data Elektronik    [XEROX]
+ 32892   807C        -      -     Merit Internodal           [HWB]
+ 32893   807D-807F   -      -     Vitalink Communications  [XEROX]
+ 32896   8080        -      -     Vitalink TransLAN III    [XEROX]
+ 32897   8081-8083   -      -     Counterpoint Computers   [XEROX]
+ 32923   809B        -      -     Appletalk                [XEROX]
+ 32924   809C-809E   -      -     Datability               [XEROX]
+ 32927   809F        -      -     Spider Systems Ltd.      [XEROX]
+ 32931   80A3        -      -     Nixdorf Computers        [XEROX]
+ 32932   80A4-80B3   -      -     Siemens Gammasonics Inc. [XEROX]
+ 32960   80C0-80C3   -      -     DCA Data Exchange Cluster[XEROX]
+         80C4                     Banyan Systems           [XEROX]
+         80C5                     Banyan Systems           [XEROX]
+ 32966   80C6        -      -     Pacer Software           [XEROX]
+ 32967   80C7        -      -     Applitek Corporation     [XEROX]
+ 32968   80C8-80CC   -      -     Intergraph Corporation   [XEROX]
+ 32973   80CD-80CE   -      -     Harris Corporation       [XEROX]
+ 32975   80CF-80D2   -      -     Taylor Instrument        [XEROX]
+ 32979   80D3-80D4   -      -     Rosemount Corporation    [XEROX]
+ 32981   80D5        -      -     IBM SNA Service on Ether [XEROX]
+ 32989   80DD        -      -     Varian Associates        [XEROX]
+ 32990   80DE-80DF   -      -     Integrated Solutions TRFS[XEROX]
+ 32992   80E0-80E3   -      -     Allen-Bradley            [XEROX]
+ 32996   80E4-80F0   -      -     Datability               [XEROX]
+ 33010   80F2        -      -     Retix                    [XEROX]
+ 33011   80F3        -      -     AppleTalk AARP (Kinetics)[XEROX]
+ 33012   80F4-80F5   -      -     Kinetics                 [XEROX]
+ 33015   80F7        -      -     Apollo Computer          [XEROX]
+ 33023   80FF-8103   -      -     Wellfleet Communications [XEROX]
+ 33031   8107-8109   -      -     Symbolics Private        [XEROX]
+ 33072   8130        -      -     Hayes Microcomputers     [XEROX]
+ 33073   8131        -      -     VG Laboratory Systems    [XEROX]
+         8132-8136                Bridge Communications    [XEROX]
+ 33079   8137-8138   -      -     Novell, Inc.             [XEROX]
+ 33081   8139-813D   -      -     KTI                      [XEROX]
+         8148                     Logicraft                [XEROX]
+         8149                     Network Computing Devices[XEROX]
+         814A                     Alpha Micro              [XEROX]
+
+
+
+Reynolds & Postel                                             [Page 170]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+ 33100   814C        -      -     SNMP                      [JKR1]
+         814D                     BIIN                     [XEROX]
+         814E                     BIIN                     [XEROX]
+         814F                     Technically Elite Concept[XEROX]
+         8150                     Rational Corp            [XEROX]
+         8151-8153                Qualcomm                 [XEROX]
+         815C-815E                Computer Protocol Pty Ltd[XEROX]
+         8164-8166                Charles River Data System[XEROX]
+         817D-818C                Protocol Engines         [XEROX]
+         818D                     Motorola Computer        [XEROX]
+         819A-81A3                Qualcomm                 [XEROX]
+         81A4                     ARAI Bunkichi            [XEROX]
+         81A5-81AE                RAD Network Devices      [XEROX]
+         81B7-81B9                Xyplex                   [XEROX]
+         81CC-81D5                Apricot Computers        [XEROX]
+         81D6-81DD                Artisoft                 [XEROX]
+         81E6-81EF                Polygon                  [XEROX]
+         81F0-81F2                Comsat Labs              [XEROX]
+         81F3-81F5                SAIC                     [XEROX]
+         81F6-81F8                VG Analytical            [XEROX]
+         8203-8205                Quantum Software         [XEROX]
+         8221-8222                Ascom Banking Systems    [XEROX]
+         823E-8240                Advanced Encryption Syste[XEROX]
+         827F-8282                Athena Programming       [XEROX]
+         8263-826A                Charles River Data System[XEROX]
+         829A-829B                Inst Ind Info Tech       [XEROX]
+         829C-82AB                Taurus Controls          [XEROX]
+         82AC-8693                Walker Richer & Quinn    [XEROX]
+         8694-869D                Idea Courier             [XEROX]
+         869E-86A1                Computer Network Tech    [XEROX]
+         86A3-86AC                Gateway Communications   [XEROX]
+         86DB                     SECTRA                   [XEROX]
+         86DE                     Delta Controls           [XEROX]
+ 34543   86DF        -      -     ATOMIC                     [JBP]
+         86E0-86EF                Landis & Gyr Powers      [XEROX]
+         8700-8710                Motorola                 [XEROX]
+         8A96-8A97                Invisible Software       [XEROX]
+ 36864   9000        -      -     Loopback                 [XEROX]
+ 36865   9001        -      -     3Com(Bridge) XNS Sys Mgmt[XEROX]
+ 36866   9002        -      -     3Com(Bridge) TCP-IP Sys  [XEROX]
+ 36867   9003        -      -     3Com(Bridge) loop detect [XEROX]
+ 65280   FF00        -      -     BBN VITAL-LanBridge cache[XEROX]
+         FF00-FF0F                ISC Bunker Ramo          [XEROX]
+
+The standard for transmission of IP datagrams over Ethernets and
+Experimental Ethernets is specified in [RFC894] and [RFC895]
+respectively.
+
+
+
+
+Reynolds & Postel                                             [Page 171]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+NOTE:  Ethernet 48-bit address blocks are assigned by the IEEE.
+
+IEEE Registration Authority
+c/o Iris Ringel
+IEEE Standards Department
+445 Hoes Lane, P.O. Box 1331
+Piscataway, NJ 08855-1331
+Phone +1 908 562 3813
+Fax: +1 908 562 1571
+
+
+IANA ETHERNET ADDRESS BLOCK
+
+
+The IANA owns an Ethernet address block which may be used for
+multicast address asignments or other special purposes.
+
+The address block in IEEE binary is:  0000 0000 0000 0000 0111 1010
+
+In the normal Internet dotted decimal notation this is 0.0.94 since
+the bytes are transmitted higher order first and bits within bytes are
+transmitted lower order first (see "Data Notation" in the
+Introduction).
+
+IEEE CSMA/CD and Token Bus bit transmission order: 00 00 5E
+
+IEEE Token Ring bit transmission order: 00 00 7A
+
+Appearance on the wire (bits transmitted from left to right):
+
+
+    0                           23                            47
+    |                           |                             |
+    1000 0000 0000 0000 0111 1010 xxxx xxx0 xxxx xxxx xxxx xxxx
+    |                                     |
+    Multicast Bit                         0 = Internet Multicast
+                                          1 = Assigned by IANA for
+                                              other uses
+
+Appearance in memory (bits transmitted right-to-left within octets,
+octets transmitted left-to-right):
+
+
+    0                           23                            47
+    |                           |                             |
+    0000 0001 0000 0000 0101 1110 0xxx xxxx xxxx xxxx xxxx xxxx
+            |                     |
+            Multicast Bit         0 = Internet Multicast
+
+
+
+Reynolds & Postel                                             [Page 172]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+                                  1 = Assigned by IANA for other uses
+
+The latter representation corresponds to the Internet standard
+bit-order, and is the format that most programmers have to deal with.
+Using this representation, the range of Internet Multicast addresses
+is:
+
+
+       01-00-5E-00-00-00  to  01-00-5E-7F-FF-FF  in hex, or
+
+       1.0.94.0.0.0  to  1.0.94.127.255.255  in dotted decimal
+
+
+
+ETHERNET VENDOR ADDRESS COMPONENTS
+
+Ethernet hardware addresses are 48 bits, expressed as 12 hexadecimal
+digits (0-9, plus A-F, capitalized).  These 12 hex digits consist of
+the first/left 6 digits (which should match the vendor of the Ethernet
+interface within the station) and the last/right 6 digits which
+specify the interface serial number for that interface vendor.
+
+Ethernet addresses might be written unhyphenated (e.g., 123456789ABC),
+or with one hyphen (e.g., 123456-789ABC), but should be written
+hyphenated by octets (e.g., 12-34-56-78-9A-BC).
+
+These addresses are physical station addresses, not multicast nor
+broadcast, so the second hex digit (reading from the left) will be
+even, not odd.
+
+At present, it is not clear how the IEEE assigns Ethernet block
+addresses.  Whether in blocks of 2**24 or 2**25, and whether
+multicasts are assigned with that block or separately.  A portion of
+the vendor block address is reportedly assigned serially, with the
+other portion intentionally assigned randomly.  If there is a global
+algorithm for which addresses are designated to be physical (in a
+chipset) versus logical (assigned in software), or globally-assigned
+versus locally-assigned addresses, some of the known addresses do not
+follow the scheme (e.g., AA0003; 02xxxx).
+
+00000C  Cisco
+00000E  Fujitsu
+00000F  NeXT
+000010  Sytek
+00001D  Cabletron
+000020  DIAB (Data Intdustrier AB)
+000022  Visual Technology
+00002A  TRW
+
+
+
+Reynolds & Postel                                             [Page 173]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+000032  GPT Limited (reassigned from GEC Computers Ltd)
+00005A  S & Koch
+00005E  IANA
+000065  Network General
+00006B  MIPS
+000077  MIPS
+00007A  Ardent
+000089  Cayman Systems  Gatorbox
+000093  Proteon
+00009F  Ameristar Technology
+0000A2  Wellfleet
+0000A3  Network Application Technology
+0000A6  Network General (internal assignment, not for products)
+0000A7  NCD             X-terminals
+0000A9  Network Systems
+0000AA  Xerox           Xerox machines
+0000B3  CIMLinc
+0000B7  Dove            Fastnet
+0000BC  Allen-Bradley
+0000C0  Western Digital
+0000C5  Farallon phone net card
+0000C6  HP Intelligent Networks Operation (formerly Eon Systems)
+0000C8  Altos
+0000C9  Emulex          Terminal Servers
+0000D7  Dartmouth College (NED Router)
+0000D8  3Com? Novell?   PS/2
+0000DD  Gould
+0000DE  Unigraph
+0000E2  Acer Counterpoint
+0000EF  Alantec
+0000FD  High Level Hardvare (Orion, UK)
+000102  BBN             BBN internal usage (not registered)
+0020AF  3COM ???
+001700  Kabel
+008064  Wyse Technology / Link Technologies
+00802B  IMAC ???
+00802D  Xylogics, Inc.  Annex terminal servers
+00808C  Frontier Software Development
+0080C2  IEEE 802.1 Committee
+0080D3  Shiva
+00AA00  Intel
+00DD00  Ungermann-Bass
+00DD01  Ungermann-Bass
+020701  Racal InterLan
+020406  BBN             BBN internal usage (not registered)
+026086  Satelcom MegaPac (UK)
+02608C  3Com            IBM PC; Imagen; Valid; Cisco
+02CF1F  CMC             Masscomp; Silicon Graphics; Prime EXL
+
+
+
+Reynolds & Postel                                             [Page 174]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+080002  3Com (Formerly Bridge)
+080003  ACC (Advanced Computer Communications)
+080005  Symbolics       Symbolics LISP machines
+080008  BBN
+080009  Hewlett-Packard
+08000A  Nestar Systems
+08000B  Unisys
+080011  Tektronix, Inc.
+080014  Excelan         BBN Butterfly, Masscomp, Silicon Graphics
+080017  NSC
+08001A  Data General
+08001B  Data General
+08001E  Apollo
+080020  Sun             Sun machines
+080022  NBI
+080025  CDC
+080026  Norsk Data (Nord)
+080027  PCS Computer Systems GmbH
+080028  TI              Explorer
+08002B  DEC
+08002E  Metaphor
+08002F  Prime Computer  Prime 50-Series LHC300
+080036  Intergraph      CAE stations
+080037  Fujitsu-Xerox
+080038  Bull
+080039  Spider Systems
+080041  DCA Digital Comm. Assoc.
+080045  ???? (maybe Xylogics, but they claim not to know this number)
+080046  Sony
+080047  Sequent
+080049  Univation
+08004C  Encore
+08004E  BICC
+080056  Stanford University
+080058  ???             DECsystem-20
+08005A  IBM
+080067  Comdesign
+080068  Ridge
+080069  Silicon Graphics
+08006E  Concurrent      Masscomp
+080075  DDE (Danish Data Elektronik A/S)
+08007C  Vitalink        TransLAN III
+080080  XIOS
+080086  Imagen/QMS
+080087  Xyplex          terminal servers
+080089  Kinetics        AppleTalk-Ethernet interface
+08008B  Pyramid
+08008D  XyVision        XyVision machines
+
+
+
+Reynolds & Postel                                             [Page 175]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+080090  Retix Inc       Bridges
+484453  HDS ???
+800010  AT&T
+AA0000  DEC             obsolete
+AA0001  DEC             obsolete
+AA0002  DEC             obsolete
+AA0003  DEC             Global physical address for some DEC machines
+AA0004  DEC             Local logical address for systems running
+                        DECNET
+
+
+ETHERNET MULTICAST ADDRESSES
+
+An Ethernet multicast address consists of the multicast bit, the
+23-bit vendor component, and the 24-bit group identifier assigned by
+the vendor.  For example, DEC is assigned the vendor component
+08-00-2B, so multicast addresses assigned by DEC have the first
+24-bits 09-00-2B (since the multicast bit is the low-order bit of the
+first byte, which is "the first bit on the wire").
+
+
+Ethernet                Type
+Address                 Field   Usage
+
+Multicast Addresses:
+
+01-00-5E-00-00-00-      0800    Internet Multicast        [RFC1112]
+01-00-5E-7F-FF-FF
+01-00-5E-80-00-00-      ????    Internet reserved by IANA
+01-00-5E-FF-FF-FF
+01-80-C2-00-00-00       -802-   Spanning tree (for bridges)
+09-00-02-04-00-01?      8080?   Vitalink printer
+09-00-02-04-00-02?      8080?   Vitalink management
+09-00-09-00-00-01       8005    HP Probe
+09-00-09-00-00-01       -802-   HP Probe
+09-00-09-00-00-04       8005?   HP DTC
+09-00-1E-00-00-00       8019?   Apollo DOMAIN
+09-00-2B-00-00-00       6009?   DEC MUMPS?
+09-00-2B-00-00-01       8039?   DEC DSM/DTP?
+09-00-2B-00-00-02       803B?   DEC VAXELN?
+09-00-2B-00-00-03       8038    DEC Lanbridge Traffic Monitor (LTM)
+09-00-2B-00-00-04       ????    DEC MAP End System Hello
+09-00-2B-00-00-05       ????    DEC MAP Intermediate System Hello
+09-00-2B-00-00-06       803D?   DEC CSMA/CD Encryption?
+09-00-2B-00-00-07       8040?   DEC NetBios Emulator?
+09-00-2B-00-00-0F       6004    DEC Local Area Transport (LAT)
+09-00-2B-00-00-1x       ????    DEC Experimental
+09-00-2B-01-00-00       8038    DEC LanBridge Copy packets
+
+
+
+Reynolds & Postel                                             [Page 176]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+                                (All bridges)
+09-00-2B-01-00-01       8038    DEC LanBridge Hello packets
+                                (All local bridges)
+                                1 packet per second, sent by the
+                                designated LanBridge
+09-00-2B-02-00-00       ????    DEC DNA Lev. 2 Routing Layer routers?
+09-00-2B-02-01-00       803C?   DEC DNA Naming Service Advertisement?
+09-00-2B-02-01-01       803C?   DEC DNA Naming Service Solicitation?
+09-00-2B-02-01-02       803E?   DEC DNA Time Service?
+09-00-2B-03-xx-xx       ????    DEC default filtering by bridges?
+09-00-2B-04-00-00       8041?   DEC Local Area Sys. Transport (LAST)?
+09-00-2B-23-00-00       803A?   DEC Argonaut Console?
+09-00-4E-00-00-02?      8137?   Novell IPX
+09-00-56-00-00-00-      ????    Stanford reserved
+09-00-56-FE-FF-FF
+09-00-56-FF-00-00-      805C    Stanford V Kernel, version 6.0
+09-00-56-FF-FF-FF
+09-00-77-00-00-01       ????    Retix spanning tree bridges
+09-00-7C-02-00-05       8080?   Vitalink diagnostics
+09-00-7C-05-00-01       8080?   Vitalink gateway?
+0D-1E-15-BA-DD-06       ????    HP
+AB-00-00-01-00-00       6001    DEC Maintenance Operation Protocol
+                                (MOP) Dump/Load Assistance
+AB-00-00-02-00-00       6002    DEC Maintenance Operation Protocol
+                                (MOP) Remote Console
+                                1 System ID packet every 8-10 minutes,
+                                by every:
+                                DEC LanBridge
+                                DEC DEUNA interface
+                                DEC DELUA interface
+                                DEC DEQNA interface
+                                (in a certain mode)
+AB-00-00-03-00-00       6003    DECNET Phase IV end node Hello
+                                packets 1 packet every 15 seconds,
+                                sent by each DECNET host
+AB-00-00-04-00-00       6003    DECNET Phase IV Router Hello packets
+                                1 packet every 15 seconds, sent by
+                                the DECNET router
+AB-00-00-05-00-00       ????    Reserved DEC through
+AB-00-03-FF-FF-FF
+AB-00-03-00-00-00       6004    DEC Local Area Transport (LAT) - old
+AB-00-04-00-xx-xx       ????    Reserved DEC customer private use
+AB-00-04-01-xx-yy       6007    DEC Local Area VAX Cluster groups
+                                Sys. Communication Architecture (SCA)
+CF-00-00-00-00-00       9000    Ethernet Configuration Test protocol
+                                (Loopback)
+
+Broadcast Address:
+
+
+
+Reynolds & Postel                                             [Page 177]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+FF-FF-FF-FF-FF-FF       0600    XNS packets, Hello or gateway search?
+                                6 packets every 15 seconds, per XNS
+                                station
+FF-FF-FF-FF-FF-FF       0800    IP (e.g. RWHOD via UDP) as needed
+FF-FF-FF-FF-FF-FF       0804    CHAOS
+FF-FF-FF-FF-FF-FF       0806    ARP (for IP and CHAOS) as needed
+FF-FF-FF-FF-FF-FF       0BAD    Banyan
+FF-FF-FF-FF-FF-FF       1600    VALID packets, Hello or gateway
+                                search?
+                                1 packets every 30 seconds, per VALID
+                                station
+FF-FF-FF-FF-FF-FF       8035    Reverse ARP
+FF-FF-FF-FF-FF-FF       807C    Merit Internodal (INP)
+FF-FF-FF-FF-FF-FF       809B    EtherTalk
+
+
+
+
+REFERENCES
+
+[RFC894]  Hornig, C., "A Standard for the Transmission of IP Datagrams
+          over Ethernet Networks, STD 41, RFC 894, Symbolics,
+          April 1984.
+
+[RFC895]  Postel, J., "A Standard for the Transmission of IP Datagrams
+          over Experimental Ethernet Networks, STD 42, RFC 895,
+          USC/Information Sciences Institute, April 1984.
+
+[RFC1112]  Deeering, S., "Host Extensions for IP Multicasting",
+           STD 5, RFC 1112, Stanford University, August 1989.
+
+PEOPLE
+
+[AXC] Andrew Cherenson <arc@SGI.COM>
+
+[DCP1] David Plummer <DCP@SCRC-QUABBIN.ARPA>
+
+[DT15] Daniel Tappan <Tappan@BBN.COM>
+
+[HWB] Hans-Werner Braun <HWB@MCR.UMICH.EDU>
+
+[JBP] Jon Postel <postel@isi.edu>
+
+[JKR1] Joyce K. Reynolds <jkrey@isi.edu>
+
+[JXM] Joseph Murdock <---none--->
+
+[XEROX] Fonda Pallone (415-813-7164)
+
+
+
+Reynolds & Postel                                             [Page 178]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/ethernet-numbers
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                             [Page 179]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+X.25 TYPE NUMBERS
+
+
+CCITT defines the high order two bits of the first octet of call user
+data as follows:
+
+
+00 - Used for other CCITT recomendations (such as X.29)
+01 - Reserved for use by "national" administrative
+     authorities
+10 - Reserved for use by international administrative authoorities
+11 - Reserved for arbitrary use between consenting DTEs
+
+Call User Data (hex)     Protocol                      Reference
+-------------------      --------                      ---------
+
+01                       PAD                               [GS2]
+C5                       Blacker front-end descr dev       [AGM]
+CC                       IP                         [RFC877,AGM]*
+CD                       ISO-IP                            [AGM]
+CF                       PPP                           [RFC1598]
+DD                       Network Monitoring                [AGM]
+
+*NOTE: ISO SC6/WG2 approved assignment in ISO 9577 (January 1990).
+
+
+REFERENCES
+
+[RFC877] Korb, J., "A Standard for the Transmission of IP Datagrams
+         Over Public Data Networks", RFC 877, Purdue University,
+         September 1983.
+
+[RFC1598] Simpson, W., "PPPin X.25", RFC 1598, Daydreamer, March 1994.
+
+
+PEOPLE
+
+[AGM]     Andy Malis <malis_a@timeplex.com>
+
+[GS2]     Greg Satz  <satz@CISCO.COM>
+
+[]
+
+
+
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/x25-type-numbers
+
+
+
+Reynolds & Postel                                             [Page 180]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+PUBLIC DATA NETWORK NUMBERS
+
+
+One of the Internet Class A Networks is the international system of
+Public Data Networks.  This section lists the mapping between the
+Internet Addresses and the Public Data Network Addresses (X.121).
+
+
+Assignments:
+
+
+  Internet           Public Data Net    Description     References
+  --------------   -----------------   -----------      ----------
+ 014.000.000.000                       Reserved              [JBP]
+ 014.000.000.001   3110-317-00035 00   PURDUE-TN              [TN]
+ 014.000.000.002   3110-608-00027 00   UWISC-TN               [TN]
+ 014.000.000.003   3110-302-00024 00   UDEL-TN                [TN]
+ 014.000.000.004   2342-192-00149 23   UCL-VTEST              [PK]
+ 014.000.000.005   2342-192-00300 23   UCL-TG                 [PK]
+ 014.000.000.006   2342-192-00300 25   UK-SATNET              [PK]
+ 014.000.000.007   3110-608-00024 00   UWISC-IBM            [MS56]
+ 014.000.000.008   3110-213-00045 00   RAND-TN               [MO2]
+ 014.000.000.009   2342-192-00300 23   UCL-CS                 [PK]
+ 014.000.000.010   3110-617-00025 00   BBN-VAN-GW           [JD21]
+ 014.000.000.011   2405-015-50300 00   CHALMERS              [UXB]
+ 014.000.000.012   3110-713-00165 00   RICE                 [PAM6]
+ 014.000.000.013   3110-415-00261 00   DECWRL               [PAM6]
+ 014.000.000.014   3110-408-00051 00   IBM-SJ               [SXA3]
+ 014.000.000.015   2041-117-01000 00   SHAPE                 [JFW]
+ 014.000.000.016   2628-153-90075 00   DFVLR4-X25            [GB7]
+ 014.000.000.017   3110-213-00032 00   ISI-VAN-GW           [JD21]
+ 014.000.000.018   2624-522-80900 52   FGAN-SIEMENS-X25      [GB7]
+ 014.000.000.019   2041-170-10000 00   SHAPE-X25             [JFW]
+ 014.000.000.020   5052-737-20000 50   UQNET                 [AXH]
+ 014.000.000.021   3020-801-00057 50   DMC-CRC1              [VXT]
+ 014.000.000.022   2624-522-80329 02   FGAN-FGANFFMVAX-X25   [GB7]
+ 014.000.000.023   2624-589-00908 01   ECRC-X25              [PXD]
+ 014.000.000.024   2342-905-24242 83   UK-MOD-RSRE          [JXE2]
+ 014.000.000.025   2342-905-24242 82   UK-VAN-RSRE           [AXM]
+ 014.000.000.026   2624-522-80329 05   DFVLRSUN-X25          [GB7]
+ 014.000.000.027   2624-457-11015 90   SELETFMSUN-X25        [BXD]
+ 014.000.000.028   3110-408-00146 00   CDC-SVL             [RAM57]
+ 014.000.000.029   2222-551-04400 00   SUN-CNUCE            [ABB2]
+ 014.000.000.030   2222-551-04500 00   ICNUCEVM-CNUCE       [ABB2]
+ 014.000.000.031   2222-551-04600 00   SPARE-CNUCE          [ABB2]
+ 014.000.000.032   2222-551-04700 00   ICNUCEVX-CNUCE       [ABB2]
+ 014.000.000.033   2222-551-04524 00   CISCO-CNUCE          [ABB2]
+ 014.000.000.034   2342-313-00260 90   SPIDER-GW            [AD67]
+
+
+
+Reynolds & Postel                                             [Page 181]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+ 014.000.000.035   2342-313-00260 91   SPIDER-EXP           [AD67]
+ 014.000.000.036   2342-225-00101 22   PRAXIS-X25A           [TXR]
+ 014.000.000.037   2342-225-00101 23   PRAXIS-X25B           [TXR]
+ 014.000.000.038   2403-712-30250 00   DIAB-TABY-GW          [FXB]
+ 014.000.000.039   2403-715-30100 00   DIAB-LKP-GW           [FXB]
+ 014.000.000.040   2401-881-24038 00   DIAB-TABY1-GW         [FXB]
+ 014.000.000.041   2041-170-10060 00   STC                  [TC27]
+ 014.000.000.042   2222-551-00652 60   CNUCE                [TC27]
+ 014.000.000.043   2422-510-05900 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.044   2422-670-08900 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.045   2422-516-01000 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.046   2422-450-00800 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.047   2422-610-00200 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.048   2422-310-00300 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.049   2422-470-08800 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.050   2422-210-04600 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.051   2422-130-28900 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.052   2422-310-27200 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.053   2422-250-05800 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.054   2422-634-05900 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.055   2422-670-08800 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.056   2422-430-07400 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.057   2422-674-07800 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.058   2422-230-16900 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.059   2422-518-02900 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.060   2422-370-03100 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.061   2422-516-03400 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.062   2422-616-04400 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.063   2422-650-23500 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.064   2422-330-02500 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.065   2422-350-01900 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.066   2422-410-00700 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.067   2422-539-06200 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.068   2422-630-07200 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.069   2422-470-12300 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.070   2422-470-13000 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.071   2422-170-04600 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.072   2422-516-04300 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.073   2422-530-00700 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.074   2422-650-18800 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.075   2422-450-24500 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.076   2062-243-15631 00   DPT-BXL-DDC          [LZ15]
+ 014.000.000.077   2062-243-15651 00   DPT-BXL-DDC2         [LZ15]
+ 014.000.000.078   3110-312-00431 00   DPT-CHI              [LZ15]
+ 014.000.000.079   3110-512-00135 00   DPT-SAT-ENG          [LZ15]
+ 014.000.000.080   2080-941-90550 00   DPT-PAR              [LZ15]
+ 014.000.000.081   4545-511-30600 00   DPT-PBSC             [LZ15]
+ 014.000.000.082   4545-513-30900 00   DPT-HONGKONG         [LZ15]
+
+
+
+Reynolds & Postel                                             [Page 182]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+ 014.000.000.083   4872-203-55000 00   UECI-TAIPEI          [LZ15]
+ 014.000.000.084   2624-551-10400 20   DPT-HANOVR           [LZ15]
+ 014.000.000.085   2624-569-00401 99   DPT-FNKFRT           [LZ15]
+ 014.000.000.086   3110-512-00134 00   DPT-SAT-SUPT         [LZ15]
+ 014.000.000.087   4602-3010-0103 20   DU-X25A              [JK64]
+ 014.000.000.088   4602-3010-0103 21   FDU-X25B             [JK64]
+ 014.000.000.089   2422-150-33700 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.090   2422-271-07100 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.091   2422-516-00100 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.092   2422-650-18800 00   Norsk Informas.       [OXG]
+ 014.000.000.093   2422-250-30400 00   Tollpost-Globe AS     [OXG]
+ 014.000.000.094                       Leissner Data AB     [PXF1]
+ 014.000.000.095                       Leissner Data AB     [PXF1]
+ 014.000.000.096                       Leissner Data AB     [PXF1]
+ 014.000.000.097                       Leissner Data AB     [PXF1]
+ 014.000.000.098                       Leissner Data AB     [PXF1]
+ 014.000.000.099                       Leissner Data AB     [PXF1]
+ 014.000.000.100                       Leissner Data AB     [PXF1]
+ 014.000.000.101                       Leissner Data AB     [PXF1]
+ 014.000.000.102                       Leissner Data AB     [PXF1]
+ 014.000.000.103                       Leissner Data AB     [PXF1]
+ 014.000.000.104                       Leissner Data AB     [PXF1]
+ 014.000.000.105                       Leissner Data AB     [PXF1]
+ 014.000.000.106                       Leissner Data AB     [PXF1]
+ 014.000.000.107                       Leissner Data AB     [PXF1]
+ 014.000.000.108                       Leissner Data AB     [PXF1]
+ 014.000.000.109                       Leissner Data AB     [PXF1]
+ 014.000.000.110                       Leissner Data AB     [PXF1]
+ 014.000.000.111                       Leissner Data AB     [PXF1]
+ 014.000.000.112                       Leissner Data AB     [PXF1]
+ 014.000.000.113                       Leissner Data AB     [PXF1]
+ 014.000.000.114                       Leissner Data AB     [PXF1]
+ 014.000.000.115                       Leissner Data AB     [PXF1]
+ 014.000.000.116                       Leissner Data AB     [PXF1]
+ 014.000.000.117                       Leissner Data AB     [PXF1]
+ 014.000.000.118                       Leissner Data AB     [PXF1]
+ 014.000.000.119                       Leissner Data AB     [PXF1]
+ 014.000.000.120                       Leissner Data AB     [PXF1]
+ 014.000.000.121                       Leissner Data AB     [PXF1]
+ 014.000.000.122                       Leissner Data AB     [PXF1]
+ 014.000.000.123                       Leissner Data AB     [PXF1]
+ 014.000.000.124                       Leissner Data AB     [PXF1]
+ 014.000.000.125                       Leissner Data AB     [PXF1]
+ 014.000.000.126                       Leissner Data AB     [PXF1]
+ 014.000.000.127                       Leissner Data AB     [PXF1]
+ 014.000.000.128                       Leissner Data AB     [PXF1]
+ 014.000.000.129  2422-150-17900 00    Tollpost-Globe AS     [OXG]
+ 014.000.000.130  2422-150-42700 00    Tollpost-Globe AS     [OXG]
+
+
+
+Reynolds & Postel                                             [Page 183]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+ 014.000.000.131  2422-190-41900 00    T-G Airfreight AS     [OXG]
+ 014.000.000.132  2422-616-16100 00    Tollpost-Globe AS     [OXG]
+ 014.000.000.133  2422-150-50700-00    Tollpost-Globe Int.   [OXG]
+ 014.000.000.134  2422-190-28100-00    Intersped AS          [OXG]
+
+ 014.000.000.135-014.255.255.254       Unassigned            [JBP]
+ 014.255.255.255                       Reserved              [JBP]
+
+The standard for transmission of IP datagrams over the Public Data
+Network is specified in RFC-1356 [69].
+
+REFERENCES
+
+[RFC877] Korb, J., "A Standard for the Transmission of IP Datagrams
+         Over Public Data Networks", RFC 877, Purdue University,
+         September 1983.
+
+
+PEOPLE
+
+[ABB2] A. Blasco Bonito <blasco@ICNUCEVM.CNUCE.CNR.IT>
+
+[AD67] Andy Davis <andy@SPIDER.CO.UK>
+
+[AXH] Arthur Harvey <harvey@gah.enet.dec.com>
+
+[AXM] Alex Martin <---none--->
+
+[BXD] Brian Dockter <---none--->
+
+[FXB] <mystery contact>
+
+[GB7] Gerd Beling <GBELING@ISI.EDU>
+
+[JBP] Jon Postel <postel@isi.edu.
+
+[JD21] Jonathan Dreyer <Dreyer@CCV.BBN.COM>
+
+[JFW] Jon F. Wilkes <Wilkes@CCINT1.RSRE.MOD.UK>
+
+[JK64] mystery contact!
+
+[JXE2] Jeanne Evans <JME%RSRE.MOD.UK@CS.UCL.AC.UK>
+
+[LZ15] Lee Ziegenhals <lcz@sat.datapoint.com>
+
+[MS56] Marvin Solomon <solomon@CS.WISC.EDU>
+
+
+
+
+Reynolds & Postel                                             [Page 184]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[MO2] Michael O'Brien <obrien@AEROSPACE.AERO.ORG>
+
+[OXG] Oyvind Gjerstad <ogj%tglobe2.UUCP@nac.no>
+
+[PAM6] Paul McNabb <pam@PURDUE.EDU>
+
+[PK] Peter Kirstein <Kirstein@NSS.CS.UCL.AC.UK>
+
+[PXD] Peter Delchiappo <---none--->
+
+[PXF1] Per Futtrup <---none--->
+
+[RAM57] Rex Mann <---none--->
+
+[SXA3] Sten Andler <---none--->
+
+[TN] Thomas Narten <narten@PURDUE.EDU>
+
+[TC27] Thomas Calderwood <TCALDERW@BBN.COM>
+
+[TXR] Tim Rylance <praxis!tkr@UUNET.UU.NET>
+
+[UXB] <mystery contact>
+
+[VXT] V. Taylor <vktaylor@NCS.DND.CA>
+
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/public-data-network-
+numbers
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                             [Page 185]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+MILNET LINK NUMBERS
+
+
+The word "link" here refers to a field in the original MILNET Host/IMP
+interface leader.  The link was originally defined as an 8-bit field.
+Later specifications defined this field as the "message-id" with a
+length of 12 bits.  The name link now refers to the high order 8 bits of
+this 12-bit message-id field.  The Host/IMP interface is defined in BBN
+Report 1822 [BBN1822].
+
+The low-order 4 bits of the message-id field are called the sub-link.
+Unless explicitly specified otherwise for a particular protocol, there
+is no sender to receiver significance to the sub-link.  The sender may
+use the sub-link in any way he chooses (it is returned in the RFNM by
+the destination IMP), the receiver should ignore the sub-link.
+
+
+Link Assignments:
+
+Decimal   Description                                   References
+-------   -----------                                   ----------
+0-63      BBNCC Monitoring                                    [MB]
+64-149    Unassigned                                         [JBP]
+150       Xerox NS IDP                            [ETHERNET,XEROX]
+151       Unassigned                                         [JBP]
+152       PARC Universal Protocol                      [PUP,XEROX]
+153       TIP Status Reporting                               [JGH]
+154       TIP Accounting                                     [JGH]
+155       Internet Protocol [regular]                 [RFC791,JBP]
+156-158   Internet Protocol [experimental]            [RFC791,JBP]
+159       Figleaf Link                                      [JBW1]
+160       Blacker Local Network Protocol                    [DM28]
+161-194   Unassigned                                         [JBP]
+195       ISO-IP                                      [RFC926,RXM]
+196-247   Experimental Protocols                             [JBP]
+248-255   Network Maintenance                                [JGH]
+
+
+
+MILNET LOGICAL ADDRESSES
+
+The MILNET facility for "logical addressing" is described in [RFC878]
+and [RFC1005].  A portion of the possible logical addresses are
+reserved for standard uses.
+
+There are 49,152 possible logical host addresses.  Of these, 256 are
+reserved for assignment to well-known functions.  Assignments for
+well-known functions are made by the IANA.  Assignments for other
+
+
+
+Reynolds & Postel                                             [Page 186]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+logical host addresses are made by the NIC.
+
+
+Logical Address Assignments:
+
+Decimal    Description                                  References
+-------    -----------                                  ----------
+0          Reserved                                          [JBP]
+1          The BBN Core Gateways                              [MB]
+2-254      Unassigned                                        [JBP]
+255        Reserved                                          [JBP]
+
+
+
+MILNET X.25 ADDRESS MAPPINGS
+
+
+All MILNET hosts are assigned addresses by the Defense Data Network
+(DDN).  The address of a MILNET host may be obtained from the Network
+Information Center (NIC), represented as an ASCII text string in what
+is called "host table format".  This section describes the process by
+which MILNET X.25 addresses may be derived from addresses in the NIC
+host table format.
+
+A NIC host table address consists of the ASCII text string
+representations of four decimal numbers separated by periods,
+corresponding to the four octeted of a thirty-two bit Internet
+address.  The four decimal numbers are referred to in this section as
+"n", "h' "l", and "i".  Thus, a host table address may be represented
+as: "n.h.l.i".  Each of these four numbers will have either one, two,
+or three decimal digits and will never have a value greater than 255.
+For example, in the host table, address: "10.2.0.124", n=10, h=2, l=0,
+and i=124.  To convert a host table address to a MILNET X.25 address:
+
+1.  If h < 64, the host table address corresponds to the X.25
+physical address:
+
+
+ZZZZ F IIIHHZZ (SS)
+
+where:
+
+     ZZZZ = 0000    as required
+
+     F = 0          because the address is a physical address;
+
+     III            is a three decimal digit respresentation of
+                    "i", right-adjusted and padded with leading
+
+
+
+Reynolds & Postel                                             [Page 187]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+                    zeros if required;
+
+     HH             is a two decimal digit representation of "h",
+                    right-adjusted and padded with leading zeros
+                    if required;
+
+     ZZ = 00        and
+
+     (SS)           is optional
+
+
+In the example given above, the host table address 10.2.0.124
+corresponds to the X.25 physical address 000001240200.
+
+2.  If h > 64 or h = 64, the host table address corresponds to the
+X.25 logical address
+
+
+ZZZZ F RRRRRZZ (SS)
+
+where:
+
+     ZZZZ = 0000    as required
+
+     F = 1          because the address is a logical address;
+
+     RRRRR          is a five decimal digit representation of
+                    the result "r" of the calculation
+
+                             r = h * 256 + i
+
+                    (Note that the decimal representation of
+                    "r" will always require five digits);
+
+     ZZ = 00        and
+
+     (SS)           is optional
+
+Thus, the host table address 10.83.0.207 corresponds to the X.25
+logical address 000012145500.
+
+In both cases, the "n" and "l" fields of the host table address are
+not used.
+
+
+REFERENCES
+
+[BBN1822] BBN, "Specifications for the Interconnection of a Host and
+
+
+
+Reynolds & Postel                                             [Page 188]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+          an IMP", Report 1822, Bolt Beranek and Newman, Cambridge,
+          Massachusetts, revised, December 1981.
+
+[ETHERNET] "The Ethernet, A Local Area Network: Data Link Layer and
+           Physical Layer Specification", AA-K759B-TK, Digital
+           Equipment Corporation, Maynard, MA.  Also as: "The Ethernet
+           - A Local Area Network", Version 1.0, Digital Equipment
+           Corporation, Intel Corporation, Xerox Corporation,
+           September 1980.  And: "The Ethernet, A Local Area Network:
+           Data Link Layer and Physical Layer Specifications",
+           Digital, Intel and Xerox, November 1982.  And: XEROX, "The
+           Ethernet, A Local Area Network: Data Link Layer and
+           Physical Layer Specification", X3T51/80-50, Xerox
+           Corporation, Stamford, CT., October 1980.
+
+[PUP] Boggs, D., J. Shoch, E. Taft, and R. Metcalfe, "PUP: An
+      Internetwork Architecture", XEROX Palo Alto Research Center,
+      CSL-79-10, July 1979; also in IEEE Transactions on
+      Communication, Volume COM-28, Number 4, April 1980.
+
+[RFC791] Postel, J., ed., "Internet Protocol - DARPA Internet Program
+         Protocol Specification", STD 5, RFC 791, USC/Information
+         Sciences Institute, September 1981.
+
+[RFC878] Malis, Andrew, "The ARPANET 1822L Host Access Protocol",
+         RFC 878, BBN Communications Corp., December 1983.
+
+[RFC926] International Standards Organization, "Protocol for Providing
+         the Connectionless-Mode Network Services", RFC 926, ISO,
+         December 1984.
+
+[RFC1005] Khanna, A., and A. Malis, "The ARPANET AHIP-E Host Access
+          Protocol (Enhanced AHIP)", RFC 1005, BBN Communications
+          Corp., May 1987.
+
+
+PEOPLE
+
+[DM28] Dennis Morris  <Morrisd@IMO-UVAX.DCA.MIL>
+
+[JBP] Jon Postel <postel@isi.edu>
+
+[JBW1] Joseph Walters, Jr. <JWalters@BBN.COM>
+
+[JGH] Jim Herman <Herman@CCJ.BBN.COM>
+
+[MB] Michael Brescia <Brescia@CCV.BBN.COM>
+
+
+
+
+Reynolds & Postel                                             [Page 189]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[RXM] Robert Myhill <Myhill@CCS.BBN.COM>
+
+[XEROX] Fonda Pallone <---none--->
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/milnet-parameters
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                             [Page 190]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+XNS PROTOCOL TYPES
+
+
+Assigned well-known socket numbers
+
+        Routing Information             1
+        Echo                            2
+        Router Error                    3
+        Experimental                40-77
+
+Assigned internet packet types
+
+        Routing Information             1
+        Echo                            2
+        Error                           3
+        Packet Exchange                 4
+        Sequenced Packet                5
+        PUP                            12
+        DoD IP                         13
+        Experimental                20-37
+
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/xns-protocol-types
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                             [Page 191]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+INTERNET / XNS PROTOCOL MAPPINGS
+
+
+Below are two tables describing the arrangement of protocol fields or
+type field assignments so that one could send XNS Datagrams on the
+MILNET or Internet Datagrams on 10Mb Ethernet, and also protocol and
+type fields so one could encapsulate each kind of Datagram in the
+other.
+
+
+        upper| DoD IP |  PUP   | NS IP  |
+lower        |        |        |        |
+--------------|--------|--------|--------|
+              |  Type  |  Type  |  Type  |
+3Mb Ethernet  |  1001  |  1000  |  3000  |
+              |  octal |  octal |  octal |
+--------------|--------|--------|--------|
+              |  Type  |  Type  |  Type  |
+10 Mb Ethernet|  0800  |  0200  |  0600  |
+              |   hex  |   hex  |   hex  |
+--------------|--------|--------|--------|
+              |  Link  |  Link  |  Link  |
+MILNET        |  155   |  152   |  150   |
+              | decimal| decimal| decimal|
+--------------|--------|--------|--------|
+
+
+
+        upper| DoD IP |  PUP   | NS IP  |
+lower        |        |        |        |
+--------------|--------|--------|--------|
+              |        |Protocol|Protocol|
+DoD IP        |   X    |   12   |   22   |
+              |        | decimal| decimal|
+--------------|--------|--------|--------|
+              |        |        |        |
+PUP           |   ?    |   X    |   ?    |
+              |        |        |        |
+--------------|--------|--------|--------|
+              |  Type  |  Type  |        |
+NS IP         |   13   |   12   |   X    |
+              | decimal| decimal|        |
+--------------|--------|--------|--------|
+
+
+
+[]
+
+
+
+
+Reynolds & Postel                                             [Page 192]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/ip-xns-mapping
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                             [Page 193]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+PRONET 80 TYPE NUMBERS
+
+
+Below is the current list of PRONET 80 Type Numbers.  Note: a protocol
+that is on this list does not necessarily mean that there is any
+implementation of it on ProNET.
+
+Of these, protocols 1, 14, and 20 are the only ones that have ever
+been seen in ARP packets.
+
+For reference, the header is (one byte/line):
+
+        destination hardware address
+        source hardware address
+        data link header version (2)
+        data link header protocol number
+        data link header reserved (0)
+        data link header reserved (0)
+
+Some protocols have been known to tuck stuff in the reserved fields.
+
+Those who need a protocol number on ProNET-10/80 should contact John
+Shriver (jas@proteon.com).
+
+
+1       IP
+2       IP with trailing headers
+3       Address Resolution Protocol
+4       Proteon HDLC
+5       VAX Debugging Protocol (MIT)
+10      Novell NetWare (IPX and pre-IPX) (old format,
+        3 byte trailer)
+11      Vianetix
+12      PUP
+13      Watstar protocol (University of Waterloo)
+14      XNS
+15      Diganostics
+16      Echo protocol (link level)
+17      Banyan Vines
+20      DECnet (DEUNA Emulation)
+21      Chaosnet
+23      IEEE 802.2 or ISO 8802/2 Data Link
+24      Reverse Address Resolution Protocol
+29      TokenVIEW-10
+31      AppleTalk LAP Data Packet
+33      Cornell Boot Server Location Protocol
+34      Novell NetWare IPX (new format, no trailer,
+        new XOR checksum)
+
+
+
+Reynolds & Postel                                             [Page 194]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/pronet80-type-numbers
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                             [Page 195]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+NOVELL SAP NUMBERS OF INTEREST
+
+For the convenience of the Internet community the IANA maitains a list
+of Novell Service Access Point (SAP) numbers.  This list is kept
+up-to-date- by contributions from the community.  Please send
+corrections and additions to IANA@ISI.EDU.
+
+Novell SAPs
+====== ====
+
+Decimal Hex     SAP Description
+======= ====    ===============
+
+0       0000    Unknown
+1       0001    User
+2       0002    User Group
+3       0003    Print Queue or Print Group
+4       0004    File Server (SLIST source)
+5       0005    Job Server
+6       0006    Gateway
+7       0007    Print Server or Silent Print Server
+8       0008    Archive Queue
+9       0009    Archive Server
+10      000a    Job Queue
+11      000b    Administration
+15      000F    Novell TI-RPC
+23      0017    Diagnostics
+32      0020    NetBIOS
+33      0021    NAS SNA Gateway
+35      0023    NACS Async Gateway or Asynchronous Gateway
+36      0024    Remote Bridge or Routing Service
+38      0026    Bridge Server or Asynchronous Bridge Server
+39      0027    TCP/IP Gateway Server
+40      0028    Point to Point (Eicon) X.25 Bridge Server
+41      0029    Eicon 3270 Gateway
+42      002a    CHI Corp ???
+44      002c    PC Chalkboard
+45      002d    Time Synchronization Server or Asynchronous Timer
+46      002e    SAP Archive Server or SMS Target Service Agent
+69      0045    DI3270 Gateway
+71      0047    Advertising Print Server
+75      004b    Btrieve VAP/NLM 5.0
+76      004c    Netware SQL VAP/NLM Server
+77      004d    Xtree Network Version Netware XTree
+80      0050    Btrieve VAP 4.11
+82      0052    QuickLink (Cubix)
+83      0053    Print Queue User
+88      0058    Multipoint X.25 Eicon Router
+
+
+
+Reynolds & Postel                                             [Page 196]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+96      0060    STLB/NLM ???
+100     0064    ARCserve
+102     0066    ARCserve 3.0
+114     0072    WAN Copy Utility
+122     007a    TES-Netware for VMS
+146     0092    WATCOM Debugger or Emerald Tape Backup Server
+149     0095    DDA OBGYN ???
+152     0098    Netware Access Server (Asynchronous gateway)
+154     009a    Netware for VMS II or Named Pipe Server
+155     009b    Netware Access Server
+158     009e    Portable Netware Server or SunLink NVT
+161     00a1    Powerchute APC UPS NLM
+170     00aa    LAWserve ???
+172     00ac    Compaq IDA Status Monitor
+256     0100    PIPE STAIL ???
+258     0102    LAN Protect Bindery
+259     0103    Oracle DataBase Server
+263     0107    Netware 386 or RSPX Remote Console
+271     010f    Novell SNA Gateway
+274     0112    Print Server (HP)
+276     0114    CSA MUX (f/Communications Executive)
+277     0115    CSA LCA (f/Communications Executive)
+278     0116    CSA CM  (f/Communications Executive)
+279     0117    CSA SMA (f/Communications Executive)
+280     0118    CSA DBA (f/Communications Executive)
+281     0119    CSA NMA (f/Communications Executive)
+282     011a    CSA SSA (f/Communications Executive)
+283     011b    CSA STATUS (f/Communications Executive)
+286     011e    CSA APPC   (f/Communications Executive)
+294     0126    SNA TEST SSA Profile
+298     012a    CSA TRACE  (f/Communications Executive)
+304     0130    Communications Executive
+307     0133    NNS Domain Server or Netware Naming Services Domain
+309     0135    Netware Naming Services Profile
+311     0137    Netware 386 Print Queue or NNS Print Queue
+321     0141    LAN Spool Server (Vap, Intel)
+338     0152    IRMALAN Gateway
+340     0154    Named Pipe Server
+360     0168    Intel PICKIT Comm Server or Intel CAS Talk Server
+369     171     UNKNOWN???
+371     0173    Compaq
+372     0174    Compaq SNMP Agent
+373     0175    Compaq
+384     0180    XTree Server or XTree Tools
+394     18A     UNKNOWN???      Running on a Novell Server
+432     01b0    GARP Gateway (net research)
+433     01b1    Binfview (Lan Support Group)
+447     01bf    Intel LanDesk Manager
+
+
+
+Reynolds & Postel                                             [Page 197]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+458     01ca    AXTEC ???
+459     01cb    Netmode ???
+460     1CC     UNKNOWN???      Sheva netmodem???
+472     01d8    Castelle FAXPress Server
+474     01da    Castelle LANPress Print Server
+476     1DC     Castille FAX/Xerox 7033 Fax Server/Excel Lan Fax
+496     01f0    LEGATO ???
+501     01f5    LEGATO ???
+563     0233    NMS Agent or Netware Management Agent
+567     0237    NMS IPX Discovery or LANtern Read/Write Channel
+568     0238    NMS IP Discovery or LANtern Trap/Alarm Channel
+570     023a    LABtern
+572     023c    MAVERICK ???
+574     23E     UNKNOWN???      Running on a Novell Server
+575     023f    Used by eleven various Novell Servers
+590     024e    Remote Something ???
+618     026a    Network Management (NMS) Service Console
+619     026b    Time Synchronization Server (Netware 4.x)
+632     0278    Directory Server (Netware 4.x)
+772     0304    Novell SAA Gateway
+776     0308    COM or VERMED 1 ???
+778     030a    Gallacticom BBS
+780     030c    Intel Netport 2 or HP JetDirect or HP Quicksilver
+800     0320    Attachmate Gateway
+807     0327    Microsoft Diagnostiocs ???
+821     0335    MultiTech Systems Multisynch Comm Server
+853     0355    Arcada Backup Exec
+858     0358    MSLCD1 ???
+865     0361    NETINELO ???
+894     037e    Twelve Novell file servers in the PC3M family
+895     037f    ViruSafe Notify
+902     0386    HP Bridge
+903     0387    HP Hub
+916     0394    NetWare SAA Gateway
+923     039b    Lotus Notes
+951     03b7    Certus Anti Virus NLM
+964     03c4    ARCserve 4.0 (Cheyenne)
+967     03c7    LANspool 3.5 (Intel)
+990     03de    Gupta Sequel Base Server or NetWare SQL
+993     03e1    Univel Unixware
+996     03e4    Univel Unixware
+1020    03fc    Intel Netport
+1021    03fd    Print SErver Queue ???
+1034    40A     ipnServer???      Running on a Novell Server
+1035    40B     UNKNOWN???
+1037    40D     LVERRMAN???     Running on a Novell Server
+1038    40E     LVLIC???        Running on a Novell Server
+1040    410     UNKNOWN???      Running on a Novell Server
+
+
+
+Reynolds & Postel                                             [Page 198]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+1044    0414    Kyocera
+1065    0429    Site Lock Virus (Brightworks)
+1074    0432    UFHELP R ???
+1075    433     Sunoptics SNMP Agent???
+1100    044c    Backup ???
+1111    457     Canon GP55???   Running on a Canon GP55 network printer
+1115    045b    Dell SCSI Array (DSA) Monitor
+1200    04b0    CD-Net (Meridian)
+1217    4C1     UNKNOWN???
+1299    513     Emulux NQA???   Something from Emulex
+1312    0520    Site Lock Checks
+1321    0529    Site Lock Checks (Brightworks)
+1325    052d    Citrix OS/2 App Server
+1344    536     Milan ???
+1408    0580    McAfee's NetShield anti-virus
+1569    621     ??              Something from Emulex
+1571    623     UNKNOWN???      Running on a Novell Server
+1900    076C    Xerox
+2857    0b29    Site Lock
+3113    0c29    Site Lock Applications
+3116    0c2c    Licensing Server
+9088    2380    LAI Site Lock
+9100    238c    Meeting Maker
+18440   4808    Site Lock Server or Site Lock Metering VAP/NLM
+21845   5555    Site Lock User
+25362   6312    Tapeware
+28416   6f00    Rabbit Gateway (3270)
+30467   7703    MODEM??
+32770   8002    NetPort Printers (Intel) or LANport
+32776   8008    WordPerfect Network Version
+34238   85BE    Cisco Enhanced Interior Routing Protocol (EIGRP)
+34952   8888    WordPerfect Network Version or Quick Network Management
+36864   9000    McAfee's NetShield anti-virus
+38404   9604    ??              CSA-NT_MON
+61727   f11f    Site Lock Metering VAP/NLM
+61951   f1ff    Site Lock
+62723   F503    ??              SCA-NT
+65535   ffff    Any Service or Wildcard
+
+This file is
+
+        ftp://ftp.isi.edu/in-notes/iana/assignments/novell-sap-numbers
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/novell-sap-numbers
+
+
+
+
+Reynolds & Postel                                             [Page 199]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+POINT-TO-POINT PROTOCOL FIELD ASSIGNMENTS
+
+PPP DLL PROTOCOL NUMBERS
+
+The Point-to-Point Protocol (PPP) Data Link Layer [146,147,175]
+contains a 16 bit Protocol field to identify the the encapsulated
+protocol.  The Protocol field is consistent with the ISO 3309 (HDLC)
+extension mechanism for Address fields.  All Protocols MUST be
+assigned such that the least significant bit of the most significant
+octet equals "0", and the least significant bit of the least
+significant octet equals "1".
+
+Assigned PPP DLL Protocol Numbers
+
+Value (in hex)  Protocol Name
+
+0001            Padding Protocol
+0003 to 001f    reserved (transparency inefficient)
+0021            Internet Protocol
+0023            OSI Network Layer
+0025            Xerox NS IDP
+0027            DECnet Phase IV
+0029            Appletalk
+002b            Novell IPX
+002d            Van Jacobson Compressed TCP/IP
+002f            Van Jacobson Uncompressed TCP/IP
+0031            Bridging PDU
+0033            Stream Protocol (ST-II)
+0035            Banyan Vines
+0037            reserved (until 1993)
+0039            AppleTalk EDDP
+003b            AppleTalk SmartBuffered
+003d            Multi-Link
+003f            NETBIOS Framing
+0041            Cisco Systems
+0043            Ascom Timeplex
+0045            Fujitsu Link Backup and Load Balancing (LBLB)
+0047            DCA Remote Lan
+0049            Serial Data Transport Protocol (PPP-SDTP)
+004b            SNA over 802.2
+004d            SNA
+004f            IP6 Header Compression
+006f            Stampede Bridging
+007d            reserved (Control Escape)             [RFC1661]
+007f            reserved (compression inefficient)    [RFC1662]
+00cf            reserved (PPP NLPID)
+00fb            compression on single link in multilink group
+00fd            1st choice compression
+
+
+
+Reynolds & Postel                                             [Page 200]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+00ff            reserved (compression inefficient)
+
+0201            802.1d Hello Packets
+0203            IBM Source Routing BPDU
+0205            DEC LANBridge100 Spanning Tree
+0231            Luxcom
+0233            Sigma Network Systems
+
+8001-801f       Not Used - reserved                   [RFC1661]
+8021            Internet Protocol Control Protocol
+8023            OSI Network Layer Control Protocol
+8025            Xerox NS IDP Control Protocol
+8027            DECnet Phase IV Control Protocol
+8029            Appletalk Control Protocol
+802b            Novell IPX Control Protocol
+802d            reserved
+802f            reserved
+8031            Bridging NCP
+8033            Stream Protocol Control Protocol
+8035            Banyan Vines Control Protocol
+8037            reserved till 1993
+8039            reserved
+803b            reserved
+803d            Multi-Link Control Protocol
+803f            NETBIOS Framing Control Protocol
+807d            Not Used - reserved                   [RFC1661]
+8041            Cisco Systems Control Protocol
+8043            Ascom Timeplex
+8045            Fujitsu LBLB Control Protocol
+8047            DCA Remote Lan Network Control Protocol (RLNCP)
+8049            Serial Data Control Protocol (PPP-SDCP)
+804b            SNA over 802.2 Control Protocol
+804d            SNA Control Protocol
+804f            IP6 Header Compression Control Protocol
+006f            Stampede Bridging Control Protocol
+80cf            Not Used - reserved                   [RFC1661]
+80fb            compression on single link in multilink group control
+80fd            Compression Control Protocol
+80ff            Not Used - reserved                   [RFC1661]
+
+c021            Link Control Protocol
+c023            Password Authentication Protocol
+c025            Link Quality Report
+c027            Shiva Password Authentication Protocol
+c029            CallBack Control Protocol (CBCP)
+c081            Container Control Protocol                  [KEN]
+c223            Challenge Handshake Authentication Protocol
+c281            Proprietary Authentication Protocol         [KEN]
+
+
+
+Reynolds & Postel                                             [Page 201]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+c26f            Stampede Bridging Authorization Protocol
+c481            Proprietary Node ID Authentication Protocol [KEN]
+
+Protocol field values in the "0xxx" to "3xxx" range identify the
+network-layer protocol of specific datagrams, and values in the "8xxx"
+to "bxxx" range identify datagrams belonging to the associated Network
+Control Protocol (NCP), if any.
+
+It is recommended that values in the "02xx" to "1exx" and "xx01" to
+"xx1f" ranges not be assigned, as they are compression inefficient.
+
+Protocol field values in the "4xxx" to "7xxx" range are used for
+protocols with low volume traffic which have no associated NCP.
+
+Protocol field values in the "cxxx" to "exxx" range identify datagrams
+as Control Protocols (such as LCP).
+
+PPP LCP AND IPCP CODES
+
+The Point-to-Point Protocol (PPP) Link Control Protocol (LCP), [146]
+the Compression Control Protocol (CCP), Internet Protocol Control
+Protocol (IPCP), [147] and other control protocols, contain an 8 bit
+Code field which identifies the type of packet.  These Codes are
+assigned as follows:
+
+Code       Packet Type
+----       -----------
+   1       Configure-Request
+   2       Configure-Ack
+   3       Configure-Nak
+   4       Configure-Reject
+   5       Terminate-Request
+   6       Terminate-Ack
+   7       Code-Reject
+   8     * Protocol-Reject
+   9     * Echo-Request
+  10     * Echo-Reply
+  11     * Discard-Request
+  12     * Identification
+  13     * Time-Remaining
+  14     + Reset-Request
+  15     + Reset-Reply
+
+* LCP Only
++ CCP Only
+
+PPP LCP CONFIGURATION OPTION TYPES
+
+
+
+
+Reynolds & Postel                                             [Page 202]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+The Point-to-Point Protocol (PPP) Link Control Protocol (LCP)
+specifies a number of Configuration Options [146] which are
+distinguished by an 8 bit Type field.  These Types are assigned as
+follows:
+
+Type       Configuration Option
+----       --------------------
+   1       Maximum-Receive-Unit
+   2       Async-Control-Character-Map
+   3       Authentication-Protocol
+   4       Quality-Protocol
+   5       Magic-Number
+   6       RESERVED
+   7       Protocol-Field-Compression
+   8       Address-and-Control-Field-Compression
+   9       FCS-Alternatives
+  10       Self-Describing-Pad
+  11       Numbered-Mode
+  12       Multi-Link-Procedure
+  13       Callback
+  14       Connect-Time
+  15       Compound-Frames
+  16       Nominal-Data-Encapsulation
+  17       Multilink-MRRU
+  18       Multilink-Short-Sequence-Number-Header-Format
+  19       Multilink-Endpoint-Discriminator
+  20       Proprietary                                     [KEN]
+  21       DCE-Identifier                            [SCHNEIDER]
+
+PPP LCP FCS-ALTERNATIVES
+
+The Point-to-Point Protocol (PPP) Link Control Protocol (LCP)
+FCS-Alternatives Configuration Option contains an 8-bit Options field
+which identifies the FCS used.  These are assigned as follows:
+
+Bit     FCS
+----    ----------
+  1     Null FCS
+  2     CCITT 16-Bit FCS
+  4     CCITT 32-bit FCS
+
+
+PPP LCP CALLBACK OPERATION FIELDS
+
+The Point-to-Point Protocol (PPP) Link Control Protocol (LCP) Callback
+Configuration Option contains an 8-bit Operations field which
+identifies the format of the Message.  These are assigned as follows:
+
+
+
+
+Reynolds & Postel                                             [Page 203]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+Operation   Description
+---------   ---------------------------
+        0   Location determined by user authentication.
+        1   Dialing string.
+        2   Location identifier.
+        3   E.164 number.
+        4   X.500 distinguished name.
+        5   unassigned
+        6   Location is determined during CBCP negotiation.
+
+PPP IPCP CONFIGURATION OPTION TYPES
+
+The Point-to-Point Protocol (PPP) Internet Protocol Control Protocol
+(IPCP) specifies a number of Configuration Options [147] which are
+distinguished by an 8 bit Type field.  These Types are assigned as
+follows:
+
+Type       Configuration Option
+----       --------------------
+   1       IP-Addresses (deprecated)
+   2       IP-Compression-Protocol
+   3       IP-Address
+
+PPP ATCP CONFIGURATION OPTION TYPES
+
+The Point-to-Point Protocol (PPP) Apple Talk Control Protocol (ATCP)
+specifies a number of Configuration Options [RFC-1378] which are
+distinguished by an 8 bit Type field.  These Types are assigned as
+follows:
+
+Type       Configuration Option
+----       --------------------
+   1       AppleTalk-Address
+   2       Routing-Protocol
+   3       Suppress-Broadcasts
+   4       AT-Compression-Protocol
+   5       Reserved
+   6       Server-information
+   7       Zone-information
+   8       Default-Router-Address
+
+PPP OSINLCP CONFIGURATION OPTION TYPES
+
+The Point-to-Point Protocol (PPP) OSI Network Layer Control Protocol
+(OSINLCP) specifies a number of Configuration Options [RFC-1377] which
+are distinguished by an 8 bit Type field.  These Types are assigned as
+follows:
+
+
+
+
+Reynolds & Postel                                             [Page 204]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+Type       Configuration Option
+----       --------------------
+   1       Align-NPDU
+
+PPP BRIDGING CONFIGURATION OPTION TYPES
+
+The Point-to-Point Protocol (PPP) Bridging Control Protocol (BCP)
+specifies a number of Configuration Options which are distinguished by
+an 8 bit Type field.  These Types are assigned as follows:
+
+Type       Configuration Option
+----       --------------------
+   1       Bridge-Identification
+   2       Line-Identification
+   3       MAC-Support
+   4       Tinygram-Compression
+   5       LAN-Identification
+   6       MAC-Address
+   7       Spanning-Tree-Protocol
+
+PPP BRIDGING MAC TYPES
+
+The Point-to-Point Protocol (PPP) Bridging Control Protocol (BCP)
+contains an 8 bit MAC Type field which identifies the MAC
+encapsulated.  These Types are assigned as follows:
+
+Type       MAC
+----       -----------
+   0       Reserved
+   1       IEEE 802.3/Ethernet   with cannonical addresses
+   2       IEEE 802.4            with cannonical addresses
+   3       IEEE 802.5            with non-cannonical addresses
+   4       FDDI                  with non-cannonical addresses
+ 5-10      reserved
+  11       IEEE 802.5            with cannonical addresses
+  12       FDDI                  with cannonical addresses
+
+PPP BRIDGING SPANNING TREE
+
+The Point-to-Point Protocol (PPP) Bridging Control Protocol (BCP)
+Spanning Tree Configuration Option contains an 8-bit Protocol field
+which identifies the spanning tree used.  These are assigned as
+follows:
+
+Protocol  Spanning Tree
+--------  ---------------
+   0      Null - no spanning tree protocol supported
+   1      IEEE 802.1D spanning tree protocol
+
+
+
+Reynolds & Postel                                             [Page 205]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+   2      IEEE 802.1G extended spanning tree protocol
+   3      IBM source route spanning tree protocol
+   4      DEC LANbridge 100 spanning tree protocol
+
+
+REFERENCES
+
+[RFC1661] Simpson, W., Editor, "The Point-to-Point Protocol (PPP)",
+          STD 51, RFC 1661, Daydreamer, July 1994.
+
+[RFC1662] Simpson, W., Editor, "PPP in HDLC-like Framing", STD 51, RFC
+          1662, Daydreamer, July 1994.
+
+
+PEOPLE
+
+[KEN]  <ken@funk.com>
+
+[SCHNEIDER] Kevin Schneider <kevin@adtran.com>
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/ppp-numbers
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                             [Page 206]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+MACHINE NAMES
+
+
+These are the Official Machine Names as they appear in the Domain Name
+System HINFO records and the NIC Host Table.  Their use is described
+in [RFC952].
+
+A machine name or CPU type may be up to 40 characters taken from the
+set of uppercase letters, digits, and the two punctuation characters
+hyphen and slash.  It must start with a letter, and end with a letter
+or digit.
+
+AMIGA-500
+AMIGA-500/010
+AMIGA-500/020
+AMIGA-500/EC030
+AMIGA-500/030
+AMIGA-600
+AMIGA-1000
+AMIGA-1000/010
+AMIGA-1000/020
+AMIGA-1000/EC030
+AMIGA-1000/030
+AMIGA-1200
+AMIGA-1200/EC030
+AMIGA-1200/030
+AMIGA-1200/EC040
+AMIGA-1200/LC040
+AMIGA-1200/040
+AMIGA-2000
+AMIGA-2000/010
+AMIGA-2000/020
+AMIGA-2000/EC030
+AMIGA-2000/030
+AMIGA-2000/LC040
+AMIGA-2000/EC040
+AMIGA-2000/040
+AMIGA-3000
+AMIGA-3000/EC040
+AMIGA-3000/LC040
+AMIGA-3000/040
+AMIGA-3000/060
+AMIGA-4000/EC030
+AMIGA-4000/030
+AMIGA-4000/LC040
+AMIGA-4000/040
+AMIGA-4000/060
+ALTO
+
+
+
+Reynolds & Postel                                             [Page 207]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+ALTOS-6800
+AMDAHL-V7
+APOLLO
+APPLE-MACINTOSH
+APPLE-POWERBOOK
+ATARI-104ST
+ATT-3B1
+ATT-3B2
+ATT-3B20
+ATT-7300
+AXP
+BBN-C/60
+BURROUGHS-B/29
+BURROUGHS-B/4800
+BUTTERFLY
+C/30
+C/70
+CADLINC
+CADR
+CDC-170
+CDC-170/750
+CDC-173
+CDTV
+CDTV/060
+CD32
+CELERITY-1200
+CLUB-386
+COMPAQ-386/20
+COMTEN-3690
+CP8040
+CRAY-1
+CRAY-X/MP
+CRAY-2
+CTIWS-117
+DANDELION
+DEC-10
+DEC-1050
+DEC-1077
+DEC-1080
+DEC-1090
+DEC-1090B
+DEC-1090T
+DEC-2020T
+DEC-2040
+DEC-2040T
+DEC-2050T
+DEC-2060
+DEC-2060T
+
+
+
+Reynolds & Postel                                             [Page 208]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+DEC-2065
+DEC-AXP
+DEC-FALCON
+DEC-KS10
+DECSTATION
+DEC-VAX
+DEC-VAXCLUSTER
+DEC-VAXSTATION
+DEC-VAX-11730
+DORADO
+DPS8/70M
+ELXSI-6400
+EVEREX-386
+FOONLY-F2
+FOONLY-F3
+FOONLY-F4
+GOULD
+GOULD-6050
+GOULD-6080
+GOULD-9050
+GOULD-9080
+H-316
+H-60/68
+H-68
+H-68/80
+H-89
+HONEYWELL-DPS-6
+HONEYWELL-DPS-8/70
+HP3000
+HP3000/64
+IBM-158
+IBM-360/67
+IBM-370/3033
+IBM-3081
+IBM-3084QX
+IBM-3101
+IBM-4331
+IBM-4341
+IBM-4361
+IBM-4381
+IBM-4956
+IBM-6152
+IBM-PC
+IBM-PC/AT
+IBM-PC/RT
+IBM-PC/XT
+IBM-RS/6000
+IBM-SERIES/1
+
+
+
+Reynolds & Postel                                             [Page 209]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+IMAGEN
+IMAGEN-8/300
+IMSAI
+INTEGRATED-SOLUTIONS
+INTEGRATED-SOLUTIONS-68K
+INTEGRATED-SOLUTIONS-CREATOR
+INTEGRATED-SOLUTIONS-CREATOR-8
+INTEL-386
+INTEL-IPSC
+IS-1
+IS-68010
+LMI
+LSI-11
+LSI-11/2
+LSI-11/23
+LSI-11/73
+M68000
+MAC-II
+MAC-POWERBOOK
+MACINTOSH
+MASSCOMP
+MC500
+MC68000
+MICROPORT
+MICROVAX
+MICROVAX-I
+MV/8000
+NAS3-5
+NCR-COMTEN-3690
+NEXT/N1000-316
+NOW
+ONYX-Z8000
+PDP-11
+PDP-11/3
+PDP-11/23
+PDP-11/24
+PDP-11/34
+PDP-11/40
+PDP-11/44
+PDP-11/45
+PDP-11/50
+PDP-11/70
+PDP-11/73
+PE-7/32
+PE-3205
+PERQ
+PLEXUS-P/60
+PLI
+
+
+
+Reynolds & Postel                                             [Page 210]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+PLURIBUS
+PRIME-2350
+PRIME-2450
+PRIME-2755
+PRIME-9655
+PRIME-9755
+PRIME-9955II
+PRIME-2250
+PRIME-2655
+PRIME-9955
+PRIME-9950
+PRIME-9650
+PRIME-9750
+PRIME-2250
+PRIME-750
+PRIME-850
+PRIME-550II
+PYRAMID-90
+PYRAMID-90MX
+PYRAMID-90X
+RIDGE
+RIDGE-32
+RIDGE-32C
+ROLM-1666
+RS/6000
+S1-MKIIA
+SMI
+SEQUENT-BALANCE-8000
+SIEMENS
+SILICON-GRAPHICS
+SILICON-GRAPHICS-IRIS
+SGI-IRIS-2400
+SGI-IRIS-2500
+SGI-IRIS-3010
+SGI-IRIS-3020
+SGI-IRIS-3030
+SGI-IRIS-3110
+SGI-IRIS-3115
+SGI-IRIS-3120
+SGI-IRIS-3130
+SGI-IRIS-4D/20
+SGI-IRIS-4D/20G
+SGI-IRIS-4D/25
+SGI-IRIS-4D/25G
+SGI-IRIS-4D/25S
+SGI-IRIS-4D/50
+SGI-IRIS-4D/50G
+SGI-IRIS-4D/50GT
+
+
+
+Reynolds & Postel                                             [Page 211]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+SGI-IRIS-4D/60
+SGI-IRIS-4D/60G
+SGI-IRIS-4D/60T
+SGI-IRIS-4D/60GT
+SGI-IRIS-4D/70
+SGI-IRIS-4D/70G
+SGI-IRIS-4D/70GT
+SGI-IRIS-4D/80GT
+SGI-IRIS-4D/80S
+SGI-IRIS-4D/120GTX
+SGI-IRIS-4D/120S
+SGI-IRIS-4D/210GTX
+SGI-IRIS-4D/210S
+SGI-IRIS-4D/220GTX
+SGI-IRIS-4D/220S
+SGI-IRIS-4D/240GTX
+SGI-IRIS-4D/240S
+SGI-IRIS-4D/280GTX
+SGI-IRIS-4D/280S
+SGI-IRIS-CS/12
+SGI-IRIS-4SERVER-8
+SPERRY-DCP/10
+SUN
+SUN-2
+SUN-2/50
+SUN-2/100
+SUN-2/120
+SUN-2/130
+SUN-2/140
+SUN-2/150
+SUN-2/160
+SUN-2/170
+SUN-3/50
+SUN-3/60
+SUN-3/75
+SUN-3/80
+SUN-3/110
+SUN-3/140
+SUN-3/150
+SUN-3/160
+SUN-3/180
+SUN-3/200
+SUN-3/260
+SUN-3/280
+SUN-3/470
+SUN-3/480
+SUN-4/60
+SUN-4/110
+
+
+
+Reynolds & Postel                                             [Page 212]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+SUN-4/150
+SUN-4/200
+SUN-4/260
+SUN-4/280
+SUN-4/330
+SUN-4/370
+SUN-4/390
+SUN-50
+SUN-100
+SUN-120
+SUN-130
+SUN-150
+SUN-170
+SUN-386i/250
+SUN-68000
+SYMBOLICS-3600
+SYMBOLICS-3670
+SYMMETRIC-375
+SYMULT
+TANDEM-TXP
+TANDY-6000
+TEK-6130
+TI-EXPLORER
+TP-4000
+TRS-80
+UNIVAC-1100
+UNIVAC-1100/60
+UNIVAC-1100/62
+UNIVAC-1100/63
+UNIVAC-1100/64
+UNIVAC-1100/70
+UNIVAC-1160
+UNKNOWN
+VAX
+VAX-11/725
+VAX-11/730
+VAX-11/750
+VAX-11/780
+VAX-11/785
+VAX-11/790
+VAX-11/8600
+VAX-8600
+VAXCLUSTER
+VAXSTATION
+WANG-PC002
+WANG-VS100
+WANG-VS400
+WYSE-386
+
+
+
+Reynolds & Postel                                             [Page 213]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+WYSE-WN5004
+WYSE-WN5008
+WYSE-WN5104
+WYSE-WN5108
+WYSE-WX15C
+WYSE-WX17C
+WYSE-WX17M
+WYSE-WX19C
+WYSE-WX19M
+WYSE-WYX14M
+WYSE-WYX5
+XEROX-1108
+XEROX-8010
+ZENITH-148
+
+
+REFERENCES
+
+[RFC952] Harrenstien, K., Stahl, M., and E. Feinler, "DoD Internet
+         Host Table Specification", RFC 952, SRI, October 1985.
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/machine-names
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                             [Page 214]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+OPERATING SYSTEM NAMES
+
+
+These are the Official System Names as they appear in the Domain Name
+System HINFO records and the NIC Host Table.  Their use is described in
+[RFC952].
+
+A system name may be up to 40 characters taken from the set of
+uppercase letters, digits, and the three punctuation characters
+hyphen, period, and slash.  It must start with a letter, and end with
+a letter or digit.
+
+
+AEGIS
+AMIGA-OS-1.2
+AMIGA-OS-1.3
+AMIGA-OS-2.0
+AMIGA-OS-2.1
+AMIGA-OS-3.0
+AMIGA-OS-3.1
+APOLLO
+AIX/370
+AIX-PS/2
+BS-2000
+CEDAR
+CGW
+CHORUS
+CHRYSALIS
+CMOS
+CMS
+COS
+CPIX
+CTOS
+CTSS
+DCN
+DDNOS
+DOMAIN
+DOS
+EDX
+ELF
+EMBOS
+EMMOS
+EPOS
+FOONEX
+FORTH
+FUZZ
+GCOS
+GPOS
+
+
+
+Reynolds & Postel                                             [Page 215]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+HDOS
+IMAGEN
+INTERCOM
+IMPRESS
+INTERLISP
+IOS
+IRIX
+ISI-68020
+ITS
+LISP
+LISPM
+LOCUS
+MACOS
+MINOS
+MOS
+MPE5
+MPE/V
+MPE/IX
+MSDOS
+MULTICS
+MUSIC
+MUSIC/SP
+MVS
+MVS/SP
+NEXUS
+NMS
+NONSTOP
+NOS-2
+NTOS
+OPENVMS
+OS/DDP
+OS/2
+OS4
+OS86
+OSX
+PCDOS
+PERQ/OS
+PLI
+PSDOS/MIT
+PRIMOS
+RMX/RDOS
+ROS
+RSX11M
+RTE-A
+SATOPS
+SCO-OPEN-DESKTOP-1.0
+SCO-OPEN-DESKTOP-1.1
+SCO-OPEN-DESKTOP-2.0
+
+
+
+Reynolds & Postel                                             [Page 216]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+SCO-OPEN-DESKTOP-3.0
+SCO-OPEN-DESKTOP-LITE-3.0
+SCO-OPEN-SERVER-3.0
+SCO-UNIX-3.2.0
+SCO-UNIX-3.2V2.0
+SCO-UNIX-3.2V2.1
+SCO-UNIX-3.2V4.0
+SCO-UNIX-3.2V4.1
+SCO-UNIX-3.2V4.2
+SCO-XENIX-386-2.3.2
+SCO-XENIX-386-2.3.3
+SCO-XENIX-386-2.3.4
+SCS
+SIMP
+SUN
+SUN-OS-3.5
+SUN-OS-4.0
+SWIFT
+TAC
+TANDEM
+TENEX
+THE-MAJOR-BBS
+TOPS10
+TOPS20
+TOS
+TP3010
+TRSDOS
+ULTRIX
+UNIX
+UNIX-BSD
+UNIX-V1AT
+UNIX-V
+UNIX-V.1
+UNIX-V.2
+UNIX-V.3
+UNIX-PC
+UNKNOWN
+UT2D
+V
+VM
+VM/370
+VM/CMS
+VM/SP
+VMS
+VMS/EUNICE
+VRTX
+WAITS
+WANG
+
+
+
+Reynolds & Postel                                             [Page 217]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+WIN32
+WYSE-WYXWARE
+X11R3
+XDE
+XENIX
+
+
+REFERENCES
+
+[RFC952] Harrenstien, K., Stahl, M., and E. Feinler, "DoD Internet
+         Host Table Specification", RFC 952, SRI, October 1985.
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/operating-system-names
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                             [Page 218]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+TERMINAL TYPE NAMES
+
+
+These are the Official Terminal Type Names.  Their use is described in
+[RFC930].  The maximum length of a name is 40 characters.
+
+A terminal names may be up to 40 characters taken from the set of
+uppercase letters, digits, and the two punctuation characters hyphen
+and slash.  It must start with a letter, and end with a letter or
+digit.
+
+
+ADDS-CONSUL-980
+ADDS-REGENT-100
+ADDS-REGENT-20
+ADDS-REGENT-200
+ADDS-REGENT-25
+ADDS-REGENT-40
+ADDS-REGENT-60
+ADDS-VIEWPOINT
+ADDS-VIEWPOINT-60
+AED-512
+AMPEX-DIALOGUE-210
+AMPEX-DIALOGUE-80
+AMPEX-210
+AMPEX-230
+ANDERSON-JACOBSON-510
+ANDERSON-JACOBSON-630
+ANDERSON-JACOBSON-832
+ANDERSON-JACOBSON-841
+ANN-ARBOR-AMBASSADOR
+ANSI
+ARDS
+BITGRAPH
+BUSSIPLEXER
+CALCOMP-565
+CDC-456
+CDI-1030
+CDI-1203
+C-ITOH-101
+C-ITOH-50
+C-ITOH-80
+CLNZ
+COMPUCOLOR-II
+CONCEPT-100
+CONCEPT-104
+CONCEPT-108
+DATA-100
+
+
+
+Reynolds & Postel                                             [Page 219]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+DATA-GENERAL-6053
+DATAGRAPHIX-132A
+DATAMEDIA-1520
+DATAMEDIA-1521
+DATAMEDIA-2500
+DATAMEDIA-3025
+DATAMEDIA-3025A
+DATAMEDIA-3045
+DATAMEDIA-3045A
+DATAMEDIA-DT80/1
+DATAPOINT-2200
+DATAPOINT-3000
+DATAPOINT-3300
+DATAPOINT-3360
+DEC-DECWRITER-I
+DEC-DECWRITER-II
+DEC-GIGI
+DEC-GT40
+DEC-GT40A
+DEC-GT42
+DEC-LA120
+DEC-LA30
+DEC-LA36
+DEC-LA38
+DEC-VT05
+DEC-VT100
+DEC-VT101
+DEC-VT102
+DEC-VT125
+DEC-VT131
+DEC-VT132
+DEC-VT200
+DEC-VT220
+DEC-VT240
+DEC-VT241
+DEC-VT300
+DEC-VT320
+DEC-VT340
+DEC-VT50
+DEC-VT50H
+DEC-VT52
+DEC-VT55
+DEC-VT61
+DEC-VT62
+DELTA-DATA-5000
+DELTA-DATA-NIH-7000
+DELTA-TELTERM-2
+DIABLO-1620
+
+
+
+Reynolds & Postel                                             [Page 220]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+DIABLO-1640
+DIGILOG-333
+DTC-300S
+DTC-382
+EDT-1200
+ETOS52-APL
+ETOS52-CRT
+ETOS52-FDW
+ETOS52-FUP
+ETOS52-GFM
+ETOS52-SPR
+EXECUPORT-4000
+EXECUPORT-4080
+FACIT-TWIST-4440
+FREEDOM-100
+FREEDOM-110
+FREEDOM-200
+GENERAL-TERMINAL-100A
+GENERAL-TERMINAL-101
+GIPSI-TX-M
+GIPSI-TX-ME
+GIPSI-TX-C4
+GIPSI-TX-C8
+GSI
+HAZELTINE-1420
+HAZELTINE-1500
+HAZELTINE-1510
+HAZELTINE-1520
+HAZELTINE-1552
+HAZELTINE-2000
+HAZELTINE-ESPRIT
+HITACHI-5601
+HITACHI-5603
+HITACHI-5603E
+HITACHI-5603EA
+HITACHI-560X
+HITACHI-560XE
+HITACHI-560XEA
+HITACHI-560PR
+HITACHI-HOAP1
+HITACHI-HOAP2
+HITACHI-HOAP3
+HITACHI-HOAP4
+HP-2392
+HP-2621
+HP-2621A
+HP-2621P
+HP-2623
+
+
+
+Reynolds & Postel                                             [Page 221]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+HP-2626
+HP-2626A
+HP-2626P
+HP-2627
+HP-2640
+HP-2640A
+HP-2640B
+HP-2645
+HP-2645A
+HP-2648
+HP-2648A
+HP-2649
+HP-2649A
+IBM-1050
+IBM-2741
+IBM-3101
+IBM-3101-10
+IBM-3151
+IBM-3179-2
+IBM-3180-2
+IBM-3196-A1
+IBM-3275-2
+IBM-3276-2
+IBM-3276-3
+IBM-3276-4
+IBM-3277-2
+IBM-3278-2
+IBM-3278-3
+IBM-3278-4
+IBM-3278-5
+IBM-3279-2
+IBM-3279-3
+IBM-3477-FC
+IBM-3477-FG
+IBM-5081
+IBM-5151
+IBM-5154
+IBM-5251-11
+IBM-5291-1
+IBM-5292-2
+IBM-5555-B01
+IBM-5555-C01
+IBM-6153
+IBM-6154
+IBM-6155
+IBM-AED
+IBM-3278-2-E
+IBM-3278-3-E
+
+
+
+Reynolds & Postel                                             [Page 222]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+IBM-3278-4-E
+IBM-3278-5-E
+IBM-3279-2-E
+IBM-3279-3-E
+IMLAC
+INFOTON-100
+INFOTON-400
+INFOTONKAS
+ISC-8001
+LSI-ADM-1
+LSI-ADM-11
+LSI-ADM-12
+LSI-ADM-2
+LSI-ADM-20
+LSI-ADM-22
+LSI-ADM-220
+LSI-ADM-3
+LSI-ADM-31
+LSI-ADM-3A
+LSI-ADM-42
+LSI-ADM-5
+MEMOREX-1240
+MICROBEE
+MICROTERM-ACT-IV
+MICROTERM-ACT-V
+MICROTERM-ERGO-301
+MICROTERM-MIME-1
+MICROTERM-MIME-2
+MICROTERM-ACT-5A
+MICROTERM-TWIST
+NEC-5520
+NETRONICS
+NETWORK-VIRTUAL-TERMINAL
+OMRON-8025AG
+PERKIN-ELMER-550
+PERKIN-ELMER-1100
+PERKIN-ELMER-1200
+PERQ
+PLASMA-PANEL
+QUME-SPRINT-5
+QUME-101
+QUME-102
+SOROC
+SOROC-120
+SOUTHWEST-TECHNICAL-PRODUCTS-CT82
+SUN
+SUPERBEE
+SUPERBEE-III-M
+
+
+
+Reynolds & Postel                                             [Page 223]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+TEC
+TEKTRONIX-4006
+TEKTRONIX-4010
+TEKTRONIX-4012
+TEKTRONIX-4013
+TEKTRONIX-4014
+TEKTRONIX-4023
+TEKTRONIX-4024
+TEKTRONIX-4025
+TEKTRONIX-4027
+TEKTRONIX-4105
+TEKTRONIX-4107
+TEKTRONIX-4110
+TEKTRONIX-4112
+TEKTRONIX-4113
+TEKTRONIX-4114
+TEKTRONIX-4115
+TEKTRONIX-4125
+TEKTRONIX-4404
+TELERAY-1061
+TELERAY-3700
+TELERAY-3800
+TELETEC-DATASCREEN
+TELETERM-1030
+TELETYPE-33
+TELETYPE-35
+TELETYPE-37
+TELETYPE-38
+TELETYPE-40
+TELETYPE-43
+TELEVIDEO-910
+TELEVIDEO-912
+TELEVIDEO-920
+TELEVIDEO-920B
+TELEVIDEO-920C
+TELEVIDEO-925
+TELEVIDEO-955
+TELEVIDEO-950
+TELEVIDEO-970
+TELEVIDEO-975
+TERMINET-1200
+TERMINET-300
+TI-700
+TI-733
+TI-735
+TI-743
+TI-745
+TI-800
+
+
+
+Reynolds & Postel                                             [Page 224]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+TYCOM
+UNIVAC-DCT-500
+VIDEO-SYSTEMS-1200
+VIDEO-SYSTEMS-5000
+VOLKER-CRAIG-303
+VOLKER-CRAIG-303A
+VOLKER-CRAIG-404
+VISUAL-200
+VISUAL-55
+WYSE-30
+WYSE-50
+WYSE-60
+WYSE-75
+WYSE-85
+WYSE-99GT
+WYSE-100
+WYSE-120
+WYSE-120ES
+WYSE-150
+WYSE-150ES
+WYSE-160
+WYSE-160ES
+WYSE-185
+WYSE-185ES
+WYSE-285
+WYSE-285ES
+WYSE-325
+WYSE-325ES
+WYSE-350
+WYSE-370
+XEROX-1720
+XTERM
+ZENITH-H19
+ZENITH-Z29
+ZENTEC-30
+
+
+REFERENCES
+
+[RFC930] Solomon, M., and E. Wimmers, "Telnet Terminal Type Option",
+         RFC 930, University of Wisconsin, Madison, January 1985.
+
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/terminal-type-names
+
+
+
+
+Reynolds & Postel                                             [Page 225]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+PROTOCOL AND SERVICE NAMES
+
+
+These are the Official Protocol Names as they appear in the Domain
+Name System WKS records and the NIC Host Table.  Their use is
+described in [RFC952].
+
+A protocol or service may be up to 40 characters taken from the set of
+uppercase letters, digits, and the punctuation character hyphen.  It
+must start with a letter, and end with a letter or digit.
+
+
+ARGUS               - ARGUS Protocol
+ARP                 - Address Resolution Protocol
+AUTH                - Authentication Service
+BBN-RCC-MON         - BBN RCC Monitoring
+BL-IDM              - Britton Lee Intelligent Database Machine
+BOOTP               - Bootstrap Protocol
+BOOTPC              - Bootstrap Protocol Client
+BOOTPS              - Bootstrap Protocol Server
+BR-SAT-MON          - Backroom SATNET Monitoring
+CFTP                - CFTP
+CHAOS               - CHAOS Protocol
+CHARGEN             - Character Generator Protocol
+CISCO-FNA           - CISCO FNATIVE
+CISCO-TNA           - CISCO TNATIVE
+CISCO-SYS           - CISCO SYSMAINT
+CLOCK               - DCNET Time Server Protocol
+CMOT                - Common Mgmnt Info Ser and Prot over TCP/IP
+COOKIE-JAR          - Authentication Scheme
+CSNET-NS            - CSNET Mailbox Nameserver Protocol
+DAYTIME             - Daytime Protocol
+DCN-MEAS            - DCN Measurement Subsystems Protocol
+DCP                 - Device Control Protocol
+DGP                 - Dissimilar Gateway Protocol
+DISCARD             - Discard Protocol
+DMF-MAIL            - Digest Message Format for Mail
+DOMAIN              - Domain Name System
+ECHO                - Echo Protocol
+EGP                 - Exterior Gateway Protocol
+EHF-MAIL            - Encoding Header Field for Mail
+EMCON               - Emission Control Protocol
+EMFIS-CNTL          - EMFIS Control Service
+EMFIS-DATA          - EMFIS Data Service
+FCONFIG             - Fujitsu Config Protocol
+FINGER              - Finger Protocol
+FTP                 - File Transfer Protocol
+FTP-DATA            - File Transfer Protocol Data
+
+
+
+Reynolds & Postel                                             [Page 226]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+GGP                 - Gateway Gateway Protocol
+GRAPHICS            - Graphics Protocol
+HMP                 - Host Monitoring Protocol
+HOST2-NS            - Host2 Name Server
+HOSTNAME            - Hostname Protocol
+ICMP                - Internet Control Message Protocol
+IGMP                - Internet Group Management Protocol
+IGP                 - Interior Gateway Protocol
+IMAP2               - Interim Mail Access Protocol version 2
+INGRES-NET          - INGRES-NET Service
+IP                  - Internet Protocol
+IPCU                - Internet Packet Core Utility
+IPPC                - Internet Pluribus Packet Core
+IP-ARC              - Internet Protocol on ARCNET
+IP-ARPA             - Internet Protocol on ARPANET
+IP-CMPRS            - Compressing TCP/IP Headers
+IP-DC               - Internet Protocol on DC Networks
+IP-DVMRP            - Distance Vector Multicast Routing Protocol
+IP-E                - Internet Protocol on Ethernet Networks
+IP-EE               - Internet Protocol on Exp. Ethernet Nets
+IP-FDDI             - Transmission of IP over FDDI
+IP-HC               - Internet Protocol on Hyperchannnel
+IP-IEEE             - Internet Protocol on IEEE 802
+IP-IPX              - Transmission of 802.2 over IPX Networks
+IP-MTU              - IP MTU Discovery Options
+IP-NETBIOS          - Internet Protocol over NetBIOS Networks
+IP-SLIP             - Transmission of IP over Serial Lines
+IP-WB               - Internet Protocol on Wideband Network
+IP-X25              - Internet Protocol on X.25 Networks
+IRTP                - Internet Reliable Transaction Protocol
+ISI-GL              - ISI Graphics Language Protocol
+ISO-TP4             - ISO Transport Protocol Class 4
+ISO-TSAP            - ISO TSAP
+LA-MAINT            - IMP Logical Address Maintenance
+LARP                - Locus Address Resoultion Protocol
+LDP                 - Loader Debugger Protocol
+LEAF-1              - Leaf-1 Protocol
+LEAF-2              - Leaf-2 Protocol
+LINK                - Link Protocol
+LOC-SRV             - Location Service
+LOGIN               - Login Host Protocol
+MAIL                - Format of Electronic Mail Messages
+MERIT-INP           - MERIT Internodal Protocol
+METAGRAM            - Metagram Relay
+MIB                 - Management Information Base
+MIT-ML-DEV          - MIT ML Device
+MFE-NSP             - MFE Network Services Protocol
+MIT-SUBNET          - MIT Subnet Support
+
+
+
+Reynolds & Postel                                             [Page 227]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+MIT-DOV             - MIT Dover Spooler
+MPM                 - Internet Message Protocol (Multimedia Mail)
+MPM-FLAGS           - MPM Flags Protocol
+MPM-SND             - MPM Send Protocol
+MSG-AUTH            - MSG Authentication Protocol
+MSG-ICP             - MSG ICP Protocol
+MUX                 - Multiplexing Protocol
+NAMESERVER          - Host Name Server
+NETBIOS-DGM         - NETBIOS Datagram Service
+NETBIOS-NS          - NETBIOS Name Service
+NETBIOS-SSN         - NETBIOS Session Service
+NETBLT              - Bulk Data Transfer Protocol
+NETED               - Network Standard Text Editor
+NETRJS              - Remote Job Service
+NI-FTP              - NI File Transfer Protocol
+NI-MAIL             - NI Mail Protocol
+NICNAME             - Who Is Protocol
+NFILE               - A File Access Protocol
+NNTP                - Network News Transfer Protocol
+NSW-FE              - NSW User System Front End
+NTP                 - Network Time Protocol
+NVP-II              - Network Voice Protocol
+OSPF                - Open Shortest Path First Interior GW Protocol
+PCMAIL              - Pcmail Transport Protocol
+POP2                - Post Office Protocol - Version 2
+POP3                - Post Office Protocol - Version 3
+PPP                 - Point-to-Point Protocol
+PRM                 - Packet Radio Measurement
+PUP                 - PUP Protocol
+PWDGEN              - Password Generator Protocol
+QUOTE               - Quote of the Day Protocol
+RARP                - A Reverse Address Resolution Protocol
+RATP                - Reliable Asynchronous Transfer Protocol
+RE-MAIL-CK          - Remote Mail Checking Protocol
+RDP                 - Reliable Data Protocol
+RIP                 - Routing Information Protocol
+RJE                 - Remote Job Entry
+RLP                 - Resource Location Protocol
+RTELNET             - Remote Telnet Service
+RVD                 - Remote Virtual Disk Protocol
+SAT-EXPAK           - Satnet and Backroom EXPAK
+SAT-MON             - SATNET Monitoring
+SEP                 - Sequential Exchange Protocol
+SFTP                - Simple File Transfer Protocol
+SGMP                - Simple Gateway Monitoring Protocol
+SNMP                - Simple Network Management Protocol
+SMI                 - Structure of Management Information
+SMTP                - Simple Mail Transfer Protocol
+
+
+
+Reynolds & Postel                                             [Page 228]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+SQLSRV              - SQL Service
+ST                  - Stream Protocol
+STATSRV             - Statistics Service
+SU-MIT-TG           - SU/MIT Telnet Gateway Protocol
+SUN-RPC             - SUN Remote Procedure Call
+SUPDUP              - SUPDUP Protocol
+SUR-MEAS            - Survey Measurement
+SWIFT-RVF           - Remote Virtual File Protocol
+TACACS-DS           - TACACS-Database Service
+TACNEWS             - TAC News
+TCP                 - Transmission Control Protocol
+TCP-ACO             - TCP Alternate Checksum Option
+TELNET              - Telnet Protocol
+TFTP                - Trivial File Transfer Protocol
+THINWIRE            - Thinwire Protocol
+TIME                - Time Server Protocol
+TP-TCP              - ISO Transport Service on top of the TCP
+TRUNK-1             - Trunk-1 Protocol
+TRUNK-2             - Trunk-2 Protocol
+UCL                 - University College London Protocol
+UDP                 - User Datagram Protocol
+NNTP                - Network News Transfer Protocol
+USERS               - Active Users Protocol
+UUCP-PATH           - UUCP Path Service
+VIA-FTP             - VIA Systems-File Transfer Protocol
+VISA                - VISA Protocol
+VMTP                - Versatile Message Transaction Protocol
+WB-EXPAK            - Wideband EXPAK
+WB-MON              - Wideband Monitoring
+XNET                - Cross Net Debugger
+XNS-IDP             - Xerox NS IDP
+
+
+REFERENCES
+
+[RFC952] Harrenstien, K., Stahl, M., and E. Feinler, "DoD Internet
+         Host Table Specification", RFC 952, SRI, October 1985.
+
+[]
+
+
+URL = ftp://ftp.isi.edu/in-notes/iana/assignments/service-names
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                             [Page 229]
+
+RFC 1700                    Assigned Numbers                October 1994
+
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Authors' Addresses
+
+   Joyce K. Reynolds
+   USC/Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, California  90292-6695
+
+   Phone: +1 310-822-1511
+   EMail: jkrey@isi.edu
+
+
+   Jon Postel
+   USC/Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, California  90292-6695
+
+   Phone: +1 310-822-1511
+   EMail: postel@isi.edu
+
+   []
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Reynolds & Postel                                             [Page 230]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1700.txt](<www.ietf.org/rfc/rfc1700.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
