### PR TITLE
Archive rfc198.txt

### DIFF
--- a/www.ietf.org/rfc/rfc198.txt
+++ b/www.ietf.org/rfc/rfc198.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                               J. Heafner - Rand
+Request for Comments #198                           20 July 1971
+NIC #7149
+Categories: D.4
+Updates:  RFC #193
+Obsoletes:  None
+
+
+
+                SITE CERTIFICATION - LINCOLN LABS 360/67
+
+
+
+        We have exercised Lincoln Labs Network software as follows: NCP,
+ICP, ASCII Telnet (user and server), login procedure, access to CMS, and
+operator and console communication.  All  behave  according  to  current
+specifications.
+
+        Multiple message responses, such as  listing  users,  were  very
+smooth under moderate to heavy load of the /67.
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+         [ into the online RFC archives by Josh Elliott 1/98 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc198.txt](<www.ietf.org/rfc/rfc198.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
