### PR TITLE
Archive rfc173.txt

### DIFF
--- a/www.ietf.org/rfc/rfc173.txt
+++ b/www.ietf.org/rfc/rfc173.txt
@@ -1,0 +1,112 @@
+
+
+
+
+
+
+Network Working Group                          P. M. Karp - MITRE
+Request for Comments #173                      D. B. McKay - IBM
+NIC 6795                                       4 June 1971
+
+
+Categories:  D.4, D.7
+Obsoletes:   None
+Updates:     None
+
+
+         Network Data Management Committee Meeting Announcement
+
+The data management discussions at the recent NWG meeting resulted in
+the formation of a Network Data Management Committee to be chaired by
+Doug McKay, IBM.  The purpose of the committee, as stated in RFC 146,
+is:
+
+      (a)  to classify the issues involved and to propose
+           various approaches;
+      (b)  to integrate the hitherto independent network
+           activities that address problems in the area of data
+           sharing; and
+      (c)  to set up and coordinate appropriate experiments
+           to test the services developed and to evaluate
+           alternative approaches.
+
+An informal meeting was held Wednesday morning, 19 May to estab- lish an
+approach for achieving the above objectives.  The attendees were:
+
+         Peggy Karp           MITRE
+         Doug McKay           IBM
+         Tom O'Sullivan       Raytheon
+         Ari Ollikainin       UCLA
+         Dr. Larry Roberts    ARPA
+         Dick Winter          CCA
+
+Due to an overlap with a file transfer committee meeting, membership of
+the data management committee was not established.
+
+A decision was made to hold a data management meeting at CCA in
+Cambridge prior to the next general NWG meeting.  The structure and
+format of the meeting will be similar to that of the network graphics
+meeting (RFC 87); that is, the price of admission for an organization is
+a working paper on one or more of the areas chosen for discussion,
+accompanied by an oral presentation.
+
+
+
+
+
+
+                                                                [Page 1]
+
+The meeting will provide an opportunity for varying viewpoints on
+network data sharing to be expressed.  The essential issues will be
+educed, thus fulfilling the committee's objective (a).  Compre- hensive
+plans for attaining objectives (b) and (c) can then be established.  We
+expect that responsibilities for carrying out objectives (b) and (c)
+will be assumed by interested committee members.
+
+One of the original objectives of the meeting was to elicit comments on
+the data language for the data computer, following a presentation of
+design specifications by CCA.  Due to a change in scheduling at CCA,
+they will discuss the facilities to be provided by the data computer
+rather than language itself.  Therefore meeting participants will have
+an opportunity to provide input to the language design which will be
+specifically directed at provision of the facilities.
+
+   Some suggested topics for position papers are:
+
+      (a)  philosophical discussion on computer network
+           data sharing;
+      (b)  syntactic and semantic considerations for data
+           description and access languages;
+      (c)  approaches for the integration of data handling
+           services already available;
+      (d)  experimentation methodology for evaluating
+           alternative data sharing techniques;
+      (e)  information content and structure of a network
+           data directory; and
+      (f)  operational or control protocol.
+
+Any or all of the above topics can be addressed in a single paper.
+Other ideas for position paper topics can be gleaned from RFC #s 144 and
+146.  Many of the comments made at the data management session, 18 May,
+at the NWG meeting (RFC 164, pp. 26-29) can be expanded and expounded
+upon.
+
+Position papers should be submitted ti Doug McKay by 16 July (received
+no later than 19 July).  A meeting agenda, copies of all submitted
+papers, and a background bibliography will be distributed to all
+participants by 23 July.  The meeting will be held at CCA, 565
+Technology Square, Cambridge, Mass. from 2 August until 4 August.  All
+participants should contact Marty Ginsberg, CCA (617-491-3670) by 16
+July for hotel reservations.
+
+       [ This RFC was put into machine readable form for entry ]
+         [ into the online RFC archives by Simone Demmel 5/97 ]
+
+
+
+
+
+
+                                                                [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc173.txt](<www.ietf.org/rfc/rfc173.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
