### PR TITLE
Archive rfc2466.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2466.txt
+++ b/www.ietf.org/rfc/rfc2466.txt
@@ -1,0 +1,899 @@
+
+
+
+
+
+
+Network Working Group                                        D. Haskin
+Request for Comments: 2466                                   S. Onishi
+Category: Standards Track                           Bay Networks, Inc.
+                                                         December 1998
+
+
+             Management Information Base for IP Version 6:
+                              ICMPv6 Group
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (1998).  All Rights Reserved.
+
+Abstract
+
+   This document is one in the series of documents that define various
+   MIB object groups for IPv6.  Specifically, the ICMPv6 group is
+   defined in this document.
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the IPv6-based
+   internets.
+
+   This document specifies a MIB module in a manner that is both
+   compliant to the SNMPv2 SMI, and semantically identical to the peer
+   SNMPv1 definitions.
+
+Table of Contents
+
+   1.  The SNMPv2 Network Management Framework .............    2
+   1.1   Object Definitions ................................    2
+   2.  Overview ............................................    2
+   3.  The ICMPv6 Group ....................................    3
+   4.  Acknowledgments ....................................    14
+   5.  References ..........................................   14
+   6.  Security Considerations .............................   15
+   7.  Authors' Addresses...................................   15
+   8.  Full Copyright Statement.............................   16
+
+
+
+
+
+Haskin & Onishi             Standards Track                     [Page 1]
+
+RFC 2466                 IPv6 MIB: ICMPv6 Group            December 1998
+
+
+1.  The SNMPv2 Network Management Framework
+
+   The SNMPv2 Network Management Framework presently consists of three
+   major components.  They are:
+
+   o the SMI, described in RFC 1902 [1] - the mechanisms used for
+     describing and naming objects for the purpose of management.
+
+   o the MIB-II, described in RFC 1213/STD 17 [3] - the core set of
+     managed objects for the Internet suite of protocols.
+
+   o RFC 1157/STD 15 [4] and RFC 1905 [5] which define two versions of the
+     protocol used for network access to managed objects.
+
+   The Framework permits new objects to be defined for the purpose of
+   experimentation and evaluation.
+
+1.1.  Object Definitions
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  Objects in the MIB are
+   defined using the subset of Abstract Syntax Notation One (ASN.1)
+   defined in the SMI.  In particular, each object type is named by an
+   OBJECT IDENTIFIER, an administratively assigned name.  The object type
+   together with an object instance serves to uniquely identify a
+   specific instantiation of the object.  For human convenience, we often
+   use a textual string, termed the descriptor, to refer to the object
+   type.
+
+2.  Overview
+
+   This document is the one in the series of documents that define
+   various MIB object groups for IPv6. These groups are the basic unit of
+   conformance: if the semantics of a group is applicable to an
+   implementation, then it must implement all objects in that group.  For
+   example, an implementation must implement the TCP group if and only if
+   it implements the TCP over IPv6 protocol.  At minimum, implementations
+   must implement the IPv6 General group [9] as well as the ICMPv6 group
+   defined in this document.
+
+   This document defines the ICMPv6 group of the IPv6 MIB.
+
+
+
+
+
+
+
+
+
+
+Haskin & Onishi             Standards Track                     [Page 2]
+
+RFC 2466                 IPv6 MIB: ICMPv6 Group            December 1998
+
+
+3.  The ICMPv6 Group
+
+    IPV6-ICMP-MIB DEFINITIONS ::= BEGIN
+
+    IMPORTS
+        MODULE-IDENTITY, OBJECT-TYPE,
+        Counter32, mib-2                 FROM SNMPv2-SMI
+        MODULE-COMPLIANCE, OBJECT-GROUP  FROM SNMPv2-CONF
+        ipv6IfEntry                      FROM IPV6-MIB;
+
+    ipv6IcmpMIB MODULE-IDENTITY
+        LAST-UPDATED "9801082155Z"
+        ORGANIZATION "IETF IPv6 Working Group"
+        CONTACT-INFO
+          "           Dimitry Haskin
+
+              Postal: Bay Networks, Inc.
+                      660 Techology Park Drive.
+                      Billerica, MA  01821
+                      US
+
+                 Tel: +1-978-916-8124
+              E-mail: dhaskin@baynetworks.com
+
+                      Steve Onishi
+
+              Postal: Bay Networks, Inc.
+                      3 Federal Street
+                      Billerica, MA 01821
+                      US
+
+                 Tel: +1-978-916-3816
+              E-mail: sonishi@baynetworks.com"
+        DESCRIPTION
+          "The MIB module for entities implementing
+           the ICMPv6."
+        ::= { mib-2 56 }
+
+    -- the ICMPv6 group
+
+    ipv6IcmpMIBObjects OBJECT IDENTIFIER ::= { ipv6IcmpMIB  1 }
+
+
+    -- Per-interface ICMPv6 statistics table
+
+    ipv6IfIcmpTable OBJECT-TYPE
+        SYNTAX     SEQUENCE OF Ipv6IfIcmpEntry
+        MAX-ACCESS not-accessible
+
+
+
+Haskin & Onishi             Standards Track                     [Page 3]
+
+RFC 2466                 IPv6 MIB: ICMPv6 Group            December 1998
+
+
+        STATUS     current
+        DESCRIPTION
+         "IPv6 ICMP statistics. This table contains statistics
+         of ICMPv6 messages that are received and sourced by
+         the entity."
+        ::= { ipv6IcmpMIBObjects 1 }
+
+    ipv6IfIcmpEntry OBJECT-TYPE
+        SYNTAX     Ipv6IfIcmpEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+         "An ICMPv6 statistics entry containing
+         objects at a particular IPv6 interface.
+
+         Note that a receiving interface is
+         the interface to which a given ICMPv6 message
+         is addressed which may not be necessarily
+         the input interface for the message.
+
+         Similarly,  the sending interface is
+         the interface that sources a given
+         ICMP message which is usually but not
+         necessarily the output interface for the message."
+        AUGMENTS { ipv6IfEntry }
+        ::= { ipv6IfIcmpTable 1 }
+
+    Ipv6IfIcmpEntry ::= SEQUENCE {
+            ipv6IfIcmpInMsgs
+                  Counter32      ,
+            ipv6IfIcmpInErrors
+                  Counter32      ,
+            ipv6IfIcmpInDestUnreachs
+                  Counter32      ,
+            ipv6IfIcmpInAdminProhibs
+                  Counter32      ,
+            ipv6IfIcmpInTimeExcds
+                  Counter32      ,
+            ipv6IfIcmpInParmProblems
+                  Counter32      ,
+            ipv6IfIcmpInPktTooBigs
+                  Counter32      ,
+            ipv6IfIcmpInEchos
+                  Counter32      ,
+            ipv6IfIcmpInEchoReplies
+                  Counter32      ,
+            ipv6IfIcmpInRouterSolicits
+                  Counter32      ,
+
+
+
+Haskin & Onishi             Standards Track                     [Page 4]
+
+RFC 2466                 IPv6 MIB: ICMPv6 Group            December 1998
+
+
+            ipv6IfIcmpInRouterAdvertisements
+                  Counter32      ,
+            ipv6IfIcmpInNeighborSolicits
+                  Counter32      ,
+            ipv6IfIcmpInNeighborAdvertisements
+                  Counter32      ,
+            ipv6IfIcmpInRedirects
+                  Counter32      ,
+            ipv6IfIcmpInGroupMembQueries
+                  Counter32      ,
+            ipv6IfIcmpInGroupMembResponses
+                  Counter32      ,
+            ipv6IfIcmpInGroupMembReductions
+                  Counter32      ,
+            ipv6IfIcmpOutMsgs
+                  Counter32      ,
+            ipv6IfIcmpOutErrors
+                  Counter32      ,
+            ipv6IfIcmpOutDestUnreachs
+                  Counter32      ,
+            ipv6IfIcmpOutAdminProhibs
+                  Counter32      ,
+            ipv6IfIcmpOutTimeExcds
+                  Counter32      ,
+            ipv6IfIcmpOutParmProblems
+                  Counter32      ,
+            ipv6IfIcmpOutPktTooBigs
+                  Counter32      ,
+            ipv6IfIcmpOutEchos
+                  Counter32      ,
+            ipv6IfIcmpOutEchoReplies
+                  Counter32      ,
+            ipv6IfIcmpOutRouterSolicits
+                  Counter32      ,
+            ipv6IfIcmpOutRouterAdvertisements
+                  Counter32      ,
+            ipv6IfIcmpOutNeighborSolicits
+                  Counter32      ,
+            ipv6IfIcmpOutNeighborAdvertisements
+                  Counter32      ,
+            ipv6IfIcmpOutRedirects
+                  Counter32      ,
+            ipv6IfIcmpOutGroupMembQueries
+                  Counter32      ,
+            ipv6IfIcmpOutGroupMembResponses
+                  Counter32      ,
+            ipv6IfIcmpOutGroupMembReductions
+                  Counter32
+
+
+
+Haskin & Onishi             Standards Track                     [Page 5]
+
+RFC 2466                 IPv6 MIB: ICMPv6 Group            December 1998
+
+
+        }
+
+    ipv6IfIcmpInMsgs OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The total number of ICMP messages received
+         by the interface which includes all those
+         counted by ipv6IfIcmpInErrors. Note that this
+         interface is the interface to which the
+         ICMP messages were addressed which may not be
+         necessarily the input interface for the messages."
+        ::= { ipv6IfIcmpEntry 1 }
+
+    ipv6IfIcmpInErrors OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMP messages which the interface
+         received but determined as having ICMP-specific
+         errors (bad ICMP checksums, bad length, etc.)."
+        ::= { ipv6IfIcmpEntry 2 }
+
+    ipv6IfIcmpInDestUnreachs OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMP Destination Unreachable
+         messages received by the interface."
+        ::= { ipv6IfIcmpEntry 3 }
+
+    ipv6IfIcmpInAdminProhibs OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMP destination
+         unreachable/communication administratively
+         prohibited messages received by the interface."
+        ::= { ipv6IfIcmpEntry 4 }
+
+    ipv6IfIcmpInTimeExcds OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+
+
+
+Haskin & Onishi             Standards Track                     [Page 6]
+
+RFC 2466                 IPv6 MIB: ICMPv6 Group            December 1998
+
+
+        DESCRIPTION
+         "The number of ICMP Time Exceeded messages
+          received by the interface."
+        ::= { ipv6IfIcmpEntry 5 }
+
+    ipv6IfIcmpInParmProblems OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMP Parameter Problem messages
+          received by the interface."
+        ::= { ipv6IfIcmpEntry 6 }
+
+    ipv6IfIcmpInPktTooBigs OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMP Packet Too Big messages
+         received by the interface."
+        ::= { ipv6IfIcmpEntry 7 }
+
+    ipv6IfIcmpInEchos OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMP Echo (request) messages
+          received by the interface."
+        ::= { ipv6IfIcmpEntry 8 }
+
+    ipv6IfIcmpInEchoReplies OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMP Echo Reply messages received
+         by the interface."
+        ::= { ipv6IfIcmpEntry 9 }
+
+    ipv6IfIcmpInRouterSolicits OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMP Router Solicit messages
+          received by the interface."
+
+
+
+Haskin & Onishi             Standards Track                     [Page 7]
+
+RFC 2466                 IPv6 MIB: ICMPv6 Group            December 1998
+
+
+        ::= { ipv6IfIcmpEntry 10 }
+
+    ipv6IfIcmpInRouterAdvertisements OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMP Router Advertisement messages
+         received by the interface."
+        ::= { ipv6IfIcmpEntry 11 }
+
+    ipv6IfIcmpInNeighborSolicits OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMP Neighbor Solicit messages
+          received by the interface."
+        ::= { ipv6IfIcmpEntry 12 }
+
+    ipv6IfIcmpInNeighborAdvertisements OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMP Neighbor Advertisement
+         messages received by the interface."
+        ::= { ipv6IfIcmpEntry 13 }
+
+    ipv6IfIcmpInRedirects OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of Redirect messages received
+         by the interface."
+        ::= { ipv6IfIcmpEntry 14 }
+
+    ipv6IfIcmpInGroupMembQueries OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMPv6 Group Membership Query
+         messages received by the interface."
+        ::= { ipv6IfIcmpEntry 15}
+
+    ipv6IfIcmpInGroupMembResponses OBJECT-TYPE
+
+
+
+Haskin & Onishi             Standards Track                     [Page 8]
+
+RFC 2466                 IPv6 MIB: ICMPv6 Group            December 1998
+
+
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMPv6 Group Membership Response messages
+         received by the interface."
+        ::= { ipv6IfIcmpEntry 16}
+
+     ipv6IfIcmpInGroupMembReductions OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMPv6 Group Membership Reduction messages
+         received by the interface."
+        ::= { ipv6IfIcmpEntry 17}
+
+    ipv6IfIcmpOutMsgs OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The total number of ICMP messages which this
+         interface attempted to send.  Note that this counter
+         includes all those counted by icmpOutErrors."
+        ::= { ipv6IfIcmpEntry 18 }
+
+    ipv6IfIcmpOutErrors OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMP messages which this interface did
+         not send due to problems discovered within ICMP
+         such as a lack of buffers.  This value should not
+         include errors discovered outside the ICMP layer
+         such as the inability of IPv6 to route the resultant
+         datagram.  In some implementations there may be no
+         types of error which contribute to this counter's
+         value."
+        ::= { ipv6IfIcmpEntry 19 }
+
+    ipv6IfIcmpOutDestUnreachs OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMP Destination Unreachable
+
+
+
+Haskin & Onishi             Standards Track                     [Page 9]
+
+RFC 2466                 IPv6 MIB: ICMPv6 Group            December 1998
+
+
+         messages sent by the interface."
+        ::= { ipv6IfIcmpEntry 20 }
+
+    ipv6IfIcmpOutAdminProhibs OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+          "Number of ICMP dest unreachable/communication
+          administratively prohibited messages sent."
+        ::= { ipv6IfIcmpEntry 21 }
+
+    ipv6IfIcmpOutTimeExcds OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMP Time Exceeded messages sent
+         by the interface."
+        ::= { ipv6IfIcmpEntry 22 }
+
+    ipv6IfIcmpOutParmProblems OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMP Parameter Problem messages
+         sent by the interface."
+        ::= { ipv6IfIcmpEntry 23 }
+
+    ipv6IfIcmpOutPktTooBigs OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMP Packet Too Big messages sent
+         by the interface."
+        ::= { ipv6IfIcmpEntry 24 }
+
+    ipv6IfIcmpOutEchos OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMP Echo (request) messages sent
+         by the interface."
+        ::= { ipv6IfIcmpEntry 25 }
+
+
+
+
+Haskin & Onishi             Standards Track                    [Page 10]
+
+RFC 2466                 IPv6 MIB: ICMPv6 Group            December 1998
+
+
+    ipv6IfIcmpOutEchoReplies OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMP Echo Reply messages sent
+         by the interface."
+        ::= { ipv6IfIcmpEntry 26 }
+
+    ipv6IfIcmpOutRouterSolicits OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMP Router Solicitation messages
+          sent by the interface."
+        ::= { ipv6IfIcmpEntry 27 }
+
+    ipv6IfIcmpOutRouterAdvertisements OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMP Router Advertisement messages
+         sent by the interface."
+        ::= { ipv6IfIcmpEntry 28 }
+
+    ipv6IfIcmpOutNeighborSolicits OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMP Neighbor Solicitation
+          messages sent by the interface."
+        ::= { ipv6IfIcmpEntry 29 }
+
+    ipv6IfIcmpOutNeighborAdvertisements OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMP Neighbor Advertisement
+         messages sent by the interface."
+        ::= { ipv6IfIcmpEntry 30 }
+
+    ipv6IfIcmpOutRedirects OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+
+
+
+Haskin & Onishi             Standards Track                    [Page 11]
+
+RFC 2466                 IPv6 MIB: ICMPv6 Group            December 1998
+
+
+        STATUS     current
+        DESCRIPTION
+         "The number of Redirect messages sent. For
+         a host, this object will always be zero,
+         since hosts do not send redirects."
+        ::= { ipv6IfIcmpEntry 31 }
+
+    ipv6IfIcmpOutGroupMembQueries OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMPv6 Group Membership Query
+         messages sent."
+        ::= { ipv6IfIcmpEntry 32}
+
+    ipv6IfIcmpOutGroupMembResponses OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMPv6 Group Membership Response
+         messages sent."
+        ::= { ipv6IfIcmpEntry 33}
+
+    ipv6IfIcmpOutGroupMembReductions OBJECT-TYPE
+        SYNTAX     Counter32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+         "The number of ICMPv6 Group Membership Reduction
+         messages sent."
+        ::= { ipv6IfIcmpEntry 34}
+
+
+   -- conformance information
+
+   ipv6IcmpConformance OBJECT IDENTIFIER ::= { ipv6IcmpMIB 2 }
+
+   ipv6IcmpCompliances
+           OBJECT IDENTIFIER ::= { ipv6IcmpConformance 1 }
+   ipv6IcmpGroups
+           OBJECT IDENTIFIER ::= { ipv6IcmpConformance 2 }
+
+   -- compliance statements
+
+   ipv6IcmpCompliance MODULE-COMPLIANCE
+       STATUS  current
+
+
+
+Haskin & Onishi             Standards Track                    [Page 12]
+
+RFC 2466                 IPv6 MIB: ICMPv6 Group            December 1998
+
+
+       DESCRIPTION
+         "The compliance statement for SNMPv2 entities which
+         implement ICMPv6."
+       MODULE  -- this module
+           MANDATORY-GROUPS { ipv6IcmpGroup }
+       ::= { ipv6IcmpCompliances 1 }
+
+   ipv6IcmpGroup OBJECT-GROUP
+       OBJECTS   {
+                   ipv6IfIcmpInMsgs,
+                   ipv6IfIcmpInErrors,
+                   ipv6IfIcmpInDestUnreachs,
+                   ipv6IfIcmpInAdminProhibs,
+                   ipv6IfIcmpInTimeExcds,
+                   ipv6IfIcmpInParmProblems,
+                   ipv6IfIcmpInPktTooBigs,
+                   ipv6IfIcmpInEchos,
+                   ipv6IfIcmpInEchoReplies,
+                   ipv6IfIcmpInRouterSolicits,
+                   ipv6IfIcmpInRouterAdvertisements,
+                   ipv6IfIcmpInNeighborSolicits,
+                   ipv6IfIcmpInNeighborAdvertisements,
+                   ipv6IfIcmpInRedirects,
+                   ipv6IfIcmpInGroupMembQueries,
+                   ipv6IfIcmpInGroupMembResponses,
+                   ipv6IfIcmpInGroupMembReductions,
+                   ipv6IfIcmpOutMsgs,
+                   ipv6IfIcmpOutErrors,
+                   ipv6IfIcmpOutDestUnreachs,
+                   ipv6IfIcmpOutAdminProhibs,
+                   ipv6IfIcmpOutTimeExcds,
+                   ipv6IfIcmpOutParmProblems,
+                   ipv6IfIcmpOutPktTooBigs,
+                   ipv6IfIcmpOutEchos,
+                   ipv6IfIcmpOutEchoReplies,
+                   ipv6IfIcmpOutRouterSolicits,
+                   ipv6IfIcmpOutRouterAdvertisements,
+                   ipv6IfIcmpOutNeighborSolicits,
+                   ipv6IfIcmpOutNeighborAdvertisements,
+                   ipv6IfIcmpOutRedirects,
+                   ipv6IfIcmpOutGroupMembQueries,
+                   ipv6IfIcmpOutGroupMembResponses,
+                   ipv6IfIcmpOutGroupMembReductions
+                 }
+       STATUS    current
+       DESCRIPTION
+            "The ICMPv6 group of objects providing information
+             specific to ICMPv6."
+
+
+
+Haskin & Onishi             Standards Track                    [Page 13]
+
+RFC 2466                 IPv6 MIB: ICMPv6 Group            December 1998
+
+
+       ::= { ipv6IcmpGroups 1 }
+
+    END
+
+4.  Acknowledgments
+
+   This document borrows from MIB works produced by IETF for IPv4-based
+   internets.
+
+   We would like to thanks the following people for constructive and
+   valuable comments:
+
+      Mike Daniele,
+      Margaret Forsythe,
+      Jean-Pierre Roch,
+      Juergen Schoenwaelder,
+      Vivek Venkatraman.
+
+5.  References
+
+   [1] SNMPv2 Working Group, Case, J., McCloghrie, K., Rose, M.,
+       and S.  Waldbusser, "Structure of Management Information for
+       Version 2 of the Simple Network Management Protocol (SNMPv2)",
+       RFC 1902, January 1996.
+
+   [2] SNMPv2 Working Group, Case, J., McCloghrie, K., Rose, M., and S.
+       Waldbusser, "Textual Conventions for Version 2 of the Simple
+       Network Management Protocol (SNMPv2)", RFC 1903, January 1996.
+
+   [3] McCloghrie, K., and M. Rose, Editors, "Management Information
+       Base for Network Management of TCP/IP-based internets: MIB-II",
+       STD 17, RFC 1213, March 1991.
+
+   [4] Case, J., Fedor, M., Schoffstall, M. and J.  Davin, "A Simple
+       Network Management Protocol (SNMP)", STD 15, RFC 1157, May 1990.
+
+   [5] SNMPv2 Working Group, Case, J., McCloghrie, K., Rose, M. and S.
+       Waldbusser, "Protocol Operations for Version 2 of the Simple
+       Network Management Protocol (SNMPv2)", RFC 1905, January 1996.
+
+   [6] McCloghrie, K. and F. Kastenholz, "Evolution of the Interfaces
+       Group of MIB-II", RFC 1573, January 1994.
+
+   [7] Deering, S. and R. Hinden, Editors, "Internet Protocol, Version 6
+       (IPv6) Specification", RFC 2460, December 1998.
+
+
+
+
+
+
+Haskin & Onishi             Standards Track                    [Page 14]
+
+RFC 2466                 IPv6 MIB: ICMPv6 Group            December 1998
+
+
+   [8] Conta, A. and S. Deering, "Internet Control Message Protocol
+       (ICMPv6) for the Internet Protocol Version 6 (IPv6)
+       Specification", RFC 2463, December 1998.
+
+   [9] Haskin, D., and S. Onishi, "Management Information Base for IP
+       Version 6: Textual Conventions and General Group", RFC 2465,
+       December 1998.
+
+6.  Security Considerations
+
+   Certain management information defined in this MIB may be considered
+   sensitive in some network environments.
+
+   Therefore, authentication of received SNMP requests and controlled
+   access to management information should be employed in such
+   environments.
+
+7.  Authors' Addresses
+
+   Dimitry Haskin
+   Bay Networks, Inc.
+   600 Technology Park Drive
+   Billerica, MA 01821
+
+   EMail: dhaskin@baynetworks.com
+
+
+   Steve Onishi
+   Bay Networks, Inc.
+   3 Federal Street
+   Billerica, MA 01821
+
+   EMail: sonishi@baynetworks.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Haskin & Onishi             Standards Track                    [Page 15]
+
+RFC 2466                 IPv6 MIB: ICMPv6 Group            December 1998
+
+
+8.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (1998).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Haskin & Onishi             Standards Track                    [Page 16]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2466.txt](<www.ietf.org/rfc/rfc2466.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
