### PR TITLE
Archive rfc2556.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2556.txt
+++ b/www.ietf.org/rfc/rfc2556.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Network Working Group                                         S. Bradner
+Request for Comments: 2556                            Harvard University
+Category: Informational                                       March 1999
+
+
+             OSI connectionless transport services on top
+           of UDP Applicability Statement for Historic Status
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard of any kind.  Distribution of this
+   memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (1999).  All Rights Reserved.
+
+Abstract
+
+   RFC 1240, "OSI connectionless transport services on top of UDP", was
+   published as a Proposed Standard in June 1991 but at this time there
+   do not seem to be any implementations which follow RFC 1240.  In
+   addition there is a growing concern over using UDP-based transport
+   protocols in environments where congestion is a possibility.
+
+1. Use of RFC 1240 Technology
+
+   A message was sent to the IETF list in October 1998 seeking any
+   information on the actual use of the technology described in RFC
+   1240.  A number of responses were received, including from the
+   International Organization for Standardization (ISO), the keeper of
+   the OSI protocols.  None of these messages pointed to any current use
+   for this technology.  Most of the messages which made any
+   recommendation did recommend that RFC 1240 be moved to historic.
+
+2. Responsiveness to Congestion
+
+   Since 1991 there has been a great deal of experience with the
+   complexities of dealing with congestion in the Internet.  Congestion
+   control algorithms have been improved but there is still work
+   underway to further understand the issues.  In this environment any
+   UDP-based protocol is somewhat worrisome since quite frequently
+   people who use UDP-based protocols invent their own reliability and
+   congestion control functions which may not include the results of the
+   current state of the art.  This leads to a dange r of congestion
+   collapse with potentially quite serious consequences for the network
+   in which it is run.  See RFC 896 for a discussion of congestion
+
+
+
+Bradner                      Informational                      [Page 1]
+
+RFC 2556                  RFC 1240 to Historic                March 1999
+
+
+   collapse.
+
+   In the case of RFC 1240, the authors seemed to assume that if some
+   level of reliability was needed in an RFC 1240 environment that the
+   reliability algorithms and the congestion control algorithms which
+   would then be required would reside in the OSI protocols running over
+   the UDP transport.  It is far from clear that any perceived
+   advantages of running over UDP would not be eclipsed by the
+   difficulties experienced in trying to create a reasonable congestion
+   control algorithm.  Implementers would likely find that running over
+   TCP as RFC 2126 describes is the better choice.
+
+3. Conclusion
+
+   Due to the lack of use of the technology described in RFC 1240 and
+   the issues surrounding congestion control in the Internet, RFC 1240
+   should be reclassified as Historic and its implementation actively
+   discouraged.
+
+4. Security Considerations
+
+   This type of non-protocol document does not directly effect the
+   security of the Internet.
+
+5. References
+
+   RFC 896   Nagle, J., "Congestion control in IP/TCP internetworks",
+             RFC 896, January 1984.
+
+   RFC 1240  Shue, C., Haggerty, W. and K. Dobbins, "OSI connectionless
+             transport services on top of UDP: Version 1.", RFC 1240
+             June 1991.
+
+   RFC 2126  Pouffary, Y. and A. Young, "ISO Transport Service on top of
+             TCP (ITOT)", RFC 2126, March 1997.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Bradner                      Informational                      [Page 2]
+
+RFC 2556                  RFC 1240 to Historic                March 1999
+
+
+6. Author's Address
+
+   Scott Bradner
+   Harvard University
+   1350 Mass Ave, rm 876
+   Cambridge, MA
+   02138
+   USA
+
+   Phone: +1 617 495 3864
+   EMail: sob@harvard.edu
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Bradner                      Informational                      [Page 3]
+
+RFC 2556                  RFC 1240 to Historic                March 1999
+
+
+7.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (1999).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Bradner                      Informational                      [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2556.txt](<www.ietf.org/rfc/rfc2556.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
