### PR TITLE
Archive rfc240.txt

### DIFF
--- a/www.ietf.org/rfc/rfc240.txt
+++ b/www.ietf.org/rfc/rfc240.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Networking Group                             A. McKenzie
+Request for Comments: 240                    BBN
+NIC #7665                                    30 September 1971
+Categories: F, G.3                           Rand 50ctu
+Updates:  none
+Obsoletes:  RFC 235
+
+
+                              SITE STATUS
+
+     Due to extensive typographic errors in RFC #235, I have
+decided to reissue the first of our experimental site status reports.
+
+     In compiling RFC #235, I followed the principle that
+timeliness was somewhat more important than extremely careful editing;
+this seemed to me to be in keeping with the original RFC philosophy.  I
+am sorry for any embarrassment this may have caused to anyone associated
+with the Network, and accept full responsibility for the content of RFC
+#235.  I will try to do a better job in the future.
+
+
+Alex McKenzie
+
+
+                              SITE STATUS
+
+
+     Beginning with this RFC, BBN will report on the status of
+most Network Hosts approximately once every two weeks.  The information
+for these reports will be gained from talking to people at each site,
+and from experimental "data".  These data will be the results of daily
+attempts to log into each of the Hosts which might be accessible to a
+Network user; the attempts will have been made from the BBN prototype
+Terminal IMP at a random time each weekday.
+
+     Several Hosts are currently excluded from the daily testing.
+These Hosts fall into two categories:
+
+     1)   Hosts which are note expected to be functioning on the
+          Network as servers (available for use from other sites) for at
+          least a month.  Included here are:
+
+               Network        Site      Computer
+               Address
+
+                 71           Rand      PDP-10
+                 74           Lincoln   TX2
+                 11           Stanford  PDP-10
+
+
+
+                                                                [Page 1]
+
+RFC #240
+
+
+                 13           Case      PDP-10
+                 14           Carnegie  PDP-10
+                 15           Paoli     B6500
+
+     2)   Hosts which are currently intended to be users only.
+          Included here are the Terminal IMPs presently in the Network
+          (AMES, MITRE, and BBN[1]).  This category also includes the
+          Network Control Center computer (Network Address 5) which is
+          use solely for gathering statistics from the Network.
+          Finally, included among these Hosts are the following:
+
+               Network        Site      Computer
+               Address
+
+                  7           Rand      IBM-360/65
+                 73           Harvard   PDP-1
+                 12           Illinois  PDP-11
+
+     The tables on the next two pages condense the information on
+Host status for September 13 through September 24.
+
+                                                        PREDICTIONS
+NETWORK SITE         COMPUTER   STATUS or PREDICTION    OBTAINED
+ADDRESS                                                 FROM
+
+ 1      UCLA         SIGMA - 7  Server                  Jon Postel
+65      UCLA         IBM-360/91 Remote Job Service now,
+                                Time-sharing in January Steve Wolf
+ 2      SRI(NIC)     PDP-10     October 11              John Melvin
+66      SRI(AI)      PDP-10     November                Len Chaiten
+ 3      UCSB         IBM-360-75 Server                  Jim White
+ 4      UTAH         PDP-10     "Soon"                  Barry Wessler
+ 5      BBN          DDP-516    NCC                     Alex McKenzie
+69      BBN          PDP-10     Server                  Dan Murphy
+ 6      MIT(Multics) H-645      "Soon"                  Mike Padlipsky
+70      MIT(DM)      PDP-10     Server                  Bob Bressler
+ 7      RAND         IBM 360/65 User only               Eric Harslem
+71      RAND         PDP-10     January                 Eric Harslem
+ 8      SDC          IBM-360/67 October 11              Bob Long
+ 9      HARVARD      PDP-10     "Soon"                  Bob Sundberg
+73      HARVARD      PDP-1      User only               Bob Sundberg
+10      LINCOLN      IBM-360/67 "Soon"                  Joel Winnet
+74      LINCOLN      TX2        Uncertain               Tom Barkalow
+11      STANFORD     PDP-10     November                Andy Moorer
+12      ILLINOIS     PDP-11     User only               John Cravits
+13      CASE         PDP-10     December 15             Charles Rose
+14      CARNEGIE     PDP-10     January                 Hal VanZoeren
+15      PAOLI        B6500      Uncertain               John Cravits
+
+
+
+                                                                [Page 2]
+
+RFC #240
+
+
+16      AMES         TIP        Installed
+17      MITRE        TIP        Installed
+30      BBN          TIP        Prototype
+
+
+NETWORK   SITE      COMPUTER                DATE AND TIME (P.M.)
+ADDRESS                         9/13  9/14  9/15  9/16  9/17  9/20
+                                4:30  3:30  6:00  10:30 1:30  12:30
+ 1        UCLA      SIGMA-7      O     O     O     D     D     D
+65[2]     UCLA      IBM 360/91   O     O     O     O     O     D
+ 2        SRI(NIC)  PDP-10       D     D     D     D     D     D
+66        SRI(AI)   PDP-10       D     D     D     D     D     D
+ 3        UCSB      IBM-360/75   O     O     O     O     O     O
+ 4        UTAH      PDP-10       D     D     D     D     D     D
+69        BBN       PDP-10       O   1/2 0   O     T   1/2 O   O
+ 6        MIT(Multics) H-645     R     R     R     D   1/2 O   D
+70        MIT(DM)   PDP-10       T     T     T     O     O     T
+ 8        SDC       IBM-360/67   D     D     D     D     T     D
+ 9        HARVARD   PDP-10       T     D     T     T     T     T
+10        LINCOLN   IBM-360/67   D   1/2 0 1/2 0   D     T     D
+
+
+NETWORK   SITE      COMPUTER     DATE AND TIME (P.M.)
+ADDRESS                         9/21  9/22  9/23  9/24
+                                4:30  3:30  2:00  5:00
+
+ 1        UCLA      SIGMA-7      O     D     T     O
+65[2]     UCLA      IBM 360/91   O     O     O     O
+ 2        SRI(NIC)  PDP-10       D     O     D     D
+66        SRI(AI)   PDP-10       D     D     D     D
+ 3        UCSB      IBM-360/75   O     O     O     O
+ 4        UTAH      PDP-10       D     D     D     D
+69        BBN       PDP-10       O   1/2 O   O     O
+ 6        MIT(Multics) H-645   1/2 O   T     T     R
+70        MIT(DM)   PDP-10     1/2 O   O     D     D
+ 8        SDC       IBM-360/67   D     D     D     D
+ 9        HARVARD   PDP-10       D     T     D     D
+10        LINCOLN   IBM-360/67   D     D   1/2 0   D
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 3]
+
+RFC #240
+
+
+where
+  D = Dead.  (Destination Host either dead orinaccessible (due to
+             network partitioning or local IMP failure) from the BBN
+             Terminal IMP).
+  R = Refused.  (Destination Host returned a CLS to the initial RFC.) T
+  = Timed Out.  (Destination Host did not respond in any way to the
+             initial RFC, although not dead.)
+  1/2 0 = 1/2 Open.  (Destination Host opened a connection but then
+             either immediately close it, or did not respond any
+             further.)
+  O = Open.  (Destination Host opened a connection and was
+             accessible to users.)
+
+Endnotes
+
+   [1] The BBN Terminal IMP (Network Address 158) is a prototype, and as
+   such is frequently not connected to the Network, but being used to
+   refine and debug the Terminal IMP programs.
+
+   [2] The UCLA IBM-360 is at the moment only able to handle Remote Job
+   Service.  BBN is not equipped to test this, but is assuming that
+   receipt of their canned message indicates that RJS is also
+   functioning.
+
+
+
+         [ This RFC was put into machine readable form for entry ]
+            [ into the online RFC archives by Roy Zimmer 9/97 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc240.txt](<www.ietf.org/rfc/rfc240.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
