### PR TITLE
Archive rfc1926.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1926.txt
+++ b/www.ietf.org/rfc/rfc1926.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                        J. Eriksson
+Request for Comments: 1926                                       KTH NOC
+Category: Informational                                     1 April 1996
+
+
+      An Experimental Encapsulation of IP Datagrams on Top of ATM
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  This memo
+   does not specify an Internet standard of any kind.  Distribution of
+   this memo is unlimited.
+
+Abstract
+
+   This RFC describes a method of encapsulating IP datagrams on top of
+   Acoustical Transmission Media (ATM).  This is a non-recommended
+   standard.  Distribution of this memo is unnecessary.
+
+Overview
+
+   The modern laptop computer of today often contains the hardware
+   needed to perform wireless communications by using Acoustical
+   Transmission Media, i.e. sound waves.  Until this moment there has
+   been no standard on how to run IP on such media.  This document is an
+   attempt to fill this silence.
+
+Frame transmission
+
+   The IP datagram is divided into four-bit chunks, in network beep
+   order, and converted to characters according to the table below.  A
+   single "b" character is prepended as a frame start signal, the
+   characters are then transmitted in ordinary morse code by modulating
+   a steady tone on and off.  The frequency of this tone is also known
+   as the Acoustical Signature (AS number) of the sender.
+
+        Bits    Character       Bits    Character
+
+        0000    "i"             1000    "u"
+        0001    "t"             1001    "m"
+        0010    "s"             1010    "v"
+        0011    "a"             1011    "f"
+        0100    "n"             1100    "w"
+        0101    "h"             1101    "l"
+        0110    "d"             1110    "k"
+        0111    "r"             1111    "g"
+
+
+
+
+
+Eriksson                     Informational                      [Page 1]
+
+RFC 1926                      IP over ATM                   1 April 1996
+
+
+   To allow more than one Local Acoustical Network (LAN) to coexist the
+   use of different AS numbers for different LANs is suggested.  This
+   document proposes seven standard AS numbers to be used, see the table
+   below for details.
+
+        Name   Frequency
+
+        "a"     440 Hz
+        "b"     494 Hz
+        "c"     523 Hz
+        "d"     587 Hz
+        "e"     659 Hz
+        "f"     698 Hz
+        "g"     784 Hz
+
+   It is assumed that for normal operation AS number "a", 440 Hz will be
+   used.
+
+Frame reception
+
+   The above process is simply performed backwards.
+
+Security Considerations
+
+   The author assumes that the users take whatever precautions that are
+   necessary before attempting to use this protocol in any crowded area.
+
+Author's Address
+
+   Johnny Eriksson
+   KTH NOC
+   EMail: bygg@sunet.se
+
+   or
+
+     -... -.-- --. --. @ ... ..- .- . - .-.-.- ... .
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Eriksson                     Informational                      [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1926.txt](<www.ietf.org/rfc/rfc1926.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
