### PR TITLE
Archive rfc204.txt

### DIFF
--- a/www.ietf.org/rfc/rfc204.txt
+++ b/www.ietf.org/rfc/rfc204.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                   Jon Postel
+Request for Comments: 204                               ULA-NMC
+NIC 7196                                                Comp. Sci.
+Categories A.5, C.3, D                                  5 August 71
+Obsoletes: none
+Related 196
+
+
+                             Sockets in use
+
+   I would like to collect information on the use of socket numbers
+for "standard" service programs. For example Loggers (telnet servers)
+Listen on socket 1. What sockets at your host are Listened to by what
+programs?
+
+   Recently Dick Watson suggested assigning socket 5 for use by a
+mail-box protocol (RFC196). Does any one object ? Are there any
+suggestions for a method of assigning sockets to standard programs?
+Should a subset of the socket numbers be reserved for use by future
+standard protocols?
+
+   Please phone or mail your answers and commtents to:
+
+                        Jon Postel
+                        The SPADE Group
+                        3732 Boelter Hall
+                        Computer Science Dept.
+                        ULA, LA. CA 90024
+
+                        (213) 825 2368
+
+       [ This RFC was put into machine readable form for entry ]
+        [ into the online RFC archives by Gruss Gottfried 6/97 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Crocker                                                         [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc204.txt](<www.ietf.org/rfc/rfc204.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
