### PR TITLE
Archive rfc217.txt

### DIFF
--- a/www.ietf.org/rfc/rfc217.txt
+++ b/www.ietf.org/rfc/rfc217.txt
@@ -1,0 +1,112 @@
+
+
+
+
+
+
+RFC 217                                       8 September 71
+NIC 7547                                      James E. White
+Categories:  G.3                      Computer Research Lab.
+Updates:  RFC 105, RFC 122               Univ. of California
+Obsoletes: RFC 74                              Santa Barbara
+
+
+               Specification Changes for
+               OLS, RJE/RJOR, and SMFS
+
+     The following documents are hereby revised:
+
+     (1)  'Specifications for Network Use of the UCSB
+          On-Line System [16 October 70, RFC 74, NIC 5417],
+
+     (2)  'Network Specifications for Remote Job Entry and
+          Remote Job Output Retrieval at UCSB' [22 March 71,
+          RFC 105, NIC 5775], and
+
+     (3)  'Network Specifications for UCSB's Simple-
+          Minded File System' [26 April 71, RFC 122,
+          NIC 5834].
+
+     Revisions are as follows:
+
+     (1)  As far as can be determined, no Network site has
+          written code to interface to the UCSB software
+          documented in RFC 74 last October.  Accordingly,
+          UCSB has terminated support for that software,
+          and hence RFC 74 is obsolete.
+
+     (2)  In accordance with subsequent Host-Host protocol
+          changes, the notion of 'message type' has been
+          dropped from the specifications for RJE and RJOR,
+          RFC 105.  RJE/RJOR no longer send, nor expect to
+          receive 8 bits of zeros as the first byte trans-
+          mitted over a connection.
+
+     (3)  In accordance with Document 2, RJE and RJOR now
+          employ a standard ICP to create a full duplex
+          connection to the user.  Accordingly, RJE and
+          RJOR listen on sockets x'201' and x'301',
+          respectively (rather than on x'200' and x'300'
+          as before).  As documented in RFC 105, RJE
+          required only a simplex connection to the user.
+          A full duplex connection is now supported, but
+          no data is transmitted to the user over the
+
+
+
+
+                                                                [Page 1]
+
+NIC 7547
+
+          added simplex connection.  RJOR now also supports
+          a full duplex connection.  However, if RJOR is
+          required to call the user back when a requested
+          job's output is ready, it still does so employing
+          a simplex connection to the user's receive socket.
+
+     (4)  RJE/RJOR and SMFS specify a byte size of
+          eight for their connection to the user's
+          receive socket.  The user may choose the
+          byte size for the other simplex connection
+          to suit himself;  any valid byte size is
+          acceptable to UCSB.
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc217.txt](<www.ietf.org/rfc/rfc217.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
