### PR TITLE
Archive rfc255.txt

### DIFF
--- a/www.ietf.org/rfc/rfc255.txt
+++ b/www.ietf.org/rfc/rfc255.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                   Ellen Wentheimer
+Request for Comments: 255                       Bolt, Beranek and Newman
+Updates: 252                                            October 26, 1971
+NIC: 7696
+
+
+   This RFC reports on the status of most Network Hosts from October 12
+   to October 22.  (Monday, October 11 was Columbus Day.)  During these
+   two weeks, the general status of these Hosts remained as it had been
+   previously.
+
+   The table on the following page summarizes the daily information on
+   Host status for this period.
+
+   NETWORK  SITE         COMPUTER      DAY, DATE AND TIME (Eastern)
+   ADDRESS                              T     W     TH     F     M
+                                      10/12 10/13  10/14 10/15 10/18
+                                      1530  1600   1600  1700  1730
+   1        UCLA         SIGMA-7        O     O     O     O      O
+   65       UCLA         IBM-360/91     O     O     O     O      O
+   2        SRI(NIC)     PDP-10         O     O    #T     O      O
+   66       SRI(AI)      PDP-10         D     D     D     D      D
+   3        UCSB         IBM-360/75     O     O     O     O      O
+   4        UTAH         PDP-10         T     D     T     D      D
+   69       BBN(TENEX)   PDP-10         D     D     O     O      D
+   6        MIT(Multics) H-645          O     D     R     T      T
+   70       MIT(DM)      PDP-10         T     D     T     T      D
+   8        SDC          IBM-360-67     D     D     D     D      D
+   9        HARVARD      PDP-10         O     D     D     D      D
+   10       LINCOLN      IBM-360-67     D     D     D     H      D
+
+
+   NETWORK  SITE         COMPUTER      DAY, DATE AND TIME (Eastern)
+   ADDRESS                              T     W     TH     F
+                                      10/19 10/20  10/21 10/22
+                                      1630  1230   1330  1430
+   1        UCLA         SIGMA-7        O     O     O     O
+   65       UCLA         IBM-360/91     O     O     O     O
+   2        SRI(NIC)     PDP-10         T     O     O     O
+   66       SRI(AI)      PDP-10         D     D     D     D
+   3        UCSB         IBM-360/75     O     O     D     O
+   4        UTAH         PDP-10         T     D     T     D
+   69       BBN(TENEX)   PDP-10         D     O     O     O
+   6        MIT(Multics) H-645          T     D     D     O
+   70       MIT(DM)      PDP-10         D     H     H     H
+   8        SDC          IBM-360-67     D     D     D     D
+   9        HARVARD      PDP-10         D     D     D     D
+   10       LINCOLN      IBM-360-67     D     H     T     H
+
+
+
+Wentheimer                                                      [Page 1]
+
+RFC 255                                                     October 1971
+
+
+   where
+
+      D = Dead (Destination Host either dead or inaccessible [due to
+      network partitioning or local IMP failure] from the BBN Terminal
+      IMP.)
+
+      R = Refused (Destination Host returned a CLS to the initial RFC.)
+
+      T = Timed out (Destination Host did not respond in any way to the
+      initial RFC, although not dead.)
+
+      H = 1/2  Open (Destination Host opened a connection but then
+      either immediately closed it, or did not respond any further.)
+
+      O = Opened (Destination Host opened a connection and was
+      accessible to user.)
+
+      * The UCLA IMB-360/91 currently has Remote Job Service (NETRJS),
+      but has not implemented a full server Telnet System.  The BBN
+      Terminal IMP is not equipped to test NETRJS however, we are
+      assuming that receipt of the UCLA explanatory message indicates
+      that NETRJS is also functioning.
+
+      # These sites advertise that they may not have their system
+      available at these times.
+
+
+
+           [This RFC was put into machine readable form for entry]
+      [into the online RFC archives by Kelly Tardif, Viagenie 10/99]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Wentheimer                                                      [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc255.txt](<www.ietf.org/rfc/rfc255.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
