### PR TITLE
Archive rfc1920.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1920.txt
+++ b/www.ietf.org/rfc/rfc1920.txt
@@ -1,0 +1,2243 @@
+
+
+
+
+
+
+Network Working Group                        Internet Architecture Board
+Request for Comments: 1920                             J. Postel, Editor
+Obsoletes: 1880, 1800, 1780, 1720,                            March 1996
+1610, 1600, 1540, 1500, 1410, 1360,
+1280, 1250, 1200, 1140, 1130, 1100, 1083
+STD: 1
+Category: Standards Track
+
+
+                  INTERNET OFFICIAL PROTOCOL STANDARDS
+
+
+Status of this Memo
+
+   This memo describes the state of standardization of protocols used in
+   the Internet as determined by the Internet Architecture Board (IAB).
+   This memo is an Internet Standard.  Distribution of this memo is
+   unlimited.
+
+Table of Contents
+
+   Introduction . . . . . . . . . . . . . . . . . . . . . . . . . . 2
+   1.  The Standardization Process  . . . . . . . . . . . . . . . . 3
+   2.  The Request for Comments Documents . . . . . . . . . . . . . 5
+   3.  Other Reference Documents  . . . . . . . . . . . . . . . . . 6
+   3.1.  Assigned Numbers . . . . . . . . . . . . . . . . . . . . . 6
+   3.2.  Gateway Requirements . . . . . . . . . . . . . . . . . . . 6
+   3.3.  Host Requirements  . . . . . . . . . . . . . . . . . . . . 6
+   3.4.  The MIL-STD Documents  . . . . . . . . . . . . . . . . . . 6
+   4.  Explanation of Terms . . . . . . . . . . . . . . . . . . . . 8
+   4.1.  Definitions of Protocol State (Maturity Level) . . . . . . 9
+   4.1.1.  Standard Protocol  . . . . . . . . . . . . . . . . . . . 9
+   4.1.2.  Draft Standard Protocol  . . . . . . . . . . . . . . . . 9
+   4.1.3.  Proposed Standard Protocol . . . . . . . . . . . . . . . 9
+   4.1.4.  Experimental Protocol  . . . . . . . . . . . . . . . . . 9
+   4.1.5.  Informational Protocol . . . . . . . . . . . . . . . .  10
+   4.1.6.  Historic Protocol  . . . . . . . . . . . . . . . . . .  10
+   4.2.  Definitions of Protocol Status (Requirement Level) . . .  10
+   4.2.1.  Required Protocol  . . . . . . . . . . . . . . . . . .  10
+   4.2.2.  Recommended Protocol . . . . . . . . . . . . . . . . .  10
+   4.2.3.  Elective Protocol  . . . . . . . . . . . . . . . . . .  10
+   4.2.4.  Limited Use Protocol . . . . . . . . . . . . . . . . .  10
+   4.2.5.  Not Recommended Protocol . . . . . . . . . . . . . . .  10
+   5.  The Standards Track  . . . . . . . . . . . . . . . . . . .  11
+   5.1.  The RFC Processing Decision Table  . . . . . . . . . . .  11
+   5.2.  The Standards Track Diagram  . . . . . . . . . . . . . .  12
+   6.  The Protocols  . . . . . . . . . . . . . . . . . . . . . .  14
+   6.1.  Recent Changes . . . . . . . . . . . . . . . . . . . . .  14
+
+
+
+Internet Architecture Board Standards Track                     [Page 1]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+   6.1.1.  New RFCs . . . . . . . . . . . . . . . . . . . . . . .  14
+   6.1.2.  Other Changes  . . . . . . . . . . . . . . . . . . . .  18
+   6.2.  Standard Protocols . . . . . . . . . . . . . . . . . . .  20
+   6.3.  Network-Specific Standard Protocols  . . . . . . . . . .  22
+   6.4.  Draft Standard Protocols . . . . . . . . . . . . . . . .  23
+   6.5.  Proposed Standard Protocols  . . . . . . . . . . . . . .  24
+   6.6.  Telnet Options . . . . . . . . . . . . . . . . . . . . .  28
+   6.7.  Experimental Protocols . . . . . . . . . . . . . . . . .  29
+   6.8.  Informational Protocols  . . . . . . . . . . . . . . . .  32
+   6.9.  Historic Protocols . . . . . . . . . . . . . . . . . . .  33
+   6.10  Obsolete Protocols . . . . . . . . . . . . . . . . . . .  35
+   7.  Contacts . . . . . . . . . . . . . . . . . . . . . . . . .  36
+   7.1.  IAB, IETF, and IRTF Contacts . . . . . . . . . . . . . .  36
+   7.1.1.  Internet Architecture Board (IAB) Contact  . . . . . .  36
+   7.1.2.  Internet Engineering Task Force (IETF) Contact . . . .  36
+   7.1.3.  Internet Research Task Force (IRTF) Contact  . . . . .  37
+   7.2.  Internet Assigned Numbers Authority (IANA) Contact . . .  38
+   7.3.  Request for Comments Editor Contact  . . . . . . . . . .  39
+   7.4.  Network Information Center Contact . . . . . . . . . . .  39
+   7.5.  Sources for Requests for Comments  . . . . . . . . . . .  40
+   8.  Security Considerations  . . . . . . . . . . . . . . . . .  40
+   9.  Author's Address . . . . . . . . . . . . . . . . . . . . .  40
+
+Introduction
+
+   A discussion of the standardization process and the RFC document
+   series is presented first, followed by an explanation of the terms.
+   Sections 6.2 - 6.10 contain the lists of protocols in each stage of
+   standardization.  Finally are pointers to references and contacts for
+   further information.
+
+   This memo is intended to be issued approximately quarterly; please be
+   sure the copy you are reading is current.  Current copies may be
+   obtained from the Network Information Center (INTERNIC) or from the
+   Internet Assigned Numbers Authority (IANA) (see the contact
+   information at the end of this memo).  Do not use this edition after
+   15-July-96.
+
+   See Section 6.1 for a description of recent changes.  In the official
+   lists in sections 6.2 - 6.10, an asterisk (*) next to a protocol
+   denotes that it is new to this document or has been moved from one
+   protocol level to another, or differs from the previous edition of
+   this document.
+
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                     [Page 2]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+1.  The Standardization Process
+
+   The Internet Architecture Board maintains this list of documents that
+   define standards for the Internet protocol suite.  See RFC-1601 for
+   the charter of the IAB and RFC-1160 for an explanation of the role
+   and organization of the IAB and its subsidiary groups, the Internet
+   Engineering Task Force (IETF) and the Internet Research Task Force
+   (IRTF).  Each of these groups has a steering group called the IESG
+   and IRSG, respectively.  The IETF develops these standards with the
+   goal of co-ordinating the evolution of the Internet protocols; this
+   co-ordination has become quite important as the Internet protocols
+   are increasingly in general commercial use.  The definitive
+   description of the Internet standards process is found in RFC-1602.
+
+   The majority of Internet protocol development and standardization
+   activity takes place in the working groups of the IETF.
+
+   Protocols which are to become standards in the Internet go through a
+   series of states or maturity levels (proposed standard, draft
+   standard, and standard) involving increasing amounts of scrutiny and
+   testing.  When a protocol completes this process it is assigned a STD
+   number (see RFC-1311).  At each step, the Internet Engineering
+   Steering Group (IESG) of the IETF must make a recommendation for
+   advancement of the protocol.
+
+   To allow time for the Internet community to consider and react to
+   standardization proposals, a minimum delay of 6 months before a
+   proposed standard can be advanced to a draft standard and 4 months
+   before a draft standard can be promoted to standard.
+
+   It is general practice that no proposed standard can be promoted to
+   draft standard without at least two independent implementations (and
+   the recommendation of the IESG).  Promotion from draft standard to
+   standard generally requires operational experience and demonstrated
+   interoperability of two or more implementations (and the
+   recommendation of the IESG).
+
+   In cases where there is uncertainty as to the proper decision
+   concerning a protocol a special review committee may be appointed
+   consisting of experts from the IETF, IRTF and the IAB with the
+   purpose of recommending an explicit action.
+
+   Advancement of a protocol to proposed standard is an important step
+   since it marks a protocol as a candidate for eventual standardization
+   (it puts the protocol "on the standards track").  Advancement to
+   draft standard is a major step which warns the community that, unless
+   major objections are raised or flaws are discovered, the protocol is
+   likely to be advanced to standard in six months.
+
+
+
+Internet Architecture Board Standards Track                     [Page 3]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+   Some protocols have been superseded by better ones or are otherwise
+   unused.  Such protocols are still documented in this memorandum with
+   the designation "historic".
+
+   Because it is useful to document the results of early protocol
+   research and development work, some of the RFCs document protocols
+   which are still in an experimental condition.  The protocols are
+   designated "experimental" in this memorandum.  They appear in this
+   report as a convenience to the community and not as evidence of their
+   standardization.
+
+   Other protocols, such as those developed by other standards
+   organizations, or by particular vendors, may be of interest or may be
+   recommended for use in the Internet.  The specifications of such
+   protocols may be published as RFCs for the convenience of the
+   Internet community.  These protocols are labeled "informational" in
+   this memorandum.
+
+   In addition to the working groups of the IETF, protocol development
+   and experimentation may take place as a result of the work of the
+   research groups of the Internet Research Task Force, or the work of
+   other individuals interested in Internet protocol development.  The
+   the documentation of such experimental work in the RFC series is
+   encouraged, but none of this work is considered to be on the track
+   for standardization until the IESG has made a recommendation to
+   advance the protocol to the proposed standard state.
+
+   A few protocols have achieved widespread implementation without the
+   approval of the IESG.  For example, some vendor protocols have become
+   very important to the Internet community even though they have not
+   been recommended by the IESG.  However, the IAB strongly recommends
+   that the standards process be used in the evolution of the protocol
+   suite to maximize interoperability (and to prevent incompatible
+   protocol requirements from arising).  The use of the terms
+   "standard", "draft standard", and "proposed standard" are reserved in
+   any RFC or other publication of Internet protocols to only those
+   protocols which the IESG has approved.
+
+   In addition to a state (like "Proposed Standard"), a protocol is also
+   assigned a status, or requirement level, in this document.  The
+   possible requirement levels ("Required", "Recommended", "Elective",
+   "Limited Use", and "Not Recommended") are defined in Section 4.2.
+   When a protocol is on the standards track, that is in the proposed
+   standard, draft standard, or standard state (see Section 5), the
+   status shown in Section 6 is the current status.
+
+   Few protocols are required to be implemented in all systems; this is
+   because there is such a variety of possible systems, for example,
+
+
+
+Internet Architecture Board Standards Track                     [Page 4]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+   gateways, routers, terminal servers, workstations, and multi-user
+   hosts.  The requirement level shown in this document is only a one
+   word label, which may not be sufficient to characterize the
+   implementation requirements for a protocol in all situations.  For
+   some protocols, this document contains an additional status paragraph
+   (an applicability statement).  In addition, more detailed status
+   information may be contained in separate requirements documents (see
+   Section 3).
+
+2.  The Request for Comments Documents
+
+   The documents called Request for Comments (or RFCs) are the working
+   notes of the "Network Working Group", that is the Internet research
+   and development community.  A document in this series may be on
+   essentially any topic related to computer communication, and may be
+   anything from a meeting report to the specification of a standard.
+
+   Notice:
+
+      All standards are published as RFCs, but not all RFCs specify
+      standards.
+
+   Anyone can submit a document for publication as an RFC.  Submissions
+   must be made via electronic mail to the RFC Editor (see the contact
+   information at the end of this memo, and see RFC 1543).
+
+   While RFCs are not refereed publications, they do receive technical
+   review from the task forces, individual technical experts, or the RFC
+   Editor, as appropriate.
+
+   The RFC series comprises a wide range of documents, ranging from
+   informational documents of general interests to specifications of
+   standard Internet protocols.  In cases where submission is intended
+   to document a proposed standard, draft standard, or standard
+   protocol, the RFC Editor will publish the document only with the
+   approval of the IESG.  For documents describing experimental work,
+   the RFC Editor will notify the IESG before publication, allowing for
+   the possibility of review by the relevant IETF working group or IRTF
+   research group and provide those comments to the author.  See Section
+   5.1 for more detail.
+
+   Once a document is assigned an RFC number and published, that RFC is
+   never revised or re-issued with the same number.  There is never a
+   question of having the most recent version of a particular RFC.
+   However, a protocol (such as File Transfer Protocol (FTP)) may be
+   improved and re-documented many times in several different RFCs.  It
+   is important to verify that you have the most recent RFC on a
+   particular protocol.  This "Internet Official Protocol Standards"
+
+
+
+Internet Architecture Board Standards Track                     [Page 5]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+   memo is the reference for determining the correct RFC for the current
+   specification of each protocol.
+
+   The RFCs are available from the INTERNIC, and a number of other
+   sites.  For more information about obtaining RFCs, see Sections 7.4
+   and 7.5.
+
+3.  Other Reference Documents
+
+   There are three other reference documents of interest in checking the
+   current status of protocol specifications and standardization.  These
+   are the Assigned Numbers, the Gateway Requirements, and the Host
+   Requirements.  Note that these documents are revised and updated at
+   different times; in case of differences between these documents, the
+   most recent must prevail.
+
+   Also, one should be aware of the MIL-STD publications on IP, TCP,
+   Telnet, FTP, and SMTP.  These are described in Section 3.4.
+
+3.1.  Assigned Numbers
+
+   The "Assigned Numbers" document lists the assigned values of the
+   parameters used in the various protocols.  For example, IP protocol
+   codes, TCP port numbers, Telnet Option Codes, ARP hardware types, and
+   Terminal Type names.  Assigned Numbers was most recently issued as
+   RFC-1700.
+
+3.2.  Requirements for IP Version 4 Routers
+
+   This document reviews the specifications that apply to gateways and
+   supplies guidance and clarification for any ambiguities.
+   Requirements for IP Version 4 Routers is RFC-1812.
+
+3.3.  Host Requirements
+
+   This pair of documents reviews and updates the specifications that
+   apply to hosts, and it supplies guidance and clarification for any
+   ambiguities.  Host Requirements was issued as RFC-1122 and RFC-1123.
+
+3.4.  The MIL-STD Documents
+
+   The Internet community specifications for IP (RFC-791) and TCP (RFC-
+   793) and the DoD MIL-STD specifications are intended to describe
+   exactly the same protocols.  Any difference in the protocols
+   specified by these sets of documents should be reported to DISA and
+   to the IESG.  It is strongly advised that the two sets of documents
+   be used together, along with RFC-1122 and RFC-1123.
+
+
+
+
+Internet Architecture Board Standards Track                     [Page 6]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+   Note that these MIL-STD are now somewhat out of date.  The
+   Requirements for IP Version 4 Routers (RFC-1812) and Host
+   Requirements (RFC-1122, RFC-1123) take precedence over both earlier
+   RFCs and the MIL-STDs.
+
+          2045-13501 Internet Routing between Autonomous Systems
+
+          2045-14502-01 Internet Transport Profile for DoD
+          Communications, Part 1: Transport and Internet Services
+
+          2045-14502-04 Internet Transport Profile for DoD
+          Communications, Part 4: LAN Media-Independent Requirements
+
+          2045-14503 Internet Transport Service Supporting OSI
+          Applications
+
+          2045-44500 Tactical Communications
+
+          2045-17503-01 Internet Message Transfer Profile for DoD
+          Communications Part 1: Simple Mail Transfer Protocol
+
+          2045-17503-02 Internet Message Transfer Profile for DoD
+          Communications Part 2: Format of Text Messages
+
+          2045-17504 Internet File Transfer Profile for DoD
+          Communications
+
+          2045-17505 Internet Domain Name Service (DNS) Profile for DoD
+          Communications
+
+          2045-17506 Internet Remote Login (RLOGIN) Profile for DoD
+          Communications
+
+          2045-17507 Internet Network Management Profile for DoD
+          Communications
+
+          2045-38000 DoD Network Management for DoD Communications
+
+   These documents are available from the Naval Publications and Forms
+   Center.  Requests can be initiated by telephone, telegraph, or mail;
+   however, it is preferred that private industry use form DD1425, if
+   possible.
+
+          Naval Publications and Forms Center, Code 3015
+          5801 Tabor Ave
+          Philadelphia, PA 19120
+          Phone: 1-215-697-3321 (order tape)
+                 1-215-697-4834 (conversation)
+
+
+
+Internet Architecture Board Standards Track                     [Page 7]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+4.  Explanation of Terms
+
+   There are two independent categorization of protocols.  The first is
+   the "maturity level" or STATE of standardization, one of "standard",
+   "draft standard", "proposed standard", "experimental",
+   "informational" or "historic".  The second is the "requirement level"
+   or STATUS of this protocol, one of "required", "recommended",
+   "elective", "limited use", or "not recommended".
+
+   The status or requirement level is difficult to portray in a one word
+   label.  These status labels should be considered only as an
+   indication, and a further description, or applicability statement,
+   should be consulted.
+
+   When a protocol is advanced to proposed standard or draft standard,
+   it is labeled with a current status.
+
+   At any given time a protocol occupies a cell of the following matrix.
+   Protocols are likely to be in cells in about the following
+   proportions (indicated by the relative number of Xs).  A new protocol
+   is most likely to start in the (proposed standard, elective) cell, or
+   the (experimental, limited use) cell.
+
+                             S T A T U S
+                     Req   Rec   Ele   Lim   Not
+                   +-----+-----+-----+-----+-----+
+           Std     |  X  | XXX | XXX |     |     |
+       S           +-----+-----+-----+-----+-----+
+           Draft   |  X  |  X  | XXX |     |     |
+       T           +-----+-----+-----+-----+-----+
+           Prop    |     |  X  | XXX |     |     |
+       A           +-----+-----+-----+-----+-----+
+           Info    |     |     |     |     |     |
+       T           +-----+-----+-----+-----+-----+
+           Expr    |     |     |     | XXX |     |
+       E           +-----+-----+-----+-----+-----+
+           Hist    |     |     |     |     | XXX |
+                   +-----+-----+-----+-----+-----+
+
+   What is a "system"?
+
+      Some protocols are particular to hosts and some to gateways; a few
+      protocols are used in both.  The definitions of the terms below
+      will refer to a "system" which is either a host or a gateway (or
+      both).  It should be clear from the context of the particular
+      protocol which types of systems are intended.
+
+
+
+
+
+Internet Architecture Board Standards Track                     [Page 8]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+4.1.  Definitions of Protocol State
+
+   Every protocol listed in this document is assigned to a "maturity
+   level" or STATE of standardization: "standard", "draft standard",
+   "proposed standard", "experimental", or "historic".
+
+   4.1.1.  Standard Protocol
+
+      The IESG has established this as an official standard protocol for
+      the Internet.  These protocols are assigned STD numbers (see RFC-
+      1311).  These are separated into two groups: (1) IP protocol and
+      above, protocols that apply to the whole Internet; and (2)
+      network-specific protocols, generally specifications of how to do
+      IP on particular types of networks.
+
+   4.1.2.  Draft Standard Protocol
+
+      The IESG is actively considering this protocol as a possible
+      Standard Protocol.  Substantial and widespread testing and comment
+      are desired.  Comments and test results should be submitted to the
+      IESG.  There is a possibility that changes will be made in a Draft
+      Standard Protocol before it becomes a Standard Protocol.
+
+   4.1.3.  Proposed Standard Protocol
+
+      These are protocol proposals that may be considered by the IESG
+      for standardization in the future.  Implementation and testing by
+      several groups is desirable.  Revision of the protocol
+      specification is likely.
+
+   4.1.4.  Experimental Protocol
+
+      A system should not implement an experimental protocol unless it
+      is participating in the experiment and has coordinated its use of
+      the protocol with the developer of the protocol.
+
+      Typically, experimental protocols are those that are developed as
+      part of an ongoing research project not related to an operational
+      service offering.  While they may be proposed as a service
+      protocol at a later stage, and thus become proposed standard,
+      draft standard, and then standard protocols, the designation of a
+      protocol as experimental may sometimes be meant to suggest that
+      the protocol, although perhaps mature, is not intended for
+      operational use.
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                     [Page 9]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+   4.1.5.  Informational Protocol
+
+      Protocols developed by other standard organizations, or vendors,
+      or that are for other reasons outside the purview of the IESG, may
+      be published as RFCs for the convenience of the Internet community
+      as informational protocols.
+
+   4.1.6.  Historic Protocol
+
+      These are protocols that are unlikely to ever become standards in
+      the Internet either because they have been superseded by later
+      developments or due to lack of interest.
+
+4.2.  Definitions of Protocol Status
+
+      This document lists a "requirement level" or STATUS for each
+      protocol.  The status is one of "required", "recommended",
+      "elective", "limited use", or "not recommended".
+
+   4.2.1.  Required Protocol
+
+      A system must implement the required protocols.
+
+   4.2.2.  Recommended Protocol
+
+      A system should implement the recommended protocols.
+
+   4.2.3.  Elective Protocol
+
+      A system may or may not implement an elective protocol. The
+      general notion is that if you are going to do something like this,
+      you must do exactly this.  There may be several elective protocols
+      in a general area, for example, there are several electronic mail
+      protocols, and several routing protocols.
+
+   4.2.4.  Limited Use Protocol
+
+      These protocols are for use in limited circumstances.  This may be
+      because of their experimental state, specialized nature, limited
+      functionality, or historic state.
+
+   4.2.5.  Not Recommended Protocol
+
+      These protocols are not recommended for general use.  This may be
+      because of their limited functionality, specialized nature, or
+      experimental or historic state.
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 10]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+5.  The Standards Track
+
+   This section discusses in more detail the procedures used by the RFC
+   Editor and the IESG in making decisions about the labeling and
+   publishing of protocols as standards.
+
+5.1.  The RFC Processing Decision Table
+
+   Here is the current decision table for processing submissions by the
+   RFC Editor.  The processing depends on who submitted it, and the
+   status they want it to have.
+
+      +==========================================================+
+      |**************|               S O U R C E                 |
+      +==========================================================+
+      | Desired      |    IAB   |   IESG   |   IRSG   |  Other   |
+      | Status       |          |          |          |          |
+      +==========================================================+
+      |              |          |          |          |          |
+      | Standard     |  Bogus   |  Publish |  Bogus   |  Bogus   |
+      | or           |   (2)    |   (1)    |   (2)    |   (2)    |
+      | Draft        |          |          |          |          |
+      | Standard     |          |          |          |          |
+      +--------------+----------+----------+----------+----------+
+      |              |          |          |          |          |
+      |              |  Refer   |  Publish |  Refer   |  Refer   |
+      | Proposed     |   (3)    |   (1)    |   (3)    |   (3)    |
+      | Standard     |          |          |          |          |
+      |              |          |          |          |          |
+      +--------------+----------+----------+----------+----------+
+      |              |          |          |          |          |
+      |              |  Notify  |  Publish |  Notify  |  Notify  |
+      | Experimental |   (4)    |   (1)    |   (4)    |   (4)    |
+      | Protocol     |          |          |          |          |
+      |              |          |          |          |          |
+      +--------------+----------+----------+----------+----------+
+      |              |          |          |          |          |
+      | Information  |  Publish |  Publish |Discretion|Discretion|
+      | or Opinion   |   (1)    |   (1)    |   (5)    |   (5)    |
+      | Paper        |          |          |          |          |
+      |              |          |          |          |          |
+      +==========================================================+
+
+      (1) Publish.
+
+      (2) Bogus.  Inform the source of the rules.  RFCs specifying
+          Standard, or Draft Standard must come from the IESG, only.
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 11]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+      (3) Refer to an Area Director for review by a WG.  Expect to see
+          the document again only after approval by the IESG.
+
+      (4) Notify both the IESG and IRSG.  If no concerns are raised in
+          two weeks then do Discretion (5), else RFC Editor to resolve
+          the concerns or do Refer (3).
+
+      (5) RFC Editor's discretion.  The RFC Editor decides if a review
+          is needed and if so by whom.  RFC Editor decides to publish or
+          not.
+
+   Of course, in all cases the RFC Editor can request or make minor
+   changes for style, format, and presentation purposes.
+
+   The IESG has designated the IESG Secretary as its agent for
+   forwarding documents with IESG approval and for registering concerns
+   in response to notifications (4) to the RFC Editor.  Documents from
+   Area Directors or Working Group Chairs may be considered in the same
+   way as documents from "other".
+
+5.2.  The Standards Track Diagram
+
+   There is a part of the STATUS and STATE categorization that is called
+   the standards track.  Actually, only the changes of state are
+   significant to the progression along the standards track, though the
+   status assignments may change as well.
+
+   The states illustrated by single line boxes are temporary states,
+   those illustrated by double line boxes are long term states.  A
+   protocol will normally be expected to remain in a temporary state for
+   several months (minimum six months for proposed standard, minimum
+   four months for draft standard).  A protocol may be in a long term
+   state for many years.
+
+   A protocol may enter the standards track only on the recommendation
+   of the IESG; and may move from one state to another along the track
+   only on the recommendation of the IESG.  That is, it takes action by
+   the IESG to either start a protocol on the track or to move it along.
+
+   Generally, as the protocol enters the standards track a decision is
+   made as to the eventual STATUS, requirement level or applicability
+   (elective, recommended, or required) the protocol will have, although
+   a somewhat less stringent current status may be assigned, and it then
+   is placed in the the proposed standard STATE with that status.  So
+   the initial placement of a protocol is into state 1.  At any time the
+   STATUS decision may be revisited.
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 12]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+         |
+         +<----------------------------------------------+
+         |                                               ^
+         V    0                                          |    4
+   +-----------+                                   +===========+
+   |   enter   |-->----------------+-------------->|experiment |
+   +-----------+                   |               +=====+=====+
+                                   |                     |
+                                   V    1                |
+                             +-----------+               V
+                             | proposed  |-------------->+
+                        +--->+-----+-----+               |
+                        |          |                     |
+                        |          V    2                |
+                        +<---+-----+-----+               V
+                             | draft std |-------------->+
+                        +--->+-----+-----+               |
+                        |          |                     |
+                        |          V    3                |
+                        +<---+=====+=====+               V
+                             | standard  |-------------->+
+                             +=====+=====+               |
+                                                         |
+                                                         V    5
+                                                   +=====+=====+
+                                                   | historic  |
+                                                   +===========+
+
+   The transition from proposed standard (1) to draft standard (2) can
+   only be by action of the IESG and only after the protocol has been
+   proposed standard (1) for at least six months.
+
+   The transition from draft standard (2) to standard (3) can only be by
+   action of the IESG and only after the protocol has been draft
+   standard (2) for at least four months.
+
+   Occasionally, the decision may be that the protocol is not ready for
+   standardization and will be assigned to the experimental state (4).
+   This is off the standards track, and the protocol may be resubmitted
+   to enter the standards track after further work.  There are other
+   paths into the experimental and historic states that do not involve
+   IESG action.
+
+   Sometimes one protocol is replaced by another and thus becomes
+   historic, or it may happen that a protocol on the standards track is
+   in a sense overtaken by another protocol (or other events) and
+   becomes historic (state 5).
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 13]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+6.  The Protocols
+
+   Subsection 6.1 lists recent RFCs and other changes.  Subsections 6.2
+   - 6.10 list the standards in groups by protocol state.
+
+6.1.  Recent Changes
+
+6.1.1.  New RFCs:
+
+      1920 - Internet Official Protocol Standards
+
+             This memo.
+
+      1918 - Address Allocation for Private Internets
+
+             This is a Best Current Practices document and does not
+             specify any level of standard.
+
+      1917 - An Appeal to the Internet Community to Return Unused IP
+             Networks (Prefixes) to the IANA
+
+             This is a Best Current Practices document and does not
+             specify any level of standard.
+
+      1916 - Enterprise Renumbering: Experience and Information
+             Solicitation
+
+             This is an information document and does not specify any
+             level of standard.
+
+      1915 - Variance for The PPP Connection Control Protocol and The
+             PPP Encryption Control Protocol
+
+             This is a Best Current Practices document and does not
+             specify any level of standard.
+
+      1914 - How to Interact with a Whois++ Mesh
+
+             A Proposed Standard protocol.
+
+      1913 - Architecture of the Whois++ Index Service
+
+             A Proposed Standard protocol.
+
+      1912 - Common DNS Operational and Configuration Errors
+
+             This is an information document and does not specify any
+             level of standard.
+
+
+
+Internet Architecture Board Standards Track                    [Page 14]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+      1911 - Voice Profile for Internet Mail
+
+             An Experimental protocol.
+
+      1910 - User-based Security Model for SNMPv2
+
+             An Experimental protocol.
+
+      1909 - An Administrative Infrastructure for SNMPv2
+
+             An Experimental protocol.
+
+      1908 - Coexistence between Version 1 and Version 2 of the
+             Internet-standard Network Management Framework
+
+             A Draft Standard protocol.
+
+      1907 - Management Information Base for Version 2 of the Simple
+             Network Management Protocol (SNMPv2)
+
+             A Draft Standard protocol.
+
+      1906 - Transport Mappings for Version 2 of the Simple Network
+             Management Protocol (SNMPv2)
+
+             A Draft Standard protocol.
+
+      1905 - Protocol Operations for Version 2 of the Simple Network
+             Management Protocol (SNMPv2)
+
+             A Draft Standard protocol.
+
+      1904 - Conformance Statements for Version 2 of the Simple Network
+             Management Protocol (SNMPv2)
+
+             A Draft Standard protocol.
+
+      1903 - Textual Conventions for Version 2 of the Simple Network
+             Management Protocol (SNMPv2)
+
+             A Draft Standard protocol.
+
+      1902 - Structure of Management Information for Version 2 of the
+             Simple Network Management Protocol (SNMPv2)
+
+             A Draft Standard protocol.
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 15]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+      1901 - Introduction to Community-based SNMPv2
+
+             An Experimental protocol.
+
+      1900 - Renumbering Needs Work
+
+             This is an information document and does not specify any
+             level of standard.
+
+      1899 - not yet issued.
+
+      1898 - CyberCash Credit Card Protocol Version 0.8
+
+             This is an information document and does not specify any
+             level of standard.
+
+      1897 - IPv6 Testing Address Allocation
+
+             An Experimental protocol.
+
+      1896 - The text/enriched MIME Content-type
+
+             This is an information document and does not specify any
+             level of standard.
+
+      1895 - The Application/CALS-1840 Content-type
+
+             This is an information document and does not specify any
+             level of standard.
+
+      1894 - An Extensible Message Format for Delivery Status
+             Notifications
+
+             A Proposed Standard protocol.
+
+      1893 - Enhanced Mail System Status Codes
+
+             A Proposed Standard protocol.
+
+      1892 - The Multipart/Report Content Type for the Reporting of Mail
+             System Administrative Messages
+
+             A Proposed Standard protocol.
+
+      1891 - SMTP Service Extension for Delivery Status Notifications
+
+             A Proposed Standard protocol.
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 16]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+      1890 - RTP Profile for Audio and Video Conferences with Minimal
+             Control
+
+             A Proposed Standard protocol.
+
+      1889 - RTP: A Transport Protocol for Real-Time Applications
+
+             A Proposed Standard protocol.
+
+      1888 - not yet issued.
+
+      1887 - An Architecture for IPv6 Unicast Address Allocation
+
+             This is an information document and does not specify any
+             level of standard.
+
+      1886 - DNS Extensions to support IP version 6
+
+             A Proposed Standard protocol.
+
+      1885 - Internet Control Message Protocol (ICMPv6) for the Internet
+             Protocol Version 6 (IPv6)
+
+             A Proposed Standard protocol.
+
+      1884 - IP Version 6 Addressing Architecture
+
+             A Proposed Standard protocol.
+
+      1883 - Internet Protocol, Version 6 (IPv6) Specification
+
+             A Proposed Standard protocol.
+
+      1882 - The 12-Days of Technology Before Christmas
+
+             This is an information document and does not specify any
+             level of standard.
+
+      1881 - IPv6 Address Allocation Management
+
+             This is an information document and does not specify any
+             level of standard.
+
+      1879 - Class A Subnet Experiment Results and Recommendations
+
+             This is an information document and does not specify any
+             level of standard.
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 17]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+      1878 - Variable Length Subnet Table For IPv4
+
+             This is an information document and does not specify any
+             level of standard.
+
+      1877 - PPP Internet Protocol Control Protocol Extensions for Name
+             Server Addresses
+
+             This is an information document and does not specify any
+             level of standard.
+
+      1876 - A Means for Expressing Location Information in the Domain
+             Name System
+
+             An Experimental protocol.
+
+      1875 - UNINETT PCA Policy Statements
+
+             This is an information document and does not specify any
+             level of standard.
+
+      1874 - SGML Media Types
+
+             An Experimental protocol.
+
+      1873 - Message/External-Body Content-ID Access Type
+
+             An Experimental protocol.
+
+      1872 - The MIME Multipart/Related Content-type
+
+             An Experimental protocol.
+
+      1865 - EDI Meets the Internet Frequently Asked Questions about
+             Electronic Data Interchange (EDI) on the Internet
+
+             This is an information document and does not specify any
+             level of standard.
+
+6.1.2.  Other Changes:
+
+   The following are changes to protocols listed in the previous
+   edition.
+
+      1451 - Manager to Manager Management Information Base
+
+             Moved to Historic.
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 18]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+      1447 - Party MIB for version 2 of the Simple Network Management
+             Protocol (SNMPv2)
+
+             Moved to Historic.
+
+      1446 - Security Protocols for version 2 of the Simple Network
+             Management Protocol (SNMPv2)
+
+             Moved to Historic.
+
+      1445 - Administrative Model for version 2 of the Simple Network
+             Management Protocol (SNMPv2)
+
+             Moved to Historic.
+
+      1058 - Routing Information Protocol
+
+             Moved to Historic.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 19]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+6.2.  Standard Protocols
+
+Protocol   Name                                      Status    RFC STD *
+========   =====================================     ======== ==== === =
+--------   Internet Official Protocol Standards      Req      1920   1
+--------   Assigned Numbers                          Req      1700   2
+--------   Host Requirements - Communications        Req      1122   3
+--------   Host Requirements - Applications          Req      1123   3
+IP         Internet Protocol                         Req       791   5
+            as amended by:--------
+--------     IP Subnet Extension                     Req       950   5
+--------     IP Broadcast Datagrams                  Req       919   5
+--------     IP Broadcast Datagrams with Subnets     Req       922   5
+ICMP       Internet Control Message Protocol         Req       792   5
+IGMP       Internet Group Multicast Protocol         Rec      1112   5
+UDP        User Datagram Protocol                    Rec       768   6
+TCP        Transmission Control Protocol             Rec       793   7
+TELNET     Telnet Protocol                           Rec   854,855   8
+FTP        File Transfer Protocol                    Rec       959   9
+SMTP       Simple Mail Transfer Protocol             Rec       821  10
+SMTP-SIZE  SMTP Service Ext for Message Size         Rec      1870  10
+SMTP-EXT   SMTP Service Extensions                   Rec      1869  10
+MAIL       Format of Electronic Mail Messages        Rec       822  11
+CONTENT    Content Type Header Field                 Rec      1049  11
+NTPV2      Network Time Protocol (Version 2)         Rec      1119  12
+DOMAIN     Domain Name System                        Rec 1034,1035  13
+DNS-MX     Mail Routing and the Domain System        Rec       974  14
+SNMP       Simple Network Management Protocol        Rec      1157  15
+SMI        Structure of Management Information       Rec      1155  16
+Concise-MIB Concise MIB Definitions                  Rec      1212  16
+MIB-II     Management Information Base-II            Rec      1213  17
+NETBIOS    NetBIOS Service Protocols                 Ele 1001,1002  19
+ECHO       Echo Protocol                             Rec       862  20
+DISCARD    Discard Protocol                          Ele       863  21
+CHARGEN    Character Generator Protocol              Ele       864  22
+QUOTE      Quote of the Day Protocol                 Ele       865  23
+USERS      Active Users Protocol                     Ele       866  24
+DAYTIME    Daytime Protocol                          Ele       867  25
+TIME       Time Server Protocol                      Ele       868  26
+TFTP       Trivial File Transfer Protocol            Ele      1350  33
+TP-TCP     ISO Transport Service on top of the TCP   Ele      1006  35
+ETHER-MIB  Ethernet MIB                              Ele      1643  50
+PPP        Point-to-Point Protocol (PPP)             Ele      1661  51
+PPP-HDLC   PPP in HDLC Framing                       Ele      1662  51
+IP-SMDS    IP Datagrams over the SMDS Service        Ele      1209  52
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+
+
+Internet Architecture Board Standards Track                    [Page 20]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+Applicability Statements:
+
+   IGMP -- The Internet Architecture Board intends to move towards
+   general adoption of IP multicasting, as a more efficient solution
+   than broadcasting for many applications.  The host interface has been
+   standardized in RFC-1112; however, multicast-routing gateways are in
+   the experimental stage and are not widely available.  An Internet
+   host should support all of RFC-1112, except for the IGMP protocol
+   itself which is optional; see RFC-1122 for more details.  Even
+   without IGMP, implementation of RFC-1112 will provide an important
+   advance: IP-layer access to local network multicast addressing.  It
+   is expected that IGMP will become recommended for all hosts and
+   gateways at some future date.
+
+   SMI, MIB-II SNMP -- The Internet Architecture Board recommends that
+   all IP and TCP implementations be network manageable.  At the current
+   time, this implies implementation of the Internet MIB-II (RFC-1213),
+   and at least the recommended management protocol SNMP (RFC-1157).
+
+   RIP -- The Routing Information Protocol (RIP) is widely implemented
+   and used in the Internet.  However, both implementors and users
+   should be aware that RIP has some serious technical limitations as a
+   routing protocol.  The IETF is currently devpeloping several
+   candidates for a new standard "open" routing protocol with better
+   properties than RIP.  The IAB urges the Internet community to track
+   these developments, and to implement the new protocol when it is
+   standardized; improved Internet service will result for many users.
+
+   TP-TCP -- As OSI protocols become more widely implemented and used,
+   there will be an increasing need to support interoperation with the
+   TCP/IP protocols.  The Internet Engineering Task Force is formulating
+   strategies for interoperation.  RFC-1006 provides one interoperation
+   mode, in which TCP/IP is used to emulate TP0 in order to support OSI
+   applications.  Hosts that wish to run OSI connection-oriented
+   applications in this mode should use the procedure described in RFC-
+   1006.  In the future, the IAB expects that a major portion of the
+   Internet will support both TCP/IP and OSI (inter-)network protocols
+   in parallel, and it will then be possible to run OSI applications
+   across the Internet using full OSI protocol "stacks".
+
+
+
+
+
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 21]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+6.3.  Network-Specific Standard Protocols
+
+All Network-Specific Standards have Elective status.
+
+Protocol   Name                                    State    RFC   STD *
+========   =====================================   =====   =====  === =
+IP-ATM     Classical IP and ARP over ATM            Prop   1577
+IP-FR      Multiprotocol over Frame Relay           Draft  1490
+ATM-ENCAP  Multiprotocol Encapsulation over ATM     Prop   1483
+IP-TR-MC   IP Multicast over Token-Ring LANs        Prop   1469
+IP-FDDI    Transmission of IP and ARP over FDDI Net Std    1390    36
+IP-HIPPI   IP and ARP on HIPPI                      Prop   1374
+IP-X.25    X.25 and ISDN in the Packet Mode         Draft  1356
+IP-FDDI    Internet Protocol on FDDI Networks       Draft  1188
+ARP        Address Resolution Protocol              Std     826    37
+RARP       A Reverse Address Resolution Protocol    Std     903    38
+IP-ARPA    Internet Protocol on ARPANET             Std BBN1822    39
+IP-WB      Internet Protocol on Wideband Network    Std     907    40
+IP-E       Internet Protocol on Ethernet Networks   Std     894    41
+IP-EE      Internet Protocol on Exp. Ethernet Nets  Std     895    42
+IP-IEEE    Internet Protocol on IEEE 802            Std    1042    43
+IP-DC      Internet Protocol on DC Networks         Std     891    44
+IP-HC      Internet Protocol on Hyperchannel        Std    1044    45
+IP-ARC     Transmitting IP Traffic over ARCNET Nets Std    1201    46
+IP-SLIP    Transmission of IP over Serial Lines     Std    1055    47
+IP-NETBIOS Transmission of IP over NETBIOS          Std    1088    48
+IP-IPX     Transmission of 802.2 over IPX Networks  Std    1132    49
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+Applicability Statements:
+
+   It is expected that a system will support one or more physical
+   networks and for each physical network supported the appropriate
+   protocols from the above list must be supported.  That is, it is
+   elective to support any particular type of physical network, and for
+   the physical networks actually supported it is required that they be
+   supported exactly according to the protocols in the above list.  See
+   also the Host and Gateway Requirements RFCs for more specific
+   information on network-specific ("link layer") protocols.
+
+
+
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 22]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+6.4.  Draft Standard Protocols
+
+Protocol   Name                                     Status          RFC
+========   =====================================    ============== =====
+COEX-MIB   Coexistence between SNMPV1 & SNMPV2      Elective       1908*
+SNMPv2-MIB MIB for SNMPv2                           Elective       1907*
+TRANS-MIB  Transport Mappings for SNMPv2            Elective       1906*
+OPS-MIB    Protocol Operations for SNMPv2           Elective       1905*
+CONF-MIB   Conformance Statements for SNMPv2        Elective       1904*
+CONV-MIB   Textual Conventions for SNMPv2           Elective       1903*
+SMIV2      SMI for SNMPv2                           Elective       1902*
+CON-MD5    Content-MD5 Header Field                 Elective       1864
+OSPF-MIB   OSPF Version 2 MIB                       Elective       1850
+STR-REP    String Representation ...                Elective       1779
+X.500syn   X.500 String Representation ...          Elective       1778
+X.500lite  X.500 Lightweight ...                    Elective       1777
+BGP-4-APP  Application of BGP-4                     Elective       1772
+BGP-4      Border Gateway Protocol 4                Elective       1771
+PPP-DNCP   PPP DECnet Phase IV Control Protocol     Elective       1762
+RMON-MIB   Remote Network Monitoring MIB            Elective       1757
+802.5-MIB  IEEE 802.5 Token Ring MIB                Elective       1748
+BGP-4-MIB  BGP-4 MIB                                Elective       1657
+POP3       Post Office Protocol, Version 3          Elective       1725
+RIP2-MIB   RIP Version 2 MIB Extension              Elective       1724
+RIP2       RIP Version 2-Carrying Additional Info.  Elective       1723
+RIP2-APP   RIP Version 2 Protocol App. Statement    Elective       1722
+SIP-MIB    SIP Interface Type MIB                   Elective       1694
+-------    Def Man Objs Parallel-printer-like       Elective       1660
+-------    Def Man Objs RS-232-like                 Elective       1659
+-------    Def Man Objs Character Stream            Elective       1658
+SMTP-8BIT  SMTP Service Ext or 8bit-MIMEtransport   Elective       1652
+OSI-NSAP   Guidelines for OSI NSAP Allocation       Elective       1629
+OSPF2      Open Shortest Path First Routing V2      Elective       1583
+ISO-TS-ECHO Echo for ISO-8473                       Elective       1575
+DECNET-MIB DECNET MIB                               Elective       1559
+-------    Message Header Ext. of Non-ASCII Text    Elective       1522
+MIME       Multipurpose Internet Mail Extensions    Elective       1521
+802.3-MIB  IEEE 802.3 Repeater MIB                  Elective       1516
+BRIDGE-MIB BRIDGE-MIB                               Elective       1493
+NTPV3      Network Time Protocol (Version 3)        Elective       1305
+IP-MTU     Path MTU Discovery                       Elective       1191
+FINGER     Finger Protocol                          Elective       1288
+BOOTP      Bootstrap Protocol                      Recommended 951,1497
+NICNAME    WhoIs Protocol                           Elective        954
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 23]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+Applicability Statements:
+
+   PPP -- Point to Point Protocol is a method of sending IP over serial
+   lines, which are a type of physical network.  It is anticipated that
+   PPP will be advanced to the network-specifics standard protocol state
+   in the future.
+
+6.5.  Proposed Standard Protocols
+
+Protocol   Name                                     Status          RFC
+========   =====================================    ============== =====
+WHOIS++M   How to Interact with a Whois++ Mesh      Elective       1914*
+WHOIS++A   Architecture of Whois++ Index Service    Elective       1913*
+DSN        Delivery Status Notifications            Elective       1894*
+EMS-CODE   Enhanced Mail System Status Codes        Elective       1893*
+MIME-RPT   Multipart/Report                         Elective       1892*
+SMTP-DSN   SMTP Delivery Status Notifications       Elective       1891*
+RTP-AV     RTP Audio/Video Profile                  Elective       1890*
+RTP        Transport Protocol for Real-Time Apps    Elective       1889*
+DNS-IPV6   DNS Extensions to support IPv6           Elective       1886*
+ICMPv6     ICMPv6 for IPv6                          Elective       1885*
+IPV6-Addr  IPv6 Addressing Architecture             Elective       1884*
+IPV6       IPv6 Specification                       Elective       1883*
+HTML       Hypertext Markup Language - 2.0          Elective       1866
+SMTP-Pipe  SMTP Serv. Ext. for Command Pipelining   Elective       1854
+MIME-Sec   MIME Object Security Services            Elective       1848
+MIME-Encyp MIME: Signed and Encrypted               Elective       1847
+WHOIS++    Architecture of the WHOIS++ service      Elective       1835
+--------   Binding Protocols for ONC RPC Version 2  Elective       1833
+XDR        External Data Representation Standard    Elective       1832
+RPC        Remote Procedure Call Protocol V. 2      Elective       1831
+--------   ESP DES-CBC Transform                    Ele/Req        1829
+--------   IP Authentication using Keyed MD5        Ele/Req        1828
+ESP        IP Encapsulating Security Payload        Ele/Req        1827
+IPV6-AH    IP Authentication Header                 Ele/Req        1826
+--------   Security Architecture for IP             Ele/Req        1825
+RREQ       Requirements for IP Version 4 Routers    Elective       1812
+URL        Relative Uniform Resource Locators       Elective       1808
+CLDAP      Connection-less LDAP                     Elective       1798
+OSPF-DC    Ext. OSPF to Support Demand Circuits     Elective       1793
+TMUX       Transport Multiplexing Protocol          Elective       1692
+TFTP-Opt   TFTP Options                             Elective       1784
+TFTP-Blk   TFTP Blocksize Option                    Elective       1783
+TFTP-Ext   TFTP Option Extension                    Elective       1782
+OSI-Dir    OSI User Friendly Naming ...             Elective       1781
+MIME-EDI   MIME Encapsulation of EDI Objects        Elective       1767
+Lang-Tag   Tags for Identification of Languages     Elective       1766
+XNSCP      PPP XNS IDP Control Protocol             Elective       1764
+
+
+
+Internet Architecture Board Standards Track                    [Page 24]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+BVCP       PPP Banyan Vines Control Protocol        Elective       1763
+Print-MIB  Printer MIB                              Elective       1759
+ATM-SIG    ATM Signaling Support for IP over ATM    Elective       1755
+IPNG       Recommendation for IP Next Generation    Elective       1752
+802.5-SSR  802.5 SSR MIB using SMIv2                Elective       1749
+SDLCSMIv2  SNADLC SDLC MIB using SMIv2              Elective       1747
+BGP4/IDRP  BGP4/IDRP for IP/OSPF Interaction        Elective       1745
+AT-MIB     Appletalk MIB                            Elective       1742
+MacMIME    MIME Encapsulation of Macintosh files    Elective       1740
+URL        Uniform Resource Locators                Elective       1738
+POP3-AUTH  POP3 AUTHentication command              Elective       1734
+IMAP4-AUTH IMAP4 Authentication Mechanisms          Elective       1731
+IMAP4      Internet Message Access Protocol V4      Elective       1730
+PPP-MP     PPP Multilink Protocol                   Elective       1717
+RDBMS-MIB  RDMS MIB - using SMIv2                   Elective       1697
+MODEM-MIB  Modem MIB - using SMIv2                  Elective       1696
+ATM-MIB    ATM Management Version 8.0 using SMIv2   Elective       1695
+SNANAU-MIB SNA NAUs MIB using SMIv2                 Elective       1665
+PPP-TRANS  PPP Reliable Transmission                Elective       1663
+BGP-4-IMP  BGP-4 Roadmap and Implementation         Elective       1656
+--------   Postmaster Convention X.400 Operations   Elective       1648
+TN3270-En  TN3270 Enhancements                      Elective       1647
+PPP-BCP    PPP Bridging Control Protocol            Elective       1638
+UPS-MIB    UPS Management Information Base          Elective       1628
+AAL5-MTU   Default IP MTU for use over ATM AAL5     Elective       1626
+PPP-SONET  PPP over SONET/SDH                       Elective       1619
+PPP-ISDN   PPP over ISDN                            Elective       1618
+DNS-R-MIB  DNS Resolver MIB Extensions              Elective       1612
+DNS-S-MIB  DNS Server MIB Extensions                Elective       1611
+FR-MIB     Frame Relay Service MIB                  Elective       1604
+PPP-X25    PPP in X.25                              Elective       1598
+OSPF-NSSA  The OSPF NSSA Option                     Elective       1587
+OSPF-Multi Multicast Extensions to OSPF             Elective       1584
+SONET-MIB  MIB SONET/SDH Interface Type             Elective       1595
+RIP-DC     Extensions to RIP to Support Demand Cir. Elective       1582
+--------   Evolution of the Interfaces Group of MIB-II Elective    1573
+PPP-LCP    PPP LCP Extensions                       Elective       1570
+X500-MIB   X.500 Directory Monitoring MIB           Elective       1567
+MAIL-MIB   Mail Monitoring MIB                      Elective       1566
+NSM-MIB    Network Services Monitoring MIB          Elective       1565
+CIPX       Compressing IPX Headers Over WAM Media   Elective       1553
+IPXCP      PPP Internetworking Packet Exchange Control Elective    1552
+DHCP-BOOTP Interoperation Between DHCP and BOOTP    Elective       1534
+DHCP-BOOTP DHCP Options and BOOTP Vendor Extensions Elective       1533
+BOOTP      Clarifications and Extensions BOOTP      Elective       1532
+DHCP       Dynamic Host Configuration Protocol      Elective       1541
+SRB-MIB    Source Routing Bridge MIB                Elective       1525
+CIDR-STRA  CIDR Address Assignment...               Elective       1519
+
+
+
+Internet Architecture Board Standards Track                    [Page 25]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+CIDR-ARCH  CIDR Architecture...                     Elective       1518
+CIDR-APP   CIDR Applicability Statement             Elective       1517
+--------   802.3 MAU MIB                            Elective       1515
+HOST-MIB   Host Resources MIB                       Elective       1514
+--------   Token Ring Extensions to RMON MIB        Elective       1513
+FDDI-MIB   FDDI Management Information Base         Elective       1512
+KERBEROS   Kerberos Network Authentication Ser (V5) Elective       1510
+GSSAPI     Generic Security Service API: C-bindings Elective       1509
+GSSAPI     Generic Security Service Application...  Elective       1508
+DASS       Distributed Authentication Security...   Elective       1507
+--------   X.400 Use of Extended Character Sets     Elective       1502
+HARPOON    Rules for Downgrading Messages...        Elective       1496
+Mapping    MHS/RFC-822 Message Body Mapping         Elective       1495
+Equiv      X.400/MIME Body Equivalences             Elective       1494
+IDPR       Inter-Domain Policy Routing Protocol     Elective       1479
+IDPR-ARCH  Architecture for IDPR                    Elective       1478
+PPP/Bridge MIB Bridge PPP MIB                       Elective       1474
+PPP/IP MIB  IP Network Control Protocol of PPP MIB  Elective       1473
+PPP/SEC MIB Security Protocols of PPP MIB           Elective       1472
+PPP/LCP MIB Link Control Protocol of PPP MIB        Elective       1471
+X25-MIB    Multiprotocol Interconnect on X.25 MIB   Elective       1461
+SNMPv2     Coexistence between SNMPv1 and SNMPv2    Elective       1452
+SNMPv2     Management Information Base for SNMPv2   Elective       1450
+SNMPv2     Transport Mappings for SNMPv2            Elective       1449
+SNMPv2     Protocol Operations for SNMPv2           Elective       1448
+SNMPv2     Conformance Statements for SNMPv2        Elective       1444
+SNMPv2     Textual Conventions for SNMPv2           Elective       1443
+SNMPv2     SMI for SNMPv2                           Elective       1442
+SNMPv2     Introduction to SNMPv2                   Elective       1441
+PEM-KEY    PEM - Key Certification                  Elective       1424
+PEM-ALG    PEM - Algorithms, Modes, and Identifiers Elective       1423
+PEM-CKM    PEM - Certificate-Based Key Management   Elective       1422
+PEM-ENC    PEM - Message Encryption and Auth        Elective       1421
+SNMP-IPX   SNMP over IPX                            Elective       1420
+SNMP-AT    SNMP over AppleTalk                      Elective       1419
+SNMP-OSI   SNMP over OSI                            Elective       1418
+FTP-FTAM   FTP-FTAM Gateway Specification           Elective       1415
+IDENT-MIB  Identification MIB                       Elective       1414
+IDENT      Identification Protocol                  Elective       1413
+DS3/E3-MIB DS3/E3 Interface Type                    Elective       1407
+DS1/E1-MIB DS1/E1 Interface Type                    Elective       1406
+BGP-OSPF   BGP OSPF Interaction                     Elective       1403
+--------   Route Advertisement In BGP2 And BGP3     Elective       1397
+SNMP-X.25  SNMP MIB Extension for X.25 Packet Layer Elective       1382
+SNMP-LAPB  SNMP MIB Extension for X.25 LAPB         Elective       1381
+PPP-ATCP   PPP AppleTalk Control Protocol           Elective       1378
+PPP-OSINLCP PPP OSI Network Layer Control Protocol  Elective       1377
+TABLE-MIB  IP Forwarding Table MIB                  Elective       1354
+
+
+
+Internet Architecture Board Standards Track                    [Page 26]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+SNMP-PARTY-MIB Administration of SNMP               Elective       1353
+SNMP-SEC   SNMP Security Protocols                  Elective       1352
+SNMP-ADMIN SNMP Administrative Model                Elective       1351
+TOS        Type of Service in the Internet          Elective       1349
+PPP-AUTH   PPP Authentication                       Elective       1334
+PPP-LINK   PPP Link Quality Monitoring              Elective       1333
+PPP-IPCP   PPP Control Protocol                     Elective       1332
+-------    X.400 1988 to 1984 downgrading           Elective       1328
+-------    Mapping between X.400(1988)              Elective       1327
+TCP-EXT    TCP Extensions for High Performance      Elective       1323
+FRAME-MIB  Management Information Base for Frame    Elective       1315
+NETFAX     File Format for the Exchange of Images   Elective       1314
+IARP       Inverse Address Resolution Protocol      Elective       1293
+FDDI-MIB   FDDI-MIB                                 Elective       1285
+-------    Encoding Network Addresses               Elective       1277
+-------    Replication and Distributed Operations   Elective       1276
+-------    COSINE and Internet X.500 Schema         Elective       1274
+BGP-MIB    Border Gateway Protocol MIB (Version 3)  Elective       1269
+ICMP-ROUT  ICMP Router Discovery Messages           Elective       1256
+IPSO       DoD Security Options for IP              Elective       1108
+OSI-UDP    OSI TS on UDP                            Elective       1240
+STD-MIBs   Reassignment of Exp MIBs to Std MIBs     Elective       1239
+IPX-IP     Tunneling IPX Traffic through IP Nets    Elective       1234
+GINT-MIB   Extensions to the Generic-Interface MIB  Elective       1229
+IS-IS      OSI IS-IS for TCP/IP Dual Environments   Elective       1195
+IP-CMPRS   Compressing TCP/IP Headers               Elective       1144
+NNTP       Network News Transfer Protocol           Elective        977
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+[Note: Ele/Req indicates elective for use with IPv4 and required for use
+with IPv6.]
+
+Applicability Statements:
+
+   OSPF - RFC 1370 is an applicability statement for OSPF.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 27]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+6.6.  Telnet Options
+
+For convenience, all the Telnet Options are collected here with both
+their state and status.
+
+Protocol   Name                           Number  State Status  RFC STD
+========   =====================================  ===== ====== ==== ===
+TOPT-BIN   Binary Transmission                 0  Std   Rec     856  27
+TOPT-ECHO  Echo                                1  Std   Rec     857  28
+TOPT-RECN  Reconnection                        2  Prop  Ele     ...
+TOPT-SUPP  Suppress Go Ahead                   3  Std   Rec     858  29
+TOPT-APRX  Approx Message Size Negotiation     4  Prop  Ele     ...
+TOPT-STAT  Status                              5  Std   Rec     859  30
+TOPT-TIM   Timing Mark                         6  Std   Rec     860  31
+TOPT-REM   Remote Controlled Trans and Echo    7  Prop  Ele     726
+TOPT-OLW   Output Line Width                   8  Prop  Ele     ...
+TOPT-OPS   Output Page Size                    9  Prop  Ele     ...
+TOPT-OCRD  Output Carriage-Return Disposition 10  Prop  Ele     652
+TOPT-OHT   Output Horizontal Tabstops         11  Prop  Ele     653
+TOPT-OHTD  Output Horizontal Tab Disposition  12  Prop  Ele     654
+TOPT-OFD   Output Formfeed Disposition        13  Prop  Ele     655
+TOPT-OVT   Output Vertical Tabstops           14  Prop  Ele     656
+TOPT-OVTD  Output Vertical Tab Disposition    15  Prop  Ele     657
+TOPT-OLD   Output Linefeed Disposition        16  Prop  Ele     658
+TOPT-EXT   Extended ASCII                     17  Prop  Ele     698
+TOPT-LOGO  Logout                             18  Prop  Ele     727
+TOPT-BYTE  Byte Macro                         19  Prop  Ele     735
+TOPT-DATA  Data Entry Terminal                20  Prop  Ele    1043
+TOPT-SUP   SUPDUP                             21  Prop  Ele     736
+TOPT-SUPO  SUPDUP Output                      22  Prop  Ele     749
+TOPT-SNDL  Send Location                      23  Prop  Ele     779
+TOPT-TERM  Terminal Type                      24  Prop  Ele    1091
+TOPT-EOR   End of Record                      25  Prop  Ele     885
+TOPT-TACACS  TACACS User Identification       26  Prop  Ele     927
+TOPT-OM    Output Marking                     27  Prop  Ele     933
+TOPT-TLN   Terminal Location Number           28  Prop  Ele     946
+TOPT-3270  Telnet 3270 Regime                 29  Prop  Ele    1041
+TOPT-X.3   X.3 PAD                            30  Prop  Ele    1053
+TOPT-NAWS  Negotiate About Window Size        31  Prop  Ele    1073
+TOPT-TS    Terminal Speed                     32  Prop  Ele    1079
+TOPT-RFC   Remote Flow Control                33  Prop  Ele    1372
+TOPT-LINE  Linemode                           34  Draft Ele    1184
+TOPT-XDL   X Display Location                 35  Prop  Ele    1096
+TOPT-ENVIR Telnet Environment Option          36  Hist  Not    1408
+TOPT-AUTH  Telnet Authentication Option       37  Exp   Ele    1416
+TOPT-ENVIR Telnet Environment Option          39  Prop  Ele    1572
+TOPT-EXTOP Extended-Options-List             255  Std   Rec     861  32
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 28]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+6.7.  Experimental Protocols
+
+All Experimental protocols have the Limited Use status.
+
+Protocol   Name                                                     RFC
+========   =====================================                   =====
+MIME-VP    Voice Profile for Internet Mail                         1911*
+SNMPV2SM   User-based Security Model for SNMPv2                    1910*
+SNMPV2AI   SNMPv2 Administrative Infrastructure                    1909*
+SNMPV2CB   Introduction to Community-based SNMPv2                  1901*
+-------    IPv6 Testing Address Allocation                         1897*
+DNS-LOC    Location Information in the DNS                         1876*
+SGML-MT    SGML Media Types                                        1874*
+CONT-MT    Access Type Content-ID                                  1873*
+RELAT-MT   Multipart/Related                                       1872*
+UNARP      ARP Extension - UNARP                                   1868
+-------    Form-based File Upload in HTML                          1867
+-------    BGP/IDRP Route Server Alternative                       1863
+-------    IP Authentication using Keyed SHA                       1852
+ESP3DES    ESP Triple DES Transform                                1851
+-------    SMTP 521 Reply Code                                     1846
+-------    SMTP Serv. Ext. for Checkpoint/Restart                  1845
+-------    X.500 Mapping X.400 and RFC 822 Addresses               1838
+-------    Tables and Subtrees in the X.500 Directory              1837
+-------    O/R Address hierarchy in X.500                          1836
+-------    SMTP Serv. Ext. Large and Binary MIME Msgs.             1830
+ST2        Stream Protocol Version 2                               1819
+-------    Content-Disposition Header                              1806
+-------    Schema Publishing in X.500 Directory                    1804
+-------    X.400-MHS use X.500 to support X.400-MHS Routing        1801
+-------    Class A Subnet Experiment                               1797
+TCP/IPXMIB TCP/IPX Connection Mib Specification                    1792
+-------    TCP And UDP Over IPX Networks With Fixed Path MTU       1791
+ICMP-DM    ICMP Domain Name Messages                               1788
+CLNP-MULT  Host Group Extensions for CLNP Multicasting             1768
+OSPF-OVFL  OSPF Database Overflow                                  1765
+RWP        Remote Write ProtocolL - Version 1.0                    1756
+NARP       NBMA Address Resolution Protocol                        1735
+DNS-DEBUG  Tools for DNS debugging                                 1713
+DNS-ENCODE DNS Encoding of Geographical Location                   1712
+TCP-POS    An Extension to TCP: Partial Order Service              1693
+-------    DNS to Distribute RFC1327 Mail Address Mapping Tables   1664
+T/TCP      TCP Extensions for Transactions                         1644
+UTF-7      A Mail-Safe Transformation Format of Unicode            1642
+MIME-UNI   Using Unicode with MIME                                 1641
+
+
+
+Internet Architecture Board Standards Track                    [Page 29]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+FOOBAR     FTP Operation Over Big Address Records                  1639
+X500-CHART Charting Networks in the X.500 Directory                1609
+X500-DIR   Representing IP Information in the X.500 Directory      1608
+SNMP-DPI   SNMP Distributed Protocol Interface                     1592
+CLNP-TUBA  Use of ISO CLNP in TUBA Environments                    1561
+REM-PRINT  TPC.INT Subdomain Remote Printing - Technical           1528
+EHF-MAIL   Encoding Header Field for Internet Messages             1505
+REM-PRT    An Experiment in Remote Printing                        1486
+RAP        Internet Route Access Protocol                          1476
+TP/IX      TP/IX: The Next Internet                                1475
+X400       Routing Coordination for X.400 Services                 1465
+DNS        Storing Arbitrary Attributes in DNS                     1464
+IRCP       Internet Relay Chat Protocol                            1459
+TOS-LS     Link Security TOS                                       1455
+SIFT/UFT   Sender-Initiated/Unsolicited File Transfer              1440
+DIR-ARP    Directed ARP                                            1433
+TEL-SPX    Telnet Authentication: SPX                              1412
+TEL-KER    Telnet Authentication: Kerberos V4                      1411
+MAP-MAIL   X.400 Mapping and Mail-11                               1405
+TRACE-IP   Traceroute Using an IP Option                           1393
+DNS-IP     Experiment in DNS Based IP Routing                      1383
+RMCP       Remote Mail Checking Protocol                           1339
+TCP-HIPER  TCP Extensions for High Performance                     1323
+MSP2       Message Send Protocol 2                                 1312
+DSLCP      Dynamically Switched Link Control                       1307
+--------   X.500 and Domains                                       1279
+IN-ENCAP   Internet Encapsulation Protocol                         1241
+CLNS-MIB   CLNS-MIB                                                1238
+CFDP       Coherent File Distribution Protocol                     1235
+SNMP-DPI   SNMP Distributed Program Interface                      1228
+IP-AX.25   IP Encapsulation of AX.25 Frames                        1226
+ALERTS     Managing Asynchronously Generated Alerts                1224
+MPP        Message Posting Protocol                                1204
+SNMP-BULK  Bulk Table Retrieval with the SNMP                      1187
+DNS-RR     New DNS RR Definitions                                  1183
+IMAP2      Interactive Mail Access Protocol                        1176
+NTP-OSI    NTP over OSI Remote Operations                          1165
+DMF-MAIL   Digest Message Format for Mail                          1153
+RDP        Reliable Data Protocol                              908,1151
+TCP-ACO    TCP Alternate Checksum Option                           1146
+IP-DVMRP   IP Distance Vector Multicast Routing                    1075
+VMTP       Versatile Message Transaction Protocol                  1045
+COOKIE-JAR Authentication Scheme                                   1004
+NETBLT     Bulk Data Transfer Protocol                              998
+IRTP       Internet Reliable Transaction Protocol                   938
+LDP        Loader Debugger Protocol                                 909
+RLP        Resource Location Protocol                               887
+NVP-II     Network Voice Protocol                              ISI-memo
+
+
+
+Internet Architecture Board Standards Track                    [Page 30]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+PVP        Packet Video Protocol                               ISI-memo
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 31]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+6.8.  Informational Protocols
+
+Information protocols have no status.
+
+Protocol   Name                                                     RFC
+=======    ====================================                    =====
+CYBERCASH  CyberCash Credit Card Protocol Version 0.8              1898*
+--------   text/enriched MIME Content-type                         1896*
+--------   Application/CALS-1840 Content-type                      1895*
+--------   PPP IPCP Extensions for Name Server Addresses           1877*
+SNPP       Simple Network Paging Protocol - Version 2              1861
+--------   ISO Transport Class 2 Non-use Explicit Flow Control     1859
+           over TCP RFC1006 extension
+--------   IP in IP Tunneling                                      1853
+--------   PPP Network Control Protocol for LAN Extension          1841
+TESS       The Exponential Security System                         1824
+NFSV3      NFS Version 3 Protocol Specification                    1813
+--------   A Format for Bibliographic Records                      1807
+SDMD       IPv4 Option for Sender Directed MD Delivery             1770
+SNTP       Simple Network Time Protocol                            1769
+SNOOP      Snoop Version 2 Packet Capture File Format              1761
+BINHEX     MIME Content Type for BinHex Encoded Files              1741
+RWHOIS     Referral Whois Protocol                                 1714
+DNS-NSAP   DNS NSAP Resource Records                               1706
+RADIO-PAGE TPC.INT Subdomain: Radio Paging -- Technical Procedures 1703
+GRE-IPv4   Generic Routing Encapsulation over IPv4                 1702
+GRE        Generic Routing Encapsulatio                            1701
+IPXWAN     Novell IPX Over Various WAN Media                       1634
+ADSNA-IP   Advanced SNA/IP: A Simple SNA Transport Protocol        1538
+AUBR       Appletalk Update-Based Routing Protocol...              1504
+TACACS     Terminal Access Control Protocol                        1492
+SUN-NFS    Network File System Protocol                            1094
+SUN-RPC    Remote Procedure Call Protocol Version 2                1057
+GOPHER     The Internet Gopher Protocol                            1436
+-------    Data Link Switching: Switch-to-Switch Protocol          1434
+LISTSERV   Listserv Distribute Protocol                            1429
+-------    Replication Requirements                                1275
+PCMAIL     Pcmail Transport Protocol                               1056
+MTP        Multicast Transport Protocol                            1301
+BSD Login  BSD Login                                               1282
+DIXIE      DIXIE Protocol Specification                            1249
+IP-X.121   IP to X.121 Address Mapping for DDN                     1236
+OSI-HYPER  OSI and LLC1 on HYPERchannel                            1223
+HAP2       Host Access Protocol                                    1221
+SUBNETASGN On the Assignment of Subnet Numbers                     1219
+SNMP-TRAPS Defining Traps for use with SNMP                        1215
+DAS        Directory Assistance Service                            1202
+MD4        MD4 Message Digest Algorithm                            1186
+
+
+
+Internet Architecture Board Standards Track                    [Page 32]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+LPDP       Line Printer Daemon Protocol                            1179
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+6.9.  Historic Protocols
+
+All Historic protocols have Not Recommended status.
+
+Protocol   Name                                                RFC  STD
+========   =====================================              ===== ===
+
+SNMPv2     Manager-to-Manager MIB                   Elective  1451     *
+SNMPv2     Party MIB for SNMPv2                     Elective  1447     *
+SNMPv2     Security Protocols for SNMPv2            Elective  1446     *
+SNMPv2     Administrative Model for SNMPv2          Elective  1445     *
+RIP        Routing Information Protocol             Ele       1058  34 *
+--------   Mapping full 822 to Restricted 822                 1137
+BGP3       Border Gateway Protocol 3 (BGP-3)             1267,1268
+--------   Gateway Requirements                      Req      1009   4
+EGP        Exterior Gateway Protocol                 Rec       904  18
+SNMP-MUX   SNMP MUX Protocol and MIB                          1227
+OIM-MIB-II OSI Internet Management: MIB-II                    1214
+IMAP3      Interactive Mail Access Protocol Version 3         1203
+SUN-RPC    Remote Procedure Call Protocol Version 1           1050
+802.4-MIP  IEEE 802.4 Token Bus MIB                           1230
+CMOT       Common Management Information Services             1189
+--------   Mail Privacy: Procedures                           1113
+--------   Mail Privacy: Key Management                       1114
+--------   Mail Privacy: Algorithms                           1115
+NFILE      A File Access Protocol                             1037
+HOSTNAME   HOSTNAME Protocol                                   953
+SFTP       Simple File Transfer Protocol                       913
+SUPDUP     SUPDUP Protocol                                     734
+BGP        Border Gateway Protocol                       1163,1164
+MIB-I      MIB-I                                              1156
+SGMP       Simple Gateway Monitoring Protocol                 1028
+HEMS       High Level Entity Management Protocol              1021
+STATSRV    Statistics Server                                   996
+POP2       Post Office Protocol, Version 2                     937
+RATP       Reliable Asynchronous Transfer Protocol             916
+HFEP       Host - Front End Protocol                           929
+THINWIRE   Thinwire Protocol                                   914
+HMP        Host Monitoring Protocol                            869
+GGP        Gateway Gateway Protocol                            823
+RTELNET    Remote Telnet Service                               818
+CLOCK      DCNET Time Server Protocol                          778
+MPM        Internet Message Protocol                           759
+
+
+
+Internet Architecture Board Standards Track                    [Page 33]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+NETRJS     Remote Job Service                                  740
+NETED      Network Standard Text Editor                        569
+RJE        Remote Job Entry                                    407
+XNET       Cross Net Debugger                              IEN-158
+NAMESERVER Host Name Server Protocol                       IEN-116
+MUX        Multiplexing Protocol                            IEN-90
+GRAPHICS   Graphics Protocol                             NIC-24308
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 34]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+6.10.  Obsolete Protocols
+
+Some of the protocols listed in this memo are described in RFCs that are
+obsoleted by newer RFCs.  "Obsolete" or "obsoleted" is not an official
+state or status of protocols.  This subsection is for information only.
+
+While it may seem to be obviously wrong to have an obsoleted RFC in the
+list of standards, there may be cases when an older standard is in the
+process of being replaced.  This process may take a year or two.
+
+Many obsoleted protocols are of little interest and are dropped from
+this memo altogether.  Some obsoleted protocols have received enough
+recognition that it seems appropriate to list them under their current
+status and with the following reference to their current replacement.
+
+RFC            RFC   Status     Title                               *
+====           ====  =========  =================================== =
+1305 obsoletes 1119  Stan/Rec   Network Time Protocol version 2
+1390 obsoletes 1188  Draf/Elec  Transmission of IP and ARP over FDDI*
+1533 obsoletes 1497  Draf/Rec   BOOTP Vendor Information Extensions
+1542 obsoletes 1532  Prop/Elec  Extensions for Bootstrap Protocol   *
+1573 obsoletes 1229  Prop/Elec  Ext. to the Generic-Interface MIB
+1773 obsoletes 1656  Prop/Elec  BGP-4 Protocol Document             *
+1902 obsoletes 1442  Prop/Elec  SMI for SNMPv2                      *
+1903 obsoletes 1443  Prop/Elec  Textual Conventions for SNMPv2      *
+1904 obsoletes 1444  Prop/Elec  Conformance Statements for SNMPv2   *
+1905 obsoletes 1448  Prop/Elec  Protocol Operations for SNMPv2      *
+1906 obsoletes 1449  Prop/Elec  Transport Mappings for SNMPv2       *
+1907 obsoletes 1450  Prop/Elec  MIB for SNMPv2                      *
+1908 obsoletes 1452  Prop/Elec  Coexistence between SNMPv1 & SNMPv2 *
+1320 obsoletes 1186  Info/      The MD4 Message Digest Algorithm
+1529 obsoletes 1486  Expe/Limi  An Experiment in Remote Printing    *
+1592 obsoletes 1228  Expe/Limi  SNMP Distributed Protocol Interface *
+1057 obsoletes 1050  Hist/Not   RPC: Remote Procedure Call Protocol
+1158 obsoletes 1156  Hist/Not   Management Information Base - I     *
+1267 obsoletes 1163  Hist/Not   A Border Gateway Protocol (BGP)
+1268 obsoletes 1164  Hist/Not   Border Gateway Protocol 3 (BGP-3)
+1421 obsoletes 1113  Hist/Not   PEM - Part I
+1422 obsoletes 1114  Hist/Not   PEM - Part II
+1423 obsoletes 1115  Hist/Not   PEM - Part III
+1655 obsoletes 1268  Hist/Not   Application of the BGP              *
+1716 obsoletes 1009  Hist/Not   Towards Requirements for IP Routers *
+
+Thanks to Lynn Wheeler for compiling the information in this subsection.
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 35]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+7.  Contacts
+
+7.1.  IAB, IETF, and IRTF Contacts
+
+   7.1.1.  Internet Architecture Board (IAB) Contact
+
+   Please send your comments about this list of protocols and especially
+   about the Draft Standard Protocols to the Internet Architecture Board
+   care of Abel Winerib, IAB Executive Director.
+
+      Contacts:
+
+         Abel Winerib
+         Executive Director of the IAB
+         Intel, JF2-64
+         2111 NE 25th Avenue
+         Hillsboro, OR 97124
+
+         1-503-696-8972
+
+         AWeinrib@ibeam.jf.intel.com
+
+
+         Brian E. Carpenter
+         Chair of the IAB
+         CERN
+         European Laboratory for Particle Physics
+         1211 Geneva 23
+         Switzerland
+
+         +41 22 767-4967
+
+         brian@dxcoms.cern.ch
+
+
+   7.1.2.  Internet Engineering Task Force (IETF) Contact
+
+      Contacts:
+
+         Fred Baker
+         Chair of the IETF
+         cisco Systems, Inc.
+         519 Lado Drive
+         Santa Barbara, CA 93111
+
+         1-805-681-0115
+
+         fred@cisco.com
+
+
+
+Internet Architecture Board Standards Track                    [Page 36]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+         Steve Coya
+         IESG Secretary
+         Corporation for National Research Initiatives
+         1895 Preston White Drive, Suite 100
+         Reston, VA 22091
+
+         1-703-620-8990
+
+         scoya@CNRI.RESTON.VA.US
+
+         Steve Coya
+         Executive Director of the IETF
+         Corporation for National Research Initiatives
+         1895 Preston White Drive, Suite 100
+         Reston, VA 22091
+
+         1-703-620-8990
+
+         scoya@CNRI.RESTON.VA.US
+
+
+   7.1.3.  Internet Research Task Force (IRTF) Contact
+
+      Contact:
+
+         Abel Winerib
+         Chair of the IRTF
+         Intel, JF2-64
+         2111 NE 25th Avenue
+         Hillsboro, OR 97124
+
+         1-503-696-8972
+
+         AWeinrib@ibeam.jf.intel.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 37]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+7.2.  Internet Assigned Numbers Authority Contact
+
+      Contact:
+
+         Joyce K. Reynolds
+         Internet Assigned Numbers Authority
+         USC/Information Sciences Institute
+         4676 Admiralty Way
+         Marina del Rey, CA  90292-6695
+
+         1-310-822-1511
+
+         IANA@ISI.EDU
+
+   The protocol standards are managed by the Internet Assigned Numbers
+   Authority.
+
+   Please refer to the document "Assigned Numbers" (RFC-1700) for
+   further information about the status of protocol documents.  There
+   are two documents that summarize the requirements for host and
+   gateways in the Internet, "Host Requirements" (RFC-1122 and RFC-1123)
+   and "Requirements for IP Version 4 Routers" (RFC-1812).
+
+      How to obtain the most recent edition of this "Internet Official
+      Protocol Standards" memo:
+
+         The file "in-notes/std/std1.txt" may be copied via FTP from the
+         FTP.ISI.EDU computer using the FTP username "anonymous" and FTP
+         password "guest".
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 38]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+7.3.  Request for Comments Editor Contact
+
+      Contact:
+
+         Jon Postel
+         RFC Editor
+         USC/Information Sciences Institute
+         4676 Admiralty Way
+         Marina del Rey, CA  90292-6695
+
+         1-310-822-1511
+
+         RFC-Editor@ISI.EDU
+
+   Documents may be submitted via electronic mail to the RFC Editor for
+   consideration for publication as RFC.  If you are not familiar with
+   the format or style requirements please request the "Instructions for
+   RFC Authors".  In general, the style of any recent RFC may be used as
+   a guide.
+
+7.4.  The Network Information Center and
+      Requests for Comments Distribution Contact
+
+      RFC's may be obtained from DS.INTERNIC.NET via FTP, WAIS, and
+      electronic mail.  Through FTP, RFC's are stored as rfc/rfcnnnn.txt
+      or rfc/rfcnnnn.ps where 'nnnn' is the RFC number.  Login as
+      "anonymous" and provide your e-mail address as the password.
+      Through WAIS, you may use either your local WAIS client or telnet
+      to DS.INTERNIC.NET and login as "wais" (no password required) to
+      access a WAIS client.  Help information and a tutorial for using
+      WAIS are available online.  The WAIS database to search is "rfcs".
+
+      Directory and Database Services also provides a mail server
+      interface.  Send a mail message to mailserv@ds.internic.net and
+      include any of the following commands in the message body:
+
+         document-by-name rfcnnnn      where 'nnnn' is the RFC number
+                                       The text version is sent.
+
+         file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC number.
+                                       and 'yyy' is 'txt' or 'ps'.
+
+         help                          to get information on how to use
+                                       the mailserver.
+
+      The InterNIC directory and database services collection of
+      resource listings, internet documents such as RFCs, FYIs, STDs,
+      and Internet Drafts, and publicly accessible databases are also
+
+
+
+Internet Architecture Board Standards Track                    [Page 39]
+
+RFC 1920                   Internet Standards                 March 1996
+
+
+      now available via Gopher.  All our collections are WAIS indexed
+      and can be searched from the Gopher menu.
+
+      To access the InterNIC Gopher Servers, please connect to
+      "internic.net" port 70.
+
+      Contact: admin@ds.internic.net
+
+7.5.  Sources for Requests for Comments
+
+   Details on many sources of RFCs via FTP or EMAIL may be obtained by
+   sending an EMAIL message to "rfc-info@ISI.EDU" with the message body
+   "help: ways_to_get_rfcs".  For example:
+
+           To: rfc-info@ISI.EDU
+           Subject: getting rfcs
+
+           help: ways_to_get_rfcs
+
+8.  Security Considerations
+
+   Security issues are not addressed in this memo.
+
+9.  Author's Address
+
+   Jon Postel
+   USC/Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone: 310-822-1511
+   Fax:   310-823-6714
+
+   Email: Postel@ISI.EDU
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 40]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1920.txt](<www.ietf.org/rfc/rfc1920.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
