### PR TITLE
Archive rfc214.txt

### DIFF
--- a/www.ietf.org/rfc/rfc214.txt
+++ b/www.ietf.org/rfc/rfc214.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                              21 August 1971
+Request for Comments 214                           E. Harslem-Rand
+NIC 7195
+Category: F
+Obsoletes: 193, 198
+
+
+                            NETWORK CHECKOUT
+
+
+      As of August 21 we had performed the following verifications
+with the sites listed below.  These verifications were done on an
+arranged basis and do not indicate any degree of continuous
+availability.
+
+      In the category "NCP-107" the heading is somewhat misleading.
+It does not indicate a thorough checkout of all the NCP functions
+described in Document 1 and RFC-107.  It only indicates that the NCP
+in question functioned to the extent required to respond to a RESET (a
+necessary condition for the Rand NCP to consider the remote host "up")
+and that the NCP performed the functions necessary for an ICP.  Thus,
+this column really indicates only a small degree of NCP completeness.
+Such function as ECHO, Give Back, error message generation and so on
+were not checked.  We have checked some of these functions with UCSB
+and SDC but not exhaustively.  This is mainly due to the tedium of
+such a process.  BBN is currently writing a protocol certifier for
+their DDP-516 host that will do this automatically.
+
+                                  User   Server          Access
+               NCP-107  ICP-156  Telnet  Telnet  Logger  Service
+UCLA Sigma7      x        x        x       x       x       x
+UCLA /91         x        x        x       x       na      x
+SRI NIC          x        x                ?       ?       ?
+UCSB             x        x        x       x       na      x
+BBN A10          x        x                x       x       x
+BBN TIP          x        x        x       x               na
+MIT Multics      x        ?
+MIT DMCG         x        x        x       x       x       x
+SDC              x        x        x       x       ?
+LINCOLN /67      x        x        x       x       x       x
+UTAH             TENEX being installed
+
+
+LEGEND:
+
+ --- the function has not been verified for the host
+
+x--- the function has been verified for the host
+
+
+
+                                                                [Page 1]
+
+21 Auguest 1971                                                  RFC 214
+
+
+na-- the function is not applicable to the host due to its
+     operating system or intended network use
+
+?--- a comment follows for that function in that host
+
+
+COMMENTS:
+
+SRI NIC -- both a server telnet and logger exist; however, they
+           do not process the telnet messages correctly
+
+MIT Multics  -- we were only able to connect to an interim
+          logger that sent a 'ts' message
+
+SDC  -- the logger causes the system to crash following login
+
+
+      Any discrepancies should be noted via phone call.  This
+RFC will be updated in about one month.
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+          [ into the online RFC archives by Brian Court 6/97 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc214.txt](<www.ietf.org/rfc/rfc214.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
