### PR TITLE
Archive rfc18.txt

### DIFF
--- a/www.ietf.org/rfc/rfc18.txt
+++ b/www.ietf.org/rfc/rfc18.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group               University of California Los Angeles
+Request for Comments: 18                                       Vint Cerf
+Category:                                                 September 1969
+
+
+
+
+It is suggested that link 1 be used for the HOST-HOST control link
+and link 0 be used for IMP-IMP control.
+
+This will facilitate communication between Hosts and reduce delays
+due to interference with IMP-IMP communications.
+
+
+
+    [This RFC has been restored to on-line status by Elmar K. Bins]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc18.txt](<www.ietf.org/rfc/rfc18.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
