### PR TITLE
Archive rfc1975.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1975.txt
+++ b/www.ietf.org/rfc/rfc1975.txt
@@ -1,0 +1,339 @@
+
+
+
+
+
+
+Network Working Group                                         D. Schremp
+Request for Comments: 1975                                      J. Black
+Category: Informational                                         J. Weiss
+                                                               Magnalink
+                                                             August 1996
+
+              PPP Magnalink Variable Resource Compression
+
+Status of This Memo
+
+   This memo provides information for the Internet community.  This memo
+   does not specify an Internet standard of any kind.  Distribution of
+   this memo is unlimited.
+
+Abstract
+
+   The Point-to-Point Protocol (PPP) [1] provides a standard method of
+   encapsulating multiple protocol datagrams over point-to-point links.
+   The PPP Compression Control Protocol [2] provides a method for
+   negotiating data compression over PPP links.
+
+   The Magnalink Variable Resource Compression Algorithm (MVRCA) allows
+   a wide range of interoperable compression implementations whose
+   performance characteristics are a function of available CPU and
+   memory resources.
+
+Introduction
+
+   The Magnalink variable resource compression algorithm defines a
+   family of interoperable compression solutions with compression
+   performance as a function of available CPU and memory resources.  It
+   addresses the need for an algorithm which can be tailored to the
+   system on which it is implemented without compromising
+   interoperability.
+
+Licensing
+
+   Source licenses are available on a non-discriminatory basis.
+
+   The contact person for evaluation under NDA and Licensing is:
+
+           Director of OEM Sales
+           Magnalink Communications Division
+           Telco Systems Inc.
+           63 Nahatan Street
+           Norwood, Mass. 02062
+           Phone: (617) 255-9400, Fax: (617) 255-5885
+           oem@magna.telco.com
+
+
+
+Schremp, Black & Weiss       Informational                      [Page 1]
+
+RFC 1975      PPP Magnalink Variable Resource Compression    August 1996
+
+
+MVRCA Packets
+
+   Before any MVRCA packets may be communicated, PPP must reach the
+   Network-Layer Protocol phase[1], and the Compression Control Protocol
+   must reach the Opened state.
+
+   The text of a Packet to be compressed begins with PPP Protocol
+   number.  The Packet header including the PPP Protocol number may have
+   already been compressed when Protocol-Field-Compression has been
+   negotiated.
+
+Reliability and Sequencing
+
+   MVRCA packets may be sent across an unreliable link or may use a
+   reliable link as described in "PPP Reliable Transmission"[3] if the
+   reliable link has been negotiated. If frames are delivered out of
+   order or a frame is dropped, the decompressor will detect this and
+   requests a resynchronization using the Reset-Req and Reset-Ack types
+   of the CCP[2], with the compressor for the affected context.
+
+Data Expansion
+
+   Although the compression algorithm may occasionally expand a data
+   packet, there is no expansion in MVRCA since any expanded data is
+   instead sent uncompressed. Dictionary synchronization is maintained
+   across uncompressed packets.
+
+Encapsulation
+
+   The encapsulation consists of the PPP Protocol Identifier, a bit to
+   indicate if the data is compressed, the Context Identifier(CID), a
+   proprietary flag bit (E), a Packet Integrity Byte(PIB), and the
+   Compressed data.
+
+       0                   1
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      | PPP Protocol Identifier       |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |C|E|   CID     |     PIB       |  C compressed flag
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+  1 data is compressed
+      | Compressed data  ...             0 data is not compressed
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
+
+
+
+
+
+
+Schremp, Black & Weiss       Informational                      [Page 2]
+
+RFC 1975      PPP Magnalink Variable Resource Compression    August 1996
+
+
+Compressed/Uncompressed Flag (C)
+
+   When attempting to compress certain types of Packets or Fragments the
+   compressor may not be effective. When this occurs the uncompressed
+   data is added to the compression History Buffer and sent across the
+   link in frame with the Compressed/Uncompressed Flag(C) set to 0.
+
+Context Identifier (CID)
+
+   Since PPP will transport multiple protocol datagrams it may be
+   advantageous to compress each protocol or each virtual circuit in a
+   different History Buffer or Context. The CID allows the compressor to
+   indicate to the decompressor which History Buffer the compressor
+   decided to use for a given Packet. The basis of this decision is up
+   to the implementor. The number of buffers and size of each buffer is
+   negotiated.
+
+   A CID of 0 indicates that the Packet by Packet context will be used
+   if it has been negotiated. The Packet by Packet context is cleared
+   between Packets so that this History Buffer is not maintained across
+   Packet boundaries.
+
+Packet Integrity Byte (PIB)
+
+   To ensure that Packets are being compressed and decompressed
+   correctly and to ensure History Buffer synchronization is maintained,
+   a Packet Integrity Byte is added to the packet header.
+
+   The packet integrity byte is defined in the full protocol
+   specification.
+
+Configuration Option Format
+
+   Description
+
+   The CCP MVRCA Configuration Option negotiates the use of MVRCA on the
+   link. By default or ultimate disagreement, no compression is used.
+
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |     Type      |    Length     |FE |P| History |  # Contexts   |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
+
+
+
+
+
+
+Schremp, Black & Weiss       Informational                      [Page 3]
+
+RFC 1975      PPP Magnalink Variable Resource Compression    August 1996
+
+
+   Type
+
+      24
+
+   Length
+
+       4
+
+
+   FE  - Features
+
+   Negotiates features specific to this compression algorithm.
+
+
+   History
+
+   Defines the size of the compression history buffer.  Valid values are
+   defined in the full protocol specification.
+
+
+   # Contexts
+
+   This is the number of contexts. Each context implies the  creation of
+   a History Buffer for that context of the size  indicated in the
+   Context History field. Values are  1-63.  This value includes both
+   the Packet by Packet context and the number of contexts for which
+   history is maintained.  Therefore, when this value is 1 and the P
+   (Packet by Packet) flag is also 1, then only in packet compression is
+   supported and history context is not retained across packet
+   boundaries.  The Context Identifier (CID) starts with 1 for contexts
+   where the history is maintained.
+
+
+   P - Packet by Packet flag
+
+   When 1, packet by packet compression is enabled for the context whose
+   context ID is 0.  When P is 0, packet by packet compression is not
+   supported.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schremp, Black & Weiss       Informational                      [Page 4]
+
+RFC 1975      PPP Magnalink Variable Resource Compression    August 1996
+
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+References
+
+   [1] Simpson, W., Editor, "The Point-to-Point Protocol (PPP)", STD 51,
+       RFC 1661, July 1994.
+
+   [2] Rand, D., "The PPP Compression Control Protocol (CCP)", RFC 1962,
+       June 1996.
+
+   [3] Rand, D., "PPP Reliable Transmission", RFC 1663, July 1994.
+
+Acknowledgments
+
+Chair's Address
+
+   The working group can be contacted via the current chair:
+
+   Karl Fox
+   Ascend Communications
+   3518 Riverside Drive, Suite 101
+   Columbus, Ohio 43221
+
+   EMail: karl@ascend.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schremp, Black & Weiss       Informational                      [Page 5]
+
+RFC 1975      PPP Magnalink Variable Resource Compression    August 1996
+
+
+Authors' Addresses
+
+   Comments about this document may also be directed to the authors.
+
+   Doug Schremp
+   Telco Systems, Inc.
+   Magnalink Communications Division
+   63 Nahatan Street
+   Norwood Ma. 02062
+
+   Phone: (617) 255-9400
+   EMail: dhs@magna.telco.com
+
+
+   Jeffrey Black
+   Telco Systems, Inc.
+   Magnalink Communications Division
+   63 Nahatan Street
+   Norwood Ma. 02062
+
+   Phone: (617) 255-9400
+   EMail: jtb@magna.telco.com
+
+
+   Jeffrey Weiss
+   Telco Systems, Inc.
+   Magnalink Communications Division
+   63 Nahatan Street
+   Norwood Ma. 02062
+
+   Phone: (617) 255-9400
+   EMail: jaw@magna.telco.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schremp, Black & Weiss       Informational                      [Page 6]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1975.txt](<www.ietf.org/rfc/rfc1975.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
