### PR TITLE
Archive rfc2500.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2500.txt
+++ b/www.ietf.org/rfc/rfc2500.txt
@@ -1,0 +1,1571 @@
+
+
+
+
+
+
+Network Working Group                    Internet Engineering Task Force
+Request for Comments: 2500                                   J. Reynolds
+Obsoletes: 2400, 2300, 2200, 2000, 1920, 1880,                 R. Braden
+1800, 1780, 1720, 1610, 1600, 1540, 1500, 1410,                  Editors
+1360, 1280, 1250, 1200, 1140, 1130, 1100, 1083                 June 1999
+STD: 1
+Category: Standards Track
+
+
+                  Internet Official Protocol Standards
+
+
+Status of this Memo
+
+   This memo describes the state of standardization of protocols used in
+   the Internet as determined by the Internet Engineering Task Force
+   (IETF).  This memo is an Internet Standard.  Distribution of this
+   memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (1999).  All Rights Reserved.
+
+Table of Contents
+
+   1.  Introduction . . . . . . . . . . . . . . . . . . . . . . .   2
+   2.  Current Technical Specifications . . . . . . . . . . . . .   4
+   2.1.  Standard Protocols . . . . . . . . . . . . . . . . . . .   5
+   2.2.  Network-Specific Standard Protocols  . . . . . . . . . .   6
+   2.3.  Draft Standard Protocols . . . . . . . . . . . . . . . .   7
+   2.4.  Proposed Standard Protocols  . . . . . . . . . . . . . .   9
+   2.5.  Experimental Protocols . . . . . . . . . . . . . . . . .  18
+   3.  Current Applicability Statements . . . . . . . . . . . . .  21
+   4.  Non-Standard Protocols . . . . . . . . . . . . . . . . . .  22
+   4.1.  Informational Protocol . . . . . . . . . . . . . . . . .  22
+   4.2.  Historic Protocols . . . . . . . . . . . . . . . . . . .  24
+   5.  Contacts . . . . . . . . . . . . . . . . . . . . . . . . .  25
+   5.1.  IAB, IETF, and IRTF Contacts . . . . . . . . . . . . . .  25
+   5.2.  Internet Assigned Numbers Authority (IANA) Contact . . .  25
+   5.3.  Request for Comments Editor Contact  . . . . . . . . . .  26
+   5.4.  Requests for Comments Distribution Contact . . . . . . .  26
+   5.5.  Sources for Requests for Comments  . . . . . . . . . . .  26
+   6.  Security Considerations  . . . . . . . . . . . . . . . . .  26
+   7.  Editors' Addresses . . . . . . . . . . . . . . . . . . . .  27
+   Full Copyright Statement . . . . . . . . . . . . . . . . . . .  28
+
+
+
+
+
+
+IETF                        Standards Track                     [Page 1]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+1. Introduction
+
+   This memo summarizes the status of Internet protocols and
+   specifications.  It is published by the RFC Editor in accordance with
+   Section 2.1 of "The Internet Standards Process -- Revision 3", RFC
+   2026, which specifies the rules and procedures by which all Internet
+   stnadards are set.  This memo is prepared by the RFC Editor for the
+   IESG and IAB.  It is a member of a series of summary memos that are
+   published approximately every one hundred RFCs; please see
+   www.rfc-editor.org.
+
+   This memo lists the level and status of the archival documents known
+   as RFCs (Request for Comments) within the Internet standards process.
+   The reader is urged to review RFC 2026 for essential context for
+   interpreting this memo.
+
+   The following introductory text is quoted directly from RFC 2026:
+
+      "The Internet, a loosely-organized international collaboration of
+      autonomous, interconnected networks, supports host-to-host
+      communication through voluntary adherence to open protocols and
+      procedures defined by Internet Standards.  There are also many
+      isolated interconnected networks, which are not connected to the
+      global Internet but use the Internet Standards.
+
+      The Internet Standards Process described in this document is
+      concerned with all protocols, procedures, and conventions that are
+      used in or by the Internet, whether or not they are part of the
+      TCP/IP protocol suite.  In the case of protocols developed and/or
+      standardized by non-Internet organizations, however, the Internet
+      Standards Process normally applies to the application of the
+      protocol or procedure in the Internet context, not to the
+      specification of the protocol itself.
+
+      In general, an Internet Standard is a specification that is stable
+      and well-understood, is technically competent, has multiple,
+      independent, and interoperable implementations with substantial
+      operational experience, enjoys significant public support, and is
+      recognizably useful in some or all parts of the Internet.
+
+      Each distinct version of an Internet standards-related
+      specification is published as part of the "Request for Comments"
+      (RFC) document series.  This archival series is the official
+      publication channel for Internet standards documents and other
+      publications of the IESG, IAB, and Internet community.  RFCs can
+      be obtained from a number of Internet hosts using anonymous FTP,
+      gopher, World Wide Web, and other Internet document-retrieval
+      systems.
+
+
+
+IETF                        Standards Track                     [Page 2]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+      The rules for formatting and submitting an RFC are defined in [5].
+      Every RFC is available in ASCII text.  Some RFCs are also
+      available in other formats.  The other versions of an RFC may
+      contain material (such as diagrams and figures) that is not
+      present in the ASCII version, and it may be formatted differently.
+
+            *********************************************************
+            *                                                       *
+            *  A stricter requirement applies to standards-track    *
+            *  specifications:  the ASCII text version is the       *
+            *  definitive reference, and therefore it must be a     *
+            *  complete and accurate specification of the standard, *
+            *  including all necessary diagrams and illustrations.  *
+            *                                                       *
+            *********************************************************
+
+      The status of Internet protocol and service specifications is
+      summarized periodically in an RFC entitled "Internet Official
+      Protocol Standards" [1].  This RFC shows the level of maturity and
+      other helpful information for each Internet protocol or service
+      specification (see section 3).
+
+      Specifications subject to the Internet Standards Process fall into
+      one of two categories:  Technical Specification (TS) and
+      Applicability Statement (AS).
+
+      Some RFCs document Internet Standards.  These RFCs form the "STD"
+      subseries of the RFC series [4].  When a specification has been
+      adopted as an Internet Standard, it is given the additional label
+      "STDxxx", but it keeps its RFC number and its place in the RFC
+      series.  (see section 4.1.3)
+
+      Some RFCs standardize the results of community deliberations about
+      statements of principle or conclusions about what is the best way
+      to perform some operations or IETF process function.  These RFCs
+      form the specification has been adopted as a BCP, it is given the
+      additional label "BCPxxx", but it keeps its RFC number and its
+      place in the RFC series. (see section 5)
+
+      Not all specifications of protocols or services for the Internet
+      should or will become Internet Standards or BCPs.  Such non-
+      standards track specifications are not subject to the rules for
+      Internet standardization.  Non-standards track specifications may
+      be published directly as "Experimental" or "Informational" RFCs at
+      the discretion of the RFC Editor in consultation with the IESG
+      (see section 4.2)."
+
+
+
+
+
+IETF                        Standards Track                     [Page 3]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+   Section 2 of this memo lists all Technical Specification RFCs that
+   are in the standards track, and Section 3 lists Applicability
+   Statement RFCs in the standards track.  Section 4 lists those
+   protocol specification RFCs that are off the standards track
+   (Informational and Historic status).  This memo does not list
+   Informational RFCs that may be of general interest to the community
+   but do not specify protocols for the Internet.  It also does not list
+   BCP RFCs.  Telnet options have been added into the lists.
+
+2. Current Technical Specifications
+
+   Subsections 2.1-2.5 list the standards in groups by protocol state.
+   In the following lists, shorthand nicknames have been shown for many
+   of the major protocols.  These names are commonly used in discourse
+   on Internet mailing lists.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+IETF                        Standards Track                     [Page 4]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+2.1.  Standard Protocols
+
+Protocol   Name                                                RFC STD *
+========   =====================================              ==== === =
+--------   Internet Official Protocol Standards               2500   1
+--------   Assigned Numbers                                   1700   2
+IP         Internet Protocol                                   791   5
+            as amended by:--------
+--------     IP Subnet Extension                               950   5
+--------     IP Broadcast Datagrams                            919   5
+--------     IP Broadcast Datagrams with Subnets               922   5
+ICMP       Internet Control Message Protocol                   792   5
+IGMP       Internet Group Multicast Protocol                  1112   5
+UDP        User Datagram Protocol                              768   6
+TCP        Transmission Control Protocol                       793   7
+TELNET     Telnet Protocol                                 854,855   8
+FTP        File Transfer Protocol                              959   9
+SMTP       Simple Mail Transfer Protocol                       821  10
+SMTP-SIZE  SMTP Service Ext for Message Size                  1870  10
+SMTP-EXT   SMTP Service Extensions                            1869  10
+MAIL       Format of Electronic Mail Messages                  822  11
+NTPV2      Network Time Protocol (Version 2)                  1119  12
+DOMAIN     Domain Name System                            1034,1035  13
+DNS-MX     Mail Routing and the Domain System                  974  14
+SNMP       Simple Network Management Protocol                 1157  15
+SMI        Structure of Management Information                1155  16
+Concise-MIB Concise MIB Definitions                           1212  16
+MIB-II     Management Information Base-II                     1213  17
+NETBIOS    NetBIOS Service Protocols                     1001,1002  19
+ECHO       Echo Protocol                                       862  20
+DISCARD    Discard Protocol                                    863  21
+CHARGEN    Character Generator Protocol                        864  22
+QUOTE      Quote of the Day Protocol                           865  23
+USERS      Active Users Protocol                               866  24
+DAYTIME    Daytime Protocol                                    867  25
+TIME       Time Server Protocol                                868  26
+TOPT-BIN   Binary Transmission                                 856  27
+TOPT-ECHO  Echo                                                857  28
+TOPT-SUPP  Suppress Go Ahead                                   858  29
+TOPT-STAT  Status                                              859  30
+TOPT-TIM   Timing Mark                                         860  31
+TOPT-EXTOP Extended-Options-List                               861  32
+TFTP       Trivial File Transfer Protocol                     1350  33
+TP-TCP     ISO Transport Service on top of the TCP            1006  35
+ETHER-MIB  Ethernet MIB                                       1643  50
+PPP        Point-to-Point Protocol (PPP)                      1661  51
+PPP-HDLC   PPP in HDLC Framing                                1662  51
+IP-SMDS    IP Datagrams over the SMDS Service                 1209  52
+
+
+
+IETF                        Standards Track                     [Page 5]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+POP3       Post Office Protocol, Version 3                    1939  53
+OSPF2      Open Shortest Path First Routing V2                2328  54
+IP-FR      Multiprotocol over Frame Relay                     2427  55*
+RIP2       RIP Version 2-Carrying Additional Info.            2453  56*
+RIP2-APP   RIP Version 2 Protocol App. Statement              1722  57*
+SMIv2      Structure of Management Information v2             2578  58*
+CONV-MIB   Textual Conventions for SNMPv2                     2579  58*
+CONF-MIB   Conformance Statements for SNMPv2                  2580  58*
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+2.2.  Network-Specific Standard Protocols
+
+Protocol   Name                                            RFC   STD *
+========   =====================================          =====  === =
+IP-ATM     Classical IP and ARP over ATM                   2225
+ATM-ENCAP  Multiprotocol Encapsulation over ATM            1483
+IP-TR-MC   IP Multicast over Token-Ring LANs               1469
+IP-FDDI    Transmission of IP and ARP over FDDI Net        1390    36
+IP-X.25    X.25 and ISDN in the Packet Mode                1356
+ARP        Address Resolution Protocol                      826    37
+RARP       A Reverse Address Resolution Protocol            903    38
+IP-ARPA    Internet Protocol on ARPANET                 BBN1822    39
+IP-WB      Internet Protocol on Wideband Network            907    40
+IP-E       Internet Protocol on Ethernet Networks           894    41
+IP-EE      Internet Protocol on Exp. Ethernet Nets          895    42
+IP-IEEE    Internet Protocol on IEEE 802                   1042    43
+IP-DC      Internet Protocol on DC Networks                 891    44
+IP-HC      Internet Protocol on Hyperchannel               1044    45
+IP-ARC     Transmitting IP Traffic over ARCNET Nets        1201    46
+IP-SLIP    Transmission of IP over Serial Lines            1055    47
+IP-NETBIOS Transmission of IP over NETBIOS                 1088    48
+IP-IPX     Transmission of 802.2 over IPX Networks         1132    49
+IP-HIPPI   IP over HIPPI                                   2067
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+
+
+
+
+
+
+
+
+
+
+
+
+IETF                        Standards Track                     [Page 6]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+2.3.  Draft Standard Protocols
+
+Protocol   Name                                                     RFC
+========   =====================================                   =====
+VACM-SNMP  View-based Access Control Model for SMMP                2575*
+USM-SNMPV3 User-based Security Model for SNMPv3                    2574*
+SNMP-APP   SNMP Applications                                       2573*
+MPD-SNMP   Message Processing & Dispatching SNMP                   2572*
+ARCH-SNMP  Architecture Describing SNMP Management Frameworks      2571*
+ICMPv6     ICMPv6 for IPv6                                         2463*
+IPV6-AUTO  IPv6 Stateless Address Autoconfiguation                 2462*
+IPV6-ND    Neighbor Discovery for IP Version 6                     2461*
+IPV6       IPv6 Specification                                      2460*
+URI-GEN    URI: Generic Syntax                                     2396
+IARP       Inverse Address Resolution Protocol                     2390
+TN3270E    Telnet Option - TN3270 Enhancements                     2355*
+TFTP-Opt   TFTP Options                                            2349
+TFTP-Blk   TFTP Blocksize Option                                   2348
+TFTP-Ext   TFTP Option Extension                                   2347
+ONE-PASS   One-Time Password System                                2289
+SMTP-Pipe  SMTP Serv. Ext. for Command Pipelining                  2197
+DHCP-BOOTP DHCP Options and BOOTP Extensions                       2132
+DHCP       Dynamic Host Configuration Protocol                     2131
+FRAME-MIB  Management Information Base for Frame                   2115
+-------    Clarifications and Extensions BOOTP                     1542
+DHCP-BOOTP Interoperation Between DHCP and BOOTP                   1534
+BOOTP      Bootstrap Protocol                                  951,2132
+MIME-CONF  MIME Conformance Criteria                               2049
+MIME-MSG   MIME Msg Header Ext for Non-ASCII                       2047
+MIME-MEDIA MIME Media Types                                        2046
+MIME       Multipurpose Internet Mail Extensions                   2045
+PPP-CHAP   PPP Challenge Handshake Authentication                  1994
+PPP-MP     PPP Multilink Protocol                                  1990
+PPP-LINK   PPP Link Quality Monitoring                             1989
+COEX-MIB   Coexistence between SNMPV1 & SNMPV2                     1908
+SNMPv2-MIB MIB for SNMPv2                                          1907
+TRANS-MIB  Transport Mappings for SNMPv2                           1906
+OPS-MIB    Protocol Operations for SNMPv2                          1905
+CON-MD5    Content-MD5 Header Field                                1864
+OSPF-MIB   OSPF Version 2 MIB                                      1850
+STR-REP    String Representation ...                               1779
+X.500syn   X.500 String Representation ...                         1778
+X.500lite  X.500 Lightweight ...                                   1777
+BGP-4-APP  Application of BGP-4                                    1772
+BGP-4      Border Gateway Protocol 4                               1771
+PPP-DNCP   PPP DECnet Phase IV Control Protocol                    1762
+RMON-MIB   Remote Network Monitoring MIB                           1757
+802.5-MIB  IEEE 802.5 Token Ring MIB                               1748
+
+
+
+IETF                        Standards Track                     [Page 7]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+RIP2-MIB   RIP Version 2 MIB Extension                             1724
+SIP-MIB    SIP Interface Type MIB                                  1694
+-------    Def Man Objs Parallel-printer-like                      1660
+-------    Def Man Objs RS-232-like                                1659
+-------    Def Man Objs Character Stream                           1658
+BGP-4-MIB  BGP-4 MIB                                               1657
+SMTP-8BIT  SMTP Service Ext or 8bit-MIMEtransport                  1652
+OSI-NSAP   Guidelines for OSI NSAP Allocation                      1629
+ISO-TS-ECHO Echo for ISO-8473                                      1575
+DECNET-MIB DECNET MIB                                              1559
+BRIDGE-MIB BRIDGE-MIB                                              1493
+NTPV3      Network Time Protocol (Version 3)                       1305
+FINGER     Finger Protocol                                         1288
+IP-MTU     Path MTU Discovery                                      1191
+TOPT-LINE  Linemode                                                1184
+NICNAME    WhoIs Protocol                                           954
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+IETF                        Standards Track                     [Page 8]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+2.4.  Proposed Standard Protocols
+
+Protocol   Name                                                     RFC
+========   =====================================                   =====
+--------   PKIX Operational Protocols: FTP and HTTP                2585*
+--------   APPN/HPR in IP Networks MIB                             2584*
+TCP-CC     TCP Congestion Control                                  2581*
+APP-MIB    Application Management MIB                              2564*
+--------   DHCP Auto-Configuration Option                          2563*
+--------   TN3270E-RT-MIB                                          2562*
+--------   TN3270E Using SMIv2 MIB                                 2561*
+--------   Internet X.509 Public Key Infra. Op. Proto. LDAPv2      2559*
+--------   SONET/SDH Interface Type MIB                            2558*
+MHTML      MIME Encap. of Aggregate Documents, such as HTML        2557*
+--------   SMTP Service Extension for Authentication               2554*
+--------   Use of BGP-4 Multipro. Ext. for IPv6 IDR                2545*
+SIP        Session Initiation Protocol                             2543*
+DHK-DNS    Storage of Diffie-Hellman Keys in DNS                   2539*
+SC-DNS     Storing Certificates in the DNS                         2538*
+--------   RSA/MD5 KEYs and SIGs in the DNS                        2537*
+--------   DSA KEYs and SIGs in the DNS                            2536*
+DNS-SECEXT Domain Name System Security Extensions                  2535*
+--------   Media Features for Display, Print, Fax                  2534*
+--------   Transmission of IPv6 Packets over IPv4                  2529*
+--------   Reserved IPv6 Subnet Anycast Addresses                  2526*
+WEBDAV     HTTP Ext. for Distributed Authoring                     2518*
+ATM-MIBMAN MIB for ATM Management                                  2515*
+ATM-TC-OID ATM Textual Conventions and OIDs                        2514*
+--------   Connection-Oriented Accounting MIB                      2513*
+--------   Accounting Information for ATM Networks                 2512*
+X.509-CRMF Internet X.509 CRMF                                     2511*
+PKICMP     Internet X.509 PKI CMP                                  2510*
+IPCOM-PPP  IP Header Compression over PPP                          2509*
+--------   Compressing IP/UDP/RTP Headers                          2508*
+--------   IP Header Compression                                   2507*
+--------   IPv6 Datagrams on ARCnet                                2497*
+DS3-E3-MIB DS3/E3 Interface Type MIB                               2496*
+--------   DS1/E1/DS2/E2 MIB                                       2495*
+--------   DSO MIB / DSOBUNDLE MIB                                 2494*
+--------   15 Minute Based Performance History TCs                 2493*
+IPv6ATMNET IPv6 over ATM Networks                                  2492*
+IPv6-NBMA  IPv6 over Non-Broadcast Multiple Access                 2491*
+--------   SMTP Serv. Ext. for Secure SMTP over TLS                2487*
+NAI        Network Access Identifier                               2486*
+--------   DCHP Option for the Open Group's UAP                    2485*
+--------   PPP LCP Internationalization Option                     2484*
+--------   Gateways and MIME Security Multiparts                   2480*
+--------   GSS-API Negotiation Mechanism                           2478*
+
+
+
+IETF                        Standards Track                     [Page 9]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+--------   Message Submission                                      2476*
+DIFFSRV    Architecture for Differentiated Service                 2475*
+--------   Differentiated Services Field                           2474*
+--------   Generic Packet Tunneling in IPv6                        2473*
+IPv6-PPP   IP Version 6 over PPP                                   2472*
+--------   IPv6 Packets over Token Ring Networks                   2470*
+--------   IPv6 Packets over FDDI Networks                         2467*
+ICMPv6-MIB ICMPv6 Group MIB                                        2466*
+--------   Textual Conventions, General Group MIB                  2465*
+--------   IPv6 Packets over Ethernet Networks                     2464*
+--------   Internet X.509 Public Key Infrastructure                2459*
+EBN-MIB    Extended Border Node MIB                                2457*
+--------   APPN TRAPS MIB                                          2456*
+APPN-MIB   APPN MIB                                                2455*
+--------   UDP MIB for IPv6                                        2454*
+--------   TCP MIB for IPv6                                        2452*
+--------   ESP CBC-Mode Cipher Algorithms                          2451*
+POP3-EXT   POP3 Extension Mechanism                                2449*
+IMIP       iCalendar Message-Based Interoperability                2447*
+ITIP       iCalendar Message-Based Interoperability                2446*
+ICALENDAR  Internet Calendaring, Scheduling Core..                 2445*
+OTP-SASL   OTP SASL Mechanism                                      2444*
+--------   OpenPGP Message Format                                  2440*
+--------   BGP Route Flap Damping                                  2439*
+--------   RTP Payload Format for JPEG-compressed Video            2435*
+--------   RTP Payload Format for BT.656 Video Encoding            2431*
+--------   RTP Payload Format for H.263+                           2429*
+--------   FTP Extensions for IPv6 and NATs                        2428
+MIME-VCARD vCard MIME Directory Profile                            2426
+TXT-DIR    MIME Content-Type for Directory Info                    2425
+CONT-DUR   Content-Duration MIME Header                            2424
+MIME-VPIM  VPIM Voice Message                                      2423
+MIME-ADPCM Toll Quality Voice - 32 kbit/s ADPC                     2422
+MIME-VP2   Voice Profile for Internet Mail V2                      2421
+--------   Multicast/UNI 3.0/3.1 based ATM MIB                     2417
+--------   NULL Encryption Algorithm and Its Use With IPsec        2410*
+IKE        The Internet Key Exchange                               2409*
+ISAKMP     Internet Security Association and Key Management Pro.   2408*
+ISAKMPSEC  IP Security Domain of Interpretation for ISAKMP         2407*
+ESP        IP Encapsulating Security Payload                       2406*
+ESPDES-CBC ESP DES-CBC Cipher Algorithm With Explicit IV           2405*
+--------   Use of HMAC-SHA-1-96 within ESP and AH                  2404*
+--------   Use of HMAC-MD5-96 within ESP and AH                    2403*
+IP-AUTH    IP Authentication Header                                2402*
+IPSEC      Security Architecture for the Internet Protocol         2401*
+DATA-URL   "data" URL scheme                                       2397
+CIDMID-URL Content-ID and Message-ID URLs                          2392
+IPCOMP     IP Payload Compression Protocol                         2393*
+
+
+
+IETF                        Standards Track                    [Page 10]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+FTP-FNEGO  Feature negotiation mechanism for FTP                   2389
+--------   MIME Multipart/form-data                                2388
+MIME-RELAT MIME Multipart/Related Content-type                     2387
+--------   Protection of BGP Sessions via TCP MD5                  2385
+POP-URL    POP URL Scheme                                          2384
+--------   Interoperation of CLS and GS with ATM                   2381
+--------   RSVP over ATM Imple. Requirements                       2380
+--------   IPv6 Aggreg. Global Unicast Addr. Format                2374
+--------   IPv6 Addressing Architecture                            2373
+TIPV3      Transaction Internet Protocol V3                        2371
+OSPF-LSA   OSPF Opaque LSA Option                                  2370
+--------   Use of URLs as Meta-Syntax...                           2369
+URLMAILTO  mailto URL scheme                                       2368
+PPP-AAL    PPP Over AAL                                            2364
+PPP-FUNI   PPP Over FUNI                                           2363
+IMAP4UIDPL IMAP4 UIDPLUS Extension                                 2359
+--------   Ethernet-like Interface Types MIB                       2358
+MOBILIPREV Reverse Tunneling for Mobile IP                         2344
+IMAP4NAME  IMAP4 Namespace                                         2342
+VRRP       Virtual Router Redundancy Protocol                      2338
+NHRP-SCSP  Distributed NHRP Service Using SCSP                     2335
+SCSP       Server Cache Synchronization Protocol                   2334
+NHRP       NBMA Next Hop Resolution Protocol                       2332
+UNI-SIG    ATM Sig Support (IPOA) UNI Signalling                   2331
+SDP        Session Description Protocol                            2327
+RTSP       Real Time Streaming Protocol                            2326
+IPOA-MIB   Classical IP and ARP Over ATM MIB                       2320
+DNS-NCACHE Negative Caching of DNS Queries                         2308
+SMFAX-IM   Simple Mode of FAX Using Internet Mail                  2305
+MINFAX-IM  Minimal FAX addr format in Internet Mail                2304
+MIN-PSTN   Min. PSTN addr format in Internet Mail                  2303
+TIFF       Tag Image File Format                                   2302
+FFIF       File Format for Internet Fax                            2301
+EMF-MDN    Extensible Message Format for MDN                       2298
+OR-ADD     O/R Address hierarchy in X.500                          2294
+SUBTABLE   Tables and Subtrees in X.500                            2293
+--------   Mobile-IPv4 Config Opt for PPP IPCP                     2290
+SLM-APP    System-Level Managed Objects for Apps                   2287
+PPP-EAP    PPP Extensible Authentication Protocol                  2284
+MEXT-BGP4  Multiprotocol Extensions for BGP-4                      2283
+RPSL       Routing Policy Specification Language                   2280
+UTF-8      UTF-8 transformation format of ISO 10646                2279
+--------   IEEE 802.12 Repeater MIB                                2266
+AGENTX     Agent Extensibility Protocol                            2257
+--------   Summary of the X.500(96) with LDAPv3                    2256
+LDAP-URL   LDAP URL Format                                         2255
+STR-LDAP   String Rep of LDAP Search Filters                       2254
+LDAP3-UTF8 LDAPv3: UTF-8 String Rep                                2253
+
+
+
+IETF                        Standards Track                    [Page 11]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+LDAP3-ATD  LDAP3-: Attribute Syntax Definitions                    2252
+LDAPV3     Lightweight Directory Access Protocol                   2251
+RTP-MPEG   RTP Payload Format for MPEG1/MPEG2                      2250
+MAIL-MIB   Mail Monitoring MIB                                     2249
+NSM-MIB    Network Services Monitoring MIB                         2248
+--------   Using Domains LDAP/X.500 Dist. Names                    2247
+SASL-ANON  Anonymous SASL Mechanism                                2245
+ACAP       Application Configuration Access                        2244
+OTP-ER     OTP Extended Responses                                  2243
+NETWAREIP  NetWare/IP Domain Name and Information                  2242
+DHCP-NDS   DHCP Options for Novell Directory Serv.                 2241
+MAUS-MIB   IEEE 802.3 Medium Attachment Units MIB                  2239
+HPR-MIB    Definitions of Managed Objects for HPR                  2238
+IGMP       Internet Group Management Protocol V2                   2236
+ABNF       Augmented BNF for Syntax Specifications                 2234
+INTERGRMIB Interfaces Group MIB                                    2233
+DLUR-MIB   Definitions of Managed Objects for DLUR                 2232
+MIME-EXT   MIME Parameter Value & Encoded Word Ext                 2231
+FTPSECEXT  FTP Security Extensions                                 2228
+---------  Simple Hit-Metering, Usage-Limiting HTTP                2227
+---------  IP Broadcast over ATM Networks                          2226
+SASL       Simple Authentication and Security Layer                2222
+IMAP4LOGIN IMAP4 Login Referrals                                   2221
+---------  Schema for Internet White Pages Service                 2218
+---------  Characterization Parameters for ISNE                    2215
+---------  Integrated Services MIB Guar Serv Ext                   2214
+---------  Integrated Services MIB using SMIv2                     2213
+GQOS       Spec. of Guaranteed Quality of Service                  2212
+---------  Spec. of Controlled-Load Net Ele Serv                   2211
+RSVP-IS    Use of RSVP with IETF Integrated Serv                   2210
+RSVP-MPR   RSVP Messaging Processing Rules                         2209
+RSVP-IPSEC RSVP Extensions for IPSEC Data Flows                    2207
+RSVP-MIB   RSVP Management Information Base                        2206
+RSVP       Resource ReSerVation Protocol V1                        2205
+RPCSEC-GSS RPCSEC_GSS Protocol Specification                       2203
+RTP-RAD    RTP Payload for Redundant Audio Data                    2198
+IMAPPOPAU  IMAP/POP AUTHorize Extension                            2195
+IMAP4MAIL  IMAP4 Mailbox Referrals                                 2193
+IMAP-URL   IMAP URL Scheme                                         2192
+---------  RTP Payload Format for H.263 Video ST                   2190
+---------  The Content-Disposition Header Field                    2183
+DNS-CLAR   Clarifications to the DNS Specification                 2181
+IMAP4-IDLE IMAP4 IDLE command                                      2177
+SLP        Service Location Protocol                               2165
+---------  X.500/LDAP Directory/MIXER Address Map.                 2164
+DNS-MCGAM  Using DNS to Distribute MCGAM                           2163
+---------  Carrying PostScript in X.400 and MIME                   2160
+---------  A MIME Body Part for FAX                                2159
+
+
+
+IETF                        Standards Track                    [Page 12]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+---------  X.400 Image Body Parts                                  2158
+---------  Mapping between X.400 and RFC-822/MIME                  2157
+MIXER      Mime Internet X.400 Enhanced Relay                      2156
+APPN-MIB   Definitions of Managed Objects for APPN                 2155
+IPv6-Jumbo TCP and UDP over IPv6 Jumbograms                        2147
+MAIL-SERV  Mailbox Names for Common Services                       2142
+URN-SYNTAX URN Syntax                                              2141
+RADIUS     Remote Authentication Dial In Service                   2138
+SDNSDU     Secure Domain Name System Dynamic Update                2137
+DNS-UPDATE Dynamic Updates in the DNS                              2136
+DC-MIB     Dial Control MIB using SMIv2                            2128
+ISDN-MIB   ISDN MIB using SMIv2                                    2127
+ITOT       ISO Transport Service on top of TCP                     2126
+BAP-BACP   PPP-BAP, PPP-BACP                                       2125
+VEMMI-URL  VEMMI URL Specification                                 2122
+ROUT-ALERT IP Router Alert Option                                  2113
+MHTML      MIME E-mail Encapsulation                               2110
+HTTP-STATE HTTP State Management Mechanism                         2109
+802.3-MIB  802.3 Repeater MIB using SMIv2                          2108
+PPP-NBFCP  PPP NetBIOS Frames Control Protocol                     2097
+TABLE-MIB  IP Forwarding Table MIB                                 2096
+RIP-TRIG   Trigger RIP                                             2091
+IMAP4-LIT  IMAP4 non-synchronizing literals                        2088
+IMAP4-QUO  IMAP4 QUOTA extension                                   2087
+IMAP4-ACL  IMAP4 ACL Extension                                     2086
+HMAC-MD5   HMAC-MD5 IP Auth. with Replay Prevention                2085
+RIP2-MD5   RIP-2 MD5 Authentication                                2082
+RIPNG-IPV6 RIPng for IPv6                                          2080
+URI-ATT    URI Attribute Type and Object Class                     2079
+GSSAP      Generic Security Service Application                    2078
+MIME-MODEL Model Primary MIME Types                                2077
+RMON-MIB   Remote Network Monitoring MIB                           2074
+HTML-INT   HTML Internationalization                               2070
+DAA        Digest Access Authentication                            2069
+HTTP-1.1   Hypertext Transfer Protocol -- HTTP/1.1                 2068
+DNS-SEC    Domain Name System Security Extensions                  2065
+IMAPV4     Internet Message Access Protocol v4rev1                 2060
+URLZ39.50  Uniform Resource Locators for Z39.50                    2056
+SNANAU-APP SNANAU APPC MIB using SMIv2                             2051
+PPP-SNACP  PPP SNA Control Protocol                                2043
+ENTITY-MIB Entity MIB using SMIv2                                  2037
+RTP-JPEG   RTP Payload Format for JPEG-compressed                  2035
+SMTP-ENH   SMTP Enhanced Error Codes                               2034
+RTP-H.261  RTP Payload Format for H.261                            2032
+RTP-CELLB  RTP Payload Format of Sun's CellB                       2029
+SPKM       Simple Public-Key GSS-API Mechanism                     2025
+DLSW-MIB   DLSw MIB using SMIv2                                    2024
+IPV6-PPP   IP Version 6 over PPP                                   2023
+
+
+
+IETF                        Standards Track                    [Page 13]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+MULTI-UNI  Multicast over UNI 3.0/3.1 based ATM                    2022
+RMON-MIB   RMON MIB using SMIv2                                    2021
+802.12-MIB IEEE 802.12 Interface MIB                               2020
+IPV6-FDDI  Transmission of IPv6 Packets Over FDDI                  2019
+TCP-ACK    TCP Selective Acknowledgement Options                   2018
+URL-ACC    URL Access-Type                                         2017
+MIME-PGP   MIME Security with PGP                                  2015
+MIB-UDP    SNMPv2 MIB for UDP                                      2013
+MIB-TCP    SNMPv2 MIB for TCP                                      2012
+MIB-IP     SNMPv2 MIB for IP                                       2011
+MOBILEIPMIBMobile IP MIB Definition using SMIv2                    2006
+MINI-IP    Minimal Encapsulation within IP                         2004
+IPENCAPIP  IP Encapsulation within IP                              2003
+MOBILEIPSUPIP Mobility Support                                     2002
+TCPSLOWSRT TCP Slow Start, Congestion Avoidance...                 2001
+BGP-COMM   BGP Communities Attribute                               1997
+DNS-NOTIFY Mech. for Notification of Zone Changes                  1996
+DNS-IZT    Incremental Zone Transfer in DNS                        1995
+SMTP-ETRN  SMTP Service Extension ETRN                             1985
+SNA        Serial Number Arithmetic                                1982
+MTU-IPV6   Path MTU Discovery for IP version 6                     1981
+PPP-FRAME  PPP in Frame Relay                                      1973
+IPV6-ETHER Transmission IPv6 Packets Over Ethernet                 1972
+PPP-ECP    PPP Encryption Control Protocol                         1968
+GSSAPI-KER Kerberos Version 5 GSS-API Mechanism                    1964
+PPP-CCP    PPP Compression Control Protocol                        1962
+GSSAPI-SOC GSS-API Auth for SOCKS Version 5                        1961
+LDAP-STR   String Rep. of LDAP Search Filters                      1960
+LDAP-URL   LDAP URL Format                                         1959
+TRANS-IPV6 Transition Mechanisms IPv6 Hosts/Routers                1933
+AUTH-SOCKS Username Authentication for SOCKS V5                    1929
+SOCKSV5    SOCKS Protocol Version 5                                1928
+WHOIS++M   How to Interact with a Whois++ Mesh                     1914
+WHOIS++A   Architecture of Whois++ Index Service                   1913
+DSN        Delivery Status Notifications                           1894
+EMS-CODE   Enhanced Mail System Status Codes                       1893
+MIME-RPT   Multipart/Report                                        1892
+SMTP-DSN   SMTP Delivery Status Notifications                      1891
+RTP-AV     RTP Audio/Video Profile                                 1890
+RTP        Transport Protocol for Real-Time Apps                   1889
+DNS-IPV6   DNS Extensions to support IPv6                          1886
+HTML       Hypertext Markup Language - 2.0                         1866
+MIME-Sec   MIME Object Security Services                           1848
+MIME-Encyp MIME: Signed and Encrypted                              1847
+WHOIS++    Architecture of the WHOIS++ service                     1835
+--------   Binding Protocols for ONC RPC Version 2                 1833
+XDR        External Data Representation Standard                   1832
+RPC        Remote Procedure Call Protocol V. 2                     1831
+
+
+
+IETF                        Standards Track                    [Page 14]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+--------   ESP DES-CBC Transform                                   1829
+--------   IP Authentication using Keyed MD5                       1828
+ESP        IP Encapsulating Security Payload                       1827
+IPV6-AH    IP Authentication Header                                1826
+--------   Security Architecture for IP                            1825
+R          Requirements for IP Version 4 Routers                   1812
+URL        Relative Uniform Resource Locators                      1808
+CLDAP      Connection-less LDAP                                    1798
+OSPF-DC    Ext. OSPF to Support Demand Circuits                    1793
+OSI-Dir    OSI User Friendly Naming ...                            1781
+MIME-EDI   MIME Encapsulation of EDI Objects                       1767
+Lang-Tag   Tags for Identification of Languages                    1766
+XNSCP      PPP XNS IDP Control Protocol                            1764
+BVCP       PPP Banyan Vines Control Protocol                       1763
+Print-MIB  Printer MIB                                             1759
+ATM-SIG    ATM Signaling Support for IP over ATM                   1755
+IPNG       Recommendation for IP Next Generation                   1752
+802.5-SSR  802.5 SSR MIB using SMIv2                               1749
+SDLCSMIv2  SNADLC SDLC MIB using SMIv2                             1747
+BGP4/IDRP  BGP4/IDRP for IP/OSPF Interaction                       1745
+AT-MIB     Appletalk MIB                                           1742
+MacMIME    MIME Encapsulation of Macintosh files                   1740
+URL        Uniform Resource Locators                               1738
+POP3-AUTH  POP3 AUTHentication command                             1734
+IMAP4-AUTH IMAP4 Authentication Mechanisms                         1731
+RDBMS-MIB  RDMS MIB - using SMIv2                                  1697
+MODEM-MIB  Modem MIB - using SMIv2                                 1696
+ATM-MIB    ATM Management Version 8.0 using SMIv2                  1695
+TMUX       Transport Multiplexing Protocol                         1692
+SNANAU-MIB SNA NAUs MIB using SMIv2                                1666
+PPP-TRANS  PPP Reliable Transmission                               1663
+--------   Postmaster Convention X.400 Operations                  1648
+PPP-BCP    PPP Bridging Control Protocol                           1638
+UPS-MIB    UPS Management Information Base                         1628
+PPP-SONET  PPP over SONET/SDH                                      1619
+PPP-ISDN   PPP over ISDN                                           1618
+DNS-R-MIB  DNS Resolver MIB Extensions                             1612
+DNS-S-MIB  DNS Server MIB Extensions                               1611
+FR-MIB     Frame Relay Service MIB                                 1604
+PPP-X25    PPP in X.25                                             1598
+OSPF-NSSA  The OSPF NSSA Option                                    1587
+OSPF-Multi Multicast Extensions to OSPF                            1584
+SONET-MIB  MIB SONET/SDH Interface Type                            1595
+RIP-DC     Extensions to RIP to Support Demand Cir.                1582
+--------   Evolution of the Interfaces Group of MIB-II Elective    1573
+TOPT-ENVIR Telnet Environment Option                               1572
+PPP-LCP    PPP LCP Extensions                                      1570
+X500-MIB   X.500 Directory Monitoring MIB                          1567
+
+
+
+IETF                        Standards Track                    [Page 15]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+CIPX       Compressing IPX Headers Over WAM Media                  1553
+IPXCP      PPP Internetworking Packet Exchange Control Elective    1552
+SRB-MIB    Source Routing Bridge MIB                               1525
+CIDR-STRA  CIDR Address Assignment...                              1519
+CIDR-ARCH  CIDR Architecture...                                    1518
+--------   802.3 MAU MIB                                           1515
+HOST-MIB   Host Resources MIB                                      1514
+--------   Token Ring Extensions to RMON MIB                       1513
+FDDI-MIB   FDDI Management Information Base                        1512
+KERBEROS   Kerberos Network Authentication Ser (V5)                1510
+GSSAPI     Generic Security Service API: C-bindings                1509
+DASS       Distributed Authentication Security...                  1507
+--------   X.400 Use of Extended Character Sets                    1502
+HARPOON    Rules for Downgrading Messages...                       1496
+Equiv      X.400/MIME Body Equivalences                            1494
+IDPR       Inter-Domain Policy Routing Protocol                    1479
+IDPR-ARCH  Architecture for IDPR                                   1478
+PPP/Bridge MIB Bridge PPP MIB                                      1474
+PPP/IP MIB  IP Network Control Protocol of PPP MIB                 1473
+PPP/SEC MIB Security Protocols of PPP MIB                          1472
+PPP/LCP MIB Link Control Protocol of PPP MIB                       1471
+X25-MIB    Multiprotocol Interconnect on X.25 MIB                  1461
+SNMPv2     Introduction to SNMPv2                                  1441
+PEM-KEY    PEM - Key Certification                                 1424
+PEM-ALG    PEM - Algorithms, Modes, and Identifiers                1423
+PEM-CKM    PEM - Certificate-Based Key Management                  1422
+PEM-ENC    PEM - Message Encryption and Auth                       1421
+SNMP-IPX   SNMP over IPX                                           1420
+SNMP-AT    SNMP over AppleTalk                                     1419
+SNMP-OSI   SNMP over OSI                                           1418
+FTP-FTAM   FTP-FTAM Gateway Specification                          1415
+IDENT-MIB  Identification MIB                                      1414
+IDENT      Identification Protocol                                 1413
+DS3/E3-MIB DS3/E3 Interface Type                                   1407
+DS1/E1-MIB DS1/E1 Interface Type                                   1406
+BGP-OSPF   BGP OSPF Interaction                                    1403
+--------   Route Advertisement In BGP2 And BGP3                    1397
+SNMP-X.25  SNMP MIB Extension for X.25 Packet Layer                1382
+SNMP-LAPB  SNMP MIB Extension for X.25 LAPB                        1381
+PPP-ATCP   PPP AppleTalk Control Protocol                          1378
+PPP-OSINLCP PPP OSI Network Layer Control Protocol                 1377
+TOPT-RFC   Remote Flow Control                                     1372
+SNMP-PARTY-MIB Administration of SNMP                              1353
+SNMP-SEC   SNMP Security Protocols                                 1352
+SNMP-ADMIN SNMP Administrative Model                               1351
+TOS        Type of Service in the Internet                         1349
+PPP-IPCP   PPP Control Protocol                                    1332
+-------    X.400 1988 to 1984 downgrading                          1328
+
+
+
+IETF                        Standards Track                    [Page 16]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+TCP-EXT    TCP Extensions for High Performance                     1323
+NETFAX     File Format for the Exchange of Images                  1314
+FDDI-MIB   FDDI-MIB                                                1285
+-------    Encoding Network Addresses                              1277
+-------    Replication and Distributed Operations                  1276
+-------    COSINE and Internet X.500 Schema                        1274
+BGP-MIB    Border Gateway Protocol MIB (Version 3)                 1269
+ICMP-ROUT  ICMP Router Discovery Messages                          1256
+OSI-UDP    OSI TS on UDP                                           1240
+STD-MIBs   Reassignment of Exp MIBs to Std MIBs                    1239
+IPX-IP     Tunneling IPX Traffic through IP Nets                   1234
+IS-IS      OSI IS-IS for TCP/IP Dual Environments                  1195
+IP-CMPRS   Compressing TCP/IP Headers                              1144
+TOPT-XDL   X Display Location                                      1096
+TOPT-TERM  Terminal Type                                           1091
+TOPT-TS    Terminal Speed                                          1079
+TOPT-NAWS  Negotiate About Window Size                             1073
+TOPT-X.3   X.3 PAD                                                 1053
+TOPT-DATA  Data Entry Terminal                                     1043
+TOPT-3270  Telnet 3270 Regime                                      1041
+NNTP       Network News Transfer Protocol                           977
+TOPT-TLN   Terminal Location Number                                 946
+TOPT-OM    Output Marking                                           933
+TOPT-TACACS  TACACS User Identification                             927
+TOPT-EOR   End of Record                                            885
+TOPT-SNDL  Send Location                                            779
+TOPT-SUPO  SUPDUP Output                                            749
+TOPT-SUP   SUPDUP                                                   736
+TOPT-BYTE  Byte Macro                                               735
+TOPT-REM   Remote Controlled Trans and Echo                         726
+TOPT-LOGO  Logout                                                   727
+TOPT-EXT   Extended ASCII                                           698
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+IETF                        Standards Track                    [Page 17]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+2.5.  Experimental Protocols
+
+Protocol   Name                                                     RFC
+========   =====================================                   =====
+-------    NewReno Modification to TCP's Fast Recovery Algorithm   2582*
+-------    Mapping between LPD and IPP Protocols                   2569*
+IPP-RAT    Rationale for the Structure of IPP                      2568*
+IPP-DG     Design Goals for an Internet Printing Protocol          2567*
+IPP-M-S    Internet Printing Protocol/1.0: Model and Semantics     2566*
+IPP-E-T    Internet Printing Protocol/1.0: Encoding and Transport  2565*
+DNS-INFO   Detached Domain Name System (DNS) Information           2540*
+PHOTURIS-E Photuris: Extended Schemes and Attributes               2523*
+PHOTURIS-S Photuris: Session-Key Management Protocol               2522*
+ICMP-SEC   ICMP Security Failures Messages                         2521*
+NHRP-MNHCS NHRP with Mobile NHCs                                   2520*
+IPPM-MET   IPPM Metrics for Measuring Connectivity                 2498*
+-------    URI Resolution Services                                 2483*
+ECN-IP     Explicit Congestion Notification (ECN) to IP            2481*
+-------    IPv6 Testing Address Allocation                         2471*
+TCP-WIN    Increasing TCP's Initial Window                         2414
+PIM-SM     Protocol Independent Multicast-Sparse Mode              2362
+-------    Domain Names and Company Name Retrieva                  2345
+RTP-MPEG   RTP Payload Format for Bundled MPEG                     2343
+-------    Intra-LIS IP Multicast/Routers over ATM using PIM       2337
+-------    Safe Response Header Field                              2310
+LDAP-NIS   Approach Using LDAP as a Network Information Service    2307
+HTTP-RVSA  HTTP Remote Variant Selection Algorithm                 2296
+TCN-HTTP   Transparent Content Negotiation in HTTP                 2295
+TOPT-COMPORT Telnet Com Port Control                               2217
+-------    Core Based Trees (CBT) Multicast Routing Architecture   2201
+-------    Core Based Trees (CBT version 2) Multicast Routing      2189
+-------    Trivial Convention using HTTP in URN Resolution         2169
+-------    Resolution of URIs using DNS                            2168
+MAP-MAIL   X.400 Mapping and Mail-11                               2162
+MIME-ODA   A MIME Body Part for ODA                                2161
+OSPF-DIG   OSPF with Digital Signature                             2154
+GKMP-ARCH  Group Key Management Protocol (GKMP) Architecture       2094
+GKMP-SPEC  Group Key Management Protocol (GKMP) Specification      2093
+TOPT-CHARSET Telnet CHARSET                                        2066
+IP-SCSI    Encapsulating IP with the SCSI                          2143
+X.500-NAME Managing the X.500 Root Naming Context                  2120
+TFTP-MULTI TFTP Multicast Option                                   2090
+IP-Echo    IP Echo Host Service                                    2075
+METER-MIB  Traffic Flow Measurement Meter MIB                      2064
+TFM-ARCH   Traffic Flow Measurement Architecture                   2063
+DNS-SRV    Location of Services in the DNS                         2052
+URAS       Uniform Resource Agents                                 2016
+GPS-AR     GPS-Based Addressing and Routing                        2009
+
+
+
+IETF                        Standards Track                    [Page 18]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+ETFTP      Enhanced Trivial File Transfer Protocol                 1986
+BGP-RR     BGP Route Reflection                                    1966
+BGP-ASC    Autonomous System Confederations for BGP                1965
+SMKD       Scalable Multicast Key Distribution                     1949
+HTML-TBL   HTML Tables                                             1942
+SNMPV2SM   User-based Security Model for SNMPv2                    1910
+SNMPV2AI   SNMPv2 Administrative Infrastructure                    1909
+SNMPV2CB   Introduction to Community-based SNMPv2                  1901
+-------    IPv6 Testing Address Allocation                         1897
+DNS-LOC    Location Information in the DNS                         1876
+SGML-MT    SGML Media Types                                        1874
+CONT-MT    Access Type Content-ID                                  1873
+UNARP      ARP Extension - UNARP                                   1868
+-------    Form-based File Upload in HTML                          1867
+-------    BGP/IDRP Route Server Alternative                       1863
+-------    IP Authentication using Keyed SHA                       1852
+ESP3DES    ESP Triple DES Transform                                1851
+-------    SMTP 521 Reply Code                                     1846
+-------    SMTP Serv. Ext. for Checkpoint/Restart                  1845
+-------    SMTP Serv. Ext. Large and Binary MIME Msgs.             1830
+ST2        Stream Protocol Version 2                               1819
+-------    Content-Disposition Header                              1806
+-------    Schema Publishing in X.500 Directory                    1804
+-------    X.400-MHS use X.500 to support X.400-MHS Routing        1801
+-------    Class A Subnet Experiment                               1797
+TCP/IPXMIB TCP/IPX Connection Mib Specification                    1792
+-------    TCP And UDP Over IPX Networks With Fixed Path MTU       1791
+ICMP-DM    ICMP Domain Name Messages                               1788
+CLNP-MULT  Host Group Extensions for CLNP Multicasting             1768
+OSPF-OVFL  OSPF Database Overflow                                  1765
+RWP        Remote Write ProtocolL - Version 1.0                    1756
+NARP       NBMA Address Resolution Protocol                        1735
+DNS-ENCODE DNS Encoding of Geographical Location                   1712
+TCP-POS    An Extension to TCP: Partial Order Service              1693
+T/TCP      TCP Extensions for Transactions                         1644
+MIME-UNI   Using Unicode with MIME                                 1641
+FOOBAR     FTP Operation Over Big Address Records                  1639
+X500-CHART Charting Networks in the X.500 Directory                1609
+X500-DIR   Representing IP Information in the X.500 Directory      1608
+SNMP-DPI   SNMP Distributed Protocol Interface                     1592
+CLNP-TUBA  Use of ISO CLNP in TUBA Environments                    1561
+REM-PRINT  TPC.INT Subdomain Remote Printing - Technical           1528
+EHF-MAIL   Encoding Header Field for Internet Messages             1505
+RAP        Internet Route Access Protocol                          1476
+TP/IX      TP/IX: The Next Internet                                1475
+X400       Routing Coordination for X.400 Services                 1465
+DNS        Storing Arbitrary Attributes in DNS                     1464
+IRCP       Internet Relay Chat Protocol                            1459
+
+
+
+IETF                        Standards Track                    [Page 19]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+TOS-LS     Link Security TOS                                       1455
+SIFT/UFT   Sender-Initiated/Unsolicited File Transfer              1440
+DIR-ARP    Directed ARP                                            1433
+TOPT-AUTH  Telnet Authentication Option                            1416
+TEL-SPX    Telnet Authentication: SPX                              1412
+TEL-KER    Telnet Authentication: Kerberos V4                      1411
+TRACE-IP   Traceroute Using an IP Option                           1393
+DNS-IP     Experiment in DNS Based IP Routing                      1383
+RMCP       Remote Mail Checking Protocol                           1339
+TCP-HIPER  TCP Extensions for High Performance                     1323
+MSP2       Message Send Protocol 2                                 1312
+DSLCP      Dynamically Switched Link Control                       1307
+--------   X.500 and Domains                                       1279
+IN-ENCAP   Internet Encapsulation Protocol                         1241
+CLNS-MIB   CLNS-MIB                                                1238
+CFDP       Coherent File Distribution Protocol                     1235
+IP-AX.25   IP Encapsulation of AX.25 Frames                        1226
+ALERTS     Managing Asynchronously Generated Alerts                1224
+MPP        Message Posting Protocol                                1204
+SNMP-BULK  Bulk Table Retrieval with the SNMP                      1187
+DNS-RR     New DNS RR Definitions                                  1183
+IMAP2      Interactive Mail Access Protocol                        1176
+NTP-OSI    NTP over OSI Remote Operations                          1165
+DMF-MAIL   Digest Message Format for Mail                          1153
+RDP        Reliable Data Protocol                              908,1151
+TCP-ACO    TCP Alternate Checksum Option                           1146
+IP-DVMRP   IP Distance Vector Multicast Routing                    1075
+VMTP       Versatile Message Transaction Protocol                  1045
+COOKIE-JAR Authentication Scheme                                   1004
+NETBLT     Bulk Data Transfer Protocol                              998
+IRTP       Internet Reliable Transaction Protocol                   938
+LDP        Loader Debugger Protocol                                 909
+RLP        Resource Location Protocol                               887
+NVP-II     Network Voice Protocol                              ISI-memo
+PVP        Packet Video Protocol                               ISI-memo
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+
+
+
+
+
+
+
+
+
+
+
+
+IETF                        Standards Track                    [Page 20]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+3. Current Applicability Statements
+
+   RFC1122 - Requirements for Internet hosts - communication layers
+             (STD 3)
+   RFC1123 - Requirements for Internet hosts - application and support
+             (STD 3)
+   RFC1370 - Applicability Statement for OSPF
+   RFC1517 - Applicability Statement for the Implementation of Classless
+             Inter-Domain Routing (CIDR)
+   RFC1722 - RIP Version 2 Protocol Applicability Statement
+   RFC1923 - RIPv1 Applicability Statement for Historic Status
+   RFC2005 - Applicability Statement for IP Mobility Support
+   RFC2039 - Applicability of Standards Track MIBs to Management of
+             World Wide Web Servers
+   RFC2081 - RIPng Protocol Applicability Statement
+   RFC2208 - Resource ReSerVation Protocol (RSVP) -- Version 1
+             Applicability Statement - Some Guidelines on Deployment
+   RFC2333 - NHRP Protocol Applicability Statement
+   RFC2556 - OSI connectionless transport services on top of UDP
+             Applicability Statement for Historic Status
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+IETF                        Standards Track                    [Page 21]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+4.  Non-Standard Protocols
+
+4.1.  Informational Protocols
+
+Please note that there are informational RFCs that do not specify
+protocols and are not listed here.
+
+Protocol   Name                                                     RFC
+=======    ====================================                    =====
+AUDIO/L16  Audio/L16 MIME content type                             2586*
+FTP-SEC    FTP Security Considerations                             2577*
+--------   6Bone Routing Practice                                  2546*
+DNS-SOC    DNS Security Operational Considerations                 2541*
+--------   Internet X.509 Public Key Infrastructure KEA            2528*
+--------   Internet X.509 Public Key Infrastructure CP & CPF       2527*
+--------   Known TCP Implementation Problems                       2525*
+EMSD       Neda's Efficient Mail Submission and Delivery Protocol  2524*
+IDRA       Framework for Inter-Domain Route Aggregation            2519*
+PPPOE      Method for Transmitting PPP Over Ethernet               2516*
+--------   MIME Types for Use with the ISO ILL Protocol            2503*
+MANET      Mobile Ad hoc Networking Performance Issues             2501*
+--------   ST2+ over ATM Protocol Spec - UNI 3.1 Version           2383
+--------   Mapping Airline Reservation, Ticketing, Messaging       2351
+KOI8-U     Ukrainian Character Set KOI8-U                          2319
+TEXT-CSS   The text/css Media Type                                 2318
+PKCS-7     PKCS #7: Cryptographic Message Syntax Version 1.5       2315
+PKCS-10    PKCS #10: Certification Request Syntax Version 1.5      2314
+PKCS-1     PKCS #1: RSA Encryption Version 1.5                     2313
+SMIME-CERT S/MIME Version 2 Certificate Handling                   2312
+SMIME-MSG  S/MIME Version 2 Message Specification                  2311
+TIFF       Tag Image File Format F Profile for Facsimile           2302
+GSMP       Ipsilon's General Switch Management Protocol            2297
+HSRP       Cisco Hot Standby Router Protocol (HSRP)                2281
+RC2-ENCRP  A Description of the RC2(r) Encryption Algorithm        2268
+SNQP       Simple Nomenclator Query Protocol                       2259
+--------   Japanese Character Encoding for Internet Messages       2237
+KEYX-DNS   Key Exchange Delegation Record for the DNS              2230
+DSP        A Dictionary Server Protocol                            2229
+NFS-URL    NFS URL Scheme                                          2224
+APP-MARC   The Application/MARC Content-type                       2220
+ODETTE-FTP ODETTE File Transfer Protocol                           2204
+ESRO       AT&T/Neda's Efficient Short Remote Operations Protocol  2188
+ICP        Internet Cache Protocol Version 2                       2186
+IPV4-MAPOS IPv4 over MAPOS Version 1                               2176
+MAPOS-SONET Multiple Access Protocol over SONET/SDH Version 1      2171
+RWHOIS     Referral Whois Protocol                                 2167
+PPP-EXT    PPP Vendor Extensions                                   2153
+UTF-7      UTF-7                                                   2152
+
+
+
+IETF                        Standards Track                    [Page 22]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+CAST-128   CAST-128 Encryption Algorithm                           2144
+RADIUS-ACC RADIUS Accounting                                       2139
+DLSCAP     Data Link Switching Client Access Protocol              2114
+PNG        Portable Network Graphics Version 1.0                   2083
+RC5        RC5, RC5-CBC, RC5-CBC-Pad, and RC5-CTS Algorithms       2040
+SNTP       Simple Network Time Protocol v4 for IPv4, IPv6 and OSI  2030
+PGP-MEF    PGP Message Exchange Formats                            1991
+PPP-DEFL   PPP Deflate Protocol                                    1979
+PPP-PRED   PPP Predictor Compression Protocol                      1978
+PPP-BSD    PPP BSD Compression Protocol                            1977
+PPP-DCE    PPP for Data Compression in DCE                         1976
+PPP-MAG    PPP Magnalink Variable Resource Compression             1975
+PPP-STAC   PPP Stac LZS Compression Protocol                       1974
+GZIP       GZIP File Format Specification Version 4.3              1952
+DEFLATE    DEFLATE Compressed Data Format Specification V. 1.3     1951
+ZLIB       ZLIB Compressed Data Format Specification V. 3.3        1950
+HTTP-1.0   Hypertext Transfer Protocol -- HTTP/1.0                 1945
+--------   text/enriched MIME Content-type                         1896
+--------   Application/CALS-1840 Content-type                      1895
+--------   PPP IPCP Extensions for Name Server Addresses           1877
+SNPP       Simple Network Paging Protocol - Version 2              1861
+--------   ISO Transport Class 2 Non-use Explicit Flow Control     1859
+           over TCP RFC1006 extension
+--------   IP in IP Tunneling                                      1853
+--------   PPP Network Control Protocol for LAN Extension          1841
+TESS       The Exponential Security System                         1824
+NFSV3      NFS Version 3 Protocol Specification                    1813
+--------   A Format for Bibliographic Records                      1807
+-------    Data Link Switching: Switch-to-Switch Protocol          1795
+BGP-4      Experience with the BGP-4 Protocol                      1773
+SDMD       IPv4 Option for Sender Directed MD Delivery             1770
+SNOOP      Snoop Version 2 Packet Capture File Format              1761
+BINHEX     MIME Content Type for BinHex Encoded Files              1741
+DNS-NSAP   DNS NSAP Resource Records                               1706
+RADIO-PAGE TPC.INT Subdomain: Radio Paging -- Technical Procedures 1703
+GRE-IPv4   Generic Routing Encapsulation over IPv4                 1702
+GRE        Generic Routing Encapsulatio                            1701
+ADSNA-IP   Advanced SNA/IP: A Simple SNA Transport Protocol        1538
+TACACS     Terminal Access Control Protocol                        1492
+MD4        MD4 Message Digest Algorithm                            1320
+SUN-NFS    Network File System Protocol                            1094
+SUN-RPC    Remote Procedure Call Protocol Version 2                1057
+GOPHER     The Internet Gopher Protocol                            1436
+LISTSERV   Listserv Distribute Protocol                            1429
+-------    Replication Requirements                                1275
+PCMAIL     Pcmail Transport Protocol                               1056
+MTP        Multicast Transport Protocol                            1301
+BSD Login  BSD Login                                               1282
+
+
+
+IETF                        Standards Track                    [Page 23]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+DIXIE      DIXIE Protocol Specification                            1249
+IP-X.121   IP to X.121 Address Mapping for DDN                     1236
+OSI-HYPER  OSI and LLC1 on HYPERchannel                            1223
+HAP2       Host Access Protocol                                    1221
+SUBNETASGN On the Assignment of Subnet Numbers                     1219
+SNMP-TRAPS Defining Traps for use with SNMP                        1215
+DAS        Directory Assistance Service                            1202
+LPDP       Line Printer Daemon Protocol                            1179
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+4.2.  Historic Protocols
+
+Protocol   Name                                                RFC  STD
+========   =====================================              ===== ===
+CONTENT    Content Type Header Field                          1049  11 *
+IPV6-UNI   IPv6 Provider-Based Unicast Address                2073
+IPV6-Addr  IPv6 Addressing Architecture                       1884
+L2F        Cisco Layer Two Forwarding Protocol                2341
+IPSO       DoD Security Options for IP                        1108
+SNMPv2     Manager-to-Manager MIB                             1451
+SNMPv2     Party MIB for SNMPv2                               1447
+SNMPv2     Security Protocols for SNMPv2                      1446
+SNMPv2     Administrative Model for SNMPv2                    1445
+RIP        Routing Information Protocol                       1058  34
+--------   Mapping full 822 to Restricted 822                 1137
+BGP3       Border Gateway Protocol 3 (BGP-3)             1267,1268
+--------   Gateway Requirements                               1009   4
+EGP        Exterior Gateway Protocol                           904  18
+SNMP-MUX   SNMP MUX Protocol and MIB                          1227
+OIM-MIB-II OSI Internet Management: MIB-II                    1214
+IMAP3      Interactive Mail Access Protocol Version 3         1203
+SUN-RPC    Remote Procedure Call Protocol Version 1           1050
+802.4-MIP  IEEE 802.4 Token Bus MIB                           1230
+CMOT       Common Management Information Services             1189
+--------   Mail Privacy: Procedures                           1113
+--------   Mail Privacy: Key Management                       1114
+--------   Mail Privacy: Algorithms                           1115
+NFILE      A File Access Protocol                             1037
+HOSTNAME   HOSTNAME Protocol                                   953
+SFTP       Simple File Transfer Protocol                       913
+SUPDUP     SUPDUP Protocol                                     734
+BGP        Border Gateway Protocol                       1163,1164
+MIB-I      MIB-I                                              1156
+TOPT-ENVIR Telnet Environment Option                          1408
+SGMP       Simple Gateway Monitoring Protocol                 1028
+HEMS       High Level Entity Management Protocol              1021
+
+
+
+IETF                        Standards Track                    [Page 24]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+STATSRV    Statistics Server                                   996
+POP2       Post Office Protocol, Version 2                     937
+RATP       Reliable Asynchronous Transfer Protocol             916
+HFEP       Host - Front End Protocol                           929
+THINWIRE   Thinwire Protocol                                   914
+HMP        Host Monitoring Protocol                            869
+GGP        Gateway Gateway Protocol                            823
+RTELNET    Remote Telnet Service                               818
+CLOCK      DCNET Time Server Protocol                          778
+MPM        Internet Message Protocol                           759
+NETRJS     Remote Job Service                                  740
+TOPT-OLD   Output Linefeed Disposition                         658
+TOPT-OVTD  Output Vertical Tab Disposition                     657
+TOPT-OVT   Output Vertical Tabstops                            656
+TOPT-OFD   Output Formfeed Disposition                         655
+TOPT-OHTD  Output Horizontal Tab Disposition                   654
+TOPT-OHT   Output Horizontal Tabstops                          653
+TOPT-OCRD  Output Carriage-Return Disposition                  652
+NETED      Network Standard Text Editor                        569
+RJE        Remote Job Entry                                    407
+XNET       Cross Net Debugger                              IEN-158
+NAMESERVER Host Name Server Protocol                       IEN-116
+MUX        Multiplexing Protocol                            IEN-90
+GRAPHICS   Graphics Protocol                             NIC-24308
+
+[Note: an asterisk at the end of a line indicates a change from the
+previous edition of this document.]
+
+5.  Contacts
+
+5.1.  IAB, IETF, and IRTF Contacts
+
+   Internet Architecture Board (IAB) Contact: www.iab.org
+
+   Internet Engineering Task Force (IETF) Contact: www.ietf.org
+
+   Internet Research Task Force (IRTF) Contact: www.irtf.org
+
+5.2.  Internet Assigned Numbers Authority Contact
+
+      See: www.iana.org
+
+      How to obtain the most recent edition of this "Internet Official
+      Protocol Standards" memo:
+
+         The file "in-notes/std/std1.txt" may be copied via FTP from the
+         FTP.ISI.EDU computer using the FTP username "anonymous" and FTP
+         password "guest".
+
+
+
+IETF                        Standards Track                    [Page 25]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+5.3.  Request for Comments Editor Contact
+
+      See: www.rfc-editor.org
+
+   Documents may be submitted via electronic mail to the RFC Editor for
+   consideration for publication as RFC.  If you are not familiar with
+   the format or style requirements please request the "Instructions for
+   RFC Authors".  In general, the style of any recent RFC may be used as
+   a guide.
+
+5.4.  Requests for Comments Distribution Contact
+
+   RFCs can be obtained via FTP from FTP.ISI.EDU, with the pathname in-
+   notes/rfcnnnn.txt (where "nnnn" refers to the number of the RFC).
+   Login with FTP username "anonymous" and password "name@host.domain".
+
+   RFCs can also be obtained via electronic mail from ISI.EDU by using
+   the RFC-INFO service.  Address the request to "rfc-info@isi.edu" with
+   a message body of:
+
+           Retrieve: RFC
+              Doc-ID: RFCnnnn
+
+   (Where "nnnn" refers to the number of the RFC (always use 4 digits -
+   the DOC-ID of RFC 822 is "RFC0822")).  The RFC-INFO@ISI.EDU server
+   provides other ways of selecting RFCs based on keywords and such; for
+   more information send a message to "rfc-info@isi.edu" with the
+   message body "help: help".
+
+   contact: RFC-Manager@ISI.EDU
+
+5.5.  Sources for Requests for Comments
+
+   Details on many sources of RFCs via FTP or EMAIL may be obtained by
+   sending an EMAIL message to "rfc-info@ISI.EDU" with the message body
+   "help: ways_to_get_rfcs".  For example:
+
+           To: rfc-info@ISI.EDU
+           Subject: getting rfcs
+
+           help: ways_to_get_rfcs
+
+6.  Security Considerations
+
+   This memo does not affect the technical security of the Internet, but
+   it does cite a number of important security specifications.
+
+
+
+
+
+IETF                        Standards Track                    [Page 26]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+7.  Editors' Addresses
+
+   Joyce K. Reynolds
+   USC/Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone: +1 310-822-1511
+   Fax:   +1 310-823-6714
+
+   EMail: JKRey@ISI.EDU
+
+
+   Robert Braden
+   USC/Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone: +1 310-822-1511
+   Fax:   +1 310-823-6714
+
+   EMail: Braden@ISI.EDU
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+IETF                        Standards Track                    [Page 27]
+
+RFC 2500                   Internet Standards                  June 1999
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (1999).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+IETF                        Standards Track                    [Page 28]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2500.txt](<www.ietf.org/rfc/rfc2500.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
