### PR TITLE
Archive rfc1878.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1878.txt
+++ b/www.ietf.org/rfc/rfc1878.txt
@@ -1,0 +1,451 @@
+
+
+
+
+
+
+Network Working Group                                         T. Pummill
+Request for Comments: 1878                                       Alantec
+Obsoletes: 1860                                               B. Manning
+Category: Informational                                              ISI
+                                                           December 1995
+
+
+                 Variable Length Subnet Table For IPv4
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  This memo
+   does not specify an Internet standard of any kind.  Distribution of
+   this memo is unlimited.
+
+Abstract
+
+   This memo clarifies issues surrounding subnetting IP networks by
+   providing a standard subnet table.  This table includes subnetting
+   for Class A, B, and C networks, as well as Network IDs, host ranges
+   and IP broadcast addresses with emphasis on Class C subnets.
+
+   This memo is intended as an informational companion to Subneting RFC
+   [1] and the Hosts Requirements RFC [2].
+
+Introduction
+
+   The growth of networking since the time of STD 5, RFC 950 and STD 3,
+   RFC 1123 has resulted in larger and more complex network subnetting.
+   The previously mentioned RFCs comprise the available guidelines for
+   creating subnetted networks, however they have occassionaly been
+   misinterpreted leading to confusion regarding proper subnetting.
+
+   This document itemizes the potential values for IPv4 subnets.
+   Additional information is provided for Hex and Decmial values,
+   classfull equivalants, and number of addresses available within the
+   indicated block.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Pummill & Manning            Informational                      [Page 1]
+
+RFC 1878                      Subnet Table                 December 1995
+
+
+Table
+
+   The following table lists the variable length subnets from 1 to 32,
+   the CIDR [3] representation form (/xx) and the Decmial equivalents.
+   (M = Million, K=Thousand, A,B,C= traditional class values)
+
+   Mask value:                             # of
+   Hex            CIDR   Decimal           addresses  Classfull
+   80.00.00.00    /1     128.0.0.0         2048 M     128 A
+   C0.00.00.00    /2     192.0.0.0         1024 M      64 A
+   E0.00.00.00    /3     224.0.0.0          512 M      32 A
+   F0.00.00.00    /4     240.0.0.0          256 M      16 A
+   F8.00.00.00    /5     248.0.0.0          128 M       8 A
+   FC.00.00.00    /6     252.0.0.0           64 M       4 A
+   FE.00.00.00    /7     254.0.0.0           32 M       2 A
+   FF.00.00.00    /8     255.0.0.0           16 M       1 A
+   FF.80.00.00    /9     255.128.0.0          8 M     128 B
+   FF.C0.00.00   /10     255.192.0.0          4 M      64 B
+   FF.E0.00.00   /11     255.224.0.0          2 M      32 B
+   FF.F0.00.00   /12     255.240.0.0       1024 K      16 B
+   FF.F8.00.00   /13     255.248.0.0        512 K       8 B
+   FF.FC.00.00   /14     255.252.0.0        256 K       4 B
+   FF.FE.00.00   /15     255.254.0.0        128 K       2 B
+   FF.FF.00.00   /16     255.255.0.0         64 K       1 B
+   FF.FF.80.00   /17     255.255.128.0       32 K     128 C
+   FF.FF.C0.00   /18     255.255.192.0       16 K      64 C
+   FF.FF.E0.00   /19     255.255.224.0        8 K      32 C
+   FF.FF.F0.00   /20     255.255.240.0        4 K      16 C
+   FF.FF.F8.00   /21     255.255.248.0        2 K       8 C
+   FF.FF.FC.00   /22     255.255.252.0        1 K       4 C
+   FF.FF.FE.00   /23     255.255.254.0      512         2 C
+   FF.FF.FF.00   /24     255.255.255.0      256         1 C
+   FF.FF.FF.80   /25     255.255.255.128    128       1/2 C
+   FF.FF.FF.C0   /26     255.255.255.192     64       1/4 C
+   FF.FF.FF.E0   /27     255.255.255.224     32       1/8 C
+   FF.FF.FF.F0   /28     255.255.255.240     16      1/16 C
+   FF.FF.FF.F8   /29     255.255.255.248      8      1/32 C
+   FF.FF.FF.FC   /30     255.255.255.252      4      1/64 C
+   FF.FF.FF.FE   /31     255.255.255.254      2     1/128 C
+   FF.FF.FF.FF   /32     255.255.255.255   This is a single host route
+
+
+
+
+
+
+
+
+
+
+
+Pummill & Manning            Informational                      [Page 2]
+
+RFC 1878                      Subnet Table                 December 1995
+
+
+Subnets and Networks
+
+   The number of available network and host addresses are derived from
+   the number of bits used for subnet masking.  The tables below depict
+   the number of subnetting bits and the resulting network, broadcast
+   address, and host addresses.  Please note that all-zeros and all-ones
+   subnets are included in Tables 1-1 and 1-2 per the current,
+   standards- based practice for using all definable subnets [4].
+
+   Table 1-1 represents traditional subnetting of a Class B network
+   address.
+
+Subnet Mask     # of nets    Net. Addr.  Host Addr Range  Brodcast Addr.
+Bits of Subnet  hosts/subnet
+
+255.255.128.0   2 nets        N.N.0.0     N.N.0-127.N      N.N.127.255
+1 bit subnet    32766         N.N.128.0   N.N.128-254.N    N.N.254.255
+
+255.255.192.0   4 nets        N.N.0.0     N.N.0-63.N       N.N.63.255
+2 bit subnet    16382         N.N.64.0    N.N.64-127.N     N.N.127.255
+                              N.N.128.0   N.N.128-191.N    N.N.191.255
+                              N.N.192.0   N.N.192-254.N    N.N.254.255
+
+255.255.224.0   8 nets        N.N.0.0     N.N.0-31.N       N.N.31.255
+3 bit subnet    8190          N.N.32.0    N.N.32-63.N      N.N.63.255
+                              N.N.64.0    N.N.64-95.N      N.N.95.255
+                              N.N.96.0    N.N.96-127.N     N.N.127.255
+                              N.N.128.0   N.N.128-159.N    N.N.159.255
+                              N.N.160.0   N.N.160-191.N    N.N.191.255
+                              N.N.192.0   N.N.192-223.N    N.N.223.255
+                              N.N.224.0   N.N.224-254.N    N.N.254.255
+
+255.255.240.0   16 nets       N.N.0.0     N.N.0-15.N       N.N.15.255
+4 bit subnet    4094          N.N.16.0    N.N.16-31.N      N.N.31.255
+                              N.N.32.0    N.N.32-47.N      N.N.47.255
+                              N.N.48.0    N.N.48-63.N      N.N.63.255
+                              N.N.64.0    N.N.64-79.N      N.N.79.255
+                              N.N.80.0    N.N.80-95.N      N.N.95.255
+                              N.N.96.0    N.N.96-111.N     N.N.111.255
+                              N.N.112.0   N.N.112-127.N    N.N.127.255
+                              N.N.128.0   N.N.128-143.N    N.N.143.255
+                              N.N.144.0   N.N.144-159.N    N.N.159.255
+                              N.N.160.0   N.N.160-175.N    N.N.175.255
+                              N.N.176.0   N.N.176-191.N    N.N.191.255
+                              N.N.192.0   N.N.192-207.N    N.N.207.255
+                              N.N.208.0   N.N.208-223.N    N.N.223.255
+                              N.N.224.0   N.N.224-239.N    N.N.239.255
+                              N.N.240.0   N.N.240-254.N    N.N.254.255
+
+
+
+Pummill & Manning            Informational                      [Page 3]
+
+RFC 1878                      Subnet Table                 December 1995
+
+
+255.255.248.0   32 nets       N.N.0.0     N.N.0-7.N        N.N.7.255
+5 bit subnet    2046          N.N.8.0     N.N.8-15.N       N.N.15.255
+                              N.N.16.0    N.N.16-23.N      N.N.23.255
+                              N.N.24.0    N.N.24-31.N      N.N.31.255
+                              N.N.32.0    N.N.32-39.N      N.N.39.255
+                              N.N.40.0    N.N.40-47.N      N.N.47.255
+                              N.N.48.0    N.N.48-55.N      N.N.55.255
+                              N.N.56.0    N.N.56-63.N      N.N.63.255
+                              N.N.64.0    N.N.64-71.N      N.N.71.255
+                              N.N.72.0    N.N.72-79.N      N.N.79.255
+                              N.N.80.0    N.N.80-87.N      N.N.87.255
+                              N.N.88.0    N.N.88-95.N      N.N.95.255
+                              N.N.96.0    N.N.96-103.N     N.N.103.255
+                              N.N.104.0   N.N.104-111.N    N.N.111.255
+                              N.N.112.0   N.N.112-119.N    N.N.119.255
+                              N.N.120.0   N.N.120-127.N    N.N.127.255
+                              N.N.128.0   N.N.128-135.N    N.N.135.255
+                              N.N.136.0   N.N.136-143.N    N.N.143.255
+                              N.N.144.0   N.N.144-151.N    N.N.151.255
+                              N.N.152.0   N.N.152-159.N    N.N.159.255
+                              N.N.160.0   N.N.160-167.N    N.N.167.255
+                              N.N.168.0   N.N.168-175.N    N.N.175.255
+                              N.N.176.0   N.N.176-183.N    N.N.183.255
+                              N.N.184.0   N.N.184-191.N    N.N.191.255
+                              N.N.192.0   N.N.192-199.N    N.N.199.255
+                              N.N.200.0   N.N.200-207.N    N.N.207.255
+                              N.N.208.0   N.N.208-215.N    N.N.215.255
+                              N.N.216.0   N.N.216-223.N    N.N.223.255
+                              N.N.224.0   N.N.224-231.N    N.N.231.255
+                              N.N.232.0   N.N.232-239.N    N.N.239.255
+                              N.N.240.0   N.N.240-247.N    N.N.247.255
+                              N.N.248.0   N.N.248-254.N    N.N.254.255
+
+255.255.252.0   64 nets       N.N.0.0     N.N.0-3.N        N.N.3.255
+6 bit subnet    1022          N.N.4.0     N.N.4-7.N        N.N.7.255
+                              N.N.8.0     N.N.8-11.N       N.N.11.255
+                              N.N.12.0    N.N.12-15.N      N.N.15.255
+                              N.N.240.0   N.N.240-243.N    N.N.243.255
+                              N.N.244.0   N.N.244-247.N    N.N.247.255
+                              N.N.248.0   N.N.248-251.N    N.N.251.255
+                              N.N.252.0   N.N.252-254.N    N.N.254.255
+
+
+255.255.254.0   128 nets      N.N.0.0     N.N.0-1.N        N.N.1.255
+7 bit subnet    510           N.N.2.0     N.N.2-3.N        N.N.3.255
+                              N.N.4.0     N.N.4-5.N        N.N.5.255
+                              N.N.250.0   N.N.250-251.N    N.N.251.255
+                              N.N.252.0   N.N.252-253.N    N.N.253.255
+
+
+
+Pummill & Manning            Informational                      [Page 4]
+
+RFC 1878                      Subnet Table                 December 1995
+
+
+                              N.N.254.0   N.N.254.N        N.N.254.255
+
+
+255.255.255.0   255 nets      N.N.0.0     N.N.0.N          N.N.0.255
+8 bit subnet    253           N.N.1.0     N.N.1.N          N.N.1.255
+                              N.N.252.0   N.N.252.N        N.N.252.255
+                              N.N.253.0   N.N.253.N        N.N.253.255
+                              N.N.254.0   N.N.254.N        N.N.254.255
+
+   Table 1-2 represents traditional subnetting of a Class C network
+   address (which is identical to extended Class B subnets).
+
+Subnet Mask     # of nets    Net. Addr.  Host Addr Range  Brodcast Addr.
+Bits of Subnet  hosts/subnet
+
+255.255.255.128 2 nets       N.N.N.0     N.N.N.1-126      N.N.N.127
+1 bit Class C   126          N.N.N.128   N.N.N.129-254    N.N.N.255
+9 bit Class B
+
+
+
+255.255.255.192 4 nets       N.N.N.0     N.N.N.1-62       N.N.N.63
+2 bit Class C   62           N.N.N.64    N.N.N.65-126     N.N.N.127
+10 bit Class B               N.N.N.128   N.N.N.129-190    N.N.N.191
+                             N.N.N.192   N.N.N.193-254    N.N.N.255
+
+255.255.255.224 8 nets       N.N.N.0     N.N.N.1-30       N.N.N.31
+3 bit Class C   30           N.N.N.32    N.N.N.33-62      N.N.N.63
+11 bit Class B               N.N.N.64    N.N.N.65-94      N.N.N.95
+                             N.N.N.96    N.N.N.97-126     N.N.N.127
+                             N.N.N.128   N.N.N.129-158    N.N.N.159
+                             N.N.N.160   N.N.N.161-190    N.N.N.191
+                             N.N.N.192   N.N.N.193-222    N.N.N.223
+                             N.N.N.224   N.N.N.225-254    N.N.N.255
+
+255.255.255.240 16 nets      N.N.N.0     N.N.N.1-14       N.N.N.15
+4 bit Class C   14           N.N.N.16    N.N.N.17-30      N.N.N.31
+12 bit Class B               N.N.N.32    N.N.N.33-46      N.N.N.47
+                             N.N.N.48    N.N.N.49-62      N.N.N.63
+                             N.N.N.64    N.N.N.65-78      N.N.N.79
+                             N.N.N.80    N.N.N.81-94      N.N.N.95
+                             N.N.N.96    N.N.N.97-110     N.N.N.111
+                             N.N.N.112   N.N.N.113-126    N.N.N.127
+                             N.N.N.128   N.N.N.129-142    N.N.N.143
+                             N.N.N.144   N.N.N.145-158    N.N.N.159
+                             N.N.N.160   N.N.N.161-174    N.N.N.175
+                             N.N.N.176   N.N.N.177-190    N.N.N.191
+                             N.N.N.192   N.N.N.193-206    N.N.N.207
+
+
+
+Pummill & Manning            Informational                      [Page 5]
+
+RFC 1878                      Subnet Table                 December 1995
+
+
+                             N.N.N.208   N.N.N.209-222    N.N.N.223
+                             N.N.N.224   N.N.N.225-238    N.N.N.239
+                             N.N.N.240   N.N.N.241-254    N.N.N.255
+
+
+255.255.255.248 32 nets      N.N.N.0     N.N.N.1-6        N.N.N.7
+5 bit Class C   6            N.N.N.8     N.N.N.9-14       N.N.N.15
+13 bit Class B               N.N.N.16    N.N.N.17-22      N.N.N.23
+                             N.N.N.24    N.N.N.25-30      N.N.N.31
+                             N.N.N.32    N.N.N.33-38      N.N.N.39
+                             N.N.N.40    N.N.N.41-46      N.N.N.47
+                             N.N.N.48    N.N.N.49-54      N.N.N.55
+                             N.N.N.56    N.N.N.57-62      N.N.N.63
+                             N.N.N.64    N.N.N.65-70      N.N.N.71
+                             N.N.N.72    N.N.N.73-78      N.N.N.79
+                             N.N.N.80    N.N.N.81-86      N.N.N.87
+                             N.N.N.88    N.N.N.89-94      N.N.N.95
+                             N.N.N.96    N.N.N.97-102     N.N.N.103
+                             N.N.N.104   N.N.N.105-110    N.N.N.111
+                             N.N.N.112   N.N.N.113-118    N.N.N.119
+                             N.N.N.120   N.N.N.121-126    N.N.N.127
+                             N.N.N.128   N.N.N.129-134    N.N.N.135
+                             N.N.N.136   N.N.N.137-142    N.N.N.143
+                             N.N.N.144   N.N.N.145-150    N.N.N.151
+                             N.N.N.152   N.N.N.153-158    N.N.N.159
+                             N.N.N.160   N.N.N.161-166    N.N.N.167
+                             N.N.N.168   N.N.N.169-174    N.N.N.175
+                             N.N.N.176   N.N.N.177-182    N.N.N.183
+                             N.N.N.184   N.N.N.185-190    N.N.N.191
+                             N.N.N.192   N.N.N.193-198    N.N.N.199
+                             N.N.N.200   N.N.N.201-206    N.N.N.207
+                             N.N.N.208   N.N.N.209-214    N.N.N.215
+                             N.N.N.216   N.N.N.217-222    N.N.N.223
+                             N.N.N.224   N.N.N.225-230    N.N.N.231
+                             N.N.N.232   N.N.N.233-238    N.N.N.239
+                             N.N.N.240   N.N.N.241-246    N.N.N.247
+                             N.N.N.248   N.N.N.249-254    N.N.N.255
+
+255.255.255.252 64 nets      N.N.N.0     N.N.N.1-2        N.N.N.3
+6 bit Class C   2            N.N.N.4     N.N.N.5-6        N.N.N.7
+14 bit Class B               N.N.N.8     N.N.N.9-10       N.N.N.11
+                             N.N.N.244   N.N.N.245-246    N.N.N.247
+                             N.N.N.248   N.N.N.249-250    N.N.N.251
+                             N.N.N.252   N.N.N.253-254    N.N.N.255
+
+
+
+
+
+
+
+Pummill & Manning            Informational                      [Page 6]
+
+RFC 1878                      Subnet Table                 December 1995
+
+
+   For the sake of completeness within this memo, tables 2-1 and 2-2
+   illistrate some options for subnet/host partions within selected
+   block sizes using calculations which exclude all-zeros and all-ones
+   subnets [2].  Many vendors only support subnetting based upon this
+   premise.  This practice is obsolete!  Modern software will be able to
+   utilize all definable networks.
+
+Table 2-1 from a /16 block
+# bits          Mask            Effective Subnets       Effective Hosts
+========        =====           =================       ===============
+2               255.255.192.0   2                       16382
+3               255.255.224.0   6                       8190
+4               255.255.240.0   14                      4094
+5               255.255.248.0   30                      2046
+6               255.255.252.0   62                      1022
+7               255.255.254.0   126                     510
+8               255.255.255.0   254                     254
+9               255.255.255.128 510                     126
+10              255.255.255.192 1022                    62
+11              255.255.255.224 2046                    30
+12              255.255.255.240 4094                    14
+13              255.255.255.248 8190                    6
+14              255.255.255.252 16382                   2
+
+Table 2-2 from a /24 block
+# bits          Mask            Effective Subnets       Effective Hosts
+========        =====           =================       ===============
+2               255.255.255.192 2                       62
+3               255.255.255.224 6                       30
+4               255.255.255.240 14                      14
+5               255.255.255.248 30                      6
+6               255.255.255.252 62                      2
+
+*Subnet all zeroes and all ones excluded. (Obsolete)
+*Host all zeroes and all ones excluded.   (Obsolete)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Pummill & Manning            Informational                      [Page 7]
+
+RFC 1878                      Subnet Table                 December 1995
+
+
+References
+
+   [1] Mogul J., "BROADCASTING INTERNET DATAGRAMS IN THE PRESENCE OF
+       SUBNETS", STD 5, RFC 922, Stanford University, October 1984.
+
+   [2] Braden R., Editor, "Requirements for Internet Hosts --
+       Application and Support", STD 3, RFC 1123, IETF, October 1989.
+
+   [3] Fuller V., Li T., Yu J., and K. Varadhan, "Classless Inter-
+       Domain Routing (CIDR): an Address Assignment and Aggregation
+       Strategy", RFC 1519, BARRNet, cicso, Merit, OARnet, September
+       1993.
+
+   [4] Baker F., "Requirements for IP Version 4 Routers", RFC 1812,
+       cisco Systems, June 1995.
+
+   [5] Mogul J., and J. Postel, "Internet Standard Subnetting
+       Procedure", STD 5, RFC 950, Stanford, USC/Information Sciences
+       Institute, August 1985.
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Authors' Addresses
+
+   Troy T. Pummill
+   Alantec
+   2115 O'Nel Drive
+   San Jose, CA  95131
+   USA
+
+   Phone: +1 408.467.4871
+   Fax:   +1 408.441.0272
+   EMail: trop@alantec.com
+
+
+   Bill Manning
+   Information Sciences Institute
+   University of Southern California
+   4676 Admiralty Way
+   Marina del Rey, CA 90292-6695
+   USA
+
+   Phone: +1 310-822-1511 x387
+   Fax:   +1 310-823-6714
+   EMail: bmanning@isi.edu
+
+
+
+
+Pummill & Manning            Informational                      [Page 8]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1878.txt](<www.ietf.org/rfc/rfc1878.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
