### PR TITLE
Archive rfc1749.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1749.txt
+++ b/www.ietf.org/rfc/rfc1749.txt
@@ -1,0 +1,563 @@
+
+
+
+
+
+
+Network Working Group                                      K. McCloghrie
+Request for Comments: 1749                                      F. Baker
+Updates: 1748                                                  E. Decker
+Category: Standards Track                            cisco Systems, Inc.
+                                                           December 1994
+
+
+           IEEE 802.5 Station Source Routing MIB using SMIv2
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Table of Contents
+
+   1. Introduction .............................................    1
+   2. The SNMPv2 Network Management Framework ..................    2
+   2.1 Object Definitions ......................................    2
+   3. Overview .................................................    2
+   3.1 Source Routing ..........................................    2
+   3.2 Relationship to RFC 1748 ................................    3
+   3.3 Relationship to RFC 1525 ................................    3
+   3.4 Static Source Routes ....................................    4
+   3.5 Destinations on the Local Ring ..........................    4
+   4. Definitions ..............................................    4
+   5. Acknowledgements .........................................    8
+   6. References ...............................................    8
+   7. Security Considerations ..................................    9
+   8. Authors' Addresses .......................................   10
+
+1.  Introduction
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the Internet community.
+   In particular, it describes managed objects used by IEEE 802.5 end-
+   stations for managing source routes on a Token Ring network where
+   IEEE source-routing is in use.  IEEE source-routing is described in
+   802.5 Token Ring Access Method and Physical Layer Specifications [8]
+   and related ISO publications [9, 10, 11].
+
+   This memo is an incremental update to RFC 1748 [6].  It is documented
+   separately from the RFC 1748 solely due to the latter's maturity
+   within the Internet standardization process.
+
+
+
+
+McCloghrie, Baker & Decker                                      [Page 1]
+
+RFC 1749      802.5 Station Source Routing MIB using SMIv2 December 1994
+
+
+2.  The SNMPv2 Network Management Framework
+
+   The SNMPv2 Network Management Framework consists of four major
+   components.  They are:
+
+      o    RFC 1442 [1] which defines the SMI, the mechanisms used for
+           describing and naming objects for the purpose of management.
+
+      o    STD 17, RFC 1213 [2] defines MIB-II, the core set of managed
+           objects for the Internet suite of protocols.
+
+      o    RFC 1445 [3] which defines the administrative and other
+           architectural aspects of the framework.
+
+      o    RFC 1448 [4] which defines the protocol used for network
+           access to managed objects.
+
+   The Framework permits new objects to be defined for the purpose of
+   experimentation and evaluation.
+
+2.1.  Object Definitions
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  Objects in the MIB are
+   defined using the subset of Abstract Syntax Notation One (ASN.1)
+   defined in the SMI.  In particular, each object type is named by an
+   OBJECT IDENTIFIER, an administratively assigned name.  The object
+   type together with an object instance serves to uniquely identify a
+   specific instantiation of the object.  For human convenience, we
+   often use a textual string, termed the descriptor, to refer to the
+   object type.
+
+3.  Overview
+
+   This memo defines a single table: the 802.5 Station Source Routing
+   Table, which contains the source routes known by a end-station on an
+   IEEE 802.5 Token Ring network in which IEEE source-routing is in use.
+
+3.1.  Source Routing
+
+   Source routing extends the 802.5 protocol [8] by assigning a unique
+   ring number to each ring within the extended LAN, and a bridge number
+   to each source routing bridge's connection to a ring.  A Routing
+   Information Field (RIF) must be included in frames which need to
+   traverse multiple rings.  The format of the RIF is:
+
+
+
+
+
+
+McCloghrie, Baker & Decker                                      [Page 2]
+
+RFC 1749      802.5 Station Source Routing MIB using SMIv2 December 1994
+
+
+              octets octets octets         octets
+               1&2    3&4    5&6            17&18
+             +------+------+------+-------+------+
+             |  RC  |  RD  |  RD  | ...   |  RD  |
+             +------+------+------+-------+------+
+                     <---- 0 to 8 RD fields ---->
+
+   The format of the Routing Control (RC) field is:
+
+                            octet 1         octet 2
+                       +---------------+---------------+
+                       |b b b l l l l l|d f f f 0 0 0 0|
+                       +---------------+---------------+
+                          ^       ^     ^   ^
+                          |       |     |   |
+     Explorer indicator --+       |     |   +-- Max frame length*
+            Length of RIF field --+     +-- Direction to use RDs
+
+     * Note that the length of the Maximum frame length subfield
+       has recently been extended to 6 bits.
+
+   The format of each Routing Descriptor (RD) field is:
+
+                     octet 1         octet 2
+                 +---------------+---------------+
+                 |r r r r r r r r r r r r i i i i|
+                 +---------------+---------------+
+                  <---- ring number ----> <----->
+                                             ^
+                                             |
+                             bridge number --+
+
+3.2.  Relationship to RFC 1748
+
+   RFC 1748 [6], the IEEE 802.5 MIB, defines managed objects used for
+   interfaces to IEEE 802.5 Token Ring subnetworks.  This memo is an
+   incremental update to RFC 1748, and is documented independently
+   solely due to the maturity of the definitions contained within RFC
+   1748.
+
+3.3.  Relationship to RFC 1525
+
+   RFC 1525 [7] defines the MIB objects specific to source-routing for
+   source-routing and SRT bridges.  This memo defines the MIB objects
+   specific to source-routing for source-routing end-stations.
+
+
+
+
+
+
+McCloghrie, Baker & Decker                                      [Page 3]
+
+RFC 1749      802.5 Station Source Routing MIB using SMIv2 December 1994
+
+
+3.4.  Static Source Routes
+
+   It is unclear how many, if any, existing systems allow the creation
+   or deletion of "static" 802.5 source routes by network management.
+   However, SNMPv2 SMI defines that the MAX-ACCESS clause as specifying
+   the maximal level of access which makes "protocol sense".  Thus, this
+   memo provides support for static source routes through the
+   dot5SrRouteStatus object, but the conformance statements allow for
+   stations which do not support static source routes, by requiring that
+   compliant agents only need provide read-access to dot5SrRouteStatus.
+
+3.5.  Destinations on the Local Ring
+
+   Entries should be included in the dot5SrRouteTable for destination
+   MAC addresses which are on the same ring as the instrumented 802.5
+   interface.  For such entries, dot5SrRouteDescr has the value of the
+   zero-length string, and dot5SrRouteControl has the corresponding
+   value.
+
+4.  Definitions
+
+TOKENRING-STATION-SR-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE
+                                         FROM SNMPv2-SMI
+    TEXTUAL-CONVENTION, RowStatus, MacAddress
+                                         FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP      FROM SNMPv2-CONF
+    mib-2, ifIndex                       FROM RFC1213-MIB;
+
+dot5SrMIB MODULE-IDENTITY
+    LAST-UPDATED "9412161000Z"
+    ORGANIZATION "IETF Interfaces MIB Working Group"
+    CONTACT-INFO
+            "       Keith McCloghrie
+            Postal: Cisco Systems, Inc.
+                    170 West Tasman Drive
+                    San Jose, CA  95134-1706
+                    US
+
+             Phone: +1 408 526 5260
+             Email: kzm@cisco.com"
+    DESCRIPTION
+            "The MIB module for managing source routes in
+            end-stations on IEEE 802.5 Token Ring networks."
+    ::= { mib-2 42 }
+
+
+
+
+McCloghrie, Baker & Decker                                      [Page 4]
+
+RFC 1749      802.5 Station Source Routing MIB using SMIv2 December 1994
+
+
+dot5SrMIBObjects OBJECT IDENTIFIER ::= { dot5SrMIB 1 }
+
+SourceRoute ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "1x:"
+    STATUS       current
+    DESCRIPTION
+                 "Represents a Source Route, containing an
+                 embedded sequence of bridge and ring ID's,
+                 as used by 802.5 Source Routing."
+    REFERENCE    "Annex C of ISO/IEC 10038: 1993,
+                 [ANSI/IEEE Std 802.1D, 1993]"
+    SYNTAX       OCTET STRING (SIZE(0..30))
+
+
+--           The 802.5 Station Source Route Table
+--
+
+dot5SrRouteTable   OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot5SrRouteEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+               "The table of source-routing routes.
+               This represents the 802.5 RIF database."
+    ::= { dot5SrMIBObjects 1 }
+
+dot5SrRouteEntry  OBJECT-TYPE
+    SYNTAX      Dot5SrRouteEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+                "Information on a specific route.
+
+                An entry is created whenever a 'Single Path
+                Explorer' or an 'All Paths Explorer' discovers
+                a route to a neighbor not currently in the table,
+                or whenever an 'All Paths Explorer' discovers a
+                better (e.g., shorter) route than the route currently
+                stored in the table.  This is done on behalf of
+                any network layer client.
+
+                The ifIndex value in the INDEX clause refers to
+                the value of MIB-II's ifIndex object for the
+                interface on which the route is in effect."
+    INDEX  { ifIndex, dot5SrRouteDestination }
+    ::= { dot5SrRouteTable 1 }
+
+Dot5SrRouteEntry ::= SEQUENCE {
+
+
+
+McCloghrie, Baker & Decker                                      [Page 5]
+
+RFC 1749      802.5 Station Source Routing MIB using SMIv2 December 1994
+
+
+    dot5SrRouteDestination   MacAddress,
+    dot5SrRouteControl       OCTET STRING,
+    dot5SrRouteDescr         SourceRoute,
+    dot5SrRouteStatus        RowStatus
+}
+
+dot5SrRouteDestination  OBJECT-TYPE
+    SYNTAX      MacAddress
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+               "The destination of this route."
+    ::= { dot5SrRouteEntry 2 }
+
+dot5SrRouteControl  OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE(2))
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+               "The value of Routing Control field for this
+               route."
+    REFERENCE  "Annex C of ISO/IEC 10038: 1993,
+               [ANSI/IEEE Std 802.1D, 1993]"
+    ::= { dot5SrRouteEntry 3 }
+
+dot5SrRouteDescr  OBJECT-TYPE
+    SYNTAX      SourceRoute
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+               "The embedded sequence of bridge and ring ID's
+               for this route.  For destinations on the
+               local ring, the value of this object is
+               the zero-length string."
+    REFERENCE  "Annex C of ISO/IEC 10038: 1993,
+               [ANSI/IEEE Std 802.1D, 1993]"
+    ::= { dot5SrRouteEntry 4 }
+
+dot5SrRouteStatus  OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+             "The status of this row.  Values of the instances
+             of dot5SrRouteControl and dot5SrRouteDescr can be
+             modified while the row's status is 'active."
+    ::= { dot5SrRouteEntry 5 }
+
+
+
+
+McCloghrie, Baker & Decker                                      [Page 6]
+
+RFC 1749      802.5 Station Source Routing MIB using SMIv2 December 1994
+
+
+-- conformance information
+
+dot5SrConformance OBJECT IDENTIFIER ::= { dot5SrMIB 2 }
+
+dot5SrGroups      OBJECT IDENTIFIER ::= { dot5SrConformance 1 }
+dot5SrCompliances OBJECT IDENTIFIER ::= { dot5SrConformance 2 }
+
+
+-- compliance statements
+
+dot5SrCompliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+        "The compliance statement for SNMPv2 entities
+        which implement the IEEE 802.5 Station Source Route
+        MIB."
+
+    MODULE  -- this module
+        MANDATORY-GROUPS { dot5SrRouteGroup }
+
+        OBJECT      dot5SrRouteStatus
+        SYNTAX      INTEGER { active(1) }   -- subset of values
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required, and only the 'active'
+            value need be supported."
+
+        OBJECT      dot5SrRouteControl
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+        OBJECT      dot5SrRouteDescr
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+    ::= { dot5SrCompliances 1 }
+
+
+-- units of conformance
+
+dot5SrRouteGroup  OBJECT-GROUP
+    OBJECTS   { dot5SrRouteControl,
+                dot5SrRouteDescr,
+                dot5SrRouteStatus
+              }
+    STATUS    current
+
+
+
+McCloghrie, Baker & Decker                                      [Page 7]
+
+RFC 1749      802.5 Station Source Routing MIB using SMIv2 December 1994
+
+
+    DESCRIPTION
+        "A collection of objects providing for the management of
+        source routes in stations on IEEE 802.5 source-routing
+        networks."
+    ::= { dot5SrGroups 1 }
+
+END
+
+5.  Acknowledgements
+
+   The need for this MIB module was agreed upon by the members of the
+   IETF Interfaces Working Group, and the definitions were derived from
+   experience with enterprise-specific MIBs presented to the Working
+   Group.
+
+6.  References
+
+   [1] Case, J., McCloghrie, K., Rose, M., and S. Waldbusser, "Structure
+       of Management Information for version 2 of the Simple Network
+       Management Protocol (SNMPv2)", RFC 1442, SNMP Research,Inc.,
+       Hughes LAN Systems, Dover Beach Consulting, Inc., Carnegie Mellon
+       University, April 1993.
+
+   [2] McCloghrie, K., and M. Rose, Editors, "Management Information
+       Base for Network Management of TCP/IP-based internets: MIB- II",
+       STD 17, RFC 1213, Hughes LAN Systems, Performance Systems
+       International, March 1991.
+
+   [3] Galvin, J., and K. McCloghrie, "Administrative Model for version
+       2 of the Simple Network Management Protocol (SNMPv2)", RFC 1445,
+       Trusted Information Systems, Hughes LAN Systems, April 1993.
+
+   [4] Case, J., McCloghrie, K., Rose, M., and S. Waldbusser, "Protocol
+       Operations for version 2 of the Simple Network Management
+       Protocol (SNMPv2)", RFC 1448, SNMP Research,Inc., Hughes LAN
+       Systems, Dover Beach Consulting, Inc., Carnegie Mellon
+       University, April 1993.
+
+   [5] Case, J., McCloghrie, K., Rose, M., and S. Waldbusser, "Textual
+       Conventions for version 2 of the Simple Network Management
+       Protocol (SNMPv2)", RFC 1443, SNMP Research Inc., Hughes LAN
+       Systems, Dover Beach Consulting, Inc., Carnegie Mellon
+       University, April 1993.
+
+   [6] McCloghrie, K., and E. Decker, "IEEE 802.5 Token Ring MIB using
+       SMIv2", RFC 1748 cisco Systems, Inc., December 1994.
+
+
+
+
+
+McCloghrie, Baker & Decker                                      [Page 8]
+
+RFC 1749      802.5 Station Source Routing MIB using SMIv2 December 1994
+
+
+   [7] McCloghrie, K., Decker, E., Langville, P., and A.  Rijsinghani,
+       "Definitions of Managed Objects for Source Routing Bridges", RFC
+       1525, Hughes LAN Systems, cisco Systems, Inc., Digital Equipment
+       Corporation, September 1993.
+
+   [8] "Token Ring Access Method and Physical Layer Specifications",
+       IEEE Standard 802.5-1989, 1989.
+
+   [9] "Information technology - Local and metropolitan area networks -
+       Part 5: Token ring access method and physical layer
+       specifications", ISO/IEC 8802-5, 1992.
+
+  [10] "Information technology - Telecommunications and information
+       exchange between systems - Local area networks - Media access
+       control (MAC) bridges", ISO/IEC 10038, 1993 [ANSI/IEEE Std
+       802.1D, 1993 Edition].
+
+  [11] "Source Routing Operation by End Systems", ISO/IEC 8802-2 PDAM5.3
+       (6N7721).
+
+7.  Security Considerations
+
+   Security issues are not discussed in this memo.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McCloghrie, Baker & Decker                                      [Page 9]
+
+RFC 1749      802.5 Station Source Routing MIB using SMIv2 December 1994
+
+
+8.  Authors' Addresses
+
+   Keith McCloghrie
+   cisco Systems, Inc.
+   170 West Tasman Drive,
+   San Jose CA 95134-1706.
+
+   Phone: (408) 526-5260
+   EMail: kzm@cisco.com
+
+
+   Fred Baker
+   cisco Systems, Inc.
+   519 Lado Drive
+   Santa Barbara, CA 93111
+
+   Phone: (805) 681-0115
+   EMail: fred@cisco.com
+
+
+   Eric B. Decker
+   cisco Systems, Inc.
+   1525 O'Brien Dr.
+   Menlo Park, California 94025
+
+   Phone: (415) 688-8241
+   EMail: cire@cisco.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McCloghrie, Baker & Decker                                     [Page 10]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1749.txt](<www.ietf.org/rfc/rfc1749.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
