### PR TITLE
Archive rfc267.txt

### DIFF
--- a/www.ietf.org/rfc/rfc267.txt
+++ b/www.ietf.org/rfc/rfc267.txt
@@ -1,0 +1,218 @@
+
+
+
+
+
+
+Network Working Group                                 Ellen Westheimer
+RFC #267                                              BBN
+NIC #7815                                             22 November 1971
+Categories:  F, G.3
+Updates: RFC #266
+Obsoletes  None
+
+      This RFC reports on the status of most Network Hosts from November
+8  to  November 19.  On November 18, however, the BBN prototype Terminal
+IMP (Network Address 158) was inaccessible due to hardware debugging.
+
+      Several Hosts are  currently  excluded  fron  the  daily  testing.
+These Hosts fall into two categories:
+
+      1)  Hosts which are not expected to be functioning on
+          the Network as servers (available for use from
+          other sites) for at least two weeks.  Included here
+          are:
+
+          Network
+          Address        Site             Computer
+
+            71           Rand             PDP-10
+            74           Lincoln          TX2
+            13           Case             PDP-10
+            14           Carnegie         PDP-10
+            15           Ames             B6500
+            16           Ames             IBM-360/67
+
+      2)  Hosts which are curently intended to be users only.
+          Included here are the Terminal IMPs, which are
+          presently in the Network (AMES, MITRE, and BBN*).
+          This category also includes the Network Control
+          Center Computer (Network Address 5) which is used
+          solely for gathering statistics from the Network.
+          Finally, included among these Hosts are the following:
+
+          Network
+          Address        Site             Computer
+
+             7           Rand             IBM-360/65
+            73           Harvard          PDP-1
+            12           Illinois         PDP-11
+
+      During these two weeks the Lincoln Labs TX2 Hosts became a Network
+User.  The SDC IBM 360/67 is now a server.
+
+
+
+
+
+                                                                [Page 1]
+
+The tables on the next two pages summarize the information on Host
+status for this period.
+
+* The BBN Terminal IMP (Network Address 158) is a prototype and
+as such is frequently not connected to the Network, but being
+used to refine and debug the Terminal IMP programs.
+
+NETWORK                            STATUS or            STATUS or
+ADDRESS    SITE        COMPUTER    PREDUCTION           PREDUCTION
+                                                        OBTAINED FROM
+
+   1       UCLA        SIGMA-7     Server               Jon Postel
+   5       UCLA        IBM-360/91  Remote Job Service
+                                    now, Telnet in
+                                    April               Bob Braden
+   2       SRI
+             (NIC)     PDP-10      Server               John Melvin
+  66       SRI
+             (AI)      PDP-10      "Soon"               Len Chaiten
+   3       UCSB        IBM-360/75  Server               Jim White
+   4       UTAH        PDP-10      "Soon"               Barry Wessler
+  *5       BBN
+             (NCC)     DDP-516     Never                Alex McKenzie
+  69       BBN
+             (TENEX)   PDP-10      Server               Dan Murphy
+   6       MIT
+             (Multics) H-645       Server               Mike Padlipsky
+  70       MIT
+             (DM)      PDP-10      Server               Bob Bressler
+  *7       RAND        IBM-360/65  User only            Eric Harslem
+ *71       RAND        PDP-10      January '72          Eric Harslem
+   8       SDC         IBM-360/67  Server               Bob Long
+   9       HARVARD     PDP-10      Server               Bob Sundberg
+ *73       HARVARD     PDP-1       User only            Bob Sundberg
+  20       LINCOLN     IBM-360/67  "Soon"               Joel Winnet
+ *74       LINCOLN     TX2         December             Tom Barkalow
+  11       STANFORD    PDP-10      "Soon"               Andy Moorer
+ *12       ILLINOIS    PDP-11      User only            John Cravits
+ *13       CASE        PDP-10      March '72            Charles Rose
+ *14       CARNEGIE    PDP-10      January '72          Hal vanZoeren
+ *15       AMES        B6500       September '72        John McConnel
+ *16       AMES        IBM-360/67  January '72          Wayne Hathaway
+*144       AMES        TIP         User only
+*145       MITRE       TIP         User only
+*158       BBN         TIP         User only
+                  (Proto-type)
+
+* host not included in daily testing.
+
+
+
+                                                                [Page 2]
+
+NETWORK
+ADDRESS   SITE       COMPUTER       DAY, DATE and TIME (Eastern)
+
+                                   M      Tu       W       Th      F
+                                 11/8    11/9    11/10   11/11   11/12
+
+  1     UCLA         SIGMA-7       O       D       O       O       O
+*65     UCLA         IBM-360/91    O       D       O       D       O
+  2     SRI (NIC)    PDP-10        O       O       O       O       T
+ 66     SRI (AI)     PDP-10        D       D       D       D       D
+  3     UCSB         IBM-360/75    O       T       O       O       D
+  4     UTAH         PDP-10        D       D       H       D       D
+ 69     BBN (TENEX)  PDP-10        H       O       O       O       O
+  6     MIT (Mulics) H-645         D       D       D       O       O
+ 70     MIT (DM)     PDP-10        O       H       T       D       O
+  8     SDC          IBM-360/67   #D      #D      #D      #D      #D
+  9     HARVARD      PDP-10        D       D       D       D       T
+ 10     LINCOLN      IBM-360/67    H       H       H       H       D
+ 11     STANFORD     PDP-10        D       T       D       D       D
+
+
+                                   M       Tu       W       F
+                                 11/15   11/16    11/17   11/19
+
+  1     UCLA         SIGMA-7       O       O       O       O
+*65     UCLA         IBM-360/91    O       O       D       O
+  2     SRI (NIC)    PDP-10        T       T       O       O
+ 66     SRI (AI)     PDP-10        D       D       D       D
+  3     UCSB         IBM-360/75    O       O       O       O
+  4     UTAH         PDP-10        D       D       D       D
+ 69     BBN (TENEX)  PDP-10        O       D       O       O
+  6     MIT (Mulics) H-645         T       D       O       H
+ 70     MIT (DM)     PDP-10        O       O       O       D
+  8     SDC          IBM-360/67   #D      #D      #D      #D
+  9     HARVARD      PDP-10        T       D       D       T
+ 10     LINCOLN      IBM-360/67    D       H       D       D
+ 11     STANFORD     PDP-10        D       D       D       D
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 3]
+
+where
+
+   D = Dead (Destination Host either dead or inaccessible [due to
+             network partitioning or local IMP failure] from the BBN
+             Terminal IMP.)
+
+   R = Refused (Destination Host returned a CLS to the initial RFC.)
+
+   T = Timed out (Destination Host did not respond in any way to the
+             initial RFC, although not dead.)
+
+   H = 1/2 Open (Destination Host opened a connection but then either
+             immediately closed it, or did not respond further.)
+
+   O = Open (Destination Host opened a connection and was accessible to
+             users.)
+
+
+   * The UCLA IBM-360/91 currently has Remote Job Service (NETRJS),
+     but has not implemented a full server Telnet System.  The BBN
+     Terminal IMP is not equipped to test NETRJS; however, we are
+     assuming that receipt of the UCLA explanatory message indicates
+     that NETRJS is also functioning.
+
+   # These sites advertise that they may not have their system
+     available at these times.
+
+       [ This RFC was put into machine readable form for entry ]
+         [ into the online RFC archives by Simone Demmel 1/98 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc267.txt](<www.ietf.org/rfc/rfc267.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
