### PR TITLE
Archive rfc1860.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1860.txt
+++ b/www.ietf.org/rfc/rfc1860.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                                         T. Pummill
+Request for Comments: 1860                                       Alantec
+Category: Informational                                       B. Manning
+                                                                     ISI
+                                                            October 1995
+
+
+                 Variable Length Subnet Table For IPv4
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  This memo
+   does not specify an Internet standard of any kind.  Distribution of
+   this memo is unlimited.
+
+Abstract
+
+   This document itemizes the potential values for IPv4 subnets.
+   Additional information is provided for Hex and Decmial values,
+   classfull equivalents, and number of addresses available within the
+   indicated block. We appreciate inputs from Bruce Pinsky (cisco) and
+   Daniel Karrenberg (RIPE).
+
+Table
+
+   The following table lists the variable length subnets from 1 to 32,
+   the CIDR representation form and the Decmial equivalents.
+
+   Mask value:
+   Hex            CIDR   Decimal           #of add    Classfull
+   80.00.00.00    /1     128.0.0.0         2048 M     128 A
+   C0.00.00.00    /2     192.0.0.0         1024 M      64 A
+   E0.00.00.00    /3     224.0.0.0          512 M      32 A
+   F0.00.00.00    /4     240.0.0.0          256 M      16 A
+   F8.00.00.00    /5     248.0.0.0          128 M       8 A
+   FC.00.00.00    /6     252.0.0.0           64 M       4 A
+   FE.00.00.00    /7     254.0.0.0           32 M       2 A
+   FF.00.00.00    /8     255.0.0.0           16 M       1 A
+   FF.80.00.00    /9     255.128.0.0          8 M     128 B
+   FF.C0.00.00   /10     255.192.0.0          4 M      64 B
+   FF.E0.00.00   /11     255.224.0.0          2 M      32 B
+   FF.F0.00.00   /12     255.240.0.0       1024 K      16 B
+   FF.F8.00.00   /13     255.248.0.0        512 K       8 B
+   FF.FC.00.00   /14     255.252.0.0        256 K       4 B
+   FF.FE.00.00   /15     255.254.0.0        128 K       2 B
+   FF.FF.00.00   /16     255.255.0.0         64 K       1 B
+   FF.FF.80.00   /17     255.255.128.0       32 K     128 C
+   FF.FF.C0.00   /18     255.255.192.0       16 K      64 C
+
+
+
+Pummill & Manning            Informational                      [Page 1]
+
+RFC 1860                      Subnet Table                  October 1995
+
+
+   FF.FF.E0.00   /19     255.255.224.0        8 K      32 C
+   FF.FF.F0.00   /20     255.255.240.0        4 K      16 C
+   FF.FF.F8.00   /21     255.255.248.0        2 K       8 C
+   FF.FF.FC.00   /22     255.255.252.0        1 K       4 C
+   FF.FF.FE.00   /23     255.255.254.0      512         2 C
+   FF.FF.FF.00   /24     255.255.255.0      256         1 C
+   FF.FF.FF.80   /25     255.255.255.128    128
+   FF.FF.FF.C0   /26     255.255.255.192     64
+   FF.FF.FF.E0   /27     255.255.255.224     32
+   FF.FF.FF.F0   /28     255.255.255.240     16
+   FF.FF.FF.F8   /29     255.255.255.248      8
+   FF.FF.FF.FC   /30     255.255.255.252      4
+   FF.FF.FF.FE   /31     255.255.255.254   This space is not usable
+   FF.FF.FF.FF   /32     255.255.255.255   This is a single host route
+
+Examples
+
+   The following tables illistrate some options for subnet/host partions
+   within selected block sizes.
+
+From a /16 block
+
+   # bits          Mask            Effective Subnets     Effective Hosts
+   ========        =====           =================     ===============
+   2               255.255.192.0   2                       16382
+   3               255.255.224.0   6                       8190
+   4               255.255.240.0   14                      4094
+   5               255.255.248.0   30                      2046
+   6               255.255.252.0   62                      1022
+   7               255.255.254.0   126                     510
+   8               255.255.255.0   254                     254
+   9               255.255.255.128 510                     126
+   10              255.255.255.192 1022                    62
+   11              255.255.255.224 2046                    30
+   12              255.255.255.240 4094                    14
+   13              255.255.255.248 8190                    6
+   14              255.255.255.252 16382                   2
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Pummill & Manning            Informational                      [Page 2]
+
+RFC 1860                      Subnet Table                  October 1995
+
+
+From a /24 block
+
+   # bits          Mask            Effective Subnets     Effective Hosts
+   ========        =====           =================     ===============
+   2               255.255.255.192 2                       62
+   3               255.255.255.224 6                       30
+   4               255.255.255.240 14                      14
+   5               255.255.255.248 30                      6
+   6               255.255.255.252 62                      2
+
+   *Subnet all zeroes and all ones excluded.
+   *Host all zeroes and all ones excluded.
+
+References
+
+   [1] Fuller, V., Li, T., Yu, J., and K. Varadhan, "Classless Inter-
+       Domain Routing (CIDR): an Address Assignment and Aggregation
+       Strategy", RFC 1519, BARRNet, cicso, Merit, OARnet, September
+       1993.
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Authors' Addresses
+
+   Troy Pummill
+
+   EMail: trop@alantec.com
+
+
+   Bill Manning
+   Information Sciences Institute
+   University of Southern California
+   4676 Admiralty Way
+   Marina del Rey, CA 90292-6695
+   USA
+
+   Phone: +1 310-822-1511 x387
+   Fax:   +1 310-823-6714
+   EMail: bmanning@isi.edu
+
+
+
+
+
+
+
+
+
+
+Pummill & Manning            Informational                      [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1860.txt](<www.ietf.org/rfc/rfc1860.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
