### PR TITLE
Archive rfc211.txt

### DIFF
--- a/www.ietf.org/rfc/rfc211.txt
+++ b/www.ietf.org/rfc/rfc211.txt
@@ -1,0 +1,731 @@
+
+
+
+
+
+
+Network Working Group                                         J.B. North
+Request for Comments: 211                    Stanford Research Institute
+Obsoletes: RFC 168 NIC 6785                                  August 1971
+NIC: 7191
+
+
+                       ARPA Network Mailing Lists
+
+   The following are three lists to be used for distribution of Network
+   documents. List A should be used by sites when they distribute their
+   own documents, to get RFC's to Liaisons as quickly as possible.  All
+   but local mail should be sent Air Mail.  Lists B and C will be used
+   by NIC in making distribution of copies to non-site Network
+   Participants and to Station Agents.
+
+   A distribution list for the Network Graphics Group has been sent to
+   members of that Group, and will included in the forthcoming Directory
+   of Network Participants.
+
+   For phone numbers and lists of name by sites, see the Current
+   Directory of Network Participants.
+
+A.  Initial Distribution List
+
+   Note: this list includes all Network Liaisons and others who should
+   receive initial distribution of RFC's, whether sent from NIC or from
+   sites.  They will also receive selected catalogs and other formal
+   documents from NIC.
+
+   Ames-CD
+
+      A. Wayne Hathaway
+      Mail Stop 233-9
+      NASA Ames Research Center
+      Moffett Field, Calif. 94035
+
+   AMES-ILLIAC
+
+      John W. McConnell
+      NASA Ames Research Center
+      Mail Stop 237-9
+      Moffett Field, Calif. 94035
+
+
+
+
+
+
+
+
+
+North                                                           [Page 1]
+
+RFC 211                ARPA Network Mailing Lists            August 1971
+
+
+   ARPA
+
+      Steve D. Crocker
+      Advanced Research Projects Agency
+      1400 Wilson Boulevard
+      Arlington, Virginia 22209
+
+   BBN-NET
+
+      Alex McKenzi
+      Bold Beranek and Newman Inc.
+      50 Moulton Street
+      Cambridge, Mass. 02138
+
+   BBN-TENEX
+
+      Robert H. Thomas
+      Bold Beranek and Newman Inc.
+      50 Moulton Street
+      Cambridge, Mass. 02138
+
+   CASE
+
+      Dr. Patrick W. Foulk
+      Jennings Computing Center
+      Room 306, Crawford Hall
+      Case Western Reserve Laboratory
+      10900 Euclid Avenue
+      Cleveland, Ohio 44106
+
+   CCA
+
+      Richard A. Winter
+      Computer Corporation of America
+      565 Technology Square
+      Cambridge, Mass. 02139
+
+   CMU
+
+      Harold R. Van Zoeren
+      Carnegie-Mellon University
+      Computer Science Department
+      Schenley Park
+      Pittsburgh, Pa. 15213
+
+
+
+
+
+
+
+North                                                           [Page 2]
+
+RFC 211                ARPA Network Mailing Lists            August 1971
+
+
+   HARV
+
+      Robert L. Sundberg
+      Harvard University
+      Aiken Computation Laboratory
+      33 Oxford Street
+      Cambridge, Mass. 02138
+
+   IMBW
+
+      Douglas McKay
+      IBM Watson Research Center
+      P.O. Box 218
+      Yorktown Heights, NY 10598
+
+   ILL
+
+      James M. Madden
+      University of Illinois
+      Center for Advanced Computation
+      168 Engineering Research Laboratory
+      Urbana, Illinois 61801
+
+   LINC-67
+
+      Joel M. Winett
+      Massachusetts Institute of Technology
+      Lincoln Laboratory
+      244 Wood Street
+      Lexington, Mass. 02173
+
+   LINC-TX2
+
+      William Kantrowitz
+      Massachusetts Institute of Technology
+      Lincoln Laboratory
+      244 Wood Street
+      Lexington, Mass. 02173
+
+   MIT-DMCG
+
+      Aphay Bhushan
+      Project MAC
+      545 Technology Square
+      Cambridge, Mass. 02139
+
+
+
+
+
+
+North                                                           [Page 3]
+
+RFC 211                ARPA Network Mailing Lists            August 1971
+
+
+   MIT-MULTICS
+
+      See MIT-DMCG
+
+   MITRE
+
+      Peggy M. Karp
+      MITRE Cooperation
+      Information Systems Dept., W140
+      Westgate Research Park
+      McLean, Va. 22101
+
+   NBS
+
+      Thomas N. Pyke, Jr.
+      National Bureau of Standards
+      Center for Computer Sciences and Technology
+      Washington,  D.C., 20234
+
+   NIC
+
+      See SRI-ARC
+
+   RADC
+
+      Thomas Lawrence
+      Rome Air Development Center (ISIM)
+      Griffiss Air Force Base
+      Rome, New York 13440
+
+   RAND
+
+      John F. Heafner
+      Rand Corporation
+      Computer Science Department
+      1700 Main Street
+      Santa Monica, CA 90406
+
+   RAY
+
+      Thomas O'Sullivan
+      Raytheon Data Systems
+      1415 Boston-Providence Turnpike
+      Norwood, Mass. 02062
+
+
+
+
+
+
+
+North                                                           [Page 4]
+
+RFC 211                ARPA Network Mailing Lists            August 1971
+
+
+   SDC
+
+      Abe S. Landsberg
+      System Development Corporation
+      2500 Colorado Avenue
+      Santa Monica, Calif. 90406
+
+   SRI
+
+      B. Michael Wilber
+      Stanford Research Institute
+      Artificial Research Institute
+      333 Ravenswood Avenue
+      Menlo Park, Calif. 94205
+
+   SRI-ARC
+
+      John T. Melvin
+      Stanford Research Institute
+      Augmentation Research Center
+      333 Ravenswood Avenue
+      Menlo Park, Calif. 94025
+
+      Jeanne B. North (for NIC)
+      Stanford Research Institute
+      Augmentation Research Center
+      333 Ravenswood Avenue
+      Menlo Park, Calif. 94025
+
+   SU-AI
+
+      James A. [Andy] Moorer
+      Stanford University
+      Computation Center, AI Project
+      Stanford, Calif. 94305
+
+   SU-HP
+
+      Edward A. Feigenbaum
+      Stanford University
+      Heuristic Programming
+      Serra House
+      Stanford, Calif. 94305
+
+
+
+
+
+
+
+
+North                                                           [Page 5]
+
+RFC 211                ARPA Network Mailing Lists            August 1971
+
+
+   UCLA-CCN
+
+      Robert T. Braden
+      University of California at Los Angeles
+      5308 Math Sciences Building
+      Los Angeles, CA 90024
+
+   UCLA-NMC
+
+      Ari O. Ollikalen
+      University of California at Los Angeles
+      Computer Science Department
+      3732 Boelter Hall
+      Los Angeles, Calif. 90024
+
+   UCSB
+
+      James E. White
+      University of California at Santa Barbara
+      Computer Research Laboratory
+      Santa Barbara, Calif. 93106
+
+   USC
+
+      James Perin
+      University of Southern California
+      School of Engineering
+      Los Angeles, Calif. 90007
+
+   UTAH
+
+      Barry D. Wessler
+      University of Utah
+      Computer Science/IRL
+      Salt Lake City, Utah 84112
+
+B.  List for Distribution from NIC
+
+   Note: These Network participants will receive all formal Network
+   documents sent from NIC, in the mailing to Liaisons when such is
+   made, otherwise at the time documents are sent to Station Agents.
+
+
+
+
+
+
+
+
+
+
+North                                                           [Page 6]
+
+RFC 211                ARPA Network Mailing Lists            August 1971
+
+
+   CCCTF
+
+      C.D. Shepard
+      Canadian Computer Communications Task Force
+      100 Metcalfe Street
+      4th Floor
+      Ottawa 2, Canada
+
+   DART
+
+      Prof. Robert F. Hargraves
+      Klewit Computation Center
+      Dartmouth University
+      Hanover, New Hampshire 03755
+
+   EDUCOM
+
+      John LeGates
+      EDUCOM
+      100 Charles River Plaza
+      Boston, Mass. 02114
+
+   MERIT
+
+      E.M. Aupperle
+      MERIT Computer Network
+      The University of Michigan
+      1037 N. University Building
+      Ann Arbor, Michigan 48104
+
+   NETH
+
+      Tjaart Schipper
+      13 Marijkestreat
+      Lederdrorp, Netherlands
+
+   SUNY
+
+      Prof. Art J. Bernstein
+      SUNY Stoneybrook
+      Dept. of Computer Science
+      Stoneybrook, L.I., N.Y. 11790
+
+
+
+
+
+
+
+
+
+North                                                           [Page 7]
+
+RFC 211                ARPA Network Mailing Lists            August 1971
+
+
+   UCI
+
+      Prof. David Farber
+      Dept. of Information and Computer Science
+      University of California
+      Irvine, Calif. 92664
+
+   UKICS
+
+      Prof. Peter Kirstein
+      Institute of Computer Science
+      University of London
+      44 Gordon Square
+      London, W.C.I. England
+
+   WASHU
+
+      Marianne Pepper
+      Washington University
+      Computer Systems Laboratory
+      724 South Euclid Avenue
+      St. Louis, Mo. 63110
+
+   WATERU
+
+      Prof. Donald Cowan
+      Dept. of Computer Science
+      University of Waterloo
+      Waterloo, Ontario, Canada
+
+C.  NIC Station Agents
+
+   Note: Station Agents receive copies from NIC of all documents
+   distributed to Liaisons, as well as documents sent as part of a
+   Station collection.  A mailing is made to Station Agents once a week,
+   or oftener when quantity warrants.
+
+   AMES-CD
+
+      See AMES-ILLIAC
+
+   AMES-ILLIAC
+
+      Stan Golding
+      Mail Stop 233-13
+      NASA Ames Research Center
+      Moffett Field, Calif. 94035
+
+
+
+
+North                                                           [Page 8]
+
+RFC 211                ARPA Network Mailing Lists            August 1971
+
+
+   ARPA
+
+      Margaret M. Opering
+      Advanced Research Projects Agency
+      1400 Wilson Boulevard
+      Arlington, Va. 22209
+
+   BBN-NET
+
+      See BBN-TENEX
+
+   BBN-TENEX
+
+      Steve G. Chipman
+      Bolt Beranek and Newman Inc.
+      50 Moulton Street
+      Cambridge, Mass. 02138
+
+   CASE
+
+      John Barden
+      Case Western Reserve University
+      Computing and Information Sciences
+      10900 Euclid Ave.
+      Cleveland, Ohio 44106
+
+   CCA
+
+      Martha A. Ginsberg
+      Computer Corporation of America
+      565 Technology Square
+      Cambridge, Mass. 02139
+
+   CMU
+
+      Carolyn M. Lisle
+      Carnegie-Mellon University
+      Computer Science Department
+      Schenley Park
+      Pittsburgh, Pa. 15213
+
+   HARV
+
+      Bradley A. Reussow
+      Harvard University
+      Aiken Computation Laboratory
+      33 Oxford Street
+      Cambridge, Mass. 02138
+
+
+
+North                                                           [Page 9]
+
+RFC 211                ARPA Network Mailing Lists            August 1971
+
+
+   IBMW
+
+      Douglas McKay
+      IBM Watson Research Center
+      P.O. Box 218
+      Yorktown Heights, N.Y. 10598
+
+   ILL
+
+      Nan Brown
+      University of Illinois
+      Center for Advanced Computation
+      168 Engineering Research Laboratory
+      Urbana, Ill. 61801
+
+   LINC-67
+
+      Carol J. Mostrom
+      Massachusetts Institute of Technology
+      Lincoln Laboratory
+      244 Wood Street
+      Lexington, Mass. 02173
+
+   LINC-TX2
+
+      see LINC-67
+
+   MIT-DMCG
+
+      Frances L. Knight
+      Project MAC
+      545 Technology Square
+      Cambridge, Mass. 02173
+
+   MIT-MULTICS
+
+      see MIT-DMCG
+
+   MITRE
+
+      Madge B. Cornell
+      MITRE Corporation
+      Information Systems Dept., W150
+      Westgate Research Park
+      McLean, Va. 22101
+
+
+
+
+
+
+North                                                          [Page 10]
+
+RFC 211                ARPA Network Mailing Lists            August 1971
+
+
+   NBS
+
+      Mrs. Shirley W. Watkins
+      National Bureau of Standards
+      Bldg. 225, Room B216
+      Washington, D.C. 20234
+
+   NIC
+
+      see SRI-ARC
+
+   RADC
+
+      Marcella D. Petell
+      Rome Air Development Center (ISIM)
+      Griffiss Air Force Base
+      Rome, New York 13440
+
+   RAND
+
+      Linda M. Connelly
+      Rand Corporation
+      Computer Science Department
+      1700 Main Street
+      Santa Monica, Calif. 90406
+
+   RAY
+
+      Laura White
+      Raytheon Data Systems
+      1415 Boston-Providence
+      Norwood, Mass. 02062
+
+   SDC
+
+      Janet W. Troxel
+      System Development Corporation
+      Information Processing Information Center
+      2500 Colorado Avenue
+      Santa Monica, Calif. 90406
+
+   SRI-AI
+
+      Rilla J. Reynolds
+      Stanford Research Institute
+      Artificial Intelligence Group
+      333 Ravenswood Avenue
+      Menlo Park, Calif. 94205
+
+
+
+North                                                          [Page 11]
+
+RFC 211                ARPA Network Mailing Lists            August 1971
+
+
+   SRI-ARC
+
+      Cindy Page
+      Stanford Research Institute
+      Augmentation Research Center
+      333 Ravenswood Ave.
+      Menlo Park, Calif. 94205
+
+   SU-AI
+
+      Barbara A. Barnett
+      Stanford University
+      Artificial Intelligence Project
+      D.C. Power Lab
+      Stanford, Calif. 94305
+
+   SU-HP
+
+      Carol Wilkinson
+      Stanford University
+      Heuristic Programming Project
+      Serra House
+      Stanford, Calif. 94305
+
+   UCLA-CCN
+
+      Imogen C. Beattie
+      University of California at Los Angeles
+      2531 Boelter Hall
+      Los Angeles, Calif. 90024
+
+   UCLA-NMC
+
+      Anita Coley
+      University of California at Los Angeles
+      Computer Science Department
+      3732 Boelter Hall
+      Los Angeles, Calif. 90024
+
+   UCSB
+
+      Connie Rosewall
+      University of California at Santa Barbara
+      Computer Research Laboratory
+      Santa Barbara, Calif. 93106
+
+
+
+
+
+
+North                                                          [Page 12]
+
+RFC 211                ARPA Network Mailing Lists            August 1971
+
+
+   USC
+
+      Linda M. Webster
+      University of Southern California
+      Olin Hall of Engineering
+      Room 240
+      Los Angeles, Calif. 90007
+
+   UTAH
+
+      Nancy F. Bruderer
+      University of Utah
+      Computer Science/IWL
+      Salt Lake City, Utah 84112
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+North                                                          [Page 13]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc211.txt](<www.ietf.org/rfc/rfc211.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
