### PR TITLE
Archive rfc1784.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1784.txt
+++ b/www.ietf.org/rfc/rfc1784.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Network Working Group                                          G. Malkin
+Request for Comments: 1784                                Xylogics, Inc.
+Updates: 1350                                                  A. Harkin
+Category: Standards Track                            Hewlett Packard Co.
+                                                              March 1995
+
+
+            TFTP Timeout Interval and Transfer Size Options
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Abstract
+
+   The Trivial File Transfer Protocol [1] is a simple, lock-step, file
+   transfer protocol which allows a client to get or put a file onto a
+   remote host.
+
+   This document describes two TFTP options. The first allows the client
+   and server to negotiate the Timeout Interval.  The second allows the
+   side receiving the file to determine the ultimate size of the
+   transfer before it begins.  The TFTP Option Extension mechanism is
+   described in [2].
+
+   This document assumes that the reader is familiar with the
+   terminology and notation of both [1] and [2].
+
+Timeout Interval Option Specification
+
+   The TFTP Read Request or Write Request packet is modified to include
+   the timeout option as follows:
+
+      +-------+---~~---+---+---~~---+---+---~~---+---+---~~---+---+
+      |  opc  |filename| 0 |  mode  | 0 | timeout| 0 |  #secs | 0 |
+      +-------+---~~---+---+---~~---+---+---~~---+---+---~~---+---+
+
+      opc
+         The opcode field contains either a 1, for Read Requests, or 2,
+         for Write Requests, as defined in [1].
+
+      filename
+         The name of the file to be read or written, as defined in [1].
+         This is a NULL-terminated field.
+
+
+
+Malkin & Harkin                                                 [Page 1]
+
+RFC 1784                      TFTP Options                    March 1995
+
+
+      mode
+         The mode of the file transfer: "netascii", "octet", or "mail",
+         as defined in [1].  This is a NULL-terminated field.
+
+      timeout
+         The Timeout Interval option, "timeout" (case insensitive).
+         This is a NULL-terminated field.
+
+      #secs
+         The number of seconds to wait before retransmitting, specified
+         in ASCII.  Valid values range between "1" and "255" octets,
+         inclusive.  This is a NULL-terminated field.
+
+   For example:
+
+      +-------+--------+---+--------+---+--------+---+--------+---+
+      |   1   | foobar | 0 | binary | 0 | timeout| 0 |    1   | 0 |
+      +-------+--------+---+--------+---+--------+---+--------+---+
+
+   is a Read Request, for the file named "foobar", in binary transfer
+   mode, with a timeout interval of 1 second.
+
+   If the server is willing to accept the timeout option, it sends an
+   Option Acknowledgment (OACK) to the client.  The specified timeout
+   value must match the value specified by the client.
+
+Transfer Size Option Specification
+
+   The TFTP Read Request or Write Request packet is modified to include
+   the tsize option as follows:
+
+      +-------+---~~---+---+---~~---+---+---~~---+---+---~~---+---+
+      |  opc  |filename| 0 |  mode  | 0 | tsize  | 0 |  size  | 0 |
+      +-------+---~~---+---+---~~---+---+---~~---+---+---~~---+---+
+
+      opc
+         The opcode field contains either a 1, for Read Requests, or 2,
+         for Write Requests, as defined in [1].
+
+
+      filename
+         The name of the file to be read or written, as defined in [1].
+         This is a NULL-terminated field.
+
+      mode
+         The mode of the file transfer: "netascii", "octet", or "mail",
+         as defined in [1].  This is a NULL-terminated field.
+
+
+
+
+Malkin & Harkin                                                 [Page 2]
+
+RFC 1784                      TFTP Options                    March 1995
+
+
+      tsize
+         The Transfer Size option, "tsize" (case insensitive).  This is
+         a NULL-terminated field.
+
+      size
+         The size of the file to be transfered, specified as a
+         NULL-terminated ASCII string.
+
+   For example:
+
+      +-------+--------+---+--------+---+--------+---+--------+---+
+      |   2   | foobar | 0 | binary | 0 | tsize  | 0 | 673312 | 0 |
+      +-------+--------+---+--------+---+--------+---+--------+---+
+
+   is a Write Request, with the 673312-octet file named "foobar", in
+   binary transfer mode.
+
+   In Read Request packets, a size of "0" is specified in the request
+   and the size of the file, in octets, is returned in the OACK.  If the
+   file is too large for the client to handle, it may abort the transfer
+   with an Error packet (error code 3).  In Write Request packets, the
+   size of the file, in octets, is specified in the request and echoed
+   back in the OACK.  If the file is too large for the server to handle,
+   it may abort the transfer with an Error packet (error code 3).
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+References
+
+   [1] Sollins, K., "The TFTP Protocol (Revision 2)", STD 33, RFC 1350,
+       MIT, July 1992.
+
+   [2] Malkin, G., and A. Harkin, "TFTP Option Extension", RFC 1782,
+       Xylogics, Inc., Hewlett Packard Co., March 1995.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Malkin & Harkin                                                 [Page 3]
+
+RFC 1784                      TFTP Options                    March 1995
+
+
+Authors' Addresses
+
+       Gary Scott Malkin
+       Xylogics, Inc.
+       53 Third Avenue
+       Burlington, MA  01803
+
+       Phone:  (617) 272-8140
+       EMail:  gmalkin@xylogics.com
+
+
+       Art Harkin
+       Internet Services Project
+       Information Networks Division
+       19420 Homestead Road MS 43LN
+       Cupertino, CA  95014
+
+       Phone: (408) 447-3755
+       EMail: ash@cup.hp.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Malkin & Harkin                                                 [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1784.txt](<www.ietf.org/rfc/rfc1784.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
