### PR TITLE
Archive rfc1999.txt

### DIFF
--- a/www.ietf.org/rfc/rfc1999.txt
+++ b/www.ietf.org/rfc/rfc1999.txt
@@ -1,0 +1,1123 @@
+
+
+
+
+
+
+Network Working Group                                         J. Elliott
+Request for Comments: 1999                                           ISI
+Category: Informational                                     January 1997
+
+
+                      Request for Comments Summary
+
+                         RFC Numbers 1900-1999
+
+Status of This Memo
+
+   This RFC is a slightly annotated list of the 100 RFCs from RFC 1900
+   through RFCs 1999.  This is a status report on these RFCs.  This memo
+   provides information for the Internet community.  It does not specify
+   an Internet standard of any kind.  Distribution of this memo is
+   unlimited.
+
+Note
+
+   Many RFCs, but not all, are Proposed Standards, Draft Standards, or
+   Standards.  Since the status of these RFCs may change during the
+   standards processing, we note here only that they are on the
+   standards track.  Please see the latest edition of "Internet Official
+   Protocol Standards" for the current state and status of these RFCs.
+   In the following, RFCs on the standards track are marked [STANDARDS-
+   TRACK].
+
+RFC     Author       Date      Title
+---     ------       ----      -----
+
+1999    Elliott      Jan 97   Requests For Comments Summary
+
+This memo.
+
+
+1998    Chen         Aug 96   An Application of the BGP Community
+                              Attribute in Multi-home Routing
+
+This document presents an application of the BGP community attribute [2]
+in simplifying the implementation and configuration of routing policies
+in the multi-provider Internet.  This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 1]
+
+RFC 1999                  Summary of 1900-1999              January 1997
+
+
+1997    Chandra      Aug 96   BGP Communities Attribute
+
+This document describes an extension to BGP which may be used to pass
+additional information to both neighboring and remote BGP peers.
+[STANDARDS-TRACK]
+
+
+1996    Vixie        Aug 96   A Mechanism for Prompt Notification of
+                              Zone Changes (DNS NOTIFY)
+
+This memo describes the NOTIFY opcode for DNS, by which a master server
+advises a set of slave servers that the master's data has been changed
+and that a query should be initiated to discover the new data.
+[STANDARDS-TRACK]
+
+
+1995    Ohta         Aug 96   Incremental Zone Transfer in DNS
+
+This document proposes extensions to the DNS protocols to provide an
+incremental zone transfer (IXFR) mechanism.  [STANDARDS-TRACK]
+
+
+1994    Simpson      Aug 96   PPP Challenge Handshake Authentication
+                              Protocol (CHAP)
+
+This document defines a method for Authentication using PPP, which uses
+a random Challenge, with a cryptographically hashed Response which
+depends upon the Challenge and a secret key.  [STANDARDS-TRACK]
+
+
+1993    Barbir       Aug 96   PPP Gandalf FZA Compression Protocol
+
+This document describes the use of the Gandalf FZA data compression
+algorithm [3] for compressing PPP encapsulated packets.  This memo
+provides information for the Internet community.  It does not specify an
+Internet standard.
+
+
+1992    Castineyra   Aug 96   The Nimrod Routing Architecture
+
+Nimrod is a scalable routing architecture designed to accommodate a
+continually expanding and diversifying internetwork.  First suggested by
+Noel Chiappa, the Nimrod architecture has undergone revision and
+refinement through the efforts of the Nimrod working group of the IETF.
+In this document, we present a detailed description of this
+architecture.  This memo provides information for the Internet
+community.  It does not specify an Internet standard.
+
+
+
+
+Elliott                      Informational                      [Page 2]
+
+RFC 1999                  Summary of 1900-1999              January 1997
+
+
+1991    Atkins       Aug 96   PGP Message Exchange Formats
+
+This document describes the format of "PGP files", i.e., messages that
+have been encrypted and/or signed with PGP.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+1990    Sklower      Aug 96   The PPP Multilink Protocol (MP)
+
+This document proposes a method for splitting, recombining and
+sequencing datagrams across multiple logical data links.  [STANDARDS-
+TRACK]
+
+
+1989    Simpson      Aug 96   PPP Link Quality Monitoring
+
+This document defines a protocol for generating Link-Quality-Reports.
+[STANDARDS-TRACK]
+
+
+1988    McAnally     Aug 96   Conditional Grant of Rights to Specific
+                              Hewlett-Packard Patents In Conjunction
+                              With the Internet Engineering Task
+                              Force's Internet-Standard Network
+                              Management Framework
+
+This grant is made to help facilitate inclusion of certain patented
+search address technology covering network device mapping in IETF
+standards-track Management Information Base (MIB) modules.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1987    Newman       Aug 96   Ipsilon's General Switch Management
+                              Protocol Specification Version 1.1
+
+The General Switch Management Protocol (GSMP), is a general purpose
+protocol to control an ATM switch. GSMP allows a controller to establish
+and release connections across the switch; add and delete leaves on a
+point-to-multipoint connection; manage switch ports; request
+configuration information; and request statistics.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 3]
+
+RFC 1999                  Summary of 1900-1999              January 1997
+
+
+1986    Polites      Aug 96   Experiments with a Simple File Transfer
+                              Protocol for Radio Links using Enhanced
+                              Trivial File Transfer Protocol (ETFTP)
+
+This document is a description of the Enhanced Trivial File Transfer
+Protocol (ETFTP). This protocol is an experimental implementation of the
+NETwork BLock Transfer Protocol (NETBLT), RFC 998 [1], as a file
+transfer application program.  This memo defines an Experimental
+Protocol for the Internet community.
+
+
+1985    De Winter    Aug 96   SMTP Service Extension
+                              for Remote Message Queue Starting
+
+This memo defines an extension to the SMTP service whereby an SMTP
+client and server may interact to give the server an opportunity to
+start the processing of its queues for messages to go to a given host.
+[STANDARDS-TRACK]
+
+
+1984    I.A.B.       Aug 96   IAB and IESG Statement on Cryptographic
+                              Technology and the Internet
+
+The Internet Architecture Board (IAB) and the Internet Engineering
+Steering Group (IESG), the bodies which oversee architecture and
+standards for the Internet, are concerned by the need for increased
+protection of international commercial transactions on the Internet, and
+by the need to offer all Internet users an adequate degree of privacy.
+This memo provides information for the Internet community.  This memo
+does not specify an Internet standard of any kind.
+
+
+1983    Malkin       Aug 96   Internet Users' Glossary
+
+There are many networking glossaries in existence.  This glossary
+concentrates on terms which are specific to the Internet.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1982    Elz          Aug 96   Serial Number Arithmetic
+
+The DNS has long relied upon serial number arithmetic, a concept which
+has never really been defined, certainly not in an IETF document, though
+which has been widely understood.  This memo supplies the missing
+definition.  It is intended to update RFC1034 and RFC1035.  [STANDARDS-
+TRACK]
+
+
+
+
+Elliott                      Informational                      [Page 4]
+
+RFC 1999                  Summary of 1900-1999              January 1997
+
+
+1981    McCann       Aug 96   Path MTU Discovery for IP version 6
+
+This document describes Path MTU Discovery for IP version 6.  It is
+largely derived from RFC 1191, which describes Path MTU Discovery for IP
+version 4.  [STANDARDS-TRACK]
+
+
+1980    Seidman      Aug 96   A Proposed Extension to HTML :
+                              Client-Side Image Maps
+
+This document specifies an extension to the HTML language, referred to
+as "Client-Side Image Maps," which resolves some limitations.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1979    Woods        Aug 96   PPP Deflate Protocol
+
+This document describes the use of the PPP Deflate compression protocol
+for compressing PPP encapsulated packets.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+1978    Rand         Aug 96   PPP Predictor Compression Protocol
+
+This document describes the use of the Predictor data compression
+algorithm for compressing PPP encapsulated packets.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+1977    Schryver     Aug 96   PPP BSD Compression Protocol
+
+This document describes the use of the Unix Compress compression
+protocol for compressing PPP encapsulated packets.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 5]
+
+RFC 1999                  Summary of 1900-1999              January 1997
+
+
+1976    Schneider    Aug 96   PPP for Data Compression in Data
+                              Circuit-Terminating Equipment (DCE)
+
+This document defines a specific set of parameters for these protocols
+and an LCP extension to define a standard way of using PPP for data
+compression of serial data in Data Circuit-Terminating Equipment (DCE).
+This memo provides information for the Internet community.  This memo
+does not specify an Internet standard of any kind.
+
+
+1975    Schremp      Aug 96   PPP Magnalink Variable Resource
+                              Compression
+
+The Magnalink Variable Resource Compression Algorithm (MVRCA) allows a
+wide range of interoperable compression implementations whose
+performance characteristics are a function of available CPU and memory
+resources.  This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+1974    Friend       Aug 96   PPP Stac LZS Compression Protocol
+
+This document describes the use of the Stac LZS data compression
+algorithm, with single or multiple compression histories, for
+compressing PPP encapsulated packets.  This memo provides information
+for the Internet community.  This memo does not specify an Internet
+standard of any kind.
+
+
+1973    Simpson      Jun 96   PPP in Frame Relay
+
+This document describes the use of Frame Relay for framing PPP
+encapsulated packets.  [STANDARDS-TRACK]
+
+
+1972    Crawford     Aug 96   A Method for the Transmission of IPv6
+                              Packets over Ethernet Networks
+
+This memo specifies the frame format for transmission of IPv6 [IPV6]
+packets and the method of forming IPv6 link-local addresses on Ethernet
+networks.  [STANDARDS-TRACK]
+
+
+1971    Thomson      Aug 96   IPv6 Stateless Address Autoconfiguration
+
+This document specifies the steps a host takes in deciding how to
+autoconfigure its interfaces in IP version 6.  [STANDARDS-TRACK]
+
+
+
+
+Elliott                      Informational                      [Page 6]
+
+RFC 1999                  Summary of 1900-1999              January 1997
+
+
+1970    Narten       Aug 96   Neighbor Discovery for IP Version 6
+                              (IPv6)
+
+This document specifies the Neighbor Discovery protocol for IP Version
+6.  [STANDARDS-TRACK]
+
+
+1969    Sklower      Jun 96   The PPP DES Encryption Protocol (DESE)
+
+This document provides specific details for the use of the DES standard
+[5, 6] for encrypting PPP encapsulated packets.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+1968    Meyer        Jun 96   The PPP Encryption Control Protocol
+                              (ECP)
+
+This document defines a method for negotiating data encryption over PPP
+links.  [STANDARDS-TRACK]
+
+
+1967    Schneider    Aug 96   PPP LZS-DCP Compression Protocol
+                              (LZS-DCP)
+
+This document describes the use of the Stac LZS data compression
+algorithm for compressing PPP encapsulated packets, using a DCP header
+[6].  This memo provides information for the Internet community.  This
+memo does not specify an Internet standard of any kind.
+
+
+1966    Bates        Jun 96   BGP Route Reflection
+                              An alternative to full mesh IBGP
+
+This document describes the use and design of a method known as "Route
+Reflection" to alleviate the the need for "full mesh" IBGP.  This memo
+defines an Experimental Protocol for the Internet community.
+
+
+1965    Traina       Jun 96   Autonomous System Confederations for BGP
+
+This document describes an extension to BGP which may be used to create
+a confederation of autonomous systems which is represented as one single
+autonomous system to BGP peers external to the confederation.  This memo
+defines an Experimental Protocol for the Internet community.
+
+
+
+
+
+
+Elliott                      Informational                      [Page 7]
+
+RFC 1999                  Summary of 1900-1999              January 1997
+
+
+1964    Linn         Jun 96   The Kerberos Version 5 GSS-API Mechanism
+
+This specification defines protocols, procedures, and conventions to be
+employed by peers implementing the Generic Security Service Application
+Program Interface (as specified in RFCs 1508 and 1509) when using
+Kerberos Version 5 technology (as specified in RFC 1510).  [STANDARDS-
+TRACK]
+
+
+1963    Schneider    Aug 96   PPP Serial Data Transport Protocol
+                              (SDTP)
+
+This document describes a new Network level protocol (from the PPP point
+of view), PPP Serial Data Transport Protocol, that provides
+encapsulation and an associated control protocol for transporting serial
+data streams over a PPP link.  This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+1962    Rand         Jun 96   The PPP Compression Control Protocol
+                              (CCP)
+
+This document defines a method for negotiating data compression over PPP
+links.  [STANDARDS-TRACK]
+
+
+1961    McMahon      Jun 96   GSS-API Authentication Method for SOCKS
+                              Version 5
+
+This document provides the specification for the SOCKS V5 GSS-API
+authentication protocol, and defines a GSS-API-based encapsulation for
+provision of integrity, authentication and optional confidentiality.
+[STANDARDS-TRACK]
+
+
+1960    Howes        Jun 96   A String Representation of LDAP
+                              Search Filters
+
+The Lightweight Directory Access Protocol (LDAP) [1] defines a network
+representation of a search filter transmitted to an LDAP server.  Some
+applications may find it useful to have a common way of representing
+these search filters in a human-readable form.  This document defines a
+human-readable string format for representing LDAP search filters.
+[STANDARDS-TRACK]
+
+
+
+
+
+
+Elliott                      Informational                      [Page 8]
+
+RFC 1999                  Summary of 1900-1999              January 1997
+
+
+1959    Howes        Jun 96   An LDAP URL Format
+
+This document describes a format for an LDAP Uniform Resource Locator
+which will allow Internet clients to have direct access to the LDAP
+protocol.  [STANDARDS-TRACK]
+
+
+1958    Carpenter    Jun 96   Architectural Principles of the Internet
+
+The Internet and its architecture have grown in evolutionary fashion
+from modest beginnings, rather than from a Grand Plan. While this
+process of evolution is one of the main reasons for the technology's
+success, it nevertheless seems useful to record a snapshot of the
+current principles of the Internet architecture. This is intended for
+general guidance and general interest, and is in no way intended to be a
+formal or invariant reference model.  This memo provides information for
+the Internet community.  This memo does not specify an Internet standard
+of any kind.
+
+
+1957    Nelson       Jun 96   Some Observations on Implementations
+                              of the Post Office Protocol (POP3)
+
+This memo provides information for the Internet community. This memo
+does not specify an Internet standard of any kind.
+
+
+1956    Engebretson  Jun 96   Registration in the MIL Domain
+
+This RFC describes the policy for the registration of second level
+domains under the ".MIL" domain.  This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+1955    Hinden       Jun 96   New Scheme for Internet Routing and
+                              Addressing (ENCAPS) for IPNG
+
+This paper proposes a new scheme which I believe is a good medium term
+solution to the routing and address problems of the internet.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 9]
+
+RFC 1999                  Summary of 1900-1999              January 1997
+
+
+1954    Newman       May 96   Transmission of Flow Labelled IPv4 on
+                              ATM Data Links Ipsilon Version 1.0
+
+This document specifies the manner for transmitting IPv4 datagrams over
+an ATM data link, both in a default manner and in the presence of flow
+labelling via Ipsilon Flow Management Protocol [IFMP].  This document
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1953    Newman       May 96   Ipsilon Flow Management Protocol
+                              Specification for IPv4 Version 1.0
+
+The Ipsilon Flow Management Protocol (IFMP), is a protocol for allowing
+a node to instruct an adjacent node to attach a layer 2 label to a
+specified IP flow.  This document provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+1952    Deutsch      May 96   GZIP file format specification
+                              version 4.3
+
+This specification defines a lossless compressed data format that is
+compatible with the widely used GZIP utility.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+1951    Deutsch      May 96   DEFLATE Compressed Data Format
+                              Specification version 1.3
+
+This specification defines a lossless compressed data format that
+compresses data using a combination of the LZ77 algorithm and Huffman
+coding, with efficiency comparable to the best currently available
+general-purpose compression methods.  This memo provides information for
+the Internet community.  This memo does not specify an Internet standard
+of any kind.
+
+
+1950    Deutsch      May 96   ZLIB Compressed Data Format
+                              Specification version 3.3
+
+This specification defines a lossless compressed data format.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+
+
+
+
+Elliott                      Informational                     [Page 10]
+
+RFC 1999                  Summary of 1900-1999              January 1997
+
+
+1949    Ballarde     May 96   Scalable Multicast Key Distribution
+
+This memo provides a scalable solution to the multicast key distribution
+problem.  This memo defines an Experimental Protocol for the Internet
+community.
+
+
+1948    Bellovin     May 96   Defending Against Sequence Number
+                              Attacks
+
+IP spoofing attacks based on sequence number spoofing have become a
+serious threat on the Internet (CERT Advisory CA-95:01).  While
+ubiquitous crypgraphic authentication is the right answer, we propose a
+simple modification to TCP implementations that should be a very
+substantial block to the current wave of attacks.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+1947    Spinellis    May 96   Greek Character Encoding for Electronic
+                              Mail Messages
+
+This document describes a standard encoding for electronic mail [RFC822]
+containing Greek text and provides implementation guide-lines.  This
+memo provides information for the Internet community.  This memo does
+not specify an Internet standard of any kind.
+
+
+1946    Jackowski    May 96   Native ATM Support for ST2+
+
+This memo describes a working implementation which enables applications
+to directly invoke ATM services in the following environments: ATM to
+internet, internet to ATM, and internet to internet across ATM.  This
+memo provides information for the Internet community.  This memo does
+not specify an Internet standard of any kind.
+
+
+1945    Berners-Lee  May 96   Hypertext Transfer Protocol -- HTTP/1.0
+
+The Hypertext Transfer Protocol (HTTP) is an application-level protocol
+with the lightness and speed necessary for distributed, collaborative,
+hypermedia information systems.  This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 11]
+
+RFC 1999                  Summary of 1900-1999              January 1997
+
+
+1944    Bradner      May 96   Benchmarking Methodology for Network
+                              Interconnect Devices
+
+This document discusses and defines a number of tests that may be used
+to describe the performance characteristics of a network interconnecting
+device.  This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+1943    Jennings     May 96   Building an X.500 Directory Service
+                              in the US
+
+This document provides definition and recommends considerations that
+must be undertaken to operate a X.500 Directory Service in the United
+States.  This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+1942    Raggett      May 96   HTML Tables
+
+This specification extends HTML to support a wide variety of tables.
+This memo defines an Experimental Protocol for the Internet community.
+
+
+1941    Sellers      May 96   Frequently Asked Questions for Schools
+
+The goal of this FYI document, produced by the Internet School
+Networking (ISN) group in the User Services Area of the Internet
+Engineering Task Force (IETF), is to act as an introduction to the
+Internet for faculty, administration, and other school personnel in
+primary and secondary schools.  This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+1940    Estrin       May 96   Source Demand Routing: Packet Format and
+                              Forwarding Specification (Version 1).
+
+The purpose of SDRP is to support source-initiated selection of routes
+to complement the route selection provided by existing routing protocols
+for both inter-domain and intra-domain routes.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 12]
+
+RFC 1999                  Summary of 1900-1999              January 1997
+
+
+1939    Myers        May 96   Post Office Protocol - Version 3
+
+The Post Office Protocol - Version 3 (POP3) is intended to permit a
+workstation to dynamically access a maildrop on a server host in a
+useful fashion.  [STANDARDS-TRACK]
+
+
+1938    Haller       May 96   A One-Time Password System
+
+This document describes a one-time password authentication system (OTP).
+[STANDARDS-TRACK]
+
+
+1937    Rekhter      May 96   "Local/Remote" Forwarding Decision in
+                              Switched Data Link Subnetworks
+
+This document describes extensions to the IP architecture that relaxes
+these constraints, thus enabling the full utilization of the services
+provided by SVC-based Data Link subnetworks.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+1936    Touch       Apr 96    Implementing the Internet Checksum in
+                              Hardware
+
+This memo presents a techniques for efficiently implementing the
+Internet Checksum in hardware. It includes PLD code for programming a
+single, low cost part to perform checksumming at 1.26 Gbps.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1935    Quarterman   Apr 96   What is the Internet, Anyway?
+
+This memo provides information for the Internet community.  This memo
+does not specify an Internet standard of any kind.
+
+
+1934    Smith        Apr 96   Ascend's Multilink Protocol Plus (MP+)
+
+This document proposes an extension to the PPP Multilink Protocol (MP)
+[1]. Multilink Protocol Plus (MP+) is a new control protocol for
+managing multiple data links that are bundled by MP.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+
+
+
+Elliott                      Informational                     [Page 13]
+
+RFC 1999                  Summary of 1900-1999              January 1997
+
+
+1933    Gilligan     Apr 96   Transition Mechanisms for IPv6 Hosts
+                              and Routers
+
+This document specifies IPv4 compatibility mechanisms that can be
+implemented by IPv6 hosts and routers.  [STANDARDS-TRACK]
+
+
+1932    Cole         Apr 96   IP over ATM: A Framework Document
+
+It is hoped that this document, in classifying ATM approaches and issues
+will help to focus the IP over ATM working group's direction.This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1931    Brownell     Apr 96   Dynamic RARP Extensions for
+                              Automatic Network Address Acquisition
+
+This memo describes extensions to the Reverse Address Resolution
+Protocol (RARP [2]) and called Dynamic RARP (DRARP, pronounced D-RARP).
+This memo provides information for the Internet community.  This memo
+does not define an Internet standard of any kind.
+
+
+1930    Hawkinson    Mar 96   Guidelines for creation, selection, and
+                              registration of an Autonomous System (AS)
+
+This memo discusses when it is appropriate to register and utilize an
+Autonomous System (AS), and lists criteria for such.  This document
+specifies an Internet Best Current Practices for the Internet Community,
+and requests discussion and suggestions for improvements.
+
+
+1929    Leech        Mar 96   Username/Password Authentication for
+                              SOCKS V5
+
+The protocol specification for SOCKS Version 5 specifies a generalized
+framework for the use of arbitrary authentication protocols in the
+initial socks connection setup. This document describes one of those
+protocols, as it fits into the SOCKS Version 5 authentication
+"subnegotiation".  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 14]
+
+RFC 1999                  Summary of 1900-1999              January 1997
+
+
+1928    Leech        Mar 96   SOCKS Protocol Version 5
+
+This memo describes a protocol that is an evolution of the previous
+version of the protocol, version 4 [1]. This new protocol stems from
+active discussions and prototype implementations.  [STANDARDS-TRACK]
+
+
+1927    Rogers       Apr 96   Suggested Additional MIME Types for
+                              Associating Documents
+
+Seven new types of MIME types are suggested in this document.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+1926    Eriksson     Apr 96   An Experimental Encapsulation of IP
+                              Datagrams on Top of ATM
+
+This RFC describes a method of encapsulating IP datagrams on top of
+Acoustical Transmission Media (ATM).  This is a non-recommended
+standard.  This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+1925    Callon       Apr 96   The Twelve Networking Truths
+
+This memo documents the fundamental truths of networking for the
+Internet community. This memo does not specify a standard, except in the
+sense that all standards must implicitly follow the fundamental truths.
+This memo provides information for the Internet community.  This memo
+does not specify an Internet standard of any kind.
+
+
+1924    Elz          Apr 96   A Compact Representation of IPv6 Addresses
+
+This document specifies a more compact representation of IPv6 addresses,
+which permits encoding in a mere 20 bytes.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 15]
+
+RFC 1999                  Summary of 1900-1999              January 1997
+
+
+1923    Halpern      Mar 96   RIPv1 Applicability Statement for
+                              Historic Status
+
+RIP Version 1 [RFC-1058] has been declared an historic document.  This
+Applicability statement provides the supporting motivation for that
+declaration.  The primary reason, as described below, is the Classful
+nature of RIPv1.  This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+1922    Zhu          Mar 96   Chinese Character Encoding for Internet
+                              Messages
+
+This memo describes methods of transporting Chinese characters in
+Internet services which transport text, such as electronic mail
+[RFC-822], network news [RFC-1036], telnet [RFC-854] and the World Wide
+Web [RFC-1866].  This memo provides information for the Internet
+community.  It does not specify an Internet standard.
+
+
+1921    Dujonc       Mar 96   TNVIP Protocol
+
+The goal of this document specifies a Telnet profile to support VIP
+terminal emulation allowing the access to the BULL hosts applications
+through a TCP/IP network.  This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+1920    I.A.B.       Mar 96   INTERNET OFFICIAL PROTOCOL STANDARDS
+
+This memo describes the state of standardization of protocols used in
+the Internet as determined by the Internet Architecture Board (IAB).
+[STANDARDS-TRACK]
+
+
+1919    Chatel       Mar 96   Classical versus Transparent IP Proxies
+
+This document explains "classical" and "transparent" proxy techniques
+and attempts to provide rules to help determine when each proxy system
+may be used without causing problems.  This memo provides information
+for the Internet community.  This memo does not specify an Internet
+standard of any kind.
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 16]
+
+RFC 1999                  Summary of 1900-1999              January 1997
+
+
+1918    Rekhter      Feb 96   Address Allocation for Private Internets
+
+This document describes address allocation for private internets.  This
+document specifies an Internet Best Current Practices for the Internet
+Community, and requests discussion and suggestions for improvements.
+
+
+1917    Nesser       Feb 96   An Appeal to the Internet Community to
+                              Return Unused IP Networks (Prefixes)
+                              to the IANA
+
+This document is an appeal to the Internet community to return unused
+address space, i.e. any block of consecutive IP prefixes, to the
+Internet Assigned Numbers Authority (IANA) or any of the delegated
+registries, for reapportionment.  This document specifies an Internet
+Best Current Practices for the Internet Community, and requests
+discussion and suggestions for improvements.
+
+
+1916    Berkowitz    Feb 96   Enterprise Renumbering: Experience and
+                              Information Solicitation
+
+Because of the urgent need for, and substantial difficulty in,
+renumbering IP networks, the PIER working group is compiling a series of
+documents to assist sites in their renumbering efforts.  The intent of
+these documents is to provide both educational and practical information
+to the Internet community.  This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+1915    Kastenholz   Feb 96   Variance for The PPP Connection Control
+                              Protocol and The PPP Encryption Control
+                              Protocol
+
+The PPP Working group has developed two protocols, one to control
+compression on PPP links; the Compression Control Protocol (CCP),
+documented in draft-ietf-pppext-compression-04.txt. The second is the
+Encryption Control Protocol (ECP), used to control encryption on serial
+links, documented in draft-ietf-pppext-encryption-03.txt.  This document
+specifies an Internet Best Current Practices for the Internet Community,
+and requests discussion and suggestions for improvements.
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 17]
+
+RFC 1999                  Summary of 1900-1999              January 1997
+
+
+1914    Faltstrom    Feb 96   How to Interact with a Whois++ Mesh
+
+In the Whois++ architecture [Deutsch94],[Weider94], mesh traversal is
+done by the client, since each server 'refers' the client to the next
+appropriate server(s).  [STANDARDS-TRACK]
+
+
+1913    Weider       Feb 96   Architecture of the Whois++ Index Service
+
+The authors describe an architecture for indexing in distributed
+databases, and apply this to the WHOIS++ protocol.  [STANDARDS-TRACK]
+
+
+1912    Barr         Feb 96   Common DNS Operational and Configuration
+                              Errors
+
+This memo describes errors often found in both the operation of Domain
+Name System (DNS) servers, and in the data that these DNS servers
+contain.  This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+1911    Vaudreuil    Feb 96   Voice Profiule of Internet Mail
+
+The following document is a profile of the Internet standard MIME and
+ESMTP protocols for use as a digital voice networking protocol.  This
+memo defines an Experimental Protocol for the Internet community.
+
+
+1910    Waters       Feb 96   User-based Security Model for SNMPv2
+
+In this administrative framework, a security model defines the
+mechanisms used to achieve an administratively-defined level of security
+for protocol interactions.  Although many such security models might be
+defined, it is the purpose of this document, User-based Security Model
+for SNMPv2, to define the first, and, as of this writing, only, security
+model for this administrative framework.  This memo defines an
+Experimental Protocol for the Internet community.
+
+
+1909    McClogherie  Feb 96   An Administrative Infrastructure for
+                              SNMPv2
+
+It is the purpose of this document, An Administrative Infrastructure for
+SNMPv2, to define an administrative framework which realizes effective
+management in a variety of configurations and environments.  This memo
+defines an Experimental Protocol for the Internet community.
+
+
+
+
+Elliott                      Informational                     [Page 18]
+
+RFC 1999                  Summary of 1900-1999              January 1997
+
+
+1908    Case         Jan 96   Coexistence between Version 1 and
+                              Version 2 of the Internet-standard
+                              Network Management Framework
+
+The purpose of this document is to describe coexistence between version
+2 of the Internet-standard Network Management Framework [1-6], termed
+the SNMP version 2 framework (SNMPv2), and the original Internet-
+standard Network Management Framework (SNMPv1>.  [STANDARDS-TRACK]
+
+
+1907    Case         Jan 96   Management Information Base for Version
+                              2 of the Simple Network Management
+                              Protocol (SNMPv2)
+
+It is the purpose of this document to define managed objects which
+describe the behavior of a SNMPv2 entity.  [STANDARDS-TRACK]
+
+
+1906    Case         Jan 96   Transport Mappings for Version 2 of the
+                              Simple Network Management Protocol (SNMPv2)
+
+It is the purpose of this document to define how the SNMPv2 maps onto an
+initial set of transport domains.  [STANDARDS-TRACK]
+
+
+1905    Case         Jan 96   Protocol Operations for Version 2 of the
+                              Simple Network Management Protocol (SNMPv2)
+
+It is the purpose of this document, Protocol Operations for SNMPv2, to
+define the operations of the protocol with respect to the sending and
+receiving of the PDUs.  [STANDARDS-TRACK]
+
+
+1904    Case         Jan 96   Conformance Statements for Version 2 of
+                              the Simple Network Management Protocol
+                              (SNMPv2)
+
+It may be useful to define the acceptable lower-bounds of
+implementation, along with the actual level of implementation achieved.
+It is the purpose of this document to define the notation used for these
+purposes.  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 19]
+
+RFC 1999                  Summary of 1900-1999              January 1997
+
+
+1903    Case         Jan 96   Textual Conventions for Version 2 of the
+                              Simple Network Management Protocol (SNMPv2)
+
+It is the purpose of this document to define the initial set of textual
+conventions available to all MIB modules.  [STANDARDS-TRACK]
+
+
+1902    Case         Jan 96   Structure of Management Information for
+                              Version 2 of the Simple Network
+                              Management Protocol (SNMPv2)
+
+It is the purpose of this document, the Structure of Management
+Information (SMI), to define that adapted subset, and to assign a set of
+associated administrative values.  [STANDARDS-TRACK]
+
+
+1901    Case         Jan 96   Introduction to Community-based SNMPv2
+
+The purpose of this document is to define the Community-based
+Administrative Framework for the SNMP version 2 framework (SNMPv2).
+This document specifies an Experimental protocol for the Internet
+community.
+
+
+1900    Carpenter    Feb 96   Renumbering Needs Work
+
+Hosts in an IP network are identified by IP addresses, and the IP
+address prefixes of subnets are advertised by routing protocols.  A
+change in such IP addressing information associated with a host or
+subnet is known as "renumbering".  This memo provides information for
+the Internet community.  This memo does not specify an Internet standard
+of any kind.
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Author's Address
+
+   Josh Elliott
+   University of Southern California
+   Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone:  (310) 822-1511
+
+   EMail: elliott@isi.edu
+
+
+
+Elliott                      Informational                     [Page 20]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc1999.txt](<www.ietf.org/rfc/rfc1999.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
