### PR TITLE
Archive rfc2300.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2300.txt
+++ b/www.ietf.org/rfc/rfc2300.txt
@@ -1,0 +1,3306 @@
+
+
+
+
+
+
+Network Working Group                        Internet Architecture Board
+Request for Comments: 2300                             J. Postel, Editor
+Obsoletes: 2200, 2000, 1920, 1880, 1800,                        May 1998
+1780, 1720, 1610, 1600, 1540, 1500, 1410,
+1360, 1280, 1250, 1200, 1140, 1130, 1100, 1083
+STD: 1
+Category: Standards Track
+
+
+                  INTERNET OFFICIAL PROTOCOL STANDARDS
+
+
+Status of this Memo
+
+   This memo describes the state of standardization of protocols used in
+   the Internet as determined by the Internet Architecture Board (IAB).
+   This memo is an Internet Standard.  Distribution of this memo is
+   unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (1998).  All Rights Reserved.
+
+Table of Contents
+
+   Introduction . . . . . . . . . . . . . . . . . . . . . . . . .   2
+   1.  The Standardization Process  . . . . . . . . . . . . . . .   3
+   2.  The Request for Comments Documents . . . . . . . . . . . .   5
+   3.  Other Reference Documents  . . . . . . . . . . . . . . . .   6
+   3.1.  Assigned Numbers . . . . . . . . . . . . . . . . . . . .   6
+   3.2.  Gateway Requirements . . . . . . . . . . . . . . . . . .   6
+   3.3.  Host Requirements  . . . . . . . . . . . . . . . . . . .   6
+   3.4.  The MIL-STD Documents  . . . . . . . . . . . . . . . . .   6
+   4.  Explanation of Terms . . . . . . . . . . . . . . . . . . .   7
+   4.1.  Definitions of Protocol State (Maturity Level) . . . . .   8
+   4.1.1.  Standard Protocol  . . . . . . . . . . . . . . . . . .   8
+   4.1.2.  Draft Standard Protocol  . . . . . . . . . . . . . . .   8
+   4.1.3.  Proposed Standard Protocol . . . . . . . . . . . . . .   8
+   4.1.4.  Experimental Protocol  . . . . . . . . . . . . . . . .   8
+   4.1.5.  Informational Protocol . . . . . . . . . . . . . . . .   9
+   4.1.6.  Historic Protocol  . . . . . . . . . . . . . . . . . .   9
+   4.2.  Definitions of Protocol Status (Requirement Level) . . .   9
+   4.2.1.  Required Protocol  . . . . . . . . . . . . . . . . . .   9
+   4.2.2.  Recommended Protocol . . . . . . . . . . . . . . . . .   9
+   4.2.3.  Elective Protocol  . . . . . . . . . . . . . . . . . .   9
+   4.2.4.  Limited Use Protocol . . . . . . . . . . . . . . . . .   9
+   4.2.5.  Not Recommended Protocol . . . . . . . . . . . . . . .   9
+   5.  The Standards Track  . . . . . . . . . . . . . . . . . . .  10
+
+
+
+Internet Architecture Board Standards Track                     [Page 1]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+   5.1.  The RFC Processing Decision Table  . . . . . . . . . . .  10
+   5.2.  The Standards Track Diagram  . . . . . . . . . . . . . .  11
+   6.  The Protocols  . . . . . . . . . . . . . . . . . . . . . .  13
+   6.1.  Recent Changes . . . . . . . . . . . . . . . . . . . . .  13
+   6.1.1.  New RFCs . . . . . . . . . . . . . . . . . . . . . . .  13
+   6.1.2.  Other Changes  . . . . . . . . . . . . . . . . . . . .  33
+   6.2.  Standard Protocols . . . . . . . . . . . . . . . . . . .  34
+   6.3.  Network-Specific Standard Protocols  . . . . . . . . . .  36
+   6.4.  Draft Standard Protocols . . . . . . . . . . . . . . . .  37
+   6.5.  Proposed Standard Protocols  . . . . . . . . . . . . . .  39
+   6.6.  Telnet Options . . . . . . . . . . . . . . . . . . . . .  46
+   6.7.  Experimental Protocols . . . . . . . . . . . . . . . . .  47
+   6.8.  Informational Protocols  . . . . . . . . . . . . . . . .  50
+   6.9.  Historic Protocols . . . . . . . . . . . . . . . . . . .  52
+   6.10  Obsolete Protocols . . . . . . . . . . . . . . . . . . .  53
+   7.  Contacts . . . . . . . . . . . . . . . . . . . . . . . . .  54
+   7.1.  IAB, IETF, and IRTF Contacts . . . . . . . . . . . . . .  54
+   7.1.1.  Internet Architecture Board (IAB) Contact  . . . . . .  54
+   7.1.2.  Internet Engineering Task Force (IETF) Contact . . . .  54
+   7.1.3.  Internet Research Task Force (IRTF) Contact  . . . . .  55
+   7.2.  Internet Assigned Numbers Authority (IANA) Contact . . .  56
+   7.3.  Request for Comments Editor Contact  . . . . . . . . . .  57
+   7.4.  Network Information Center Contact . . . . . . . . . . .  57
+   7.5.  Sources for Requests for Comments  . . . . . . . . . . .  58
+   8.  Security Considerations  . . . . . . . . . . . . . . . . .  58
+   9.  Author's Address . . . . . . . . . . . . . . . . . . . . .  58
+   10. Full Copyright Statement . . . . . . . . . . . . . . . . .  59
+
+Introduction
+
+   A discussion of the standardization process and the RFC document
+   series is presented first, followed by an explanation of the terms.
+   Sections 6.2 - 6.10 contain the lists of protocols in each stage of
+   standardization.  Finally are pointers to references and contacts for
+   further information.
+
+   This memo is intended to be issued every one hundred RFCs; please be
+   sure the copy you are reading is current.  Current copies may be
+   obtained from the Requests for Comments Editor (RFC-EDITOR) or from
+   the Internet Assigned Numbers Authority (IANA) (see the contact
+   information at the end of this memo).
+
+   See Section 6.1 for a description of recent changes.  In the official
+   lists in sections 6.2 - 6.10, an asterisk (*) next to a protocol
+   denotes that it is new to this document or has been moved from one
+   protocol level to another, or differs from the previous edition of
+   this document.
+
+
+
+
+Internet Architecture Board Standards Track                     [Page 2]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+1.  The Standardization Process
+
+   The Internet Architecture Board maintains this list of documents that
+   define standards for the Internet protocol suite.  See RFC-1601 for
+   the charter of the IAB and RFC-1160 for an explanation of the role
+   and organization of the IAB and its subsidiary groups, the Internet
+   Engineering Task Force (IETF) and the Internet Research Task Force
+   (IRTF).  Each of these groups has a steering group called the IESG
+   and IRSG, respectively.  The IETF develops these standards with the
+   goal of co-ordinating the evolution of the Internet protocols; this
+   co-ordination has become quite important as the Internet protocols
+   are increasingly in general commercial use.  The definitive
+   description of the Internet standards process is found in RFC-1602.
+
+   The majority of Internet protocol development and standardization
+   activity takes place in the working groups of the IETF.
+
+   Protocols which are to become standards in the Internet go through a
+   series of states or maturity levels (proposed standard, draft
+   standard, and standard) involving increasing amounts of scrutiny and
+   testing.  When a protocol completes this process it is assigned a STD
+   number (see RFC-1311).  At each step, the Internet Engineering
+   Steering Group (IESG) of the IETF must make a recommendation for
+   advancement of the protocol.
+
+   To allow time for the Internet community to consider and react to
+   standardization proposals, a minimum delay of 6 months before a
+   proposed standard can be advanced to a draft standard and 4 months
+   before a draft standard can be promoted to standard.
+
+   It is general practice that no proposed standard can be promoted to
+   draft standard without at least two independent implementations (and
+   the recommendation of the IESG).  Promotion from draft standard to
+   standard generally requires operational experience and demonstrated
+   interoperability of two or more implementations (and the
+   recommendation of the IESG).
+
+   In cases where there is uncertainty as to the proper decision
+   concerning a protocol a special review committee may be appointed
+   consisting of experts from the IETF, IRTF and the IAB with the
+   purpose of recommending an explicit action.
+
+   Advancement of a protocol to proposed standard is an important step
+   since it marks a protocol as a candidate for eventual standardization
+   (it puts the protocol "on the standards track").  Advancement to
+   draft standard is a major step which warns the community that, unless
+   major objections are raised or flaws are discovered, the protocol is
+   likely to be advanced to standard.
+
+
+
+Internet Architecture Board Standards Track                     [Page 3]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+   Some protocols have been superseded by better ones or are otherwise
+   unused.  Such protocols are still documented in this memorandum with
+   the designation "historic".
+
+   Because it is useful to document the results of early protocol
+   research and development work, some of the RFCs document protocols
+   which are still in an experimental condition.  The protocols are
+   designated "experimental" in this memorandum.  They appear in this
+   report as a convenience to the community and not as evidence of their
+   standardization.
+
+   Other protocols, such as those developed by other standards
+   organizations, or by particular vendors, may be of interest or may be
+   recommended for use in the Internet.  The specifications of such
+   protocols may be published as RFCs for the convenience of the
+   Internet community.  These protocols are labeled "informational" in
+   this memorandum.
+
+   In addition to the working groups of the IETF, protocol development
+   and experimentation may take place as a result of the work of the
+   research groups of the Internet Research Task Force, or the work of
+   other individuals interested in Internet protocol development.  The
+   the documentation of such experimental work in the RFC series is
+   encouraged, but none of this work is considered to be on the track
+   for standardization until the IESG has made a recommendation to
+   advance the protocol to the proposed standard state.
+
+   A few protocols have achieved widespread implementation without the
+   approval of the IESG.  For example, some vendor protocols have become
+   very important to the Internet community even though they have not
+   been recommended by the IESG.  However, the IAB strongly recommends
+   that the standards process be used in the evolution of the protocol
+   suite to maximize interoperability (and to prevent incompatible
+   protocol requirements from arising).  The use of the terms
+   "standard", "draft standard", and "proposed standard" are reserved in
+   any RFC or other publication of Internet protocols to only those
+   protocols which the IESG has approved.
+
+   In addition to a state (like "Proposed Standard"), a protocol is also
+   assigned a status, or requirement level, in this document.  The
+   possible requirement levels ("Required", "Recommended", "Elective",
+   "Limited Use", and "Not Recommended") are defined in Section 4.2.
+   When a protocol is on the standards track, that is in the proposed
+   standard, draft standard, or standard state (see Section 5), the
+   status shown in Section 6 is the current status.
+
+   Few protocols are required to be implemented in all systems; this is
+   because there is such a variety of possible systems, for example,
+
+
+
+Internet Architecture Board Standards Track                     [Page 4]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+   gateways, routers, terminal servers, workstations, and multi-user
+   hosts.  The requirement level shown in this document is only a one
+   word label, which may not be sufficient to characterize the
+   implementation requirements for a protocol in all situations.  For
+   some protocols, this document contains an additional status paragraph
+   (an applicability statement).  In addition, more detailed status
+   information may be contained in separate requirements documents (see
+   Section 3).
+
+2.  The Request for Comments Documents
+
+   The documents called Request for Comments (or RFCs) are the working
+   notes of the "Network Working Group", that is the Internet research
+   and development community.  A document in this series may be on
+   essentially any topic related to computer communication, and may be
+   anything from a meeting report to the specification of a standard.
+
+   Notice:
+
+      All standards are published as RFCs, but not all RFCs specify
+      standards.
+
+   Anyone can submit a document for publication as an RFC.  Submissions
+   must be made via electronic mail to the RFC Editor (see the contact
+   information at the end of this memo, and see RFC 2223).
+
+   While RFCs are not refereed publications, they do receive technical
+   review from the task forces, individual technical experts, or the RFC
+   Editor, as appropriate.
+
+   The RFC series comprises a wide range of documents, ranging from
+   informational documents of general interests to specifications of
+   standard Internet protocols.  In cases where submission is intended
+   to document a proposed standard, draft standard, or standard
+   protocol, the RFC Editor will publish the document only with the
+   approval of the IESG.  For documents describing experimental work,
+   the RFC Editor will notify the IESG before publication, allowing for
+   the possibility of review by the relevant IETF working group or IRTF
+   research group and provide those comments to the author.  See Section
+   5.1 for more detail.
+
+   Once a document is assigned an RFC number and published, that RFC is
+   never revised or re-issued with the same number.  There is never a
+   question of having the most recent version of a particular RFC.
+   However, a protocol (such as File Transfer Protocol (FTP)) may be
+   improved and re-documented many times in several different RFCs.  It
+   is important to verify that you have the most recent RFC on a
+   particular protocol.  This "Internet Official Protocol Standards"
+
+
+
+Internet Architecture Board Standards Track                     [Page 5]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+   memo is the reference for determining the correct RFC for the current
+   specification of each protocol.
+
+   The RFCs are available from the RFC-EDITOR, and a number of other
+   sites.  For more information about obtaining RFCs, see Sections 7.4
+   and 7.5.
+
+3.  Other Reference Documents
+
+   There are three other reference documents of interest in checking the
+   current status of protocol specifications and standardization.  These
+   are the Assigned Numbers, the Gateway Requirements, and the Host
+   Requirements.  Note that these documents are revised and updated at
+   different times; in case of differences between these documents, the
+   most recent must prevail.
+
+   Also, one should be aware of the MIL-STD publications on IP, TCP,
+   Telnet, FTP, and SMTP.  These are described in Section 3.4.
+
+3.1.  Assigned Numbers
+
+   The "Assigned Numbers" document lists the assigned values of the
+   parameters used in the various protocols.  For example, IP protocol
+   codes, TCP port numbers, Telnet Option Codes, ARP hardware types, and
+   Terminal Type names.  Assigned Numbers was most recently issued as
+   RFC-1700.
+
+3.2.  Requirements for IP Version 4 Routers
+
+   This document reviews the specifications that apply to gateways and
+   supplies guidance and clarification for any ambiguities.
+   Requirements for IP Version 4 Routers is RFC-1812.
+
+3.3.  Host Requirements
+
+   This pair of documents reviews and updates the specifications that
+   apply to hosts, and it supplies guidance and clarification for any
+   ambiguities.  Host Requirements was issued as RFC-1122 and RFC-1123.
+
+3.4.  The MIL-STD Documents
+
+   The DoD MIL-STD Internet specifications are out of date and have been
+   discontinued.  The DoD's Joint Technical Architecture (JTA) lists the
+   current set of IETF STDs and RFCs that the DoD intends to use in all
+   new and upgraded Command, Control, Communications, Computers, and
+   Intelligence (C4I) acquisitions.  A copy of the JTA can be obtained
+   from http://www-jta.itsi.disa.mil.
+
+
+
+
+Internet Architecture Board Standards Track                     [Page 6]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+4.  Explanation of Terms
+
+   There are two independent categorization of protocols.  The first is
+   the "maturity level" or STATE of standardization, one of "standard",
+   "draft standard", "proposed standard", "experimental",
+   "informational" or "historic".  The second is the "requirement level"
+   or STATUS of this protocol, one of "required", "recommended",
+   "elective", "limited use", or "not recommended".
+
+   The status or requirement level is difficult to portray in a one word
+   label.  These status labels should be considered only as an
+   indication, and a further description, or applicability statement,
+   should be consulted.
+
+   When a protocol is advanced to proposed standard or draft standard,
+   it is labeled with a current status.
+
+   At any given time a protocol occupies a cell of the following matrix.
+   Protocols are likely to be in cells in about the following
+   proportions (indicated by the relative number of Xs).  A new protocol
+   is most likely to start in the (proposed standard, elective) cell, or
+   the (experimental, limited use) cell.
+
+                             S T A T U S
+                     Req   Rec   Ele   Lim   Not
+                   +-----+-----+-----+-----+-----+
+           Std     |  X  | XXX | XXX |     |     |
+       S           +-----+-----+-----+-----+-----+
+           Draft   |  X  |  X  | XXX |     |     |
+       T           +-----+-----+-----+-----+-----+
+           Prop    |     |  X  | XXX |     |     |
+       A           +-----+-----+-----+-----+-----+
+           Info    |     |     |     |     |     |
+       T           +-----+-----+-----+-----+-----+
+           Expr    |     |     |     | XXX |     |
+       E           +-----+-----+-----+-----+-----+
+           Hist    |     |     |     |     | XXX |
+                   +-----+-----+-----+-----+-----+
+
+   What is a "system"?
+
+      Some protocols are particular to hosts and some to gateways; a few
+      protocols are used in both.  The definitions of the terms below
+      will refer to a "system" which is either a host or a gateway (or
+      both).  It should be clear from the context of the particular
+      protocol which types of systems are intended.
+
+
+
+
+
+Internet Architecture Board Standards Track                     [Page 7]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+4.1.  Definitions of Protocol State
+
+   Every protocol listed in this document is assigned to a "maturity
+   level" or STATE of standardization: "standard", "draft standard",
+   "proposed standard", "experimental", or "historic".
+
+   4.1.1.  Standard Protocol
+
+      The IESG has established this as an official standard protocol for
+      the Internet.  These protocols are assigned STD numbers (see RFC-
+      1311).  These are separated into two groups: (1) IP protocol and
+      above, protocols that apply to the whole Internet; and (2)
+      network-specific protocols, generally specifications of how to do
+      IP on particular types of networks.
+
+   4.1.2.  Draft Standard Protocol
+
+      The IESG is actively considering this protocol as a possible
+      Standard Protocol.  Substantial and widespread testing and comment
+      are desired.  Comments and test results should be submitted to the
+      IESG.  There is a possibility that changes will be made in a Draft
+      Standard Protocol before it becomes a Standard Protocol.
+
+   4.1.3.  Proposed Standard Protocol
+
+      These are protocol proposals that may be considered by the IESG
+      for standardization in the future.  Implementation and testing by
+      several groups is desirable.  Revision of the protocol
+      specification is likely.
+
+   4.1.4.  Experimental Protocol
+
+      A system should not implement an experimental protocol unless it
+      is participating in the experiment and has coordinated its use of
+      the protocol with the developer of the protocol.
+
+      Typically, experimental protocols are those that are developed as
+      part of an ongoing research project not related to an operational
+      service offering.  While they may be proposed as a service
+      protocol at a later stage, and thus become proposed standard,
+      draft standard, and then standard protocols, the designation of a
+      protocol as experimental may sometimes be meant to suggest that
+      the protocol, although perhaps mature, is not intended for
+      operational use.
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                     [Page 8]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+   4.1.5.  Informational Protocol
+
+      Protocols developed by other standard organizations, or vendors,
+      or that are for other reasons outside the purview of the IESG, may
+      be published as RFCs for the convenience of the Internet community
+      as informational protocols.
+
+   4.1.6.  Historic Protocol
+
+      These are protocols that are unlikely to ever become standards in
+      the Internet either because they have been superseded by later
+      developments or due to lack of interest.
+
+4.2.  Definitions of Protocol Status
+
+      This document lists a "requirement level" or STATUS for each
+      protocol.  The status is one of "required", "recommended",
+      "elective", "limited use", or "not recommended".
+
+   4.2.1.  Required Protocol
+
+      A system must implement the required protocols.
+
+   4.2.2.  Recommended Protocol
+
+      A system should implement the recommended protocols.
+
+   4.2.3.  Elective Protocol
+
+      A system may or may not implement an elective protocol. The
+      general notion is that if you are going to do something like this,
+      you must do exactly this.  There may be several elective protocols
+      in a general area, for example, there are several electronic mail
+      protocols, and several routing protocols.
+
+   4.2.4.  Limited Use Protocol
+
+      These protocols are for use in limited circumstances.  This may be
+      because of their experimental state, specialized nature, limited
+      functionality, or historic state.
+
+   4.2.5.  Not Recommended Protocol
+
+      These protocols are not recommended for general use.  This may be
+      because of their limited functionality, specialized nature, or
+      experimental or historic state.
+
+
+
+
+
+Internet Architecture Board Standards Track                     [Page 9]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+5.  The Standards Track
+
+   This section discusses in more detail the procedures used by the RFC
+   Editor and the IESG in making decisions about the labeling and
+   publishing of protocols as standards.
+
+5.1.  The RFC Processing Decision Table
+
+   Here is the current decision table for processing submissions by the
+   RFC Editor.  The processing depends on who submitted it, and the
+   status they want it to have.
+
+      +==========================================================+
+      |**************|               S O U R C E                 |
+      +==========================================================+
+      | Desired      |    IAB   |   IESG   |   IRSG   |  Other   |
+      | Status       |          |          |          |          |
+      +==========================================================+
+      |              |          |          |          |          |
+      | Standard     |  Bogus   |  Publish |  Bogus   |  Bogus   |
+      | or           |   (2)    |   (1)    |   (2)    |   (2)    |
+      | Draft        |          |          |          |          |
+      | Standard     |          |          |          |          |
+      +--------------+----------+----------+----------+----------+
+      |              |          |          |          |          |
+      |              |  Refer   |  Publish |  Refer   |  Refer   |
+      | Proposed     |   (3)    |   (1)    |   (3)    |   (3)    |
+      | Standard     |          |          |          |          |
+      |              |          |          |          |          |
+      +--------------+----------+----------+----------+----------+
+      |              |          |          |          |          |
+      |              |  Notify  |  Publish |  Notify  |  Notify  |
+      | Experimental |   (4)    |   (1)    |   (4)    |   (4)    |
+      | Protocol     |          |          |          |          |
+      |              |          |          |          |          |
+      +--------------+----------+----------+----------+----------+
+      |              |          |          |          |          |
+      | Information  |  Publish |  Publish |Discretion|Discretion|
+      | or Opinion   |   (1)    |   (1)    |   (5)    |   (5)    |
+      | Paper        |          |          |          |          |
+      |              |          |          |          |          |
+      +==========================================================+
+
+      (1) Publish.
+
+      (2) Bogus.  Inform the source of the rules.  RFCs specifying
+          Standard, or Draft Standard must come from the IESG, only.
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 10]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+      (3) Refer to an Area Director for review by a WG.  Expect to see
+          the document again only after approval by the IESG.
+
+      (4) Notify both the IESG and IRSG.  If no concerns are raised in
+          two weeks then do Discretion (5), else RFC Editor to resolve
+          the concerns or do Refer (3).
+
+      (5) RFC Editor's discretion.  The RFC Editor decides if a review
+          is needed and if so by whom.  RFC Editor decides to publish or
+          not.
+
+   Of course, in all cases the RFC Editor can request or make minor
+   changes for style, format, and presentation purposes.
+
+   The IESG has designated the IESG Secretary as its agent for
+   forwarding documents with IESG approval and for registering concerns
+   in response to notifications (4) to the RFC Editor.  Documents from
+   Area Directors or Working Group Chairs may be considered in the same
+   way as documents from "other".
+
+5.2.  The Standards Track Diagram
+
+   There is a part of the STATUS and STATE categorization that is called
+   the standards track.  Actually, only the changes of state are
+   significant to the progression along the standards track, though the
+   status assignments may change as well.
+
+   The states illustrated by single line boxes are temporary states,
+   those illustrated by double line boxes are long term states.  A
+   protocol will normally be expected to remain in a temporary state for
+   several months (minimum six months for proposed standard, minimum
+   four months for draft standard).  A protocol may be in a long term
+   state for many years.
+
+   A protocol may enter the standards track only on the recommendation
+   of the IESG; and may move from one state to another along the track
+   only on the recommendation of the IESG.  That is, it takes action by
+   the IESG to either start a protocol on the track or to move it along.
+
+   Generally, as the protocol enters the standards track a decision is
+   made as to the eventual STATUS, requirement level or applicability
+   (elective, recommended, or required) the protocol will have, although
+   a somewhat less stringent current status may be assigned, and it then
+   is placed in the the proposed standard STATE with that status.  So
+   the initial placement of a protocol is into state 1.  At any time the
+   STATUS decision may be revisited.
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 11]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+         |
+         +<----------------------------------------------+
+         |                                               ^
+         V    0                                          |    4
+   +-----------+                                   +===========+
+   |   enter   |-->----------------+-------------->|experiment |
+   +-----------+                   |               +=====+=====+
+                                   |                     |
+                                   V    1                |
+                             +-----------+               V
+                             | proposed  |-------------->+
+                        +--->+-----+-----+               |
+                        |          |                     |
+                        |          V    2                |
+                        +<---+-----+-----+               V
+                             | draft std |-------------->+
+                        +--->+-----+-----+               |
+                        |          |                     |
+                        |          V    3                |
+                        +<---+=====+=====+               V
+                             | standard  |-------------->+
+                             +=====+=====+               |
+                                                         |
+                                                         V    5
+                                                   +=====+=====+
+                                                   | historic  |
+                                                   +===========+
+
+   The transition from proposed standard (1) to draft standard (2) can
+   only be by action of the IESG and only after the protocol has been
+   proposed standard (1) for at least six months.
+
+   The transition from draft standard (2) to standard (3) can only be by
+   action of the IESG and only after the protocol has been draft
+   standard (2) for at least four months.
+
+   Occasionally, the decision may be that the protocol is not ready for
+   standardization and will be assigned to the experimental state (4).
+   This is off the standards track, and the protocol may be resubmitted
+   to enter the standards track after further work.  There are other
+   paths into the experimental and historic states that do not involve
+   IESG action.
+
+   Sometimes one protocol is replaced by another and thus becomes
+   historic, or it may happen that a protocol on the standards track is
+   in a sense overtaken by another protocol (or other events) and
+   becomes historic (state 5).
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 12]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+6.  The Protocols
+
+   Subsection 6.1 lists recent RFCs and other changes.  Subsections 6.2
+   - 6.10 list the standards in groups by protocol state.
+
+6.1.  Recent Changes
+
+6.1.1.  New RFCs:
+
+      2352 - A Convention For Using Legal Names as Domain Names
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2351 - Mapping of Airline Reservation, Ticketing, and Messaging
+             Traffic over IP
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2350 - Not yet issued.
+
+      2349 - TFTP Timeout Interval and Transfer Size Options
+
+             A Draft Standard protocol.
+
+      2348 - TFTP Blocksize Option
+
+             A Draft Standard protocol.
+
+      2347 - TFTP Option Extension
+
+             A Draft Standard protocol.
+
+      2346 - Making Postscript and PDF International
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2345 - Domain Names and Company Name Retrieval
+
+             An Experimental protocol.
+
+      2344 - Reverse Tunneling for Mobile IP
+
+             A Proposed Standard protocol.
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 13]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+      2343 - RTP Payload Format for Bundled MPEG
+
+             An Experimental protocol.
+
+      2342 - IMAP4 Namespace
+
+             A Proposed Standard protocol.
+
+      2341 - Cisco Layer Two Forwarding (Protocol) "L2F"
+
+             A Historic protocol.
+
+      2340 - Not yet issued.
+
+      2339 - An Agreement Between the Internet Society, the IETF, and
+             Sun Microsystems, Inc.  in the matter of NFS V.4 Protocols
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2338 - Virtual Router Redundancy Protocol
+
+             A Proposed Standard protocol.
+
+      2337 - Intra-LIS IP multicast among routers over ATM using Sparse
+             Mode PIM
+
+             An Experimental protocol.
+
+      2336 - Not yet issued.
+
+      2335 - A Distributed NHRP Service Using SCSP
+
+             A Proposed Standard protocol.
+
+      2334 - Server Cache Synchronization Protocol (SCSP)
+
+             A Proposed Standard protocol.
+
+      2333 - NHRP Protocol Applicability Statement
+
+             A Proposed Standard protocol.
+
+      2332 - NBMA Next Hop Resolution Protocol (NHRP)
+
+             A Proposed Standard protocol.
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 14]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+      2331 - ATM Signalling Support for IP over ATM - UNI Signalling 4.0
+             Update
+
+             A Proposed Standard protocol.
+
+      2330 - Framework for IP Performance Metrics
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2329 - OSPF Standardization Report
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2328 - OSPF Version 2
+
+             A Standard protocol.
+
+      2327 - SDP: Session Description Protocol
+
+             A Proposed Standard protocol.
+
+      2326 - Real Time Streaming Protocol (RTSP)
+
+             A Proposed Standard protocol.
+
+      2325 - Definitions of Managed Objects for Drip-Type Heated
+             Beverage Hardware Devices using SMIv2
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2324 - Hyper Text Coffee Pot Control Protocol (HTCPCP/1.0)
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2323 - IETF Identification and Security Guidelines
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2322 - Management of IP numbers by peg-dhcp
+
+             This is an information document and does not specify any
+             level of standard.
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 15]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+      2321 - RITA -- The Reliable Internetwork Troubleshooting Agent
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2320 - Definitions of Managed Objects for Classical IP and ARP
+             Over ATM Using SMIv2 (IPOA-MIB)
+
+             A Proposed Standard protocol.
+
+      2319 - Ukrainian Character Set KOI8-U
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2318 - The text/css Media Type
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2317 - Classless IN-ADDR.ARPA delegation
+
+             This is a Best Current Practices document and does not
+             specify any level of standard.
+
+      2316 - Report of the IAB Security Architecture Workshop
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2315 - PKCS #7: Cryptographic Message Syntax Version 1.5
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2314 - PKCS #10: Certification Request Syntax Version 1.5
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2313 - PKCS #1: RSA Encryption Version 1.5
+
+             This is an information document and does not specify any
+             level of standard.
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 16]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+      2312 - S/MIME Version 2 Certificate Handling
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2311 - S/MIME Version 2 Message Specification
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2310 - The Safe Response Header Field
+
+             An Experimental protocol.
+
+      2309 - Recommendations on Queue Management and Congestion
+             Avoidance in the Internet
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2308 - Negative Caching of DNS Queries (DNS NCACHE)
+
+             A Proposed Standard protocol.
+
+      2307 - An Approach for Using LDAP as a Network Information Service
+
+             An Experimental protocol.
+
+      2306 - Tag Image File Format (TIFF) - F Profile for Facsimile
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2305 - A Simple Mode of Facsimile Using Internet Mail
+
+             A Proposed Standard protocol.
+
+      2304 - Minimal FAX address format in Internet Mail
+
+             A Proposed Standard protocol.
+
+      2303 - Minimal PSTN address format in Internet Mail
+
+             A Proposed Standard protocol.
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 17]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+      2302 - Tag Image File Format (TIFF) - image/tiff MIME Sub-type
+             Registration
+
+             A Proposed Standard protocol.
+
+      2301 - File Format for Internet Fax
+
+             A Proposed Standard protocol.
+
+      2300 - This memo.
+
+      2299 - Not yet issued.
+
+      2298 - An Extensible Message Format for Message Disposition
+             Notifications
+
+             A Proposed Standard protocol.
+
+      2297 - Ipsilon's General Switch Management Protocol Specification
+             Version 2.0
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2296 - HTTP Remote Variant Selection Algorithm -- RVSA/1.0
+
+             An Experimental protocol.
+
+      2295 - Transparent Content Negotiation in HTTP
+
+             An Experimental protocol.
+
+      2294 - Representing the O/R Address hierarchy in the X.500
+             Directory Information Tree
+
+             A Proposed Standard protocol.
+
+      2293 - Representing Tables and Subtrees in the X.500 Directory
+
+             A Proposed Standard protocol.
+
+      2292 - Advanced Sockets API for IPv6
+
+             This is an information document and does not specify any
+             level of standard.
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 18]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+      2291 - Requirements for a Distributed Authoring and Versioning
+             Protocol for the World Wide Web
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2290 - Mobile-IPv4 Configuration Option for PPP IPCP
+
+             A Proposed Standard protocol.
+
+      2289 - A One-Time Password System
+
+             A Draft Standard protocol.
+
+      2288 - Using Existing Bibliographic Identifiers as Uniform
+             Resource Names
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2287 - Definitions of System-Level Managed Objects for
+             Applications
+
+             A Proposed Standard protocol.
+
+      2286 - Test Cases for HMAC-RIPEMD160 and HMAC-RIPEMD128
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2285 - Benchmarking Terminology for LAN Switching Devices
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2284 - PPP Extensible Authentication Protocol (EAP)
+
+             A Proposed Standard protocol.
+
+      2283 - Multiprotocol Extensions for BGP-4
+
+             A Proposed Standard protocol.
+
+      2282 - IAB and IESG Selection, Confirmation, and Recall Process:
+             Operation of the Nominating and Recall Committees
+
+             This is a Best Current Practices document and does not
+             specify any level of standard.
+
+
+
+Internet Architecture Board Standards Track                    [Page 19]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+      2281 - Cisco Hot Standby Router Protocol (HSRP)
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2280 - Routing Policy Specification Language (RPSL)
+
+             A Proposed Standard protocol.
+
+      2279 - UTF-8, a transformation format of ISO 10646
+
+             A Proposed Standard protocol.
+
+      2278 - IANA Charset Registration Procedures
+
+             This is a Best Current Practices document and does not
+             specify any level of standard.
+
+      2277 - IETF Policy on Character Sets and Languages
+
+             This is a Best Current Practices document and does not
+             specify any level of standard.
+
+      2276 - Architectural Principles of Uniform Resource Name
+             Resolution
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2275 - View-based Access Control Model (VACM) for the Simple
+             Network Management Protocol (SNMP)
+
+             A Proposed Standard protocol.
+
+      2274 - User-based Security Model (USM) for version 3 of the Simple
+             Network Management Protocol (SNMPv3)
+
+             A Proposed Standard protocol.
+
+      2273 - SNMPv3 Applications
+
+             A Proposed Standard protocol.
+
+      2272 - Message Processing and Dispatching for the Simple Network
+             Management Protocol (SNMP)
+
+             A Proposed Standard protocol.
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 20]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+      2271 - An Architecture for Describing SNMP Management Frameworks
+
+             A Proposed Standard protocol.
+
+      2270 - Using a Dedicated AS for Sites Homed to a Single Provider
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2269 - Using the MARS Model in non-ATM NBMA Networks
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2268 - A Description of the RC2(r) Encryption Algorithm
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2267 - Network Ingress Filtering: Defeating Denial of Service
+             Attacks which employ IP Source Address Spoofing
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2266 - Definitions of Managed Objects for IEEE 802.12 Repeater
+             Devices
+
+             A Proposed Standard protocol.
+
+      2265 - View-based Access Control Model (VACM) for the Simple
+             Network Management Protocol (SNMP)
+
+             A Proposed Standard protocol.
+
+      2264 - User-based Security Model (USM) for version 3 of the Simple
+             Network Management Protocol (SNMPv3)
+
+             A Proposed Standard protocol.
+
+      2263 - SNMPv3 Applications
+
+             A Proposed Standard protocol.
+
+      2262 - Message Processing and Dispatching for the Simple Network
+             Management Protocol (SNMP)
+
+             A Proposed Standard protocol.
+
+
+
+Internet Architecture Board Standards Track                    [Page 21]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+      2261 - An Architecture for Describing SNMP Management Frameworks
+
+             A Proposed Standard protocol.
+
+      2260 - Scalable Support for Multi-homed Multi-provider
+             Connectivity
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2259 - Simple Nomenclator Query Protocol (SNQP)
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2258 - Internet Nomenclator Project
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2257 - Agent Extensibility (AgentX) Protocol Version 1
+
+             A Proposed Standard protocol.
+
+      2256 - A Summary of the X.500(96) User Schema for use with LDAPv3
+
+             A Proposed Standard protocol.
+
+      2255 - The LDAP URL Format
+
+             A Proposed Standard protocol.
+
+      2254 - The String Representation of LDAP Search Filters
+
+             A Proposed Standard protocol.
+
+      2253 - Lightweight Directory Access Protocol (v3): UTF-8 String
+             Representation of Distinguished Names
+
+             A Proposed Standard protocol.
+
+      2252 - Lightweight Directory Access Protocol (v3): Attribute
+             Syntax Definitions
+
+             A Proposed Standard protocol.
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 22]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+      2251 - Lightweight Directory Access Protocol (v3)
+
+             A Proposed Standard protocol.
+
+      2250 - RTP Payload Format for MPEG1/MPEG2 Video
+
+             A Proposed Standard protocol.
+
+      2249 - Mail Monitoring MIB
+
+             A Proposed Standard protocol.
+
+      2248 - Network Services Monitoring MIB
+
+             A Proposed Standard protocol.
+
+      2247 - Using Domains in LDAP/X.500 Distinguished Names
+
+             A Proposed Standard protocol.
+
+      2246 - Not yet issued.
+
+      2245 - Anonymous SASL Mechanism
+
+             A Proposed Standard protocol.
+
+      2244 - ACAP -- Application Configuration Access Protocol
+
+             A Proposed Standard protocol.
+
+      2243 - OTP Extended Responses
+
+             A Proposed Standard protocol.
+
+      2242 - NetWare/IP Domain Name and Information
+
+             A Proposed Standard protocol.
+
+      2241 - DHCP Options for Novell Directory Services
+
+             A Proposed Standard protocol.
+
+      2240 - A Legal Basis for Domain Name Allocation
+
+             This is an information document and does not specify any
+             level of standard.
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 23]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+      2239 - Definitions of Managed Objects for IEEE 802.3 Medium
+             Attachment Units (MAUs) using SMIv2
+
+             A Proposed Standard protocol.
+
+      2238 - Definitions of Managed Objects for HPR using SMIv2
+
+             A Proposed Standard protocol.
+
+      2237 - Japanese Character Encoding for Internet Messages
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2236 - Internet Group Management Protocol, Version 2
+
+             A Proposed Standard protocol.
+
+      2235 - Hobbes' Internet Timeline
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2234 - Augmented BNF for Syntax Specifications: ABNF
+
+             A Proposed Standard protocol.
+
+      2233 - The Interfaces Group MIB using SMIv2
+
+             A Proposed Standard protocol.
+
+      2232 - Definitions of Managed Objects for DLUR using SMIv2
+
+             A Proposed Standard protocol.
+
+      2231 - MIME Parameter Value and Encoded Word Extensions: Character
+             Sets, Languages, and Continuations
+
+             A Proposed Standard protocol.
+
+      2230 - Key Exchange Delegation Record for the DNS
+
+             This is an information document and does not specify any
+             level of standard.
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 24]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+      2229 - A Dictionary Server Protocol
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2228 - FTP Security Extensions
+
+             A Proposed Standard protocol.
+
+      2227 - Simple Hit-Metering and Usage-Limiting for HTTP
+
+             A Proposed Standard protocol.
+
+      2226 - IP Broadcast over ATM Networks
+
+             A Proposed Standard protocol.
+
+      2225 - Classical IP and ARP over ATM
+
+             A Proposed Standard protocol.
+
+      2224 - NFS URL Scheme
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2223 - Instructions to RFC Authors
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2222 - Simple Authentication and Security Layer (SASL)
+
+             A Proposed Standard protocol.
+
+      2221 - IMAP4 Login Referrals
+
+             A Proposed Standard protocol.
+
+      2220 - The Application/MARC Content-type
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2219 - Use of DNS Aliases for Network Services
+
+             This is a Best Current Practices document and does not
+             specify any level of standard.
+
+
+
+Internet Architecture Board Standards Track                    [Page 25]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+      2218 - A Common Schema for the Internet White Pages Service
+
+             A Proposed Standard protocol.
+
+      2217 - Telnet Com Port Control Option
+
+             An Experimental protocol.
+
+      2216 - Network Element Service Specification Template
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2215 - General Characterization Parameters for Integrated Service
+             Network Elements
+
+             A Proposed Standard protocol.
+
+      2214 - Integrated Services Management Information Base Guaranteed
+             Service Extensions using SMIv2
+
+             A Proposed Standard protocol.
+
+      2213 - Integrated Services Management Information Base using SMIv2
+
+             A Proposed Standard protocol.
+
+      2212 - Specification of Guaranteed Quality of Service
+
+             A Proposed Standard protocol.
+
+      2211 - Specification of the Controlled-Load Network Element
+             Service
+
+             A Proposed Standard protocol.
+
+      2210 - The Use of RSVP with IETF Integrated Services
+
+             A Proposed Standard protocol.
+
+      2209 - Resource ReSerVation Protocol (RSVP) -- Version 1 Message
+             Processing Rules
+
+             A Proposed Standard protocol.
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 26]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+      2208 - Resource ReSerVation Protocol (RSVP) -- Version 1
+             Applicability Statement Some Guidelines on Deployment
+
+             A Proposed Standard protocol.
+
+      2207 - RSVP Extensions for IPSEC Data Flows
+
+             A Proposed Standard protocol.
+
+      2206 - RSVP Management Information Base using SMIv2
+
+             A Proposed Standard protocol.
+
+      2205 - Resource ReSerVation Protocol (RSVP) -- Version 1
+             Functional Specification
+
+             A Proposed Standard protocol.
+
+      2204 - ODETTE File Transfer Protocol
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2203 - RPCSEC_GSS Protocol Specification
+
+             A Proposed Standard protocol.
+
+      2202 - Test Cases for HMAC-MD5 and HMAC-SHA-1
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2201 - Core Based Trees (CBT) Multicast Routing Architecture
+
+             An Experimental protocol.
+
+      2200 - Internet Official Protocol Standards
+
+             A Standard protocol.
+
+      2199 - Request for Comments Summary - RFC Numbers 2100-2199
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2198 - RTP Payload for Redundant Audio Data
+
+             A Proposed Standard protocol.
+
+
+
+Internet Architecture Board Standards Track                    [Page 27]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+      2197 - SMTP Service Extension for Command Pipelining
+
+             A Draft Standard protocol.
+
+      2196 - Site Security Handbook
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2195 - IMAP/POP AUTHorize Extension for Simple Challenge/Response
+
+             A Proposed Standard protocol.
+
+      2194 - Review of Roaming Implementations
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2193 - IMAP4 Mailbox Referrals
+
+             A Proposed Standard protocol.
+
+      2192 - IMAP URL Scheme
+
+             A Proposed Standard protocol.
+
+      2191 - VENUS - Very Extensive Non-Unicast Service
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2190 - RTP Payload Format for H.263 Video Streams
+
+             A Proposed Standard protocol.
+
+      2189 - Core Based Trees (CBT version 2) Multicast Routing
+
+             An Experimental protocol.
+
+      2188 - AT&T/Neda's Efficient Short Remote Operations (ESRO)
+             Protocol Specification Version 1.
+
+             This is an information document and does not specify any
+             level of standard.
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 28]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+      2187 - Application of Internet Cache Protocol (ICP), version 2
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2186 - Internet Cache Protocol (ICP), version 2
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2185 - Routing Aspects of IPv6 Transition
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2184 - MIME Parameter Value and Encoded Word Extensions: Character
+             Sets, Languages, and Continuations
+
+             A Proposed Standard protocol.
+
+      2183 - Communicating Presentation Information in Internet
+             Messages: The Content-Disposition Header Field
+
+             A Proposed Standard protocol.
+
+      2182 - Selection and Operation of Secondary DNS Servers
+
+             This is a Best Current Practices document and does not
+             specify any level of standard.
+
+      2181 - Clarifications to the DNS Specification
+
+             A Proposed Standard protocol.
+
+      2180 - IMAP4 Multi-Accessed Mailbox Practice
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2179 - Network Security For Trade Shows
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2178 - OSPF Version 2
+
+             A Draft Standard protocol.
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 29]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+      2177 - IMAP4 IDLE command
+
+             A Proposed Standard protocol.
+
+      2176 - IPv4 over MAPOS Version 1
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2175 - MAPOS 16 - Multiple Access Protocol over SONET/SDH with 16
+             Bit Addressing
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2174 - A MAPOS version 1 Extension - Switch-Switch Protocol
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2173 - A MAPOS version 1 Extension - Node Switch Protocol
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2172 - MAPOS Version 1 Assigned Numbers
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2171 - MAPOS - Multiple Access Protocol over SONET/SDH Version 1
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2170 - Application REQuested IP over ATM (AREQUIPA)
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2169 - A Trivial Convention for using HTTP in URN Resolution
+
+             An Experimental protocol.
+
+      2168 - Resolution of Uniform Resource Identifiers using the Domain
+             Name System
+
+             An Experimental protocol.
+
+
+
+Internet Architecture Board Standards Track                    [Page 30]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+      2167 - Referral Whois (RWhois) Protocol V1.5
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2166 - APPN Implementer's Workshop Closed Pages Document DLSw v2.0
+             Enhancements
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2165 - Service Location Protocol
+
+             A Proposed Standard protocol.
+
+      2164 - Use of an X.500/LDAP directory to support MIXER address
+             mapping
+
+             A Proposed Standard protocol.
+
+      2163 - Using the Internet DNS to Distribute MIXER Conformant
+             Global Address Mapping (MCGAM)
+
+             A Proposed Standard protocol.
+
+      2162 - MaXIM-11 - Mapping between X.400 / Internet mail and
+             Mail-11 mail
+
+             An Experimental protocol.
+
+      2161 - A MIME Body Part for ODA
+
+             An Experimental protocol.
+
+      2160 - Carrying PostScript in X.400 and MIME
+
+             A Proposed Standard protocol.
+
+      2159 - A MIME Body Part for FAX
+
+             A Proposed Standard protocol.
+
+      2158 - X.400 Image Body Parts
+
+             A Proposed Standard protocol.
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 31]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+      2157 - Mapping between X.400 and RFC-822/MIME Message Bodies
+
+             A Proposed Standard protocol.
+
+      2156 - MIXER (Mime Internet X.400 Enhanced Relay): Mapping between
+             X.400 and RFC 822/MIME
+
+             A Proposed Standard protocol.
+
+      2155 - Definitions of Managed Objects for APPN using SMIv2
+
+             A Proposed Standard protocol.
+
+      2154 - OSPF with Digital Signature
+
+             An Experimental protocol.
+
+      2151 - A Primer On Internet and TCP/IP Tools and Utilities
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2150 - Humanities and Arts: Sharing Center Stage on the Internet
+
+             This is an information document and does not specify any
+             level of standard.
+
+      2148 - Deployment of the Internet White Pages Service
+
+             This is a Best Current Practices document and does not
+             specify any level of standard.
+
+      2115 - Management Information Base for Frame Relay DTEs Using
+             SMIv2
+
+             A Draft Standard protocol.
+
+      2094 - Group Key Management Protocol (GKMP) Architecture
+
+             An Experimental protocol.
+
+      2093 - Group Key Management Protocol (GKMP) Specification
+
+             An Experimental protocol.
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 32]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+6.1.2.  Other Changes:
+
+   The following are changes to protocols listed in the previous
+   edition.
+
+      2349 - TFTP Timeout Interval and Transfer Size Options
+
+             Elevated to Draft Standard.
+
+      2348 - TFTP Blocksize Option
+
+             Elevated to Draft Standard.
+
+      2347 - TFTP Option Extension
+
+             Elevated to Draft Standard.
+
+      2328 - OSPF Version 2
+
+             Elevated to Standard.
+
+      2289 - A One-Time Password System
+
+             Elevated to Draft Standard.
+
+      2197 - SMTP Service Extension for Command Pipelining
+
+             Elevated to Draft Standard.
+
+      2115 - Management Information Base for Frame Relay DTEs Using
+             SMIv2
+
+             Elevated to Draft Standard.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 33]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+6.2.  Standard Protocols
+
+Protocol   Name                                      Status    RFC STD *
+========   =====================================     ======== ==== === =
+--------   Internet Official Protocol Standards      Req      2300   1
+--------   Assigned Numbers                          Req      1700   2
+--------   Host Requirements - Communications        Req      1122   3
+--------   Host Requirements - Applications          Req      1123   3
+IP         Internet Protocol                         Req       791   5
+            as amended by:--------
+--------     IP Subnet Extension                     Req       950   5
+--------     IP Broadcast Datagrams                  Req       919   5
+--------     IP Broadcast Datagrams with Subnets     Req       922   5
+ICMP       Internet Control Message Protocol         Req       792   5
+IGMP       Internet Group Multicast Protocol         Rec      1112   5
+UDP        User Datagram Protocol                    Rec       768   6
+TCP        Transmission Control Protocol             Rec       793   7
+TELNET     Telnet Protocol                           Rec   854,855   8
+FTP        File Transfer Protocol                    Rec       959   9
+SMTP       Simple Mail Transfer Protocol             Rec       821  10
+SMTP-SIZE  SMTP Service Ext for Message Size         Rec      1870  10
+SMTP-EXT   SMTP Service Extensions                   Rec      1869  10
+MAIL       Format of Electronic Mail Messages        Rec       822  11
+CONTENT    Content Type Header Field                 Rec      1049  11
+NTPV2      Network Time Protocol (Version 2)         Rec      1119  12
+DOMAIN     Domain Name System                        Rec 1034,1035  13
+DNS-MX     Mail Routing and the Domain System        Rec       974  14
+SNMP       Simple Network Management Protocol        Rec      1157  15
+SMI        Structure of Management Information       Rec      1155  16
+Concise-MIB Concise MIB Definitions                  Rec      1212  16
+MIB-II     Management Information Base-II            Rec      1213  17
+NETBIOS    NetBIOS Service Protocols                 Ele 1001,1002  19
+ECHO       Echo Protocol                             Rec       862  20
+DISCARD    Discard Protocol                          Ele       863  21
+CHARGEN    Character Generator Protocol              Ele       864  22
+QUOTE      Quote of the Day Protocol                 Ele       865  23
+USERS      Active Users Protocol                     Ele       866  24
+DAYTIME    Daytime Protocol                          Ele       867  25
+TIME       Time Server Protocol                      Ele       868  26
+TFTP       Trivial File Transfer Protocol            Ele      1350  33
+TP-TCP     ISO Transport Service on top of the TCP   Ele      1006  35
+ETHER-MIB  Ethernet MIB                              Ele      1643  50
+PPP        Point-to-Point Protocol (PPP)             Ele      1661  51
+PPP-HDLC   PPP in HDLC Framing                       Ele      1662  51
+IP-SMDS    IP Datagrams over the SMDS Service        Ele      1209  52
+POP3       Post Office Protocol, Version 3           Ele      1939  53
+OSPF2      Open Shortest Path First Routing V2       Ele      2328  54 *
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 34]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+Applicability Statements:
+
+   IGMP -- The Internet Architecture Board intends to move towards
+   general adoption of IP multicasting, as a more efficient solution
+   than broadcasting for many applications.  The host interface has been
+   standardized in RFC-1112; however, multicast-routing gateways are in
+   the experimental stage and are not widely available.  An Internet
+   host should support all of RFC-1112, except for the IGMP protocol
+   itself which is optional; see RFC-1122 for more details.  Even
+   without IGMP, implementation of RFC-1112 will provide an important
+   advance: IP-layer access to local network multicast addressing.  It
+   is expected that IGMP will become recommended for all hosts and
+   gateways at some future date.
+
+   SMI, MIB-II SNMP -- The Internet Architecture Board recommends that
+   all IP and TCP implementations be network manageable.  At the current
+   time, this implies implementation of the Internet MIB-II (RFC-1213),
+   and at least the recommended management protocol SNMP (RFC-1157).
+
+   RIP -- The Routing Information Protocol (RIP) is widely implemented
+   and used in the Internet.  However, both implementors and users
+   should be aware that RIP has some serious technical limitations as a
+   routing protocol.  The IETF is currently devpeloping several
+   candidates for a new standard "open" routing protocol with better
+   properties than RIP.  The IAB urges the Internet community to track
+   these developments, and to implement the new protocol when it is
+   standardized; improved Internet service will result for many users.
+
+   TP-TCP -- As OSI protocols become more widely implemented and used,
+   there will be an increasing need to support interoperation with the
+   TCP/IP protocols.  The Internet Engineering Task Force is formulating
+   strategies for interoperation.  RFC-1006 provides one interoperation
+   mode, in which TCP/IP is used to emulate TP0 in order to support OSI
+   applications.  Hosts that wish to run OSI connection-oriented
+   applications in this mode should use the procedure described in RFC-
+   1006.  In the future, the IAB expects that a major portion of the
+   Internet will support both TCP/IP and OSI (inter-)network protocols
+   in parallel, and it will then be possible to run OSI applications
+   across the Internet using full OSI protocol "stacks".
+
+   OSPF -- RFC 1370 is an applicability statement for OSPF.
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 35]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+6.3.  Network-Specific Standard Protocols
+
+All Network-Specific Standards have Elective status.
+
+Protocol   Name                                    State    RFC   STD *
+========   =====================================   =====   =====  === =
+IP-ATM     Classical IP and ARP over ATM            Prop   2225       *
+IP-FR      Multiprotocol over Frame Relay           Draft  1490
+ATM-ENCAP  Multiprotocol Encapsulation over ATM     Prop   1483
+IP-TR-MC   IP Multicast over Token-Ring LANs        Prop   1469
+IP-FDDI    Transmission of IP and ARP over FDDI Net Std    1390    36
+IP-X.25    X.25 and ISDN in the Packet Mode         Draft  1356
+ARP        Address Resolution Protocol              Std     826    37
+RARP       A Reverse Address Resolution Protocol    Std     903    38
+IP-ARPA    Internet Protocol on ARPANET             Std BBN1822    39
+IP-WB      Internet Protocol on Wideband Network    Std     907    40
+IP-E       Internet Protocol on Ethernet Networks   Std     894    41
+IP-EE      Internet Protocol on Exp. Ethernet Nets  Std     895    42
+IP-IEEE    Internet Protocol on IEEE 802            Std    1042    43
+IP-DC      Internet Protocol on DC Networks         Std     891    44
+IP-HC      Internet Protocol on Hyperchannel        Std    1044    45
+IP-ARC     Transmitting IP Traffic over ARCNET Nets Std    1201    46
+IP-SLIP    Transmission of IP over Serial Lines     Std    1055    47
+IP-NETBIOS Transmission of IP over NETBIOS          Std    1088    48
+IP-IPX     Transmission of 802.2 over IPX Networks  Std    1132    49
+IP-HIPPI   IP over HIPPI                            Draft  2067
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+Applicability Statements:
+
+   It is expected that a system will support one or more physical
+   networks and for each physical network supported the appropriate
+   protocols from the above list must be supported.  That is, it is
+   elective to support any particular type of physical network, and for
+   the physical networks actually supported it is required that they be
+   supported exactly according to the protocols in the above list.  See
+   also the Host and Gateway Requirements RFCs for more specific
+   information on network-specific ("link layer") protocols.
+
+
+
+
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 36]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+6.4.  Draft Standard Protocols
+
+Protocol   Name                                     Status          RFC
+========   =====================================    ============== =====
+TFTP-Opt   TFTP Options                             Elective       2349*
+TFTP-Blk   TFTP Blocksize Option                    Elective       2348*
+TFTP-Ext   TFTP Option Extension                    Elective       2347*
+ONE-PASS   One-Time Password System                 Elective       2289*
+SMTP-Pipe  SMTP Serv. Ext. for Command Pipelining   Elective       2197*
+BOOTP      DHCP Options and BOOTP Extensions        Recommended    2132
+DHCP       Dynamic Host Configuration Protocol      Elective       2131
+FRAME-MIB  Management Information Base for Frame    Elective       2115*
+-------    Clarifications and Extensions BOOTP      Elective       1542
+DHCP-BOOTP Interoperation Between DHCP and BOOTP    Elective       1534
+BOOTP      Bootstrap Protocol                      Recommended 951,1497
+MIME-CONF  MIME Conformance Criteria                Elective       2049
+MIME-MSG   MIME Msg Header Ext for Non-ASCII        Elective       2047
+MIME-MEDIA MIME Media Types                         Elective       2046
+MIME       Multipurpose Internet Mail Extensions    Elective       2045
+PPP-CHAP   PPP Challenge Handshake Authentication   Elective       1994
+PPP-MP     PPP Multilink Protocol                   Elective       1990
+PPP-LINK   PPP Link Quality Monitoring              Elective       1989
+COEX-MIB   Coexistence between SNMPV1 & SNMPV2      Elective       1908
+SNMPv2-MIB MIB for SNMPv2                           Elective       1907
+TRANS-MIB  Transport Mappings for SNMPv2            Elective       1906
+OPS-MIB    Protocol Operations for SNMPv2           Elective       1905
+CONF-MIB   Conformance Statements for SNMPv2        Elective       1904
+CONV-MIB   Textual Conventions for SNMPv2           Elective       1903
+SMIV2      SMI for SNMPv2                           Elective       1902
+CON-MD5    Content-MD5 Header Field                 Elective       1864
+OSPF-MIB   OSPF Version 2 MIB                       Elective       1850
+STR-REP    String Representation ...                Elective       1779
+X.500syn   X.500 String Representation ...          Elective       1778
+X.500lite  X.500 Lightweight ...                    Elective       1777
+BGP-4-APP  Application of BGP-4                     Elective       1772
+BGP-4      Border Gateway Protocol 4                Elective       1771
+PPP-DNCP   PPP DECnet Phase IV Control Protocol     Elective       1762
+RMON-MIB   Remote Network Monitoring MIB            Elective       1757
+802.5-MIB  IEEE 802.5 Token Ring MIB                Elective       1748
+RIP2-MIB   RIP Version 2 MIB Extension              Elective       1724
+RIP2       RIP Version 2-Carrying Additional Info.  Elective       1723
+RIP2-APP   RIP Version 2 Protocol App. Statement    Elective       1722
+SIP-MIB    SIP Interface Type MIB                   Elective       1694
+-------    Def Man Objs Parallel-printer-like       Elective       1660
+-------    Def Man Objs RS-232-like                 Elective       1659
+-------    Def Man Objs Character Stream            Elective       1658
+BGP-4-MIB  BGP-4 MIB                                Elective       1657
+SMTP-8BIT  SMTP Service Ext or 8bit-MIMEtransport   Elective       1652
+
+
+
+Internet Architecture Board Standards Track                    [Page 37]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+OSI-NSAP   Guidelines for OSI NSAP Allocation       Elective       1629
+ISO-TS-ECHO Echo for ISO-8473                       Elective       1575
+DECNET-MIB DECNET MIB                               Elective       1559
+BRIDGE-MIB BRIDGE-MIB                               Elective       1493
+NTPV3      Network Time Protocol (Version 3)        Elective       1305
+IP-MTU     Path MTU Discovery                       Elective       1191
+FINGER     Finger Protocol                          Elective       1288
+NICNAME    WhoIs Protocol                           Elective        954
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+Applicability Statements:
+
+   PPP -- Point to Point Protocol is a method of sending IP over serial
+   lines, which are a type of physical network.  It is anticipated that
+   PPP will be advanced to the network-specifics standard protocol state
+   in the future.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 38]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+6.5.  Proposed Standard Protocols
+
+Protocol   Name                                     Status          RFC
+========   =====================================    ============== =====
+MOBILIPREV Reverse Tunneling for Mobile IP          Elective       2344*
+IMAP4NAME  IMAP4 Namespace                          Elective       2342*
+VRRP       Virtual Router Redundancy Protocol       Elective       2338*
+NHRP-SCSP  Distributed NHRP Service Using SCSP      Elective       2335*
+SCSP       Server Cache Synchronization Protocol    Elective       2334*
+NHRP-APP   NHRP Protocol Applicability Statement    Elective       2333*
+NHRP       NBMA Next Hop Resolution Protocol        Elective       2332*
+UNI-SIG    ATM Sig Support (IPOA) UNI Signalling    Elective       2331*
+SDP        Session Description Protocol             Elective       2327*
+RTSP       Real Time Streaming Protocol             Elective       2326*
+IPOA-MIB   Classical IP and ARP Over ATM MIB        Elective       2320*
+DNS-NCACHE Negative Caching of DNS Queries          Elective       2308*
+SMFAX-IM   Simple Mode of FAX Using Internet Mail   Elective       2305*
+MINFAX-IM  Minimal FAX addr format in Internet Mail Elective       2304*
+MIN-PSTN   Min. PSTN addr format in Internet Mail   Elective       2303*
+TIFF       Tag Image File Format                    Elective       2302*
+FFIF       File Format for Internet Fax             Elective       2301*
+EMF-MDN    Extensible Message Format for MDN        Elective       2298*
+OR-ADD     O/R Address hierarchy in X.500           Elective       2294*
+SUBTABLE   Tables and Subtrees in X.500             Elective       2293*
+--------   Mobile-IPv4 Config Opt for PPP IPCP      Elective       2290*
+SLM-APP    System-Level Managed Objects for Apps    Elective       2287*
+PPP-EAP    PPP Extensible Authentication Protocol   Elective       2284*
+MEXT-BGP4  Multiprotocol Extensions for BGP-4       Elective       2283*
+RPSL       Routing Policy Specification Language    Elective       2280*
+UTF-8      UTF-8 transformation format of ISO 10646 Elective       2279*
+VACM-SNMP  View-based Access Control Model for SMMP Elective       2275*
+USM-SNMPV3 User-based Security Model for SNMPv3     Elective       2274*
+SNMPV3-APP SNMPv3 Applications                      Elective       2273*
+MPD-SNMP   Message Processing & Dispatching SNMP    Elective       2272*
+ARCH-SNMP  Architecture Describing SNMP Frameworks  Elective       2271*
+--------   IEEE 802.12 Repeater MIB                 Elective       2266*
+AGENTX     Agent Extensibility Protocol             Elective       2257*
+--------   Summary of the X.500(96) with LDAPv3     Elective       2256*
+LDAP-URL   LDAP URL Format                          Elective       2255*
+STR-LDAP   String Rep of LDAP Search Filters        Elective       2254*
+LDAP3-UTF8 LDAPv3: UTF-8 String Rep                 Elective       2253*
+LDAP3-ATD  LDAP3-: Attribute Syntax Definitions     Elective       2252*
+LDAPV3     Lightweight Directory Access Protocol    Elective       2251*
+RTP-MPEG   RTP Payload Format for MPEG1/MPEG2       Elective       2250*
+MAIL-MIB   Mail Monitoring MIB                      Elective       2249*
+NSM-MIB    Network Services Monitoring MIB          Elective       2248*
+--------   Using Domains LDAP/X.500 Dist. Names     Elective       2247*
+SASL-ANON  Anonymous SASL Mechanism                 Elective       2245*
+
+
+
+Internet Architecture Board Standards Track                    [Page 39]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+ACAP       Application Configuration Access         Elective       2244*
+OTP-ER     OTP Extended Responses                   Elective       2243*
+NETWAREIP  NetWare/IP Domain Name and Information   Elective       2242*
+DHCP-NDS   DHCP Options for Novell Directory Serv.  Elective       2241*
+MAUS-MIB   IEEE 802.3 Medium Attachment Units MIB   Elective       2239*
+HPR-MIB    Definitions of Managed Objects for HPR   Elective       2238*
+IGMP       Internet Group Management Protocol V2    Elective       2236*
+ABNF       Augmented BNF for Syntax Specifications  Elective       2234*
+INTERGRMIB Interfaces Group MIB                     Elective       2233*
+DLUR-MIB   Definitions of Managed Objects for DLUR  Elective       2232*
+MIME-EXT   MIME Parameter Value & Encoded Word Ext  Elective       2231*
+FTPSECEXT  FTP Security Extensions                  Elective       2228*
+---------  Simple Hit-Metering, Usage-Limiting HTTP Elective       2227*
+---------  IP Broadcast over ATM Networks           Elective       2226*
+AAL5-MTU   Default IP MTU for use over ATM AAL5     Elective       2225*
+SASL       Simple Authentication and Security Layer Elective       2222*
+IMAP4LOGIN IMAP4 Login Referrals                    Elective       2221*
+---------  Schema for Internet White Pages Service  Elective       2218*
+---------  Characterization Parameters for ISNE     Elective       2215*
+---------  Integrated Services MIB Guar Serv Ext    Elective       2214*
+---------  Integrated Services MIB using SMIv2      Elective       2213*
+GQOS       Spec. of Guaranteed Quality of Service   Elective       2212*
+---------  Spec. of Controlled-Load Net Ele Serv    Elective       2211*
+RSVP-IS    Use of RSVP with IETF Integrated Serv    Elective       2210*
+RSVP-MPR   RSVP Messaging Processing Rules          Elective       2209*
+RSVP-APP   RSVP Applicability Statement             Elective       2208*
+RSVP-IPSEC RSVP Extensions for IPSEC Data Flows     Elective       2207*
+RSVP-MIB   RSVP Management Information Base         Elective       2206*
+RSVP       Resource ReSerVation Protocol V1         Elective       2205*
+RPCSEC-GSS RPCSEC_GSS Protocol Specification        Elective       2203*
+RTP-RAD    RTP Payload for Redundant Audio Data     Elective       2198*
+IMAPPOPAU  IMAP/POP AUTHorize Extension             Elective       2195*
+IMAP4MAIL  IMAP4 Mailbox Referrals                  Elective       2193*
+IMAP-URL   IMAP URL Scheme                          Elective       2192*
+---------  RTP Payload Format for H.263 Video ST    Elective       2190*
+MIME-EXT   MIME Parameter Value & Encoded Word Ext  Elective       2184*
+---------  The Content-Disposition Header Field     Elective       2183*
+DNS-CLAR   Clarifications to the DNS Specification  Elective       2181*
+IMAP4-IDLE IMAP4 IDLE command                       Elective       2177*
+SLP        Service Location Protocol                Elective       2165*
+---------  X.500/LDAP Directory/MIXER Address Map.  Elective       2164*
+DNS-MCGAM  Using DNS to Distribute MCGAM            Elective       2163*
+---------  Carrying PostScript in X.400 and MIME    Elective       2160*
+---------  A MIME Body Part for FAX                 Elective       2159*
+---------  X.400 Image Body Parts                   Elective       2158*
+---------  Mapping between X.400 and RFC-822/MIME   Elective       2157*
+MIXER      Mime Internet X.400 Enhanced Relay       Elective       2156*
+APPN-MIB   Definitions of Managed Objects for APPN  Elective       2155*
+
+
+
+Internet Architecture Board Standards Track                    [Page 40]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+IPv6-Jumbo TCP and UDP over IPv6 Jumbograms         Elective       2147
+MAIL-SERV  Mailbox Names for Common Services        Elective       2142
+URN-SYNTAX URN Syntax                               Elective       2141
+RADIUS     Remote Authentication Dial In Service    Elective       2138
+SDNSDU     Secure Domain Name System Dynamic Update Elective       2137
+DNS-UPDATE Dynamic Updates in the DNS               Elective       2136
+DC-MIB     Dial Control MIB using SMIv2             Elective       2128
+ISDN-MIB   ISDN MIB using SMIv2                     Elective       2127
+ITOT       ISO Transport Service on top of TCP      Elective       2126
+BAP-BACP   PPP-BAP, PPP-BACP                        Elective       2125
+VEMMI-URL  VEMMI URL Specification                  Elective       2122
+ROUT-ALERT IP Router Alert Option                   Elective       2113
+MIME-RELAT MIME Multipart/Related Content-type      Elective       2112
+CIDMID-URL Content-ID and Message-ID URLs           Elective       2111
+MHTML      MIME E-mail Encapsulation                Elective       2110
+HTTP-STATE HTTP State Management Mechanism          Elective       2109
+802.3-MIB  802.3 Repeater MIB using SMIv2           Elective       2108
+PPP-NBFCP  PPP NetBIOS Frames Control Protocol      Elective       2097
+TABLE-MIB  IP Forwarding Table MIB                  Elective       2096
+RIP-TRIG   Trigger RIP                              Elective       2091
+IMAP4-LIT  IMAP4 non-synchronizing literals         Elective       2088
+IMAP4-QUO  IMAP4 QUOTA extension                    Elective       2087
+IMAP4-ACL  IMAP4 ACL Extension                      Elective       2086
+HMAC-MD5   HMAC-MD5 IP Auth. with Replay Prevention Elective       2085
+RIP2-MD5   RIP-2 MD5 Authentication                 Elective       2082
+RIPNG-IPV6 RIPng for IPv6                           Elective       2080
+URI-ATT    URI Attribute Type and Object Class      Elective       2079
+GSSAP      Generic Security Service Application     Elective       2078
+MIME-MODEL Model Primary MIME Types                 Elective       2077
+RMON-MIB   Remote Network Monitoring MIB            Elective       2074
+IPV6-UNI   IPv6 Provider-Based Unicast Address      Elective       2073
+HTML-INT   HTML Internationalization                Elective       2070
+DAA        Digest Access Authentication             Elective       2069
+HTTP-1.1   Hypertext Transfer Protocol -- HTTP/1.1  Elective       2068
+DNS-SEC    Domain Name System Security Extensions   Elective       2065
+IMAPV4     Internet Message Access Protocol v4rev1  Elective       2060
+URLZ39.50  Uniform Resource Locators for Z39.50     Elective       2056
+SNANAU-APP SNANAU APPC MIB using SMIv2              Elective       2051
+PPP-SNACP  PPP SNA Control Protocol                 Elective       2043
+ENTITY-MIB Entity MIB using SMIv2                   Elective       2037
+RTP-JPEG   RTP Payload Format for JPEG-compressed   Elective       2035
+SMTP-ENH   SMTP Enhanced Error Codes                Elective       2034
+RTP-H.261  RTP Payload Format for H.261             Elective       2032
+RTP-CELLB  RTP Payload Format of Sun's CellB        Elective       2029
+SPKM       Simple Public-Key GSS-API Mechanism      Elective       2025
+DLSW-MIB   DLSw MIB using SMIv2                     Elective       2024
+IPV6-PPP   IP Version 6 over PPP                    Elective       2023
+MULTI-UNI  Multicast over UNI 3.0/3.1 based ATM     Elective       2022
+
+
+
+Internet Architecture Board Standards Track                    [Page 41]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+RMON-MIB   RMON MIB using SMIv2                     Elective       2021
+802.12-MIB IEEE 802.12 Interface MIB                Elective       2020
+IPV6-FDDI  Transmission of IPv6 Packets Over FDDI   Elective       2019
+TCP-ACK    TCP Selective Acknowledgement Options    Elective       2018
+URL-ACC    URL Access-Type                          Elective       2017
+MIME-PGP   MIME Security with PGP                   Elective       2015
+MIB-UDP    SNMPv2 MIB for UDP                       Elective       2013
+MIB-TCP    SNMPv2 MIB for TCP                       Elective       2012
+MIB-IP     SNMPv2 MIB for IP                        Elective       2011
+MOBILEIPMIBMobile IP MIB Definition using SMIv2     Elective       2006
+MOBILEIPAPPApplicability Statement for IP Mobility  Elective       2005
+MINI-IP    Minimal Encapsulation within IP          Elective       2004
+IPENCAPIP  IP Encapsulation within IP               Elective       2003
+MOBILEIPSUPIP Mobility Support                      Elective       2002
+TCPSLOWSRT TCP Slow Start, Congestion Avoidance...  Elective       2001
+BGP-COMM   BGP Communities Attribute                Elective       1997
+DNS-NOTIFY Mech. for Notification of Zone Changes   Elective       1996
+DNS-IZT    Incremental Zone Transfer in DNS         Elective       1995
+SMTP-ETRN  SMTP Service Extension ETRN              Elective       1985
+SNA        Serial Number Arithmetic                 Elective       1982
+MTU-IPV6   Path MTU Discovery for IP version 6      Elective       1981
+PPP-FRAME  PPP in Frame Relay                       Elective       1973
+IPV6-ETHER Transmission IPv6 Packets Over Ethernet  Elective       1972
+IPV6-AUTO  IPv6 Stateless Address Autoconfiguation  Elective       1971
+IPV6-ND    Neighbor Discovery for IP Version 6      Elective       1970
+PPP-ECP    PPP Encryption Control Protocol          Elective       1968
+GSSAPI-KER Kerberos Version 5 GSS-API Mechanism     Elective       1964
+PPP-CCP    PPP Compression Control Protocol         Elective       1962
+GSSAPI-SOC GSS-API Auth for SOCKS Version 5         Elective       1961
+LDAP-STR   String Rep. of LDAP Search Filters       Elective       1960
+LDAP-URL   LDAP URL Format                          Elective       1959
+TRANS-IPV6 Transition Mechanisms IPv6 Hosts/Routers Elective       1933
+AUTH-SOCKS Username Authentication for SOCKS V5     Elective       1929
+SOCKSV5    SOCKS Protocol Version 5                 Elective       1928
+WHOIS++M   How to Interact with a Whois++ Mesh      Elective       1914
+WHOIS++A   Architecture of Whois++ Index Service    Elective       1913
+DSN        Delivery Status Notifications            Elective       1894
+EMS-CODE   Enhanced Mail System Status Codes        Elective       1893
+MIME-RPT   Multipart/Report                         Elective       1892
+SMTP-DSN   SMTP Delivery Status Notifications       Elective       1891
+RTP-AV     RTP Audio/Video Profile                  Elective       1890
+RTP        Transport Protocol for Real-Time Apps    Elective       1889
+DNS-IPV6   DNS Extensions to support IPv6           Elective       1886
+ICMPv6     ICMPv6 for IPv6                          Elective       1885
+IPV6-Addr  IPv6 Addressing Architecture             Elective       1884
+IPV6       IPv6 Specification                       Elective       1883
+HTML       Hypertext Markup Language - 2.0          Elective       1866
+MIME-Sec   MIME Object Security Services            Elective       1848
+
+
+
+Internet Architecture Board Standards Track                    [Page 42]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+MIME-Encyp MIME: Signed and Encrypted               Elective       1847
+WHOIS++    Architecture of the WHOIS++ service      Elective       1835
+--------   Binding Protocols for ONC RPC Version 2  Elective       1833
+XDR        External Data Representation Standard    Elective       1832
+RPC        Remote Procedure Call Protocol V. 2      Elective       1831
+--------   ESP DES-CBC Transform                    Ele/Req        1829
+--------   IP Authentication using Keyed MD5        Ele/Req        1828
+ESP        IP Encapsulating Security Payload        Ele/Req        1827
+IPV6-AH    IP Authentication Header                 Ele/Req        1826
+--------   Security Architecture for IP             Ele/Req        1825
+RREQ       Requirements for IP Version 4 Routers    Elective       1812
+URL        Relative Uniform Resource Locators       Elective       1808
+CLDAP      Connection-less LDAP                     Elective       1798
+OSPF-DC    Ext. OSPF to Support Demand Circuits     Elective       1793
+OSI-Dir    OSI User Friendly Naming ...             Elective       1781
+MIME-EDI   MIME Encapsulation of EDI Objects        Elective       1767
+Lang-Tag   Tags for Identification of Languages     Elective       1766
+XNSCP      PPP XNS IDP Control Protocol             Elective       1764
+BVCP       PPP Banyan Vines Control Protocol        Elective       1763
+Print-MIB  Printer MIB                              Elective       1759
+ATM-SIG    ATM Signaling Support for IP over ATM    Elective       1755
+IPNG       Recommendation for IP Next Generation    Elective       1752
+802.5-SSR  802.5 SSR MIB using SMIv2                Elective       1749
+SDLCSMIv2  SNADLC SDLC MIB using SMIv2              Elective       1747
+BGP4/IDRP  BGP4/IDRP for IP/OSPF Interaction        Elective       1745
+AT-MIB     Appletalk MIB                            Elective       1742
+MacMIME    MIME Encapsulation of Macintosh files    Elective       1740
+URL        Uniform Resource Locators                Elective       1738
+POP3-AUTH  POP3 AUTHentication command              Elective       1734
+IMAP4-AUTH IMAP4 Authentication Mechanisms          Elective       1731
+RDBMS-MIB  RDMS MIB - using SMIv2                   Elective       1697
+MODEM-MIB  Modem MIB - using SMIv2                  Elective       1696
+ATM-MIB    ATM Management Version 8.0 using SMIv2   Elective       1695
+TMUX       Transport Multiplexing Protocol          Elective       1692
+SNANAU-MIB SNA NAUs MIB using SMIv2                 Elective       1666
+PPP-TRANS  PPP Reliable Transmission                Elective       1663
+--------   Ethernet-like Interface Types MIB        Elective       1650
+--------   Postmaster Convention X.400 Operations   Elective       1648
+TN3270-En  TN3270 Enhancements                      Elective       1647
+PPP-BCP    PPP Bridging Control Protocol            Elective       1638
+UPS-MIB    UPS Management Information Base          Elective       1628
+PPP-SONET  PPP over SONET/SDH                       Elective       1619
+PPP-ISDN   PPP over ISDN                            Elective       1618
+DNS-R-MIB  DNS Resolver MIB Extensions              Elective       1612
+DNS-S-MIB  DNS Server MIB Extensions                Elective       1611
+FR-MIB     Frame Relay Service MIB                  Elective       1604
+PPP-X25    PPP in X.25                              Elective       1598
+OSPF-NSSA  The OSPF NSSA Option                     Elective       1587
+
+
+
+Internet Architecture Board Standards Track                    [Page 43]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+OSPF-Multi Multicast Extensions to OSPF             Elective       1584
+SONET-MIB  MIB SONET/SDH Interface Type             Elective       1595
+RIP-DC     Extensions to RIP to Support Demand Cir. Elective       1582
+--------   Evolution of the Interfaces Group of MIB-II Elective    1573
+PPP-LCP    PPP LCP Extensions                       Elective       1570
+X500-MIB   X.500 Directory Monitoring MIB           Elective       1567
+CIPX       Compressing IPX Headers Over WAM Media   Elective       1553
+IPXCP      PPP Internetworking Packet Exchange Control Elective    1552
+SRB-MIB    Source Routing Bridge MIB                Elective       1525
+CIDR-STRA  CIDR Address Assignment...               Elective       1519
+CIDR-ARCH  CIDR Architecture...                     Elective       1518
+CIDR-APP   CIDR Applicability Statement             Elective       1517
+--------   802.3 MAU MIB                            Elective       1515
+HOST-MIB   Host Resources MIB                       Elective       1514
+--------   Token Ring Extensions to RMON MIB        Elective       1513
+FDDI-MIB   FDDI Management Information Base         Elective       1512
+KERBEROS   Kerberos Network Authentication Ser (V5) Elective       1510
+GSSAPI     Generic Security Service API: C-bindings Elective       1509
+DASS       Distributed Authentication Security...   Elective       1507
+--------   X.400 Use of Extended Character Sets     Elective       1502
+HARPOON    Rules for Downgrading Messages...        Elective       1496
+Equiv      X.400/MIME Body Equivalences             Elective       1494
+IDPR       Inter-Domain Policy Routing Protocol     Elective       1479
+IDPR-ARCH  Architecture for IDPR                    Elective       1478
+PPP/Bridge MIB Bridge PPP MIB                       Elective       1474
+PPP/IP MIB  IP Network Control Protocol of PPP MIB  Elective       1473
+PPP/SEC MIB Security Protocols of PPP MIB           Elective       1472
+PPP/LCP MIB Link Control Protocol of PPP MIB        Elective       1471
+X25-MIB    Multiprotocol Interconnect on X.25 MIB   Elective       1461
+SNMPv2     Introduction to SNMPv2                   Elective       1441
+PEM-KEY    PEM - Key Certification                  Elective       1424
+PEM-ALG    PEM - Algorithms, Modes, and Identifiers Elective       1423
+PEM-CKM    PEM - Certificate-Based Key Management   Elective       1422
+PEM-ENC    PEM - Message Encryption and Auth        Elective       1421
+SNMP-IPX   SNMP over IPX                            Elective       1420
+SNMP-AT    SNMP over AppleTalk                      Elective       1419
+SNMP-OSI   SNMP over OSI                            Elective       1418
+FTP-FTAM   FTP-FTAM Gateway Specification           Elective       1415
+IDENT-MIB  Identification MIB                       Elective       1414
+IDENT      Identification Protocol                  Elective       1413
+DS3/E3-MIB DS3/E3 Interface Type                    Elective       1407
+DS1/E1-MIB DS1/E1 Interface Type                    Elective       1406
+BGP-OSPF   BGP OSPF Interaction                     Elective       1403
+--------   Route Advertisement In BGP2 And BGP3     Elective       1397
+SNMP-X.25  SNMP MIB Extension for X.25 Packet Layer Elective       1382
+SNMP-LAPB  SNMP MIB Extension for X.25 LAPB         Elective       1381
+PPP-ATCP   PPP AppleTalk Control Protocol           Elective       1378
+PPP-OSINLCP PPP OSI Network Layer Control Protocol  Elective       1377
+
+
+
+Internet Architecture Board Standards Track                    [Page 44]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+SNMP-PARTY-MIB Administration of SNMP               Elective       1353
+SNMP-SEC   SNMP Security Protocols                  Elective       1352
+SNMP-ADMIN SNMP Administrative Model                Elective       1351
+TOS        Type of Service in the Internet          Elective       1349
+PPP-IPCP   PPP Control Protocol                     Elective       1332
+-------    X.400 1988 to 1984 downgrading           Elective       1328
+TCP-EXT    TCP Extensions for High Performance      Elective       1323
+NETFAX     File Format for the Exchange of Images   Elective       1314
+IARP       Inverse Address Resolution Protocol      Elective       1293
+FDDI-MIB   FDDI-MIB                                 Elective       1285
+-------    Encoding Network Addresses               Elective       1277
+-------    Replication and Distributed Operations   Elective       1276
+-------    COSINE and Internet X.500 Schema         Elective       1274
+BGP-MIB    Border Gateway Protocol MIB (Version 3)  Elective       1269
+ICMP-ROUT  ICMP Router Discovery Messages           Elective       1256
+OSI-UDP    OSI TS on UDP                            Elective       1240
+STD-MIBs   Reassignment of Exp MIBs to Std MIBs     Elective       1239
+IPX-IP     Tunneling IPX Traffic through IP Nets    Elective       1234
+IS-IS      OSI IS-IS for TCP/IP Dual Environments   Elective       1195
+IP-CMPRS   Compressing TCP/IP Headers               Elective       1144
+NNTP       Network News Transfer Protocol           Elective        977
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+[Note: Ele/Req indicates elective for use with IPv4 and required for use
+with IPv6.]
+
+Applicability Statements:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 45]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+6.6.  Telnet Options
+
+For convenience, all the Telnet Options are collected here with both
+their state and status.
+
+Protocol   Name                           Number  State Status  RFC STD
+========   =====================================  ===== ====== ==== ===
+TOPT-BIN   Binary Transmission                 0  Std   Rec     856  27
+TOPT-ECHO  Echo                                1  Std   Rec     857  28
+TOPT-RECN  Reconnection                        2  Prop  Ele     ...
+TOPT-SUPP  Suppress Go Ahead                   3  Std   Rec     858  29
+TOPT-APRX  Approx Message Size Negotiation     4  Prop  Ele     ...
+TOPT-STAT  Status                              5  Std   Rec     859  30
+TOPT-TIM   Timing Mark                         6  Std   Rec     860  31
+TOPT-REM   Remote Controlled Trans and Echo    7  Prop  Ele     726
+TOPT-OLW   Output Line Width                   8  Prop  Ele     ...
+TOPT-OPS   Output Page Size                    9  Prop  Ele     ...
+TOPT-OCRD  Output Carriage-Return Disposition 10  Prop  Ele     652
+TOPT-OHT   Output Horizontal Tabstops         11  Prop  Ele     653
+TOPT-OHTD  Output Horizontal Tab Disposition  12  Prop  Ele     654
+TOPT-OFD   Output Formfeed Disposition        13  Prop  Ele     655
+TOPT-OVT   Output Vertical Tabstops           14  Prop  Ele     656
+TOPT-OVTD  Output Vertical Tab Disposition    15  Prop  Ele     657
+TOPT-OLD   Output Linefeed Disposition        16  Prop  Ele     658
+TOPT-EXT   Extended ASCII                     17  Prop  Ele     698
+TOPT-LOGO  Logout                             18  Prop  Ele     727
+TOPT-BYTE  Byte Macro                         19  Prop  Ele     735
+TOPT-DATA  Data Entry Terminal                20  Prop  Ele    1043
+TOPT-SUP   SUPDUP                             21  Prop  Ele     736
+TOPT-SUPO  SUPDUP Output                      22  Prop  Ele     749
+TOPT-SNDL  Send Location                      23  Prop  Ele     779
+TOPT-TERM  Terminal Type                      24  Prop  Ele    1091
+TOPT-EOR   End of Record                      25  Prop  Ele     885
+TOPT-TACACS  TACACS User Identification       26  Prop  Ele     927
+TOPT-OM    Output Marking                     27  Prop  Ele     933
+TOPT-TLN   Terminal Location Number           28  Prop  Ele     946
+TOPT-3270  Telnet 3270 Regime                 29  Prop  Ele    1041
+TOPT-X.3   X.3 PAD                            30  Prop  Ele    1053
+TOPT-NAWS  Negotiate About Window Size        31  Prop  Ele    1073
+TOPT-TS    Terminal Speed                     32  Prop  Ele    1079
+TOPT-RFC   Remote Flow Control                33  Prop  Ele    1372
+TOPT-LINE  Linemode                           34  Draft Ele    1184
+TOPT-XDL   X Display Location                 35  Prop  Ele    1096
+TOPT-ENVIR Telnet Environment Option          36  Hist  Not    1408
+TOPT-AUTH  Telnet Authentication Option       37  Exp   Ele    1416
+TOPT-ENVIR Telnet Environment Option          39  Prop  Ele    1572
+TOPT-TN3270E TN3270 Enhancements              40  Prop  Ele    1647
+TOPT-AUTH  Telnet XAUTH                       41  Exp
+
+
+
+Internet Architecture Board Standards Track                    [Page 46]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+TOPT-CHARSET Telnet CHARSET                   42  Exp          2066
+TOPR-RSP   Telnet Remote Serial Port          43  Exp
+TOPT-COMPORT Telnet Com Port Control          44  Exp          2217    *
+TOPT-EXTOP Extended-Options-List             255  Std   Rec     861  32
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+6.7.  Experimental Protocols
+
+All Experimental protocols have the Limited Use status.
+
+Protocol   Name                                                     RFC
+========   =====================================                   =====
+-------    Domain Names and Company Name Retrieva                  2345*
+RTP-MPEG   RTP Payload Format for Bundled MPEG                     2343*
+-------    Intra-LIS IP Multicast/Routers over ATM using PIM       2337*
+-------    Safe Response Header Field                              2310*
+LDAP-NIS   Approach Using LDAP as a Network Information Service    2307*
+HTTP-RVSA  HTTP Remote Variant Selection Algorithm                 2296*
+TCN-HTTP   Transparent Content Negotiation in HTTP                 2295*
+-------    Core Based Trees (CBT) Multicast Routing Architecture   2201*
+-------    Core Based Trees (CBT version 2) Multicast Routing      2189*
+-------    Trivial Convention using HTTP in URN Resolution         2169*
+-------    Resolution of URIs using DNS                            2168*
+MAP-MAIL   X.400 Mapping and Mail-11                               2162*
+MIME-ODA   A MIME Body Part for ODA                                2161*
+OSPF-DIG   OSPF with Digital Signature                             2154*
+GKMP-ARCH  Group Key Management Protocol (GKMP) Architecture       2094*
+GKMP-SPEC  Group Key Management Protocol (GKMP) Specification      2093*
+IP-SCSI    Encapsulating IP with the SCSI                          2143
+X.500-NAME Managing the X.500 Root Naming Context                  2120
+TFTP-MULTI TFTP Multicast Option                                   2090
+IP-Echo    IP Echo Host Service                                    2075
+METER-MIB  Traffic Flow Measurement Meter MIB                      2064
+TFM-ARCH   Traffic Flow Measurement Architecture                   2063
+DNS-SRV    Location of Services in the DNS                         2052
+URAS       Uniform Resource Agents                                 2016
+GPS-AR     GPS-Based Addressing and Routing                        2009
+ETFTP      Enhanced Trivial File Transfer Protocol                 1986
+BGP-RR     BGP Route Reflection                                    1966
+BGP-ASC    Autonomous System Confederations for BGP                1965
+SMKD       Scalable Multicast Key Distribution                     1949
+HTML-TBL   HTML Tables                                             1942
+MIME-VP    Voice Profile for Internet Mail                         1911
+SNMPV2SM   User-based Security Model for SNMPv2                    1910
+SNMPV2AI   SNMPv2 Administrative Infrastructure                    1909
+SNMPV2CB   Introduction to Community-based SNMPv2                  1901
+
+
+
+Internet Architecture Board Standards Track                    [Page 47]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+-------    IPv6 Testing Address Allocation                         1897
+DNS-LOC    Location Information in the DNS                         1876
+SGML-MT    SGML Media Types                                        1874
+CONT-MT    Access Type Content-ID                                  1873
+UNARP      ARP Extension - UNARP                                   1868
+-------    Form-based File Upload in HTML                          1867
+-------    BGP/IDRP Route Server Alternative                       1863
+-------    IP Authentication using Keyed SHA                       1852
+ESP3DES    ESP Triple DES Transform                                1851
+-------    SMTP 521 Reply Code                                     1846
+-------    SMTP Serv. Ext. for Checkpoint/Restart                  1845
+-------    SMTP Serv. Ext. Large and Binary MIME Msgs.             1830
+ST2        Stream Protocol Version 2                               1819
+-------    Content-Disposition Header                              1806
+-------    Schema Publishing in X.500 Directory                    1804
+-------    X.400-MHS use X.500 to support X.400-MHS Routing        1801
+-------    Class A Subnet Experiment                               1797
+TCP/IPXMIB TCP/IPX Connection Mib Specification                    1792
+-------    TCP And UDP Over IPX Networks With Fixed Path MTU       1791
+ICMP-DM    ICMP Domain Name Messages                               1788
+CLNP-MULT  Host Group Extensions for CLNP Multicasting             1768
+OSPF-OVFL  OSPF Database Overflow                                  1765
+RWP        Remote Write ProtocolL - Version 1.0                    1756
+NARP       NBMA Address Resolution Protocol                        1735
+DNS-ENCODE DNS Encoding of Geographical Location                   1712
+TCP-POS    An Extension to TCP: Partial Order Service              1693
+T/TCP      TCP Extensions for Transactions                         1644
+MIME-UNI   Using Unicode with MIME                                 1641
+FOOBAR     FTP Operation Over Big Address Records                  1639
+X500-CHART Charting Networks in the X.500 Directory                1609
+X500-DIR   Representing IP Information in the X.500 Directory      1608
+SNMP-DPI   SNMP Distributed Protocol Interface                     1592
+CLNP-TUBA  Use of ISO CLNP in TUBA Environments                    1561
+REM-PRINT  TPC.INT Subdomain Remote Printing - Technical           1528
+EHF-MAIL   Encoding Header Field for Internet Messages             1505
+RAP        Internet Route Access Protocol                          1476
+TP/IX      TP/IX: The Next Internet                                1475
+X400       Routing Coordination for X.400 Services                 1465
+DNS        Storing Arbitrary Attributes in DNS                     1464
+IRCP       Internet Relay Chat Protocol                            1459
+TOS-LS     Link Security TOS                                       1455
+SIFT/UFT   Sender-Initiated/Unsolicited File Transfer              1440
+DIR-ARP    Directed ARP                                            1433
+TEL-SPX    Telnet Authentication: SPX                              1412
+TEL-KER    Telnet Authentication: Kerberos V4                      1411
+TRACE-IP   Traceroute Using an IP Option                           1393
+DNS-IP     Experiment in DNS Based IP Routing                      1383
+RMCP       Remote Mail Checking Protocol                           1339
+
+
+
+Internet Architecture Board Standards Track                    [Page 48]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+TCP-HIPER  TCP Extensions for High Performance                     1323
+MSP2       Message Send Protocol 2                                 1312
+DSLCP      Dynamically Switched Link Control                       1307
+--------   X.500 and Domains                                       1279
+IN-ENCAP   Internet Encapsulation Protocol                         1241
+CLNS-MIB   CLNS-MIB                                                1238
+CFDP       Coherent File Distribution Protocol                     1235
+IP-AX.25   IP Encapsulation of AX.25 Frames                        1226
+ALERTS     Managing Asynchronously Generated Alerts                1224
+MPP        Message Posting Protocol                                1204
+SNMP-BULK  Bulk Table Retrieval with the SNMP                      1187
+DNS-RR     New DNS RR Definitions                                  1183
+IMAP2      Interactive Mail Access Protocol                        1176
+NTP-OSI    NTP over OSI Remote Operations                          1165
+DMF-MAIL   Digest Message Format for Mail                          1153
+RDP        Reliable Data Protocol                              908,1151
+TCP-ACO    TCP Alternate Checksum Option                           1146
+IP-DVMRP   IP Distance Vector Multicast Routing                    1075
+VMTP       Versatile Message Transaction Protocol                  1045
+COOKIE-JAR Authentication Scheme                                   1004
+NETBLT     Bulk Data Transfer Protocol                              998
+IRTP       Internet Reliable Transaction Protocol                   938
+LDP        Loader Debugger Protocol                                 909
+RLP        Resource Location Protocol                               887
+NVP-II     Network Voice Protocol                              ISI-memo
+PVP        Packet Video Protocol                               ISI-memo
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 49]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+6.8.  Informational Protocols
+
+Information protocols have no status.
+
+Protocol   Name                                                     RFC
+=======    ====================================                    =====
+--------   Mapping Airline Reservation, Ticketing, Messaging       2351*
+KOI8-U     Ukrainian Character Set KOI8-U                          2319*
+TEXT-CSS   The text/css Media Type                                 2318*
+PKCS-7     PKCS #7: Cryptographic Message Syntax Version 1.5       2315*
+PKCS-10    PKCS #10: Certification Request Syntax Version 1.5      2314*
+PKCS-1     PKCS #1: RSA Encryption Version 1.5                     2313*
+SMIME-CERT S/MIME Version 2 Certificate Handling                   2312*
+SMIME-MSG  S/MIME Version 2 Message Specification                  2311*
+TIFF       Tag Image File Format F Profile for Facsimile           2302*
+GSMP       Ipsilon's General Switch Management Protocol            2297*
+HSRP       Cisco Hot Standby Router Protocol (HSRP)                2281*
+RC2-ENCRP  A Description of the RC2(r) Encryption Algorithm        2268*
+SNQP       Simple Nomenclator Query Protocol                       2259*
+--------   Japanese Character Encoding for Internet Messages       2237*
+KEYX-DNS   Key Exchange Delegation Record for the DNS              2230*
+DSP        A Dictionary Server Protocol                            2229*
+NFS-URL    NFS URL Scheme                                          2224*
+APP-MARC   The Application/MARC Content-type                       2220*
+ODETTE-FTP ODETTE File Transfer Protocol                           2204*
+ESRO       AT&T/Neda's Efficient Short Remote Operations Protocol  2188*
+ICP        Internet Cache Protocol Version 2                       2186*
+IPV4-MAPOS IPv4 over MAPOS Version 1                               2176*
+MAPOS-SONET Multiple Access Protocol over SONET/SDH Version 1      2171*
+RWHOIS     Referral Whois Protocol                                 2167*
+PPP-EXT    PPP Vendor Extensions                                   2153
+UTF-7      UTF-7                                                   2152
+CAST-128   CAST-128 Encryption Algorithm                           2144
+DLSCAP     Data Link Switching Client Access Protocol              2114
+PNG        Portable Network Graphics Version 1.0                   2083
+RC5        RC5, RC5-CBC, RC5-CBC-Pad, and RC5-CTS Algorithms       2040
+SNTP       Simple Network Time Protocol v4 for IPv4, IPv6 and OSI  2030
+PGP-MEF    PGP Message Exchange Formats                            1991
+PPP-DEFL   PPP Deflate Protocol                                    1979
+PPP-PRED   PPP Predictor Compression Protocol                      1978
+PPP-BSD    PPP BSD Compression Protocol                            1977
+PPP-DCE    PPP for Data Compression in DCE                         1976
+PPP-MAG    PPP Magnalink Variable Resource Compression             1975
+PPP-STAC   PPP Stac LZS Compression Protocol                       1974
+GZIP       GZIP File Format Specification Version 4.3              1952
+DEFLATE    DEFLATE Compressed Data Format Specification V. 1.3     1951
+ZLIB       ZLIB Compressed Data Format Specification V. 3.3        1950
+HTTP-1.0   Hypertext Transfer Protocol -- HTTP/1.0                 1945
+
+
+
+Internet Architecture Board Standards Track                    [Page 50]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+--------   text/enriched MIME Content-type                         1896
+--------   Application/CALS-1840 Content-type                      1895
+--------   PPP IPCP Extensions for Name Server Addresses           1877
+SNPP       Simple Network Paging Protocol - Version 2              1861
+--------   ISO Transport Class 2 Non-use Explicit Flow Control     1859
+           over TCP RFC1006 extension
+--------   IP in IP Tunneling                                      1853
+--------   PPP Network Control Protocol for LAN Extension          1841
+TESS       The Exponential Security System                         1824
+NFSV3      NFS Version 3 Protocol Specification                    1813
+--------   A Format for Bibliographic Records                      1807
+-------    Data Link Switching: Switch-to-Switch Protocol          1795
+BGP-4      Experience with the BGP-4 Protocol                      1773
+SDMD       IPv4 Option for Sender Directed MD Delivery             1770
+SNOOP      Snoop Version 2 Packet Capture File Format              1761
+BINHEX     MIME Content Type for BinHex Encoded Files              1741
+DNS-NSAP   DNS NSAP Resource Records                               1706
+RADIO-PAGE TPC.INT Subdomain: Radio Paging -- Technical Procedures 1703
+GRE-IPv4   Generic Routing Encapsulation over IPv4                 1702
+GRE        Generic Routing Encapsulatio                            1701
+ADSNA-IP   Advanced SNA/IP: A Simple SNA Transport Protocol        1538
+TACACS     Terminal Access Control Protocol                        1492
+MD4        MD4 Message Digest Algorithm                            1320
+SUN-NFS    Network File System Protocol                            1094
+SUN-RPC    Remote Procedure Call Protocol Version 2                1057
+GOPHER     The Internet Gopher Protocol                            1436
+LISTSERV   Listserv Distribute Protocol                            1429
+-------    Replication Requirements                                1275
+PCMAIL     Pcmail Transport Protocol                               1056
+MTP        Multicast Transport Protocol                            1301
+BSD Login  BSD Login                                               1282
+DIXIE      DIXIE Protocol Specification                            1249
+IP-X.121   IP to X.121 Address Mapping for DDN                     1236
+OSI-HYPER  OSI and LLC1 on HYPERchannel                            1223
+HAP2       Host Access Protocol                                    1221
+SUBNETASGN On the Assignment of Subnet Numbers                     1219
+SNMP-TRAPS Defining Traps for use with SNMP                        1215
+DAS        Directory Assistance Service                            1202
+LPDP       Line Printer Daemon Protocol                            1179
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 51]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+6.9.  Historic Protocols
+
+All Historic protocols have Not Recommended status.
+
+Protocol   Name                                                RFC  STD
+========   =====================================              ===== ===
+L2F        Cisco Layer Two Forwarding Protocol                2341     *
+IPSO       DoD Security Options for IP              Elective  1108
+SNMPv2     Manager-to-Manager MIB                   Elective  1451
+SNMPv2     Party MIB for SNMPv2                     Elective  1447
+SNMPv2     Security Protocols for SNMPv2            Elective  1446
+SNMPv2     Administrative Model for SNMPv2          Elective  1445
+RIP        Routing Information Protocol             Ele       1058  34
+--------   Mapping full 822 to Restricted 822                 1137
+BGP3       Border Gateway Protocol 3 (BGP-3)             1267,1268
+--------   Gateway Requirements                      Req      1009   4
+EGP        Exterior Gateway Protocol                 Rec       904  18
+SNMP-MUX   SNMP MUX Protocol and MIB                          1227
+OIM-MIB-II OSI Internet Management: MIB-II                    1214
+IMAP3      Interactive Mail Access Protocol Version 3         1203
+SUN-RPC    Remote Procedure Call Protocol Version 1           1050
+802.4-MIP  IEEE 802.4 Token Bus MIB                           1230
+CMOT       Common Management Information Services             1189
+--------   Mail Privacy: Procedures                           1113
+--------   Mail Privacy: Key Management                       1114
+--------   Mail Privacy: Algorithms                           1115
+NFILE      A File Access Protocol                             1037
+HOSTNAME   HOSTNAME Protocol                                   953
+SFTP       Simple File Transfer Protocol                       913
+SUPDUP     SUPDUP Protocol                                     734
+BGP        Border Gateway Protocol                       1163,1164
+MIB-I      MIB-I                                              1156
+SGMP       Simple Gateway Monitoring Protocol                 1028
+HEMS       High Level Entity Management Protocol              1021
+STATSRV    Statistics Server                                   996
+POP2       Post Office Protocol, Version 2                     937
+RATP       Reliable Asynchronous Transfer Protocol             916
+HFEP       Host - Front End Protocol                           929
+THINWIRE   Thinwire Protocol                                   914
+HMP        Host Monitoring Protocol                            869
+GGP        Gateway Gateway Protocol                            823
+RTELNET    Remote Telnet Service                               818
+CLOCK      DCNET Time Server Protocol                          778
+MPM        Internet Message Protocol                           759
+NETRJS     Remote Job Service                                  740
+NETED      Network Standard Text Editor                        569
+RJE        Remote Job Entry                                    407
+XNET       Cross Net Debugger                              IEN-158
+
+
+
+Internet Architecture Board Standards Track                    [Page 52]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+NAMESERVER Host Name Server Protocol                       IEN-116
+MUX        Multiplexing Protocol                            IEN-90
+GRAPHICS   Graphics Protocol                             NIC-24308
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+6.10.  Obsolete Protocols
+
+Some of the protocols listed in this memo are described in RFCs that are
+obsoleted by newer RFCs.  "Obsolete" or "obsoleted" is not an official
+state or status of protocols.  This subsection is for information only.
+
+While it may seem to be obviously wrong to have an obsoleted RFC in the
+list of standards, there may be cases when an older standard is in the
+process of being replaced.  This process may take a year or two.
+
+Many obsoleted protocols are of little interest and are dropped from
+this memo altogether.  Some obsoleted protocols have received enough
+recognition that it seems appropriate to list them under their current
+status and with the following reference to their current replacement.
+
+RFC            RFC   Status     Title                               *
+====           ====  =========  =================================== =
+1305 obsoletes 1119 Stan/Rec    Network Time Protocol version 2
+
+Thanks to Lynn Wheeler for compiling the information in this
+subsection.
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 53]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+7.  Contacts
+
+7.1.  IAB, IETF, and IRTF Contacts
+
+   7.1.1.  Internet Architecture Board (IAB) Contact
+
+   Please send your comments about this list of protocols and especially
+   about the Draft Standard Protocols to the Internet Architecture Board
+   care of Abel Winerib, IAB Executive Director.
+
+      Contacts:
+
+         Abel Winerib
+         Executive Director of the IAB
+         Intel, JF2-64
+         2111 NE 25th Avenue
+         Hillsboro, OR 97124
+
+         1-503-696-8972
+
+         AWinerib@ibeam.jf.intel.com
+
+
+         Brian E. Carpenter
+         Chair of the IAB
+         IBM United Kingdon Laboratories
+         Hursley Park
+         Winchester
+         Hampshire SO21 2JN
+
+         +44 1962 816833
+
+         brian@hursley.ibm.com
+
+
+   7.1.2.  Internet Engineering Task Force (IETF) Contact
+
+      Contacts:
+
+         Fred Baker
+         Chair of the IETF
+         cisco Systems, Inc.
+         519 Lado Drive
+         Santa Barbara, CA 93111
+
+         1-805-681-0115
+
+         fred@cisco.com
+
+
+
+Internet Architecture Board Standards Track                    [Page 54]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+         Steve Coya
+         IESG Secretary
+         Corporation for National Research Initiatives
+         1895 Preston White Drive, Suite 100
+         Reston, VA 22091
+
+         1-703-620-8990
+
+         scoya@IETF.ORG
+
+         Steve Coya
+         Executive Director of the IETF
+         Corporation for National Research Initiatives
+         1895 Preston White Drive, Suite 100
+         Reston, VA 22091
+
+         1-703-620-8990
+
+         scoya@IETF.ORG
+
+
+   7.1.3.  Internet Research Task Force (IRTF) Contact
+
+      Contact:
+
+         Abel Winerib
+         Chair of the IRTF
+         Intel, JF2-64
+         2111 NE 25th Avenue
+         Hillsboro, OR 97124
+
+         1-503-696-8972
+
+         AWinerib@ibeam.jf.intel.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 55]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+7.2.  Internet Assigned Numbers Authority Contact
+
+      Contact:
+
+         Joyce K. Reynolds
+         Internet Assigned Numbers Authority
+         USC/Information Sciences Institute
+         4676 Admiralty Way
+         Marina del Rey, CA  90292-6695
+
+         1-310-822-1511
+
+         IANA@IANA.ORG
+
+   The protocol standards are managed by the Internet Assigned Numbers
+   Authority.
+
+   Please refer to the document "Assigned Numbers" (RFC-1700) for
+   further information about the status of protocol documents.  There
+   are two documents that summarize the requirements for host and
+   gateways in the Internet, "Host Requirements" (RFC-1122 and RFC-1123)
+   and "Requirements for IP Version 4 Routers" (RFC-1812).
+
+      How to obtain the most recent edition of this "Internet Official
+      Protocol Standards" memo:
+
+         The file "in-notes/std/std1.txt" may be copied via FTP from the
+         FTP.ISI.EDU computer using the FTP username "anonymous" and FTP
+         password "guest".
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 56]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+7.3.  Request for Comments Editor Contact
+
+      Contact:
+
+         Jon Postel
+         RFC Editor
+         USC/Information Sciences Institute
+         4676 Admiralty Way
+         Marina del Rey, CA  90292-6695
+
+         1-310-822-1511
+
+         RFC-Editor@ISI.EDU
+
+   Documents may be submitted via electronic mail to the RFC Editor for
+   consideration for publication as RFC.  If you are not familiar with
+   the format or style requirements please request the "Instructions for
+   RFC Authors".  In general, the style of any recent RFC may be used as
+   a guide.
+
+7.4.  The Network Information Center and
+      Requests for Comments Distribution Contact
+
+   RFCs can be obtained via FTP from FTP.ISI.EDU, with the pathname in-
+   notes/rfcnnnn.txt (where "nnnn" refers to the number of the RFC).
+   Login with FTP username "anonymous" and password "name@host.domain".
+
+   RFCs can also be obtained via electronic mail from ISI.EDU by using
+   the RFC-INFO service.  Address the request to "rfc-info@isi.edu" with
+   a message body of:
+
+           Retrieve: RFC
+              Doc-ID: RFCnnnn
+
+   (Where "nnnn" refers to the number of the RFC (always use 4 digits -
+   the DOC-ID of RFC 822 is "RFC0822")).  The RFC-INFO@ISI.EDU server
+   provides other ways of selecting RFCs based on keywords and such; for
+   more information send a message to "rfc-info@isi.edu" with the
+   message body "help: help".
+
+   contact: RFC-Manager@ISI.EDU
+
+
+
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 57]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+7.5.  Sources for Requests for Comments
+
+   Details on many sources of RFCs via FTP or EMAIL may be obtained by
+   sending an EMAIL message to "rfc-info@ISI.EDU" with the message body
+   "help: ways_to_get_rfcs".  For example:
+
+           To: rfc-info@ISI.EDU
+           Subject: getting rfcs
+
+           help: ways_to_get_rfcs
+
+8.  Security Considerations
+
+   Security issues are not addressed in this memo.
+
+9.  Author's Address
+
+   Jon Postel
+   USC/Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone: 310-822-1511
+   Fax:   310-823-6714
+
+   EMail: Postel@ISI.EDU
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 58]
+
+RFC 2300                   Internet Standards                   May 1998
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (1998).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Internet Architecture Board Standards Track                    [Page 59]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2300.txt](<www.ietf.org/rfc/rfc2300.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
