### PR TITLE
Archive rfc21.txt

### DIFF
--- a/www.ietf.org/rfc/rfc21.txt
+++ b/www.ietf.org/rfc/rfc21.txt
@@ -1,0 +1,83 @@
+Network Working Group                                            V. Cerf
+Request for Comments: 21                                            UCLA
+                                                        October 17, 1969
+
+
+
+At UCLA on October 10, there was a network meeting attended by:
+
+           SDC                             UCLA
+
+        John Kreznar                    Vint Cerf
+        Dick Linde                      Steve Crocker
+        Marty Bleier                    Jon Postel
+        Bob Long                        Michel Elie
+
+
+           UCSB
+
+        Ron Stoughton
+        Nancy O'Hara
+        George Gregg
+
+
+
+Topics discussed:
+
+        1.  Revisions to BBN memo 1822
+        
+        2.  Revisions to NWG/RFC 11
+
+        3.  Transmission of multiple control messages
+
+
+
+1.  Changes to BBN Memo No. 1822 (underlined)
+    As informally communicated by Dave Wa
+
+    p. 11 "The IMP program can handle up to 63 active transmit links
+    and 63 active receive links at a time.  If the Host attempts to
+    send a message on a new link when 63 active transmit links already
+    exist, a "Link Table Full" message will be sent from the IMP to
+    the Host, and the message will be discarded."
+    
+    p. 11 "1.  Any link that is not used for a period of 26 seconds
+       will have its entry automatically deleted by the IMP program."
+
+
+
+[Cerf:  How about deleting only if the transmit link table is full?
+
+ Crocker:  No, because there is no other way for links to be deleted
+           so they would always tend to accumulate.  Furthermore,
+           the table at one site may be full while another site may
+           not be.]
+
+    p. 13  "5 Regular with discard."
+
+    This allows IMP systems to generate traffic which never actually
+    reaches any Hosts since it will be discarded when it reaches the 
+    top of the IMP-HOST queue in the destination Host's IMP.  The
+    Network Measurement Center will make use of this feature.
+
+    p. 13  Message type 6 is no longer assigned, and message type 10
+    is really in octal so is actually type 8.  Types 9-15 are unassigned.
+
+    p. 17   Type 10 is really type 8.
+
+2.  Revisions to NWG/RFC 11
+
+    This memo has been obsoleted by developments at UCLA and
+    discussions with other nodes.  NWG/RFC 22 contains some of the
+    major changes.  An updated version of NWG/RFC 11 is forthcoming.
+
+3.  George Gregg of UCSB will publish NWG/RFC 23 concerning the
+    transmission of multiple control messages over control links.
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc21.txt](<www.ietf.org/rfc/rfc21.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
