### PR TITLE
Archive rfc2626.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2626.txt
+++ b/www.ietf.org/rfc/rfc2626.txt
@@ -1,0 +1,15403 @@
+
+
+
+
+
+
+Network Working Group                                     P. Nesser II
+Request for Comments: 2626                  Nesser & Nesser Consulting
+Category: Informational                                      June 1999
+
+
+          The Internet and the Millennium Problem (Year 2000)
+
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard of any kind.  Distribution of this
+   memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (1999).  All Rights Reserved.
+
+Abstract
+
+   The Year 2000 Working Group (WG) has conducted an investigation into
+   the millennium problem as it regards Internet related protocols.
+   This investigation only targeted the protocols as documented in the
+   Request For Comments Series (RFCs).  This investigation discovered
+   little reason for concern with regards to the functionality of the
+   protocols.  A few minor cases of older implementations still using
+   two digit years (ala RFC 850) were discovered, but almost all
+   Internet protocols were given a clean bill of health.  Several cases
+   of "period" problems were discovered, where a time field would "roll
+   over" as the size of field was reached.  In particular, there are
+   several protocols, which have 32 bit, signed integer representations
+   of the number of seconds since January 1, 1970 which will turn
+   negative at Tue Jan 19 03:14:07 GMT 2038.  Areas whose protocols will
+   be effected by such problems have been notified so that new revisions
+   will remove this limitation.
+
+1. Introduction
+
+   According to the trade press billions of dollars will be spend the
+   upcoming years on the year 2000 problem, also called the millennium
+   problem (though the third millennium will really start in 2001). This
+   problem consists of the fact that many software packages and some
+   protocols use a two-digit field for the year in a date field. Most of
+   the problems seem to be in administrative and financial programs, or
+   in the hardcoded microcomputers found in electronic equipment.  A lot
+   of organizations are now starting to make an inventory of which
+   software and tools they use will suffer from the millennium problem.
+
+
+
+
+Nesser                       Informational                      [Page 1]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+   With the increasing popularity of the Internet, more and more
+   organizations use the Internet as a serious business tool.  This
+   means that most organizations will want to analyze the millennium
+   problems due to the use of Internet protocols and popular Internet
+   software. In the trade press the first articles suggest that the
+   Internet will collapse at midnight the 31st of December 1999.
+
+   To counter these suggestions, and to avoid having countless companies
+   redo the same investigation, this effort was undertaken by the IETF.
+   The Year 2000 WG has made an inventory of all-important Internet
+   protocols that have been documented in the Request for Comments (RFC)
+   series.  Only protocols directly related to the Internet will be
+   considered.
+
+   This document is divided into a number of sections.  Section 1 is the
+   Introduction which you are now reading.  Section 2 is a disclaimer
+   about the completeness of this effort.  Section 3 describes areas in
+   which millenium problems have been found, while Section 4 describes a
+   few other "period" problems.  Section 5 describes potential fixes to
+   problems that have been identified. Section 6 describes the
+   methodology used in the investigation. Sections 7 through 22 are
+   devoted to the 15 different groupings of protocols and RFCs.  Section
+   23 discusses security considerations, Section 24 is devoted to
+   references, and Section 25 is the author contact information.
+   Appendix A is the list of RFCs examined broken down by category.
+   Appendix B is a PERL program used to make a first cut identification
+   of problems, and Appendix C is the output of that PERL program.
+
+   The editor of this document would like to acknowledge the critical
+   contributions of the follow for direct performance of research and
+   the provision of text: Alex Latzko, Robert Elz, Erik Huizer, Gillian
+   Greenwood, Barbara Jennings, R.E. (Robert) Moore, David Mills, Lynn
+   Kubinec, Michael Patton, Chris Newman, Erik-Jan Bos, Paul Hoffman,
+   and Rick H. Wesson.  The pace with which this group has operated has
+   only been achievable by the intimate familiarity of the contributors
+   with the protocols and ready access to the collective knowledge of
+   the IETF.
+
+2. Disclaimer
+
+   This RFC is not complete.  It is an effort to analyze the Y2K impact
+   on hundreds of protocols but is likely to have missed some protocols
+   and misunderstood others.  Organizations should not attempt to claim
+   any legitimacy or approval for any particular protocol based on this
+   document.  The efforts have concentrated on the identification of
+   potential problems, rather than solutions to any of the problems that
+   have been identified. Any proposed solutions are only that: proposed.
+   A formal engineering review should take place before any solution is
+
+
+
+Nesser                       Informational                      [Page 2]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+   adopted.
+
+   It should also be noted that the research was performd on RFCs 1
+   through 2128.  At that time the IESG was charted with not allowing
+   any new RFCs to be published that had any Year 2000 issues.   Since
+   that cutoff time there has been work to correct issues discovered by
+   this Working Group.  In particular, RWhois as documented by RFC 1714
+   has been updated to fix the problems found.  RFC 2167 now documents a
+   fixed version of the RWhois protocol.  The work of this group was to
+   look backwards, and hence new RFC's which supplant the old are
+   expected to make the information in this RFC obsolete.  The work of
+   this group will truly be complete when this document is completely
+   obsolete.
+
+   A number of people have suggested looking into other "special" dates.
+   For example, the first leap year, the first "double digit" day
+   (January 10, 2000), January 1, 2001, etc.  There is not one place
+   where days have been used in the protocols defined by the RFC series
+   so there is little reason to believe that any of these special dates
+   will have any impact.
+
+3. Summary of Year 2000 Problems
+
+   Here is a brief description of all the Millennium issues discovered
+   in the course of this research.  Note that many of the RFCs are
+   unclear on the issue.  They mandate the use of UTCTime but do not
+   specify whether the two-digit or four-digit year representation
+   should be used.
+
+3.1 "Directory Services"
+
+       rfc1274.txt - References UTC date/time
+       rfc1276.txt - References UTC date/time for version control.
+       rfc1488.txt - References UTC Time as printable strings.
+       rfc1608.txt - Refers to uTCTimeSyntax
+       rfc1609.txt - Refers to uTCTimeSyntax
+       rfc1778.txt - Refers to uTCTimeSyntax
+
+3.2  "Information Services and File Transfer"
+
+   HTTP 1.1, as defined in RFC 2068, requires all newly generated date
+   stamps to conform to RFC 1123 date formats which are Year 2000
+   compliant, but it also requires acceptance of the older non-compliant
+   RFC850 formats.  Some specific recommendations have been passed to
+   the HTTP WG.
+
+
+
+
+
+
+Nesser                       Informational                      [Page 3]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+   HTML 2.0, as defined in RFC 1866, could allow a very subtle Year 2000
+   problem, but once again this recommendation has been passed on the
+   HTML WG.
+
+   RFC 1778 on String Representations of Standard Attribute Syntax's
+   define UTC Time in Section 2.21 and uses that definition in Section
+   2.25 on User Certificates.  Since UTC Time is being used, there is a
+   potential millennium issue.
+
+   RFC 1440 on SIFT/UFT: Sender-Initiated/Unsolicited File Transfer
+   defines an optional DATE command in Section 5 of the form mm/dd/yy
+   which is subject to millennium issues.
+
+3.3 "Electronic Mail"
+
+   After reviewing all mail-related RFCs, it was discovered that while
+   some obsolete standards required two-digit years, all currently used
+   standards require four-digit years and are thus not prone to typical
+   Year 2000 problems.
+
+   RFCs 821 and 822, the main basis for SMTP mail exchange and message
+   format, originally required two-digit years. However, both of these
+   RFCs were later modified by RFC 1123 in 1989, which strongly
+   recommended 4-digit years.
+
+3.4 "Name Serving"
+
+   While not a protocol issue, there is a common habit of writing serial
+   numbers for DNS zone files in the form YYXXXXXX.  The only real
+   requirement on the serial numbers is that they be increasing (see RFC
+   1982 for a complete description) and a change from 99XXXXXX to
+   00XXXXXX cause a failure.  See the section on "Name Serving" for a
+   complete description of the issues.
+
+3.5  "Network Management"
+
+   Version 2 of SNMP's MIB definition language (SMIv2) specifies the use
+   of UCTTimes for time stamping MIB modules.  Even though these time
+   stamps do not flow in any network protocols, there could be as issue
+   with management applications, depending on implementations.
+
+3.6  "Network News"
+
+   There does exist a problem in both NNTP, RFC 977, and the Usenet News
+   Message Format, RFC 10336.  They both specify two-digit year format.
+   A working group has been formed to update the network news protocols
+   in general, and addressing this problem is on their list of work
+   items.
+
+
+
+Nesser                       Informational                      [Page 4]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+3.7  "Real-Time Services"
+
+   A Year 2000 problem does occur in the Simple Network Paging Protocol,
+   versions 2 & 3. Both define a HOLDuntil option which uses a
+   YYMMDDHHMMSS+/-GMT field. Version 3 also defines a MSTAtus command,
+   which is required to store,dates and times as YYMMDDHHMMSS+/-GMT.
+
+   There is a small Year 2000 issue in RFC 1786 on the Representation of
+   IP Routing Policies in the ripe-81++ Routing Registry.  In Appendices
+   C the "changed" object parameter defines a format of <email-address>
+   YYMMDD, and similarly in Appendix D "withdrawn" object identifier has
+   he format of YYMMDD.  Since these are only identifiers there should
+   be little operational impact.  Some application software may need to
+   be modified.
+
+3.8 "Security"
+
+   RFC 1507 on Distributed Authentication Security Services (DASS) use
+   UTCTime.  Because of the imprecision of the UTC time definition there
+   could be problems with this protocol.
+
+   RFCs 1421-1424 specifies that PEM uses UTC time formats which could
+   have a Millennium issue.
+
+4. Summary of Other "Periodicity" Problems
+
+   By far, the largest area of "period" problems occurs in the year
+   2038.  Many protocols use a 32-bit field to record the number of
+   seconds since January 1, 1970.
+
+4.1  "Name Serivces"
+
+   DNS Security uses 32-bit timestamps which will roll over in 2038.
+   This issue has been refered to the appropriate Working Group so that
+   the details of rollover can be established.
+
+4.2  "Routing"
+
+   IDPR suffers from the classic Year 2038 problem, by having a
+   timestamp counter which rolls over at that time.
+
+5. Suggested Solutions
+
+   The real solution to the problem is to use 4 digit year fields for
+   applications and hardware systems.  For counters that key off of a
+   certain time (January 1, 1970 for example) need to either: define a
+   wrapping solution, or to define a larger number space (greater than
+   32-bits), or to make more efficient use of the 32-bit space. However,
+
+
+
+Nesser                       Informational                      [Page 5]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+   it will be impossible to completely replace currently deployed
+   systems, so solutions for handling problems are in order.
+
+5.1 Fixed Solution
+
+   A number of organizations and groups have suggested a fixed solution
+   to the problem of two digit years.  Given a two-digit year YY, if YY
+   is greater than or equal to 50, the year shall be interpreted as
+   19YY; and where YY is less than 50, the year shall be intrepreted as
+   20YY.
+
+   While a simple and straightforward solution, it only pushes the
+   problem off 40 to 50 years, until the artificially generated Year
+   2050 problem needs to be addressed.  However, it is easy to implement
+   and deploy, so it might be the most commonly adopted solution.
+
+5.2 Sliding Window
+
+   Another solution is the "sliding window" approach.  In this approach,
+   some value N is selected, and any two digit year that is less than or
+   equal to the current two digit year plus N is considered the future,
+   while any other two digit year is considered in the past.
+
+   For example, choosing N equal to 10,  If the current year is 2012,
+   and I get a two digit year that is any of 12, 13, 14, 15, 16, 17, 18,
+   19, 20, 21 or 22, assume it is 20YY (i.e. the future), otherwise
+   consider it to be in the past(1923-1999, 2000-2011).
+
+   This solution has two advantages.  First, no new fixed year problems
+   are introduced.  Second, different applications and protocols could
+   choose different values of N.  The drawback is that this solution is
+   harder to implement, and to work well the value of N will need to be
+   constant across different implementations.
+
+6. Methodology
+
+   The first task was dividing the types of RFC's into logical groups
+   rather than the strict numeric publishing order.  Sixteen specific
+   areas were identified.  They are: "Autoconfiguration" , "Directory
+   Services", "Disk Sharing", "Games and Chat" ,"Information Services &
+   File Transfer", "Network & Transport Layer", "Electronic Mail",
+   "NTP", Name Serving", "Network Management", "News", "Real Time
+   Services", "Routing", "Security", "Virtual Terminal", and "Other".
+   In addition to these categories, many hundreds of RFC's were
+   immediately eliminated based on content.  That is not to say that all
+   Informational RFC's were not considered, many did contain some
+   technical content or overview whichdemanded scrutiny.
+
+
+
+
+Nesser                       Informational                      [Page 6]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+   Each area was assigned to a team for investigation.  Although each
+   team used whatever additional investigation techniques which seemed
+   appropriate (including completely reading each RFC, and in some cases
+   the source code for the reference implementation) at minimum each
+   team used an automatic scanning system to search for the following
+   items (case insensitively) in each RFC:
+
+        - date
+        - GMT
+        - UTCTime
+        - year
+        - yy (that is not part of yyyy)
+        - two-digit, 2-digit, 2digit
+        - century
+        - 1900 & 2000
+
+   Note that all of these strings except "UTCTime" may occur in
+   conjunction with a date format that accommodates the Year 2000
+   crossing, as well as with one that does not.  So "hits" on these
+   string do not necessarily indicate Year 2000 problems: they simply
+   identify elements that need to be examined.
+
+   After the documents were scanned, therefore, each "hit" was examined
+   individually.  Those that cause no Year 2000 problems (e.g., those
+   that encode the year as a two-byte integer, or as a four-character
+   display string) are not discussed here.  Those that do cause Year
+   2000 problems are identified in this document, and the nature and
+   impact of the problems they cause are described.
+
+7. Autoconfiguration
+
+7.1 Summary
+
+   The RFC's which were categorized into this group were primarily the
+   BOOT Protocol (BOOTP) and the Dynamic Host Configuration Protocol
+   (DHCP) for both IP version four and six.
+
+   Examination of the BOOTP protocols and most popular implementations
+   show no year 2000 problems.  All times are references as 32 bit
+   integers in seconds of UTC time.  An investigation of all DHCP and
+   the IPv6 Autoconfiguration mechanisms produced no year 2000 problems.
+   All references to time, in particular lease lengths, are 32 bit
+   integers in seconds, allowing lease times of well over 100 years.
+
+
+
+
+
+
+
+
+Nesser                       Informational                      [Page 7]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+7.2 Specifics
+
+   The following RFCs were examined for possible millennium problems:
+   906, 951, 1048, 1084, 1395, 1497, 1531, 1532, 1533, 1534, 1541, 1542,
+   1970, & 1971.  RFC 951's only reference to time or dates is a two-
+   byte field in the packet, which is number of second since the hosts,
+   was booted.  RFC's 1048, 1084, 1395, 1497, 1531, & 1532 have either
+   no references to dates and time, or they are the same as the RFCs,
+   which obsoleted them, discussed in the next paragraph.
+
+   RFC 1533 enumerates all the known DHCP field types and a number of
+   these have to do with time.  Section 3.4 defines a "Time Offset"
+   field which specifies the offset of the clients subnet in seconds
+   from UTC.  This 4 byte field has no millennium issues.  Section 9.2
+   defines the IP Address Lease Time field which is used by clients to
+   request a specific lease time.  This four byte field is an unsigned
+   integer containing a number of seconds.  Section 9.9 defines a
+   Renewal Time Value field, Section 9.10 defines a Rebinding Time
+   Value, both of which are similarly 32 bit fields, which have no
+   millennium issues.
+
+   RFC 1534 has no references to times or dates.
+
+   RFC 1541 has two mentions of times/dates.  The first is the "secs"
+   field which, similarly to RFC 951, is a 16-bit field for the number
+   of seconds since the host has booted.  There is also a discussion in
+   section 3.3 about "Interpretation and Representation of Time Values"
+   which while clearly states that there is no millennium or period
+   problems.
+
+   RFC 1542 also references the "secs" field mentioned previously.
+
+   RFC 1970 mentions a number of variables, which are time related.  In
+   section 4.2 "Router Advertisement Message Format" the following
+   fields are defined: Router Lifetime, Reachable Time, & Retrans Timer.
+   In section 4.6.2 "Prefix Information" the following are defined:
+   Valid Lifetime, & Preferred Lifetime.  In section 6.2.1 "Router
+   Configuration Variables the following are defined: MaxRtrAdvInterval,
+   MinRtrAdvInterval, AdvReachableTime, AdvRetransTimer,
+   AdvDefaultLifetime, AdvValidLifetime, & AdvPreferredLifetime.  All of
+   these fields specify counters of some sort which have no millennium
+   or periodicity problems.
+
+   RFC 1971 has some discussion of preferred lifetimes, depreciated
+   lifetimes and valid lifetimes of leases, but only discusses them in
+   an expository way.
+
+
+
+
+
+Nesser                       Informational                      [Page 8]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+8. Directory Services
+
+8.1 Summary
+
+   The RFC's which were categorized into this group were primarily X.500
+   related RFC's, Whois, Rwhois, Whois++, and the Lightweight Directory
+   Access Protocol (LDAP).
+
+   Upon review of the Directory Services related RFC's, no serious year
+   2000 problems were discovered.  Some minor issues were noted and
+   explained below in the specific portion of this section.
+
+8.2 Specifics
+
+   RFCs that mentioned UTC Time or made reference to uTCTimeSyntax could
+   fail to be Y2K compliant. These should be updated to specify the four
+   year version of uTCTimeSyntax rather than giving the option of using
+   a two-year date representation. The following RFCs fall into this
+   category:
+
+       rfc1274.txt - References UTC date/time
+       rfc1276.txt - References UTC date/time for version control.
+       rfc1488.txt - References UTC Time as printable strings.
+       rfc1608.txt - Refers to uTCTimeSyntax
+       rfc1609.txt - Refers to uTCTimeSyntax
+       rfc1778.txt - Refers to uTCTimeSyntax
+
+   Two RFC's have unusual date specifications and specify their own date
+   format. Both of these support Y2K compliant dates.
+
+   RFC1714 (RWhois) specifies date formats that are not Y2K compliant,
+   but it also supports dates that are. Implementers of the RWhois
+   protocol should only use the %MY4 format
+
+   RFC1834 (Whois++) requires the use of dates, but it didn't specify
+   the format, syntax, or representation of the date string to be used.
+
+9. Disk Sharing
+
+9.1 Summary
+
+   The RFC's which were categorized into this group were those related
+   to the Network File System (NFS).  Other popular disk sharing
+   protocols like SMB and AFS were referred to their respective
+   trustee's for review.
+
+   After careful review, NFS has no year 2000 problems.
+
+
+
+
+Nesser                       Informational                      [Page 9]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+9.2 Specifics
+
+   The references to time in this protocol are the times of file data
+   modification, file access, and file metadata change (mtime, atime,
+   and time, respectively).  These times are kept as 32 bit unsigned
+   quantities in seconds since 1970-01-01, and so the NFS protocol will
+   not experience an Epoch event until the year 2106.
+
+10. Games and Chat
+
+10.1 Summary
+
+   The RFC's which were categorized into this group were related to the
+   Internet Relay Chat Protocol (IRC).  No millennium problems exist in
+   the IRC protocol.
+
+10.2 Specifics
+
+   There is only a single instance of time or date related information
+   in the IRC protocol as specified by RFC 1459.  Section 4.3.4 defines
+   a TIME message type which queries a server for its local time.  No
+   mention is made of the format of the reply or how it is parsed, the
+   assumption being specific implementations will handle the reply and
+   parse it appropriately.
+
+11. Information Services & File Transfer
+
+11.1 Summary
+
+   The RFC's which were categorized into this group were divided among
+   World Wide Web (WWW) protocols and File Transfer Protocols (FTP).
+   WWW protocols include the Hypertext Transfer Protocol (HTTP), a
+   variety of Uniform Resource formats (URL, URAs, etc.) and the
+   HyperText Markup Language(HTML).  FTP protocols include the well
+   known FTP protocol, the Trivial File Transfer Protocol (TFTP) and a
+   variety of extensions to these protocols.  Other information services
+   includes the Finger Protocol and the LPD protocol.
+
+   HTTP 1.1, as defined in RFC 2068, requires all newly generated date
+   stamps to conform to RFC 1123 date formats which are Year 2000
+   compliant, but it also requires acceptance of the older non-compliant
+   RFC850 formats.  Some specific recommendations are listed below and
+   have been passed to the HTTP WG.
+
+   HTML 2.0, as defined in RFC 1866, could allow a very subtle Year 2000
+   problem, but once again this recommendation has been passed on the
+   HTML WG.
+
+
+
+
+Nesser                       Informational                     [Page 10]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+   RFC 1778 on String Representations of Standard Attribute Syntax's
+   define UTC Time in Section 2.21 and uses that definition in Section
+   2.25 on User Certificates.  Since UTC Time is being used, there is a
+   potential millennium issue.
+
+   RFC 1440 on SIFT/UFT: Sender-Initiated/Unsolicited File Transfer
+   defines an optional DATE command in Section 5 of the form mm/dd/yy
+   which is subject to millennium issues.
+
+11.2 Specifics
+
+   The main IETF standards-track document on the HTTP protocol is
+   RFC2068 on HTTP 1.1.  It notes that historically three different date
+   formats have been used, and that one of them uses a two-digit year
+   field.  In section 3.3.1 it requires HTTP 1.1 implementations to
+   generate this RFC1123 format:
+
+        Sun, 06 Nov 1994 08:49:37 GMT  ; RFC 822, updated by RFC 1123
+
+   instead of this RFC850 format:
+
+        Sunday, 06-Nov-94 08:49:37 GMT ; RFC 850, obsoleted by RFC 1036
+
+   Unfortunately, many existing servers, serving on the order of one
+   fifth of the current HTTP traffic, send dates in the ambiguous RFC850
+   format.
+
+   Section 19.3 of the RFC2068 says this:
+
+     o  HTTP/1.1 clients and caches should assume that an RFC-850 date
+        which appears to be more than 50 years in the future is in fact
+        in the past (this helps solve the "year 2000" problem).
+
+   This avoids a "stale cache" problem, which would cause the user to
+   see out-of-date data.
+
+   RFC 1986 documents experiments with a simple file transfer program
+   over radio links using Enhanced Trivial FTP (ETFTP).  There are a
+   number of timers defined which are all in seconds and have no year
+   2000 issues.
+
+   In RFC 1866, on HTML 2.0,the <META> tag allows the embedding of
+   recommended values for some HTTP headers, including Expires.  E.g.
+
+       <META HTTP-EQUIV="Expires"
+             CONTENT="Tue, 04 Dec 1993 21:29:02 GMT">
+
+   Servers should rewrite these dates into RFC1123 format if necessary.
+
+
+
+Nesser                       Informational                     [Page 11]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+   RFC 1807 defines a format for bibliographic records and it specifies
+   a DATE format, which requires 4 digit year fields.
+
+   RFC 1788 defines ICMP Domain Name messages.  Section 3 defines a
+   Domain Name Reply Packet, which contains a signed 32-bit integer.
+   This timer is not Year 2000 reliant and is certainly large enough for
+   it purposes.
+
+   RFC 1784 on TFTP Timeout Intervals and Transfer Size Options uses a
+   field for the number of seconds for the timeout.  It is an ASCII
+   value from 1 to 255 octets in length.  There is no Y2K issue.
+
+   RFC 1778 on String Representations of Standard Attribute Syntax's
+   define UTC Time in Section 2.21 and uses that definition in Section
+   2.25 on User Certificates.  Since UTC Time is being used, there is a
+   potential millennium issue.
+
+   RFC 1777 on LDAP defines a timelimit in Section 4.3 which is
+   expressed in seconds, but does not define any limits.
+
+   RFC 1440 on SIFT/UFT: Sender-Initiated/Unsolicited File Transfer
+   defines an optional DATE command in Section 5 of the form mm/dd/yy,
+   which is subject to millennium issues.
+
+   RFC 1068 on the Background File Transfer Protocol (BFTP) defines two
+   commands in Sections B.2.12 and B.2.13, the Submit and Time commands.
+   >From the example usage's given in Appendix C it is clear that this
+   protocol will function correctly though the year 9999.
+
+   RFC 1037 on NFILE (a file access protocol) discusses the a Date
+   representation in Section 7.1 as the number of seconds since January
+   1, 1900, but does not limit the field size.  There should be no Y2K
+   issues.
+
+   RFC 998 on NETBLT defines a Death time in Section 8, which is the
+   sender's death time in seconds.
+
+   RFC 978 on the Voice File Interchange Protocol defines the Total Time
+   of a message to be a 32-bit number of deci-seconds.  This limits the
+   size of a message but has no millennium issues.
+
+   RFC 969 was obsoleted by RFC 998.
+
+   RFC 916 defines the Reliable Asynchronous Transfer Protocol (RATP).
+   Three timers are discussed in an expository manner in Section 5.4 and
+   its subsections.  There are no relevant issues.
+
+
+
+
+
+Nesser                       Informational                     [Page 12]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+   RFCs 2122, 2056, 2055, 2054, 2044, 2016, 1960, 1959, 1874, 1865, 1862,
+   1843, 1842, 1823, 1815, 1808, 1798, 1785, 1783, 1782, 1779, 1766,
+   1738, 1737, 1736, 1729, 1728, 1727, 1639, 1633, 1630, 1625, 1554,
+   1545, 1530, 1529, 1528, 1489, 1486, 1436, 1415, 1413, 1350, 1345,
+   1312, 1302, 1288, 1278, 1241, 1235, 1196, 1194, 1179, 1123, 1003, 971,
+   965, 959, 949, 913, 887, 866, 865, 864, 863, 862, 797, 795, 783, 775,
+   765, 751, 743, 742, 740, 737, 725, 722, 707, 691, 683, 662, 640, 624,
+   614, 607, 599, 412, 411, 410, 407, and 406 were found to have no
+   references to dates or times, and hence no millennium issues.
+
+   RFCs 712, 697, 633, 630, 622, 610, 593, 592, 589, 573, 571, 570, 553,
+   551, 549, 543, 535, 532, 525, 520, 514, 506, 505, 504, 501, 499, 493,
+   490, 487, 486, 485, 480, 479, 478, 477, 472, 468, 467, 463, 454, 451,
+   448, 446, 438, 437, 436, 430, 429, 418, 414, and 409 were not
+   available for review.
+
+   RFCS below 400 were considered too obsolete to even consider.
+
+12. Network & Transport Layer
+
+12.1 Summary
+
+   The RFC's which were categorized into this group were the Internet
+   Protocol (IP) versions four and six, the Transmission Control
+   Protocol (TCP), the User Datagram Protocol (UDP), the Point-to-Point
+   Protocol (PPP) and its extensions, Internet Control Message Protocol
+   (ICMP), the Address Resolution Protocol (ARP) and Remote Procedure
+   Call (RPC) protocol.  A variety of less known protocols were also
+   examined.
+
+   After careful review of the nearly 400 RFC's in this catagory, no
+   millennium or year 2000 problems were found.
+
+12.2 Specifics
+
+   RFC 2125 on the PPP Bandwidth Allocation Protocol (BAP) in section
+   5.3 discusses the use if mandatory timers, but gives no mention as to
+   how they are implemented.
+
+   RFC 2114 on a Data Link Switching Client Access Protocol defines a
+   retry timer of five seconds in Section 3.4.1.
+
+   RFC 2097 on the PPP NetBIOS Frame Control Protocol discuesses several
+   timer and timeouts in Section 2.1, none of which suffers from a year
+   2000 problem.
+
+   RFC 2075 on the IP Echo Host Service discusses timestamps and has no
+   millennium issues.
+
+
+
+Nesser                       Informational                     [Page 13]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+   RFC 2005 on the Applicability for Mobile IP discusses using
+   timestamps as a security measure to avoid replay attacks (Section
+   3.), but does not quantify them.  There are no expected issues.
+
+   RFC 2002 on IP Mobility Support uses a 16-bit field for the lifetime
+   of a connection and notes the 18.2 hour limitation that this imposes.
+   Section 5.6.1 on replay protection requires the use of 64-bit time
+   fields, of a similar format to NTP packets.
+
+   RFC 1981 on Path MTU Discovery for IPv6 discusses timestamps and
+   their potential use to purge stale information in section 5.3.  There
+   is no millennium issues in this use.
+
+   RFC 1963 on the PPP Serial Data Transport Protocol defines a flow
+   expiration time in section 4.9 which has no year 2000 issues.
+
+   RFC 1833 on Binding Protocols for ONC RPC Version 2 defines a
+   variable in Section 2.2.1 called RPCBPROC_GETTIME which returns the
+   local time in seconds since 1/1/1970.  Since this value is not fields
+   width dependent, it may or may not wrap around the 32-bit value
+   depending on the operating system parameters.
+
+   RFC 1762 on the PPP DECnet Phase IV Control Protocol discusses a
+   number of timers in Section 5 (General Considerations).  None of
+   these timers experience any millennium issues.
+
+   RFC 1761 on Snoop Version 2 Packet Capture File Format discusses two
+   32-bit timestamp values on Section 4 on Packet Record Formats.  The
+   first of these may wrap in the year 2038, but should not effect
+   anything of any import.
+
+   RFC 1755 on ATM Signalling Support for IP Over ATM discusses timing
+   issues in Section 3.4 on VC Teardown.  These limited timers have no
+   year 2000 issues.
+
+   RFC 1692 on the Transport Multiplexing Protocol (TMux) defines a TTL
+   in Section 2.3 and a timer in Section 3.3.  Neither of these suffer
+   from any millennium or year 2000 issues.
+
+   RFC 1661 on PPP defines three timers in Section 4.6, none of which
+   have any year 2000 issues.
+
+   RFC 1644 on T/TCP (TCP Extensions for Transactions) mentions RFC 1323
+   and the extended timers recommended in it.
+
+   RFC 1575 defines an echo function for CNLP discusses in the narrative
+   the use of the Lifetime Field in Section 5.3.  There is nothing to
+   suggest that there is any year 2000 issues.
+
+
+
+Nesser                       Informational                     [Page 14]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+   RFC 1329 on Dual MAC FDDI Networks discusses ARP cache administration
+   in Section 9.3 and 9.4 and various timers to expire entries.
+
+   RFC 1256 on ICMP Router Discovery Messages talks about lifetime
+   fields in Section 2 and defines three router configuration variables
+   in Section 4.1.  None of these have any millennium issues.
+
+   RFC 792 on ICMP discusses Timestamps and Timestamp Reply messages
+   which define a 32-bit timestamp which contains the number of
+   milliseconds since midnight UT.
+
+   RFC 791 on the Internet Protocol defines a packet type 68 which is an
+   Internet Timestamp, which defines a 32-bit field which contains the
+   number of milliseconds since midnght UT.
+
+   RFC 781 was defines the same option which is codified in RFC 791 as a
+   packet type 68.
+
+   RFC's 2126, 2118, 2113, 2107, 2106, 2105, 2098, 2067, 2043, 2023,
+   2019, 2018, 2009, 2004, 2003, 2001, 1994, 1993, 1990, 1989, 1979,
+   1978, 1977, 1976, 1975, 1974, 1973, 1972, 1967, 1962, 1954, 1946,
+   1937, 1936, 1934, 1933, 1932, 1931, 1926, 1924, 1919, 1918, 1917,
+   1916, 1915, 1897, 1888, 1887, 1885, 1884, 1883, 1881, 1878, 1877,
+   1868, 1860, 1859, 1853, 1841, 1832, 1831, 1809, 1795, 1791, 1770,
+   1764, 1763, 1756, 1754, 1752, 1744, 1735, 1726, 1719, 1717, 1710,
+   1707, 1705, 1698, 1693, 1688, 1687, 1686, 1683, 1682, 1681, 1680,
+   1679, 1678, 1677, 1676, 1674, 1673, 1672, 1671, 1670, 1669, 1667,
+   1663, 1662, 1638, 1634, 1631, 1629, 1624, 1622, 1621, 1620, 1619,
+   1618, 1613, 1605, 1604, 1598, 1590, 1577, 1570, 1561, 1560, 1553,
+   1552, 1551, 1549, 1548, 1547, 1538, 1526, 1518, 1498, 1490, 1483,
+   1475, 1466, 1454, 1435, 1434, 1433, 1393, 1390, 1385, 1379, 1378,
+   1377, 1376, 1375, 1374, 1365, 1363, 1362, 1356, 1347, 1337, 1335,
+   1334, 1333, 1332, 1331, 1326, 1323, 1314, 1307, 1306, 1294, 1293,
+   1277, 1263, 1240, 1237, 1236, 1234, 1226, 1223, 1220, 1219, 1210,
+   1209, 1201, 1191, 1188, 1185, 1172, 1171, 1166, 1162, 1151, 1146,
+   1145, 1144, 1141, 1139, 1134, 1132, 1122, 1110, 1106, 1103, 1088,
+   1086, 1085, 1078, 1072, 1071, 1070, 1069, 1063, 1062, 1057, 1055,
+   1051, 1050, 1046, 1045, 1044, 1042, 1030, 1029, 1027, 1025, 1016,
+   1008, 1007, 1006, 1002, 1001, 994, 986, 983, 982, 970, 964, 963, 962,
+   955, 948, 942, 941, 940, 936, 935, 932, 926, 925, 924, 922, 919, 917,
+   914, 905, 903, 896, 895, 894, 893, 892, 891, 889, 879, 877, 874, 872,
+   871, 848, 829, 826, 824, 815, 814, 813, 801, 793, 789, 787, 777, 768,
+   761, 760, 759, 730, 704, 696, 695, 692, 690, 689, 687, 685, 680, 675,
+   674, 660, 632, 626, 613, 611 were reviewed but were found to have no
+   millennium references.
+
+
+
+
+
+
+Nesser                       Informational                     [Page 15]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+   RFC's 594, 591, 576, 550, 548, 528, 521, 489, 488, 473, 460, 459, 450,
+   449, 445, 442, 434, 426, 417, 398, 395, 394, 359, 357, 348, 347, 346,
+   343, 312, 301, 300, 271, 241, 210, 203, 202, 197, 190, 178, 176, 175,
+   166, 165, 161, 151, 150, 146, 145, 143, 142, 128, 127, 123, 122, 93,
+   91, 80, 79, 70, 67, 65, 62, 60, 59, 56, 55, 54, 53, 41, 38, 33, 23,
+   22, 20, 19, 17, 12 were deemed too old to be considered for millennium
+   investigation.
+
+13. Electronic Mail
+
+13.1 Summary
+
+   The RFC's which were categorized into this group were the Simple Mail
+   Transfer Protocol (SMTP), Internet Mail Access Protocol (IMAP), Post
+   Office Protocol (POP), Multipurpose Internet Mail Exchange (MIME),
+   and X.400 to SMTP interaction.
+
+   After reviewing all mail-related RFCs, it was discovered that while
+   some obsolete standards required two-digit years, all currently used
+   standards require four-digit years and are thus not prone to typical
+   Year 2000 problems.
+
+13.2 Specifics
+
+   RFCs 821 and 822, the main basis for SMTP mail exchange and message
+   format, originally required two-digit years. However, both of these
+   RFCs were later modified by RFC 1123 in 1989, which strongly
+   recommended 4-digit years.  Although there might be a few very old
+   SMTP systems using two-digit years, it is believed that almost all
+   mail sent over the Internet today uses four-digit years. Mail that
+   contains two-digit years in its SMTP headers will not "fail", but
+   might be mis-sorted in message stores and mail user agents. This
+   problem is avoided entirely by taking the RFC 1123 change as a
+   requirement, rather than merely as a recommendation.
+
+   IMAP versions 1, 2, and 3 used two-digit years, but IMAP version 4
+   (defined in RFCs 1730 and 1732 in 1994) requires four-digit years.
+   There are still a few IMAP 2 servers and clients in use on the
+   Internet today, but IMAP version 4 has already taken over almost all
+   of the IMAP market. Mail stored on an IMAP server or client with
+   two-digit years will not "fail", but could possibly be mis-sorted or
+   prematurely expired.
+
+   RFC 1153 describes a format for digests of mailing lists, and uses
+   two-digit dates. This format is not widely used. The use of two-digit
+   dates could possibly cause missorting of stored messages.
+
+
+
+
+
+Nesser                       Informational                     [Page 16]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+   RFC 1327, which describes mapping between X.400 mail and SMTP mail,
+   uses the UTCTime format.
+
+   RFC 1422 describes the structure of certificates that were used in
+   PEM (and are expected to be used in many other mail and non-mail
+   services). Those certificates use dates in UTCTime format. Poorly
+   written software might prematurely expire or validate a certificate
+   based on comparisons of the date with the current date, although no
+   current software is known to do this.
+
+   14. Network Time Protocols
+
+14.1 Summary
+
+   The RFC's which were categorized into this group were the Network
+   Time Protocol (NTP), and the Time Protocol.
+
+   NTP has been certified year 2000 compliant, while the Time Protocol
+   will "roll over" at Thu Feb 07 00:54:54 2036 GMT.  Since NTP is the
+   current defacto standard for network time this does not seem to be an
+   issue.
+
+14.2 Specifics
+
+   There is no reference anywhere in the NTP specification or
+   implementation to any reference epoch other than 1 January 1900. In
+   short, NTP doesn't know anything about the millennium.
+
+   >From the Time Protocol RFC (868):
+
+       S: Send the time as a 32 bit binary number.
+
+       ...
+
+       The time is the number of seconds since 00:00 (midnight) 1 January
+       1900 GMT, such that the time 1 is 12:00:01 am on 1 January 1900
+       GMT; this base will serve until the year 2036.
+
+15. Name Services
+
+15.1 Summary
+
+   The RFC's which were categorized into this group were the Domain Name
+   System (DNS), it's advanced add on features (Incremental Zone
+   Transfer, etc.).
+
+   There have been no year 2000 relayed problems found with the DNS
+   protocols, or common implementations of them.
+
+
+
+Nesser                       Informational                     [Page 17]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+15.2 Specifics
+
+   One is a common practice of writing serial numbers in zone files as
+   if they represent a date, and using only two digits of the year.
+   That practice cannot survive into the year 2000.  This is not a
+   protocol problem, the serial number is simply an integer, and any
+   value is OK, provided it always increases (see rfc1982 for a
+   definition of what that means).  In any case, a change from 97abcd
+   (or similar) to 00abcd would be a decrease and so is not permitted.
+   Zone file maintainers have two choices, one easy (though irrational)
+   one would be to continue from 99 to 100 and so on.  The other, is
+   simply to switch, at any time between now and when the serial number
+   first needs updating after the year 2000, to use 4 digits to
+   represent the year instead of 2.  As long as there are no more than 6
+   digits in the "abcd" part, and this is done sometime before the year
+   2100, this is always an increase, and therefore always safe.  Should
+   any zone files be of the form yyabcdefg (with 7 digits after a 2-
+   digit year) then the procedures of section 7 of rfc2182 should be
+   adopted to convert the serial number to some other value.
+
+   The other item of note is related to timestamps in DNS security.
+   Those are represented as 32 bit counts of seconds, based in 1970, and
+   hence have no year 2000 problems.  however, they do obviously have a
+   natural end of life, and sometime before that time is reached, the
+   definitions of those fields need to be corrected, perhaps to allow
+   them to represent the number of seconds elapsed since the base,
+   modulo 2^32, which is likely to be adequate for the purposes of DNS
+   security (signatures and keys are unlikely to need to be valid for
+   more than 70 years).  In any case, more work is needed in this area
+   in the not too far distant future.
+
+16 Network Management
+
+16.1 Summary
+
+   The RFC's which were categorized into this group were the Simple
+   Network Management Protocol (SNMP), a large number of Management
+   Information Bases (MIBs) and the Common Management Information
+   Protocol over TCP/IP (CMOT).
+
+   Although a few discrepancies have been found and outlined below, none
+   of them should have an impact on interoperability.
+
+16.2 Specifics
+
+   16.2.1 Use of GeneralizedTime in CMOT as defined in RFCs 1095 and
+   1189.
+
+
+
+
+Nesser                       Informational                     [Page 18]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+   The standards for CMOT specify an unusual use for the GeneralizedTime
+   type.  (GeneralizedTime has a four-digit representation of the year.)
+
+   If the system generating the PDU does not have the current time, yet
+   does have the time since last boot, then GeneralizedTime can be used
+   to encode this information.  The time since last boot will be added
+   to the base time "0001 Jan 1 00:00:00.00" using the Gregorian
+   calendar algorithm.
+
+   This is really a "Year 0" problem rather than a Year 2000 problem,
+   and in any case, CMOT is not currently deployed.
+
+16.2.2 UTCTime in SNMP Definitions
+
+   UTCTime is an ASN.1 type that includes a two-digit representation of
+   the year.  There are several options for UTCTime in ASN.1, that vary
+   in precision and in local versus GMT, but these options all have
+   two-digit years.  The standards for SNMP definitions specify one
+   particular format:
+
+          YYMMDDHHMMZ
+
+   The first usage of UTCTime in the standards for SNMP definitions goes
+   all the way back to RFC 1303.  It has persisted unchanged up through
+   the current specifications in RFC 1902.  The role of UTCTime in SNMP
+   definitions is to record the history of an SNMP MIB module in the
+   module itself, via two ASN.1 macros:
+
+       o   LAST-UPDATED
+       o   REVISION
+
+   Management applications that store and use MIB modules need to be
+   smart about interpreting these UTCTimes, by prepending a "19" or a
+   "20" as appropriate.
+
+16.2.3  Objects in the Printer MIB (RFC 1559)
+
+   There are two objects in the Printer MIB that allow use of a date as
+   an object value with no explicit guidance for formatting the value.
+   The objects are prtInterpreterLangVersion and prtInterpreterVersion.
+   Both are defined with a syntax of OCTET STRING.  The descriptions for
+   the objects allow the object value to contain a date, version code or
+   other product specific information to identify the interpreter or
+   language.  The descriptions do not include an explicit statement
+   recommending use of a four-digit year when a date is used as the
+   object value.
+
+
+
+
+
+Nesser                       Informational                     [Page 19]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+16.2.4  Dates in Mobile Network Tracing Records (RFC 2041)
+
+   The RFC specifies trace headers and footers with date fields that are
+   character arrays of size 32.  While 32 characters certainly provide
+   enough room for a four-digit year, there's no explicit statement that
+   these years must be represented with four digits.
+
+17 Network News
+
+17.1 Summary
+
+   The RFC's which were categorized into this group were related to the
+   Network News Protocol (NNTP).
+
+   There does exist a problem in both NNTP, RFC 977, and the Usenet News
+   Message Format, RFC 10336.  They both specify two-digit year format.
+   A working group has been formed to update the network news protocols
+   in general, and addressing this problem is on their list of work
+   items.
+
+17.2 Specifics
+
+   The NNTP transfer protocols defined in RFC 977.  Sections 3.7.1, the
+   definition of the NEWGROUPS command, and 3.8.1, the NEWNEWS command,
+   that dates must be specified in YYMMDD format.
+
+   The format for USENET news messages is defined in RFC 1036.  The Date
+   line is defined in section 2.1.2 and it is specified in RFC-822
+   format.  It specifically disallows the standard UNIX ctime(3) format,
+   which would allow for four digit years.  Section 2.2.4 on Expires
+   also mandates the same two-digit year format.
+
+18. Real Time Services
+
+18.1 Summary
+
+   The RFC's which were categorized into this group were related to IP
+   Multicast, RTP, and Internet Stream Protocol.  A Year 2000 problem
+   does occur in the Simple Network Paging Protocol, versions 2 & 3.
+   Both define a HOLDuntil option which uses a YYMMDDHHMMSS+/-GMT field.
+   Version 3 also defines a MSTAtus command, which is required to store,
+   dates and times as YYMMDDHHMMSS+/-GMT.
+
+18.2 Specifics
+
+   RFC 2102 discusses Multicast support for NIMROD and has no mention of
+   dates or time.  RFC 2090 on TFTP Multicast options is also free from
+   any date/time references.
+
+
+
+Nesser                       Informational                     [Page 20]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+   RFC 2038 on RTP MPEG formats has three references to time: a
+   Presentation Time Stamp (PTS), a Decoding Time Stamp (DTS), and a
+   System Clock (SC) reference time.  Each RTP packet contains a
+   timestamp derived from the sender 90 kHz clock reference.  Each of
+   the header fields are defined in section 2.1, 3, and 3.3 are 32 bit
+   fields.  No mention is made of a "zero" start time, so it is presumed
+   that this format will be valid until at least 2038.
+
+   Similarly RFC 2035 on the RTP JPEG format defines the same timestamp
+   in section 3.  RFC 2032 on RTP H.261 video streams uses a calculated
+   time based on the original frame so once again there is no millennium
+   issue.  RFC 2029 on the RTP format for Sun's CellB video encoding
+   mentions the RTP timestamp in section 2.1.
+
+   RFC 2022 defines support for multicast over UNI 3.0/3.1 based ATM
+   networks.  Section 5.  defines a timeout value for connections
+   between one and twenty minutes.  Section 5.1.1 discusses several
+   timers that are bound between five and ten seconds, while 5.1.3
+   requires an inactivity timer, which should also run between one and
+   twenty minutes.  Sections 5.1.5, 5.1.5.1, 5.1.5.2, 5.2.2, 5.4, 5.4.1,
+   5.4.2, 5.4.3, 6.1.3 and Appendix E all defines numerous timers, none
+   of which have any millennium issues.
+
+   RFC 1890 on RTP profiles for audio and video conferences discusses a
+   sampling frequency which has no issues.  RFC 1889 on RTP discusses
+   time formats in section 4, as the same 64 bit unsigned integer format
+   that NTP uses.  There is a "period" problem, which will occur in the
+   year 2106.  Section 5.1 is a more formalized discussion of the
+   timestamp properties, while Section 6.3.1 discusses a variety of
+   different timers all using the 64 bit field format, or a compressed
+   32-bit version of the inner octet of bytes.  Section 8.2 discusses
+   loop detection and how the various timers are used to determine if
+   looping occurs.
+
+   RFC 1861 on Version 3 of the Simple Network Paging Protocol does have
+   a Year 2000 problem.  The protocol defines a HOLDuntil command in
+   section 4.5.6 and a MSTAtus command in section 4.6.10, both of which
+   require dates/times to be stored as YYMMDDHHMMSS+/-GMT.  Clearly this
+   format will be invalid after the end of 1999.
+
+   RFC 1821 has no date/time references.  RFC 1819 on Version 2 of the
+   Internet Stream Protocol defines a HELLO message format in section
+   6.1.2, which does contain a timer which is updated every millisecond.
+   No year 2000 problems exist with this protocol.
+
+   RFC 1645 on Version 2 of the Simple Network Paging Protocol contains
+   the same HOLDuntil field problem as version 3.  The definition is
+   contained section 4.4.6.
+
+
+
+Nesser                       Informational                     [Page 21]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+   RFC 1458 on the Requirements of Multicast Protocols discusses a
+   retransmission timer in section 4.23. and a general discussion of
+   timer expiration in section 5, neither of which have any millennium
+   concerns.  RFC 1301 on the Multicast Transport Protocol defines a
+   heartbeat interval of time in section 2.1, as well as retention and
+   windows.  Formal definitions for each are contained in sections
+   2.2.7, 2.2.8 and 2.2.9.  The heartbeat is a 32 bit unsigned field,
+   while the Window and Retention are both 16 bit unsigned fields.
+   Section 3.4.2 gives examples values for these fields, which indicate
+   no millennium issues.
+
+   RFC 1193 on Client Requirements for Real Time Services talks about
+   time in section 4.4, but there are no Year 2000 issues.  RFC 1190
+   have been obsoleted by RFC 1819, but the hello timer issues are
+   similar.
+
+   RFCs 1789, 1768, 1703, 1614, 1569, 1568, 1546, 1469, 1453, 1313,
+   1257, 1197, 1112, 1054, 988, 966, 947, 809, 804, 803, 798, 769, 741,
+   511, 508, 420, 408 and 251 contain no date or time references.
+
+19. Routing
+
+19.1 Summary
+
+   The RFC's which were categorized into this group were Routing
+   Information Protocol (RIP), the Open Shortest Path First (OSPF)
+   protocol, Classless InterDomain Routing (CIDR),the Border Gateway
+   Protocol (BGP), and the InterDomain Routing Protocol (IDRP).
+
+   After careful examination both BGP and RIP have been found Year 2000
+   compliant.
+
+   There is a small Year 2000 issue in RFC 1786 on the Representation of
+   IP Routing Policies in the ripe-81++ Routing Registry.  In Appendices
+   C the "changed" object parameter defines a format of <email-address>
+   YYMMDD, and similarly in Appendix D "withdrawn" object identifier has
+   he format of YYMMDD.  Since these are only identifiers there should
+   be little operational impact.  Some application software may need to
+   be modified.
+
+   IDPR suffers from the classic Year 2038 problem, by having a
+   timestamp counter which rolls over at that time.
+
+19.2 Specifics
+
+   RFC 2091 on Extensions to RIP to Support Demand Circuits defines
+   three required and one optional timers in section 6.  The Database
+   Timer (6.1), the Hold down Timer (6.2), the Retransmission Time (6.3)
+
+
+
+Nesser                       Informational                     [Page 22]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+   and the Over-Subscription Timer (6.4) are all counters, which have no
+   millennium, issues.  RFC 2081 on the applicability of RIPng discusses
+   deletion of routes for a variety of issues, one of which is the
+   garbage- collection timer exceeds 120 seconds.  There are no Year
+   2000 issues.  RFC 2080 on RIPng for IPv6, discusses various times in
+   section 2.6, none of which have any millennium problems.
+
+   RFC 1987 on Ipsilon's General Switch Management protocol there is a
+   Duration field defined in section 4, which has no relevant problems.
+   Section 8.2 defines the procedure for dealing with timers.  RFC 1953
+   on Ipsilon's Flow Management Specification for IPv4 defines the same
+   procedure in section 3.2, as well as a lifetime field in the Redirect
+   Message (Section 4.1).  There are no millennium issues in either
+   case.
+
+   There is a small Year 2000 issue in RFC 1786 on the Representation of
+   IP Routing Policies in the ripe-81++ Routing Registry.  In Appendices
+   C the "changed" object parameter defines a format of <email-address>
+   YYMMDD, and similarly in Appendix D "withdrawn" object identifier has
+   he format of YYMMDD.  Since these are only identifiers there should
+   be little operational impact.  Some application software may need to
+   be modified.
+
+   RFC 1771 defines the Border Gateway Protocol (BGP).  BGP does not
+   have knowledge of absolute time, only relative time.  There are five
+   timers defined: Hold Timer, ConnectRetry Timer, KeepAlive Timer,
+   MinRoueAdvertisementInterval and MinASOriginationInterval.  There are
+   no known issues regarding BGP and the millennium.
+
+   In RFC 1584, which defines Multicast Extensions to OSPF, three timers
+   are defined in section 8.2: IGMPPollingInterval, IGMPTimeout, and
+   IGMP polling timer.  Section 8.4 defines an age parameter for the
+   local groups database and section 9.3 outlines how to implement that
+   age parameter.  It is not expected that any connections lifetime will
+   be long enough to cause any issues with these timers.
+
+   RFC 1583, OSPF, there are two types of timers defined in section 4.4,
+   single-shot timers and interval timers.  There are a number of timers
+   defined in Section 9 including: HelloInterval, RouterDeadInterval,
+   InfTransDelay, Hello Timer, Wait Timer and RxmtInterval.  Section 10
+   also defines the Inactivity Timer.  No millennium problem exists for
+   any of these timers.
+
+   RFC 1582 is an earlier version of RFC 2091.  Section 7 documents the
+   same timers as noted above, with the same lack of a millennium issue.
+
+   RFC 1504 on Appletalk Update-Based Routing Protocol defines a 10-
+   second period in Section 3, and hence has no relevant issues.
+
+
+
+Nesser                       Informational                     [Page 23]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+   RFC 1479 which specifies IDPR Version 1, defines a timestamp field in
+   section 1.5.1, which is a 32 bit unsigned integer number of seconds
+   since January 1, 1970.  The authors recognize the problem of
+   timestamp exhaustion in 2038, but feel that the protocol will not be
+   in use for that period.  Sections 1.7, 2.1, and 4.3.1 also discuss
+   the timestamp field.  RFC 1478 on the IDPR Architecture, also
+   discusses the same timestamp field in section 3.3.4.  RFC 1477 again
+   refers to the IDPR timestamp in section 4.2.  Thus IDPR has no Year
+   2000 issue, but does have a period problem in the year 2038.
+
+   RFC 1075 on Distance Vector Multicast Routing Protocol devotes
+   section 7 to time values.  None of the timers have any millennium
+   issues.  RFC 1074, on the NFSNET backbone SPF IGP defines several
+   hardcoded timers values in section 5.
+
+   RFC 1058 on RIP discusses the 30-second timers in section 3.3.  There
+   is no millennium issues related to RIP.
+
+   RFC 995 on the Requirements for Internet Gateways has extensive
+   discussions of timers in section 7.1 and throughout A.1 and A.2.
+   None of these timers suffer from the millennium problem.
+
+   RFC 911 on EGP on Berkeley Unix recommend timer values of 30 and 120
+   seconds.
+
+   RFC 904 which defines the Exterior Gateway Protocol (EGP).  There are
+   a number of timers discussed in sections 4.1.1 and 4.1.4.  None of
+   these timers suffer from any relevant problems.
+
+   RFCs 2103, 2092, 2073, 2072, 2042, 2008, 1998, 1997, 1992, 1966, 1955,
+   1940, 1930, 1925, 1923, 1863, 1817, 1812, 1793, 1787, 1774, 1773,
+   1772, 1765, 1753, 1745, 1723, 1722, 1721, 1716, 1702, 1701, 1668,
+   1656, 1655, 1654, 1587, 1586, 1585, 1581, 1520, 1519, 1517, 1482,
+   1476, 1439, 1403, 1397, 1388, 1387, 1383, 1380, 1371, 1370, 1364,
+   1338, 1322, 1268, 1267, 1266, 1265, 1264, 1254, 1246, 1245, 1222,
+   1195, 1164, 1163, 1142, 1136, 1133, 1126, 1125, 1124,1104, 1102, 1092,
+   1009, 985, 981, 975, 950, 898, 890, 888, 875, and 823 contain no date
+   or time references.
+
+20. Security
+
+20.1 Summary
+
+   The RFC's which were categorized into this group were kerberos
+   authentication protocol, Remote Authentication Dial In User Service
+   (RADIUS), One Time Password System (OTP), Privacy Enhanced Mail
+   (PEM), security extensions to a variety of protocols including (but
+   not limited to) RIPv2, HTTP, MIME, PPP, IP, Telnet and FTP.
+
+
+
+Nesser                       Informational                     [Page 24]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+   Encryption and authentication algorithms are also examined.
+
+   RFC 1507 on Distributed Authentication Security Services (DASS)
+   discusses time and secure time in an expository manner in Sections
+   1.2.2, 1.4.4 and 2.1.  Section 3.6 defines absolute time as an UTC
+   time with a precision of 1 second, and Section 4.1 discusses ANS.1
+   encoding of time values.  Because of the imprecision of the UTC time
+   definition there could be problems with this protocol.
+
+   RFCs 1421-1424 specifies that PEM uses UTC time formats which could
+   have a Millennium issue since the year specification only provides
+   the last two digits of the year.
+
+20.2 Specifics
+
+   RFC 2082 on RIP-2 MD5 Authentication requires storage of security
+   keys for a specified lifetime in sections 4.1 and 4.2.  There are no
+   millennium issues in this protocol.
+
+   RFC 2078 on the GSSAPI Version 2 defines numerous calls that use
+   timers for inputs and outputs.  Sections 2.1.1, 2.1.3, 2.1.4, 2.1.5,
+   2.2.1, 2.2.2, 2.2.5 and 2.2.6 all use the lifetime_rec field, which
+   is defined as an integer counter in seconds.  There should be no
+   relevant problems with this protocol.
+
+   RFC 2069 on Digest Authentication for HTTP, defines a 'date' and a
+   1123 formats which is not subject to millennium issues.  Section 3.2
+   discusses dates and times in the context of thwarting replay attacks,
+   but have no relevant issues.
+
+   RFC 2065 on DNS Security extensions first discusses time in section
+   2.3.3.  The SIG RDATA format is defined in Section 4.1 discusses
+   "time signed" field and defines it to be a 32 bit unsigned integer
+   number of seconds since January 1, 1970.  There will be a period
+   problem in 2038 because of rollover.  Section 4.5 on the file
+   representations of SIG RRs specifies the time field is expressed as
+   YYYYMMDDHHMMSS which is clearly Year 2000 compliant.
+
+   RFC 2059 on RADIUS account formats defines a "time" attribute, which
+   is optional which is a 32 bit unsigned integer number of seconds
+   since January 1, 1970.  Likewise RFC 2058 on RADIUS also defines this
+   optional attribute in the same way.  There will be a potential period
+   problem that occurs on 2038.
+
+   RFC 2035 on the Simple Public Key GSSAPI Mechanism talks about secure
+   timestamps in the background and overview sections only in an
+   expository manner.
+
+
+
+
+Nesser                       Informational                     [Page 25]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+   RFC 1969 on the PPP DES Encryption Protocol uses time as an example
+   in Section 4 when discussing how to encrypt the first packet of a
+   stream.  It is suggested that the first 32 bits be used for the
+   number of seconds since January 1, 1970.  There could thus be a
+   potential operations problem in 2038.
+
+   RFC 1898 on the CyberCash Credit Card Protocol provides an example
+   message in Section 2.7 which uses a date field of the form
+   YYYYMMDDHHMM that is clearly Y2K compliant.
+
+   RFC 1510, which defines Kerberos Version 5, makes extensive use of
+   times in the security model.  There are discussions in the
+   Introduction, as well as Sections 1.2, and 3.1.3.  Kerberos uses
+   ASN.1 definitions to abstract values, and hence defines a base
+   definition for KerberosTime which is a generalized time format in
+   Section 5.2.  >From the text: "Example: The only valid format for UTC
+   time 6 minutes, 27 seconds after 9 p.m. on 6 November 1985 is
+   19851106210627Z."  A side note is that the MIT reference
+   implementation of the Kerberos, by default set the expiration of
+   tickets to December 31, 1999.  This is not protocol related but could
+   have some operational impacts.
+
+   RFC 1509 on GSSAPI C-bindings makes a single reference that all
+   counters are in seconds and assigned as 32 bit unsigned integers.
+   Hence GSSAPI mechanisms may have problems in 2038.
+
+   RFC 1507 on Distributed Authentication Security Services (DASS)
+   discusses time and secure time in an expository manner in Sections
+   1.2.2, 1.4.4 and 2.1.  Section 3.6 defines absolute time as an UTC
+   time with a precision of 1 second, and Section 4.1 discusses ANS.1
+   encoding of time values.  Because of the imprecision of the UTC time
+   definition there could be problems with this protocol.
+
+   RFC 1424 on PEM Part IV defines a self-signed certificate request in
+   Section 3.1.  The validity period start and end times are both
+   suggested to be January 1, 1970.  RFC 1422 on PEM Part II defines the
+   validity period for a certificate in Section 3.3.6.  It is
+   recommended that UTC Time formats are used, and notes the lack of a
+   century so that comparisons between different centuries must be done
+   with care.  No suggestions on how to do this are included.  Sections
+   3.5.2 also discusses validity period in PEM CRLs.  RFC 1421 on PEM
+   Part I discusses validity periods in an expository way.  PEM as a
+   whole could have problems after December 31, 1999 based on its use of
+   UTC Time.
+
+   RFCs 1113, 1114, and 1115 specify the original version of PEM and
+   have been obsoleted bye 1421, 1422, 1423, & 1424.
+
+
+
+
+Nesser                       Informational                     [Page 26]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+   RFCs 2104, 2085, 2084, 2057, 2040, 2015, 1984, 1968, 1964, 1961, 1949,
+   1948, 1938, 1929, 1928, 1858, 1852, 1851, 1829, 1828, 1827, 1826,
+   1825, 1824, 1760, 1751, 1750, 1704, 1675, 1579, 1535, 1511, 1492,
+   1457, 1455, 1423, 1416, 1412, 1411, 1409, 1408, 1321, 1320, 1319,
+   1281, 1244, 1186, 1170, 1156, 1108, 1004, 972, 931, 927, 912, and 644
+   contain no date or time references.
+
+21. Virtual Terminal
+
+21.1 Summary
+
+   The RFC's which were categorized into this group were Telnet and its
+   many extensions, as well as the Secure SHell (SSH) protocol.  The X
+   window system was not considered since it is not an IETF protocol.
+   Official acknowledgement by the trustee's of the X window system was
+   given that they will examine the protocol.
+
+   Unencrypted Telnet and TN3270 have both been found to be Year 2000
+   Compliant.  The SSH protocols are also Year 2000 compliant.
+
+   21.2 Specifics
+
+   RFC 1013 on the X Windows version 11 alpha protocol defines are 32
+   bit unsigned integer timestamp in Section 4.
+
+   RFCs 2066, 1647, 1576, 1572, 1571, 1372, 1282, 1258, 1221, 1205, 1184,
+   1143, 1116, 1097, 1096, 1091, 1080, 1079, 1073, 1053, 1043, 1041,
+   1005, 946, 933, 930, 929, 907, 885, 884, 878, 861, 860, 859, 858, 857,
+   856, 855, 854, 851, 818, 802, 782, 779, 764, 749, 748, 747, 746, 736,
+   735, 734, 732, 731, 729, 728, 727, 726, 721, 719, 718, 701, 698, 658,
+   657, 656, 655, 654, 653, 652, 651, 647, 636, 431, 399, 393, 386, 365,
+   352, 340, 339, 328, 311, 297, 231, and 215 contain no date or time
+   references.
+
+
+   RFCs 703, 702, 688, 679, 669, 659, 600, 596, 595, 587, 563, 562, 560,
+   559, 513, 495, 470, 466, 461, 447, 435, 377, 364, 318, 296, 216, 206,
+   205, 177, 158, 139, 137, 110, 97 were unavailable.
+
+22.  Other
+
+22.1 Summary
+
+   This grouping was a hodge-podge of informational RFCs, April Fool's
+   Jokes, IANA lists, and experimental RFCs.  None were found to have
+   any millennium issues.
+
+
+
+
+
+Nesser                       Informational                     [Page 27]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+22.2 Specifics
+
+   RFCs 2123, 2036, 2014, 2000, 1999, 1958, 1935, 1900, 1879, 1855, 1822,
+   1814, 1810, 1799, 1776, 1718, 1715, 1700, 1699, 1640, 1627, 1610,
+   1607, 1601, 1600, 1599, 1594, 1580, 1578, 1574, 1550, 1540, 1539,
+   1527, 1499, 1463, 1462, 1438, 1410, 1402, 1401, 1391, 1367, 1366,
+   1360, 1359, 1358, 1349, 1340, 1336, 1325, 1324, 1300, 1291, 1287,
+   1261, 1250, 1249, 1206, 1200, 1199, 1177, 1175, 1174, 1152, 1149,
+   1140, 1135, 1127, 1118, 1111, 1100, 1099, 1077, 1060, 1039, 1020,
+   1019, 999, 997, 992, 990, 980, 960, 945, 944, 943, 939, 909, 902, 900,
+   899, 873, 869, 846, 845, 844, 843, 842, 840, 839, 838, 837, 836, 835,
+   834, 833, 832, 831, 820, 817, 800, 776, 774, 770, 766, 762, 758, 755,
+   750, 745, 717, 637, 603, 602, 590, 581, 578, 529, 527, 526, 523, 519,
+   518, 496, 491, 432, 404, 403, 401, 372, 363, 356, 345, 330, 329, 327,
+   317, 316, 313, 295, 282, 263, 242, 239, 234, 232, 225, 223, 213, 209,
+   204, 198, 195, 173, 170, 169, 167, 154, 149, 148, 147, 140, 138, 132,
+   131, 130, 129, 126, 121, 112, 109, 107, 100, 95, 90, 68, 64, 57, 52,
+   51, 46, 43, 37, 27, 25, 21, 15, 10, and 9 were examined and none were
+   found to have any date or time references, let alone millennium or Year
+   2000 issues.
+
+23. Security Considerations
+
+   Although this document does consider the implications of various
+   security protocols, there is no need for additional security
+   considerations.  The effect of a potential year 2000 problem may
+   cause some security problems, but those problems are more of specific
+   applications rather than protocol deficiencies introduced in this
+   document.
+
+24. References
+
+   Because of the exhaustive nature of this investigation, the reader is
+   referred to the list of published RFC's available from the IETF
+   Secretariat or the RFC Editor, rather than republishing them here.
+
+25. Editors' Address
+
+   Philip J. Nesser II
+   Nesser & Nesser Consulting
+   13501 100th Ave N.E.
+   Suite 5202
+   Kirkland, WA 98052
+
+   Phone: 425-481-4303
+   EMail: pjnesser@nesser.com
+          pjnesser@martigny.ai.mit.edu
+
+
+
+
+Nesser                       Informational                     [Page 28]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+Appendix A:  List of RFC's for each Area
+
+   The following list contains the RFC's grouped by area that were
+   searched for year 2000 problems.
+
+   Each line contains three fields are separated by '::'.  The first
+   filed is the RFC number, the second field is the type of RFC (S =
+   Standard, DS = Draft Standard, PS = Proposed Standard, E =
+   Experimental, H = Historical, I = Informational, BC = Best Current
+   Practice, '' = No Type), and the third field is the Title.
+
+A.1 Autoconfiguration
+
+1971:: PS::  IPv6 Stateless Address Autoconfiguration
+1970:: PS::  Neighbor Discovery for IP Version 6 (IPv6)
+1542:: PS::  Clarifications and Extensions for the Bootstrap Protocol
+1541:: PS::  Dynamic Host Configuration Protocol
+1534:: PS::  Interoperation Between DHCP and BOOTP
+1533:: PS::  DHCP Options and BOOTP Vendor Extensions
+1532:: PS::  Clarifications and Extensions for the Bootstrap Protocol
+1531:: PS::  Dynamic Host Configuration Protocol
+1497:: DS::  BOOTP Vendor Information Extensions
+1395:: DS::  BOOTP Vendor Information Extensions
+1084:: DS::  BOOTP vendor information extensions
+1048:: DS::  BOOTP vendor information extensions
+951::  DS::  Bootstrap Protocol
+906::    ::  Bootstrap loading using TFTP
+
+A.2 Directory Services
+
+2120:: E ::  Managing the X.500 Root Naming Context
+2079:: PS::  Definition of X.500 Attribute Types and an Object Class
+             to Hold Uniform Resource Identifiers (URIs)
+1943::  I::  Building an X.500 Directory Service in the US
+1914:: PS::  How to interact with a Whois++ mesh
+1913:: PS::  Architecture of the Whois++ Index Service
+1838::  E::  Use of the X.500 Directory to support mapping between
+             X.400 and RFC 822 Addresses
+1837::  E::  Representing Tables and Subtrees in the X.500 Directory
+1836::  E::  Representing the O/R Address hierarchy in the X.500
+             Directory Information Tree
+1835:: PS::  Architecture of the WHOIS++ service
+1834::  I::  Whois and Network Information Lookup Service Whois++
+1781:: PS::  Using the OSI Directory to Achieve User Friendly Naming
+1714::  I::  Referral Whois Protocol (RWhois)
+1684::  I::  Introduction to White Pages services based on X.500
+1637::  E::  DNS NSAP Resource Records
+1632::  I::  A Revised Catalog of Available X.500 Implementations
+
+
+
+Nesser                       Informational                     [Page 29]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1617::  I::  Naming and Structuring Guidelines for X.500 Directory Pilots
+1609::  E::  Charting Networks in the X.500 Directory
+1608::  E::  Representing IP Information in the X.500 Directory
+1588::  I::  WHITE PAGES MEETING REPORT
+1562::  I::  Naming Guidelines for the AARNet X.500 Directory Service
+1491::  I::  A Survey of Advanced Usages of X.500
+1488:: PS::  The X.500 String Representation of Standard Attribute
+             Syntaxes
+1487:: PS::  X.500 Lightweight Directory Access Protocol
+1485:: PS::  A String Representation of Distinguished Names
+1484::  E::  Using the OSI Directory to achieve User Friendly Naming
+1430::  I::  A Strategic Plan for Deploying an Internet X.500
+             Directory Service
+1400::  I::  Transition and Modernization of the Internet Registration
+             Service
+1384::  I::  Naming Guidelines for Directory Pilots
+1355::  I::  Privacy and Accuracy Issues in Network Information
+             Center Databases
+1330::  I::  Recommendations for the Phase I Deployment of OSI
+             Directory Services (X.500) and OSI Message Handling
+             Services (X.400) within the ESnet Community
+1309::  I::  Technical Overview of Directory Services Using the
+             X.500 Protocol
+1308::  I::  Executive Introduction to Directory Services Using the
+             X.500 Protocol
+1292::  I::  A Catalog of Available X.500 Implementations
+1279::   ::  X.500 and Domains
+1276:: PS::  Replication and Distributed Operations extensions to
+             provide an Internet Directory using X.500
+1275::  I::  Replication Requirements to provide an Internet Directory
+             using X.500
+1274:: PS::  The COSINE and Internet X.500 Schema
+1255::  I::  A Naming Scheme for c=US
+1218::   ::  A Naming Scheme for c=US
+1202::  I::  Directory Assistance Service
+1107::   ::  Plan for Internet directory services
+ 954:: DS::  NICNAME/WHOIS
+ 953::  H::  Hostname Server
+ 812::   ::  NICNAME/WHOIS
+ 756::   ::  NIC name server - a datagram-based information utility
+ 752::   ::  Universal host table
+============ ==========================================================
+Disk Sharing
+1813::  I::  NFS Version 3 Protocol Specification
+1094::  H::  NFS: Network File System Protocol specification
+============ ==========================================================
+Games and Chat
+1459::  E::  Internet Relay Chat Protocol
+
+
+
+Nesser                       Informational                     [Page 30]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+======================================================================
+Information Services & File Transfer
+2122:: PS::  VEMMI URL Specification
+2070:: PS::  Internationalization of the Hypertext Markup Language
+2068:: PS::  Hypertext Transfer Protocol -- HTTP/1.1
+2056:: PS::  Uniform Resource Locators for Z39.50
+2055::  I::  WebNFS Server Specification
+2054::  I::  WebNFS Client Specification
+2044::  I::  UTF-8, a transformation format of Unicode and ISO 10646
+2016::  E::  Uniform Resource Agents (URAs)
+1986::  E::  Experiments with a Simple File Transfer Protocol for
+             Radio Links using Enhanced Trivial File Transfer
+             Protocol (ETFTP)
+1980::  I::  A Proposed Extension to HTML: Client-Side Image Maps
+1960:: PS::  A String Representation of LDAP Search Filters
+1959:: PS::  An LDAP URL Format
+1945::  I::  Hypertext Transfer Protocol -- HTTP/1.0
+1942::  E::  HTML Tables
+1874::  E::  SGML Media Types
+1867::  E::  Form-based File Upload in HTML
+1866:: PS::  Hypertext Markup Language - 2.0
+1865::  I::  EDI Meets the Internet: Frequently Asked Questions
+             about Electronic Data Interchange (EDI) on the Internet
+1862::  I::  Report of the IAB Workshop on Internet Information
+              Infrastructure, October 12-14, 1994
+1843::  I::  HZ - A Data Format for Exchanging Files of Arbitrarily
+             Mixed Chinese and ASCII characters
+1842::  I::  ASCII Printable Characters-Based Chinese Character
+             Encoding for Internet Messages
+1823::  I::  The LDAP Application Program Interface
+1815::  I::  Character Sets ISO-10646 and ISO-10646-J-1
+1808:: PS::  Relative Uniform Resource Locators
+1807::  I::  A Format for Bibliographic Records
+1798:: PS::  Connection-less Lightweight Directory Access Protocol
+1788::  E::  ICMP Domain Name Messages
+1785::  I::  TFTP Option Negotiation Analysis
+1784:: PS::  TFTP Timeout Interval and Transfer Size Options
+1783:: PS::  TFTP Blocksize Option
+1782:: PS::  TFTP Option Extension
+1779:: DS::  A String Representation of Distinguished Names
+1778:: DS::  The String Representation of Standard Attribute Syntaxes
+1777:: DS::  Lightweight Directory Access Protocol
+1766:: PS::  Tags for the Identification of Languages
+1738:: PS::  Uniform Resource Locators (URL)
+1737::  I::  Functional Requirements for Uniform Resource Names
+1736::  I::  Functional Requirements for Internet Resource Locators
+1729::  I::  Using the Z39.50 Information Retrieval Protocol in the
+             Internet Environment
+
+
+
+Nesser                       Informational                     [Page 31]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1728::  I::  Resource Transponders
+1727::  I::  A Vision of an Integrated Internet Information Service
+1639::  E::  FTP Operation Over Big Address Records (FOOBAR)
+1633::  I::  Integrated Services in the Internet Architecture
+1630::  I::  Universal Resource Identifiers in WWW
+1625::  I::  WAIS over Z39.50-1988
+1558::  I::  A String Representation of LDAP Search Filters
+1554::  I::  ISO-2022-JP-2: Multilingual Extension of ISO-2022-JP
+1545::  E::  FTP Operation Over Big Address Records (FOOBAR)
+1530::  I::  Principles of Operation for the TPC.INT Subdomain:
+             General Principles and Policy
+1529::  I::  Principles of Operation for the TPC.INT Subdomain:
+             Remote Printing -- Administrative Policies
+1528::  E::  Principles of Operation for the TPC.INT Subdomain:
+             Remote Printing -- Technical Procedures
+1489::  I::  Registration of a Cyrillic Character Set
+1486::  E::  An Experiment in Remote Printing
+1440::  E::  SIFT/UFT: Sender-Initiated/Unsolicited File Transfer
+1436::  I::  The Internet Gopher Protocol (a distributed document
+             search and retrieval protocol)
+1415:: PS::  FTP-FTAM Gateway Specification
+1413:: PS::  Identification Protocol
+1350::  S::  THE TFTP PROTOCOL (REVISION 2)
+1345::  I::  Character Mnemonics & Character Sets
+1312::  E::  Message Send Protocol
+1302::  I::  Building a Network Information Services Infrastructure
+1288:: DS::  The Finger User Information Protocol
+1278::  I::  A String Encoding of Presentation Address
+1241::  E::  A Scheme for an Internet Encapsulation Protocol: Version 1
+1235::  E::  The Coherent File Distribution Protocol
+1196:: DS::  The Finger User Information Protocol
+1194:: DS::  The Finger User Information Protocol
+1179::  I::  Line Printer Daemon Protocol
+1123::  S::  Requirements for Internet hosts - application and support
+1068::   ::  Background File Transfer Program BFTP
+1037::  H::  NFILE - a file access protocol
+1003::   ::  Issues in defining an equations representation standard
+ 998::  E::  NETBLT: A bulk data transfer protocol
+ 978::   ::  Voice File Interchange Protocol VFIP
+ 971::   ::  Survey of data representation standards
+ 969::   ::  NETBLT: A bulk data transfer protocol
+ 965::   ::  Format for a graphical communication protocol
+ 959::  S::  File Transfer Protocol
+ 949::   ::  FTP unique-named store command
+ 916::  H::  Reliable Asynchronous Transfer Protocol RATP
+ 913::  H::  Simple File Transfer Protocol
+ 887::  E::  Resource Location Protocol
+ 866::  S::  Active users
+
+
+
+Nesser                       Informational                     [Page 32]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+ 865::  S::  Quote of the Day Protocol
+ 864::  S::  Character Generator Protocol
+ 863::  S::  Discard Protocol
+ 862::  S::  Echo Protocol
+ 797::   ::  Format for Bitmap files
+ 795::   ::  Service mappings
+ 783:: DS::  TFTP Protocol revision 2
+ 775::   ::  Directory oriented FTP commands
+ 765::   ::  File Transfer Protocol specification
+ 751::   ::  Survey of FTP mail and MLFL
+ 743::   ::  FTP extension: XRSQ/XRCP
+ 742:: PS::  NAME/FINGER Protocol
+ 740::  H::  NETRJS Protocol
+ 737::   ::  FTP extension: XSEN
+ 725::   ::  RJE protocol for a resource sharing network
+ 722::   ::  Thoughts on interactions in distributed services
+ 712::   ::  Distributed Capability Computing System DCCS
+ 707::   ::  High-level framework for network-based resource sharing
+ 697::   ::  CWD command of FTP
+ 691::   ::  One more try on the FTP
+ 683::   ::  FTPSRV - Tenex extension for paged files
+ 662::   ::  Performance improvement in ARPANET file transfers
+             from Multics
+ 640::   ::  Revised FTP reply codes
+ 633::   ::  IMP/TIP preventive maintenance schedule
+ 630::   ::  FTP error code usage for more reliable mail service
+ 624::   ::  Comments on the File Transfer Protocol
+ 622::   ::  Scheduling IMP/TIP down time
+ 614::   ::  Response to RFC 607: "Comments on the File Transfer
+              Protocol"
+ 610::   ::  Further datalanguage design concepts
+ 607::   ::  Comments on the File Transfer Protocol
+ 599::   ::  Update on NETRJS
+ 593::   ::  Telnet and FTP implementation schedule change
+ 592::   ::  Some thoughts on system design to facilitate resource
+             sharing
+ 589::   ::  CCN NETRJS server messages to remote user
+ 573::   ::  Data and file transfer: Some measurement results
+ 571::   ::  Tenex FTP problem
+ 570::   ::  Experimental input mapping between NVT ASCII and UCSB
+             On Line System
+ 553::   ::  Draft design for a text/graphics protocol
+ 551::   ::  [Letter from Feinroth re: NYU, ANL, and LBL entering
+             the net, and FTP protocol]
+ 549::   ::  Minutes of Network Graphics Group meeting, 15-17
+              July 1973
+ 543::   ::  Network journal submission and delivery
+ 542::   ::  File Transfer Protocol
+
+
+
+Nesser                       Informational                     [Page 33]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+ 535::   ::  Comments on File Access Protocol
+ 532::   ::  UCSD-CC Server-FTP facility
+ 525::   ::  MIT-MATHLAB meets UCSB-OLS -an example of resource sharing
+ 520::   ::  Memo to FTP group: Proposal for File Access Protocol
+ 514::   ::  Network make-work
+ 506::   ::  FTP command naming problem
+ 505::   ::  Two solutions to a file transfer access problem
+ 504::   ::  Distributed resources workshop announcement
+ 501::   ::  Un-muddling "free file transfer"
+ 499::   ::  Harvard's network RJE
+ 493::   ::  E.W., Jr Graphics Protocol
+ 490::   ::  Surrogate RJS for UCLA-CCN
+ 487::   ::  Free file transfer
+ 486::   ::  Data transfer revisited
+ 485::   ::  MIX and MIXAL at UCSB
+ 480::   ::  Host-dependent FTP parameters
+ 479::   ::  Use of FTP by the NIC Journal
+ 478::   ::  FTP server-server interaction - II
+ 477::   ::  Remote Job Service at UCSB
+ 472::   ::  Illinois' reply to Maxwell's request for graphics
+             information NIC 14925
+ 468::   ::  FTP data compression
+ 467::   ::  Proposed change to Host-Host Protocol:Resynchronization
+             of connection status
+ 463::   ::  FTP comments and response to RFC 430
+ 454::   ::  File Transfer Protocol - meeting announcement and a new
+             proposed document
+ 451::   ::  Tentative proposal for a Unified User Level Protocol
+ 448::   ::  Print files in FTP
+ 446::   ::  Proposal to consider a network program resource notebook
+ 438::   ::  FTP server-server interaction
+ 437::   ::  Data Reconfiguration Service at UCSB
+ 436::   ::  Announcement of RJS at UCSB
+ 430::   ::  Comments on File Transfer Protocol
+ 429::   ::  Character generator process
+ 418::   ::  Server file transfer under TSS/360 at NASA Ames
+ 414::   ::  File Transfer Protocol FTP status and further comments
+ 412::   ::  User FTP documentation
+ 411::   ::  New MULTICS network software features
+ 410::   ::  Removal of the 30-second delay when hosts come up
+ 409::   ::  Tenex interface to UCSB's Simple-Minded File System
+ 407::  H::  Remote Job Entry Protocol
+ 406::   ::  Scheduled IMP software releases
+ 396::   ::  Network Graphics Working Group meeting - second iteration
+ 387::   ::  Some experiences in implementing Network Graphics
+             Protocol Level 0
+ 385::   ::  Comments on the File Transfer Protocol
+ 382::   ::  Mathematical software on the ARPA Network
+
+
+
+Nesser                       Informational                     [Page 34]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+ 374::   ::  IMP system announcement
+ 373::   ::  Arbitrary character sets
+ 368::   ::  Comments on "Proposed Remote Job Entry Protocol"
+ 367::   ::  Network host status
+ 366::   ::  Network host status
+ 361::   ::  Deamon processes on host 106
+ 360::   ::  Proposed Remote Job Entry Protocol
+ 354::   ::  File Transfer Protocol
+ 351::   ::  Graphics information form for the ARPANET graphics
+             resources notebook
+ 342::   ::  Network host status
+ 338::   ::  EBCDIC/ASCII mapping for network RJE
+ 336::   ::  Level 0 Graphic Input Protocol
+ 335::   ::  New interface - IMP/360
+ 332::   ::  Network host status
+ 325::   ::  Network Remote Job Entry program - NETRJS
+ 324::   ::  RJE Protocol meeting
+ 314::   ::  Network Graphics Working Group meeting
+ 310::   ::  Another look at Data and File Transfer Protocols
+ 309::   ::  Data and File Transfer workshop announcement
+ 307::   ::  Using network Remote Job Entry
+ 306::   ::  Network host status
+ 299::   ::  Information management system
+ 298::   ::  Network host status
+ 294::   ::  On the use of "set data type" transaction in
+             File Transfer Protocol
+ 293::   ::  Network host status
+ 292::   ::  E.W., Jr Graphics Protocol: Level 0 only
+ 288::   ::  Network host status
+ 287::   ::  Status of network hosts
+ 286::   ::  Network library information system
+ 285::   ::  Network graphics
+ 283::   ::  NETRJT: Remote Job Service Protocol for TIPS
+ 281::   ::  Suggested addition to File Transfer Protocol
+ 268::   ::  Graphics facilities information
+ 267::   ::  Network host status
+ 266::   ::  Network host status
+ 265::   ::  File Transfer Protocol
+ 264::   ::  Data Transfer Protocol
+ 255::   ::  Status of network hosts
+ 252::   ::  Network host status
+ 250::   ::  Some thoughts on file transfer
+ 238::   ::  Comments on DTP and FTP proposals
+ 217::   ::  Specifications changes for OLS, RJE/RJOR, and SMFS
+ 199::   ::  Suggestions for a network data-tablet graphics protocol
+ 192::   ::  Some factors which a Network Graphics Protocol must
+             consider
+ 191::   ::  Graphics implementation and conceptualization at
+
+
+
+Nesser                       Informational                     [Page 35]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+             Augmentation Research Center
+ 189::   ::  Interim NETRJS specifications
+ 184::   ::  Proposed graphic display modes
+ 183::   ::  EBCDIC codes and their mapping to ASCII
+ 181::   ::  Modifications to RFC 177
+ 174::   ::  UCLA - computer science graphics overview
+ 172::   ::  File Transfer Protocol
+ 163::   ::  Data transfer protocols
+ 141::   ::  Comments on RFC 114: A File Transfer Protocol
+ 134::   ::  Network Graphics meeting
+ 133::   ::  File transfer and recovery
+ 125::   ::  Response to RFC 86: Proposal for network standard format
+             for a graphics data stream
+ 114::   ::  File Transfer Protocol
+ 105::   ::  Network specifications for Remote Job Entry and Remote
+             Job Output Retrieval at UCSB
+  98::   ::  Logger Protocol proposal
+  94::   ::  Some thoughts on network graphics
+  88::   ::  NETRJS: A third level protocol for Remote JobEntry
+  86::   ::  Proposal for a network standard format for a data stream
+             to control graphics display
+  83::   ::  Language-machine for data reconfiguration
+ ========== ============================================================
+Internet & Network Layer
+2126:: PS::  ISO Transport Service on top of TCP (ITOT)
+2125:: PS::  The PPP Bandwidth Allocation Protocol (BAP) The PPP
+             Bandwidth Allocation Control Protocol (BACP)
+2118::  I::  Microsoft Point-To-Point Compression (MPPC) Protocol
+2114::  I::  Data Link Switching Client Access Protocol
+2113:: PS::  IP Router Alert Option
+2107::  I::  Ascend Tunnel Management Protocol - ATMP
+2106::  I::  Data Link Switching Remote Access Protocol
+2105::  I::  Cisco Systems' Tag Switching Architecture Overview
+2098::  I::  Toshiba's Router Architecture Extensions for ATM:Overview
+2097:: PS::  The PPP NetBIOS Frames Control Protocol (NBFCP)
+2075::  I::  IP Echo Host Service
+2067:: DS::  IP over HIPPI
+2043:: PS::  The PPP SNA Control Protocol (SNACP)
+2023:: PS::  IP Version 6 over PPP
+2019:: PS::  Transmission of IPv6 Packets Over FDDI
+2018:: PS::  TCP Selective Acknowledgment Options
+2009::  E::  GPS-Based Addressing and Routing
+2005:: PS::  Applicability Statement for IP Mobility Support
+2004:: PS::  Minimal Encapsulation within IP
+2003:: PS::  IP Encapsulation within IP
+2002:: PS::  IP Mobility Support
+2001:: PS::  TCP Slow Start, Congestion Avoidance, Fast Retransmit,
+             and Fast Recovery Algorithms
+
+
+
+Nesser                       Informational                     [Page 36]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1994:: DS::  PPP Challenge Handshake Authentication Protocol (CHAP)
+1993::  I::  PPP Gandalf FZA Compression Protocol
+1990:: DS::  The PPP Multilink Protocol (MP)
+1989:: DS::  PPP Link Quality Monitoring
+1981:: PS::  Path MTU Discovery for IP version 6
+1979::  I::  PPP Deflate Protocol
+1978::  I::  PPP Predictor Compression Protocol
+1977::  I::  PPP BSD Compression Protocol
+1976::  I::  PPP for Data Compression in Data Circuit-Terminating
+             Equipment (DCE)
+1975::  I::  PPP Magnalink Variable Resource Compression
+1974::  I::  PPP Stac LZS Compression Protocol
+1973:: PS::  PPP in Frame Relay
+1972:: PS::  A Method for the Transmission of IPv6 Packets over
+             Ethernet Networks
+1967::  I::  PPP LZS-DCP Compression Protocol (LZS-DCP)
+1963::  I::  PPP Serial Data Transport Protocol (SDTP)
+1962:: PS::  The PPP Compression Control Protocol (CCP)
+1954::  I::  Transmission of Flow Labelled IPv4 on ATM Data Links
+             Ipsilon Version 1.0
+1946::  I::  Native ATM Support for ST2+
+1937::  I::  Local/Remote Forwarding Decision in Switched Data
+             Link Subnetworks
+1936::  I::  Implementing the Internet Checksum in Hardware
+1934::  I::  Ascend's Multilink Protocol Plus (MP+)
+1933:: PS::  Transition Mechanisms for IPv6 Hosts and Routers
+1932::  I::  IP over ATM: A Framework Document
+1931::  I::  Dynamic RARP Extensions and Administrative Support for
+             Automatic Network Address Allocation
+1926::  I::  An Experimental Encapsulation of IP Datagrams on
+             Top of ATM
+1924::  I::  A Compact Representation of IPv6 Addresses
+1919::  I::  Classical versus Transparent IP Proxies
+1918:: BC::  Address Allocation for Private Internets
+1917:: BC::  An Appeal to the Internet Community to Return Unused
+             IP Networks (Prefixes) to the IANA
+1916::  I::  Enterprise Renumbering
+1915:: BC::  Variance for The PPP Connection Control Protocol and
+             The PPP Encryption Control Protocol
+1897::  E::  IPv6 Testing Address Allocation
+1888::  E::  OSI NSAPs and IPv6
+1887::  I::  An Architecture for IPv6 Unicast Address Allocation
+1885:: PS::  Internet Control Message Protocol (ICMPv6) for the Internet
+             Protocol Version 6 (IPv6)
+1884:: PS::  IP Version 6 Addressing Architecture
+1883:: PS::  Internet Protocol, Version 6 (IPv6) Specification
+1881::  I::  IPv6 Address Allocation Management
+1878::  I::  Variable Length Subnet Table For IPv4
+
+
+
+Nesser                       Informational                     [Page 37]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1877::  I::  PPP Internet Protocol Control Protocol Extensions for
+             Name Server Addresses
+1868::  E::  ARP Extension - UNARP
+1860::  I::  Variable Length Subnet Table For IPv4
+1859::  I::  ISO Transport Class 2 Non-use of Explicit Flow Control
+             over TCP RFC1006 extension
+1853::  I::  IP in IP Tunneling
+1841::  I::  PPP Network Control Protocol for LAN Extension
+1833:: PS::  Binding Protocols for ONC RPC Version 2
+1832:: PS::  XDR
+1831:: PS::  RPC
+1809::  I::  Using the Flow Label Field in IPv6
+1795::  I::  Data Link Switching
+1791::  E::  TCP And UDP Over IPX Networks With Fixed Path MTU
+1770::  I::  IPv4 Option for Sender Directed Multi-Destination Delivery
+1764:: PS::  The PPP XNS IDP Control Protocol (XNSCP)
+1763:: PS::  The PPP Banyan Vines Control Protocol (BVCP)
+1762:: DS::  The PPP DECnet Phase IV Control Protocol (DNCP)
+1761::  I::  Snoop Version 2 Packet Capture File Format
+1756::  E::  REMOTE WRITE PROTOCOL - VERSION 1.0
+1755:: PS::  ATM Signaling Support for IP over ATM
+1754::  I::  IP over ATM Working Group's Recommendations for the
+             ATM Forum's Multiprotocol BOF Version 1
+1752:: PS::  The Recommendation for the IP Next Generation Protocol
+1744::  I::  Observations on the Management of the Internet Address
+             Space
+1735::  E::  NBMA Address Resolution Protocol (NARP)
+1726::  I::  Technical Criteria for Choosing IP
+1719::  I::  A Direction for IPng
+1717:: PS::  The PPP Multilink Protocol (MP)
+1710::  I::  Simple Internet Protocol Plus White Paper
+1707::  I::  CATNIP
+1705::  I::  Six Virtual Inches to the Left
+1698::  I::  Octet Sequences for Upper-Layer OSI to Support Basic
+             Communications Applications
+1693::  E::  An Extension to TCP
+1692:: PS::  Transport Multiplexing Protocol (TMux)
+1688::  I::  IPng Mobility Considerations
+1687::  I::  A Large Corporate User's View of IPng
+1686::  I::  IPng Requirements
+1683::  I::  Multiprotocol Interoperability In IPng
+1682::  I::  IPng BSD Host Implementation Analysis
+1681::  I::  On Many Addresses per Host
+1680::  I::  IPng Support for ATM Services
+1679::  I::  HPN Working Group Input to the IPng Requirements
+             Solicitation
+1678::  I::  IPng Requirements of Large Corporate Networks
+1677::  I::  Tactical Radio Frequency Communication Requirements
+
+
+
+Nesser                       Informational                     [Page 38]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+             for IPng
+1676::  I::  INFN Requirements for an IPng
+1674::  I::  A Cellular Industry View of IPng
+1673::  I::  Electric Power Research Institute Comments on IPng
+1672::  I::  Accounting Requirements for IPng
+1671::  I::  IPng White Paper on Transition and Other Considerations
+1670::  I::  Input to IPng Engineering Considerations
+1669::  I::  Market Viability as a IPng Criteria
+1667::  I::  Modeling and Simulation Requirements for IPng
+1663:: PS::  PPP Reliable Transmission
+1662::  S::  PPP in HDLC-like Framing
+1661::  S::  The Point-to-Point Protocol (PPP)
+1644::  E::  T/TCP -- TCP Extensions for Transactions Functional
+             Specification
+1638:: PS::  PPP Bridging Control Protocol (BCP)
+1634::  I::  Novell IPX Over Various WAN Media (IPXWAN)
+1631::  I::  The IP Network Address Translator (Nat)
+1629:: DS::  Guidelines for OSI NSAP Allocation in the Internet
+1626:: PS::  Default IP MTU for use over ATM AAL5
+1624::  I::  Computation of the Internet Checksum via Incremental
+             Update
+1622::  I::  Pip Header Processing
+1621::  I::  Pip Near-term Architecture
+1620::  I::  Internet Architecture Extensions for Shared Media
+1619:: PS::  PPP over SONET/SDH
+1618:: PS::  PPP over ISDN
+1613::  I::  cisco Systems X.25 over TCP (XOT)
+1605::  I::  SONET to Sonnet Translation
+1604:: PS::  Definitions of Managed Objects for Frame Relay Service
+1598:: PS::  PPP in X.25
+1590::  I::  Media Type Registration Procedure
+1577:: PS::  Classical IP and ARP over ATM
+1575:: DS::  An Echo Function for CLNP (ISO 8473)
+1570:: PS::  PPP LCP Extensions
+1561::  E::  Use of ISO CLNP in TUBA Environments
+1560::  I::  The MultiProtocol Internet
+1553:: PS::  Compressing IPX Headers Over WAN Media (CIPX)
+1552:: PS::  The PPP Internetwork Packet Exchange Control
+             Protocol (IPXCP)
+1551::  I::  Novell IPX Over Various WAN Media (IPXWAN)
+1549:: DS::  PPP in HDLC Framing
+1548:: DS::  The Point-to-Point Protocol (PPP)
+1547::  I::  Requirements for an Internet Standard
+             Point-to-Point Protocol
+1538::  I::  Advanced SNA/IP
+1526::  I::  Assignment of System Identifiers for TUBA/CLNP Hosts
+1518:: PS::  An Architecture for IP Address Allocation with CIDR
+1498::  I::  On the Naming and Binding of Network Destinations
+
+
+
+Nesser                       Informational                     [Page 39]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1490:: DS::  Multiprotocol Interconnect over Frame Relay
+1483:: PS::  Multiprotocol Encapsulation over ATM Adaptation Layer 5
+1475::  E::  TP/IX
+1466::  I::  Guidelines for Management of IP Address Space
+1454::  I::  Comparison of Proposals for Next Version of IP
+1435::  I::  IESG Advice from Experience with Path MTU Discovery
+1434::  I::  Data Link Switching
+1433::  E::  Directed ARP
+1393::  E::  Traceroute Using an IP Option
+1390::  S::  Transmission of IP and ARP over FDDI Networks
+1385::  I::  EIP
+1379::  I::  Extending TCP for Transactions -- Concepts
+1378:: PS::  The PPP AppleTalk Control Protocol (ATCP)
+1377:: PS::  The PPP OSI Network Layer Control Protocol (OSINLCP)
+1376:: PS::  The PPP DECnet Phase IV Control Protocol (DNCP)
+1375::  I::  Suggestion for New Classes of IP Addresses
+1374:: PS::  IP and ARP on HIPPI
+1365::  I::  An IP Address Extension Proposal
+1363::  E::  A Proposed Flow Specification
+1362::  I::  Novell IPX Over Various WAN Media (IPXWAN)
+1356:: PS::  Multiprotocol Interconnect on X.25 and ISDN in the
+             Packet Mode
+1347::  I::  TCP and UDP with Bigger Addresses (TUBA), A Simple
+             Proposal for Internet Addressing and Routing
+1337::  I::  TIME-WAIT Assassination Hazards in TCP
+1335::   ::  A Two-Tier Address Structure for the Internet
+1334:: PS::  PPP Authentication Protocols
+1333:: PS::  PPP Link Quality Monitoring
+1332:: PS::  The PPP Internet Protocol Control Protocol (IPCP)
+1331:: PS::  The Point-to-Point Protocol (PPP) for the Transmission
+             of Multi-protocol Datagrams over Point-to-Point Links
+1329::  I::  Thoughts on Address Resolution for Dual MAC FDDI Networks
+1326::  I::  Mutual Encapsulation Considered Dangerous
+1323:: PS::  TCP Extensions for High Performance
+1314:: PS::  A File Format for the Exchange of Images in the Internet
+1307::  E::  Dynamically Switched Link Control Protocol
+1306::  I::  Experiences Supporting By-Request Circuit-Switched T3
+             Networks
+1294:: PS::  Multiprotocol Interconnect over Frame Relay
+1293:: PS::  Inverse Address Resolution Protocol
+1277:: PS::  Encoding Network Addresses to Support Operation Over
+             Non-OSI Lower Layers
+1263::  I::  TCP Extensions Considered Harmful
+1256:: PS::  ICMP Router Discovery Messages
+1240:: PS::  OSI Connectionless Transport Services on top of UDP
+1237:: PS::  Guidelines for OSI NSAP Allocation in the Internet
+1236::   ::  IP to X.121 Address Mapping for DDN
+1234:: PS::  Tunneling IPX Traffic through IP Networks
+
+
+
+Nesser                       Informational                     [Page 40]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1226::  E::  Internet Protocol Encapsulation of AX.25 Frames
+1223::   ::  OSI CLNS and LLC1 Protocols on Network Systems HYPERchannel
+1220:: PS::  Point-to-Point Protocol Extensions for Bridging
+1219::   ::  On the Assignment of Subnet Numbers
+1210::   ::  Network and Infrastructure User Requirements for
+             Transatlantic Research Collaboration - Brussels,
+             July 16-18, and Washington July 24-25, 1990
+1209:: DS::  The Transmission of IP Datagrams over the SMDS Service
+1201::  H::  Transmitting IP Traffic over ARCNET Networks
+1191:: DS::  Path MTU Discovery
+1188:: DS::  A Proposed Standard for the Transmission of IP Datagrams
+             over FDDI Networks
+1185::  E::  TCP Extension for High-Speed Paths
+1172:: PS::  The Point-to-Point Protocol (PPP) Initial Configuration
+             Options
+1171:: DS::  The Point-to-Point Protocol for the Transmission of
+             Multi-Protocol Datagrams Over Point-to-Point Links
+1166::   ::  Internet Numbers
+1162::   ::  Connectionless Network Protocol (ISO 8473) and End
+             System to Intermediate System (ISO 9542) Management
+             Information Base
+1151::  E::  Version 2 of the Reliable Data Protocol (RDP)
+1146::  E::  TCP Alternate Checksum Options
+1145::  E::  TCP Alternate Checksum Options
+1144:: PS::  Compressing TCP/IP headers for low-speed serial links
+1141::   ::  Incremental Updating of the Internet Checksum
+1139:: PS::  Echo function for ISO 8473
+1134:: PS::  Point-to-Point Protocol
+1132::  S::  Standard for the transmission of 802.2 packets over
+             IPX networks
+1122::  S::  Requirements for Internet hosts - communication layers
+1110::   ::  Problem with the TCP big window option
+1106::   ::  TCP big window and NAK options
+1103:: PS::  Proposed standard for the transmission of IP datagrams
+             over FDDI Networks
+1088::  S::  Standard for the transmission of IP datagrams over
+             NetBIOS networks
+1086::   ::  ISO-TP0 bridge between TCP and X.25
+1085::   ::  ISO presentation services on top of TCP/IP based internets
+1078::   ::  TCP port service Multiplexer TCPMUX
+1072::  E::  TCP extensions for long-delay paths
+1071::   ::  Computing the Internet checksum
+1070::   ::  Use of the Internet as a subnetwork for experimentation
+             with the OSI network layer
+1069::   ::  Guidelines for the use of Internet-IP addressesin the
+             ISO Connectionless-Mode Network Protocol
+1063::   ::  IP MTU Discovery options
+1062::   ::  Internet numbers
+
+
+
+Nesser                       Informational                     [Page 41]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1057::  I::  RPC
+1055::  S::  Nonstandard for transmission of IP datagrams over serial
+             lines
+1051::  S::  Standard for the transmission of IP datagrams and ARP
+             packets over ARCNET networks
+1050::  H::  RPC
+1046::   ::  Queuing algorithm to provide type-of-service for IP links
+1045::  E::  VMTP
+1044::  S::  Internet Protocol on Network System's HYPERchannel
+1042::  S::  Standard for the transmission of IP datagrams over
+             IEEE 802 networks
+1030::   ::  On testing the NETBLT Protocol over divers networks
+1029::   ::  More fault tolerant approach to address resolution for
+             a Multi-LAN system of Ethernets
+1027::   ::  Using ARP to implement transparent subnet gateways
+1025::   ::  TCP and IP bake off
+1016::   ::  Something a host could do with source quench
+1008::   ::  Implementation guide for the ISO Transport Protocol
+1007::   ::  Military supplement to the ISO Transport Protocol
+1006::  S::  ISO transport services on top of the TCP
+1002::  S::  Protocol standard for a NetBIOS service on a TCP/UDP
+             transport
+1001::  S::  Protocol standard for a NetBIOS service on a TCP/UDP
+             transport
+ 994::   ::  Final text of DIS 8473,Protocol for Providing the
+             Connectionless-mode Network Service
+ 986::   ::  Guidelines for the use of Internet-IP addressesin the
+             ISO Connectionless-Mode Network Protocol [Working draft]
+ 983::   ::  ISO transport arrives on top of the TCP
+ 982::   ::  Guidelines for the specification of the structure of the
+             Domain Specific Part DSP of the ISO standard NSAP address
+ 970::   ::  On packet switches with infinite storage
+ 964::   ::  Some problems with the specification of the Military
+             Standard Transmission Control Protocol
+ 963::   ::  Some problems with the specification of the Military
+             Standard Internet Protocol
+ 962::   ::  TCP-4 prime
+ 955::   ::  Towards a transport service for transaction processing
+             applications
+ 948::   ::  Two methods for the transmission of IP datagrams over
+             IEEE 802.3 networks
+ 942::   ::  Transport protocols for Department of Defense data
+             networks
+ 941::   ::  Addendum to the networkservice definition covering
+             network layer addressing
+ 940::   ::  Toward an Internet standard scheme for subnetting
+ 936::   ::  Another Internet subnet addressing scheme
+ 935::   ::  Reliable link layer protocols
+
+
+
+Nesser                       Informational                     [Page 42]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+ 932::   ::  Subnetwork addressing scheme
+ 926::   ::  Protocol for providing the connectionless mode network
+             services
+ 925::   ::  Multi-LAN address resolution
+ 924::   ::  Official ARPA-Internet protocols for connecting
+             personal computers to the Internet
+ 922::  S::  Broadcasting Internet datagrams in the presence of subnets
+ 919::  S::  Broadcasting Internet datagrams
+ 917::   ::  Internet subnets
+ 914::  H::  Thinwire protocol for connecting personal computers to
+             the Internet
+ 905::   ::  ISO Transport Protocol specification ISO DP 8073
+ 903::  S::  Reverse Address Resolution Protocol
+ 896::   ::  Congestion control in IP/TCP internetworks
+ 895::  S::  Standard for the transmission of IP datagrams over
+             experimental Ethernet networks
+ 894::  S::  Standard for the transmission of IP datagrams over
+             Ethernet networks
+ 893::   ::  Trailer encapsulations
+ 892::   ::  ISO Transport Protocol specification [Draft]
+ 891::  S::  DCN local-network protocols
+ 889::   ::  Internet delay experiments
+ 879::   ::  TCP maximum segment size and related topics
+ 877::  S::  Standard for the transmission of IP datagrams over
+             public data networks
+ 874::   ::  Critique of X.25
+ 872::   ::  TCP-on-a-LAN
+ 871::   ::  Perspective on the ARPANET reference model
+ 848::   ::  Who provides the "little" TCP services?
+ 829::   ::  Packet satellite technology reference sources
+ 826::  S::  Ethernet Address Resolution Protocol
+ 824::   ::  CRONUS Virtual Local Network
+ 815::   ::  IP datagram reassembly algorithms
+ 814::   ::  Name, addresses, ports, and routes
+ 813::   ::  Window and acknowlegement strategy in TCP
+ 801::   ::  NCP/TCP transition plan
+ 793::  S::  Transmission Control Protocol
+ 792::  S::  Internet Control Message Protocol
+ 791::  S::  Internet Protocol
+ 789::   ::  Vulnerabilities of network control protocols
+ 787::   ::  Connectionless data transmission survey/tutorial
+ 781::   ::  Specification of the Internet Protocol IP timestamp option
+ 777::   ::  Internet Control Message Protocol
+ 768::  S::  User Datagram Protocol
+ 761::   ::  DOD Standard Transmission Control Protocol
+ 760::   ::  DoD standard Internet Protocol
+ 759::  H::  Internet Message Protocol
+ 730::   ::  Extensible field addressing
+
+
+
+Nesser                       Informational                     [Page 43]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+ 704::   ::  IMP/Host and Host/IMP Protocol change
+ 696::   ::  Comments on the IMP/Host and Host/IMP Protocol changes
+ 695::   ::  Official change in Host-Host Protocol
+ 692::   ::  Comments on IMP/Host Protocol changes RFCs 687 and 690
+ 690::   ::  Comments on the proposed Host/IMP Protocol changes
+ 689::   ::  Tenex NCP finite state machine for connections
+ 687::   ::  IMP/Host and Host/IMP Protocol changes
+ 685::   ::  Response time in cross network debugging
+ 680::   ::  Message Transmission Protocol
+ 675::   ::  Specification of Internet Transmission Control Program
+ 674::   ::  Procedure call documents - version 2
+ 660::   ::  Some changes to the IMP and the IMP/Host interface
+ 632::   ::  Throughput degradations for single packet messages
+ 626::   ::  On a possible lockup condition in IMP subnet due to
+             message sequencing
+ 613::   ::  Network connectivity
+ 611::   ::  Two changes to the IMP/Host Protocol to improve
+             user/network communications
+ 594::   ::  Speedup of Host-IMP interface
+ 591::   ::  Addition to the Very Distant Host specifications
+ 576::   ::  Proposal for modifying linking
+ 550::   ::  NIC NCP experiment
+ 548::   ::  Hosts using the IMP Going Down message
+ 528::   ::  Software checksumming in the IMP and network reliability
+ 521::   ::  Restricted use of IMP DDT
+ 489::   ::  Comment on resynchronization of connection status proposal
+ 488::   ::  NLS classes at network sites
+ 476::   ::  IMP/TIP memory retrofit schedule rev. 2
+ 473::   ::  MIX and MIXAL?
+ 460::   ::  NCP survey
+ 459::   ::  Network questionnaires
+ 450::   ::  MULTICS sampling timeout change
+ 449::   ::  Current flow-control scheme for IMPSYS
+ 445::   ::  IMP/TIP preventive maintenance schedule
+ 442::   ::  Current flow-control scheme for IMPSYS
+ 434::   ::  IMP/TIP memory retrofit schedule
+ 426::   ::  Reconnection Protocol
+ 417::   ::  Link usage violation
+ 398::   ::  ICP sockets
+ 395::   ::  Switch settings on IMPs and TIPs
+ 394::   ::  Two proposed changes to the IMP-Host Protocol
+ 359::   ::  Status of the release of the new IMP System
+ 357::   ::  Echoing strategy for satellite links
+ 348::   ::  Discard process
+ 347::   ::  Echo process
+ 346::   ::  Satellite considerations
+ 343::   ::  IMP System change notification
+ 312::   ::  Proposed change in IMP-to-Host Protocol
+
+
+
+Nesser                       Informational                     [Page 44]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+ 301::   ::  BBN IMP #5 and NCC schedule March 4, 1971
+ 300::   ::  ARPA Network mailing lists
+ 271::   ::  IMP System change notifications
+ 241::   ::  Connecting computers to MLC ports
+ 210::   ::  Improvement of flow control
+ 203::   ::  Achieving reliable communication
+ 202::   ::  Possible deadlock in ICP
+ 197::   ::  Initial Connection Protocol - Reviewed
+ 190::   ::  DEC PDP-10-IMLAC communications system
+ 178::   ::  Network graphic attention handling
+ 176::   ::  Comments on "Byte size for connections"
+ 175::   ::  Comments on "Socket conventions reconsidered"
+ 166::   ::  Data Reconfiguration Service
+ 165::   ::  Proffered official Initial Connection Protocol
+ 161::   ::  Solution to the race condition in the ICP
+ 151::   ::  Comments on a proffered official ICP
+ 150::   ::  Use of IPC facilities
+ 146::   ::  Views on issues relevant to data sharing on computer
+             networks
+ 145::   ::  Initial Connection Protocol control commands
+ 143::   ::  Regarding proffered official ICP
+ 142::   ::  Time-out mechanism in the Host-Host Protocol
+ 128::   ::  Bytes
+ 127::   ::  Comments on RFC 123
+ 123::   ::  Proffered official ICP
+ 122::   ::  Network specifications for UCSB's Simple-Minded File
+             System
+  93::   ::  Initial Connection Protocol
+  91::   ::  Proposed User-User Protocol
+  80::   ::  Protocols and data formats
+  79::   ::  Logger Protocol error
+  70::   ::  Note on padding
+  67::   ::  Proposed change to Host/IMP spec to eliminate marking
+  65::   ::  Comments on Host/Host Protocol document #1
+  62::   ::  Systems for interprocess communication in a resource
+             sharing computer network
+  60::   ::  Simplified NCP Protocol
+  59::   ::  Flow control - fixed versus demand allocation
+  56::   ::  Third level protocol
+  55::   ::  Prototypical implementation of the NCP
+  54::   ::  Official protocol proffering
+  53::   ::  Official protocol mechanism
+  41::   ::  IMP-IMP teletype communication
+  38::   ::  Comments on network protocol from NWG/RFC #36
+  33::   ::  New Host-Host Protocol
+  23::   ::  Transmission of multiple control messages
+  22::   ::  Host-host control message formats
+  20::   ::  ASCII format for network interchange
+
+
+
+Nesser                       Informational                     [Page 45]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+  19::   ::  Two protocol suggestions to reduce congestion at
+             swap bound nodes
+  17::   ::  Some questions re
+  12::   ::  IMP-Host interface flow diagrams
+=====================================================================
+Mail
+2112:: PS::  The MIME Multipart/Related Content-type
+2111:: PS::  Content-ID and Message-ID Uniform Resource Locators
+2110:: PS::  MIME E-mail Encapsulation of Aggregate Documents, such
+             as HTML (MHTML)
+2109:: PS::  HTTP State Management Mechanism
+2095:: PS::  IMAP/POP AUTHorize Extension for Simple Challenge/Response
+2088:: PS::  IMAP4 non-synchroniziong literals
+2087:: PS::  IMAP4 QUOTA extension
+2086:: PS::  IMAP4 ACL extension
+2077:: PS::  The Model Primary Content Type for Multipurpose
+             Internet Mail Extensions
+2076::  I::  Common Internet Message Headers
+2062::  I::  Internet Message Access Protocol - Obsolete Syntax
+2061::  I::  IMAP4 COMPATIBILITY WITH IMAP2BIS
+2060:: PS::  INTERNET MESSAGE ACCESS PROTOCOL - VERSION 4rev1
+2049:: DS::  Multipurpose Internet Mail Extensions (MIME) Part Five
+2048:: BC::  Multipurpose Internet Mail Extensions (MIME) Part Four
+2047:: DS::  MIME (Multipurpose Internet Mail Extensions) Part Three
+2046:: DS::  Multipurpose Internet Mail Extensions (MIME) Part Two
+2045:: DS::  Multipurpose Internet Mail Extensions (MIME) Part One
+2034:: PS::  SMTP Service Extension for Returning Enhanced Error Codes
+2033::  I::  Local Mail Transfer Protocol
+2017:: PS::  Definition of the URL MIME External-Body Access-Type
+1991::  I::  PGP Message Exchange Formats
+1985:: PS::  SMTP Service Extension for Remote Message Queue Starting
+1957::  I::  Some Observations on Implementations of the Post Office
+             Protocol (POP3)
+1947::  I::  Greek Character Encoding for Electronic Mail Messages
+1939::  S::  Post Office Protocol - Version 3
+1927::  I::  Suggested Additional MIME Types for Associating Documents
+1922::  I::  Chinese Character Encoding for Internet Messages
+1911::  E::  Voice Profile for Internet Mail
+1896::  I::  The text/enriched MIME Content-type
+1895::  I::  The Application/CALS-1840 Content-type
+1894:: PS::  An Extensible Message Format for Delivery Status
+             Notifications
+1893:: PS::  Enhanced Mail System Status Codes
+1892:: PS::  The Multipart/Report Content Type for the Reporting
+             of Mail System Administrative Messages
+1891:: PS::  SMTP Service Extension for Delivery Status Notifications
+1873::  E::  Message/External-Body Content-ID Access Type
+1872::  E::  The MIME Multipart/Related Content-type
+
+
+
+Nesser                       Informational                     [Page 46]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1870::  S::  SMTP Service Extension for Message Size Declaration
+1869::  S::  SMTP Service Extensions
+1864:: DS::  The Content-MD5 Header Field
+1854:: PS::  SMTP Service Extension for Command Pipelining
+1848:: PS::  MIME Object Security Services
+1847:: PS::  Security Multiparts for MIME
+1846::  E::  SMTP 521 reply code
+1845::  E::  SMTP Service Extension for Checkpoint/Restart
+1844::  I::  Multimedia E-mail (MIME) User Agent checklist
+1830::  E::  SMTP Service Extensions for Transmission of Large
+             and Binary MIME Messages
+1820::  I::  Multimedia E-mail (MIME) User Agent Checklist
+1806::  E::  Communicating Presentation Information in Internet
+             Messages
+1804::  E::  Schema Publishing in X.500 Directory
+1803::  I::  Recommendations for an X.500 Production Directory Service
+1801::  E::  MHS use of the X.500 Directory to support MHS Routing
+1767:: PS::  MIME Encapsulation of EDI Objects
+1741::  I::  MIME Content Type for BinHex Encoded Files
+1740:: PS::  MIME Encapsulation of Macintosh files - MacMIME
+1734:: PS::  POP3 AUTHentication command
+1733::  I::  DISTRIBUTED ELECTRONIC MAIL MODELS IN IMAP4
+1732::  I::  IMAP4 COMPATIBILITY WITH IMAP2 AND IMAP2BIS
+1731:: PS::  IMAP4 Authentication mechanisms
+1730:: PS::  INTERNET MESSAGE ACCESS PROTOCOL - VERSION 4
+1725:: DS::  Post Office Protocol - Version 3
+1711::  I::  Classifications in E-mail Routing
+1685::  I::  Writing X.400 O/R Names
+1653:: DS::  SMTP Service Extension for Message Size Declaration
+1652:: DS::  SMTP Service Extension for 8bit-MIMEtransport
+1651:: DS::  SMTP Service Extensions
+1649::  I::  Operational Requirements for X.400 Management Domains
+             in the GO-MHS Community
+1648:: PS::  Postmaster Convention for X.400 Operations
+1642::  E::  UTF-7 - A Mail-Safe Transformation Format of Unicode
+1641::  E::  Using Unicode with MIME
+1616::  I::  X.400(1988) for the Academic and Research Community
+             in Europe
+1615::  I::  Migrating from X.400(84) to X.400(88)
+1563::  I::  The text/enriched MIME Content-type
+1557::  I::  Korean Character Encoding for Internet Messages
+1556::  I::  Handling of Bi-directional Texts in MIME
+1555::  I::  Hebrew Character Encoding for Internet Messages
+1544:: PS::  The Content-MD5 Header Field
+1524::  I::  A User Agent Configuration Mechanism For Multimedia
+             Mail Format Information
+1523::  I::  The text/enriched MIME Content-type
+1522:: DS::  MIME (Multipurpose Internet Mail Extensions) Part Two
+
+
+
+Nesser                       Informational                     [Page 47]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1521:: DS::  MIME (Multipurpose Internet Mail Extensions) Part One
+1506::  I::  A tutorial on gatewaying between X.400 and Internet mail
+1505::  E::  Encoding Header Field for Internet Messages
+1502:: PS::  X.400 Use of Extended Character Sets
+1496:: PS::  Rules for downgrading messages from X.400/88 to X.400/84
+             when MIME content-types are present in the messages
+1495:: PS::  Mapping between X.400 and RFC-822 Message Bodies
+1494:: PS::  Equivalences between 1988 X.400 and RFC-822 Message Bodies
+1468::  I::  Japanese Character Encoding for Internet Messages
+1465::  E::  Routing coordination for X.400 MHS services within a
+             multi protocol / multi network environment Table Format
+             V3 for static routing
+1460:: DS::  Post Office Protocol - Version 3
+1456::  I::  Conventions for Encoding the Vietnamese Language VISCII
+1437::  I::  The Extension of MIME Content-Types to a New Medium
+1429::  I::  Listserv Distribute Protocol
+1428::  I::  Transition of Internet Mail from Just-Send-8 to
+             8Bit-SMTP/MIME
+1427:: PS::  SMTP Service Extension for Message Size Declaration
+1426:: PS::  SMTP Service Extension for 8bit-MIMEtransport
+1425:: PS::  SMTP Service Extensions
+1405::  E::  Mapping between X.400(1984/1988) and Mail-11 (DECnet mail)
+1357::  I::  A Format for E-mailing Bibliographic Records
+1344::  I::  Implications of MIME for Internet Mail Gateways
+1343::  I::  A User Agent Configuration Mechanism For Multimedia
+             Mail Format Information
+1342:: PS::  Representation of Non-ASCII Text in Internet Message
+             Headers
+1341:: PS::  MIME (Multipurpose Internet Mail Extensions)
+1339::  E::  Remote Mail Checking Protocol
+1328:: PS::  X.400 1988 to 1984 downgrading
+1327:: PS::  Mapping between X.400(1988) / ISO 10021 and RFC 822
+1225:: DS::  Post Office Protocol - Version 3
+1211::   ::  Problems with the Maintenance of Large Mailing Lists
+1204::  E::  Message Posting Protocol (MPP)
+1203::  H::  Interactive Mail Access Protocol - Version 3
+1176::  E::  Interactive Mail Access Protocol - Version 2
+1168::   ::  Intermail and Commercial Mail Relay Services
+1159::  E::  Message Send Protocol
+1154::  E::  Encoding Header Field for Internet Messages
+1153::  E::  Digest Message Format
+1148::  E::  Mapping between X.400 (1988) / ISO 10021 and RFC 822
+1138::  I::  Mapping between X.400(1988) / ISO 10021 and RFC 822
+1137::  E::  Mapping between full RFC 822 and RFC 822 with restricted
+             encoding
+1090::   ::  SMTP on X.25
+1082::  H::  Post Office Protocol - version 3
+1081:: PS::  Post Office Protocol - version 3
+
+
+
+Nesser                       Informational                     [Page 48]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1064::  H::  Interactive Mail Access Protocol
+1056::  I::  PCMAIL
+1049::  S::  Content-type header field for Internet messages
+1047::   ::  Duplicate messages and SMTP
+1026:: PS::  Addendum to RFC 987
+ 993::   ::  PCMAIL
+ 987:: PS::  Mapping between X.400 and RFC 822
+ 984::   ::  PCMAIL
+ 976::   ::  UUCP mail interchange format standard
+ 974::  S::  Mail routing and the domain system
+ 937::  H::  Post Office Protocol - version 2
+ 934::   ::  Proposed standard for message encapsulation
+ 918::   ::  Post Office Protocol
+ 915::   ::  Network mail path service
+ 910::   ::  Multimedia mail meeting notes
+ 886::   ::  Proposed standard for message header munging
+ 876::   ::  Survey of SMTP implementations
+ 841::   ::  Specification for message format for Computer Based
+             Message Systems
+ 822::  S::  Standard for the format of ARPA Internet text messages
+ 821::  S::  Simple Mail Transfer Protocol
+ 808::   ::  Summary of computer mail services meeting held at BBN
+             on 10 January 1979
+ 807::   ::  Multimedia mail meeting notes
+ 805::   ::  Computer mail meeting notes
+ 788::   ::  Simple Mail Transfer Protocol
+ 786::   ::  Mail Transfer Protocol
+ 785::   ::  Mail Transfer Protocol
+ 784::   ::  Mail Transfer Protocol
+ 780::   ::  Mail Transfer Protocol
+ 773::   ::  Comments on NCP/TCP mail service transition strategy
+ 772::   ::  Mail Transfer Protocol
+ 771::   ::  Mail transition plan
+ 767::   ::  Structured format for transmission of multi-media
+             documents
+ 763::   ::  Role mailboxes
+ 757::   ::  Suggested solution to the naming, addressing, and
+             delivery problem for ARPANET message systems
+ 754::   ::  Out-of-net host addresses for mail
+ 753::   ::  Internet Message Protocol
+ 744::   ::  MARS - a Message Archiving and Retrieval Service
+ 733::   ::  Standard for theformat of ARPA network text messages
+ 724::   ::  Proposed official standard for the format of ARPA
+             Network messages
+ 720::   ::  Address specification syntax for network mail
+ 714::   ::  Host-Host Protocol for an ARPANET-type network
+ 713::   ::  MSDTP-Message Services Data Transmission Protocol
+ 706::   ::  On the junk mail problem
+
+
+
+Nesser                       Informational                     [Page 49]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+ 577::   ::  Mail priority
+ 574::   ::  Announcement of a mail facility at UCSB
+ 561::   ::  Standardizingnetwork mail headers
+ 555::   ::  Responses to critiques of the proposed mail protocol
+ 539::   ::  Thoughts on the mail protocol proposed in RFC524
+ 534::   ::  Lost message detection
+ 533::   ::  Message-ID numbers
+ 524::   ::  Proposed Mail Protocol
+ 516::   ::  Lost message detection
+ 512::   ::  More on lost message detection
+ 510::   ::  Request for network mailbox addresses
+ 498::   ::  On mail service to CCN
+ 475::   ::  FTP and network mail system
+ 469::   ::  Network mail meeting summary
+ 458::   ::  Mail retrieval via FTP
+ 453::   ::  Meeting announcement to discuss a network mail system
+ 333::   ::  Proposed experiment with a Message Switching Protocol
+ 278::   ::  Revision of theMail Box Protocol
+ 224::   ::  Comments on Mailbox Protocol
+ 221::   ::  Mail Box Protocol
+ 196::   ::  Mail Box Protocol
+  58::   ::  Logical message synchronization
+  42::   ::  Message data types
+=====================================================================
+NTP
+2030::  I::  Simple Network Time Protocol (SNTP) Version 4 for IPv4,
+             IPv6 and OSI
+1769::  I::  Simple Network Time Protocol (SNTP)
+1708::  I::  NTP PICS PROFORMA For the Network Time Protocol Version 3
+1589::  I::  A Kernel Model for Precision Timekeeping
+1361::  I::  Simple Network Time Protocol (SNTP)
+1305:: PS::  Network Time Protocol (v3)
+1165::  E::  Network Time Protocol (NTP) over the OSI Remote Operations
+             Service
+1129::   ::  Internet time synchronization
+1128::   ::  Measured performance of the Network Time Protocol in the
+             Internet system
+1119::  S::  Network Time Protocol version 2 specification and
+             implementation
+1059::   ::  Network Time Protocol version 1 specification and
+             implementation
+ 958::   ::  Network Time Protocol NTP
+ 957::   ::  Experiments in network clock synchronization
+ 956::   ::  Algorithms for synchronizing network clocks
+ 868::  S::  Time Protocol
+ 867::  S::  Daytime Protocol
+ 778::  H::  DCNET Internet Clock Service
+ 738::   ::  Time server
+
+
+
+Nesser                       Informational                     [Page 50]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+  29::   ::  Response to RFC 28
+  28::   ::  Time standards
+=====================================================================
+Name Serving
+2053::  I::  The AM (Armenia) Domain
+2052::  E::  A DNS RR for specifying the location of services (DNS SRV)
+2010::  I::  Operational Criteria for Root Name Servers
+1996:: PS::  A Mechanism for Prompt Notification of Zone Changes
+             (DNS NOTIFY)
+1995:: PS::  Incremental Zone Transfer in DNS
+1982:: PS::  Serial Number Arithmetic
+1956::  I::  Registration in the MIL Domain
+1912::  I::  Common DNS Operational and Configuration Errors
+1886:: PS::  DNS Extensions to support IP version 6
+1876::  E::  A Means for Expressing Location Information in the
+             Domain Name System
+1794::  I::  DNS Support for Load Balancing
+1713::  I::  Tools for DNS debugging
+1712::  E::  DNS Encoding of Geographical Location
+1706::  I::  DNS NSAP Resource Records
+1664::  E::  Using the Internet DNS to Distribute RFC1327 Mail
+             Address Mapping Tables
+1591::  I::  Domain Name System Structure and Delegation
+1537::  I::  Common DNS Data File Configuration Error
+1536::  I::  Common DNS Implementation Errors and Suggested Fixes.
+1480::  I::  The US Domain
+1464::  E::  Using the Domain Name System To Store Arbitrary
+             String Attributes
+1394::  I::  Relationship of Telex Answerback Codes to Internet Domains
+1386::  I::  The US Domain
+1348::  E::  DNS NSAP RRs
+1183::  E::  New DNS RR Definitions
+1101::   ::  DNS encoding of network names and other types
+1035::  S::  Domain names - implementation and specification
+1034::  S::  Domain names - concepts and facilities
+1033::   ::  Domain administrators operations guide
+1032::   ::  Domain administrators guide
+1031::   ::  MILNET name domain transition
+ 973::   ::  Domain system changes and observations
+ 952::   ::  DoD Internet host table specification
+ 921::   ::  Domain name system implementation schedule - revised
+ 920::   ::  Domain requirements
+ 897::   ::  Domain name system implementation schedule
+ 883::   ::  Domain names
+ 882::   ::  Domain names
+ 881::   ::  Domain names plan and schedule
+ 849::   ::  Suggestions for improved host table distribution
+ 830::   ::  Distributed system for Internet name service
+
+
+
+Nesser                       Informational                     [Page 51]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+ 819::   ::  Domain naming convention for Internet user applications
+ 811::   ::  Hostnames Server
+ 810::   ::  DoD Internet host table specification
+ 799::   ::  Internet name domains
+ 796::   ::  Address mappings
+ 627::   ::  ASCII text file of hostnames
+ 625::   ::  On-line hostnames service
+ 623::   ::  Comments on on-line host name service
+ 620::   ::  Request for monitor host table updates
+ 608::   ::  Host names on-line
+ 606::   ::  Host names on-line
+ 289::   ::  What we hope is an official list of host names
+ 280::   ::  Draft of host names
+ 273::   ::  More on standard host names
+ 247::   ::  Proffered set of standard host names
+ 237::   ::  NIC view of standard host names
+ 236::   ::  Standard host names
+ 233::   ::  Standardization of host call letters
+ 229::   ::  Standard host names
+ 226::   ::  Standardization of host mnemonics
+=====================================================================
+Network Management
+2128:: PS::  Dial Control Management Information Base using SMIv2
+2127:: PS::  ISDN Management Information Base
+2124::  I::  Light-weight Flow Admission Protocol Specification
+             Version 1.0
+2108:: PS::  Definitions of Managed Objects for IEEE 802.3 Repeater
+             Devices using SMIv2
+2096:: PS::  IP Forwarding Table MIB
+2089::  I::  V2ToV1 Mapping SNMPv2 onto SNMPv1 within a bi-lingual
+             SNMP agent
+2074:: PS::  Remote Network Monitoring MIB Protocol Identifiers
+2064::  E::  Traffic Flow Measurement
+2063::  E::  Traffic Flow Measurement
+2051:: PS::  Definitions of Managed Objects for APPC
+2041::  I::  Mobile Network Tracing
+2039::  I::  Applicability of Standards Track MIBs to Management
+             of World Wide Web Servers
+2037:: PS::  Entity MIB
+2024:: PS::  Definitions of Managed Objects for Data Link Switching
+             using SNMPv2
+2021:: PS::  Remote Network Monitoring Management Information
+             Base Version 2 using SMIv2
+2020:: PS::  Definitions of Managed Objects for IEEE 802.12 Interfaces
+2013:: PS::  SNMPv2 Management Information Base for the User
+             Datagram Protocol using SMIv2
+2012:: PS::  SNMPv2 Management Information Base for the
+             Transmission Control Protocol
+
+
+
+Nesser                       Informational                     [Page 52]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2011:: PS::  SNMPv2 Management Information Base for the Internet
+             Protocol using SMIv2
+2006:: PS::  The Definitions of Managed Objects for IP Mobility
+             Support using SMIv2
+1944::  I::  Benchmarking Methodology for Network Interconnect Devices
+1910::  E::  User-based Security Model for SNMPv2
+1909::  E::  An Administrative Infrastructure for SNMPv2
+1908:: DS::  Coexistence between Version 1 and Version 2 of the
+             Internet-standard Network Management Framework
+1907:: DS::  Management Information Base for Version 2 of the
+             Simple Network Management Protocol (SNMPv2)
+1906:: DS::  Transport Mappings for Version 2 of the Simple Network
+             Management Protocol (SNMPv2)
+1905:: DS::  Protocol Operations for Version 2 of the Simple Network
+             Management Protocol (SNMPv2)
+1904:: DS::  Conformance Statements for Version 2 of the Simple
+             Network Management Protocol (SNMPv2)
+1903:: DS::  Textual Conventions for Version 2 of the Simple
+             Network Management Protocol (SNMPv2)
+1902:: DS::  Structure of Management Information for Version 2 of
+             the Simple Network Management Protocol (SNMPv2)
+1901::  E::  Introduction to Community-based SNMPv2
+1857::  I::  A Model for Common Operational Statistics
+1856::  I::  The Opstat Client-Server Model for Statistics Retrieval
+1850:: DS::  OSPF Version 2 Management Information Base
+1792::  E::  TCP/IPX Connection Mib Specification
+1759:: PS::  Printer MIB
+1757:: DS::  Remote Network Monitoring Management Information Base
+1749:: PS::  IEEE 802.5 Station Source Routing MIB using SMIv2
+1748:: DS::  IEEE 802.5 MIB using SMIv2
+1747:: PS::  Definitions of Managed Objects for SNA Data Link Control
+1743:: DS::  IEEE 802.5 MIB using SMIv2
+1742:: PS::  AppleTalk Management Information Base II
+1724:: DS::  RIP Version 2 MIB Extension
+1697:: PS::  Relational Database Management System (RDBMS)
+             Management Information Base (MIB) using SMIv2
+1696:: PS::  Modem Management Information Base (MIB) using SMIv2
+1695:: PS::  Definitions of Managed Objects for ATM Management
+             Version 8.0 using SMIv2
+1694:: DS::  Definitions of Managed Objects for SMDS Interfaces
+             using SMIv2
+1666:: PS::  Definitions of Managed Objects for SNA NAUs using SMIv2
+1665:: PS::  Definitions of Managed Objects for SNA NAUs using SMIv2
+1660:: DS::  Definitions of Managed Objects for Parallel-printer-like
+             Hardware Devices using SMIv2
+1659:: DS::  Definitions of Managed Objects for RS-232-like
+             Hardware Devices using SMIv2
+1658:: DS::  Definitions of Managed Objects for Character Stream
+
+
+
+Nesser                       Informational                     [Page 53]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+             Devices using SMIv2
+1657:: PS::  Definitions of Managed Objects for the Fourth Version
+             of the Border Gateway Protocol (BGP-4) using SMIv2
+1650:: PS::  Definitions of Managed Objects for the Ethernet-like
+             Interface Types using SMIv2
+1643:: PS::  Definitions of Managed Objects for the Ethernet-like
+             Interface Types
+1628:: PS::  UPS Management Information Base
+1623::  S::  Definitions of Managed Objects for the Ethernet-like
+             Interface Types
+1612:: PS::  DNS Resolver MIB Extensions
+1611:: PS::  DNS Server MIB Extensions
+1596:: PS::  Definitions of Managed Objects for Frame Relay Service
+1595:: PS::  Definitions of Managed Objects for the SONET/SDH
+             Interface Type
+1593::  I::  SNA APPN Node MIB
+1592::  E::  Simple Network Management Protocol Distributed Protocol
+             Interface Version 2.0
+1573:: PS::  Evolution of the Interfaces Group of MIB-II
+1567:: PS::  X.500 Directory Monitoring MIB
+1566:: PS::  Mail Monitoring MIB
+1565:: PS::  Network Services Monitoring MIB
+1564::  I::  DSA Metrics (OSI-DS 34 (v3))
+1559:: DS::  DECnet Phase IV MIB Extensions
+1525:: PS::  Definitions of Managed Objects for Source Routing Bridges
+1516:: DS::  Definitions of Managed Objects for IEEE 802.3
+             Repeater Devices
+1515:: PS::  Definitions of Managed Objects for IEEE 802.3
+             Medium Attachment Units (MAUs)
+1514:: PS::  Host Resources MIB
+1513:: PS::  Token Ring Extensions to the Remote Network Monitoring MIB
+1512:: PS::  FDDI Management Information Base
+1503::  I::  Algorithms for Automating Administration in SNMPv2
+             Managers
+1493:: DS::  Definitions of Managed Objects for Bridges
+1474:: PS::  The Definitions of Managed Objects for the Bridge
+             Network Control Protocol of the Point-to-Point Protocol
+1473:: PS::  The Definitions of Managed Objects for the IP Network
+             Control Protocol of the Point-to-Point Protocol
+1472:: PS::  The Definitions of Managed Objects for the Security
+             Protocols of the Point-to-Point Protocol
+1471:: PS::  The Definitions of Managed Objects for the Link Control
+             Protocol of the Point-to-Point Protocol
+1470::  I::  FYI on a Network Management Tool Catalog
+1461:: PS::  SNMP MIB extension for MultiProtocol Interconnect over
+             X.25
+1452:: PS::  Coexistence between version 1 and version 2 of the
+             Internet-standard Network Management Framework
+
+
+
+Nesser                       Informational                     [Page 54]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1451:: PS::  Manager to Manager Management Information Base
+1450:: PS::  Management Information Base for version 2 of the Simple
+             Network Management Protocol (SNMPv2)
+1449:: PS::  Transport Mappings for version 2 of the Simple Network
+             Management Protocol (SNMPv2)
+1448:: PS::  Protocol Operations for version 2 of the Simple Network
+             Management Protocol (SNMPv2)
+1447:: PS::  Party MIB for version 2 of the Simple Network Management
+             Protocol (SNMPv2)
+1446:: PS::  Security Protocols for version 2 of the Simple Network
+             Management Protocol (SNMPv2)
+1445:: PS::  Administrative Model for version 2 of the Simple Network
+             Management Protocol (SNMPv2)
+1444:: PS::  Conformance Statements for version 2 of the Simple
+             Network Management Protocol (SNMPv2)
+1443:: PS::  Textual Conventions for version 2 of the Simple Network
+             Management Protocol (SNMPv2)
+1442:: PS::  Structure of Management Information for version 2 of the
+             Simple Network Management Protocol (SNMPv2)
+1441:: PS::  Introduction to version 2 of the Internet-standard
+             Network Management Framework
+1431::  I::  DUA Metrics
+1420:: PS::  SNMP over IPX
+1419:: PS::  SNMP over AppleTalk
+1418:: PS::  SNMP over OSI
+1414:: PS::  Ident MIB
+1407:: PS::  Definitions of Managed Objects for the DS3/E3 Interface
+             Type
+1406:: PS::  Definitions of Managed Objects for the DS1 and E1
+             Interface Types
+1404::  I::  A Model for Common Operational Statistics
+1398:: DS::  Definitions of Managed Objects for the Ethernet-like
+             Interface Types
+1389:: PS::  RIP Version 2 MIB Extension
+1382:: PS::  SNMP MIB Extension for the X.25 Packet Layer
+1381:: PS::  SNMP MIB Extension for X.25 LAPB
+1369::  I::  Implementation Notes and Experience for The Internet
+             Ethernet MIB
+1368:: PS::  Definitions of Managed Objects for IEEE 802.3 Repeater
+             Devices
+1354:: PS::  IP Forwarding Table MIB
+1353::  H::  Definitions of Managed Objects for Administration of
+             SNMP Parties
+1352::  H::  SNMP Security Protocols
+1351::  H::  SNMP Administrative Model
+1346::  I::  Resource Allocation, Control, and Accounting for the
+             Use of Network Resources
+1318:: PS::  Definitions of Managed Objects for Parallel-printer-like
+
+
+
+Nesser                       Informational                     [Page 55]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+             Hardware Devices
+1317:: PS::  Definitions of Managed Objects for RS-232-like
+             Hardware Devices
+1316:: PS::  Definitions of Managed Objects for Character Stream
+             Devices
+1315:: PS::  Management Information Base for Frame Relay DTEs
+1304:: PS::  Definitions of Managed Objects for the SIP Interface Type
+1303::  I::  A Convention for Describing SNMP-based Agents
+1298::  I::  SNMP over IPX
+1289:: PS::  DECnet Phase IV MIB Extensions
+1286:: PS::  Definitions of Managed Objects for Bridges
+1285:: PS::  FDDI Management Information Base
+1284:: PS::  Definitions of Managed Objects for the Ethernet-like
+              Interface Types
+1283::  E::  SNMP over OSI
+1273::  I::  A Measurement Study of Changes in Service-Level
+             Reachability in the Global TCP/IP Internet
+1272::  I::  Internet Accounting
+1271:: PS::  Remote Network Monitoring Management Information Base
+1270::  I::  SNMP Communications Services
+1269:: PS::  Definitions of Managed Objects for the Border Gateway
+             Protocol (Version 3)
+1262::   ::  Guidelines for Internet Measurement Activities
+1253:: PS::  OSPF Version 2 Management Information Base
+1252:: PS::  OSPF Version 2 Management Information Base
+1248:: PS::  OSPF Version 2 Management Information Base
+1247:: DS::  OSPF Version 2
+1243:: PS::  AppleTalk Management Information Base
+1242::  I::  Benchmarking Terminology for Network Interconnection
+             Devices
+1239:: PS::  Reassignment of Experimental MIBs to Standard MIBs
+1238::  E::  CLNS MIB - for use with Connectionless Network
+             Protocol (ISO 8473) and End System to Intermediate
+             System (ISO 9542)
+1233::  H::  Definitions of Managed Objects for the DS3 Interface Type
+1232::  H::  Definitions of Managed Objects for the DS1 Interface Type
+1231:: DS::  IEEE 802.5 Token Ring MIB
+1230::  H::  IEEE 802.4 Token Bus MIB
+1229:: DS::  Extensions to the Generic-Interface MIB
+1228::  E::  SNMP-DPI - Simple Network Management Protocol
+             Distributed Program Interface
+1227::  E::  SNMP MUX Protocol and MIB
+1224::  E::  Techniques for Managing Asynchronously Generated Alerts
+1215::  I::  A Convention for Defining Traps for use with the SNMP
+1214::  H::  OSI Internet Management
+1213::  S::  Management Information Base for Network Management of
+             TCP/IP-based internets
+1212::  S::  Concise MIB Definitions
+
+
+
+Nesser                       Informational                     [Page 56]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1189::  H::  The Common Management Information Services and Protocols
+             for the Internet
+1187::  E::  Bulk Table Retrieval with the SNMP
+1161::  E::  SNMP over OSI
+1158:: PS::  Management Information Base for Network Management of
+             TCP/IP-based internets
+1157::  S::  A Simple Network Management Protocol (SNMP)
+1155::  S::  Structure and Identification of Management Information
+             for TCP/IP-based Internets
+1109::   ::  Report of the second Ad Hoc Network Management Review
+             Group
+1098::   ::  Simple Network Management Protocol SNMP
+1095:: DS::  Common Management Information Services and Protocol
+             over TCP/IP CMOT
+1089::   ::  SNMP over Ethernet
+1067::   ::  Simple Network Management Protocol
+1066::  H::  Management Information Base for network management of
+             TCP/IP-based internets
+1065::  H::  Structure and identification of management information
+             for TCP/IP-based internets
+1052::   ::  IAB recommendations for the development of Internet
+             network management standards
+1028::  H::  Simple Gateway Monitoring Protocol
+1024::   ::  HEMS variable definitions
+1023::   ::  HEMS monitoring and control language
+1022::   ::  High-level Entity Management Protocol HEMP
+1021::  H::  High-level Entity Management System HEMS
+1012::   ::  Bibliography of Request For Comments 1 through 999
+1011::  S::  Official Internet protocols
+1010::  S::  Assigned numbers
+ 996::  H::  Statistics server
+ 619::   ::  Mean round-trip times in the ARPANET
+ 618::   ::  Few observations on NCP statistics
+ 616::   ::  Latest network maps
+ 615::   ::  Proposed Network Standard Data Pathname Syntax
+ 612::   ::  Traffic statistics December 1973
+ 601::   ::  Traffic statistics November 1973
+ 586::   ::  Traffic statistics October 1973
+ 579::   ::  Traffic statistics September 1973
+ 568::   ::  Response to RFC 567 - cross country network bandwidth
+ 567::   ::  Cross country network bandwidth
+ 566::   ::  Traffic statistics August 1973
+ 565::   ::  Storing network survey data at the datacomputer
+ 557::   ::  Revelations in network host measurements
+ 546::   ::  Tenex load averages for July 1973
+ 545::   ::  Of what quality be the UCSB resources evaluators?
+ 538::   ::  Traffic statistics June 1973
+ 531::   ::  Feast or famine? A response to two recent RFC's about
+
+
+
+Nesser                       Informational                     [Page 57]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+             network information
+ 522::   ::  Traffic statistics May 1973
+ 509::   ::  Traffic statistics April 1973
+ 500::   ::  Integration of data management systems on a computer
+             network
+ 482::   ::  Traffic statistics February 1973
+ 455::   ::  Traffic statistics January 1973
+ 443::   ::  Traffic statistics December 1972
+ 423::   ::  UCLA Campus Computing Network liaison staff for ARPANET
+ 422::   ::  Traffic statistics November 1972
+ 421::   ::  Software consulting service for network users
+ 416::   ::  ARC system will be unavailable for use during
+             Thanksgivingweek
+ 415::   ::  Tenex bandwidth
+ 413::   ::  Traffic statistics October 1972
+ 400::   ::  Traffic statistics September 1972
+ 392::   ::  Measurement of host costs for transmitting network data
+ 391::   ::  Traffic statistics August 1972
+ 389::   ::  UCLA Campus Computing Network liaison staff for ARPA
+             Network
+ 388::   ::  NCP statistics
+ 384::   ::  Official site idents for organizations in the ARPA
+             Network
+ 381::   ::  Three aids to improved network operation
+ 378::   ::  Traffic statistics July 1972
+ 369::   ::  Evaluation of ARPANET services January-March, 1972
+ 362::   ::  Network host status
+ 353::   ::  Network host status
+ 344::   ::  Network host status
+ 326::   ::  Network host status
+ 323::   ::  Formation of Network Measurement Group NMG
+ 308::   ::  ARPANET host availability data
+ 304::   ::  Data management system proposal for the ARPA network
+ 302::   ::  Exercising the ARPANET
+ 274::   ::  Establishing a local guide for network usage
+ 227::   ::  Data transfer rates Rand/UCLA
+ 212::   ::  NWG meeting on network usage
+ 193::   ::  Network checkout
+ 188::   ::  Data management meeting announcement
+ 156::   ::  Status of the Illinois site
+ 153::   ::  SRI ARC-NIC status
+  96::   ::  Interactive network experiment to study modes of
+             access tothe Network Information Center
+  32::   ::  Connecting M.I.T. computers to the
+             ARPA Computer-to-computer communication network
+  18::   ::  [Link assignments]
+======================================================================
+
+
+
+
+Nesser                       Informational                     [Page 58]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+Network News
+1036::   ::  Standard for interchange of USENET messages
+ 977:: PS::  Network News Transfer Protocol
+ 850::   ::  Standard for interchange of USENET messages
+===================================================================
+Real Time Services
+:: ::
+2102::  I::  Multicast Support for Nimrod
+2090::  E::  TFTP Multicast Option
+2038:: PS::  RTP Payload Format for MPEG1/MPEG2 Video
+2035:: PS::  RTP Payload Format for JPEG-compressed Video
+2032:: PS::  RTP payload format for H.261 video streams
+2029:: PS::  RTP Payload Format of Sun's CellB Video Encoding
+2022:: PS::  Support for Multicast over UNI 3.0/3.1 based ATM
+             Networks
+1890:: PS::  RTP Profile for Audio and Video Conferences with Minimal
+             Control
+1889:: PS::  RTP
+1861::  I::  Simple Network Paging Protocol - Version 3 - Two-Way
+             Enhanced
+1821::  I::  Integration of Real-time Services in an IP-ATM Network
+             Architecture
+1819::  E::  Internet Stream Protocol Version 2 (ST2) Protocol
+             Specification - Version ST2+
+1789::  I::  INETPhone
+1768::  E::  Host Group Extensions for CLNP Multicasting
+1703::  I::  Principles of Operation for the TPC.INT Subdomain
+1645::  I::  Simple Network Paging Protocol - Version 2
+1614::  I::  Network Access to Multimedia Information
+1569::  I::  Principles of Operation for the TPC.INT Subdomain
+1568::  I::  Simple Network Paging Protocol - Version 1(b)
+1546::  I::  Host Anycasting Service
+1469:: PS::  IP Multicast over Token-Ring Local Area Networks
+1458::  I::  Requirements for Multicast Protocols
+1453::  I::  A Comment on Packet Video Remote Conferencing and the
+             Transport/Network Layers
+1313::  I::  Today's Programming for KRFC AM 1313 Internet Talk Radio
+1301::  I::  Multicast Transport Protocol
+1257::  I::  Isochronous Applications Do Not Require
+             Jitter-Controlled Networks
+1197::  I::  Using ODA for Translating Multimedia Information
+1193::   ::  Client Requirements for Real-Time Communication Services
+1190::  E::  Experimental Internet Stream Protocol, Version 2 (ST-II)
+1112::  S::  Host extensions for IP multicasting
+1054::   ::  Host extensions for IP multicasting
+ 988::   ::  Host extensions for IP multicasting
+ 966::   ::  Host groups
+ 947::   ::  Multi-network broadcasting within the Internet
+
+
+
+Nesser                       Informational                     [Page 59]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+ 809::   ::  UCL facsimile system
+ 804::   ::  CCITT draft recommendation T.4 [Standardization of
+             Group 3 facsimile apparatus for document transmission]
+ 803::   ::  Dacom 450/500 facsimile data transcoding
+ 798::   ::  Decoding facsimile data from the Rapicom 450
+ 769::   ::  Rapicom 450 facsimile file format
+ 741::   ::  Specifications for the Network Voice Protocol NVP
+ 511::   ::  Enterprise phone service to NIC from ARPANET sites
+ 508::   ::  Real-time data transmission on the ARPANET
+ 420::   ::  CCA ICCC weather demo
+ 408::   ::  NETBANK
+ 251::   ::  Weather data
+=====================================================================
+Routing
+2103::  I::  Mobility Support for Nimrod
+2092::  I::  Protocol Analysis for Triggered RIP
+2091:: PS::  Triggered Extensions to RIP to Support Demand Circuits
+2081::  I::  RIPng Protocol Applicability Statement
+2080:: PS::  RIPng for IPv6
+2073:: PS::  An IPv6 Provider-Based Unicast Address Format
+2072::  I::  Router Renumbering Guide
+2042::  I::  Registering New BGP Attribute Types
+2008:: BC::  Implications of Various Address Allocation Policies for
+             Internet Routing
+1998::  I::  An Application of the BGP Community Attribute in
+             Multi-home Routing
+1997:: PS::  BGP Communities Attribute
+1992::  I::  The Nimrod Routing Architecture
+1987::  I::  Ipsilon's General Switch Management Protocol
+             Specification Version 1.1
+1966::  E::  BGP Route Reflection An alternative to full mesh IBGP
+1965::  E::  Autonomous System Confederations for BGP
+1955::  I::  New Scheme for Internet Routing and Addressing (ENCAPS)
+             for IPN
+1953::  I::  Ipsilon Flow Management Protocol Specification for
+             IPv4 Version 1.0
+1940::  I::  Source Demand Routing
+1930:: BC::  Guidelines for creation, selection, and registration
+             of an Autonomous System (AS)
+1925::  I::  The Twelve Networking Truths
+1923::  I::  RIPv1 Applicability Statement for Historic Status
+1863::  E::  A BGP/IDRP Route Server alternative to a full mesh routing
+1817::  I::  CIDR and Classful Routing
+1812:: PS::  Requirements for IP Version 4 Routers
+1793:: PS::  Extending OSPF to Support Demand Circuits
+1787::  I::  Routing in a Multi-provider Internet
+1786::  I::  Representation of IP Routing Policies in a Routing
+             Registry (ripe-81++)
+
+
+
+Nesser                       Informational                     [Page 60]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1774::  I::  BGP-4 Protocol Analysis
+1773::  I::  Experience with the BGP-4 protocol
+1772:: DS::  Application of the Border Gateway Protocol in the Internet
+1771:: DS::  A Border Gateway Protocol 4 (BGP-4)
+1765::  E::  OSPF Database Overflow
+1753::  I::  IPng Technical Requirements Of the Nimrod Routing and
+             Addressing Architecture
+1745:: PS::  BGP4/IDRP for IP---OSPF Interaction
+1723:: DS::  RIP Version 2 Carrying Additional Information
+1722:: DS::  RIP Version 2 Protocol Applicability Statement
+1721::  I::  RIP Version 2 Protocol Analysis
+1716::  I::  Towards Requirements for IP Routers
+1702::  I::  Generic Routing Encapsulation over IPv4 networks
+1701::  I::  Generic Routing Encapsulation (GRE)
+1668::  I::  Unified Routing Requirements for IPng
+1656::  I::  BGP-4 Protocol Document Roadmap and Implementation
+             Experience
+1655:: PS::  Application of the Border Gateway Protocol in the
+             Internet
+1654:: PS::  A Border Gateway Protocol 4 (BGP-4)
+1587:: PS::  The OSPF NSSA Option
+1586::  I::  Guidelines for Running OSPF Over Frame Relay Networks
+1585::  I::  MOSPF
+1584:: PS::  Multicast Extensions to OSPF
+1583:: DS::  OSPF Version 2
+1582:: PS::  Extensions to RIP to Support Demand Circuits
+1581::  I::  Protocol Analysis for Extensions to RIP to Support
+             Demand Circuits
+1520::  I::  Exchanging Routing Information Across Provider Boundaries
+             in the CIDR Environment
+1519:: PS::  Classless Inter-Domain Routing (CIDR)
+1517:: PS::  Applicability Statement for the Implementation of
+             Classless Inter-Domain Routing (CIDR)
+1504::  I::  Appletalk Update-Based Routing Protocol
+1482::  I::  Aggregation Support in the NSFNET Policy Routing Database
+1479:: PS::  Inter-Domain Policy Routing Protocol Specification
+1478:: PS::  An Architecture for Inter-Domain Policy Routing
+1477::  I::  IDPR as a Proposed Standard
+1476::  E::  RAP
+1439::  I::  The Uniqueness of Unique Identifiers
+1403:: PS::  BGP OSPF Interaction
+1397:: PS::  Default Route Advertisement In BGP2 And BGP3 Versions Of
+             The Border Gateway Protocol
+1388:: PS::  RIP Version 2 Carrying Additional Information
+1387::  I::  RIP Version 2 Protocol Analysis
+1383::  I::  An Experiment in DNS Based IP Routing
+1380::  I::  IESG Deliberations on Routing and Addressing
+1371::  I::  Choosing a "Common IGP" for the IP Internet (The
+
+
+
+Nesser                       Informational                     [Page 61]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+             IESG's Recommendation to the IAB)
+1370:: PS::  Applicability Statement for OSPF
+1364:: PS::  BGP OSPF Interaction
+1338::  I::  Supernetting
+1322::  I::  A Unified Approach to Inter-Domain Routing
+1268:: DS::  Application of the Border Gateway Protocol in the Internet
+1267:: DS::  A Border Gateway Protocol 3 (BGP-3)
+1266::  I::  Experience with the BGP Protocol
+1265::  I::  BGP Protocol Analysis
+1264::  I::  Internet Routing Protocol Standardization Criteria
+1254::  I::  Gateway Congestion Control Survey
+1246::  I::  Experience with the OSPF Protocol
+1245::  I::  OSPF Protocol Analysis
+1222::   ::  Advancing the NSFNET Routing Architecture
+1195:: PS::  Use of OSI IS-IS for Routing in TCP/IP and Dual
+             Environments
+1164:: PS::  Application of the Border Gateway Protocol in the Internet
+1163:: PS::  A Border Gateway Protocol (BGP)
+1142::  I::  OSI IS-IS Intra-domain Routing Protocol
+1136::   ::  Administrative Domains and Routing Domains
+1133::   ::  Routing between the NSFNET and the DDN
+1131:: PS::  OSPF specification
+1126::   ::  Goals and functional requirements for inter-autonomous
+             system routing
+1125::   ::  Policy requirements for inter Administrative Domain
+             routing
+1124::   ::  Policy issues in interconnecting networks
+1105::  E::  Border Gateway Protocol BGP
+1104::   ::  Models of policy based routing
+1102::   ::  Policy routing in Internet protocols
+1092::   ::  EGP and policy based routing in the new NSFNET backbone
+1075::  E::  Distance Vector Multicast Routing Protocol
+1074::   ::  NSFNET backbone SPF based Interior Gateway Protocol
+1058::  S::  Routing Information Protocol
+1009::  H::  Requirements for Internet gateways
+ 995::   ::  End System to Intermediate System Routing Exchange
+             Protocol for use in conjunction with ISO 8473
+ 985::   ::  Requirements for Internet gateways - draft
+ 981::   ::  Experimental multiple-path routing algorithm
+ 975::   ::  Autonomous confederations
+ 950::  S::  Internet standard subnetting procedure
+ 911::   ::  EGP Gateway under Berkeley UNIX 4.2
+ 904::  H::  Exterior Gateway Protocol formal specification
+ 898::   ::  Gateway special interest group meeting notes
+ 890::   ::  Exterior Gateway Protocol implementation schedule
+ 888::   ::  STUB Exterior Gateway Protocol
+ 875::   ::  Gateways, architectures, and heffalumps
+ 827::   ::  Exterior Gateway Protocol EGP
+
+
+
+Nesser                       Informational                     [Page 62]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+ 823::  H::  DARPA Internet gateway
+=====================================================================
+Security
+2104::  I::  HMAC
+2085:: PS::  HMAC-MD5 IP Authentication with Replay Prevention
+2084::  I::  Considerations for Web Transaction Security
+2082:: PS::  RIP-2 MD5 Authentication
+2078:: PS::  Generic Security Service Application Program Interface,
+             Version 2
+2069:: PS::  An Extension to HTTP
+2065:: PS::  Domain Name System Security Extensions
+2059::  I::  RADIUS Accounting
+2058:: PS::  Remote Authentication Dial In User Service (RADIUS)
+2057::  I::  Source directed access control on the Internet.
+2040::  I::  The RC5, RC5-CBC, RC5-CBC-Pad, and RC5-CTS Algorithms
+2025:: PS::  The Simple Public-Key GSS-API Mechanism (SPKM)
+2015::   ::  MIME Security with Pretty Good Privacy (PGP)
+1984::  I::  IAB and IESG Statement on Cryptographic Technology and
+             the Internet
+1969::  I::  The PPP DES Encryption Protocol (DESE)
+1968:: PS::  The PPP Encryption Control Protocol (ECP)
+1964:: PS::  The Kerberos Version 5 GSS-API Mechanism
+1961:: PS::  GSS-API Authentication Method for SOCKS Version 5
+1949::  E::  Scalable Multicast Key Distribution
+1948::  I::  Defending Against Sequence Number Attacks
+1938:: PS::  A One-Time Password System
+1929:: PS::  Username/Password Authentication for SOCKS V5
+1928:: PS::  SOCKS Protocol Version 5
+1898::  I::  CyberCash Credit Card Protocol Version 0.8
+1858::  I::  Security Considerations for IP Fragment Filtering
+1852::  E::  IP Authentication using Keyed SHA
+1851::  E::  The ESP Triple DES-CBC Transform
+1829:: PS::  The ESP DES-CBC Transform
+1828:: PS::  IP Authentication using Keyed MD5
+1827:: PS::  IP Encapsulating Security Payload (ESP)
+1826:: PS::  IP Authentication Header
+1825:: PS::  Security Architecture for the Internet Protocol
+1824::  I::  The Exponential Security System TESS
+1760::  I::  The S/KEY One-Time Password System
+1751::  I::  A Convention for Human-Readable 128-bit Keys
+1750::  I::  Randomness Recommendations for Security
+1704::  I::  On Internet Authentication
+1675::  I::  Security Concerns for IPng
+1579::  I::  Firewall-Friendly FTP
+1535::  I::  A Security Problem and Proposed Correction With Widely
+             Deployed DNS Software
+1511::  I::  Common Authentication Technology Overview
+1510:: PS::  The Kerberos Network Authentication Service (V5)
+
+
+
+Nesser                       Informational                     [Page 63]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1509:: PS::  Generic Security Service API
+1508:: PS::  Generic Security Service Application Program Interface
+1507::  E::  DASS - Distributed Authentication Security Service
+1492::  I::  An Access Control Protocol, Sometimes Called TACACS
+1457::  I::  Security Label Framework for the Internet
+1455::  E::  Physical Link Security Type of Service
+1424:: PS::  Privacy Enhancement for Internet Electronic Mail
+1423:: PS::  Privacy Enhancement for Internet Electronic Mail
+1422:: PS::  Privacy Enhancement for Internet Electronic Mail
+1421:: PS::  Privacy Enhancement for Internet Electronic Mail
+1416::  E::  Telnet Authentication Option
+1412::  E::  Telnet Authentication
+1411::  E::  Telnet Authentication
+1409::  E::  Telnet Authentication Option
+1408::  H::  Telnet Environment Option
+1321::  I::  The MD5 Message-Digest Algorithm
+1320::  I::  The MD4 Message-Digest Algorithm
+1319::  I::  The MD2 Message-Digest Algorithm
+1281::  I::  Guidelines for the Secure Operation of the Internet
+1244::  I::  Site Security Handbook
+1186::  I::  The MD4 Message Digest Algorithm
+1170::  I::  Public Key Standards and Licenses
+1156::  S::  Management Information Base for Network Management of
+             TCP/IP-based internets
+1115::  H::  Privacy enhancement for Internet electronic mail
+1114::  H::  Privacy enhancement for Internet electronic mail
+1113::  H::  Privacy enhancement for Internet electronic mail
+1108:: PS::  U.S. Department of Defense Security Options for the
+             Internet Protocol
+1040::   ::  Privacy enhancement for Internet electronic mail
+1038::   ::  Draft revised IP security option
+1004::  E::  Distributed-protocol authentication scheme
+ 989::   ::  Privacy enhancement for Internet electronic mail
+ 972::   ::  Password Generator Protocol
+ 931::  E::  Authentication server
+ 927::   ::  TACACS user identification Telnet option
+ 912::   ::  Authentication service
+ 644::   ::  On the problem of signature authentication for
+             network mail
+=====================================================================
+Virtual Terminal
+2066::  E::  TELNET CHARSET Option
+1647:: PS::  TN3270 Enhancements
+1646::  I::  TN3270 Extensions for LUname and Printer Selection
+1576::  I::  TN3270 Current Practices
+1572:: PS::  Telnet Environment Option
+1571::  I::  Telnet Environment Option Interoperability Issues
+1372:: PS::  Telnet Remote Flow Control Option
+
+
+
+Nesser                       Informational                     [Page 64]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1282::  I::  BSD Rlogin
+1258::  I::  BSD Rlogin
+1221::   ::  Host Access Protocol (HAP) Specification - Version 2
+1205::   ::  5250 Telnet Interface
+1184:: DS::  Telnet Linemode Option
+1143::   ::  The Q Method of Implementing TELNET Option Negotiation
+1116:: PS::  Telnet Linemode option
+1097::   ::  Telnet subliminal-message option
+1096::   ::  Telnet X display location option
+1091::   ::  Telnet terminal-type option
+1080::   ::  Telnet remote flow control option
+1079::   ::  Telnet terminal speed option
+1073::   ::  Telnet window size option
+1053::   ::  Telnet X.3 PAD option
+1043::   ::  Telnet Data Entry Terminal option
+1041::   ::  Telnet 3270 regime option
+1013::   ::  X Window System Protocol, version 11
+1005::   ::  ARPANET AHIP-E Host Access Protocol enhanced AHIP
+ 946::   ::  Telnet terminal location number option
+ 933::   ::  Output marking Telnet option
+ 930::   ::  Telnet terminal type option
+ 929::   ::  Proposed Host-Front End Protocol
+ 907::  S::  Host Access Protocol specification
+ 885::   ::  Telnet end of record option
+ 884::   ::  Telnet terminal type option
+ 878::   ::  ARPANET 1822L Host Access Protocol
+ 861::   ::  Telnet extended options
+ 860::  S::  Telnet timing mark option
+ 859::  S::  Telnet status option
+ 858::  S::  Telnet Suppress Go Ahead option
+ 857::  S::  Telnet echo option
+ 856::  S::  Telnet binary transmission
+ 855::  S::  Telnet option specifications
+ 854::  S::  Telnet Protocol specification
+ 851::   ::  ARPANET 1822L Host Access Protocol
+ 818::  H::  Remote User Telnet service
+ 802::   ::  ARPANET 1822L Host Access Protocol
+ 782::   ::  Virtual Terminal management model
+ 779::   ::  Telnet send-location option
+ 764::   ::  Telnet Protocol specification
+ 749::   ::  Telnet SUPDUP-Output option
+ 748::   ::  Telnet randomly-lose option
+ 747::   ::  Recent extensions to the SUPDUP Protocol
+ 746::   ::  SUPDUP graphics extension
+ 736::   ::  Telnet SUPDUP option
+ 735::   ::  Revised Telnet byte macro option
+ 734::  H::  SUPDUP Protocol
+ 732::   ::  Telnet Data Entry Terminal option
+
+
+
+Nesser                       Informational                     [Page 65]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+ 731::   ::  Telnet Data Entry Terminal option
+ 729::   ::  Telnet byte macro option
+ 728::   ::  Minor pitfall in the Telnet Protocol
+ 727::   ::  Telnet logout option
+ 726::   ::  Remote Controlled Transmission and Echoing Telnet option
+ 721::   ::  Out-of-band control signals in a Host-to-Host Protocol
+ 719::   ::  Discussion on RCTE
+ 718::   ::  Comments on RCTE from the Tenex implementation experience
+ 703::   ::  July, 1975, survey of New-Protocol Telnet Servers
+ 702::   ::  September, 1974, survey of New-Protocol Telnet servers
+ 701::   ::  August, 1974, survey of New-Protocol Telnet servers
+ 698::   ::  Telnet extended ASCII option
+ 688::   ::  Tentative schedule for the new Telnet implementation for
+             the TIP
+ 679::   ::  February, 1975, survey of New-Protocol Telnet servers
+ 669::   ::  November, 1974, survey of New-Protocol Telnet servers
+ 659::   ::  Announcing additional Telnet options
+ 658::   ::  Telnet output linefeed disposition
+ 657::   ::  Telnet output vertical tab disposition option
+ 656::   ::  Telnet output vertical tabstops option
+ 655::   ::  Telnet output formfeed disposition option
+ 654::   ::  Telnet output horizontal tab disposition option
+ 653::   ::  Telnet output horizontal tabstops option
+ 652::   ::  Telnet output carriage-return disposition option
+ 651::   ::  Revised Telnet status option
+ 647::   ::  Proposed protocol for connecting host computers to
+             ARPA-like networks via front end processors
+ 636::   ::  TIP/Tenex reliability improvements
+ 600::   ::  Interfacing an Illinois plasma terminal to the ARPANET
+ 596::   ::  Second thoughts on Telnet Go-Ahead
+ 595::   ::  Second thoughts in defense of the Telnet Go-Ahead
+ 587::   ::  Announcing new Telnet options
+ 563::   ::  Comments on the RCTE Telnet option
+ 562::   ::  Modifications to the Telnet specification
+ 560::   ::  Remote Controlled Transmission and Echoing Telnet option
+ 559::   ::  Comments on the new Telnet Protocol and its implementation
+ 513::   ::  Comments on the new Telnet specifications
+ 495::   ::  Telnet Protocol specifications
+ 470::   ::  Change in socket for TIP news facility
+ 466::   ::  Telnet logger/server for host LL-67
+ 461::   ::  Telnet Protocol meeting announcement
+ 447::   ::  IMP/TIP memory retrofit schedule
+ 435::   ::  Telnet issues
+ 431::   ::  Update on SMFS login and logout
+ 399::   ::  SMFS login and logout
+ 393::   ::  Comments on Telnet Protocol changes
+ 386::   ::  Letter to TIP users-2
+ 377::   ::  Using TSO via ARPA Network Virtual Terminal
+
+
+
+Nesser                       Informational                     [Page 66]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+ 365::   ::  Letter to all TIP users
+ 364::   ::  Serving remote users on the ARPANET
+ 352::   ::  TIP site information form
+ 340::   ::  Proposed Telnet changes
+ 339::   ::  MLTNET
+ 328::   ::  Suggested Telnet Protocol changes
+ 318::   ::  [Ad hoc Telnet Protocol]
+ 311::   ::  New console attachments to the USCB host
+ 297::   ::  TIP message buffers
+ 296::   ::  DS-1 display system
+ 231::   ::  Service center standards for remote usage
+ 230::   ::  Toward reliable operation of minicomputer-based
+             terminals on a TIP
+ 216::   ::  Telnet access to UCSB's On-Line System
+ 215::   ::  NCP, ICP, and Telnet
+ 206::   ::  User Telnet - description of an initial implementation
+ 205::   ::  NETCRT - a character display protocol
+ 177::   ::  Device independent graphical display description
+ 158::   ::  Telnet Protocol
+ 139::   ::  Discussion of Telnet Protocol
+ 137::   ::  Telnet Protocol - a proposed document
+ 110::   ::  Conventions for using an IBM 2741 terminal as a
+             user console for access to network server hosts
+  97::   ::  First cut at a proposed Telnet Protocol
+=====================================================================
+Other
+2123::  I::  Traffic Flow Measurement
+2121::  I::  Issues affecting MARS Cluster Size
+2119:: BC::  Key words for use in RFCs to Indicate Requirement Levels
+2101::  I::  IPv4 Address Behaviour Today
+2100::  I::  The Naming of Hosts
+2099::  I::  Request for Comments Summary RFC Numbers 2000-2099
+2083::  I::  PNG (Portable Network Graphics) Specification Version 1.0
+2071::  I::  Network Renumbering Overview
+2050:: BC::  INTERNET REGISTRY IP ALLOCATION GUIDELINES
+2036::  I::  Observations on the use of Components of the Class
+             A Address Space within the Internet
+2031::  I::  IETF-ISOC relationship
+2028:: BC::  The Organizations Involved in the IETF Standards Process
+2027:: BC::  IAB and IESG Selection, Confirmation, and Recall Process
+2026:: BC::  The Internet Standards Process -- Revision 3
+2014:: BC::  IRTF Research Group Guidelines and Procedures
+2007::  I::  Catalogue of Network Training Materials
+2000::  S::  INTERNET OFFICIAL PROTOCOL STANDARDS
+1999::  I::  Request for Comments Summary RFC Numbers 1900-1999
+1988::  I::  Conditional Grant of Rights to Specific Hewlett-Packard
+             Patents In Conjunction With the Internet Engineering
+             Task Force's Internet-Standard Network Management
+
+
+
+Nesser                       Informational                     [Page 67]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+             Framework
+1983::  I::  Internet Users' Glossary
+1958::  I::  Architectural Principles of the Internet
+1952::  I::  GZIP file format specification version 4.3
+1951::  I::  DEFLATE Compressed Data Format Specification version 1.3
+1950::  I::  ZLIB Compressed Data Format Specification version 3.3
+1941::  I::  Frequently Asked Questions for Schools
+1935::  I::  What is the Internet, Anyway?
+1920::  S::  INTERNET OFFICIAL PROTOCOL STANDARDS
+1900::  I::  Renumbering Needs Work
+1899::  I::  Request for Comments Summary RFC Numbers 1800-1899
+1882::  I::  The 12-Days of Technology Before Christmas
+1880::  S::  INTERNET OFFICIAL PROTOCOL STANDARDS
+1879::  I::  Class A Subnet Experiment Results and Recommendations
+1875::  I::  UNINETT PCA Policy Statements
+1871:: BC::  Addendum to RFC 1602 -- Variance Procedure
+1855::  I::  Netiquette Guidelines
+1822::  I::  A Grant of Rights to Use a Specific IBM patent with
+             Photuris
+1818::  S::  Best Current Practices
+1816::  I::  U.S. Government Internet Domain Names
+1814::  I::  Unique Addresses are Good
+1811::  I::  U.S. Government Internet Domain Names
+1810::  I::  Report on MD5 Performance
+1805::  I::  Location-Independent Data/Software Integrity Protocol
+1802::  I::  Introducing Project Long Bud
+1800::  S::  INTERNET OFFICIAL PROTOCOL STANDARDS
+1799::  I::  Request for Comments Summary RFC Numbers 1700-1799
+1797::  E::  Class A Subnet Experiment
+1796::  I::  Not All RFCs are Standards
+1790::  I::  An Agreement between the Internet Society and Sun
+             Microsystems, Inc. in the Matter of ONC RPC and
+             XDR Protocols
+1780::  S::  INTERNET OFFICIAL PROTOCOL STANDARDS
+1776::  I::  The Address is the Message
+1775::  I::  To Be "On" the Internet
+1758::  I::  NADF Standing Documents
+1746::  I::  Ways to Define User Expectations
+1739::  I::  A Primer On Internet and TCP/IP Tools
+1720::  S::  INTERNET OFFICIAL PROTOCOL STANDARDS
+1718::  I::  The Tao of IETF - A Guide for New Attendees of the
+             Internet Engineering Task Force
+1715::  I::  The H Ratio for Address Assignment Efficiency
+1709::  I::  K-12 Internetworking Guidelines
+1700::  S::  ASSIGNED NUMBERS
+1699::  I::  Request for Comments Summary RFC Numbers 1600-1699
+1691::  I::  The Document Architecture for the Cornell Digital Library
+1690::  I::  Introducing the Internet Engineering and Planning
+
+
+
+Nesser                       Informational                     [Page 68]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+             Group (IEPG)
+1689::  I::  A Status Report on Networked Information Retrieval
+1640::  I::  The Process for Organization of Internet Standards
+             Working Group (POISED)
+1636::  I::  Report of IAB Workshop on Security in the Internet
+             Architecture - February 8-10, 1994
+1635::  I::  How to Use Anonymous FTP
+1627::  I::  Network 10 Considered Harmful (Some Practices
+             Shouldn't be Codified)
+1610::  S::  INTERNET OFFICIAL PROTOCOL STANDARDS
+1607::  I::  A VIEW FROM THE 21ST CENTURY
+1606::  I::  A Historical Perspective On The Usage Of IP Version 9
+1603::  I::  IETF Working Group Guidelines and Procedures
+y1602::  I::  The Internet Standards Process -- Revision 2
+1601::  I::  Charter of the Internet Architecture Board (IAB)
+1600::  S::  INTERNET OFFICIAL PROTOCOL STANDARDS
+1599::  I::  Request for Comments Summary RFC Numbers 1500 - 1599
+1597::  I::  Address Allocation for Private Internets
+1594::  I::  FYI on Questions and Answer Answers to Commonly
+             asked "New Internet User" Questions
+1580::  I::  Guide to Network Resource Tools
+1578::  I::  FYI on Questions and Answers
+1574::  I::  Essential Tools for the OSI Internet
+1550::  I::  IP
+1543::  I::  Instructions to RFC Authors
+1540::  S::  INTERNET OFFICIAL PROTOCOL STANDARDS
+1539::  I::  The Tao of IETF - A Guide for New Attendees of the
+             Internet Engineering Task Force
+1527::  I::  What Should We Plan Given the Dilemma of the Network?
+1501::  I::  OS/2 User Group
+1500::  S::  INTERNET OFFICIAL PROTOCOL STANDARDS
+1499::  I::  Request for Comments Summary RFC Numbers 1400-1499
+1481::  I::  IAB Recommendation for an Intermediate Strategy to
+             Address the Issue of Scaling
+1467::  I::  Status of CIDR Deployment in the Internet
+1463::  I::  FYI on Introducing the Internet--A Short Bibliography
+             of Introductory Internetworking Readings for the
+             Network Novice
+1462::  I::  FYI on "What is the Internet?"
+1438::  I::  Internet Engineering Task Force Statements Of
+             Boredom (SOBs)
+1432::  I::  Recent Internet Books
+1417::  I::  NADF Standing Documents
+1410::  S::  IAB OFFICIAL PROTOCOL STANDARDS
+1402::  I::  There's Gold in them thar Networks! Searching for
+             Treasure in all the Wrong Places
+1401::  I::  Correspondence between the IAB and DISA on the use
+             of DNS throughout the Internet
+
+
+
+Nesser                       Informational                     [Page 69]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1399::  I::  Request for Comments Summary RFC Numbers 1300-1399
+1396::  I::  The Process for Organization of Internet Standards
+             Working Group (POISED)
+1392::  I::  Internet Users' Glossary
+1391::  I::  The Tao of IETF
+1367::  I::  Schedule for IP Address Space Management Guidelines
+1366::  I::  Guidelines for Management of IP Address Space
+1360::  S::  IAB OFFICIAL PROTOCOL STANDARDS
+1359::  I::  Connecting to the Internet What Connecting
+             Institutions Should Anticipate
+1358::  I::  Charter of the Internet Architecture Board (IAB)
+1349:: PS::  Type of Service in the Internet Protocol Suite
+1340::  S::  ASSIGNED NUMBERS
+1336::  I::  Who's Who in the Internet Biographies of IAB,
+             IESG and IRSG Members
+1325::  I::  FYI on Questions and Answers Answers to Commonly
+             asked "New Internet User" Questions
+1324::  I::  A Discussion on Computer Network Conferencing
+1311::  I::  Introduction to the STD Notes
+1310::  I::  The Internet Standards Process
+1300::  I::  Remembrances of Things Past
+1299::  I::  Request for Comments Summary RFC Numbers 1200-1299
+1297::  I::  NOC Internal Integrated Trouble Ticket System
+             Functional Specification Wishlist
+             ("NOC TT REQUIREMENTS")
+1296::  I::  Internet Growth (1981-1991)
+1295::  I::  User Bill of Rights for entries and listings in the
+             Public Directory
+1291::  I::  Mid-Level Networks
+1290::  I::  There's Gold in them thar Networks! or Searching for
+             Treasure in all the Wrong Places
+1287::  I::  Towards the Future Internet Architecture
+1280::  S::  IAB OFFICIAL PROTOCOL STANDARDS
+1261::  I::  Transition of NIC Services
+1259::  I::  Building The Open Road
+1251::   ::  Who's Who in the Internet
+1250::  S::  IAB Official Protocol Standards
+1249::  I::  DIXIE Protocol Specification
+1217::   ::  Memo from the Consortium for Slow Commotion Research (CSCR)
+1216::   ::  Gigabit Network Economics and Paradigm Shifts
+1208::   ::  A Glossary of Networking Terms
+1207::   ::  Answers to Commonly asked "Experienced Internet User"
+             Questions
+1206::   ::  FYI on Questions and Answers - Answers to Commonly
+             asked "New Internet User" Questions
+1200::  S::  IAB Official Protocol Standards
+1199::  I::  Request for Comments Summary RFC Numbers 1100-1199
+1198::  I::  FYI on the X Window System
+
+
+
+Nesser                       Informational                     [Page 70]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1192::   ::  Commercialization of the Internet Summary Report
+1181::   ::  RIPE Terms of Reference
+1180::   ::  A TCP/IP Tutorial
+1178::   ::  Choosing a Name for Your Computer
+1177::   ::  FYI on Questions and Answers - Answers to Commonly
+             Asked "New Internet User" Questions
+1175::   ::  FYI on Where to Start - A Bibliography of
+             Internetworking Information
+1174::  I::  IAB Recommended Policy on Distributing Internet
+             Identifier Assignment and IAB Recommended Policy Change
+             to Internet "Connected" Status
+1173::   ::  Responsibilities of Host and Network Managers
+             Summary of the "Oral Tradition" of the Internet
+1169::   ::  Explaining the Role of GOSIP
+1167::   ::  Thoughts on the National Research and Education Network
+1160::   ::  The Internet Activities Board
+1152::   ::  Workshop Report
+1150::  I::  F.Y.I. on F.Y.I.
+1149::   ::  A Standard for the Transmission of IP Datagrams
+             on Avian Carriers
+1147::  I::  FYI on a Network Management Tool Catalog
+1140::  S::  IAB Official Protocol Standards
+1135::   ::  Helminthiasis of the Internet
+1130::  S::  IAB official protocol standards
+1127::   ::  Perspective on the Host Requirements RFCs
+1121::   ::  Act one - the poems
+1120::   ::  Internet Activities Board
+1118::   ::  Hitchhikers guide to the Internet
+1117::   ::  Internet numbers
+1111::   ::  Request for comments on Request for Comments
+1100::  S::  IAB official protocol standards
+1099::  I::  Request for Comments Summary RFC Numbers 1000-1099
+1093::   ::  NSFNET routing architecture
+1087::   ::  Ethics and the Internet
+1083::  S::  IAB official protocol standards
+1077::   ::  Critical issues in high bandwidth networking
+1076::   ::  HEMS monitoring and control language
+1060::  S::  ASSIGNED NUMBERS
+1039::   ::  DoD statement on Open Systems Interconnection protocols
+1020::   ::  Internet numbers
+1019::   ::  Report of the Workshop on Environments for
+             Computational Mathematics
+1018::   ::  Some comments on SQuID
+1017::   ::  Network requirements for scientific research
+1015::   ::  Implementation plan for interagency research Internet
+1014::   ::  XDR
+1000::   ::  Request For Comments reference guide
+ 999::   ::  Requests For Comments summary notes
+
+
+
+Nesser                       Informational                     [Page 71]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+ 997::   ::  Internet numbers
+ 992::   ::  On communication support for fault tolerant process groups
+ 991::  S::  Official ARPA-Internet protocols
+ 990::   ::  Assigned numbers
+ 980::   ::  Protocol document order information
+ 979::   ::  PSN End-to-End functional specification
+ 968::   ::  Twas the night before start-up
+ 967::   ::  All victims together
+ 961::  S::  Official ARPA-Internet protocols
+ 960::   ::  Assigned numbers
+ 945::   ::  DoD statement on the NRC report
+ 944::  S::  Official ARPA-Internet protocols
+ 943::   ::  Assigned numbers
+ 939::   ::  Executive summary of the NRC report on transport
+             protocols for Department of Defense data networks
+ 938::  E::  Internet Reliable Transaction Protocol functional
+             and interface specification
+ 928::   ::  Introduction to proposed DoD standard H-FP
+ 923::   ::  Assigned numbers
+ 909::  E::  Loader Debugger Protocol
+ 908::  E::  Reliable Data Protocol
+ 902::   ::  ARPA Internet Protocol policy
+ 901::  S::  Official ARPA-Internet protocols
+ 900::   ::  Assigned Numbers
+ 899::   ::  Request For Comments summary notes
+ 880::  S::  Official protocols
+ 873::   ::  Illusion of vendor support
+ 870::   ::  Assigned numbers
+ 869::  H::  Host Monitoring Protocol
+ 852::   ::  ARPANET short blocking feature
+ 847::   ::  Summary of Smallberg surveys
+ 846::   ::  Who talks TCP? - survey of 22 February 1983
+ 845::   ::  Who talks TCP? - survey of 15 February 1983
+ 844::   ::  Who talks ICMP, too? - Survey of 18 February 1983
+ 843::   ::  Who talks TCP? - survey of 8 February 83
+ 842::   ::  Who talks TCP? - survey of 1 February 83
+ 840::  S::  Official protocols
+ 839::   ::  Who talks TCP?
+ 838::   ::  Who talks TCP?
+ 837::   ::  Who talks TCP?
+ 836::   ::  Who talks TCP?
+ 835::   ::  Who talks TCP?
+ 834::   ::  Who talks TCP?
+ 833::   ::  Who talks TCP?
+ 832::   ::  Who talks TCP?
+ 831::   ::  Backup access to the European side of SATNET
+ 828::   ::  Data communications
+ 825::   ::  Request for comments on Requests For Comments
+
+
+
+Nesser                       Informational                     [Page 72]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+ 820::   ::  Assigned numbers
+ 817::   ::  Modularity and efficiency in protocol implementation
+ 816::   ::  Fault isolation and recovery
+ 806::   ::  Proposed Federal Information Processing Standard
+ 800::   ::  Request For Comments summary notes
+ 794::   ::  Pre-emption
+ 790::   ::  Assigned numbers
+ 776::   ::  Assigned numbers
+ 774::   ::  Internet Protocol Handbook
+ 770::   ::  Assigned numbers
+ 766::   ::  Internet Protocol Handbook
+ 762::   ::  Assigned numbers
+ 758::   ::  Assigned numbers
+ 755::   ::  Assigned numbers
+ 750::   ::  Assigned numbers
+ 745::   ::  JANUS interface specifications
+ 739::   ::  Assigned numbers
+ 717::   ::  Assigned network numbers
+ 716::   ::  Interim revision to Appendix F of BBN 1822
+ 708::   ::  Elements of a distributed programming system
+ 705::   ::  Front-end Protocol B6700 version
+ 700::   ::  Protocol experiment
+ 699::   ::  Request For Comments summary notes
+ 694::   ::  Protocol information
+ 686::   ::  Leaving well enough alone
+ 684::   ::  Commentary on procedure calling as a network protocol
+ 681::   ::  Network UNIX
+ 678::   ::  Standard file formats
+ 677::   ::  Maintenance of duplicate databases
+ 672::   ::  Multi-site data collection facility
+ 671::   ::  Note on Reconnection Protocol
+ 667::   ::  BBN host ports
+ 666::   ::  Specification of the Unified User-Level Protocol
+ 663::   ::  Lost message detection and recovery protocol
+ 661::   ::  Protocol information
+ 645::   ::  Network Standard Data Specification syntax
+ 643::   ::  Network Debugging Protocol
+ 642::   ::  Ready line philosophy and implementation
+ 638::   ::  IMP/TIP preventive maintenance schedule
+ 637::   ::  Change of network address for SU-DSL
+ 635::   ::  Assessment of ARPANET protocols
+ 634::   ::  Change in network address for Haskins Lab
+ 631::   ::  International meeting on minicomputers and data
+             communication
+ 629::   ::  Scenario for using the Network Journal
+ 628::   ::  Status of RFC numbers and a note on pre-assigned
+             journal numbers
+ 621::   ::  NIC user directories at SRI ARC
+
+
+
+Nesser                       Informational                     [Page 73]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+ 617::   ::  Note on socket number assignment
+ 609::   ::  Statement of upcoming move of NIC/NLS service
+ 604::   ::  Assigned link numbers
+ 603::   ::  Response to RFC 597
+ 602::   ::  The stockings were hung by the chimney with care
+ 598::   ::  RFC index - December 5, 1973
+ 597::   ::  Host status
+ 590::   ::  MULTICS address change
+ 588::   ::  London node is now up
+ 585::   ::  ARPANET users interest working group meeting
+ 584::   ::  Charter for ARPANET Users Interest Working Group
+ 582::   ::  Comments on RFC 580
+ 581::   ::  Corrections to RFC 560
+ 580::   ::  Note to protocol designers and implementers
+ 578::   ::  Using MIT-Mathlab MACSYMA from MIT-DMS Muddle
+ 569::  H::  NETED
+ 552::   ::  Single access to standard protocols
+ 547::   ::  Change to the Very Distant Host specification
+ 544::   ::  Locating on-line documentation at SRI-ARC
+ 537::   ::  Announcement of NGG meeting July 16-17
+ 530::   ::  Report on the Survey project
+ 529::   ::  Note on protocol synch sequences
+ 527::   ::  ARPAWOCKY
+ 526::   ::  Technical meeting
+ 523::   ::  SURVEY is in operation again
+ 519::   ::  Resource evaluation
+ 518::   ::  ARPANET accounts
+ 515::   ::  Specifications for datalanguage
+ 503::   ::  Socket number list
+ 496::   ::  TNLS quick reference card is available
+ 494::   ::  Availability of MIX and MIXAL in the Network
+ 492::   ::  Response to RFC 467
+ 491::   ::  What is "Free"?
+ 483::   ::  Cancellation of the resource notebook framework meeting
+ 474::   ::  Announcement of NGWG meeting
+ 464::   ::  Resource notebook framework
+ 462::   ::  Responding to user needs
+ 457::   ::  TIPUG
+ 456::   ::  Memorandum
+ 441::   ::  Inter-Entity Communication - an experiment
+ 440::   ::  Scheduled network software maintenance
+ 439::   ::  PARRY encounters the DOCTOR
+ 433::   ::  Socket number list
+ 432::   ::  Network logical map
+ 425::   ::  But my NCP costs $500 a day
+ 419::   ::  To
+ 405::   ::  Correction to RFC 404
+ 404::   ::  Host address changes involving Rand and ISI
+
+
+
+Nesser                       Informational                     [Page 74]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+ 403::   ::  Desirability of a network 1108 service
+ 402::   ::  ARPA Network mailing lists
+ 401::   ::  Conversion of NGP-0 coordinates to device specific
+             coordinates
+ 390::   ::  TSO scenario
+ 379::   ::  Using TSO at  CCN
+ 376::   ::  Network host status
+ 372::   ::  Notes on a conversation with Bob Kahn on the ICCC
+ 371::   ::  Demonstration at International Computer Communications
+             Conference
+ 370::   ::  Network host status
+ 363::   ::  ARPA Network mailing lists
+ 356::   ::  ARPA Network Control Center
+ 355::   ::  Response to NWG/RFC 346
+ 350::   ::  User accounts for UCSB On-Line System
+ 349::   ::  Proposed standard socket numbers
+ 345::   ::  Interest in mixed integer programming MPSX on NIC
+             360/91 at CCN
+ 334::   ::  Network use on May 8
+ 331::   ::  IMP System change notification
+ 330::   ::  Network host status
+ 329::   ::  ARPA Network mailing lists
+ 327::   ::  Data and File Transfer workshop notes
+ 322::   ::  Well known socket numbers
+ 321::   ::  CBI networking activity at MITRE
+ 320::   ::  Workshop on hard copy line printers
+ 319::   ::  Network host status
+ 317::   ::  Official Host-Host Protocol modification
+ 316::   ::  ARPA Network Data Management Working Group
+ 315::   ::  Network host status
+ 313::   ::  Computer based instruction
+ 305::   ::  Unknown host numbers
+ 303::   ::  ARPA Network mailing lists
+ 295::   ::  Report of the Protocol Workshop, 12 October 1971
+ 291::   ::  Data management meeting announcement
+ 290::   ::  Computer networks and data sharing
+ 282::   ::  Graphics meeting report
+ 276::   ::  NIC course
+ 270::   ::  Correction to BBN Report No. 1822 NIC NO 7958
+ 269::   ::  Some experience with file transfer
+ 263::   ::  Very Distant Host interface
+ 256::   ::  IMPSYS change notification
+ 254::   ::  Scenarios for using ARPANET computers
+ 253::   ::  Second Network Graphics meeting details
+ 249::   ::  Coordination of equipment and supplies purchase
+ 246::   ::  Network Graphics meeting
+ 245::   ::  Reservations for Network Group meeting
+ 243::   ::  Network and data sharing bibliography
+
+
+
+Nesser                       Informational                     [Page 75]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+ 242::   ::  Data descriptive language for shared data
+ 240::   ::  Site status
+ 239::   ::  Host mnemonics proposed in RFC 226 NIC 7625
+ 235::   ::  Site status
+ 234::   ::  Network Working Group meeting schedule
+ 232::   ::  Postponement of network graphics meeting
+ 228::   ::  Clarification
+ 225::   ::  Rand/UCSB network graphics experiment
+ 223::   ::  Network Information Center schedule for network users
+ 219::   ::  User's view of the datacomputer
+ 218::   ::  Changing the IMP status reporting facility
+ 214::   ::  Network checkpoint
+ 213::   ::  IMP System change notification
+ 211::   ::  ARPA Network mailing lists
+ 209::   ::  Host/IMP interface documentation
+ 208::   ::  Address tables
+ 207::   ::  September Network Working Group meeting
+ 204::   ::  Sockets in use
+ 200::   ::  RFC list by number
+ 198::   ::  Site certification - Lincoln Labs 360/67
+ 195::   ::  Data computers-data descriptions and access language
+ 194::   ::  Data Reconfiguration Service - compiler/interpreter
+             implementation notes
+ 187::   ::  Network/440 protocol concept
+ 186::   ::  Network graphics loader
+ 185::   ::  NIC distribution of manuals and handbooks
+ 182::   ::  Compilation of list of relevant site reports
+ 180::   ::  File system questionnaire
+ 179::   ::  Link number assignments
+ 173::   ::  Network data management committee meeting announcement
+ 171::   ::  Data Transfer Protocol
+ 170::   ::  RFC list by number
+ 169::   ::  Computer networks
+ 168::   ::  ARPA Network mailing lists
+ 167::   ::  Socket conventions reconsidered
+ 164::   ::  Minutes of Network Working Group meeting, 5/16
+             through 5/19/71
+ 162::   ::  NETBUGGER3
+ 160::   ::  RFC brief list
+ 157::   ::  Invitation to the Second Symposium on Problems in the
+             Optimization of Data Communications Systems
+ 155::   ::  ARPA Network mailing lists
+ 154::   ::  Exposition style
+ 149::   ::  Best laid plans
+ 148::   ::  Comments on RFC 123
+ 147::   ::  Definition of a socket
+ 140::   ::  Agenda for the May NWG meeting
+ 138::   ::  Status report on proposed Data Reconfiguration Service
+
+
+
+Nesser                       Informational                     [Page 76]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+ 136::   ::  Host accounting and administrative procedures
+ 135::   ::  Response to NWG/RFC 110
+ 132::   ::  Typographical error in RFC 107
+ 131::   ::  Response to RFC 116
+ 130::   ::  Response to RFC 111
+ 129::   ::  Request for comments on socket name structure
+ 126::   ::  Graphics facilities at Ames Research Center
+ 124::   ::  Typographical error in RFC 107
+ 121::   ::  Network on-line operators
+ 120::   ::  Network PL1 subprograms
+ 119::   ::  Network Fortran subprograms
+ 118::   ::  Recommendations for facility documentation
+ 117::   ::  Some comments on the official protocol
+ 116::   ::  Structure of the May NWG meeting
+ 115::   ::  Some Network Information Center policies on handling
+             documents
+ 113::   ::  Network activity report
+ 112::   ::  User/Server Site Protocol
+ 111::   ::  Pressure from the chairman
+ 109::   ::  Level III Server Protocol for the Lincoln Laboratory
+             NIC 360/67 Host
+ 108::   ::  Attendance list at the Urbana NWG meeting, February
+             17-19,1971
+ 107::   ::  Output of the Host-Host Protocol glitch cleaning committee
+ 106::   ::  User/Server Site Protocol network host questionnaire
+ 104::   ::  Link 191
+ 103::   ::  Implementation of interrupt keys
+ 102::   ::  Output of the Host-Host Protocol glitch cleaning committee
+ 101::   ::  Notes on the Network Working Group meeting,
+             Urbana, Illinois, February 17, 1971
+ 100::   ::  Categorization and guide to NWG/RFCs
+  99::   ::  Network meeting
+  95::   ::  Distribution of NWG/RFC's through the NIC
+  90::   ::  CCN as a network service center
+  89::   ::  Some historic moments in networking
+  87::   ::  Topic for discussion at the next Network Working Group
+             meeting
+  85::   ::  Network Working Group meeting
+  84::   ::  List of NWG/RFC's 1-80
+  82::   ::  Network meeting notes
+  81::   ::  Request for reference information
+  78::   ::  NCP status report
+  77::   ::  Network meeting report
+  76::   ::  Connection by name
+  75::   ::  Network meeting
+  74::   ::  Specifications for network use of the UCSB On-Line System
+  73::   ::  Response to NWG/RFC 67
+  72::   ::  Proposed moratorium on changes to network protocol
+
+
+
+Nesser                       Informational                     [Page 77]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+  71::   ::  Reallocation in case of input error
+  69::   ::  Distribution list change for MIT
+  68::   ::  Comments on memory allocation control commands
+  66::  ::  NIC - third level ideas and other noise
+  64::   ::  Getting rid of marking
+  63::   ::  Belated network meeting report
+  61::   ::  Note on interprocess communication in a resource
+             sharing computer network
+  57::   ::  Thoughts and reflections on NWG/RFC 54
+  52::   ::  Updated distribution list
+  51::   ::  Proposal for a Network Interchange Language
+  50::   ::  Comments on the Meyer proposal
+  49::   ::  Conversations with S. Crocker UCLA
+  48::   ::  Possible protocol plateau
+  47::   ::  BBN's comments on NWG/RFC #33
+  46::   ::  ARPA Network protocol notes
+  45::   ::  New protocol is coming
+  44::   ::  Comments on NWG/RFC 33 and 36
+  43::   ::  Proposed meeting [LIL]
+  40::   ::  More comments on the forthcoming protocol
+  39::   ::  Comments on protocol re
+  37::   ::  Network meeting epilogue, etc
+  36::   ::  Protocol notes
+  35::   ::  Network meeting
+  34::   ::  Some brief preliminary notes on the Augmentation
+             Research Center clock
+  31::   ::  Binary message forms in computer
+  30::   ::  Documentation conventions
+  27::   ::  Documentation conventions
+  25::   ::  No high link numbers
+  24::   ::  Documentation conventions
+  21::   ::  Network meeting
+  16::   ::  M.I.T
+  15::   ::  Network subsystem for time sharing hosts
+  13::   ::  [Referring to NWG/RFC 11]
+  11::   ::  Implementation of the Host-Host software procedures
+             in GORDO
+  10::   ::  Documentation conventions
+   9::   ::  Host software
+   8::   ::  Functional specifications for the ARPA Network
+   7::   ::  Host-IMP interface
+   6::   ::  Conversation with Bob Kahn
+   5::   ::  Decode Encode Language
+   4::   ::  Network timetable
+   3::   ::  Documentation conventions
+   2::   ::  Host software
+   1::   ::  Host software
+
+
+
+
+Nesser                       Informational                     [Page 78]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+Appendix B:  Automatic Script to Implement Methodology
+
+#!/usr/bin/perl
+
+# Program to read text files (such as RFCs and Internet Drafts) and
+#    output items that might relate to year 2000 issues, particularly
+#    2-digit years.
+
+# Version 1.1a. Slight modification by Philip J. Nesser
+#    (phil@nesser.com) to split lines from old RFC's that are
+#    too wide to conform with current RFC standards.
+
+# Version 1.1. By Paul Hoffman (phoffman@imc.org). This is a
+#    quick-and-dirty hack and could be written more elegantly and
+#    more efficiently. There may be bugs in this software. For
+#    example, there was an off-by-one-line bug in version 1.0.
+#    Use this code at your own risk. This code may be freely
+#    redistributed.
+
+# Some people like using disk files, others like STDIN and STDOUT.
+#    This program accomodates both types by setting the $UsageType
+#    variable. 'file' means input comes from the first argument on
+#    the command line, output goes to that filename with a ".out"
+#    extension; 'std' means STDIN and STDOUT.
+$UsageType = 'file';  # Should be 'file' or 'std'
+
+# @CheckWords is a list of words to look for. This list is used in
+#    addition to the automatic checking for "yy" on a line without "YYYY".
+#    You might want to add "year yyyy" to this list, but then a large
+#    proportion of the RFCs and drafts get selected
+
+@CheckWords = qw(UTCTime two-digit 2-digit 2digit century 1900 2000);
+
+if($UsageType eq 'file') {
+        if($ARGV[0] eq '')
+                { die "You must specify the name of the file to open.\n" }
+        $InName = $ARGV[0];
+        unless(-r $InName) { die "Could not read $InName.\n" }
+        open(IN, $InName) or die "Could not open $InName.\n";
+        $OutName = "$InName.out";
+        open(OUT, ">$OutName") or die "Could not write to $OutName.\n";
+        $OutStuff = '';  # Holder for what we're going to print out
+} else {  # Do STDIN and STDOUT
+        open(IN, "-"); open(OUT, ">-");
+}
+
+# Read the whole file into an array. This is a tad wasteful of memory
+#    but makes the output easier.
+
+
+
+Nesser                       Informational                     [Page 79]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+@All = ();
+while(<IN>) { push(@All, $_) }
+$LastLine = $#All;
+
+# Process the instance of "yy" not followed by "yy"
+for($i = 0; $i <= $LastLine; $i += 1 ) {
+        next unless(grep(/yy/i, $All[$i]));
+        next if(grep(/yyyy/i, $All[$i]));
+        &PrintFive($i, "'yy' on a line without 'yyyy'");
+}
+
+# Next do the words that should cause extra concern
+foreach $Word (@CheckWords) {
+        for($i = 0; $i <= $LastLine; $i += 1 ) {
+                next unless(grep(/$Word/i, $All[$i]));
+                &PrintFive($i, "$Word");
+        }
+}
+
+# All done. If writing to a file, and nothing got written, delete the
+#    file so that you can quickly scan for the ".out" files.
+#    (A better-written program would have waited to do the opens
+#    until here so the unlink wouldn't be necessary. Oh, well.)
+if($UsageType eq 'file') {
+        if(length($OutStuff) > 0) {
+                $OutStuff = "+=+=+=+=+= File $InName +=+=+=+=+= \n$OutStuff\n
+                print OUT $OutStuff; close(OUT);
+        } else {  # Nothing to put in the .out
+                close(OUT);
+                unlink($OutName) or die "Couldn't unlink $OutName\n";
+        }
+}
+exit;
+
+# Print the five lines around the word found
+sub PrintFive {
+    my $Where = shift(@_); my $Msg = shift(@_);
+    my ($WhereRealLine, $Start, $End, $j);
+
+    $WhereRealLine = $Where + 1;
+    $OutStuff .= "$Msg found at line $WhereRealLine:\n";
+    $Start = $WhereRealLine - 2; $End = $WhereRealLine + 2;
+    if($Where < 2) { $Start = 0 }
+    if($Where > $LastLine - 2) { $End = $LastLine }
+    for($j = $Start; $j <= $End; $j += 1) {
+        if (length($All[$j-1]) > 64) {
+            $FirstHalf = substr($All[$j-1], 0, 64) . "\n";
+            $LastHalf = "$j(continued):\t\t" . substr($All[$j-1], 64);
+
+
+
+Nesser                       Informational                     [Page 80]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+            $OutStuff .= "$j:  " . $FirstHalf . $LastHalf;
+            }
+        else {
+        $OutStuff .= "$j:  " . $All[$j-1]
+        }
+    }
+    $OutStuff .= "\n";
+}
+
+Appendix C:  Output of the script in Appendix B on all RFC's from 1
+          through 2479
+
++=+=+=+=+= File rfc0052.txt +=+=+=+=+=
+2000 found at line 141:
+139:
+140:      Chuck Rose                              Case University
+141:      Jennings Computing Center               (216) 368-2000
+142:      Case Western Reserve University                x2808
+143:      10900 Euclid Avenue
+
++=+=+=+=+= File rfc0090.txt +=+=+=+=+=
+2000 found at line 71:
+69:                           consoles);
+70:
+71:                        j) Six data communication ports (3 dial @
+71(continued):          2000 baud,
+72:                           1 dedicated @ 4800 baud, and 2 dedicate
+72(continued):          d @ 50,000
+73:                           baud) for remote batch entry terminals;
+73(continued):
+
++=+=+=+=+= File rfc0230.txt +=+=+=+=+=
+2000 found at line 92:
+90:  as for conventional synchronous block communication, since start
+90(continued):           and
+91:  stop bits for each character would need to be transmitted. This
+91(continued):          loss
+92:  is not substantial and does occur now for 2000 bps TIP-terminal
+93:  communication.
+94:
+
+2000 found at line 134:
+132:  92 transmitting sites in the U.S. and Canada were used with stan
+132(continued):         dard
+133:  Bell System Dataphone datasets used at both ends.  At both 1200
+133(continued):         and
+134:  2000 bps, approximately 82% of the calls had error rates of 1 er
+134(continued):         ror in
+
+
+
+Nesser                       Informational                     [Page 81]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+135:  10^5 bits or better, assuming an equal number of short, medium,
+135(continued):         and
+136:  long hauls.
+
++=+=+=+=+= File rfc0241.txt +=+=+=+=+=
+2000 found at line 32:
+30:     justifiable on the basis that the IMP and Host computers were
+30(continued):
+31:     expected to be either in the same room (up to 30 feet of cabl
+31(continued):          e) or,
+32:     via the Distant Host option, within 2000 feet on well- contro
+32(continued):          lled,
+33:     shielded cables.  A connection through common carrier facilit
+33(continued):          ies is
+34:     not comparably free of errors.  Usage of common- carrier line
+34(continued):          s for
+
+
++=+=+=+=+= File rfc0263.txt +=+=+=+=+=
+2000 found at line 22:
+20:  of the occasional desire to interface a Host to some IMP via a
+21:  long-distance connection (where long-distance, in this context,
+22:  is any cable run longer than 2000 feet but may typically be tens
+22(continued):
+23:  of miles) via either a hard-wire or telephone circuit.  We belie
+23(continued):          ve
+24:  that any good solution to the general problem of interfacing Hos
+24(continued):          ts
+
++=+=+=+=+= File rfc0662.txt +=+=+=+=+=
+2000 found at line 143:
+141:  by a rather short cable (approximately 100 feet long.) The CISL
+141(continued):         Multics is
+142:  connected to the IMP number 6 (port 0) by an approximately l5OO
+142(continued):         feet long cable.
+143:  8oth IMPs are in close physical proximity (approximately 2000 fe
+143(continued):         et,) and are
+144:  connected to each other by a 5O kilobits per second line. The re
+144(continued):         sults given
+145:  above show considerable improvement in the performance with the
+145(continued):         new IMP DIM.
+
++=+=+=+=+= File rfc0713.txt +=+=+=+=+=
+2000 found at line 830:
+828:  succeeding bytes in the stream used to encode the object.
+829:
+830:  A data object requiring 20000 (47040 octal) bytes would
+831:  appear in the stream as follows.
+
+
+
+Nesser                       Informational                     [Page 82]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+832:
+
+2000 found at line 837:
+835:  10000010 -- specifying that the next 2 bytes
+836:  contain the stream length
+837:  01001110 -- first byte of number 20000
+838:  00100000 -- second byte
+839:  .
+
+2000 found at line 845:
+843:  .
+844:
+845:  Interpretation of the contents of the 20000 bytes in
+846:  the stream can be performed by a module which knows the
+847:  specific format of the non-atomic type specified by DEFGH in
+
++=+=+=+=+= File rfc0724.txt +=+=+=+=+=
+2-digit found at line 1046:
+1044:                                                  <4-digit-year>
+1045:           <slash-date>      ::=   <numeric-month> "/" <date-of-mo
+1045(continued):                nth>
+1046:                                                   "/" <2-digit-ye
+1046(continued):                ar>
+1047:           <numeric-month>   ::=   <one or two decimal digits>
+1048:           <day-of-month>    ::=   <one or two decimal digits>
+
+2-digit found at line 1062:
+1060:                                 | "December" | "Dec"
+1061:           <4-digit-year>    ::=   <four decimal digits>
+1062:           <2-digit-year>    ::=   <two decimal digits>
+1063:           <time>            ::=   <24-hour-time> "-" <time-zone>
+1064:           <24-hour-time>    ::=   <hour> <minute>
+
+2-digit found at line 1675:
+1673:       A.  ALPHABETICAL LISTING OF SYNTAX RULES
+1674:
+1675:       <2-digit-year>    ::=   <two decimal digits>
+1676:       <4-digit-year>    ::=   <four decimal digits>
+1677:       <24-hour-time>    ::=   <hour> <minute>
+
+2-digit found at line 1829:
+1827:
+1828:       <slash-date>      ::=   <numeric-month> "/" <date-of-month>
+1828(continued):
+1829:                                               "/" <2-digit-year>
+1830:       <space>           ::=   <TELNET ASCII space (decimal 32)>
+1831:
+
+
+
+
+Nesser                       Informational                     [Page 83]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc0731.txt +=+=+=+=+=
+2000 found at line 1571:
+1569:             RFC 728, 1977.
+1570:
+1571:       9.  Hazeltine 2000 Desk Top Display Operating Instructions.
+1571(continued):
+1572:             Hazeltine IB-1866A, 1870.
+1573:
+
++=+=+=+=+= File rfc0732.txt +=+=+=+=+=
+2000 found at line 1681:
+1679:         1977.
+1680:
+1681:    9.   Hazeltine 2000 Desk Top Display Operating Instructions. H
+1681(continued):                azeltine
+1682:         IB-1866A, 1870.
+1683:
+
++=+=+=+=+= File rfc0733.txt +=+=+=+=+=
+2-digit found at line 333:
+331:
+332:  "<n>(element)" is  equivalent  to  "<n>*<n>(element)";  that  is
+332(continued):         ,
+333:  exactly  <n>  occurrences of (element).  Thus 2DIGIT is a 2-digi
+333(continued):         t
+334:  number, and 3ALPHA is a string of three alphabetic characters.
+335:
+
+2digit found at line 333:
+331:
+332:  "<n>(element)" is  equivalent  to  "<n>*<n>(element)";  that  is
+332(continued):         ,
+333:  exactly  <n>  occurrences of (element).  Thus 2DIGIT is a 2-digi
+333(continued):         t
+334:  number, and 3ALPHA is a string of three alphabetic characters.
+335:
+
+2digit found at line 947:
+945:              /  "Sunday"    / "Sun"
+946:
+947:  date        =  1*2DIGIT ["-"] month         ; day month year
+948:                 ["-"] (2DIGIT /4DIGIT)       ;  e.g. 20 Aug [19]7
+948(continued):         7
+949:
+
+2digit found at line 948:
+946:
+947:  date        =  1*2DIGIT ["-"] month         ; day month year
+
+
+
+Nesser                       Informational                     [Page 84]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+948:                 ["-"] (2DIGIT /4DIGIT)       ;  e.g. 20 Aug [19]7
+948(continued):         7
+949:
+950:  month       =  "January"   / "Jan"  / "February"  / "Feb"
+
+2digit found at line 967:
+965:                                              ;  (seconds optional
+965(continued):         )
+966:
+967:  hour        =  2DIGIT [":"] 2DIGIT [ [":"] 2DIGIT ]
+968:                                              ; 0000[00] - 2359[59
+968(continued):         ]
+969:
+
+2digit found at line 1718:
+1716:  CTL         =  <any TELNET ASCII control character and DEL>
+1717:
+1718:  date        =  1*2DIGIT ["-"] month ["-"] (2DIGIT /4DIGIT)
+1719:  date-field  =  "Date"       ":" date-time
+1720:  date-time   =  [ day-of-week "," ] date time
+
+2digit found at line 1754:
+1752:  host-indicator =  1*( ("at" / "@") node )
+1753:  host-phrase =  phrase  host-indicator
+1754:  hour        =  2DIGIT [":"] 2DIGIT [ [":"] 2DIGIT ]
+1755:  HTAB        =  <TELNET ASCII horizontal-tab>
+1756:
+
++=+=+=+=+= File rfc0734.txt +=+=+=+=+=
+2000 found at line 184:
+182:  Bit name  Value           Meaning
+183:
+184:  %TOALT            200000,,0       characters  175  and 176  are
+184(continued):         converted to
+185:                            altmode (033) on input.
+186:
+
+2000 found at line 264:
+262:                             NORMALLY OFF.
+263:
+264:  %TOSA1              2000,,0       characters  001-037  should
+264(continued):           be  displayed
+265:                            using  the  Stanford/ITS  extended
+265(continued):           ASCII
+266:                            graphics character set instead of
+266(continued):           uparrow
+
+2000 found at line 354:
+
+
+
+Nesser                       Informational                     [Page 85]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+352:  %TXTOP    4000    This character has the [TOP] key depressed.
+353:
+354:  %TXSFL    2000    Reserved, must be zero.
+355:
+356:  %TXSFT    1000    Reserved, must be zero.
+
+2000 found at line 634:
+632:  Value     Key
+633:
+634:   2000     Reserved
+635:   1000     Reserved
+636:   0400     <META>
+
++=+=+=+=+= File rfc0738.txt +=+=+=+=+=
+1900 found at line 41:
+39:  without sending anything.
+40:
+41:  The time is the number of seconds since 0000 (midnight) 1 Januar
+41(continued):          y 1900
+42:  GMT, such that the time 1 is 12:00:01 am on 1 January 1900 GMT;
+42(continued):          this
+43:  base will serve until the year 2036.  As a further example, the
+43(continued):          most
+
+1900 found at line 42:
+40:
+41:  The time is the number of seconds since 0000 (midnight) 1 Januar
+41(continued):          y 1900
+42:  GMT, such that the time 1 is 12:00:01 am on 1 January 1900 GMT;
+42(continued):          this
+43:  base will serve until the year 2036.  As a further example, the
+43(continued):          most
+44:  recent leap year as of this writing began from the time 2,398,29
+44(continued):          1,200
+
++=+=+=+=+= File rfc0745.txt +=+=+=+=+=
+2000 found at line 562:
+560:  Circuits, EIA standard RS-422," April 1975; Engineering Dept.,
+561:  Electronic Industries Assn., 2001 Eye St., N.W., Washington, D.C
+561(continued):         .,
+562:  20006.
+563:
+564:  REA bulletin 345-67, Rural Electrification Admin., U.S. Dept. of
+564(continued):
+
++=+=+=+=+= File rfc0746.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 341:
+339:           %TDGRF                 ;Enter graphics.
+
+
+
+Nesser                       Informational                     [Page 86]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+340:           %GOCLR                 ;Clear the screen.
+341:           %GOMVA xx yy           ;Set cursor.
+342:           %GODLA xx yy           ;Draw line from there.
+343:           << repeat last two commands for each line >>
+
+'yy' on a line without 'yyyy' found at line 342:
+340:           %GOCLR                 ;Clear the screen.
+341:           %GOMVA xx yy           ;Set cursor.
+342:           %GODLA xx yy           ;Draw line from there.
+343:           << repeat last two commands for each line >>
+344:           %TDNOP                 ;Exit graphics.
+
+2000 found at line 859:
+857:  %TRGIN  0,,400000  terminal can provide graphics input.
+858:
+859:  %TRGHC  0,,200000  terminal has a hard-copy device to which outp
+859(continued):         ut can
+860:                     be diverted.
+861:
+
++=+=+=+=+= File rfc0752.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 218:
+216:  word 4          The name of the site in SIXBIT.
+217:  word 5          The user name who compiled the file, usually in
+217(continued):         SIXBIT.
+218:  word 6          Date of compilation as SIXBIT YYMMDD.
+219:  word 7          Time of compilation as SIXBIT HHMMSS.
+220:  word 8          Address in file of NAME table.
+
++=+=+=+=+= File rfc0754.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 76:
+74:
+75:  Messages are transmitted as a character string to an address whi
+75(continued):          ch is
+76:  specified "outside" the message.  The destination host ("YYY") i
+76(continued):          s
+77:  specified to the sending (or user) FTP as the argument of the "o
+77(continued):          pen
+78:  connection" command, and the destination user ("XXX") is specifi
+78(continued):          ed to
+
+'yy' on a line without 'yyyy' found at line 81:
+79:  the receiving (or server) FTP as the argument of the "MAIL" (or
+79(continued):          "MLFL")
+80:  command.  In Tenex, when mail is queued this outside information
+80(continued):           is
+81:  saved in the file name ("[---].XXX@YYY").
+82:
+
+
+
+Nesser                       Informational                     [Page 87]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+83:  The proposed solutions are briefly characterized.
+
+'yy' on a line without 'yyyy' found at line 239:
+237:
+238:
+239:     "[---].XXX@YYY", not anything from the header.  Only the stri
+239(continued):         ng "XXX"
+240:     is passed to the FTP server.
+241:
+
++=+=+=+=+= File rfc0759.txt +=+=+=+=+=
+two-digit found at line 1414:
+1412:        yyyy-mm-dd-hh:mm:ss,fff+hh:mm
+1413:
+1414:      Where yyyy is the four-digit year, mm is the two-digit month
+1414(continued):                , dd is
+1415:      the two-digit day, hh is the two-digit hour in 24 hour time,
+1415(continued):                 mm is
+1416:      the two-digit minute, ss is the two-digit second, and fff is
+1416(continued):                 the
+
+two-digit found at line 1415:
+1413:
+1414:      Where yyyy is the four-digit year, mm is the two-digit month
+1414(continued):                , dd is
+1415:      the two-digit day, hh is the two-digit hour in 24 hour time,
+1415(continued):                 mm is
+1416:      the two-digit minute, ss is the two-digit second, and fff is
+1416(continued):                 the
+1417:      decimal fraction of the second.  To this basic date and time
+1417(continued):                 is
+
+two-digit found at line 1416:
+1414:      Where yyyy is the four-digit year, mm is the two-digit month
+1414(continued):                , dd is
+1415:      the two-digit day, hh is the two-digit hour in 24 hour time,
+1415(continued):                 mm is
+1416:      the two-digit minute, ss is the two-digit second, and fff is
+1416(continued):                 the
+1417:      decimal fraction of the second.  To this basic date and time
+1417(continued):                 is
+1418:      appended the offset from Greenwich as plus or minus hh hours
+1418(continued):                 and mm
+
++=+=+=+=+= File rfc0767.txt +=+=+=+=+=
+two-digit found at line 710:
+708:        yyyy-mm-dd-hh:mm:ss,fff+hh:mm
+709:
+
+
+
+Nesser                       Informational                     [Page 88]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+710:      Where yyyy is the four-digit year, mm is the two-digit month
+710(continued):         , dd is
+711:      the two-digit day, hh is the two-digit hour in 24 hour time,
+711(continued):          mm is
+712:      the two-digit minute, ss is the two-digit second, and fff is
+712(continued):          the
+
+two-digit found at line 711:
+709:
+710:      Where yyyy is the four-digit year, mm is the two-digit month
+710(continued):         , dd is
+711:      the two-digit day, hh is the two-digit hour in 24 hour time,
+711(continued):          mm is
+712:      the two-digit minute, ss is the two-digit second, and fff is
+712(continued):          the
+713:      decimal fraction of the second.  To this basic date and time
+713(continued):          is
+
+two-digit found at line 712:
+710:      Where yyyy is the four-digit year, mm is the two-digit month
+710(continued):         , dd is
+711:      the two-digit day, hh is the two-digit hour in 24 hour time,
+711(continued):          mm is
+712:      the two-digit minute, ss is the two-digit second, and fff is
+712(continued):          the
+713:      decimal fraction of the second.  To this basic date and time
+713(continued):          is
+714:      appended the offset from Greenwich as plus or minus hh hours
+714(continued):          and mm
+
++=+=+=+=+= File rfc0786.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 71:
+69:
+70:           The date-time will be in the default TOPS20 ODTIM forma
+70(continued):          t
+71:           "dd-mmm-yy hh:mm:ss" (24 hour time).
+72:
+73:        The files will named "arbitrary.NIMAIL.-1", where "arbitra
+73(continued):          ry" will
+
++=+=+=+=+= File rfc0788.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 1592:
+1590:              <daytime> ::= "at" <SP> <date> <SP> <time>
+1591:
+1592:              <date> ::= <dd> "-" <mon> "-" <yy>
+1593:
+1594:              <time> ::= <hh> ":" <mm> ":" <ss> "-" <zone>
+
+
+
+
+Nesser                       Informational                     [Page 89]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+'yy' on a line without 'yyyy' found at line 1602:
+1600:                        "JUL" | "AUG" | "SEP" | "OCT" | "NOV" | "D
+1600(continued):                EC"
+1601:
+1602:              <yy> ::= the two decimal integer year of the century
+1602(continued):                 in the
+1603:                        range 01 to 99.
+1604:
+
+century found at line 1602:
+1600:                        "JUL" | "AUG" | "SEP" | "OCT" | "NOV" | "D
+1600(continued):                EC"
+1601:
+1602:              <yy> ::= the two decimal integer year of the century
+1602(continued):                 in the
+1603:                        range 01 to 99.
+1604:
+
++=+=+=+=+= File rfc0809.txt +=+=+=+=+=
+2000 found at line 3349:
+3347:
+3348:        #define WID     0000000   /* Write Image Data */
+3349:        #define WGD     0020000   /* Write Graphic Data */
+3350:        #define WAC     0022000   /* Write AlphanumCh */
+3351:
+
+2000 found at line 3350:
+3348:        #define WID     0000000   /* Write Image Data */
+3349:        #define WGD     0020000   /* Write Graphic Data */
+3350:        #define WAC     0022000   /* Write AlphanumCh */
+3351:
+3352:        #define LWM     0024000   /* Load Write Mode */
+
+2000 found at line 3379:
+3377:
+3378:        #define ERS     0030000   /* Erase */
+3379:        #define ERL     0032000   /* Erase Line */
+3380:        #define SLU     0034000   /* Special Location Update */
+3381:        #define   SCRL_ZAP 0100   /* unlimited scroll speed */
+
+2000 found at line 3392:
+3390:        #define LLB     0070000   /* Load Lb */
+3391:        #define LLC     0074000   /* Load Lc */
+3392:        #define   LGW     02000   /* perform write */
+3393:
+3394:        #define NOP     0110000   /* No-Operation */
+
+2000 found at line 3396:
+
+
+
+Nesser                       Informational                     [Page 90]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+3394:        #define NOP     0110000   /* No-Operation */
+3395:
+3396:        #define SPD     0120000   /* Select Special Device */
+3397:        #define LPA     0130000   /* Load Peripheral Address */
+3398:        #define LPR     0140000   /* Load Peripheral Register */
+
+2000 found at line 3405:
+3403:        #define   ALPHA   06000   /* LPR - Alphanumeric data */
+3404:        #define   GRAPH   04000   /* LPR - Graphic data */
+3405:        #define   IMAGE   02000   /* LPR - Image data */
+3406:        #define   LTHENH  01000   /* take lo byte then hi byte */
+3407:        #define   DROPBYTE 0400   /* drop last byte */
+
+2000 found at line 3408:
+3406:        #define   LTHENH  01000   /* take lo byte then hi byte */
+3407:        #define   DROPBYTE 0400   /* drop last byte */
+3408:        #define INTERR    02000   /* SPD - Interrupt Enable */
+3409:        #define TEST      04000   /* SPD - Diagnostic Test */
+3410:
+
++=+=+=+=+= File rfc0810.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 146:
+144:     , (comma)          is used as a data element delimiter
+145:
+146:     XXX/YYY            indicates protocol information of the type
+146(continued):
+147:                        TRANSPORT/SERVICE.
+148:
+
++=+=+=+=+= File rfc0820.txt +=+=+=+=+=
+2000 found at line 674:
+672:        014.000.000.001   311031700035 00     PURDUE-TN
+672(continued):            [CXK]
+673:        014.000.000.002   311060800027 00     UWISC-TN
+673(continued):            [CXK]
+674:        014.000.000.003   311030200024 00     UDEL-TN
+674(continued):            [CXK]
+675:        014.000.000.004   234219200149 23     UCL-VTEST
+675(continued):             [PK]
+676:        014.000.000.005   234219200300 23     UCL-TG
+676(continued):             [PK]
+
++=+=+=+=+= File rfc0821.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 1944:
+1942:              <daytime> ::= <SP> <date> <SP> <time>
+1943:
+1944:              <date> ::= <dd> <SP> <mon> <SP> <yy>
+1945:
+
+
+
+Nesser                       Informational                     [Page 91]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1946:              <time> ::= <hh> ":" <mm> ":" <ss> <SP> <zone>
+
+'yy' on a line without 'yyyy' found at line 1954:
+1952:                        "JUL" | "AUG" | "SEP" | "OCT" | "NOV" | "D
+1952(continued):                EC"
+1953:
+1954:              <yy> ::= the two decimal integer year of the century
+1954(continued):                 in the
+1955:                        range 00 to 99.
+1956:
+
+century found at line 1954:
+1952:                        "JUL" | "AUG" | "SEP" | "OCT" | "NOV" | "D
+1952(continued):                EC"
+1953:
+1954:              <yy> ::= the two decimal integer year of the century
+1954(continued):                 in the
+1955:                        range 00 to 99.
+1956:
+
++=+=+=+=+= File rfc0822.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 1635:
+1633:       5.1.  SYNTAX
+1634:
+1635:       date-time   =  [ day "," ] date time        ; dd mm yy
+1636:                                                   ;  hh:mm:ss zzz
+1636(continued):
+1637:
+
+'yy' on a line without 'yyyy' found at line 2701:
+2699:       dates       =   orig-date                   ; Original
+2700:                     [ resent-date ]               ; Forwarded
+2701:       date-time   =  [ day "," ] date time        ; dd mm yy
+2702:                                                   ;  hh:mm:ss zzz
+2702(continued):
+2703:       day         =  "Mon"  / "Tue" /  "Wed"  / "Thu"
+
+2-digit found at line 344:
+342:
+343:            "<n>(element)" is equivalent to "<n>*<n>(element)"; th
+343(continued):         at is,
+344:       exactly  <n>  occurrences  of (element). Thus 2DIGIT is a 2
+344(continued):         -digit
+345:       number, and 3ALPHA is a string of three alphabetic characte
+345(continued):         rs.
+346:
+
+2digit found at line 344:
+
+
+
+Nesser                       Informational                     [Page 92]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+342:
+343:            "<n>(element)" is equivalent to "<n>*<n>(element)"; th
+343(continued):         at is,
+344:       exactly  <n>  occurrences  of (element). Thus 2DIGIT is a 2
+344(continued):         -digit
+345:       number, and 3ALPHA is a string of three alphabetic characte
+345(continued):         rs.
+346:
+
+2digit found at line 1641:
+1639:                   /  "Fri"  / "Sat" /  "Sun"
+1640:
+1641:       date        =  1*2DIGIT month 2DIGIT        ; day month yea
+1641(continued):                r
+1642:                                                   ;  e.g. 20 Jun
+1642(continued):                82
+1643:
+
+2digit found at line 1650:
+1648:       time        =  hour zone                    ; ANSI and Mili
+1648(continued):                tary
+1649:
+1650:       hour        =  2DIGIT ":" 2DIGIT [":" 2DIGIT]
+1651:                                                   ; 00:00:00 - 23
+1651(continued):                :59:59
+1652:
+
+2digit found at line 2697:
+2695:       CTL         =  <any ASCII control           ; (  0- 37,  0.
+2695(continued):                - 31.)
+2696:                       character and DEL>          ; (    177,
+2696(continued):                 127.)
+2697:       date        =  1*2DIGIT month 2DIGIT        ; day month yea
+2697(continued):                r
+2698:                                                   ;  e.g. 20 Jun
+2698(continued):                82
+2699:       dates       =   orig-date                   ; Original
+
+2digit found at line 2747:
+2745:       field-name  =  1*<any CHAR, excluding CTLs, SPACE, and ":">
+2745(continued):
+2746:       group       =  phrase ":" [#mailbox] ";"
+2747:       hour        =  2DIGIT ":" 2DIGIT [":" 2DIGIT]
+2748:                                                   ; 00:00:00 - 23
+2748(continued):                :59:59
+2749:       HTAB        =  <ASCII HT, horizontal-tab>   ; (     11,
+2749(continued):                   9.)
+
+
+
+
+Nesser                       Informational                     [Page 93]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc0850.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 227:
+225:  network.  One format that is acceptable to both is
+226:
+227:       Weekday, DD-Mon-YY HH:MM:SS TIMEZONE
+228:
+229:  Several examples of  valid  dates  appear  in  the  sample
+
++=+=+=+=+= File rfc0867.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 67:
+65:        Another popular syntax is that used in SMTP:
+66:
+67:           dd mmm yy hh:mm:ss zzz
+68:
+69:           Example:
+
++=+=+=+=+= File rfc0868.txt +=+=+=+=+=
+1900 found at line 19:
+17:  This protocol provides a site-independent, machine readable date
+17(continued):           and
+18:  time.  The Time service sends back to the originating source the
+18(continued):           time in
+19:  seconds since midnight on January first 1900.
+20:
+21:  One motivation arises from the fact that not all systems have a
+
+1900 found at line 83:
+81:  The Time
+82:
+83:  The time is the number of seconds since 00:00 (midnight) 1 Janua
+83(continued):          ry 1900
+84:  GMT, such that the time 1 is 12:00:01 am on 1 January 1900 GMT;
+84(continued):          this
+85:  base will serve until the year 2036.
+
+1900 found at line 84:
+82:
+83:  The time is the number of seconds since 00:00 (midnight) 1 Janua
+83(continued):          ry 1900
+84:  GMT, such that the time 1 is 12:00:01 am on 1 January 1900 GMT;
+84(continued):          this
+85:  base will serve until the year 2036.
+86:
+
++=+=+=+=+= File rfc0869.txt +=+=+=+=+=
+2000 found at line 1639:
+1637:                    400      HDH
+1638:                   1000      Cassette Writer
+
+
+
+Nesser                       Informational                     [Page 94]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1639:                   2000      Propagation Delay Measurement
+1640:                   4000      X25
+1641:                  10000      Profile Measurements
+
+2000 found at line 1642:
+1640:                   4000      X25
+1641:                  10000      Profile Measurements
+1642:                  20000      Self Authenticating Password
+1643:                  40000      Host traffic Matrix
+1644:                 100000      Experimental/Special
+
+2000 found at line 1669:
+1667:                200      Trace ON
+1668:               1000      Statistics ON
+1669:               2000      Message Generator ON
+1670:               4000      Packet Trace ON
+1671:              10000      Host Data Checksum is BAD
+
+2000 found at line 1672:
+1670:               4000      Packet Trace ON
+1671:              10000      Host Data Checksum is BAD
+1672:              20000      Reload Location SET
+1673:
+1674:
+
++=+=+=+=+= File rfc0884.txt +=+=+=+=+=
+2000 found at line 236:
+234:        GENERAL-TERMINAL-100A
+235:        HAZELTINE-1500
+236:        HAZELTINE-2000
+237:        HP-2621
+238:        HP-2640A
+
++=+=+=+=+= File rfc0899.txt +=+=+=+=+=
+1900 found at line 337:
+335:     provides a site-independent, machine readable date and time.
+335(continued):          The
+336:     Time service sends back to the originating source the time in
+336(continued):          seconds
+337:     since midnight on January first 1900.
+338:
+339:  867     Postel       May 83      Daytime Protocol
+
++=+=+=+=+= File rfc0900.txt +=+=+=+=+=
+2000 found at line 1595:
+1593:     HAZELTINE-1510
+1594:     HAZELTINE-1520
+1595:     HAZELTINE-2000
+
+
+
+Nesser                       Informational                     [Page 95]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1596:     HP-2621
+1597:     HP-2621A
+
+
++=+=+=+=+= File rfc0909.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 859:
+857:       responses from the target.  A session begins when a host op
+857(continued):         ens  a
+858:       transport  connection to a target listening on a well known
+858(continued):          port.
+859:       LDP uses RDP port number zzz or TCP port number  yyy.   Whe
+859(continued):         n  the
+860:       connection  has been established, the host sends a HELLO co
+860(continued):         mmand,
+861:       and the target  replies  with  a  HELLO_REPLY.   The  HELLO
+861(continued):         _REPLY
+
++=+=+=+=+= File rfc0923.txt +=+=+=+=+=
+2000 found at line 1769:
+1767:     HAZELTINE-1510
+1768:     HAZELTINE-1520
+1769:     HAZELTINE-2000
+1770:     HP-2621
+1771:     HP-2621A
+
++=+=+=+=+= File rfc0937.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 327:
+325:        FOLD mailbox                      - Error
+326:        READ [n]                          #xxx
+327:        RETR                              =yyy
+328:        ACKS
+329:        ACKD
+
++=+=+=+=+= File rfc0943.txt +=+=+=+=+=
+2000 found at line 1829:
+1827:     HAZELTINE-1510
+1828:     HAZELTINE-1520
+1829:     HAZELTINE-2000
+1830:     HP-2621
+1831:     HP-2621A
+
++=+=+=+=+= File rfc0952.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 159:
+157:     ,(comma)        is used as a data element delimiter
+158:
+159:     XXX/YYY         indicates protocol information of the type
+160:                     TRANSPORT/SERVICE.
+161:
+
+
+
+Nesser                       Informational                     [Page 96]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc0956.txt +=+=+=+=+=
+1900 found at line 748:
+746:
+747:        3.  The data format should be based on the UDP Time format
+747(continued):         , which
+748:            specifies 32-bit time in seconds since 1 January 1900,
+748(continued):          but
+749:            extended additional bits for the fractional part of a
+749(continued):         second.
+750:
+
+1900 found at line 826:
+824:     experiment the results indicated by UDP and ICMP are compared
+824(continued):         .  In
+825:     the UDP Time protocol time is indicated as a 32-bit field in
+825(continued):         seconds
+826:     past 0000 UT on 1 January 1900, while in the ICMP Timestamp m
+826(continued):         essage
+827:     time is indicated as a 32-bit field in milliseconds past 0000
+827(continued):          UT of
+828:     each day.
+
+2000 found at line 1392:
+1390:           CU-ARPA.CS.CORNELL.EDU  -1              -514
+1391:           UCI-ICSE.ARPA           -1              -1896
+1392:           UCI-ICSC.ARPA           1               2000
+1393:           DCN9.ARPA               -7              -6610
+1394:           TRANTOR.ARPA            10              10232
+
++=+=+=+=+= File rfc0958.txt +=+=+=+=+=
+century found at line 41:
+39:     NTP provides the protocol mechanisms to synchronize time in p
+39(continued):          rinciple
+40:     to precisions in the order of nanoseconds while preserving a
+41:     non-ambiguous date, at least for this century.  The protocol
+41(continued):          includes
+42:     provisions to specify the precision and estimated error of th
+42(continued):          e local
+43:     clock and the characteristics of the reference clock to which
+43(continued):           it may
+
+1900 found at line 143:
+141:
+142:     NTP timestamps are represented as a 64-bit fixed-point number
+142(continued):         , in
+143:     seconds relative to 0000 UT on 1 January 1900.  The integer p
+143(continued):         art is
+144:     in the first 32 bits and the fraction part in the last 32 bit
+
+
+
+Nesser                       Informational                     [Page 97]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+144(continued):         s, as
+145:     shown in the following diagram.
+
++=+=+=+=+= File rfc0960.txt +=+=+=+=+=
+2000 found at line 1659:
+1657:        014.000.000.018   2624-522-80900 52   DFVLR5-X25
+1657(continued):                  [HDC1]
+1658:        014.000.000.019   2041-170-10000 00   SHAPE-X25
+1658(continued):                   [JFW]
+1659:        014.000.000.020   5052-737-20000 50   UQNET
+1659(continued):                   [AXH]
+1660:        014.000.000.021   3020-801-00057 50   DMC-CRC1
+1660(continued):                  [JR17]
+1661:        014.000.000.022-014.255.255.254       Unassigned
+1661(continued):                   [JBP]
+
+2000 found at line 1984:
+1982:     AEGIS
+1983:     APOLLO
+1984:     BS-2000
+1985:     CEDAR
+1986:     CGW
+
+2000 found at line 2350:
+2348:     HAZELTINE-1510
+2349:     HAZELTINE-1520
+2350:     HAZELTINE-2000
+2351:     HP-2621
+2352:     HP-2621A
+
++=+=+=+=+= File rfc0973.txt +=+=+=+=+=
+2000 found at line 377:
+375:        We might add the following to the parent zone:
+376:
+377:         99.128.IN-ADDR.ARPA. 2000 NS  Q.ISI.EDU.
+378:                              2000 NS  XX.MIT.EDU.
+379:         Q.ISI.EDU.           2000 A   <address of Q.ISI.EDU.>
+
+2000 found at line 378:
+376:
+377:         99.128.IN-ADDR.ARPA. 2000 NS  Q.ISI.EDU.
+378:                              2000 NS  XX.MIT.EDU.
+379:         Q.ISI.EDU.           2000 A   <address of Q.ISI.EDU.>
+380:         XX.MIT.EDU.          2000 A   <address of XX.MIT.EDU.>
+
+2000 found at line 379:
+377:         99.128.IN-ADDR.ARPA. 2000 NS  Q.ISI.EDU.
+378:                              2000 NS  XX.MIT.EDU.
+
+
+
+Nesser                       Informational                     [Page 98]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+379:         Q.ISI.EDU.           2000 A   <address of Q.ISI.EDU.>
+380:         XX.MIT.EDU.          2000 A   <address of XX.MIT.EDU.>
+381:
+
+2000 found at line 380:
+378:                              2000 NS  XX.MIT.EDU.
+379:         Q.ISI.EDU.           2000 A   <address of Q.ISI.EDU.>
+380:         XX.MIT.EDU.          2000 A   <address of XX.MIT.EDU.>
+381:
+382:        and the following to the child zone:
+
+2000 found at line 384:
+382:        and the following to the child zone:
+383:
+384:         99.128.IN-ADDR.ARPA. 2000 NS  Q.ISI.EDU.
+385:                              2000 NS  XX.MIT.EDU.
+386:                              5000 SOA <SOA information>
+
+2000 found at line 385:
+383:
+384:         99.128.IN-ADDR.ARPA. 2000 NS  Q.ISI.EDU.
+385:                              2000 NS  XX.MIT.EDU.
+386:                              5000 SOA <SOA information>
+387:         Q.ISI.EDU.           2000 A   <address of Q.ISI.EDU.>
+
+2000 found at line 387:
+385:                              2000 NS  XX.MIT.EDU.
+386:                              5000 SOA <SOA information>
+387:         Q.ISI.EDU.           2000 A   <address of Q.ISI.EDU.>
+388:         XX.MIT.EDU.          2000 A   <address of XX.MIT.EDU.>
+389:
+
+2000 found at line 388:
+386:                              5000 SOA <SOA information>
+387:         Q.ISI.EDU.           2000 A   <address of Q.ISI.EDU.>
+388:         XX.MIT.EDU.          2000 A   <address of XX.MIT.EDU.>
+389:
+390:     SOA serials
+
++=+=+=+=+= File rfc0977.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 814:
+812:     the same format as the LIST command.
+813:
+814:     The date is sent as 6 digits in the format YYMMDD, where YY i
+814(continued):         s the
+815:     last two digits of the year, MM is the two digits of the mont
+815(continued):         h (with
+816:     leading zero, if appropriate), and DD is the day of the month
+
+
+
+Nesser                       Informational                     [Page 99]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+816(continued):          (with
+
+century found at line 817:
+815:     last two digits of the year, MM is the two digits of the mont
+815(continued):         h (with
+816:     leading zero, if appropriate), and DD is the day of the month
+816(continued):          (with
+817:     leading zero, if appropriate).  The closest century is assume
+817(continued):         d as
+818:     part of the year (i.e., 86 specifies 1986, 30 specifies 2030,
+818(continued):          99 is
+819:     1999, 00 is 2000).
+
+2000 found at line 819:
+817:     leading zero, if appropriate).  The closest century is assume
+817(continued):         d as
+818:     part of the year (i.e., 86 specifies 1986, 30 specifies 2030,
+818(continued):          99 is
+819:     1999, 00 is 2000).
+820:
+821:     Time must also be specified.  It must be as 6 digits HHMMSS w
+821(continued):         ith HH
+
+2000 found at line 1190:
+1188:
+1189:     (client asks for new newsgroups since April 3, 1985)
+1190:     C:      NEWGROUPS 850403 020000
+1191:
+1192:     S:      231 New newsgroups since 03/04/85 02:00:00 follow
+
+2000 found at line 1275:
+1273:
+1274:     (client asks for new newsgroups since 2 am, May 15, 1985)
+1275:     C:      NEWGROUPS 850515 020000
+1276:     S:      235 New newsgroups since 850515 follow
+1277:     S:      net.fluff
+
+2000 found at line 1282:
+1280:
+1281:     (client asks for new news articles since 2 am, May 15, 1985)
+1282:     C:      NEWNEWS * 850515 020000
+1283:     S:      230 New news since 850515 020000 follows
+1284:     S:      <1772@foo.UUCP>
+
+2000 found at line 1283:
+1281:     (client asks for new news articles since 2 am, May 15, 1985)
+1282:     C:      NEWNEWS * 850515 020000
+1283:     S:      230 New news since 850515 020000 follows
+
+
+
+Nesser                       Informational                    [Page 100]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1284:     S:      <1772@foo.UUCP>
+1285:     S:      <87623@baz.UUCP>
+
+
++=+=+=+=+= File rfc0985.txt +=+=+=+=+=
+2000 found at line 505:
+503:        Very Distant Host (VDH) methods are not recommended for ne
+503(continued):         w
+504:        implementations.  The Distant Host (DH) method is used whe
+504(continued):         n the
+505:        host and IMP are separated by not more than about 2000 fee
+505(continued):         t of
+506:        cable, while the HDLC Distant Host is used for greater dis
+506(continued):         tances
+507:        where a modem is required.  Retransmission, resequencing a
+507(continued):         nd flow
+
++=+=+=+=+= File rfc0987.txt +=+=+=+=+=
+UTCTime found at line 1100:
+1098:           X.408 (sections 4.2.2 and 5.2.2).
+1099:
+1100:        3.3.5.  UTCTime
+1101:
+1102:           Both UTCTime and the RFC 822 822.date-time syntax conta
+1102(continued):                in: Year
+
+UTCTime found at line 1102:
+1100:        3.3.5.  UTCTime
+1101:
+1102:           Both UTCTime and the RFC 822 822.date-time syntax conta
+1102(continued):                in: Year
+1103:           (lowest two digits), Month, Day of Month, hour, minute,
+1103(continued):                 second
+1104:           (optional), and Timezone.  822.date-time also contains
+1104(continued):                an
+
+UTCTime found at line 1107:
+1105:           optional day of the week, but this is redundant.  There
+1105(continued):                fore a
+1106:           symmetrical mapping can be made between these construct
+1106(continued):                s <5>.
+1107:           The UTCTime format which specifies the timezone offset
+1107(continued):                should
+1108:           be used, in line with CEN/CENELEC recommendations.
+1109:
+
+UTCTime found at line 3395:
+3393:
+
+
+
+Nesser                       Informational                    [Page 101]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+3394:        The extended syntax of zone defined in the JNT Mail Protoc
+3394(continued):                ol
+3395:        should be used in the mapping of UTCTime defined in chapte
+3395(continued):                r 3.
+3396:
+3397:     5.  Lack of separate 822-P1 originator specification
+
+UTCTime found at line 3910:
+3908:     <5>  In practice, a gateway will need to parse various illega
+3908(continued):                l
+3909:          variants on 822.date-time.  In cases where 822.date-time
+3909(continued):                 cannot
+3910:          be parsed, it is recommended that the derived UTCTime is
+3910(continued):                 set to
+3911:          the value at the time of translation.
+3912:
+
+2digit found at line 2785:
+2783:                              last-trace ";"
+2784:                              "ext" 1*DIGIT
+2785:                              "flags" 2DIGIT
+2786:                              [ "intended" mailbox ] ";"
+2787:                              [ "info" printablestring ]
+
++=+=+=+=+= File rfc0990.txt +=+=+=+=+=
+2000 found at line 2265:
+2263:          014.000.000.018   2624-522-80900 52   DFVLR5-X25
+2263(continued):                   [GB7]
+2264:          014.000.000.019   2041-170-10000 00   SHAPE-X25
+2264(continued):                   [JFW]
+2265:          014.000.000.020   5052-737-20000 50   UQNET
+2265(continued):                   [AXH]
+2266:          014.000.000.021   3020-801-00057 50   DMC-CRC1
+2266(continued):                  [JR17]
+2267:          014.000.000.022   2624-522-80902 77   DFVLRVAX-X25
+2267(continued):                   [GB7]
+
+2000 found at line 2584:
+2582:     AEGIS
+2583:     APOLLO
+2584:     BS-2000
+2585:     CEDAR
+2586:     CGW
+
+2000 found at line 2945:
+2943:     HAZELTINE-1510
+2944:     HAZELTINE-1520
+2945:     HAZELTINE-2000
+
+
+
+Nesser                       Informational                    [Page 102]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2946:     HP-2621
+2947:     HP-2621A
+
++=+=+=+=+= File rfc0996.txt +=+=+=+=+=
+2000 found at line 76:
+74:
+75:          Process type: 000027  options: 040000
+76:          Subnet: DMV  status: 376  hello: 15  timeout: 2000
+77:          Foreign address: [192.5.39.87]  max size: 576
+78:          Input packets      3645    Output packets  3690
+
++=+=+=+=+= File rfc1000.txt +=+=+=+=+=
+1900 found at line 3105:
+3103:        protocol provides a site-independent, machine readable dat
+3103(continued):                e and
+3104:        time.  The Time service sends back to the originating sour
+3104(continued):                ce the
+3105:        time in seconds since midnight on January first 1900.
+3106:
+3107:     867     Postel       May 83      Daytime Protocol
+
++=+=+=+=+= File rfc1009.txt +=+=+=+=+=
+2000 found at line 1412:
+1410:        method is used when the host and IMP (the Defense Communic
+1410(continued):                ation
+1411:        Agency calls it a Packet Switch Node or PSN) are separated
+1411(continued):                 by not
+1412:        more than about 2000 feet of cable, while the HDLC Distant
+1412(continued):                 Host
+1413:        (HDH) is used for greater distances where a modem is requi
+1413(continued):                red.
+1414:        Under HDH, retransmission, resequencing and flow control a
+1414(continued):                re
+
++=+=+=+=+= File rfc1010.txt +=+=+=+=+=
+2000 found at line 969:
+967:         014.000.000.018   2624-522-80900 52   DFVLR5-X25
+967(continued):            [GB7]
+968:         014.000.000.019   2041-170-10000 00   SHAPE-X25
+968(continued):            [JFW]
+969:         014.000.000.020   5052-737-20000 50   UQNET
+969(continued):            [AXH]
+970:         014.000.000.021   3020-801-00057 50   DMC-CRC1
+970(continued):           [JR17]
+971:         014.000.000.022   2624-522-80902 77   DFVLRVAX-X25
+971(continued):            [GB7]
+
+2000 found at line 1353:
+
+
+
+Nesser                       Informational                    [Page 103]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1351:     AEGIS
+1352:     APOLLO
+1353:     BS-2000
+1354:     CEDAR
+1355:     CGW
+
+2000 found at line 1719:
+1717:     HAZELTINE-1510
+1718:     HAZELTINE-1520
+1719:     HAZELTINE-2000
+1720:     HP-2621
+1721:     HP-2621A
+
++=+=+=+=+= File rfc1024.txt +=+=+=+=+=
+1900 found at line 535:
+533:
+534:     The local system clock, measured in milliseconds since 00:00
+534(continued):         1
+535:     January 1900 UTC.  Assumed to be only a local estimate of the
+535(continued):          time.
+536:     The value 0 is reserved for an uninitialized clock (For examp
+536(continued):         le, an
+537:     uninitialized time-of-day chip.)
+
+1900 found at line 546:
+544:     A network synchronized clock, which is assumed to be synchron
+544(continued):         ized
+545:     across some part of a network.  The clock value is measured i
+545(continued):         n
+546:     milliseconds since 00:00 1 January 1900 UTC.  Specific inform
+546(continued):         ation
+547:     about the synchronization protocol is found in the system var
+547(continued):         iable
+548:     dictionary.  The value 0 is used to indicate an uninitialized
+548(continued):          clock.
+
++=+=+=+=+= File rfc1036.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 196:
+194:      both is:
+195:
+196:                        Wdy, DD Mon YY HH:MM:SS TIMEZONE
+197:
+198:      Several examples of valid dates appear in the sample message
+198(continued):          above.
+
++=+=+=+=+= File rfc1037.txt +=+=+=+=+=
+1900 found at line 541:
+539:      Date                A numeric data token.  The date is expre
+
+
+
+Nesser                       Informational                    [Page 104]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+539(continued):         ssed in
+540:                          Universal Time format, which measures a
+540(continued):         time as
+541:                          the number of seconds since January 1, 1
+541(continued):         900, at
+542:                          midnight GMT.
+543:
+
+1900 found at line 2544:
+2542:     The creation date of the file.  The date is expressed in Univ
+2542(continued):                ersal
+2543:     Time format, which measures a time as the number of seconds s
+2543(continued):                ince
+2544:     January 1, 1900, at midnight GMT.  Creation date does not nec
+2544(continued):                essarily
+2545:     mean the time the file system created the directory entry or
+2545(continued):                records
+2546:     of the file.  For systems that support modification or append
+2546(continued):                ing to
+
++=+=+=+=+= File rfc1038.txt +=+=+=+=+=
+2000 found at line 317:
+315:
+316:     The values of this field are assigned by DCA Code R130, Washi
+316(continued):         ngton,
+317:     D.C.  20305-2000.  Each value corresponds to a requestor who,
+317(continued):          once
+318:     assigned, becomes the authority for the remainder of the opti
+318(continued):         on
+319:     definition for that value.
+
++=+=+=+=+= File rfc1050.txt +=+=+=+=+=
+2000 found at line 323:
+321:  7.3 Program Number Assignment
+322:
+323:     Program numbers are given out in groups of hexadecimal 200000
+323(continued):         00
+324:     (decimal 536870912) according to the following chart:
+325:
+
+2000 found at line 327:
+325:
+326:                   0 - 1fffffff   defined by Sun
+327:            20000000 - 3fffffff   defined by user
+328:            40000000 - 5fffffff   transient
+329:            60000000 - 7fffffff   reserved
+
++=+=+=+=+= File rfc1057.txt +=+=+=+=+=
+
+
+
+Nesser                       Informational                    [Page 105]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2000 found at line 339:
+337:  7.3 Program Number Assignment
+338:
+339:     Program numbers are given out in groups of hexadecimal 200000
+339(continued):         00
+340:     (decimal 536870912) according to the following chart:
+341:
+
+2000 found at line 343:
+341:
+342:                   0 - 1fffffff   defined by Sun
+343:            20000000 - 3fffffff   defined by user
+344:            40000000 - 5fffffff   transient
+345:            60000000 - 7fffffff   reserved
+
++=+=+=+=+= File rfc1059.txt +=+=+=+=+=
+century found at line 142:
+140:     mechanisms to synchronize time in principle to precisions in
+140(continued):         the
+141:     order of nanoseconds while preserving a non-ambiguous date we
+141(continued):         ll into
+142:     the next century.  The protocol includes provisions to specif
+142(continued):         y the
+143:     characteristics and estimate the error of the local clock and
+143(continued):          the
+144:     time server to which it may be synchronized.  It also include
+144(continued):         s
+
+1900 found at line 574:
+572:     frequency to the TA time scale.  At 0000 hours on 1 January 1
+572(continued):         972 the
+573:     NTP time scale was set to 2,272,060,800, representing the num
+573(continued):         ber of
+574:     TA seconds since 0000 hours on 1 January 1900.  The insertion
+574(continued):          of leap
+575:     seconds in UTC does not affect the oscillator itself, only th
+575(continued):         e
+576:     translation between TA and UTC, or conventional civil time.
+576(continued):         However,
+
+1900 found at line 649:
+647:     main product of the protocol, a special timestamp format has
+647(continued):         been
+648:     established.  NTP timestamps are represented as a 64-bit unsi
+648(continued):         gned
+649:     fixed-point number, in seconds relative to 0000 UT on 1 Janua
+649(continued):         ry 1900.
+650:     The integer part is in the first 32 bits and the fraction par
+
+
+
+Nesser                       Informational                    [Page 106]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+650(continued):         t in the
+651:     last 32 bits, as shown in the following diagram.
+
+1900 found at line 690:
+688:     the Integer Part) has been set and that the 64-bit field will
+688(continued):
+689:     overflow some time in 2036.  Should NTP be in use in 2036, so
+689(continued):         me
+690:     external means will be necessary to qualify time relative to
+690(continued):         1900 and
+691:     time relative to 2036 (and other multiples of 136 years).
+692:     Timestamped data requiring such qualification will be so prec
+692(continued):         ious
+
++=+=+=+=+= File rfc1060.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 2324:
+2322:     AB-00-03-00-00-00       6004    DEC Local Area Transport
+2322(continued):                (LAT) - old
+2323:     AB-00-04-00-xx-xx       ????    Reserved DEC customer private
+2323(continued):                 use
+2324:     AB-00-04-01-xx-yy       6007    DEC Local Area VAX Cluster gr
+2324(continued):                 oups
+2325:                                     System Communication Architec
+2325(continued):                ture (SCA)
+2326:     CF-00-00-00-00-00       9000    Ethernet Configuration Test
+2326(continued):                 protocol (Loopback)
+
+2000 found at line 2729:
+2727:         014.000.000.018   2624-522-80900 52   FGAN-SIEMENS-X25
+2727(continued):                   [GB7]
+2728:         014.000.000.019   2041-170-10000 00   SHAPE-X25
+2728(continued):                   [JFW]
+2729:         014.000.000.020   5052-737-20000 50   UQNET
+2729(continued):                   [AXH]
+2730:         014.000.000.021   3020-801-00057 50   DMC-CRC1
+2730(continued):                   [VXT]
+2731:         014.000.000.022   2624-522-80329 02   FGAN-FGANFFMVAX-X25
+2731(continued):                   [GB7]
+
+2000 found at line 3155:
+3153:     AEGIS                     MACOS                     TP3010
+3154:     APOLLO                    MINOS                     TRSDOS
+3155:     BS-2000                   MOS                       ULTRIX
+3156:     CEDAR                     MPE5                      UNIX
+3157:     CGW                       MSDOS                     UNIX-BSD
+
+2000 found at line 3508:
+3506:     HAZELTINE-1520                        IBM-3278-5-E
+
+
+
+Nesser                       Informational                    [Page 107]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+3507:     HAZELTINE-1552                        IBM-3279-2-E
+3508:     HAZELTINE-2000                        IBM-3279-3-E
+3509:     HAZELTINE-ESPRIT                      IMLAC
+3510:     HP-2392                               INFOTON-100
+
++=+=+=+=+= File rfc1064.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 1321:
+1319:                         "NO" SP text_line / "BAD" SP text_line)
+1320:
+1321:     date            ::= string in form "dd-mmm-yy hh:mm:ss-zzz"
+1322:
+1323:     envelope        ::= "(" env_date SP env_subject SP env_from S
+1323(continued):                P
+
++=+=+=+=+= File rfc1085.txt +=+=+=+=+=
+UTCTime found at line 1501:
+1499:
+1500:                 commonReference
+1501:                     UTCTime,
+1502:
+1503:                 additionalReferenceInformation[0]
+
++=+=+=+=+= File rfc1094.txt +=+=+=+=+=
+2000 found at line 878:
+876:
+877:        0040000 This is a directory; "type" field should be NFDIR.
+877(continued):
+878:        0020000 This is a character special file; "type" field sho
+878(continued):         uld
+879:                be NFCHR.
+880:        0060000 This is a block special file; "type" field should
+880(continued):         be
+
+2000 found at line 883:
+881:                NFBLK.
+882:        0100000 This is a regular file; "type" field should be NFR
+882(continued):         EG.
+883:        0120000 This is a symbolic link file;  "type" field should
+883(continued):          be
+884:                NFLNK.
+885:        0140000 This is a named socket; "type" field should be NFN
+885(continued):         ON.
+
+2000 found at line 887:
+885:        0140000 This is a named socket; "type" field should be NFN
+885(continued):         ON.
+886:        0004000 Set user id on execution.
+
+
+
+
+Nesser                       Informational                    [Page 108]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+887:        0002000 Set group id on execution.
+888:        0001000 Save swapped text even after use.
+889:        0000400 Read permission for owner.
+
++=+=+=+=+= File rfc1108.txt +=+=+=+=+=
+2000 found at line 187:
+185:     throughout DoD common user data networks, users of these netw
+185(continued):         orks
+186:     should submit requirements for additional Protection Authorit
+186(continued):         y Flags
+187:     to DISA DISDB, Washington, D.C.  20305-2000, for review and a
+187(continued):         pproval.
+188:     Such review and approval should be sought prior to design,
+189:     development or deployment of any system which would make use
+189(continued):         of
+
+2000 found at line 774:
+772:     data networks, and to maximize interoperability, each activit
+772(continued):         y should
+773:     submit its plans for the definition and use of an Additional
+773(continued):         Security
+774:     Info Format Code to DISA DISDB, Washington, D.C.  20305-2000
+774(continued):         for
+775:     review and approval.  DISA DISDB will forward plans to the In
+775(continued):         ternet
+776:     Activities Board for architectural review and, if required, a
+776(continued):          cleared
+
++=+=+=+=+= File rfc1114.txt +=+=+=+=+=
+UTCTime found at line 922:
+920:                issuer          Name,
+921:                list            SEQUENCE RCLEntry,
+922:                lastUpdate      UTCTime,
+923:                nextUpdate      UTCTime}
+924:
+
+UTCTime found at line 923:
+921:                list            SEQUENCE RCLEntry,
+922:                lastUpdate      UTCTime,
+923:                nextUpdate      UTCTime}
+924:
+925:        RCLEntry        ::=     SEQUENCE {
+
+UTCTime found at line 927:
+925:        RCLEntry        ::=     SEQUENCE {
+926:                subject         CertificateSerialNumber,
+
+
+
+
+
+Nesser                       Informational                    [Page 109]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+927:                revocationDate  UTCTime}
+928:
+929:  3.4  Certificate Definition and Usage
+
+UTCTime found at line 1296:
+1294:
+1295:           Validity ::=    SEQUENCE{
+1296:                   notBefore       UTCTime,
+1297:                   notAfter        UTCTime}
+1298:
+
+UTCTime found at line 1297:
+1295:           Validity ::=    SEQUENCE{
+1296:                   notBefore       UTCTime,
+1297:                   notAfter        UTCTime}
+1298:
+1299:           SubjectPublicKeyInfo ::=        SEQUENCE{
+
++=+=+=+=+= File rfc1117.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 4965:
+4963:          jwmanly%amherst.bitnet@MITVMA.MIT.EDU
+4964:  [JWN10] Norris, James W         a02jwn1%niu.bitnet@CUNYVM.CUNY.E
+4964(continued):                DU
+4965:  [JY24]  Yu, Jessica             jyy@MERIT.EDU
+4966:  [JY33]  Yoshida, Jun            ---none---
+4967:  [KA4]   Auerbach, Karl          auerbach@CSL.SRI.COM
+
+
++=+=+=+=+= File rfc1123.txt +=+=+=+=+=
+2digit found at line 3239:
+3237:           The syntax for the date is hereby changed to:
+3238:
+3239:              date = 1*2DIGIT month 2*4DIGIT
+3240:
+3241:
+
+century found at line 3253:
+3251:
+3252:           All mail software SHOULD use 4-digit years in dates, to
+3252(continued):                 ease
+3253:           the transition to the next century.
+3254:
+3255:           There is a strong trend towards the use of numeric time
+3255(continued):                zone
+
+
++=+=+=+=+= File rfc1133.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 493:
+
+
+
+Nesser                       Informational                    [Page 110]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+491:     Telephone:      313 936-2655
+492:     Fax:            313 747-3745
+493:     EMail:          jyy@merit.edu
+494:
+495:     Hans-Werner Braun
+
++=+=+=+=+= File rfc1138.txt +=+=+=+=+=
+UTCTime found at line 1471:
+1469:     the full BNF easier to parse.
+1470:
+1471:  3.3.5.  UTCTime
+1472:
+1473:     Both UTCTime and the RFC 822 822.date-time syntax contain:  Y
+1473(continued):                ear
+
+UTCTime found at line 1473:
+1471:  3.3.5.  UTCTime
+1472:
+1473:     Both UTCTime and the RFC 822 822.date-time syntax contain:  Y
+1473(continued):                ear
+1474:     (lowest two digits), Month, Day of Month, hour, minute, secon
+1474(continued):                d
+1475:     (optional), and Timezone.  822.date-time also contains an opt
+1475(continued):                ional
+
+UTCTime found at line 1482:
+1480:          In practice, a gateway will need to parse various illega
+1480(continued):                l
+1481:          variants on 822.date-time.  In cases where 822.date-time
+1481(continued):
+1482:          cannot be parsed, it is recommended that the derived UTC
+1482(continued):                Time
+1483:          is set to the value at the time of translation.
+1484:
+
+UTCTime found at line 1485:
+1483:          is set to the value at the time of translation.
+1484:
+1485:     The UTCTime format which specifies the timezone offset should
+1485(continued):                 be
+1486:     used.
+1487:
+
+UTCTime found at line 4469:
+4467:
+4468:     The extended syntax of zone defined in the JNT Mail Protocol
+4468(continued):                should
+4469:     be used in the mapping of UTCTime defined in Chapter 3.
+
+
+
+Nesser                       Informational                    [Page 111]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+4470:
+4471:  6.  Lack of 822-MTS originator specification
+
++=+=+=+=+= File rfc1147.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 9715:
+9713:            cerns to security and management personnel at DDN faci
+9713(continued):                li-
+9714:            ties.  It is available online, via kermit or anonymous
+9714(continued):                 FTP,
+9715:            from nic.ddn.mil, in SCC:DDN-SECURITY-yy-nn.TXT (where
+9715(continued):                 "yy"
+9716:            is the year and "nn" is the bulletin number).  The SCC
+9716(continued):                 pro-
+9717:            vides immediate assistance with DDN-related host secur
+9717(continued):                ity
+
+century found at line 1096:
+1094:            "NETMON." These tools were independently developed, ar
+1094(continued):                e
+1095:            functionally different, run in different environments,
+1095(continued):                 and
+1096:            are no more related than Richard Burton the 19th centu
+1096(continued):                ry
+1097:            explorer and Richard Burton the 20th century actor.  B
+1097(continued):                YU's
+1098:            tool "NETMON" is listed as "NETMON (I)," MITRE's as "N
+1098(continued):                ETMON
+
+century found at line 1097:
+1095:            functionally different, run in different environments,
+1095(continued):                 and
+1096:            are no more related than Richard Burton the 19th centu
+1096(continued):                ry
+1097:            explorer and Richard Burton the 20th century actor.  B
+1097(continued):                YU's
+1098:            tool "NETMON" is listed as "NETMON (I)," MITRE's as "N
+1098(continued):                ETMON
+1099:            (II)," and the tool from SNMP Research as "NETMON (III
+1099(continued):                )."
+
+2000 found at line 4134:
+4132:                 libraries), but this has not been done.  Curses i
+4132(continued):                s very
+4133:                 slow and cpu intensive on VMS, but the tool has b
+4133(continued):                een
+
+
+
+
+
+
+Nesser                       Informational                    [Page 112]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+4134:                 run in a window on a VAXstation 2000.  Just don't
+4134(continued):                 try
+4135:                 to run it on a terminal connected to a 11/750.
+4136:
+
++=+=+=+=+= File rfc1148.txt +=+=+=+=+=
+UTCTime found at line 1475:
+1473:     the full BNF easier to parse.
+1474:
+1475:  3.3.5.  UTCTime
+1476:
+1477:     Both UTCTime and the RFC 822 822.date-time syntax contain:  Y
+1477(continued):                ear
+
+UTCTime found at line 1477:
+1475:  3.3.5.  UTCTime
+1476:
+1477:     Both UTCTime and the RFC 822 822.date-time syntax contain:  Y
+1477(continued):                ear
+1478:     (lowest two digits), Month, Day of Month, hour, minute, secon
+1478(continued):                d
+1479:     (optional), and Timezone.  822.date-time also contains an opt
+1479(continued):                ional
+
+UTCTime found at line 1486:
+1484:          In practice, a gateway will need to parse various illega
+1484(continued):                l
+1485:          variants on 822.date-time.  In cases where 822.date-time
+1485(continued):
+1486:          cannot be parsed, it is recommended that the derived UTC
+1486(continued):                Time
+1487:          is set to the value at the time of translation.
+1488:
+
+UTCTime found at line 1489:
+1487:          is set to the value at the time of translation.
+1488:
+1489:     The UTCTime format which specifies the timezone offset should
+1489(continued):                 be
+1490:     used.
+1491:
+
+
+
+
+
+
+
+
+
+
+Nesser                       Informational                    [Page 113]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+UTCTime found at line 4566:
+4564:
+4565:     The extended syntax of zone defined in the JNT Mail Protocol
+4565(continued):                should
+4566:     be used in the mapping of UTCTime defined in Chapter 3.
+4567:
+4568:  6.  Lack of 822-MTS originator specification
+
++=+=+=+=+= File rfc1152.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 937:
+935:     Reservation Multiple-Access).
+936:
+937:     Finally, Yechiam Yemeni (YY, Columbia University) discussed h
+937(continued):         is work
+938:     on a protocol silicon compiler.  In order to exploit the pote
+938(continued):         ntial
+939:     parallelism, he is planning to use one processor per connecti
+939(continued):         on.
+
++=+=+=+=+= File rfc1153.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 119:
+117:
+118:
+119:  Date: ddd, dd mmm yy hh:mm:ss zzz
+120:  From: listname-REQUEST@fqhn
+121:  Reply-To: listname@fqhn
+
+'yy' on a line without 'yyyy' found at line 122:
+120:  From: listname-REQUEST@fqhn
+121:  Reply-To: listname@fqhn
+122:  Subject: listname Digest Vyy #nn
+123:  To: listname@fqhn
+124:
+
+'yy' on a line without 'yyyy' found at line 125:
+123:  To: listname@fqhn
+124:
+125:  listname Digest             ddd, dd mmm yy       Volume yy : Iss
+125(continued):         ue   nn
+126:
+127:  Today's Topics:
+
+'yy' on a line without 'yyyy' found at line 137:
+135:  ----------------------------------------------------------------
+135(continued):         ------
+136:
+
+
+
+
+
+Nesser                       Informational                    [Page 114]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+137:  Date: ddd, dd mmm yy hh:mm:ss zzz
+138:  From: Joe User <username@fqhn>
+139:  Subject: Message One Subject
+
+'yy' on a line without 'yyyy' found at line 147:
+145:  ------------------------------
+146:
+147:  Date: ddd, dd mmm yy hh:mm:ss zzz
+148:  From: Jane User <username@fqhn>
+149:  Subject: Message Two Subject
+
+'yy' on a line without 'yyyy' found at line 157:
+155:  ------------------------------
+156:
+157:  End of listname Digest Vyy Issue #nn
+158:  ************************************
+159:
+
++=+=+=+=+= File rfc1161.txt +=+=+=+=+=
+1900 found at line 322:
+320:     on the protocol-ID
+321:
+322:                                   03019000
+323:
+324:  5.  Acknowledgements
+
+2000 found at line 210:
+208:     (1)  <nsap> is a hex string defining the nsap, e.g.,
+209:
+210:                       "snmp"/NS+4900590800200038bafe00
+211:
+212:     Similarly, SNMP traps are, by convention, sent to a manager l
+212(continued):         istening
+
+2000 found at line 291:
+289:     (1)  <nsap> is a hex string defining the nsap, e.g.,
+290:
+291:                       "snmp"/NS+4900590800200038bafe00
+292:
+293:     Similarly, SNMP traps are, by convention, sent to a manager l
+293(continued):         istening
+
+
++=+=+=+=+= File rfc1164.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 1267:
+1265:     Phone:  (313) 936-3000
+
+
+
+
+
+Nesser                       Informational                    [Page 115]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1266:
+1267:     Email:  JYY@MERIT.EDU
+1268:
+1269:
+
++=+=+=+=+= File rfc1166.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 8270:
+8268:     [JWN10]         Norris, James W.
+8269:                     a02jwn1%niu.bitnet@CUNYVM.CUNY.EDU
+8270:     [JY24]          Yu, Jessica              jyy@MERIT.EDU
+8271:     [JY33]          Yoshida, Jun             ---none---
+8272:     [JY35]          Young, Jeff              ---none---
+
++=+=+=+=+= File rfc1167.txt +=+=+=+=+=
+2000 found at line 89:
+87:     are also likely play a role along with Switched Multi-megabit
+87(continued):           Data
+88:     Service (SMDS) provided by telecommunications carriers.  It a
+88(continued):          lso
+89:     would be fair to ask what role FTS-2000 might play in the sys
+89(continued):          tem, at
+90:     least in support of government access to the NREN, and possib
+90(continued):          ly in
+91:     support of national agency network facilities.
+
++=+=+=+=+= File rfc1173.txt +=+=+=+=+=
+century found at line 72:
+70:     only choice; I don't see any prospect of either the governmen
+70(continued):          t or
+71:     private enterprise building a monolithic, centralized, ubiqui
+71(continued):          tous "Ma
+72:     Datagram" network provider in this century.
+73:
+74:  2. Responsibilities of Network Managers
+
++=+=+=+=+= File rfc1176.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 1435:
+1433:                         "NO" SP text_line / "BAD" SP text_line)
+1434:
+1435:     date            ::= string in form "dd-mmm-yy hh:mm:ss-zzz"
+1436:
+1437:     envelope        ::= "(" env_date SP env_subject SP env_from S
+1437(continued):                P
+
++=+=+=+=+= File rfc1185.txt +=+=+=+=+=
+2000 found at line 208:
+206:        1.1MBps, no matter how high the theoretical transfer rate
+206(continued):         of the
+
+
+
+Nesser                       Informational                    [Page 116]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+207:        path.  This corresponds to cycling the sequence number spa
+207(continued):         ce in
+208:        Twrap= 2000 secs, which is safe in today's Internet.
+209:
+210:        Based on this reasoning, an earlier RFC [McKenzie89] has c
+210(continued):         autioned
+
++=+=+=+=+= File rfc1190.txt +=+=+=+=+=
+2000 found at line 7630:
+7628:                                       link failure
+7629:
+7630:          2000  DefaultRecoveryTimeout Interval between successive
+7630(continued):
+7631:                                       HELLOs to/from active neigh
+7631(continued):                bors
+7632:
+
++=+=+=+=+= File rfc1191.txt +=+=+=+=+=
+2000 found at line 925:
+923:                65535  Hyperchannel                  RFC 1044
+924:     65535
+925:     32000             Just in case
+926:                17914  16Mb IBM Token Ring           ref. [6]
+927:     17914
+
++=+=+=+=+= File rfc1203.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 2102:
+2100:                      "NO" SP text_line / "BAD" SP text_line)
+2101:
+2102:  date            ::= string in form "dd-mmm-yy hh:mm:ss-zzz"
+2103:
+2104:  envelope        ::= "(" env_date SP env_subject SP env_from SP
+
+2000 found at line 2614:
+2612:          question.  For example:
+2613:
+2614:            tag42 FETCH 197 BODY 2000:3999
+2615:
+2616:          would fetch the second two thousand bytes of the body of
+2616(continued):                 message
+
++=+=+=+=+= File rfc1207.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 136:
+134:        directory.  Information includes packet counts by NSS and
+134(continued):         byte
+135:        counts for type of use (ftp, smtp, telnet, etc.).  Filenam
+135(continued):         es are
+136:        of the form 'NSFyy-mm.type'.
+
+
+
+Nesser                       Informational                    [Page 117]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+137:
+138:        Files are available for anonymous ftp; use 'guest' as the
+
++=+=+=+=+= File rfc1210.txt +=+=+=+=+=
+2000 found at line 1548:
+1546:     Franci Bigi (1)
+1547:     CEC
+1548:     Rue de la Loi 2000
+1549:     B-1049
+1550:     Brussels
+
+2000 found at line 1756:
+1754:     Rolf Speth (1)
+1755:     CEC
+1756:     Rue de la Loi 2000
+1757:     B-1049
+1758:     Brussels
+
+2000 found at line 1773:
+1771:     Jose Torcato (1), (2)
+1772:     CEC, TR 61 0/10
+1773:     Rue de la Loi 2000
+1774:     B-1049
+1775:     Brussels
+
+2000 found at line 1801:
+1799:     Karel De Vriendt (1)
+1800:     CEC
+1801:     Rue de la Loi 2000
+1802:     B-1049
+1803:     Brussels
+
+2000 found at line 1837:
+1835:     Rosalie Zobel (1) (2)
+1836:     CEC
+1837:     Rue de la Loi 2000
+1838:     B-1049
+1839:     Brussels
+
++=+=+=+=+= File rfc1211.txt +=+=+=+=+=
+1900 found at line 1591:
+1589:
+1590:     westine 49% mconnect OSI3.NCSL.NIST.GOV
+1591:     connecting to host OSI3.NCSL.NIST.GOV (0x6c300681), port 0x19
+1591(continued):                00
+1592:     connection open
+1593:     220 osi3.ncsl.nist.gov sendmail 4.0/NIST(rbj/dougm) ready at
+
+
+
+
+Nesser                       Informational                    [Page 118]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2000 found at line 2363:
+2361:        Office Automation Division
+2362:        Code H610
+2363:        Washington, DC 20305-2000
+2364:
+2365:        Hostname: DCA-EMS.DCA.MIL
+
++=+=+=+=+= File rfc1218.txt +=+=+=+=+=
+2000 found at line 1249:
+1247:     Rapport Communication, Inc.
+1248:     3055 Q Street NW
+1249:     Washington, DC  20007
+1250:
+1251:     Tel: +1 202-342-2727
+
++=+=+=+=+= File rfc1224.txt +=+=+=+=+=
+2000 found at line 983:
+981:        and placed in an ethernet packet).  120 request packets ar
+981(continued):         e sent
+982:        each cycle (3 for each of 40 nodes), and 120 response pack
+982(continued):         ets are
+983:        expected.  72000 bytes (240 packets at 300 bytes each) mus
+983(continued):         t be
+984:        transferred during each poll cycle, merely to determine th
+984(continued):         at the
+985:        network is fine.
+
++=+=+=+=+= File rfc1244.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 2481:
+2479:              and concerns to security and management personnel at
+2479(continued):                 DDN
+2480:              facilities.  It is available online, via kermit or a
+2480(continued):                nonymous
+2481:              FTP, from the host NIC.DDN.MIL, in SCC:DDN-SECURITY-
+2481(continued):                yy-
+2482:              nn.TXT (where "yy" is the year and "nn" is the bulle
+2482(continued):                tin
+2483:              number).  The SCC provides immediate assistance with
+2483(continued):                 DDN-
+
+'yy' on a line without 'yyyy' found at line 2482:
+2480:              facilities.  It is available online, via kermit or a
+2480(continued):                nonymous
+2481:              FTP, from the host NIC.DDN.MIL, in SCC:DDN-SECURITY-
+2481(continued):                yy-
+2482:              nn.TXT (where "yy" is the year and "nn" is the bulle
+2482(continued):                tin
+2483:              number).  The SCC provides immediate assistance with
+
+
+
+Nesser                       Informational                    [Page 119]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2483(continued):                 DDN-
+2484:              related host security problems; call (800) 235-3155
+2484(continued):                (6:00
+
++=+=+=+=+= File rfc1251.txt +=+=+=+=+=
+2000 found at line 316:
+314:             where growing above 100 network numbers seemed excess
+314(continued):         ive.
+315:             Todays number of networks in the global infrastructur
+315(continued):         e
+316:             exceeds 2000 connected networks, and many more if iso
+316(continued):         lated
+317:             network islands get included.
+318:
+
++=+=+=+=+= File rfc1254.txt +=+=+=+=+=
+2000 found at line 592:
+590:     number of packet arrivals, over which packets are dropped wit
+590(continued):         h
+591:     uniform probability.  For instance, in a sample implementatio
+591(continued):         n, if
+592:     this interval spanned 2000 packet arrivals, and a suitable
+593:     probability of drop was 0.001, then two random variables woul
+593(continued):         d be
+594:     drawn in a uniform distribution in the range of 1 to 2,000.
+594(continued):         The
+
+2000 found at line 859:
+857:     indicates that to get good, consistent performance, we may ne
+857(continued):         ed to
+858:     have up to 5 to 10 times the number of active source-destinat
+858(continued):         ion
+859:     pairs. In a typical gateway, this may require around 1000 to
+859(continued):         2000
+860:     queues.
+861:
+
++=+=+=+=+= File rfc1255.txt +=+=+=+=+=
+2000 found at line 1361:
+1359:     Rapport Communication, Inc.
+1360:     3055 Q Street NW
+1361:     Washington, DC  20007
+1362:
+1363:     Tel: +1 202-342-2727
+
++=+=+=+=+= File rfc1259.txt +=+=+=+=+=
+century found at line 345:
+343:     should never go back to any monopoly arrangement like the pre
+
+
+
+Nesser                       Informational                    [Page 120]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+343(continued):         -
+344:     divestiture AT&T which held back market-driven innovation in
+345:     telecommunications for half a century.  Given the interconnec
+345(continued):         tion
+346:     technology now available, we should never again have to accep
+346(continued):         t the
+347:     argument that we have to sacrifice interoperability for effic
+347(continued):         iency,
+
+century found at line 594:
+592:
+593:        In light of the possibilities for new service offerings by
+593(continued):          the
+594:        21st century, as well as the growing importance of
+595:        telecommunications and information services to US economic
+595(continued):          and
+596:        social development, limiting our concept of universal serv
+596(continued):         ice to
+
+century found at line 744:
+742:     If we have the vision and commitment to try this, the transfo
+742(continued):         rmation
+743:     of the network frontier from wilderness to civilization need
+743(continued):         not
+744:     display the brutality of 19th century imperialism.  As commer
+744(continued):         cial
+745:     opportunities to offer applications and services develop,
+746:     entrepreneurs will discover that ease of use sells. The norma
+746(continued):         l,
+
+2000 found at line 1115:
+1113:     California v. FCC (9th Cir. 1990).
+1114:
+1115:     18.  NTIA Telecomm 2000 at 79.
+1116:
+1117:     19.  Committee on Energy and Commerce, Subcommittee on
+
++=+=+=+=+= File rfc1270.txt +=+=+=+=+=
+2000 found at line 594:
+592:     Hopkinton, Mass. 01748
+593:
+594:     Phone: (508) 435-2000
+595:
+596:     Email: kasten@europa.clearpoint.com
+
++=+=+=+=+= File rfc1274.txt +=+=+=+=+=
+UTCTime found at line 1051:
+1049:       lastModifiedTime ATTRIBUTE
+
+
+
+Nesser                       Informational                    [Page 121]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1050:           WITH ATTRIBUTE-SYNTAX
+1051:               uTCTimeSyntax
+1052:       ::= {pilotAttributeType 23}
+1053:
+
+UTCTime found at line 2990:
+2988:       lastModifiedTime ATTRIBUTE
+2989:           WITH ATTRIBUTE-SYNTAX
+2990:               uTCTimeSyntax
+2991:       ::= {pilotAttributeType 23}
+2992:
+
++=+=+=+=+= File rfc1276.txt +=+=+=+=+=
+UTCTime found at line 558:
+556:          }
+557:
+558:  EDBVersion ::= UTCTime
+558(continued):             40
+559:
+560:  ___________________Figure_2:__Replication_Protocol______________
+560(continued):         _______
+
+UTCTime found at line 938:
+936:          }
+937:
+938:  EDBVersion ::= UTCTime
+939:  END
+940:
+
++=+=+=+=+= File rfc1283.txt +=+=+=+=+=
+1900 found at line 317:
+315:     on the protocol-ID
+316:
+317:                                   03019000
+318:
+319:     This is an X.25 protocol-ID assigned for local purposes.
+
+2000 found at line 206:
+204:     (1)  <nsap> is a hex string defining the nsap, e.g.,
+205:
+206:                       "snmp"/NS+4900590800200038bafe00
+207:
+208:     Similarly, SNMP traps are, by convention, sent to a manager l
+208(continued):         istening
+
+2000 found at line 278:
+276:     (1)  <nsap> is a hex string defining the nsap, e.g.,
+277:
+
+
+
+Nesser                       Informational                    [Page 122]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+278:                       "snmp"/NS+4900590800200038bafe00
+279:
+280:
+
++=+=+=+=+= File rfc1284.txt +=+=+=+=+=
+2000 found at line 1146:
+1144:     Hopkinton Mass 01748
+1145:
+1146:     Phone: 508-435-2000
+1147:     EMail: kasten@europa.clearpoint.com
+1148:
+
++=+=+=+=+= File rfc1285.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 219:
+217:            -- The unique identifier for the FDDI station.  This i
+217(continued):         s a
+218:            -- string of 8 octets, represented as
+219:            --                                X' yy yy xx xx xx xx
+219(continued):          xx xx'
+220:            -- with the low order 6 octet (xx) from a unique IEEE
+221:            -- assigned address.  The high order two bits of the I
+221(continued):         EEE
+
+'yy' on a line without 'yyyy' found at line 232:
+230:
+231:            -- (Universal/Local) bit should both be zero.  The fir
+231(continued):         st two
+232:            -- octets, the yy octets, are implementor-defined.
+233:            --
+234:            -- The representation of the address portion of the st
+234(continued):         ation id
+
++=+=+=+=+= File rfc1290.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 549:
+547:        Anonymous FTP to nis.nsf.net
+548:        cd stats
+549:        get nsfyy-mm.ptraffic  where yy is year, 91 and mm is mont
+549(continued):         h, 06
+550:        get nsf91-06.ptraffic  ptraffic is the packet traffic
+551:
+
+'yy' on a line without 'yyyy' found at line 552:
+550:        get nsf91-06.ptraffic  ptraffic is the packet traffic
+551:
+552:        get nsfyy-mm.btraffic  where yy is year, 91 and mm is mont
+552(continued):         h, 06
+553:        get nsf91-06.btraffic  btraffic is the byte traffic
+554:
+
+
+
+Nesser                       Informational                    [Page 123]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc1292.txt +=+=+=+=+=
+UTCTime found at line 3648:
+3646:
+3647:
+3648:         When comparing attributes of UTCtime syntax, if the secon
+3648(continued):                ds field
+3649:         is omitted, QUIPU does not perform the match correctly (i
+3649(continued):                .e., the
+3650:         seconds field in  the attribute values should be ignored,
+3650(continued):                but  are
+
+2000 found at line 4158:
+4156:
+4157:     UCOM.X 500 runs on: Sun 3, Sun 4, IBM RS 6000, Philips P 9000
+4157(continued):                , DEC
+4158:     machines, Bull DPX 2000, HP 9000/300, Siemens IN 6000 and 386
+4158(continued):                -based
+4159:     PCs.   It can easily be ported to any UNIX machine.
+4160:
+
+2000 found at line 4803:
+4801:  HARDWARE PLATFORMS
+4802:
+4803:     3Com's OSI/TCP CS/2000 and CS/2100.
+4804:
+4805:  SOFTWARE PLATFORMS
+
+2000 found at line 4807:
+4805:  SOFTWARE PLATFORMS
+4806:
+4807:     The "SW/2000-OT Vers  1.0" software runs on 3Com's OSI/TCP CS/
+4807(continued):                2000 and
+4808:     CS/2100, both stand-alone systems.
+4809:
+
+2000 found at line 4812:
+4810:  AVAILABILITY
+4811:
+4812:     The dual-stack OSI/TCP terminal server and its "SW/2000-OT Ve
+4812(continued):                rs 1.0"
+4813:     software is available from:
+4814:
+
+
+
+
+
+
+
+
+
+Nesser                       Informational                    [Page 124]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc1295.txt +=+=+=+=+=
+2000 found at line 98:
+96:     Rapport Communication
+97:     3055 Q Street NW
+98:     Washington, DC  20007
+99:
+100:     Phone: +1 202-342-2727
+
++=+=+=+=+= File rfc1303.txt +=+=+=+=+=
+UTCTime found at line 189:
+187:             TYPE NOTATION ::=
+188:                               "LAST-UPDATED"
+189:                                   value(update      UTCTime)
+190:                               "PRODUCT-RELEASE"
+191:                                   value(release     DisplayString
+191(continued):         )
+
++=+=+=+=+= File rfc1305.txt +=+=+=+=+=
+century found at line 428:
+426:  mechanisms to synchronize time in principle to precisions in the
+426(continued):          order
+427:  of nanoseconds while preserving a non-ambiguous date well into t
+427(continued):         he next
+428:  century. The protocol includes provisions to specify the charact
+428(continued):         eristics
+429:  and estimate the error of the local clock and the time server to
+429(continued):          which
+430:  it may be synchronized. It also includes provisions for operatio
+430(continued):         n with a
+
+century found at line 4529:
+4527:  political and ritual needs characteristic of the societies in wh
+4527(continued):                ich they
+4528:  flourished. Astronomical observations to establish the winter an
+4528(continued):                d summer
+4529:  solstices were in use three to four millennia ago. By the 14th c
+4529(continued):                entury
+4530:  BC the Shang Chinese had established the solar year as 365.25 da
+4530(continued):                ys and
+4531:  the lunar month as 29.5 days. The lunisolar calendar, in which t
+4531(continued):                he
+
+century found at line 4548:
+4546:  with the Shang Chinese, the ancient Egyptians had thus establish
+4546(continued):                ed the
+4547:  solar year at 365.25 days, or within about 11 minutes of the pre
+4547(continued):                sent
+4548:  measured value. In 432 BC, about a century after the Chinese had
+
+
+
+Nesser                       Informational                    [Page 125]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+4548(continued):                 done
+4549:  so, the Greek astronomer Meton calculated there were 110 lunar m
+4549(continued):                onths of
+4550:  29 days and 125 lunar months of 30 days for a total of 235 lunar
+4550(continued):                 months
+
+century found at line 4565:
+4563:  not complete until 8 AD.
+4564:
+4565:  The seven-day Sumerian week was introduced only in the fourth ce
+4565(continued):                ntury AD
+4566:  by Emperor Constantine I. During the Roman era a 15-year census
+4566(continued):                cycle,
+4567:  called the Indiction cycle, was instituted for taxation purposes
+4567(continued):                . The
+
+century found at line 4588:
+4586:  but 14 of these were removed in the Gregorian calendar. While th
+4586(continued):                e
+4587:  Gregorian calendar is in use throughout most of the world today,
+4587(continued):                 some
+4588:  countries did not adopt it until early in the twentieth century.
+4588(continued):
+4589:  While it remains a fascinating field for time historians, the ab
+4589(continued):                ove
+4590:  narrative provides conclusive evidence that conjugating calendar
+4590(continued):                 dates
+
+century found at line 4620:
+4618:  sometimes used to represent dates near our own era in convention
+4618(continued):                al time
+4619:  and with fewer digits, is defined as MJD = JD <196> 2,400,000.5.
+4619(continued):
+4620:  Following the convention that our century began at 0h on 1 Janua
+4620(continued):                ry 1900,
+4621:  at which time the tropical year was already 12h old, that eclect
+4621(continued):                ic
+4622:  instant corresponds to MJD 15,020.0. Thus, the Julian timescale
+4622(continued):                ticks in
+
+century found at line 4640:
+4638:  through observations of the Sun, Moon and planets. In 1958 the s
+4638(continued):                tandard
+4639:  second was defined as 1/31,556,925.9747 of the tropical year tha
+4639(continued):                t began
+4640:  this century. On this scale the tropical year is 365.2421987 day
+4640(continued):                s and
+4641:  the lunar month - one complete revolution of the Moon around the
+
+
+
+Nesser                       Informational                    [Page 126]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+4641(continued):                 Earth -
+4642:  is 29.53059 days; however, the actual tropical year can be deter
+4642(continued):                mined
+
+1900 found at line 851:
+849:  product of the protocol, a special timestamp format has been
+850:  established. NTP timestamps are represented as a 64-bit unsigned
+850(continued):          fixed-
+851:  point number, in seconds relative to 0h on 1 January 1900. The i
+851(continued):         nteger
+852:  part is in the first 32 bits and the fraction part in the last 3
+852(continued):         2 bits.
+853:  This format allows convenient multiple-precision arithmetic and
+
+1900 found at line 873:
+871:  integer part) has been set and that the 64-bit field will overfl
+871(continued):         ow some
+872:  time in 2036. Should NTP be in use in 2036, some external means
+872(continued):         will be
+873:  necessary to qualify time relative to 1900 and time relative to
+873(continued):         2036
+874:  (and other multiples of 136 years). Timestamped data requiring s
+874(continued):         uch
+875:  qualification will be so precious that appropriate means should
+875(continued):         be
+
+1900 found at line 4620:
+4618:  sometimes used to represent dates near our own era in convention
+4618(continued):                al time
+4619:  and with fewer digits, is defined as MJD = JD <196> 2,400,000.5.
+4619(continued):
+4620:  Following the convention that our century began at 0h on 1 Janua
+4620(continued):                ry 1900,
+4621:  at which time the tropical year was already 12h old, that eclect
+4621(continued):                ic
+4622:  instant corresponds to MJD 15,020.0. Thus, the Julian timescale
+4622(continued):                ticks in
+
+1900 found at line 4724:
+4722:  always coincident with it. At 0h on 1 January 1972 (MJD 41,317.0
+4722(continued):                ), the
+4723:  first tick of the UTC Era, the NTP clock was set to 2,272,060,80
+4723(continued):                0,
+4724:  representing the number of standard seconds since 0h on 1 Januar
+4724(continued):                y 1900
+
+
+
+
+
+
+Nesser                       Informational                    [Page 127]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+4725:  (MJD 15,020.0). The insertion of leap seconds in UTC and subsequ
+4725(continued):                ently
+4726:  into NTP does not affect the UTC or NTP oscillator, only the con
+4726(continued):                version
+
+2000 found at line 4489:
+4487:  the Mid-Continent Chain, the deployment of LORAN-C transmitters
+4487(continued):                now
+4488:  provides complete coverage of the U.S. LORAN-C timing receivers,
+4488(continued):                 such as
+4489:  the Austron 2000, are specialized and extremely expensive (up to
+4489(continued):
+4490:  $20,000). They are used primarily to monitor local cesium clocks
+4490(continued):                 and are
+4491:  not suited for unattended, automatic operation. While the LORAN-
+4491(continued):                C system
+
++=+=+=+=+= File rfc1309.txt +=+=+=+=+=
+century found at line 48:
+46:
+47:     As the pace of industry, science, and technological developme
+47(continued):          nt
+48:     quickened over the past century, it became increasingly proba
+48(continued):          ble that
+49:     someone in a geographically distant location would be trying
+49(continued):          to solve
+50:     the same problems you were trying to solve, or that someone i
+50(continued):          n a
+
++=+=+=+=+= File rfc1314.txt +=+=+=+=+=
+2000 found at line 1109:
+1107:     00DE        YPosition              011F   0005   00000001  00
+1107(continued):                00016C
+1108:     00EA        Group4Options          0125   0004   00000001  00
+1108(continued):                000002
+1109:     00F6        ResolutionUnit         0128   0003   00000001  00
+1109(continued):                020000
+1110:     0102        Software               0131   0002   00000008  00
+1110(continued):                000174
+1111:     010E        DateTime               0132   0002   00000014  00
+1111(continued):                00017C
+
++=+=+=+=+= File rfc1323.txt +=+=+=+=+=
+2000 found at line 320:
+318:        1.1MBps, no matter how high the theoretical transfer rate
+318(continued):         of the
+319:        path.  This corresponds to cycling the sequence number spa
+319(continued):         ce in
+
+
+
+Nesser                       Informational                    [Page 128]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+320:        Twrap= 2000 secs, which is safe in today's Internet.
+321:
+322:        It is important to understand that the culprit is not the
+322(continued):         larger
+
++=+=+=+=+= File rfc1325.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 611:
+609:        In addition, back issues of the Report are available for a
+609(continued):         nonymous
+610:        FTP from the host NIS.NSF.NET in the 'imr' directory with
+610(continued):         the file
+611:        names in the form IMRYY-MM.TXT, where YY is the last two d
+611(continued):         igits of
+612:        the year and MM two digits for the month.  For example, th
+612(continued):         e June
+613:        1991 Report is in the file IMR91-06.TXT.
+
++=+=+=+=+= File rfc1327.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 2618:
+2616:          attributes remaining in the O/R address shall be encoded
+2616(continued):                 on
+2617:          the LHS.  This is to ensure a reversible mapping. For
+2618:          example, if the is an addres /S=XX/O=YY/ADMD=A/C=NN/ and
+2618(continued):                 a
+2619:          mapping for /ADMD=A/C=NN/ is used, then /S=XX/O=YY/ is
+2620:          encoded on the LHS.
+
+'yy' on a line without 'yyyy' found at line 2619:
+2617:          the LHS.  This is to ensure a reversible mapping. For
+2618:          example, if the is an addres /S=XX/O=YY/ADMD=A/C=NN/ and
+2618(continued):                 a
+2619:          mapping for /ADMD=A/C=NN/ is used, then /S=XX/O=YY/ is
+2620:          encoded on the LHS.
+2621:
+
+'yy' on a line without 'yyyy' found at line 2665:
+2663:
+2664:             C          = "XX"
+2665:             ADMD       = "YY"
+2666:             O          = "ZZ"
+2667:             "RFC-822"  = "Smith(a)ZZ.YY.XX"
+
+'yy' on a line without 'yyyy' found at line 2667:
+2665:             ADMD       = "YY"
+2666:             O          = "ZZ"
+
+
+
+
+
+
+Nesser                       Informational                    [Page 129]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2667:             "RFC-822"  = "Smith(a)ZZ.YY.XX"
+2668:
+2669:     This is mapped first to an RFC 822 address, and then back to
+2669(continued):                the
+
+'yy' on a line without 'yyyy' found at line 2673:
+2671:
+2672:             C          = "XX"
+2673:             ADMD       = "YY"
+2674:             O          = "ZZ"
+2675:             Surname    = "Smith"
+
+UTCTime found at line 1483:
+1481:     the full BNF easier to parse.
+1482:
+1483:  3.3.5.  UTCTime
+1484:
+1485:     Both UTCTime and the RFC 822 822.date-time syntax contain:  Y
+1485(continued):                ear
+
+UTCTime found at line 1485:
+1483:  3.3.5.  UTCTime
+1484:
+1485:     Both UTCTime and the RFC 822 822.date-time syntax contain:  Y
+1485(continued):                ear
+1486:     (lowest two digits), Month, Day of Month, hour, minute, secon
+1486(continued):                d
+1487:     (optional), and Timezone.  822.date-time also contains an opt
+1487(continued):                ional
+
+UTCTime found at line 1494:
+1492:          In practice, a gateway will need to parse various illega
+1492(continued):                l
+1493:          variants on 822.date-time.  In cases where 822.date-time
+1493(continued):
+1494:          cannot be parsed, it is recommended that the derived UTC
+1494(continued):                Time
+1495:          is set to the value at the time of translation.
+1496:
+
+UTCTime found at line 1497:
+1495:          is set to the value at the time of translation.
+1496:
+1497:     When mapping to X.400, the UTCTime format which specifies the
+1497(continued):
+1498:     timezone offset shall be used.
+1499:
+
+
+
+
+Nesser                       Informational                    [Page 130]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+UTCTime found at line 5143:
+5141:
+5142:        The extended syntax of zone defined in the JNT Mail Protoc
+5142(continued):                ol shall
+5143:        be used in the mapping of UTCTime defined in Chapter 3.
+5144:
+5145:     7.  Lack of 822-MTS originator specification
+
++=+=+=+=+= File rfc1330.txt +=+=+=+=+=
+2000 found at line 1770:
+1768:     While ESnet will provide X.400 routing service for systems, i
+1768(continued):                t cannot
+1769:     provide routing via commercial X.400 carriers at this time.
+1769(continued):                The
+1770:     FTS-2000 charge for routing X.400 messages is $.45 (US) plus
+1770(continued):                X.25
+1771:     packet charges.  This could result in a charge of several dol
+1771(continued):                lars for
+1772:     large messages, a real possibility with the multi-media capac
+1772(continued):                ity of
+
++=+=+=+=+= File rfc1336.txt +=+=+=+=+=
+2000 found at line 378:
+376:             where growing above 100 network numbers seemed excess
+376(continued):         ive.
+377:             Todays number of networks in the global infrastructur
+377(continued):         e
+378:             exceeds 2000 connected networks, and many more if iso
+378(continued):         lated
+379:             network islands get included.
+380:
+
++=+=+=+=+= File rfc1338.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 401:
+399:     3.2.  Historic growth rates
+400:
+401:        MM/YY     ROUTES                        MM/YY     ROUTES
+402:                  ADVERTISED                              ADVERTIS
+402(continued):         ED
+403:        ------------------------                ------------------
+403(continued):         -----
+
+'yy' on a line without 'yyyy' found at line 1060:
+1058:        1071 Beal Ave.
+1059:        Ann Arbor, MI 48109
+1060:        email: jyy@merit.edu
+1061:
+1062:
+
+
+
+Nesser                       Informational                    [Page 131]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc1340.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 3390:
+3388:     AB-00-03-00-00-00        6004    DEC Local Area Transport
+3388(continued):                 (LAT) - old
+3389:     AB-00-04-00-xx-xx        ????    Reserved DEC customer private
+3389(continued):                use
+3390:     AB-00-04-01-xx-yy        6007    DEC Local Area VAX Cluster
+3390(continued):                groups
+3391:                              Sys. Communication Architecture (SCA)
+3392:     CF-00-00-00-00-00        9000    Ethernet Configuration Test
+3392(continued):                protocol
+
+1900 found at line 4066:
+4064:         014.000.000.063    2422-650-23500 00   Tollpost-Globe AS
+4064(continued):                 [OXG]
+4065:         014.000.000.064    2422-330-02500 00   Tollpost-Globe AS
+4065(continued):                 [OXG]
+4066:         014.000.000.065    2422-350-01900 00   Tollpost-Globe AS
+4066(continued):                 [OXG]
+4067:         014.000.000.066    2422-410-00700 00   Tollpost-Globe AS
+4067(continued):                 [OXG]
+4068:         014.000.000.067    2422-539-06200 00   Tollpost-Globe AS
+4068(continued):                 [OXG]
+
+2000 found at line 1300:
+1298:     nkd              1650/tcp
+1299:     nkd              1650/udp
+1300:     callbook         2000/tcp
+1301:     callbook         2000/udp
+1302:     dc               2001/tcp
+
+2000 found at line 1301:
+1299:     nkd              1650/udp
+1300:     callbook         2000/tcp
+1301:     callbook         2000/udp
+1302:     dc               2001/tcp
+1303:     wizard           2001/udp    curry
+
+2000 found at line 4013:
+4011:         014.000.000.018    2624-522-80900 52   FGAN-SIEMENS-X25
+4011(continued):                [GB7]
+4012:         014.000.000.019    2041-170-10000 00   SHAPE-X25
+4012(continued):                [JFW]
+4013:         014.000.000.020    5052-737-20000 50   UQNET
+4013(continued):                [AXH]
+4014:         014.000.000.021    3020-801-00057 50   DMC-CRC1
+4014(continued):                [VXT]
+4015:         014.000.000.022    2624-522-80329 02   FGAN-FGANFFMVAX-X25
+
+
+
+Nesser                       Informational                    [Page 132]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+4015(continued):                [GB7]
+
+
+2000 found at line 4838:
+4836:     AIX/370                    LOCUS                     SWIFT
+4837:     AIX-PS/2                   MACOS                     TAC
+4838:     BS-2000                    MINOS                     TANDEM
+4839:     CEDAR              MOS                       TENEX
+4840:     CGW                        MPE5                      TOPS10
+
+2000 found at line 5188:
+5186:     HAZELTINE-1520                         IBM-3278-3
+5187:     HAZELTINE-1552                         IBM-3278-4
+5188:     HAZELTINE-2000                         IBM-3278-5
+5189:     HAZELTINE-ESPRIT                       IBM-3279-2
+5190:     HITACHI-5601                           IBM-3279-3
+
++=+=+=+=+= File rfc1348.txt +=+=+=+=+=
+2000 found at line 143:
+141:     Or in net 11110031f67293.nsap-in-addr.arpa:
+142:
+143:     67894444333322220000  NSAP-PTR        host.school.de.
+144:
+145:     The RR data is the ASCII representation of the digits.  It is
+145(continued):          encoded
+
++=+=+=+=+= File rfc1357.txt +=+=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 260:
+258:
+259:  ID (M) -- This is the second field of any record.  It is also a
+260:          mandatory field.  Its format is "ID:: XXX//YYY", where X
+260(continued):         XX is
+261:          the publisher-ID (the controlled symbol of the publisher
+261(continued):         )
+262:          and YYY is the ID (e.g., report number) of the publicati
+262(continued):         on as
+
+'yy' on a line without 'yyyy' found at line 262:
+260:          mandatory field.  Its format is "ID:: XXX//YYY", where X
+260(continued):         XX is
+261:          the publisher-ID (the controlled symbol of the publisher
+261(continued):         )
+262:          and YYY is the ID (e.g., report number) of the publicati
+262(continued):         on as
+263:          assigned by the publisher.  This ID is typically printed
+263(continued):          on
+264:          the cover, and may contain slashes.
+
+
+
+
+Nesser                       Informational                    [Page 133]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+'yy' on a line without 'yyyy' found at line 682:
+680:
+681:     In order to avoid conflicts among the symbols of the publishi
+681(continued):         ng
+682:     organizations (the XXX part of the "ID:: XXX//YYY") it is sug
+682(continued):         gested
+683:     that the various organizations that publish reports (such as
+684:     universities, departments, and laboratories) register their
+
+2-digit found at line 291:
+289:
+290:          The format for ENTRY date is "Month Day, Year".  The mon
+290(continued):         th must
+291:          be alphabetic (spelled out).    The "Day" is a 1- or 2-d
+291(continued):         igit
+292:          number.  The "Year" is a 4-digit number.
+293:
+
+2-digit found at line 457:
+455:  DATE (O) -- The publication date.  The formats are "Month Year"
+455(continued):         and
+456:          "Month Day, Year".  The month must be alphabetic (spelle
+456(continued):         d out).
+457:          The "Day" is a 1- or 2-digit number.  The "Year" is a 4-
+457(continued):         digit
+458:          number.
+459:
+
++=+=+=+=+= File rfc1361.txt +=+=+=+=+=
+1900 found at line 132:
+130:     main product of the protocol, a special timestamp format has
+130(continued):         been
+131:     established. NTP timestamps are represented as a 64-bit unsig
+131(continued):         ned
+132:     fixed-point number, in seconds relative to 0h on 1 January 19
+132(continued):         00. The
+133:     integer part is in the first 32 bits and the fraction part in
+133(continued):          the
+134:     last 32 bits. This format allows convenient multiple-precisio
+134(continued):         n
+
+1900 found at line 145:
+143:     overflow some time in 2036. Should NTP or SNTP be in use in 2
+143(continued):         036,
+144:     some external means will be necessary to qualify time relativ
+144(continued):         e to
+
+
+
+
+
+Nesser                       Informational                    [Page 134]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+145:     1900 and time relative to 2036 (and other multiples of 136 ye
+145(continued):         ars).
+146:     Timestamped data requiring such qualification will be so prec
+146(continued):         ious
+147:     that appropriate means should be readily available. There wil
+147(continued):         l exist
+
++=+=+=+=+= File rfc1379.txt +=+=+=+=+=
+2000 found at line 847:
+845:
+846:
+847:     objective an MSL of at least 2000 seconds.  If there were no
+847(continued):         TIME-
+848:     WAIT delay, the ultimate limit on transaction rate would be s
+848(continued):         et by
+849:     speed-of-light delays in the network and by the latency of ho
+849(continued):         st
+
+2000 found at line 988:
+986:        the official delay of 240 seconds, formula [1] implies a u
+986(continued):         pper
+987:        bound (as RTT -> 0) of TRmax = 268 Tps; with our target MS
+987(continued):         L of
+988:        2000 sec, TRmax = 32 Tps.  These values are unacceptably l
+988(continued):         ow.
+989:
+990:        To improve this transaction rate, we could use TCP timesta
+990(continued):         mps to
+
+2000 found at line 1079:
+1077:        segment lifetime MSL.  For reasonable limiting values of R
+1077(continued):                , Ts,
+1078:        and MSL, formula [6] leads to a very low value of TRmax.
+1078(continued):                For
+1079:        example, with MSL= 2000 secs, R=10**9 Bps, and Ts = 0.5 se
+1079(continued):                c, TRmax
+1080:        < 2*10**-3 Tps.
+1081:
+
+2000 found at line 1136:
+1134:             TRmax * MSL < 2**31
+1135:
+1136:        For example, if MSL =  2000 seconds then TRmax < 10**6 Tp.
+1136(continued):                  These
+1137:        are acceptable limits for transaction processing.  However
+1137(continued):                , if
+1138:        they are not, we could augment CC with TCP timestamps to o
+1138(continued):                btain
+
+
+
+Nesser                       Informational                    [Page 135]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2000 found at line 1276:
+1274:
+1275:       (a) no timestamps       2**31/MSL        MSL        3rd seq
+1275(continued):                uence
+1276:                          e.g., MSL=2000 sec
+1276(continued):                space
+1277:                               TRmax = 10**6
+1278:
+
++=+=+=+=+= File rfc1405.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 378:
+376:     maps into
+377:
+378:          C=xx; ADMD=yyy; PRMD=zzz; O=ooo; OU=uuu; DD.Dnet=net;
+379:          DD.Mail-11=route::node::localpart;
+380:
+
+'yy' on a line without 'yyyy' found at line 384:
+382:
+383:          xx  = country code of the gateway performing the convers
+383(continued):         ion
+384:          yyy = Admd of the gateway performing the conversion
+385:          zzz = Prmd of the gateway performing the conversion
+386:          ooo = Organisation of the gateway performing the convers
+386(continued):         ion
+
+'yy' on a line without 'yyyy' found at line 474:
+472:       it is connected to. In this case the mapping is trivial:
+473:
+474:          C=xx; ADMD=yyy; PRMD=zzz; O=ooo; OU=uuu; DD.Dnet=net;
+475:          DD.Mail-11=route::node::localpart;
+476:
+
+'yy' on a line without 'yyyy' found at line 477:
+475:          DD.Mail-11=route::node::localpart;
+476:
+477:     (see sect. 5.2 for explication of 'xx','yyy','zzz','ooo','uuu
+477(continued):         ','net')
+478:
+479:     maps into
+
+'yy' on a line without 'yyyy' found at line 487:
+485:       described into section 5.4 apply:
+486:
+487:          C=xx; ADMD=yyy; PRMD=www; DD.Dnet=net;
+488:          DD.Mail-11=route::node::localpart;
+489:
+
+
+
+
+Nesser                       Informational                    [Page 136]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+'yy' on a line without 'yyyy' found at line 492:
+490:     maps into
+491:
+492:          gwnode::gw%"C=xx;ADMD=yyy;PRMD=www;DD.Dnet=net;
+493:          DD.Mail-11=route::node::localpart;"
+494:
+
+'yy' on a line without 'yyyy' found at line 595:
+593:     maps into
+594:
+595:         C=xx; ADMD=yyy; DD.Dnet=net;
+596:         DD.Mail-11=route::gwnode::gw(p)(q)x400-text-address(q);
+597:
+
++=+=+=+=+= File rfc1409.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 311:
+309:                                          IAC SB AUTHENTICATION RE
+309(continued):         PLY
+310:                                          KERBEROS_V4 CLIENT|MUTUA
+310(continued):         L
+311:                                          RESPONSE yy yy yy yy yy
+311(continued):         yy yy yy
+312:                                          IAC SE
+313:
+
++=+=+=+=+= File rfc1411.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 163:
+161:                                          IAC SB AUTHENTICATION RE
+161(continued):         PLY
+162:                                          KERBEROS_V4 CLIENT|MUTUA
+162(continued):         L
+163:                                          RESPONSE yy yy yy yy yy
+163(continued):         yy yy yy
+164:                                          IAC SE
+165:
+
++=+=+=+=+= File rfc1415.txt +=+=+=+=+=
+2000 found at line 2814:
+2812:        2         1016 Grouping threshold violation       |    503
+2812(continued):
+2813:        2         1017 Inconsistent PDU request           |    503
+2813(continued):
+2814:        2         2000 Association with user not allowed  |    532
+2814(continued):
+2815:        2         2002 Unsupported service class          |    504
+2815(continued):
+2816:        0         2003 Unsupported functional unit        |    211
+2816(continued):
+
+
+
+Nesser                       Informational                    [Page 137]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc1416.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 318:
+316:                                          IAC SB AUTHENTICATION RE
+316(continued):         PLY
+317:                                          KERBEROS_V4 CLIENT|MUTUA
+317(continued):         L
+318:                                          RESPONSE yy yy yy yy yy
+318(continued):         yy yy yy
+319:                                          IAC SE
+320:
+
++=+=+=+=+= File rfc1417.txt +=+=+=+=+=
+2000 found at line 156:
+154:                         c/o Rapport Communication
+155:                         3055 Q Street NW
+156:                         Washington, DC 20007
+157:                         US
+158:
+
+2000 found at line 198:
+196:     Rapport Communication
+197:     3055 Q Street NW
+198:     Washington, DC  20007
+199:
+200:     Phone: +1 202-342-2727
+
++=+=+=+=+= File rfc1421.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 1148:
+1146:      BAoTF1JTQSBEYXRhIFNlY3VyaXR5LCBJbmMuMQ8wDQYDVQQLEwZCZXRhIDEx
+1146(continued):                DTAL
+1147:      BgNVBAsTBFRMQ0EwHhcNOTEwOTAxMDgwMDAwWhcNOTIwOTAxMDc1OTU5WjBR
+1147(continued):                MQsw
+1148:      CQYDVQQGEwJVUzEgMB4GA1UEChMXUlNBIERhdGEgU2VjdXJpdHksIEluYy4x
+1148(continued):                DzAN
+1149:      BgNVBAsTBkJldGEgMTEPMA0GA1UECxMGTk9UQVJZMHAwCgYEVQgBAQICArwD
+1149(continued):                YgAw
+1150:      XwJYCsnp6lQCxYykNlODwutF/jMJ3kL+3PjYyHOwk+/9rLg6X65B/LD4bJHt
+1150(continued):                O5XW
+
+'yy' on a line without 'yyyy' found at line 1150:
+1148:      CQYDVQQGEwJVUzEgMB4GA1UEChMXUlNBIERhdGEgU2VjdXJpdHksIEluYy4x
+1148(continued):                DzAN
+1149:      BgNVBAsTBkJldGEgMTEPMA0GA1UECxMGTk9UQVJZMHAwCgYEVQgBAQICArwD
+1149(continued):                YgAw
+1150:      XwJYCsnp6lQCxYykNlODwutF/jMJ3kL+3PjYyHOwk+/9rLg6X65B/LD4bJHt
+1150(continued):                O5XW
+1151:      cqAz/7R7XhjYCm0PcqbdzoACZtIlETrKrcJiDYoP+DkZ8k1gCk7hQHpbIwID
+1151(continued):                AQAB
+
+
+
+Nesser                       Informational                    [Page 138]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1152:      MA0GCSqGSIb3DQEBAgUAA38AAICPv4f9Gx/tY4+p+4DB7MV+tKZnvBoy8zgo
+1152(continued):                MGOx
+
+'yy' on a line without 'yyyy' found at line 1256:
+1254:      BAoTF1JTQSBEYXRhIFNlY3VyaXR5LCBJbmMuMQ8wDQYDVQQLEwZCZXRhIDEx
+1254(continued):                DTAL
+1255:      BgNVBAsTBFRMQ0EwHhcNOTEwOTAxMDgwMDAwWhcNOTIwOTAxMDc1OTU5WjBR
+1255(continued):                MQsw
+1256:      CQYDVQQGEwJVUzEgMB4GA1UEChMXUlNBIERhdGEgU2VjdXJpdHksIEluYy4x
+1256(continued):                DzAN
+1257:      BgNVBAsTBkJldGEgMTEPMA0GA1UECxMGTk9UQVJZMHAwCgYEVQgBAQICArwD
+1257(continued):                YgAw
+1258:      XwJYCsnp6lQCxYykNlODwutF/jMJ3kL+3PjYyHOwk+/9rLg6X65B/LD4bJHt
+1258(continued):                O5XW
+
+'yy' on a line without 'yyyy' found at line 1258:
+1256:      CQYDVQQGEwJVUzEgMB4GA1UEChMXUlNBIERhdGEgU2VjdXJpdHksIEluYy4x
+1256(continued):                DzAN
+1257:      BgNVBAsTBkJldGEgMTEPMA0GA1UECxMGTk9UQVJZMHAwCgYEVQgBAQICArwD
+1257(continued):                YgAw
+1258:      XwJYCsnp6lQCxYykNlODwutF/jMJ3kL+3PjYyHOwk+/9rLg6X65B/LD4bJHt
+1258(continued):                O5XW
+1259:      cqAz/7R7XhjYCm0PcqbdzoACZtIlETrKrcJiDYoP+DkZ8k1gCk7hQHpbIwID
+1259(continued):                AQAB
+1260:      MA0GCSqGSIb3DQEBAgUAA38AAICPv4f9Gx/tY4+p+4DB7MV+tKZnvBoy8zgo
+1260(continued):                MGOx
+
++=+=+=+=+= File rfc1422.txt +=+=+=+=+=
+UTCTime found at line 1596:
+1594:
+1595:     Validity ::=    SEQUENCE{
+1596:             notBefore       UTCTime,
+1597:             notAfter        UTCTime}
+1598:
+
+UTCTime found at line 1597:
+1595:     Validity ::=    SEQUENCE{
+1596:             notBefore       UTCTime,
+1597:             notAfter        UTCTime}
+1598:
+1599:     SubjectPublicKeyInfo ::=        SEQUENCE{
+
+UTCTime found at line 1640:
+1638:             signature       AlgorithmIdentifier,
+1639:             issuer          Name,
+1640:             lastUpdate      UTCTime,
+1641:             nextUpdate      UTCTime,
+1642:             revokedCertificates
+
+
+
+Nesser                       Informational                    [Page 139]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+UTCTime found at line 1641:
+1639:             issuer          Name,
+1640:             lastUpdate      UTCTime,
+1641:             nextUpdate      UTCTime,
+1642:             revokedCertificates
+1643:                             SEQUENCE OF CRLEntry OPTIONAL}
+
+UTCTime found at line 1647:
+1645:     CRLEntry ::= SEQUENCE{
+1646:             userCertificate SerialNumber,
+1647:             revocationDate UTCTime}
+1648:
+1649:  References
+
+century found at line 463:
+461:     confusion relating to daylight savings time.  Note that UTCT
+462:     expresses the value of a year modulo 100 (with no indication
+462(continued):         of
+463:     century), hence comparisons involving dates in different cent
+463(continued):         uries
+464:     must be performed with care.
+465:
+
++=+=+=+=+= File rfc1432.txt +=+=+=+=+=
+2000 found at line 711:
+709:            Digital Press
+710:            buddenhagen@cecv01.enet.dec.com McGraw-Hill
+711:            617-276-1498                    212-512-2000
+712:            fax: 617-276-4314               1221 Ave. of the Ameri
+712(continued):         cas
+713:            Digital Equipment Corporation   New York, NY 10020
+
++=+=+=+=+= File rfc1437.txt +=+=+=+=+=
+2000 found at line 185:
+183:     generation of the X.400 specification, X.400-1996.  This will
+183(continued):          give
+184:     the community ample time to define a more complete specificat
+184(continued):         ion for
+185:     matter transport as part of X.400-2000, and possibly even a r
+185(continued):         eadily-
+186:     implementable specification as part of X.400-2004, although s
+186(continued):         ome will
+187:     no doubt argue that this would be too strong a break with tra
+187(continued):         dition.
+
++=+=+=+=+= File rfc1440.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 332:
+330:     The time stamp on the file as it appears at the sending site
+
+
+
+Nesser                       Informational                    [Page 140]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+330(continued):         may be
+331:     sent and applied to the copy at the receiving site.  The form
+331(continued):          is US
+332:     mm/dd/yy and hh:mm:ss.  A time zone is optional.  If the time
+332(continued):          zone is
+333:     omitted, local time is assumed.  If the DATE command is omitt
+333(continued):         ed, time
+334:     and date of arrival are assumed.
+
++=+=+=+=+= File rfc1442.txt +=+=+=+=+=
+UTCTime found at line 362:
+360:            BEGIN
+361:                TYPE NOTATION ::=
+362:                              "LAST-UPDATED" value(Update UTCTime)
+362(continued):
+363:                              "ORGANIZATION" Text
+364:                              "CONTACT-INFO" Text
+
+UTCTime found at line 378:
+376:                            | Revisions Revision
+377:                Revision ::=
+378:                              "REVISION" value(Update UTCTime)
+379:                              "DESCRIPTION" Text
+380:
+
++=+=+=+=+= File rfc1453.txt +=+=+=+=+=
+1900 found at line 516:
+514:
+515:     [XTP92]     Xpress Transfer Protocol, version 3.6, XTP Forum,
+515(continued):
+516:                 1900 State Street, Suite D, Santa Barbara, Califo
+516(continued):         rnia
+517:                 93101 USA, January 11, 1992.
+518:
+
++=+=+=+=+= File rfc1458.txt +=+=+=+=+=
+2000 found at line 1026:
+1024:     Reading, MA 01867
+1025:
+1026:     Phone:  (617) 942-2000
+1027:     EMail:  rebraudes@tasc.com
+1028:
+
+2000 found at line 1035:
+1033:     Reading, MA 01867
+1034:
+
+
+
+
+
+Nesser                       Informational                    [Page 141]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1035:     Phone:  (617) 942-2000
+1036:     EMail: gszabele@tasc.com
+1037:
+
++=+=+=+=+= File rfc1465.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 499:
+497:                  Switzerland
+498:
+499:        <Update-info> ::= "Update: FORMAT=V3; DATE=" 'yymmdd' \
+500:                              "; START=" 'yymmdd' \
+501:                              ["; END=" 'yymmdd'] <CR>
+
+'yy' on a line without 'yyyy' found at line 500:
+498:
+499:        <Update-info> ::= "Update: FORMAT=V3; DATE=" 'yymmdd' \
+500:                              "; START=" 'yymmdd' \
+501:                              ["; END=" 'yymmdd'] <CR>
+502:                  The <Update-info> contains also the format ident
+502(continued):         ifier.
+
+'yy' on a line without 'yyyy' found at line 501:
+499:        <Update-info> ::= "Update: FORMAT=V3; DATE=" 'yymmdd' \
+500:                              "; START=" 'yymmdd' \
+501:                              ["; END=" 'yymmdd'] <CR>
+502:                  The <Update-info> contains also the format ident
+502(continued):         ifier.
+503:
+
+'yy' on a line without 'yyyy' found at line 512:
+510:
+511:                  The date of the last update of a document is giv
+511(continued):         en in
+512:                  the form 'yymmdd'.
+513:                  A start date must be set.  A document can be pub
+513(continued):         lished
+514:                  this way before the information in it is valid.
+514(continued):          (This
+
+'yy' on a line without 'yyyy' found at line 1673:
+1671:                              | <DirectoryName> )
+1672:
+1673:        <Update-info> ::= "Update: FORMAT=V3; DATE=" 'yymmdd' \
+1674:                              "; START=" 'yymmdd' \
+1675:                              ["; END=" 'yymmdd'] <CR>
+
+'yy' on a line without 'yyyy' found at line 1674:
+1672:
+1673:        <Update-info> ::= "Update: FORMAT=V3; DATE=" 'yymmdd' \
+
+
+
+Nesser                       Informational                    [Page 142]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1674:                              "; START=" 'yymmdd' \
+1675:                              ["; END=" 'yymmdd'] <CR>
+1676:
+
+'yy' on a line without 'yyyy' found at line 1675:
+1673:        <Update-info> ::= "Update: FORMAT=V3; DATE=" 'yymmdd' \
+1674:                              "; START=" 'yymmdd' \
+1675:                              ["; END=" 'yymmdd'] <CR>
+1676:
+1677:        <window-size> ::= "RTS-window-size: " \
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Nesser                       Informational                    [Page 143]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc1467.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 408:
+406:
+407:     [6] Solensky, F., Internet Growth Charts, "big-internet" mail
+407(continued):         ing
+408:         list, munnari.oz.au:big-internet/nsf-netnumbers-<yymm>.ps
+408(continued):
+409:
+410:  9. Other relevant documents
+
++=+=+=+=+= File rfc1470.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 247:
+245:
+246:     DATE OF MOST RECENT UPDATE TO THIS CATALOG ENTRY
+247:             <YYMMDD>
+248:
+249:  Keywords
+
+2000 found at line 4696:
+4694:                 libraries), but this has not been done.  Curses i
+4694(continued):                s very
+4695:                 slow and cpu intensive on VMS, but the tool has b
+4695(continued):                een
+4696:                 run in a window on a VAXstation 2000.  Just don't
+4696(continued):                 try
+4697:                 to run it on a terminal connected to a 11/750.
+4698:
+
++=+=+=+=+= File rfc1479.txt +=+=+=+=+=
+century found at line 752:
+750:     We note that none of the IDPR protocols contain explicit prov
+750(continued):         isions
+751:     for dealing with an exhausted timestamp space.  As timestamp
+751(continued):         space
+752:     exhaustion will not occur until well into the next century, w
+752(continued):         e expect
+753:     timestamp space viability to outlast the IDPR protocols.
+754:
+
++=+=+=+=+= File rfc1486.txt +=+=+=+=+=
+2000 found at line 745:
+743:          Date: Sun, 11 Apr 1993 20:34:12 -0800
+744:          Subject: Comments on "An Experiment in Remote Printing"
+745:          Message-ID: <19930411203412000.123@tpd.org>
+746:          MIME-Version: 1.0
+747:          Content-Type: text/plain; charset=us-ascii
+
+
+
+
+
+Nesser                       Informational                    [Page 144]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc1488.txt +=+=+=+=+=
+UTCTime found at line 302:
+300:  2.21.  UTC Time
+301:
+302:     Values of type uTCTimeSyntax are encoded as if they were Prin
+302(continued):         table
+303:     Strings with the strings containing a UTCTime value.
+304:
+
+UTCTime found at line 303:
+301:
+302:     Values of type uTCTimeSyntax are encoded as if they were Prin
+302(continued):         table
+303:     Strings with the strings containing a UTCTime value.
+304:
+305:  2.22.  Guide (search guide)
+
+UTCTime found at line 377:
+375:   <algorithm-id> ::= <oid> '#' <algorithm-parameters>
+376:
+377:   <utc-time> ::= an encoded UTCTime value
+378:
+379:   <hex-string> ::= <hex-digit> | <hex-digit> <hex-string>
+
++=+=+=+=+= File rfc1500.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 1950:
+1948:                                         The text version is sent.
+1948(continued):
+1949:
+1950:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+1950(continued):                umber.
+1951:                                         and 'yyy' is 'txt' or 'ps
+1951(continued):                '.
+1952:
+
+'yy' on a line without 'yyyy' found at line 1951:
+1949:
+1950:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+1950(continued):                umber.
+1951:                                         and 'yyy' is 'txt' or 'ps
+1951(continued):                '.
+1952:
+1953:           help                          to get information on how
+1953(continued):                 to use
+
++=+=+=+=+= File rfc1507.txt +=+=+=+=+=
+UTCTime found at line 5111:
+5109:
+
+
+
+Nesser                       Informational                    [Page 145]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+5110:     Validity ::= SEQUENCE {
+5111:             NotBefore       UTCTime,
+5112:             NotAfter        UTCTime
+5113:             }
+
+UTCTime found at line 5112:
+5110:     Validity ::= SEQUENCE {
+5111:             NotBefore       UTCTime,
+5112:             NotAfter        UTCTime
+5113:             }
+5114:
+
+UTCTime found at line 6297:
+6295:     Version ::=      INTEGER { 1988(0)} SerialNumber ::= INTEGER
+6295(continued):                Validity
+6296:     ::=     SEQUENCE{
+6297:             notBefore               UTCTime,
+6298:             notAfter                UTCTime}
+6299:
+
+UTCTime found at line 6298:
+6296:     ::=     SEQUENCE{
+6297:             notBefore               UTCTime,
+6298:             notAfter                UTCTime}
+6299:
+6300:     SubjectPublicKeyInfo  ::=  SEQUENCE {
+
++=+=+=+=+= File rfc1512.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 243:
+241:            FddiSMTStationIdType ::= OCTET STRING (SIZE (8))
+242:            -- The unique identifier for the FDDI station.  This i
+242(continued):         s a
+243:            -- string of 8 octets, represented as X' yy yy xx xx x
+243(continued):         x xx
+244:            -- xx xx' with the low order 6 octet (xx) from a uniqu
+244(continued):         e IEEE
+245:            -- assigned address.  The high order two bits of the I
+245(continued):         EEE
+
+'yy' on a line without 'yyyy' found at line 248:
+246:            -- address, the group address bit and the administrati
+246(continued):         on bit
+247:            -- (Universal/Local) bit should both be zero.  The fir
+247(continued):         st two
+248:            -- octets, the yy octets, are implementor-defined.
+249:            --
+250:            -- The representation of the address portion of the st
+250(continued):         ation id
+
+
+
+Nesser                       Informational                    [Page 146]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc1519.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 401:
+399:     3.2  Historic growth rates
+400:
+401:        MM/YY     ROUTES                        MM/YY     ROUTES
+402:                  ADVERTISED                              ADVERTIS
+402(continued):         ED
+403:        ------------------------                ------------------
+403(continued):         -----
+
+'yy' on a line without 'yyyy' found at line 1318:
+1316:     Ann Arbor, MI 48109
+1317:
+1318:     EMail: jyy@merit.edu
+1319:
+1320:
+
++=+=+=+=+= File rfc1527.txt +=+=+=+=+=
+century found at line 793:
+791:     ubiquitous as the current telephone network and provides all
+792:     Americans with access to information in much the same way as
+792(continued):         public
+793:     libraries were created for a similar purpose a century ago.
+794:
+795:     Congress must understand that the NREN is not just a new tech
+795(continued):         nology
+
+century found at line 875:
+873:     regulated companies from becoming viable players.  We must re
+873(continued):         alize
+874:     that we are about to enter a power struggle for the control o
+874(continued):         f the
+875:     information resources of the 21st century that promises to be
+875(continued):          every
+876:     bit as harsh and bruising as the power struggle for natural r
+876(continued):         esources
+877:     was at the end of the last century.
+
+century found at line 877:
+875:     information resources of the 21st century that promises to be
+875(continued):          every
+876:     bit as harsh and bruising as the power struggle for natural r
+876(continued):         esources
+877:     was at the end of the last century.
+878:
+879:     While the intentions of most appear to be good, as this study
+879(continued):          has
+
+
+
+
+Nesser                       Informational                    [Page 147]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc1537.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 165:
+163:     Example: zone file for foo.xx:
+164:
+165:     pqr          MX 100  relay.yy.
+166:     xyz          MX 100  relay.yy           (no trailing dot!)
+167:
+
+'yy' on a line without 'yyyy' found at line 166:
+164:
+165:     pqr          MX 100  relay.yy.
+166:     xyz          MX 100  relay.yy           (no trailing dot!)
+167:
+168:
+
+'yy' on a line without 'yyyy' found at line 177:
+175:     When fully written out this stands for:
+176:
+177:        pqr.foo.xx.  MX 100  relay.yy.
+178:        xyz.foo.xx.  MX 100  relay.yy.foo.xx.   (name extension!)
+179:
+
+'yy' on a line without 'yyyy' found at line 178:
+176:
+177:        pqr.foo.xx.  MX 100  relay.yy.
+178:        xyz.foo.xx.  MX 100  relay.yy.foo.xx.   (name extension!)
+179:
+180:  6. Missing secondary servers
+
+'yy' on a line without 'yyyy' found at line 256:
+254:
+255:           foo.xx.      MX 100  gateway.xx.
+256:                        MX 200  fallback.yy.
+257:           *.foo.xx.    MX 100  gateway.xx.
+258:                        MX 200  fallback.yy.
+
+'yy' on a line without 'yyyy' found at line 258:
+256:                        MX 200  fallback.yy.
+257:           *.foo.xx.    MX 100  gateway.xx.
+258:                        MX 200  fallback.yy.
+259:  8. Hostnames
+260:
+
+2000 found at line 89:
+87:            86400 ; Refresh     24 hours
+88:             7200 ; Retry        2 hours
+
+
+
+
+
+Nesser                       Informational                    [Page 148]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+89:          2592000 ; Expire      30 days
+90:           345600 ; Minimum TTL  4 days
+91:
+
++=+=+=+=+= File rfc1540.txt +=+=+=+=+=
+1836:                                         The text version is sent.
+1836(continued):
+1837:
+1838:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+1838(continued):                umber.
+1839:                                         and 'yyy' is 'txt' or 'ps
+1839(continued):                '.
+1840:
+
+'yy' on a line without 'yyyy' found at line 1839:
+1837:
+1838:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+1838(continued):                umber.
+1839:                                         and 'yyy' is 'txt' or 'ps
+1839(continued):                '.
+1840:
+1841:           help                          to get information on how
+1841(continued):                 to use
+
++=+=+=+=+= File rfc1555.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 155:
+153:     In addition, Listserv usually maintains automatic archives of
+153(continued):          all
+154:     postings to a list.  These archives, contained in the file "l
+154(continued):         istname
+155:     LOGyymm", do not contain the MIME headers, so all encoding
+156:     information will be lost.  This is a limitation of the Listse
+156(continued):         rv
+157:     software.
+
++=+=+=+=+= File rfc1564.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 811:
+809:
+810:     The following searches should be tried.  Unless otherwise sta
+810(continued):         ted, the
+811:     "XXX" or "YYY" part of the search filter should be chosen in
+811(continued):         such a
+812:     way as to return a single result.  Unless stated otherwise th
+812(continued):         e
+813:     results should return all attributes for the entry.
+
+
+
+
+
+
+Nesser                       Informational                    [Page 149]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+'yy' on a line without 'yyyy' found at line 848:
+846:
+847:             objectClass=person AND
+848:             (commonName=XXX* OR telephoneNumber=*YYY)
+849:
+850:     75. Search returning all entries (i.e., 100 entries in the si
+850(continued):         ngle
+
+2000 found at line 527:
+525:
+526:     42. If the DSA runs as a static server, state the start-up ti
+526(continued):         me for a
+527:         DSA with a database of 20000 entries.  If this varies wid
+527(continued):         ely
+528:         according to configuration options, give figures for the
+528(continued):         various
+529:         options.  ...............................................
+529(continued):         ........
+
+2000 found at line 709:
+707:
+708:     i.  The tests should be made against an organisational databa
+708(continued):         se of
+709:         20000 entries.  Some tests are against subsets of this da
+709(continued):         ta, and
+710:         so the database should be set up according to the followi
+710(continued):         ng
+711:         instructions.
+
+2000 found at line 713:
+711:         instructions.
+712:
+713:         Create an organisational DSA with 20000 entries below the
+713(continued):
+714:         organisation node.  Sub-divide this data into a number of
+714(continued):
+715:         organisational units, one of which should contain 1000 en
+715(continued):         tries,
+
+2000 found at line 808:
+806:         unit.
+807:
+808:     ii. An organisation subtree search, on the subtree of 20000 e
+808(continued):         ntries.
+809:
+810:     The following searches should be tried.  Unless otherwise sta
+810(continued):         ted, the
+
+
+
+
+Nesser                       Informational                    [Page 150]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2000 found at line 851:
+849:
+850:     75. Search returning all entries (i.e., 100 entries in the si
+850(continued):         ngle
+851:         level search, and all 20000 entries in the subtree search
+851(continued):         :
+852:
+853:             objectClass=*
+
++=+=+=+=+= File rfc1578.txt +=+=+=+=+=
+2000 found at line 1946:
+1944:     700 13th Street, NW
+1945:     Suite 950
+1946:     Washington, DC  20005
+1947:     USA
+1948:
+
++=+=+=+=+= File rfc1589.txt +=+=+=+=+=
+2000 found at line 1979:
+1977:        presumably with negligible frequency error.
+1978:
+1979:        #define MAXPHASE 512000      /* max phase error (us) */
+1980:        #ifdef PPS_SYNC
+1981:        #define MAXFREQ 100          /* max frequency error (ppm)
+1981(continued):                */
+
++=+=+=+=+= File rfc1593.txt +=+=+=+=+=
+2000 found at line 1088:
+1086:                             response(6)
+1087:
+1088:    --              enumeration values between 2000 and 3999 are r
+1088(continued):                eserved
+1089:    --              for IP socket traces,
+1090:
+
+2000 found at line 1149:
+1147:                             testReq(26),
+1148:
+1149:    --              enumeration values between 2000 and 3999 are r
+1149(continued):                eserved
+1150:    --              for IP socket traces.
+1151:                             ipTestFrame(2001),
+
++=+=+=+=+= File rfc1594.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 379:
+377:                                         The text version is sent.
+377(continued):
+378:
+
+
+
+Nesser                       Informational                    [Page 151]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+379:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+379(continued):         umber.
+380:                                         and 'yyy' is 'txt' or 'ps
+380(continued):         '.
+381:
+
+'yy' on a line without 'yyyy' found at line 380:
+378:
+379:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+379(continued):         umber.
+380:                                         and 'yyy' is 'txt' or 'ps
+380(continued):         '.
+381:
+382:           help                          to get information on how
+382(continued):          to use
+
+'yy' on a line without 'yyyy' found at line 574:
+572:        In addition, back issues of the Report are available for a
+572(continued):         nonymous
+573:        FTP from the host ftp.isi.edu in the in-notes/imr director
+573(continued):         y, with
+574:        the file names in the form imryymm.txt, where yy is the la
+574(continued):         st two
+575:        digits of the year and mm two digits for the month.  For e
+575(continued):         xample,
+576:        the July 1992 Report is in the file imr9207.txt.
+
++=+=+=+=+= File rfc1595.txt +=+=+=+=+=
+2000 found at line 300:
+298:
+299:             ifSpeed           Speed of line rate for SONET/SDH,
+300:                               (e.g., 155520000 bps).
+301:
+302:             ifPhysAddress     The value of the Circuit Identifier
+302(continued):         .
+
+2000 found at line 357:
+355:             ifSpeed           set to speed of SONET/SDH path
+356:                               (e.g., an STS-1 path has a
+357:                               rate of 50112000 bps.)
+358:
+359:             ifPhysAddress     Circuit Identifier or OCTET STRING
+359(continued):         of
+
++=+=+=+=+= File rfc1600.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 1950:
+1948:                                         The text version is sent.
+1948(continued):
+
+
+
+Nesser                       Informational                    [Page 152]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1949:
+1950:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+1950(continued):                umber.
+1951:                                         and 'yyy' is 'txt' or 'ps
+1951(continued):                '.
+1952:
+
+'yy' on a line without 'yyyy' found at line 1951:
+1949:
+1950:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+1950(continued):                umber.
+1951:                                         and 'yyy' is 'txt' or 'ps
+1951(continued):                '.
+1952:
+1953:           help                          to get information on how
+1953(continued):                 to use
+
++=+=+=+=+= File rfc1607.txt +=+=+=+=+=
+century found at line 12:
+10:
+11:
+12:                        A VIEW FROM THE 21ST CENTURY
+13:
+14:  Status of this Memo
+
+century found at line 60:
+58:  Cerf
+58(continued):          [Page 1]
+59:
+60:  RFC 1607              A View from the 21st Century          1 Ap
+60(continued):          ril 1994
+61:
+62:
+
+century found at line 116:
+114:  Cerf
+114(continued):         [Page 2]
+115:
+116:  RFC 1607              A View from the 21st Century          1 Ap
+116(continued):         ril 1994
+117:
+118:
+
+century found at line 172:
+170:  Cerf
+170(continued):         [Page 3]
+171:
+172:  RFC 1607              A View from the 21st Century          1 Ap
+
+
+
+Nesser                       Informational                    [Page 153]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+172(continued):         ril 1994
+173:
+174:
+
+century found at line 228:
+226:  Cerf
+226(continued):         [Page 4]
+227:
+228:  RFC 1607              A View from the 21st Century          1 Ap
+228(continued):         ril 1994
+229:
+230:
+
+century found at line 284:
+282:  Cerf
+282(continued):         [Page 5]
+283:
+284:  RFC 1607              A View from the 21st Century          1 Ap
+284(continued):         ril 1994
+285:
+286:
+
+century found at line 340:
+338:  Cerf
+338(continued):         [Page 6]
+339:
+340:  RFC 1607              A View from the 21st Century          1 Ap
+340(continued):         ril 1994
+341:
+342:
+
+century found at line 396:
+394:  Cerf
+394(continued):         [Page 7]
+395:
+396:  RFC 1607              A View from the 21st Century          1 Ap
+396(continued):         ril 1994
+397:
+398:
+
+century found at line 452:
+450:  Cerf
+450(continued):         [Page 8]
+451:
+452:  RFC 1607              A View from the 21st Century          1 Ap
+452(continued):         ril 1994
+453:
+454:
+
+
+
+Nesser                       Informational                    [Page 154]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+century found at line 508:
+506:  Cerf
+506(continued):         [Page 9]
+507:
+508:  RFC 1607              A View from the 21st Century          1 Ap
+508(continued):         ril 1994
+509:
+510:
+
+century found at line 564:
+562:  Cerf                                                           [
+562(continued):         Page 10]
+563:
+564:  RFC 1607              A View from the 21st Century          1 Ap
+564(continued):         ril 1994
+565:
+566:
+
+century found at line 620:
+618:  Cerf                                                           [
+618(continued):         Page 11]
+619:
+620:  RFC 1607              A View from the 21st Century          1 Ap
+620(continued):         ril 1994
+621:
+622:
+
+century found at line 676:
+674:  Cerf                                                           [
+674(continued):         Page 12]
+675:
+676:  RFC 1607              A View from the 21st Century          1 Ap
+676(continued):         ril 1994
+677:
+678:
+
+century found at line 732:
+730:  Cerf                                                           [
+730(continued):         Page 13]
+731:
+732:  RFC 1607              A View from the 21st Century          1 Ap
+732(continued):         ril 1994
+733:
+734:
+
+2000 found at line 663:
+661:     transmission, switching and computing in a cost-effective
+662:     way.  For a long time, this technology involved rather
+
+
+
+Nesser                       Informational                    [Page 155]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+663:     bulky equipment - some of the early 3DV clips from 2000-
+664:     2005 showed rooms full of gear required to steer beams
+665:     around. A very interesting combination of fiber optics and
+
++=+=+=+=+= File rfc1608.txt +=+=+=+=+=
+UTCTime found at line 240:
+238:       provider   :: DistinguishedNameSyntax,
+239:        /* points to network provider */
+240:       onlineDate :: uTCTimeSyntax
+241:        /* date when network got connected to the Internet */
+242:
+
+UTCTime found at line 370:
+368:       asGuardian :: DistinguishedNameSyntax, */
+369:        /* DN of guardian of this AS */
+370:       lastModifiedDate :: UTCtimeSyntax */
+371:        /* important as routes change frequently */
+372:
+
+UTCTime found at line 423:
+421:           that the number was assigned to. This does not
+422:           imply that assTo "owns" this number now. */
+423:       assDate :: uTCTimeSyntax,
+424:        /* date of assignment for this number */
+425:       nicHandle :: CaseIgnoreStringSyntax,
+
+UTCTime found at line 1048:
+1046:     speed:                       id-nw-at.10    :numericString
+1047:     traffic:                     id-nw-at.11    :numericString
+1048:     configurationDate:           id-nw-at.12    :utcTime
+1049:     configurationHistory:        id-nw-at.13    :caseIgnoreString
+1049(continued):
+1050:     nodeName,nd:                 id-nw-at.14    :caseIgnoreString
+1050(continued):
+
+UTCTime found at line 1071:
+1069:
+1070:
+1071:     onlineDate:                  id-nw-at.27    :utcTime
+1072:     ipNodeName,IPnd:             id-nw-at.28    :caseIgnoreString
+1072(continued):
+1073:     protocol:                    id-nw-at.29    :caseIgnoreString
+1073(continued):
+
+UTCTime found at line 1083:
+1081:     assBy:                       id-nw-at.37    :DN
+1082:     assTo:                       id-nw-at.38    :DN
+1083:     assDate:                     id-nw-at.39    :utcTime
+
+
+
+Nesser                       Informational                    [Page 156]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1084:     nicHandle:                   id-nw-at.40    :caseIgnoreString
+1084(continued):
+1085:     relNwElement:                id-nw-at.41    :DN
+
+
++=+=+=+=+= File rfc1609.txt +=+=+=+=+=
+UTCTime found at line 588:
+586:        /* (average) use in percent of nominal bandwidth
+587:              [ this needs more specification later ] */
+588:       configurationDate ::  uTCTimeSyntax,
+589:        /* date when network was configured in current
+590:              shape */
+
++=+=+=+=+= File rfc1610.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 1950:
+1948:                                         The text version is sent.
+1948(continued):
+1949:
+1950:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+1950(continued):                umber.
+1951:                                         and 'yyy' is 'txt' or 'ps
+1951(continued):                '.
+1952:
+
+'yy' on a line without 'yyyy' found at line 1951:
+1949:
+1950:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+1950(continued):                umber.
+1951:                                         and 'yyy' is 'txt' or 'ps
+1951(continued):                '.
+1952:
+1953:           help                          to get information on how
+1953(continued):                 to use
+
+century found at line 926:
+924:               An Experimental protocol.
+925:
+926:        1607 - A View from the 21st Century
+927:
+928:               This is an information document and does not specif
+928(continued):         y any
+
++=+=+=+=+= File rfc1614.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 1565:
+1563:     The general format of a Gopher+ view descriptor is:
+1564:
+
+
+
+
+
+Nesser                       Informational                    [Page 157]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1565:        xxx/yyy zzz: <nnnK>
+1566:
+1567:
+
+'yy' on a line without 'yyyy' found at line 1575:
+1573:
+1574:
+1575:     where xxx is a general type-of-information advisory, yyy is w
+1575(continued):                hat
+1576:     information format you need understand to interpret this info
+1576(continued):                rmation,
+1577:     zzz is a language advisory (coded using POSIX definitions), a
+1577(continued):                nd nnn
+
+'yy' on a line without 'yyyy' found at line 1584:
+1582:     the need to be consistent in the use of type/encoding attribu
+1582(continued):                tes with
+1583:     the MIME specification.  The Gopher+ Type Registry may thus
+1584:     eventually disappear, together with the set of xxx/yyy values
+1584(continued):                 it
+1585:     currently contains.)
+1586:
+
++=+=+=+=+= File rfc1625.txt +=+=+=+=+=
+2000 found at line 255:
+253:               ( use = "wb", relation = "ro", term = 0 )
+254:               AND
+255:               ( use = "wb", relation = "ro", term = 2000 )
+256:              )
+257:
+
++=+=+=+=+= File rfc1632.txt +=+=+=+=+=
+UTCTime found at line 3795:
+3793:       association is rejected. However, if a chain operation is r
+3793(continued):                equired
+3794:       to  check the DN, the bind IS allowed.
+3795:     - When comparing attributes of UTCtime syntax, if the seconds
+3795(continued):                 field
+3796:       is  omitted, QUIPU does not perform the match correctly (i.e
+3796(continued):                ., the
+3797:       seconds field in the attribute values should be ignored, bu
+3797(continued):                t are
+
+
+
+
+
+
+
+
+
+Nesser                       Informational                    [Page 158]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2000 found at line 1214:
+1212:      1-800-257-OPEN (U.S. and Canada)
+1213:      1-612-482-6736 (worldwide)
+1214:      FAX: 1-612-482-2000 (worldwide)
+1215:      EMAIL: info@cdc.com
+1216:               or
+
++=+=+=+=+= File rfc1635.txt +=+=+=+=+=
+1900 found at line 605:
+603:     Most archive machines perform other functions as well.  Pleas
+603(continued):         e
+604:     respect the needs of their primary users and restrict your FT
+604(continued):         P access
+605:     to non-prime hours (generally between 1900 and 0600 hours loc
+605(continued):         al time
+606:     for that site) whenever possible.  It is especially important
+606(continued):          to
+607:     remember this for sites located on another continent or acros
+607(continued):         s a
+
++=+=+=+=+= File rfc1645.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 590:
+588:      554 Error, failed (technical reason)
+589:
+590:  4.4.6 HOLDuntil <YYMMDDHHMMSS> [+/-GMTdifference]
+591:
+592:     The HOLDuntil command allows for the delayed delivery of a me
+592(continued):         ssage,
+
++=+=+=+=+= File rfc1646.txt +=+=+=+=+=
+2000 found at line 428:
+426:
+427:                  Command Rejected                     0X10030000
+428:                  Intervention Required                0X08020000
+429:                  Data Check                           0X10010000
+430:                  Operation Check                      0X10050000
+
+2000 found at line 431:
+429:                  Data Check                           0X10010000
+430:                  Operation Check                      0X10050000
+431:                  Component Disconnected (LU)          0X08020000
+432:
+433:     Note 2*:   Device End -  A positive response to the Server's
+433(continued):         data
+
++=+=+=+=+= File rfc1647.txt +=+=+=+=+=
+2000 found at line 1355:
+1353:                   0x00           Command Reject        0x10030000
+
+
+
+Nesser                       Informational                    [Page 159]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1353(continued):
+1354:
+1355:                   0x01        Intervention Required    0x08020000
+1355(continued):
+1356:
+1357:                   0x02           Operation Check       0x10050000
+1357(continued):
+
++=+=+=+=+= File rfc1671.txt +=+=+=+=+=
+1900 found at line 410:
+408:     Phone:  +41 22 767-4967
+409:     Fax:    +41 22 767-7155
+410:     Telex:  419000 cer ch
+411:     EMail: brian@dxcoms.cern.ch
+412:
+
++=+=+=+=+= File rfc1679.txt +=+=+=+=+=
+century found at line 95:
+93:     examined below. The time frame for design, development, and
+94:     deployment of HPN based systems and subsystems is 1996 into t
+94(continued):          he
+95:     twenty first century.
+96:
+97:     Three general problem domains have been identified by the HPN
+97(continued):           working
+
++=+=+=+=+= File rfc1689.txt +=+=+=+=+=
+century found at line 6899:
+6897:     vision of how information management must change in the 1990s
+6897(continued):                 to meet
+6898:     the social and economic opportunities and challenges of the 2
+6898(continued):                1st
+6899:     century.  Members of the Coalition Task Force include, among
+6899(continued):                others,
+6900:     higher education institutions, publishers, network service pr
+6900(continued):                oviders,
+6901:     computer hardware, software, and systems companies, library n
+6901(continued):                etworks
+
+2000 found at line 421:
+419:        archie did for the world of ftp.  A central server periodi
+419(continued):         cally
+420:        scans the complete menu hierarchies of Gopher servers appe
+420(continued):         aring on
+
+
+
+
+
+
+
+Nesser                       Informational                    [Page 160]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+421:        an ever-expanding list (over 2000 sites as of November 199
+421(continued):         3).  The
+422:        resulting index is provided by a veronica server and can b
+422(continued):         e
+423:        accessed by any gopher client.
+
+2000 found at line 471:
+469:
+470:        There are currently (as of November 1993) some 500 registe
+470(continued):         red WAIS
+471:        databases with an estimated 2000 additional databases that
+471(continued):          are not
+472:        yet registered.  There are approximately another 100 comme
+472(continued):         rcial
+473:        WAIS databases.
+
++=+=+=+=+= File rfc1693.txt +=+=+=+=+=
+2000 found at line 574:
+572:         4  Baker          Boston                $849    Sportswea
+572(continued):         r
+573:         5  Baker          Washington          $3,100    Weights
+574:         6  Baker          Washington           $2000    Camping G
+574(continued):         ear
+575:         7  Baker          Atlanta               $290    Baseball
+575(continued):         Gloves
+576:         8  Baker          Boston              $1,500    Sportswea
+576(continued):         r
+
++=+=+=+=+= File rfc1696.txt +=+=+=+=+=
+2000 found at line 109:
+107:
+108:  mdmMIB MODULE-IDENTITY
+109:      LAST-UPDATED "9406120000Z"
+110:      ORGANIZATION "IETF Modem Management Working Group"
+111:
+
++=+=+=+=+= File rfc1698.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 513:
+511:     31  80  {1         - RDN, [SET OF]
+512:     30  80  {2         - AttributeValueAssertion, [SEQUENCE]
+513:     06  03  5504yy     -- OID identifying an attribute named in
+514:                        -- the Directory standard
+515:                        -- which one is determined by yy
+
+'yy' on a line without 'yyyy' found at line 515:
+513:     06  03  5504yy     -- OID identifying an attribute named in
+514:                        -- the Directory standard
+515:                        -- which one is determined by yy
+
+
+
+Nesser                       Informational                    [Page 161]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+516:     13  La  xxxxxx     -- [Printable string]
+517:                        -- could be T61 string, with tag 14
+
+'yy' on a line without 'yyyy' found at line 522:
+520:
+521:     The most likely attributes for an RDN have the following hex
+521(continued):         values
+522:     for yy.
+523:
+524:          CommonName               03
+
+'yy' on a line without 'yyyy' found at line 903:
+901:
+902:
+903:        yy is exactly one octet (i.e., one hex digit per y) holdin
+903(continued):         g part
+904:        of the length
+905:
+
+'yy' on a line without 'yyyy' found at line 918:
+916:        innermost nest of construction)
+917:
+918:        yy - as part of a value - a variable value, each y represe
+918(continued):         nts one
+919:        hex digit
+920:
+
++=+=+=+=+= File rfc1699.txt +=+=+=+=+=
+century found at line 1050:
+1048:
+1049:
+1050:  1607    Cerf         Apr 94   A VIEW FROM THE 21ST CENTURY
+1051:
+1052:  This document is a composition of letters discussing a possible
+1052(continued):                future.
+
++=+=+=+=+= File rfc1700.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 9905:
+9903:  AB-00-03-00-00-00       6004    DEC Local Area Transport (LAT) -
+9903(continued):                 old
+9904:  AB-00-04-00-xx-xx       ????    Reserved DEC customer private us
+9904(continued):                e
+9905:  AB-00-04-01-xx-yy       6007    DEC Local Area VAX Cluster group
+9905(continued):                s
+9906:                                  Sys. Communication Architecture
+9906(continued):                (SCA)
+9907:  CF-00-00-00-00-00       9000    Ethernet Configuration Test prot
+9907(continued):                ocol
+
+
+
+Nesser                       Informational                    [Page 162]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1900 found at line 10173:
+10171:   014.000.000.063   2422-650-23500 00   Tollpost-Globe AS     [OX
+10171(continued):               G]
+10172:   014.000.000.064   2422-330-02500 00   Tollpost-Globe AS     [OX
+10172(continued):               G]
+10173:   014.000.000.065   2422-350-01900 00   Tollpost-Globe AS     [OX
+10173(continued):               G]
+10174:   014.000.000.066   2422-410-00700 00   Tollpost-Globe AS     [OX
+10174(continued):               G]
+10175:   014.000.000.067   2422-539-06200 00   Tollpost-Globe AS     [OX
+10175(continued):               G]
+
+1900 found at line 10255:
+10253:
+10254:
+10255:   014.000.000.131  2422-190-41900 00    T-G Airfreight AS     [OX
+10255(continued):               G]
+10256:   014.000.000.132  2422-616-16100 00    Tollpost-Globe AS     [OX
+10256(continued):               G]
+10257:   014.000.000.133  2422-150-50700-00    Tollpost-Globe Int.   [OX
+10257(continued):               G]
+
+1900 found at line 11112:
+11110:  1569    621     ??              Something from Emulex
+11111:  1571    623     UNKNOWN???      Running on a Novell Server
+11112:  1900    076C    Xerox
+11113:  2857    0b29    Site Lock
+11114:  3113    0c29    Site Lock Applications
+
+2000 found at line 2822:
+2820:  tcp-id-port     1999/tcp   cisco identification port
+2821:  tcp-id-port     1999/udp   cisco identification port
+2822:  callbook        2000/tcp
+2823:  callbook        2000/udp
+2824:  dc              2001/tcp
+
+2000 found at line 2823:
+2821:  tcp-id-port     1999/udp   cisco identification port
+2822:  callbook        2000/tcp
+2823:  callbook        2000/udp
+2824:  dc              2001/tcp
+2825:  wizard          2001/udp    curry
+
+2000 found at line 10120:
+10118:   014.000.000.018   2624-522-80900 52   FGAN-SIEMENS-X25      [GB
+10118(continued):               7]
+10119:   014.000.000.019   2041-170-10000 00   SHAPE-X25             [JF
+10119(continued):               W]
+
+
+
+Nesser                       Informational                    [Page 163]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+10120:   014.000.000.020   5052-737-20000 50   UQNET                 [AX
+10120(continued):               H]
+10121:   014.000.000.021   3020-801-00057 50   DMC-CRC1              [VX
+10121(continued):               T]
+10122:   014.000.000.022   2624-522-80329 02   FGAN-FGANFFMVAX-X25   [GB
+10122(continued):               7]
+
+2000 found at line 11572:
+11570:  AMIGA-1200/LC040
+11571:  AMIGA-1200/040
+11572:  AMIGA-2000
+11573:  AMIGA-2000/010
+11574:  AMIGA-2000/020
+
+2000 found at line 11573:
+11571:  AMIGA-1200/040
+11572:  AMIGA-2000
+11573:  AMIGA-2000/010
+11574:  AMIGA-2000/020
+11575:  AMIGA-2000/EC030
+
+2000 found at line 11574:
+11572:  AMIGA-2000
+11573:  AMIGA-2000/010
+11574:  AMIGA-2000/020
+11575:  AMIGA-2000/EC030
+11576:  AMIGA-2000/030
+
+2000 found at line 11575:
+11573:  AMIGA-2000/010
+11574:  AMIGA-2000/020
+11575:  AMIGA-2000/EC030
+11576:  AMIGA-2000/030
+11577:  AMIGA-2000/LC040
+
+2000 found at line 11576:
+11574:  AMIGA-2000/020
+11575:  AMIGA-2000/EC030
+11576:  AMIGA-2000/030
+11577:  AMIGA-2000/LC040
+11578:  AMIGA-2000/EC040
+
+2000 found at line 11577:
+11575:  AMIGA-2000/EC030
+11576:  AMIGA-2000/030
+11577:  AMIGA-2000/LC040
+11578:  AMIGA-2000/EC040
+11579:  AMIGA-2000/040
+
+
+
+Nesser                       Informational                    [Page 164]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2000 found at line 11578:
+11576:  AMIGA-2000/030
+11577:  AMIGA-2000/LC040
+11578:  AMIGA-2000/EC040
+11579:  AMIGA-2000/040
+11580:  AMIGA-3000
+
+2000 found at line 11579:
+11577:  AMIGA-2000/LC040
+11578:  AMIGA-2000/EC040
+11579:  AMIGA-2000/040
+11580:  AMIGA-3000
+11581:  AMIGA-3000/EC040
+
+2000 found at line 12014:
+12012:  AIX/370
+12013:  AIX-PS/2
+12014:  BS-2000
+12015:  CEDAR
+12016:  CGW
+
+2000 found at line 12356:
+12354:  HAZELTINE-1520
+12355:  HAZELTINE-1552
+12356:  HAZELTINE-2000
+12357:  HAZELTINE-ESPRIT
+12358:  HITACHI-5601
+
++=+=+=+=+= File rfc1705.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 1166:
+1164:     will be made.
+1165:
+1166:     node.sub.domain.name    IN     TA   xx.yy.zz.aa.bb.cc.dd.ee
+1167:
+1168:     ee.dd.cc.bb.aa.zz.yy.aa.in-addr.tcp IN  PTR node.sub.domain.n
+1168(continued):                ame.
+
+'yy' on a line without 'yyyy' found at line 1168:
+1166:     node.sub.domain.name    IN     TA   xx.yy.zz.aa.bb.cc.dd.ee
+1167:
+1168:     ee.dd.cc.bb.aa.zz.yy.aa.in-addr.tcp IN  PTR node.sub.domain.n
+1168(continued):                ame.
+1169:
+1170:     Using these entries, along with the existing DNS A records, a
+1170(continued):
+
+
+
+
+
+
+Nesser                       Informational                    [Page 165]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+'yy' on a line without 'yyyy' found at line 1172:
+1170:     Using these entries, along with the existing DNS A records, a
+1170(continued):
+1171:     requesting node can determine where the remote node is locate
+1171(continued):                d.  The
+1172:     format xx.yy.zz is the IEEE assigned portion and aa.bb.cc.dd.
+1172(continued):                ee is
+1173:     the encoded machine serial number as described in section 4.1
+1173(continued):                .
+1174:
+
++=+=+=+=+= File rfc1712.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 208:
+206:  @     IN    SOA     marsh.cs.curtin.edu.au. postmaster.cs.curtin
+206(continued):         .edu.au.
+207:                  (
+208:                          94070503        ; Serial (yymmddnn)
+209:                          10800           ; Refresh (3 hours)
+210:                          3600            ; Retry (1 hour)
+
++=+=+=+=+= File rfc1713.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 104:
+102:     University, but then Eric Wassenaar from Nikhef did a major r
+102(continued):         ewrite
+103:     and still seems to be actively working on improving it.  The
+103(continued):         program
+104:     is available from ftp://ftp.nikhef.nl/pub/network/host_YYMMDD
+104(continued):         .tar.Z
+105:     (YYMMDD is the date of the latest release).
+106:
+
+'yy' on a line without 'yyyy' found at line 105:
+103:     and still seems to be actively working on improving it.  The
+103(continued):         program
+104:     is available from ftp://ftp.nikhef.nl/pub/network/host_YYMMDD
+104(continued):         .tar.Z
+105:     (YYMMDD is the date of the latest release).
+106:
+107:     By default, host just maps host names to Internet addresses,
+107(continued):         querying
+
++=+=+=+=+= File rfc1714.txt +=+=+=+=+=
+2000 found at line 414:
+412:     Example of use:
+413:
+414:     -limit 2000
+415:
+416:  2.3.3 schema
+
+
+
+Nesser                       Informational                    [Page 166]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc1718.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 969:
+967:     mailing list.  File names beginning with "1" (one) contain ge
+967(continued):         neral
+968:     IETF information.  This is only a partial list of the availab
+968(continued):         le
+969:     files.  (The 'yymm' below refers to the year and month.)
+970:
+971:     o  0mtg-agenda.txt                Agenda for the meeting
+
+'yy' on a line without 'yyyy' found at line 972:
+970:
+971:     o  0mtg-agenda.txt                Agenda for the meeting
+972:     o  0mtg-at-a-glance-yymm.txt      Logistics information for t
+972(continued):         he meeting
+973:     o  0mtg-rsvp.txt                  Meeting registration form
+974:     o  0mtg-sites.txt                 Future meeting sites and da
+974(continued):         tes
+
+'yy' on a line without 'yyyy' found at line 975:
+973:     o  0mtg-rsvp.txt                  Meeting registration form
+974:     o  0mtg-sites.txt                 Future meeting sites and da
+974(continued):         tes
+975:     o  0mtg-multicast-guide-yymm.txt  Schedule for MBone-multicas
+975(continued):         t sessions
+976:     o  0mtg-traveldirections-yymm.txt Directions to the meeting s
+976(continued):         ite
+977:     o  0tao.txt                       This document
+
+'yy' on a line without 'yyyy' found at line 976:
+974:     o  0mtg-sites.txt                 Future meeting sites and da
+974(continued):         tes
+975:     o  0mtg-multicast-guide-yymm.txt  Schedule for MBone-multicas
+975(continued):         t sessions
+976:     o  0mtg-traveldirections-yymm.txt Directions to the meeting s
+976(continued):         ite
+977:     o  0tao.txt                       This document
+978:
+
++=+=+=+=+= File rfc1720.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 2230:
+2228:                                         The text version is sent.
+2228(continued):
+2229:
+
+
+
+
+
+
+
+Nesser                       Informational                    [Page 167]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2230:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+2230(continued):                umber.
+2231:                                         and 'yyy' is 'txt' or 'ps
+2231(continued):                '.
+2232:
+
+'yy' on a line without 'yyyy' found at line 2231:
+2229:
+2230:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+2230(continued):                umber.
+2231:                                         and 'yyy' is 'txt' or 'ps
+2231(continued):                '.
+2232:
+2233:           help                          to get information on how
+2233(continued):                 to use
+
++=+=+=+=+= File rfc1730.txt +=+=+=+=+=
+2digit found at line 3334:
+3332:     date            ::= date_text / <"> date_text <">
+3333:
+3334:     date_day        ::= 1*2digit
+3335:                         ;; Day of month
+3336:
+
+2digit found at line 3337:
+3335:                         ;; Day of month
+3336:
+3337:     date_day_fixed  ::= (SPACE digit) / 2digit
+3338:                         ;; Fixed-format version of date_day
+3339:
+
+2digit found at line 3348:
+3346:     date_year       ::= 4digit
+3347:
+3348:     date_year_old   ::= 2digit
+3349:                         ;; OBSOLETE, (year - 1900)
+3350:
+
+2digit found at line 3657:
+3655:     TEXT_CHAR       ::= <any CHAR except CR and LF>
+3656:
+3657:     time            ::= 2digit ":" 2digit ":" 2digit
+3658:                         ;; Hours minutes seconds
+3659:
+
+1900 found at line 3349:
+3347:
+3348:     date_year_old   ::= 2digit
+
+
+
+Nesser                       Informational                    [Page 168]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+3349:                         ;; OBSOLETE, (year - 1900)
+3350:
+3351:     date_time       ::= <"> (date_time_new / date_time_old) <">
+
++=+=+=+=+= File rfc1732.txt +=+=+=+=+=
+century found at line 254:
+252:
+253:        The format of dates and times has changed due to the impen
+253(continued):         ding end
+254:        of the century.  Clients that fail to accept a four-digit
+254(continued):         year or
+255:        a signed four-digit timezone value will not work properly
+255(continued):         with
+256:        IMAP4.
+
++=+=+=+=+= File rfc1733.txt +=+=+=+=+=
+2000 found at line 94:
+92:     message or part of a message.  For example, a user connected
+92(continued):          to an
+93:     IMAP4 server via a dialup link can determine that a message h
+93(continued):          as a
+94:     2000 byte text segment and a 40 megabyte video segment, and e
+94(continued):          lect to
+95:     fetch only the text segment.
+96:
+
++=+=+=+=+= File rfc1739.txt +=+=+=+=+=
+century found at line 1044:
+1042:           1.EDU            Reserved Domain
+1043:           2.EDU            Reserved Domain
+1044:           22CF.EDU         22nd Century Foundation
+1045:           3.EDU            Reserved Domain
+1046:     ** There are 1499 more matches.  Show them? N
+
++=+=+=+=+= File rfc1740.txt +=+=+=+=+=
+2000 found at line 383:
+381:        This field denotes the version of AppleSingle format in th
+381(continued):         e event
+382:        the format evolves (more fields may be added to the header
+382(continued):         ).  The
+383:        version described in this note is version $00020000 or
+384:        0x00020000.
+385:
+
+2000 found at line 384:
+382:        the format evolves (more fields may be added to the header
+382(continued):         ).  The
+383:        version described in this note is version $00020000 or
+
+
+
+Nesser                       Informational                    [Page 169]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+384:        0x00020000.
+385:
+386:     Filler
+
+2000 found at line 590:
+588:     #define F_fStationary   0x0800 /* file is a stationary pad */
+588(continued):
+589:     #define F_fNameLocked   0x1000 /* file can't be renamed by Fi
+589(continued):         nder */
+590:     #define F_fHasBundle    0x2000 /* file has a bundle */
+591:     #define F_fInvisible    0x4000 /* file's icon is invisible */
+591(continued):
+592:     #define F_fAlias        0x8000 /* file is an alias file (Syst
+592(continued):         em 7) */
+
+2000 found at line 624:
+622:
+623:         uint32 magicNum; /* internal file type tag */
+624:         uint32 versionNum; /* format version: 2 = 0x00020000 */
+625:         uchar8 filler[16]; /* filler, currently all bits 0 */
+626:         uint16 numEntries; /* number of entries which follow */
+
+2000 found at line 752:
+750:
+751:     /* Times are stored as a "signed number of seconds before of
+751(continued):         after
+752:      * 12:00 a.m. (midnight), January 1, 2000 Greenwich Mean Time
+752(continued):          (GMT).
+753:      * Applications must convert to their native date and time
+754:      * conventions." Any unknown entries are set to 0x80000000
+
++=+=+=+=+= File rfc1747.txt +=+=+=+=+=
+2000 found at line 736:
+734:
+735:                              sdlcPortAdminTopology == multipoint
+735(continued):         "
+736:                      DEFVAL { 2000 }
+737:                      ::= { sdlcPortAdminEntry 9 }
+738:
+
++=+=+=+=+= File rfc1752.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 1929:
+1927:
+1928:     We recommend that a new IPng Transition (NGTRANS) Working Gro
+1928(continued):                up be
+1929:     formed with Bob Gilligan of Sun Microsystems and xxx of yyy a
+1929(continued):                s co-
+1930:     chairs to design the mechanisms and procedures to support the
+
+
+
+Nesser                       Informational                    [Page 170]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1930(continued):
+1931:     transition of the Internet from IPv4 to IPv6 and to give advi
+1931(continued):                ce on
+
++=+=+=+=+= File rfc1758.txt +=+=+=+=+=
+2000 found at line 180:
+178:                         c/o Rapport Communication
+179:                         2721 N Street NW
+180:                         Washington, DC 20007
+181:                         US
+182:
+
+2000 found at line 205:
+203:     Rapport Communication
+204:     2721 N Street NW
+205:     Washington, DC  20007
+206:
+207:     Phone: +1 202-342-2727
+
++=+=+=+=+= File rfc1759.txt +=+=+=+=+=
+2000 found at line 1488:
+1486:        -- on Unicode in the MIBenum range of 1000-1999.
+1487:        -- See IANA Registry for vendor developed character sets
+1488:        -- in the MIBenum range of 2000-xxxx.
+1489:     }
+1490:
+
++=+=+=+=+= File rfc1769.txt +=+=+=+=+=
+1900 found at line 218:
+216:     main product of the protocol, a special timestamp format has
+216(continued):         been
+217:     established. NTP timestamps are represented as a 64-bit unsig
+217(continued):         ned
+218:     fixed-point number, in seconds relative to 0h on 1 January 19
+218(continued):         00. The
+219:     integer part is in the first 32 bits and the fraction part in
+219(continued):          the
+220:     last 32 bits. In the fraction part, the non-significant low-o
+220(continued):         rder
+
+1900 found at line 248:
+246:     overflow some time in 2036. Should NTP or SNTP be in use in 2
+246(continued):         036,
+247:     some external means will be necessary to qualify time relativ
+247(continued):         e to
+248:     1900 and time relative to 2036 (and other multiples of 136 ye
+248(continued):         ars).
+249:     Timestamped data requiring such qualification will be so prec
+
+
+
+Nesser                       Informational                    [Page 171]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+249(continued):         ious
+250:     that appropriate means should be readily available. There wil
+250(continued):         l exist
+
++=+=+=+=+= File rfc1778.txt +=+=+=+=+=
+UTCTime found at line 309:
+307:  2.21.  UTC Time
+308:
+309:     Values of type uTCTimeSyntax are encoded as if they were Prin
+309(continued):         table
+310:     Strings with the strings containing a UTCTime value.
+311:
+
+UTCTime found at line 310:
+308:
+309:     Values of type uTCTimeSyntax are encoded as if they were Prin
+309(continued):         table
+310:     Strings with the strings containing a UTCTime value.
+311:
+312:  2.22.  Guide (search guide)
+
+UTCTime found at line 399:
+397:
+398:
+399:       <utc-time> ::= an encoded UTCTime value
+400:
+401:       <hex-string> ::= <hex-digit> | <hex-digit> <hex-string>
+
++=+=+=+=+= File rfc1780.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 2118:
+2116:                                         The text version is sent.
+2116(continued):
+2117:
+2118:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+2118(continued):                umber.
+2119:                                         and 'yyy' is 'txt' or 'ps
+2119(continued):                '.
+2120:
+
+'yy' on a line without 'yyyy' found at line 2119:
+2117:
+2118:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+2118(continued):                umber.
+2119:                                         and 'yyy' is 'txt' or 'ps
+2119(continued):                '.
+2120:
+2121:           help                          to get information on how
+2121(continued):                 to use
+
+
+
+Nesser                       Informational                    [Page 172]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc1786.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 2992:
+2990:     USA
+2991:     +1 313 936 2655
+2992:     jyy@merit.edu
+2993:
+2994:
+
+'yy' on a line without 'yyyy' found at line 3694:
+3692:
+3693:       Format:
+3694:            <email-address> YYMMDD
+3695:
+3696:
+
+'yy' on a line without 'yyyy' found at line 3704:
+3702:
+3703:            <email-address> should be the address of the person wh
+3703(continued):                o made
+3704:            the last change. YYMMDD denotes the date this change w
+3704(continued):                as made.
+3705:
+3706:       Example:
+
+'yy' on a line without 'yyyy' found at line 3950:
+3948:
+3949:          Format:
+3950:               <email-address> YYMMDD
+3951:
+3952:               <email-address> should be the address of the person
+3952(continued):                 who
+
+'yy' on a line without 'yyyy' found at line 3953:
+3951:
+3952:               <email-address> should be the address of the person
+3952(continued):                 who
+3953:               made the last change. YYMMDD denotes the date this
+3953(continued):                change
+3954:               was made.
+3955:
+
+'yy' on a line without 'yyyy' found at line 4170:
+4168:
+4169:          Format:
+4170:               <email-address> YYMMDD
+4171:
+4172:               <email-address> should be the address of the person
+4172(continued):                 who
+
+
+
+Nesser                       Informational                    [Page 173]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+'yy' on a line without 'yyyy' found at line 4173:
+4171:
+4172:               <email-address> should be the address of the person
+4172(continued):                 who
+4173:               made the last change. YYMMDD denotes the date this
+4173(continued):                change
+4174:               was made.
+4175:
+
+'yy' on a line without 'yyyy' found at line 4305:
+4303:
+4304:          Format:
+4305:               YYMMDD
+4306:
+4307:               YYMMDD denotes the date this route was withdrawn.
+
+'yy' on a line without 'yyyy' found at line 4307:
+4305:               YYMMDD
+4306:
+4307:               YYMMDD denotes the date this route was withdrawn.
+4308:
+4309:
+
+'yy' on a line without 'yyyy' found at line 4394:
+4392:
+4393:          Format:
+4394:               <email-address> YYMMDD
+4395:
+4396:               <email-address> should be the address of the person
+4396(continued):                 who
+
+'yy' on a line without 'yyyy' found at line 4397:
+4395:
+4396:               <email-address> should be the address of the person
+4396(continued):                 who
+4397:               made the last change. YYMMDD denotes the date this
+4397(continued):                change
+4398:               was made.
+4399:
+
++=+=+=+=+= File rfc1800.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 1950:
+1948:                                         The text version is sent.
+1948(continued):
+1949:
+1950:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+
+
+
+
+
+Nesser                       Informational                    [Page 174]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1950(continued):                umber.
+1951:                                         and 'yyy' is 'txt' or 'ps
+1951(continued):                '.
+1952:
+
+'yy' on a line without 'yyyy' found at line 1951:
+1949:
+1950:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+1950(continued):                umber.
+1951:                                         and 'yyy' is 'txt' or 'ps
+1951(continued):                '.
+1952:
+1953:           help                          to get information on how
+1953(continued):                 to use
+
++=+=+=+=+= File rfc1806.txt +=+=+=+=+=
+century found at line 8:
+6:
+7:  Network Working Group                                          R
+7(continued):           . Troost
+8:  Request for Comments: 1806                           New Century
+8(continued):            Systems
+9:  Category: Experimental                                         S
+9(continued):           . Dorner
+10:                                                     QUALCOMM Inco
+10(continued):          rporated
+
+century found at line 402:
+400:
+401:     Rens Troost
+402:     New Century Systems
+403:     324 East 41st Street #804
+404:     New York, NY, 10017 USA
+
+century found at line 408:
+406:     Phone: +1 (212) 557-2050
+407:     Fax: +1 (212) 557-2049
+408:     EMail: rens@century.com
+409:
+410:
+
++=+=+=+=+= File rfc1807.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 318:
+316:          mandatory field.   The ID field identifies the bibliogra
+316(continued):         phic
+317:          record and is used in management of these records.
+
+
+
+
+
+Nesser                       Informational                    [Page 175]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+318:          Its format is "ID:: XXX//YYY", where XXX is the
+319:          publisher-ID (the controlled symbol of the publisher)
+320:          and YYY is the ID (e.g., report number) of the
+
+'yy' on a line without 'yyyy' found at line 320:
+318:          Its format is "ID:: XXX//YYY", where XXX is the
+319:          publisher-ID (the controlled symbol of the publisher)
+320:          and YYY is the ID (e.g., report number) of the
+321:          publication as assigned by the publisher.  This ID is
+322:          typically printed on the cover, and may contain slashes.
+322(continued):
+
+'yy' on a line without 'yyyy' found at line 767:
+765:          in its "ID::".
+766:
+767:          Format:   END:: XXX//YYY
+768:
+769:          Example:  END:: OUKS//CS-TR-91-123
+
+'yy' on a line without 'yyyy' found at line 778:
+776:
+777:     In order to avoid conflicts among the symbols of the publishi
+777(continued):         ng
+778:     organizations (the XXX part of the "ID:: XXX//YYY") it is sug
+778(continued):         gested
+779:     that the various organizations that publish reports (such as
+780:     universities, departments, and laboratories) register their
+
+2-digit found at line 348:
+346:          The format for ENTRY date is "Month Day, Year".  The
+347:          month must be alphabetic (spelled out).  The "Day" is a
+348:          1- or 2-digit number.  The "Year" is a 4-digit number.
+349:
+350:          Format:   ENTRY:: <date>
+
+2-digit found at line 513:
+511:  DATE (O) -- The publication date.  The formats are "Month Year"
+512:          and "Month Day, Year".  The month must be alphabetic
+513:          (spelled out).  The "Day" is a 1- or 2-digit number.  Th
+513(continued):         e
+514:          "Year" is a 4- digit number.
+515:
+
+1900 found at line 406:
+404:          omitted, the record is assumed to be a new record and no
+404(continued):         t
+405:          a revision.  If the revision date is specified as 0, thi
+405(continued):         s
+
+
+
+Nesser                       Informational                    [Page 176]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+406:          is assumed to be January 1, 1900 (the previous RFC, used
+406(continued):
+407:          revision data of 0, 1, 2, 3, etc. this specification is
+407(continued):         for
+408:          programs that might process records from RFC1357).
+
++=+=+=+=+= File rfc1815.txt +=+=+=+=+=
+2000 found at line 187:
+185:        8 BASIC GREEK                      0370-03CF
+186:        10 CYRILLIC                        0400-04FF
+187:        32 GENERAL PUNCTUATION             2000-206F  See note 1,
+187(continued):         below.
+188:        39 MATHEMATICAL OPERATORS          2200-22FF  See note 1,
+188(continued):         below.
+189:        44 BOX DRAWING                     2500-257F
+
++=+=+=+=+= File rfc1819.txt +=+=+=+=+=
+2000 found at line 5855:
+5853:      5   HelloLossFactor         Number of consecutively missed H
+5853(continued):                ELLO
+5854:                                  messages before declaring link f
+5854(continued):                ailure
+5855:   2000   DefaultRecoveryTimeout  Interval between successive HELL
+5855(continued):                Os
+5856:                                  to/from active neighbors
+5857:
+
++=+=+=+=+= File rfc1831.txt +=+=+=+=+=
+2000 found at line 401:
+399:  7.3 Program Number Assignment
+400:
+401:     Program numbers are given out in groups of hexadecimal 200000
+401(continued):         00
+402:     (decimal 536870912) according to the following chart:
+403:
+
+2000 found at line 405:
+403:
+404:                0 - 1fffffff   defined by rpc@sun.com
+405:         20000000 - 3fffffff   defined by user
+406:         40000000 - 5fffffff   transient
+407:         60000000 - 7fffffff   reserved
+
++=+=+=+=+= File rfc1848.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 1881:
+1879:          Content-Transfer-Encoding: base64
+1880:
+1881:          AfR1WSeyLhy5AtcX0ktUVlbFC1vvcoCjYWy/yYjVj48eqzUVvGTGMsV6
+
+
+
+Nesser                       Informational                    [Page 177]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1881(continued):                MdlynU
+1882:          d4jcJgRnQIQvIxm2VRgH8W8MkAlul+RWGu7jnxjp0sNsU562+RZr0f4F
+1882(continued):                3K3n4w
+1883:          onUUP265UvvMj23RSTguZ/nl/OxnFM6SzDgV39V/i/RofqI=
+
+'yy' on a line without 'yyyy' found at line 1994:
+1992:        U6B13vzpE8wMSVefzaCTSpXRSCh08ceVEZrIYS53/CKZV2/Sga71pGNlux
+1992(continued):                8MsJpY
+1993:        Lwdj5Q3NKocg1LMngMo8yrMAe+avMjfOnhui49Xon1Gft+N5XDH/+wI9qx
+1993(continued):                I9fkQv
+1994:        NZVDlWIhCYEkxd5ke549tLkJjEqHQbgJW5C+K/uxdiD2dBt+nRCXcuO0Px
+1994(continued):                3yKRyY
+1995:        g/9BgTf36padSHuv48xBg5YaqaEWpEzLI0Qd31vAyP23rqiPhfBn6sjhQ2
+1995(continued):                KrWhiF
+1996:        2l3TV8kQsIGHHZUkaUbqkXJe6PEdWWhwsqCFPDdkpjzQRrTuJH6xleNUFg
+1996(continued):                +CG1V+
+
++=+=+=+=+= File rfc1861.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 766:
+764:      554 Error, failed (technical reason)
+765:
+766:  4.5.6 HOLDuntil <YYMMDDHHMMSS> [+/-GMTdifference]
+767:
+768:     The HOLDuntil command allows for the delayed delivery of a me
+768(continued):         ssage,
+
+'yy' on a line without 'yyyy' found at line 1061:
+1059:     the current transaction should be kept in the following forma
+1059(continued):                t:
+1060:
+1061:      YYMMDDHHMMSS+GMT   (example: 950925143501+7)
+1062:
+1063:
+
++=+=+=+=+= File rfc1865.txt +=+=+=+=+=
+1900 found at line 1564:
+1562:
+1563:     START
+1564:     GET ITU-1900
+1565:     END
+1566:
+
+2000 found at line 1745:
+1743:                     Logistics Management Institute
+1744:                     Attn. Library
+1745:                     2000 Corporate Ridge
+1746:                     McLean, Virginia, 22102-7805
+1747:
+
+
+
+Nesser                       Informational                    [Page 178]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc1866.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 1078:
+1076:      <div class=chapter><h1>foo</h1><p>...</div>
+1077:        => <H1>,"foo",</H1>,<P>,"..."
+1078:      xxx <P ID=z23> yyy
+1079:        => "xxx ",<P>," yyy
+1080:      Let &alpha; &amp; &beta; be finite sets.
+
+'yy' on a line without 'yyyy' found at line 1079:
+1077:        => <H1>,"foo",</H1>,<P>,"..."
+1078:      xxx <P ID=z23> yyy
+1079:        => "xxx ",<P>," yyy
+1080:      Let &alpha; &amp; &beta; be finite sets.
+1081:        => "Let &alpha; & &beta; be finite sets."
+
++=+=+=+=+= File rfc1876.txt +=+=+=+=+=
+2000 found at line 103:
+101:               exponent.
+102:
+103:               Since 20000000m (represented by the value 0x29) is
+103(continued):         greater
+104:               than the equatorial diameter of the WGS 84 ellipsoi
+104(continued):         d
+105:               (12756274m), it is therefore suitable for use as a
+
+2000 found at line 219:
+217:
+218:  rwy04L.logan-airport.boston.  LOC   42 21 28.764 N 71 00 51.617
+218(continued):         W
+219:                                      -44m 2000m
+220:
+221:
+
++=+=+=+=+= File rfc1880.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 2062:
+2060:                                         The text version is sent.
+2060(continued):
+2061:
+2062:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+2062(continued):                umber.
+2063:                                         and 'yyy' is 'txt' or 'ps
+2063(continued):                '.
+2064:
+
+'yy' on a line without 'yyyy' found at line 2063:
+2061:
+2062:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+2062(continued):                umber.
+
+
+
+Nesser                       Informational                    [Page 179]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2063:                                         and 'yyy' is 'txt' or 'ps
+2063(continued):                '.
+2064:
+2065:           help                          to get information on how
+2065(continued):                 to use
+
++=+=+=+=+= File rfc1888.txt +=+=+=+=+=
+1900 found at line 859:
+857:     Group Leader, Communications Systems      Phone:  +41 22 767-
+857(continued):         4967
+858:     Computing and Networks Division           Fax:    +41 22 767-
+858(continued):         7155
+859:     CERN                                      Telex:  419000 cer
+859(continued):         ch
+860:     European Laboratory for Particle Physics  Email: brian@dxcoms
+860(continued):         .cern.ch
+861:     1211 Geneva 23, Switzerland
+
++=+=+=+=+= File rfc1889.txt +=+=+=+=+=
+1900 found at line 518:
+516:     Wallclock time (absolute time) is represented using the times
+516(continued):         tamp
+517:     format of the Network Time Protocol (NTP), which is in second
+517(continued):         s
+518:     relative to 0h UTC on 1 January 1900 [5]. The full resolution
+518(continued):          NTP
+519:     timestamp is a 64-bit unsigned fixed-point number with the in
+519(continued):         teger
+520:     part in the first 32 bits and the fractional part in the last
+520(continued):          32
+
+2000 found at line 1526:
+1524:                        v                 ^
+1525:     ntp_sec =0xb44db705 v               ^ dlsr=0x0005.4000 (    5
+1525(continued):                .250s)
+1526:     ntp_frac=0x20000000  v             ^  lsr =0xb705:2000 (46853
+1526(continued):                .125s)
+1527:       (3024992016.125 s)  v           ^
+1528:     r                      v         ^ RR(n)
+
+2000 found at line 1535:
+1533:     A     0xb710:8000 (46864.500 s)
+1534:     DLSR -0x0005:4000 (    5.250 s)
+1535:     LSR  -0xb705:2000 (46853.125 s)
+1536:     -------------------------------
+1537:     delay 0x   6:2000 (    6.125 s)
+
+
+
+
+
+Nesser                       Informational                    [Page 180]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2000 found at line 1537:
+1535:     LSR  -0xb705:2000 (46853.125 s)
+1536:     -------------------------------
+1537:     delay 0x   6:2000 (    6.125 s)
+1538:
+1539:             Figure 2: Example for round-trip time computation
+
+2000 found at line 3182:
+3180:      * Big-endian mask for version, padding bit and packet type p
+3180(continued):                air
+3181:      */
+3182:     #define RTCP_VALID_MASK (0xc000 | 0x2000 | 0xfe)
+3183:     #define RTCP_VALID_VALUE ((RTP_VERSION << 14) | RTCP_SR)
+3184:
+
++=+=+=+=+= File rfc1890.txt +=+=+=+=+=
+2000 found at line 293:
+291:
+292:     The sampling frequency should be drawn from the set: 8000, 11
+292(continued):         025,
+293:     16000, 22050, 24000, 32000, 44100 and 48000 Hz. (The Apple Ma
+293(continued):         cintosh
+294:     computers have native sample rates of 22254.54 and 11127.27,
+294(continued):         which
+295:     can be converted to 22050 and 11025 with acceptable quality b
+295(continued):         y
+
+2000 found at line 568:
+566:
+567:     Sampling rate and channel count are contained in the payload.
+567(continued):          MPEG-I
+568:     audio supports sampling rates of 32000, 44100, and 48000 Hz (
+568(continued):         ISO/IEC
+569:     11172-3, section 1.1; "Scope"). MPEG-II additionally supports
+569(continued):          ISO/IEC
+570:     11172-3 Audio...").
+
++=+=+=+=+= File rfc1898.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 1271:
+1269:      3rWM5Ir3ier3/7WM5Ir36+v35v73ife1jOWK94n3/7T3/ffm5uD+7N339/f3
+1269(continued):                9/eq3ff3
+1270:      9/eFiJK5tLizsoeSmpW7uLS8/7iio7Wisfv38biio7uyufv3tfv35uH+7N3d
+1270(continued):                9/exuKX3
+1271:      5+z3vuu4oqO7srnsvvz8/venoqO0v7al/7iio7WisYy+iv7s3ff3p6KjtL+2
+1271(continued):                pf/wi7nw
+1272:      3ard3Q==
+1273:     $$-CyberCash-End-7Tm/djB05pLIw3JAyy5E7A==-$$
+
+
+
+
+Nesser                       Informational                    [Page 181]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+'yy' on a line without 'yyyy' found at line 1273:
+1271:      5+z3vuu4oqO7srnsvvz8/venoqO0v7al/7iio7WisYy+iv7s3ff3p6KjtL+2
+1271(continued):                pf/wi7nw
+1272:      3ard3Q==
+1273:     $$-CyberCash-End-7Tm/djB05pLIw3JAyy5E7A==-$$
+1274:
+1275:     #############################################################
+1275(continued):                ########
+
+'yy' on a line without 'yyyy' found at line 1328:
+1326:     merchant-date: 19950121100505.nnn
+1327:     merchant-response-code: failure/success/etc.
+1328:     pr-hash: 7Tm/djB05pLIw3JAyy5E7A==
+1329:     pr-signed-hash:
+1330:      a/0meaMHRinNVd8nq/fKsYg5AfTZZUCX0S3gkjAhZTmcrkp6RZvppmDd/P7l
+1330(continued):                boFLFDBh
+
+'yy' on a line without 'yyyy' found at line 1340:
+1338:      rHzP5YqaMnk5iRBHvwKb5MaxKXGOOef5ms8M5W8lI2d0XPecH4xNBn8BMAJ6
+1338(continued):                iSkZmszo
+1339:      QfDeWgga48g2tqlA6ifZGp7daDR81lumtGMCvg==
+1340:     $$-CyberCash-End-7Tm/djB05pLIw3JAyy5E7A==-$$
+1341:
+1342:     #############################################################
+1342(continued):                ########
+
+'yy' on a line without 'yyyy' found at line 1474:
+1472:      mjD6ickhd+SQZhbRCNerlTiQGhuL4wUAxzGh8aHk2oXjoMpVzWw2EImPu5Qa
+1472(continued):                PEc36xgr
+1473:      mNz8vCovDiuy3tZ42IGArxBweasLPLCbm0Y=
+1474:     $$-CyberCash-End-7Tm/djB05pLIw3JAyy5E7A==-$$
+1475:
+1476:     #############################################################
+1476(continued):                ########
+
+'yy' on a line without 'yyyy' found at line 1482:
+1480:     order-id: 12313424234242
+1481:     merchant-amount: usd 10.00
+1482:     pr-hash: 7Tm/djB05pLIw3JAyy5E7A==
+1483:     pr-signed-hash:
+1484:      a/0meaMHRinNVd8nq/fKsYg5AfTZZUCX0S3gkjAhZTmcrkp6RZvppmDd/P7l
+1484(continued):                boFLFDBh
+
+'yy' on a line without 'yyyy' found at line 1490:
+1488:     date: 19950121100505.nnn
+1489:     merchant-signature:
+1490:      v4qZMe2d7mUXztVdC3ZPMmMgYHlBA7bhR96LSehKP15ylqR/1KwwbBAX8CEq
+1490(continued):                ns55UIYY
+
+
+
+Nesser                       Informational                    [Page 182]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1491:      GGMwPMGoF+GDPM7GlC6fReQ5wyvV1PnETSVO9/LAyRz0zzRYuyVueOjWDlr5
+1491(continued):
+1492:
+
+'yy' on a line without 'yyyy' found at line 1593:
+1591:      mjD6ickhd+SQZhbRCNerlTiQGhuL4wUAxzGh8aHk2oXjoMpVzWw2EImPu5Qa
+1591(continued):                PEc36xgr
+1592:      mNz8vCovDiuy3tZ42IGArxBweasLPLCbm0Y=
+1593:     $$-CyberCash-End-7Tm/djB05pLIw3JAyy5E7A==-$$
+1594:
+1595:     #############################################################
+1595(continued):                ########
+
+'yy' on a line without 'yyyy' found at line 1602:
+1600:     order-id: 1231-3424-234242
+1601:     merchant-amount: usd 10.00
+1602:     pr-hash: 7Tm/djB05pLIw3JAyy5E7A==
+1603:     pr-signed-hash:
+1604:      a/0meaMHRinNVd8nq/fKsYg5AfTZZUCX0S3gkjAhZTmcrkp6RZvppmDd/P7l
+1604(continued):                boFLFDBh
+
+'yy' on a line without 'yyyy' found at line 1692:
+1690:      mjD6ickhd+SQZhbRCNerlTiQGhuL4wUAxzGh8aHk2oXjoMpVzWw2EImPu5Qa
+1690(continued):                PEc36xgr
+1691:      mNz8vCovDiuy3tZ42IGArxBweasLPLCbm0Y=
+1692:     $$-CyberCash-End-7Tm/djB05pLIw3JAyy5E7A==-$$
+1693:
+1694:     #############################################################
+1694(continued):                ########
+
+'yy' on a line without 'yyyy' found at line 1804:
+1802:      mjD6ickhd+SQZhbRCNerlTiQGhuL4wUAxzGh8aHk2oXjoMpVzWw2EImPu5Qa
+1802(continued):                PEc36xgr
+1803:      mNz8vCovDiuy3tZ42IGArxBweasLPLCbm0Y=
+1804:     $$-CyberCash-End-7Tm/djB05pLIw3JAyy5E7A==-$$
+1805:
+1806:     #############################################################
+1806(continued):                ########
+
+'yy' on a line without 'yyyy' found at line 1821:
+1819:     response-code: failure/success/etc.
+1820:     order-id: 1231-3424-234242
+1821:     pr-hash: 7Tm/djB05pLIw3JAyy5E7A==
+1822:     pr-signed-hash:
+1823:      8zqw0ipqtLtte0tBz5/5VPNJPPonfTwkfZPbtuk5lqMykKDvThhO0ycrfT7e
+1823(continued):                Xrn/hLUC
+
+'yy' on a line without 'yyyy' found at line 1827:
+
+
+
+Nesser                       Informational                    [Page 183]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1825:     retrieval-reference-number: 432112344321
+1826:     authorization-code: a12323
+1827:     card-hash: 7Tm/djB05pLIw3JAyy5E7A==
+1828:     {
+1829:     card-prefix: nnxxxx  [Returned if merchant is not full-PAN]
+
+'yy' on a line without 'yyyy' found at line 1948:
+1946:      mjD6ickhd+SQZhbRCNerlTiQGhuL4wUAxzGh8aHk2oXjoMpVzWw2EImPu5Qa
+1946(continued):                PEc36xgr
+1947:      mNz8vCovDiuy3tZ42IGArxBweasLPLCbm0Y=
+1948:     $$-CyberCash-End-7Tm/djB05pLIw3JAyy5E7A==-$$
+1949:
+1950:     #############################################################
+1950(continued):                ########
+
+'yy' on a line without 'yyyy' found at line 1958:
+1956:     order-id: 12313424234242
+1957:     merchant-amount: usd 10.00
+1958:     pr-hash: 7Tm/djB05pLIw3JAyy5E7A==
+1959:
+1960:
+
+'yy' on a line without 'yyyy' found at line 2050:
+2048:      CEUEvQhcmruopwEeehv+bejc3fDDZ23JKrbhlZ17lSvFR14PKFsi32pXFqTO
+2048(continued):                0ej9GTc5
+2049:      L6c8nM3tI1qdHNCe0N5f7ASdKS0tYSxAYJLIR6MqPrXjNJEaRx7Vu1odMlkg
+2049(continued):                rzGOV1fo
+2050:      5w33BQHK3U2h+1e5zYBeHY3ZYG4nmylYYXIye4xpuPN4QU0dGrWZoImYE44Q
+2050(continued):                Owjd5ozl
+2051:      xulPBjj6cpEI/9wTwR3tpkBb4ZfYirxxnoj9JUkPK9Srv9iJ
+2052:     $$-CyberCash-End-7Tm/djB05pLIw3JAyy5E7A==-$$
+
+'yy' on a line without 'yyyy' found at line 2052:
+2050:      5w33BQHK3U2h+1e5zYBeHY3ZYG4nmylYYXIye4xpuPN4QU0dGrWZoImYE44Q
+2050(continued):                Owjd5ozl
+2051:      xulPBjj6cpEI/9wTwR3tpkBb4ZfYirxxnoj9JUkPK9Srv9iJ
+2052:     $$-CyberCash-End-7Tm/djB05pLIw3JAyy5E7A==-$$
+2053:
+2054:     #############################################################
+2054(continued):                ########
+
+'yy' on a line without 'yyyy' found at line 2064:
+2062:     response-code: failure/success/etc.
+2063:     order-id: 1231-3424-234242
+2064:     pr-hash: 7Tm/djB05pLIw3JAyy5E7A==
+2065:     pr-signed-hash:
+2066:      IV8gWHx1f8eCkWsCsMOE3M8mnTbQ7IBBcEmyGDAwjdbaLu5Qm/bh06OX1npe
+2066(continued):                2d3Hijxy
+
+
+
+Nesser                       Informational                    [Page 184]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+'yy' on a line without 'yyyy' found at line 2068:
+2066:      IV8gWHx1f8eCkWsCsMOE3M8mnTbQ7IBBcEmyGDAwjdbaLu5Qm/bh06OX1npe
+2066(continued):                2d3Hijxy
+2067:      +X8vKcVE6l6To27u7A7UmGm+po9lCUSLxgtyqyn3jWhHZpc5NZpwoTCf2pAK
+2067(continued):
+2068:     card-hash: 7Tm/djB05pLIw3JAyy5E7A==
+2069:     card-number: 4811123456781234
+2070:     card-type: visa
+
+'yy' on a line without 'yyyy' found at line 2151:
+2149:     transaction: 123123213
+2150:     date: 19950121100505.nnn
+2151:     $$-CyberCash-End-7Tm/djB05pLIw3JAyy5E7A==-$$
+2152:
+2153:     #############################################################
+2153(continued):                ########
+
+'yy' on a line without 'yyyy' found at line 2193:
+2191:            by their CyberCash application...
+2192:     supported-versions: 08.win, 0.81win, 0.8mac
+2193:     $$-CyberCash-End-7Tm/djB05pLIw3JAyy5E7A==-$$
+2194:
+2195:     #############################################################
+2195(continued):                ########
+
+'yy' on a line without 'yyyy' found at line 2359:
+2357:
+2358:
+2359:      35XiC9Yn8flE4Va14UxMf2RCR1B/XoV6AEd64KwPeCYyOYvwbRcYpRMBXFLy
+2359(continued):                YgWM+ME1
+2360:      +yp7c66SrCBhW4Q8AJYQ+5j5uyO7uKyyq7OhrV0IMpRDPjiQXZMooLZOifJP
+2360(continued):                mpvJ66hC
+2361:      VZuWMuA6LR+TJzWUm4sUP9Zb6zMQShedUyOPrtw1vkJXU1vZ5aI8OJAgUcLE
+2361(continued):                itcD+dsY
+
+'yy' on a line without 'yyyy' found at line 2360:
+2358:
+2359:      35XiC9Yn8flE4Va14UxMf2RCR1B/XoV6AEd64KwPeCYyOYvwbRcYpRMBXFLy
+2359(continued):                YgWM+ME1
+2360:      +yp7c66SrCBhW4Q8AJYQ+5j5uyO7uKyyq7OhrV0IMpRDPjiQXZMooLZOifJP
+2360(continued):                mpvJ66hC
+2361:      VZuWMuA6LR+TJzWUm4sUP9Zb6zMQShedUyOPrtw1vkJXU1vZ5aI8OJAgUcLE
+2361(continued):                itcD+dsY
+2362:      Df4CzA00fC10POkJ58HZB/pSBfUrHAa+IqMHyZkV/HBi9TjTwmktJi+8T9or
+2362(continued):                XS0jSvor
+
+'yy' on a line without 'yyyy' found at line 2502:
+2500:      lw51IHbmo1Jj7H6wyNnRpEjy4tM73jcosBfGeQDHxgyH1uaiFNr2D+WvmuYo
+
+
+
+Nesser                       Informational                    [Page 185]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2500(continued):                7eun2dsy
+2501:      Wve2O/FwicWHvkg5aDPsgOjzetsn1JCNZzbW
+2502:     $$-CyberCash-End-7Tm/djB05pLIw3JAyy5E7A==-$$
+2503:
+2504:     #############################################################
+2504(continued):                ########
+
+'yy' on a line without 'yyyy' found at line 2591:
+2589:     x-opaque: [if can't decrypt]
+2590:      9/eFiJK5tLizsoeSmpW7uLS8/7iio7Wisfv38biio7uyufv3tfv35uH+7N3d
+2590(continued):                9/exuKX3
+2591:      5+z3vuu4oqO7srnsvvz8/venoqO0v7al/7iio7WisYy+iv7s3ff3p6KjtL+2
+2591(continued):                pf/wi7nw
+2592:
+2593:     #############################################################
+2593(continued):                ########
+
+'yy' on a line without 'yyyy' found at line 2653:
+2651:     x-opaque: [if can't decrypt]
+2652:      9/eFiJK5tLizsoeSmpW7uLS8/7iio7Wisfv38biio7uyufv3tfv35uH+7N3d
+2652(continued):                9/exuKX3
+2653:      5+z3vuu4oqO7srnsvvz8/venoqO0v7al/7iio7WisYy+iv7s3ff3p6KjtL+2
+2653(continued):                pf/wi7nw
+2654:
+2655:     #############################################################
+2655(continued):                ########
+
++=+=+=+=+= File rfc1900.txt +=+=+=+=+=
+1900 found at line 8:
+6:
+7:  Network Working Group                                       B. C
+7(continued):           arpenter
+8:  Request for Comments: 1900                                    Y.
+8(continued):            Rekhter
+9:  Category: Informational
+9(continued):                IAB
+10:                                                             Febru
+10(continued):          ary 1996
+
+1900 found at line 60:
+58:  Carpenter & Rekhter          Informational
+58(continued):          [Page 1]
+59:
+60:  RFC 1900                 Renumbering Needs Work            Febru
+60(continued):          ary 1996
+61:
+62:
+
+
+
+
+Nesser                       Informational                    [Page 186]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1900 found at line 116:
+114:  Carpenter & Rekhter          Informational
+114(continued):         [Page 2]
+115:
+116:  RFC 1900                 Renumbering Needs Work            Febru
+116(continued):         ary 1996
+117:
+118:
+
+1900 found at line 172:
+170:  Carpenter & Rekhter          Informational
+170(continued):         [Page 3]
+171:
+172:  RFC 1900                 Renumbering Needs Work            Febru
+172(continued):         ary 1996
+173:
+174:
+
+1900 found at line 207:
+205:     Phone:  +41 22 767-4967
+206:     Fax:    +41 22 767-7155
+207:     Telex:  419000 cer ch
+208:     EMail: brian@dxcoms.cern.ch
+209:
+
++=+=+=+=+= File rfc1902.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 2027:
+2025:     Several clauses defined in this document use the UTC Time for
+2025(continued):                mat:
+2026:
+2027:       YYMMDDHHMMZ
+2028:
+2029:       where: YY - last two digits of year
+
+'yy' on a line without 'yyyy' found at line 2029:
+2027:       YYMMDDHHMMZ
+2028:
+2029:       where: YY - last two digits of year
+2030:              MM - month (01 through 12)
+2031:              DD - day of month (01 through 31)
+
+UTCTime found at line 136:
+134:  BEGIN
+135:      TYPE NOTATION ::=
+136:                    "LAST-UPDATED" value(Update UTCTime)
+137:                    "ORGANIZATION" Text
+138:                    "CONTACT-INFO" Text
+
+
+
+
+Nesser                       Informational                    [Page 187]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+UTCTime found at line 152:
+150:                  | Revisions Revision
+151:      Revision ::=
+152:                    "REVISION" value(Update UTCTime)
+153:                    "DESCRIPTION" Text
+154:
+
++=+=+=+=+= File rfc1910.txt +=+=+=+=+=
+2000 found at line 1702:
+1700:
+1701:  usecMIB MODULE-IDENTITY
+1702:      LAST-UPDATED "9601120000Z"
+1703:      ORGANIZATION "IETF SNMPv2 Working Group"
+1704:      CONTACT-INFO
+
++=+=+=+=+= File rfc1917.txt +=+=+=+=+=
+century found at line 259:
+257:     should be noted that careful extrapolations of the current tr
+257(continued):         ends
+258:     suggest that the address space will be exhausted early in the
+258(continued):          next
+259:     century.
+260:
+261:  3. Problem
+
++=+=+=+=+= File rfc1920.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 2174:
+2172:                                         The text version is sent.
+2172(continued):
+2173:
+2174:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+2174(continued):                umber.
+2175:                                         and 'yyy' is 'txt' or 'ps
+2175(continued):                '.
+2176:
+
+'yy' on a line without 'yyyy' found at line 2175:
+2173:
+2174:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+2174(continued):                umber.
+2175:                                         and 'yyy' is 'txt' or 'ps
+2175(continued):                '.
+2176:
+2177:           help                          to get information on how
+2177(continued):                 to use
+
+
+
+
+
+
+Nesser                       Informational                    [Page 188]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1900 found at line 851:
+849:               An Experimental protocol.
+850:
+851:        1900 - Renumbering Needs Work
+852:
+853:               This is an information document and does not specif
+853(continued):         y any
+
++=+=+=+=+= File rfc1941.txt +=+=+=+=+=
+2000 found at line 2826:
+2824:     700 13th Street, NW
+2825:     Suite 950
+2826:     Washington, DC  20005
+2827:     Phone:  202-434-8954
+2828:     EMail:  sellers@quest.arc.nasa.gov
+
++=+=+=+=+= File rfc1945.txt +=+=+=+=+=
+2-digit found at line 500:
+498:         Specific repetition: "<n>(element)" is equivalent to
+499:         "<n>*<n>(element)"; that is, exactly <n> occurrences of
+500:         (element). Thus 2DIGIT is a 2-digit number, and 3ALPHA is
+500(continued):          a
+501:         string of three alphabetic characters.
+502:
+
+2digit found at line 500:
+498:         Specific repetition: "<n>(element)" is equivalent to
+499:         "<n>*<n>(element)"; that is, exactly <n> occurrences of
+500:         (element). Thus 2DIGIT is a 2-digit number, and 3ALPHA is
+500(continued):          a
+501:         string of three alphabetic characters.
+502:
+
+2digit found at line 872:
+870:         asctime-date   = wkday SP date3 SP time SP 4DIGIT
+871:
+872:         date1          = 2DIGIT SP month SP 4DIGIT
+873:                          ; day month year (e.g., 02 Jun 1982)
+874:         date2          = 2DIGIT "-" month "-" 2DIGIT
+
+2digit found at line 874:
+872:         date1          = 2DIGIT SP month SP 4DIGIT
+873:                          ; day month year (e.g., 02 Jun 1982)
+874:         date2          = 2DIGIT "-" month "-" 2DIGIT
+875:                          ; day-month-year (e.g., 02-Jun-82)
+876:         date3          = month SP ( 2DIGIT | ( SP 1DIGIT ))
+
+
+
+
+
+Nesser                       Informational                    [Page 189]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2digit found at line 876:
+874:         date2          = 2DIGIT "-" month "-" 2DIGIT
+875:                          ; day-month-year (e.g., 02-Jun-82)
+876:         date3          = month SP ( 2DIGIT | ( SP 1DIGIT ))
+877:                          ; month day (e.g., Jun  2)
+878:
+
+2digit found at line 879:
+877:                          ; month day (e.g., Jun  2)
+878:
+879:         time           = 2DIGIT ":" 2DIGIT ":" 2DIGIT
+880:                          ; 00:00:00 - 23:59:59
+881:
+
++=+=+=+=+= File rfc1967.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 276:
+274:                    +-----+----....................----+
+275:
+276:        where:  C0 and 80 are representative LZS-DCP headers; nn,
+276(continued):         xx, yy,
+277:                and zz are values determined by the packet's conte
+277(continued):         xt.
+278:
+
++=+=+=+=+= File rfc1980.txt +=+=+=+=+=
+century found at line 301:
+299:              ALT="Our products">
+300:        <AREA SHAPE=RECT COORDS="0,51,100,100 HREF="technology.htm
+300(continued):         l"
+301:              ALT="Technology for the next century">
+302:        </MAP>
+303:
+
++=+=+=+=+= File rfc1997.txt +=+=+=+=+=
+2000 found at line 130:
+128:     690 may define research, educational and commercial community
+128(continued):          values
+129:     that may be used for policy routing as defined by the operato
+129(continued):         rs of
+130:     that AS using community attribute values 0x02B20000 through
+131:     0x02B2FFFF).
+132:
+
+
+
+
+
+
+
+
+
+Nesser                       Informational                    [Page 190]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc1999.txt +=+=+=+=+=
+1900 found at line 14:
+12:                        Request for Comments Summary
+13:
+14:                           RFC Numbers 1900-1999
+15:
+16:  Status of This Memo
+
+1900 found at line 18:
+16:  Status of This Memo
+17:
+18:     This RFC is a slightly annotated list of the 100 RFCs from RF
+18(continued):          C 1900
+19:     through RFCs 1999.  This is a status report on these RFCs.  T
+19(continued):          his memo
+20:     provides information for the Internet community.  It does not
+20(continued):           specify
+
+1900 found at line 60:
+58:  Elliott                      Informational
+58(continued):          [Page 1]
+59:
+60:  RFC 1999                  Summary of 1900-1999              Janu
+60(continued):          ary 1997
+61:
+62:
+
+1900 found at line 116:
+114:  Elliott                      Informational
+114(continued):         [Page 2]
+115:
+116:  RFC 1999                  Summary of 1900-1999              Janu
+116(continued):         ary 1997
+117:
+118:
+
+1900 found at line 172:
+170:  Elliott                      Informational
+170(continued):         [Page 3]
+171:
+172:  RFC 1999                  Summary of 1900-1999              Janu
+172(continued):         ary 1997
+173:
+174:
+
+1900 found at line 228:
+226:  Elliott                      Informational
+226(continued):         [Page 4]
+
+
+
+Nesser                       Informational                    [Page 191]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+227:
+228:  RFC 1999                  Summary of 1900-1999              Janu
+228(continued):         ary 1997
+229:
+230:
+
+1900 found at line 284:
+282:  Elliott                      Informational
+282(continued):         [Page 5]
+283:
+284:  RFC 1999                  Summary of 1900-1999              Janu
+284(continued):         ary 1997
+285:
+286:
+
+1900 found at line 340:
+338:  Elliott                      Informational
+338(continued):         [Page 6]
+339:
+340:  RFC 1999                  Summary of 1900-1999              Janu
+340(continued):         ary 1997
+341:
+342:
+
+1900 found at line 396:
+394:  Elliott                      Informational
+394(continued):         [Page 7]
+395:
+396:  RFC 1999                  Summary of 1900-1999              Janu
+396(continued):         ary 1997
+397:
+398:
+
+1900 found at line 452:
+450:  Elliott                      Informational
+450(continued):         [Page 8]
+451:
+452:  RFC 1999                  Summary of 1900-1999              Janu
+452(continued):         ary 1997
+453:
+454:
+
+1900 found at line 508:
+506:  Elliott                      Informational
+506(continued):         [Page 9]
+507:
+
+
+
+
+
+Nesser                       Informational                    [Page 192]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+508:  RFC 1999                  Summary of 1900-1999              Janu
+508(continued):         ary 1997
+509:
+510:
+
+1900 found at line 564:
+562:  Elliott                      Informational                     [
+562(continued):         Page 10]
+563:
+564:  RFC 1999                  Summary of 1900-1999              Janu
+564(continued):         ary 1997
+565:
+566:
+
+1900 found at line 620:
+618:  Elliott                      Informational                     [
+618(continued):         Page 11]
+619:
+620:  RFC 1999                  Summary of 1900-1999              Janu
+620(continued):         ary 1997
+621:
+622:
+
+1900 found at line 676:
+674:  Elliott                      Informational                     [
+674(continued):         Page 12]
+675:
+676:  RFC 1999                  Summary of 1900-1999              Janu
+676(continued):         ary 1997
+677:
+678:
+
+1900 found at line 732:
+730:  Elliott                      Informational                     [
+730(continued):         Page 13]
+731:
+732:  RFC 1999                  Summary of 1900-1999              Janu
+732(continued):         ary 1997
+733:
+734:
+
+1900 found at line 788:
+786:  Elliott                      Informational                     [
+786(continued):         Page 14]
+787:
+
+
+
+
+
+
+Nesser                       Informational                    [Page 193]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+788:  RFC 1999                  Summary of 1900-1999              Janu
+788(continued):         ary 1997
+789:
+790:
+
+1900 found at line 844:
+842:  Elliott                      Informational                     [
+842(continued):         Page 15]
+843:
+844:  RFC 1999                  Summary of 1900-1999              Janu
+844(continued):         ary 1997
+845:
+846:
+
+1900 found at line 900:
+898:  Elliott                      Informational                     [
+898(continued):         Page 16]
+899:
+900:  RFC 1999                  Summary of 1900-1999              Janu
+900(continued):         ary 1997
+901:
+902:
+
+1900 found at line 956:
+954:  Elliott                      Informational                     [
+954(continued):         Page 17]
+955:
+956:  RFC 1999                  Summary of 1900-1999              Janu
+956(continued):         ary 1997
+957:
+958:
+
+1900 found at line 1012:
+1010:  Elliott                      Informational                     [
+1010(continued):                Page 18]
+1011:
+1012:  RFC 1999                  Summary of 1900-1999              Janu
+1012(continued):                ary 1997
+1013:
+1014:
+
+1900 found at line 1068:
+1066:  Elliott                      Informational                     [
+1066(continued):                Page 19]
+1067:
+
+
+
+
+
+
+Nesser                       Informational                    [Page 194]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1068:  RFC 1999                  Summary of 1900-1999              Janu
+1068(continued):                ary 1997
+1069:
+1070:
+
+1900 found at line 1095:
+1093:
+1094:
+1095:  1900    Carpenter    Feb 96   Renumbering Needs Work
+1096:
+1097:  Hosts in an IP network are identified by IP addresses, and the I
+1097(continued):                P
+
++=+=+=+=+= File rfc2000.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 3070:
+3068:                                         The text version is sent.
+3068(continued):
+3069:
+3070:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+3070(continued):                umber.
+3071:                                         and 'yyy' is 'txt' or 'ps
+3071(continued):                '.
+3072:
+
+'yy' on a line without 'yyyy' found at line 3071:
+3069:
+3070:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+3070(continued):                umber.
+3071:                                         and 'yyy' is 'txt' or 'ps
+3071(continued):                '.
+3072:
+3073:           help                          to get information on how
+3073(continued):                 to use
+
+1900 found at line 1264:
+1262:               This memo.
+1263:
+1264:        1999 - Request for Comments Summary RFC Numbers 1900-1999
+1265:
+1266:               This is an information document and does not specif
+1266(continued):                y any
+
+2000 found at line 8:
+6:
+7:  Network Working Group                        Internet Architectu
+7(continued):           re Board
+8:  Request for Comments: 2000                             J. Postel
+8(continued):           , Editor
+
+
+
+Nesser                       Informational                    [Page 195]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+9:  Obsoletes: 1920, 1880, 1800, 1780, 1720,                   Febru
+9(continued):           ary 1997
+10:  1610, 1600, 1540, 1500, 1410, 1360,
+
+2000 found at line 60:
+58:  Internet Architecture Board Standards Track
+58(continued):          [Page 1]
+59:
+60:  RFC 2000                   Internet Standards              Febru
+60(continued):          ary 1997
+61:
+62:
+
+2000 found at line 116:
+114:  Internet Architecture Board Standards Track
+114(continued):         [Page 2]
+115:
+116:  RFC 2000                   Internet Standards              Febru
+116(continued):         ary 1997
+117:
+118:
+
+2000 found at line 172:
+170:  Internet Architecture Board Standards Track
+170(continued):         [Page 3]
+171:
+172:  RFC 2000                   Internet Standards              Febru
+172(continued):         ary 1997
+173:
+174:
+
+2000 found at line 228:
+226:  Internet Architecture Board Standards Track
+226(continued):         [Page 4]
+227:
+228:  RFC 2000                   Internet Standards              Febru
+228(continued):         ary 1997
+229:
+230:
+
+2000 found at line 284:
+282:  Internet Architecture Board Standards Track
+282(continued):         [Page 5]
+283:
+284:  RFC 2000                   Internet Standards              Febru
+284(continued):         ary 1997
+285:
+286:
+
+
+
+Nesser                       Informational                    [Page 196]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2000 found at line 340:
+338:  Internet Architecture Board Standards Track
+338(continued):         [Page 6]
+339:
+340:  RFC 2000                   Internet Standards              Febru
+340(continued):         ary 1997
+341:
+342:
+
+2000 found at line 396:
+394:  Internet Architecture Board Standards Track
+394(continued):         [Page 7]
+395:
+396:  RFC 2000                   Internet Standards              Febru
+396(continued):         ary 1997
+397:
+398:
+
+2000 found at line 452:
+450:  Internet Architecture Board Standards Track
+450(continued):         [Page 8]
+451:
+452:  RFC 2000                   Internet Standards              Febru
+452(continued):         ary 1997
+453:
+454:
+
+2000 found at line 508:
+506:  Internet Architecture Board Standards Track
+506(continued):         [Page 9]
+507:
+508:  RFC 2000                   Internet Standards              Febru
+508(continued):         ary 1997
+509:
+510:
+
+2000 found at line 564:
+562:  Internet Architecture Board Standards Track                    [
+562(continued):         Page 10]
+563:
+564:  RFC 2000                   Internet Standards              Febru
+564(continued):         ary 1997
+565:
+566:
+
+2000 found at line 620:
+618:  Internet Architecture Board Standards Track                    [
+618(continued):         Page 11]
+
+
+
+Nesser                       Informational                    [Page 197]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+619:
+620:  RFC 2000                   Internet Standards              Febru
+620(continued):         ary 1997
+621:
+622:
+
+2000 found at line 676:
+674:  Internet Architecture Board Standards Track                    [
+674(continued):         Page 12]
+675:
+676:  RFC 2000                   Internet Standards              Febru
+676(continued):         ary 1997
+677:
+678:
+
+2000 found at line 732:
+730:  Internet Architecture Board Standards Track                    [
+730(continued):         Page 13]
+731:
+732:  RFC 2000                   Internet Standards              Febru
+732(continued):         ary 1997
+733:
+734:
+
+2000 found at line 788:
+786:  Internet Architecture Board Standards Track                    [
+786(continued):         Page 14]
+787:
+788:  RFC 2000                   Internet Standards              Febru
+788(continued):         ary 1997
+789:
+790:
+
+2000 found at line 844:
+842:  Internet Architecture Board Standards Track                    [
+842(continued):         Page 15]
+843:
+844:  RFC 2000                   Internet Standards              Febru
+844(continued):         ary 1997
+845:
+846:
+
+2000 found at line 900:
+898:  Internet Architecture Board Standards Track                    [
+898(continued):         Page 16]
+899:
+
+
+
+
+
+Nesser                       Informational                    [Page 198]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+900:  RFC 2000                   Internet Standards              Febru
+900(continued):         ary 1997
+901:
+902:
+
+2000 found at line 956:
+954:  Internet Architecture Board Standards Track                    [
+954(continued):         Page 17]
+955:
+956:  RFC 2000                   Internet Standards              Febru
+956(continued):         ary 1997
+957:
+958:
+
+2000 found at line 1012:
+1010:  Internet Architecture Board Standards Track                    [
+1010(continued):                Page 18]
+1011:
+1012:  RFC 2000                   Internet Standards              Febru
+1012(continued):                ary 1997
+1013:
+1014:
+
+2000 found at line 1068:
+1066:  Internet Architecture Board Standards Track                    [
+1066(continued):                Page 19]
+1067:
+1068:  RFC 2000                   Internet Standards              Febru
+1068(continued):                ary 1997
+1069:
+1070:
+
+2000 found at line 1124:
+1122:  Internet Architecture Board Standards Track                    [
+1122(continued):                Page 20]
+1123:
+1124:  RFC 2000                   Internet Standards              Febru
+1124(continued):                ary 1997
+1125:
+1126:
+
+2000 found at line 1180:
+1178:  Internet Architecture Board Standards Track                    [
+1178(continued):                Page 21]
+1179:
+
+
+
+
+
+
+Nesser                       Informational                    [Page 199]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1180:  RFC 2000                   Internet Standards              Febru
+1180(continued):                ary 1997
+1181:
+1182:
+
+2000 found at line 1236:
+1234:  Internet Architecture Board Standards Track                    [
+1234(continued):                Page 22]
+1235:
+1236:  RFC 2000                   Internet Standards              Febru
+1236(continued):                ary 1997
+1237:
+1238:
+
+2000 found at line 1260:
+1258:               A Proposed Standard protocol.
+1259:
+1260:        2000 - Internet Official Protocol Standards
+1261:
+1262:               This memo.
+
+2000 found at line 1292:
+1290:  Internet Architecture Board Standards Track                    [
+1290(continued):                Page 23]
+1291:
+1292:  RFC 2000                   Internet Standards              Febru
+1292(continued):                ary 1997
+1293:
+1294:
+
+2000 found at line 1348:
+1346:  Internet Architecture Board Standards Track                    [
+1346(continued):                Page 24]
+1347:
+1348:  RFC 2000                   Internet Standards              Febru
+1348(continued):                ary 1997
+1349:
+1350:
+
+2000 found at line 1404:
+1402:  Internet Architecture Board Standards Track                    [
+1402(continued):                Page 25]
+1403:
+1404:  RFC 2000                   Internet Standards              Febru
+1404(continued):                ary 1997
+1405:
+1406:
+
+
+
+
+Nesser                       Informational                    [Page 200]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2000 found at line 1460:
+1458:  Internet Architecture Board Standards Track                    [
+1458(continued):                Page 26]
+1459:
+1460:  RFC 2000                   Internet Standards              Febru
+1460(continued):                ary 1997
+1461:
+1462:
+
+2000 found at line 1516:
+1514:  Internet Architecture Board Standards Track                    [
+1514(continued):                Page 27]
+1515:
+1516:  RFC 2000                   Internet Standards              Febru
+1516(continued):                ary 1997
+1517:
+1518:
+
+2000 found at line 1572:
+1570:  Internet Architecture Board Standards Track                    [
+1570(continued):                Page 28]
+1571:
+1572:  RFC 2000                   Internet Standards              Febru
+1572(continued):                ary 1997
+1573:
+1574:
+
+2000 found at line 1628:
+1626:  Internet Architecture Board Standards Track                    [
+1626(continued):                Page 29]
+1627:
+1628:  RFC 2000                   Internet Standards              Febru
+1628(continued):                ary 1997
+1629:
+1630:
+
+2000 found at line 1684:
+1682:  Internet Architecture Board Standards Track                    [
+1682(continued):                Page 30]
+1683:
+1684:  RFC 2000                   Internet Standards              Febru
+1684(continued):                ary 1997
+1685:
+1686:
+
+2000 found at line 1740:
+1738:  Internet Architecture Board Standards Track                    [
+1738(continued):                Page 31]
+
+
+
+Nesser                       Informational                    [Page 201]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1739:
+1740:  RFC 2000                   Internet Standards              Febru
+1740(continued):                ary 1997
+1741:
+1742:
+
+2000 found at line 1796:
+1794:  Internet Architecture Board Standards Track                    [
+1794(continued):                Page 32]
+1795:
+1796:  RFC 2000                   Internet Standards              Febru
+1796(continued):                ary 1997
+1797:
+1798:
+
+2000 found at line 1852:
+1850:  Internet Architecture Board Standards Track                    [
+1850(continued):                Page 33]
+1851:
+1852:  RFC 2000                   Internet Standards              Febru
+1852(continued):                ary 1997
+1853:
+1854:
+
+2000 found at line 1859:
+1857:  Protocol   Name                                      Status    R
+1857(continued):                FC STD *
+1858:  ========   =====================================     ======== ==
+1858(continued):                == === =
+1859:  --------   Internet Official Protocol Standards      Req      20
+1859(continued):                00   1
+1860:  --------   Assigned Numbers                          Req      17
+1860(continued):                00   2
+1861:  --------   Host Requirements - Communications        Req      11
+1861(continued):                22   3
+
+2000 found at line 1908:
+1906:  Internet Architecture Board Standards Track                    [
+1906(continued):                Page 34]
+1907:
+1908:  RFC 2000                   Internet Standards              Febru
+1908(continued):                ary 1997
+1909:
+1910:
+
+2000 found at line 1964:
+1962:  Internet Architecture Board Standards Track                    [
+1962(continued):                Page 35]
+
+
+
+Nesser                       Informational                    [Page 202]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1963:
+1964:  RFC 2000                   Internet Standards              Febru
+1964(continued):                ary 1997
+1965:
+1966:
+
+2000 found at line 2020:
+2018:  Internet Architecture Board Standards Track                    [
+2018(continued):                Page 36]
+2019:
+2020:  RFC 2000                   Internet Standards              Febru
+2020(continued):                ary 1997
+2021:
+2022:
+
+2000 found at line 2076:
+2074:  Internet Architecture Board Standards Track                    [
+2074(continued):                Page 37]
+2075:
+2076:  RFC 2000                   Internet Standards              Febru
+2076(continued):                ary 1997
+2077:
+2078:
+
+2000 found at line 2132:
+2130:  Internet Architecture Board Standards Track                    [
+2130(continued):                Page 38]
+2131:
+2132:  RFC 2000                   Internet Standards              Febru
+2132(continued):                ary 1997
+2133:
+2134:
+
+2000 found at line 2188:
+2186:  Internet Architecture Board Standards Track                    [
+2186(continued):                Page 39]
+2187:
+2188:  RFC 2000                   Internet Standards              Febru
+2188(continued):                ary 1997
+2189:
+2190:
+
+2000 found at line 2244:
+2242:  Internet Architecture Board Standards Track                    [
+2242(continued):                Page 40]
+2243:
+2244:  RFC 2000                   Internet Standards              Febru
+2244(continued):                ary 1997
+
+
+
+Nesser                       Informational                    [Page 203]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2245:
+2246:
+
+2000 found at line 2300:
+2298:  Internet Architecture Board Standards Track                    [
+2298(continued):                Page 41]
+2299:
+2300:  RFC 2000                   Internet Standards              Febru
+2300(continued):                ary 1997
+2301:
+2302:
+
+2000 found at line 2356:
+2354:  Internet Architecture Board Standards Track                    [
+2354(continued):                Page 42]
+2355:
+2356:  RFC 2000                   Internet Standards              Febru
+2356(continued):                ary 1997
+2357:
+2358:
+
+2000 found at line 2412:
+2410:  Internet Architecture Board Standards Track                    [
+2410(continued):                Page 43]
+2411:
+2412:  RFC 2000                   Internet Standards              Febru
+2412(continued):                ary 1997
+2413:
+2414:
+
+2000 found at line 2468:
+2466:  Internet Architecture Board Standards Track                    [
+2466(continued):                Page 44]
+2467:
+2468:  RFC 2000                   Internet Standards              Febru
+2468(continued):                ary 1997
+2469:
+2470:
+
+2000 found at line 2524:
+2522:  Internet Architecture Board Standards Track                    [
+2522(continued):                Page 45]
+2523:
+2524:  RFC 2000                   Internet Standards              Febru
+2524(continued):                ary 1997
+2525:
+2526:
+
+
+
+
+Nesser                       Informational                    [Page 204]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2000 found at line 2580:
+2578:  Internet Architecture Board Standards Track                    [
+2578(continued):                Page 46]
+2579:
+2580:  RFC 2000                   Internet Standards              Febru
+2580(continued):                ary 1997
+2581:
+2582:
+
+2000 found at line 2636:
+2634:  Internet Architecture Board Standards Track                    [
+2634(continued):                Page 47]
+2635:
+2636:  RFC 2000                   Internet Standards              Febru
+2636(continued):                ary 1997
+2637:
+2638:
+
+2000 found at line 2692:
+2690:  Internet Architecture Board Standards Track                    [
+2690(continued):                Page 48]
+2691:
+2692:  RFC 2000                   Internet Standards              Febru
+2692(continued):                ary 1997
+2693:
+2694:
+
+2000 found at line 2748:
+2746:  Internet Architecture Board Standards Track                    [
+2746(continued):                Page 49]
+2747:
+2748:  RFC 2000                   Internet Standards              Febru
+2748(continued):                ary 1997
+2749:
+2750:
+
+2000 found at line 2804:
+2802:  Internet Architecture Board Standards Track                    [
+2802(continued):                Page 50]
+2803:
+2804:  RFC 2000                   Internet Standards              Febru
+2804(continued):                ary 1997
+2805:
+2806:
+
+2000 found at line 2860:
+2858:  Internet Architecture Board Standards Track                    [
+2858(continued):                Page 51]
+
+
+
+Nesser                       Informational                    [Page 205]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2859:
+2860:  RFC 2000                   Internet Standards              Febru
+2860(continued):                ary 1997
+2861:
+2862:
+
+2000 found at line 2916:
+2914:  Internet Architecture Board Standards Track                    [
+2914(continued):                Page 52]
+2915:
+2916:  RFC 2000                   Internet Standards              Febru
+2916(continued):                ary 1997
+2917:
+2918:
+
+2000 found at line 2972:
+2970:  Internet Architecture Board Standards Track                    [
+2970(continued):                Page 53]
+2971:
+2972:  RFC 2000                   Internet Standards              Febru
+2972(continued):                ary 1997
+2973:
+2974:
+
+2000 found at line 3028:
+3026:  Internet Architecture Board Standards Track                    [
+3026(continued):                Page 54]
+3027:
+3028:  RFC 2000                   Internet Standards              Febru
+3028(continued):                ary 1997
+3029:
+3030:
+
+2000 found at line 3084:
+3082:  Internet Architecture Board Standards Track                    [
+3082(continued):                Page 55]
+3083:
+3084:  RFC 2000                   Internet Standards              Febru
+3084(continued):                ary 1997
+3085:
+3086:
+
++=+=+=+=+= File rfc2007.txt +=+=+=+=+=
+2000 found at line 1156:
+1154:
+1155:  Access-Type: gopher
+
+
+
+
+
+Nesser                       Informational                    [Page 206]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1156:  URL: <URL:gopher://gopher.cic.net:2000/11/hunt>
+1157:
+1158:  Access-Type: www
+
++=+=+=+=+= File rfc2015.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 153:
+151:
+152:       hIwDY32hYGCE8MkBA/wOu7d45aUxF4Q0RKJprD3v5Z9K1YcRJ2fve87lMlD
+152(continued):         lx4Oj
+153:       eW4GDdBfLbJE7VUpp13N19GL8e/AqbyyjHH4aS0YoTk10QQ9nnRvjY8nZL3
+153(continued):         MPXSZ
+154:       g9VGQxFeGqzykzmykU6A26MSMexR4ApeeON6xzZWfo+0yOqAq6lb46wsvld
+154(continued):         Z96YA
+155:       AABH78hyX7YX4uT1tNCWEIIBoqqvCeIMpp7UQ2IzBrXg6GtukS8NxbukLea
+155(continued):         mqVW3
+
++=+=+=+=+= File rfc2025.txt +=+=+=+=+=
+UTCTime found at line 751:
+749:             context-id       Random-Integer,   -- see Section 6.3
+749(continued):
+750:             pvno             BIT STRING,       -- protocol versio
+750(continued):         n number
+751:             timestamp        UTCTime OPTIONAL, -- mandatory for S
+751(continued):         PKM-2
+752:             randSrc          Random-Integer,
+753:             targ-name        Name,
+
+UTCTime found at line 923:
+921:             context-id       Random-Integer,  -- see Section 6.3
+922:             pvno [0]         BIT STRING OPTIONAL, -- prot. versio
+922(continued):         n number
+923:             timestamp        UTCTime OPTIONAL, -- mandatory for S
+923(continued):         PKM-2
+924:             randTarg         Random-Integer,
+925:             src-name [1]     Name OPTIONAL,
+
+UTCTime found at line 2159:
+2157:             context-id       Random-Integer,
+2158:             pvno             BIT STRING,
+2159:             timestamp        UTCTime OPTIONAL, -- mandatory for S
+2159(continued):                PKM-2
+2160:             randSrc          Random-Integer,
+2161:             targ-name        Name,
+
+UTCTime found at line 2248:
+2246:
+2247:             pvno [0]         BIT STRING OPTIONAL,
+2248:             timestamp        UTCTime OPTIONAL, -- mandatory for S
+
+
+
+Nesser                       Informational                    [Page 207]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2248(continued):                PKM-2
+2249:             randTarg         Random-Integer,
+2250:             src-name [1]     Name OPTIONAL,
+
+UTCTime found at line 2459:
+2457:
+2458:     Validity ::= SEQUENCE {
+2459:             notBefore         UTCTime,
+2460:             notAfter          UTCTime
+2461:     }
+
+UTCTime found at line 2460:
+2458:     Validity ::= SEQUENCE {
+2459:             notBefore         UTCTime,
+2460:             notAfter          UTCTime
+2461:     }
+2462:
+
+UTCTime found at line 2493:
+2491:             signature               AlgorithmIdentifier,
+2492:             issuer                  Name,
+2493:             thisUpdate              UTCTime,
+2494:             nextUpdate              UTCTime OPTIONAL,
+2495:             revokedCertificates     SEQUENCE OF SEQUENCE {
+
+UTCTime found at line 2494:
+2492:             issuer                  Name,
+2493:             thisUpdate              UTCTime,
+2494:             nextUpdate              UTCTime OPTIONAL,
+2495:             revokedCertificates     SEQUENCE OF SEQUENCE {
+2496:                  userCertificate       CertificateSerialNumber,
+
+UTCTime found at line 2497:
+2495:             revokedCertificates     SEQUENCE OF SEQUENCE {
+2496:                  userCertificate       CertificateSerialNumber,
+2497:                  revocationDate        UTCTime           } OPTION
+2497(continued):                AL
+2498:     }
+2499:
+
++=+=+=+=+= File rfc2028.txt +=+=+=+=+=
+2000 found at line 320:
+318:     Digital Equipment Corporation
+319:     1401 H Street NW
+320:     Washington DC 20005
+321:
+322:     Phone:  +1 202 383 5615
+
+
+
+
+Nesser                       Informational                    [Page 208]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc2030.txt +=+=+=+=+=
+1900 found at line 321:
+319:     main product of the protocol, a special timestamp format has
+319(continued):         been
+320:     established. NTP timestamps are represented as a 64-bit unsig
+320(continued):         ned
+321:     fixed-point number, in seconds relative to 0h on 1 January 19
+321(continued):         00. The
+322:     integer part is in the first 32 bits and the fraction part in
+322(continued):          the
+323:     last 32 bits. In the fraction part, the non-significant low o
+323(continued):         rder can
+
+1900 found at line 362:
+360:     64-bit field will overflow some time in 2036 (second 4,294,96
+360(continued):         7,296).
+361:     Should NTP or SNTP be in use in 2036, some external means wil
+361(continued):         l be
+362:     necessary to qualify time relative to 1900 and time relative
+362(continued):         to 2036
+363:     (and other multiples of 136 years). There will exist a 200-pi
+363(continued):         cosecond
+364:     interval, henceforth ignored, every 136 years when the 64-bit
+364(continued):          field
+
+1900 found at line 375:
+373:        following convention: If bit 0 is set, the UTC time is in
+373(continued):         the
+374:        range 1968-2036 and UTC time is reckoned from 0h 0m 0s UTC
+374(continued):          on 1
+375:        January 1900. If bit 0 is not set, the time is in the rang
+375(continued):         e 2036-
+376:        2104 and UTC time is reckoned from 6h 28m 16s UTC on 7 Feb
+376(continued):         ruary
+377:        2036. Note that when calculating the correspondence, 2000
+377(continued):         is not a
+
+2000 found at line 377:
+375:        January 1900. If bit 0 is not set, the time is in the rang
+375(continued):         e 2036-
+376:        2104 and UTC time is reckoned from 6h 28m 16s UTC on 7 Feb
+376(continued):         ruary
+377:        2036. Note that when calculating the correspondence, 2000
+377(continued):         is not a
+378:        leap year. Note also that leap seconds are not counted in
+378(continued):         the
+379:        reckoning.
+
+
+
+
+Nesser                       Informational                    [Page 209]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc2048.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 738:
+736:
+737:       To: ietf-types@iana.org
+738:       Subject: Registration of MIME media type XXX/YYY
+739:
+740:       MIME media type name:
+
++=+=+=+=+= File rfc2050.txt +=+=+=+=+=
+1900 found at line 638:
+636:     [RFC 1814] Gerich, E., "Unique Addresses are Good", June 1995
+636(continued):         .
+637:
+638:     [RFC 1900] Carpenter, B., and Y. Rekhter, "Renumbering Needs
+638(continued):         Work",
+639:        February 1996.
+640:
+
++=+=+=+=+= File rfc2052.txt +=+=+=+=+=
+1900 found at line 420:
+418:          Errors", RFC 1912, February 1996.
+419:
+420:     RFC 1900: Carpenter, B., and Y. Rekhter, "Renumbering Needs W
+420(continued):         ork",
+421:          RFC 1900, February 1996.
+422:
+
+1900 found at line 421:
+419:
+420:     RFC 1900: Carpenter, B., and Y. Rekhter, "Renumbering Needs W
+420(continued):         ork",
+421:          RFC 1900, February 1996.
+422:
+423:     RFC 1920: Postel, J., "INTERNET OFFICIAL PROTOCOL STANDARDS",
+423(continued):
+
++=+=+=+=+= File rfc2060.txt +=+=+=+=+=
+2digit found at line 3782:
+3780:  date            ::= date_text / <"> date_text <">
+3781:
+3782:  date_day        ::= 1*2digit
+3783:                      ;; Day of month
+3784:
+
+2digit found at line 3785:
+3783:                      ;; Day of month
+3784:
+
+
+
+
+Nesser                       Informational                    [Page 210]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+3785:  date_day_fixed  ::= (SPACE digit) / 2digit
+3786:                      ;; Fixed-format version of date_day
+3787:
+
+2digit found at line 4101:
+4099:  TEXT_CHAR       ::= <any CHAR except CR and LF>
+4100:
+4101:  time            ::= 2digit ":" 2digit ":" 2digit
+4102:                      ;; Hours minutes seconds
+4103:
+
++=+=+=+=+= File rfc2062.txt +=+=+=+=+=
+2digit found at line 330:
+328:                     ::= partial
+329:
+330:     date_year_old   ::= 2digit
+331:                         ;; (year - 1900)
+332:
+
+1900 found at line 331:
+329:
+330:     date_year_old   ::= 2digit
+331:                         ;; (year - 1900)
+332:
+333:     date_time_old   ::= <"> date_day_fixed "-" date_month "-" dat
+333(continued):         e_year
+
++=+=+=+=+= File rfc2063.txt +=+=+=+=+=
+2000 found at line 716:
+714:
+715:                           start time = 1            start time =
+715(continued):         1
+716:     Usage record N:       flow count = 2000      flow count = 200
+716(continued):         0 (done)
+717:
+718:                           start time = 1            start time =
+718(continued):         5
+
+2000 found at line 725:
+723:
+724:     In the continuing flow case, the same flow was reported when
+724(continued):         its
+725:     count was 2000, and again at 3000:  the total count to date i
+725(continued):         s 3000.
+726:     In the OLD/NEW case, the old flow had a count of 2000.  Its r
+726(continued):         ecord
+727:
+
+
+
+
+Nesser                       Informational                    [Page 211]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2000 found at line 726:
+724:     In the continuing flow case, the same flow was reported when
+724(continued):         its
+725:     count was 2000, and again at 3000:  the total count to date i
+725(continued):         s 3000.
+726:     In the OLD/NEW case, the old flow had a count of 2000.  Its r
+726(continued):         ecord
+727:
+728:
+
++=+=+=+=+= File rfc2068.txt +=+=+=+=+=
+2-digit found at line 772:
+770:       Specific repetition: "<n>(element)" is equivalent to
+771:       "<n>*<n>(element)"; that is, exactly <n> occurrences of (el
+771(continued):         ement).
+772:       Thus 2DIGIT is a 2-digit number, and 3ALPHA is a string of
+772(continued):         three
+773:       alphabetic characters.
+774:
+
+2digit found at line 772:
+770:       Specific repetition: "<n>(element)" is equivalent to
+771:       "<n>*<n>(element)"; that is, exactly <n> occurrences of (el
+771(continued):         ement).
+772:       Thus 2DIGIT is a 2-digit number, and 3ALPHA is a string of
+772(continued):         three
+773:       alphabetic characters.
+774:
+
+2digit found at line 1163:
+1161:            asctime-date = wkday SP date3 SP time SP 4DIGIT
+1162:
+1163:            date1        = 2DIGIT SP month SP 4DIGIT
+1164:                           ; day month year (e.g., 02 Jun 1982)
+1165:            date2        = 2DIGIT "-" month "-" 2DIGIT
+
+2digit found at line 1165:
+1163:            date1        = 2DIGIT SP month SP 4DIGIT
+1164:                           ; day month year (e.g., 02 Jun 1982)
+1165:            date2        = 2DIGIT "-" month "-" 2DIGIT
+1166:                           ; day-month-year (e.g., 02-Jun-82)
+1167:            date3        = month SP ( 2DIGIT | ( SP 1DIGIT ))
+
+
+
+
+
+
+
+
+
+Nesser                       Informational                    [Page 212]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2digit found at line 1167:
+1165:            date2        = 2DIGIT "-" month "-" 2DIGIT
+1166:                           ; day-month-year (e.g., 02-Jun-82)
+1167:            date3        = month SP ( 2DIGIT | ( SP 1DIGIT ))
+1168:                           ; month day (e.g., Jun  2)
+1169:
+
+2digit found at line 1170:
+1168:                           ; month day (e.g., Jun  2)
+1169:
+1170:            time         = 2DIGIT ":" 2DIGIT ":" 2DIGIT
+1171:                           ; 00:00:00 - 23:59:59
+1172:
+
+2digit found at line 7652:
+7650:
+7651:            warning-value = warn-code SP warn-agent SP warn-text
+7652:            warn-code  = 2DIGIT
+7653:            warn-agent = ( host [ ":" port ] ) | pseudonym
+7654:                            ; the name or pseudonym of the server
+7654(continued):                adding
+
+1900 found at line 1083:
+1081:     for TCP connections on that port of that host, and the Reques
+1081(continued):                t-URI
+1082:     for the resource is abs_path. The use of IP addresses in URL'
+1082(continued):                s SHOULD
+1083:     be avoided whenever possible (see RFC 1900 [24]). If the abs_
+1083(continued):                path is
+1084:     not present in the URL, it MUST be given as "/" when used as
+1084(continued):                a
+1085:     Request-URI for a resource (section 5.1.2).
+
+1900 found at line 8249:
+8247:
+8248:     [24] Carpenter, B., and Y. Rekhter, "Renumbering Needs Work",
+8248(continued):                 RFC
+8249:     1900, IAB, February 1996.
+8250:
+8251:     [25] Deutsch, P., "GZIP file format specification version 4.3
+8251(continued):                ." RFC
+
+2000 found at line 8453:
+8451:    o  HTTP/1.1 clients and caches should assume that an RFC-850 d
+8451(continued):                ate
+8452:       which appears to be more than 50 years in the future is in
+8452(continued):                fact
+
+
+
+
+Nesser                       Informational                    [Page 213]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+8453:       in the past (this helps solve the "year 2000" problem).
+8454:
+8455:
+
++=+=+=+=+= File rfc2071.txt +=+=+=+=+=
+1900 found at line 738:
+736:        December 1995.
+737:
+738:   [16] Carpenter, B., and Y. Rekhter, "Renumbering Needs Work", R
+738(continued):         FC 1900,
+739:        February 1996.
+740:
+
++=+=+=+=+= File rfc2072.txt +=+=+=+=+=
+1900 found at line 206:
+204:     Many discussions of renumbering emphasize interactions among
+205:     organizations' numbering plans and those of the global Intern
+205(continued):         et
+206:     [RFC1900].  There can be equally strong motivations for renum
+206(continued):         bering
+207:     in organizations that never connect to the global Internet.
+208:
+
+1900 found at line 209:
+207:     in organizations that never connect to the global Internet.
+208:
+209:     According to RFC1900, "Unless and until viable alternatives a
+209(continued):         re
+210:     developed, extended deployment of Classless Inter-Domain Rout
+210(continued):         ing
+211:     (CIDR) is vital to keep the Internet routing system alive and
+211(continued):          to
+
+1900 found at line 2606:
+2604:    February 1996.
+2605:
+2606:    [RFC1900] Carpenter, B., and Y. Rekhter, "Renumbering Needs Wo
+2606(continued):                rk", RFC
+2607:    1900, February 1996.
+2608:
+
+1900 found at line 2607:
+2605:
+2606:    [RFC1900] Carpenter, B., and Y. Rekhter, "Renumbering Needs Wo
+2606(continued):                rk", RFC
+2607:    1900, February 1996.
+
+
+
+
+
+Nesser                       Informational                    [Page 214]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2608:
+2609:    [RPS] Alaettinoglu, C., Bates, T., Gerich, E., Terpstra, M., a
+2609(continued):                nd C.
+
++=+=+=+=+= File rfc2074.txt +=+=+=+=+=
+2000 found at line 2041:
+2039:         From [RFC1831]:
+2040:
+2041:         Program numbers are given out in groups of hexadecimal 20
+2041(continued):                000000
+2042:         (decimal 536870912) according to the following chart:
+2043:
+
+2000 found at line 2045:
+2043:
+2044:                       0 - 1fffffff   defined by rpc@sun.com
+2045:                20000000 - 3fffffff   defined by user
+2046:                40000000 - 5fffffff   transient
+2047:                60000000 - 7fffffff   reserved
+
++=+=+=+=+= File rfc2077.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 315:
+313:           Subject: model data file
+314:
+315:           I1ZSTUwgVjEuMCBhc2NpaQojIFRoaXMgZmlsZSB3YXMgIGdlbmVyY..
+315(continued):         .
+316:           byBDb21tdW5pY2F0aW9ucwojIGh0dHA6Ly93d3cuY2hhY28uY29tC..
+316(continued):         .
+317:           IyB1c2VkIGluIHJvb20gMTkyICh0ZXN0IHJvb20pCiAgIAojIFRvc..
+317(continued):         .
+
++=+=+=+=+= File rfc2095.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 131:
+129:       C: A0001 AUTHENTICATE CRAM-MD5
+130:       S: + PDE4OTYuNjk3MTcwOTUyQHBvc3RvZmZpY2UucmVzdG9uLm1jaS5uZX
+130(continued):         Q+
+131:       C: dGltIGI5MTNhNjAyYzdlZGE3YTQ5NWI0ZTZlNzMzNGQzODkw
+132:       S: A0001 OK CRAM authentication successful
+133:
+
+'yy' on a line without 'yyyy' found at line 161:
+159:        AUTHENTICATE command (or the similar POP3 AUTH command), y
+159(continued):         ielding
+160:
+161:             dGltIGI5MTNhNjAyYzdlZGE3YTQ5NWI0ZTZlNzMzNGQzODkw
+162:
+163:
+
+
+
+
+Nesser                       Informational                    [Page 215]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc2096.txt +=+=+=+=+=
+1900 found at line 134:
+132:
+133:  ipForward MODULE-IDENTITY
+134:      LAST-UPDATED "9609190000Z"     -- Thu Sep 26 16:34:47 PDT 19
+134(continued):         96
+135:      ORGANIZATION "IETF OSPF Working Group"
+136:      CONTACT-INFO
+
+1900 found at line 147:
+145:      DESCRIPTION
+146:              "The MIB module for the display of CIDR multipath IP
+146(continued):          Routes."
+147:      REVISION      "9609190000Z"
+148:      DESCRIPTION
+149:              "Revisions made by the OSPF WG."
+
++=+=+=+=+= File rfc2099.txt +=+=+=+=+=
+2000 found at line 14:
+12:                        Request for Comments Summary
+13:
+14:                           RFC Numbers 2000-2099
+15:
+16:  Status of This Memo
+
+2000 found at line 18:
+16:  Status of This Memo
+17:
+18:     This RFC is a slightly annotated list of the 100 RFCs from RF
+18(continued):          C 2000
+19:     through RFCs 2099.  This is a status report on these RFCs.  T
+19(continued):          his memo
+20:     provides information for the Internet community.  It does not
+20(continued):           specify
+
+2000 found at line 60:
+58:  Elliott                      Informational
+58(continued):          [Page 1]
+59:
+60:  RFC 2099                  Summary of 2000-2099                Ma
+60(continued):          rch 1997
+61:
+62:
+
+2000 found at line 116:
+114:  Elliott                      Informational
+114(continued):         [Page 2]
+115:
+
+
+
+Nesser                       Informational                    [Page 216]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+116:  RFC 2099                  Summary of 2000-2099                Ma
+116(continued):         rch 1997
+117:
+118:
+
+2000 found at line 172:
+170:  Elliott                      Informational
+170(continued):         [Page 3]
+171:
+172:  RFC 2099                  Summary of 2000-2099                Ma
+172(continued):         rch 1997
+173:
+174:
+
+2000 found at line 228:
+226:  Elliott                      Informational
+226(continued):         [Page 4]
+227:
+228:  RFC 2099                  Summary of 2000-2099                Ma
+228(continued):         rch 1997
+229:
+230:
+
+2000 found at line 284:
+282:  Elliott                      Informational
+282(continued):         [Page 5]
+283:
+284:  RFC 2099                  Summary of 2000-2099                Ma
+284(continued):         rch 1997
+285:
+286:
+
+2000 found at line 340:
+338:  Elliott                      Informational
+338(continued):         [Page 6]
+339:
+340:  RFC 2099                  Summary of 2000-2099                Ma
+340(continued):         rch 1997
+341:
+342:
+
+2000 found at line 396:
+394:  Elliott                      Informational
+394(continued):         [Page 7]
+395:
+396:  RFC 2099                  Summary of 2000-2099                Ma
+
+
+
+
+
+Nesser                       Informational                    [Page 217]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+396(continued):         rch 1997
+397:
+398:
+
+2000 found at line 452:
+450:  Elliott                      Informational
+450(continued):         [Page 8]
+451:
+452:  RFC 2099                  Summary of 2000-2099                Ma
+452(continued):         rch 1997
+453:
+454:
+
+2000 found at line 508:
+506:  Elliott                      Informational
+506(continued):         [Page 9]
+507:
+508:  RFC 2099                  Summary of 2000-2099                Ma
+508(continued):         rch 1997
+509:
+510:
+
+2000 found at line 564:
+562:  Elliott                      Informational                     [
+562(continued):         Page 10]
+563:
+564:  RFC 2099                  Summary of 2000-2099                Ma
+564(continued):         rch 1997
+565:
+566:
+
+2000 found at line 620:
+618:  Elliott                      Informational                     [
+618(continued):         Page 11]
+619:
+620:  RFC 2099                  Summary of 2000-2099                Ma
+620(continued):         rch 1997
+621:
+622:
+
+2000 found at line 676:
+674:  Elliott                      Informational                     [
+674(continued):         Page 12]
+675:
+676:  RFC 2099                  Summary of 2000-2099                Ma
+676(continued):         rch 1997
+677:
+678:
+
+
+
+Nesser                       Informational                    [Page 218]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2000 found at line 732:
+730:  Elliott                      Informational                     [
+730(continued):         Page 13]
+731:
+732:  RFC 2099                  Summary of 2000-2099                Ma
+732(continued):         rch 1997
+733:
+734:
+
+2000 found at line 788:
+786:  Elliott                      Informational                     [
+786(continued):         Page 14]
+787:
+788:  RFC 2099                  Summary of 2000-2099                Ma
+788(continued):         rch 1997
+789:
+790:
+
+2000 found at line 844:
+842:  Elliott                      Informational                     [
+842(continued):         Page 15]
+843:
+844:  RFC 2099                  Summary of 2000-2099                Ma
+844(continued):         rch 1997
+845:
+846:
+
+2000 found at line 900:
+898:  Elliott                      Informational                     [
+898(continued):         Page 16]
+899:
+900:  RFC 2099                  Summary of 2000-2099                Ma
+900(continued):         rch 1997
+901:
+902:
+
+2000 found at line 956:
+954:  Elliott                      Informational                     [
+954(continued):         Page 17]
+955:
+956:  RFC 2099                  Summary of 2000-2099                Ma
+956(continued):         rch 1997
+957:
+958:
+
+2000 found at line 1012:
+1010:  Elliott                      Informational                     [
+1010(continued):                Page 18]
+
+
+
+Nesser                       Informational                    [Page 219]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1011:
+1012:  RFC 2099                  Summary of 2000-2099                Ma
+1012(continued):                rch 1997
+1013:
+1014:
+
+2000 found at line 1068:
+1066:  Elliott                      Informational                     [
+1066(continued):                Page 19]
+1067:
+1068:  RFC 2099                  Summary of 2000-2099                Ma
+1068(continued):                rch 1997
+1069:
+1070:
+
+2000 found at line 1124:
+1122:  Elliott                      Informational                     [
+1122(continued):                Page 20]
+1123:
+1124:  RFC 2099                  Summary of 2000-2099                Ma
+1124(continued):                rch 1997
+1125:
+1126:
+
+2000 found at line 1144:
+1142:
+1143:
+1144:  2000    I.A.B.       Feb 97   INTERNET OFFICIAL PROTOCOL STANDAR
+1144(continued):                DS
+1145:
+1146:  This memo describes the state of standardization of protocols us
+1146(continued):                ed in
+
++=+=+=+=+= File rfc2101.txt +=+=+=+=+=
+1900 found at line 353:
+351:
+352:        Changing providers is just one possible reason for renumbe
+352(continued):         ring.
+353:        The informational document [RFC 1900] shows why renumberin
+353(continued):         g is an
+354:        increasingly frequent event.  Both DHCP [RFC 1541] and PPP
+354(continued):          [RFC
+355:        1661] promote the use of dynamic address allocation.
+
+1900 found at line 534:
+532:     solutions for renumbering sites.  The need to contain the  ov
+532(continued):         erhead
+533:     in a rapidly growing Internet routing system is likely to mak
+
+
+
+Nesser                       Informational                    [Page 220]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+533(continued):         e
+534:     renumbering  more and more common [RFC 1900].
+535:
+536:     The need to scale the Internet routing system, and the use of
+536(continued):          CIDR as
+
+1900 found at line 632:
+630:     Protocol", RFC 1825, September 1995.
+631:
+632:     [RFC 1900] Carpenter, B., and Y. Rekhter, "Renumbering Needs
+632(continued):         Work",
+633:     RFC 1900, February 1996.
+634:
+
+1900 found at line 633:
+631:
+632:     [RFC 1900] Carpenter, B., and Y. Rekhter, "Renumbering Needs
+632(continued):         Work",
+633:     RFC 1900, February 1996.
+634:
+635:     [RFC 1918] Rekhter, Y.,  Moskowitz, B., Karrenberg, D., de Gr
+635(continued):         oot, G.
+
++=+=+=+=+= File rfc2109.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 1054:
+1052:     date value in a fixed-length variant format in place of Max-A
+1052(continued):                ge:
+1053:
+1054:     Wdy, DD-Mon-YY HH:MM:SS GMT
+1055:
+1056:     Note that the Expires date format contains embedded spaces, a
+1056(continued):                nd that
+
++=+=+=+=+= File rfc2116.txt +=+=+=+=+=
+2000 found at line 4132:
+4130:        * MAIL.X-OD V2.3
+4131:
+4132:        * MAIL.2000 V1.2, AKOM
+4133:
+4134:        * MS-Mail
+
+2000 found at line 5393:
+5391:           1-800-257-OPEN (U.S. and Canada)
+5392:           1-612-482-6736 (worldwide)
+5393:           FAX: 1-612-482-2000 (worldwide)
+5394:           EMAIL: info@cdc.com
+5395:             or
+
+
+
+
+Nesser                       Informational                    [Page 221]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc2134.txt +=+=+=+=+=
+2000 found at line 30:
+28:
+29:     To:    Department of Consumer and Regulatory Affairs
+30:            Washington, D.C.  20001
+31:
+32:         We, the undersigned natural persons of the age of eightee
+32(continued):          n years
+
+2000 found at line 140:
+138:     8. The address, including street and number, of the initial
+139:        registered office of the corporation is c/o C T Corporatio
+139(continued):         n
+140:        System, 1030 15th Street, N.W., Washington, D.C. 20005, an
+140(continued):         d the
+141:        name of its initial registered agent at such address is C
+141(continued):         T
+142:        Corporation System.
+
++=+=+=+=+= File rfc2150.txt +=+=+=+=+=
+century found at line 2197:
+2195:     scholarly music resources. http://rism.harvard.edu/RISM/
+2196:
+2197:     Crescendo is used in the web pages at http://mcentury.citi.do
+2197(continued):                c.ca
+2198:     along with a growing number of others.  One very interesting
+2198(continued):                use of
+2199:     Crescendo occurs on the Music Theory Online publication, a se
+2199(continued):                rious
+
+century found at line 3150:
+3148:     Joseph Aiuto
+3149:     Sepideh Boroumand
+3150:     Michael Century
+3151:     Kelly Cooper
+3152:     Lile Elam
+
++=+=+=+=+= File rfc2151.txt +=+=+=+=+=
+2000 found at line 1805:
+1803:    * About Hill Associates
+1804:    * HAI Products and Services Catalog
+1805:    * Datacomm/2000-ED Series
+1806:    * Contacting Hill Associates
+1807:    * Employment Opportunities
+
+2000 found at line 2808:
+2806:
+2807:  [23] _____, Editor, "Internet Official Protocol Standards,"
+
+
+
+Nesser                       Informational                    [Page 222]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2808:       STD 1/RFC 2000, Internet Architecture Board, February 1997.
+2808(continued):
+2809:
+2810:  [24] _____, "Introduction to the STD Notes," RFC 1311, USC/Infor
+2810(continued):                mation
+
++=+=+=+=+= File rfc2156.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 3210:
+3208:          the prefix, all attributes remaining in the OR address s
+3208(continued):                hall be
+3209:          encoded on the LHS.  This is to ensure a reversible mapp
+3209(continued):                ing. For
+3210:          example, if there is an address /S=XX/O=YY/ADMD=A/C=NN/
+3210(continued):                and a
+3211:          mapping for /ADMD=A/C=NN/ is used, then /S=XX/O=YY/ is e
+3211(continued):                ncoded
+3212:          on the LHS.
+
+'yy' on a line without 'yyyy' found at line 3211:
+3209:          encoded on the LHS.  This is to ensure a reversible mapp
+3209(continued):                ing. For
+3210:          example, if there is an address /S=XX/O=YY/ADMD=A/C=NN/
+3210(continued):                and a
+3211:          mapping for /ADMD=A/C=NN/ is used, then /S=XX/O=YY/ is e
+3211(continued):                ncoded
+3212:          on the LHS.
+3213:
+
+'yy' on a line without 'yyyy' found at line 3317:
+3315:
+3316:                C          = "XX"
+3317:                ADMD       = "YY"
+3318:                O          = "ZZ"
+3319:                "RFC-822"  = "Smith(a)ZZ.YY.XX"
+
+'yy' on a line without 'yyyy' found at line 3319:
+3317:                ADMD       = "YY"
+3318:                O          = "ZZ"
+3319:                "RFC-822"  = "Smith(a)ZZ.YY.XX"
+3320:
+3321:     This is mapped first to an RFC 822 address, and then back to
+3321(continued):                the
+
+
+
+
+
+
+
+
+
+Nesser                       Informational                    [Page 223]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+'yy' on a line without 'yyyy' found at line 3325:
+3323:
+3324:                C          = "XX"
+3325:                ADMD       = "YY"
+3326:                O          = "ZZ"
+3327:                Surname    = "Smith"
+
+UTCTime found at line 1705:
+1703:           "yen*{165}"
+1704:
+1705:  3.3.5.  UTCTime
+1706:
+1707:     Both UTCTime and the RFC 822 822.date-time syntax contain: Ye
+1707(continued):                ar,
+
+UTCTime found at line 1707:
+1705:  3.3.5.  UTCTime
+1706:
+1707:     Both UTCTime and the RFC 822 822.date-time syntax contain: Ye
+1707(continued):                ar,
+1708:     Month, Day of Month, hour, minute, second (optional), and Tim
+1708(continued):                ezone
+1709:     (technically a time differential in UTCTime).  822.date-time
+1709(continued):                also
+
+UTCTime found at line 1709:
+1707:     Both UTCTime and the RFC 822 822.date-time syntax contain: Ye
+1707(continued):                ar,
+1708:     Month, Day of Month, hour, minute, second (optional), and Tim
+1708(continued):                ezone
+1709:     (technically a time differential in UTCTime).  822.date-time
+1709(continued):                also
+1710:     contains an optional day of the week, but this is redundant.
+1710(continued):                 With
+1711:     the exception of Year, a symmetrical mapping can be made betw
+1711(continued):                een
+
+UTCTime found at line 1717:
+1715:        In practice, a gateway will need to parse various illegal
+1715(continued):                variants
+1716:        on 822.date-time.  In cases where 822.date-time cannot be
+1716(continued):                parsed,
+1717:        it is recommended that the derived UTCTime is set to the v
+1717(continued):                alue at
+1718:        the time of translation.  Such errors may be noted in an R
+1718(continued):                FC 822
+1719:        comment, to aid detection and correction.
+
+
+
+
+Nesser                       Informational                    [Page 224]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+UTCTime found at line 1721:
+1719:        comment, to aid detection and correction.
+1720:
+1721:     When mapping to X.400, the UTCTime format which specifies the
+1721(continued):
+1722:     timezone offset shall be used.
+1723:
+
+UTCTime found at line 1745:
+1743:     RFC 822, as modified by RFC 1123, requires use of a four digi
+1743(continued):                t year.
+1744:     Note that the original RFC 822 uses a two digit date, which i
+1744(continued):                s no
+1745:     longer legal.  UTCTime uses a two digit date.  To map a year
+1745(continued):                from RFC
+1746:     822 to X.400, simply use the last two digits.  To map a year
+1746(continued):                from
+1747:     X.400 to RFC 822, assume that the two digit year refers to a
+1747(continued):                year in
+
++=+=+=+=+= File rfc2162.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 797:
+795:        maps into
+796:
+797:          C=xx; ADMD=yyy; PRMD=zzz; O=ooo; OU=uuu; DD.Dnet=net;
+798:          DD.Mail-11=route::node::localpart;
+799:
+
+'yy' on a line without 'yyyy' found at line 806:
+804:        maps into
+805:
+806:          C=xx; ADMD=yyy; PRMD=zzz; O=ooo; OU=uuu; DD.Dnet=net;
+807:          DD.Mail-11=node-clns::localpart;
+808:
+
+'yy' on a line without 'yyyy' found at line 812:
+810:
+811:          xx  = country code of the gateway performing the convers
+811(continued):         ion
+812:          yyy = Admd of the gateway performing the conversion
+813:          zzz = Prmd of the gateway performing the conversion
+814:          ooo = Organisation of the gateway performing the convers
+814(continued):         ion
+
+'yy' on a line without 'yyyy' found at line 915:
+913:       it is connected to. In this case the mapping is trivial:
+914:
+915:          C=xx; ADMD=yyy; PRMD=zzz; O=ooo; OU=uuu; DD.Dnet=net;
+
+
+
+Nesser                       Informational                    [Page 225]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+916:          DD.Mail-11=route::node::localpart;
+917:
+
+'yy' on a line without 'yyyy' found at line 918:
+916:          DD.Mail-11=route::node::localpart;
+917:
+918:     (see sect. 5.2 for explication of 'xx','yyy','zzz','ooo','uuu
+918(continued):         ','net')
+919:
+920:     maps into
+
+'yy' on a line without 'yyyy' found at line 926:
+924:     and for DECnet/OSI addresses
+925:
+926:          C=xx; ADMD=yyy; PRMD=zzz; O=ooo; OU=uuu; DD.Dnet=net;
+927:          DD.Mail-11=node-clns::localpart;
+928:
+
+'yy' on a line without 'yyyy' found at line 937:
+935:       described into section 5.4 apply:
+936:
+937:          C=xx; ADMD=yyy; PRMD=www; DD.Dnet=net;
+938:          DD.Mail-11=route::node::localpart;
+939:
+
+'yy' on a line without 'yyyy' found at line 942:
+940:     maps into
+941:
+942:          gwnode::gw%"C=xx;ADMD=yyy;PRMD=www;DD.Dnet=net;
+943:          DD.Mail-11=route::node::localpart;"
+944:
+
+'yy' on a line without 'yyyy' found at line 961:
+959:     Again for DECnet/OSI addresses:
+960:
+961:          C=xx; ADMD=yyy; PRMD=www; DD.Dnet=net;
+962:          DD.Mail-11=node-clns::localpart;
+963:
+
+'yy' on a line without 'yyyy' found at line 966:
+964:     maps into
+965:
+966:          gwnode::gw%"C=xx;ADMD=yyy;PRMD=www;DD.Dnet=net;
+967:          DD.Mail-11=node-clns::localpart;"
+968:
+
+'yy' on a line without 'yyyy' found at line 1095:
+1093:     maps into
+
+
+
+Nesser                       Informational                    [Page 226]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1094:
+1095:         C=xx; ADMD=yyy; DD.Dnet=net;
+1096:         DD.Mail-11=route::gwnode::gw(p)(q)x400-text-address(q);
+1097:
+
+'yy' on a line without 'yyyy' found at line 1104:
+1102:     maps into
+1103:
+1104:         C=xx; ADMD=yyy; DD.Dnet=net;
+1105:         DD.Mail-11=gwnode::gw(p)(q)x400-text-address(q);
+1106:
+
++=+=+=+=+= File rfc2167.txt +=+=+=+=+=
+2digit found at line 1026:
+1024:
+1025:     year = 4digit
+1026:     month = 2digit
+1027:     day = 2digit
+1028:     hour = 2digit
+
+2digit found at line 1027:
+1025:     year = 4digit
+1026:     month = 2digit
+1027:     day = 2digit
+1028:     hour = 2digit
+1029:     minute = 2digit
+
+2digit found at line 1028:
+1026:     month = 2digit
+1027:     day = 2digit
+1028:     hour = 2digit
+1029:     minute = 2digit
+1030:     second = 2digit
+
+2digit found at line 1029:
+1027:     day = 2digit
+1028:     hour = 2digit
+1029:     minute = 2digit
+1030:     second = 2digit
+1031:     milli-second = 3digit
+
+2digit found at line 1030:
+1028:     hour = 2digit
+1029:     minute = 2digit
+1030:     second = 2digit
+1031:     milli-second = 3digit
+1032:     host-name = dns-char *(dns-char / ".")
+
+
+
+
+Nesser                       Informational                    [Page 227]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2digit found at line 3186:
+3184:
+3185:     year = 4digit
+3186:     month = 2digit
+3187:     day = 2digit
+3188:     hour = 2digit
+
+2digit found at line 3187:
+3185:     year = 4digit
+3186:     month = 2digit
+3187:     day = 2digit
+3188:     hour = 2digit
+3189:     minute = 2digit
+
+2digit found at line 3188:
+3186:     month = 2digit
+3187:     day = 2digit
+3188:     hour = 2digit
+3189:     minute = 2digit
+3190:     second = 2digit
+
+2digit found at line 3189:
+3187:     day = 2digit
+3188:     hour = 2digit
+3189:     minute = 2digit
+3190:     second = 2digit
+3191:
+
+2digit found at line 3190:
+3188:     hour = 2digit
+3189:     minute = 2digit
+3190:     second = 2digit
+3191:
+3192:
+
+2000 found at line 1229:
+1227:     C -class rwhois.net domain host
+1228:     S %class domain:description:Domain information
+1229:     S %class domain:version:19970103101232000
+1230:     S %class
+1231:
+
+2000 found at line 3626:
+3624:      soa          000800h
+3625:      status       001000h
+3626:      xfer         002000h
+3627:      X            004000h
+3628:
+
+
+
+Nesser                       Informational                    [Page 228]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc2170.txt +=+=+=+=+=
+2000 found at line 427:
+425:                                          Server: MyAgent/1.0
+426:                                          ATM-Service: CBR
+427:                                          ATM-QoS-PCR: 2000
+428:                                          Content-type: video/mpeg
+428(continued):
+429:
+
+2000 found at line 464:
+462:                                          Server: MyAgent/1.0 ATM.
+462(continued):         address
+463:                                          ATM-Service: CBR
+464:                                          ATM-QoS-PCR: 2000
+465:                                          Content-type: video/mpeg
+465(continued):
+466:
+
++=+=+=+=+= File rfc2179.txt +=+=+=+=+=
+2000 found at line 292:
+290:       a setuid file anywhere in the system, including those on NF
+290(continued):         S
+291:       mounted partitions.
+292:     * "find / -group kmem -perm -2000 -print" will do the same fo
+292(continued):         r kmem
+293:       group permissions.
+294:
+
++=+=+=+=+= File rfc2182.txt +=+=+=+=+=
+2000 found at line 495:
+493:
+494:     Instead, for this example, set the primary's serial number to
+494(continued):
+495:     2000000000, and wait for the secondary servers to update to t
+495(continued):         hat
+496:     zone.  The value 2000000000 is chosen as a value a lot bigger
+496(continued):          than
+497:     the current value, but less that 2^31 bigger (2^31 is 2147483
+497(continued):         648).
+
+2000 found at line 496:
+494:     Instead, for this example, set the primary's serial number to
+494(continued):
+495:     2000000000, and wait for the secondary servers to update to t
+495(continued):         hat
+496:     zone.  The value 2000000000 is chosen as a value a lot bigger
+496(continued):          than
+497:     the current value, but less that 2^31 bigger (2^31 is 2147483
+
+
+
+Nesser                       Informational                    [Page 229]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+497(continued):         648).
+498:     This is then an increment of the serial number [RFC1982].
+
+2000 found at line 502:
+500:     Next, after all servers needing updating have the zone with t
+500(continued):         hat
+501:     serial number, the serial number can be set to 4000000000.
+502:     4000000000 is 2000000000 more than 2000000000 (fairly clearly
+502(continued):         ), and
+503:
+504:
+
++=+=+=+=+= File rfc2183.txt +=+=+=+=+=
+century found at line 8:
+6:
+7:  Network Working Group                                          R
+7(continued):           . Troost
+8:  Request for Comments: 2183                           New Century
+8(continued):            Systems
+9:  Updates: 1806                                                  S
+9(continued):           . Dorner
+10:  Category: Standards Track                          QUALCOMM Inco
+10(continued):          rporated
+
+century found at line 587:
+585:
+586:          Rens Troost
+587:          New Century Systems
+588:          324 East 41st Street #804
+589:          New York, NY, 10017 USA
+
+century found at line 593:
+591:          Phone: +1 (212) 557-2050
+592:          Fax: +1 (212) 557-2049
+593:          EMail: rens@century.com
+594:
+595:
+
++=+=+=+=+= File rfc2195.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 131:
+129:       C: A0001 AUTHENTICATE CRAM-MD5
+130:       S: + PDE4OTYuNjk3MTcwOTUyQHBvc3RvZmZpY2UucmVzdG9uLm1jaS5uZX
+130(continued):         Q+
+131:       C: dGltIGI5MTNhNjAyYzdlZGE3YTQ5NWI0ZTZlNzMzNGQzODkw
+132:       S: A0001 OK CRAM authentication successful
+133:
+
+'yy' on a line without 'yyyy' found at line 161:
+
+
+
+Nesser                       Informational                    [Page 230]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+159:        AUTHENTICATE command (or the similar POP3 AUTH command), y
+159(continued):         ielding
+160:
+161:             dGltIGI5MTNhNjAyYzdlZGE3YTQ5NWI0ZTZlNzMzNGQzODkw
+162:
+163:
+
++=+=+=+=+= File rfc2200.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 2118:
+2116:                                         The text version is sent.
+2116(continued):
+2117:
+2118:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+2118(continued):                umber.
+2119:                                         and 'yyy' is 'txt' or 'ps
+2119(continued):                '.
+2120:
+
+'yy' on a line without 'yyyy' found at line 2119:
+2117:
+2118:           file /ftp/rfc/rfcnnnn.yyy     where 'nnnn' is the RFC n
+2118(continued):                umber.
+2119:                                         and 'yyy' is 'txt' or 'ps
+2119(continued):                '.
+2120:
+2121:           help                          to get information on how
+2121(continued):                 to use
+
+2000 found at line 9:
+7:  Network Working Group                        Internet Architectu
+7(continued):           re Board
+8:  Request for Comments: 2200                             J. Postel
+8(continued):           , Editor
+9:  Obsoletes: 2000, 1920, 1880, 1800, 1780,                       J
+9(continued):           une 1997
+10:  1720, 1610, 1600, 1540, 1500, 1410, 1360,
+11:  1280, 1250, 1200, 1140, 1130, 1100, 1083
+
+2000 found at line 921:
+919:               level of standard.
+920:
+921:        2099 - Request for Comments Summary - RFC Numbers 2000-209
+921(continued):         9
+922:
+923:               This is an information document and does not specif
+923(continued):         y any
+
+
+
+
+
+Nesser                       Informational                    [Page 231]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc2203.txt +=+=+=+=+=
+2000 found at line 1096:
+1094:        GSS_S_GAP_TOKEN                 0x00000010
+1095:        GSS_S_BAD_MECH                  0x00010000
+1096:        GSS_S_BAD_NAME                  0x00020000
+1097:        GSS_S_BAD_NAMETYPE              0x00030000
+1098:        GSS_S_BAD_BINDINGS              0x00040000
+
+2000 found at line 1113:
+1111:        GSS_S_UNAVAILABLE               0x00100000
+1112:        GSS_S_DUPLICATE_ELEMENT         0x00110000
+1113:        GSS_S_NAME_NOT_MN               0x00120000
+1114:        GSS_S_CALL_INACCESSIBLE_READ    0x01000000
+1115:        GSS_S_CALL_INACCESSIBLE_WRITE   0x02000000
+
+2000 found at line 1115:
+1113:        GSS_S_NAME_NOT_MN               0x00120000
+1114:        GSS_S_CALL_INACCESSIBLE_READ    0x01000000
+1115:        GSS_S_CALL_INACCESSIBLE_WRITE   0x02000000
+1116:        GSS_S_CALL_BAD_STRUCTURE        0x03000000
+1117:
+
++=+=+=+=+= File rfc2204.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 292:
+290:        available for transmission.
+291:
+292:     Date stamp (YYMMDD)
+293:
+294:        A file qualifier indicating the date the Virtual File was
+294(continued):         made
+
+'yy' on a line without 'yyyy' found at line 1866:
+1864:     |   1 | SFIDDSN   | Virtual File Dataset Name             | V
+1864(continued):                 X(26) |
+1865:     |  27 | SFIDRSV1  | Reserved                              | F
+1865(continued):                 X(9)  |
+1866:     |  36 | SFIDDATE  | Virtual File Date stamp, (YYMMDD)     | V
+1866(continued):                 X(6)  |
+1867:     |  42 | SFIDTIME  | Virtual File Time stamp, (HHMMSS)     | V
+1867(continued):                 X(6)  |
+1868:     |  48 | SFIDUSER  | User Data                             | V
+1868(continued):                 X(8)  |
+
+'yy' on a line without 'yyyy' found at line 1895:
+1893:     SFIDDATE  Virtual File Date stamp                           S
+1893(continued):                tring(6)
+1894:
+1895:       Format: 'YYMMDD'  6 decimal digits representing the year, m
+
+
+
+Nesser                       Informational                    [Page 232]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1895(continued):                onth
+1896:               and day respectively [ISO-8601].
+1897:
+
+'yy' on a line without 'yyyy' found at line 2394:
+2392:     |   1 | EERPDSN   | Virtual File Dataset Name             | V
+2392(continued):                 X(26) |
+2393:     |  27 | EERPRSV1  | Reserved                              | F
+2393(continued):                 X(9)  |
+2394:     |  36 | EERPDATE  | Virtual File Date stamp, (YYMMDD)     | V
+2394(continued):                 X(6)  |
+2395:     |  42 | EERPTIME  | Virtual File Time stamp, (HHMMSS)     | V
+2395(continued):                 X(6)  |
+2396:     |  48 | EERPUSER  | User Data                             | V
+2396(continued):                 X(8)  |
+
+'yy' on a line without 'yyyy' found at line 2429:
+2427:     EERPDATE  Virtual File Date stamp                           S
+2427(continued):                tring(6)
+2428:
+2429:       Format: 'YYMMDD'  6 decimal digits representing the year, m
+2429(continued):                onth
+2430:               and day respectively [ISO-8601].
+2431:
+
+2000 found at line 304:
+302:     field.  Since the ODETTE-FTP only uses this information to id
+302(continued):         entify a
+303:     particular Virtual File it will continue to operate correctly
+303(continued):          in the
+304:     year 2000 and beyond.
+305:
+306:     The User Monitor may use the Virtual File Date attribute in l
+306(continued):         ocal
+
+2000 found at line 308:
+306:     The User Monitor may use the Virtual File Date attribute in l
+306(continued):         ocal
+307:     processes involving date comparisons and calculations.  Any s
+307(continued):         uch use
+308:     falls outside the scope of this protocol and year 2000 handli
+308(continued):         ng is a
+309:     local implementation issue.
+310:
+
++=+=+=+=+= File rfc2227.txt +=+=+=+=+=
+2000 found at line 1949:
+1947:         Toward the Development of Web Measurement Standards.  Thi
+
+
+
+Nesser                       Informational                    [Page 233]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1947(continued):                s is a
+1948:         draft paper, currently available at http://
+1949:         www2000.ogsm.vanderbilt.edu/novak/web.standards/webstand.
+1949(continued):                html.
+1950:         Cited by permission of the author; do not quote or cite w
+1950(continued):                ithout
+1951:         permission.
+
++=+=+=+=+= File rfc2234.txt +=+=+=+=+=
+2-digit found at line 424:
+422:
+423:     That is, exactly  <N>  occurrences  of <element>. Thus 2DIGIT
+423(continued):          is a
+424:     2-digit number, and 3ALPHA is a string of three alphabetic
+425:     characters.
+426:
+
+2digit found at line 423:
+421:          <n>*<n>element
+422:
+423:     That is, exactly  <N>  occurrences  of <element>. Thus 2DIGIT
+423(continued):          is a
+424:     2-digit number, and 3ALPHA is a string of three alphabetic
+425:     characters.
+
++=+=+=+=+= File rfc2235.txt +=+=+=+=+=
+2000 found at line 862:
+860:
+861:  1997
+862:       2000th RFC: "Internet Official Protocol Standards"
+863:
+864:       71,618 mailing lists registered at Liszt, a mailing list di
+864(continued):         rectory
+
++=+=+=+=+= File rfc2244.txt +=+=+=+=+=
+2digit found at line 3555:
+3553:                          ;; Timestamp in UTC
+3554:
+3555:     time-day           = 2DIGIT ;; 01-31
+3556:
+3557:     time-hour          = 2DIGIT ;; 00-23
+
+2digit found at line 3557:
+3555:     time-day           = 2DIGIT ;; 01-31
+3556:
+3557:     time-hour          = 2DIGIT ;; 00-23
+3558:
+3559:     time-minute        = 2DIGIT ;; 00-59
+
+
+
+Nesser                       Informational                    [Page 234]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2digit found at line 3559:
+3557:     time-hour          = 2DIGIT ;; 00-23
+3558:
+3559:     time-minute        = 2DIGIT ;; 00-59
+3560:
+3561:     time-month         = 2DIGIT ;; 01-12
+
+2digit found at line 3561:
+3559:     time-minute        = 2DIGIT ;; 00-59
+3560:
+3561:     time-month         = 2DIGIT ;; 01-12
+3562:
+3563:     time-second        = 2DIGIT ;; 00-60
+
+2digit found at line 3563:
+3561:     time-month         = 2DIGIT ;; 01-12
+3562:
+3563:     time-second        = 2DIGIT ;; 00-60
+3564:
+3565:     time-subsecond     = *DIGIT
+
+2000 found at line 2217:
+2215:        criteria):
+2216:            AND COMPARE "modtime" "+i;octet" "19951206103400"
+2217:                COMPARE "modtime" "-i;octet" "19960112000000"
+2218:        refers to all entries modified between 10:34 December 6 19
+2218(continued):                95 and
+2219:        midnight January 12, 1996 UTC.
+
++=+=+=+=+= File rfc2252.txt +=+=+=+=+=
+UTCTime found at line 1300:
+1298:
+1299:     Values in this syntax are encoded as if they were printable s
+1299(continued):                trings
+1300:     with the strings containing a UTCTime value.  This is histori
+1300(continued):                cal; new
+1301:     attribute definitions SHOULD use GeneralizedTime instead.
+1302:
+
++=+=+=+=+= File rfc2261.txt +=+=+=+=+=
+2000 found at line 1923:
+1921:
+1922:     snmpFrameworkMIB MODULE-IDENTITY
+1923:         LAST-UPDATED "9711200000Z"            -- 20 November 1997
+1923(continued):
+1924:         ORGANIZATION "SNMPv3 Working Group"
+1925:         CONTACT-INFO "WG-email:   snmpv3@tis.com
+
+
+
+
+Nesser                       Informational                    [Page 235]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc2262.txt +=+=+=+=+=
+2000 found at line 818:
+816:
+817:     snmpMPDMIB MODULE-IDENTITY
+818:         LAST-UPDATED "9711200000Z"              -- 20 November 19
+818(continued):         97
+819:         ORGANIZATION "SNMPv3 Working Group"
+820:         CONTACT-INFO "WG-email:   snmpv3@tis.com
+
++=+=+=+=+= File rfc2264.txt +=+=+=+=+=
+2000 found at line 1715:
+1713:
+1714:  snmpUsmMIB MODULE-IDENTITY
+1715:      LAST-UPDATED "9711200000Z"            -- 20 Nov 1997, midnig
+1715(continued):                ht
+1716:      ORGANIZATION "SNMPv3 Working Group"
+1717:      CONTACT-INFO "WG-email:   snmpv3@tis.com
+
++=+=+=+=+= File rfc2265.txt +=+=+=+=+=
+2000 found at line 554:
+552:
+553:  snmpVacmMIB       MODULE-IDENTITY
+554:      LAST-UPDATED "9711200000Z"            -- 20 Nov 1997, midnig
+554(continued):         ht
+555:      ORGANIZATION "SNMPv3 Working Group"
+556:      CONTACT-INFO "WG-email:   snmpv3@tis.com
+
++=+=+=+=+= File rfc2271.txt +=+=+=+=+=
+2000 found at line 1923:
+1921:
+1922:     snmpFrameworkMIB MODULE-IDENTITY
+1923:         LAST-UPDATED "9711200000Z"            -- 20 November 1997
+1923(continued):
+1924:         ORGANIZATION "SNMPv3 Working Group"
+1925:         CONTACT-INFO "WG-email:   snmpv3@tis.com
+
++=+=+=+=+= File rfc2272.txt +=+=+=+=+=
+2000 found at line 818:
+816:
+817:     snmpMPDMIB MODULE-IDENTITY
+818:         LAST-UPDATED "9711200000Z"              -- 20 November 19
+818(continued):         97
+819:         ORGANIZATION "SNMPv3 Working Group"
+820:         CONTACT-INFO "WG-email:   snmpv3@tis.com
+
++=+=+=+=+= File rfc2274.txt +=+=+=+=+=
+2000 found at line 1715:
+1713:
+
+
+
+Nesser                       Informational                    [Page 236]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1714:  snmpUsmMIB MODULE-IDENTITY
+1715:      LAST-UPDATED "9711200000Z"            -- 20 Nov 1997, midnig
+1715(continued):                ht
+1716:      ORGANIZATION "SNMPv3 Working Group"
+1717:      CONTACT-INFO "WG-email:   snmpv3@tis.com
+
++=+=+=+=+= File rfc2275.txt +=+=+=+=+=
+2000 found at line 554:
+552:
+553:  snmpVacmMIB       MODULE-IDENTITY
+554:      LAST-UPDATED "9711200000Z"            -- 20 Nov 1997, midnig
+554(continued):         ht
+555:      ORGANIZATION "SNMPv3 Working Group"
+556:      CONTACT-INFO "WG-email:   snmpv3@tis.com
+
++=+=+=+=+= File rfc2280.txt +=+=+=+=+=
+2000 found at line 2119:
+2117:     missing, they default to:
+2118:
+2119:        flap_damp(1000, 2000, 750, 900, 900, 20000)
+2120:
+2121:     That is, a penalty of 1000 is assigned at each route flap, th
+2121(continued):                e route
+
+2000 found at line 2122:
+2120:
+2121:     That is, a penalty of 1000 is assigned at each route flap, th
+2121(continued):                e route
+2122:     is suppressed when penalty reaches 2000.  The penalty is redu
+2122(continued):                ced in
+2123:     half after 15 minutes (900 seconds) of stability regardless o
+2123(continued):                f
+2124:     whether the route is up or down.  A supressed route is reused
+2124(continued):                 when
+
++=+=+=+=+= File rfc2281.txt +=+=+=+=+=
+1900 found at line 854:
+852:     Santa Clara, CA 95054
+853:
+854:     Phone: (408) 327-1900
+855:     EMail: tli@juniper.net
+856:
+
+
+
+
+
+
+
+
+
+Nesser                       Informational                    [Page 237]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1900 found at line 863:
+861:     Santa Clara, CA 95054
+862:
+863:     Phone: (408) 327-1900
+864:     EMail: cole@juniper.net
+865:
+
++=+=+=+=+= File rfc2287.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 1439:
+1437:         DESCRIPTION
+1438:             "The full path and filename of the process.
+1439:             For example, '/opt/MYYpkg/bin/myyproc' would
+1440:             be returned for process 'myyproc' whose execution
+1441:             path is '/opt/MYYpkg/bin/myyproc'."
+
+'yy' on a line without 'yyyy' found at line 1440:
+1438:             "The full path and filename of the process.
+1439:             For example, '/opt/MYYpkg/bin/myyproc' would
+1440:             be returned for process 'myyproc' whose execution
+1441:             path is '/opt/MYYpkg/bin/myyproc'."
+1442:         ::= { sysApplElmtRunEntry 7 }
+
+'yy' on a line without 'yyyy' found at line 1441:
+1439:             For example, '/opt/MYYpkg/bin/myyproc' would
+1440:             be returned for process 'myyproc' whose execution
+1441:             path is '/opt/MYYpkg/bin/myyproc'."
+1442:         ::= { sysApplElmtRunEntry 7 }
+1443:
+
+'yy' on a line without 'yyyy' found at line 1706:
+1704:         DESCRIPTION
+1705:             "The full path and filename of the process.
+1706:             For example, '/opt/MYYpkg/bin/myyproc' would
+1707:             be returned for process 'myyproc' whose execution
+1708:             path was '/opt/MYYpkg/bin/myyproc'."
+
+'yy' on a line without 'yyyy' found at line 1707:
+1705:             "The full path and filename of the process.
+1706:             For example, '/opt/MYYpkg/bin/myyproc' would
+1707:             be returned for process 'myyproc' whose execution
+1708:             path was '/opt/MYYpkg/bin/myyproc'."
+1709:         ::= { sysApplElmtPastRunEntry 6 }
+
+
+
+
+
+
+
+
+
+Nesser                       Informational                    [Page 238]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+'yy' on a line without 'yyyy' found at line 1708:
+1706:             For example, '/opt/MYYpkg/bin/myyproc' would
+1707:             be returned for process 'myyproc' whose execution
+1708:             path was '/opt/MYYpkg/bin/myyproc'."
+1709:         ::= { sysApplElmtPastRunEntry 6 }
+1710:
+
+2000 found at line 402:
+400:
+401:     sysApplMIB MODULE-IDENTITY
+402:         LAST-UPDATED "9710200000Z"
+403:         ORGANIZATION "IETF Applications MIB Working Group"
+404:         CONTACT-INFO
+
++=+=+=+=+= File rfc2292.txt +=+=+=+=+=
+2000 found at line 547:
+545:     #define ND_NA_FLAG_ROUTER        0x80000000
+546:     #define ND_NA_FLAG_SOLICITED     0x40000000
+547:     #define ND_NA_FLAG_OVERRIDE      0x20000000
+548:     #else   /* BYTE_ORDER == LITTLE_ENDIAN */
+549:     #define ND_NA_FLAG_ROUTER        0x00000080
+
++=+=+=+=+= File rfc2298.txt +=+=+=+=+=
+2000 found at line 1310:
+1308:     Date: Wed, 20 Sep 1995 00:19:00 (EDT) -0400
+1309:     From: Joe Recipient <Joe_Recipient@mega.edu>
+1310:     Message-Id: <199509200019.12345@mega.edu>
+1311:     Subject: Disposition notification
+1312:     To: Jane Sender <Jane_Sender@huge.com>
+
++=+=+=+=+= File rfc2300.txt +=+=+=+=+=
+2000 found at line 9:
+7:  Network Working Group                        Internet Architectu
+7(continued):           re Board
+8:  Request for Comments: 2300                             J. Postel
+8(continued):           , Editor
+9:  Obsoletes: 2200, 2000, 1920, 1880, 1800,
+9(continued):           May 1998
+10:  1780, 1720, 1610, 1600, 1540, 1500, 1410,
+11:  1360, 1280, 1250, 1200, 1140, 1130, 1100, 1083
+
++=+=+=+=+= File rfc2308.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 873:
+871:               NS2.XX.EXAMPLE.   600 IN NXT XX.EXAMPLE. NXT A NXT
+871(continued):         SIG
+872:               NS2.XX.EXAMPLE.   600 IN SIG NXT ... XX.EXAMPLE. ..
+872(continued):         .
+873:               EXAMPLE.        65799 IN NS  NS1.YY.EXAMPLE.
+
+
+
+Nesser                       Informational                    [Page 239]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+874:               EXAMPLE.        65799 IN NS  NS2.YY.EXAMPLE.
+875:               EXAMPLE.        65799 IN SIG NS ... XX.EXAMPLE. ...
+875(continued):
+
+'yy' on a line without 'yyyy' found at line 874:
+872:               NS2.XX.EXAMPLE.   600 IN SIG NXT ... XX.EXAMPLE. ..
+872(continued):         .
+873:               EXAMPLE.        65799 IN NS  NS1.YY.EXAMPLE.
+874:               EXAMPLE.        65799 IN NS  NS2.YY.EXAMPLE.
+875:               EXAMPLE.        65799 IN SIG NS ... XX.EXAMPLE. ...
+875(continued):
+876:           Additional
+
+'yy' on a line without 'yyyy' found at line 879:
+877:               XX.EXAMPLE.     65800 IN KEY 0x4100 1 1 ...
+878:               XX.EXAMPLE.     65800 IN SIG KEY ... EXAMPLE. ...
+879:               NS1.YY.EXAMPLE. 65799 IN A   10.100.0.1
+880:               NS1.YY.EXAMPLE. 65799 IN SIG A ... EXAMPLE. ...
+881:               NS2.YY.EXAMPLE. 65799 IN A   10.100.0.2
+
+'yy' on a line without 'yyyy' found at line 880:
+878:               XX.EXAMPLE.     65800 IN SIG KEY ... EXAMPLE. ...
+879:               NS1.YY.EXAMPLE. 65799 IN A   10.100.0.1
+880:               NS1.YY.EXAMPLE. 65799 IN SIG A ... EXAMPLE. ...
+881:               NS2.YY.EXAMPLE. 65799 IN A   10.100.0.2
+882:               NS3.YY.EXAMPLE. 65799 IN SIG A ... EXAMPLE. ...
+
+'yy' on a line without 'yyyy' found at line 881:
+879:               NS1.YY.EXAMPLE. 65799 IN A   10.100.0.1
+880:               NS1.YY.EXAMPLE. 65799 IN SIG A ... EXAMPLE. ...
+881:               NS2.YY.EXAMPLE. 65799 IN A   10.100.0.2
+882:               NS3.YY.EXAMPLE. 65799 IN SIG A ... EXAMPLE. ...
+883:               EXAMPLE.        65799 IN KEY 0x4100 1 1 ...
+
+'yy' on a line without 'yyyy' found at line 882:
+880:               NS1.YY.EXAMPLE. 65799 IN SIG A ... EXAMPLE. ...
+881:               NS2.YY.EXAMPLE. 65799 IN A   10.100.0.2
+882:               NS3.YY.EXAMPLE. 65799 IN SIG A ... EXAMPLE. ...
+883:               EXAMPLE.        65799 IN KEY 0x4100 1 1 ...
+884:               EXAMPLE.        65799 IN SIG KEY ... . ...
+
+2000 found at line 805:
+803:          $ORIGIN XX.EXAMPLE.
+804:          @       IN      SOA     NS1.XX.EXAMPLE. HOSTMATER.XX.EXA
+804(continued):         MPLE. (
+805:                                  1997102000      ; serial
+806:                                  1800    ; refresh (30 mins)
+807:                                  900     ; retry (15 mins)
+
+
+
+Nesser                       Informational                    [Page 240]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc2311.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 269:
+267:     Sending agents MUST encode signing time through the year 2049
+267(continued):          as
+268:     UTCTime; signing times in 2050 or later MUST be encoded as
+269:     GeneralizedTime. Agents MUST interpret the year field (YY) as
+269(continued):
+270:     follows: if YY is greater than or equal to 50, the year is
+271:     interpreted as 19YY; if YY is less than 50, the year is inter
+271(continued):         preted
+
+'yy' on a line without 'yyyy' found at line 270:
+268:     UTCTime; signing times in 2050 or later MUST be encoded as
+269:     GeneralizedTime. Agents MUST interpret the year field (YY) as
+269(continued):
+270:     follows: if YY is greater than or equal to 50, the year is
+271:     interpreted as 19YY; if YY is less than 50, the year is inter
+271(continued):         preted
+272:     as 20YY.
+
+'yy' on a line without 'yyyy' found at line 271:
+269:     GeneralizedTime. Agents MUST interpret the year field (YY) as
+269(continued):
+270:     follows: if YY is greater than or equal to 50, the year is
+271:     interpreted as 19YY; if YY is less than 50, the year is inter
+271(continued):         preted
+272:     as 20YY.
+273:
+
+'yy' on a line without 'yyyy' found at line 272:
+270:     follows: if YY is greater than or equal to 50, the year is
+271:     interpreted as 19YY; if YY is less than 50, the year is inter
+271(continued):         preted
+272:     as 20YY.
+273:
+274:  2.5.2 S/MIME Capabilities Attribute
+
+UTCTime found at line 268:
+266:
+267:     Sending agents MUST encode signing time through the year 2049
+267(continued):          as
+268:     UTCTime; signing times in 2050 or later MUST be encoded as
+269:     GeneralizedTime. Agents MUST interpret the year field (YY) as
+269(continued):
+270:     follows: if YY is greater than or equal to 50, the year is
+
+1900 found at line 1972:
+1970:     Mountain View, CA  94043
+
+
+
+Nesser                       Informational                    [Page 241]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1971:
+1972:     Phone: (415) 254-1900
+1973:     EMail: repka@netscape.com
+1974:
+
++=+=+=+=+= File rfc2312.txt +=+=+=+=+=
+1900 found at line 1049:
+1047:     Mountain View, CA  94043
+1048:
+1049:     Phone: (415) 254-1900
+1050:     EMail: jsw@netscape.com
+1051:
+
++=+=+=+=+= File rfc2326.txt +=+=+=+=+=
+2digit found at line 906:
+904:     smpte-type   =   "smpte" | "smpte-30-drop" | "smpte-25"
+905:                                     ; other timecodes may be adde
+905(continued):         d
+906:     smpte-time   =   1*2DIGIT ":" 1*2DIGIT ":" 1*2DIGIT [ ":" 1*2
+906(continued):         DIGIT ]
+907:                         [ "." 1*2DIGIT ]
+908:
+
+2digit found at line 907:
+905:                                     ; other timecodes may be adde
+905(continued):         d
+906:     smpte-time   =   1*2DIGIT ":" 1*2DIGIT ":" 1*2DIGIT [ ":" 1*2
+906(continued):         DIGIT ]
+907:                         [ "." 1*2DIGIT ]
+908:
+909:     Examples:
+
+2digit found at line 940:
+938:     npt-hhmmss   =   npt-hh ":" npt-mm ":" npt-ss [ "." *DIGIT ]
+939:     npt-hh       =   1*DIGIT     ; any positive number
+940:     npt-mm       =   1*2DIGIT    ; 0-59
+941:     npt-ss       =   1*2DIGIT    ; 0-59
+942:
+
+2digit found at line 941:
+939:     npt-hh       =   1*DIGIT     ; any positive number
+940:     npt-mm       =   1*2DIGIT    ; 0-59
+941:     npt-ss       =   1*2DIGIT    ; 0-59
+942:
+943:     Examples:
+
+
+
+
+
+
+Nesser                       Informational                    [Page 242]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc2332.txt +=+=+=+=+=
+1900 found at line 2839:
+2837:     1620 Tuckerstown Road               3260 Jay St.
+2838:     Dresher, PA 19025 USA               Santa Clara, CA 95054
+2839:     Phone:  +1 215 830 0692             Phone:  +1 408 327 1900
+2840:     EMail: dave@corecom.com             EMail:  bcole@jnx.com
+2841:
+
++=+=+=+=+= File rfc2353.txt +=+=+=+=+=
+2000 found at line 211:
+209:     native IP DLC, this field is not used to convey a port number
+209(continued):          for
+210:     replies; moreover, the zero setting is not used.  IANA has re
+210(continued):         gistered
+211:     port numbers 12000 through 12004 for use in these two fields
+211(continued):         by the
+212:     native IP DLC; use of these port numbers allows prioritizatio
+212(continued):         n in the
+213:     IP network.  For more details of the use of these fields, see
+213(continued):          2.6.1,
+
+2000 found at line 1694:
+1692:
+1693:     At an intermediate HPR node, link activation failure can be r
+1693(continued):                eported
+1694:     with sense data X'08010000' or X'80020000'.  At a node with r
+1694(continued):                oute-
+1695:     selection responsibility, such failure can be reported with s
+1695(continued):                ense
+1696:     data X'80140001'.
+
+2000 found at line 1841:
+1839:  | the same connection network.                           |
+1839(continued):                       |
+1840:  +--------------------------------------------------------+------
+1840(continued):                -------+
+1841:  | Link failure                                           | X'800
+1841(continued):                20000' |
+1842:  +--------------------------------------------------------+------
+1842(continued):                -------+
+1843:  | Route selection services has determined that no path   | X'801
+1843(continued):                40001' |
+
+2000 found at line 1868:
+1866:     will be able to exploit routers that provide priority functio
+1866(continued):                n.
+1867:
+1868:     The 5 UDP port numbers, 12000-12004 (decimal), have been assi
+
+
+
+Nesser                       Informational                    [Page 243]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1868(continued):                gned by
+1869:     the Internet Assigned Number Authority (IANA).  Four of these
+1869(continued):                 port
+1870:     numbers are used for ANR-routed network layer packets (NLPs)
+1870(continued):                and
+
+2000 found at line 1872:
+1870:     numbers are used for ANR-routed network layer packets (NLPs)
+1870(continued):                and
+1871:     correspond to the APPN transmission priorities (network, 1200
+1871(continued):                1; high,
+1872:     12002; medium, 12003; and low, 12004), and one port number (1
+1872(continued):                2000) is
+1873:     used for a set of LLC commands (i.e., XID, TEST, DISC, and DM
+1873(continued):                ) and
+1874:     function-routed NLPs (i.e., XID_DONE_RQ and XID_DONE_RSP).  T
+1874(continued):                hese
+
+2000 found at line 2417:
+2415:     the source port number is not relevant.  That is, the firewal
+2415(continued):                l should
+2416:     accept traffic with the IP addresses of the HPR/IP nodes and
+2416(continued):                with
+2417:     destination port numbers in the range 12000 to 12004.  Second
+2417(continued):                , the
+2418:     possibility exists for an attack using forged UDP datagrams;
+2418(continued):                such
+2419:     attacks could cause the RTP connection to fail or even introd
+2419(continued):                uce
+
++=+=+=+=+= File rfc2355.txt +=+=+=+=+=
+2000 found at line 1488:
+1486:                0x00           Command Reject        0x10030000
+1487:
+1488:                0x01        Intervention Required    0x08020000
+1489:
+1490:                0x02           Operation Check       0x10050000
+
++=+=+=+=+= File rfc2361.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 30:
+28:     * video/vnd.avi; codec=XXX identifies a specific video codec
+28(continued):          (i.e.,
+29:       XXX) within the AVI Registry.
+30:     * audio/vnd.wave; codec=YYY identifies a specific audio codec
+30(continued):
+31:       (i.e., YYY) within the WAVE Registry.
+32:
+
+
+
+
+Nesser                       Informational                    [Page 244]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+'yy' on a line without 'yyyy' found at line 31:
+29:       XXX) within the AVI Registry.
+30:     * audio/vnd.wave; codec=YYY identifies a specific audio codec
+30(continued):
+31:       (i.e., YYY) within the WAVE Registry.
+32:
+33:     Appendix A and Appendix B provides an authoritative reference
+33(continued):           for the
+
+2000 found at line 354:
+352:    Compaq Computer Corporation
+353:    20555 SH 249
+354:    Houston, TX 77269-2000 USA
+355:
+356:    A.6     IBM CVSD
+
+2000 found at line 1474:
+1472:    PO Box 582
+1473:    Stellenbosch Stellenbosch South Africa
+1474:    27 21 888 2000
+1475:
+1476:    A.75    DF GSM610
+
+2000 found at line 1487:
+1485:    PO Box 582
+1486:    Stellenbosch 7600 South Africa
+1487:    27 21 888 2000
+1488:
+1489:    A.76    ISIAudio
+
+2000 found at line 1545:
+1543:    4900 Old Ironsides Drive
+1544:    Santa Clara, California 95054 USA
+1545:    (408) 492-2000
+1546:
+1547:    A.79    Dolby AC3 SPDIF
+
+2000 found at line 1993:
+1991:    A.104   DVM
+1992:
+1993:    WAVE form Registration Number (hex):    0x2000
+1994:    Codec ID in the IANA Namespace:         audio/vnd.wave;codec=2
+1994(continued):                000
+1995:    WAVE form wFormatTag ID:                WAVE_FORMAT_DVM
+
+2000 found at line 1994:
+1992:
+1993:    WAVE form Registration Number (hex):    0x2000
+
+
+
+Nesser                       Informational                    [Page 245]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1994:    Codec ID in the IANA Namespace:         audio/vnd.wave;codec=2
+1994(continued):                000
+1995:    WAVE form wFormatTag ID:                WAVE_FORMAT_DVM
+1996:    Contact:
+
+2000 found at line 3180:
+3178:    707 California Street
+3179:    Mountain View, California 94041 USA
+3180:    650-526-2000
+3181:
+3182:
+
+2000 found at line 3211:
+3209:    707 California Street
+3210:    Mountain View, California 94041 USA
+3211:    650-526-2000
+3212:
+3213:    B.83    TrueMotion 2.0
+
+2000 found at line 3239:
+3237:    707 California Street
+3238:    Mountain View, California 94041 USA
+3239:    650-526-2000
+3240:
+3241:
+
++=+=+=+=+= File rfc2368.txt +=+=+=+=+=
+two-digit found at line 240:
+238:     scheme is not a problem: those characters may appear in mailt
+238(continued):         o URLs,
+239:     they just may not appear in unencoded form. The standard URL
+239(continued):         encoding
+240:     mechanisms ("%" followed by a two-digit hex number) must be u
+240(continued):         sed in
+241:     certain cases.
+242:
+
+
++=+=+=+=+= File rfc2373.txt +=+=+=+=+=
+2digit found at line 1192:
+1190:        IPv4address = 1*3DIGIT "." 1*3DIGIT "." 1*3DIGIT "." 1*3DI
+1190(continued):                GIT
+1191:
+1192:        IPv6prefix  = hexpart "/" 1*2DIGIT
+1193:
+1194:        hexpart = hexseq | hexseq "::" [ hexseq ] | "::" [ hexseq
+1194(continued):                ]
+
+
+
+
+Nesser                       Informational                    [Page 246]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
++=+=+=+=+= File rfc2378.txt +=+=+=+=+=
+2digit found at line 1078:
+1076:     response = code [index] [field] text CRLF
+1077:
+1078:     code     = [-] LDIG 2DIGIT ":"
+1079:     index    = number ":"
+1080:     field    = 1*SPACE attribute ":" 1*SPACE
+
++=+=+=+=+= File rfc2389.txt +=+=+=+=+=
+2digit found at line 133:
+131:
+132:          error-response = error-code SP *TCHAR CRLF
+133:          error-code     = ("4" / "5") 2DIGIT
+134:
+135:     Note that in ABNF, strings literals are case insensitive.  Th
+135(continued):         at
+
++=+=+=+=+= File rfc2397.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 107:
+105:     a/TPg7JpJHxyendzWTBfX0cxOnKPjgBzi4diinWGdkF8kjdfnycQZXZeYGejm
+105(continued):         Jl
+106:     ZeGl9i2icVqaNVailT6F5iJ90m6mvuTS4OK05M0vDk0Q4XUtwvKOzrcd3iq9u
+106(continued):         is
+107:     F81M1OIcR7lEewwcLp7tuNNkM3uNna3F2JQFo97Vriy/Xl4/f1cf5VWzXyym7
+107(continued):         PH
+108:     hhx4dbgYKAAA7"
+109:     ALT="Larry">
+
++=+=+=+=+= File rfc2400.txt +=+=+=+=+=
+2000 found at line 9:
+7:  Network Working Group                        Internet Architectu
+7(continued):           re Board
+8:  Request for Comments: 2400                                     J
+8(continued):           . Postel
+9:  Obsoletes: 2300, 2200, 2000, 1920, 1880,                     J.
+9(continued):           Reynolds
+10:  1800, 1780, 1720, 1610, 1600, 1540, 1500, 1410,
+10(continued):           Editors
+11:  1360, 1280, 1250, 1200, 1140, 1130, 1100, 1083            Septem
+11(continued):          ber 1998
+
++=+=+=+=+= File rfc2407.txt +=+=+=+=+=
+2000 found at line 832:
+830:
+831:       Attribute #2:
+
+
+
+
+
+
+Nesser                       Informational                    [Page 247]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+832:         0x00020004  (AF = 0, type = SA Duration, length = 4 bytes
+832(continued):         )
+833:         0x00015180  (value = 0x15180 = 86400 seconds = 24 hours)
+834:
+
+2000 found at line 848:
+846:
+847:       Attribute #4:
+848:         0x00020004  (AF = 0, type = SA Duration, length = 4 bytes
+848(continued):         )
+849:         0x000186A0  (value = 0x186A0 = 100000KB = 100MB)
+850:
+
++=+=+=+=+= File rfc2409.txt +=+=+=+=+=
+2000 found at line 1257:
+1255:     Field Size:                         185
+1256:     Group Prime/Irreducible Polynomial:
+1257:                      0x020000000000000000000000000000200000000000
+1257(continued):                000001
+1258:     Group Generator One:                0x18
+1259:     Group Curve A:                      0x0
+
++=+=+=+=+= File rfc2412.txt +=+=+=+=+=
+2000 found at line 1689:
+1687:     As of early 1996, it appears that for 90 bits of cryptographi
+1687(continued):                c
+1688:     strength, one should use a modular exponentiation group modul
+1688(continued):                us of
+1689:     2000 bits.  For 128 bits of strength, a 3000 bit modulus is r
+1689(continued):                equired.
+1690:
+1691:  3. Specifying and Deriving Security Associations
+
+2000 found at line 2761:
+2759:           Length (32 bit words):          6
+2760:           Data (hex):
+2761:              02000000 00000000 00000000 00000020 00000000 0000000
+2761(continued):                1
+2762:        Generator:
+2763:           X coordinate:                   22 (decimal)
+
+2000 found at line 2976:
+2974:
+2975:     [Stinson]    Stinson, Douglas, Cryptography Theory and Practi
+2975(continued):                ce. CRC
+
+
+
+
+
+
+Nesser                       Informational                    [Page 248]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2976:                  Press, Inc., 2000, Corporate Blvd., Boca Raton,
+2976(continued):                FL,
+2977:                  33431-9868, ISBN 0-8493-8521-0, 1995
+2978:
+
++=+=+=+=+= File rfc2425.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 1106:
+1104:   9ucyBDb3JwLjEYMBYGA1UEAxMPVGltb3RoeSBBIEhvd2VzMSEwHwYJKoZIhvcNA
+1104(continued):                QkBF
+1105:   hJob3dlc0BuZXRzY2FwZS5jb20xFTATBgoJkiaJk/IsZAEBEwVob3dlczBcMA0G
+1105(continued):                CSqG
+1106:   SIb3DQEBAQUAA0sAMEgCQQC0JZf6wkg8pLMXHHCUvMfL5H6zjSk4vTTXZpYyrdN
+1106(continued):                2dXc
+1107:   oX49LKiOmgeJSzoiFKHtLOIboyludF90CgqcxtwKnAgMBAAGjNjA0MBEGCWCGSA
+1107(continued):                GG+E
+1108:   IBAQQEAwIAoDAfBgNVHSMEGDAWgBT84FToB/GV3jr3mcau+hUMbsQukjANBgkqh
+1108(continued):                kiG9
+
++=+=+=+=+= File rfc2426.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 1479:
+1477:           MPVGltb3RoeSBBIEhvd2VzMSEwHwYJKoZIhvcNAQkBFhJob3dlc0BuZ
+1477(continued):                XRz
+1478:           Y2FwZS5jb20xFTATBgoJkiaJk/IsZAEBEwVob3dlczBcMA0GCSqGSIb
+1478(continued):                3DQ
+1479:           EBAQUAA0sAMEgCQQC0JZf6wkg8pLMXHHCUvMfL5H6zjSk4vTTXZpYyr
+1479(continued):                dN2
+1480:           dXcoX49LKiOmgeJSzoiFKHtLOIboyludF90CgqcxtwKnAgMBAAGjNjA
+1480(continued):                0MB
+1481:           EGCWCGSAGG+EIBAQQEAwIAoDAfBgNVHSMEGDAWgBT84FToB/GV3jr3m
+1481(continued):                cau
+
+2-digit found at line 372:
+370:     and minutes (e.g., +hh:mm). The time is specified as a 24-hou
+370(continued):         r clock.
+371:     Hour values are from 00 to 23, and minute values are from 00
+371(continued):         to 59.
+372:     Hour and minutes are 2-digits with high order zeroes required
+372(continued):          to
+373:     maintain digit count. The extended format for ISO 8601 UTC of
+373(continued):         fsets
+374:     MUST be used. The extended format makes use of a colon charac
+374(continued):         ter as a
+
+
+
+
+
+
+
+
+
+Nesser                       Informational                    [Page 249]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2digit found at line 379:
+377:     The value is defined by the following notation:
+378:
+379:          time-hour       = 2DIGIT        ;00-23
+380:          time-minute     = 2DIGIT        ;00-59
+381:          utc-offset      = ("+" / "-") time-hour ":" time-minute
+
+2digit found at line 380:
+378:
+379:          time-hour       = 2DIGIT        ;00-23
+380:          time-minute     = 2DIGIT        ;00-59
+381:          utc-offset      = ("+" / "-") time-hour ":" time-minute
+382:
+
+2digit found at line 2051:
+2049:
+2050:     utc-offset-value = ("+" / "-") time-hour ":" time-minute
+2051:     time-hour    = 2DIGIT                ;00-23
+2052:     time-minute  = 2DIGIT                ;00-59
+2053:
+
+2digit found at line 2052:
+2050:     utc-offset-value = ("+" / "-") time-hour ":" time-minute
+2051:     time-hour    = 2DIGIT                ;00-23
+2052:     time-minute  = 2DIGIT                ;00-59
+2053:
+2054:  5.  Differences From vCard v2.1
+
++=+=+=+=+= File rfc2440.txt +=+=+=+=+=
+2000 found at line 3227:
+3225:     Encryption Standard. This algorithm will work with (at least)
+3225(continued):                 128,
+3226:     192, and 256-bit keys. We expect that this algorithm will be
+3226(continued):                selected
+3227:     from the candidate algorithms in the year 2000.
+3228:
+3229:  12.8. OpenPGP CFB mode
+
++=+=+=+=+= File rfc2445.txt +=+=+=+=+=
+'yy' on a line without 'yyyy' found at line 2234:
+2232:                  ( ";" "BYDAY" "=" bywdaylist )          /
+2233:                  ( ";" "BYMONTHDAY" "=" bymodaylist )    /
+2234:                  ( ";" "BYYEARDAY" "=" byyrdaylist )     /
+2235:                  ( ";" "BYWEEKNO" "=" bywknolist )       /
+2236:                  ( ";" "BYMONTH" "=" bymolist )          /
+
+'yy' on a line without 'yyyy' found at line 2288:
+2286:       ordmoday   = 1DIGIT / 2DIGIT       ;1 to 31
+
+
+
+Nesser                       Informational                    [Page 250]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2287:
+2288:       byyrdaylist = yeardaynum / ( yeardaynum *("," yeardaynum) )
+2288(continued):
+2289:
+2290:       yeardaynum = ([plus] ordyrday) / (minus ordyrday)
+
+'yy' on a line without 'yyyy' found at line 2388:
+2386:     the month.
+2387:
+2388:     The BYYEARDAY rule part specifies a COMMA character (US-ASCII
+2388(continued):                 decimal
+2389:     44) separated list of days of the year. Valid values are 1 to
+2389(continued):                 366 or
+2390:     -366 to -1. For example, -1 represents the last day of the ye
+2390(continued):                ar
+
+'yy' on a line without 'yyyy' found at line 2461:
+2459:     specified FREQ and INTERVAL rule parts, the BYxxx rule parts
+2459(continued):                are
+2460:     applied to the current set of evaluated occurrences in the fo
+2460(continued):                llowing
+2461:     order: BYMONTH, BYWEEKNO, BYYEARDAY, BYMONTHDAY, BYDAY, BYHOU
+2461(continued):                R,
+2462:     BYMINUTE, BYSECOND and BYSETPOS; then COUNT and UNTIL are eva
+2462(continued):                luated.
+2463:
+
+'yy' on a line without 'yyyy' found at line 6804:
+6802:           (2000 9:00 AM EDT)June 10;July 10
+6803:           (2001 9:00 AM EDT)June 10;July 10
+6804:       Note: Since none of the BYDAY, BYMONTHDAY or BYYEARDAY comp
+6804(continued):                onents
+6805:       are specified, the day is gotten from DTSTART
+6806:
+
+'yy' on a line without 'yyyy' found at line 6820:
+6818:
+6819:       DTSTART;TZID=US-Eastern:19970101T090000
+6820:       RRULE:FREQ=YEARLY;INTERVAL=3;COUNT=10;BYYEARDAY=1,100,200
+6821:
+6822:       ==> (1997 9:00 AM EST)January 1
+
+two-digit found at line 1919:
+1917:     of values. The format for the value type is expressed as the
+1917(continued):                [ISO
+1918:     8601] complete representation, basic format for a calendar da
+1918(continued):                te. The
+1919:     textual format specifies a four-digit year, two-digit month,
+
+
+
+Nesser                       Informational                    [Page 251]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1919(continued):                and
+1920:     two-digit day of the month. There are no separator characters
+1920(continued):                 between
+1921:     the year, month and day component text.
+
+two-digit found at line 1920:
+1918:     8601] complete representation, basic format for a calendar da
+1918(continued):                te. The
+1919:     textual format specifies a four-digit year, two-digit month,
+1919(continued):                and
+1920:     two-digit day of the month. There are no separator characters
+1920(continued):                 between
+1921:     the year, month and day component text.
+1922:
+
+two-digit found at line 2610:
+2608:     of day. The format is based on the [ISO 8601] complete
+2609:     representation, basic format for a time of day. The text form
+2609(continued):                at
+2610:     consists of a two-digit 24-hour of the day (i.e., values 0-23
+2610(continued):                ), two-
+2611:     digit minute in the hour (i.e., values 0-59), and two-digit s
+2611(continued):                econds
+2612:     in the minute (i.e., values 0-60). The seconds value of 60 MU
+2612(continued):                ST only
+
+two-digit found at line 2611:
+2609:     representation, basic format for a time of day. The text form
+2609(continued):                at
+2610:     consists of a two-digit 24-hour of the day (i.e., values 0-23
+2610(continued):                ), two-
+2611:     digit minute in the hour (i.e., values 0-59), and two-digit s
+2611(continued):                econds
+2612:     in the minute (i.e., values 0-60). The seconds value of 60 MU
+2612(continued):                ST only
+2613:     to be used to account for "leap" seconds. Fractions of a seco
+2613(continued):                nd are
+
+two-digit found at line 4583:
+4581:     Values for latitude and longitude shall be expressed as decim
+4581(continued):                al
+4582:     fractions of degrees. Whole degrees of latitude shall be repr
+4582(continued):                esented
+
+
+
+
+
+
+
+
+Nesser                       Informational                    [Page 252]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+4583:     by a two-digit decimal number ranging from 0 through 90. Whol
+4583(continued):                e
+4584:     degrees of longitude shall be represented by a decimal number
+4584(continued):                 ranging
+4585:     from 0 through 180. When a decimal fraction of a degree is sp
+4585(continued):                ecified,
+
+2digit found at line 1911:
+1909:
+1910:
+1911:       date-month         = 2DIGIT        ;01-12
+1912:       date-mday          = 2DIGIT        ;01-28, 01-29, 01-30, 01
+1912(continued):                -31
+1913:                                          ;based on month/year
+
+2digit found at line 1912:
+1910:
+1911:       date-month         = 2DIGIT        ;01-12
+1912:       date-mday          = 2DIGIT        ;01-28, 01-29, 01-30, 01
+1912(continued):                -31
+1913:                                          ;based on month/year
+1914:
+
+2digit found at line 2258:
+2256:       byseclist  = seconds / ( seconds *("," seconds) )
+2257:
+2258:       seconds    = 1DIGIT / 2DIGIT       ;0 to 59
+2259:
+2260:       byminlist  = minutes / ( minutes *("," minutes) )
+
+2digit found at line 2262:
+2260:       byminlist  = minutes / ( minutes *("," minutes) )
+2261:
+2262:       minutes    = 1DIGIT / 2DIGIT       ;0 to 59
+2263:
+2264:       byhrlist   = hour / ( hour *("," hour) )
+
+2digit found at line 2266:
+2264:       byhrlist   = hour / ( hour *("," hour) )
+2265:
+2266:       hour       = 1DIGIT / 2DIGIT       ;0 to 23
+2267:
+2268:       bywdaylist = weekdaynum / ( weekdaynum *("," weekdaynum) )
+
+2digit found at line 2276:
+2274:       minus      = "-"
+2275:
+2276:       ordwk      = 1DIGIT / 2DIGIT       ;1 to 53
+
+
+
+Nesser                       Informational                    [Page 253]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2277:
+2278:       weekday    = "SU" / "MO" / "TU" / "WE" / "TH" / "FR" / "SA"
+2278(continued):
+
+2digit found at line 2286:
+2284:       monthdaynum = ([plus] ordmoday) / (minus ordmoday)
+2285:
+2286:       ordmoday   = 1DIGIT / 2DIGIT       ;1 to 31
+2287:
+2288:       byyrdaylist = yeardaynum / ( yeardaynum *("," yeardaynum) )
+2288(continued):
+
+2digit found at line 2292:
+2290:       yeardaynum = ([plus] ordyrday) / (minus ordyrday)
+2291:
+2292:       ordyrday   = 1DIGIT / 2DIGIT / 3DIGIT      ;1 to 366
+2293:
+2294:       bywknolist = weeknum / ( weeknum *("," weeknum) )
+
+2digit found at line 2307:
+2305:       bymolist   = monthnum / ( monthnum *("," monthnum) )
+2306:
+2307:       monthnum   = 1DIGIT / 2DIGIT       ;1 to 12
+2308:
+2309:       bysplist   = setposday / ( setposday *("," setposday) )
+
+2digit found at line 2595:
+2593:       time               = time-hour time-minute time-second [tim
+2593(continued):                e-utc]
+2594:
+2595:       time-hour          = 2DIGIT        ;00-23
+2596:       time-minute        = 2DIGIT        ;00-59
+2597:       time-second        = 2DIGIT        ;00-60
+
+2digit found at line 2596:
+2594:
+2595:       time-hour          = 2DIGIT        ;00-23
+2596:       time-minute        = 2DIGIT        ;00-59
+2597:       time-second        = 2DIGIT        ;00-60
+2598:       ;The "60" value is used to account for "leap" seconds.
+
+2digit found at line 2597:
+2595:       time-hour          = 2DIGIT        ;00-23
+2596:       time-minute        = 2DIGIT        ;00-59
+2597:       time-second        = 2DIGIT        ;00-60
+2598:       ;The "60" value is used to account for "leap" seconds.
+2599:
+
+
+
+
+Nesser                       Informational                    [Page 254]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1900 found at line 2988:
+2986:       DTSTAMP:19970901T1300Z
+2987:       DTSTART:19970903T163000Z
+2988:       DTEND:19970903T190000Z
+2989:       SUMMARY:Annual Employee Review
+2990:       CLASS:PRIVATE
+
+2000 found at line 1716:
+1714:     The following are examples of this property parameter:
+1715:
+1716:       DTSTART;TZID=US-Eastern:19980119T020000
+1717:
+1718:       DTEND;TZID=US-Eastern:19980119T030000
+
+2000 found at line 2029:
+2027:     New York on Janurary 19, 1998:
+2028:
+2029:            DTSTART;TZID=US-Eastern:19980119T020000
+2030:
+2031:     Example: The following represents July 14, 1997, at 1:30 PM i
+2031(continued):                n New
+
+2000 found at line 2822:
+2820:     Property names, parameter names and enumerated parameter valu
+2820(continued):                es are
+2821:     case insensitive. For example, the property name "DUE" is the
+2821(continued):                 same as
+2822:     "due" and "Due", DTSTART;TZID=US-Eastern:19980714T120000 is t
+2822(continued):                he same
+2823:     as DtStart;TzID=US-Eastern:19980714T120000.
+2824:
+
+2000 found at line 2823:
+2821:     case insensitive. For example, the property name "DUE" is the
+2821(continued):                 same as
+2822:     "due" and "Due", DTSTART;TZID=US-Eastern:19980714T120000 is t
+2822(continued):                he same
+2823:     as DtStart;TzID=US-Eastern:19980714T120000.
+2824:
+2825:  4.6 Calendar Components
+
+2000 found at line 3566:
+3564:     Time took effect in Fall 1967 for New York City:
+3565:
+3566:       DTSTART:19671029T020000
+3567:
+3568:       TZOFFSETFROM:-0400
+
+
+
+
+Nesser                       Informational                    [Page 255]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2000 found at line 3631:
+3629:       LAST-MODIFIED:19870101T000000Z
+3630:       BEGIN:STANDARD
+3631:       DTSTART:19971026T020000
+3632:       RDATE:19971026T020000
+3633:       TZOFFSETFROM:-0400
+
+2000 found at line 3632:
+3630:       BEGIN:STANDARD
+3631:       DTSTART:19971026T020000
+3632:       RDATE:19971026T020000
+3633:       TZOFFSETFROM:-0400
+3634:       TZOFFSETTO:-0500
+
+2000 found at line 3638:
+3636:       END:STANDARD
+3637:       BEGIN:DAYLIGHT
+3638:       DTSTART:19971026T020000
+3639:
+3640:
+
+2000 found at line 3647:
+3645:
+3646:
+3647:       RDATE:19970406T020000
+3648:       TZOFFSETFROM:-0500
+3649:       TZOFFSETTO:-0400
+
+2000 found at line 3665:
+3663:       TZURL:http://zones.stds_r_us.net/tz/US-Eastern
+3664:       BEGIN:STANDARD
+3665:       DTSTART:19671029T020000
+3666:       RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10
+3667:       TZOFFSETFROM:-0400
+
+2000 found at line 3672:
+3670:       END:STANDARD
+3671:       BEGIN:DAYLIGHT
+3672:       DTSTART:19870405T020000
+3673:       RRULE:FREQ=YEARLY;BYDAY=1SU;BYMONTH=4
+3674:       TZOFFSETFROM:-0500
+
+2000 found at line 3688:
+3686:       LAST-MODIFIED:19870101T000000Z
+3687:       BEGIN:STANDARD
+3688:       DTSTART:19671029T020000
+3689:       RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10
+3690:       TZOFFSETFROM:-0400
+
+
+
+Nesser                       Informational                    [Page 256]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2000 found at line 3704:
+3702:
+3703:       BEGIN:DAYLIGHT
+3704:       DTSTART:19870405T020000
+3705:       RRULE:FREQ=YEARLY;BYDAY=1SU;BYMONTH=4;UNTIL=19980404T070000
+3705(continued):                Z
+3706:       TZOFFSETFROM:-0500
+
+2000 found at line 3721:
+3719:       LAST-MODIFIED:19870101T000000Z
+3720:       BEGIN:STANDARD
+3721:       DTSTART:19671029T020000
+3722:       RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10
+3723:       TZOFFSETFROM:-0400
+
+2000 found at line 3728:
+3726:       END:STANDARD
+3727:       BEGIN:DAYLIGHT
+3728:       DTSTART:19870405T020000
+3729:       RRULE:FREQ=YEARLY;BYDAY=1SU;BYMONTH=4;UNTIL=19980404T070000
+3729(continued):                Z
+3730:       TZOFFSETFROM:-0500
+
+2000 found at line 3735:
+3733:       END:DAYLIGHT
+3734:       BEGIN:DAYLIGHT
+3735:       DTSTART:19990424T020000
+3736:       RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=4
+3737:       TZOFFSETFROM:-0500
+
+2000 found at line 5352:
+5350:       FREEBUSY;FBTYPE=BUSY-UNAVAILABLE:19970308T160000Z/PT8H30M
+5351:
+5352:       FREEBUSY;FBTYPE=FREE:19970308T160000Z/PT3H,19970308T200000Z
+5352(continued):                /PT1H
+5353:
+5354:       FREEBUSY;FBTYPE=FREE:19970308T160000Z/PT3H,19970308T200000Z
+5354(continued):                /PT1H,
+
+2000 found at line 5354:
+5352:       FREEBUSY;FBTYPE=FREE:19970308T160000Z/PT3H,19970308T200000Z
+5352(continued):                /PT1H
+5353:
+5354:       FREEBUSY;FBTYPE=FREE:19970308T160000Z/PT3H,19970308T200000Z
+5354(continued):                /PT1H,
+5355:        19970308T230000Z/19970309T000000Z
+5356:
+
+
+
+
+Nesser                       Informational                    [Page 257]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2000 found at line 6069:
+6067:       RECURRENCE-ID;VALUE=DATE:19960401
+6068:
+6069:       RECURRENCE-ID;RANGE=THISANDFUTURE:19960120T120000Z
+6070:
+6071:  4.8.4.5 Related To
+
+2000 found at line 6507:
+6505:       RDATE;TZID=US-EASTERN:19970714T083000
+6506:
+6507:       RDATE;VALUE=PERIOD:19960403T020000Z/19960403T040000Z,
+6508:        19960404T010000Z/PT3H
+6509:
+
+2000 found at line 6623:
+6621:
+6622:       DTSTART;TZID=US-Eastern:19980101T090000
+6623:       RRULE:FREQ=YEARLY;UNTIL=20000131T090000Z;
+6624:        BYMONTH=1;BYDAY=SU,MO,TU,WE,TH,FR,SA
+6625:       or
+
+2000 found at line 6626:
+6624:        BYMONTH=1;BYDAY=SU,MO,TU,WE,TH,FR,SA
+6625:       or
+6626:       RRULE:FREQ=DAILY;UNTIL=20000131T090000Z;BYMONTH=1
+6627:
+6628:       ==> (1998 9:00 AM EDT)January 1-31
+
+2000 found at line 6630:
+6628:       ==> (1998 9:00 AM EDT)January 1-31
+6629:           (1999 9:00 AM EDT)January 1-31
+6630:           (2000 9:00 AM EDT)January 1-31
+6631:
+6632:     Weekly for 10 occurrences
+
+2000 found at line 6802:
+6800:           (1998 9:00 AM EDT)June 10;July 10
+6801:           (1999 9:00 AM EDT)June 10;July 10
+6802:           (2000 9:00 AM EDT)June 10;July 10
+6803:           (2001 9:00 AM EDT)June 10;July 10
+6804:       Note: Since none of the BYDAY, BYMONTHDAY or BYYEARDAY comp
+6804(continued):                onents
+
+2000 found at line 6824:
+6822:       ==> (1997 9:00 AM EST)January 1
+6823:           (1997 9:00 AM EDT)April 10;July 19
+
+
+
+
+
+Nesser                       Informational                    [Page 258]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+6824:           (2000 9:00 AM EST)January 1
+6825:           (2000 9:00 AM EDT)April 9;July 18
+6826:           (2003 9:00 AM EST)January 1
+
+2000 found at line 6825:
+6823:           (1997 9:00 AM EDT)April 10;July 19
+6824:           (2000 9:00 AM EST)January 1
+6825:           (2000 9:00 AM EDT)April 9;July 18
+6826:           (2003 9:00 AM EST)January 1
+6827:           (2003 9:00 AM EDT)April 10;July 19
+
+2000 found at line 6897:
+6895:       ==> (1998 9:00 AM EST)February 13;March 13;November 13
+6896:           (1999 9:00 AM EDT)August 13
+6897:           (2000 9:00 AM EDT)October 13
+6898:       ...
+6899:
+
+2000 found at line 6920:
+6918:
+6919:       ==> (1996 9:00 AM EST)November 5
+6920:           (2000 9:00 AM EST)November 7
+6921:           (2004 9:00 AM EST)November 2
+6922:       ...
+
+2000 found at line 7612:
+7610:
+7611:       BEGIN:VCALENDAR PRODID:-//xyz Corp//NONSGML PDA Calendar Ve
+7611(continued):                rson
+7612:       1.0//EN VERSION:2.0 BEGIN:VEVENT DTSTAMP:19960704T120000Z
+7613:       UID:uid1@host.com ORGANIZER:MAILTO:jsmith@host.com
+7614:       DTSTART:19960918T143000Z DTEND:19960920T220000Z STATUS:CONF
+7614(continued):                IRMED
+
+2000 found at line 7614:
+7612:       1.0//EN VERSION:2.0 BEGIN:VEVENT DTSTAMP:19960704T120000Z
+7613:       UID:uid1@host.com ORGANIZER:MAILTO:jsmith@host.com
+7614:       DTSTART:19960918T143000Z DTEND:19960920T220000Z STATUS:CONF
+7614(continued):                IRMED
+7615:
+7616:
+
+2000 found at line 7640:
+7638:       TZID:US-Eastern
+7639:       BEGIN:STANDARD
+7640:       DTSTART:19981025T020000
+7641:       RDATE:19981025T020000
+7642:       TZOFFSETFROM:-0400
+
+
+
+Nesser                       Informational                    [Page 259]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2000 found at line 7641:
+7639:       BEGIN:STANDARD
+7640:       DTSTART:19981025T020000
+7641:       RDATE:19981025T020000
+7642:       TZOFFSETFROM:-0400
+7643:       TZOFFSETTO:-0500
+
+2000 found at line 7647:
+7645:       END:STANDARD
+7646:       BEGIN:DAYLIGHT
+7647:       DTSTART:19990404T020000
+7648:       RDATE:19990404T020000
+7649:       TZOFFSETFROM:-0500
+
+2000 found at line 7648:
+7646:       BEGIN:DAYLIGHT
+7647:       DTSTART:19990404T020000
+7648:       RDATE:19990404T020000
+7649:       TZOFFSETFROM:-0500
+7650:       TZOFFSETTO:-0400
+
+2000 found at line 7740:
+7738:       BEGIN:VALARM
+7739:       ACTION:AUDIO
+7740:       TRIGGER:19980403T120000
+7741:       ATTACH;FMTTYPE=audio/basic:http://host.com/pub/audio-
+7742:        files/ssbanner.aud
+
+2000 found at line 7755:
+7753:       PRODID:-//ABC Corporation//NONSGML My Product//EN
+7754:       BEGIN:VJOURNAL
+7755:       DTSTAMP:19970324T120000Z
+7756:       UID:uid5@host1.com
+7757:       ORGANIZER:MAILTO:jsmith@host.com
+
+
++=+=+=+=+= File rfc2446.txt +=+=+=+=+=
+1900 found at line 3347:
+3345:     ORGANIZER:mailto:a@example.com
+3346:     DTSTART:19970701T200000Z
+3347:     DTSTAMP:19970611T190000Z
+3348:     SUMMARY:ST. PAUL SAINTS -VS- DULUTH-SUPERIOR DUKES
+3349:     UID:0981234-1234234-23@example.com
+
+1900 found at line 3373:
+3371:     BEGIN:VEVENT
+3372:     ORGANIZER:mailto:a@example.com
+3373:     DTSTAMP:19970612T190000Z
+
+
+
+Nesser                       Informational                    [Page 260]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+3374:     DTSTART:19970701T210000Z
+3375:     DTEND:19970701T230000Z
+
+1900 found at line 3410:
+3408:     SEQUENCE:2
+3409:     UID:0981234-1234234-23@example.com
+3410:     DTSTAMP:19970613T190000Z
+3411:     END:VEVENT
+3412:     END:VCALENDAR
+
+1900 found at line 3461:
+3459:     DTEND;TZID=America-Chicago:19970701T180000
+3460:     DTSTART;TZID=America-Chicago:19970702T160000
+3461:     DTSTAMP:19970614T190000Z
+3462:     STATUS:CONFIRMED
+3463:     LOCATION;VALUE=URI:http://www.midwaystadium.com/
+
+1900 found at line 3505:
+3503:     BEGIN:VEVENT
+3504:     ORGANIZER:mailto:a@example.com
+3505:     DTSTAMP:19970614T190000Z
+3506:     UID:0981234-1234234-23@example.com
+3507:     DTSTART;VALUE=DATE:19970714
+
+1900 found at line 3594:
+3592:     ATTENDEE;RSVP=FALSE;TYPE=ROOM:conf_Big@example.com
+3593:     ATTENDEE;ROLE=NON-PARTICIPANT;RSVP=FALSE:Mailto:E@example.com
+3593(continued):
+3594:     DTSTAMP:19970611T190000Z
+3595:     DTSTART:19970701T200000Z
+3596:     DTEND:19970701T2000000Z
+
+1900 found at line 3618:
+3616:     SEQUENCE:0
+3617:     REQUEST-STATUS:2.0;Success
+3618:     DTSTAMP:19970612T190000Z
+3619:     END:VEVENT
+3620:     END:VCALENDAR
+
+1900 found at line 3655:
+3653:     ATTENDEE;ROLE=NON-PARTICIPANT;RSVP=FALSE:Mailto:E@example.com
+3653(continued):
+3654:     DTSTART:19970701T180000Z
+3655:     DTEND:19970701T190000Z
+3656:     SUMMARY:Phone Conference
+3657:     UID:calsrv.example.com-873970198738777@example.com
+
+
+
+
+
+Nesser                       Informational                    [Page 261]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1900 found at line 3659:
+3657:     UID:calsrv.example.com-873970198738777@example.com
+3658:     SEQUENCE:1
+3659:     DTSTAMP:19970613T190000Z
+3660:     STATUS:CONFIRMED
+3661:     END:VEVENT
+
+1900 found at line 3680:
+3678:     ATTENDEE;RSVP=TRUE;TYPE=INDIVIDUAL:Mailto:B@example.com
+3679:     ATTENDEE;RSVP=TRUE;TYPE=INDIVIDUAL:Mailto:C@example.com
+3680:     DTSTART:19970701T190000Z
+3681:     DTEND:19970701T200000Z
+3682:     SUMMARY:Discuss the Merits of the election results
+
+1900 found at line 3686:
+3684:     UID:calsrv.example.com-873970198738777a@example.com
+3685:     SEQUENCE:0
+3686:     DTSTAMP:19970611T190000Z
+3687:     STATUS:CONFIRMED
+3688:     END:VEVENT
+
+1900 found at line 3713:
+3711:     ATTENDEE;RSVP=TRUE;TYPE=INDIVIDUAL:Mailto:C@example.com
+3712:     DTSTART:19970701T160000Z
+3713:     DTEND:19970701T190000Z
+3714:     DTSTAMP:19970612T190000Z
+3715:     SUMMARY:Discuss the Merits of the election results
+
+1900 found at line 3714:
+3712:     DTSTART:19970701T160000Z
+3713:     DTEND:19970701T190000Z
+3714:     DTSTAMP:19970612T190000Z
+3715:     SUMMARY:Discuss the Merits of the election results
+3716:     LOCATION:Green Conference Room
+
+1900 found at line 3721:
+3719:     UID:calsrv.example.com-873970198738777a@example.com
+3720:     SEQUENCE:0
+3721:     DTSTAMP:19970611T190000Z
+3722:     END:VEVENT
+3723:     END:VCALENDAR
+
+1900 found at line 3738:
+3736:     ATTENDEE;RSVP=TRUE;TYPE=INDIVIDUAL:Mailto:B@example.com
+3737:     ATTENDEE;RSVP=TRUE;TYPE=INDIVIDUAL:Mailto:C@example.com
+3738:     DTSTAMP:19970613T190000Z
+3739:     DTSTART:19970701T160000Z
+3740:     DTEND:19970701T190000Z
+
+
+
+Nesser                       Informational                    [Page 262]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1900 found at line 3740:
+3738:     DTSTAMP:19970613T190000Z
+3739:     DTSTART:19970701T160000Z
+3740:     DTEND:19970701T190000Z
+3741:     SUMMARY:Discuss the Merits of the election results - changed
+3741(continued):                to
+3742:       meet B's schedule
+
+1900 found at line 3769:
+3767:     UID:calsrv.example.com-873970198738777@example.com
+3768:     SEQUENCE:0
+3769:     DTSTAMP:19970614T190000Z
+3770:     END:VEVENT
+3771:     END:VCALENDAR
+
+1900 found at line 3884:
+3882:     SEQUENCE:0
+3883:     REQUEST-STATUS:2.0;Success
+3884:     DTSTAMP:19970611T190000Z
+3885:     END:VEVENT
+3886:     END:VCALENDAR
+
+1900 found at line 3906:
+3904:     SEQUENCE:0
+3905:     STATUS:CONFIRMED
+3906:     DTSTAMP:19970611T190000Z
+3907:     END:VEVENT
+3908:     END:VCALENDAR
+
+1900 found at line 3936:
+3934:     SEQUENCE:0
+3935:     REQUEST-STATUS:2.0;Success
+3936:     DTSTAMP:19970614T190000Z
+3937:     END:VEVENT
+3938:     END:VCALENDAR
+
+1900 found at line 3967:
+3965:     SEQUENCE:0
+3966:     REQUEST-STATUS:2.0;Success
+3967:     DTSTAMP:19970614T190000Z
+3968:     END:VEVENT
+3969:     END:VCALENDAR
+
+1900 found at line 4072:
+4070:     SEQUENCE:1
+4071:     STATUS:CANCELLED
+4072:     DTSTAMP:19970613T190000Z
+4073:     END:VEVENT
+
+
+
+Nesser                       Informational                    [Page 263]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+4074:     END:VCALENDAR
+
+1900 found at line 4157:
+4155:     ATTENDEE;ROLE=NON-PARTICIPANT;
+4156:      RSVP=FALSE:Mailto:E@example.com
+4157:     DTSTAMP:19970611T190000Z
+4158:     DTSTART:19970701T200000Z
+4159:     DTEND:19970701T203000Z
+
+1900 found at line 4193:
+4191:     ATTENDEE;TYPE=INDIVIDUAL:Mailto:C@example.com
+4192:     ATTENDEE;TYPE=INDIVIDUAL:Mailto:D@example.com
+4193:     DTSTAMP:19970611T190000Z
+4194:     DTSTART:19970701T200000Z
+4195:     DTEND:19970701T203000Z
+
+1900 found at line 4232:
+4230:     DTSTART:19980101T124200Z
+4231:     DTEND:19980107T124200Z
+4232:     FREEBUSY:19980101T180000Z/19980101T190000Z
+4233:     FREEBUSY:19980103T020000Z/19980103T050000Z
+4234:     FREEBUSY:19980107T020000Z/19980107T050000Z
+
+1900 found at line 4236:
+4234:     FREEBUSY:19980107T020000Z/19980107T050000Z
+4235:     FREEBUSY:19980113T000000Z/19980113T010000Z
+4236:     FREEBUSY:19980115T190000Z/19980115T200000Z
+4237:     FREEBUSY:19980115T220000Z/19980115T230000Z
+4238:     FREEBUSY:19980116T013000Z/19980116T043000Z
+
+1900 found at line 4288:
+4286:     ATTENDEE:Mailto:B@example.com
+4287:     ATTENDEE:Mailto:C@example.com
+4288:     DTSTAMP:19970613T190000Z
+4289:     DTSTART:19970701T080000Z
+4290:     DTEND:19970701T200000
+
+1900 found at line 4319:
+4317:
+4318:
+4319:     DTSTAMP:19970613T190030Z
+4320:     END:VFREEBUSY
+4321:     END:VCALENDAR
+
+1900 found at line 4359:
+4357:     ATTENDEE;RSVP=TRUE;TYPE=INDIVIDUAL:B@example.fr
+4358:     ATTENDEE;RSVP=TRUE;TYPE=INDIVIDUAL:c@example.jp
+4359:     DTSTAMP:19970613T190030Z
+
+
+
+Nesser                       Informational                    [Page 264]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+4360:     DTSTART;TZID=America-SanJose:19970701T140000
+4361:     DTEND;TZID=America-SanJose:19970701T150000
+
+1900 found at line 5193:
+5191:     to each of the start of each recurring instance. Hence, if th
+5191(continued):                e
+5192:     initial "VTODO" calendar component specifies a "DTSTART" prop
+5192(continued):                erty
+5193:     value of "19970701T190000Z" and a "DUE" property value of
+5194:     "19970801T190000Z" the interval of one day which is applied t
+5194(continued):                o each
+5195:     recurring instance of the "VTODO" calendar component to deter
+5195(continued):                mine the
+
+1900 found at line 5194:
+5192:     initial "VTODO" calendar component specifies a "DTSTART" prop
+5192(continued):                erty
+5193:     value of "19970701T190000Z" and a "DUE" property value of
+5194:     "19970801T190000Z" the interval of one day which is applied t
+5194(continued):                o each
+5195:     recurring instance of the "VTODO" calendar component to deter
+5195(continued):                mine the
+5196:     "DUE" date of the instance.
+
+2000 found at line 3346:
+3344:     BEGIN:VEVENT
+3345:     ORGANIZER:mailto:a@example.com
+3346:     DTSTART:19970701T200000Z
+3347:     DTSTAMP:19970611T190000Z
+3348:     SUMMARY:ST. PAUL SAINTS -VS- DULUTH-SUPERIOR DUKES
+
+2000 found at line 3437:
+3435:     TZURL:http://zones.stds_r_us.net/tz/America-Chicago
+3436:     BEGIN:STANDARD
+3437:     DTSTART:19671029T020000
+3438:     RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10
+3439:     TZOFFSETFROM:-0500
+
+2000 found at line 3444:
+3442:     END:STANDARD
+3443:     BEGIN:DAYLIGHT
+3444:     DTSTART:19870405T020000
+3445:     RRULE:FREQ=YEARLY;BYDAY=1SU;BYMONTH=4
+3446:     TZOFFSETFROM:-0600
+
+2000 found at line 3595:
+3593:     ATTENDEE;ROLE=NON-PARTICIPANT;RSVP=FALSE:Mailto:E@example.com
+3593(continued):
+
+
+
+Nesser                       Informational                    [Page 265]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+3594:     DTSTAMP:19970611T190000Z
+3595:     DTSTART:19970701T200000Z
+3596:     DTEND:19970701T2000000Z
+3597:     SUMMARY:Conference
+
+2000 found at line 3596:
+3594:     DTSTAMP:19970611T190000Z
+3595:     DTSTART:19970701T200000Z
+3596:     DTEND:19970701T2000000Z
+3597:     SUMMARY:Conference
+3598:     UID:calsrv.example.com-873970198738777@example.com
+
+2000 found at line 3681:
+3679:     ATTENDEE;RSVP=TRUE;TYPE=INDIVIDUAL:Mailto:C@example.com
+3680:     DTSTART:19970701T190000Z
+3681:     DTEND:19970701T200000Z
+3682:     SUMMARY:Discuss the Merits of the election results
+3683:     LOCATION:Green Conference Room
+
+2000 found at line 3901:
+3899:      DELEGATED-FROM="Mailto:C@example.com":Mailto:E@example.com
+3900:     DTSTART:19970701T180000Z
+3901:     DTEND:19970701T200000Z
+3902:     SUMMARY:Phone Conference
+3903:     UID:calsrv.example.com-873970198738777@example.com
+
+2000 found at line 3996:
+3994:     SUMMARY:Phone Conference
+3995:     DTSTART:19970701T180000Z
+3996:     DTEND:19970701T200000Z
+3997:     DTSTAMP:19970614T200000Z
+3998:     COMMENT:DELEGATE (ATTENDEE Mailto:E@example.com) DECLINED YOU
+3998(continued):                R
+
+2000 found at line 3997:
+3995:     DTSTART:19970701T180000Z
+3996:     DTEND:19970701T200000Z
+3997:     DTSTAMP:19970614T200000Z
+3998:     COMMENT:DELEGATE (ATTENDEE Mailto:E@example.com) DECLINED YOU
+3998(continued):                R
+3999:      INVITATION
+
+2000 found at line 4158:
+4156:      RSVP=FALSE:Mailto:E@example.com
+4157:     DTSTAMP:19970611T190000Z
+4158:     DTSTART:19970701T200000Z
+4159:     DTEND:19970701T203000Z
+4160:     SUMMARY:Phone Conference
+
+
+
+Nesser                       Informational                    [Page 266]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2000 found at line 4194:
+4192:     ATTENDEE;TYPE=INDIVIDUAL:Mailto:D@example.com
+4193:     DTSTAMP:19970611T190000Z
+4194:     DTSTART:19970701T200000Z
+4195:     DTEND:19970701T203000Z
+4196:     RRULE:FREQ=WEEKLY
+
+2000 found at line 4233:
+4231:     DTEND:19980107T124200Z
+4232:     FREEBUSY:19980101T180000Z/19980101T190000Z
+4233:     FREEBUSY:19980103T020000Z/19980103T050000Z
+4234:     FREEBUSY:19980107T020000Z/19980107T050000Z
+4235:     FREEBUSY:19980113T000000Z/19980113T010000Z
+
+2000 found at line 4234:
+4232:     FREEBUSY:19980101T180000Z/19980101T190000Z
+4233:     FREEBUSY:19980103T020000Z/19980103T050000Z
+4234:     FREEBUSY:19980107T020000Z/19980107T050000Z
+4235:     FREEBUSY:19980113T000000Z/19980113T010000Z
+4236:     FREEBUSY:19980115T190000Z/19980115T200000Z
+
+2000 found at line 4236:
+4234:     FREEBUSY:19980107T020000Z/19980107T050000Z
+4235:     FREEBUSY:19980113T000000Z/19980113T010000Z
+4236:     FREEBUSY:19980115T190000Z/19980115T200000Z
+4237:     FREEBUSY:19980115T220000Z/19980115T230000Z
+4238:     FREEBUSY:19980116T013000Z/19980116T043000Z
+
+2000 found at line 4237:
+4235:     FREEBUSY:19980113T000000Z/19980113T010000Z
+4236:     FREEBUSY:19980115T190000Z/19980115T200000Z
+4237:     FREEBUSY:19980115T220000Z/19980115T230000Z
+4238:     FREEBUSY:19980116T013000Z/19980116T043000Z
+4239:     END:VFREEBUSY
+
+2000 found at line 4290:
+4288:     DTSTAMP:19970613T190000Z
+4289:     DTSTART:19970701T080000Z
+4290:     DTEND:19970701T200000
+4291:     UID:calsrv.example.com-873970198738777@example.com
+4292:     END:VFREEBUSY
+
+2000 found at line 4308:
+4306:     ATTENDEE:Mailto:B@example.com
+4307:     DTSTART:19970701T080000Z
+4308:     DTEND:19970701T200000Z
+4309:     UID:calsrv.example.com-873970198738777@example.com
+4310:     FREEBUSY:19970701T090000Z/PT1H,19970701T140000Z/PT30M
+
+
+
+Nesser                       Informational                    [Page 267]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2000 found at line 4340:
+4338:     TZURL:http://zones.stds_r_us.net/tz/America-SanJose
+4339:     BEGIN:STANDARD
+4340:     DTSTART:19671029T020000
+4341:     RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10
+4342:     TZOFFSETFROM:-0700
+
+2000 found at line 4347:
+4345:     END:STANDARD
+4346:     BEGIN:DAYLIGHT
+4347:     DTSTART:19870405T020000
+4348:     RRULE:FREQ=YEARLY;BYDAY=1SU;BYMONTH=4
+4349:     TZOFFSETFROM:-0800
+
+2000 found at line 4446:
+4444:     SUMMARY:IETF Calendaring Working Group Meeting
+4445:     DTSTART:19970601T210000Z
+4446:     DTEND:19970601T220000Z
+4447:     LOCATION:Conference Call
+4448:     DTSTAMP:19970526T083000Z
+
+2000 found at line 4473:
+4471:     SUMMARY:IETF Calendaring Working Group Meeting
+4472:     DTSTART:19970703T210000Z
+4473:     DTEND:19970703T220000Z
+4474:     LOCATION:Conference Call
+4475:     DTSTAMP:19970626T093000Z
+
+2000 found at line 4565:
+4563:     SUMMARY:IETF Calendaring Working Group Meeting
+4564:     DTSTART:19970901T210000Z
+4565:     DTEND:19970901T220000Z
+4566:     LOCATION:Building 32, Microsoft, Seattle, WA
+4567:     DTSTAMP:19970526T083000Z
+
+2000 found at line 4601:
+4599:     SUMMARY:IETF Calendaring Working Group Meeting
+4600:     DTSTART:19970715T210000Z
+4601:     DTEND:19970715T220000Z
+4602:     LOCATION:Conference Call
+4603:     DTSTAMP:19970629T093000Z
+
+2000 found at line 4631:
+4629:     SUMMARY:Review Accounts
+4630:     DTSTART:19980303T210000Z
+4631:     DTEND:19980303T220000Z
+4632:     LOCATION:The White Room
+4633:     DTSTAMP:19980301T093000Z
+
+
+
+Nesser                       Informational                    [Page 268]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2000 found at line 4664:
+4662:     SUMMARY:Review Accounts
+4663:     DTSTART:19980303T210000Z
+4664:     DTEND:19980303T220000Z
+4665:     DTSTAMP:19980303T193000Z
+4666:     LOCATION:The Usual conference room
+
+2000 found at line 4690:
+4688:     SUMMARY:Review Accounts
+4689:     DTSTART:19980303T210000Z
+4690:     DTEND:19980303T220000Z
+4691:     DTSTAMP:19980303T193000Z
+4692:     LOCATION:The White Room
+
+2000 found at line 4730:
+4728:     SUMMARY:Review Accounts
+4729:     DTSTART:19980304T180000Z
+4730:     DTEND:19980304T200000Z
+4731:     DTSTAMP:19980303T193000Z
+4732:     LOCATION:Conference Room A
+
+2000 found at line 4781:
+4779:     SUMMARY:Review Accounts
+4780:     DTSTART:19980315T180000Z
+4781:     DTEND:19980315T200000Z
+4782:     DTSTAMP:19980307T193000Z
+4783:     LOCATION:Conference Room A
+
+2000 found at line 4811:
+4809:     SUMMARY:Review Accounts
+4810:     DTSTART:19980304T180000Z
+4811:     DTEND:19980304T200000Z
+4812:     DTSTAMP:19980303T193000Z
+4813:     LOCATION:Conference Room A
+
+2000 found at line 4863:
+4861:     CLASS:PUBLIC
+4862:     SUMMARY:IETF Calendaring Working Group Meeting
+4863:     DTSTART:19970715T220000Z
+4864:     DTEND:19970715T230000Z
+4865:     LOCATION:Conference Call
+
+2000 found at line 4903:
+4901:     SUMMARY:IETF Calendaring Working Group Meeting
+4902:     DTSTART:19970601T210000Z
+4903:     DTEND:19970601T220000Z
+4904:     DTSTAMP:19970602T094000Z
+4905:     LOCATION:Conference Call
+
+
+
+Nesser                       Informational                    [Page 269]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+2000 found at line 5018:
+5016:     UID:calsrv.example.com-873970198738777-00@example.com
+5017:     SEQUENCE:0
+5018:     DTSTAMP:19970717T200000Z
+5019:     STATUS:Needs Action
+5020:     END:VTODO
+
+2000 found at line 5179:
+5177:     UID:calsrv.example.com-873970198738777-00@example.com
+5178:     SEQUENCE:0
+5179:     DTSTAMP:19970717T200000Z
+5180:     STATUS:NEEDS ACTION
+5181:     PRIORITY:1
+
+2000 found at line 5236:
+5234:     VERSION:2.0
+5235:     BEGIN:VJOURNAL
+5236:     DTSTART:19971002T200000Z
+5237:     ORGANIZER:MAILTO:A@Example.com
+5238:     SUMMARY:Phone conference minutes
+
+2000 found at line 5358:
+5356:     SEQUENCE:3
+5357:     RRULE:FREQ=WEEKLY
+5358:     RDATE;VALUE=PERIOD:19970819T210000Z/199700819T220000Z
+5359:     ORGANIZER:Mailto:A@example.com
+5360:     ATTENDEE;ROLE=CHAIR;PARTSTAT=ACCEPTED:Mailto:A@example.com
+
+2000 found at line 5365:
+5363:     SUMMARY:IETF Calendaring Working Group Meeting
+5364:     DTSTART:19970801T210000Z
+5365:     DTEND:19970801T220000Z
+5366:     RECURRENCE-ID:19970809T210000Z
+5367:     DTSTAMP:19970726T083000
+
++=+=+=+=+= File rfc2447.txt +=+=+=+=+=
+1900 found at line 421:
+419:     ATTENDEE;ROLE=CHAIR;ATTSTAT=ACCEPTED:mailto:sman@netscape.com
+419(continued):
+420:     ATTENDEE;RSVP=YES:mailto:stevesil@microsoft.com
+421:     DTSTAMP:19970611T190000Z
+422:     DTSTART:19970701T210000Z
+423:     DTEND:19970701T230000Z
+
+
+
+
+
+
+
+
+Nesser                       Informational                    [Page 270]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+1900 found at line 475:
+473:     ATTENDEE;ROLE=CHAIR;ATTSTAT=ACCEPTED:mailto:foo1@example.com
+474:     ATTENDEE;RSVP=YES;TYPE=INDIVIDUAL:mailto:foo2@example.com
+475:     DTSTAMP:19970611T190000Z
+476:     DTSTART:19970701T170000Z
+477:     DTEND:19970701T173000Z
+
+1900 found at line 523:
+521:     ATTENDEE;ROLE=CHAIR;ATTSTAT=ACCEPTED:mailto:foo1@example.com
+522:     ATTENDEE;RSVP=YES;TYPE=INDIVIDUAL:mailto:foo2@example.com
+523:     DTSTAMP:19970611T190000Z
+524:     DTSTART:19970701T180000Z
+525:     DTEND:19970701T183000Z
+
+1900 found at line 584:
+582:     BEGIN:VEVENT
+583:     ORGANIZER:MAILTO:FOO1@EXAMPLE.COM
+584:     DTSTAMP:19970611T190000Z
+585:     DTSTART:19970715T150000Z
+586:     DTEND:19970715T230000Z
+
+1900 found at line 631:
+629:     ATTENDEE;ROLE=CHAIR;ATTSTAT=ACCEPTED:mailto:foo1@example.com
+630:     ATTENDEE;RSVP=YES;TYPE=INDIVIDUAL:mailto:foo2@example.com
+631:     DTSTAMP:19970611T190000Z
+632:     DTSTART:19970701T210000Z
+633:     DTEND:19970701T230000Z
+
+1900 found at line 722:
+720:     ATTENDEE;RSVP=YES;TYPE=INDIVIDUAL:mailto:foo2@example.com
+721:     ATTENDEE;RSVP=YES;TYPE=INDIVIDUAL:mailto:foo3@example.com
+722:     DTSTAMP:19970611T190000Z
+723:     DTSTART:19970621T170000Z
+724:     DTEND:199706211T173000Z
+
++=+=+=+=+= File rfc2455.txt +=+=+=+=+=
+2-digit found at line 7166:
+7164:
+7165:            Since this object incorporates the Year 2000-unfriendl
+7165(continued):                y
+7166:            2-digit year specified in SMI for the LAST-UPDATED fie
+7166(continued):                ld, and
+7167:
+7168:
+
+2000 found at line 7165:
+7163:            determining the level of the MIB supported by an agent
+7163(continued):                .
+
+
+
+Nesser                       Informational                    [Page 271]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+7164:
+7165:            Since this object incorporates the Year 2000-unfriendl
+7165(continued):                y
+7166:            2-digit year specified in SMI for the LAST-UPDATED fie
+7166(continued):                ld, and
+7167:
+
++=+=+=+=+= File rfc2461.txt +=+=+=+=+=
+2000 found at line 2347:
+2345:                                   consecutive advertisements.
+2346:
+2347:                               Default: 2592000 seconds (30 days),
+2347(continued):                 fixed
+2348:                               (i.e., stays the same in consecutiv
+2348(continued):                e
+2349:                               advertisements).
+
++=+=+=+=+= File rfc2470.txt +=+=+=+=+=
+2000 found at line 65:
+63:     rely on manual configuration or router advertisements [DISC]
+63(continued):          to
+64:     determine actual MTU sizes. Common default values include
+65:     approximately 2000, 4000, and 8000 octets.
+66:
+67:     In the absence of any other information, an implementation sh
+67(continued):          ould use
+
+Appendix D:  Discussion of HTTP 1.0 Issues
+
+   HTTP:
+
+   The main IETF standards-track document on the HTTP protocol is
+   RFC2068 on HTTP 1.1.  It notes that historically three different date
+   formats have been used, and that one of them uses a two-digit year
+   field.  In section 3.3.1 it requires HTTP 1.1 implementations to
+   generate this RFC1123 format:
+
+        Sun, 06 Nov 1994 08:49:37 GMT  ; RFC 822, updated by RFC 1123
+
+   instead of this RFC850 format:
+
+             Sunday, 06-Nov-94 08:49:37 GMT ; RFC 850, obsoleted by RFC
+        1036
+
+   Unfortunately, many existing servers, serving on the order of one
+   fifth of the current HTTP traffic, send dates in the ambiguous RFC850
+   format.
+
+
+
+
+Nesser                       Informational                    [Page 272]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+Section 19.3 of the RFC2068 says this:
+
+     o  HTTP/1.1 clients and caches should assume that an RFC-850 date
+        which appears to be more than 50 years in the future is in fact
+        in the past (this helps solve the "year 2000" problem).
+
+   This avoids a "stale cache" problem, which would cause the user to
+   see out-of-date data.
+
+   But to avoid unnecessary delays and bandwidth indicated in Scenario 2
+   below, this should be extended to say that a date which appears to be
+   more than 50 years in the past may be assumed to be in the future, if
+   a future date is legal for that field.
+
+   Scenario 3 indicates that servers may also want to follow these
+   rules.
+
+    Here is some more background and justification for these arguments.
+
+   The following headers use full dates:
+
+   HTTP/1.0:
+           Date:
+           Expires:                # can be in the future
+           If-Modified-Since:      # required to be in the past
+           Last-Modified:          # required to be in the past
+           Retry-After:            # can be in the future, also takes
+                                           # relative time - number of seconds
+
+   HTTP/1.1:
+           If-Range:
+           If-Unmodified-Since:    # required to be in the past
+
+   Note that clock skew between hosts can lead to confusion here - see
+   the RFC for details.
+
+   Here are some scenarios of the implications of RFC850 dates, which
+   include stale caches, unnecessary requests for things, which are
+   validly cached, delays for the user, extra bandwidth, and presenting
+   incorrect information to the user.
+
+   Some cases involve comparisons with the current time, and others may
+   involve comparisons between dates from different sources.  The
+   abbreviation "/99" is used to imply an RFC850 date with the value
+   "99" for the year.
+
+
+
+
+
+
+Nesser                       Informational                    [Page 273]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+   RFC850 date from server
+
+   Scenario 1:
+           If a client gets an Expires /99 date after the year 2000, it
+           should interpret it as 1999, to avoid ending up with a stale
+           cache entry.
+
+           This is as already specified in RFC2068.
+
+   Scenario 2:
+           If a client gets an Expires /00 date before the year 2000,
+           and subsequently is faced with a choice to either retrieve
+           the document from its cache or look for an updated copy, it
+           may interpret it as the year 2000, to avoid the unnecessary
+           delay and bandwidth of an extra request.
+
+   RFC850 date from client
+
+   Scenario 3:
+           If a server gets an If-Modified-Since /99 date from a client
+           after the year 2000, it should interpret it as 1999 when
+           comparing with the local modification date, in order to
+           possibly avoid sending a full GET response rather than a HEAD
+           response.
+
+           Note that an If-Modified-Since header must never be in the
+           future.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Nesser                       Informational                    [Page 274]
+
+RFC 2626  The Internet and the Millennium Problem (Year 2000)  June 1999
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (1999).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Nesser                       Informational                    [Page 275]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2626.txt](<www.ietf.org/rfc/rfc2626.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
