### PR TITLE
Archive rfc2028.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2028.txt
+++ b/www.ietf.org/rfc/rfc2028.txt
@@ -1,0 +1,395 @@
+
+
+
+
+
+
+Network Working Group                                           R. Hovey
+Request for Comments: 2028                 Digital Equipment Corporation
+BCP: 11                                                       S. Bradner
+Category: Best Current Practice                       Harvard University
+                                                            October 1996
+
+
+        The Organizations Involved in the IETF Standards Process
+
+Status of this Memo
+
+   This document specifies an Internet Best Current Practices for the
+   Internet Community, and requests discussion and suggestions for
+   improvements.  Distribution of this memo is unlimited.
+
+Abstract
+
+   This document describes the individuals and organizations involved in
+   the IETF.  This includes descriptions of the IESG, the IETF Working
+   Groups and the relationship between the IETF and the Internet
+   Society.
+
+1. Documents controlling the process
+
+1.1 The IETF Standards Process
+
+   The process used by the Internet community for the standardization of
+   protocols and procedures is described in [B].  That document defines
+   the stages in the standardization process, the requirements for
+   moving a document between stages and the types of documents used
+   during this process.  It also addresses the intellectual property
+   rights and copyright issues associated with the standards process.
+
+2. Key individuals in the Process
+
+2.1  The Request for Comments Editor
+
+   The RFC publication series [B] is managed by an Editor (which may in
+   practice be one or more individuals) responsible both for the
+   mechanics of RFC publication and for upholding the traditionally high
+   technical and editorial standards of the RFC series.
+
+   The functions of the RFC Editor are performed by one or more
+   individuals or organizations selected in accordance with the
+   procedures defined by the RFC Editor charter [G].
+
+
+
+
+
+
+Hovey & Bradner          Best Current Practice                  [Page 1]
+
+RFC 2028                   IETF Organizations               October 1996
+
+
+2.2 The Working Group Chair
+
+   Each IETF Working Group is headed by a chair (or by co-chairs) with
+   the responsibility for directing the group's activities, presiding
+   over the group's meetings, and ensuring that the commitments of the
+   group with respect to its role in the Internet standards process are
+   met. In particular, the WG chair is the formal point of contact
+   between the WG and the IESG, via the Area Director of the area to
+   which the WG is assigned.
+
+   The details on the selection and responsibilites of an IETF Working
+   Group chair can be found in [A].
+
+2.3  The Document Editor
+
+   Most IETF Working Groups focus their efforts on a document, or set of
+   documents, that capture the results of the group's work.  A Working
+   Group generally designates a person or persons to serve as the Editor
+   for a particular document.  The Document Editor is responsible for
+   ensuring that the contents of the document accurately reflect the
+   decisions that have been made by the working group.
+
+   As a general practice, the Working Group Chair and Document Editor
+   positions are filled by different individuals to help ensure that the
+   resulting documents accurately reflect the consensus of the Working
+   Group and that all processes are followed.
+
+3. Key organizations in the Process
+
+   The following organizations and organizational roles are involved in
+   the Internet standards process.  Contact information is contained in
+   Appendix A.
+
+3.1  Internet Engineering Task Force
+
+   The Internet Engineering Task Force (IETF) is an open international
+   community of network designers, operators, vendors and researchers
+   concerned with the evolution of the Internet architecture and the
+   smooth operation of the Internet.  It is the principal body engaged
+   in the development of new Internet Standard specifications.
+
+3.2 IETF Working Groups
+
+   The technical work of the IETF is done in its Working Groups, which
+   are organized by topics into several Areas (e.g., routing, network
+   management, security, etc.) under the coordination of Area Directors.
+   Working Groups typically have a narrow focus and a lifetime bounded
+   by completion of a specific task.
+
+
+
+Hovey & Bradner          Best Current Practice                  [Page 2]
+
+RFC 2028                   IETF Organizations               October 1996
+
+
+   For all purposes relevant to the Internet Standards development
+   process, membership in the IETF and its Working Groups is defined to
+   be established solely and entirely by individual participation in
+   IETF and Working Group activities. Participation in the IETF and its
+   Working Groups is by individual technical contributors rather than by
+   formal representatives of organizations.
+
+   Anyone with the time and interest to do so is entitled and urged to
+   participate actively in one or more IETF Working Groups and to attend
+   IETF meetings which are held three times a year.  In most cases
+   active Working Group participation is possible through electronic
+   mail alone.  Internet video conferencing is also being used to allow
+   for remote participation.
+
+   To ensure a fair and open process, participants in the IETF and its
+   Working Groups must be able to disclose, and must disclose to the
+   Working Group chairs any relevant current or pending intellectual
+   property rights that are reasonably and personally known to the
+   participant if they participate in discussions about a specific
+   technology.
+
+   New Working Groups are established within the IETF by explicit
+   charter.  The guidelines and procedures for the formation and
+   operation of IETF working groups are described in detail in [A].
+
+   A Working Group is managed by one or more Working Group chairs (see
+   section 2.2).  It may also include editors of documents that record
+   the group's work (see section 2.3). Further details of Working Group
+   operation are contained in [A]
+
+   IETF Working Groups display a spirit of cooperation as well as a high
+   degree of technical maturity;  IETF participants recognize that the
+   greatest benefit for all members of the Internet community results
+   from cooperative development of technically superior protocols and
+   services.
+
+3.3  IETF Secretariat
+
+   The administrative functions necessary to support the activities of
+   the IETF are performed by a Secretariat consisting of the IETF
+   Executive Director and his or her staff. The IETF Executive Director
+   is the formal point of contact for matters concerning any and all
+   aspects of the Internet standards process, and is responsible for
+   maintaining the formal public record of the Internet standards
+   process [B].
+
+
+
+
+
+
+Hovey & Bradner          Best Current Practice                  [Page 3]
+
+RFC 2028                   IETF Organizations               October 1996
+
+
+3.4  Internet Society
+
+   The Internet Society (ISOC) is an international organization
+   concerned with the growth and evolution of the worldwide Internet and
+   with the social, political, and technical issues that arise from its
+   use.  The ISOC is an organization with individual and organizational
+   members.  The ISOC is managed by a Board of Trustees elected by the
+   worldwide individual membership.
+
+   Internet standardization is an organized activity of the ISOC, with
+   the Board of Trustees being responsible for ratifying the procedures
+   and rules of the Internet standards process [B].
+
+   The way in which the members of the ISOC Board of Trustees are
+   selected, and other matters concerning the operation of the Internet
+   Society, are described in the ISOC By Laws [C].
+
+3.5 Internet Engineering Steering Group
+
+
+   The Internet Engineering Steering Group (IESG) is the part of the
+   Internet Society responsible for the management of the IETF technical
+   activities.  It administers the Internet Standards process according
+   to the rules and procedures defined in [B].  The IESG is responsible
+   for the actions associated with the progression of technical
+   specification along the "standards track" including the initial
+   approval of new Working Groups and the final approval of
+   specifications as Internet Standards.  The IESG is composed of the
+   IETF Area Directors and the chair of the IETF, who also serves as the
+   chair of the IESG.
+
+   The members of the IESG are nominated by a nominations committee (the
+   Nomcom), and are approved by the IAB.  See [E] for a detailed
+   description of the Nomcom procedures. Other matters concerning its
+   organization and operation, are described in the IESG charter [does
+   not yet exist].
+
+3.6  Internet Architecture Board
+
+   The Internet Architecture Board (IAB) is chartered by the Internet
+   Society Trustees to provide oversight of the architecture of the
+   Internet and its protocols.  The IAB appoints the IETF chair and is
+   responsible for approving other IESG candidates put forward by the
+   IETF nominating committee. The IAB is also responsible for reviewing
+   and approving the charters of new Working Groups that are proposed
+   for the IETF.
+
+   The IAB provides oversight of the process used to create Internet
+
+
+
+Hovey & Bradner          Best Current Practice                  [Page 4]
+
+RFC 2028                   IETF Organizations               October 1996
+
+
+   Standards and serves as an appeal board for complaints of improper
+   execution of the standards process [B]. In general it acts as source
+   of advice to the IETF, the ISOC and the ISOC Board of Trustees
+   concerning technical, architectural, procedural, and policy matters
+   pertaining to the Internet and its enabling technologies.
+
+   The members of the IAB are nominated by a nominations committee (the
+   Nomcom), and are approved by the ISOC board.  See [E] for a detailed
+   description of the Nomcom procedures.  The membership of the IAB
+   consists of members selected by the Nomcom process and the IETF chair
+   sitting as a ex-officio member.  Other matters concerning its
+   organization and operation, are described in the IAB charter [D].
+
+3.7  Internet Assigned Numbers Authority
+
+   Many protocol specifications include numbers, keywords, and other
+   parameters that must be uniquely assigned.  Examples include version
+   numbers, protocol numbers, port numbers, and MIB numbers. The
+   Internet Assigned Numbers Authority (IANA) is responsible for
+   assigning the values of these protocol parameters for the Internet.
+   The IANA publishes tables of all currently assigned numbers and
+   parameters in RFCs entitled "Assigned Numbers" [E]. The IANA
+   functions as the "top of the pyramid" for DNS and Internet Address
+   assignment establishing policies for these functions.
+
+   The functions of the IANA are performed by one or more individuals or
+   organizations selected in accordance with the procedures defined by
+   the IANA charter [F].
+
+3.8 Internet Research Task Force
+
+   The Internet Research Task Force (IRTF) is not directly involved in
+   the Internet standards process.  It investigates topics considered to
+   be too uncertain, too advanced, or insufficiently well-understood to
+   be the subject of Internet standardization.  When an IRTF activity
+   generates a specification that is sufficiently stable to be
+   considered for Internet standardization, the specification is
+   processed through the IETF using the rules in this document.
+
+   The IRTF is composed of individual Working Groups, but its structure
+   and mode of operation is much less formal than that of the IETF, due
+   in part to the fact that it does not participate directly in the
+   Internet standards process.  The organization and program of work of
+   the IRTF is overseen by the Internet Research Steering Group (IRSG),
+   which consists of the chairs of the IRTF Working Groups.  Details of
+   the organization and operation of the IRTF and its Working Groups may
+   be found in [H].
+
+
+
+
+Hovey & Bradner          Best Current Practice                  [Page 5]
+
+RFC 2028                   IETF Organizations               October 1996
+
+
+4. Security Considerations
+
+   Security is not addressed in this memo.
+
+5. References
+
+   [A]  Huizer,E. and D. Crocker, "IETF Working Group Guidelines and
+   Procedures", RFC 1603, March 1994.
+
+   [B] Bradner, S., Editor, "The Internet Standards Process -- Revision
+   3", RFC 2026, October 1996.
+
+   [C] By - Laws for the Internet Society, as amended:
+   gopher://info.isoc.org/00/isoc/basic_docs/bylaws.txt
+
+   [D]  Huitema, C. and the IAB, "Charter of the Internet  Architecture
+   Board (IAB)", RFC 1601, March 1994.
+
+   [E] Galvin, J (Ed.), "IAB and IESG Selection, Confirmation, and
+   Recall Process: Operation of the Nominating and Recall Committees",
+   RFC 2027, October 1996.
+
+   [F] IANA Charter, Work in Progress.
+
+   [G] RFC Editor Charter, Work in Progress.
+
+   [H] IRTF Charter, RFC 2014, October 1996.
+
+5. Authors' Addresses:
+
+   Richard Hovey
+   Digital Equipment Corporation
+   1401 H Street NW
+   Washington DC 20005
+
+   Phone:  +1 202 383 5615
+   EMail:  hovey@wnpv01.enet.dec.com
+
+   Scott Bradner
+   Harvard University
+   1350 Mass Ave. Rm 813
+   Cambridge MA 02138
+
+   Phone: +1 617 495 3864
+   EMail: sob@harvard.edu
+
+
+
+
+
+
+Hovey & Bradner          Best Current Practice                  [Page 6]
+
+RFC 2028                   IETF Organizations               October 1996
+
+
+Appendix A - Contact Information
+
+   IETF - ietf@ietf.org, http://www.ietf.org
+
+   IESG - iesg@ietf.org, http://www.ietf.org/iesg.html
+
+   IAB - iab@ietf.org, http://www.iab.org/iab
+
+   RFC Editor - rfc-ed@isi.edu, http://www.isi.edu/rfc-editor
+
+   IANA - iana@iana.org, http://www.iana.org/iana/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hovey & Bradner          Best Current Practice                  [Page 7]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2028.txt](<www.ietf.org/rfc/rfc2028.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
