### PR TITLE
Archive rfc229.txt

### DIFF
--- a/www.ietf.org/rfc/rfc229.txt
+++ b/www.ietf.org/rfc/rfc229.txt
@@ -1,0 +1,165 @@
+
+
+
+
+
+
+Network Working Group                                         Jon Postel
+Request for Comments: #229                                    UCLA-NMC
+NIC 7646                                                      Computer Science
+Categories: D.3                                               22 September 71
+Related: #226
+Obsoletes: None
+
+                          STANDARD HOST NAMES
+
+I suggest 8 character names and the following list:
+
+          Site                  Standard Name              Alternate Name
+          ----                  -------------              --------------
+            1                     UCLA-NMC                     SEX
+
+            65                    UCLA-CCN                     CCN
+
+            2                     SRI-ARC                      NIC
+
+            66                    SRI-AI
+
+            3                     UCSB
+
+            4                     UTAH
+
+            5                     BBN-NCC                      NCC
+
+            69                    BBN-A                        BBN
+
+            133                   BBN-B
+
+            6                     MIT-MLTX                     MULTICS
+
+            70                    MIT-DMCG                     DMCG
+
+            7                     RAND-65
+
+            71                    RAND-10
+
+            8                     SDC
+
+            9                     HARV
+
+            73                    HARV-1
+
+            137                   HARV-11
+
+
+
+
+
+                                                                [Page 1]
+
+Network Working Group                                         Jon Postel
+Request for Comments: #229                                    22 September 71
+
+          Site                  Standard Name
+          ----                  -------------
+            10                    LL-67
+
+            74                    LL-TX2
+
+            11                    STAN
+
+            12                    ILL
+
+            13                    CASE
+
+            14                    CMU
+
+            15                    BUROUGHS
+
+            16                    AMES-67
+
+            144                   AMES-TIP
+
+            145                   MITRE
+
+            18                    RADC
+
+            146                   RADC-TIP
+
+            19                    NBS
+
+            147                   NBS-TIP
+
+            148                   ETAC
+
+            21                    TINKER
+
+            22                    MCLELLAN
+
+            23                    USC
+
+            151                   USC-TIP
+
+            152                   GWC
+
+
+
+
+
+
+
+                                                                [Page 2]
+
+Network Working Group                                         Jon Postel
+Request for Comments: #229                                    22 September 71
+
+
+          Site                  Standard Name
+          ----                  -------------
+            25                    NCAR
+
+            153                   NCAR-TIP
+
+            158                   BBN-TIP
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc229.txt](<www.ietf.org/rfc/rfc229.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
