### PR TITLE
Archive rfc1747.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1747.txt
+++ b/www.ietf.org/rfc/rfc1747.txt
@@ -1,0 +1,3755 @@
+
+
+
+
+
+
+Network Working Group                                 J. Hilgeman, Chair
+Request for Comments: 1747                    Apertus Technologies, Inc.
+Category: Standards Track                                         S. Nix
+                                                          Metaplex, Inc.
+                                                               A. Bartky
+                                                     Sync Research, Inc.
+                                                        W. Clark, Editor
+                                                     cisco Systems, Inc.
+                                                            January 1995
+
+
+    Definitions of Managed Objects for SNA Data Link Control (SDLC)
+                              using SMIv2
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Abstract
+
+   This specification defines an extension to the Management Information
+   Base (MIB) for use with SNMP-based network management.  In
+   particular, it defines objects for managing the configuration,
+   monitoring and control of data link controls in an SNA environment.
+   This draft identifies managed objects for SNA Synchronous Data Link
+   Control (SDLC) links only.
+
+Table of Contents
+
+   1.     The SNMPv2 Network Management Framework  .................  2
+   1.1      Object Definitions  ....................................  2
+   2.     Overview  ................................................  2
+   2.1      Tables Defined in the SNADLC SDLC MIB  .................  3
+   2.2      Row Creation Mechanism  ................................  3
+   2.3      Relationship to the Interfaces Group  ..................  4
+   3.     Definitions  .............................................  7
+   3.1      Port Administrative Table  .............................  9
+   3.2      Port Operational Table  ...............................  14
+   3.3      Port Statistics Table  ................................  20
+   3.4      Link Station Administrative Table  ....................  26
+   3.5      Link Station Operational Table  .......................  35
+   3.6      Link Station Statistics Table  ........................  44
+   3.7      Trap Definitions  .....................................  56
+   3.8      Compliance Statements  ................................  57
+
+
+
+Hilgeman, Nix, Bartky & Clark                                   [Page 1]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+   4.     Acknowledgments  ........................................  65
+   5.     References  .............................................  65
+   6.     Glossary  ...............................................  66
+   7.     Security Considerations  ................................  67
+   8.     Authors' Addresses  .....................................  67
+
+1.  The SNMPv2 Network Management Framework
+
+   The SNMPv2 Network Management Framework consists of four major
+   components.  They are:
+
+      o    RFC 1441 which defines the SMI, the mechanisms used for
+           describing and naming objects for the purpose of management.
+
+      o    STD 17, RFC 1213 defines MIB-II, the core set of managed
+           objects for the Internet suite of protocols.
+
+      o    RFC 1445 which defines the administrative and other
+           architectural aspects of the framework.
+
+      o    RFC 1448 which defines the protocol used for network access
+           to managed objects.
+
+   The Framework permits new objects to be defined for the purpose of
+   experimentation and evaluation.
+
+1.1.  Object Definitions
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  Objects in the MIB are
+   defined using the subset of Abstract Syntax Notation One (ASN.1)
+   defined in the SMI.  In particular, each object object type is named
+   by an OBJECT IDENTIFIER, an administratively assigned name.  The
+   object type together with an object instance serves to uniquely
+   identify a specific instantiation of the object.  For human
+   convenience, we often use a textual string, termed the descriptor, to
+   refer to the object type.
+
+2.  Overview
+
+   This memo identifies the proposed set of objects for configuring,
+   monitoring, and controlling SDLC ports and link stations.
+
+
+
+
+
+
+
+
+
+Hilgeman, Nix, Bartky & Clark                                   [Page 2]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+2.1.  Tables Defined in the SNADLC SDLC MIB
+
+   The SNADLC MIB is composed of two managed entities with three tables
+   each.  The two managed entities for SDLC are:
+
+     o    Ports: the physical connection, and
+
+     o    Link Stations: the logical connections on the Port.
+
+   The three management tables are:
+
+     o    Adminstration: objects used for configuring and controlling
+          the operation of a Port or Link Station,
+
+     o    Operational: objects that reflect the run-time state of the
+          Port or Link Station, and
+
+     o    Statistics: objects that reflect the operating metrics of the
+          Port or Link Station.
+
+   Considering the above combinations, the following are the actual
+   tables found in this MIB:
+
+     1)   Port Administration Table,
+
+     2)   Port Operation Table,
+
+     3)   Port Statistics Table,
+
+     4)   Link Station Administration Table,
+
+     5)   Link Station Operation Table,
+
+     6)   Link Station Statistics Table.
+
+   All variables in this MIB relate to SDLC ports and link stations
+   only.  Any variable relating to higher-layer entities in SNA such as
+   Physical Units (PU) and Logical Units (LU) are found in the SNA NAU
+   MIB [4].
+
+2.2.  Row Creation Mechanism
+
+   Row creation mechanism for the sdlcLSAdminTable is based on the use
+   of the RowStatus object.  It follows the rules for the use in SNMPv1
+   context proposed in the memo "Row creation with SNMPv1" [5].  Before
+   accepting the destroy value for an entry, an agent has to verify the
+   operational state of the corresponding entry in the sdlcLSOperTable
+   entry.
+
+
+
+Hilgeman, Nix, Bartky & Clark                                   [Page 3]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+2.3.  Relationship to the Interfaces Group
+
+   This memo shall conform to the recommendations of [6].
+
+   The SDLC layer of each SDLC Port shall be modeled by a row in the
+   ifTable with an ifType using the IANA assigned number for SDLC (17).
+   Each SDLC port interface must comply with the following conformance
+   groups in [6]:
+
+     - ifGeneralGroup
+     - ifStackGroup
+     - ifPacketGroup
+
+   An implementation may optionally comply with the ifTestGroup defined
+   in that memo to execute vendor specific tests.  An example of this
+   would be to perform LPDA test functions.
+
+   The SDLC port's relation with its physical, or lower-layer interface
+   (i.e., RS-232, V.35, etc.) shall be modeled by a row in the
+   ifStackTable with the ifStackHigherLayer pointing to the SDLC port
+   ifTable instance and the ifStackLowerLayer pointing to the physical
+   media-specific ifTable instance.  The media-specific objects of these
+   lower-layer interfaces will, of course, be described in their
+   respective MIBs (i.e., [1]).
+
+   The following table provides specific implementation guidelines for
+   all the interface group objects listed in the conformance tables
+   above.
+
+Object              Use for an SDLC Port
+
+ifIndex             Each SDLC port is represented by an ifEntry. All
+                    SDLC port tables shall be indexed by ifIndex.
+
+ifDescr             Description of the SDLC port.
+
+ifType              The IANA value reserved for SDLC - 17.
+
+ifMtu               Refer to [6].
+
+ifSpeed             This object shall reflect the value of the
+                    corresponding object in the ifEntry of the
+                    associated lower-layer interface.
+
+ifPhysAddress       A string denoting the physical location of the SDLC
+                    port within its node.  This shall have unique
+                    significance within each implementing node.
+
+
+
+
+Hilgeman, Nix, Bartky & Clark                                   [Page 4]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+ifAdminStatus       This object shall reflect the value of the
+                    corresponding object in the ifEntry of the
+                    associated lower-layer interface.
+
+ifOperStatus        This object shall reflect the value of the
+                    corresponding object in the ifEntry of the
+                    associated lower-layer interface.
+
+ifLastChange        Refer to [6].
+
+ifInOctets          Refer to [6].
+
+ifInUcastPkts       This object shall count packets received from a
+                    specific SDLC poll address.  Packets for the SDLC
+                    broadcast address of x'FF' are not counted.
+
+ifInDiscards        Refer to [6].
+
+ifInErrors          Refer to [6].  Specific counters for these errors
+                    are kept in the sdlcPortStatsTable.
+
+ifInUnknownProtos   This counter shall return zero for SDLC ports.
+
+ifOutOctets         Refer to [6].
+
+ifOutUcastPkts      This object shall count packets transmitted to a
+                    specific SDLC poll address (not x'FF').
+
+ifOutDiscards       Refer to [6].
+
+ifOutErrors         Refer to [6].  Specific counters for these errors
+                    are kept in the sdlcPortStatsTable.
+
+ifName              The textual name of the SDLC port or an octet string
+                    of zero length.
+
+ifInMulticastPkts   The value is 0 (not applicable to the SDLC layer).
+
+ifInBroadcastPkts   This object shall count packets received on this
+                    interface addressed to the SDLC broadcast address
+                    (x'FF').  Only point-to-point ports supporting a
+                    secondary switched station should return non-zero
+                    values.
+
+ifOutMulticastPkts  The value is 0 (not applicable to the SDLC layer).
+
+ifOutBroadcastPkts  This object shall count packets transmitted on this
+                    interface which were addressed to the SDLC broadcast
+
+
+
+Hilgeman, Nix, Bartky & Clark                                   [Page 5]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                    address (x'FF').  Only point-to-point ports
+                    supporting a primary switched station should
+                    return non-zero values.
+
+ifHC*               Not part of the conformance group.
+
+ifLinkUpDownTrapEnable
+                    Refer to [6].  Default is disabled (2).
+
+ifHighSpeed         Refer to [6].
+
+ifPromiscuousMode   Should return false if this interface receives only
+                    packets addressed to its SDLC poll address(es).
+                    However, in certain implementations, the lower-layer
+                    interface shall present all frames to the SDLC port
+                    regardless of the poll address.  Such frames may be
+                    the result of a misconfigured peer or the secondary
+                    end of a multipoint connection.  Such
+                    implementations should return true for this
+                    object.
+
+ifConnectorPresent  Set to 'false'.
+
+ifStackHigherLayer  For each SDLC port there will be an ifStackEntry
+                    with this object's value referring to the ifIndex of
+                    the SDLC port's ifEntry for the SDLC layer.
+
+ifStackLowerLayer   For each SDLC port there will be an ifStackEntry
+                    with this object's value referring to the ifIndex of
+                    the physical layer interface's ifEntry for that SDLC
+                    port.
+
+ifStackStatus       Refer to [6].
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hilgeman, Nix, Bartky & Clark                                   [Page 6]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+3.  Definitions
+
+SNA-SDLC-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE,
+    Counter32, Integer32, TimeTicks
+        FROM SNMPv2-SMI
+    DisplayString, RowStatus, TimeInterval
+        FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP
+        FROM SNMPv2-CONF
+    mib-2, ifIndex, ifAdminStatus, ifOperStatus
+        FROM RFC1213-MIB;
+
+
+snaDLC MODULE-IDENTITY
+        LAST-UPDATED  "9411150000Z"
+        ORGANIZATION  "IETF SNA DLC MIB Working Group"
+        CONTACT-INFO
+                "        Wayne Clark
+
+                 Postal: cisco Systems, Inc.
+                         3100 Smoketree Ct.
+                         Suite 1000
+                         Raleigh, NC 27604
+                         US
+
+                    Tel: +1 919 878 6958
+
+                 E-Mail: wclark@cisco.com"
+
+        DESCRIPTION
+                "This is the MIB module for objects used to
+                 manage SDLC devices."
+
+::= { mib-2 41 }
+
+--
+--  The following data link controls are modelled in this MIB module:
+--
+--     1. SDLC
+--
+
+sdlc        OBJECT IDENTIFIER ::= { snaDLC 1 }
+
+
+
+
+
+
+Hilgeman, Nix, Bartky & Clark                                   [Page 7]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+--
+--  THE SDLC GROUP
+--  ==============
+--
+--  The following resources are modelled in the SDLC group of this
+--  MIB module:
+--
+--     1. PORTS
+--     2. LINK STATIONS
+
+sdlcPortGroup OBJECT IDENTIFIER ::= { sdlc 1 } -- Physical Ports
+sdlcLSGroup   OBJECT IDENTIFIER ::= { sdlc 2 } -- Logical Link Stations
+
+--
+--  THE SDLC PORT GROUP
+--  ===================
+--
+--  The following classes of information is modelled for each SDLC port:
+--
+--     1.  ADMINISTRATIVE ( read/write)
+--     2.  OPERATIONAL    ( read-only)
+--     3.  STATISTICS     ( read-only)
+
+--  Information not found in this group is found in tables described in
+--  the following RFCs:
+--
+--    1.  RFC1213  - MIB-II
+--
+--            TABLE                      INDEX
+--            ====================       ====================
+--        a.  ifTable                    ifIndex
+--
+--    2.  RFC1659  - The RS232-like MIB
+--
+--            TABLE                      INDEX
+--            ====================       ====================
+--        a.  rs232PortTable             rs232PortIndex
+--        b.  rs232SyncPortTable         rs232SyncPortIndex
+--        c.  rs232InSigTable            rs232InSigPortIndex,
+--                                       rs232InSigName
+--        d.  rs232OutSigTable           rs232OutSigPortIndex,
+--                                       rs232OutSigName
+--     ** e.  rs232AsyncPortTable        rs232AsyncPortIndex
+--
+--     ** rs232AsyncPortTable for ISO 3309.3 ( Start-Stop SDLC).
+
+
+
+
+
+
+Hilgeman, Nix, Bartky & Clark                                   [Page 8]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+--  *************************************************************
+--  *                                                           *
+--  *           THE SDLC PORT ADMINISTRATIVE TABLE              *
+--  *                                                           *
+--  *************************************************************
+
+sdlcPortAdminTable  OBJECT-TYPE
+                    SYNTAX      SEQUENCE OF SdlcPortAdminEntry
+                    MAX-ACCESS  not-accessible
+                    STATUS      current
+                    DESCRIPTION
+                        "This table contains objects that can be
+                        changed to manage an SDLC port.    Changing one
+                        of these parameters may take effect in the
+                        operating port immediately or may wait until
+                        the interface is restarted depending on the
+                        details of the implementation.
+
+                        Most of the objects in this read-write table
+                        have corresponding read-only objects in the
+                        sdlcPortOperTable that return the current
+                        operating value.
+
+                        The operating values may be different from
+                        these configured values if  a configured
+                        parameter was changed after the interface was
+                        started."
+                     ::= { sdlcPortGroup 1 }
+
+sdlcPortAdminEntry  OBJECT-TYPE
+                    SYNTAX      SdlcPortAdminEntry
+                    MAX-ACCESS  not-accessible
+                    STATUS      current
+                    DESCRIPTION
+                        "A list of configured values for an SDLC port."
+                    INDEX   { ifIndex }
+                    ::= { sdlcPortAdminTable 1 }
+
+SdlcPortAdminEntry  ::= SEQUENCE
+{
+        sdlcPortAdminName           DisplayString,
+        sdlcPortAdminRole           INTEGER,
+        sdlcPortAdminType           INTEGER,
+        sdlcPortAdminTopology       INTEGER,
+        sdlcPortAdminISTATUS        INTEGER,
+        sdlcPortAdminACTIVTO        TimeInterval,
+        sdlcPortAdminPAUSE          TimeInterval,
+        sdlcPortAdminSERVLIM        Integer32,
+
+
+
+Hilgeman, Nix, Bartky & Clark                                   [Page 9]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+        sdlcPortAdminSlowPollTimer  TimeInterval
+}
+
+sdlcPortAdminName   OBJECT-TYPE
+                    SYNTAX      DisplayString (SIZE (1..10))
+                    MAX-ACCESS  read-write
+                    STATUS      current
+                    DESCRIPTION
+                        "An octet string that defines the physical port
+                        to which this interface is assigned.  It has
+                        implementation-specific significance. Its value
+                        shall be unique within the administered
+                        system.  It must contain only ASCII printable
+                        characters.  Should an implementation choose to
+                        accept a write operation  for this object, it
+                        causes the logical port definition associated
+                        with the table instance to be moved to  a
+                        different physical port.  A write operation
+                        shall not take effect until the port is cycled
+                        inactive."
+                    ::= { sdlcPortAdminEntry 1 }
+
+sdlcPortAdminRole   OBJECT-TYPE
+                    SYNTAX      INTEGER
+                    {
+                        primary(1),
+                        secondary(2),
+                        negotiable(3)
+                    }
+                    MAX-ACCESS  read-write
+                    STATUS      current
+                    DESCRIPTION
+                        "This object describes the role that the link
+                        station shall assume the next time a connection
+                        is established.
+
+                        Even though this is defined as a port object,
+                        it is a link station attribute in the sense
+                        that a role is per link station.  However, it
+                        is not possible to vary link station roles on a
+                        particular port.  For example, if an SDLC port
+                        is configured to primary, all link stations on
+                        that port must be primary."
+                    ::= { sdlcPortAdminEntry 2 }
+
+sdlcPortAdminType   OBJECT-TYPE
+                    SYNTAX      INTEGER
+                    {
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 10]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                         leased(1),
+                         switched(2)
+                    }
+                    MAX-ACCESS  read-write
+                    STATUS      current
+                    DESCRIPTION
+                        "This parameter defines whether the SDLC port
+                        is to connect to a leased or switched line.  A
+                        write operation to this administrative  value
+                        shall not take effect until the SDLC port has
+                        been cycled inactive."
+                    DEFVAL { leased }
+                    ::= { sdlcPortAdminEntry 3 }
+
+sdlcPortAdminTopology  OBJECT-TYPE
+                    SYNTAX      INTEGER
+                    {
+                         pointToPoint(1),
+                         multipoint(2)
+                    }
+                    MAX-ACCESS  read-write
+                    STATUS      current
+                    DESCRIPTION
+                        "This parameter defines whether the SDLC port is
+                        capable of operating in either a point-to-point
+                        or multipoint topology.
+
+                        sdlcPortAdminTopology == multipoint implies the
+                        port can also operate in a point-to-point
+                        topology.  sdlcPortAdminTopology ==
+                        pointToPoint does not imply the port can
+                        operate in a multipoint topology.
+
+                        A write operation to this administrative value
+                        shall not take effect until the SDLC port has
+                        been cycled inactive."
+                    DEFVAL { pointToPoint }
+                    ::= { sdlcPortAdminEntry 4 }
+
+sdlcPortAdminISTATUS  OBJECT-TYPE
+                    SYNTAX      INTEGER
+                    {
+                         inactive(1),
+                         active(2)
+                    }
+                    MAX-ACCESS  read-write
+                    STATUS      current
+                    DESCRIPTION
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 11]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                        "This parameter controls the initial value of
+                        the administrative status, ifAdminStatus, of
+                        this SDLC port at port start-up.  Depending
+                        on the implementation, a write operation to
+                        this administrative object may not take effect
+                        until the SDLC port has been cycled inactive."
+                    DEFVAL { active }
+                    ::= { sdlcPortAdminEntry 5 }
+
+sdlcPortAdminACTIVTO    OBJECT-TYPE
+                    SYNTAX      TimeInterval
+                    MAX-ACCESS  read-write
+                    STATUS      current
+                    DESCRIPTION
+                        "This parameter defines the period of time (in
+                        1/100ths of a second) that the port will allow a
+                        switched line to remain inactive before
+                        disconnecting.  A switched line is considered
+                        to be inactive if there are no I-Frames being
+                        transferred.  A value of zero indicates no
+                        timeout.  Depending on the implementation, a
+                        write operation to this administered value may
+                        not take effect until the port is cycled
+                        inactive.
+
+                        This object only has meaning for SDLC ports
+                        where sdlcPortAdminType == switched
+
+                        The object descriptor contains the name of an
+                        NCP configuration parameter, ACTIVTO.  Please
+                        note that the value of this object represents
+                        1/100ths of a second while the NCP ACTIVTO is
+                        represented in seconds."
+                    DEFVAL { 0 }
+                    ::= { sdlcPortAdminEntry 6 }
+
+sdlcPortAdminPAUSE  OBJECT-TYPE
+                    SYNTAX      TimeInterval
+                    MAX-ACCESS  read-write
+                    STATUS      current
+                    DESCRIPTION
+                        "This object defines the minimum elapsed time
+                        (in 1/100ths of a second) between any two
+                        traversals of the poll list for a primary SDLC
+                        port.  Depending on the implementation, a write
+                        operation to this administered value  may not
+                        take effect until the port is cycled inactive.
+
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 12]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                        The object descriptor contains the name of an
+                        NCP configuration parameter, PAUSE.  Please
+                        note that the value of this object represents
+                        1/100ths of a second while the NCP PAUSE is
+                        represented in 1/10ths of a second.
+
+                        This object only has meaning for SDLC ports
+                        where sdlcPortAdminRole == primary "
+                    DEFVAL { 200 }
+                    ::= { sdlcPortAdminEntry 7 }
+
+sdlcPortAdminSERVLIM OBJECT-TYPE
+                    SYNTAX      Integer32
+                    MAX-ACCESS  read-write
+                    STATUS      current
+                    DESCRIPTION
+                        "This object defines the number of times the
+                        active poll list will be traversed before
+                        polling a station on the slow poll list for a
+                        primary, multipoint SDLC port.  Depending  on
+                        the implementation, a write operation to this
+                        administered value  may not take effect until
+                        the port is cycled inactive.
+
+                        This object only has meaning for SDLC ports
+                        where
+                            sdlcPortAdminRole == primary
+                        and
+                            sdlcPortAdminTopology == multipoint "
+                    DEFVAL { 20 }
+                    ::= { sdlcPortAdminEntry 8 }
+
+sdlcPortAdminSlowPollTimer OBJECT-TYPE
+                    SYNTAX      TimeInterval
+                    MAX-ACCESS  read-write
+                    STATUS      current
+                    DESCRIPTION
+                        "This object describes the elapsed time (in
+                        1/100ths of a second) between polls for failed
+                        secondary link station addresses.  Depending
+                        on the implementation, a write operation to
+                        this administered value  may not take effect
+                        until the port is cycled inactive.
+
+                        This object only has meaning for SDLC ports
+                        where
+                            sdlcPortAdminRole == primary
+                        and
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 13]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                            sdlcPortAdminTopology == multipoint "
+                    DEFVAL { 2000 }
+                    ::= { sdlcPortAdminEntry 9 }
+
+--  *************************************************************
+--  *                                                           *
+--  *                THE SDLC PORT OPERATIONAL TABLE            *
+--  *                                                           *
+--  *************************************************************
+
+sdlcPortOperTable   OBJECT-TYPE
+                    SYNTAX      SEQUENCE OF SdlcPortOperEntry
+                    MAX-ACCESS  not-accessible
+                    STATUS      current
+                    DESCRIPTION
+                        "This table contains current SDLC port
+                        parameters.  Many of these objects have
+                        corresponding objects inthe sdlcPortAdminTable."
+                    ::= { sdlcPortGroup 2 }
+
+sdlcPortOperEntry   OBJECT-TYPE
+                    SYNTAX      SdlcPortOperEntry
+                    MAX-ACCESS  not-accessible
+                    STATUS      current
+                    DESCRIPTION
+                        "Currently set parameters for a specific SDLC
+                        port."
+                    INDEX   { ifIndex }
+                    ::= { sdlcPortOperTable 1 }
+
+SdlcPortOperEntry   ::= SEQUENCE
+{
+        sdlcPortOperName                DisplayString,
+        sdlcPortOperRole                INTEGER,
+        sdlcPortOperType                INTEGER,
+        sdlcPortOperTopology            INTEGER,
+        sdlcPortOperISTATUS             INTEGER,
+        sdlcPortOperACTIVTO             TimeInterval,
+        sdlcPortOperPAUSE               TimeInterval,
+        sdlcPortOperSlowPollMethod      INTEGER,
+        sdlcPortOperSERVLIM             Integer32,
+        sdlcPortOperSlowPollTimer       TimeInterval,
+        sdlcPortOperLastModifyTime      TimeTicks,
+        sdlcPortOperLastFailTime        TimeTicks,
+        sdlcPortOperLastFailCause       INTEGER
+}
+
+sdlcPortOperName    OBJECT-TYPE
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 14]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                    SYNTAX      DisplayString (SIZE (1..8))
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "An octet string that describes the physical
+                        port to which this interface is currently
+                        attached.  It has  implementation-specific
+                        significance."
+                    ::= { sdlcPortOperEntry 1 }
+
+sdlcPortOperRole    OBJECT-TYPE
+                    SYNTAX      INTEGER
+                    {
+                        primary(1),
+                        secondary(2),
+                        undefined(3)
+                    }
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object describes the role that the link
+                        station has assumed on this connection.
+
+                        Even though this is defined as a port object,
+                        it is a link station attribute in the sense
+                        that a role is per link station.  However, it
+                        is not possible to vary link station roles on a
+                        particular port.  For example, if an SDLC port
+                        is configured to primary, all link stations on
+                        that port must be primary.
+
+                        The value of sdlcPortOperRole is undefined(3)
+                        whenever the link station role has not yet been
+                        established by the mode setting command."
+                    ::= { sdlcPortOperEntry 2 }
+
+sdlcPortOperType    OBJECT-TYPE
+                    SYNTAX      INTEGER
+                    {
+                         leased(1),
+                         switched(2)
+                    }
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This parameter defines whether the SDLC port
+                        is currently operating as though connected to a
+                        leased or switched line."
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 15]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                    ::= { sdlcPortOperEntry 3 }
+
+sdlcPortOperTopology  OBJECT-TYPE
+                    SYNTAX      INTEGER
+                    {
+                         pointToPoint(1),
+                         multipoint(2)
+                    }
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This parameter defines whether the SDLC port is
+                        currently operating in a point-to-point or
+                        multipoint topology."
+                    ::= { sdlcPortOperEntry 4 }
+
+sdlcPortOperISTATUS OBJECT-TYPE
+                    SYNTAX      INTEGER
+                    {
+                         inactive(1),
+                         active(2)
+                    }
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This parameter describes the initial value of
+                        the administrative status, ifAdminStatus, of
+                        this SDLC port at last port start-up."
+                    ::= { sdlcPortOperEntry 5 }
+
+
+sdlcPortOperACTIVTO OBJECT-TYPE
+                    SYNTAX      TimeInterval
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This parameter defines the period of time (in
+                        100ths of a second) that the port will allow a
+                        switched line to remain inactive before
+                        disconnecting.  A switched line is considered
+                        to be inactive if there are no I-Frames being
+                        transferred.
+
+                        The object descriptor contains the name of an
+                        NCP configuration parameter, ACTIVTO.  Please
+                        note that the value of this object represents
+                        1/100ths of a second while the NCP ACTIVTO is
+                        represented in seconds.
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 16]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                        A value of zero indicates no timeout."
+                    ::= { sdlcPortOperEntry 6 }
+
+sdlcPortOperPAUSE   OBJECT-TYPE
+                    SYNTAX      TimeInterval
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object describes the current minimum
+                        elapsed time (in 1/100ths of a second) between
+                        any two traversals of the poll list for a
+                        primary SDLC port.
+
+                        The object descriptor contains the name of an
+                        NCP configuration parameter, PAUSE.  Please
+                        note that the value of this object represents
+                        1/100ths of a second while the NCP PAUSE is
+                        represented in 1/10ths of a second.
+
+                        This object only has meaning for SDLC ports
+                        where
+                            sdlcPortAdminRole == primary "
+                    ::= { sdlcPortOperEntry 7 }
+
+sdlcPortOperSlowPollMethod OBJECT-TYPE
+                    SYNTAX      INTEGER
+                    {
+                         servlim(1),
+                         pollpause(2),
+                         other(3)
+                    }
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object defines the exact method that is in
+                        effect for periodically polling failed secondary
+                        link station addresses.
+
+                        If sdlcPortOperSlowPollMethod == servlim, then
+                        sdlcPortOperSERVLIM defines the actual polling
+                        characteristics.
+
+                        If sdlcPortOperSlowPollMethod == pollpause,
+                        then sdlcPortOperSlowPollTimer defines the
+                        actual polling characteristics.
+
+                        If sdlcPortOperSlowPollMethod == other, then
+                        the polling characteristics are modeled in
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 17]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                        vendor-specific objects.
+
+                        This object only has meaning for SDLC ports
+                        where
+                            sdlcPortOperRole == primary
+                        and
+                            sdlcPortOperTopology == multipoint "
+                    ::= { sdlcPortOperEntry 8 }
+
+sdlcPortOperSERVLIM OBJECT-TYPE
+                    SYNTAX      Integer32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object describes the number of times the
+                        active poll list is currently being traversed
+                        before polling a station on the slow poll list
+                        for a primary, multipoint SDLC port.
+
+                        This object only has meaning for SDLC ports
+                        where
+                            sdlcPortOperRole == primary
+                        and
+                            sdlcPortOperTopology == multipoint "
+                    ::= { sdlcPortOperEntry 9 }
+
+sdlcPortOperSlowPollTimer OBJECT-TYPE
+                    SYNTAX      TimeInterval
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object describes the elapsed time (in
+                        1/100ths of a second) between polls for failed
+                        secondary link station addresses.
+
+                        This object only has meaning for SDLC ports
+                        where
+                            sdlcPortOperRole == primary
+                        and
+                            sdlcPortOperTopology == multipoint "
+                    ::= { sdlcPortOperEntry 10 }
+
+sdlcPortOperLastModifyTime    OBJECT-TYPE
+                    SYNTAX      TimeTicks
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object describes the value of sysUpTime
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 18]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                         when this port definition was last modified.
+                         If the port has not been modified, then this
+                         value shall be zero."
+                    ::= { sdlcPortOperEntry 11 }
+
+sdlcPortOperLastFailTime    OBJECT-TYPE
+                    SYNTAX      TimeTicks
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object describes the value of sysUpTime
+                        when this SDLC port last failed.  If the port
+                        has not failed, then this value shall be zero."
+                    ::= { sdlcPortOperEntry 12 }
+
+sdlcPortOperLastFailCause    OBJECT-TYPE
+                    SYNTAX      INTEGER
+                    {
+                        undefined(1),
+                        physical(2)
+                    }
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This enumerated object describes the cause of
+                        the last failure of this SDLC port.  If the
+                        port has not failed, then this object has a
+                        value of undefined(1)."
+                    DEFVAL { undefined }
+                    ::= { sdlcPortOperEntry 13 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 19]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+--  *************************************************************
+--  *                                                           *
+--  *           THE SDLC PORT STATISTICS TABLE                  *
+--  *                                                           *
+--  *************************************************************
+
+sdlcPortStatsTable  OBJECT-TYPE
+                    SYNTAX      SEQUENCE OF SdlcPortStatsEntry
+                    MAX-ACCESS  not-accessible
+                    STATUS      current
+                    DESCRIPTION
+                        "Each entry in this table contains statistics
+                        for a specific SDLC port."
+                     ::= { sdlcPortGroup 3 }
+
+sdlcPortStatsEntry  OBJECT-TYPE
+                    SYNTAX      SdlcPortStatsEntry
+                    MAX-ACCESS  not-accessible
+                    STATUS      current
+                    DESCRIPTION
+                        "A list of statistics for an SDLC port."
+                    INDEX   { ifIndex }
+                    ::= { sdlcPortStatsTable 1 }
+
+SdlcPortStatsEntry ::= SEQUENCE
+{
+        sdlcPortStatsPhysicalFailures Counter32,
+        sdlcPortStatsInvalidAddresses Counter32,
+        sdlcPortStatsDwarfFrames      Counter32,
+        sdlcPortStatsPollsIn          Counter32,
+        sdlcPortStatsPollsOut         Counter32,
+        sdlcPortStatsPollRspsIn       Counter32,
+        sdlcPortStatsPollRspsOut      Counter32,
+        sdlcPortStatsLocalBusies      Counter32,
+        sdlcPortStatsRemoteBusies     Counter32,
+        sdlcPortStatsIFramesIn        Counter32,
+        sdlcPortStatsIFramesOut       Counter32,
+        sdlcPortStatsOctetsIn         Counter32,
+        sdlcPortStatsOctetsOut        Counter32,
+        sdlcPortStatsProtocolErrs     Counter32,
+        sdlcPortStatsActivityTOs      Counter32,
+        sdlcPortStatsRNRLIMITs        Counter32,
+        sdlcPortStatsRetriesExps      Counter32,
+        sdlcPortStatsRetransmitsIn    Counter32,
+        sdlcPortStatsRetransmitsOut   Counter32
+}
+
+sdlcPortStatsPhysicalFailures OBJECT-TYPE
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 20]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total number of times
+                        this port has failed due to its physical media
+                        since port startup.  At port startup time,
+                        this object must be initialized to zero."
+                    ::= { sdlcPortStatsEntry 1 }
+
+sdlcPortStatsInvalidAddresses OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total number of
+                        frames received by this port with invalid link
+                        station addresses."
+                    ::= { sdlcPortStatsEntry 2 }
+
+sdlcPortStatsDwarfFrames OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total number of
+                        frames received by this port which were
+                        delivered intact by the physical layer but were
+                        too short to be legal.
+
+                        Ignoring the frame check sequence (FCS), a
+                        frame is considered to be too short if it
+                        is less than 2 bytes for sdlcLSOperMODULO of
+                        eight, or if it is less than 3 bytes for
+                        sdlcLSOperMODULO of onetwentyeight."
+
+                    ::= { sdlcPortStatsEntry 3 }
+
+sdlcPortStatsPollsIn OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                         "This object reflects the total number of polls
+                         received by this port since the port was
+                         created."
+
+                    ::= { sdlcPortStatsEntry 4 }
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 21]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+sdlcPortStatsPollsOut OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                         "This object reflects the total number of polls
+                         sent by this port since the port was created."
+
+                    ::= { sdlcPortStatsEntry 5 }
+
+sdlcPortStatsPollRspsIn OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                         "This object reflects the total number of poll
+                         responses received by this port since the port
+                         was created."
+
+                    ::= { sdlcPortStatsEntry 6 }
+
+sdlcPortStatsPollRspsOut OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                         "This object reflects the total number of poll
+                         responses sent by this port since the port was
+                         created."
+
+                    ::= { sdlcPortStatsEntry 7 }
+
+sdlcPortStatsLocalBusies OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                         "This object reflects the total number of
+                         times that the local SDLC link stations on
+                         this port have entered a busy state (RNR).
+                         This object is initialized to zero when the
+                         port is created."
+                    ::= { sdlcPortStatsEntry 8 }
+
+sdlcPortStatsRemoteBusies OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 22]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                    DESCRIPTION
+                         "This object reflects the total number of
+                         times that the adjacent (i.e., remote) SDLC
+                         link stations on this port have entered a busy
+                         state (RNR).  This object is initialized to
+                         zero when the port is created."
+                    ::= { sdlcPortStatsEntry 9 }
+
+sdlcPortStatsIFramesIn OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                         "This object reflects the total number of
+                         I-Frames that have been received by SDLC link
+                         stations on this port.  This object is
+                         initialized to zero when the port is created."
+                    ::= { sdlcPortStatsEntry 10 }
+
+sdlcPortStatsIFramesOut OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                         "This object reflects the total number of
+                         I-Frames that have been transmitted by SDLC
+                         link stations on this port.  This object is
+                         initialized to zero when the port is created."
+                    ::= { sdlcPortStatsEntry 11 }
+
+sdlcPortStatsOctetsIn OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                         "This object reflects the total octets
+                         received from adjacent SDLC link stations on
+                         this port.  This object covers the address,
+                         control, and information field of I-Frames
+                         only.  This object is initialized to zero when
+                         the port is created."
+                    ::= { sdlcPortStatsEntry 12 }
+
+sdlcPortStatsOctetsOut OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 23]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                         "This object reflects the total octets
+                         transmitted to adjacent SDLC link stations on
+                         this port.  This object covers the address,
+                         control, and information field of I-Frames
+                         only.  This object is initialized to zero when
+                         the port is created."
+                    ::= { sdlcPortStatsEntry 13 }
+
+sdlcPortStatsProtocolErrs OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                         "This object reflects the total number of
+                         times that the SDLC link stations on this port
+                         have deactivated the link as a result of
+                         having received a protocol violation from the
+                         adjacent link station.  This object is
+                         initialized to zero when the port is created."
+                    ::= { sdlcPortStatsEntry 14 }
+
+sdlcPortStatsActivityTOs OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                         "This object reflects the total number of
+                         times that the SDLC link stations on this port
+                         have deactivated the link as a result of no
+                         activity on the link.  This object is
+                         initialized to zero when the port is created."
+                    ::= { sdlcPortStatsEntry 15 }
+
+sdlcPortStatsRNRLIMITs OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                         "This object reflects the total number of
+                         times that the SDLC link stations on this port
+                         have deactivated the link as a result of its
+                         RNRLIMIT timer expiring.  This object is
+                         initialized to zero when the port is created."
+                    ::= { sdlcPortStatsEntry 16 }
+
+sdlcPortStatsRetriesExps OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 24]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                    STATUS      current
+                    DESCRIPTION
+                         "This object reflects the total number of
+                         times that the SDLC link stations on this port
+                         have deactivated the link as a result of a
+                         retry sequence being exhausted.  This object
+                         is initialized to zero when the port is
+                         created."
+                    ::= { sdlcPortStatsEntry 17 }
+
+sdlcPortStatsRetransmitsIn OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                         "This object reflects the total number of
+                         I-Frames retransmitted by remote link stations
+                         for all SDLC link stations on this port.  This
+                         object is initialized to zero when the port is
+                         created."
+                    ::= { sdlcPortStatsEntry 18 }
+
+sdlcPortStatsRetransmitsOut OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                         "This object reflects the total number of
+                         I-Frames retransmitted by all local SDLC link
+                         stations on this port.  This object is
+                         initialized to zero when the port is created."
+                    ::= { sdlcPortStatsEntry 19 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 25]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+--
+--  THE SDLC LINK STATION GROUP
+--  ===========================
+--
+
+--  The following classes of information is modelled for each SDLC link
+--  station:
+--
+--     1.  ADMINISTRATIVE ( read-write)
+--     2.  OPERATIONAL    ( read-only)
+--     3.  STATISTICS     ( read-only)
+
+--  *************************************************************
+--  *                                                           *
+--  *        THE SDLC LINK STATION ADMINISTRATIVE TABLE         *
+--  *                                                           *
+--  *************************************************************
+
+sdlcLSAdminTable  OBJECT-TYPE
+                    SYNTAX      SEQUENCE OF SdlcLSAdminEntry
+                    MAX-ACCESS  not-accessible
+                    STATUS      current
+                    DESCRIPTION
+                        "This table contains objects that can be
+                        changed to manage an SDLC link station.
+                        Changing one of these parameters may take
+                        effect in the operating link immediately or may
+                        wait until the link is restarted depending on
+                        the details of the implementation.
+
+                        The entries in sdlcLSAdminTable can be created
+                        either by an agent or a management station. The
+                        management station can create an entry in
+                        sdlcLSAdminTable by setting the appropriate
+                        value in sdlcLSAdminRowStatus.
+
+                        Most of the objects in this read-create table
+                        have corresponding read-only objects in the
+                        sdlcLSOperTable that reflect the current
+                        operating value.
+
+                        The operating values may be different from
+                        these configured values if changed by XID
+                        negotiation or if a configured parameter was
+                        changed after the link was started."
+                    ::= { sdlcLSGroup 1 }
+
+sdlcLSAdminEntry    OBJECT-TYPE
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 26]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                    SYNTAX      SdlcLSAdminEntry
+                    MAX-ACCESS  not-accessible
+                    STATUS      current
+                    DESCRIPTION
+                         "A list of configured values for an SDLC link
+                         station."
+                    INDEX   { ifIndex, sdlcLSAddress }
+                    ::= { sdlcLSAdminTable 1 }
+
+SdlcLSAdminEntry ::= SEQUENCE
+{
+        sdlcLSAddress           INTEGER,
+        sdlcLSAdminName         DisplayString,
+        sdlcLSAdminState        INTEGER,
+        sdlcLSAdminISTATUS      INTEGER,
+        sdlcLSAdminMAXDATASend  Integer32,
+        sdlcLSAdminMAXDATARcv   Integer32,
+        sdlcLSAdminREPLYTO      TimeInterval,
+        sdlcLSAdminMAXIN        INTEGER,
+        sdlcLSAdminMAXOUT       INTEGER,
+        sdlcLSAdminMODULO       INTEGER,
+        sdlcLSAdminRETRIESm     INTEGER,
+        sdlcLSAdminRETRIESt     TimeInterval,
+        sdlcLSAdminRETRIESn     Integer32,
+        sdlcLSAdminRNRLIMIT     TimeInterval,
+        sdlcLSAdminDATMODE      INTEGER,
+        sdlcLSAdminGPoll        INTEGER,
+        sdlcLSAdminSimRim       INTEGER,
+        sdlcLSAdminXmitRcvCap   INTEGER,
+        sdlcLSAdminRowStatus    RowStatus
+}
+
+sdlcLSAddress       OBJECT-TYPE
+                    SYNTAX      INTEGER (1..255)
+                    MAX-ACCESS  read-create
+                    STATUS      current
+                    DESCRIPTION
+                         "This value is the poll address of the
+                         secondary link station for this SDLC link.  It
+                         uniquely identifies the SDLC link station
+                         within a single SDLC port."
+                    ::= { sdlcLSAdminEntry 1 }
+
+sdlcLSAdminName     OBJECT-TYPE
+                    SYNTAX      DisplayString (SIZE (1..10))
+                    MAX-ACCESS  read-create
+                    STATUS      current
+                    DESCRIPTION
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 27]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                        "An octet string that defines the local name of
+                        the SDLC link station.  This field may be sent
+                        in the XID3 control vector 0x0E, type 0xF7."
+                    ::= { sdlcLSAdminEntry 2 }
+
+sdlcLSAdminState    OBJECT-TYPE
+                    SYNTAX      INTEGER
+                    {
+                         inactive(1),
+                         active(2)
+                    }
+                    MAX-ACCESS  read-create
+                    STATUS      current
+                    DESCRIPTION
+                        "This object controls the desired state of the
+                        SDLC station.  The managed system shall attempt
+                        to keep the operational state, sdlcLSOperState,
+                        consistent with this value."
+                    DEFVAL { active }
+                    ::= { sdlcLSAdminEntry 3 }
+
+sdlcLSAdminISTATUS  OBJECT-TYPE
+                    SYNTAX      INTEGER
+                    {
+                         inactive(1),
+                         active(2)
+                    }
+                    MAX-ACCESS  read-create
+                    STATUS      current
+                    DESCRIPTION
+                        "This parameter controls the desired state,
+                        sdlcLSAdminState, of the SDLC link station at
+                        link station start-up."
+                    DEFVAL { active }
+                    ::= { sdlcLSAdminEntry 4 }
+
+sdlcLSAdminMAXDATASend  OBJECT-TYPE
+                    SYNTAX      Integer32
+                    MAX-ACCESS  read-create
+                    STATUS      current
+                    DESCRIPTION
+                        "This object contains the maximum PDU size that
+                        the local link station thinks it can send to
+                        the adjacent link station before having
+                        received any XID from the ALS.  After the
+                        maximum PDU size that the ALS can receive is
+                        known (via XID exchange) that value is
+                        reflected in sdlcLSOperMAXDATASend and takes
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 28]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                        precedence over this object.
+
+                        This value includes the Transmission Header
+                        (TH) and the Request Header (RH)."
+                    ::= { sdlcLSAdminEntry 5 }
+
+sdlcLSAdminMAXDATARcv  OBJECT-TYPE
+                    SYNTAX      Integer32
+                    MAX-ACCESS  read-create
+                    STATUS      current
+                    DESCRIPTION
+                        "This object contains the maximum PDU size that
+                        the local link station can receive from the
+                        adjacent link station.  This value is sent in
+                        the XID to the ALS.
+
+                        This value includes the Transmission Header
+                        (TH) and the Request Header (RH)."
+                    ::= { sdlcLSAdminEntry 6 }
+
+sdlcLSAdminREPLYTO  OBJECT-TYPE
+                    SYNTAX      TimeInterval
+                    MAX-ACCESS  read-create
+                    STATUS      current
+                    DESCRIPTION
+                        "This object controls the reply timeout (in
+                        1/100ths of a second) for an SDLC link
+                        station.  If the link station does not receive
+                        a response to a poll or message before the
+                        specified time expires then the appropriate
+                        error recovery shall be initiated.
+
+                        The object descriptor contains the name of an
+                        NCP configuration parameter, REPLYTO.  Please
+                        note that the value of this object represents
+                        1/100ths of a second while the NCP REPLYTO is
+                        represented in 1/10ths of a second.
+
+                        Depending on the implementation, a write
+                        operation to this administered value  may not
+                        change the operational value, sdlcLSOperREPLYTO,
+                        until the link station is cycled inactive.
+
+                        This object only has meaning for SDLC ports
+                        where sdlcPortAdminRole == primary "
+                    DEFVAL { 100 }
+                    ::= { sdlcLSAdminEntry 7 }
+
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 29]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+sdlcLSAdminMAXIN    OBJECT-TYPE
+                    SYNTAX      INTEGER (1..127)
+                    MAX-ACCESS  read-create
+                    STATUS      current
+                    DESCRIPTION
+                        "This object controls the maximum number of
+                        unacknowledged I-frames which an SDLC link
+                        station may receive.  This should range from 1
+                        to (sdlcLSAdminMODULO - 1).  This value is sent
+                        in the XID to the ALS.
+
+                        A write operation to this administered value
+                        will not change the operational value,
+                        sdlcLSOperMAXIN, until the link station is
+                        cycled inactive."
+                    DEFVAL { 7 }
+                    ::= { sdlcLSAdminEntry 8 }
+
+sdlcLSAdminMAXOUT   OBJECT-TYPE
+                    SYNTAX      INTEGER (1..127)
+                    MAX-ACCESS  read-create
+                    STATUS      current
+                    DESCRIPTION
+                        "This object controls the maximum number of
+                        consecutive unacknowledged I-frames which an
+                        SDLC link station shall send without an
+                        acknowledgement.  This shall range from 1 to
+                        (sdlcLSAdminMODULO - 1).
+
+                        For link stations on switched SDLC lines,
+                        certain implementions may choose to override
+                        this administered value with the value
+                        received in the XID exchange.
+
+                        Depending on the implementation, a write
+                        operation to this administered value may not
+                        change the operational value,
+                        sdlcLSOperMAXOUT, until the link station is
+                        cycled inactive.
+
+                        An implementation can support only modulo 8,
+                        only modulo 128, or both."
+                    DEFVAL { 1 }
+                    ::= { sdlcLSAdminEntry 9 }
+
+sdlcLSAdminMODULO   OBJECT-TYPE
+                    SYNTAX      INTEGER
+                    {
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 30]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                        eight(8),
+                        onetwentyeight(128)
+                    }
+                    MAX-ACCESS  read-create
+                    STATUS      current
+                    DESCRIPTION
+                        "This object controls the modulus for an SDLC
+                        link station.  This modulus determines the size
+                        of the rotating acknowledgement window used the
+                        SDLC link station pair.
+
+                        A write operation to this administered value
+                        will not change the operational value,
+                        sdlcLSOperMODULO, until the link station is
+                        cycled inactive.
+
+                        An implementation can support only modulo 8,
+                        only modulo 128, or both."
+                    DEFVAL { eight }
+                    ::= { sdlcLSAdminEntry 10 }
+
+sdlcLSAdminRETRIESm OBJECT-TYPE
+                    SYNTAX      INTEGER (0..128)
+                    MAX-ACCESS  read-create
+                    STATUS      current
+                    DESCRIPTION
+                        "This object controls number of retries in a
+                        retry sequence for the local SDLC link
+                        station.  A retry sequence is a series of
+                        retransmitted frames ( data or control) for
+                        which no positive acknowledgement is received.
+
+                        The number of times that the retry sequence is
+                        to be repeated is controlled by the object:
+                        sdlcLSAdminRETRIESn.  The interval between retry
+                        sequences is controlled by the object:
+                        sdlcLSAdminRETRIESt.
+
+                        A value of zero indicates no retries. If the
+                        value of sdlcLSAdminRETRIESm is zero, then the
+                        values of sdlcLSAdminRETRIESt and
+                        sdlcLSAdminRETRIESn should also be zero.
+
+                        Depending on the implementation, a write
+                        operation to this administered value  may not
+                        change the operational value,
+                        sdlcLSOperRETRIESm, until the link station is
+                        cycled inactive."
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 31]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                    DEFVAL { 15 }
+                    ::= { sdlcLSAdminEntry 11 }
+
+sdlcLSAdminRETRIESt OBJECT-TYPE
+                    SYNTAX      TimeInterval
+                    MAX-ACCESS  read-create
+                    STATUS      current
+                    DESCRIPTION
+                        "This object controls the interval (in 1/100ths
+                        of a second) between retry sequences for the
+                        local SDLC link station if multiple retry
+                        sequences are specified .  A retry sequence is
+                        a series of retransmitted frames ( data or
+                        control) for which no positive acknowledgement
+                        is received.
+
+                        The number of repeated retries sequences is
+                        controlled by the object: sdlcLSAdminRETRIESn.
+                        The retries per sequence is controlled by the
+                        object:  sdlcLSAdminRETRIESm.
+
+                        The object descriptor contains the name of an
+                        NCP configuration parameter, RETRIESt.  Please
+                        note that the value of this object represents
+                        1/100ths of a second while the NCP RETRIESt is
+                        represented in seconds.
+
+                        Depending on the implementation, a write
+                        operation to this administered value  may not
+                        change the operational value,
+                        sdlcLSOperRETRIESt, until the link station is
+                        cycled inactive."
+                    DEFVAL { 0 }
+                    ::= { sdlcLSAdminEntry 12 }
+
+sdlcLSAdminRETRIESn OBJECT-TYPE
+                    SYNTAX      Integer32
+                    MAX-ACCESS  read-create
+                    STATUS      current
+                    DESCRIPTION
+                        "This object controls the number of times that
+                        a retry sequence is repeated for the local SDLC
+                        link station.  A retry sequence is a series of
+                        retransmitted frames ( data or control) for
+                        which no positive acknowledgement is received.
+
+                        The interval between retry sequences is
+                        controlled by the object: sdlcLSAdminRETRIESn.
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 32]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                        The retries per sequence is controlled by the
+                        object:  sdlcLSAdminRETRIESm.
+
+                        Depending on the implementation, a write
+                        operation to this administered value  may not
+                        change the operational value,
+                        sdlcLSOperRETRIESn, until the link station is
+                        cycled inactive."
+                    DEFVAL { 0 }
+                    ::= { sdlcLSAdminEntry 13 }
+
+sdlcLSAdminRNRLIMIT OBJECT-TYPE
+                    SYNTAX      TimeInterval
+                    MAX-ACCESS  read-create
+                    STATUS      current
+                    DESCRIPTION
+                        "This object controls the length of time (in
+                        1/100ths of a second) that an SDLC link station
+                        will allow its adjacent link station to remain
+                        in a busy (RNR) state before declaring it
+                        inoperative.
+
+                        A value of sdlcLSAdminRNRLIMIT == 0 means there
+                        is no limit.
+
+                        The object descriptor contains the name of an
+                        NCP configuration parameter, RNRLIMIT.  Please
+                        note that the value of this object represents
+                        1/100ths of a second while the NCP RNRLIMIT is
+                        represented in minutes.
+
+                        Depending on the implementation, a write
+                        operation to this administered value  may not
+                        change the operational value,
+                        sdlcLSOperRNRLIMIT, until the link station is
+                        cycled inactive."
+                    DEFVAL { 18000 }
+                    ::= { sdlcLSAdminEntry 14 }
+
+sdlcLSAdminDATMODE  OBJECT-TYPE
+                    SYNTAX      INTEGER
+                    {
+                        half(1),
+                        full(2)
+                    }
+                    MAX-ACCESS  read-create
+                    STATUS      current
+                    DESCRIPTION
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 33]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                        "This object controls whether communications
+                        mode with the adjacent link station is
+                        two-way-alternate (half) or two-way-simultaneous
+                        (full).
+
+                        A write operation to this administered value
+                        will not change the operational value,
+                        sdlcLSOperDATMODE, until the link station is
+                        cycled inactive."
+                    DEFVAL { half }
+                    ::= { sdlcLSAdminEntry 15 }
+
+sdlcLSAdminGPoll    OBJECT-TYPE
+                    SYNTAX      INTEGER (0..254)
+                    MAX-ACCESS  read-create
+                    STATUS      current
+                    DESCRIPTION
+                        "This object describes the group poll address
+                        for this link station instance.  If group poll
+                        is not in effect for this link station
+                        instance, the value for sdlcLSAdminGPoll should
+                        be zero.
+
+                        Depending on the implementation, a write
+                        operation to this administered value may not
+                        change the operational value, sdlcLSOperGPoll,
+                        until the link station is cycled inactive."
+                    ::= { sdlcLSAdminEntry 16 }
+
+sdlcLSAdminSimRim   OBJECT-TYPE
+                    SYNTAX      INTEGER
+                    {
+                         no(1),
+                         yes(2)
+                    }
+                    MAX-ACCESS  read-create
+                    STATUS      current
+                    DESCRIPTION
+                        "This object controls the support for
+                        transmission and receipt of SIM and RIM control
+                        frames for this link station.  The value of
+                        this object controls the setting of the
+                        transmit-receive capability sent in the XID
+                        field."
+                    DEFVAL { no }
+                    ::= { sdlcLSAdminEntry 17 }
+
+sdlcLSAdminXmitRcvCap OBJECT-TYPE
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 34]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                    SYNTAX      INTEGER
+                    {
+                         twa(1),
+                         tws(2)
+                    }
+                    MAX-ACCESS  read-create
+                    STATUS      current
+                    DESCRIPTION
+                        "This object controls the transmit-receive
+                        capabilities for this SDLC link station.  The
+                        value of this object establishes the value of
+                        the transmit-receive capability indicator sent
+                        in the XID image to the adjacent link station."
+                    DEFVAL { twa }
+                    ::= { sdlcLSAdminEntry 18 }
+
+sdlcLSAdminRowStatus OBJECT-TYPE
+                    SYNTAX      RowStatus
+                    MAX-ACCESS  read-create
+                    STATUS      current
+                    DESCRIPTION
+                        "This object is used by a management station to
+                        create or delete the row entry in
+                        sdlcLSAdminTable following the RowStatus
+                        textual convention.
+
+                        Upon successful creation of the row, an agent
+                        automatically creates a corresponding entry in
+                        the sdlcLSOperTable with sdlcLSOperState equal
+                        to 'discontacted (1)'."
+                    ::= { sdlcLSAdminEntry 19 }
+
+--  *************************************************************
+--  *                                                           *
+--  *           THE SDLC LINK STATION OPERATIONAL TABLE         *
+--  *                                                           *
+--  *************************************************************
+
+sdlcLSOperTable     OBJECT-TYPE
+                    SYNTAX      SEQUENCE OF SdlcLSOperEntry
+                    MAX-ACCESS  not-accessible
+                    STATUS      current
+                    DESCRIPTION
+                          "This table contains current SDLC link
+                          parameters.  Many of these objects have
+                          corresponding objects in the
+                          sdlcLSAdminTable."
+                    ::= { sdlcLSGroup 2 }
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 35]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+sdlcLSOperEntry     OBJECT-TYPE
+                    SYNTAX      SdlcLSOperEntry
+                    MAX-ACCESS  not-accessible
+                    STATUS      current
+                    DESCRIPTION
+                         "A list of status and control values for an
+                         SDLC link station."
+                    INDEX   { ifIndex, sdlcLSAddress }
+                    ::= { sdlcLSOperTable 1 }
+
+SdlcLSOperEntry     ::= SEQUENCE
+{
+        sdlcLSOperName                  DisplayString,
+        sdlcLSOperRole                  INTEGER,
+        sdlcLSOperState                 INTEGER,
+        sdlcLSOperMAXDATASend           Integer32,
+        sdlcLSOperREPLYTO               TimeInterval,
+        sdlcLSOperMAXIN                 INTEGER,
+        sdlcLSOperMAXOUT                INTEGER,
+        sdlcLSOperMODULO                INTEGER,
+        sdlcLSOperRETRIESm              INTEGER,
+        sdlcLSOperRETRIESt              TimeInterval,
+        sdlcLSOperRETRIESn              INTEGER,
+        sdlcLSOperRNRLIMIT              TimeInterval,
+        sdlcLSOperDATMODE               INTEGER,
+        sdlcLSOperLastModifyTime        TimeTicks,
+        sdlcLSOperLastFailTime          TimeTicks,
+        sdlcLSOperLastFailCause         INTEGER,
+        sdlcLSOperLastFailCtrlIn        OCTET STRING,
+        sdlcLSOperLastFailCtrlOut       OCTET STRING,
+        sdlcLSOperLastFailFRMRInfo      OCTET STRING,
+        sdlcLSOperLastFailREPLYTOs      Counter32,
+        sdlcLSOperEcho                  INTEGER,
+        sdlcLSOperGPoll                 INTEGER,
+        sdlcLSOperSimRim                INTEGER,
+        sdlcLSOperXmitRcvCap            INTEGER
+}
+
+sdlcLSOperName      OBJECT-TYPE
+                    SYNTAX      DisplayString (SIZE (1..10))
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                         "An octet string that defines the name of the
+                         remote SDLC link station.  This field is
+                         received in the XID3 control vector 0x0E, type
+                         0xF7."
+                    ::= { sdlcLSOperEntry 1 }
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 36]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+sdlcLSOperRole      OBJECT-TYPE
+                    SYNTAX      INTEGER
+                    {
+                        primary(1),
+                        secondary(2),
+                        undefined(3)
+                    }
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the current role that the
+                        link station is assuming.
+
+                        The value of sdlcLSOperRole is undefined(3)
+                        whenever the link station role has not yet been
+                        established by the mode setting command."
+                    ::= { sdlcLSOperEntry 2 }
+
+sdlcLSOperState     OBJECT-TYPE
+                    SYNTAX      INTEGER
+                    {
+                        discontacted(1),
+                        contactPending(2),
+                        contacted(3),
+                        discontactPending(4)
+                    }
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object describes the operational state of
+                        the SDLC link station.  The managed system
+                        shall attempt to keep this value consistent
+                        with the administered state, sdlcLSAdminState"
+                    ::= { sdlcLSOperEntry 3 }
+
+sdlcLSOperMAXDATASend   OBJECT-TYPE
+                    SYNTAX      Integer32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object contains the actual maximum PDU
+                        size that the local link station can send to
+                        the adjacent link station.  This object is
+                        established from the value received in the XID
+                        from the adjacent link station.  If no XID
+                        is received, then this value is implementation
+                        dependent (for instance, it could be the value
+                        of sdlcLSAdminMAXDATASend).
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 37]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                        This value includes the Transmission Header
+                        (TH) and the Request Header (RH)."
+                    ::= { sdlcLSOperEntry 4 }
+
+sdlcLSOperREPLYTO   OBJECT-TYPE
+                    SYNTAX      TimeInterval
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the current reply timeout
+                        (in 1/100ths of a second) for an SDLC link
+                        station.  If the link station does not receive
+                        a response to a poll or message before the
+                        specified time expires then the appropriate
+                        error recovery shall be initiated.
+
+                        The object descriptor contains the name of an
+                        NCP configuration parameter, REPLYTO.  Please
+                        note that the value of this object represents
+                        1/100ths of a second while the NCP REPLYTO is
+                        represented in 1/10ths of a second.
+
+                        This object only has meaning for SDLC ports
+                        where sdlcPortOperRole == primary "
+                    ::= { sdlcLSOperEntry 5 }
+
+sdlcLSOperMAXIN    OBJECT-TYPE
+                    SYNTAX      INTEGER (1..127)
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the current maximum
+                        number of unacknowledged I-frames which an SDLC
+                        link station may receive.  This shall range
+                        from 1 to (sdlcLSOperMODULO - 1)."
+                    ::= { sdlcLSOperEntry 6 }
+
+sdlcLSOperMAXOUT    OBJECT-TYPE
+                    SYNTAX      INTEGER (1..127)
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object controls the maximum number of
+                        consecutive unacknowledged I-frames which an
+                        SDLC link station shall send without an
+                        acknowledgement.  This shall range from 1 to
+                        (sdlcLSAdminMODULO - 1).
+
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 38]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                        This value may controlled by the administered
+                        MAXOUT, sdlcLSAdminMAXOUT, or by the MAXIN value
+                        received during the XID exchange."
+                    ::= { sdlcLSOperEntry 7 }
+
+sdlcLSOperMODULO   OBJECT-TYPE
+                    SYNTAX      INTEGER
+                    {
+                        eight(8),
+                        onetwentyeight(128)
+                    }
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the current modulus for
+                        an SDLC link station.  This modulus determines
+                        the size of rotating acknowledgement window
+                        used by the SDLC link station pair."
+                     DEFVAL { eight }
+                    ::= { sdlcLSOperEntry 8 }
+
+sdlcLSOperRETRIESm  OBJECT-TYPE
+                    SYNTAX      INTEGER (0..128)
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object controls number of retries in a
+                        retry sequence for an SDLC link station.  A
+                        retry sequence is a series of retransmitted
+                        frames ( data or control) for which no positive
+                        acknowledgement is received.
+
+                        The current number of times that the retry
+                        sequence is to be repeated is reflected by the
+                        object:  sdlcLSOperRETRIESn.  The current
+                        interval between retry sequences is reflected
+                        by the object:  sdlcLSOperRETRIESt."
+                    ::= { sdlcLSOperEntry 9 }
+
+sdlcLSOperRETRIESt  OBJECT-TYPE
+                    SYNTAX      TimeInterval
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the current interval (in
+                        1/100ths of a second) between retry sequences
+                        for an SDLC link station if multiple retry
+                        sequences are specified.  A retry sequence is a
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 39]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                        series of retransmitted frames ( data or
+                        control) for which no positive acknowledgement
+                        is received.
+
+                        The object descriptor contains the name of an
+                        NCP configuration parameter, RETRIESt.  Please
+                        note that the value of this object represents
+                        1/100ths of a second while the NCP RETRIESt is
+                        represented in seconds.
+
+                        The current number of repeated retries
+                        sequences is reflected by the object:
+                        sdlcLSOperRETRIESn.  The current retries per
+                        sequence is reflected by the object:
+                        sdlcLSOperRETRIESm."
+                    ::= { sdlcLSOperEntry 10 }
+
+sdlcLSOperRETRIESn OBJECT-TYPE
+                    SYNTAX      INTEGER (0..127)
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the current number of
+                        times that a retry sequence is repeated for an
+                        SDLC link station.  A retry sequence is a
+                        series of retransmitted frames ( data or
+                        control) for which no positive acknowledgement
+                        is received.
+
+                        The current interval between retry sequences is
+                        reflected by the object: sdlcLSOperRETRIESn.
+                        The current retries per sequence is reflected
+                        by the object:  sdlcLSOperRETRIESm."
+                    ::= { sdlcLSOperEntry 11 }
+
+sdlcLSOperRNRLIMIT  OBJECT-TYPE
+                    SYNTAX      TimeInterval
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the current length of
+                        time (in 1/100ths of a second) that an SDLC
+                        link station will allow its adjacent link
+                        station to remain in a busy (RNR) state before
+                        declaring it inoperative.
+
+                        The object descriptor contains the name of an
+                        NCP configuration parameter, RNRLIMIT.  Please
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 40]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                        note that the value of this object represents
+                        1/100ths of a second while the NCP RNRLIMIT is
+                        represented in minutes.
+
+                        A value of sdlcLSOperRNRLIMIT == 0 means there
+                        is no limit."
+                    ::= { sdlcLSOperEntry 12 }
+
+sdlcLSOperDATMODE   OBJECT-TYPE
+                    SYNTAX      INTEGER
+                    {
+                        half(1),
+                        full(2)
+                    }
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects whether the current
+                        communications mode with the adjacent link
+                        station is two-way-alternate (half) or
+                        two-way-simultaneous (full)."
+                    ::= { sdlcLSOperEntry 13 }
+
+sdlcLSOperLastModifyTime    OBJECT-TYPE
+                    SYNTAX      TimeTicks
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object describes the value of sysUpTime
+                         when this link station definition was last
+                         modified.  If the link station has not been
+                         modified, then this value shall be zero."
+                    ::= { sdlcLSOperEntry 14 }
+
+sdlcLSOperLastFailTime    OBJECT-TYPE
+                    SYNTAX      TimeTicks
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object describes the value of sysUpTime
+                         when this SDLC link station last failed.  If
+                         the link station has not failed, then this
+                         value shall be zero."
+                    ::= { sdlcLSOperEntry 15 }
+
+sdlcLSOperLastFailCause    OBJECT-TYPE
+                    SYNTAX      INTEGER
+                    {
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 41]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                        undefined(1),
+                        rxFRMR(2),
+                        txFRMR(3),
+                        noResponse(4),
+                        protocolErr(5),
+                        noActivity(6),
+                        rnrLimit(7),
+                        retriesExpired(8)
+                    }
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This enumerated object reflects the cause of
+                        the last failure of this SDLC link station.  If
+                        the link station has not failed, then this
+                        object will have a value of undefined(1)."
+                    DEFVAL { undefined }
+                    ::= { sdlcLSOperEntry 16 }
+
+sdlcLSOperLastFailCtrlIn  OBJECT-TYPE
+                    SYNTAX      OCTET STRING (SIZE(1..2))
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the last control octet or
+                        octets (depending on modulus) received by this
+                        SDLC link station at the time of the last
+                        failure.  If the link station has not failed,
+                        then this value has no meaning."
+                    ::= { sdlcLSOperEntry 17 }
+
+sdlcLSOperLastFailCtrlOut  OBJECT-TYPE
+                    SYNTAX      OCTET STRING (SIZE(1..2))
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the last control octet or
+                        octets (depending on modulus) sent by this SDLC
+                        link station at the time of the last failure.
+                        If the link station has not failed, then this
+                        value has no meaning."
+                    ::= { sdlcLSOperEntry 18 }
+
+sdlcLSOperLastFailFRMRInfo  OBJECT-TYPE
+                    SYNTAX      OCTET STRING (SIZE(3))
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 42]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                        "This object reflects the information field of
+                        the FRMR frame if the last failure for this
+                        SDLC link station was as a result of an invalid
+                        frame.  Otherwise, this field has no meaning."
+                    ::= { sdlcLSOperEntry 19 }
+
+sdlcLSOperLastFailREPLYTOs  OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the number of times that
+                        the REPLYTO timer had expired for an SDLC link
+                        station at the time of the last failure. If the
+                        link station has not failed, then this value
+                        has no meaning."
+                    ::= { sdlcLSOperEntry 20 }
+
+sdlcLSOperEcho      OBJECT-TYPE
+                    SYNTAX      INTEGER
+                    {
+                         no(1),
+                         yes(2)
+                    }
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object identifies whether the echo bit is
+                         in effect for this particular link station."
+                    DEFVAL { no }
+                    ::= { sdlcLSOperEntry 21 }
+
+sdlcLSOperGPoll     OBJECT-TYPE
+                    SYNTAX      INTEGER (0..254)
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object describes the group poll address
+                        in effect for this link station instance."
+                    DEFVAL { 0 }
+                    ::= { sdlcLSOperEntry 22 }
+
+sdlcLSOperSimRim    OBJECT-TYPE
+                    SYNTAX      INTEGER
+                    {
+                         no(1),
+                         yes(2)
+                    }
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 43]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the support for
+                        transmission and receipt of SIM and RIM control
+                        frames for the adjacent link station.  The
+                        value of this object is set from the XID field
+                        received from the adjacent link station."
+                    DEFVAL { no }
+                    ::= { sdlcLSOperEntry 23 }
+
+sdlcLSOperXmitRcvCap OBJECT-TYPE
+                    SYNTAX      INTEGER
+                    {
+                         twa(1),
+                         tws(2)
+                    }
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the transmit-receive
+                        capabilities for the adjacent SDLC link
+                        station.  The value of this object is the value
+                        of the transmit-receive capability indicator
+                        received in the XID image from the adjacent
+                        link station."
+                    DEFVAL { twa }
+                    ::= { sdlcLSOperEntry 24 }
+
+
+--  *************************************************************
+--  *                                                           *
+--  *           THE SDLC LINK STATION STATISTICS TABLE          *
+--  *                                                           *
+--  *************************************************************
+
+sdlcLSStatsTable  OBJECT-TYPE
+                    SYNTAX      SEQUENCE OF SdlcLSStatsEntry
+                    MAX-ACCESS  not-accessible
+                    STATUS      current
+                    DESCRIPTION
+                        "Each entry in this table contains statistics
+                        for a specific SDLC link station."
+                     ::= { sdlcLSGroup 3 }
+
+sdlcLSStatsEntry  OBJECT-TYPE
+                    SYNTAX      SdlcLSStatsEntry
+                    MAX-ACCESS  not-accessible
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 44]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                    STATUS      current
+                    DESCRIPTION
+                        "A list of statistics for an SDLC link station."
+                    INDEX   { ifIndex, sdlcLSAddress }
+                    ::= { sdlcLSStatsTable 1 }
+
+SdlcLSStatsEntry ::= SEQUENCE
+{
+        sdlcLSStatsBLUsIn             Counter32,
+        sdlcLSStatsBLUsOut            Counter32,
+        sdlcLSStatsOctetsIn           Counter32,
+        sdlcLSStatsOctetsOut          Counter32,
+        sdlcLSStatsPollsIn            Counter32,
+        sdlcLSStatsPollsOut           Counter32,
+        sdlcLSStatsPollRspsIn         Counter32,
+        sdlcLSStatsPollRspsOut        Counter32,
+        sdlcLSStatsLocalBusies        Counter32,
+        sdlcLSStatsRemoteBusies       Counter32,
+        sdlcLSStatsIFramesIn          Counter32,
+        sdlcLSStatsIFramesOut         Counter32,
+        sdlcLSStatsUIFramesIn         Counter32,
+        sdlcLSStatsUIFramesOut        Counter32,
+        sdlcLSStatsXIDsIn             Counter32,
+        sdlcLSStatsXIDsOut            Counter32,
+        sdlcLSStatsTESTsIn            Counter32,
+        sdlcLSStatsTESTsOut           Counter32,
+        sdlcLSStatsREJsIn             Counter32,
+        sdlcLSStatsREJsOut            Counter32,
+        sdlcLSStatsFRMRsIn            Counter32,
+        sdlcLSStatsFRMRsOut           Counter32,
+        sdlcLSStatsSIMsIn             Counter32,
+        sdlcLSStatsSIMsOut            Counter32,
+        sdlcLSStatsRIMsIn             Counter32,
+        sdlcLSStatsRIMsOut            Counter32,
+        sdlcLSStatsDISCIn             Counter32,
+        sdlcLSStatsDISCOut            Counter32,
+        sdlcLSStatsUAIn               Counter32,
+        sdlcLSStatsUAOut              Counter32,
+        sdlcLSStatsDMIn               Counter32,
+        sdlcLSStatsDMOut              Counter32,
+        sdlcLSStatsSNRMIn             Counter32,
+        sdlcLSStatsSNRMOut            Counter32,
+        sdlcLSStatsProtocolErrs       Counter32,
+        sdlcLSStatsActivityTOs        Counter32,
+        sdlcLSStatsRNRLIMITs          Counter32,
+        sdlcLSStatsRetriesExps        Counter32,
+        sdlcLSStatsRetransmitsIn      Counter32,
+        sdlcLSStatsRetransmitsOut     Counter32
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 45]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+}
+
+sdlcLSStatsBLUsIn   OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total basic link
+                        units (BLUs; frames) received from an adjacent
+                        SDLC link station since link station startup.
+                        At link station startup time, this object must
+                        be initialized to zero."
+                    ::= { sdlcLSStatsEntry 1 }
+
+sdlcLSStatsBLUsOut   OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total basic link
+                        units (BLUs; frames), transmitted to an
+                        adjacent SDLC link station since link station
+                        startup.  At link station startup time, this
+                        object must be initialized to zero."
+                    ::= { sdlcLSStatsEntry 2 }
+
+sdlcLSStatsOctetsIn OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total octets received
+                        from an adjacent SDLC link station since link
+                        station startup.  This object covers the
+                        address, control, and information field of
+                        I-Frames only.  At link station startup time,
+                        this object must be initialized to zero."
+                    ::= { sdlcLSStatsEntry 3 }
+
+sdlcLSStatsOctetsOut OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total octets
+                        transmitted to an adjacent SDLC link station
+                        since link station startup.  This object covers
+                        the address, control, and information field of
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 46]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                        I-Frames only.  At link station startup time,
+                        this object must be initialized to zero."
+                    ::= { sdlcLSStatsEntry 4 }
+
+sdlcLSStatsPollsIn  OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total polls received
+                        from an adjacent SDLC link station since link
+                        station startup.  At link station startup time,
+                        this object must be initialized to zero."
+                    ::= { sdlcLSStatsEntry 5 }
+
+sdlcLSStatsPollsOut OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total polls sent to
+                        an adjacent SDLC link station since link
+                        station startup.  At link station startup time,
+                        this object must be initialized to zero."
+                    ::= { sdlcLSStatsEntry 6 }
+
+sdlcLSStatsPollRspsOut OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total number of poll
+                        responses sent to the adjacent SDLC link
+                        station since link station startup.  This value
+                        includes I-frames that are sent in response to
+                        a poll.
+
+                        At link station startup time, this object must
+                        be initialized to zero."
+                    ::= { sdlcLSStatsEntry 7 }
+
+sdlcLSStatsPollRspsIn OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total number of poll
+                        responses received from the adjacent SDLC link
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 47]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                        station since station startup.  This value
+                        includes I-frames that are received in response
+                        to a poll.
+
+                        At link station startup time, this object must
+                        be initialized to zero."
+                    ::= { sdlcLSStatsEntry 8 }
+
+sdlcLSStatsLocalBusies OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total number of times
+                        that the local SDLC link station has entered a
+                        busy state (RNR) since link station startup.
+                        At link station startup time, this object must
+                        be initialized to zero."
+                    ::= { sdlcLSStatsEntry 9 }
+
+sdlcLSStatsRemoteBusies OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total number of times
+                        that an adjacent ( remote) SDLC link station
+                        has entered a busy state (RNR) since link
+                        station startup.  At link station startup time,
+                        this object must be initialized to zero."
+                    ::= { sdlcLSStatsEntry 10 }
+
+sdlcLSStatsIFramesIn OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total I-frames
+                        received from an adjacent SDLC link station
+                        since link station startup.  At link station
+                        startup time, this object must be initialized
+                        to zero."
+                    ::= { sdlcLSStatsEntry 11 }
+
+sdlcLSStatsIFramesOut OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 48]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                    DESCRIPTION
+                        "This object reflects the total I-frames
+                        transmitted to an adjacent SDLC link station
+                        since link station startup.  At link station
+                        startup time, this object must be initialized
+                        to zero."
+                    ::= { sdlcLSStatsEntry 12 }
+
+sdlcLSStatsUIFramesIn OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total UI-frames
+                        received from an adjacent SDLC link station
+                        since link station startup."
+                    ::= { sdlcLSStatsEntry 13 }
+
+sdlcLSStatsUIFramesOut OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                       "This object reflects the total UI-frames
+                       transmitted to an adjacent SDLC link station
+                       since link station startup."
+                    ::= { sdlcLSStatsEntry 14 }
+
+sdlcLSStatsXIDsIn   OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total XID frames
+                        received from an adjacent SDLC link station
+                        since link station startup."
+                    ::= { sdlcLSStatsEntry 15 }
+
+sdlcLSStatsXIDsOut  OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total XID frames
+                        transmitted to an adjacent SDLC link station
+                        since link station startup."
+                    ::= { sdlcLSStatsEntry 16 }
+
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 49]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+sdlcLSStatsTESTsIn   OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total TEST frames,
+                        commands or responses, received from an
+                        adjacent SDLC link station since link station
+                        startup."
+                    ::= { sdlcLSStatsEntry 17 }
+
+sdlcLSStatsTESTsOut  OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total TEST frames,
+                        commands or responses, transmitted to an
+                        adjacent SDLC link station since link station
+                        startup."
+                    ::= { sdlcLSStatsEntry 18 }
+
+sdlcLSStatsREJsIn   OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total REJ frames
+                        received from an adjacent SDLC link station
+                        since link station startup."
+                    ::= { sdlcLSStatsEntry 19 }
+
+sdlcLSStatsREJsOut  OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total REJ frames
+                        transmitted to an adjacent SDLC link station
+                        since link station startup."
+                    ::= { sdlcLSStatsEntry 20 }
+
+sdlcLSStatsFRMRsIn  OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total frame reject
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 50]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                        (FRMR) frames received from an adjacent SDLC
+                        link station since link station startup."
+                    ::= { sdlcLSStatsEntry 21 }
+
+sdlcLSStatsFRMRsOut  OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total frame reject
+                        (FRMR) frames transmitted to an adjacent SDLC
+                        link station since link station startup."
+                    ::= { sdlcLSStatsEntry 22 }
+
+sdlcLSStatsSIMsIn   OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total set
+                        initialization mode (SIM) frames received from
+                        an adjacent SDLC link station since link station
+                        startup."
+                    ::= { sdlcLSStatsEntry 23 }
+
+sdlcLSStatsSIMsOut  OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total set
+                        initialization mode (SIM) frames transmitted to
+                        an adjacent SDLC link station since link station
+                        startup.  At link station startup time, this
+                        object must be initialized to zero."
+                    ::= { sdlcLSStatsEntry 24 }
+
+sdlcLSStatsRIMsIn   OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total request
+                        initialization mode (RIM) frames received from
+                        an adjacent SDLC link station since link station
+                        startup.  At link station startup time, this
+                        object must be initialized to zero."
+                    ::= { sdlcLSStatsEntry 25 }
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 51]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+sdlcLSStatsRIMsOut  OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total request
+                        initialization mode (RIM) frames transmitted to
+                        an adjacent SDLC link station since link station
+                        startup.  At link station startup time, this
+                        object must be initialized to zero."
+                    ::= { sdlcLSStatsEntry 26 }
+
+sdlcLSStatsDISCIn   OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total number of
+                         disconnect (DISC) requests received from an
+                         adjacent SDLC link station since link station
+                         startup.  At link station startup time, this
+                         object must be initialized to zero."
+                    ::= { sdlcLSStatsEntry 27 }
+
+sdlcLSStatsDISCOut  OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total number of
+                         disconnect (DISC) requests transmited to an
+                         adjacent SDLC link station since link station
+                         startup.  At link station startup time, this
+                         object must be initialized to zero."
+                    ::= { sdlcLSStatsEntry 28 }
+
+sdlcLSStatsUAIn     OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total number of
+                         unnumbered acknowledgements (UA) requests
+                         received from an adjacent SDLC link station
+                         since link station startup.  At link station
+                         startup time, this object must be initialized
+                         to zero."
+                    ::= { sdlcLSStatsEntry 29 }
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 52]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+sdlcLSStatsUAOut    OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total number of
+                         unnumbered acknowledgements (UA) requests
+                         transmited to an adjacent SDLC link station
+                         since link station startup.  At link station
+                         startup time, this object must be initialized
+                         to zero."
+                    ::= { sdlcLSStatsEntry 30 }
+
+sdlcLSStatsDMIn     OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total number of
+                         disconnect mode (DM) requests received from an
+                         adjacent SDLC link station since link station
+                         startup.  At link station startup time, this
+                         object must be initialized to zero."
+                    ::= { sdlcLSStatsEntry 31 }
+
+sdlcLSStatsDMOut    OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total number of
+                         disconnect mode (DM) requests transmited to an
+                         adjacent SDLC link station since link station
+                         startup.  At link station startup time, this
+                         object must be initialized to zero."
+                    ::= { sdlcLSStatsEntry 32 }
+
+sdlcLSStatsSNRMIn   OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total number of
+                         set normal response mode (SNRM/SNRME) requests
+                         received from an adjacent SDLC link station
+                         since link station startup.  At link station
+                         startup time, this object must be initialized
+                         to zero."
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 53]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                    ::= { sdlcLSStatsEntry 33 }
+
+sdlcLSStatsSNRMOut  OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total number of
+                         set normal response mode (SNRM/SNRME) requests
+                         transmited to an adjacent SDLC link station
+                         since link station startup.  At link station
+                         startup time, this object must be initialized
+                         to zero."
+                    ::= { sdlcLSStatsEntry 34 }
+
+sdlcLSStatsProtocolErrs OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total occurrences,
+                        since link station startup, where this SDLC
+                        link station has inactivated the link as a
+                        result of receiving a frame from its adjacent
+                        link station which was in violation of the
+                        protocol.  At link station startup time, this
+                        object must be initialized to zero."
+                    ::= { sdlcLSStatsEntry 35 }
+
+sdlcLSStatsActivityTOs OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total occurrences,
+                        since startup, where this SDLC link station has
+                        inactivated the link as a result of no activity
+                        on the link.  At link station startup time,
+                        this object must be initialized to zero."
+                    ::= { sdlcLSStatsEntry 36 }
+
+sdlcLSStatsRNRLIMITs OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total occurrences,
+                        since startup, where this SDLC link station has
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 54]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                        inactivated the link as a result of its
+                        RNRLIMIT timer expiring.  At link station
+                        startup time, this object must be initialized
+                        to zero."
+                    ::= { sdlcLSStatsEntry 37 }
+
+sdlcLSStatsRetriesExps OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total occurrences,
+                        since startup, where this SDLC link station has
+                        inactivated the link as a result of a retry
+                        sequence being exhausted.  At link station
+                        startup time, this object must be initialized
+                        to zero."
+                    ::= { sdlcLSStatsEntry 38 }
+
+sdlcLSStatsRetransmitsIn OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+                    DESCRIPTION
+                        "This object reflects the total number of
+                         information frames retransmitted by the remote
+                         link station because the N(s) received from
+                         that link station indicated that one or more
+                         information frames sent by that station were
+                         lost.  This event causes the first missing
+                         information frame of a window and all
+                         subsequent information frames to be
+                         retransmitted.  At link station startup time,
+                         this object must be initialized to zero.
+
+                         Management: If the value of
+                         sdlcLSStatsRetransmitsIn grows over time, then
+                         the quality of the serial line is in
+                         question.  You might want to look at
+                         decreasing the value for
+                         sdlcLSAdminMAXDATASend to compensate for the
+                         lower quality line."
+                    ::= { sdlcLSStatsEntry 39 }
+
+sdlcLSStatsRetransmitsOut OBJECT-TYPE
+                    SYNTAX      Counter32
+                    MAX-ACCESS  read-only
+                    STATUS      current
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 55]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                    DESCRIPTION
+                        "This object reflects the total number of
+                         information frames retransmitted to a remote
+                         link station because the N(r) received from
+                         that link station indicated that one or more
+                         information frames sent to that station were
+                         lost. This event causes the first missing
+                         information frame of a window and all
+                         subsequent information frames to be
+                         retransmitted.  At link station startup time,
+                         this object must be initialized to zero.
+
+                         Management: If the value of
+                         sdlcLSStatsRetransmitsOut grows over time,
+                         then the quality of the serial line is in
+                         question.  You might want to look at
+                         decreasing the value for sdlcLSAdminMAXDATASend
+                         to compensate for the lower quality line."
+                    ::= { sdlcLSStatsEntry 40 }
+
+--
+--  TRAP DEFINITIONS
+--
+
+--
+--  Notifications
+--
+
+sdlcTraps  OBJECT IDENTIFIER ::= { sdlc 3 }
+
+sdlcPortStatusChange NOTIFICATION-TYPE
+                     OBJECTS    { ifIndex,
+                                  ifAdminStatus,
+                                  ifOperStatus,
+                                  sdlcPortOperLastFailTime,
+                                  sdlcPortOperLastFailCause
+                                }
+                     STATUS  current
+                     DESCRIPTION
+                         "This trap indicates that the state of an SDLC
+                         port has transitioned to active or inactive."
+                     ::= { sdlcTraps 1 }
+
+sdlcLSStatusChange   NOTIFICATION-TYPE
+                     OBJECTS    { ifIndex,
+                                  sdlcLSAddress,
+                                  sdlcLSOperState,
+                                  sdlcLSAdminState,
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 56]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                                  sdlcLSOperLastFailTime,
+                                  sdlcLSOperLastFailCause,
+                                  sdlcLSOperLastFailFRMRInfo,
+                                  sdlcLSOperLastFailCtrlIn,
+                                  sdlcLSOperLastFailCtrlOut,
+                                  sdlcLSOperLastFailREPLYTOs
+                                }
+                     STATUS  current
+                     DESCRIPTION
+                         "This trap indicates that the state of an SDLC
+                         link station has transitioned to contacted or
+                         discontacted."
+                     ::= { sdlcTraps 2 }
+
+
+--
+-- Conformance Information
+--
+
+sdlcConformance OBJECT IDENTIFIER ::= { sdlc 4 }
+
+sdlcCompliances   OBJECT IDENTIFIER ::= { sdlcConformance 1 }
+sdlcGroups        OBJECT IDENTIFIER ::= { sdlcConformance 2 }
+
+--
+-- Compliance Statements
+--
+
+sdlcCoreCompliance MODULE-COMPLIANCE
+                     STATUS current
+                     DESCRIPTION
+                         "The core compliance statement for all SDLC
+                         nodes."
+                     MODULE
+                         MANDATORY-GROUPS
+                         {
+                             sdlcCorePortAdminGroup,
+                             sdlcCorePortOperGroup,
+                             sdlcCorePortStatsGroup,
+                             sdlcCoreLSAdminGroup,
+                             sdlcCoreLSOperGroup,
+                             sdlcCoreLSStatsGroup
+                         }
+
+                     OBJECT      sdlcPortAdminName
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 57]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                     OBJECT      sdlcPortAdminRole
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     OBJECT      sdlcPortAdminType
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     OBJECT      sdlcPortAdminTopology
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     OBJECT      sdlcPortAdminISTATUS
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     OBJECT      sdlcLSAddress
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     OBJECT      sdlcLSAdminName
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     OBJECT      sdlcLSAdminState
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     OBJECT      sdlcLSAdminISTATUS
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     OBJECT      sdlcLSAdminMAXDATASend
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     OBJECT      sdlcLSAdminMAXDATARcv
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 58]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                         "Write access is not required."
+
+                     OBJECT      sdlcLSAdminMAXIN
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     OBJECT      sdlcLSAdminMAXOUT
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     OBJECT      sdlcLSAdminMODULO
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     OBJECT      sdlcLSAdminRETRIESm
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     OBJECT      sdlcLSAdminRETRIESt
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     OBJECT      sdlcLSAdminRETRIESn
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     OBJECT      sdlcLSAdminRNRLIMIT
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     OBJECT      sdlcLSAdminDATMODE
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     OBJECT      sdlcLSAdminGPoll
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     OBJECT      sdlcLSAdminSimRim
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 59]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     OBJECT      sdlcLSAdminRowStatus
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     ::= { sdlcCompliances 1 }
+
+sdlcPrimaryCompliance  MODULE-COMPLIANCE
+                     STATUS current
+                     DESCRIPTION
+                         "The compliance statement for all nodes that
+                         are performing the role of a Primary link
+                         station."
+                     MODULE
+                         MANDATORY-GROUPS { sdlcPrimaryGroup }
+
+                     OBJECT      sdlcPortAdminPAUSE
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     OBJECT      sdlcLSAdminREPLYTO
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     ::= { sdlcCompliances 2 }
+
+sdlcPrimaryMultipointCompliance  MODULE-COMPLIANCE
+                     STATUS current
+                     DESCRIPTION
+                         "The compliance statement for all nodes that
+                         are performing the role of a primary link
+                         station on a multipoint line."
+                     MODULE
+                         MANDATORY-GROUPS { sdlcPrimaryMultipointGroup }
+
+                     OBJECT      sdlcPortAdminSERVLIM
+                     MIN-ACCESS  read-only
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     OBJECT      sdlcPortAdminSlowPollTimer
+                     MIN-ACCESS  read-only
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 60]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                     DESCRIPTION
+                         "Write access is not required."
+
+                     ::= { sdlcCompliances 3 }
+
+
+--
+-- Core Conformance Groups for All Link Stations
+--
+
+sdlcCoreGroups OBJECT IDENTIFIER ::= { sdlcGroups 1 }
+
+sdlcCorePortAdminGroup OBJECT-GROUP
+                     OBJECTS
+                     {
+                         sdlcPortAdminName,      sdlcPortAdminRole,
+                         sdlcPortAdminType,      sdlcPortAdminTopology,
+                         sdlcPortAdminISTATUS
+                     }
+                     STATUS current
+                     DESCRIPTION
+                         "The sdlcCorePortAdminGroup defines objects
+                         which are common to the PortAdmin group of all
+                         compliant link stations."
+                     ::= { sdlcCoreGroups 1 }
+
+sdlcCorePortOperGroup OBJECT-GROUP
+                     OBJECTS
+                     {
+                         sdlcPortOperName,
+                         sdlcPortOperRole,
+                         sdlcPortOperType,
+                         sdlcPortOperTopology,
+                         sdlcPortOperISTATUS,
+                         sdlcPortOperACTIVTO,
+                         sdlcPortOperLastFailTime,
+                         sdlcPortOperLastFailCause
+                     }
+                     STATUS current
+                     DESCRIPTION
+                         "The sdlcCorePortOperGroup defines objects
+                         which are common to the PortOper group of all
+                         compliant link stations."
+                     ::= { sdlcCoreGroups 2 }
+
+
+sdlcCorePortStatsGroup OBJECT-GROUP
+                     OBJECTS
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 61]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                     {
+                         sdlcPortStatsPhysicalFailures,
+                         sdlcPortStatsInvalidAddresses,
+                         sdlcPortStatsDwarfFrames
+                     }
+                     STATUS current
+                     DESCRIPTION
+                         "The sdlcCorePortStatsGroup defines objects
+                         which are common to the PortStats group of all
+                         compliant link stations."
+                     ::= { sdlcCoreGroups 3 }
+
+
+sdlcCoreLSAdminGroup OBJECT-GROUP
+                     OBJECTS
+                     {
+                         sdlcLSAddress,
+                         sdlcLSAdminName,
+                         sdlcLSAdminState,
+                         sdlcLSAdminISTATUS,
+                         sdlcLSAdminMAXDATASend,
+                         sdlcLSAdminMAXDATARcv,
+                         sdlcLSAdminMAXIN,
+                         sdlcLSAdminMAXOUT,
+                         sdlcLSAdminMODULO,
+                         sdlcLSAdminRETRIESm,
+                         sdlcLSAdminRETRIESt,
+                         sdlcLSAdminRETRIESn,
+                         sdlcLSAdminRNRLIMIT,
+                         sdlcLSAdminDATMODE,
+                         sdlcLSAdminGPoll,
+                         sdlcLSAdminSimRim,
+                         sdlcLSAdminRowStatus
+                     }
+                     STATUS current
+                     DESCRIPTION
+                         "The sdlcCorePortAdminGroup defines objects
+                         which are common to the PortAdmin group of all
+                         compliant link stations."
+                     ::= { sdlcCoreGroups 4 }
+
+sdlcCoreLSOperGroup  OBJECT-GROUP
+                     OBJECTS
+                     {
+                         sdlcLSOperRole,
+                         sdlcLSOperState,
+                         sdlcLSOperMAXDATASend,
+                         sdlcLSOperMAXIN,
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 62]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                         sdlcLSOperMAXOUT,
+                         sdlcLSOperMODULO,
+                         sdlcLSOperRETRIESm,
+                         sdlcLSOperRETRIESt,
+                         sdlcLSOperRETRIESn,
+                         sdlcLSOperRNRLIMIT,
+                         sdlcLSOperDATMODE,
+                         sdlcLSOperLastFailTime,
+                         sdlcLSOperLastFailCause,
+                         sdlcLSOperLastFailCtrlIn,
+                         sdlcLSOperLastFailCtrlOut,
+                         sdlcLSOperLastFailFRMRInfo,
+                         sdlcLSOperLastFailREPLYTOs,
+                         sdlcLSOperEcho,
+                         sdlcLSOperGPoll
+                     }
+                     STATUS current
+                     DESCRIPTION
+                         "The sdlcCorePortOperGroup defines objects
+                         which are common to the PortOper group of all
+                         compliant link stations."
+                     ::= { sdlcCoreGroups 5 }
+
+
+sdlcCoreLSStatsGroup OBJECT-GROUP
+                     OBJECTS
+                     {
+                         sdlcLSStatsBLUsIn,
+                         sdlcLSStatsBLUsOut,
+                         sdlcLSStatsOctetsIn,
+                         sdlcLSStatsOctetsOut,
+                         sdlcLSStatsPollsIn,
+                         sdlcLSStatsPollsOut,
+                         sdlcLSStatsPollRspsIn,
+                         sdlcLSStatsPollRspsOut,
+                         sdlcLSStatsLocalBusies,
+                         sdlcLSStatsRemoteBusies,
+                         sdlcLSStatsIFramesIn,
+                         sdlcLSStatsIFramesOut,
+                         sdlcLSStatsRetransmitsIn,
+                         sdlcLSStatsRetransmitsOut,
+                         sdlcLSStatsUIFramesIn,
+                         sdlcLSStatsUIFramesOut,
+                         sdlcLSStatsXIDsIn,
+                         sdlcLSStatsXIDsOut,
+                         sdlcLSStatsTESTsIn,
+                         sdlcLSStatsTESTsOut,
+                         sdlcLSStatsREJsIn,
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 63]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                         sdlcLSStatsREJsOut,
+                         sdlcLSStatsFRMRsIn,
+                         sdlcLSStatsFRMRsOut,
+                         sdlcLSStatsSIMsIn,
+                         sdlcLSStatsSIMsOut,
+                         sdlcLSStatsRIMsIn,
+                         sdlcLSStatsRIMsOut,
+                         sdlcLSStatsProtocolErrs,
+                         sdlcLSStatsRNRLIMITs,
+                         sdlcLSStatsRetriesExps
+                     }
+                     STATUS current
+                     DESCRIPTION
+                         "The sdlcCorePortStatsGroup defines objects
+                         which are common to the PortStats group of all
+                         compliant link stations."
+                     ::= { sdlcCoreGroups 6 }
+
+
+--
+-- Conformance Groups for Primary Link Stations
+--
+
+sdlcPrimaryGroups OBJECT IDENTIFIER ::= { sdlcGroups 2 }
+
+sdlcPrimaryGroup OBJECT-GROUP
+                     OBJECTS
+                     {
+                         sdlcPortAdminPAUSE,
+                         sdlcPortOperPAUSE,
+                         sdlcLSAdminREPLYTO,
+                         sdlcLSOperREPLYTO
+                     }
+                     STATUS current
+                     DESCRIPTION
+                         "The sdlcPrimaryGroup defines objects which
+                         are common to all compliant primary link
+                         stations."
+                     ::= { sdlcPrimaryGroups 1 }
+
+sdlcPrimaryMultipointGroup OBJECT-GROUP
+                     OBJECTS
+                     {
+                         sdlcPortAdminSERVLIM,
+                         sdlcPortAdminSlowPollTimer,
+                         sdlcPortOperSlowPollMethod,
+                         sdlcPortOperSERVLIM,
+                         sdlcPortOperSlowPollTimer
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 64]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+                     }
+                     STATUS current
+                     DESCRIPTION
+                         "The sdlcPrimaryMultipointGroup defines objects
+                         which are common to all compliant primary link
+                         stations that are in a multipoint topology."
+                     ::= { sdlcPrimaryGroups 2 }
+
+
+END
+
+4.  Acknowledgments
+
+   Thanks goes to the SNADLC MIB working group for reviewing this MIB
+   and for their infinite patience through the editing process.
+
+5.  References
+
+   [1] Stewart, B., "Definitions of Managed Objects for RS-232-like
+       Hardware Devices using SMIv2", RFC 1659, Xyplex, July 1994.
+
+   [2] "Synchronous Data Link Control: Concepts", IBM Publication No.
+       GA27-3093-04, 5th edition, May 1992.
+
+   [3] "Vocabulary for Data Processing Telecommunications, and Office
+       Systems", IBM Publication No. GC20-1699-6.
+
+   [4] Kostick, D., Kielczewski, Z., and K. Shih, Editors, "Definitions
+       of Managed Objects for SNA NAUs using SMIv2", RFC 1666, Eicon
+       Technology Corporation, Bell Communications Research, Novell,
+       August 1994.
+
+   [5] Waldbusser, S., "Row Creation with SNMPv1", Work in Progress.
+
+   [6] McCloghrie K., and F. Kastenholz, "Evolution of the Interfaces
+       Group of MIB-II", RFC 1573, Hughes LAN Syst, FTP Software,
+       January 1994.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 65]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+6.  Glossary
+
+     link station
+         A link station comprises procedures and control information
+         that coordinate the transfer of data between two nodes joined
+         by a link connection.  All traffic over the link connection is
+         from the primary link station to one or more secondary link
+         stations, or from a secondary link station to the primary link
+         station.
+
+     primary link station
+         The link station instance on a link connection that is
+         responsible for the control of the data link.  There must be
+         only one primary link station on a link connection.  The
+         primary link station issues commands to one or more secondary
+         link stations.
+
+     secondary link station
+         The link station instance on a link connection that receives
+         commands from the primary link station and issues responses to
+         it.
+
+     switched line
+         A telecommunications line in which the connection is
+         established by dialing.  For switched lines, the SDLC startup
+         sequence typically begins with a null exchange identifier (null
+         XID).
+
+     leased line
+         A telecommunications line on which connections do not have to
+         be established by dialing.  For leased lines, the SDLC startup
+         sequence may or may not begin with an exchange identifer (XID).
+         While there are interface (e.g., RS.232) differences between
+         leased and switched lines, those interface differences do not
+         map one-to-one with differences in the SDLC startup protocol
+         (i.e., the interface and the SDLC protocol are independent from
+         one another).
+
+     point-to-point link
+         A link that connects the single primary link station to single
+         secondary link station.  A point-to-point link may be either
+         switched or leased.
+
+     multipoint link
+         A link that connects the single primary link station to several
+         secondary link stations.  A multipoint link may be either
+         switched or leased.  Note: The physical interface signals for a
+         multipoint link are different than for a point-to-point link.
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 66]
+
+RFC 1747              SNADLC SDLC MIB using SMIv2           January 1995
+
+
+         Synonymous with multidrop line.
+
+7.  Security Considerations
+
+   Security issues are not discussed in this memo.
+
+8.  Authors' Addresses
+
+   Jeff Hilgeman (chair)
+   Apertus Technologies, Inc.
+   7275 Flying Cloud Dr.
+   Eden Prarie, MN  55344
+
+   Phone: 1 612 828 0668
+   EMail: jeffh@apertus.com
+
+
+   Shannon D. Nix
+   Metaplex, Inc.
+   7412 Wingfoot Dr.
+   Raleigh, NC  27615
+
+   Phone: 1 919 878 0811
+   EMail: snix@metaplex.com
+
+
+   Alan Bartky
+   Sync Research, Inc.
+   7 Studebaker
+   Irvine, CA  92718
+
+   Phone: 1 714 588 2070
+   EMail: alan@sync.com
+
+
+   Wayne Clark (editor)
+   cisco Systems, Inc.
+   3100 Smoketree Ct.
+   Suite 1000
+   Raleigh, NC 27604
+
+   Phone: 1 919 878 6958
+   EMail: wclark@cisco.com
+
+
+
+
+
+
+
+
+Hilgeman, Nix, Bartky & Clark                                  [Page 67]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1747.txt](<www.ietf.org/rfc/rfc1747.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
