### PR TITLE
Archive rfc246.txt

### DIFF
--- a/www.ietf.org/rfc/rfc246.txt
+++ b/www.ietf.org/rfc/rfc246.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                       A. Vezza
+Request For Comments #246
+NIC 7687                                    October 5, 1971
+
+
+
+                        Network Graphics Meeting
+                        ------------------------
+
+
+        The next Networks Graphics Meeting has been scheduled
+
+   to commence the evening of Sunday, November 21st and adjourn
+
+   Tuesday, November 23rd.  The Stanford Artifical Intellegence
+
+   Project will host the meeting.
+
+
+        Additional information will be forthcoming from Andy
+
+   Moorer of Stanford AI.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+         [ This RFC was put into machine readable form for entry ]
+         [ into the online RFC archives by BBN Corp. under the   ]
+         [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc246.txt](<www.ietf.org/rfc/rfc246.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
