### PR TITLE
Archive rfc196.txt

### DIFF
--- a/www.ietf.org/rfc/rfc196.txt
+++ b/www.ietf.org/rfc/rfc196.txt
@@ -1,0 +1,218 @@
+
+
+
+
+
+
+NETWORK WORKING GROUP                      Richard W. Watson
+Request for Comments #196                  SRI-ARC
+NIC 7141                                   July 20, 1971
+Categories: A.5, D.7
+Obsoletes: none
+Updates: none
+
+                      A MAIL BOX PROTOCOL
+
+The purpose of this protocol is to provide at each site a
+standard mechanism to receive sequential files for immediate or
+deferred printing or other uses.  The files for deferred printing
+would probably be stored on intermediate disk files, although
+details of how a file is handled, stored, manipulated, or printed
+at a site are not the concern of this protocol.
+
+It is also assumed that there would be a program at the sending
+site which sends the file in the format given below with the
+optional control codes when appropriate.  This program could
+probably be accessed as a subcommand of the Telnet program.
+
+The motivation for developing this protocol is the Network
+Information Center's (NIC) need to be able to deliver messages
+and documents to remote sites, and to be able to receive
+documents for cataloging, redistribution, and other purposes from
+remote site without having to know the details of path name
+conventions and file system commands at each site.  Multiple mail
+boxes (128) are allowed at each site and are identified as
+described below.  The default is mail box number 0 for use with
+the standard mail printer defined below.
+
+A mail box, as we see it, is simply a sequential file to which
+messages and documents are appended, separated by an appropriate
+site dependent code.
+
+Although this protocol will enable people to transmit messages
+directly without going through the NIC, we want to encourage
+people to use the NIC as much as possible, so that dialogue will
+be recorded, cataloged and available for viewing online at NIC,
+using the powerful facilities of the ARC on Line System (NLS).
+
+The Mail Box Protocol will use established network conventions,
+specifically the Network Control Program, Initial Connection
+Protocol, and Data Transfer Protocol, NIC 7104.
+
+The normal transmission is to be full 7-bit ASCII in 8-bit bytes,
+the high order bit set to zero.
+
+
+
+
+                                                                [Page 1]
+
+A MAIL BOX PROTOCOL                             RFC 196  NIC 7141
+
+The standard receiving mail printer for mail box number 0 is
+assumed to have a print line 72 characters wide, and a page of 66
+lines.  The new line convention will be carriage return (X'OD')
+followed by line feed (X'OA') as per the Telnet Protocol RFC 158,
+NIC 6768.  The standard printer will accept form feed (X'OC') as
+meaning move paper to the top of a new page.
+
+It is the senders responsibility to control the length of the
+print line and page. If more than 72 characters per line are sent
+or if more than 66 lines are sent without a form feed, than the
+receiving site can handle these situations as appropriate for
+them.  These conventions can be changed by control codes as
+described below.
+
+A message or document being sent to any mail box is a string of 8
+bit bytes.
+
+At the head of the message or document sent to mail box number 0
+there is to be an initial address string terminated by a form
+feed.  This address string is to contain the sender's name and
+address, and the receiver's name and address formatted in some
+reasonable, easy-to-read form for a clerk to read and distribute.
+Comments could also be included in the address string.
+
+The format of information in mail boxes other than mail box
+number 0 is not explicitly defined by this protocol.
+
+Initial Connection
+
+   Initial Connection will be as per the Official Initial
+   Connection Protocol, Documents #2, NIC 7101, to a standard
+   socket not yet assigned.  A candidate socket number would be
+   socket #5.
+
+Data Transmission
+
+   Data Transmission will be as per the Data Transfer Protocol,
+   RFC 171, NIC 6793.  That is, there will be a Modes Available
+   handshake, and then transmission of special control
+   information and data. A message or document is defined to be a
+   block of data.  Control information is to be global.  That is,
+   once a control mode is set it is assumed to apply during the
+
+
+
+
+
+
+
+                                                                [Page 2]
+
+A MAIL BOX PROTOCOL                             RFC 196  NIC 7141
+
+   life of the connection unless explicitly changed. More than
+   one document may be sent during the life of the connection
+   unless the infinite bit stream mode is used.  In the latter
+   case there will be one message or document per connection.  A
+   reasonable convention for control information sent using the
+   infinite bit stream mode seems to be to assume that is applies
+   only to the next data stream connection from the host which
+   sent the control stream.
+
+Control Information
+
+   The sending process should be capable of allowing the user to
+   indicate the control codes associated with the transmission of
+   a mail item.  The control codes can be used with any mail box
+   number.
+
+   Mail Box Number
+
+      A site may find, as is the case at NIC, that it is useful
+      to have more than one receiving mail box, each to be
+      associated with a different process.
+
+      The mail box number for material to be printed by the
+      standard mail printer is mail box number 0 and is used by
+      default.
+
+      Code X'DO'
+
+         Meaning: A seven bit binary number in an eight bit field
+         with the high order bit set to zero is to follow
+         indicating the receiving mail box number.
+
+   Transmission Code Type
+
+      The default code type is 7-bit ASCII in an 8 bit field,
+      high order bit to zero.
+
+      'Code X'AO'
+
+         Meaning: A Data Type signal indicating that the
+         transmission code is 7-bit ASCII in an 8-bit field, high
+         order set to zero.
+
+
+
+
+
+
+
+                                                                [Page 3]
+
+A MAIL BOX PROTOCOL                             RFC 196  NIC 7141
+
+      Code X'A1'
+
+         Meaning: Transparency, i.e. a stream of 8 bit bytes.
+
+      Code X'A2'
+
+         Meaning:  EBCDIC
+
+      Other character codes could be added in the future.
+
+   Printer Control Codes
+
+      The default settings are a print line of 72 characters and
+      a print page of 66 lines.
+
+      Code X'D1
+
+         Meaning:  Set line width to 72 characters.
+
+      Code X'D2'
+
+         Meaning:  Use the full width of your printer.
+
+      Code X'D3'
+
+         Meaning:  Set page size to 66 lines.
+
+      Code X'D4'
+
+         Meaning:  Set page size to infinite.
+
+      Other virtual printer control codes can be added in the
+      future.
+
+      Other classes of control codes can be added as the need
+      arises.
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+                                                                [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc196.txt](<www.ietf.org/rfc/rfc196.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
