### PR TITLE
Archive rfc252.txt

### DIFF
--- a/www.ietf.org/rfc/rfc252.txt
+++ b/www.ietf.org/rfc/rfc252.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                                      E. Wentheimer
+Request for Comments: 252                       Bolt, Beranek and Newman
+Category: F, G.3                                          8 October 1971
+NIC: 7696
+
+
+   The purpose of this RFC is to report on the recent status of most
+   Network Hosts.  During September 27 through September 29 the BBN
+   prototype Terminal IMP (Network Address 158) was inaccessible due to
+   hardware debugging.  The Network was, therefore, not examined on
+   these days.
+
+   Three Hosts which were not officially able to act as Server's at the
+   time of RFC #240 are now able to do so.  These Hosts are:
+
+         NETWORK          SITE              COMPUTER
+         ADDRESS
+         2                SRI (NIC)         PDF-10
+         6                MIT (Multics)     H-645
+         9                HARVARD           PDP-10
+
+   The Harvard PDP-10, however, has limited core space.  They will,
+   therefore, run the Telnet program only occasionally.
+
+   The following two tables summarize the information on the Host status
+   for September 30 - October 8.
+
+
+   NETWORK  SITE  COMPUTER          DAY, DATE AND TIME (Eastern)
+   ADDRESS                   TH    F     M     Tu    W     Th     F
+                             9/30  10/1  10/4  10/5  10/6  10/7  10/8
+                             1100  1753  1200  1600  1100  1300  1530
+
+    1     UCLA     SIGMA-7     O     T     D      O   #D    O     O
+   *65    UCLA     IBM-360/91  O     O     D      O    D    O     O
+    2     SRI(NIC) PDP-10      O    #D     T     #T    O    T    #D
+    66    SRI(AI)  PDP-10      D     D     D     D     D    D     D
+    3     UCSB     IBM-360/75  D     O     O     O     O    O     O
+    4     UTAH     PDP-10      D     D     D     D     D    D     D
+    69    BBN(TENEX)  PDP-10   T     T     O     O     O    D     D
+    6     MIT(Multics)H-645    O     O     D     T     D    T     T
+    70    MIT(DM)     PDP-10   D     H     D     T     D    T     T
+    8     SDC         IBM-360  D     D     D     D     D    D     D
+    9     HARVARD     PDP-10   T     D     T     D     D    T     T
+    10    LINCOLN     IBM-360  H     H     H     H     D    T     D
+
+
+
+
+
+
+Wnetheimer                                                      [Page 1]
+
+RFC 252                                                     October 1971
+
+
+   where
+
+      D = Dead (Destination Host either dead or inaccessible [due to
+      network partitioning or local IMP failure] from the BBN Terminal
+      IMP.)
+
+      R = Refused (Destination Host returned a CLS to the initial RFC.)
+
+      T = Timed out (Destination Host did not respond in any way to the
+      initial RFC, although not dead.)
+
+      H = 1/2  Open (Destination Host opened a connection but then
+      either immediately closed it, or did not respond any further.)
+
+      0 = Opened (Destination Host opened a connection and was
+      accessible to user.)
+
+      * The UCLA IMB-360/91 currently has Remote Job Service (NETRJS),
+        but has not implemented a full server Telnet System.  The BBN
+        Terminal IMP is not equipped to test NETRJS however, we are
+        assuming that receipt of the UCLA explanatory message indicates
+        that NETRJS is also functioning.
+
+      # These sites advertise that they may not have their system
+        available # at these times.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Wnetheimer                                                      [Page 2]
+
+RFC 252                                                     October 1971
+
+
+   NETWORK  SITE   COMPUTER     STATUS or        "STATUS or PREDICTIONS"
+   ADDRESS                      PREDICTION        OBTAINED FROM
+
+     1      UCLA     SIGMA-7     Server            Jon Postel
+     65     UCLA     IBM-360/91  Remote Job
+                                 Service now,
+                                 Telnet in April   Bob Braden
+     2      SRI(NIC) PDP-10      Server            John Melvin
+     66     SRI(AI)  PDP-10      November          Len Chaiten
+     3      UCSB     IBM-360/75  Server            Jim White
+     4      UTAH     PDP-10      "Soon"            Barry Wessler
+     5      BBN(NCC) DDP-516     Never             Alex McKenzie
+     69     BBN(TENEX)  PDP-10   Server            Dan Murphy
+     6      MIT(Multics)H-645    Server            Mike Padliosky
+     70     MIT(DM)  PDP-10      Server            Bob Bressler
+     7      RAND     IBM 360/65  User only         Eric Harslem
+     71     RAND     PDP-10      January           Eric Harslem
+     8      SDC      IBM-360/67  "Soon"            Bob Long
+     9      HARVARD  PDP-10      Server            Bob Sundberg
+     73     HARVARD  PDP-1       User only         Bob Sundberg
+     10     LINCOLN  IBM-360     "Soon"            Joel Winnet
+     74     LINCOLN  TX2         Uncertain         Tom Barkalow
+     11     STANFORD PDP-10      November          Andy Moorer
+     12     ILLINOIS PDP-11      User only         John Cravits
+     13     CASE     PDP-10      December 15       Charles Rose
+     14     CARNEGIE PDP-10      January           Hal VanZoeren
+     15     PAOLI    B6500       Uncertain         John Cravits
+     16     AMES     TIP         User only
+     17     MITRE    TIP         User only
+     18     BBN(TIP) Prototype TIP   User only
+
+
+          [This RFC was put into machine readable form for entry]
+     [into the online RFC archives by Kelly Tardif, Via Genie 10/1999]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Wnetheimer                                                      [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc252.txt](<www.ietf.org/rfc/rfc252.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
