### PR TITLE
Archive rfc222.txt

### DIFF
--- a/www.ietf.org/rfc/rfc222.txt
+++ b/www.ietf.org/rfc/rfc222.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                        R. Metcalfe
+Request for Comments: 222                                    Project MAC
+NIC: 7621                                              13 September 1971
+
+
+   As described in RFC's #207 and #212, the next meeting of the ARPA
+   Computer Network Working Group (NWG) will be held at MIT Project MAC
+   in Cambridge, Massachusetts, October 10-14, 1971.
+
+   The first phase of the NWG meeting is to be a workshop for a
+   representative group of system programmers from those sites with
+   operational TELNET interfaces.  From noon, Sunday, October 10, until
+   sometime late Monday evening, teams of workshop participants will hit
+   the ARPA network from MAC consoles in an intensive effort to study
+   its operational characteristics and to work on any remaining trouble
+   spots in protocols and their implementations.
+
+   Although the NWG meeting is geared for heavy attendance, our
+   facilities and objectives make it important that no more than a dozen
+   system programmers be present for the grueling workshop sessions
+   planned.  These system programmers should be from sites with
+   operational TELNET interfaces (user and/or server) and should have a
+   working knowledge of protocols, their own NCP's, and TELNET
+   implementations.  Sites wishing to send a system programmer should
+   leave his name and address with Anne Speare at (617) 864-6900 x1458.
+
+   In preparation for the workshop, we are working on documentation
+   describing our user TELNET and a site-use scenario booklet to be used
+   at the workshop in exercising various systems.  It is our intention
+   to establish a pattern of routine usage with as many sites as
+   possible prior to the workshop.  In developing the site-use scenario
+   booklet, we will be looking for advice and comment from participating
+   hosts.
+
+   Because the use of computers with operational network protocols is
+   central to the success of the workshop, we are working hard to bring
+   our developing system into a period of stability and are making
+   special arrangements for on-site hardware repair personnel.  To the
+   extent that participating sites can make similar preparations, the
+   chances for a successful workshop will be improved.
+
+   We are hoping that knowledgeable network people will be on call at
+   the various sites during the workshop so that there will be some hope
+   of fixing minor implementation problems on the fly.
+
+   We will begin the workshop at noon on Sunday, October 10 with a brief
+   strategy meeting in Project MAC's second floor conference room, #217,
+   545 Technology Square, Cambridge, Massachusetts.  Our first mission
+
+
+
+Metcalfe                                                        [Page 1]
+
+RFC 220              System Programmer's Workshop      13 September 1971
+
+
+   will be to establish and exercise all possible TELNET connections
+   with MAC's PDP-10 (Host 70.).  When this first check-off is complete,
+   we will meet again to discuss difficulties and to regroup for our
+   second mission.  By appropriately nesting TELNET's, we will pair up
+   to systematically fill in the matrix of possible TELNET connections.
+
+   During the workshop we expect to be finding and fixing implementation
+   problems, discussing protocol, and getting an extremely valuable
+   introduction to the use of a wide variety of hosts.  Our experience
+   in the workshop will be an important input to the NWG sessions to
+   follow.  In particular, we are to generate specific reports for the
+   protocol review and status sessions.
+
+   See you then.
+
+   Bob Metcalfe
+
+   (617) 864-6900
+    x1429 Office
+    x1458 Secretary
+    x2910 Computer Room
+
+   Room 203
+   Project MAC
+   545 Technology Square
+   Cambridge, Massachusetts 02139
+
+
+         [ This RFC was put into machine readable form for entry ]
+             [ into the online RFC archives by Ryan Kato 6/01]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Metcalfe                                                        [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc222.txt](<www.ietf.org/rfc/rfc222.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
