### PR TITLE
Archive rfc1886.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1886.txt
+++ b/www.ietf.org/rfc/rfc1886.txt
@@ -1,0 +1,268 @@
+
+
+
+
+
+
+Network Working Group                                         S. Thomson
+Request for Comments: 1886                                      Bellcore
+Category: Standards Track                                     C. Huitema
+                                                                   INRIA
+                                                           December 1995
+
+
+                DNS Extensions to support IP version 6
+
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+
+Abstract
+
+   This document defines the changes that need to be made to the Domain
+   Name System to support hosts running IP version 6 (IPv6).  The
+   changes include a new resource record type to store an IPv6 address,
+   a new domain to support lookups based on an IPv6 address, and updated
+   definitions of existing query types that return Internet addresses as
+   part of additional section processing.  The extensions are designed
+   to be compatible with existing applications and, in particular, DNS
+   implementations themselves.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Thompson & Huitema          Standards Track                    [Page 1]
+
+RFC 1886                  IPv6 DNS Extensions              December 1995
+
+
+1. INTRODUCTION
+
+   Current support for the storage of Internet addresses in the Domain
+   Name System (DNS)[1,2] cannot easily be extended to support IPv6
+   addresses[3] since applications assume that address queries return
+   32-bit IPv4 addresses only.
+
+   To support the storage of IPv6 addresses we define the following
+   extensions:
+
+      o A new resource record type is defined to map a domain name to an
+        IPv6 address.
+
+      o A new domain is defined to support lookups based on address.
+
+      o Existing queries that perform additional section processing to
+        locate IPv4 addresses are redefined to perform additional
+        section processing on both IPv4 and IPv6 addresses.
+
+   The changes are designed to be compatible with existing software. The
+   existing support for IPv4 addresses is retained. Transition issues
+   related to the co-existence of both IPv4 and IPv6 addresses in DNS
+   are discussed in [4].
+
+
+2. NEW RESOURCE RECORD DEFINITION AND DOMAIN
+
+   A new record type is defined to store a host's IPv6 address. A host
+   that has more than one IPv6 address must have more than one such
+   record.
+
+
+2.1 AAAA record type
+
+   The AAAA resource record type is a new record specific to the
+   Internet class that stores a single IPv6 address.
+
+   The value of the type is 28 (decimal).
+
+
+2.2 AAAA data format
+
+   A 128 bit IPv6 address is encoded in the data portion of an AAAA
+   resource record in network byte order (high-order byte first).
+
+
+
+
+Thompson & Huitema          Standards Track                    [Page 2]
+
+RFC 1886                  IPv6 DNS Extensions              December 1995
+
+
+2.3 AAAA query
+
+   An AAAA query for a specified domain name in the Internet class
+   returns all associated AAAA resource records in the answer section of
+   a response.
+
+   A type AAAA query does not perform additional section processing.
+
+
+2.4 Textual format of AAAA records
+
+   The textual representation of the data portion of the AAAA resource
+   record used in a master database file is the textual representation
+   of a IPv6 address as defined in [3].
+
+
+2.5 IP6.INT Domain
+
+   A special domain is defined to look up a record given an address. The
+   intent of this domain is to provide a way of mapping an IPv6 address
+   to a host name, although it may be used for other purposes as well.
+   The domain is rooted at IP6.INT.
+
+   An IPv6 address is represented as a name in the IP6.INT domain by a
+   sequence of nibbles separated by dots with the suffix ".IP6.INT". The
+   sequence of nibbles is encoded in reverse order, i.e. the low-order
+   nibble is encoded first, followed by the next low-order nibble and so
+   on. Each nibble is represented by a hexadecimal digit. For example,
+   the inverse lookup domain name corresponding to the address
+
+       4321:0:1:2:3:4:567:89ab
+
+   would be
+
+b.a.9.8.7.6.5.0.4.0.0.0.3.0.0.0.2.0.0.0.1.0.0.0.0.0.0.0.1.2.3.4.IP6.INT.
+
+
+
+3. MODIFICATIONS TO EXISTING QUERY TYPES
+
+   All existing query types that perform type A additional section
+   processing, i.e. name server (NS), mail exchange (MX) and mailbox
+   (MB) query types, must be redefined to perform both type A and type
+   AAAA additional section processing. These new definitions mean that a
+   name server must add any relevant IPv4 addresses and any relevant
+
+
+
+Thompson & Huitema          Standards Track                    [Page 3]
+
+RFC 1886                  IPv6 DNS Extensions              December 1995
+
+
+   IPv6 addresses available locally to the additional section of a
+   response when processing any one of the above queries.
+
+
+4. SECURITY CONSIDERATIONS
+
+   Security issues are not discussed in this memo.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Thompson & Huitema          Standards Track                    [Page 4]
+
+RFC 1886                  IPv6 DNS Extensions              December 1995
+
+
+5. REFERENCES
+
+
+   [1]  Mockapetris, P., "Domain Names - Concepts and Facilities", STD
+        13, RFC 1034, USC/Information Sciences Institute, November 1987.
+
+   [2]  Mockapetris, P., "Domain Names - Implementation and Specifica-
+        tion", STD 13, RFC 1035, USC/Information Sciences Institute,
+        November 1987.
+
+   [3]  Hinden, R., and S. Deering, Editors, "IP Version 6 Addressing
+        Architecture", RFC 1884, Ipsilon Networks, Xerox PARC, December
+        1995.
+
+
+   [4]  Gilligan, R., and E. Nordmark, "Transition Mechanisms for IPv6
+        Hosts and Routers", Work in Progress.
+
+
+Authors' Addresses
+
+   Susan Thomson
+   Bellcore
+   MRE 2P343
+   445 South Street
+   Morristown, NJ 07960
+   U.S.A.
+
+   Phone: +1 201-829-4514
+   EMail: set@thumper.bellcore.com
+
+
+   Christian Huitema
+   INRIA, Sophia-Antipolis
+   2004 Route des Lucioles
+   BP 109
+   F-06561 Valbonne Cedex
+   France
+
+   Phone: +33 93 65 77 15
+   EMail: Christian.Huitema@MIRSA.INRIA.FR
+
+
+
+
+
+
+
+Thompson & Huitema          Standards Track                    [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1886.txt](<www.ietf.org/rfc/rfc1886.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
