### PR TITLE
Archive rfc245.txt

### DIFF
--- a/www.ietf.org/rfc/rfc245.txt
+++ b/www.ietf.org/rfc/rfc245.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                          Carol Falls - MAC
+Request For Comments #245                      October 5, 1971
+NIC 7675
+
+
+
+             Reservations for Network Working Group Meeting
+             ----------------------------------------------
+
+
+        Guaranteed arrival reservations for rooms at the Hotel
+
+   Sonesta in Cambridge, Massachusetts have been made for NWGM
+
+   attendees who have made reservations through Project MAC.
+
+   The cost of a single room will be $23.00 per night.
+
+        If for any reason a reservation must be cancelled, the
+
+   hotel must be notified of cancellation before 6 P.M. the day
+
+   of the reservation.
+
+        To cancel a reservation on October 9th, 10th, or 11th,
+
+   call the hotel directly.  At other times, cancellations can be
+
+   handled by Carol Falls at 864-6900 ext. 1450.
+
+
+
+
+
+
+
+
+
+         [ This RFC was put into machine readable form for entry ]
+         [ into the online RFC archives by BBN Corp. under the   ]
+         [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc245.txt](<www.ietf.org/rfc/rfc245.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
