### PR TITLE
Archive rfc2158.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2158.txt
+++ b/www.ietf.org/rfc/rfc2158.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Network Working Group                                    H. Alvestrand
+Request for Comments: 2158                                     UNINETT
+Category: Standards Track                                 January 1998
+
+
+                         X.400 Image Body Parts
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (1998).  All Rights Reserved.
+
+1.  Introduction
+
+   This document contains the body parts defined in RFC 1495 for
+   carrying image formats that were originally defined in MIME through
+   an X.400 system.
+
+   It also documents the OIDs assigned to these data formats as FTAM
+   body parts, which allow the MIME types to be converted to FTAM body
+   parts; this will probably be more useful than the new body parts
+   defined here.
+
+2.  Newly defined X.400 body parts
+
+2.1.  The JPEG body part
+
+   The following Extended Body Part is defined for JPEG data streams.
+   It has no parameters.
+
+       jpeg-body-part EXTENDED-BODY-PART-TYPE
+         DATA            OCTET STRING
+         ::= mime-jpeg-body
+
+       mime-jpeg-body OBJECT IDENTIFIER ::=
+               { mixer-bp-data 3 }
+
+   The content is as defined in [MIME].
+
+
+
+
+
+
+Alvestrand                  Standards Track                     [Page 1]
+
+RFC 2158                 X.400 Image Body Parts             January 1998
+
+
+2.2.  The GIF body part
+
+   The following Extended Body Part is defined for GIF data streams.  It
+   has no parameters.
+
+       gif-body-part EXTENDED-BODY-PART-TYPE
+         DATA            OCTET STRING
+         ::= mime-gif-body
+
+       mime-gif-body OBJECT IDENTIFIER ::=
+               { mixer-bp-data 4 }
+
+   The content is as defined in [MIME].
+
+3.  Defined equivalences with MIME types
+
+3.1.  image/jpeg - jpeg-body-part
+
+   X.400 Body Part: Extended Body Part, OID jpeg-body-part
+   MIME Content-Type: image/jpeg
+   Conversion: None
+
+3.2.  image/jpeg - FTAM EMA JPEG
+
+   X.400 Body Part: FTAM EMA JPEG
+   MIME Content-Type: image/jpeg
+   Conversion: None
+
+   The OID assigned to JPEG by EMA in [MAWG] is
+
+   { ema objects(2) messaging (2) attachments(1) jpeg-image(6) }
+
+   while EMA's OID is
+
+   { joint-iso-ccitt(2) country(16) us(840) organization(1)
+   ema(113694) }
+
+   making the total OID, numeric only
+
+   { 2 16 840 1 113694 2 2 1 6 }
+
+3.3.  image/gif - gif-body-part
+
+   X.400 Body Part: Extended Body Part, OID gif-body-part
+   MIME Content-Type: image/gif
+   Conversion: None
+
+
+
+
+
+Alvestrand                  Standards Track                     [Page 2]
+
+RFC 2158                 X.400 Image Body Parts             January 1998
+
+
+3.4.  image/gif - FTAM EMA GIF
+
+   X.400 Body Part: FTAM EMA GIF
+   MIME Content-Type: image/jpeg
+   Conversion: None
+
+   The OID assigned to JPEG by EMA in [MAWG] is
+
+   { ema objects(2) messaging (2) attachments(1) gif-image(4) }
+
+4.  Security Considerations
+
+   Security issues are not considered in this memo.
+
+5.  References
+
+   [MIME]
+       Freed, N., and N. Borenstein, "Multipurpose Internet Mail
+       Extensions (MIME) Part One: Format of Internet Message Bodies",
+       RFC 2045, November 1996.
+
+   [MAWG]
+       Electronic Messaging Association Message Attachment Working Group
+       (MAWG): File Transfer Body Part Feasibility Project Guide -
+       version 1.5.1 - March 1996.
+
+6.  Author's Address
+
+   Harald Tveit Alvestrand
+   UNINETT
+   Postboks 6883 Elgeseter
+   N-7002 TRONDHEIM
+
+   Phone: +47 73 59 70 94
+   EMail: Harald.T.Alvestrand@uninett.no
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Alvestrand                  Standards Track                     [Page 3]
+
+RFC 2158                 X.400 Image Body Parts             January 1998
+
+
+7.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (1998).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Alvestrand                  Standards Track                     [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2158.txt](<www.ietf.org/rfc/rfc2158.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
