### PR TITLE
Archive rfc1983.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1983.txt
+++ b/www.ietf.org/rfc/rfc1983.txt
@@ -1,0 +1,3475 @@
+
+
+
+
+
+
+Network Working Group                                  G. Malkin, Editor
+Request for Comments: 1983                                      Xylogics
+FYI: 18                                                      August 1996
+Obsoletes: 1392
+Category: Informational
+
+
+                        Internet Users' Glossary
+
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  This memo
+   does not specify an Internet standard of any kind.  Distribution of
+   this memo is unlimited.
+
+
+Abstract
+
+   There are many networking glossaries in existence.  This glossary
+   concentrates on terms which are specific to the Internet.  Naturally,
+   there are entries for some basic terms and acronyms because other
+   entries refer to them.
+
+
+Acknowledgements
+
+   This document is the work of the User Glossary Working Group of the
+   User Services Area of the Internet Engineering Task Force.  I would
+   especially like to thank Ryan Moats/InterNIC for his careful review
+   and many contributions to this document.
+
+
+Table of Contents
+
+   non-letter  . .  2      I . . . . . . . 26      R . . . . . . . 46
+   A . . . . . . .  2      J . . . . . . . 33      S . . . . . . . 49
+   B . . . . . . .  7      K . . . . . . . 33      T . . . . . . . 52
+   C . . . . . . . 10      L . . . . . . . 33      U . . . . . . . 55
+   D . . . . . . . 14      M . . . . . . . 35      V . . . . . . . 57
+   E . . . . . . . 18      N . . . . . . . 39      W . . . . . . . 57
+   F . . . . . . . 20      O . . . . . . . 42      X . . . . . . . 59
+   G . . . . . . . 22      P . . . . . . . 43      Y . . . . . . . 60
+   H . . . . . . . 23      Q . . . . . . . 46      Z . . . . . . . 60
+
+   References  . . . . . . . . . . . . . . . . . . . . . . . . . . 61
+   Security Considerations . . . . . . . . . . . . . . . . . . . . 62
+   Editor's Address  . . . . . . . . . . . . . . . . . . . . . . . 62
+
+
+
+Malkin                       Informational                      [Page 1]
+
+RFC 1983                        Glossary                     August 1996
+
+
+Glossary
+
+   10Base2
+      A physical layer communications specification for 10Mbps, baseband
+      data transmission over a coaxial cable (Thinnet) with a maximum
+      cable segment length of 200 meters.
+
+   10Base5
+      A physical layer communications specification for 10Mbps, baseband
+      data transmission over a coaxial cable (Thicknet) with a maximum
+      cable segment length of 500 meters.
+
+   10BaseF
+      A physical layer communications specification for 10Mbps, baseband
+      data transmission over a fiber-optic cable.
+
+   10BaseT
+      A physical layer communications specification for 10Mbps, baseband
+      data transmission over a twisted-pair copper wire.
+
+   802.x
+      The set of IEEE standards for the definition of LAN protocols.
+      See also: IEEE.
+
+   822
+      See: RFC 822
+
+   :-)
+      This odd symbol is one of the ways a person can portray "mood" in
+      the very flat medium of computers--by using "smiley faces".  This
+      is "metacommunication", and there are literally hundreds of such
+      symbols, from the obvious to the obscure.  This particular example
+      expresses "happiness".  Don't see it?  Tilt your head to the left
+      90 degrees.  Smiles are also used to denote sarcasm.
+      [Source: ZEN]
+
+   abstract syntax
+      A description of a data structure that is independent of machine-
+      oriented structures and encodings.
+      [Source: RFC1208]
+
+   Abstract Syntax Notation One (ASN.1)
+      The language used by the OSI protocols for describing abstract
+      syntax.  This language is also used to encode SNMP packets.  ASN.1
+      is defined in ISO documents 8824.2 and 8825.2.  See also: Basic
+      Encoding Rules.
+
+
+
+
+
+Malkin                       Informational                      [Page 2]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   Acceptable Use Policy (AUP)
+      Many transit networks have policies which restrict the use to
+      which the network may be put.  For example, some networks may only
+      be used for non-commercial purposes.  Some AUPs limit the type of
+      material which can be made available to the public (e.g.,
+      pornographic material).  Enforcement of AUPs varies with the
+      network.  See also: netiquette.
+
+   Access Control List (ACL)
+      Most network security systems operate by allowing selective use of
+      services.  An Access Control List is the usual means by which
+      access to, and denial of, services is controlled.  It is simply a
+      list of the services available, each with a list of the hosts
+      permitted to use the service.
+
+   ACK
+      See: Acknowledgment
+
+   acknowledgment (ACK)
+      A type of message sent to indicate that a block of data arrived at
+      its destination without error.  See also: Negative
+      Acknowledgement.
+      [Source: NNSC]
+
+   ACL
+      See: Access Control List
+
+   AD
+      See: Administrative Domain
+
+   address
+      There are four types of addresses in common use within the
+      Internet.  They are email address; IP, internet or Internet
+      address; hardware or MAC address; and URL.  See also: email
+      address, IP address, internet address, MAC address, Uniform
+      Resource Locator.
+
+   address mask
+      A bit mask used to identify which bits in an IP address correspond
+      to the network and subnet portions of the address.  This mask is
+      often referred to as the subnet mask because the network portion
+      of the address (i.e., the network mask) can be determined by the
+      encoding inherent in an IP address.  See also: Classless Inter-
+      domain Routing.
+
+
+
+
+
+
+
+Malkin                       Informational                      [Page 3]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   address resolution
+      Conversion of a network-layer address (e.g. IP address) into the
+      corresponding physical address (e.g., MAC address).  See also: IP
+      address, MAC address.
+
+   Address Resolution Protocol (ARP)
+      Used to dynamically discover the low level physical network
+      hardware address that corresponds to the high level IP address for
+      a given host.  ARP is limited to physical network systems that
+      support broadcast packets that can be heard by all hosts on the
+      network.  See also: proxy ARP, Reverse Address Resolution
+      Protocol.
+
+   Administrative Domain (AD)
+      A collection of hosts and routers, and the interconnecting
+      network(s), managed by a single administrative authority.
+
+   Advanced Research Projects Agency (ARPA)
+      An agency of the U.S. Department of Defense responsible for the
+      development of new technology for use by the military.  ARPA
+      (formerly known as DARPA, nee ARPA) was responsible for funding
+      much of the development of the Internet we know today, including
+      the Berkeley version of Unix and TCP/IP.
+      [Source: NNSC]
+
+   Advanced Research Projects Agency Network (ARPANET)
+      A pioneering longhaul network funded by ARPA.  Now retired, it
+      served as the basis for early networking research as well as a
+      central backbone during the development of the Internet.  The
+      ARPANET consisted of individual packet switching computers
+      interconnected by leased lines.  See also: Advanced Research
+      Projects Agency.
+      [Source: FYI4]
+
+   agent
+      In the client-server model, the part of the system that performs
+      information preparation and exchange on behalf of a client or
+      server application.
+      [Source: RFC1208]
+
+   alias
+      A name, usually short and easy to remember, that is translated
+      into another name, usually long and difficult to remember.
+
+   American National Standards Institute (ANSI)
+      This organization is responsible for approving U.S. standards in
+      many areas, including computers and communications.  Standards
+      approved by this organization are often called ANSI standards
+
+
+
+Malkin                       Informational                      [Page 4]
+
+RFC 1983                        Glossary                     August 1996
+
+
+      (e.g., ANSI C is the version of the C language approved by ANSI).
+      ANSI is a member of ISO.  See also: International Organization for
+      Standardization.
+      [Source: NNSC]
+
+   American Standard Code for Information Interchange (ASCII)
+      A standard character-to-number encoding widely used in the
+      computer industry.  See also: EBCDIC.
+
+   anonymous FTP
+      Anonymous FTP allows a user to retrieve documents, files,
+      programs, and other archived data from anywhere in the Internet
+      without having to establish a userid and password.  By using the
+      special userid of "anonymous" the network user will bypass local
+      security checks and will have access to publicly accessible files
+      on the remote system.  See also: archive site, File Transfer
+      Protocol, World Wide Web.
+
+   ANSI
+      See: American National Standards Institute
+
+   API
+      See: Application Program Interface
+
+   Appletalk
+      A networking protocol developed by Apple Computer for
+      communication between Apple Computer products and other computers.
+      This protocol is independent of the network layer on which it is
+      run.  Current implementations exist for Localtalk, a 235Kb/s local
+      area network; and Ethertalk, a 10Mb/s local area network.
+      [Source: NNSC]
+
+   application
+      A program that performs a function directly for a user.  FTP, mail
+      and Telnet clients are examples of network applications.
+
+   application layer
+      The top layer of the network protocol stack.  The application
+      layer is concerned with the semantics of work (e.g. formatting
+      electronic mail messages).  How to represent that data and how to
+      reach the foreign node are issues for lower layers of the network.
+      [Source: MALAMUD]
+
+   Application Program Interface (API)
+      A set of calling conventions which define how a service is invoked
+      through a software package.
+      [Source: RFC1208]
+
+
+
+
+Malkin                       Informational                      [Page 5]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   archie
+      A system to automatically gather, index and serve information on
+      the Internet.  The initial implementation of archie provided an
+      indexed directory of filenames from all anonymous FTP archives on
+      the Internet.  Later versions provide other collections of
+      information.  See also: archive site, Gopher, Prospero, Wide Area
+      Information Servers.
+
+   archive site
+      A machine that provides access to a collection of files across the
+      Internet.  For example, an anonymous FTP archive site provides
+      access to arcived material via the FTP protocol.  WWW servers can
+      also serve as archive sites.  See also: anonymous FTP, archie,
+      Gopher, Prospero, Wide Area Information Servers, World Wide Web.
+
+   ARP
+      See: Address Resolution Protocol
+
+   ARPA
+      See: Advanced Research Projects Agency
+
+   ARPANET
+      See: Advanced Research Projects Agency Network
+
+   AS
+      See: Autonomous System
+
+   ASCII
+      See: American Standard Code for Information Interchange
+
+   ASN.1
+      See: Abstract Syntax Notation One
+
+   assigned numbers
+      The RFC [STD2] which documents the currently assigned values from
+      several series of numbers used in network protocol
+      implementations.  This RFC is updated periodically and, in any
+      case, current information can be obtained from the Internet
+      Assigned Numbers Authority (IANA).  If you are developing a
+      protocol or application that will require the use of a link,
+      socket, port, protocol, etc., please contact the IANA to receive a
+      number assignment.  See also: Internet Assigned Numbers Authority,
+      STD.
+      [Source: STD2]
+
+
+
+
+
+
+
+Malkin                       Informational                      [Page 6]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   Asynchronous Transfer Mode (ATM)
+      A standard which defines high-load, high-speed (1.544Mbps through
+      1.2Gbps), fixed-size packet (cell) switching with dynamic
+      bandwidth allocation.  ATM is also known as "fast packet."
+
+   ATM
+      See: Asynchronous Transfer Mode
+
+   AUP
+      See: Acceptable Use Policy
+
+   authentication
+      The verification of the identity of a person or process.
+      [Source: MALAMUD]
+
+   Autonomous System (AS)
+      A collection of routers under a single administrative authority
+      using a common Interior Gateway Protocol for routing packets.
+
+   backbone
+      The top level in a hierarchical network.  Stub and transit
+      networks which connect to the same backbone are guaranteed to be
+      interconnected.  See also: stub network, transit network.
+
+   bandwidth
+      Technically, the difference, in Hertz (Hz), between the highest
+      and lowest frequencies of a transmission channel.  However, as
+      typically used, the amount of data that can be sent through a
+      given communications circuit.
+
+   bang path
+      A series of machine names used to direct electronic mail from one
+      user to another, typically by specifying an explicit UUCP path
+      through which the mail is to be routed.  See also: email address,
+      mail path, UNIX-to-UNIX CoPy.
+
+   baseband
+      A transmission medium through which digital signals are sent
+      without complicated frequency shifting.  In general, only one
+      communication channel is available at any given time.  Ethernet is
+      an example of a baseband network.  See also: broadband, Ethernet.
+      [Source: NNSC]
+
+
+
+
+
+
+
+
+
+Malkin                       Informational                      [Page 7]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   Basic Encoding Rules (BER)
+      Standard rules for encoding data units described in ASN.1.
+      Sometimes incorrectly lumped under the term ASN.1, which properly
+      refers only to the abstract syntax description language, not the
+      encoding technique.  See also: Abstract Syntax Notation One.
+      [Source: NNSC]
+
+   BBS
+      See: Bulletin Board System
+
+   BCNU
+      Be Seein' You
+
+   BCP
+      The newest subseries of RFCs which are written to describe Best
+      Current Practices in the Internet.  Rather than specifying a
+      protocol, these documents specify the best ways to use the
+      protocols and the best ways to configure options to ensure
+      interoperability between various vendors' products.  BCPs carry
+      the endorsement of the IESG.  See also: Request For Comments,
+      Internet Engineering Steering Group.
+
+   BER
+      See: Basic Encoding Rules
+
+   Berkeley Internet Name Daemon (BIND)
+      Implementation of a DNS server developed and distributed by the
+      University of California at Berkeley.  Many Internet hosts run
+      BIND, and it is the ancestor of many commercial BIND
+      implementations.  See also: Domain Name System.
+
+   Berkeley Software Distribution (BSD)
+      Implementation of the UNIX operating system and its utilities
+      developed and distributed by the University of California at
+      Berkeley.  "BSD" is usually preceded by the version number of the
+      distribution, e.g., "4.3 BSD" is version 4.3 of the Berkeley UNIX
+      distribution.  Many Internet hosts run BSD software, and it is the
+      ancestor of many commercial UNIX implementations.
+      [Source: NNSC]
+
+   BGP
+      See: Border Gateway Protocol
+
+   big-endian
+      A format for storage or transmission of binary data in which the
+      most significant bit (or byte) comes first.  The term comes from
+      "Gulliver's Travels" by Jonathan Swift.  The Lilliputians, being
+      very small, had correspondingly small political problems.  The
+
+
+
+Malkin                       Informational                      [Page 8]
+
+RFC 1983                        Glossary                     August 1996
+
+
+      Big-Endian and Little-Endian parties debated over whether soft-
+      boiled eggs should be opened at the big end or the little end.
+      See also: little-endian.
+      [Source: RFC1208]
+
+   binary
+      11001001
+
+   BIND
+      See: Berkeley Internet Name Daemon
+
+   Birds Of a Feather (BOF)
+      A Birds Of a Feather (flocking together) is an informal discussion
+      group.  It is formed, often ad hoc, to consider a specific issue
+      and, therefore, has a narrow focus.  See also: Working Group.
+
+   Bitnet
+      An academic computer network that provides interactive electronic
+      mail and file transfer services, using a store-and-forward
+      protocol, based on IBM Network Job Entry protocols.  Bitnet-II
+      encapsulates the Bitnet protocol within IP packets and depends on
+      the Internet to route them.
+
+   BOF
+      See: Birds Of a Feather
+
+   BOOTP
+      The Bootstrap Protocol, described in RFC 1542, is used for booting
+      diskless nodes.  See also: Dynamic Host Configuration Protocol,
+      Reverse Address Resolution Protocol.
+
+   Border Gateway Protocol (BGP)
+      The Border Gateway Protocol is an exterior gateway protocol
+      defined in RFC 1771.  It's design is based on experience gained
+      with EGP, as defined in RFC 904, and EGP usage in the NSFNET
+      Backbone, as described in RFCs 1092 and 1093.  See also: Exterior
+      Gateway Protocol.
+
+   bounce
+      The return of a piece of mail because of an error in its delivery.
+      [Source: ZEN]
+
+   bridge
+      A device which forwards traffic between network segments based on
+      datalink layer information.  These segments would have a common
+      network layer address.  See also: gateway, router.
+
+
+
+
+
+Malkin                       Informational                      [Page 9]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   broadband
+      A transmission medium capable of supporting a wide range of
+      frequencies.  It can carry multiple signals by dividing the total
+      capacity of the medium into multiple, independent bandwidth
+      channels, where each channel operates only on a specific range of
+      frequencies.  See also: baseband.
+
+   broadcast
+      A special type of multicast packet which all nodes on the network
+      are always willing to receive.  See also: multicast, unicast.
+
+   broadcast storm
+      An incorrect packet broadcast onto a network that causes multiple
+      hosts to respond all at once, typically with equally incorrect
+      packets which causes the storm to grow exponentially in severity.
+      See also: Ethernet meltdown.
+
+   brouter
+      A device which bridges some packets (i.e. forwards based on
+      datalink layer information) and routes other packets (i.e.
+      forwards based on network layer information).  The bridge/route
+      decision is based on configuration information.  See also: bridge,
+      router.
+
+   BSD
+      See: Berkeley Software Distribution
+
+   BTW
+      By The Way
+
+   Bulletin Board System (BBS)
+      A computer, and associated software, which typically provides
+      electronic messaging services, archives of files, and any other
+      services or activities of interest to the bulletin board system's
+      operator.  Although BBS's have traditionally been the domain of
+      hobbyists, an increasing number of BBS's are connected directly to
+      the Internet, and many BBS's are currently operated by government,
+      educational, and research institutions.  See also: Electronic
+      Mail, Internet, Usenet.
+      [Source: NWNET]
+
+   Campus Wide Information System (CWIS)
+      A CWIS makes information and services publicly available on campus
+      via kiosks, and makes interactive computing available via kiosks,
+      interactive computing systems and campus networks. Services
+      routinely include directory information, calendars, bulletin
+      boards, databases.
+
+
+
+
+Malkin                       Informational                     [Page 10]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   CCIRN
+      See: Coordinating Committee for Intercontinental Research Networks
+
+   CCITT
+      See: Comite Consultatif International de Telegraphique et
+      Telephonique
+
+   CERT
+      See: Computer Emergency Response Team
+
+   checksum
+      A computed value which is dependent upon the contents of a packet.
+      This value is sent along with the packet when it is transmitted.
+      The receiving system computes a new checksum based upon the
+      received data and compares this value with the one sent with the
+      packet.  If the two values are the same, the receiver has a high
+      degree of confidence that the data was received correctly.  See
+      also: Cyclic Redundancy Check.
+      [Source: NNSC]
+
+   CIDR
+      See: Classless Inter-domain Routing
+
+   circuit switching
+      A communications paradigm in which a dedicated communication path
+      is established between two hosts, and on which all packets travel.
+      The telephone system is an example of a circuit switched network.
+      See also: connection-oriented, connectionless, packet switching.
+
+   Classless Inter-domain Routing (CIDR)
+      A proposal, set forth in RFC 1519, to allocate IP addresses so as
+      to allow the addresses to be aggregated when advertised as routes.
+      It is based on the elimination of intrinsic IP network addresses;
+      that is, the determination of the network address based on the
+      first few bits of the IP address.  See also: IP address, network
+      address, supernet.
+
+   client
+      A computer system or process that requests a service of another
+      computer system or process.  A workstation requesting the contents
+      of a file from a file server is a client of the file server.  See
+      also: client-server model, server.
+      [Source: NNSC]
+
+
+
+
+
+
+
+
+Malkin                       Informational                     [Page 11]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   client-server model
+      A common way to describe the paradigm of many network protocols.
+      Examples include the name-server/name-resolver relationship in DNS
+      and the file-server/file-client relationship in NFS.  See also:
+      client, server, Domain Name System, Network File System.
+
+   CNI
+      See: Coalition for Networked Information
+
+   Coalition for Networked Information (CNI)
+      A consortium formed by American Research Libraries, CAUSE, and
+      EDUCOM (no, they are not acronyms) to promote the creation of, and
+      access to, information resources in networked environments in
+      order to enrich scholarship and enhance intellectual productivity.
+
+   Comite Consultatif International de Telegraphique et Telephonique (
+      CCITT)
+      This organization is now part of the International
+      Telecommunications Union and is responsible for making technical
+      recommendations about telephone and data communications systems.
+      Every four years CCITT holds plenary sessions where they adopt new
+      standards; the most recent was in 1992.  Recently, the ITU
+      reorganized and CCITT was renamed the ITU-TSS.  See also:
+      International Telecommunications Union - Telecommunications
+      Standards Sector.
+
+   Computer Emergency Response Team (CERT)
+      The CERT was formed by ARPA in November 1988 in response to the
+      needs exhibited during the Internet worm incident.  The CERT
+      charter is to work with the Internet community to facilitate its
+      response to computer security events involving Internet hosts, to
+      take proactive steps to raise the community's awareness of
+      computer security issues, and to conduct research targeted at
+      improving the security of existing systems.  CERT products and
+      services include 24-hour technical assistance for responding to
+      computer security incidents, product vulnerability assistance,
+      technical documents, and tutorials.  In addition, the team
+      maintains a number of mailing lists (including one for CERT
+      Advisories), and provides an anonymous FTP server, at "cert.org",
+      where security-related documents and tools are archived.  The CERT
+      may be reached by email at "cert@cert.org" and by telephone at
+      +1-412-268-7090 (24-hour hotline).  See also: Advanced Research
+      Projects Agency, worm.
+
+   congestion
+      Congestion occurs when the offered load exceeds the capacity of a
+      data communication path.
+
+
+
+
+Malkin                       Informational                     [Page 12]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   connection-oriented
+      The data communication method in which communication proceeds
+      through three well-defined phases: connection establishment, data
+      transfer, connection release.  TCP is a connection-oriented
+      protocol.  See also: circuit switching, connectionless, packet
+      switching, Transmission Control Protocol.
+
+   connectionless
+      The data communication method in which communication occurs
+      between hosts with no previous setup.  Packets between two hosts
+      may take different routes, as each is independent of the other.
+      UDP is a connectionless protocol.  See also: circuit switching,
+      connection-oriented, packet switching, User Datagram Protocol.
+
+   Coordinating Committee for Intercontinental Research Networks (CCIRN)
+      A committee that includes the United States FNC and its
+      counterparts in North America and Europe.  Co-chaired by the
+      executive directors of the FNC and the European Association of
+      Research Networks (RARE), the CCIRN provides a forum for
+      cooperative planning among the principal North American and
+      European research networking bodies.  See also: Federal Networking
+      Council, RARE.
+      [Source: MALAMUD]
+
+   core gateway
+      Historically, one of a set of gateways (routers) operated by the
+      Internet Network Operations Center at Bolt, Beranek and Newman
+      (BBN).  The core gateway system formed a central part of Internet
+      routing in that all groups must advertise paths to their networks
+      from a core gateway.
+      [Source: MALAMUD]
+
+   Corporation for Research and Educational Networking (CREN)
+      This organization was formed in October 1989, when Bitnet and
+      CSNET (Computer + Science NETwork) were combined under one
+      administrative authority.  CSNET is no longer operational, but
+      CREN still runs Bitnet.  See also: Bitnet.
+      [Source: NNSC]
+
+   cracker
+      A cracker is an individual who attempts to access computer systems
+      without authorization.  These individuals are often malicious, as
+      opposed to hackers, and have many means at their disposal for
+      breaking into a system.  See also: hacker, Computer Emergency
+      Response Team, Trojan Horse, virus, worm.
+
+   CRC
+      See: cyclic redundancy check
+
+
+
+Malkin                       Informational                     [Page 13]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   CREN
+      See: Corporation for Research and Educational Networking
+
+   CU-SeeMe
+      Pronnounced "See you, See me," CU-SeeMe is a publicly available
+      videoconferencing program developed at Cornell University.  It
+      allows anyone with audio/video capabilites and an Internet
+      connection to videoconference with anyone else with the same
+      capabilities.  It also allows multiple people to tie into the same
+      videoconference.
+
+   CWIS
+      See: Campus Wide Information system
+
+   Cyberspace
+      A term coined by William Gibson in his fantasy novel Neuromancer
+      to describe the "world" of computers, and the society that gathers
+      around them.
+      [Source: ZEN]
+
+   Cyclic Redundancy Check (CRC)
+      A number derived from a set of data that will be transmitted.  By
+      recalculating the CRC at the remote end and comparing it to the
+      value originally transmitted, the receiving node can detect some
+      types of transmission errors.  See also: checksum.
+      [Source: MALAMUD]
+
+   DANTE
+      A non-profit company founded in July 1993 to help the European
+      research community enhance their networking facilities.  It
+      focuses on the establishment of a high-speed computer network
+      infrastructure.
+
+   DARPA
+      Defense Advanced Research Projects Agency
+      See: Advanced Research Projects Agency
+
+   Data Encryption Key (DEK)
+      Used for the encryption of message text and for the computation of
+      message integrity checks (signatures).  See also: encryption.
+
+   Data Encryption Standard (DES)
+      A popular, standard encryption scheme.  See also: encryption,
+      Pretty Good Privacy, RSA.
+
+   datagram
+      A self-contained, independent entity of data carrying sufficient
+      information to be routed from the source to the destination
+
+
+
+Malkin                       Informational                     [Page 14]
+
+RFC 1983                        Glossary                     August 1996
+
+
+      computer without reliance on earlier exchanges between this source
+      and destination computer and the transporting network.  See also:
+      frame, packet.
+      [Source: J. Postel]
+
+   DCA
+      See: Defense Information Systems Agency
+
+   DCE
+      Data Circuit-terminating Equipment
+
+   DCE
+      See: Distributed Computing Environment
+
+   DDN
+      See: Defense Data Network
+
+   DDN NIC
+      See: Defense Data Network Network Information Center
+
+   DECnet
+      A proprietary network protocol designed by Digital Equipment
+      Corporation.  The functionality of each Phase of the
+      implementation, such as Phase IV and Phase V, is different.
+
+   default route
+      A routing table entry which is used to direct packets addressed to
+      networks not explicitly listed in the routing table.
+      [Source: MALAMUD]
+
+   Defense Data Network (DDN)
+      A global communications network serving the US Department of
+      Defense composed of MILNET, other portions of the Internet, and
+      classified networks which are not part of the Internet.  The DDN
+      is used to connect military installations and is managed by the
+      Defense Information Systems Agency.  See also: Defense Information
+      Systems Agency.
+
+   Defense Data Network Network Information Center (DDN NIC)
+      Previously called "The NIC", the DDN NIC's primary responsibility
+      was the assignment of Internet network addresses and Autonomous
+      System numbers, the administration of the root domain, and
+      providing information and support services to the Internet for the
+      DDN.  Since the creation of the InterNIC, the DDN NIC performs
+      these functions only for the DDN.  See also: Autonomous System,
+      network address, Internet Registry, InterNIC, Network Information
+      Center, Request For Comments.
+
+
+
+
+Malkin                       Informational                     [Page 15]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   Defense Information Systems Agency (DISA)
+      Formerly called the Defense Communications Agency (DCA), this is
+      the government agency responsible for managing the DDN portion of
+      the Internet, including the MILNET.  Currently, DISA administers
+      the DDN, and supports the user assistance services of the DDN NIC.
+      See also: Defense Data Network.
+
+   DEK
+      See: Data Encryption Key
+
+   DES
+      See: Data Encryption Standard
+
+   dialup
+      A temporary, as opposed to dedicated, connection between machines
+      established over a phone line (analog or ISDN).  See also:
+      Integrated Services Digital Network.
+
+   Directory Access Protocol
+      X.500 protocol used for communication between a Directory User
+      Agent and a Directory System Agent.
+      [Source: MALAMUD]
+
+   Directory System Agent (DSA)
+      The software that provides the X.500 Directory Service for a
+      portion of the directory information base.  Generally, each DSA is
+      responsible for the directory information for a single
+      organization or organizational unit.
+      [Source: RFC1208]
+
+   Directory User Agent (DUA)
+      The software that accesses the X.500 Directory Service on behalf
+      of the directory user.  The directory user may be a person or
+      another software element.
+      [Source: RFC1208]
+
+   DISA
+      See: Defense Information Systems Agency
+
+   Distributed Computing Environment (DCE)
+      An architecture of standard programming interfaces, conventions,
+      and server functionalities (e.g., naming, distributed file system,
+      remote procedure call) for distributing applications transparently
+      across networks of heterogeneous computers.  Promoted and
+      controlled by the Open Software Foundation (OSF), a consortium led
+      by Digital, IBM and Hewlett Packard.
+      [Source: RFC1208]
+
+
+
+
+Malkin                       Informational                     [Page 16]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   distributed database
+      A collection of several different data repositories that looks
+      like a single database to the user.  A prime example in the
+      Internet is the Domain Name System.
+
+   DIX Ethernet
+      See: Ethernet
+
+   DNS
+      See: Domain Name System
+
+   domain
+      "Domain" is a heavily overused term in the Internet.  It can be
+      used in the Administrative Domain context, or the Domain Name
+      context.  See also: Administrative Domain, Domain Name System.
+
+   Domain Name System (DNS)
+      The DNS is a general purpose distributed, replicated, data query
+      service.  The principal use is the lookup of host IP addresses
+      based on host names.  The style of host names now used in the
+      Internet is called "domain name", because they are the style of
+      names used to look up anything in the DNS.  Some important domains
+      are: .COM (commercial), .EDU (educational), .NET (network
+      operations), .GOV (U.S. government), and .MIL (U.S. military).
+      Most countries also have a domain.  The country domain names are
+      based on ISO 3166.  For example, .US (United States), .UK (United
+      Kingdom), .AU (Australia).  See also: Fully Qualified Domain Name,
+      Mail Exchange Record.
+
+   dot address (dotted decimal notation)
+      Dot address refers to the common notation for IP addresses of the
+      form A.B.C.D; where each letter represents, in decimal, one byte
+      of a four byte IP address.  See also: IP address.
+      [Source: FYI4]
+
+   DSA
+      See: Directory System Agent
+
+   DTE
+      Data Terminal Equipment
+
+   DUA
+      See: Directory User Agent
+
+
+
+
+
+
+
+
+Malkin                       Informational                     [Page 17]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   dynamic adaptive routing
+      Automatic rerouting of traffic based on a sensing and analysis of
+      current actual network conditions.  NOTE: this does not include
+      cases of routing decisions taken on predefined information.
+      [Source: J. Postel]
+
+   E1
+      The basic building block for European multi-megabit data rates,
+      with a bandwidth of 2.048Mbps.  See also: T1.
+
+   E3
+      A European standard for transmitting data at 57.344Mbps.  See
+      also: T3.
+
+   EARN
+      European Academic and Research Network.  See: Trans-European
+      Research and Education Networking Association.
+
+   EBCDIC
+      See: Extended Binary Coded Decimal Interchange Code
+
+   Ebone
+      A pan-European backbone service.
+
+   EFF
+      See: Electronic Frontier Foundation
+
+   EGP
+      See: Exterior Gateway Protocol
+
+   Electronic Frontier Foundation (EFF)
+      A foundation established to address social and legal issues
+      arising from the impact on society of the increasingly pervasive
+      use of computers as a means of communication and information
+      distribution.
+
+   Electronic Mail (email)
+      A system whereby a computer user can exchange messages with other
+      computer users (or groups of users) via a communications network.
+      Electronic mail is one of the most popular uses of the Internet.
+      [Source: NNSC]
+
+   email
+      See: Electronic mail
+
+   email address
+      The domain-based or UUCP address that is used to send electronic
+      mail to a specified destination.  For example an editor's address
+
+
+
+Malkin                       Informational                     [Page 18]
+
+RFC 1983                        Glossary                     August 1996
+
+
+      is "gmalkin@xylogics.com".  See also: bang path, mail path, UNIX-
+      to-UNIX CoPy.
+      [Source: ZEN]
+
+   encapsulation
+      The technique used by layered protocols in which a layer adds
+      header information to the protocol data unit (PDU) from the layer
+      above.  For example, in Internet terminology, a packet would
+      contain a header from the physical layer, followed by a header
+      from the datalink layer (e.g.  Ethernet), followed by a header
+      from the network layer (IP), followed by a header from the
+      transport layer (e.g. TCP), followed by the application protocol
+      data.
+      [Source: RFC1208]
+
+   encryption
+      Encryption is the manipulation of a packet's data in order to
+      prevent any but the intended recipient from reading that data.
+      There are many types of data encryption, and they are the basis of
+      network security.  See also: Data Encryption Standard.
+
+   error checking
+      The examination of received data for transmission errors.  See
+      also: checksum, Cyclic Redundancy Check.
+
+   Ethernet
+      A 10-Mb/s standard for LANs, initially developed by Xerox, and
+      later refined by Digital, Intel and Xerox (DIX).  All hosts are
+      connected to a coaxial cable where they contend for network access
+      using a Carrier Sense Multiple Access with Collision Detection
+      (CSMA/CD) paradigm.  See also: 802.x, Local Area Network, token
+      ring.
+
+   Ethernet meltdown
+      An event that causes saturation, or near saturation, on an
+      Ethernet.  It usually results from illegal or misrouted packets
+      and typically lasts only a short time.  See also: broadcast storm.
+      [Source: COMER]
+
+   Extended Binary Coded Decimal Interchange Code (EBCDIC)
+      A standard character-to-number encoding used primarily by IBM
+      computer systems.  See also: ASCII.
+
+   Exterior Gateway Protocol (EGP)
+      A protocol which distributes routing information to the routers
+      which connect autonomous systems.  The term "gateway" is
+      historical, as "router" is currently the preferred term.  There is
+      also a routing protocol called EGP defined in RFC 904.  See also:
+
+
+
+Malkin                       Informational                     [Page 19]
+
+RFC 1983                        Glossary                     August 1996
+
+
+      Autonomous System, Border Gateway Protocol, Interior Gateway
+      Protocol.
+
+   eXternal Data Representation (XDR)
+      A standard for machine independent data structures developed by
+      Sun Microsystems and defined in RFCs 1014 and 1832.  It is similar
+      to ASN.1.  See also: Abstract Syntax Notation One.
+      [Source: RFC1208]
+
+   FARNET
+      A non-profit corporation, established in 1987, whose mission is to
+      advance the use of computer networks to improve research and
+      education.
+
+   FAQ
+      Frequently Asked Question
+
+   FDDI
+      See: Fiber Distributed Data Interface
+
+   Federal Information Exchange (FIX)
+      One of the connection points between the American governmental
+      internets and the Internet.
+      [Source: SURA]
+
+   Federal Networking Council (FNC)
+      The coordinating group of representatives from those federal
+      agencies involved in the development and use of federal
+      networking, especially those networks using TCP/IP and the
+      Internet.  Current members include representatives from DOD, DOE,
+      ARPA, NSF, NASA, and HHS.  See also: Advanced Research Projects
+      Agency, National Science Foundation.
+
+   Fiber Distributed Data Interface (FDDI)
+      A high-speed (100Mb/s) LAN standard.  The underlying medium is
+      fiber optics, and the topology is a dual-attached, counter-
+      rotating token ring.  See also: Local Area Network, token ring.
+      [Source: RFC1208]
+
+   file transfer
+      The copying of a file from one computer to another over a computer
+      network.  See also: File Transfer Protocol, Kermit, Gopher, World
+      Wide Web.
+
+
+
+
+
+
+
+
+Malkin                       Informational                     [Page 20]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   File Transfer Protocol (FTP)
+      A protocol which allows a user on one host to access, and transfer
+      files to and from, another host over a network.  Also, FTP is
+      usually the name of the program the user invokes to execute the
+      protocol.  See also: anonymous FTP.
+
+   finger
+      A protocol, defined in RFC 1288, that allows information about a
+      system or user on a system to be retrived.  Finger also refers to
+      the commonly used program which retrieves this information.
+      Information about all logged in users, as well is information
+      about specific users may be retrieved from local or remote
+      systems.  Some sites consider finger to be a security risk and
+      have either disabled it, or replaced it with a simple message.
+
+   FIX
+      See: Federal Information Exchange
+
+   flame
+      A strong opinion and/or criticism of something, usually as a frank
+      inflammatory statement, in an electronic mail message.  It is
+      common to precede a flame with an indication of pending fire (i.e.
+      FLAME ON!).  Flame Wars occur when people start flaming other
+      people for flaming when they shouldn't have.  See also: Electronic
+      Mail, Usenet.
+
+   FLEA
+      See: Four Letter Extended Acronym
+
+   FNC
+      See: Federal Networking Council
+
+   Four Letter Extended Acronym (FLEA)
+      A recognition of the fact that there are far too many TLAs.  See
+      also: Three Letter Acronym.
+
+   FQDN
+      See: Fully Qualified Domain Name
+
+   fragment
+      A piece of a packet.  When a router is forwarding an IP packet to
+      a network that has a maximum transmission unit smaller than the
+      packet size, it is forced to break up that packet into multiple
+      fragments.  These fragments will be reassembled by the IP layer at
+      the destination host.  See also: Maximum Transmission Unit.
+
+
+
+
+
+
+Malkin                       Informational                     [Page 21]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   fragmentation
+      The IP process in which a packet is broken into smaller pieces to
+      fit the requirements of a physical network over which the packet
+      must pass.  See also: reassembly.
+
+   frame
+      A frame is a datalink layer "packet" which contains the header and
+      trailer information required by the physical medium.  That is,
+      network layer packets are encapsulated to become frames.  See
+      also: datagram, encapsulation, packet.
+
+   freenet
+      Community-based bulletin board system with email, information
+      services, interactive communications, and conferencing.  Freenets
+      are funded and operated by individuals and volunteers -- in one
+      sense, like public television.  They are part of the National
+      Public Telecomputing Network (NPTN), an organization based in
+      Cleveland, Ohio, devoted to making computer telecommunication and
+      networking services as freely available as public libraries.
+      [Source: LAQUEY]
+
+   FTP
+      See: File Transfer Protocol
+
+   Fully Qualified Domain Name (FQDN)
+      The FQDN is the full name of a system, rather than just its
+      hostname.  For example, "venera" is a hostname and
+      "venera.isi.edu" is an FQDN.  See also: hostname, Domain Name
+      System.
+
+   FYI
+      For Your Information
+
+   FYI
+      A subseries of RFCs that are not technical standards or
+      descriptions of protocols.  FYIs convey general information about
+      topics related to TCP/IP or the Internet.  See also: Request For
+      Comments.
+
+   gated
+      Gatedaemon.  A program which supports multiple routing protocols
+      and protocol families.  It may be used for routing, and makes an
+      effective platform for routing protocol research.  The software is
+      freely available by anonymous FTP from "gated.cornell.edu".
+      Pronounced "gate-dee".  See also: Exterior Gateway Protocol, Open
+      Shortest-Path First, Routing Information Protocol, routed.
+
+
+
+
+
+Malkin                       Informational                     [Page 22]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   gateway
+      The term "router" is now used in place of the original definition
+      of "gateway".  Currently, a gateway is a communications
+      device/program which passes data between networks having similar
+      functions but dissimilar implementations.  This should not be
+      confused with a protocol converter.  By this definition, a router
+      is a layer 3 (network layer) gateway, and a mail gateway is a
+      layer 7 (application layer) gateway.  See also: mail gateway,
+      router, protocol converter.
+
+   Gopher
+      A distributed information service, developed at the University of
+      Minnesota, that makes hierarchical collections of information
+      available across the Internet.  Gopher uses a simple protocol,
+      defined in RFC 1436, that allows a single Gopher client to access
+      information from any accessible Gopher server, providing the user
+      with a single "Gopher space" of information.  Public domain
+      versions of the client and server are available.  See also:
+      archie, archive site, Prospero, Wide Area Information Servers.
+
+   GOSIP
+      See: Government OSI Profile
+
+   Government OSI Profile (GOSIP)
+      A subset of OSI standards specific to U.S. Government
+      procurements, designed to maximize interoperability in areas where
+      plain OSI standards are ambiguous or allow excessive options.
+
+   hacker
+      A person who delights in having an intimate understanding of the
+      internal workings of a system, computers and computer networks in
+      particular.  The term is often misused in a pejorative context,
+      where "cracker" would be the correct term.  See also: cracker.
+
+   header
+      The portion of a packet, preceding the actual data, containing
+      source and destination information. It may also error checking and
+      other fields.  A header is also the part of an electronic mail
+      message which precedes the body of a message and contains, among
+      other things, the message originator, date and time.  See also:
+      Electronic Mail, packet, error checking.
+
+   heterogeneous network
+      A network running multiple network layer protocols.  See also:
+      DECnet, IP, IPX, XNS, homogeneous network.
+
+
+
+
+
+
+Malkin                       Informational                     [Page 23]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   hierarchical routing
+      The complex problem of routing on large networks can be simplified
+      by reducing the size of the networks.  This is accomplished by
+      breaking a network into a hierarchy of networks, where each level
+      is responsible for its own routing.  The Internet has, basically,
+      three levels: the backbones, the mid-levels, and the stub
+      networks.  The backbones know how to route between the mid-levels,
+      the mid-levels know how to route between the sites, and each site
+      (being an autonomous system) knows how to route internally.  See
+      also: Autonomous System, Exterior Gateway Protocol, Interior
+      Gateway Protocol, stub network, transit network.
+
+   High Performance Computing and Communications (HPCC)
+      High performance computing encompasses advanced computing,
+      communications, and information technologies, including scientific
+      workstations, supercomputer systems, high speed networks, special
+      purpose and experimental systems, the new generation of large
+      scale parallel systems, and application and systems software with
+      all components well integrated and linked over a high speed
+      network.
+      [Source: HPCC]
+
+   High Performance Parallel Interface (HIPPI)
+      An emerging ANSI standard which extends the computer bus over
+      fairly short distances at speeds of 800 and 1600 Mb/s.  HIPPI is
+      often used in a computer room to connect a supercomputer to
+      routers, frame buffers, mass-storage peripherals, and other
+      computers.  See also: American National Standards Institute
+      [Source: MALAMUD]
+
+   HIPPI
+      See: High Performance Parallel Interface
+
+   HTML
+      See: Hypertext Markup Language
+
+   homogeneous network
+      A network running a single network layer protocol.  See also:
+      DECnet, IP, IPX, XNS, heterogeneous network.
+
+   hop
+      A term used in routing.  A path to a destination on a network is a
+      series of hops, through routers, away from the origin.
+
+
+
+
+
+
+
+
+Malkin                       Informational                     [Page 24]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   host
+      A computer that allows users to communicate with other host
+      computers on a network.  Individual users communicate by using
+      application programs, such as electronic mail, Telnet and FTP.
+      [Source: NNSC]
+
+   host address
+      See: internet address
+
+   hostname
+      The name given to a machine.  See also: Fully Qualified Domain
+      Name.
+      [Source: ZEN]
+
+   host number
+      See: host address
+
+   HPCC
+      See: High Performance Computing and Communications
+
+   HTTP
+      See: Hypertext Transfer Protocol
+
+   hub
+      A device connected to several other devices.  In ARCnet, a hub is
+      used to connect several computers together.  In a message handling
+      service, a hub is used for the transfer of messages across the
+      network.
+      [Source: MALAMUD]
+
+   hyperlink
+      A pointer within a hypertext document which points (links) to
+      another document, which may or may not also be a hypertext
+      document.  See also: hypertext.
+
+   hypertext
+      A document, written in HTML, which contains hyperlinks to other
+      documents, which may or may not also be hypertext documents.
+      Hypertext documents are usually retrieved using WWW.  See also:
+      hyperlink, Hypertext Markup Language, World Wide Web.
+
+   Hypertext Markup Language (HTML)
+      The language used to create hypertext documents.  It is a subset
+      of SGML and includes the mechanisms to establish hyperlinks to
+      other documents.  See also: hypertext, hyperlink, Standardized
+      General Markup Language.
+
+
+
+
+
+Malkin                       Informational                     [Page 25]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   Hypertext Transfer Protocol (HTTP)
+      The protocol used by WWW to transfer HTML files.  A formal
+      standard is still under development in the IETF.  See also:
+      hyperlink, hypertext, Hypertext Markup Language, World Wide Web.
+
+   I-D
+      See: Internet-Draft
+
+   IAB
+      See: Internet Architecture Board
+
+   IANA
+      See: Internet Assigned Numbers Authority
+
+   ICMP
+      See: Internet Control Message Protocol
+
+   IEEE
+      Institute of Electrical and Electronics Engineers
+
+   IEEE 802
+      See: 802.x
+
+   IEN
+      See: Internet Experiment Note
+
+   IEPG
+      See: Internet Engineering Planning Group
+
+   IESG
+      See: Internet Engineering Steering Group
+
+   IETF
+      See: Internet Engineering Task Force
+
+   IINREN
+      See: Interagency Interim National Research and Education Network
+
+   IGP
+      See: Interior Gateway Protocol
+
+   IMHO
+      In My Humble Opinion
+
+   IMR
+      See: Internet Monthly Report
+
+
+
+
+
+Malkin                       Informational                     [Page 26]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   Integrated Services Digital Network (ISDN)
+      An emerging technology which is beginning to be offered by the
+      telephone carriers of the world.  ISDN combines voice and digital
+      network services in a single medium, making it possible to offer
+      customers digital data services as well as voice connections
+      through a single "wire."  The standards that define ISDN are
+      specified by CCITT.  See also: CCITT.
+      [Source: RFC1208]
+
+   Interagency Interim National Research and Education Network (IINREN)
+      An evolving operating network system.  Near term (1992-1996)
+      research and development activities will provide for the smooth
+      evolution of this networking infrastructure into the future
+      gigabit NREN.
+      [Source: HPCC]
+
+   Interior Gateway Protocol (IGP)
+      A protocol which distributes routing information to the routers
+      within an autonomous system.  The term "gateway" is historical, as
+      "router" is currently the preferred term.  See also: Autonomous
+      System, Exterior Gateway Protocol, Open Shortest-Path First,
+      Routing Information Protocol.
+
+   Intermediate System (IS)
+      An OSI system which performs network layer forwarding.  It is
+      analogous to an IP router.  See also: Open Systems
+      Interconnection, router.
+
+   Intermediate System-Intermediate System (IS-IS)
+      The OSI IGP.  See also: Open Systems Interconnection, Interior
+      Gateway Protocol.
+
+   International Organization for Standardization (ISO)
+      A voluntary, nontreaty organization founded in 1946 which is
+      responsible for creating international standards in many areas,
+      including computers and communications.  Its members are the
+      national standards organizations of the 89 member countries,
+      including ANSI for the U.S.  See also: American National Standards
+      Institute, Open Systems Interconnection.
+      [Source: TAN]
+
+   International Telecommunications Union (ITU)
+      An agency of the United Nations which coordinates the various
+      national telecommunications standards so that people in one
+      country can communicate with people in another country.
+
+
+
+
+
+
+Malkin                       Informational                     [Page 27]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   International Telecommunications Union -
+           Telecommunications Standards Sector (ITU-TSS)
+      The new name for CCITT since the ITU reorganization. The function
+      is the same; only the name has been changed
+
+   internet
+      While an internet is a network, the term "internet" is usually
+      used to refer to a collection of networks interconnected with
+      routers.  See also: network.
+
+   Internet
+      (note the capital "I") The Internet is the largest internet in the
+      world.  Is a three level hierarchy composed of backbone networks
+      (e.g. Ultranet), mid-level networks (e.g., NEARnet) and stub
+      networks.  The Internet is a multiprotocol internet.  See also:
+      backbone, mid-level network, stub network, transit network,
+      Internet Protocol.
+
+   internet address
+      A IP address that uniquely identifies a node on an internet.  An
+      Internet address (capital "I"), uniquely identifies a node on the
+      Internet.  See also: internet, Internet, IP address.
+
+   Internet Architecture Board (IAB)
+
+      The IAB has been many things over the years.  Originally the
+      Internet Activities Board, it was responsible for the development
+      of the protocols which make up the Internet.  It later changed its
+      name and charter to become the group most responsible for the
+      architecture of the Internet, leaving the protocol details to the
+      IESG.  In June of 1992, it was chartered as a component of the
+      Internet Society; this is the charter it holds today.  The IAB is
+      responsible for approving nominations to the IESG, architectural
+      oversight for Internet Standard Protocols, IETF standards process
+      oversight and appeals, IANA and RFC activities, and liaison to
+      peer standards groups (e.g., ISO).  See also: Internet Engineering
+      Task Force, Internet Research Task Force, Internet Engineering
+      Steering Group, Internet Assigned Numbers Authority, Request for
+      Comments.
+
+   Internet Assigned Numbers Authority (IANA)
+      The central registry for various Internet protocol parameters,
+      such as port, protocol and enterprise numbers, and options, codes
+      and types.  The currently assigned values are listed in the
+      "Assigned Numbers" document [STD2].  To request a number
+      assignment, contact the IANA at "iana@isi.edu".  See also:
+      assigned numbers, STD.
+
+
+
+
+Malkin                       Informational                     [Page 28]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   Internet Control Message Protocol (ICMP)
+      ICMP is an extension to the Internet Protocol.  It allows for the
+      generation of error messages, test packets and informational
+      messages related to IP.
+      [Source: FYI4]
+
+   Internet-Draft (I-D)
+      Internet-Drafts are working documents of the IETF, its Areas, and
+      its Working Groups.   As the name implies, Internet-Drafts are
+      draft documents.  They are valid for a maximum of six months and
+      may be updated, replaced, or obsoleted by other documents at any
+      time.  Very often, I-Ds are precursors to RFCs.  See also:
+      Internet Engineering Task Force, Request For Comments.
+
+   Internet Engineering Planning Group (IEPG)
+      A group, primarily composed of Internet service operators, whose
+      goal is to promote a globally coordinated Internet operating
+      environment.  Membership is open to all.
+
+   Internet Engineering Steering Group (IESG)
+      The IESG is composed of the IETF Area Directors and the IETF
+      Chair.  It provides the first technical review of Internet
+      standards and is responsible for day-to-day "management" of the
+      IETF.  See also: Internet Engineering Task Force.
+
+   Internet Engineering Task Force (IETF)
+      The IETF is a large, open community of network designers,
+      operators, vendors, and researchers whose purpose is to coordinate
+      the operation, management and evolution of the Internet, and to
+      resolve short-range and mid-range protocol and architectural
+      issues.  It is a major source of proposals for protocol standards
+      which are submitted to the IAB for final approval.  The IETF meets
+      three times a year and extensive minutes are included in the IETF
+      Proceedings.  See also: Internet, Internet Architecture Board.
+      [Source: FYI4]
+
+   Internet Experiment Note (IEN)
+      A series of reports pertinent to the Internet.  IENs were
+      published in parallel to RFCs and were intended to be  "working
+      documents."  They have been replaced by Internet-Drafts and are
+      currently of historic value only.  See also: Internet-Draft,
+      Request For Comments.
+
+   Internet Monthly Report (IMR)
+      Published monthly, the purpose of the Internet Monthly Reports is
+      to communicate to the Internet Research Group the accomplishments,
+      milestones reached, or problems discovered by the participating
+      organizations.
+
+
+
+Malkin                       Informational                     [Page 29]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   internet number
+      See: internet address
+
+   Internet Protocol (IP, IPv4)
+      The Internet Protocol (version 4), defined in RFC 791, is the
+      network layer for the TCP/IP Protocol Suite.  It is a
+      connectionless, best-effort packet switching protocol.  See also:
+      packet switching, TCP/IP Protocol Suite, Internet Protocol Version
+      6.
+
+   Internet Protocol Version 6 (IPng, IPv6)
+      IPv6 (version 5 is a stream protocol used for special
+      applications) is a new version of the Internet Protocol which is
+      designed to be an evolutionary step from its predecessor, version
+      4.  There are many RFCs defining various portions of the protocol,
+      its auxiliary protocols, and the transition plan from IPv4.  The
+      core RFCs are 1883 through 1886.  The name IPng (IP next
+      generation) is a nod to STNG (Star Trek Next Generation).
+
+   Internet Registry (IR)
+      The IANA has the discretionary authority to delegate portions of
+      its responsibility and, with respect to network address and
+      Autonomous System identifiers, has lodged this responsibility with
+      an IR.  The IR function is performed by the DDN NIC.  See also:
+      Autonomous System, network address, Defense Data Network...,
+      Internet Assigned Numbers Authority.
+
+   Internet Relay Chat (IRC)
+      A world-wide "party line" protocol that allows one to converse
+      with others in real time.  IRC is structured as a network of
+      servers, each of which accepts connections from client programs,
+      one per user.  See also: talk.
+      [Source: HACKER]
+
+   Internet Research Steering Group (IRSG)
+      The "governing body" of the IRTF.  See also: Internet Research
+      Task Force.
+      [Source: MALAMUD]
+
+   Internet Research Task Force (IRTF)
+      The IRTF is chartered by the IAB to consider long-term Internet
+      issues from a theoretical point of view.  It has Research Groups,
+      similar to IETF Working Groups, which are each tasked to discuss
+      different research topics.  Multi-cast audio/video conferencing
+      and privacy enhanced mail are samples of IRTF output.  See also:
+      Internet Architecture Board, Internet Engineering Task Force,
+      Privacy Enhanced Mail.
+
+
+
+
+Malkin                       Informational                     [Page 30]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   Internet Society (ISOC)
+      The Internet Society is a non-profit, professional membership
+      organization which facilitates and supports the technical
+      evolution of the Internet, stimulates interest in and educates the
+      scientific and academic communities, industry and the public about
+      the technology, uses and applications of the Internet, and
+      promotes the development of new applications for the system.  The
+      Society provides a forum for discussion and collaboration in the
+      operation and use of the global Internet infrastructure.  The
+      Internet Society publishes a quarterly newsletter, the Internet
+      Society News, and holds an annual conference, INET.  The
+      development of Internet technical standards takes place under the
+      auspices of the Internet Society with substantial support from the
+      Corporation for National Research Initiatives under a cooperative
+      agreement with the US Federal Government.
+      [Source: V. Cerf]
+
+   Internetwork Packet eXchange (IPX)
+      Novell's protocol used by Netware.  A router with IPX routing can
+      interconnect LANs so that Novell Netware clients and servers can
+      communicate.  See also: Local Area Network.
+
+   InterNIC
+      A five year project, partially supported by the National Science
+      Foundation, to provide network information services to the
+      networking community.  The InterNIC began operations in April of
+      1993 and is now a collaborative project of two organizations:
+      AT&T, which provides Directory and Database Services from South
+      Plainsfield, NJ; and Network Solutions, Inc., which provides
+      Registration Services from their headquarters in Herndon, VA.
+      Services are provided via the Internet, and by telephone, FAX, and
+      hardcopy.
+
+   interoperability
+      The ability of software and hardware on multiple machines from
+      multiple vendors to communicate meaningfully.
+
+   IP (IPv4)
+      See: Internet Protocol
+
+   IPng (IPv6)
+      See: Internet Protocol Version 6
+
+   IP address
+      The 32-bit address defined by the Internet Protocol in RFC 791.
+      It is usually represented in dotted decimal notation.  See also:
+      dot address, internet address, Internet Protocol, network address,
+      subnet address, host address.
+
+
+
+Malkin                       Informational                     [Page 31]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   IP datagram
+      See: datagram
+
+   IPX
+      See: Internetwork Packet eXchange
+
+   IR
+      See: Internet Registry
+
+   IRC
+      See: Internet Relay Chat
+
+   IRSG
+      See: Internet Research Steering Group
+
+   IRTF
+      See: Internet Research Task Force
+
+   IS
+      See: Intermediate System
+
+   IS-IS
+      See: Intermediate System-Intermediate System
+
+   ISDN
+      See: Integrated Services Digital Network
+
+   ISO
+      See: International Organization for Standardization
+
+   ISO Development Environment (ISODE)
+      Software that allows OSI services to use a TCP/IP network.
+      Pronounced eye-so-dee-eee.  See also: Open Systems
+      Interconnection, TCP/IP Protocol Suite.
+
+   ISOC
+      See: Internet Society
+
+   ISODE
+      See: ISO Development Environment
+
+   ITU
+      See: International Telecommunications Union -
+           Telecommunications Standards Sector
+
+   ITU-TSS
+      See: International Telecommunications Union
+
+
+
+
+Malkin                       Informational                     [Page 32]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   JKREY
+      Joyce K. Reynolds
+
+   KA9Q
+      A popular implementation of TCP/IP and associated protocols for
+      amateur packet radio systems.  See also: TCP/IP Protocol Suite.
+      [Source: RFC1208]
+
+   Kerberos
+      Kerberos is the security system of MIT's Project Athena.  It is
+      based on symmetric key cryptography.  See also: encryption.
+
+   Kermit
+      A popular file transfer protocol developed by Columbia University.
+      Because Kermit runs in most operating environments, it provides an
+      easy method of file transfer.  Kermit is NOT the same as FTP.  See
+      also: File Transfer Protocol
+      [Source: MALAMUD]
+
+   Knowbot
+      A "Knowledge Robot" is a program which seeks out information based
+      on specified criteria.  "Knowbot," as trademarked by CNRI, refers
+      specifically to the search engine for Knowbot Information
+      Services.  See also: Corporation for National Research
+      Initiatives, X.500, white pages, whois, netfind.
+
+   Knowbot Information Services
+      An experimental directory service.  See also: white pages, whois,
+      X.500.
+
+   LAN
+      See: Local Area Network
+
+   layer
+      Communication networks for computers may be organized as a set of
+      more or less independent protocols, each in a different layer
+      (also called level).  The lowest layer governs direct host-to-host
+      communication between the hardware at different hosts; the highest
+      consists of user applications.  Each layer builds on the layer
+      beneath it.  For each layer, programs at different hosts use
+      protocols appropriate to the layer to communicate with each other.
+      TCP/IP has five layers of protocols; OSI has seven.  The
+      advantages of different layers of protocols is that the methods of
+      passing information from one layer to another are specified
+      clearly as part of the protocol suite, and changes within a
+      protocol layer are prevented from affecting the other layers.
+      This greatly simplifies the task of designing and maintaining
+      communication programs.  See also: Open Systems Interconnection,
+
+
+
+Malkin                       Informational                     [Page 33]
+
+RFC 1983                        Glossary                     August 1996
+
+
+      TCP/IP Protocol Suite.
+
+   LDAP
+      See: Lightweight Directory Access Protocol
+
+   Lightweight Directory Access Protocol
+      This protocol provides access for management and browser
+      applications that provide read/write interactive access to the
+      X.500 Directory.  See also: X.500.
+
+   link
+      A pointer which may be used to retreive the file or data to which
+      the pointer points.
+
+   list server
+      An automated mailing list distribution system.  List servers
+      handle the administrivia of mailing list maintenance, such as the
+      adding and deleting of list members.
+
+   little-endian
+      A format for storage or transmission of binary data in which the
+      least significant byte (bit) comes first.  See also: big-endian.
+      [Source: RFC1208]
+
+   LLC
+      See: Logical Link Control
+
+   Local Area Network (LAN)
+      A data network intended to serve an area of only a few square
+      kilometers or less.  Because the network is known to cover only a
+      small area, optimizations can be made in the network signal
+      protocols that permit data rates up to 100Mb/s.  See also:
+      Ethernet, Fiber Distributed Data Interface, token ring,
+      Metropolitan Area Network, Wide Area Network.
+      [Source: NNSC]
+
+   Logical Link Control (LLC)
+      The upper portion of the datalink layer, as defined in IEEE 802.2.
+      The LLC sublayer presents a uniform interface to the user of the
+      datalink service, usually the network layer.  Beneath the LLC
+      sublayer is the MAC sublayer.  See also: 802.x, layer, Media
+      Access Control.
+
+   Lurking
+      No active participation on the part of a subscriber to an mailing
+      list or USENET newsgroup.  A person who is lurking is just
+      listening to the discussion.  Lurking is encouraged for beginners
+      who need to get up to speed on the history of the group.  See
+
+
+
+Malkin                       Informational                     [Page 34]
+
+RFC 1983                        Glossary                     August 1996
+
+
+      also: Electronic Mail, mailing list, Usenet.
+      [Source: LAQUEY]
+
+   Lycos
+      Lycos, Inc. is a new venture formed in late June 1995, to develop
+      and market the Lycos technology originally developed under the
+      direction of Dr. Michael ("Fuzzy") Mauldin at Carnegie Mellon
+      University.  The part of Lycos you see when you do a search is the
+      search engine.  "Lycos" comes from Lycosidae, a cosmopolitan
+      family of relatively large active ground spiders (Wolf Spiders)
+      that catch their prey by pursuit, rather than in a web.
+      [Source: Lycos's FAQ]
+
+   MAC
+      See: Media Access Control
+
+   MAC address
+      The hardware address of a device connected to a shared media.  See
+      also: Media Access Control, Ethernet, token ring.
+      [Source: MALAMUD]
+
+   mail bridge
+      A mail gateway that forwards electronic mail between two or more
+      networks while ensuring that the messages it forwards meet certain
+      administrative criteria.  A mail bridge is simply a specialized
+      form of mail gateway that enforces an administrative policy with
+      regard to what mail it forwards.  See also: Electronic Mail, mail
+      gateway.
+      [Source: NNSC]
+
+   Mail Exchange Record (MX Record)
+      A DNS resource record type indicating which host can handle mail
+      for a particular domain.  See also: Domain Name System, Electronic
+      Mail.
+      [Source: MALAMUD]
+
+   mail exploder
+      Part of an electronic mail delivery system which allows a message
+      to be delivered to a list of addresses.  Mail exploders are used
+      to implement mailing lists.  Users send messages to a single
+      address and the mail exploder takes care of delivery to the
+      individual mailboxes in the list.  See also: Electronic Mail,
+      email address, mailing list.
+      [Source: RFC1208]
+
+
+
+
+
+
+
+Malkin                       Informational                     [Page 35]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   mail gateway
+      A machine that connects two or more electronic mail systems
+      (including dissimilar mail systems) and transfers messages between
+      them.  Sometimes the mapping and translation can be quite complex,
+      and it generally requires a store-and-forward scheme whereby the
+      message is received from one system completely before it is
+      transmitted to the next system, after suitable translations.  See
+      also: Electronic Mail.
+      [Source: RFC1208]
+
+   mail path
+      A series of machine names used to direct electronic mail from one
+      user to another.  This system of email addressing has been used
+      primarily in UUCP networks which are trying to eliminate its use
+      altogether.  See also: bang path, email address, UNIX-to-UNIX
+      CoPy.
+
+   mail server
+      A software program that distributes files or information in
+      response to requests sent via email.  Internet examples include
+      Almanac and netlib.  Mail servers have also been used in Bitnet to
+      provide FTP-like services.  See also: Bitnet, Electronic Mail,
+      FTP.
+      [Source: NWNET]
+
+   mailing list
+      A list of email addresses, used by a mail exploder, to forward
+      messages to groups of people.  Generally, a mailing list is used
+      to discuss certain set of topics, and different mailing lists
+      discuss different topics.  A mailing list may be moderated.  This
+      means that messages sent to the list are actually sent to a
+      moderator who determines whether or not to send the messages on to
+      everyone else.  Requests to subscribe to, or leave, a mailing list
+      should ALWAYS be sent to the list's "-request" address (e.g.
+      ietf-request@cnri.reston.va.us for the IETF mailing list) or
+      majordomo server.  See also: Electronic Mail, mail exploder, email
+      address, moderator, majordomo.
+
+   majordomo
+      A program which handles mailing list maintenance (affectionately
+      known as administrivia) such as adding and removing addresses from
+      mailing lists.  See also: email address, mailing list.
+
+   MAN
+      See: Metropolitan Area Network
+
+
+
+
+
+
+Malkin                       Informational                     [Page 36]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   Management Information Base (MIB)
+      The set of parameters an SNMP management station can query or set
+      in the SNMP agent of a network device (e.g. router).  Standard,
+      minimal MIBs have been defined, and vendors often have Private
+      enterprise MIBs.  In theory, any SNMP manager can talk to any SNMP
+      agent with a properly defined MIB.  See also: client-server model,
+      Simple Network Management Protocol.
+      [Source: BIG-LAN]
+
+   Martian
+      A humorous term applied to packets that turn up unexpectedly on
+      the wrong network because of bogus routing entries.  Also used as
+      a name for a packet which has an altogether bogus (non-registered
+      or ill-formed) internet address.
+      [Source: RFC1208]
+
+   Maximum Transmission Unit (MTU)
+      The largest frame length which may be sent on a physical medium.
+      See also: frame, fragment, fragmentation.
+
+   mbone
+      The Multicast Backbone is based on IP multicasting using class-D
+      addresses.  The mbone concept was adopted at the March 1992 IETF
+      in San Diego, during which it was used to audiocast to 40 people
+      throughout the world.  At the following meeting, in Cambridge, the
+      name mbone was adopted.  Since then the audiocast has become full
+      two-way audio/video conferencing using two video channels, four
+      audio channels, and involving hundreds of remote users.  See also:
+      multicast, Internet Engineering Task Force.
+
+   MD-2, MD-4, MD-5
+      See: Message Digest
+
+   Media Access Control (MAC)
+      The lower portion of the datalink layer.  The MAC differs for
+      various physical media.  See also: MAC Address, Ethernet, Logical
+      Link Control, token ring.
+
+   Message Digest (MD-2, MD-4, MD-5)
+      Message digests are algorithmic operations, generally performed on
+      text, which produce a unique signature for that text.  MD-2,
+      described in RFC 1319; MD-4, described in RFC 1320; and MD-5,
+      described in RFC 1321 all produce a 128-bit signature.  They
+      differ in their operating speed and resistance to crypto-analytic
+      attack.  Generally, one must be traded off for the other.
+
+   message switching
+      See: packet switching
+
+
+
+Malkin                       Informational                     [Page 37]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   Metropolitan Area Network (MAN)
+      A data network intended to serve an area approximating that of a
+      large city.  Such networks are being implemented by innovative
+      techniques, such as running fiber cables through subway tunnels.
+      A popular example of a MAN is SMDS.  See also: Local Area Network,
+      Switched Multimegabit Data Service, Wide Area Network.
+      [Source: NNSC]
+
+   MIB
+      See: Management Information Base
+
+   Microcom Networking Protocol (MNP)
+      A series of protocols built into most modems which error-check or
+      compress data being transmitted over a phone line.
+
+   mid-level network
+      Mid-level networks (a.k.a. regionals) make up the second level of
+      the Internet hierarchy.  They are the transit networks which
+      connect the stub networks to the backbone networks.  See also:
+      backbone, Internet, stub network, transit network.
+
+   MIME
+      See: Multipurpose Internet Mail Extensions
+
+   MNP
+      See: Microcom Networking Protocol
+
+   moderator
+      A person, or small group of people, who manage moderated mailing
+      lists and newsgroups.  Moderators are responsible for determining
+      which email submissions are passed on to list.  See also:
+      Electronic Mail, mailing list, Usenet.
+
+   MOSPF
+      Multicast Open Shortest-Path First. See: Open Shortest-Path First.
+
+   MTU
+      See: Maximum Transmission Unit
+
+   MUD
+      See: Multi-User Dungeon
+
+   multicast
+      A packet with a special destination address which multiple nodes
+      on the network may be willing to receive.  See also: broadcast,
+      unicast.
+
+
+
+
+
+Malkin                       Informational                     [Page 38]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   multihomed host
+      A host which has more than one connection to a network.  The host
+      may send and receive data over any of the links but will not route
+      traffic for other nodes.  See also: host, router.
+      [Source: MALAMUD]
+
+   Multipurpose Internet Mail Extensions (MIME)
+      An extension to Internet email which provides the ability to
+      transfer non-textual data, such as graphics, audio and fax.  See
+      also: Electronic Mail
+
+   Multi-User Dungeon (MUD)
+      Adventure, role playing games, or simulations played on the
+      Internet.  Devotees call them "text-based virtual reality
+      adventures."  The games can feature fantasy combat, booby traps
+      and magic.  Players interact in real time and can change the
+      "world" in the game as they play it.  Most MUDs are based on the
+      Telnet protocol.  See also: Telnet.
+      [Source: LAQUEY]
+
+   MX Record
+      See: Mail Exchange Record
+
+   NAK
+      See: Negative Acknowledgment
+
+   name resolution
+      The process of mapping a name into its corresponding address.  See
+      also: Domain Name System.
+      [Source: RFC1208]
+
+   namespace
+      A commonly distributed set of names in which all names are unique.
+      [Source: MALAMUD]
+
+   National Institute of Standards and Technology (NIST)
+      United States governmental body that provides assistance in
+      developing standards.  Formerly the National Bureau of Standards.
+      [Source: MALAMUD]
+
+   National Research and Education Network (NREN)
+      The NREN is the realization of an interconnected gigabit computer
+      network devoted to Hign Performance Computing and Communications.
+      See also: HPPC, IINREN.
+      [Source: HPCC]
+
+
+
+
+
+
+Malkin                       Informational                     [Page 39]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   National Science Foundation (NSF)
+      A U.S. government agency whose purpose is to promote the
+      advancement of science.  NSF funds science researchers, scientific
+      projects, and infrastructure to improve the quality of scientific
+      research.  The NSFNET, funded by NSF, was once an essential part
+      of academic and research communications.  It was a highspeed,
+      hierarchical "network of networks."  At the highest level, it had
+      a backbone network of nodes, interconnected with T3 (45Mbps)
+      facilities which spaned the continental United States.  Attached
+      to that were mid-level networks, and attached to the mid-levels
+      were campus and local networks.  See also: backbone network, mid-
+      level network.
+
+   Negative Acknowledgment (NAK)
+      Response to the receipt of either a corrupted or unnexpected
+      packet of information.  See also: Acknowledgement.
+
+   netfind
+      A research prototype to provide a simple Internet "white pages"
+      user directory.  Developed at the University of Colorado, Boulder,
+      it tries to locate telephone and email information given a
+      person's name and a rough description of where the person works.
+      See also: Knowbot, whois, white pages, X.500.
+      [Source: Ryan Moats]
+
+   netiquette
+      A pun on "etiquette" referring to proper behavior on a network.
+      RFC 1855 (FYI 28) contains a netiquette guide produced by the User
+      Services area of the IETF.  See also: Acceptable Use Policy,
+      Internet Engineering Task Force.
+
+   Netnews
+      See: Usenet
+
+   network
+      A computer network is a data communications system which
+      interconnects computer systems at various different sites.  A
+      network may be composed of any combination of LANs, MANs or WANs.
+      See also: Local Area Network, Metropolitan Area Network, Wide Area
+      Network, internet.
+
+   network address
+      The network portion of an IP address.  For a class A network, the
+      network address is the first byte of the IP address.  For a class
+      B network, the network address is the first two bytes of the IP
+      address.  For a class C network, the network address is the first
+      three bytes of the IP address.  In each case, the remainder is the
+      host address.  In the Internet, assigned network addresses are
+
+
+
+Malkin                       Informational                     [Page 40]
+
+RFC 1983                        Glossary                     August 1996
+
+
+      globally unique.  See also: Internet, IP address, subnet address,
+      host address, Internet Registry.
+
+   Network File System (NFS)
+      A protocol developed by Sun Microsystems, and defined in RFC 1094
+      (RFC 1813 defines Version 3), which allows a computer system to
+      access files over a network as if they were on its local disks.
+      This protocol has been incorporated in products by more than two
+      hundred companies, and is now a de facto Internet standard.
+      [Source: NNSC]
+
+   Network Information Center (NIC)
+      A NIC provides information, assistance and services to network
+      users.  See also: Network Operations Center.
+
+   Network Information Services (NIS)
+      A set of services, generally provided by a NIC, to assist users in
+      using the network.  See also: Network Information Center.
+
+   Network News Transfer Protocol (NNTP)
+      A protocol, defined in RFC 977, for the distribution, inquiry,
+      retrieval, and posting of news articles.  See also: Usenet.
+
+   network mask
+      See: address mask
+
+   network number
+      See: network address
+
+   Network Operations Center (NOC)
+      A location from which the operation of a network or internet is
+      monitored.  Additionally, this center usually serves as a
+      clearinghouse for connectivity problems and efforts to resolve
+      those problems.  See also: Network Information Center.
+      [Source: NNSC]
+
+   Network Time Protocol (NTP)
+      A protocol that assures accurate local timekeeping with reference
+      to radio and atomic clocks located on the Internet.  This protocol
+      is capable of synchronizing distributed clocks within milliseconds
+      over long time periods.  See also: Internet.
+      [Source: NNSC]
+
+   NFS
+      See: Network File System
+
+   NIC
+      See: Network Information Center
+
+
+
+Malkin                       Informational                     [Page 41]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   NIC.DDN.MIL
+      This is the domain name of the DDN NIC.  See also: Defense Data
+      Network, Domain Name System, Network Information Center.
+
+   NIS
+      See: Network Information Services
+
+   NIST
+      See: National Institute of Standards and Technology
+
+   NNTP
+      See: Network News Transfer Protocol
+
+   NOC
+      See: Network Operations Center
+
+   Nodal Switching System (NSS)
+      Main routing nodes in the NSFnet backbone.  See also: backbone,
+      National Science Foundation.
+      [Source: MALAMUD]
+
+   node
+      An addressable device attached to a computer network.  See also:
+      host, router.
+
+   NREN
+      See: National Research and Education Network
+
+   NSF
+      See: National Science Foundation
+
+   NSS
+      See: Nodal Switching System
+
+   NTP
+      See: Network Time Protocol
+
+   OCLC
+      See: Online Computer Library Catalog
+
+   octet
+      An octet is 8 bits.  This term is used in networking, rather than
+      byte, because some systems have bytes that are not 8 bits long.
+
+   Online Computer Library Catalog
+      OCLC is a nonprofit membership organization offering computer-
+      based services to libraries, educational organizations, and their
+      users.  The OCLC library information network connects more than
+
+
+
+Malkin                       Informational                     [Page 42]
+
+RFC 1983                        Glossary                     August 1996
+
+
+      10,000 libraries worldwide.  Libraries use the OCLC System for
+      cataloging, interlibrary loan, collection development,
+      bibliographic verification, and reference searching.
+      [Source: OCLC]
+
+   Open Shortest-Path First (OSPF)
+      A link state, as opposed to distance vector, routing protocol.  It
+      is an Internet standard IGP defined in RFCs 1583 and 1793.  The
+      multicast version, MOSPF, is defined in RFC 1584.  See also:
+      Interior Gateway Protocol, Routing Information Protocol.
+
+   Open Systems Interconnection (OSI)
+      A suite of protocols, designed by ISO committees, to be the
+      international standard computer network architecture.  See also:
+      International Organization for Standardization.
+
+   OSI
+      See: Open Systems Interconnection
+
+   OSI Reference Model
+      A seven-layer structure designed to describe computer network
+      architectures and the way that data passes through them.  This
+      model was developed by the ISO in 1978 to clearly define the
+      interfaces in multivendor networks, and to provide users of those
+      networks with conceptual guidelines in the construction of such
+      networks.  See also: International Organization for
+      Standardization.
+      [Source: NNSC]
+
+   OSPF
+      See: Open Shortest-Path First
+
+   packet
+      The unit of data sent across a network.  "Packet" a generic term
+      used to describe unit of data at all levels of the protocol stack,
+      but it is most correctly used to describe application data units.
+      See also: datagram, frame.
+
+   Packet InterNet Groper (PING)
+      A program used to test reachability of destinations by sending
+      them an ICMP echo request and waiting for a reply.  The term is
+      used as a verb: "Ping host X to see if it is up!"  See also:
+      Internet Control Message Protocol.
+      [Source: RFC1208]
+
+
+
+
+
+
+
+Malkin                       Informational                     [Page 43]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   Packet Switch Node (PSN)
+      A dedicated computer whose purpose is to accept, route and forward
+      packets in a packet switched network.  See also: packet switching,
+      router.
+      [Source: NNSC]
+
+   packet switching
+      A communications paradigm in which packets (messages) are
+      individually routed between hosts, with no previously established
+      communication path.  See also: circuit switching, connection-
+      oriented, connectionless.
+
+   PD
+      Public Domain
+
+   PDU
+      See: Protocol Data Unit
+
+   PEM
+      See: Privacy Enhanced Mail
+
+   PGP
+      See: Pretty Good Privacy
+
+   PING
+      See: Packet INternet Groper
+
+   Point Of Presence (POP)
+      A site where there exists a collection of telecommunications
+      equipment, usually digital leased lines and multi-protocol
+      routers.
+
+   Point-to-Point Protocol (PPP)
+      The Point-to-Point Protocol, defined in RFC 1661, provides a
+      method for transmitting packets over serial point-to-point links.
+      There are many other RFCs which define extensions to the basic
+      protocol.  See also: Serial Line IP.
+      [Source: FYI4]
+
+   POP
+      See: Post Office Protocol and Point Of Presence
+
+   port
+      A port is a transport layer demultiplexing value.  Each
+      application has a unique port number associated with it.  See
+      also: Transmission Control Protocol, User Datagram Protocol.
+
+
+
+
+
+Malkin                       Informational                     [Page 44]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   Post Office Protocol (POP)
+      A protocol designed to allow single user hosts to read electronic
+      mail from a server.  Version 3, the most recent and most widely
+      used, is defined in RFC 1725.  See also: Electronic Mail.
+
+   Postal Telegraph and Telephone (PTT)
+      Outside the USA, PTT refers to a telephone service provider, which
+      is usually a monopoly, in a particular country.
+
+   postmaster
+      The person responsible for taking care of electronic mail
+      problems, answering queries about users, and other related work at
+      a site.  See also: Electronic Mail.
+      [Source: ZEN]
+
+   PPP
+      See: Point-to-Point Protocol
+
+   Pretty Good Privacy (PGP)
+      A program, developed by Phil Zimmerman, which cryptographically
+      protects files and electronic mail from being read by others.  It
+      may also be used to digitally sign a document or message, thus
+      authenticating the creator.  See also: encryption, Data Encryption
+      Standard, RSA.
+
+   Privacy Enhanced Mail (PEM)
+      Internet email which provides confidentiality, authentication and
+      message integrity using various encryption methods.  See also:
+      Electronic Mail, encryption.
+
+   Prospero
+      A distributed filesystem which provides the user with the ability
+      to create multiple views of a single collection of files
+      distributed across the Internet.  Prospero provides a file naming
+      system, and file access is provided by existing access methods
+      (e.g. anonymous FTP and NFS).  The Prospero protocol is also used
+      for communication between clients and servers in the archie
+      system.  See also: anonymous FTP, archie, archive site, Gopher,
+      Network File System, Wide Area Information Servers.
+
+   protocol
+      A formal description of message formats and the rules two
+      computers must follow to exchange those messages.  Protocols can
+      describe low-level details of machine-to-machine interfaces (e.g.,
+      the order in which bits and bytes are sent across a wire) or
+      high-level exchanges between allocation programs (e.g., the way in
+      which two programs transfer a file across the Internet).
+      [Source: MALAMUD]
+
+
+
+Malkin                       Informational                     [Page 45]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   protocol converter
+      A device/program which translates between different protocols
+      which serve similar functions (e.g. TCP and TP4).
+
+   Protocol Data Unit (PDU)
+      "PDU" is internationalstandardscomitteespeak for packet.  See
+      also: packet.
+
+   protocol stack
+      A layered set of protocols which work together to provide a set of
+      network functions.  See also: layer, protocol.
+
+   proxy ARP
+      The technique in which one machine, usually a router, answers ARP
+      requests intended for another machine.  By "faking" its identity,
+      the router accepts responsibility for routing packets to the
+      "real" destination.  Proxy ARP allows a site to use a single IP
+      address with two physical networks.  Subnetting would normally be
+      a better solution.  See also: Address Resolution Protocol
+      [Source: RFC1208]
+
+   PSN
+      See: Packet Switch Node.
+
+   PTT
+      See: Postal, Telegraph and Telephone
+
+   queue
+      A backup of packets awaiting processing.
+
+   RARE
+      Reseaux Associes pour la Recherche Europeenne.  See: Trans-
+      European Research and Education Networking Association.
+
+   RARP
+      See: Reverse Address Resolution Protocol
+
+   RBOC
+      Regional Bell Operating Company
+
+   Read The F*cking Manual (RTFM)
+      This acronym is often used when someone asks a simple or common
+      question.
+
+   Read The Source Code (RTSC)
+      This acronym is often used when a software developer asks a
+      question about undocumented code.
+
+
+
+
+Malkin                       Informational                     [Page 46]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   reassembly
+      The IP process in which a previously fragmented packet is
+      reassembled before being passed to the transport layer.  See also:
+      fragmentation.
+
+   recursive
+      See: recursive
+
+   regional
+      See: mid-level network
+
+   remote login
+      Operating on a remote computer, using a protocol over a computer
+      network, as though locally attached.  See also: Telnet.
+
+   Remote Procedure Call (RPC)
+      An easy and popular paradigm for implementing the client-server
+      model of distributed computing.  In general, a request is sent to
+      a remote system to execute a designated procedure, using arguments
+      supplied, and the result returned to the caller.  There are many
+      variations and subtleties in various implementations, resulting in
+      a variety of different (incompatible) RPC protocols.
+      [Source: RFC1208]
+
+   repeater
+      A device which propagates electrical signals from one cable to
+      another.  See also: bridge, gateway, router.
+
+   Request For Comments (RFC)
+      The document series, begun in 1969, which describes the Internet
+      suite of protocols and related experiments.  Not all (in fact very
+      few) RFCs describe Internet standards, but all Internet standards
+      are written up as RFCs.  The RFC series of documents is unusual in
+      that the proposed protocols are forwarded by the Internet research
+      and development community, acting on their own behalf, as opposed
+      to the formally reviewed and standardized protocols that are
+      promoted by organizations such as CCITT and ANSI.  See also: BCP,
+      FYI, STD.
+
+   Reseaux IP Europeens (RIPE)
+      A collaboration between European networks which use the TCP/IP
+      protocol suite.
+
+   Reverse Address Resolution Protocol (RARP)
+      A protocol, defined in RFC 903, which provides the reverse
+      function of ARP.  RARP maps a hardware (MAC) address to an
+      internet address.  It is used primarily by diskless nodes when
+      they first initialize to find their internet address.  See also:
+
+
+
+Malkin                       Informational                     [Page 47]
+
+RFC 1983                        Glossary                     August 1996
+
+
+      Address Resolution Protocol, BOOTP, internet address, MAC address.
+
+   RFC
+      See: Request For Comments
+
+   RFC 822
+      The Internet standard format for electronic mail message headers.
+      Mail experts often refer to "822 messages."  The name comes from
+      RFC 822, which contains the specification.  822 format was
+      previously known as 733 format.  See also: Electronic Mail.
+      [Source: COMER]
+
+   RIP
+      See: Routing Information Protocol
+
+   RIPE
+      See: Reseaux IP Europeenne
+
+   Round-Trip Time (RTT)
+      A measure of the current delay on a network.
+      [Source: MALAMUD]
+
+   route
+      The path that network traffic takes from its source to its
+      destination.  Also, a possible path from a given host to another
+      host or destination.
+
+   routed
+      Route Daemon.  A program which runs under 4.2BSD/4.3BSD UNIX
+      systems (and derived operating systems) to propagate routes among
+      machines on a local area network, using the RIP protocol.
+      Pronounced "route-dee".  See also: Routing Information Protocol,
+      gated.
+
+   router
+      A device which forwards traffic between networks.  The forwarding
+      decision is based on network layer information and routing tables,
+      often constructed by routing protocols.  See also: bridge,
+      gateway, Exterior Gateway Protocol, Interior Gateway Protocol.
+
+   routing
+      The process of selecting the correct interface and next hop for a
+      packet being forwarded.  See also: hop, router, Exterior Gateway
+      Protocol, Interior Gateway Protocol.
+
+   routing domain
+      A set of routers exchanging routing information within an
+      administrative domain.  See also: Administrative Domain, router.
+
+
+
+Malkin                       Informational                     [Page 48]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   Routing Information Protocol (RIP)
+      A distance vector, as opposed to link state, routing protocol.  It
+      is an Internet standard IGP defined in RFC 1058.  See also:
+      Interior Gateway Protocol, Open Shortest-Path First.
+
+   RPC
+      See: Remote Procedure Call
+
+   RSA
+      A public-key cryptographic system which may be used for encryption
+      and authentication.  It was invented in 1977 and named for its
+      inventors: Ron Rivest, Adi Shamir, and Leonard Adleman.  See also:
+      encryption, Data Encryption Standard, Pretty Good Privacy.
+
+   RTFM
+      See: Read The F*cking Manual
+
+   RTSC
+      See: Read The Source Code
+
+   RTT
+      See: Round-Trip Time
+
+   SDH
+      See: Synchronous Digital Hierarchy
+
+   Serial Line IP (SLIP)
+      A protocol used to run IP over serial lines, such as telephone
+      circuits or RS-232 cables, interconnecting two systems.  SLIP is
+      defined in RFC 1055, but is not an Internet Standard.  It is being
+      replaced by PPP.  See also: Point-to-Point Protocol.
+
+   server
+      A provider of resources (e.g. file servers and name servers).  See
+      also: client, Domain Name System, Network File System.
+
+   SGML
+      See: Standardized Generalized Markup Language
+
+   SIG
+      Special Interest Group
+
+   signature
+      The three or four line message at the bottom of a piece of email
+      or a Usenet article which identifies the sender.  Large signatures
+      (over five lines) are generally frowned upon.  See also:
+      Electronic Mail, Usenet.
+
+
+
+
+Malkin                       Informational                     [Page 49]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   Simple Mail Transfer Protocol (SMTP)
+      A protocol used to transfer electronic mail between computers.  It
+      is specified in RFC 821, with extensions specified in many other
+      RFCs.  It is a server to server protocol, so other protocols are
+      used to access the messages.  See also: Electronic Mail, Post
+      Office Protocol, RFC 822.
+
+   Simple Network Management Protocol (SNMP)
+      The Internet standard protocol developed to manage nodes on an IP
+      network.  The first version is defined in RFC 1157 (STD 15).
+      SNMPv2 (version 2) is defined in too many RFCs to list.  It is
+      currently possible to manage wiring hubs, toasters, jukeboxes,
+      etc.  See also: Management Information Base.
+
+   SLIP
+      See: Serial Line IP
+
+   SMDS
+      See: Switched Multimegabit Data Service
+
+   SMI
+      See: Structure of Management Information
+
+   SMTP
+      See: Simple Mail Transfer Protocol
+
+   SNA
+      See: Systems Network Architecture
+
+   snail mail
+      A pejorative term referring to the U.S. postal service.
+
+   SNMP
+      See: Simple Network Management Protocol
+
+   SONET
+      See: Synchronous Optical NETwork
+
+   Standardized Generalized Markup Language (SGML)
+      An international standard for the definition of system-
+      independent, device-independent methods of representing text in
+      electronic form.  See also: Hypertext Markup Language.
+
+   STD
+      A subseries of RFCs that specify Internet standards.  The official
+      list of Internet standards is in STD 1.  See also: Request For
+      Comments.
+
+
+
+
+Malkin                       Informational                     [Page 50]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   stream-oriented
+      A type of transport service that allows its client to send data in
+      a continuous stream.  The transport service will guarantee that
+      all data will be delivered to the other end in the same order as
+      sent and without duplicates.  See also: Transmission Control
+      Protocol.
+      [Source: MALAMUD]
+
+   Structure of Management Information (SMI)
+      The rules used to define the objects that can be accessed via a
+      network management protocol.  These rules are defined in RFC 1155
+      (STD 17).  The acronym is pronounced "Ess Em Eye."  See also:
+      Management Information Base.  .br [Source: RFC1208]
+
+   stub network
+      A stub network only carries packets to and from local hosts.  Even
+      if it has paths to more than one other network, it does not carry
+      traffic for other networks.  See also: backbone, transit network.
+
+   subnet
+      A portion of a network, which may be a physically independent
+      network segment, which shares a network address with other
+      portions of the network and is distinguished by a subnet number.
+      A subnet is to a network what a network is to an internet.  See
+      also: internet, network.
+      [Source: FYI4]
+
+   subnet address
+      The subnet portion of an IP address.  In a subnetted network, the
+      host portion of an IP address is split into a subnet portion and a
+      host portion using an address (subnet) mask.  See also: address
+      mask, IP address, network address, host address.
+
+   subnet mask
+      See: address mask
+
+   subnet number
+      See: subnet address
+
+  supernet
+      An aggregation of IP network addresses advertised as a single
+      classless network address.  For example, given four Class C IP
+      networks: 192.0.8.0, 192.0.9.0, 192.0.10.0 and 192.0.11.0, each
+      having the intrinsic network mask of 255.255.255.0; one can
+      advertise the address 192.0.8.0 with a subnet mask of
+      255.255.252.0.  See also: IP address, network address, network
+      mask, Classless Inter-domain Routing.
+
+
+
+
+Malkin                       Informational                     [Page 51]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   Switched Multimegabit Data Service (SMDS)
+      An emerging high-speed datagram-based public data network service
+      developed by Bellcore and expected to be widely used by telephone
+      companies as the basis for their data networks.  See also:
+      Metropolitan Area Network.
+      [Source: RFC1208]
+
+   Synchronous Digital Hierarchy (SDH)
+      The European standard for high-speed data communications over
+      fiber-optic media.  The transmission rates range from 155.52Mbps
+      to 2.5Gbps.
+
+   Synchronous Optical NETwork (SONET)
+      SONET is an international standard for high-speed data
+      communications over fiber-optic media.  The transmission rates
+      range from 51.84Mbps to 2.5Gbps.
+
+   Systems Network Architecture (SNA)
+      A proprietary networking architecture used by IBM and IBM-
+      compatible mainframe computers.
+      [Source: NNSC]
+
+   T1
+      A term for a digital carrier facility used to transmit a DS-1
+      formatted digital signal at 1.544 megabits per second.
+
+   T3
+      A term for a digital carrier facility used to transmit a DS-3
+      formatted digital signal at 44.746 megabits per second.
+      [Source: FYI4]
+
+   TAC
+      See: Terminal Access Controller (TAC)
+
+   talk
+      A protocol which allows two people on remote computers to
+      communicate in a real-time fashion.  See also: Internet Relay
+      Chat.
+
+   TCP
+      See: Transmission Control Protocol
+
+   TCP/IP Protocol Suite
+      Transmission Control Protocol over Internet Protocol.  This is a
+      common shorthand which refers to the suite of transport and
+      application protocols which runs over IP.  See also: IP, ICMP,
+      TCP, UDP, FTP, Telnet, SMTP, SNMP.
+
+
+
+
+Malkin                       Informational                     [Page 52]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   TELENET
+      The original name for what is now SprintNet.  It should not be
+      confused with the Telnet protocol or application program.
+
+   Telnet
+      Telnet is the Internet standard protocol for remote terminal
+      connection service.  It is defined in RFC 854 and extended with
+      options by many other RFCs.
+
+   TERENA
+      See: Trans-European Research and Education Networking Association
+
+   Terminal Access Controller (TAC)
+      A device which was once used to connect terminals to the Internet,
+      usually using dialup modem connections and the TACACS protocol.
+      While the device is no longer in use, TACACS+ is a protocol in
+      current use.
+
+   terminal emulator
+      A program that allows a computer to emulate a terminal.  The
+      workstation thus appears as a terminal to the remote host.
+      [Source: MALAMUD]
+
+   terminal server
+      A device which connects many terminals to a LAN through one
+      network connection.  A terminal server can also connect many
+      network users to its asynchronous ports for dial-out capabilities
+      and printer access.  See also: Local Area Network.
+
+   Three Letter Acronym (TLA)
+      A tribute to the use of acronyms in the computer field.  See also:
+      Extended Four Letter Acronym.
+
+   Time to Live (TTL)
+      A field in the IP header which indicates how long this packet
+      should be allowed to survive before being discarded.  It is
+      primarily used as a hop count.  See also: Internet Protocol.
+      [Source: MALAMUD]
+
+   TLA
+      See: Three Letter Acronym
+
+   TN3270
+      A variant of the Telnet program that allows one to attach to IBM
+      mainframes and use the mainframe as if you had a 3270 or similar
+      terminal.
+      [Source: BIG-LAN]
+
+
+
+
+Malkin                       Informational                     [Page 53]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   token ring
+      A token ring is a type of LAN with nodes wired into a ring.  Each
+      node constantly passes a control message (token) on to the next;
+      whichever node has the token can send a message.  Often, "Token
+      Ring" is used to refer to the IEEE 802.5 token ring standard,
+      which is the most common type of token ring.  See also: 802.x,
+      Local Area Network.
+
+   topology
+      A network topology shows the computers and the links between them.
+      A network layer must stay abreast of the current network topology
+      to be able to route packets to their final destination.
+      [Source: MALAMUD]
+
+   traceroute
+      A program available on many systems which traces the path a packet
+      takes to a destination.  It is mostly used to debug routing
+      problems between hosts.  There is also a traceroute protocol
+      defined in RFC 1393.
+
+   Trans-European Research and Education Networking Association (TERENA)
+      TERENA was formed in October 1994 by the merger of RARE and EARN
+      to promote and participate in the development of a high quality
+      international information and telecommunications infrastructure
+      for the benefit of research and education.  See also: Reseaux
+      Associes pour la Recherche Europeenne, European Academic and
+      Research Network.
+      [Source: TERENA Statutes]
+
+   transceiver
+      Transmitter-receiver.  The physical device that connects a host
+      interface to a local area network, such as Ethernet.  Ethernet
+      transceivers contain electronics that apply signals to the cable
+      and sense collisions.
+      [Source: RFC1208]
+
+   transit network
+      A transit network passes traffic between networks in addition to
+      carrying traffic for its own hosts.  It must have paths to at
+      least two other networks.  See also: backbone, stub network.
+
+   Transmission Control Protocol (TCP)
+      An Internet Standard transport layer protocol defined in RFC 793.
+      It is connection-oriented and stream-oriented, as opposed to UDP.
+      See also: connection-oriented, stream-oriented, User Datagram
+      Protocol.
+
+
+
+
+
+Malkin                       Informational                     [Page 54]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   Trojan Horse
+      A computer program which carries within itself a means to allow
+      the creator of the program access to the system using it.  See
+      also: virus, worm.
+
+   TTFN
+      Ta-Ta For Now
+
+   TTL
+      See: Time to Live
+
+   tunnelling
+      Tunnelling refers to encapsulation of protocol A within protocol
+      B, such that A treats B as though it were a datalink layer.
+      Tunnelling is used to get data between administrative domains
+      which use a protocol that is not supported by the internet
+      connecting those domains.  See also: Administrative Domain.
+
+   twisted pair
+      A type of cable in which pairs of conductors are twisted together
+      to produce certain electrical properties.
+
+   UDP
+      See: User Datagram Protocol
+
+   unicast
+      An address which only one host will recognize.  See also:
+      broadcast, multicast.
+
+   Uniform Resource Locators (URL)
+      A URL is a compact (most of the time) string representation for a
+      resource available on the Internet.  URLs are primarily used to
+      retrieve information using WWW.  The syntax and semantics for URLs
+      are defined in RFC 1738.  See also: World Wide Web.
+
+   Universal Time Coordinated (UTC)
+      This is Greenwich Mean Time.
+      [Source: MALAMUD]
+
+   UNIX-to-UNIX CoPy (UUCP)
+      This was initially a program run under the UNIX operating system
+      that allowed one UNIX system to send files to another UNIX system
+      via dial-up phone lines.  Today, the term is more commonly used to
+      describe the large international network which uses the UUCP
+      protocol to pass news and electronic mail.  See also: Electronic
+      Mail, Usenet.
+
+
+
+
+
+Malkin                       Informational                     [Page 55]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   urban legend
+      A story, which may have started with a grain of truth, that has
+      been embroidered and retold until it has passed into the realm of
+      myth.  It is an interesting phenonmenon that these stories get
+      spread so far, so fast and so often.  Urban legends never die,
+      they just end up on the Internet!  Some legends that periodically
+      make their rounds include "The Infamous Modem Tax," "Craig
+      Shergold/Brain Tumor/Get Well Cards," and "The $250 Cookie
+      Recipe."
+      [Source: LAQUEY]
+
+   URL
+      See: Uniform Resource Locators
+
+   Usenet
+      A collection of thousands of topically named newsgroups, the
+      computers which run the protocols, and the people who read and
+      submit Usenet news.  Not all Internet hosts subscribe to Usenet
+      and not all Usenet hosts are on the Internet.  See also: Network
+      News Transfer Protocol, UNIX-to-UNIX CoPy.
+      [Source: NWNET]
+
+   User Datagram Protocol (UDP)
+      An Internet Standard transport layer protocol defined in RFC 768.
+      It is a connectionless protocol which adds a level of reliability
+      and multiplexing to IP.  See also: connectionless, Transmission
+      Control Protocol.
+
+   UTC
+      See: Universal Time Coordinated
+
+   UUCP
+      See: UNIX-to-UNIX CoPy
+
+   uudecode
+      A program which reverses the effect of uuencode.  See also:
+      uuencode.
+
+   uuencode
+      A program which reversibly converts a binary file in ASCII.  It is
+      used to send binary files via email, which generally does not
+      allow (or garbles) the transmission of binary information.  The
+      original binary can be restored with uudecode.  The encoding
+      process generally creates an ASCII file larger than the original
+      binary, so compressing the binary before running uuencode is
+      highly recommended.
+
+
+
+
+
+Malkin                       Informational                     [Page 56]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   Veronica
+      A Gopher utility which effectively searches Gopher servers based
+      on a user's list of keywords.  The name was chosen to be a "mate"
+      to another utility named "Archie."  It later became an acronym for
+      Very Easy Rodent Oriented Netwide Index to Computer Archives.  See
+      also: archie, Gopher.
+
+   virtual circuit
+      A network service which provides connection-oriented service
+      without necessarily doing circuit-switching.  See also:
+      connection-oriented.
+
+   virus
+      A program which replicates itself on computer systems by
+      incorporating itself into other programs which are shared among
+      computer systems.  See also: Trojan Horse, worm.
+
+   W3
+      See: World Wide Web
+
+   WAIS
+      See: Wide Area Information Servers
+
+   WAN
+      See: Wide area network
+
+   WebCrawler
+      A WWW search engine.  The aim of the WebCrawler Project is to
+      provide a high-quality, fast, and free Internet search service.
+      The WebCrawler may be reached at "http://webcrawler.com/".
+      [Source: WebCrawler's "WebCrawler Facts"]
+
+   WG
+      See: Working Group
+
+   white pages
+      The Internet supports several databases that contain basic
+      information about users, such as e-mail addresses, telephone
+      numbers, and postal addresses.  These databases can be searched to
+      get information about particular individuals.  Because they serve
+      a function akin to the telephone book, these databases are often
+      referred to as "white pages."  See also: Knowbot, netfind, whois,
+      X.500, InterNIC.
+
+   whois
+      An Internet program which allows users to query a database of
+      people and other Internet entities, such as domains, networks, and
+      hosts.  The primary database is kept at the InterNIC.  The
+
+
+
+Malkin                       Informational                     [Page 57]
+
+RFC 1983                        Glossary                     August 1996
+
+
+      information stored includes a person's company name, address,
+      phone number and email address.  The latest version of the
+      protocol, WHOIS++, is defined in RFCs 1834 and 1835.  See also:
+      InterNIC, white pages, Knowbot, netfind, X.500.
+
+   Wide Area Information Servers (WAIS)
+      A distributed information service which offers simple natural
+      language input, indexed searching for fast retrieval, and a
+      "relevance feedback" mechanism which allows the results of initial
+      searches to influence future searches.  Public domain
+      implementations are available.  See also: archie, Gopher,
+      Prospero.
+
+   Wide Area Network (WAN)
+      A network, usually constructed with serial lines, which covers a
+      large geographic area.  See also: Local Area Network, Metropolitan
+      Area Network.
+
+   Working Group (WG)
+      A working group, within the IETF, is a group of people who work
+      under a charter to achieve a certain goal.  That goal may be the
+      creation of an Informational document, the creation of a protocol
+      specification, or the resolution of problems in the Internet.
+      Most working groups have a finite lifetime.  That is, once a
+      working group has achieved its goal, it disbands.  There is no
+      official membership for a working group.  Unofficially, a working
+      group member is somebody who is on that working group's mailing
+      list; however, anyone may attend a working group meeting.  See
+      also: Internet Engineering Task Force, Birds Of a Feather.
+
+   World Wide Web (WWW, W3)
+      A hypertext-based, distributed information system created by
+      researchers at CERN in Switzerland.  Users may create, edit or
+      browse hypertext documents.  The clients and servers are freely
+      available.
+
+   worm
+      A computer program which replicates itself and is self-
+      propagating.  Worms, as opposed to viruses, are meant to spawn in
+      network environments.  Network worms were first defined by Shoch &
+      Hupp of Xerox in ACM Communications (March 1982).  The Internet
+      worm of November 1988 is perhaps the most famous; it successfully
+      propagated itself on over 6,000 systems across the Internet.  See
+      also: Trojan Horse, virus.
+
+   WRT
+      With Respect To
+
+
+
+
+Malkin                       Informational                     [Page 58]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   WWW
+      See: World Wide Web
+
+   WYSIWYG
+      What You See is What You Get
+
+   X
+      X is the name for TCP/IP based network-oriented window systems.
+      Network window systems allow a program to use a display on a
+      different computer.   The most widely-implemented window system is
+      X11 - a component of MIT's Project Athena.
+
+   X.25
+      A data communications interface specification developed to
+      describe how data passes into and out of public data
+      communications networks.  The CCITT and ISO approved protocol
+      suite defines protocol layers 1 through 3.
+
+   X.400
+      The CCITT and ISO standard for electronic mail.  It is widely used
+      in Europe and Canada.
+
+   X.500
+      The CCITT and ISO standard for electronic directory services.  See
+      also: white pages, Knowbot, whois.
+
+   XDR
+      See: eXternal Data Representation
+
+   Xerox Network System (XNS)
+      A protocol suite developed by Xerox Corporation to run on LAN and
+      WAN networks, where the LANs are typically Ethernet.
+      Implementations exist for both Xerox's workstations and 4.3BSD,
+      and 4.3BSD-derived, systems.  XNS denotes not only the protocol
+      stack, but also an architecture of standard programming
+      interfaces, conventions, and service functions for authentication,
+      directory, filing, email, and remote procedure call.  XNS is also
+      the name of Xerox's implementation.  See also: Ethernet, Berkeley
+      Software Distribution, Local Area Network, Wide Area Network.
+      [Source: Jeff Hodges]
+
+   XNS
+      See: Xerox Network System
+
+
+
+
+
+
+
+
+Malkin                       Informational                     [Page 59]
+
+RFC 1983                        Glossary                     August 1996
+
+
+   Yahoo!
+
+      Yahoo! is a hierarchical subject-oriented guide for the World Wide
+      Web and Internet.  Yahoo! lists sites and categorizes them into
+      appropriate subject categories.  Yahoo! may be reached at
+      "http://www.yahoo.com/".
+      [Source: Yahoo's "What is Yahoo?"]
+
+   Yellow Pages (YP)
+      A historic (i.e., no longer in use) service used by UNIX
+      administrators to manage databases distributed across a network.
+
+   YP
+      See: Yellow Pages
+
+   zone
+      A logical group of network devices.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Malkin                       Informational                     [Page 60]
+
+RFC 1983                        Glossary                     August 1996
+
+
+References
+
+   BIG-LAN "BIG-LAN Frequently Asked Questions Memo", BIG-LAN DIGEST
+           V4:I8, February 14, 1992.
+
+   COMER   Comer, Douglas, "Internetworking with TCP/IP: Principles,
+           Protocols and Architecture", Prentice Hall, Englewood Cliffs,
+           NJ, 1991.
+
+   FYI4    Malkin, G., A. Marine, "FYI on Questions and Answers: Answers
+           to Commonly asked "New Internet User" Questions", RFC 1325
+           (FYI 4), Xylogics, SRI, May 1992.
+
+   HACKER  "THIS IS THE JARGON FILE", Version 2.9.8, January 1992.
+
+   HPCC    "Grand Challenges 1993: High Performance Computing and
+           Communications", Committee on Physical, Mathmatical and
+           Engineering Sciences of the Federal Coordinating Council for
+           Science, Engineering and Technology.
+
+   MALAMUD Malamud, Carl, "Analyzing Sun Networks", Van Nostrand
+           Reinhold, New York, NY, 1992.
+
+   NNSC    "NNSC's Hypercard Tour of the Internet".
+
+   LAQUEY  LaQuey, Tracy, with Jeanne C. Ryer, "The Internet Companion:
+           A Beginner's Guide to Global Networking", Addison-Wesley,
+           Reading, MA, 1992.
+
+   NWNET   Kochmer, Jonathan, and NorthWestNet, "The Internet Passport:
+           NorthWestNets Guide to Our World Online", NorthWestNet,
+           Bellevue, WA, 1992.
+
+   RFC1208 Jacobsen, O., D. Lynch, "A Glossary of Networking Terms", RFC
+           1208, Interop, Inc., March 1991.
+
+   STD1    Postel, J., "INTERNET OFFICIAL PROTOCOL STANDARDS", RFC 1920
+           (STD 1), March 1996.
+
+   STD2    Reynolds, J., J. Postel, "ASSIGNED NUMBERS", RFC 1700 (STD
+           2), ISI, October 1994.
+
+   TAN     Tanenbaum, Andrew S., "Computer Networks; 2nd ed.", Prentice
+           Hall, Englewood Cliffs, NJ, 1989.
+
+   ZEN     Kehoe, Brendan P., "Zen and the Art of the Internet",
+           February 1992.
+
+
+
+
+Malkin                       Informational                     [Page 61]
+
+RFC 1983                        Glossary                     August 1996
+
+
+Security Considerations
+
+   While security is not explicitly discussed in this document, some of
+   the glossary's entries are security related.  See the entries for
+   Access Control List (ACL), authentication, Computer Emergency
+   Response Team (CERT), cracker, Data Encryption Key (DEK), Data
+   Encryption Standard (DES), encryption, Kerberos, Message Digest (MD-
+   2, MD-4, MD-5), Pretty Good Privacy (PGP), Privacy Enhanced Mail
+   (PEM), RSA, Trojan Horse, virus, and worm.
+
+
+Editor's Address
+
+   Gary Scott Malkin
+   Xylogics/Bay Networks
+   53 Third Avenue
+   Burlington, MA 01803
+
+   Phone:  (617) 238-6237
+   EMail:  gmalkin@Xylogics.COM
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Malkin                       Informational                     [Page 62]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1983.txt](<www.ietf.org/rfc/rfc1983.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
