### PR TITLE
Archive rfc234.txt

### DIFF
--- a/www.ietf.org/rfc/rfc234.txt
+++ b/www.ietf.org/rfc/rfc234.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                           A. Vezza
+Request for Comments: 234                                October 5, 1971
+NIC: 7651
+Updates: #204, #212, #222
+
+
+                 Network Working Group Meeting Schedule
+
+1) System Programmers Workshop
+
+   Commences at 12 noon, Sunday October 10th in the 8th floor conference
+   Room at Project MAC: 545 Main Street, (Technology Square), Cambridge,
+   Mass.
+
+2) NIC-Tutorial
+
+   Commences at 9:00 A.M., Tuesday, October 12th in the 2nd floor
+   Console Area at Project MAC: 545 Main Street, (Technology Square),
+   Cambridge, Mass.
+
+3) Protocol, TIP, and Date Management Workshops
+
+   Commences at 9:00 A.M., Tuesday, October 12th.  Persons attending
+   these workshops will meet in the 5th floor Conference Room at Project
+   MAC: 545 Main Street, (Technology Square), Cambridge, Mass. for a
+   short briefing.  Meeting rooms for these three workshops will be
+   announced at the briefing.
+
+4) Plenary Session
+
+   Commences at 9:00 A.M., Wednesday, October 13th in the Center for
+   Advanced Engineering Study Auditorium, Room 9-150.  (See map)
+
+5) Cocktails and Dinner
+
+   Cocktails at 5:30 P.M. in the Faculty Club Penthouse.  Roast Prime
+   Ribs of Beef will be served at 7:15 P.M. in a Faculty Club dining
+   room.
+
+6) Panel Discussion
+
+   Commences at 9:00 A.M., Thursday, October 14th in the CAES
+   Auditorium, Room 9-150.  (See map)
+
+
+          [This RFC was put into machine readable form for entry]
+      [into the online RFC archives by Kelly Tardif, Viagénie 10/99]
+
+
+
+
+Vezza                                                           [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc234.txt](<www.ietf.org/rfc/rfc234.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
