### PR TITLE
Archive rfc1923.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1923.txt
+++ b/www.ietf.org/rfc/rfc1923.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                                         J. Halpern
+Request for Comments: 1923                            Newbridge Networks
+Category: Informational                                       S. Bradner
+                                                      Harvard University
+                                                              March 1996
+
+
+           RIPv1 Applicability Statement for Historic Status
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  This memo
+   does not specify an Internet standard of any kind.  Distribution of
+   this memo is unlimited.
+
+Abstract
+
+   RIP Version 1 [RFC-1058] has been declared an historic document.
+   This Applicability statement provides the supporting motivation for
+   that declaration.  The primary reason, as described below, is the
+   Classful nature of RIPv1.
+
+1.0 Introduction
+
+   RIP version 1 (RIPv1) (as defined by RFC 1058) was one of the first
+   dynamic routing protocols used in the internet.  It was developed as
+   a technique for passing around network reachability information for
+   what we now consider relatively simple topologies.
+
+   The Internet has changed significantly since RIPv1 was defined,
+   particularly with the introduction and use of subnets and CIDR.
+
+   While RIPv1 is widely used in private networks, it can no longer be
+   considered applicable for use in the global Internet.
+
+2.0 RIPv1 restrictions
+
+   RIPv1 has a number of restrictions and behaviors which restrict its
+   useability in the global Internet.
+
+2.1 Classfulness
+
+   Chief among these is that it is a classful routing protocol.  RIP
+   packets do not carry prefix masks.  The prefix length is inferred
+   from the address.  For non-local addresses, the prefix is always the
+   "natural" (classful) length. (e.g., 24 bits for a "Class C" network
+   address.)  For networks to which a local interface exists, if the
+   interface is subnetted with some specific mask, then RIPv1 assumes
+
+
+
+Halpern & Bradner            Informational                      [Page 1]
+
+RFC 1923   RIPv1 Applicability Statement for Historic Status  March 1996
+
+
+   that the mask used locally is the correct mask to apply for all
+   subnets of that network.
+
+   This has a number of effects.
+
+   1) RIPv1 can not be used with variable length subnetting.  In the
+      presence of variable length subnetting it will consistently
+      misinterpret prefix lengths.
+
+   2) RIPv1 is difficult to use with supernetting.  All CIDR supernets
+      must be exploded and advertised to RIPv1 as individual "natural"
+      classful advertisements.
+
+   3) Even when the networks running RIPv1 are themselves only subnetted
+      in fixed ways, if the remainder of the network has variable
+      subnetting then one must carefully make sure that RIPv1 does not
+      destroy the mask information when it passes through those subnets
+      running RIPv1.  Put another way, co-existence with mutual
+      information exchange between RIPv1 and more advanced routing
+      protocols is problematic at best.  Note that this applies even when
+      the other routing protocol is RIPv2.
+
+   4) The Internet will soon be making use of addresses which appear to
+      RIPv1 to be parts of Class A networks. Networks using RIPv1 may not
+      be able to reach all sites assigned the subsections of a single A.
+
+2.2 Simple Distance Vector
+
+   RIPv1 is a simple distance vector protocol.  It has been enhanced
+   with various techniques, including Split Horizon and Poison Reverse
+   in order to enable it to perform better in somewhat complicated
+   networks.
+
+   However, being a simple distance vector protocol, it will run into
+   difficulty. First and foremost, it will occasionally have to count to
+   infinity in order to purge bad routes.  This delays the convergence
+   of routing.  In order to keep this short, RIPv1 defines infinity as
+   16 hops.  That means that networks with diameters larger than that
+   can not use RIP.  Even getting close to that limit can cause
+   confusion for some implementations.
+
+3.0 Conclusion
+
+   The recommendation of this Applicability statement is that if there
+   is reason to run RIP in a network environment, one should use RIPv2
+   (RFC 1723).
+
+
+
+
+
+Halpern & Bradner            Informational                      [Page 2]
+
+RFC 1923   RIPv1 Applicability Statement for Historic Status  March 1996
+
+
+   RIPv1 itself should only be used in simple topologies, with simple
+   reachability. It may be used by any site which uses fixed subnetting
+   internally, and either uses a default route to deal with external
+   traffic or is not connected to the global Internet or to other
+   organizations.
+
+   RIPv1 may also be used as a local advertising technology if the
+   information to be used fits within its capabilities.
+
+4.0 Security Considerations
+
+   RIPv1 includes no security functions.  RIPv2 includes a mechanism for
+   authenticating the sender of the routing information.  Sites which
+   are worried about the vulnerability of their routing infrastructure
+   and which feel they must run a RIP-like protocol should use RIPv2.
+
+5.0 Authors' Addresses
+
+   Joel M. Halpern
+   Newbridge Networks Inc.
+   593 Herndon Parkway Herndon,
+   VA 22070-5241
+
+   Phone: +1 703 708 5954
+   EMail: jhalpern@newbridge.com
+
+
+   Scott Bradner
+   Harvard University
+   1350 Mass Ave, Rm 813
+   Cambridge MA 02138
+
+   Phone: +1 617 495 3864
+   EMail: sob@harvard.edu
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Halpern & Bradner            Informational                      [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1923.txt](<www.ietf.org/rfc/rfc1923.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
