### PR TITLE
Archive rfc236.txt

### DIFF
--- a/www.ietf.org/rfc/rfc236.txt
+++ b/www.ietf.org/rfc/rfc236.txt
@@ -1,0 +1,112 @@
+
+
+
+
+
+
+Network Working Group                                          Jon Postel
+Request for Comments: #236                                     UCLA-NMC
+NIC 7661                                                       Computer Science
+Categories: D.3                                                27 September 71
+Related: #226, 229
+Obsoletes: 229
+
+
+                          STANDARD HOST NAMES
+
+
+In RFC #226, Peggy Karp suggested that there be a set of standard host names,
+that the names be 6 characters in length, and gave a partial list.  In RFC
+#229, I suggested 8 character names and gave a longer list.  Here I present
+my list again with some modifications.
+
+I also suggest that as far as possible the Standard host names be consistent
+with the site names used by the Network Information Center.  It also seems
+to me to be a good idea to consult with each host's technical liaison officer
+before assigning that host's name.
+
+It has been brought to my attention that programmers are lazy and don't like
+to deal with character strings longer than one computer word or containing
+characters other than the capital letters A-Z or the digits 0-9.  Thus, I
+have included an alternate list which is limited to 4 character names using
+only the alphanumerics.
+
+
+  Site                       Standard Name                       Alternate Name
+  ----                       -------------                       --------------
+
+   1                           UCLA-NMC                            NMC
+   65                          UCLA-CCN                            CCN
+   2                           SRI-ARC                             NIC
+   66                          SRI-AI                              SRAI
+   3                           UCSB                                UCSB
+   4                           UTAH                                UTAH
+   5                           BBN-NCC                             NCC
+   69                          BBN                                 BBN
+   133                         BBN-B                               BBNB
+   6                           MIT-MLTX                            MLTX
+   70                          MIT-DMCG                            DMCG
+   7                           RAND-65                             RAND
+   71                          RAND-10                             RND1
+   8                           SDC                                 SDC
+   9                           HARV-10                             HARV
+   73                          HARV-1                              HRV1
+   137                         HARV-11                             HRV2
+
+
+
+                                                                [Page 1]
+
+Network Working Group                                          Jon Postel
+Request for Comments: #236                                     UCLA-NMC
+
+
+                                                               27 September 71
+  Site                       Standard Name                       Alternate Name
+  ----                       -------------                       --------------
+
+   10                          LL-67                               LL67
+   74                          LL-TX2                              TX2
+   11                          SU-AI                               SUAI
+   75                          SU-HP                               SUHP
+   12                          ILL                                 ILL
+   13                          CASE                                CASE
+   14                          CMU                                 CMU
+   15                          BUROUGHS                            BURR
+   16                          AMES-67                             AMES
+   144                         AMES-TIP                            AMET
+   145                         MITR-TIP                            MTRT
+   18                          RADC                                RADC
+   146                         RADC-TIP                            RADT
+   19                          NBS                                 NBS
+   147                         NBS-TIP                             NBST
+   148                         ETAC-TIP                            ETAT
+   21                          TINKER                              OCAF
+   22                          MCLELLAN                            SMAF
+   23                          USC                                 USC
+   151                         USC-TIP                             USCT
+   152                         GWC-TIP                             GWCT
+   25                          NCAR                                NCAR
+   153                         NCAR-TIP                            NCAT
+   158                         BBN-TIP                             BBNT
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc236.txt](<www.ietf.org/rfc/rfc236.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
