### PR TITLE
Archive rfc24.txt

### DIFF
--- a/www.ietf.org/rfc/rfc24.txt
+++ b/www.ietf.org/rfc/rfc24.txt
@@ -1,0 +1,138 @@
+Network Working Group                                         S. Crocker
+Request for Comments: 24                                            UCLA
+                                                          21 November 69
+
+
+
+                        DOCUMENTATION CONVENTIONS
+
+
+
+This note is a revision of NWG/RFC 10 and 16.
+
+The Network Working Group consists of interested people from existing or
+potential ARPA network sites.  Membership is not closed.
+
+The Network Working Group (NWG) is concerned with the HOST software,
+the strategies for using the network, and initial experience with the
+network.
+
+Documentation of the NWG's effort is through notes such as this.  Notes
+may be produced at any site by and included in this series.
+
+
+CONTENT
+
+The content of a NWG note may be any thought, suggestion, etc. related
+to the HOST software or other aspect of the network.  Notes are
+encouraged to be timely rather than polished.  Philosophical positions
+without examples or other specifics, specific suggestions or
+implementation techniques without introductory or background explication,
+and explicit questions without any attempted answers are all acceptable.
+The minimum length for a NWG note is one sentence.
+
+
+These standards (or lack of them) are stated explicitly for two reasons.
+First, there is a tendency to view a written statement as ipso facto
+authoritative, and we hope to promote the exchange and discussion of
+considerably less than authoritative ideas.  Second, there is a natural
+hesitancy to publish something unpolished, and we hope to ease this
+inhibition.
+
+
+FORM
+
+Every NWG note should bear the following information:
+
+        1.  "Network Working Group"
+            "Request for Comnments: X" (X underscored)
+              where X is a serial number.  Serial numbers are
+              assigned by Steve Crocker at UCLA.
+
+        2.  Author and affiliation
+
+        3.  Date
+
+        4.  Title
+            The title need not be unique.
+
+
+DISTRIBUTION
+
+One copy only will be sent from the author's site to:
+
+        1.  Abhai Bhushan, MIT
+        2.  Steve Carr, Utah
+        3.  Jerry Cole, SDC
+        4.  Steve Crocker, UCLA
+        5.  Bill English SRI
+        6.  Kim Fry, MITRE
+        7.  John Haefner, RAND
+        8.  Bob Kahn, BB&N
+        9.  Larry Roberts, ARPA
+       10.  Paul Rovner, LL
+       11.  Ron Stoughton, ECSB
+
+Reproduction if desired may be handled locally.
+
+
+ADDRESSES
+
+Below are the most current addresses I have.  Please correct as necessary:
+
+        Abhai Bhushan                           MIT
+        Room 807 - Project MAC                  (617) 864-6790 X5857
+        545 Technology Square
+        Cambridge, Mass. 02139
+
+        Steve Carr                              Utah
+        Computer Science Dept.                  (801) 322-8224
+        University of Utah
+        Salt Lake City, Utah 84112
+
+        Jerry Cole                              SDC
+        7842 Croyden                            2500 Colorado
+        Los Angeles, Calif. 90045               (213) 393-9411, X6135
+                                                                X67019
+                                                                 (Sec'y)
+
+        Steve Crocker                           UCLA
+        3732 Boelter Hall                       (213) 825-4864
+        UCLA                                          825-2543 (Sec'y)
+        Los Angeles, Calif. 90024
+
+        Bill English                            SRI
+        Stanford Research Institute             (415) 326-6200
+        333 Ravenswood
+        Menlo Park, Calif. 94025
+
+        Kim Fry                                 MITRE
+        The MITRE Corp.                         (703) 893-3500, X355
+        Westgate Research Park                                  X318
+        McLean, Va. 22101
+
+        John Haefner                            RAND
+        The Rand Corporation                    (213) 393-0411
+        1700 Main Street
+        Santa Monica, Calif. 90406
+
+        Robert Kahn                             BBN
+        Bolt, Beranek and Newman                (617) 491-1850
+        50 Moulton St.                          
+        Cambridge, Mass. 02138
+
+        Larry Roberts                           ARPA
+        ODS/ARPA                                (202) OX7-8663
+        3D167 Pentagon                                OX7-8654
+        Washington, D.C.  20301
+
+        Paul D. Rovner                          LL
+        Mass. Inst. of Tech.                    (617) 562-5500 X7211
+        Lincoln Laboratory B-115                
+        P.O. Box 73
+        Lexington, Mass. 02173
+
+        Ron Stoughton                           UCSB
+        Computer Research Lab                   (805) 961-3221
+        UCSB
+        Santa Barbara, Calif. 94025


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc24.txt](<www.ietf.org/rfc/rfc24.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
