### PR TITLE
Archive rfc1957.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1957.txt
+++ b/www.ietf.org/rfc/rfc1957.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                          R. Nelson
+Request for Comments: 1957                               Crynwr Software
+Updates: 1939                                                  June 1996
+Category: Informational
+
+
+                 Some Observations on Implementations
+                   of the Post Office Protocol (POP3)
+
+Status of this Memo
+
+   This memo provides information for the Internet community. This memo
+   does not specify an Internet standard of any kind. Distribution of
+   this memo is unlimited.
+
+Observations
+
+   Sometimes an implementation is mistaken for a standard.  POP3 servers
+   and clients are no exception.  The widely-used UCB POP3 server,
+   popper, which has been further developed by Qualcomm, always has
+   additional information following the status indicator.  So, the
+   status indicator always has a space following it.  Two POP3 clients
+   have been observed to expect that space, and fail when it has not
+   been found.  The RFC does not require the space, hence this memo.
+   These clients are the freely copyable Unix "popclient" and the
+   proprietary "netApp Systems Internet Series".  The authors of both of
+   these have been contacted, and new releases will not expect the
+   space, but old versions should be supported.
+
+   In addition, two popular clients require optional parts of the RFC.
+   Netscape requires UIDL, and Eudora requires TOP.
+
+   The optional APOP authentication command has not achieved wide
+   penetration yet.  Newer versions of the Qualcomm POP server implement
+   it.  Known client implementations of APOP include GNU Emacs VM client
+   and Eudora Lite and Eudora Pro.
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+References
+
+   [1]  Myers, J., and M. Rose, "Post Office Protocol - Version 3",
+        STD 53, RFC 1939, May 1996.
+
+
+
+
+
+
+Nelson                       Informational                      [Page 1]
+
+RFC 1957             Notes on POP3 Implementations             June 1996
+
+
+Author's Address
+
+   Russell Nelson
+   Crynwr Software
+   521 Pleasant Valley Rd.
+   Potsdam, NY 13676
+
+   Phone: +1.315.268.1925
+   FAX:   +1.315.268.9201
+   EMail: nelson@crynwr.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Nelson                       Informational                      [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1957.txt](<www.ietf.org/rfc/rfc1957.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
