### PR TITLE
Archive rfc256.txt

### DIFF
--- a/www.ietf.org/rfc/rfc256.txt
+++ b/www.ietf.org/rfc/rfc256.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                B. Cosell
+RFC #256                                             BBN
+NIC #7697                                            3 November 1971
+Categories:  B.1
+Updates:  None
+Obsoletes:  None
+
+
+                       IMPSYS Change Notification
+
+        We will shortly install (or perhaps will have already
+   installed) a new version of the IMP system, Version 2513.  The
+   new version incorporates two principal changes:
+
+     1.  A Host will be prevented from sending any messages
+         into the Network for between 40 seconds and a
+         minute and a quarter after he comes alive (this
+         has been changed from between 30 seconds and a
+         minute).
+
+     2.  The IMP has been given the ability to test its Host
+         interfaces under control of the NCC.  This will help
+         us isolate the trouble when the IMP Host communication
+         path is faulty.
+
+
+     BC/jm
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc256.txt](<www.ietf.org/rfc/rfc256.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
