### PR TITLE
Archive rfc2099.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2099.txt
+++ b/www.ietf.org/rfc/rfc2099.txt
@@ -1,0 +1,1179 @@
+
+
+
+
+
+
+Network Working Group                                         J. Elliott
+Request for Comments: 2099                                           ISI
+Category: Informational                                       March 1997
+
+
+                      Request for Comments Summary
+
+                         RFC Numbers 2000-2099
+
+Status of This Memo
+
+   This RFC is a slightly annotated list of the 100 RFCs from RFC 2000
+   through RFCs 2099.  This is a status report on these RFCs.  This memo
+   provides information for the Internet community.  It does not specify
+   an Internet standard of any kind.  Distribution of this memo is
+   unlimited.
+
+Note
+
+   Many RFCs, but not all, are Proposed Standards, Draft Standards, or
+   Standards.  Since the status of these RFCs may change during the
+   standards processing, we note here only that they are on the
+   standards track.  Please see the latest edition of "Internet Official
+   Protocol Standards" for the current state and status of these RFCs.
+   In the following, RFCs on the standards track are marked [STANDARDS-
+   TRACK].
+
+RFC     Author       Date      Title
+---     ------       ----      -----
+
+2099    Elliott      Mar 97   Request for Comments Summary
+
+This memo.
+
+
+2098    Katsube      Feb 97   Toshiba's Router Architecture Extensions
+                              for ATM : Overview
+
+This memo describes a new internetworking architecture which makes
+better use of the property of ATM.  This memo provides information for
+the Internet community.  This memo does not specify an Internet standard
+of any kind.
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 1]
+
+RFC 2099                  Summary of 2000-2099                March 1997
+
+
+2097    Pall         Jan 97   The PPP NetBIOS Frames Control Protocol
+                              (NBFCP)
+
+This document defines the Network Control Protocol for establishing and
+configuring the NBF protocol over PPP.  The NBFCP protocol is only
+applicable for an end system to connect to a peer system or the LAN that
+peer system is connected to.  [STANDARDS-TRACK]
+
+
+2096    Baker        Jan 97   IP Forwarding Table MIB
+
+This memo defines an update to RFC 1354.  The significant difference
+between this MIB and RFC 1354 is the recognition (explicitly discussed
+but by consensus left to future work) that CIDR routes may have the same
+network number but different network masks.  [STANDARDS-TRACK]
+
+
+2095    Klensin      Jan 97   IMAP/POP AUTHorize Extension for Simple
+                              Challenge/Response
+
+This specification provides a simple challenge-response authentication
+protocol that is suitable for use with IMAP4.  [STANDARDS-TRACK]
+
+
+2094    Harney       Mar 97   Group Key Management Protocol (GKMP)
+                              Architecture
+
+This specification proposes a protocol to create grouped symmetric keys
+and distribute them amongst communicating peers.  This memo defines an
+Experimental Protocol for the Internet community.
+
+
+2093    Harney       Mar 97   Group Key Management Protocol (GKMP)
+                              Specification
+
+This specification proposes a protocol to create grouped symmetric keys
+and distribute them amongst communicating peers.  This memo defines an
+Experimental Protocol for the Internet community.
+
+
+2092    Sherry       Jan 97   Protocol Analysis for Triggered RIP
+
+As required by Routing Protocol Criteria [1], this report documents the
+key features of Triggered Extensions to RIP to Support Demand Circuits
+[2] and the current implementation experience.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+
+
+Elliott                      Informational                      [Page 2]
+
+RFC 2099                  Summary of 2000-2099                March 1997
+
+
+2091    Meyer        Jan 97   Triggered Extensions to RIP to Support
+                              Demand Circuits
+
+This document defines a modification which can be applied to Bellman-
+Ford (distance vector) algorithm information broadcasting protocols.
+[STANDARDS-TRACK]
+
+
+2090    Emberson     Feb 97   TFTP Multicast Option
+
+This document describes a new TFTP option. This new option will allow
+the multiple clients to receive the same file concurrently through the
+use of Multicast packets.  This memo defines an Experimental Protocol
+for the Internet community.
+
+
+2089    Wijnen       Jan 97   V2ToV1 Mapping SNMPv2 onto SNMPv1 within
+                              a bi-lingual SNMP agent
+
+The goal of this memo is to document a common way of mapping an SNMPv2
+response into an SNMPv1 response within a bi-lingual SNMP agent (one
+that supports both SNMPv1 and SNMPv2).  This memo provides information
+for the Internet community.  This memo does not specify an Internet
+standard of any kind.
+
+
+2088    Myers        Jan 97   IMAP4 non-synchronizing literals
+
+The Internet Message Access Protocol [IMAP4] contains the "literal"
+syntactic construct for communicating strings.  When sending a literal
+from client to server, IMAP4 requires the client to wait for the server
+to send a command continuation request between sending the octet count
+and the string data.  This document specifies an alternate form of
+literal which does not require this network round trip.  [STANDARDS-
+TRACK]
+
+
+2087    Myers        Jan 97   IMAP4 QUOTA extension
+
+The QUOTA extension of the Internet Message Access Protocol [IMAP4]
+permits administrative limits on resource usage (quotas) to be
+manipulated through the IMAP protocol.  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 3]
+
+RFC 2099                  Summary of 2000-2099                March 1997
+
+
+2086    Myers        Jan 97   IMAP4 ACL extension
+
+The ACL extension of the Internet Message Access Protocol [IMAP4]
+permits access control lists to be manipulated through the IMAP
+protocol.  [STANDARDS-TRACK]
+
+
+2085    Oehler       Feb 97   HMAC-MD5 IP Authentication with Replay
+                              Prevention
+
+This document describes a keyed-MD5 transform to be used in conjunction
+with the IP Authentication Header [RFC-1826]. The particular transform
+is based on [HMAC-MD5].  An option is also specified to guard against
+replay attacks.  [STANDARDS-TRACK]
+
+
+2084    Bossert      Jan 97   Considerations for Web Transaction
+                              Security
+
+This document specifies the requirements for the provision of security
+services to the HyperText Transport Protocol.  These services include
+confidentiality, integrity, user authentication, and authentication of
+servers/services, including proxied or gatewayed services.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+2083    Boutell      Jan 97   PNG (Portable Network Graphics)
+                              Specification Version 1.0
+
+This document describes PNG (Portable Network Graphics), an extensible
+file format for the lossless, portable, well-compressed storage of
+raster images.  This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+2082    Baker        Jan 97   RIP-2 MD5 Authentication
+
+Growth in the Internet has made us aware of the need for improved
+authentication of routing information.  RIP-2 provides for
+unauthenticated service (as in classical RIP), or password
+authentication.  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 4]
+
+RFC 2099                  Summary of 2000-2099                March 1997
+
+
+2081    Malkin       Jan 97   RIPng Protocol Applicability Statement
+
+As required by Routing Protocol Criteria (RFC 1264), this report defines
+the applicability of the RIPng protocol within the Internet.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+2080    Malkin       Jan 97   RIPng for IPv6
+
+This document specifies a routing protocol for an IPv6 internet.  It is
+based on protocols and algorithms currently in wide use in the IPv4
+Internet [STANDARDS-TRACK]
+
+
+2079    Smith        Jan 97   Definition of an X.500 Attribute Type
+                              and an Object Class to Hold Uniform
+                              Resource Identifiers (URIs)
+
+This document builds on the experimentation to date and defines a new
+attribute type and an auxiliary object class to allow URIs, including
+URLs, to be stored in directory entries in a standard way.  [STANDARDS-
+TRACK]
+
+
+2078    Linn         Jan 97   Generic Security Service Application
+                              Program Interface, Version 2
+
+The Generic Security Service Application Program Interface (GSS-API), as
+defined in RFC-1508, provides security services to callers in a generic
+fashion, supportable with a range of underlying mechanisms and
+technologies and hence allowing source-level portability of applications
+to different environments.  [STANDARDS-TRACK]
+
+
+2077    Nelson       Jan 97   The Model Primary Content Type for
+                              Multipurpose Internet Mail Extensions
+
+The purpose of this memo is to propose an update to Internet RFC 2045 to
+include a new primary content-type to be known as "model".  [STANDARDS-
+TRACK]
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 5]
+
+RFC 2099                  Summary of 2000-2099                March 1997
+
+
+2076    Palme        Feb 97   Common Internet Message Headers
+
+This memo contains a table of commonly occurring headers in headings of
+e-mail messages.  This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+2075    Partridge    Jan 97   IP Echo Host Service
+
+This memo describes how to implement an IP echo host.  IP echo hosts
+send back IP datagrams after exchanging the source and destination IP
+addresses.  This memo defines an Experimental Protocol for the Internet
+community.
+
+
+2074    Bierman      Jan 97   Remote Network Monitoring MIB Protocol
+                              Identifiers
+
+This memo defines an experimental portion of the Management Information
+Base (MIB) for use with network management protocols in the Internet
+community.  In particular, it describes the algorithms required to
+identify different protocol encapsulations managed with the Remote
+Network Monitoring MIB Version 2 [RMON2].  [STANDARDS-TRACK]
+
+
+2073    Rekhter      Jan 97   An IPv6 Provider-Based Unicast Address
+                              Format
+
+This document defines an IPv6 provider-based unicast address format for
+use in the Internet.  [STANDARDS-TRACK]
+
+
+2072    Berkowitz    Jan 97   Router Renumbering Guide
+
+Routers interact with numerous network infrastructure servers, including
+DNS and SNMP.  These interactions, not just the pure addressing and
+routing structure, must be considered as part of router renumbering.
+This memo provides information for the Internet community.  This memo
+does not specify an Internet standard of any kind.
+
+
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 6]
+
+RFC 2099                  Summary of 2000-2099                March 1997
+
+
+2071    Ferguson     Jan 97   Network Renumbering Overview:
+                              Why would I want it and what is it anyway?
+
+This document attempts to clearly define the concept of network
+renumbering and discuss some of the more pertinent reasons why an
+organization would have a need to do so.  This memo provides information
+for the Internet community.  This memo does not specify an Internet
+standard of any kind.
+
+
+2070    Yergeau      Jan 97   Internationalization of the Hypertext
+                              Markup Language
+
+This document is meant to address the issue of the internationalization
+(i18n, i followed by 18 letters followed by n) of HTML by extending the
+specification of HTML and giving additional recommendations for proper
+internationalization support.  [STANDARDS-TRACK]
+
+
+2069    Franks       Jan 97   An Extension to HTTP : Digest Access
+                              Authentication
+
+The protocol referred to as "HTTP/1.0" includes the specification for a
+Basic Access Authentication scheme.  This scheme is not considered to be
+a secure method of user authentication, as the user name and password
+are passed over the network as clear text.  A specification for a
+different authentication scheme is needed to address this severe
+limitation.  This document provides specification for such a scheme,
+referred to as "Digest Access Authentication".  [STANDARDS-TRACK]
+
+
+2068    Fielding     Jan 97   Hypertext Transfer Protocol -- HTTP/1.1
+
+The Hypertext Transfer Protocol (HTTP) is an application-level protocol
+for distributed, collaborative, hypermedia information systems.
+[STANDARDS-TRACK]
+
+
+2067    Renwick      Jan 97   IP over HIPPI
+
+ANSI Standard X3.218-1993 (HIPPI-LE[3]) defines the encapsulation of
+IEEE 802.2 LLC PDUs and, by implication, IP on HIPPI.  This memo is a
+revision of RFC 1374, "IP and ARP on HIPPI", and is intended to replace
+it in the Standards Track.  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 7]
+
+RFC 2099                  Summary of 2000-2099                March 1997
+
+
+2066    Gellens      Jan 97   TELNET CHARSET Option
+
+This document specifies a mechanism for passing character set and
+translation information between a TELNET client and server.  This memo
+defines an Experimental Protocol for the Internet community.
+
+
+2065    Eastlake     Jan 97   Domain Name System Security Extensions
+
+The Domain Name System (DNS) has become a critical operational part of
+the Internet infrastructure yet it has no strong security mechanisms to
+assure data integrity or authentication.  Extensions to the DNS are
+described that provide these services to security aware resolvers or
+applications through the use of cryptographic digital signatures.
+[STANDARDS-TRACK]
+
+
+2064    Brownlee     Jan 97   Traffic Flow Measurement:  Meter MIB
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, this memo defines managed objects used for obtaining traffic
+flow information from network traffic meters.  This memo defines an
+Experimental Protocol for the Internet community.
+
+
+2063    Brownlee     Jan 97   Traffic Flow Measurement:  Architecture
+
+This document describes an architecture for the measurement and
+reporting of network traffic flows, discusses how this relates to an
+overall network traffic flow architecture, and describes how it can be
+used within the Internet.  This memo defines an Experimental Protocol
+for the Internet community.
+
+
+2062    Crispin      Dec 96   Internet Message Access Protocol -
+                              Obsolete Syntax
+
+This document describes obsolete syntax which may be encountered by
+IMAP4 implementations which deal with older versions of the Internet
+Mail Access Protocol.  This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 8]
+
+RFC 2099                  Summary of 2000-2099                March 1997
+
+
+2061    Crispin      Dec 96   IMAP4 COMPATIBILITY WITH IMAP2BIS
+
+This document is intended to be read along with RFC 1176 and the most
+recent IMAP4 specification (RFC 2060) to assist implementors in creating
+an IMAP4 implementation to interoperate with implementations that
+conform to earlier specifications.  This memo provides information for
+the Internet community.  This memo does not specify an Internet standard
+of any kind.
+
+
+2060    Crispin      Dec 96   INTERNET MESSAGE ACCESS PROTOCOL -
+                              VERSION 4rev1
+
+The Internet Message Access Protocol, Version 4rev1 (IMAP4rev1) allows a
+client to access and manipulate electronic mail messages on a server.
+[STANDARDS-TRACK]
+
+
+2059    Rigney       Jan 97   RADIUS Accounting
+
+This document describes a protocol for carrying accounting information
+between a Network Access Server and a shared Accounting Server.  This
+memo provides information for the Internet community.  This memo does
+not specify an Internet standard of any kind.
+
+
+2058    Rigney       Jan 97   Remote Authentication Dial In User
+                              Service (RADIUS)
+
+This document describes a protocol for carrying authentication,
+authorization, and configuration information between a Network Access
+Server which desires to authenticate its links and a shared
+Authentication Server.  [STANDARDS-TRACK]
+
+
+2057    Bradner      Nov 96   Source Directed Access Control on the
+                              Internet
+
+This memo was developed from a deposition that I submitted as part of a
+challenge to the Communications Decency Act of 1996, part of the
+Telecommunications Reform Act of 1996.  This memo provides information
+for the Internet community.  This memo does not specify an Internet
+standard of any kind.
+
+
+
+
+
+
+
+
+Elliott                      Informational                      [Page 9]
+
+RFC 2099                  Summary of 2000-2099                March 1997
+
+
+2056    Denenberg    Nov 96   Uniform Resource Locators for Z39.50
+
+Z39.50 is an information retrieval protocol that does not fit neatly
+into a retrieval model designed primarily around the stateless fetch of
+data.  Instead, it models a general user inquiry as a session-oriented,
+multi-step task, any step of which may be suspended temporarily while
+the server requests additional parameters from the client before
+continuing.  [STANDARDS-TRACK]
+
+
+2055    Callaghan    Oct 96   WebNFS Server Specification
+
+This document describes the specifications for a server of WebNFS
+clients.  This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+2054    Callaghan    Oct 96   WebNFS Client Specification
+
+This document describes a lightweight binding mechanism that allows NFS
+clients to obtain service from WebNFS-enabled servers with a minimum of
+protocol overhead.  This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+2053    Der-Danieliantz  Oct 96   The AM (Armenia) Domain
+
+The AM Domain is an official Internet top-level domain of Armenia.  This
+memo provides information for the Internet community.  This memo does
+not specify an Internet standard of any kind.
+
+
+2052    Gulbrandsen  Oct 96   A DNS RR for specifying the location of
+                              services (DNS SRV)
+
+This document describes a DNS RR which specifies the location of the
+server(s) for a specific protocol and domain (like a more general form
+of MX).  This memo defines an Experimental Protocol for the Internet
+community.
+
+
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 10]
+
+RFC 2099                  Summary of 2000-2099                March 1997
+
+
+2051    Allen        Oct 96   Definitions of Managed Objects for APPC
+                              using SMIv2
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it defines objects for managing the configuration,
+monitoring and controlling of network devices with APPC (Advanced
+Program-to-Program Communications) capabilities.  This memo identifies
+managed objects for the SNA LU6.2 protocols.  [STANDARDS-TRACK]
+
+
+2050    Hubbard      Nov 96   INTERNET REGISTRY IP ALLOCATION
+                              GUIDELINES
+
+This document describes the registry system for the distribution of
+globally unique Internet address space and registry operations.
+Particularly this document describes the rules and guidelines governing
+the distribution of this address space.  This document specifies an
+Internet Best Current Practices for the Internet Community, and requests
+discussion and suggestions for improvements.
+
+
+2049    Freed        Nov 96   Multipurpose Internet Mail Extensions
+                              (MIME) Part Five: Conformance Criteria
+                              and Examples
+
+This set of documents, collectively called the Multipurpose Internet
+Mail Extensions, or MIME, redefines the format of messages.  This fifth
+and final document describes MIME conformance criteria as well as
+providing some illustrative examples of MIME message formats,
+acknowledgements, and the bibliography.  [STANDARDS-TRACK]
+
+
+2048    Freed        Nov 96   Multipurpose Internet Mail Extensions
+                              (MIME) Part Four: Registration
+                              Procedures
+
+This set of documents, collectively called the Multipurpose Internet
+Mail Extensions, or MIME, redefines the format of messages.  This fourth
+document, RFC 2048, specifies various IANA registration procedures for
+some MIME facilities.  This document specifies an Internet Best Current
+Practices for the Internet Community, and requests discussion and
+suggestions for improvements.
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 11]
+
+RFC 2099                  Summary of 2000-2099                March 1997
+
+
+2047    Moore        Nov 96   MIME (Multipurpose Internet Mail
+                              Extensions) Part Three: Message Header
+                              Extensions for Non-ASCII Text
+
+This particular document is the third document in the series.  It
+describes extensions to RFC 822 to allow non-US-ASCII text data in
+Internet mail header fields.  [STANDARDS-TRACK]
+
+
+2046    Freed        Nov 96   Multipurpose Internet Mail Extensions
+                              (MIME) Part Two: Media Types
+
+This second document defines the general structure of the MIME media
+typing system and defines an initial set of media types.  [STANDARDS-
+TRACK]
+
+
+2045    Freed        Nov 96   Multipurpose Internet Mail Extensions
+                              (MIME) Part One: Format of Internet
+                              Message Bodies
+
+This initial document specifies the various headers used to describe the
+structure of MIME messages.  [STANDARDS-TRACK]
+
+
+2044    Yergeau      Oct 96   UTF-8, a transformation format of
+                              Unicode and ISO 10646
+
+The Unicode Standard, version 1.1, and ISO/IEC 10646-1:1993 jointly
+define a 16 bit character set which encompasses most of the world's
+writing systems.  UTF-8, the object of this memo, has the characteristic
+of preserving the full US-ASCII range.  This memo provides information
+for the Internet community.  This memo does not specify an Internet
+standard of any kind.
+
+
+2043    Fuqua        Oct 96   The PPP SNA Control Protocol (SNACP)
+
+This document defines the Network Control Protocols for establishing and
+configuring Systems Network Architecture (SNA) over PPP and SNA over LLC
+802.2 over PPP.  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 12]
+
+RFC 2099                  Summary of 2000-2099                March 1997
+
+
+2042    Manning      Jan 97   Registering New BGP Attribute Types
+
+This document describes the process for creating new BGP attribute type
+codes.  Basic attribute type codes are described in RFC 1771, pages 12
+through 15.  These, and new attribute type codes that are used in the
+Internet are registered with the IANA.  This memo provides information
+for the Internet community.  This memo does not specify an Internet
+standard of any kind.
+
+
+2041    Noble        Oct 96   Mobile Network Tracing
+
+This RFC argues that mobile network tracing provides both tools to
+improve our understanding of wireless channels, as well as to build
+realistic, repeatable testbeds for mobile software and systems.  This
+memo provides information for the Internet community.  This memo does
+not specify an Internet standard of any kind.
+
+
+2040    Baldwin      Oct 96   The RC5, RC5-CBC, RC5-CBC-Pad, and
+                              RC5-CTS Algorithms
+
+This document defines four ciphers with enough detail to ensure
+interoperability between different implementations.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+2039    Kalbfleisch  Nov 96   Applicablity of Standards Track MIBs to
+                              Management of World Wide Web Servers
+
+This document was produced at the request of the Network Management Area
+Director following the HTTP-MIB BOF at the 35th IETF meeting to report
+on the applicability of the existing standards track MIBs to management
+of WWW servers.  This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+2038    Hoffman      Oct 96   RTP Payload Format for MPEG1/MPEG2 Video
+
+This memo describes a packetization scheme for MPEG video and audio
+streams.  The scheme proposed can be used to transport such a video or
+audio flow over the transport protocols supported by RTP.  [STANDARDS-
+TRACK]
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 13]
+
+RFC 2099                  Summary of 2000-2099                March 1997
+
+
+2037    McCloghrie   Oct 96   Entity MIB using SMIv2
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it describes managed objects used for managing multiple
+logical and physical entities managed by a single SNMP agent.
+[STANDARDS-TRACK]
+
+
+2036    Huston       Oct 96   Observations on the use of Components of
+                              the Class A Address Space within the
+                              Internet
+
+This document is a commentary on the recommendation that IANA commence
+allocation of the presently unallocated components of the Class A
+address space to registries, for deployment within the Internet as
+class-less address blocks.  This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+2035    Berc         Oct 96   RTP Payload Format for JPEG-compressed
+                              Video
+
+This memo describes the RTP payload format for JPEG video streams.  The
+packet format is optimized for real-time video streams where codec
+parameters change rarely from frame to frame.  [STANDARDS-TRACK]
+
+
+2034    Freed        Oct 96   SMTP Service Extension for
+                              Returning Enhanced Error Codes
+
+This memo defines an extension to the SMTP service [RFC-821, RFC-1869]
+whereby an SMTP server augments its responses with the enhanced mail
+system status codes defined in RFC 1893.  [STANDARDS-TRACK]
+
+
+2033    Myers        Oct 96   Local Mail Transfer Protocol
+
+SMTP [SMTP] [HOST-REQ] and its service extensions [ESMTP] provide a
+mechanism for transferring mail reliably and efficiently.  The design of
+the SMTP protocol effectively requires the server to manage a mail
+delivery queue.  This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 14]
+
+RFC 2099                  Summary of 2000-2099                March 1997
+
+
+2032    Turletti     Oct 96   RTP Payload Format for H.261 Video
+                              Streams
+
+This memo describes a scheme to packetize an H.261 video stream for
+transport using the Real-time Transport Protocol, RTP, with any of the
+underlying protocols that carry RTP.  [STANDARDS-TRACK]
+
+
+2031    Huizer       Oct 96   IETF-ISOC relationship
+
+This memo summarises the issues on IETF - ISOC relationships as the have
+been discussed by the Poised Working Group. The purpose of the document
+is to gauge consensus on these issues. And to allow further discussions
+where necessary.  This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+2030    Mills        Oct 96   Simple Network Time Protocol (SNTP)
+                              Version 4 for IPv4, IPv6 and OSI
+
+This memorandum describes the Simple Network Time Protocol (SNTP)
+Version 4, which is an adaptation of the Network Time Protocol (NTP)
+used to synchronize computer clocks in the Internet.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+2029    Speer        Oct 96   RTP Payload Format of Sun's CellB Video
+                              Encoding
+
+This memo describes a packetization scheme for the CellB video encoding.
+The scheme proposed allows applications to transport CellB video flows
+over protocols used by RTP.  This document is meant for implementors of
+video applications that want to use RTP and CellB.  [STANDARDS-TRACK]
+
+
+2028    Hovey       Oct 96   The Organizations Involved in the IETF
+                             Standards Process
+
+This document describes the individuals and organizations involved in
+the IETF.  This includes descriptions of the IESG, the IETF Working
+Groups and the relationship between the IETF and the Internet Society.
+This document specifies an Internet Best Current Practices for the
+Internet Community, and requests discussion and suggestions for
+improvements.
+
+
+
+
+
+
+Elliott                      Informational                     [Page 15]
+
+RFC 2099                  Summary of 2000-2099                March 1997
+
+
+2027    Galvin      Oct 96   IAB and IESG Selection, Confirmation, and
+                             Recall Process: Operation of the
+                             Nominating and Recall Committees
+
+The process by which the members of the IAB and IESG are selected,
+confirmed, and recalled has been exercised four times since its formal
+creation.  The evolution of the process has relied principally on oral
+tradition as a means by which the lessons learned could be passed on to
+successive committees.  This document is a self-consistent, organized
+compilation of the process as it is known today.  This document
+specifies an Internet Best Current Practices for the Internet Community,
+and requests discussion and suggestions for improvements.
+
+
+2026    Bradner      Oct 96   The Internet Standards Process --
+                              Revision 3
+
+This memo documents the process used by the Internet community for the
+standardization of protocols and procedures.  It defines the stages in
+the standardization process, the requirements for moving a document
+between stages and the types of documents used during this process.
+This document specifies an Internet Best Current Practices for the
+Internet Community, and requests discussion and suggestions for
+improvements.
+
+
+2025    Adams        Oct 96   The Simple Public-Key GSS-API Mechanism
+                              (SPKM)
+
+This specification defines protocols, procedures, and conventions to be
+employed by peers implementing the Generic Security Service Application
+Program Interface (as specified in RFCs 1508 and 1509) when using the
+Simple Public-Key Mechanism.  [STANDARDS-TRACK]
+
+
+2024    Chen         Oct 96   Definitions of Managed Objects for Data
+                              Link Switching using SMIv2
+
+This specification defines an extension to the Management Information
+Base (MIB) for use with SNMP-based network management.  In particular,
+it defines objects for configuring, monitoring, and controlling Data
+Link Switches (DLSw).  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 16]
+
+RFC 2099                  Summary of 2000-2099                March 1997
+
+
+2023    Haskin       Oct 96   IP Version 6 over PPP
+
+This document defines the method for transmission of IP Version 6 [2]
+packets over PPP links as well as the Network Control Protocol (NCP) for
+establishing and configuring the IPv6 over PPP.  [STANDARDS-TRACK]
+
+
+2022    Armitage     Nov 96   Support for Multicast over UNI 3.0/3.1
+                              based ATM Networks.
+
+This memo describes a mechanism to support the multicast needs of Layer
+3 protocols in general, and describes its application to IP multicasting
+in particular.  [STANDARDS-TRACK]
+
+
+2021    Waldbusser   Jan 97   Remote Network Monitoring Management
+                              Information Base Version 2 using SMIv2
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing remote network monitoring
+devices.  [STANDARDS-TRACK]
+
+
+2020    Flick        Oct 96   Definitions of Managed Objects for IEEE
+                              802.12 Interfaces
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing network interfaces based on
+IEEE 802.12.  [STANDARDS-TRACK]
+
+
+2019    Crawford     Oct 96   A Method for the Transmission of IPv6
+                              Packets over FDDI Networks
+
+This memo specifies the MTU and frame format for transmission of IPv6
+[IPV6] packets on FDDI networks, including a method for MTU
+determination in the presence of 802.1d bridges to other media.
+[STANDARDS-TRACK]
+
+
+2018    Mathis       Oct 96   TCP Selective Acknowledgment Options
+
+This memo proposes an implementation of SACK and discusses its
+performance and related issues.  [STANDARDS-TRACK]
+
+
+
+
+
+Elliott                      Informational                     [Page 17]
+
+RFC 2099                  Summary of 2000-2099                March 1997
+
+
+2017    Freed        Oct 96   Definition of the URL
+                              MIME External-Body Access-Type
+
+This memo defines a new access-type for message/external-body MIME parts
+for Uniform Resource Locators (URLs).  [STANDARDS-TRACK]
+
+
+2016    Daigle       Oct 96   Uniform Resource Agents (URAs)
+
+This paper presents an experimental architecture for an agent system
+that provides sophisticated Internet information access and management.
+This memo defines an Experimental Protocol for the Internet community.
+
+
+2015    Elkins       Oct 96   MIME Security with Pretty Good Privacy
+                              (PGP)
+
+This document describes how Pretty Good Privacy (PGP) can be used to
+provide privacy and authentication using the Multipurpose Internet Mail
+Extensions (MIME) security content types described in RFC1847.
+[STANDARDS-TRACK]
+
+
+2014    Weinrib      Oct 96   IRTF Research Group Guidelines and
+                              Procedures
+
+This document describes the guidelines and procedures for formation and
+operation of IRTF Research Groups.  It describes the relationship
+between IRTF participants, Research Groups, the Internet Research
+Steering Group (IRSG) and the Internet Architecture Board (IAB).  This
+document specifies an Internet Best Current Practices for the Internet
+Community, and requests discussion and suggestions for improvements.
+
+
+2013    McCloghrie   Nov 96   SNMPv2 Management Information Base for
+                              the User Datagram Protocol using SMIv2
+
+This document is the MIB module which defines managed objects for
+managing implementations of the User Datagram Protocol (UDP).
+[STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 18]
+
+RFC 2099                  Summary of 2000-2099                March 1997
+
+
+2012    McCloghrie   Nov 96   SNMPv2 Management Information Base for
+                              the Transmission Control Protocol using
+                              SMIv2
+
+This document is the MIB module which defines managed objects for
+managing implementations of the Transmission Control Protocol (TCP).
+[STANDARDS-TRACK]
+
+
+2011    McCloghrie   Nov 96   SNMPv2 Management Information Base
+                              for the Internet Protocol using SMIv2
+
+This document is the MIB module which defines managed objects for
+managing implementations of the Internet Protocol (IP) and its
+associated Internet Control Message Protocol (ICMP).  [STANDARDS-TRACK]
+
+
+2010    Manning      Oct 96   Operational Criteria for Root Name
+                              Servers
+
+This document specifies the operational requirements of root name
+servers, including host hardware capacities, name server software
+revisions, network connectivity, and physical environment.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+2009    Imielinski   Nov 96   GPS-Based Addressing and Routing
+
+This document describes a possible experiment with geographic addresses.
+It uses several specific IP addresses and domain names in the discussion
+as concrete examples to aid in understanding the concepts.  This memo
+defines an Experimental Protocol for the Internet community.
+
+
+2008    Rekhter      Oct 96   Implications of Various Address
+                              Allocation Policies for Internet Routing
+
+The purpose of this document is to articulate certain relevant
+fundamental technical issues that must be considered in formulating
+unicast address allocation and management policies for the Public
+Internet, and to provide recommendations with respect to these policies.
+This document specifies an Internet Best Current Practices for the
+Internet Community, and requests discussion and suggestions for
+improvements.
+
+
+
+
+
+
+Elliott                      Informational                     [Page 19]
+
+RFC 2099                  Summary of 2000-2099                March 1997
+
+
+2007    Foster       Oct 96   Catalogue of Network Training Materials
+
+The purpose of this document is to provide a catalogue of quality
+Network Training Materials for use by Internet trainers in training
+their users.  This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+2006    Cong         Oct 96   The Definitions of Managed Objects for
+                              IP Mobility Support using SMIv2
+
+This memo defines the Management Information Base (MIB) for use with
+network management protocols in TCP/IP-based internets.  In particular,
+it describes managed objects used for managing the Mobile Node, Foreign
+Agent and Home Agent of the Mobile IP Protocol.  [STANDARDS-TRACK]
+
+
+
+2005    Solomon      Oct 96   Applicability Statement for IP Mobility
+                              Support
+
+As required by [RFC 1264], this report discusses the applicability of
+Mobile IP to provide host mobility in the Internet.  In particular, this
+document describes the key features of Mobile IP and shows how the
+requirements for advancement to Proposed Standard RFC have been
+satisfied.  [STANDARDS-TRACK]
+
+
+2004    Perkins      Oct 96   Minimal Encapsulation within IP
+
+This document specifies a method by which an IP datagram may be
+encapsulated (carried as payload) within an IP datagram, with less
+overhead than "conventional" IP encapsulation that adds a second IP
+header to each encapsulated datagram.  [STANDARDS-TRACK]
+
+
+2003    Perkins      Oct 96   IP Encapsulation within IP
+
+This document specifies a method by which an IP datagram may be
+encapsulated (carried as payload) within an IP datagram.  [STANDARDS-
+TRACK]
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 20]
+
+RFC 2099                  Summary of 2000-2099                March 1997
+
+
+2002    Perkins      Oct 96   IP Mobility Support
+
+This document specifies protocol enhancements that allow transparent
+routing of IP datagrams to mobile nodes in the Internet.  [STANDARDS-
+TRACK]
+
+
+2001    Stevens      Jan 97   TCP Slow Start, Congestion Avoidance,
+                              Fast Retransmit, and Fast Recovery
+                              Algorithms
+
+Modern implementations of TCP contain four intertwined algorithms that
+have never been fully documented as Internet standards: slow start,
+congestion avoidance, fast retransmit, and fast recovery.  [STANDARDS-
+TRACK]
+
+
+2000    I.A.B.       Feb 97   INTERNET OFFICIAL PROTOCOL STANDARDS
+
+This memo describes the state of standardization of protocols used in
+the Internet as determined by the Internet Architecture Board (IAB).
+This memo is an Internet Standard.
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Author's Address
+
+   Josh Elliott
+   University of Southern California
+   Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone:  (310) 822-1511
+
+   EMail: elliott@isi.edu
+
+
+
+
+
+
+
+
+
+
+
+
+
+Elliott                      Informational                     [Page 21]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2099.txt](<www.ietf.org/rfc/rfc2099.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
