### PR TITLE
Archive rfc1799.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1799.txt
+++ b/www.ietf.org/rfc/rfc1799.txt
@@ -1,0 +1,1179 @@
+
+
+
+
+
+
+Network Working Group                                         M. Kennedy
+Request for Comments: 1799                                           ISI
+Category: Informational                                     January 1997
+
+
+                      Request for Comments Summary
+
+                         RFC Numbers 1700-1799
+
+Status of This Memo
+
+   This RFC is a slightly annotated list of the 100 RFCs from RFC 1700
+   through RFCs 1799.  This is a status report on these RFCs.  This memo
+   provides information for the Internet community.  It does not specify
+   an Internet standard of any kind.  Distribution of this memo is
+   unlimited.
+
+Note
+
+   Many RFCs, but not all, are Proposed Standards, Draft Standards, or
+   Standards.  Since the status of these RFCs may change during the
+   standards processing, we note here only that they are on the
+   standards track.  Please see the latest edition of "Internet Official
+   Protocol Standards" for the current state and status of these RFCs.
+   In the following, RFCs on the standards track are marked [STANDARDS-
+   TRACK].
+
+RFC     Author       Date      Title
+---     ------       ----      -----
+
+1799    Kennedy     Jan 97     Requests For Comments Summary
+
+This memo.
+
+
+1798    Young       Jun 95      Connection-less Lightweight X.500
+                                Directory Access Protocol
+
+The protocol described in this document is designed to provide access to
+the Directory while not incurring the resource requirements of the
+Directory Access Protocol (DAP). [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 1]
+
+RFC 1799                  Summary of 1700-1799              January 1997
+
+
+1797    IANA        Apr 95      Class A Subnet Experiment
+
+There appears to be some interest in experimenting with subnetting the
+class A addresses. It is suggested that conducting an experiment now to
+identify and fix any software that does not properly handle subnetted
+class A addresses would be useful and important. This document defines
+an Experimental Protocol for the Internet community.  This does not
+specify an Internet standard of any kind.
+
+
+1796    Huitema     Apr 95      Not All RFCs are Standards
+
+This document discusses the relationship of the Request for Comments
+(RFCs) notes to Internet Standards. This memo provides information for
+the Internet community.  This memo does not specify an Internet standard
+of any kind.
+
+
+1795     Wells      Apr 95      Data Link Switching: Switch-to-Switch
+                                Protocol
+                                AIW DLSw RIG: DLSw Closed Pages, DLSw
+                                Standard Version 1.0
+
+This RFC describes use of Data Link Switching over TCP/IP. This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1794     Brisco     Apr 95     DNS Support for Load Balancing
+
+This RFC is meant to first chronicle a foray into the IETF DNS Working
+Group, discuss other possible alternatives to provide/simulate load
+balancing support for DNS, and to provide an ultimate, flexible solution
+for providing DNS support for balancing loads of many types. This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1793     Moy         Apr 95    Extending OSPF to Support Demand Circuits
+
+This memo defines enhancements to the OSPF protocol that allow efficient
+operation over "demand circuits". [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 2]
+
+RFC 1799                  Summary of 1700-1799              January 1997
+
+
+1792     Sung        Apr 95    TCP/IPX Connection Mib Specification
+
+New MIB objects, tcpIpxConnTable, udpIpxTable, tcpUnspecConnTable and
+udpUnspecTable are presented in this paper, to be used in place of
+tcpConnTable and udpListenerTable when TCP and UDP are running over IPX.
+This document defines an Experimental Protocol for the Internet
+community.  This does not specify an Internet standard of any kind.
+
+
+1791     Sung        Apr 95    TCP And UDP Over IPX Networks With
+                               Fixed Path MTU
+
+TCP/IPX allows TCP/IP applications to run over IPX networks by letting
+TCP and UDP run over IPX.  And this memo specifies the packet format and
+operational procedures for running TCP and UDP over IPX. This document
+defines an Experimental Protocol for the Internet community.  This does
+not specify an Internet standard of any kind.
+
+
+1790    Cerf         Apr 95    An Agreement between the Internet
+                               Society and Sun Microsystems, Inc.
+                               in the Matter of ONC RPC and XDR
+                               Protocols
+
+This RFC is an official public record of an agreement between SUN
+Microsystems and the Internet Society.  This memo provides information
+for the Internet community.  It does not specify an Internet standard of
+any kind.
+
+
+1789    Yang        Apr 95     INETPhone: Telephone Services and
+                               Servers on Internet
+
+This RFC presents a true telephone service, called INETPhone, which
+supports voice communication through the Internet. This memo provides
+information for the Internet community.  It does not specify an Internet
+standard of any kind.
+
+
+1788    Simpson     Apr 95     ICMP Domain Name Messages
+
+This document specifies ICMP messages for learning the Fully Qualified
+Domain Name associated with an IP address. This document defines an
+Experimental Protocol for the Internet community.  This does not specify
+an Internet standard of any kind.
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 3]
+
+RFC 1799                  Summary of 1700-1799              January 1997
+
+
+1787    Rekhter    Apr 95     Routing in a Multi-provider Internet
+
+This document presents some of the issues related to network layer
+routing in a multi-provider Internet, and specifically to the unicast
+routing. This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+1786    Bates      Mar 95     Representation of IP Routing Policies
+
+This document is an update to the original `ripe-81' proposal for
+representing and storing routing polices within the RIPE database. It
+incorporates several extensions proposed by Merit Inc. and gives details
+of a generalized IP routing policy representation to be used by all
+Internet routing registries.  It acts as both tutorial and provides
+details of database objects and attributes that use and make up a
+routing registry. This memo provides information for the Internet
+community. This memo does not specify an Internet standard of any kind.
+
+
+1785    Malkin     Mar 95     TFTP Option Negotiation Analysis
+
+This document was written to allay concerns that the presence of options
+in a TFTP Request packet might cause pathological behavior on servers
+which do not support TFTP option negotiation. This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+1784    Malkin     Mar 95    TFTP Timeout Interval and Transfer
+                             Size Options
+
+This document describes two TFTP options. The first allows the client
+and server to negotiate the Timeout Interval.  The second allows the
+side receiving the file to determine the ultimate size of the transfer
+before it begins. [STANDARDS-TRACK]
+
+
+1783    Malkin     Mar 95    TFTP Blocksize Option
+
+This document describes a TFTP option which allows the client and server
+to negotiate a blocksize more applicable to the network medium.
+[STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 4]
+
+RFC 1799                  Summary of 1700-1799              January 1997
+
+
+1782    Malkin     Mar 95    TFTP Option Extension
+
+The Trivial File Transfer Protocol is a simple, lock-step, file transfer
+protocol which allows a client to get or put a file onto a remote host.
+This document describes a simple extension to TFTP to allow option
+negotiation prior to the file transfer.
+
+
+1781    Kille     Mar 95    Using the OSI Directory to Achieve
+                            User Friendly Naming
+
+This proposal sets out some conventions for representing names in a
+friendly manner, and shows how this can be used to achieve really
+friendly naming. [STANDARDS-TRACK]
+
+
+1780   IAB       Mar 95    Internet Official Protocol Standards
+
+This memo describes the state of standardization of protocols used in
+the Internet as determined by the Internet Architecture Board (IAB).
+[STANDARDS-TRACK]
+
+
+1779   Kille     Mar 95     A String Representation of Distinguished
+                            Names
+
+The OSI Directory uses distinguished names as the primary keys to
+entries in the directory.  Distinguished Names are encoded in ASN.1.
+When a distinguished name is communicated between to users not using a
+directory protocol (e.g., in a mail message), there is a need to have a
+user-oriented string representation of distinguished name. This
+specification defines a string format for representing names, which is
+designed to give a clean representation of commonly used names, whilst
+being able to represent any distinguished name. [STANDARDS-TRACK]
+
+
+1778   Howes    Mar 95     The String Representation of Standard
+                           Attribute Syntaxes
+
+The Lightweight Directory Access Protocol (LDAP) requires that the
+contents of AttributeValue fields in protocol elements be octet strings.
+This document defines the requirements that must be satisfied by
+encoding rules used to render X.500 Directory attribute syntaxes into a
+form suitable for use in the LDAP, then goes on to define the encoding
+rules for the standard set of attribute syntaxes.  [STANDARDS-TRACK]
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 5]
+
+RFC 1799                  Summary of 1700-1799              January 1997
+
+
+1777   Yeong     Mar 95     Lightweight Directory Access Protocol
+
+The protocol described in this document is designed to provide access to
+the X.500 Directory while not incurring the resource requirements of the
+Directory Access Protocol (DAP).This protocol is specifically targeted
+at simple management applications and browser applications that provide
+simple read/write interactive access to the X.500 Directory, and is
+intended to be a complement to the DAP itself.  [STANDARDS-TRACK]
+
+
+1776   Crocker   Apr 95     The Address is the Message
+
+Declaring that the address is the message, the IPng WG has selected a
+packet format which includes 1696 bytes of address space. This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1775   Crocker   Mar 95    To Be "On" the Internet
+
+The Internet permits different levels of access for consumers and
+providers of service.  The nature of those differences is quite
+important in the capabilities They afford.  Hence, it is appropriate to
+provide terminology that distinguishes among the range, so that the
+Internet community can gain some clarity when distinguishing whether a
+user (or an organization) is "on" the Internet.  This document suggests
+four terms, for distinguishing the major classes of access. This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1774   Traina   Mar 95    BGP-4 Protocol Analysis
+
+The purpose of this report is to document how the requirements for
+advancing a routing protocol to Draft Standard have been satisfied by
+the Border Gateway Protocol version 4 (BGP-4). This report summarizes
+the key features of BGP, and analyzes the protocol with respect to
+scaling and performance. This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 6]
+
+RFC 1799                  Summary of 1700-1799              January 1997
+
+
+1773    Traina  Mar 95   Experience with the BGP-4 protocol
+
+The purpose of this memo is to document how the requirements for
+advancing a routing protocol to Draft Standard have been satisfied by
+Border Gateway Protocol version 4 (BGP-4).  This report documents
+experience with BGP. This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+1772   Rekhter  Mar 95   Application of the Border Gateway
+                         Protocol in the Internet
+
+
+This document, together with its companion document, "A Border Gateway
+Protocol 4 (BGP-4)", define an inter-autonomous system routing protocol
+for the Internet. This document describes the usage of the BGP in the
+Internet.  [STANDARDS-TRACK]
+
+
+1771   Rekhter  Mar 95   A Border Gateway Protocol 4 (BGP-4)
+
+This document, together with its companion document, "Application of the
+Border Gateway Protocol in the Internet", define an inter-autonomous
+system routing protocol for the Internet. [STANDARDS-TRACK]
+
+
+1770   Graff   Mar 95   IPv4 Option for Sender Directed
+                        Multi-Destination Delivery
+
+This memo defines an IPv4 option to provide a sender directed multi-
+destination delivery mechanism called Selective Directed Broadcast Mode
+(SDBM). This memo provides information for the Internet community.  This
+memo does not specify an Internet standard of any kind.
+
+
+1769   Mills   Mar 95   Simple Network Time Protocol (SNTP)
+
+This memorandum describes the Simple Network Time Protocol (SNTP), which
+is an adaptation of the Network Time Protocol (NTP) used to synchronize
+computer clocks in the Internet. This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 7]
+
+RFC 1799                  Summary of 1700-1799              January 1997
+
+
+1768   Marlow  Mar 95   Host Group Extensions for CLNP Multicasting
+
+This memo provides a specification for multicast extensions to the CLNP
+protocol similar to those provided to IP by RFC1112. This memo defines
+an Experimental Protocol for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1767   Crocker  Mar 95   MIME Encapsulation of EDI Objects
+
+Since there are many different EDI specifications, the current document
+defines three distinct categories as three different MIME content-types.
+[STANDARDS-TRACK]
+
+
+1766   Alvestrand Mar 95  Tags for the Identification of Languages
+
+This document describes a language tag for use in cases where it is
+desired to indicate the language used in an information object.
+[STANDARDS-TRACK]
+
+
+1765   Moy       Mar 95   OSPF Database Overflow
+
+This memo details a way of gracefully handling unanticipated database
+overflows. This memo defines an Experimental Protocol for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+1764   Senum     Mar 95   The PPP XNS IDP Control Protocol (XNSCP)
+
+This document defines the Network Control Protocol for establishing and
+configuring the Xerox Network Systems (XNS) Internet Datagram Protocol
+(IDP) over PPP. [STANDARDS-TRACK]
+
+
+1763   Senum     Mar 95   The PPP Banyan Vines Control Protocol (BVCP)
+
+This document defines the Network Control Protocol for establishing and
+configuring the Banyan VINES protocol over PPP. [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 8]
+
+RFC 1799                  Summary of 1700-1799              January 1997
+
+
+1762   Senum     Mar 95   The PPP DECnet Phase IV Control Protocol
+                          (DNCP)
+
+This document defines the NCP for establishing and configuring Digital's
+DNA Phase IV Routing protocol (DECnet Phase IV) over PPP.  This document
+applies only to DNA Phase IV Routing messages (both data and control),
+and not to other DNA Phase IV protocols (MOP, LAT, etc). [STANDARDS-
+TRACK]
+
+
+1761   Callaghan  Feb 95  Snoop Version 2 Packet Capture File Format
+
+This paper describes the file format used by "snoop", a packet
+monitoring and capture program developed by Sun.  This paper is provided
+so that people can write compatible programs to generate and interpret
+snoop packet capture files. This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+1760   Haller     Feb 95  The S/KEY One-Time Password System
+
+This document describes the S/KEY* One-Time Password system as released
+for public use by Bellcore. This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+1759   Smith      Mar 95  Printer MIB
+
+A printer is the physical device that takes media from an input source,
+produces marks on that media according to some page description or page
+control language and puts the result in some output destination,
+possibly with finishing applied. The information needed in the
+management of the physical printer and the management of a printing job
+overlap highly and many of the tasks in each management area require the
+same or similar information. [STANDARDS-TRACK]
+
+
+1758   N.A.D.F.   Feb 95    NADF Standing Documents: A Brief Overview
+
+The purpose of this document is to provide a brief overview of the
+NADF's Standing Document series. This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 9]
+
+RFC 1799                  Summary of 1700-1799              January 1997
+
+
+1757   Waldbusser Feb 95   Remote Network Monitoring Management
+                           Information Base
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing remote network monitoring
+devices. [STANDARDS-TRACK]
+
+
+1756    Rinne     Jan 95   REMOTE WRITE PROTOCOL - VERSION 1.0
+
+This document describes a simple Remote Write Protocol (RWP). This memo
+defines an Experimental Protocol for the Internet community.  This memo
+does not specify an Internet standard of any kind.
+
+
+1755    Perez     Feb 95   ATM Signaling Support for IP over ATM
+
+This memo describes the ATM call control signaling exchanges needed to
+support Classical IP over ATM implementations as described in RFC 1577.
+[STANDARDS-TRACK]
+
+
+1754    Laubach   Jan 95   IP over ATM Working Group's
+                           Recommendations for the ATM Forum's
+                           Multiprotocol BOF
+                           Version 1
+
+This document represents an initial list of requirements submitted to
+the ATM Forum's Multiprotocol BOF for the operation of IP over ATM
+networks as determined by the IETF IP over ATM Working Group and other
+working groups. This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+1753     Chiappa   Dec 94   IPng Technical Requirements
+                            Of the Nimrod Routing and Addressing
+                            Architecture
+
+This document presents the requirements that the Nimrod routing and
+addressing architecture has upon the internetwork layer protocol. To be
+most useful to Nimrod, any protocol selected as the IPng should satisfy
+these requirements. This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 10]
+
+RFC 1799                  Summary of 1700-1799              January 1997
+
+
+1752     Bradner   Jan 95   The Recommendation for the IP Next
+                            Generation Protocol
+
+This document presents the recommendation of the IPng Area Directors on
+what should be used to replace the current version of the Internet
+Protocol. [STANDARDS-TRACK]
+
+
+1751     McDonald   Dec 94   A Convention for Human-Readable 128-bit
+                             Keys
+
+This memo proposes a convention for use with Internet applications &
+protocols using 128-bit cryptographic keys. This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+1750     Eastlake    Dec 94  Randomness Recommendations for Security
+
+Choosing random quantities to foil a resourceful and motivated adversary
+is surprisingly difficult.  This paper points out many pitfalls in using
+traditional pseudo-random number generation techniques for choosing such
+quantities.  It recommends the use of truly random hardware techniques
+and shows that the existing hardware on many systems can be used for
+this purpose. This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+1749   McCloghrie    Dec 94   IEEE 802.5 Station Source Routing MIB
+                              using SMIv2
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it describes managed objects used by IEEE 802.5 end-stations
+for managing source routes on a Token Ring network where IEEE source-
+routing is in use. [STANDARDS-TRACK]
+
+
+1748   McCloghrie    Dec 94   IEEE 802.5 MIB using SMIv2
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it describes managed objects used for managing subnetworks
+which use the IEEE 802.5 Token Ring technology described in 802.5 Token
+Ring Access Method and Physical Layer Specifications, IEEE Standard
+802.5-1989. [STANDARDS-TRACK]
+
+
+
+
+
+Kennedy                      Informational                     [Page 11]
+
+RFC 1799                  Summary of 1700-1799              January 1997
+
+
+1747   Hilgeman     Jan 95   Definitions of Managed Objects for SNA
+                             Data Link Control (SDLC) using SMIv2
+
+This specification defines an extension to the Management Information
+Base (MIB) for use with SNMP-based network management.  In particular,
+it defines objects for managing the configuration, monitoring and
+control of data link controls in an SNA environment. [STANDARDS-TRACK]
+
+
+1746   Manning      Dec 94   Ways to Define User Expectations
+
+This paper covers basic fundamentals that must be understood when one
+defines, interprets, or implements methods to control user expectations
+on or over the Internet. This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+1745    Varadhan     Dec 94   BGP4/IDRP for IP---OSPF Interaction
+
+This memo defines the various criteria to be used when designing an
+Autonomous System Border Router (ASBR) that will run either BGP4 or IDRP
+for IP with other ASBRs external to the AS and OSPF as its IGP.
+[STANDARDS-TRACK]
+
+
+1744     Huston      Dec 94   Observations on the Management of
+                              the Internet Address Space
+
+This memo examines some of the issues associated with the current
+management practices of the Internet IPv4 address space, and examines
+the potential outcomes of these practices as the unallocated address
+pool shrinks in size. This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+1743     McCloghrie  Dec 94    IEEE 802.5 MIB using SMIv2
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it describes managed objects used for managing subnetworks
+which use the IEEE 802.5 Token Ring technology described in 802.5 Token
+Ring Access Method and Physical Layer Specifications, IEEE Standard
+802.5-1989. [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 12]
+
+RFC 1799                  Summary of 1700-1799              January 1997
+
+
+1742     Waldbusser  Jan 95    AppleTalk Management Information Base II
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing AppleTalk networks.
+[STANDARDS-TRACK]
+
+
+1741     Falstrom     Dec 94  MIME Content Type for BinHex Encoded Files
+
+This memo describes the format to use when sending BinHex4.0 files via
+MIME [BORE93]. This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+1740     Falstron     Dec 94   MIME Encapsulation of Macintosh Files -
+                               MacMIME
+
+This memo describes the format to use when sending Apple Macintosh files
+via MIME [BORE93]. [STANDARDS-TRACK]
+
+
+1739     Kessler       Dec 94   A Primer On Internet and TCP/IP Tools
+
+This memo is an introductory guide to some of the TCP/IP and Internet
+tools and utilities that allow users to access the wide variety of
+information on the network, from determining if a particular host is up
+to viewing a multimedia thesis on foreign policy. It also describes
+discussion lists accessible from the Internet, ways to obtain Internet
+documents, and resources that help users weave their way through the
+Internet. This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+1738     Berners-Lee   Dec 94   Uniform Resource Locators (URL)
+
+This document specifies a Uniform Resource Locator (URL), the syntax and
+semantics of formalized information for location and access of resources
+via the Internet. [STANDARDS-TRACK]
+
+
+1737     Sollins       Dec 94   Functional Requirements for Uniform
+                                Resource Names
+
+This document specifies a minimum set of requirements for a kind of
+Internet resource identifier known as Uniform Resource Names (URNs).
+This memo provides information for the Internet community.  This memo
+does not specify an Internet standard of any kind.
+
+
+
+Kennedy                      Informational                     [Page 13]
+
+RFC 1799                  Summary of 1700-1799              January 1997
+
+
+1736     Kunze        Feb 95    Functional Recommendations for
+                                Internet Resource Locators
+
+This document specifies a minimum set of requirements for Internet
+resource locators, which convey location and access information for
+resources. This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+1735     Heinanen     Dec 94    NBMA Address Resolution Protocol (NARP)
+
+This document describes the NBMA Address Resolution Protocol (NARP).
+NARP can be used by a source terminal (host or router) connected to a
+Non-Broadcast, Multi-Access link layer (NBMA) network to find out the
+NBMA addresses of the a destination terminal provided that the
+destination terminal is connected to the same NBMA network. This memo
+defines an Experimental Protocol for the Internet community.  This memo
+does not specify an Internet standard of any kind.
+
+
+1734     Myers        Dec 94   POP3 AUTHentication command
+
+This document describes the optional AUTH command, for indicating an
+authentication mechanism to the server, performing an authentication
+protocol exchange, and optionally negotiating a protection mechanism for
+subsequent protocol interactions. [STANDARDS-TRACK]
+
+
+1733     Crispin      Dec 94   Distributed Electronic Mail
+                               Models in IMAP4
+
+
+There are three fundamental models of client/server email: offline,
+online, and disconnected use.  IMAP4 can be used in any one of these
+three models.  This memo provides information for the Internet
+community. This memo does not specify an Internet standard of any kind.
+
+
+1732     Crispin      Dec 94   IMAP4 COMPATIBILITY WITH IMAP2
+                               AND IMAP2BIS
+
+This is a summary of hints and recommendations to enable an IMAP4
+implementation to interoperate with implementations that conform to
+earlier specifications. This memo provides information for the Internet
+community. This memo does not specify an Internet standard of any kind.
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 14]
+
+RFC 1799                  Summary of 1700-1799              January 1997
+
+
+1731    Myers         Dec 94   IMAP4 Authentication Mechanisms
+
+The Internet Message Access Protocol, Version 4 [IMAP4] contains the
+AUTHENTICATE command, for identifying and authenticating a user to an
+IMAP4 server and for optionally negotiating a protection mechanism for
+subsequent protocol interactions.  This document describes several
+authentication mechanisms for use by the IMAP4 AUTHENTICATE command.
+[STANDARDS-TRACK]
+
+
+1730    Crispin       Dec 94   Internet Message Access Protocol
+                               - Version 4
+
+The Internet Message Access Protocol, Version 4 (IMAP4) allows a client
+to access and manipulate electronic mail messages on a server. IMAP4
+permits manipulation of remote message folders, called "mailboxes", in a
+way that is functionally equivalent to local mailboxes.  IMAP4 also
+provides the capability for an offline client to resynchronize with the
+server. [STANDARDS-TRACK]
+
+
+1729    Lynch        Dec 94    Using the Z39.50 Information
+                               Retrieval Protocol in the Internet
+                               Environment
+
+This memo describes an approach to the implementation of the ANSI/NISO
+Z39.50-1992 Standard for Information Retrieval in the TCP/IP environment
+which is currently in wide use by the Z39.50 implementor community. This
+memo provides information for the Internet community.  This memo does
+not specify an Internet standard of any kind.
+
+
+1728    Weider      Dec 94    Resource Transponders
+
+This paper describes an automatic mechanism, the resource transponder,
+for maintaining resource location information.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+1727    Weider      Dec 94    A Vision of an Integrated Internet
+                              Information Service
+
+This paper lays out a vision of how Internet information services might
+be integrated over the next few years, and discusses in some detail what
+steps will be needed to achieve this integration. This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+
+Kennedy                      Informational                     [Page 15]
+
+RFC 1799                  Summary of 1700-1799              January 1997
+
+
+1726    Partridge   Dec 94   Technical Criteria for Choosing
+                             IP The Next Generation (IPng)
+
+This RFC specifies criteria related to mobility for consideration in
+design and selection of the Next Generation of IP. This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+1725    Myers       Nov 94   Post Office Protocol - Version 3
+
+This memo is a revision to RFC 1460, a Draft Standard. [STANDARDS-TRACK]
+
+
+1724    Malkin      Nov 94   RIP Version 2 MIB Extension
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing RIP Version 2.  [STANDARDS-
+TRACK]
+
+
+1723    Malkin     Nov 94    RIP Version 2
+                             Carrying Additional Information
+
+This document specifies an extension of the Routing Information Protocol
+(RIP), o expand the amount of useful information carried in RIP messages
+and to add a measure of security.  This memo obsoletes RFC 1388, which
+specifies an update to the "Routing Information Protocol" STD 34, RFC
+1058. [STANDARDS-TRACK]
+
+
+1722    Malkin     Nov 94    RIP Version 2 Protocol Applicability
+                             Statement
+
+As required by Routing Protocol Criteria (RFC 1264), this report defines
+the applicability of the RIP-2 protocol within the Internet.  This
+report is a prerequisite to advancing RIP-2 on the standards track.
+[STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 16]
+
+RFC 1799                  Summary of 1700-1799              January 1997
+
+
+1721    Malkin    Nov 94    RIP Version 2 Protocol Analysis
+
+As required by Routing Protocol Criteria (RFC 1264), this report
+documents the key features of the RIP-2 protocol and the current
+implementation experience.  This report is a prerequisite to advancing
+RIP-2 on the standards track. This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+1720    IAB       Nov 94    Internet Official Protocol Standards
+
+This memo describes the state of standardization of protocols used in
+the Internet as determined by the Internet Architecture Board (IAB).
+[STANDARDS-TRACK]
+
+
+1719    Gross     Dec 94    A Direction for IPng
+                              Specification and Implementation
+
+This RFC specifies criteria related to mobility for consideration in
+design and selection of the Next Generation of IP. This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+1718    IETF Secretariat  Nov 94   The Tao of IETF
+                                   A Guide for New Attendees of the
+                                   Internet Engineering Task Force
+
+The purpose of this For Your Information (FYI) RFC is to explain to the
+newcomers how the IETF works. This memo provides information for the
+Internet community.  It does not specify an Internet standard. [FYI 17]
+
+
+1717    Sklower        Nov 94     The PPP Multilink Protocol (MP)
+
+This document proposes a method for splitting, recombining and
+sequencing datagrams across multiple logical data links. [STANDARDS-
+TRACK]
+
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 17]
+
+RFC 1799                  Summary of 1700-1799              January 1997
+
+
+1716    Almquist       Nov 94     Towards Requirements for IP Routers
+
+The goal of this work is to replace RFC-1009, Requirements for Internet
+Gateways ([INTRO:1]) with a new document. It defines and discusses
+requirements for devices which perform the network layer forwarding
+function of the Internet protocol suite. This memo provides information
+for the Internet community.  This memo does not specify an Internet
+standard of any kind.
+
+
+1715    Huitema        Nov 94     The H Ratio for Address Assignment
+                                  Efficiency
+
+This document was submitted to the IETF IPng area in response to RFC
+1550. This memo provides information for the Internet community.  This
+memo does not specify an Internet standard of any kind.
+
+
+1714    Williamson     Nov 94     Referral Whois Protocol (RWhois)
+
+This memo describes version 1.0 of the client/server interaction of
+RWhois.  RWhois provides a distributed system for the display of
+hierarchical information. This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+1713    Romao          Nov 94      Tools for DNS debugging
+
+Although widely used (and most of the times unnoticed), DNS (Domain Name
+System) is too much overlooked, in the sense that people, especially
+administrators, tend to ignore possible anomalies as long as
+applications that need name-to-address mapping continue to work.  This
+document presents some tools available for domain administrators to
+detect and correct those anomalies. This memo provides information for
+the Internet community.  This memo does not specify an Internet standard
+of any kind.
+
+
+1712    Farrell        Nov 94     DNS Encoding of Geographical Location
+
+This document defines the format of a new Resource Record (RR) for the
+Domain Naming System (DNS), and reserves a corresponding DNS type
+mnemonic and numerical code. This memo defines an Experimental Protocol
+for the Internet community.  This memo does not specify an Internet
+standard of any kind.
+
+
+
+
+
+Kennedy                      Informational                     [Page 18]
+
+RFC 1799                  Summary of 1700-1799              January 1997
+
+
+1711     Houttuin      Oct 94     Classifications in E-mail Routing
+
+This paper presents a classification for e-mail routing issues. This
+memo provides information for the Internet community.  This memo does
+not specify an Internet standard of any kind.
+
+
+1710     Hinden       Oct 94      Simple Internet Protocol Plus
+                                  White Paper
+
+This document was submitted to the IETF IPng area in response to RFC
+1550. This memo provides information for the Internet community.  This
+memo does not specify an Internet standard of any kind.
+
+
+1709     Gargano      Nov 94      K-12 Internetworking Guidelines
+
+The K-12 community traditionally has not had this level of staffing
+available for telecommunications planning.  This document is intended to
+bridge that gap and provides a recommended technical direction, an
+introduction to the role the Internet now plays in K-12 education and
+technical guidelines for building a campus data communications
+infrastructure that provides internetworking services and connections to
+the Internet. This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+1708     Gowin       Oct 94      NTP PICS PROFORMA
+                                 For the Network Time Protocol
+                                 Version 3
+
+This RFC describes a PICS Proforma translated into an Internet
+acceptable form. This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+1707     McGovern    Oct 94     CATNIP: Common Architecture for
+                                the Internet
+
+This document was submitted to the IETF IPng area in response to RFC
+1550. This paper describes a common architecture for the network layer
+protocol. This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 19]
+
+RFC 1799                  Summary of 1700-1799              January 1997
+
+
+1706    Manning     Oct 94     DNS NSAP Resource Records
+
+This document defines the format of one new Resource Record (RR) for the
+DNS for domain name-to-NSAP mapping. The RR may be used with any NSAP
+address format.  This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+1705    Carlson     Oct 94      Six Virtual Inches to the Left:
+                                The Problem with IPng
+
+This document was submitted to the IETF IPng area in response to RFC
+1550. This RFC suggests that a new version of TCP (TCPng), and UDP, be
+developed and deployed. This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+1704    Haller      Oct 94      On Internet Authentication
+
+This document describes a spectrum of authentication technologies and
+provides suggestions to protocol developers on what kinds of
+authentication might be suitable for some kinds of protocols and
+applications used in the Internet. This document provides information
+for the Internet community.  This memo does not specify an Internet
+standard of any kind.
+
+
+1703    Rose       Oct 94      Principles of Operation for the TPC.INT
+                               Subdomain:
+                               Radio Paging -- Technical Procedures
+
+This memo describes a technique for radio paging using the Internet mail
+infrastructure.  In particular, this memo focuses on the case in which
+radio pagers are identified via the international telephone network.
+This memo provides information for the Internet community.  This memo
+does not specify an Internet standard of any kind.
+
+
+1702    Hanks       Oct 94    Generic Routing Encapsulation over
+                              IPv4 networks
+
+This memo addresses the case of using IP as the delivery protocol or the
+payload protocol and the special case of IP as both the delivery and
+payload.  This memo also describes using IP addresses and autonomous
+system numbers as part of a GRE source route. This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+
+
+Kennedy                      Informational                     [Page 20]
+
+RFC 1799                  Summary of 1700-1799              January 1997
+
+
+1701    Hanks       Oct 94   Generic Routing Encapsulation (GRE)
+
+This document specifies a protocol for performing encapsulation of an
+arbitrary network layer protocol over another arbitrary network layer
+protocol. This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+1700    Reynolds     Oct 94      Assigned Numbers
+
+This RFC is a snapshot of the ongoing process of the assignment of
+protocol parameters for the Internet protocol suite.  To make the
+current information readily available the assignments are kept up-to-
+date in a set of online text files. This memo is a status report on the
+parameters (i.e., numbers and keywords) used in protocols in the
+Internet community.
+
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Author's Address
+
+   Mary Kennedy
+   University of Southern California
+   Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone:  (310) 822-1511
+
+   EMail:  MKENNEDY@ISI.EDU
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                     [Page 21]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1799.txt](<www.ietf.org/rfc/rfc1799.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
