### PR TITLE
Archive rfc2027.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2027.txt
+++ b/www.ietf.org/rfc/rfc2027.txt
@@ -1,0 +1,619 @@
+
+
+
+
+
+
+Network Working Group                                         J. Galvin
+Request for Comments: 2027                                  CommerceNet
+BCP: 10                                                    October 1996
+Category: Best Current Practice
+
+
+       IAB and IESG Selection, Confirmation, and Recall Process:
+           Operation of the Nominating and Recall Committees
+
+
+Status of this Memo
+
+   This document specifies an Internet Best Current Practices for the
+   Internet Community, and requests discussion and suggestions for
+   improvements.  Distribution of this memo is unlimited.
+
+Abstract
+
+   The process by which the members of the IAB and IESG are selected,
+   confirmed, and recalled has been exercised four times since its
+   formal creation.  The evolution of the process has relied principally
+   on oral tradition as a means by which the lessons learned could be
+   passed on to successive committees.  This document is a self-
+   consistent, organized compilation of the process as it is known
+   today.
+
+Table of Contents
+
+   1 Introduction ................................................    1
+   2 General .....................................................    3
+   3 Nominating Committee Selection...............................    6
+   4 Nominating Committee Operation...............................    7
+   5 Member Recall ...............................................   10
+   6 Security Considerations .....................................   11
+   7 Editor's Address ............................................   11
+
+1.  Introduction
+
+   By 1992, many aspects of the operation of the Internet Architecture
+   Board (IAB), Internet Engineering Task Force (IETF), and the Internet
+   Engineering Steering Group (IESG) had been reviewed and changes were
+   being implemented.  Included in those changes was the process by
+   which members of the IAB and IESG are selected, confirmed, and
+   recalled.  Since 1992, the process of selection and confirmation has
+   been exercised four times: 1992, 1993, 1994, and 1995.  The recall
+   process has not been exercised.
+
+
+
+
+
+Galvin                   Best Current Practice                  [Page 1]
+
+RFC 2027              NOMCOM and Recall Operation           October 1996
+
+
+   A single paragraph in RFC1602 is the extent to which the process has
+   been formally recorded to date.  Informally, following the 1992
+   exercise of the process, an internet draft was distributed recording
+   many of the details of the operation of that first nominating
+   committee.  In addition, in both 1994 and 1995, the POISED working
+   group met, which facilitated the "oral tradition" transference of the
+   selection and confirmation process lessons learned, including the
+   email archives of the working group mailing list.  This document is a
+   self-consistent, organized compilation of the process as described by
+   each of these sources.
+
+   The process described here includes only items for which the
+   consensus of those participating in the various discussions was
+   easily recognized.  As a result, two assumptions are made.
+
+   (1)  The Internet Research Task Force (IRTF) and Internet
+        Research Steering Group (IRSG) are not a part of the process
+        described here.
+
+   (2)  The organization (and re-organization) of the IESG is not a
+        part of the process described here.
+
+   In addition, this document specifies time frames for which the frame
+   of reference is IETF meetings.  The time frames assume that the IETF
+   meets at least once per year with that meeting occurring during the
+   North American Spring time, i.e., the IETF meets at least on or about
+   March of each year.
+
+   The remainder of this document is divided into four major topics as
+   follows.
+
+   General
+        This a set of rules and constraints that apply to the
+        selection and confirmation process as a whole.
+
+   Nominating Committee Selection
+        This is the process by which volunteers from the IETF
+        community are recognized to serve on the committee that
+        nominates candidates to serve on the IESG and IAB.
+
+   Nominating Committee Operation
+        This is the set of principles, rules, and constraints
+        that guide the activities of the nominating committee,
+        including the confirmation process.
+
+
+
+
+
+
+
+Galvin                   Best Current Practice                  [Page 2]
+
+RFC 2027              NOMCOM and Recall Operation           October 1996
+
+
+   Member Recall
+        This is the process by which the behavior of a sitting
+        member of the IESG or IAB may be questioned, perhaps
+        resulting in the removal of the sitting member.
+
+2.  General
+
+   The following set of rules apply to the selection and confirmation
+   process as a whole.  If necessary, a paragraph discussing the
+   interpretation of each rule is included.
+
+   (1)  The principal function of the nominating committee is to
+        recruit and nominate candidates for open IESG and IAB
+        positions.
+
+        The nominating committee does not select the open positions
+        to be filled; it is instructed as to which positions to fill.
+        At a minimum, the nominating committee will be given the title
+        of the position to be filled.  The nominating committee may be
+        given a desirable set of qualifications for the candidates
+        nominated to fill a position.  The nominating committee does not
+        confirm its candidates; it presents its candidates to the
+        appropriate confirming body as indicated below.
+
+   (2)  The annual selection and confirmation process is expected to be
+        completed within 3 months.
+
+        The annual selection and confirmation process is expected to be
+        completed one month prior to the friday of the week before the
+        Spring IETF.  It is expected to begin 4 months prior to the
+        friday of the week before the Spring IETF.
+
+   (3)  One-half of each of the then current IESG and IAB positions is
+        selected to be refilled each year.
+
+        A given position is selected every other year.  The intent is to
+        replace no more than 50% of the sitting IESG and IAB members in
+        any one year.
+
+        A position may be refilled with its sitting member, if the
+        sitting member is nominated by the nominating committee.
+
+   (4)  Confirmed candidates are expected to serve at least a 2 year
+        term.
+
+        All member terms end during the Spring IETF meeting
+        corresponding to the end of the term for which they were
+        confirmed.  The term ends no later than the second to last
+
+
+
+Galvin                   Best Current Practice                  [Page 3]
+
+RFC 2027              NOMCOM and Recall Operation           October 1996
+
+
+        day and no sooner than the Open Plenary session of the Spring
+        IETF, as determined by the mutual agreement of the confirmed
+        candidate and the currently sitting member.  The term begins no
+        later than the last day and no sooner than the Open Plenary
+        session of the Spring IETF meeting, as determined by the mutual
+        agreement of the confirmed candidate and the currently sitting
+        member.
+
+   (5)  Mid-term IESG vacancies are filled by the same rules as
+        documented here with four qualifications.  First, the most
+        recently constituted nominating committee is reconvened to
+        nominate a candidate to fill the vacancy.  Second, the
+        selection and confirmation process is expected to be completed
+        within 1 month, with a prorated time period for all other time
+        periods not otherwise specified.  Third, the confirming body
+        has two weeks from the day it is notified of a candidate to
+        reject the candidate, otherwise the candidate is assumed to
+        have been confirmed.  Fourth, the term of the confirmed
+        candidate will be either:
+
+   a.   the remainder of the term of the open position if that remainder
+        is not less than one year.
+
+   b.   the remainder of the term of the open position plus the next
+        2 year term if that remainder is less than one year.
+
+   (6)  Mid-term IAB vacancies are filled by the same rules as
+        documented here with four qualifications.  First, the most
+        recently constituted nominating committee is reconvened to
+        nominate a candidate to fill the vacancy.  Second, the selection
+        and confirmation process is expected to be completed within
+        1 month, with a prorated time period for all other time periods
+        not otherwise specified.  Third, the confirming body has two
+        weeks from the day it is notified of a candidate to reject the
+        candidate, otherwise the candidate is assumed to have been
+        confirmed.  Fourth, the term of the confirmed candidate will
+        be either:
+
+   a.   the remainder of the term of the open position if that remainder
+        is not less than one year.
+
+   b.   the remainder of the term of the open position plus the next
+        2 year term if that remainder is less than one year.
+
+   (7)  All deliberations and supporting information of all the
+        participants in the selection and confirmation process are
+        private. The nominating committee and confirming body members
+        will be exposed to confidential information as a result of
+
+
+
+Galvin                   Best Current Practice                  [Page 4]
+
+RFC 2027              NOMCOM and Recall Operation           October 1996
+
+
+        their deliberations, their interactions with those they consult,
+        and from nominees who provide requested supporting information.
+        All members and all other participants are expected to handle
+        this information in a manner consistent with its sensitivity.
+
+   (8)  Unless otherwise specified, the advise and consent model is used
+        throughout the process.  This model is characterized as follows.
+
+   a.   The IETF Executive Director advises the nominating committee of
+        the IESG and IAB positions to be refilled.
+
+   b.   The nominating committee selects candidates and advises the
+        confirming bodies of them.
+
+   c.   The sitting IAB members review the IESG candidates, consenting
+        to some, all, or none.
+
+        If all of the candidates are confirmed, the job of the
+        nominating committee with respect to filling the open IESG
+        positions is considered complete.  If some or none of the
+        candidates are confirmed, the nominating committee must
+        reconvene to select alternate candidates for the rejected
+        candidates.  Any additional time required by the nominating
+        committee should not exceed its maximum time allotment.
+
+   d.   The Internet Society Board of Trustees reviews the IAB
+        candidates, consenting to some, all, or none.
+
+        If all of the candidates are confirmed, the job of the
+        nominating committee with respect to filling the open IAB
+        positions is considered complete.  If some or none of the
+        candidates are confirmed, the nominating committee must
+        reconvene to select alternate candidates for the rejected
+        candidates.  Any additional time required by the nominating
+        committee should not exceed its maximum time allotment.
+
+   e.   The confirming bodies decide their consent according to a
+        mechanism of their own choosing, which must ensure that at
+        least one-half of the sitting members agree with the
+        decision.
+
+        At least one-half of the sitting members of the confirming
+        bodies must agree to either confirm or reject each individual
+        nominee. The agreement must be decided within a reasonable
+        timeframe.  The agreement may be decided by conducting a
+        formal vote, by asserting consensus based on informal
+        exchanges (email), or by whatever mechanism is used to
+        conduct the normal business of the confirming body.
+
+
+
+Galvin                   Best Current Practice                  [Page 5]
+
+RFC 2027              NOMCOM and Recall Operation           October 1996
+
+
+3.  Nominating Committee Selection
+
+   The following set of rules apply to the creation of the nominating
+   committee and the selection of its members.
+
+(1)  The committee is comprised of at least a non-voting Chair, 10
+     voting volunteers, and 2 non-voting liaisons.
+
+     A Chair is permitted to invite additional non-voting advisors to
+     participate in some or all of the deliberations of the committee.
+
+(2)  The Internet Society President appoints the non-voting Chair, who
+     must meet the usual requirements for membership in the nominating
+     committee.
+
+     The nominating committee Chair must agree to invest the time
+     necessary to complete the duties of the nominating committee
+     and to perform in the best interests of the IETF community
+     during the performance of those duties.
+
+(3)  The Chair obtains the list of IESG and IAB positions to be
+     refilled and publishes it along with a solicitation for
+     names of volunteers from the IETF community willing to
+     serve on the nominating committee.
+
+     The list of open positions is published with the solicitation to
+     facilitate community members choosing between volunteering for an
+     open position and volunteering for the nominating committee.
+
+     The list and solicitation must be publicized using at least the
+     same mechanism used by the IETF secretariat for its announcements.
+
+(4)  Members of the IETF community must have attended at least 2 of the
+     last 3 IETF meetings in order to volunteer.
+
+(5)  Internet Society Board of Trustees, sitting members of the IAB,
+     and sitting members of the IESG may not volunteer.
+
+(6)  The Chair randomly selects the 10 voting volunteers from the pool
+     of names of volunteers.
+
+(7)  The sitting IAB and IESG members each appoint a non-voting liaison
+     to the nominating committee from their current membership who are
+     not sitting in an open position.
+
+(8)  The Chair may solicit additional non-voting liaisons from other
+     organizations, who must meet the usual requirements for membership
+     in the nominating committee.
+
+
+
+Galvin                   Best Current Practice                  [Page 6]
+
+RFC 2027              NOMCOM and Recall Operation           October 1996
+
+
+4.  Nominating Committee Operation
+
+   The following rules apply to the operation of the nominating
+   committee.  If necessary, a paragraph discussing the interpretation
+   of each rule is included.
+
+   The rules are organized approximately in the order in which they
+   would be invoked.
+
+   The term nominee refers to an individual under consideration by the
+   nominating committee.  The term candidate efers to a nominee that has
+   been selected by the nominating committee to be considered for
+   confirmation by a confirming body.  A confirmed candidate is a
+   candidate that has been reviewed and approved by a confirming body.
+
+   (1)  All rules and special circumstances not otherwise specified
+        are at the discretion of the Chair.
+
+        Exceptional circumstances will occasionally arise during the
+        normal operation of the nominating committee.  This rule is
+        intended to foster the continued forward progress of the
+        committee.  All members of the committee should consider
+        whether the exception is worthy of mention in the next
+        revision of this document and followup accordingly.
+
+   (2)  The Chair must establish and publicize milestones, which must
+        include at least a call for nominations.
+
+        There is a defined time period during which the selection and
+        confirmation process must be completed.  The Chair must
+        establish a set of milestones which, if met in a timely
+        fashion, will result in the completion of the process on
+        time.  The Chair should allow time for iterating the
+        activities of the committee if one or more candidates
+        is not confirmed.
+
+        The milestones must be publicized using at least the same
+        mechanism used by the IETF secretariat for its announcements.
+
+   (3)  The Chair must establish a voting mechanism.
+
+        The committee must be able to objectively determine when
+        a decision has been made during its deliberations.  The
+        criteria for determining closure must be established and
+        known to all members of the nominating committee.
+
+   (4)  At least a quorum of committee members must participate in
+        a vote. A quorum is comprised of at least 7 voting members.
+
+
+
+Galvin                   Best Current Practice                  [Page 7]
+
+RFC 2027              NOMCOM and Recall Operation           October 1996
+
+
+   (5)  The Chair may establish a process by which a member of the
+        nominating committee may be recalled.
+
+        The process, if established, must be agreed to by a 3/4
+        majority of the members of the nominating committee,
+        including the non-voting members since they would be
+        subject to the same process.
+
+   (6)  All members of the nominating committee may participate in all
+        deliberations.
+
+        The emphasis of this rule is that no member, whether voting or
+        non-voting, can be explicitly excluded from any deliberation.
+        However, a member may individually choose not to participate
+        in a deliberation.
+
+   (7)  The Chair announces the open positions to be filled and
+        the call for nominees.
+
+        The announcements must be publicized using at least the same
+        mechanism used by the IETF secretariat for its announcements.
+
+   (8)  Any member of the IETF community may nominate any member
+        of the IETF community for any open position.
+
+        A self-nomination is permitted.
+
+   (9)  Nominating committee members must not be nominees.
+
+        To be a nominee is to enter the process of being selected
+        as a candidate and confirmed.  Nominating committee members
+        are not eligible to be considered for filling any open
+        position.
+
+   (10) Members of the IETF community who were recalled from any
+        IESG or IAB position during the previous two years must
+        not be nominees.
+
+   (11) The nominating committee selects candidates based on its
+        understanding of the IETF community's consensus of the
+        qualifications required to fill the open positions.
+
+   (12) Nominees should be advised that they are being considered
+        and must consent to their nomination prior to being
+        confirmed.
+
+        The nominating committee should help nominees provide
+        justification to their employers.
+
+
+
+Galvin                   Best Current Practice                  [Page 8]
+
+RFC 2027              NOMCOM and Recall Operation           October 1996
+
+
+        A nominee's consent must be written (email is acceptable)
+        and include a commitment to provide the resources necessary
+        to fill the open position and an assurance that the nominee
+        will perform the duties of the position for which they are
+        being considered in the best interests of the IETF community.
+
+   (13) The nominating committee advises the confirming bodies of
+        their candidates, specifying a single candidate for each
+        open position and a testament as to how each candidate
+        meets the qualifications of an open position.
+
+        The testament may include a brief resume of the candidate
+        and a summary of the deliberations of the nominating committee.
+
+   (14) With respect to any action to be taken in the context of
+        notifying and announcing confirmed candidates, and notifying
+        rejected nominees and candidates, the action must be valid
+        according to all of the rules specified below prior to its
+        execution.
+
+   a.   Up until a candidate is confirmed, the identity of the
+        candidate must be kept strictly confidential.
+
+   b.   The identity of all nominees must be kept strictly confidential
+        (except that the nominee may publicize their intentions).
+
+   c.   Rejected nominees may be notified as soon as they are rejected.
+
+   d.   Rejected candidates may be notified as soon as they are rejected.
+
+   e.   Rejected nominees and candidates must be notified prior to
+        announcing confirmed candidates.
+
+   f.   Confirmed candidates may be notified and announced as soon as
+        they are confirmed.
+
+        It is consistent with these rules for a nominee to never know if
+        they were a candidate or not.
+
+        It is consistent with these rules for a nominating committee to
+        reject some nominees early in the process and to keep some
+        nominees as alternates in case a candidate is rejected by a
+        confirming body. In the matter of whether a confirmed candidate
+        was a first choice or an alternate, that information need not
+        ever be disclosed and, in fact, probably never should be.
+
+
+
+
+
+
+Galvin                   Best Current Practice                  [Page 9]
+
+RFC 2027              NOMCOM and Recall Operation           October 1996
+
+
+        It is consistent with these rules for confirmed candidates
+        to be notified and announced as quickly as possible instead
+        of requiring all confirmed candidates to wait until all open
+        positions have been refilled.
+
+        The announcements must be publicized using at least the same
+        mechanism used by the IETF secretariat for its announcements.
+
+5.  Member Recall
+
+   The following rules apply to the recall process.  If necessary, a
+   paragraph discussing the interpretation of each rule is included.
+
+   (1)  Anyone may request the recall of any sitting IAB or IESG member,
+        at any time, upon written (email is acceptable) request with
+        justification to the Internet Society President.
+
+   (2)  Internet Society President shall appoint a Recall Committee
+        Chair.
+
+        The Internet Society President must not evaluate the recall
+        request.  It is explicitly the responsibility of the IETF
+        community to evaluate the behavior of its leaders.
+
+   (3)  The recall committee is created according to the same rules
+        as is the nominating committee with the qualifications that
+        the person being investigated and the person requesting the
+        recall must not be a member of the recall committee in any
+        capacity.
+
+   (4)  The recall committee operates according to the same rules as
+        the nominating committee with the qualification that there
+        is no confirmation process.
+
+   (5)  The recall committee investigates the circumstances of the
+        justification for the recall and votes on its findings.
+
+        The investigation must include at least both an opportunity
+        for the member being recalled to present a written statement
+        and consultation with third parties.
+
+   (6)  A 3/4 majority of the members who vote on the question is
+        required for a recall.
+
+        If a sitting member is recalled the open position is to be
+        filled according to the mid-term vacancy rules.
+
+
+
+
+
+Galvin                   Best Current Practice                 [Page 10]
+
+RFC 2027              NOMCOM and Recall Operation           October 1996
+
+
+6.  Security Considerations
+
+   Any selection, confirmation, or recall process necessarily involves
+   investigation into the qualifications and activities of prospective
+   candidates.  The investigation may reveal confidential or otherwise
+   private information about candidates to those participating in the
+   process.  Each person who participates in any aspect of the process
+   has a responsibility to maintain the confidentiality of any and all
+   information not explicitly identified as suitable for public
+   dissemination.
+
+7.  Editor's Address
+
+       James M. Galvin
+       CommerceNet
+       P.O. Box 220
+       Glenwood, MD 21738
+
+       Email: galvin@commerce.net
+       Phone: +1 410.795.6882
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Galvin                   Best Current Practice                 [Page 11]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2027.txt](<www.ietf.org/rfc/rfc2027.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
