### PR TITLE
Archive rfc1956.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1956.txt
+++ b/www.ietf.org/rfc/rfc1956.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                     D. Engebretson
+Request for Comments: 1956                                      R. Plzak
+Category:  Informational                                         DoD NIC
+                                                               June 1996
+
+
+                     Registration in the MIL Domain
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  This memo
+   does not specify an Internet standard of any kind.  Distribution of
+   this memo is unlimited.
+
+Introduction
+
+   This RFC describes the policy for the registration of second level
+   domains under the ".MIL" domain.
+
+Policy
+
+   A.  The ".MIL" domain is delegated from the root authority to the US
+   Department of Defense (DoD).  Only US military services, unified or
+   specified commands, and operating agencies of the DoD which do not
+   report through military service chains can be registered as a second
+   level domain under the ".MIL" domain.  All other DoD organizations
+   will register through their respective second level domain
+   administrators using the registration procedures established by those
+   offices.  The ".MIL" domain is administered by the DoD Network
+   Information Center (NIC).
+
+   B.  The domain names under the ".MIL" will be descriptive of the
+   organization they will service.  The domain name length is preferred
+   to be 12 characters or less, and must be unique (first come first
+   serve if duplicates occur).
+
+   C.  Each second level domain under the ".MIL" domain will be
+   supported by at least two name servers.  Preferably these servers
+   will be located in two separate networks.  All DNS servers supporting
+   subdomains of the ".MIL" domain must be in the ".MIL" domain.
+
+   D.  Prospective second level domain administrators in the ".MIL"
+   domain will request registration using the template provided by the
+   DoD NIC.  The templates are available via anonymous FTP or
+   interactively via the DoD NIC World Wide Web Homepage.  The domain
+   request template shall be submitted to the DoD NIC hostmaster
+   (hostmaster@nic.ddn.mil).  The DoD NIC hostmaster will only accept
+   domain registration templates from registered ".MIL" users.
+
+
+
+Engebretson & Plzak          Informational                      [Page 1]
+
+RFC 1956              Management of the MIL Domain             June 1996
+
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Authors' Addresses
+
+   D.W. Engebretson
+   DISA/D343
+   11440 Isaac Newton Square
+   Reston, VA 22090
+
+   Phone: +1 703 735 8065
+   EMail:  engebred@ncr.disa.mil
+
+
+   Raymond Plzak
+   Department of Defense Network Information Center
+   14200 Parkridge Drive Suite 200
+   Chantilly, VA 22021
+
+   Phone: +1 800 365 3642
+   EMail: plzak@nic.ddn.mil
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Engebretson & Plzak          Informational                      [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1956.txt](<www.ietf.org/rfc/rfc1956.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
