### PR TITLE
Archive rfc2013.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2013.txt
+++ b/www.ietf.org/rfc/rfc2013.txt
@@ -1,0 +1,339 @@
+
+
+
+
+
+
+Network Working Group                              K. McCloghrie, Editor
+Request for Comments: 2013                                 Cisco Systems
+Updates: 1213                                              November 1996
+Category: Standards Track
+
+
+                   SNMPv2 Management Information Base
+               for the User Datagram Protocol using SMIv2
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+IESG Note:
+
+   The IP, UDP, and TCP MIB modules currently support only IPv4.  These
+   three modules use the IpAddress type defined as an OCTET STRING of
+   length 4 to represent the IPv4 32-bit internet addresses.  (See RFC
+   1902, SMI for SNMPv2.)  They do not support the new 128-bit IPv6
+   internet addresses.
+
+Table of Contents
+
+   1. Introduction .................................................   1
+   2. Definitions ..................................................   2
+   2.1 The UDP Group ...............................................   3
+   2.2 Conformance Information .....................................   5
+   2.2.1 Compliance Statements .....................................   5
+   2.2.2 Units of Conformance ......................................   5
+   3. Acknowledgements .............................................   6
+   4. References ...................................................   6
+   5. Security Considerations ......................................   6
+   6. Editor's Address .............................................   6
+
+1.  Introduction
+
+   A management system contains: several (potentially many) nodes, each
+   with a processing entity, termed an agent, which has access to
+   management instrumentation; at least one management station; and, a
+   management protocol, used to convey management information between
+   the agents and management stations.  Operations of the protocol are
+   carried out under an administrative framework which defines
+   authentication, authorization, access control, and privacy policies.
+
+
+
+
+McCloghrie                  Standards Track                     [Page 1]
+
+RFC 2013                   SNMPv2 MIB for UDP              November 1996
+
+
+   Management stations execute management applications which monitor and
+   control managed elements.  Managed elements are devices such as
+   hosts, routers, terminal servers, etc., which are monitored and
+   controlled via access to their management information.
+
+   Management information is viewed as a collection of managed objects,
+   residing in a virtual information store, termed the Management
+   Information Base (MIB).  Collections of related objects are defined
+   in MIB modules.  These modules are written using a subset of OSI's
+   Abstract Syntax Notation One (ASN.1) [1], termed the Structure of
+   Management Information (SMI) [2].
+
+   This document is the MIB module which defines managed objects for
+   managing implementations of the User Datagram Protocol (UDP) [3].
+
+   The managed objects in this MIB module were originally defined using
+   the SNMPv1 framework as a part of MIB-II [4].  This document defines
+   the same objects for UDP using the SNMPv2 framework.
+
+2.  Definitions
+
+UDP-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Counter32,
+    IpAddress, mib-2                   FROM SNMPv2-SMI
+    MODULE-COMPLIANCE, OBJECT-GROUP    FROM SNMPv2-CONF;
+
+
+udpMIB MODULE-IDENTITY
+    LAST-UPDATED "9411010000Z"
+    ORGANIZATION "IETF SNMPv2 Working Group"
+    CONTACT-INFO
+            "        Keith McCloghrie
+
+             Postal: Cisco Systems, Inc.
+                     170 West Tasman Drive
+                     San Jose, CA  95134-1706
+                     US
+
+             Phone:  +1 408 526 5260
+             Email:  kzm@cisco.com"
+
+
+
+
+
+
+
+
+
+McCloghrie                  Standards Track                     [Page 2]
+
+RFC 2013                   SNMPv2 MIB for UDP              November 1996
+
+
+    DESCRIPTION
+            "The MIB module for managing UDP implementations."
+    REVISION      "9103310000Z"
+    DESCRIPTION
+            "The initial revision of this MIB module was part of MIB-
+            II."
+    ::= { mib-2 50 }
+
+-- the UDP group
+
+udp      OBJECT IDENTIFIER ::= { mib-2 7 }
+
+udpInDatagrams OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The total number of UDP datagrams delivered to UDP users."
+    ::= { udp 1 }
+
+udpNoPorts OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The total number of received UDP datagrams for which there
+            was no application at the destination port."
+    ::= { udp 2 }
+
+udpInErrors OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The number of received UDP datagrams that could not be
+            delivered for reasons other than the lack of an application
+            at the destination port."
+    ::= { udp 3 }
+
+udpOutDatagrams OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The total number of UDP datagrams sent from this entity."
+    ::= { udp 4 }
+
+
+
+
+
+McCloghrie                  Standards Track                     [Page 3]
+
+RFC 2013                   SNMPv2 MIB for UDP              November 1996
+
+
+-- the UDP Listener table
+
+-- The UDP listener table contains information about this
+-- entity's UDP end-points on which a local application is
+-- currently accepting datagrams.
+
+udpTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF UdpEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "A table containing UDP listener information."
+    ::= { udp 5 }
+
+udpEntry OBJECT-TYPE
+    SYNTAX      UdpEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Information about a particular current UDP listener."
+    INDEX   { udpLocalAddress, udpLocalPort }
+    ::= { udpTable 1 }
+
+UdpEntry ::= SEQUENCE {
+        udpLocalAddress  IpAddress,
+        udpLocalPort     INTEGER
+    }
+
+udpLocalAddress OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The local IP address for this UDP listener.  In the case of
+            a UDP listener which is willing to accept datagrams for any
+            IP interface associated with the node, the value 0.0.0.0 is
+            used."
+    ::= { udpEntry 1 }
+
+udpLocalPort OBJECT-TYPE
+    SYNTAX      INTEGER (0..65535)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The local port number for this UDP listener."
+    ::= { udpEntry 2 }
+
+
+
+
+
+McCloghrie                  Standards Track                     [Page 4]
+
+RFC 2013                   SNMPv2 MIB for UDP              November 1996
+
+
+-- conformance information
+
+udpMIBConformance OBJECT IDENTIFIER ::= { udpMIB 2 }
+
+udpMIBCompliances OBJECT IDENTIFIER ::= { udpMIBConformance 1 }
+udpMIBGroups      OBJECT IDENTIFIER ::= { udpMIBConformance 2 }
+
+-- compliance statements
+
+udpMIBCompliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+            "The compliance statement for SNMPv2 entities which
+            implement UDP."
+    MODULE  -- this module
+        MANDATORY-GROUPS { udpGroup
+                           }
+    ::= { udpMIBCompliances 1 }
+
+-- units of conformance
+
+udpGroup OBJECT-GROUP
+    OBJECTS   { udpInDatagrams, udpNoPorts,
+                udpInErrors, udpOutDatagrams,
+                udpLocalAddress, udpLocalPort }
+    STATUS    current
+    DESCRIPTION
+            "The udp group of objects providing for management of UDP
+            entities."
+    ::= { udpMIBGroups 1 }
+
+END
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McCloghrie                  Standards Track                     [Page 5]
+
+RFC 2013                   SNMPv2 MIB for UDP              November 1996
+
+
+3.  Acknowledgements
+
+   This document contains a modified subset of RFC 1213.
+
+4.  References
+
+   [1]  Information processing systems - Open Systems Interconnection
+        Specification of Abstract Syntax Notation One (ASN.1),
+        International Organization for Standardization.  International
+        Standard 8824, (December, 1987).
+
+   [2]  McCloghrie, K., Editor, "Structure of Management Information
+        for version 2 of the Simple Network Management Protocol
+        (SNMPv2)", RFC 1902, Cisco Systems, January 1996.
+
+   [3]  Postel, J., "User Datagram Protocol", STD 6, RFC 768, USC-ISI,
+        August 1980.
+
+   [4]  McCloghrie, K., and Rose, M., "Management Information Base for
+        Network Management of TCP/IP-based internets: MIB-II", STD 17,
+        RFC 1213, March 1991.
+
+5.  Security Considerations
+
+   Security issues are not discussed in this memo.
+
+6.  Editor's Address
+
+   Keith McCloghrie
+   Cisco Systems, Inc.
+   170 West Tasman Drive
+   San Jose, CA  95134-1706
+   US
+
+   Phone: +1 408 526 5260
+   EMail: kzm@cisco.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McCloghrie                  Standards Track                     [Page 6]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2013.txt](<www.ietf.org/rfc/rfc2013.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
