### PR TITLE
Archive rfc2079.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2079.txt
+++ b/www.ietf.org/rfc/rfc2079.txt
@@ -1,0 +1,283 @@
+
+
+
+
+
+
+Network Working Group                                          M. Smith
+Request for Comments: 2079                      Netscape Communications
+Category: Standards Track                                  January 1997
+
+
+   Definition of an X.500 Attribute Type and an Object Class to Hold
+                  Uniform Resource Identifiers (URIs)
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Abstract
+
+   Uniform Resource Locators (URLs) are being widely used to specify the
+   location of Internet resources.  There is an urgent need to be able
+   to include URLs in directories that conform to the LDAP and X.500
+   information models, and a desire to include other types of Uniform
+   Resource Identifiers (URIs) as they are defined.  A number of
+   independent groups are already experimenting with the inclusion of
+   URLs in LDAP and X.500 directories.  This document builds on the
+   experimentation to date and defines a new attribute type and an
+   auxiliary object class to allow URIs, including URLs, to be stored in
+   directory entries in a standard way.
+
+Background and Intended Usage
+
+   Uniform Resource Locators (URLs) as defined by [1] are the first of
+   several types of Uniform Resource Identifiers (URIs) being defined by
+   the IETF.  URIs are widely used on the Internet, most notably within
+   Hypertext Markup Language [2] documents. This document defines an
+   X.500 [3,4] attribute type called labeledURI and an auxiliary object
+   class called labeledURIObject to hold all types of URIs, including
+   URLs.  These definitions are designed for use in LDAP and X.500
+   directories, and may be used in other contexts as well.
+
+
+
+
+
+
+
+
+
+
+
+
+Smith                       Standards Track                     [Page 1]
+
+RFC 2079          URI Attribute Type and Object Class       January 1997
+
+
+Schema Definition of the labeledURI Attribute Type
+
+   Name:             labeledURI
+   ShortName:        None
+   Description:      Uniform Resource Identifier with optional label
+   OID:              umichAttributeType.57 (1.3.6.1.4.1.250.1.57)
+   Syntax:           caseExactString
+   SizeRestriction:  None
+   SingleValued:     False
+
+Discussion of the labeledURI Attribute Type
+
+   The labeledURI attribute type has the caseExactString syntax (since
+   URIs are case-sensitive) and it is multivalued.  Values placed in the
+   attribute should consist of a URI (at the present time, a URL)
+   optionally followed by one or more space characters and a label.
+   Since space characters are not allowed to appear un-encoded in URIs,
+   there is no ambiguity about where the label begins.  At the present
+   time, the URI portion must comply with the URL specification [1].
+   Multiple labeledURI values will generally indicate different
+   resources that are all related to the X.500 object, but may indicate
+   different locations for the same resource.
+
+   The label is used to describe the resource to which the URI points,
+   and is intended as a friendly name fit for human consumption.  This
+   document does not propose any specific syntax for the label part.  In
+   some cases it may be helpful to include in the label some indication
+   of the kind and/or size of the resource referenced by the URI.
+
+   Note that the label may include any characters allowed by the
+   caseExactString syntax, but that the use of non-IA5 (non-ASCII)
+   characters is discouraged as not all directory clients may handle
+   them in the same manner.  If non-IA5 characters are included, they
+   should be represented using the X.500 conventions, not the HTML
+   conventions (e.g., the character that is an "a" with a ring above it
+   should be encoded using the T.61 sequence 0xCA followed by an "a"
+   character; do not use the HTML escape sequence "&aring").
+
+Examples of labeledURI Attribute Values
+
+   An example of a labeledURI attribute value that does not include a
+   label:
+
+                   ftp://ds.internic.net/rfc/rfc822.txt
+
+
+
+
+
+
+
+Smith                       Standards Track                     [Page 2]
+
+RFC 2079          URI Attribute Type and Object Class       January 1997
+
+
+   An example of a labeledURI attribute value that contains a tilde
+   character in the URL (special characters in a URL must be encoded as
+   specified by the URL document [1]).  The label is "LDAP Home Page":
+
+             http://www.umich.edu/%7Ersug/ldap/ LDAP Home Page
+
+   Another example.  This one includes a hint in the label to help the
+   user realize that the URL points to a photo image.
+
+        http://champagne.inria.fr/Unites/rennes.gif Rennes [photo]
+
+Schema Definition of the labeledURIObject Object Class
+
+   Name:              labeledURIObject
+   Description:       object that contains the URI attribute type
+   OID:               umichObjectClass.15 (1.3.6.1.4.1.250.3.15)
+   SubclassOf:        top
+   MustContain:
+   MayContain:        labeledURI
+
+Discussion of the labeledURIObject Object Class
+
+   The labeledURIObject class is a subclass of top and may contain the
+   labeledURI attribute.  The intent is that this object class can be
+   added to existing directory objects to allow for inclusion of URI
+   values.  This approach does not preclude including the labeledURI
+   attribute type directly in other object classes as appropriate.
+
+Security Considerations
+
+   Security considerations are not discussed in this memo, except to
+   note that blindly inserting the label portion of a labeledURI
+   attribute value into an HTML document is not recommended, as this may
+   allow a malicious individual to include HTML tags in the label that
+   mislead viewers of the entire document in which the labeledURI value
+   was inserted.
+
+Acknowledgments
+
+   Paul-Andre Pays, Martijn Koster, Tim Howes, Rakesh Patel, Russ
+   Wright, and Hallvard Furuseth provided invaluable assistance in the
+   creation of this document.
+
+   This material is based in part upon work supported by the National
+   Science Foundation under Grant No. NCR-9416667.
+
+
+
+
+
+
+Smith                       Standards Track                     [Page 3]
+
+RFC 2079          URI Attribute Type and Object Class       January 1997
+
+
+Appendix:  The labeledURL Attribute Type (Deprecated)
+
+   An earlier draft of this document defined an additional attribute
+   type called labeledURL.  This attribute type is deprecated, and
+   should not be used when adding new values to directory entries.  The
+   original motivation for including a separate attribute type to hold
+   URLs was that this would better enable efficient progammatic access
+   to specific types of URIs.  After some deliberation, the IETF-ASID
+   working group concluded that it was better to simply have one
+   attribute than two.
+
+   The schema definition for labeledURL is included here for historical
+   reference only.  Directory client software may want to support this
+   schema definition (in addition to labeledURI) to ease the transition
+   away from labeledURL for those sites that are using it.
+
+   Name:             labeledURL
+   ShortName:        None
+   Description:      Uniform Resource Locator with optional label
+   OID:              umichAttributeType.41 (1.3.6.1.4.1.250.1.41)
+   Syntax:           caseExactString
+   SizeRestriction:  None
+   SingleValued:     False
+   OID:              umichAttributeType.41 (1.3.6.1.4.1.250.1.41)
+
+References
+
+   [1] Berners-Lee, T., Masinter, L., and M. McCahill, "Uniform
+   Resource Locators (URL)", RFC 1738, CERN, Xerox Corporation,
+   University of Minnesota, December 1994.
+   <URL:ftp://ds.internic.net/rfc/rfc1738.txt>
+
+   [2] Berners-Lee, T., and D. Connolly, "Hypertext Markup Language -
+   2.0", RFC 1866, <URL:ftp://ds.internic.net/rfc/rfc1866.txt>
+
+   [3] The Directory: Overview of Concepts, Models and Service.  CCITT
+   Recommendation X.500, 1988.
+
+   [4] Information Processing Systems -- Open Systems Interconnection --
+   The Directory: Overview of Concepts, Models and Service.  ISO/IEC JTC
+   1/SC21; International Standard 9594-1, 1988.
+
+
+
+
+
+
+
+
+
+
+Smith                       Standards Track                     [Page 4]
+
+RFC 2079          URI Attribute Type and Object Class       January 1997
+
+
+Author's Address
+
+   Mark Smith
+   Netscape Communications Corp.
+   501 E. Middlefield Rd.
+   Mountain View, CA 94043, USA
+
+   Phone:  +1 415 937-3477
+   EMail:  mcs@netscape.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Smith                       Standards Track                     [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2079.txt](<www.ietf.org/rfc/rfc2079.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
