### PR TITLE
Archive rfc243.txt

### DIFF
--- a/www.ietf.org/rfc/rfc243.txt
+++ b/www.ietf.org/rfc/rfc243.txt
@@ -1,0 +1,395 @@
+
+
+
+
+
+
+Request for Comments: 243                               Alvin P. Mullery
+Category: T                             Thomas J. Watson Research Center
+NIC: 7673                                         Yorktown Heights, N.Y.
+                                                         October 5, 1971
+
+
+                 NETWORK AND DATA SHARING BIBLIOGRAPHY
+
+
+   GENERAL DATA STRUCTURES
+
+   F. D. Anzelno, "A Data-Storage Format for Information System Files,"
+   IEEE Trans. Computers, vol. c-20, pp. 39-43, January 1971.
+
+   E. F. Codd, "A Relational Model of Data for Large Shared Data Banks,"
+   Comm. ACM, vol 13, pp. 377-387, June 1970.
+
+   C. T. Davies, "A Logical Concept for the Control and Management of
+   Data",  AR-0803-00.
+
+   S. E. Madnick and J. W. Alsop II, "A Modular Approach to File System
+   Design," 1969 Spring Joint Computer Conf., AFIPS Proc., vol 34, pp.
+   1-13, 1969.
+
+   W. C. McGee, "File Structures for Generalized Data Management," Proc.
+   IFIPS Congress 68, pp. 1233, 1968.
+
+   P. D. Rovner and J. A. Feldman, "The IEAP Language and Data
+   Structure," Proc IFIPS Congress 68, pp. 579, 1968.
+
+
+   DATA DESCRIPTION
+
+   T. H. Bonn, "A Standard for Computer Networks,"Computer, vol. 4, p.
+   10-14, May/June, 1971.
+
+   "Data Base Task Group Report," CODASYL Program Language Committee.
+
+   "IBM Data Base Task Group Representative Minority Report," CODASYL
+   Program Language Committee, Oct. 17, 1969.
+
+   M. Donaldson, S. Robinovitz, and B. Wolfe, "Proposed MICIS Standard
+   for Data Description," Michigan Interuniversity Committee on
+   Information Systems, Dec. 4, 1970.
+
+
+
+
+
+
+
+Mullery                                                         [Page 1]
+
+RFC 243          Network and Data Sharing Bibliography      October 1971
+
+
+   M. Ellis and K. Nelson, "A Data Description Language for Hierarchical
+   Data Files," Data and Computation Center for the Social Sciences at
+   The University of Wisconsin, Social Science Building, Madison,
+   Wisconsin, November 1970.
+
+   D. Evans and A. Van Dam, "Data Structure Programming Language," Proc.
+   IFIP Congress 68, pp. 557-564, 1968.
+
+   G. A. Gibson, "Draft:  Data Description Language," fdt (a publication
+   of the ACM Special Interest Committee on File Description and
+   Translation), vol. 1, p. 9-13, 10 August 1969.
+
+   L. V. Haibt and A. P. Mullery, "Data Descriptive Language for Shared
+   Data," IBM Research Report RC3476, August 1971.
+
+   A. W. Holt, "Information System Theory Project," Applied Data
+   Research, Princeton, Rept. ADR-RFF-6606, Sept. 1968.
+
+   G. J. Lipovshy, "The Architecture of Large Distributed Logic
+   Associative Memory," Univ. of Illinois, Urbana, Rept. R-424, July
+   1969 (contains a discussion of representation structures suitable for
+   describing complex data bases).
+
+   C. N. Mooers, "A Standard Method for the Description of External Data
+   Formats," part IV of "Standards for User Procedures and Data Formats
+   in Automatic Information Systems and Networks," Zator, Co., Cambridge
+   Mass., Aug. 28, 1967.
+
+   C. N. Mooers, "Data Descriptive Languages," fdt (a publication of the
+   ACM Special Interest Committee on File Description and Translation),
+   vol. 1, p. 31-36, 10 August 1969.
+
+   H. R. Morse, "Efficiency and the Use of Data Definition Techniques,"
+   fdt (a publication of the ACM Special Interest Committee on File
+   Description and Translation), vol. 1, p. 20-23, 10 August 1969.
+
+   M. Schaefer, "User's Guide for DRL:  General Description," System
+   Development Corporation, Santa Monica, Calif., Rept. TM-3870/001/01,
+   September, 1969.
+
+   D. P. Smith, "A Data Description Facility," Pennsylvania Univ., AD-
+   703244, April 1970.
+
+   T. A. Standish, "A Data Definition Facility for Programming
+   Languages," Carnegie Institute of Technology, AD-658042, May 18,
+   1967. B. Wegbreit, "The Treatment of Data Types in EL1" Technical
+   Report, Division of Engineering and Applied Physics, Harvard Univ.,
+   May 1971.
+
+
+
+Mullery                                                         [Page 2]
+
+RFC 243          Network and Data Sharing Bibliography      October 1971
+
+
+   B. Wegbreit, "The Treatment of Data Types in EL1" Technical Report,
+   Division of Engineering and Applied Physics, Harvard Univ., May 1971.
+
+
+   DATA CONVERSION
+
+   R. Anderson, E. Harslem, and J. Heafner, "Language-Machine for Data
+   Reconfiguration," ARPA Network Working Group, Request for Comments
+   no. 83, Rept. NIC 5621, 18 December 1970.
+
+   K. Sattley, R. F. Millstein, S. Marshall, "On Program
+   Transferability," Applied Data Research, Inc., Rept. RADC-TR-70-217,
+   Nov. 1970.
+
+   M. Schaefer, "DBL - A Language for Converting Data Bases,"
+   Datamation, vol. 16, pp. 123, June 1970.
+
+
+   DATA MANAGEMENT
+
+   W. W. Chu, "Optimal File Allocation in a Multiple Computer System,"
+   IEEE Trans. Computers, vol. C-18, pp. 885-889, October 1969.
+
+   P. G. Hebalkar, "A Graph Model for Analysis of Deadlock Prevention in
+   Systems with Parallel Computations," IBM Research Report RC3367,
+   April 22, 1971.
+
+   N. B. W. Lampson, "A Scheduling Philosophy for Multi-Processing
+   Systems," Comm. ACM, vol. 11, p. 347-360, May, 1968.
+
+   P. J. Owens, "Phase II, A Data Management System Model," IBM Research
+   Rept. RJ665, Jan. 29, 1970.
+
+   M. E. Senko, V. Y. Lum, P. J. Owens, "A File Organization Evaluation
+   Model (FOREM)," Proc IFIP Congress 68, August, 1968.
+
+   A. Shoshani and A. J. Bernstein, "Synchronization in a Parallel-
+   Accessed Data Base," Comm. ACM, vol 12, pp. 604-607, Nov. 1969.  V.
+   K. M. Whitney, "A Study of Optimal File Assignment and Communication
+   Network Configuration in Remote-Access Computer Message Processing
+   and Communication Systems," SEL Technical Report No. 48, System
+   Engineering Lab, Dept. of Elect. Engin., University of Michigan,
+   September, 1970.
+
+
+
+
+
+
+
+
+Mullery                                                         [Page 3]
+
+RFC 243          Network and Data Sharing Bibliography      October 1971
+
+
+   DATA SECURITY
+
+   P. Baran, "On Distributed Communication:  IX. Security, Secrecy, and
+   Tamper-Free Considerations," The RAND Corporation, AD-444839, August
+   1964.
+
+
+   DATA TRANSMISSION
+
+   "Proposed Character Set for Roman Alphabet and Romanized Non-Roman
+   Alphabets" American Standards Institute Document X3.2/836, May 29,
+   1969.
+
+   "Final Report of the Electronic Industries Association Committee on
+   Netting Computer System," Marc Bendick, Chairman, System Dev. Corp.
+   Rept. SP-3514, May, 1970.
+
+   K. A. Bartlett, "Transmission Control in a Local Data Network," Proc.
+   IFIP Congress 68, p. 704-708.  August 1968.
+
+   K. A. Bartlett, "Transmission Control in a Local Data Network," Proc.
+   IFIP Congress 68, p. 704-708.  August 1968.
+
+   S. Carr, S. Crocker, V. Cerf, "Host-Host Communication Protocol in
+   the ARPA Network," 1970 Spring Joint Computer Conf., AFIPS Proc., vol
+   36, pp. 589-598, 1970.
+
+   D. W. Davies, "Communication Networks to Serve Rapid-response
+   Computers,"  Proc IFIP Congress 68, p. 650-656, August 1968.
+
+   D. W. Davies, "The Principles of a Data Communication Network for
+   Computers and Remote Peripherals," Proc IFIP Congress 68, p. 709-714,
+   August 1968.
+
+   "Computer Netting, Standardization, and Systems Management," Computer
+   Netting Committee, Defense Communication Council, Electronic
+   Industries Association, I. Bialick, Chairman, 15 September 1969.
+
+   H. Frank, "Analysis and Optimization of Store-and Forward Computer
+   Networks," Network Analysis Corporation, AD-707438, June 15, 1970.
+
+   M. E. Jacobs, "Standard Format for Data Exchange," Special Libraries,
+   vol. 59, pp 258-260, April 1968.
+
+
+
+
+
+
+
+
+Mullery                                                         [Page 4]
+
+RFC 243          Network and Data Sharing Bibliography      October 1971
+
+
+   D. Karp and S. Seroussi, "A Communication Interface for Computer
+   Networks," IBM Research Report No. RC3417, June 1971.
+
+   John L. Little, "Some Evolving Conventions and Standards for
+   Character Information Code in Six, Seven, and Eight Bits," NBS
+   Technical Note 478, May 1969.
+
+   J. L. Little, C. N. Mooers, "Standards for User Procedures and Data
+   Formats in Automated Information Systems and Networks," 1968 Spring
+   Joint Computer Conf., AFIPS Proc., vol 32, pp 89-94, 1968.
+
+   P. T. Wilkinson and R. A. Scantlebury, "The Control Functions in a
+   Local Data Network,"  Proc IFIP Congress 68, p. 734-738, August 1968.
+
+   NETWORK DESIGN
+
+   A. A. Benvenuto, et al., "System Load Sharing Study," The MITRE
+   Corporation, Rept. MTB-5062, 1969.
+
+   E. K. Bowden, Sr., "Priority Assignment in a Network of Computers,"
+   IEEE Trans. Computers, vol. C-18 pp. 1021-1026, Nov. 1969.
+
+   P. R. Cox, "General System Organisation of Multi-Processor
+   Configurations," Software 70, Sheffield England, p. 33-40, April
+   1970.
+
+   H. Frank, J. T. Frisch, and W. Chow, "Topological Considerations in
+   the Design of the ARPA Network," 1970, Spring Joint Computer Conf.,
+   AFIPS Proc., vol. 36, p. 581-587, 1970.
+
+   D. Fredericksen and R. W. Ryniker, "A Computer Network Interface for
+   OS/MVT," IBM Research Report RC3317, April 1971.
+
+   R. C. Gunderson and J. O. Johnson, "Engineering Design and
+   Implementation of a Multi-Computer Data Processing System for a Navy
+   Command and Control Center," Proc. 7th International Convention on
+   Military Electronics, Western Periodicals, North Hollywood Calif.,
+   1968.
+
+   R. M. Hamaker, "Distributed Computer Systems," Telecommunications,
+   vol. 4, p 25-30, March 1970.
+
+   F. Hansler, G. K. McAuliffe, R. S. Wilkov, "Reliability
+   Considerations in Centralized Computer Networks," IBM Research Report
+   RC3354, May 1971.
+
+
+
+
+
+
+Mullery                                                         [Page 5]
+
+RFC 243          Network and Data Sharing Bibliography      October 1971
+
+
+   W. G. Howe and T. R. Kibler, "Control Concepts of Logical Network
+   Machine," IBM Research Report RC3331, April 1971.
+
+   L. Kleinrock, "Analytic and Simulation Methods in Computer Network
+   Design," 1970 Spring Joint Computer Conf., AFIPS Proc., vol. 36, p.
+   569-579, 1970.
+
+   L. Kleinrock, "Models for Computer Networks," Proc. IEEE. Conf. on
+   Commun., Session 21, p. 9-16, June 1969.
+
+   A. L. Leiner, W. A. Notz, J. L. Smith, and A. Weinberger, "PILOT, A
+   New Multiple Computer System," J. ACM, vol 6, p. 315-335, July 1959.
+
+   D. B. McKay and D. P. Karp, "Network/440 - - IBM Research Computer
+   Sciences Department Computer Network," IBM Research Report RC3431,
+   July 1971.
+
+   D. B. McKay and D. P. Karp, "A Network/440 Protocol Concept," IBM
+   Research Report RC3432, July 1971.
+
+   D. B. McKay, D. P. Karp, J. W. Meyer, and R. S. Nachbar, "Exploratory
+   Research on Netting at IBM," Research Report RC3486, June 1971.
+
+   "An Experimental Computer Network," MIT Lexington, Rept. ESD-TR-69-
+   74, March 1969.
+
+   L. G. Roberts, and B. D. Wessler, "Computer Network Development to
+   Achieve Resource Sharing," 1970 Spring Joint Computer Conf., AFIPS
+   Proc., vol. 36, p. 543-549, 1970.
+
+   J. J. Russell and D. C. Knight, "Communication and Systems
+   Development in the C. S. T. R. O. (Commonwealth Scientific and
+   Industrial Research Organization) Network," Proc. 3rd Australian
+   Computer Conference, p. 384-386, 1966.
+
+   R. M. Rutldege, A. L. Vareha, L. C. Varian, A. H. Weis, S. F.
+   Seroussi, J. W. Meyer, J. F. Jaffee, and M. A. K. Angell, "An
+   Interactive Network of Time-Sharing Computers," Proc. 24th National
+   Conference, A. C. M. Publication p-69, p. 431-442, 1969.
+
+   J. F. Sherlock, "The Simulation of a Multi-Computer System," IEEE
+   Trans. Computers, vol C-19, pp. 1114-1117, Nov. 1970.
+
+   A. Shoshani and E. G. Coffman, "Sequencing Tasks in Multi-Process,
+   Multiple Resource Systems to Avoid Deadlocks," Proc. 11th Annual
+   Symposium on Switching and Automata Theory, p. 225-233, Oct. 1970.
+
+
+
+
+
+Mullery                                                         [Page 6]
+
+RFC 243          Network and Data Sharing Bibliography      October 1971
+
+
+   A. H. Weis, "Distributed Network Activity at IBM," IBM Research
+   Report RC3392, June 1971.
+
+
+
+
+
+
+
+          [This RFC was put into machine readable form for entry]
+     [into the online RFC archives by Kelly Tardif, Viagénie 10/1999]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Mullery                                                         [Page 7]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc243.txt](<www.ietf.org/rfc/rfc243.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
