### PR TITLE
Archive rfc239.txt

### DIFF
--- a/www.ietf.org/rfc/rfc239.txt
+++ b/www.ietf.org/rfc/rfc239.txt
@@ -1,0 +1,61 @@
+
+
+
+
+
+
+Network Working Group                                        R. Braden
+Request for Comments:  #239                                  UCLA-CCN
+NIC 7664                                                     23 September 1971
+Categories: D.3
+Related:  #226, 229, 236
+
+                  HOST MNEMONICS PROPOSED IN RFC #226
+
+   (Note from NIC: These are comments sent by R.Braden to P. Karp in NIC
+   7626, and are now issued as NIC 7664, RFC 239 to include them in the
+   dialogue along with RFC 226, 229, 236)
+
+        CCN is in full agreement that a standard set of host mnemonics
+   should be selected.  However, your proposed set is not fully
+   satisfactory.
+
+   1.  The set you suggest was created, I assume, by the systems
+       programmer(s) who wrote TELNET in TENEX.  It is a set of
+       historical accidents, and shows it.
+
+   2.  A better source for standard mnemonics might be the NIC site
+       codes, since these have been chosen with more care and will
+       become familiar as we begin to use the NIC on-line.  Surely
+       the NIC is a more reasonable source for a defacto standard
+       than a particular system programmer.
+
+   3.  Should mnemonics be limited to 6 characters?
+
+   4.  The most recent list from BBN (NIC #7181, RFC #208,
+       August 9, 1971) shows 40 hosts.  You show only 20.  Your
+       proposed standard should include known hosts at this time.
+
+   5.  The mnemonic "UCLA36" seems a particularly bad choice; "UCLA91"
+       would be much better.
+
+   6.  Also, we at CCN object to the short form "UCLA" for the NMC
+       Sigma 7; that also is historical.  We propose the following:
+
+           host 1: UCLAS7 or UCLANM;         host 65: UCLA91.
+
+   7.  "SRIARC" is a poor choice; everybody calls it the NIC.  So we
+       suggest "SRINIC" for host 2.
+
+        Please, let's not perpetrate systems programmers' midnight
+   decisions on all future Network users!  Standards are vital, and
+   deserve a little care.
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+9
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc239.txt](<www.ietf.org/rfc/rfc239.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
