### PR TITLE
Archive rfc25.txt

### DIFF
--- a/www.ietf.org/rfc/rfc25.txt
+++ b/www.ietf.org/rfc/rfc25.txt
@@ -1,0 +1,18 @@
+Network Working Group                                      Steve Crocker
+Request for Comments: 25                                            UCLA
+                                                         30 October 1969
+
+
+
+
+                           NO HIGH LINK NUMBERS
+
+
+
+
+Because it may be desirable to reserve one or more link numbers for
+instrumentation purposes, and because 256 link numbers are many more
+than are needed, we suggest that no link number over 63 be used.  At
+UCLA, we will implement our tables to take advantage of this limitation.
+We also note that 32 may be even more realistic, but 64 is certainly
+sufficient.


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc25.txt](<www.ietf.org/rfc/rfc25.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
