### PR TITLE
Archive rfc249.txt

### DIFF
--- a/www.ietf.org/rfc/rfc249.txt
+++ b/www.ietf.org/rfc/rfc249.txt
@@ -1,0 +1,112 @@
+
+
+
+
+
+
+                                                       NIC 7690
+Network Working Group                                  R. F. Borelli
+Request for Comments #249                              University of Illinois
+                                                       Center for Advanced
+                                                         Computation
+                                                       October 8, 1971
+
+              Coordination of Equipment and Supplies Purchase
+              -----------------------------------------------
+
+        The purpose of this message is to pass on to all members of the
+   Network an agreement reached between Messrs. Steve Crocker of ARPA and
+   R. F. Borelli of the University of Illinois.  The Center for Advanced
+   Computation has agreed to study the feasibility of a coordinating point
+   for purchases of equipment and supplies to be used on the network.
+
+        To this end, the Center will compile a list of common equipment and
+   supplies needed by Network members and ascertain the value of contacting
+   the appropriate manufacturers and distributers in order to negotiate the
+   best possible group price.  Thereafter, the results of the negotiations
+   will be passed on to Network members with a resulting listing of items,
+   costs and supplies.
+
+        The two biggest pitfalls with this concept are:
+             1.  Insufficient demand for commonly required items.
+             2.  Not satisfying each organization's administrative
+                 requirements for competitive bidding on items
+                 which are not sole-source justified.
+
+        At this time, it appears to be premature to allow this to stop the
+   idea.  After the listing of items and range of sources are collected and
+   analyzed, these two points can be addressed.  In fact, this project may
+   have to be abandoned; however, there are sufficient reasons to believe
+   that these problems can be overcome to make the venture workable.
+
+       We request that all members of the Network forward to the Center,
+   ATTN. R. F. Borelli, a descriptive listing of equipment and supplies
+   they require in this fiscal year.  Particular attention must be paid to
+   listing all the acceptable alternates to increase the changes of
+   commonality.  For example: TI-725 terminals could be considered a
+   substitute for Teleterms 1030's, etc.  The only items excluded at this
+   time are 2400 ft. Magnetic Computer Tapes, tabulating cards, and
+   conventional computer printer paper.  Any added suggestions or ideas are
+   both encouraged and welcomed.
+
+        A sample format of information is attached.
+
+
+
+
+
+                                                                [Page 1]
+
+          Sample Format of Information Requirement is as Follows:
+          ------------------------------------------------------
+                                                                  Current
+                                                                 Estimated
+   Quantity      Description and Special Needs      Mfgr.           Cost
+   --------      -----------------------------      -----       -----------
+
+       3         Remote Terminals                 Texas Instr.  $4,200.00 @
+                 Model TI-725 with upper and            or
+                  lower case                      Teleterms
+
+   100 rolls/mo  Electro Static Printer Paper      Gould        $10.00/roll
+
+
+   Requested by:
+
+                     University of Illinois
+                     Center for Advanced Computation
+                     Urbana, Illinois  61801
+                     Telephone:  (217) 333-6375
+
+
+   A listing of items not intended as all-inclusive are:
+
+       1.  Gould Electrostatic Printers and printer paper.
+       2.  Computek graphics terminals.
+       3.  ARDS graphics terminals.
+       4.  CRT alphanumeric terminals (Hazeltine, Datapoint, DEC, etc.).
+       5.  Hard-copy portable terminals (TI-725, Teleterm 1030, NCR etc.).
+       6.  Teletype (ASR and KSR-33, 35 and 37)
+       7.  Plasma panels.
+       8.  Plotters (CalComp, Bendix, Calma, etc.).
+       9.  Digitizers and scanners.
+      10.  Computers (PDP-11, PDP-10).
+      11.  Computer peripherals (TU-56, TC-11, etc.).
+      12.  IMLAC's.
+
+
+
+         [ This RFC was put into machine readable form for entry ]
+         [ into the online RFC archives by BBN Corp. under the   ]
+         [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+                                                                [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc249.txt](<www.ietf.org/rfc/rfc249.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
