### PR TITLE
Archive rfc2160.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2160.txt
+++ b/www.ietf.org/rfc/rfc2160.txt
@@ -1,0 +1,283 @@
+
+
+
+
+
+
+Network Working Group                                    H. Alvestrand
+Request for Comments: 2160                                     UNINETT
+Category: Standards Track                                 January 1998
+
+
+                 Carrying PostScript in X.400 and MIME
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (1998).  All Rights Reserved.
+
+Table of Contents
+
+   1 Introduction ............................................    1
+   2 The PostScript body part ................................    1
+   3 The PostScript FTBP .....................................    2
+   4 The Application/PostScript content-type .................    2
+   5 MIXER conversion ........................................    2
+   6 MIXER conversion ........................................    2
+   7 OID Assignments .........................................    3
+   8 Security Issues .........................................    3
+   9 Trademark Issues ........................................    3
+   10 References .............................................    3
+   11 Author's Address .......................................    4
+   12 Full Copyright Statement ...............................    5
+
+1.  Introduction
+
+   This document describes methods for carrying PostScript information
+   in the two standard mail systems MIME and X.400, and the conversion
+   between them. It uses the notational conventions of [BODYMAP], and
+   the conversion is further described in [MIXER].
+
+   Two ways of carrying PostScript in X.400 are described.  One is using
+   the FTAM Body Part, and one uses the Extended Body Part originally
+   described in RFC 1494.
+
+   The FTAM method is recommended.
+
+
+
+
+
+Alvestrand                  Standards Track                     [Page 1]
+
+RFC 2160         Carrying PostScript in X.400 and MIME      January 1998
+
+
+2.  The PostScript body part
+
+   Carrying PostScript in X.400 as an Extended Body Part was originally
+   defined in RFC 1494.  This specification carries that work forward
+   now that RFC 1494 is obsoleted by [BODYMAP].
+
+   The following Extended Body Part is defined for PostScript data
+   streams.  It has no parameters.
+
+
+      postscript-body-part EXTENDED-BODY-PART-TYPE
+        DATA             OCTET STRING
+        ::= mime-postscript-body
+
+      mime-postscript-body OBJECT IDENTIFIER ::=
+                { mixer-bp-data 2 }
+
+3.  The PostScript FTBP
+
+   The PostScript FTBP is identified by having the
+   FileTransferParameters.environment.application-reference set to id-
+   mime-ftbp-postscript.
+
+   The definition is:
+
+    id-mime-ftbp-postscript OBJECT IDENTIFIER ::=
+                       { mixer-bp-data 6 }
+
+4.  The Application/PostScript content-type
+
+   In MIME, PostScript is carried in the body part
+   "application/PostScript", which is defined in RFC 1521.
+
+5.  MIXER conversion
+
+   X.400 Body Part: Extended Body Part, OID mime-postscript-body MIME
+   Content-Type: application/postscript Conversion Type: No conversion
+
+   The two representations of PostScript both contain a single stream of
+   octets. This stream of octets can be copied with no problems between
+   the representations. No other data needs to be converted.
+
+6.  MIXER conversion
+
+   X.400 Body Part: FTBP, OID mime-ftbp-postscript-body MIME Content-
+   Type: application/postscript Conversion Type: No conversion
+
+
+
+
+
+Alvestrand                  Standards Track                     [Page 2]
+
+RFC 2160         Carrying PostScript in X.400 and MIME      January 1998
+
+
+   The two representations of PostScript both contain a single stream of
+   octets. This stream of octets can be copied with no problems between
+   the representations. No other data needs to be converted.
+
+7.  OID Assignments
+
+   The first OID is also defined in [BODYMAP].
+
+    POSTSCRIPT-MAPPINGS DEFINITIONS ::= BEGIN
+    EXPORTS -- everything --;
+
+    IMPORTS
+       mixer-bp-data
+           FROM MIXER-MAPPINGS
+
+    id-mime-postscript-body OBJECT IDENTIFIER ::=
+            { mixer-bp-data 2 };
+    id-mime-ftbp-postscript OBJECT IDENTIFIER ::=
+            { mixer-bp-data 6 };
+
+    END
+
+8.  Security Issues
+
+   The issues concerning PostScript and security are well discussed in
+   RFC 2046.  No additional security issues are identified by this memo.
+
+9.  Trademark Issues
+
+   PostScript is a trademark of Adobe Systems, Inc.
+
+10.  References
+
+[MIXER]
+     Kille, S., "MIXER: Mapping between X.400
+     and RFC 822/MIME", RFC 2156, January 1998.
+
+[BODYMAP]
+     Alvestrand, H., "Mapping between X.400 and RFC 822/MIME
+     Message Bodies", RFC 2157, January 1998.
+
+
+
+
+
+
+
+
+
+
+
+Alvestrand                  Standards Track                     [Page 3]
+
+RFC 2160         Carrying PostScript in X.400 and MIME      January 1998
+
+
+11.  Author's Address
+
+   Harald Tveit Alvestrand
+   UNINETT
+   Postboks 6883 Elgeseter
+   N-7002 TRONDHEIM
+
+   Phone: +47 73 59 70 94
+   EMail: Harald.T.Alvestrand@uninett.no
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Alvestrand                  Standards Track                     [Page 4]
+
+RFC 2160         Carrying PostScript in X.400 and MIME      January 1998
+
+
+12.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (1998).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Alvestrand                  Standards Track                     [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2160.txt](<www.ietf.org/rfc/rfc2160.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
