### PR TITLE
Archive rfc200.txt

### DIFF
--- a/www.ietf.org/rfc/rfc200.txt
+++ b/www.ietf.org/rfc/rfc200.txt
@@ -1,0 +1,395 @@
+
+
+
+
+
+
+Request for Comments: 200                                 August 1, 1971
+NIC: 7152                                               (Author unknown)
+
+                           RFC List by Number
+
+1st Author  Title                          Date              NIC   RFC
+
+Crocker     HOST Software                  7 April 1969      4687   1
+Duvall      HOST Software                  9 April 1969      4688   2
+Crocker     Documentation Conventions      9 April 1969      4689   3
+Shapiro     Network Timetable              24 March 1969     4690   4
+Rulifson    DEL                            2 June 1969       4691   5
+Crocker     Conversation with Bob Kahn     10 April 1969     4692   6
+Deloche     HOST-IMP Interface             May 1969          4693   7
+Deloche     ARPA Network Functional        5 May 1969        4694   8
+            Specifications
+Deloche     HOST Software                  1 May 1969        4695   9
+Crocker     Documentation Conventions      29 July 1969      4696   10
+Deloche     Implementation of the          1 August 1969     4718   11
+            HOST-HOST Software Procedures
+            in GORDO
+Wingfield   IMP-HOST Interface Flow        26 August 1969    4697   12
+            Diagrams
+Cerf        Referring to NWG/RFC: 11       20 August 1969    4698   13
+            (no RFC by this number ever issued)                     14
+Carr        Network Subsystem for          25 September 1969 4754   15
+            Time-Sharing HOSTS
+Crocker     M.I.T. (address)               27 August 1969    4719   16
+Kreznar     Some Questions Re: HOST-IMP    27 August 1969    4699   17
+            Protocol
+Cerf        (use of links 1 and 2)         September 1969    4720   18
+Kreznar     Two Protocol Suggestions to    7 October 1969    4721   19
+            Reduce Congestion at
+            Swap-Bound Nodes
+Cerf        ASCII Format for Network       16 October 1969   4722   20
+            Interchange
+Cerf        (report of Network meeting)    17 October 1969   4723   21
+Cerf        HOST-HOST Control Message      17 October 1969   4724   22
+            Formats
+Gregg       Transmission of Multiple       16 October 1969   4725   23
+            Control Messages
+Crocker     Documentation Conventions      21 November 1969  4726   24
+Crocker     No High Link Numbers           30 October 1969   4727   25
+                   (no RFC by this number ever issued)              26
+Crocker     Documentation Conventions      9 December 1969   4729   27
+English     Time Standards                 13 January 1970   4730   28
+Kahn        Note in Response to Bill       19 January 1970   4731   29
+            English's Request for Comments
+
+
+
+                                                                [Page 1]
+
+RFC 200                    RFC List by Number                August 1971
+
+
+Crocker     Documentation Conventions      4 February 1970   4732   30
+Bobrow      Binary Message Formats in      February 1968     4733   31
+            Computer Network
+Vedder      Connecting M.I.T. Computers    31 January 1969   4734   32
+            to the ARPA Computer-to-Computer
+Crocker     New HOST-HOST Protocol         12 February 1970  4735   33
+English     Some Brief Preliminary Notes   26 February 1970  4736   34
+            on ARC Clock
+Crocker     Network Meeting                3 March 1970      4737   35
+Crocker     Protocol Notes                 16 March 1970     4738   36
+Crocker     Network Meeting Epilogue, etc. 20 March 1970     4739   37
+Wolfe       Comments on Network Protocol   20 March 1970     4740   38
+            from NWG/RFC 36
+Harslem     Comments on Protocol Re:       25 March 1970     4741   39
+Harslem     More Comments on the           27 March 1970     4742   40
+            Forthcoming Protocol
+Melvin      IMP-IMP Teletype Communication 30 March 1970     4743   41
+Ancona      Message Data Types             31 March 1970     4744   42
+Nemeth      Proposed Meeting               6 April 1970      4745   43
+Shoshani    Comments on NWG/RFC 33 and 36  10 April 1970     4746   44
+Postel      New Protocol is Coming         14 April 1970     4747   45
+Meyer       ARPA Network Protocol Notes    17 April 1970     4748   46
+Postel      BBN's Comments on NWG/RFC 33   20 April 1970     4749   47
+Postel      A Possible Protocol Plateau    21 April 1970     4750   48
+Meyer       Conversations with Steve       25 April 1970     4728   49
+            Crocker (UCLA)
+Harslem     Comments on the Meyer Proposal 30 April 1970     4751   50
+Elie        Proposal for the Network       4 May 1970        4752   51
+            Interchange Language
+Postel      Updated Distribution List      1 July 1970       4753   52
+Crocker     An Official Protocol Mechanism 9 June 1970       4755   53
+Crocker     An Official Protocol Proffering18 June 1970      4756   54
+Newkirk     A Prototypical Implementation  19 June 1970      4757   55
+            of the NCP
+Belove      Third Level Protocol           June 1970         4758   56
+Kraley      Thoughts and Reflections on    19 June 1970      4759   57
+            NWG/RFC 54
+Skinner     Logical Message Synchronization 26 June 1970     4760   58
+Meyer       Flow Control - Fixed Versus    27 June 1970      4761   59
+            Demand Allocation
+Kalin       Simplified NCP Protocol        13 July 1970      4762   60
+Walden      A Note on Interprocess         17 July 1970      4961   61
+            Communication in a Resource Sharing
+Walden      A System For Interprocess      3 August 1970     4962   62
+            Communication in a Resource Sharing
+Cerf        Belated Network Meeting Report 31 July 1970      4963   63
+Elie        Getting Rid of Marking         (undated)         4964   64
+
+
+
+
+                                                                [Page 2]
+
+RFC 200                    RFC List by Number                August 1971
+
+
+Walden      Comments on Host-Host Protocol  29 August 1970   4965   65
+            Document No. 1 (by S. Crocker
+Crocker     3rd Level Ideas and Other Noise 26 August 1970    5409  66
+Crowther    Proposed Change to Host/IMP     (undated)         5410  67
+            Spec to Eliminate Marking
+Elie        Comments on Memory Allocation   31 August 1970    5411  68
+            Control Commands (CEASE, ALL, GVB
+Bhushan     Distribution List Change for MIT22 September 1970 5412  69
+Crocker     A Note on Padding               15 October 1970   5413  70
+Schipper    Reallocation in Case of Input   25 September 1970 5414  71
+            Error
+Bressler    Proposed Moratorium on Changes  28 September 1970 5415  72
+            to Network Protocol
+Crocker     Response to NWG/RFC 67          25 September 1970 5416  73
+White       Specification for Network use   16 October 1970   5417  74
+            of the UCSB On-Line System
+Crocker     Network Meeting                 14 October 1970   5418  75
+Bouknight   Connection-By Name: User        28 October 1970   5180  76
+            Oriented Protocol
+Grossman    Syntax and Semantics for the    (undated)         5419  76
+            Terminal User Control Language for                      enc
+Postel      Network Meeting Report          (undated)         5604  77
+Harslem     NCP Status Report: UCSB/RAND    November 1970     5199  78
+Meyer       Logger Protocol Error           16 November 1970  5601  79
+Harslem     Protocols and Data Formats      1 December 1970   5608  80
+Bouknight   Request for Reference           3 December 1970   5609  81
+            Information
+Meyer       Network Meeting Notes           9 December 1970   5619  82
+Anderson    Language-Machine for Data       18 December 1970  5621  83
+            Reconfiguration
+North       List of NWG/RFC's 1-80          23 December 1970  5620  84
+Crocker     Network Working Group Meeting   5 January 1971    5624  85
+Crocker     Proposal for a Network Standard 5 January 1971    5631  86
+            Format for a Data Stream to
+Vezza       Topic for Discussion at the     12 January 1970   5632  87
+            Next Network Group Meeting
+Braden      NETRJS--A Third Level Protocol  13 January 1971   5668  88
+            for Remote Job Entry
+Metcalfe    Some Historic Moments in        19 January 1971   5697  89
+            Networking
+Braden      CN as a Network Service Center  25 January 1971   5707  90
+Mealy       A Proposed User-User Protocol   27 December 1970  5708  91
+            (no RFC by this number ever issued)                     92
+McKenzie    Initial Connection Protocol     27 January 1971   5721  93
+Harslem     Some Thoughts on Network        3 February 1971   5725  94
+            Graphics
+Crocker     Distribution of NWG/RFC's       4 February 1971   5731  95
+            Through the NIC
+
+
+
+                                                                [Page 3]
+
+RFC 200                    RFC List by Number                August 1971
+
+
+Watson      AN Interactive Network          12 February 1971  5739  99
+            Experiment to Study Modes of
+            Access to the
+Melvin      A First Cut at a Proposed       15 February 1971  5740  97
+            Telnet Protocol
+Meyer       Logger Protocol Proposal        11 February 1971  5744  98
+Karp        Network Meeting                 22 February 1971  5758  99
+Karp        Categorization and Guide to     26 February 1971  5761  100
+            NWG/RFCs
+Watson      Notes on the Network Working    23 February 1971  5762  101
+            Group Meeting (Urbana, Illinois
+Crocker     Output of the Host/Host Protocol 22-23 February   5763  102
+            Glitch Cleaning Committee             1971
+Kalin       Implementation of Interrupt Keys 24 February 1971 5764  103
+Postel      Link 191                        25 February 1971  5768  104
+White       Network Specifications for      22 March 1971     5775  105
+            remote Job Entry and Remote Job
+O'Sullivan  User/Server Site Protocol       3 March 1971      5776  106
+Bressler    Output of the Host-Host Protocol 23 March 1971    5806  107
+            Glitch Cleaning Committee
+Watson      Attendance List at the Urbana   25 March 1971     5807  108
+            NWG Meeting, February 17-19,
+            1971
+Winett      Level III Server Protocol for   24 March 1971     5808  109
+            the Lincoln Laboratory 360/67
+            Host
+Winett      Convention for Using an IBM 2741 25 March 1971    5809  110
+            terminal as a User Console for
+Crocker     Pressure from the Chairman       31 March 1971    5814  111
+O'Sullivan  User/Server Site Protocol        1 April 1971     5816  112
+            Network Host Questionnaire
+Harslem     Network Activity Report,         5 April 1971     5820  113
+            UCSB--RAND
+Bhushan     A File Transfer Protocol         16 April 1971    5823  114
+Watson      Some Network Information Center  16 April 1971    5822  115
+            Policies for Handling
+            Documentation
+Crocker     Structure of the May NWG Mtg.    12 April 1971    5825  116
+Wong        Some Comments on the Official    7 April 1971     5826  117
+            Protocol
+Watson      Recommendations for Facility     16 April 1971    5830  118
+            Documentation
+Krilanovich Network Fortran Subprograms      16 April 1971    5831  119
+Krilanovich Network PL1 Subprograms          16 April 1971    5832  120
+Krilanovich Network On-Line Operators        16 April 1971    5833  121
+White       Network Specifications for       26 April 1971    5834  122
+            UCSB's Simple-Minded File System
+Crocker     A Proffered Official ICP         20 April 1971    5837  123
+
+
+
+                                                                [Page 4]
+
+RFC 200                    RFC List by Number                August 1971
+
+
+Melvin      Typographical Error in RFC 107   19 April 1971    5840  124
+McConnell   Response to RFC 86, Proposal for 18 April 1971    5841  125
+            Network Standard Format for a
+McConnell   Ames Graphics Facilities at Ames 18 April 1971    5842  126
+            Research Center
+Postel      Comments on RFC 123              20 April 1971    5843  127
+Postel      Bytes                            21 April 1971    5844  128
+Harslem     A Request for Comments on Socket 22 April 1971    5845  129
+            Name Structure
+Heafner     Response to RFC 111              22 April 1971    5848  130
+            (Pressure from the Chairman)
+Harslem     Response to RFC 116              22 April 1971    5849  131
+            (May NWG Meeting)
+White       Typographical Error in RFC 107   28 April 1971    6708  132
+Sundberg    File Transfer and Recovery       27 April 1971    6710  133
+Vezza       Network Graphics Meeting         29 April 1971    6711  134
+Hathaway    Response to NWG/RFC 110          29 April 1971    6712  135
+Kahn        Host Accounting and              29 April 1971    6713  136
+            Administrative Procedures
+O'Sullivan  TELNET Protocol --               30 April 1971    6714  137
+            A Proposed Document
+O'Sullivan  TELNET Protocol --               8 May 1971       6783  137
+            A Proposed Document (rev.)                              rev
+Anderson    Status Report on Proposed Data   28 April 1971    6715  138
+            Reconfiguration Service
+O'Sullivan  Discussion on TELNET Protocol    7 May 1971       6717  139
+Crocker     Agenda for the May NWG Meeting   4 May 1971       6725  140
+Harslem     Comments on RFC 114 (A File      29 April 1971    6726  141
+            Transfer Protocol)
+Kline       Time-out Mechanism in Host-Host  3 May 1971       6727  142
+            Protocol
+Naylor      Regarding Proffered Official ICP 3 May 1971       6728  143
+Shoshani    Data Sharing on Computer Networks30 April 1971    6729  144
+Postel      Initial Connection Protocol      4 May 1971       6739  145
+            Control Commands
+Karp        Views on Issues Relevant to Data 12 May 1971      6742  146
+            Sharing on Computer Networks
+Winett      The Definition of a Socket       7 May 1971       6750  147
+Bhushan     Comments on RFC 123              7 May 1971       6751  148
+Crocker     The Best Laid Plans . . .        10 May 1971      6752  149
+Kalin       The Use of IPC Facilities --     5 May 1971       6754  150
+            A Working Paper
+Shoshani    Comments on a Proffered Official 10 May 1971      6755  151
+            ICP (RFCs 123, 127)
+Wilber      SRI Artificial Intelligence      10 May 1971      6756  152
+            Status Report
+Melvin      SRI ARC-NIC Status               15 May 1971      6758  153
+Crocker     Exposition Style                 12 May 1971      6759  154
+
+
+
+                                                                [Page 5]
+
+RFC 200                    RFC List by Number                August 1971
+
+
+North       ARPA Network Mailing Lists       May 1971         5760  155
+Bouknight   Status of the Illinois Site      26 April 1971    6761  156
+            (Response to RFC 116)
+Cerf        Invitation to the Second         12 May 1971      6762  157
+            Symposium on Problems in the Optimization
+O'Sullivan  TELNET Protocol --               19 May 1971      6768  158
+            A Proposed Document
+            (no RFC by this number ever issued)                     159
+NIC         RFC Brief List --                18 May 1971      6771  160
+            Title or Partial Title
+Shoshani    A Solution to the Race           19 May 1971      6772  161
+            Condition in ICP
+Kampe       NETBUGGER3                       22 May 1971      6774  162
+Cerf        Data Transfer Protocols          19 May 1971      6775  163
+Heafner     Minutes of the Network Group     25 May 1971      6778  164
+            Meeting, 5/16 through 5/19/71
+Postel      A Preferred Official Initial     25 May 1971      6779  165
+            Connection Protocol
+Anderson    Data Reconfiguration Service --  25 May 1971      6780  166
+            An Implementation Specification
+Bhushan     Socket Conventions Reconsidered  24 May 1971      6784  167
+NIC         ARPA Network Mailing Lists       26 May 1971      6785  168
+Crocker     Computer Networks --             27 May 1971      6789  169
+            IEEE Computer Society Workshop
+NIC         RFC List by Number               1 June 1971      6790  170
+Bhushan,others  The Data Transfer Protocol   23 June 1971     6793  171
+Bhushan,others  The File Transfer Protocol   23 June 1971     6794  172
+Karp        Network Data Management Comittee 4 June 1971      6795  173
+            Meeting Announcement
+Postel      UCLA-Computer Science Graphics   8 June 1971      6799  174
+            Overview
+Harslem     Comments on the "Socket          11 June 1971     7074  175
+            Conventions Reconsidered"
+Bhushan     Comments on Byte Size for        14 June 1971     7100  176
+            Connections
+McConnell   A Device Independent Graphical   15 June 1971     7102  177
+            Display Description
+Cotton      Network Graphic Attention        27 June 1971     7118  178
+            Handling
+McKenzie    Link Number Assignments          25 June 1971     7119  179
+McKenzie    File System Questionnaire        25 June 1971     7123  180
+McConnell   Modifications to RFC 177         27 June 1971     7124  181
+North       Compilation of List of Relevant  25 June 1971     7126  182
+            Site Reports
+Winett      The EBCDIC Codes and Their       16 July 1971     7127  183
+            Mapping to ASCII
+Kelley      Proposed Graphic Display Modes   6 July 1971      7128  184
+North       NIC Distribution of Manuals and  9 July 1971      7129  185
+
+
+
+                                                                [Page 6]
+
+RFC 200                    RFC List by Number                August 1971
+
+
+            Handbooks
+Bisot       A Network Graphics Loader        12 July 1971     7130  186
+McKay       A Network/440 Protocol Concept   July 1971        7131  187
+Karp        Data Management Meeting          25 July 1971     7132  188
+            Announcement
+Braden      Interim NETRJS Specifications    15 July 1971     7133  189
+Deutsch     DEC PDP-10 -- IMLAC Communication 13 July 1971    7135  190
+            System
+Irby        Graphics Implementation and      13 July 1971     7136  191
+            Conceptualization at ARC
+Watson      Some Factors Which A Network     12 July 1971     7136  192
+            Graphic Protocol Must Consider
+Harslem     Network Checkout                 14 July 1971     7136  193
+Cerf        Data Reconfiguration Service --  12 July 1971     7139  194
+            Compiler/Interpreter
+            Implementation
+Mealy       Data Computers -- Data           16 July 1971     7140  195
+            Descriptions and Access Language
+Watson      A Mail BOX Protocol              20 July 1971     7141  196
+Shoshani    Initial Connection Protocol --   14 July 1971     7142  197
+            Reviewed
+Heafner     Site Certification --            21 July 1971     7149  198
+            Lincoln Labs 360/37
+Williams    Suggestions for Network Data     July 1971        7151  199
+            Tablet
+NIC         RFC List by Number               1 August 1971    7152  200
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Misrad Todorovac 3/98 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 7]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc200.txt](<www.ietf.org/rfc/rfc200.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
