### PR TITLE
Archive rfc1988.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1988.txt
+++ b/www.ietf.org/rfc/rfc1988.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                        G. McAnally
+Request for Comments: 1988                                    D. Gilbert
+Category: Informational                                         J. Flick
+                                                 Hewlett Packard Company
+                                                             August 1996
+
+
+    Conditional Grant of Rights to Specific Hewlett-Packard Patents
+       In Conjunction With the Internet Engineering Task Force's
+             Internet-Standard Network Management Framework
+
+Status of This Memo
+
+   This memo provides information for the Internet community.  This memo
+   does not specify an Internet standard of any kind.  Distribution of
+   this memo is unlimited.
+
+Note:
+
+   This document is NOT a standard.  It is an announcement to interested
+   parties of a conditional grant by the Hewlett-Packard Company (HP) of
+   certain rights to use autotopology network management technology
+   covered by specific HP patents in conjunction with the Internet
+   Engineering Task Force's (IETF's) Internet-standard network
+   management framework.
+
+Purpose
+
+   This grant is made to help facilitate inclusion of certain patented
+   search address technology covering network device mapping in IETF
+   standards-track Management Information Base (MIB) modules.  HP is
+   offering this search address technology to the IETF as a technique
+   for mapping network devices.  It should be noted that the
+   confirmatory license mentioned is optional, since the grant of rights
+   is automatic.
+
+A Grant of Rights to Hewlett-Packard US Patents 5,293,635 and 5,421,024
+
+   HP hereby covenants that it will not assert any claims in US Patents
+   5,293,635, 5,421,024, any continuations, divisions, or
+   continuations-in-part of either, or any non-US counterparts of any of
+   the foregoing against any party that makes, uses, sells, imports, or
+   offers for sale, an implementation of an IETF standards-track MIB
+   module that includes HP's contributed search address technology, or
+   any derivative of that contribution, provided that the MIB module is
+   employed to implement the Internet-standard network management
+   framework.  Such grant of rights is limited in that it does not
+   include a right to incorporate such HP search address technology into
+
+
+
+McAnally, Gilbert & Flick    Informational                      [Page 1]
+
+RFC 1988               Search Address Patent Use             August 1996
+
+
+   proprietary MIB modules.
+
+   This grant of rights will permanently terminate with respect to any
+   party (and to any subsidiary of a party) that asserts a patent it
+   owns or controls, either directly or indirectly, against HP or any of
+   its subsidiaries for implementation of, or operation of any system
+   utilizing, search address technology.  The termination of rights will
+   occur as of the date the patent is asserted against HP.
+
+   A written confirmation of this grant, and/or a license under any
+   other HP patent under HP's then-current terms, conditions, and
+   royalty rates, can be obtained by sending a request to:
+
+           Patent Counsel
+           Hewlett-Packard Company
+           3000 Hanover Street
+           Palo Alto, CA 94304
+           USA
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Authors' Addresses
+
+   Gary McAnally
+   Hewlett-Packard Company
+   8000 Foothills Blvd.
+   Roseville, CA 95747
+   USA
+
+
+   Douglas Gilbert
+   Hewlett-Packard Company
+   3000 Hanover Street
+   Palo Alto, CA 94304
+   USA
+
+
+   John Flick
+   Hewlett-Packard Company
+   8000 Foothills Blvd. M.S. 5556
+   Roseville, CA 95747-5556
+   USA
+
+   Phone: (916) 785-4018
+   EMail: johnf@hprnd.rose.hp.com
+
+
+
+
+McAnally, Gilbert & Flick    Informational                      [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1988.txt](<www.ietf.org/rfc/rfc1988.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
