### PR TITLE
Archive rfc233.txt

### DIFF
--- a/www.ietf.org/rfc/rfc233.txt
+++ b/www.ietf.org/rfc/rfc233.txt
@@ -1,0 +1,112 @@
+
+
+
+
+
+
+Network Working Group           28 Sept 71              Abhay Bhushan
+RFC #233, NIC #7650                                     Bob Metcalfe
+
+                 Standardization of Host Call Letters
+                 ------------------------------------
+
+We agree with Peggy Karp (See RFC #226) that there would be some
+benefit in standardizing the symbolic host names used in TELNET
+programs.  It should be recognized that there is a trade-off
+between brevity and mnemonicism.  It is our feeling that a good
+set of host call letters can be developed using only four
+characters (see Jim White's in RFC #206.)  Each host should
+suggest its own call letters.  Upper and lower case letters
+should be used interchangeably.  The following is our currently
+recommended list:
+
+       Host Number    Name-4            Name-8
+       -----------    ------            ------
+             1          sex             sex-ucla
+             65         ccn             ccn-ucla
+             2          nic             nic-sri
+             66         srai            sri-ai
+             3          ucsb            ucsb
+             4          utah            utah
+             5          bbn5            bbn-516
+             69         bbna            bbn-10x
+             133        bbnb            bbn-x10x
+             6          mult            multics
+             70         dmcg            mit-dmcg
+             134        its             mit-ai
+             7          ra65            rand-65
+             71         ra10            rand-10
+             8          sdc             sdc
+             9          harv            harvard
+             73         har1            harvpdp1
+             137        ha11            harpdp11
+             10         ll67            linc-67
+             74         tx2             linc-tx2
+             11         stan            stanford
+             12         ill             illinois
+             13         case            case
+             14         cmu             cmu
+             15         paol            paoli
+             16         ames            ames-67
+             144        amtp            ames-tip
+             145        mttp            mitretip
+             18         radc            radc
+             146        rdtp            radc-tip
+
+
+
+                                                                [Page 1]
+
+             19         nbs             nbspdp11
+             147        nbtp            nbs-tip
+             148        etac            etac
+             21         tink            tink-418
+             22         mccl            mccl-418
+             23         usc             usc-44
+             151        ustp            usc-tip
+             152        gwc             gwc-tip
+             25         ncar            ncar7600
+             153        nctp            ncar-tip
+             158        bbtp            bbn-tip
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc233.txt](<www.ietf.org/rfc/rfc233.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
