### PR TITLE
Archive rfc227.txt

### DIFF
--- a/www.ietf.org/rfc/rfc227.txt
+++ b/www.ietf.org/rfc/rfc227.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                         J. Heafner
+Request for Comments: 227                                     E. Harslem
+NIC: 7631                                             September 17, 1971
+Updates: RFC 113
+
+
+                    DATA TRANSFER RATES (RAND/UCLA)
+
+   The attached memo indicates data rates typical of our use of RJS at
+   UCLA CCN.  Earlier timing tests (similar but more detailed) with UCSB
+   showed that most of the time was lost because of: (1) channel
+   contention with our disk drive access; (2) our NCP runs at a higher
+   priority than batch jobs but lower than text editing and interactive
+   graphics; (3) OS interrupt handling is very slow on both ends; (4)
+   spooling time of the remote system.
+
+
+
+
+                               MEMORANDUM
+
+TO:      John Heafner
+FROM:    Bob Hoffman
+COPIES:  Bob Mobley, Herb Shukiar
+
+Here are some of the transmission rates I have noted over the network
+between Rand and UCLA.  These were all taken at night when little else
+was happening on our 65.
+
+SEND TO UCLA
+
+   # Cards    Blocksize (bytes)  Time (secs)   Rate (bits/secs)
+      642        80                   50             8218
+      375        80                   30             8000
+      509       800                   20            16288
+
+RECEIVE FROM UCLA
+
+   For all figures below, the receiving file has blocksize of 1330
+   bytes, and each line is assumed to contain 100 bytes.  This last
+   assumption is fairly accurate, since most of the lines were from PL/I
+   for which this is a very good number.  Thus, for each rate, the
+   number of bytes is the # Lines * 100.
+
+   # Lines          Time (secs)      Rate (bits/secs)
+      4900              200             19600
+       872               47             14843
+      3900              185             16865
+
+
+
+Heafner & Harslem                                               [Page 1]
+
+RFC 227             DATA TRANSFER RATES (RAND/UCLA)       September 1971
+
+
+   As you can see from the send figures, blocking makes about a 2:1
+   difference.  Memory also recalls a 2 or 3 to 1 advantage for blocking
+   on receive when we were getting unblocked files from UCSB.
+
+    REH:gb
+
+         [This RFC was put into machine readable form for entry]
+     [into the online RFC archives by Kelly Tardif, Viagénie 10/99]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Heafner & Harslem                                               [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc227.txt](<www.ietf.org/rfc/rfc227.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
