### PR TITLE
Archive rfc2199.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2199.txt
+++ b/www.ietf.org/rfc/rfc2199.txt
@@ -1,0 +1,1291 @@
+
+
+
+
+
+
+Network Working Group                                           A. Ramos
+Request for Comments: 2199                                           ISI
+Category: Informational                                     January 1998
+
+
+                      Request for Comments Summary
+
+                         RFC Numbers 2100-2199
+
+Status of This Memo
+
+   This RFC is a slightly annotated list of the 100 RFCs from RFC 2100
+   through RFCs 2199.  This is a status report on these RFCs.  This memo
+   provides information for the Internet community.  It does not specify
+   an Internet standard of any kind.  Distribution of this memo is
+   unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (1998).  All Rights Reserved.
+
+Note
+
+   Many RFCs, but not all, are Proposed Standards, Draft Standards, or
+   Standards.  Since the status of these RFCs may change during the
+   standards processing, we note here only that they are on the
+   standards track.  Please see the latest edition of "Internet Official
+   Protocol Standards" for the current state and status of these RFCs.
+   In the following, RFCs on the standards track are marked [STANDARDS-
+   TRACK].
+
+RFC     Author          Date      Title
+---     ------          ----      -----
+
+
+2199    Ramos           Jan 98  Request for Comments Summary
+
+This memo.
+
+
+2198    Perkins         Sep 97  RTP Payload for Redundant Audio Data
+
+This document describes a payload format for use with the real-time
+transport protocol (RTP), version 2, for encoding redundant audio data.
+[STANDARDS-TRACK]
+
+
+
+
+
+
+Ramos                        Informational                      [Page 1]
+
+RFC 2199                  Summary of 2100-2199              January 1998
+
+
+2197    Freed           Sep 97  SMTP Service Extension
+                                for Command Pipelining
+
+This memo defines an extension to the SMTP service whereby a server can
+indicate the extent of its ability to accept multiple commands in a
+single TCP send operation. [STANDARDS-TRACK]
+
+
+2196    Fraser          Sep 97  Site Security Handbook
+
+This handbook is a guide to developing computer security policies and
+procedures for sites that have systems on the Internet.  The purpose of
+this handbook is to provide practical guidance to administrators trying
+to secure their information and services.  The subjects covered include
+policy content and formation, a broad range of technical system and
+network security topics, and security incident response.  This memo
+provides information for the Internet community.  It does not specify an
+Internet standard of any kind.
+
+
+2195     Klensin        Sep 97  IMAP/POP AUTHorize Extension for Simple
+                                Challenge/Response
+
+This specification provides a simple challenge-response authentication
+protocol that is suitable for use with IMAP4. [STANDARDS TRACK]
+
+
+2194    Aboba           Sep 97  Review of Roaming Implementations
+
+This document reviews the design and functionality of existing roaming
+implementations.  Examples of cases where roaming capability might be
+required include ISP "confederations" and ISP-provided corporate network
+access support.  This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+2193    Gahrns          Sep 97  IMAP4 Mailbox Referrals
+
+Mailbox referrals allow clients to seamlessly access mailboxes that are
+distributed across several IMAP4 servers. [STANDARDS-TRACK]
+
+
+2192    Newman          Sep 97  IMAP URL Scheme
+
+This document defines a URL scheme for referencing objects on an IMAP
+server. [STANDARDS-TRACK]
+
+
+
+
+
+Ramos                        Informational                      [Page 2]
+
+RFC 2199                  Summary of 2100-2199              January 1998
+
+
+2191    Armitage        Sep 97  VENUS - Very Extensive Non-Unicast Service
+
+This document focuses exclusively on the problems associated with
+extending the MARS model to cover multiple clusters or clusters spanning
+more than one subnet. It describes a hypothetical solution, dubbed "Very
+Extensive NonUnicast Service" (VENUS), and shows how complex such a
+service would be.  This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+2190    Zhu             Sep 97  RTP Payload Format for H.263 Video Streams
+
+This document specifies the payload format for encapsulating an H.263
+bitstream in the Real-Time Transport Protocol (RTP). [STANDARDS TRACK]
+
+
+2189    Ballardie       Sep 97  Core Based Trees (CBT version 2)
+                                Multicast Routing
+
+This document describes the Core Based Tree (CBT version 2) network
+layer multicast routing protocol. CBT builds a shared multicast
+distribution tree per group, and is suited to inter- and intra-domain
+multicast routing.  This memo defines an Experimental Protocol for the
+Internet community.
+
+
+2188    Banan           Sep 97  AT&T/Neda's Efficient Short Remote
+                                Operations (ESRO) Protocol
+                                Specification Version 1.2
+
+This document specifies the service model, the notation and protocol for
+Efficient Short Remote Operations (ESRO).  This memo provides
+information for the Internet community.  It does not specify an Internet
+standard of any kind.
+
+
+2187    Wessels         Sep 97  Application of Internet Cache Protocol
+                                (ICP), version 2
+
+This document describes the application of ICPv2 (Internet Cache
+Protocol version 2, RFC2186) to Web caching.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+
+
+
+
+
+
+Ramos                        Informational                      [Page 3]
+
+RFC 2199                  Summary of 2100-2199              January 1998
+
+
+2186    Wessels         Sep 97  Internet Cache Protocol (ICP), version 2
+
+This document describes version 2 of the Internet Cache Protocol (ICPv2)
+as currently implemented in two World-Wide Web proxy cache packages.
+This memo provides information for the Internet community.  This memo
+does not specify an Internet standard of any kind.
+
+
+2185    Callon          Sep 97  Routing Aspects Of IPv6 Transition
+
+This document gives an overview of the routing aspects of the IPv6
+transition.  It is based on the protocols defined in the document
+"Transition Mechanisms for IPv6 Hosts and Routers."  Readers should be
+familiar with the transition mechanisms before reading this document.
+This memo provides information for the Internet community.  This memo
+does not specify an Internet standard of any kind.
+
+
+2184    Freed           Aug 97  MIME Parameter Value and Encoded Word
+                                Extensions:Character Sets, Languages,
+                                and Continuations
+
+This memo defines extensions to the RFC 2045 media type and RFC 2183
+disposition parameter value mechanisms. [STANDARDS-TRACK]
+
+
+2183    Troost          Aug 97  Communicating Presentation Information
+                                in Internet Messages: The Content-
+                                Disposition Header Field
+
+This memo provides a mechanism whereby messages conforming to the MIME
+specifications [RFC 2045, RFC 2046, RFC 2047, RFC 2048, RFC 2049] can
+convey presentational information.  It specifies the "Content-
+Disposition" header field, which is optional and valid for any MIME
+entity ("message" or "body part"). [STANDARDS-TRACK]
+
+
+2182    Elz             Jul 97  Selection and Operation of Secondary
+                                DNS Servers
+
+This document discusses the selection of secondary servers for DNS
+zones.The number of servers appropriate for a zone is also discussed,
+and some general secondary server maintenance issues considered.  This
+memo provides information for the Internet community.  This memo does
+not specify an Internet standard of any kind.
+
+
+
+
+
+
+Ramos                        Informational                      [Page 4]
+
+RFC 2199                  Summary of 2100-2199              January 1998
+
+
+2181    Elz             Jul 97  Clarifications to the DNS Specification
+
+This document considers some areas that have been identified as problems
+with the specification of the Domain Name System, and proposes remedies
+for the defects identified. [STANDARDS TRACK]
+
+
+2180    Gahrns          Jul 97  IMAP4 Multi-Accessed Mailbox Practice
+
+The behavior described in this document reflects the practice of some
+existing servers or behavior that the consensus of the IMAP mailing list
+has deemed to be reasonable.  The behavior described within this
+document is believed to be [RFC-2060] compliant. However, this document
+is not meant to define IMAP4 compliance, nor is it an exhaustive list of
+valid IMAP4 behavior.  This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+2179    Gwinn           Jul 97  Network Security For Trade Shows
+
+This document is designed to assist vendors and other participants in
+trade shows, such as Networld+Interop, in designing effective protection
+against network and system attacks by unauthorized individuals.  This
+memo provides information for the Internet community.  This memo does
+not specify an Internet standard of any kind.
+
+
+2178    Moy             Jul 97  OSPF Version 2
+
+
+This document considers some areas that have been identified as problems
+with the specification of the Domain Name System, and proposes remedies
+for the defects identified. [STANDARDS TRACK]
+
+
+2177    Leiba           Jun 97  IMAP4 IDLE command
+
+This document specifies the syntax of an IDLE command, which will allow
+a client to tell the server that it's ready to accept such real-time
+updates. [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+
+Ramos                        Informational                      [Page 5]
+
+RFC 2199                  Summary of 2100-2199              January 1998
+
+
+2176    Murakami        Jun 97  IPv4 over MAPOS Version 1
+
+This memo documents a mechanism for supporting Version 4 of the Internet
+Protocol (IPv4) on Version 1 of the Multiple Access Protocol over
+SONET/SDH.  This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+2175     Murakami       Jun 97  SONET/SDH with 16 Bit Addressing
+
+This memo documents MAPOS 16, a multiple access protocol for
+transmission of network-protocol datagrams, encapsulated in HDLC frames
+with 16 bit addressing, over SONET/SDH.  This memo provides information
+for the Internet community.  This memo does not specify an Internet
+standard of any kind.
+
+
+2174    Murakami       Jun 97   A MAPOS version 1 Extension -
+                                Switch-Switch Protocol
+
+This memo documents a MAPOS (Multiple Access Protocol over SONET/SDH)
+version 1 extension, Switch Switch Protocol which provides dynamic
+routing for unicast, broadcast, and multicast.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+2173    Murakami       Jun 97   A MAPOS version 1 Extension - Node
+                                Switch Protocol
+
+This document describes a MAPOS extension, Node Switch Protocol, for
+automatic node address assignment.  This memo provides information for
+the Internet community.  This memo does not specify an Internet standard
+of any kind.
+
+
+2172     Maruyama       Jun 97  MAPOS Version 1 Assigned Numbers
+
+This memo documents the parameters used in the Multiple Access Protocol
+over SONET/SDH Version 1.  This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+
+
+
+
+
+
+
+Ramos                        Informational                      [Page 6]
+
+RFC 2199                  Summary of 2100-2199              January 1998
+
+
+2171    Murakami       Jun 97   MAPOS - Multiple Access Protocol over
+                                SONET/SDH  Version 1
+
+This memo documents a multiple access protocol for transmission of
+network-protocol datagrams, encapsulated in High-Level Data Link Control
+(HDLC) frames, over SONET/SDH.  This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+2170    Almesberger     Jul 97  Application REQuested IP over ATM
+                                (AREQUIPA)
+
+This document specifies a method for allowing ATM-attached hosts that
+have direct ATM connectivity to set up end-to-end IP over ATM
+connections within the reachable ATM cloud, on request from
+applications, and for the exclusive use by the requesting applications.
+This memo provides information for the Internet community.  This memo
+does not specify an Internet standard of any kind.
+
+
+2169    Daniel          Jun 97  A Trivial Convention for using HTTP in
+                                URN Resolution
+
+This document specifies the "THTTP" resolution protocol - a trivial
+convention for encoding resolution service requests and responses as
+HTTP 1.0 or 1.1 requests and responses.  This memo defines an
+Experimental Protocol for the Internet community.  This memo does not
+specify an Internet standard of any kind.  Discussion and suggestions
+for improvement are requested.
+
+
+2168    Daniel          Jun 97  Resolution of Uniform Resource
+                                Identifiers using the Domain Name System
+
+The requirements document for URN resolution systems defines the concept
+of a "resolver discovery service". This document describes the first,
+experimental, RDS. It is implemented by a new DNS Resource Record, NAPTR
+(Naming Authority PoinTeR), that provides rules for mapping parts of
+URIs to domain names.  This memo defines an Experimental Protocol for
+the Internet community.
+
+
+
+
+
+
+
+
+
+
+Ramos                        Informational                      [Page 7]
+
+RFC 2199                  Summary of 2100-2199              January 1998
+
+
+2167    Williamson      Jun 97  Referral Whois (RWhois) Protocol V1.5
+
+This memo describes Version 1.5 of the client/server interaction of
+RWhois.  RWhois provides a distributed system for the discovery,
+retrieval, and maintenance of directory information.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+2166    Bryant          Jun 97  APPN Implementer's Workshop
+                                Closed Pages Document
+
+This document specifies a set of extensions to RFC 1795 designed to
+improve the scalability of DLSw clarifications to RFC 1795 in the light
+of the implementation experience to-date.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+2165    Veizades        Jun 97  Service Location Protocol
+
+The Service Location Protocol provides a scalable framework for the
+discovery and selection of network services.  Using this protocol,
+computers using the Internet no longer need so much static configuration
+of network services for network based applications.  This is especially
+important as computers become more portable, and users less tolerant or
+able to fulfill the demands of network system administration.
+[STANDARDS-TRACK]
+
+
+2164    Kille           Jan 98  Use of an X.500/LDAP directory to
+                                support MIXER address mapping
+
+This specification defines how to represent and maintain these mappings
+(MIXER Conformant Global Address Mappings of MCGAMs) in an X.500 or LDAP
+directory.  [STANDARDS-TRACK]
+
+
+2163    Allocchio       Jan 98  Using the Internet DNS to Distribute
+                                MIXER Conformant Global Address
+                                Mapping (MCGAM)
+
+This memo is the complete technical specification to store in the
+Internet Domain Name System (DNS) the mapping information (MCGAM) needed
+by MIXER conformant e-mail gateways and other tools to map RFC822 domain
+names into X.400 O/R names and vice versa.  [STANDARDS-TRACK]
+
+
+
+
+
+Ramos                        Informational                      [Page 8]
+
+RFC 2199                  Summary of 2100-2199              January 1998
+
+
+2162    Allocchio       Jan 98  MaXIM-11 - Mapping between X.400 /
+                                Internet mail and Mail-11 mail
+
+The standard referred shortly into this document as "X.400" relates to
+the ISO/IEC 10021 - CCITT 1984, 1988 and 1992 X.400 Series
+Recommendations covering the Message Oriented Text Interchange Service
+(MOTIS). This document covers the Inter Personal Messaging System (IPMS)
+only.  This memo defines an Experimental Protocol for the Internet
+community.
+
+
+2161    Alvestrand      Jan 98  A MIME Body Part for ODA
+
+This document contains the definitions, originally contained in RFC 1495
+and RFC 1341, on how to carry ODA in MIME, and how to translate it to
+its X.400 representation.  This memo defines an Experimental Protocol
+for the Internet community.
+
+
+2160    Alvestrand      Jan 98  Carrying PostScript in X.400 and MIME
+
+This document describes methods for carrying PostScript information in
+the two standard mail systems MIME and X.400, and the conversion between
+them.  [STANDARDS-TRACK]
+
+
+2159    Alvestrand      Jan 98  A MIME Body Part for FAX
+
+This document contains the definitions, originally contained in RFC
+1494, on how to carry CCITT G3Fax in MIME, and how to translate it to
+its X.400 representation.  [STANDARDS-TRACK]
+
+
+2158    Alvestrand      Jan 98  X.400 Image Body Parts
+
+This document contains the body parts defined in RFC 1495 for carrying
+image formats that were originally defined in MIME through an X.400
+system.  [STANDARDS-TRACK]
+
+
+2157    Alvestrand      Jan 98  Mapping between X.400 and RFC-822/MIME
+                                Message Bodies
+
+This document defines how to map body parts of X.400 messages into MIME
+entities and vice versa, including the handling of multipart messages
+and forwarded messages.  [STANDARDS-TRACK]
+
+
+
+
+
+Ramos                        Informational                      [Page 9]
+
+RFC 2199                  Summary of 2100-2199              January 1998
+
+
+2156    Kille           Jan 98  MIXER (Mime Internet X.400 Enhanced
+                                Relay): Mapping between X.400 and
+                                RFC 822/MIME
+
+This document relates primarily to the ITU-T 1988 and 1992 X.400 Series
+Recommendations / ISO IEC 10021 International Standard.  This ISO/ITU-T
+standard is referred to in this document as "X.400", which is a
+convenient shorthand.  [STANDARDS-TRACK]
+
+
+2155    Clouston        Jun 97  Definitions of Managed Objects
+                                for APPN using SMIv2
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it defines objects for monitoring and controlling network
+devices with APPN (Advanced Peer-to-Peer Networking) capabilities.  This
+memo identifies managed objects for the APPN protocol.  [STANDARDS-
+TRACK]
+
+
+2154    Murphy          Jun 97  OSPF with Digital Signatures
+
+This memo describes the extensions to OSPF required to add digital
+signature authentication to Link State data, and to provide a
+certification mechanism for router data.  Added LSA processing and key
+management is detailed.  A method for migration from, or co-existence
+with, standard OSPF V2 is described.  This memo defines an Experimental
+Protocol for the Internet community.
+
+
+2153    Simpson         May 97   PPP Vendor Extensions
+
+The Point-to-Point Protocol (PPP) provides a standard method for
+transporting multi-protocol datagrams over point-to-point links.  PPP
+defines an extensible Link Control Protocol (LCP) for establishing,
+configuring, and testing the data-link connection; and a family of
+Network Control Protocols (NCPs) for establishing and configuring
+different network-layer protocols.  This document provides information
+for the Internet community.  It does not specify an Internet standard of
+any kind.
+
+
+
+
+
+
+
+
+
+
+Ramos                        Informational                     [Page 10]
+
+RFC 2199                  Summary of 2100-2199              January 1998
+
+
+2152    Goldsmith       May 97  A Mail-Safe Transformation Format
+                                of Unicode
+
+This document describes a transformation format of Unicode that contains
+only 7-bit ASCII octets and is intended to be readable by humans in the
+limiting case that the document consists of characters from the US-ASCII
+repertoire. It also specifies how this transformation format is used in
+the context of MIME and RFC 1641, "Using Unicode with MIME".  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+2151    Kessler         Jun 97  A Primer On Internet and TCP/IP Tools
+                                and Utilities
+
+This memo is an introductory guide to many of the most commonly-
+available TCP/IP and Internet tools and utilities. It also describes
+discussion lists accessible from the Internet, ways to obtain Internet
+and TCP/IP documents, and some resources that help users weave their way
+through the Internet.  This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+2150    Max             Oct 97  Humanities and Arts: Sharing Center
+                                Stage on the Internet
+
+The purpose of this document is to provide members of the Arts and
+Humanities communities with an introduction to the Internet as a
+valuable tool, resource, and medium for the creation, presentation, and
+preservation of Arts and Humanities-based content.  This memo provides
+information for the Internet community.  It does not specify an Internet
+standard of any kind.
+
+
+2149   Talpade          May 97  Multicast Server Architectures for
+                                MARS-based ATM multicasting
+
+This memo provides details on the design and implementation of an MCS,
+building on the core mechanisms defined in RFC 2022.  It also provides a
+mechanism for using multiple MCSs per group for providing fault
+tolerance.  This approach can be used with RFC 2022 based MARS server
+and clients, without needing any change in their functionality.  This
+memo provides information for the Internet community.  This memo does
+not specify an Internet standard of any kind.
+
+
+
+
+
+
+
+Ramos                        Informational                     [Page 11]
+
+RFC 2199                  Summary of 2100-2199              January 1998
+
+
+2148    Alvestrand      Sep 97  Deployment of the Internet White Pages
+                                Service
+
+This document describes the way in which the Internet White Pages
+Service is best exploited using today's experience, today's protocols,
+today's products and today's procedures.  This document specifies an
+Internet Best Current Practices for the Internet Community, and requests
+discussion and suggestions for improvements.
+
+
+2147    Borman          May 97  TCP and UDP over IPv6 Jumbograms
+
+IPv6 supports datagrams larger than 65535 bytes long, often referred to
+as jumbograms, through use of the Jumbo Payload hop-by-hop option.  The
+UDP protocol has a 16-bit length field that keeps it from being able to
+make use of jumbograms, and though TCP does not have a length field,
+both the MSS option and the Urgent field are constrained by 16-bits.
+This document describes some simple changes that can be made to allow
+TCP and UDP to make use of IPv6 jumbograms.  [STANDARDS-TRACK]
+
+
+2146     FNC            May 97  U.S. Government Internet Domain Names
+
+
+This memo provides an update and clarification to RFC 1816.  This
+document describes the registration policies for the top-level domain
+".GOV".  The purpose of the domain is to provide naming conventions that
+identify US Federal government agencies in order to facilitate access to
+their electronic resources.  This memo provides guidance for
+registrations by Federal Agencies that avoids name duplication and
+facilitates responsiveness to the public.  It restricts registrations to
+coincide with the approved structure of the US government and the advice
+of its Chief Information Officers.  This memo provides information for
+the Internet community.  This memo does not specify an Internet standard
+of any kind.
+
+
+2145    Mogul           May 97  Use and Interpretation of
+                                HTTP Version Numbers
+
+HTTP request and response messages include an HTTP protocol version
+number.  Some confusion exists concerning the proper use and
+interpretation of HTTP version numbers, and concerning interoperability
+of HTTP implementations of different protocol versions.  This document
+is an attempt to clarify the situation. This memo provides information
+for the Internet community.  This memo does not specify an Internet
+standard of any kind.
+
+
+
+
+Ramos                        Informational                     [Page 12]
+
+RFC 2199                  Summary of 2100-2199              January 1998
+
+
+2144    Adams           May 97  The CAST-128 Encryption Algorithm
+
+There is a need in the Internet community for an unencumbered encryption
+algorithm with a range of key sizes that can provide security for a
+variety of cryptographic applications and protocols.  This document
+describes an existing algorithm that can be used to satisfy this
+requirement.  This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+2143    Elliston        May 97  Encapsulating IP with the Small
+                                Computer System Interface
+
+This document outlines a protocol for connecting hosts running the
+TCP/IP protocol suite over a Small Computer System Interface (SCSI) bus.
+This memo defines an Experimental Protocol for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+2142    Crocker         May 97  MAILBOX NAMES FOR
+                                COMMON SERVICES, ROLES AND FUNCTIONS
+
+This specification enumerates and describes Internet mail addresses
+(mailbox name @ host reference) to be used when contacting personnel at
+an organization. [STANDARDS-TRACK]
+
+
+2141    Moats           May 97  URN Syntax
+
+Uniform Resource Names (URNs) are intended to serve as persistent,
+location-independent, resource identifiers. This document sets forward
+the canonical syntax for URNs. [STANDARDS-TRACK]
+
+
+2140    Touch           Apr 97  TCP Control Block Interdependence
+
+This memo makes the case for interdependent TCP control blocks, where
+part of the TCP state is shared among similar concurrent connections, or
+across similar connection instances. TCP state includes a combination of
+parameters, such as connection state, current round-trip time estimates,
+congestion control information, and process information.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+
+
+
+
+
+
+Ramos                        Informational                     [Page 13]
+
+RFC 2199                  Summary of 2100-2199              January 1998
+
+
+2139    Rigney          Apr 97  RADIUS Accounting
+
+This document describes a protocol for carrying accounting information
+between a Network Access Server and a shared Accounting Server.  This
+memo provides information for the Internet community.  This memo does
+not specify an Internet standard of any kind.
+
+
+2138    Rigney          Apr 97  Remote Authentication Dial In User
+                                Service (RADIUS)
+
+This document describes a protocol for carrying authentication,
+authorization, and configuration information between a Network Access
+Server which desires to authenticate its links and a shared
+Authentication Server. [STANDARDS-TRACK]
+
+
+2137    Eastlake 3rd     Apr 97 Secure Domain Name System Dynamic
+                                Update
+
+This memo describes how to use DNSSEC digital signatures covering
+requests and data to secure updates and restrict updates to those
+authorized to perform them as indicated by the updater's possession of
+cryptographic keys.  [STANDARDS-TRACK]
+
+
+2136    Vixie           Apr 97  Dynamic Updates in the Domain Name
+                                System (DNS UPDATE)
+
+Using this specification of the UPDATE opcode, it is possible to add or
+delete RRs or RRsets from a specified zone.  Prerequisites are specified
+separately from update operations, and can specify a dependency upon
+either the previous existence or nonexistence of an RRset, or the
+existence of a single RR.  [STANDARDS-TRACK]
+
+
+2135    ISOC BOT        Apr 97  Internet Society By-Laws
+
+
+These are the by-laws of the Internet Society, as amended, as of June
+1996.  They are published for the information of the IETF community at
+the request of the poisson working group.  Please refer to the ISOC web
+page (www.isoc.org) for the current version of the by-laws.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+
+
+
+
+Ramos                        Informational                     [Page 14]
+
+RFC 2199                  Summary of 2100-2199              January 1998
+
+
+2134    ISOC BOT         Apr 97 ARTICLES OF INCORPORATION
+                                OF INTERNET SOCIETY
+
+These are the articles of incorporation of the Internet Society.  They
+are published for the information of the IETF community at the request
+of the poisson working group.  This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+2133    Gilligan        Apr 97  Basic Socket Interface Extensions
+                                for IPv6
+
+This memo defines a set of extensions to the socket interface to support
+the larger address size and new features of IPv6.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+2132    Alexander       Mar 97  DHCP Options and BOOTP Vendor
+                                Extensions
+
+This document specifies the current set of DHCP options.  Future options
+will be specified in separate RFCs.  The current list of valid options
+is also available in ftp://ftp.isi.edu/in-notes/iana/assignments.
+[STANDARDS-TRACK]
+
+
+2131    Droms           Mar 97  Dynamic Host Configuration Protocol
+
+The Dynamic Host Configuration Protocol (DHCP) provides a framework for
+passing configuration information to hosts on a TCPIP network.  DHCP is
+based on the Bootstrap Protocol (BOOTP), adding the capability of
+automatic allocation of reusable network addresses and additional
+configuration options.  [STANDARDS-TRACK]
+
+
+2130   Weider           Apr 97  The Report of the IAB Character Set
+                                Workshop held 29 February - 1 March,
+                                1996
+
+This report details the conclusions of an IAB-sponsored invitational
+workshop held 29 February  - 1 March, 1996, to discuss the use of
+character sets on the Internet.  It motivates the need to have character
+set handling in Internet protocols which transmit text, provides a
+conceptual framework for specifying character sets, recommends the use
+of MIME tagging for transmitted text, recommends a default character set
+*without* stating that there is no need for other character sets, and
+
+
+
+Ramos                        Informational                     [Page 15]
+
+RFC 2199                  Summary of 2100-2199              January 1998
+
+
+makes a series of recommendations to the IAB, IANA, and the IESG for
+furthering the integration of the character set framework into text
+transmission protocols.  This memo provides information for the Internet
+community.  This memo does not specify an Internet standard of any kind.
+
+
+2129    Nagami          Apr 97  Toshiba's Flow Attribute Notification
+                                Protocol (FANP) Specification
+
+This memo discusses Flow Attribute Notification Protocol (FANP), which
+is a protocol between neighbor nodes for the management of cut-through
+packet forwarding functionalities.  This memo provides information for
+the Internet community.  This memo does not specify an Internet standard
+of any kind.
+
+
+2128    Roeck           Mar 97  Dial Control Management Information
+                                Base using SMIv2
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it describes managed objects used for managing demand access
+circuits, including ISDN.  [STANDARDS-TRACK]
+
+
+2127     Roeck           Mar 97 ISDN Management Information Base using
+                                SMIv2
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it defines a minimal set of managed objects for SNMP-based
+management of ISDN terminal interfaces.  [STANDARDS-TRACK]
+
+
+2126    Pouffary        Mar 97  ISO Transport Service on top of TCP
+                                (ITOT)
+
+This document is a revision to STD35, RFC1006.  This document describes
+the mechanism to allow ISO Transport Services to run over TCP over IPv4
+or IPv6. It also defines a number of new features, which are not
+provided in RFC1006.  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+Ramos                        Informational                     [Page 16]
+
+RFC 2199                  Summary of 2100-2199              January 1998
+
+
+2125    Richards        Mar 97  The PPP Bandwidth Allocation Protocol
+                                (BAP), The PPP Bandwidth Allocation
+                                Control Protocol (BACP)
+
+This document proposes a method to manage the dynamic bandwidth
+allocation of implementations supporting the PPP multilink protocol.
+This is done by defining the Bandwidth Allocation Protocol (BAP), as
+well as its associated control protocol, the Bandwidth Allocation
+Control Protocol (BACP).  [STANDARDS-TRACK]
+
+
+2124    Amsden          Mar 97  Cabletron's Light-weight Flow
+                                Admission Protocol Specification
+
+This document specifies the protocol between the switch Connection
+Control Entity (CCE) and the external FAS.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+2123    Brownlee        Mar 97  Traffic Flow Measurement:  Experiences
+                                with NeTraMet
+
+This memo records experiences in implementing and using the Traffic Flow
+Measurement Architecture and Meter MIB. It discusses the implementation
+of NeTraMet (a traffic meter) and NeMaC (a combined manager and meter
+reader), considers the writing of meter rule sets and gives some
+guidance on setting up a traffic flow measurement system using NeTraMet.
+This memo provides information for the Internet community.  This memo
+does not specify an Internet standard of any kind.
+
+
+2122    Mavrakis        Mar 97  VEMMI URL Specification
+
+A new URL scheme, "vemmi" is defined.  VEMMI is a new international
+standard for on-line multimedia services, that is both an ITU-T
+(International Telecommunications Union, ex.  CCITT) International
+Standard (T.107) and an European Standard (ETSI European
+Telecommunications Standard Institute) standard (ETS 300 382, obsoleted
+by ETS 300 709).  [STANDARDS-TRACK]
+
+
+2121   Armitage         Mar 97  Issues affecting MARS Cluster Size
+
+This document provides a qualitative look at the issues constraining a
+MARS Cluster's size, including the impact of VC limits in switches and
+NICs, geographical distribution of cluster members, and the use of VC
+
+
+
+
+Ramos                        Informational                     [Page 17]
+
+RFC 2199                  Summary of 2100-2199              January 1998
+
+
+Mesh or MCS modes to support multicast groups.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+2120    Chadwick        Mar 97  Managing the X.500 Root Naming Context
+
+This document describes the use of 1993 ISO X.500 Standard protocols for
+managing the root context. Whilst the ASN.1 is compatible with that of
+the X.500 Standard, the actual settings of the parameters are
+supplementary to that of the X.500 Standard.  This memo defines an
+Experimental Protocol for the Internet community.
+
+
+2119    Bradner         Mar 97  Key words for use in RFCs to Indicate
+                                Requirement Levels
+
+In many standards track documents several words are used to signify the
+requirements in the specification.  These words are often capitalized.
+This document defines these words as they should be interpreted in IETF
+documents.  This document specifies an Internet Best Current Practices
+for the Internet Community, and requests discussion and suggestions for
+improvements.
+
+
+2118    Pall            Mar 97  Microsoft Point-To-Point Compression
+                                (MPPC) Protocol
+
+This document describes the use of the Microsoft Point to Point
+Compression protocol (also referred to as MPPC in this document) for
+compressing PPP encapsulated packets.  This memo provides information
+for the Internet community.  This memo does not specify an Internet
+standard of any kind.
+
+
+2117    Estrin          Jun 97  Protocol Independent Multicast-Sparse
+                                Mode (PIM-SM): Protocol Specification
+
+This document describes a protocol for efficiently routing to multicast
+groups that may span wide-area (and inter-domain) internets.  This memo
+defines an Experimental Protocol for the Internet community.
+
+
+
+
+
+
+
+
+
+
+Ramos                        Informational                     [Page 18]
+
+RFC 2199                  Summary of 2100-2199              January 1998
+
+
+2116    Apple           Apr 97  X.500 Implementations Catalog-96
+
+This document is a revision to [RFC 1632]: A Revised Catalog of
+Available X.500 Implementations and is based on the results of data
+collection via a WWW home page that enabled implementors to submit new
+or updated descriptions of currently available implementations of X.500,
+including commercial products and openly available offerings. [RFC 1632]
+is a revision of [RFC 1292].  This document contains detailed
+description of 31 X.500 implementations - DSAs, DUAs, and DUA
+interfaces.  This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+2115    Brown           Sep 97  Management Information Base for Frame
+                                Relay DTEs Using SMIv2
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP- based internets.  In
+particular, it defines objects for managing Frame Relay interfaces on
+DTEs.  [STANDARDS-TRACK]
+
+
+2114    Chiang          Feb 97  Data Link Switching Client Access
+                                Protocol
+
+This memo describes the Data Link Switching Client Access Protocol that
+is used between workstations and routers to transport SNA/ NetBIOS
+traffic over TCP sessions.  This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+2113    Katz            Feb 97  IP Router Alert Option
+
+This memo describes a new IP Option type that alerts transit routers to
+more closely examine the contents of an IP packet.  [STANDARDS-TRACK]
+
+
+2112    Levinson        Mar 97  The MIME Multipart/Related
+                                Content-type
+
+The Multipart/Related content-type provides a common mechanism for
+representing objects that are aggregates of related MIME body parts.
+This document defines the Multipart/Related content-type and provides
+examples of its use.  [STANDARDS-TRACK]
+
+
+
+
+
+
+Ramos                        Informational                     [Page 19]
+
+RFC 2199                  Summary of 2100-2199              January 1998
+
+
+2111    Levinson        Mar 97  Content-ID and Message-ID Uniform
+                                Resource Locators
+
+The Uniform Resource Locator (URL) schemes, "cid:" and "mid:" allow
+references to messages and the body parts of messages.  For example,
+within a single multipart message, one HTML body part might include
+embedded references to other parts of the same message.  [STANDARDS-
+TRACK]
+
+
+2110    Palme           Mar 97  MIME E-mail Encapsulation of Aggregate
+                                Documents, such as HTML (MHTML)
+
+This document describes a set of guidelines that will allow conforming
+mail user agents to be able to send, deliver and display these objects,
+such as HTML objects, that can contain links represented by URIs.
+[STANDARDS-TRACK]
+
+
+2109    Kristol         Feb 97  HTTP State Management Mechanism
+
+This document specifies a way to create a stateful session with HTTP
+requests and responses.  It describes two new headers, Cookie and Set-
+Cookie, which carry state information between participating origin
+servers and user agents.  The method described here differs from
+Netscape's Cookie proposal, but it can interoperate with HTTP/1.0 user
+agents that use Netscape's method.  [STANDARDS-TRACK]
+
+
+2108    de Graaf        Feb 97  Definitions of Managed Objects
+                                for IEEE 802.3 Repeater Device
+                                using SMIv2
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it defines objects for managing IEEE 802.3 10 and 100
+Mb/second baseband repeaters based on IEEE Std 802.3 Section 30, "10 &
+100 Mb/s Management," October 26, 1995.  [STANDARDS-TRACK]
+
+
+2107    Hamzeh          Feb 97  Ascend Tunnel Management Protocol - ATMP
+
+This document specifies a generic tunnel management protocol that allows
+remote dial-in users to access their home network as if they were
+directly attached to the home network.  This memo provides information
+for the Internet community.  This memo does not specify an Internet
+standard of any kind.
+
+
+
+
+Ramos                        Informational                     [Page 20]
+
+RFC 2199                  Summary of 2100-2199              January 1998
+
+
+2106    Chiang          Feb 97  Data Link Switching Remote Access
+                                Protocol
+
+
+This memo describes the Data Link Switching Remote Access Protocol that
+is used between workstations and routers to transport SNA/ NetBIOS
+traffic over TCP sessions.  This memo provides information for the
+Internet community.  This memo does not specify an Internet standard of
+any kind.
+
+
+2105    Rekhter         Feb 97  Cisco Systems' Tag Switching
+                                Architecture Overview
+
+This document provides an overview of a novel approach to network layer
+packet forwarding, called tag switching. The two main components of  the
+tag switching architecture - forwarding and control - are described.
+This memo provides information for the Internet community.  This memo
+does not specify an Internet standard of any kind.
+
+
+2104    Krawcyzk        Feb 97  HMAC: Keyed-Hashing for Message
+                                Authentication
+
+This document describes HMAC, a mechanism for message authentication
+using cryptographic hash functions. HMAC can be used with any iterative
+cryptographic hash function, e.g., MD5, SHA-1, in combination with a
+secret shared key.  The cryptographic strength of HMAC depends on the
+properties of the underlying hash function.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind
+
+
+2103    Ramanathan      Feb 97  Mobility Support for Nimrod :
+                                Challenges and Solution Approaches
+
+We discuss the issue of mobility in Nimrod.  While a mobility solution
+is not part of the Nimrod architecture, Nimrod does require that the
+solution have certain characteristics.  We identify the requirements
+that Nimrod has of any solution for mobility support.  We also classify
+and compare existing approaches for supporting mobility within an
+internetwork and discuss their advantages and disadvantages.  This memo
+provides information for the Internet community.  This memo does not
+specify an Internet standard of any kind.
+
+
+
+
+
+
+
+Ramos                        Informational                     [Page 21]
+
+RFC 2199                  Summary of 2100-2199              January 1998
+
+
+2102    Ramanathan      Feb 97  Multicast Support for Nimrod :
+                                Challenges and Solution Approaches
+
+Nimrod does not specify a particular solution for multicasting.  Rather,
+Nimrod may use any of a number of emerging multicast techniques.  We
+identify the requirements that Nimrod has of a solution for multicast
+support.  This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+
+2101    Carpenter       Feb 97  IPv4 Address Behaviour Today
+
+The main purpose of this note is to clarify the current interpretation
+of the 32-bit IP version 4 address space, whose significance has changed
+substantially since it was originally defined.  This memo provides
+information for the Internet community.  This memo does not specify an
+Internet standard of any kind.
+
+
+2100    Ashworth        Apr 97  The Naming of Hosts
+
+This RFC is a commentary on the difficulty of deciding upon an
+acceptably distinctive hostname for one's computer, a problem which
+grows in direct proportion to the logarithmically increasing size of the
+Internet.  This memo provides information for the Internet community.
+This memo does not specify an Internet standard of any kind.
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Author's Address
+
+   Alegre Ramos
+   University of Southern California
+   Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone:  (310) 822-1511
+
+   EMail: ramos@isi.edu
+
+
+
+
+
+
+
+
+
+Ramos                        Informational                     [Page 22]
+
+RFC 2199                  Summary of 2100-2199              January 1998
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (1998).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ramos                        Informational                     [Page 23]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2199.txt](<www.ietf.org/rfc/rfc2199.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
