### PR TITLE
Archive rfc23.txt

### DIFF
--- a/www.ietf.org/rfc/rfc23.txt
+++ b/www.ietf.org/rfc/rfc23.txt
@@ -1,0 +1,22 @@
+Network Working Group                                           G. Gregg
+Request for Comments: 23                                            UCSB
+                                                         16 October 1969
+
+
+
+                TRANSMISSION OF MULTIPLE CONTROL MESSAGES
+
+
+
+
+The network program at a site must be prepared to send or receive more
+than one control message in a single control communication.
+
+During the time that the control link is blocked awaiting RFNM, it is
+possible that a number of control messages to a particular remote host
+will accumulate.  When the link is unblocked, these should all be sent
+in a single communication for greatest efficiency.
+
+For receiving, it will be necessary to have a loop which returns to
+decode and take action on successive control messages until the control
+communication is exhausted.


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc23.txt](<www.ietf.org/rfc/rfc23.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
