### PR TITLE
Archive rfc232.txt

### DIFF
--- a/www.ietf.org/rfc/rfc232.txt
+++ b/www.ietf.org/rfc/rfc232.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+RFC #232
+NIC #7649
+A. Vezza
+                    September 23, 1971
+
+
+     At the last Network Graphics meeting held in July at
+
+M.I.T., we tentatively scheduled the next Network Graphics
+
+meeting which is being hosted by Stanford AI, for October
+
+17, 18, and 19.  Because the Network Working Group meeting
+
+is being held on October 10, 11, 12, 13, and 14 it has been
+
+decided to postpone the Network Graphics meeting.  As soon
+
+as a new date for the meeting is established it will be
+
+announced via an RFC.  It is expected that the meeting will
+
+be held in the San Francisco area sometime in November or
+
+early December.
+
+
+
+
+[ This RFC was put into machine readable form for entry ]
+[ into the online RFC archives by BBN Corp. under the   ]
+[ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc232.txt](<www.ietf.org/rfc/rfc232.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
