### PR TITLE
Archive rfc235.txt

### DIFF
--- a/www.ietf.org/rfc/rfc235.txt
+++ b/www.ietf.org/rfc/rfc235.txt
@@ -1,0 +1,283 @@
+
+
+
+
+
+
+Network Working Group                                      E. Westheimer
+Request for Comments: 235                                            BBN
+NIC: 7652                                             September 27, 1971
+Obsoletes: None
+Updates: None
+
+
+                              SITE STATUS
+
+   Beginning with this RFC, BBN will report on the status of most
+   Network Hosts approximately once every two weeks.  The information
+   for these reports will be gained from talking to people at each site,
+   and from experimental "data".  These data will be the results of
+   daily attempts to log into each of the Hosts which might be
+   accessible to a Network user; the attempts will have been made from
+   the BBN prototype Terminal IMP at a random time each weekday.
+
+   Several Hosts are currently excluded from the daily testing.  These
+   Hosts fall into two categories:
+
+      1)  Hosts which are not expected to be functioning on the Network
+      as servers (available for use from other sites) for at least a
+      month.  Included here are:
+
+            Network             Site              Computer
+            Address
+
+             71                 Rand              PDP-10
+             74                 Lincoln           TX2
+             11                 Stanford          PDP-10
+             13                 Case              PDP-10
+             14                 Carnegie          PDP-10
+             15                 Paoli             B6500
+
+      2)  Hosts which are currently intended to be users only.  Included
+      here are the Terminal IMPs presently in the Network (AMES, MITRE,
+      and BBN*).  This category also includes the Network Control Center
+      computer (Network Address 5) which is used solely for gathering
+      statistics from the Network.  Finally, included among these Hosts
+      are the following:
+
+
+
+
+
+
+
+
+
+
+
+Westheimer                                                      [Page 1]
+
+RFC 235                       Site Status                 September 1971
+
+
+            Network              Site               Computer
+            Address
+
+               7                 Rand               IBM-360
+              73                 Harvard            PDP-1
+              12                 Illinois           PDP-11
+
+   The tables on the next two pages condense the information on Host
+   status for September 13 through September 24.
+
+________________
+* The BBN Terminal IMP (Network Address 158) is a prototype, and as such
+is frequently not connected to the Network, but being used to refine and
+debug the Terminal IMP programs.
+
+    WE/jm
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Westheimer                                                      [Page 2]
+
+RFC 235                       Site Status                 September 1971
+
+
+NETWORK   SITE         COMPUTER    STATUS OR PREDICTION     CONTRACT
+ADDRESS
+
+1        UCLA          SIGMA-7   Server                   John Postel
+65       UCLA          IBM-360   Remote Job Service now,
+                                 Time-sharing in January  Steve Wolf
+2        SRI(NIC)      PDP-10    October11                John Melvin
+66       SRI(AI)       PDP-10    November                 Len Chaiten
+3        UCSB          IBM-360   Server                   Jim White
+4        UTAH          PDP-10    soon                     Barry Wessler
+5        BBN           DDP-516   NCC                      Alex McKenzie
+69       BBN           PDP-10    Server                   Dan Murphy
+6        MIT(Multics)  H-465     Soon                     Mike Padlipsky
+70       MIT(DM)       PDP-10    Server                   Bob Bressler
+7        RAND          IBM-360   User only                Eric Harslem
+71       RAND          PDP-10    January                  Eric Harslem
+8        SDC           IBM-360   October 11               Bob Long
+9        HARVARD       PDP-10    Soon                     Bob Sundberg
+73       HARVARD       PDP-1     User only                Bob Sundberg
+10       LINCOLN       IBM-360   Soon                     Joel Winnet
+74       LINCOLN       TX2       Uncertain                Tom Barklow
+11       STANFORD      PDP-10    November                 Andy Moorer
+12       ILLINOIS      PDP-11    User only                John Cravits
+13       CASE          PDP-10    December 15              Charles Rose
+14       CARNEGIE      PDP-10    January                  Hal Van Zoeren
+15       PAOLI         B6500     Uncertain                John Cravits
+16       AMES          DDP-316   Terminal IMP             Does not apply
+17       MITRE         DDP-316   Terminal IMP             Does not apply
+30       BBN           DDP-316   Terminal IMP(Prototype)  Does not apply
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Westheimer                                                      [Page 3]
+
+RFC 235                       Site Status                 September 1971
+
+
+   NETWORK SITE       COMPUTER     DATE AND TIME (P.M.)
+   ADDRESS                        9/13  9/14  9/15  9/16   9/17
+                                  4:30  3:30  6:00  10:30  1:30
+   1     UCLA         SIGMA 7        0     0     0      D     D
+   *65   UCLA         PDP-10         0     0     0      0     0
+   2     SRI(NIC)     PDP-10         D     D     D      D     D
+   66    SRI(AI)      PDP-10         D     D     D      D     D
+   3     UCSB         IBM-360        0     0     0      0     0
+   4     UTAH         PDP-10         D     D     D      D     D
+   69    BBN          PDP-10         0   1/2 0   0      T   1/2 0
+   6     MIT(Multics) DDP-645        R     R     R      D   1/2 0
+   70    MIT(DM)      PDP-10         T     T     T      O     0
+   8     SDC          IBM-360        D     D     D      D     T
+   9     HARVARD      PDP-10         T     D     T      T     T
+   10    LINCOLN      IBM-360        D    1/2 0 1/2 0   D     T
+
+
+   NETWORK SITE      COMPUTER     DATE AND TIME (P.M.)
+   ADDRESS                        9/20   9/21  9/22  9/23  9/24
+                                  12:30  4:30  3:30  2:00  5:00
+   1     UCLA         SIGMA  7        D     0     D     T     0
+   *65   UCLA         PDP-10          D     0     0     0     0
+   2     SRI(NIC)     PDP-10          D     D     0     D     D
+   66    SRI(AI)      PDP-10          D     D     D     D     D
+   3     UCSB         IBM-360         0     0     0     0     0
+   4     UTAH         PDP-10          D     D     D     D     D
+   69    BBN          PDP-10          0   1/2 0   0   1/2 0   0
+   6     MIT(Multics) DDP-645         D   1/2 0   T     T     R
+   70    MIT(DM)      PDP-10          T   1/2 0   0     D     TD
+   8     SDC          IBM-360         D     D     D     D     D
+   9     HARVARD      PDP-10          T     D     T     D     D
+   10    LINCOLN      IBM-360         D     D     D   1/2 0   D
+
+
+   where
+
+      D = Dead. (Destination Host either dead or inaccessible (due to
+      network partitioning or local IMP failure from the BBN Terminal
+      IMP)
+
+      R = Refused. (Destination Host returned a CLS to the initial RFC.)
+
+      T = Timed out. (Destination Host did not responding any way to the
+      initial RFC, although not dead.)
+
+      1/2 0 = 1/2 Open. (Destination Host opened a connection but then
+      either immediately closed it, or did not respond any further.)
+
+
+
+
+Westheimer                                                      [Page 4]
+
+RFC 235                       Site Status                 September 1971
+
+
+      0 = Open. (Destination Host opened a connection and was accessible
+      to users.
+
+      * The UCLA IBM-360 is at the moment only able to handle Remote Job
+      Service.  BBN is not equipped to test this, but is assuming that
+      receipt of their canned message indicates that RJS is also
+      functioning.
+
+
+
+
+        [This RFC was put into machine readable form for entry]
+     [into the online RFC archives by Kelly Tardif, Viagénie 10/99]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Westheimer                                                      [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc235.txt](<www.ietf.org/rfc/rfc235.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
