### PR TITLE
Archive rfc266.txt

### DIFF
--- a/www.ietf.org/rfc/rfc266.txt
+++ b/www.ietf.org/rfc/rfc266.txt
@@ -1,0 +1,112 @@
+
+
+
+
+
+
+Network Working Group                      Ellen Westheimer
+RFC #266                                   Bolt Beranek and Newman Inc.
+NIC #7814                                  8 November 1971
+Categories:  F, G, 3
+Updates:  RFC 255
+Obsoletes:  None
+
+
+
+
+
+
+
+
+
+
+                          NETWORK HOST STATUS
+
+
+
+
+
+
+
+
+
+
+
+   This RFC reports on the status of most.Network Hosts from October 26
+   to November 5.  (Massachusetts celebrated Armistice day on Monday,
+   October 25.) During these two weeks the general status of these hosts
+   remained as it had been previously.
+
+   The table on the following page summarizes the daily information on
+   host status for this period.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+
+NETWORK
+ADDRESS  SITE       COMPUTER            DAY, DATE AND TIME (EASTERN)
+-------  ----       --------            ----------------------------
+                                T     W    Th     F    M    T    W    Th   F
+                              10/26 10/27 10/28 10/29 11/1 11/2 11/3 11/4 11/5
+                              1430  1200  1300  1300  1630 1330 1330 1330 1330
+   1     UCLA       SIGMA-7     O     O     O     T    O    T    O    O    O
+ *65     UCLA       IBM-360/91  O     D     O     O    O    O    O    O    O
+   2     SRI(NIC)   PDP-10      O     O     O     O    D    O    D    O    O
+  66     SRI(AI)    PDP-10      D     D     D     D    D    D    D    D    D
+   3     UCSB       IBM-360/75  D     O     O     O    O    D    D    O    O
+   4     UTAH       PDP-10      T     T     T     D    D    D    D    D    T
+  69     BBN(TENEX) PDP-10      D     O     D     D    O    O    O    O    O
+   6     MIT(MULTICS) H-645     O     D     D     O    O    O    O    T    O
+  70     MIT(DM)    PDP-10      D     H     T     O    O    O    O    O    T
+   8     SDC        IBM-360/67  D     D     D     D    D    D    D    D    D
+   9     HARVARD    PDP-10      D     D     T     D    D    D    D    D    D
+  10     LINCOLN    IBM-360/67  H     D     H     T    T    H    H    D    H
+
+where
+
+D=  Dead (Destination Host either dead or inaccessible [due to network
+    partitioning or local IMP failure] from the BBN Terminal IMP.)
+
+R=  Refused (Destination Host returned a CLS to the initial RFC.)
+
+T=  Timed out (Destination Host did not respond in any way to the
+    initial RFC, although not dead.)
+
+H=  1/2 Open (Destination Host opened a connection but then either
+    immediately closed it, or did not respond any further.)
+
+O=  Open (Destination Host opened a connection and was accessible to
+    users.)
+
+* The UCLA IBM-360/91 currently has Remote Job Service (NETRJS), but
+  has not implemented a full server Telnet System.  The BBN Terminal
+  IMP is not equipped to test NETRJS;  however, we are assuming that
+  receipt of the UCLA explanatory message indicates that NETRJS is also
+  functioning.
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+                                                                [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc266.txt](<www.ietf.org/rfc/rfc266.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
