### PR TITLE
Archive rfc2014.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2014.txt
+++ b/www.ietf.org/rfc/rfc2014.txt
@@ -1,0 +1,731 @@
+
+
+
+
+
+
+Network Working Group                                        A. Weinrib
+Request for Comments: 2014                            Intel Corporation
+BCP: 8                                                        J. Postel
+Category: Best Current Practice                                     ISI
+                                                           October 1996
+
+
+             IRTF Research Group Guidelines and Procedures
+
+Status of this Memo
+
+   This document specifies an Internet Best Current Practices for the
+   Internet Community, and requests discussion and suggestions for
+   improvements.  Distribution of this memo is unlimited.
+
+Abstract
+
+   The Internet Research Task Force (IRTF) has responsibility for
+   organizing groups to investigate research topics related to the
+   Internet protocols, applications, and technology. IRTF activities are
+   organized into Research Groups.  This document describes the
+   guidelines and procedures for formation and operation of IRTF
+   Research Groups.  It describes the relationship between IRTF
+   participants, Research Groups, the Internet Research Steering Group
+   (IRSG) and the Internet Architecture Board (IAB).  The basic duties
+   of IRTF participants, including the IRTF Chair, Research Group Chairs
+   and IRSG members are defined.
+
+1.   INTRODUCTION
+
+   This document defines guidelines and procedures for Internet Research
+   Task Force (IRTF) Research Groups.  The IRTF focuses on longer term
+   research issues related to the Internet while the parallel
+   organization, the Internet Engineering Task Force (IETF), focuses on
+   the shorter term issues of engineering and standards making.
+
+   The Internet is a loosely-organized international collaboration of
+   autonomous, interconnected networks; it supports host-to-host
+   communication through voluntary adherence to open protocols and
+   procedures defined by Internet Standards, a collection of which are
+   commonly known as "the TCP/IP protocol suite".  Development and
+   review of potential Internet Standards from all sources is conducted
+   by the Internet Engineering Task Force (IETF).  The Internet
+   Standards Process is defined in [1].
+
+
+
+
+
+
+
+Weinrib & Postel         Best Current Practice                  [Page 1]
+
+RFC 2014             IRTF Research Group Guidelines         October 1996
+
+
+   The IRTF is a composed of a number of focused, long-term, small
+   Research Groups.  These groups work on topics related to Internet
+   protocols, applications, architecture and technology. Research Groups
+   are expected to have the stable long term membership needed to
+   promote the development of research collaboration and teamwork in
+   exploring research issues.  Participation is by individual
+   contributors, rather than by representatives of organizations.
+
+   The IRTF is managed by the IRTF Chair in consultation with the
+   Internet Research Steering Group (IRSG).  The IRSG membership
+   includes the IRTF Chair, the chairs of the various Research Group and
+   possibly other individuals ("members at large") from the research
+   community.
+
+   The IRTF Chair is appointed by the IAB, the Research Group chairs are
+   appointed as part of the formation of Research Groups (as detailed
+   below) and the IRSG members at large are chosen by the IRTF Chair in
+   consultation with the rest of the IRSG and on approval by the IAB.
+
+   In addition to managing the Research Groups, the IRSG may from time
+   to time hold topical workshops focusing on research areas of
+   importance to the evolution of the Internet, or more general
+   workshops to, for example, discuss research priorities from an
+   Internet perspective.
+
+   This document defines procedures and guidelines for formation and
+   operation of Research Groups in the IRTF.  The duties of the IRTF
+   Chair, the Research Group Chairs and IRSG members are also described.
+   Except for members at large of the IRSG, there is no general
+   participation in the IRTF, only participation in a specific Research
+   Group.
+
+   The document uses: "shall", "will", "must" and "is required" where it
+   describes steps in the process that are essential, and uses:
+   "suggested", "should" and "may" where guidelines are described that
+   are not essential, but are strongly recommended to help smooth
+   Research Group operation.  The terms "they", "them" and "their" are
+   used in this document as third-person singular pronouns.
+
+1.1. IRTF approach
+
+   The reader is encouraged to study The Internet Standards Process [1]
+   to gain a complete understanding of the philosophy, procedures and
+   guidelines of the IETF and its approach to standards making.
+
+   The IRTF does not set standards, and thus has somewhat different and
+   complementary philosophy and procedures.  In particular, an IRTF
+   Research Group is expected to be long-lived, producing a sequence of
+
+
+
+Weinrib & Postel         Best Current Practice                  [Page 2]
+
+RFC 2014             IRTF Research Group Guidelines         October 1996
+
+
+   "products" over time.  The products of a Research Group are research
+   results that may be disseminated by publication in scholarly journals
+   and conferences, as white papers for the community, as Informational
+   RFCs, and so on.  In addition, it is expected that technologies
+   developed in a Research Group will be brought to the IETF as input to
+   IETF Working Group(s) for possible standardization.   However,
+   Research Group input carries no more weight than other community
+   input, and goes through the same standards setting process as any
+   other proposal.
+
+   IRTF Research Groups are formed to encourage research in areas of
+   importance to the evolution of the Internet.  Clearly, anyone may
+   conduct such research, whether or not they are members of a Research
+   Group.  The expectation is that by sponsoring Research Groups, the
+   IRTF can foster cross-organizational collaboration, help to create
+   "critical mass" in important research areas, and add to the
+   visibility and impact of the work.
+
+   IRTF Research Groups may have open or closed memberships.  Limited
+   membership may be advantageous to the formation of the long term
+   working relationships that are critical to successful collaborative
+   research.  However, limited membership must be used with care and
+   sensitivity to avoid unnecessary fragmentation of the work of the
+   research community. Allowing limited membership is in stark contrast
+   to IETF Working Groups, which are always open; this contrast reflects
+   the different goals and environments of the two organizations-
+   research vs. standards setting.
+
+   To ameliorate the effects of closed membership, all Research Groups
+   are required to regularly report progress to the community, and are
+   encouraged to hold occasional open meetings (most likely co-located
+   with IETF meetings). In addition, the IRTF may host open plenaries at
+   regular IETF meetings during which research results of interest to
+   the community are presented.  Finally, multiple Research Groups
+   working in the same general area may be formed if appropriate.
+
+   Even more than the IETF, the work of the IRSG is expected to be
+   marked by informality.  The goal is to encourage and foster valuable
+   research, not to add burdensome bureaucracy to the endeavor.
+
+1.2. Acknowledgments
+
+   This document is based on the March 1994 RFC "IETF Working Group
+   Guidelines and Procedures" by E. Huizer and D. Crocker [2].
+
+
+
+
+
+
+
+Weinrib & Postel         Best Current Practice                  [Page 3]
+
+RFC 2014             IRTF Research Group Guidelines         October 1996
+
+
+2.  RESEARCH GROUP FORMATION
+
+   Research Groups are the activity centers in the IRTF.  A Research
+   Group is typically created to address a research area related to
+   Internet protocols, applications, architecture or technology area.
+   Research Groups have the stable long term membership needed to
+   promote the development of research collaboration and teamwork in
+   exploring research issues.  Participation is by individual
+   contributors, rather than by representatives of organizations.
+
+   A Research Group may be established at the initiative of an
+   individual or group of individuals.  Anyone interested in creating an
+   IRTF Research Group must submit a charter for the proposed group to
+   the IRTF Chair along with a list of proposed founding members.  The
+   charter will be reviewed by the IRSG and then forwarded to the IAB
+   for approval.
+
+   If approved, the charter is placed on the IRTF Web site, and
+   published in the Internet Monthly Report (IMR).
+
+2.1. Criteria for formation
+
+   In determining whether it is appropriate to create a Research Group,
+   the IRTF Chair, the IRSG and the IAB will consider several issues:
+
+   -  Is the research area that the Research Group plans to address
+      clear and relevant for the Internet community?
+
+   -  Will the formation of the Research Group foster work that would
+      not be done otherwise.  For instance, membership drawn from more
+      than a single institution, more than a single country, and so on,
+      is to be encouraged.
+
+   -  Do the Research Group's activities overlap with those of another
+      Research Group?  If so, it may still be appropriate to create the
+      Research Group, but this question must be considered carefully
+      since subdividing efforts often dilutes the available technical
+      expertise.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Weinrib & Postel         Best Current Practice                  [Page 4]
+
+RFC 2014             IRTF Research Group Guidelines         October 1996
+
+
+   -  Is there sufficient interest and expertise in the Research Group's
+      topic with at least several people willing to expend the effort
+      that is likely to produce significant results over time?  Research
+      Groups require considerable effort, including management of the
+      Research Group process, editing of Research Group documents, and
+      contribution to the document text.  IRTF experience suggests that
+      these roles typically cannot all be handled by one person; at
+      least four or five active participants are typically required.  To
+      help in this determination, a proposal to create a Research Group
+      should include a list of potential charter members.
+
+   The Internet Architecture Board (IAB) will also review the charter of
+   the proposed Research Group to determine the relationship of the
+   proposed work to the overall architecture of the Internet Protocol
+   Suite.
+
+2.2. Charter
+
+   A charter is a contract between a Research Group and the IRTF to
+   conduct research in the designated area. Charters may be renegotiated
+   periodically to reflect changes to the current status, organization
+   or goals of the Research Group.
+
+   The formation of a Research Group requires a charter which is
+   initially negotiated between a prospective Research Group Chair and
+   the IRTF Chair.  When the prospective Chair and the IRTF Chair are
+   satisfied with the charter form and content, it becomes the basis for
+   forming a Research Group.
+
+   A IRTF Research Group charter consists of five sections:
+
+   1.  Research Group Name
+
+      A Research Group name should be reasonably descriptive or
+      identifiable.  Additionally, the group shall define an acronym
+      (maximum 8 printable ASCII characters) to reference the group in
+      the IRTF directories, mailing lists, and general documents.  The
+      name and acronym must not conflict with any IETF names and
+      acronyms.
+
+   2.  Chair(s)
+
+      The Research Group may have one or two Chair(s) to perform the
+      administrative functions of the group. The email address(es) of
+      the Chair(s) shall be included.
+
+
+
+
+
+
+Weinrib & Postel         Best Current Practice                  [Page 5]
+
+RFC 2014             IRTF Research Group Guidelines         October 1996
+
+
+   3.  Mailing list(s)
+
+      Each Research Group shall have an address (possibly the Chair's)
+      for members of the Internet community to send queries regarding
+      the Research Group.    For instance, for requests to join the
+      group.
+
+      A Research Group, whether limited membership or open, will have an
+      "interest" Internet mailing list open to all interested parties.
+      This list is used for an open discussion of the issues and
+      announcements of results as they become available.  Included
+      should be the address to which an interested party sends a
+      subscription request for the interest list and the procedures to
+      follow when subscribing, and the location of the interest mailing
+      list archive.
+
+      It is expected that a Research Group may also have a mailing list
+      limited to the regular meeting participants on which substantial
+      part of the work of a Research Group is likely to be conducted via
+      e-mail.
+
+   4.  Membership Policy
+
+      The Charter must define the membership policy (whether open or
+      limited), and the procedure to apply for membership in the group.
+      While limited membership is permitted, it is in no way encouraged
+      or required.
+
+   5.  Description of Research Group
+
+      The focus and intent of the group shall be set forth briefly. By
+      reading this section alone, an individual should be able to decide
+      whether this group is relevant to their own work.  The first
+      paragraph must give a brief summary of the research area, basis,
+      goal(s) and approach(es) planned for the Research Group.  This
+      paragraph will frequently be used as an overview of the Research
+      Group's effort.
+
+      To facilitate evaluation of the intended work and to provide on-
+      going guidance to the Research Group, the charter shall describe
+      the proposed research and shall discuss objectives and expected
+      impact with respect to the Internet Architecture.
+
+3.  RESEARCH GROUP OPERATION
+
+   Research Groups are autonomous and each determines most of the
+   details of its own operation with respect to session participation,
+   reaching closure, norms of behavior, etc.  Since the products are
+
+
+
+Weinrib & Postel         Best Current Practice                  [Page 6]
+
+RFC 2014             IRTF Research Group Guidelines         October 1996
+
+
+   research results, not Internet standards, consensus of the group is
+   not required.  Rather, the measure of success is the quality and
+   impact of the research results.
+
+   A number of procedural questions and issues will arise over time, and
+   it is the function of the Research Group Chair to manage the group
+   process, keeping in mind that the overall purpose of the group is to
+   make progress towards realizing the Research Group's goals and
+   objectives.
+
+   There are few hard and fast rules on organizing or conducting
+   Research Group activities, but a set of guidelines and practices have
+   evolved over time that have proven successful. These are listed here,
+   with actual choices typically determined by the Research Group
+   members and the Chair.
+
+3.1. Meeting planning
+
+   For coordinated, structured Research Group interactions, the Chair
+   must publish to the group mailing list a draft agenda well in advance
+   of the actual meeting. The agenda needs to contain at least:
+
+   -    The items for discussion;
+
+   -    The estimated time necessary per item; and
+
+   -    A clear indication of what documents the participants will
+        need to read before the meeting in order to be well
+        prepared.
+
+   A Research Group will conduct much of its business via its electronic
+   mail distribution list(s).  It is also likely to meet periodically to
+   accomplish those things that are better achieved in more interactive
+   meetings, such as brainstorming, heated altercations, etc.  Meetings
+   may be scheduled as telephone conference, video teleconference, or
+   face-to-face (physical) meetings.
+
+   It is strongly encouraged that all Research Group meetings be
+   recorded in written minutes, to keep informed members who were not
+   present and the community at large and to document the proceedings
+   for present and future members.  These minutes should include the
+   agenda for the meeting, an account of the high points of the
+   discussion, and a list of attendees.  Unless the Research Group chair
+   decides otherwise, the minutes should be sent to the interest group
+   and made available through the IRTF Web and ftp sites.
+
+
+
+
+
+
+Weinrib & Postel         Best Current Practice                  [Page 7]
+
+RFC 2014             IRTF Research Group Guidelines         October 1996
+
+
+3.2. Meeting venue
+
+   Each Research Group will determine the balance of email and face-to-
+   face meetings that is appropriate for making progress on its goals.
+
+   Electronic mail permits the easiest and most affordable
+   participation; face-to-face meetings often permit better focus, more
+   productive debate and enhanced working relationships.
+
+   Face-to-face meetings are encouraged to be held co-located with the
+   regular IETF meetings to minimize travel, since IRTF members are
+   often also active in the IETF and to encourage the cross-
+   fertilization that occurs during hallway and after-hours
+   interactions.  Furthermore, as described above, even limited-
+   membership Research Groups are encouraged to hold occasional open
+   meetings; an IETF meeting would serve as an ideal venue for such an
+   event.
+
+3.3. Meeting management
+
+   The challenge to managing Research Group meetings is to balance the
+   need for consideration of the various issues, opinions and approaches
+   against the need to allow forward progress.  The Research Group, as a
+   whole, has the final responsibility for striking this balance.
+
+4.  RESEARCH GROUP TERMINATION
+
+   If, at some point, it becomes evident that a Research Group is not
+   making progress in the research areas defined in its charter, or
+   fails to regularly report the results of its research to the
+   community, the IRTF Chair can, in consultation with Group, either:
+
+      1.   Require that the group recharter to refocus on a different
+      set of problems,
+
+      2.   Request that the group choose new Chair(s), or
+
+      3.   Disband the group.
+
+   If the Research Group disagrees with the IRTF Chair's choice, it may
+   appeal to the IAB.
+
+5.  STAFF ROLES
+
+   Research Groups require considerable care and feeding.  In addition
+   to general participation, successful  Research Groups benefit from
+   the efforts of participants filling specific functional roles.
+
+
+
+
+Weinrib & Postel         Best Current Practice                  [Page 8]
+
+RFC 2014             IRTF Research Group Guidelines         October 1996
+
+
+5.1. IRTF Chair
+
+   The IRTF Chair is responsible for ensuring that  Research Groups
+   produce coherent, coordinated, architecturally consistent and timely
+   output as a contribution to the overall evolution of the Internet
+   architecture.  In addition to the detailed tasks related to  Research
+   Groups outlined below, the IRTF Chair may also from time to time
+   arrange for topical workshops attended by the IRSG and perhaps other
+   experts in the field.
+
+   Planning
+
+      The IRTF Chair monitors the range of activities.  This may include
+      encouraging the formation of Research Groups directly, rather than
+      waiting for proposals from IRTF participants.
+
+   Coordination of Research Groups
+
+      The IRTF Chair coordinates the work done by the various Research
+      Groups.
+
+   Reporting
+
+      The IRTF Chair reports on IRTF progress to the to the IAB and the
+      wider Internet community (including via the IMR).
+
+   Progress tracking
+
+      The IRTF Chair tracks and manages the progress of the various
+      Research Groups with the aid of a regular status report on
+      documents and accomplishments from the Research Group Chairs. The
+      resulting reports are made available to the community at large at
+      regular intervals.
+
+5.2.  IRSG Member
+
+   Members of the IRSG are responsible for advising the IRTF Chair on
+   the chartering of new Research Groups and other matters relating to
+   the smooth operation of the IRTF.  In addition, most IRSG members are
+   also Research Group chairs.
+
+
+
+
+
+
+
+
+
+
+
+Weinrib & Postel         Best Current Practice                  [Page 9]
+
+RFC 2014             IRTF Research Group Guidelines         October 1996
+
+
+5.3. Research Group Chair
+
+   The Research Group Chair is concerned with making forward progress in
+   the areas under investigation, and has wide discretion in the conduct
+   of Research Group business.  The Chair must ensure that a number of
+   tasks are performed, either directly or by others assigned to the
+   tasks.  This encompasses at the very least the following:
+
+   Ensuring the Research Group process and content management
+
+      The Chair has ultimate responsibility for ensuring that a Research
+      Group achieves forward progress.  For some  Research Groups, this
+      can be accomplished by having the Chair perform all management-
+      related activities.  In other  Research Groups -- particularly
+      those with large or divisive participation -- it is helpful to
+      allocate process and/or secretarial functions to other
+      participants.  Process management pertains strictly to the style
+      of Research Group interaction and not to its content.  The
+      secretarial function encompasses preparation of minutes, and
+      possibly editing of group-authored  documents.
+
+   Moderate the Research Group email list
+
+      The Chair should attempt to ensure that the discussions on this
+      list are relevant and that not devolve to "flame" attacks or rat-
+      hole into technical trivia.  The Chair should make sure that
+      discussions on the list are summarized and that the outcome is
+      well documented (to avoid repetition).
+
+   Organize, prepare and chair face-to-face and on-line formal meetings
+
+      The Chair should plan and announce meetings well in advance.  (See
+      section on Meeting Planning for procedures.)
+
+   Communicate results of meetings
+
+      The Chair and/or Secretary must ensure that minutes of a meeting
+      are taken.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Weinrib & Postel         Best Current Practice                 [Page 10]
+
+RFC 2014             IRTF Research Group Guidelines         October 1996
+
+
+   Distribute the work
+
+      It is expected that all Research Group participants will actively
+      contribute to the work of the group. Research Group membership is
+      expected to be a long term commitment by a set of motivated
+      members of the research community.  Of course, at any given time
+      more of the work is likely to be done by a few participants with
+      particular interests, set of skills and ideas. It is the task of
+      the Chair to motivate enough experts to allow for a fair
+      distribution of the workload.
+
+   Document development
+
+      Research Groups produce documents and documents need authors.
+      However, authorship of papers related to the work of a Research
+      Group is one of the primary reasons that researchers become
+      members, so finding motivated authors should not be a problem.
+
+      It is up to the Research Group to decide the authorship of papers
+      resulting from Research Group activities.  In particular,
+      authorship by the entire group is not required.
+
+   Document publication
+
+      The Chair and/or Secretary will work with the RFC Editor to ensure
+      documents to be published as RFCs conform with RFC publication
+      requirements and to coordinate any editorial changes suggested by
+      the RFC Editor.
+
+5.4. Research Group Editor/Secretary
+
+   Taking minutes and editing jointly-authored Research Group documents
+   often is performed by a specifically-designated participant or set of
+   participants.
+
+6.  RESEARCH GROUP DOCUMENTS
+
+6.1. Meeting documents
+
+   All relevant documents for a meeting (including the final agenda)
+   should be published to the group mailing list and available at least
+   two weeks before a meeting starts.
+
+
+
+
+
+
+
+
+
+Weinrib & Postel         Best Current Practice                 [Page 11]
+
+RFC 2014             IRTF Research Group Guidelines         October 1996
+
+
+   It is strongly suggested that the Research Group Chair make sure that
+   an anonymous FTP directory or Web site be available for the upcoming
+   meeting.  All relevant documents (including the final agenda and the
+   minutes of the last meeting) should be placed in this directory.
+   This has the advantage that all participants can retrieve all files
+   in this directory and thus make sure they have all relevant
+   documents. Also, it will be helpful to provide electronic mail-based
+   retrieval for those documents.
+
+6.2. Request For Comments (RFC)
+
+   The work of an IRTF Research Group usually results in publication of
+   research papers and other documents, as well as documents as part of
+   the Informational or Experimental Request For Comments (RFCs) series
+   [1].  This series is the archival publication record for the Internet
+   community.  A document can be written by an individual in a Research
+   Group, by a group as a whole with a designated Editor, or by others
+   not involved with the IRTF.  The designated author(s) need not
+   include the group Chair(s).
+
+   NOTE: The RFC series is a publication mechanism only and publication
+   does not determine the status of a document.  Status is determined
+   through separate, explicit status labels.  In other words, the reader
+   is reminded that all Internet Standards are published as RFCs, but
+   NOT all RFCs specify standards.
+
+   The RFC's authors are expected to work with the RFC Editor to meet
+   all formatting, review and other requirements that the Editor may
+   impose. Usually, in case of a submission intended as an Informational
+   or Experimental RFC minimal review is necessary, although publication
+   in the Experimental track generally requires IESG review.  However,
+   in all cases initial publication as an Internet Draft is preferred.
+
+   If the Research Group or the RFC Editor thinks that an extensive
+   review is appropriate, the IRTF Chair may be asked to conduct one.
+   This review may either be done by the IRTF Chair, the IRSG, or an
+   independent reviewer selected by the IRTF Chair.  Occasionally,
+   review by the IETF or IESG may be appropriate.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Weinrib & Postel         Best Current Practice                 [Page 12]
+
+RFC 2014             IRTF Research Group Guidelines         October 1996
+
+
+7.  SECURITY CONSIDERATIONS
+
+   Security issues are not discussed in this memo.
+
+8.  REFERENCES
+
+   [1] Internet Architecture Board and Internet Engineering Steering
+       Group, "The Internet Standards Process -- Revision 2", RFC 1602,
+       IAB, IESG, March 1994.  Soon to be replaced by "The Internet
+       Standards Process -- Revision 3", Work in Progress.
+
+   [2] Huizer, E. and D. Crocker, "IETF Working Group Guidelines and
+       Procedures", RFC 1603, March 1994.
+
+9.  AUTHORS' ADDRESSES
+
+   Abel Weinrib
+   Intel Corporation, MS JF2-74
+   2111 NE 25th Ave.
+   Hillsboro, OR 97124
+
+   Phone:  503-264-8972
+   EMail:  weinrib@intel.com
+
+
+   Jon Postel
+   USC - ISI, Suite 1001
+   4676 Admiralty Way
+   Marina del Rey, CA  90292-6695
+
+   Phone: 310-822-1511
+   EMail: postel@isi.edu
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Weinrib & Postel         Best Current Practice                 [Page 13]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2014.txt](<www.ietf.org/rfc/rfc2014.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
