### PR TITLE
Archive rfc228.txt

### DIFF
--- a/www.ietf.org/rfc/rfc228.txt
+++ b/www.ietf.org/rfc/rfc228.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                        Dave Walden
+Request for Comments #228                    BBN
+NIC #7645                                    22 September 1971
+Categories:  B.2, C.2
+Updates:  RFC #70
+Obsoletes:  none
+
+
+                             CLARIFICATION
+
+     The second statement before statement 20 in the FORTRAN
+
+program on page 7 of RFC #70 should read
+
+                             N=1
+
+
+
+
+DCW/jm
+
+
+
+
+
+
+
+    [ This RFC was put into machine readable form for entry ]
+    [ into the online RFC archives by BBN Corp. under the   ]
+    [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc228.txt](<www.ietf.org/rfc/rfc228.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
