### PR TITLE
Archive rfc2670.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2670.txt
+++ b/www.ietf.org/rfc/rfc2670.txt
@@ -1,0 +1,4035 @@
+
+
+
+
+
+
+Network Working Group                                   M. St. Johns, Ed.
+Request for Comments: 2670                                  @Home Network
+Category: Proposed Standard                                   August 1999
+
+
+       Radio Frequency (RF) Interface Management Information Base
+                for MCNS/DOCSIS compliant RF interfaces
+
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (1999).  All Rights Reserved.
+
+Abstract
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the Internet community.
+   In particular, it defines a basic set of managed objects for SNMP-
+   based management of MCNS/DOCSIS compliant Radio Frequency (RF)
+   interfaces.
+
+   This memo specifies a MIB module in a manner that is compliant to the
+   SNMP SMIv2 [5][6][7].  The set of objects are consistent with the
+   SNMP framework and existing SNMP standards.
+
+   This memo is a product of the IPCDN working group within the Internet
+   Engineering Task Force.  Comments are solicited and should be
+   addressed to the working group's mailing list at ipcdn@terayon.com
+   and/or the author.
+
+ Table of Contents
+
+   1 The SNMP Management Framework ................................... 3
+   2 Glossary ........................................................ 4
+   2.1 CATV .......................................................... 4
+   2.2 Channel ....................................................... 4
+   2.3 CM ............................................................ 4
+   2.4 CMTS .......................................................... 4
+   2.5 Codeword ...................................................... 4
+   2.6 Data Packet ................................................... 4
+
+
+
+St. Johns                       Standard                        [Page 1]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+   2.7 dBmV .......................................................... 4
+   2.8 DOCSIS ........................................................ 5
+   2.9 Downstream .................................................... 5
+   2.10 Head-end ..................................................... 5
+   2.11 MAC Packet ................................................... 5
+   2.12 MCNS ......................................................... 5
+   2.13 Mini-slot .................................................... 5
+   2.14 QPSK ......................................................... 5
+   2.15 QAM .......................................................... 5
+   2.16 RF ........................................................... 5
+   2.17 Symbol-times ................................................. 5
+   2.18 Upstream ..................................................... 6
+   3 Overview ........................................................ 6
+   3.1 Structure of the MIB .......................................... 6
+   3.1.1 docsIfBaseObjects ........................................... 6
+   3.1.2 docsIfCmObjects ............................................. 7
+   3.1.3 docsIfCmtsObjects ........................................... 7
+   3.2 Relationship to the Interfaces MIB ............................ 7
+   3.2.1 Layering Model .............................................. 7
+   3.2.2 Virtual Circuits ............................................ 8
+   3.2.3 ifTestTable ................................................. 9
+   3.2.4 ifRcvAddressTable ........................................... 9
+   3.2.5 ifEntry ..................................................... 9
+   3.2.5.1 ifEntry for Downstream interfaces ......................... 9
+   3.2.5.1.1 ifEntry for Downstream interfaces in Cable Modem
+        Termination Systems .......................................... 9
+   3.2.5.1.2 ifEntry for Downstream interfaces in Cable Modems ...... 11
+   3.2.5.2 ifEntry for Upstream interfaces .......................... 12
+   3.2.5.2.1  ifEntry for Upstream interfaces in Cable Modem
+        Termination Systems ......................................... 12
+   3.2.5.2.2 ifEntry for Upstream interfaces in Cable Modems ........ 14
+   3.2.5.3 ifEntry for the MAC Layer ................................ 15
+   4 Definitions .................................................... 18
+   5 Acknowledgments ................................................ 69
+   6 References ..................................................... 69
+   7 Security Considerations ........................................ 70
+   8 Intellectual Property .......................................... 71
+   9 Author's Address ............................................... 71
+   10 Full Copyright Statement ...................................... 72
+
+
+
+
+
+
+
+
+
+
+
+
+St. Johns                       Standard                        [Page 2]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+1.  The SNMP Management Framework
+
+   The SNMP Management Framework presently consists of five major
+   components:
+
+   o   An overall architecture, described in RFC 2571 [1].
+
+   o   Mechanisms for describing and naming objects and events for the
+       purpose of management. The first version of this Structure of
+       Management Information (SMI) is called SMIv1 and described in STD
+       16, RFC 1155 [2], STD 16, RFC 1212 [3] and RFC 1215 [4]. The
+       second version, called SMIv2, is described in STD 58, RFC 2578
+       [5], STD 58, RFC 2579 [6] and STD 58, RFC 2580 [7].
+
+   o   Message protocols for transferring management information. The
+       first version of the SNMP message protocol is called SNMPv1 and
+       described in RFC 1157 [8]. A second version of the SNMP message
+       protocol, which is not an Internet standards track protocol, is
+       called SNMPv2c and described in RFC 1901 [9] and RFC 1906 [10].
+       The third version of the message protocol is called SNMPv3 and
+       described in RFC 1906 [10], RFC 2572 [11] and RFC 2574 [12].
+
+   o   Protocol operations for accessing management information. The
+       first set of protocol operations and associated PDU formats is
+       described in STD 15, RFC 1157 [8]. A second set of protocol
+       operations and associated PDU formats is described in RFC 1905
+       [13].
+
+   o   A set of fundamental applications described in RFC 2573 [14] and
+       the view-based access control mechanism described in RFC 2575
+       [15].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  Objects in the MIB are
+   defined using the mechanisms defined in the SMI.
+
+   This memo specifies a MIB module that is compliant to the SMIv2. A
+   MIB conforming to the SMIv1 can be produced through the appropriate
+   translations. The resulting translated MIB MUST be semantically
+   equivalent, except where objects or events are omitted because no
+   translation is possible (use of Counter64). Some machine readable
+   information in SMIv2 will be converted into textual descriptions in
+   SMIv1 during the translation process. However, this loss of machine
+   readable information is not considered to change the semantics of the
+   MIB.
+
+
+
+
+
+
+St. Johns                       Standard                        [Page 3]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+2.  Glossary
+
+   The terms in this document are derived either from normal cable
+   system usage, or from the documents associated with the Data Over
+   Cable Service Interface Specification process.
+
+2.1.  CATV
+
+   Originally "Community Antenna Television", now used to refer to any
+   cable or hybrid fiber and cable system used to deliver video signals
+   to a community.
+
+2.2.  Channel
+
+   A specific frequency allocation with an RF medium, specified by
+   channel width in Hertz (cycles per second) and by center frequency.
+   Within the US Cable Systems, upstream channels are generally
+   allocated from the 5-42MHz range while down stream channels are
+   generally allocated from the 50-750MHz range depending on the
+   capabilities of the given system.  The typical broadcast channel
+   width in the US is 6MHz.  Upstream channel widths for DOCSIS vary.
+
+2.3.  CM   Cable Modem.
+
+   A CM acts as a "slave" station in a DOCSIS compliant cable data
+   system.
+
+2.4.  CMTS   Cable Modem Termination System.
+
+   A generic term covering a cable bridge or cable router in a head-end.
+   A CMTS acts as the master station in a DOCSIS compliant cable data
+   system.  It is the only station that transmits downstream, and it
+   controls the scheduling of upstream transmissions by its associated
+   CMs.
+
+2.5.  Codeword
+
+   See [16]. A characteristic of the Foward Error Correction scheme used
+   above the RF media layer.
+
+2.6.  Data Packet
+
+   The payload portion of the MAC Packet.
+
+2.7.  dBmV
+
+   Decibel relative to one milli-volt. A measure of RF power.
+
+
+
+
+St. Johns                       Standard                        [Page 4]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+2.8.  DOCSIS
+
+   "Data Over Cable Interface Specification".  A term referring to the
+   ITU-T J.112 Annex B standard for cable modem systems [20].
+
+2.9.  Downstream
+
+   The direction from the head-end towards the subscriber.
+
+2.10.  Head-end
+
+   The origination point in most cable systems of the subscriber video
+   signals.
+
+2.11.  MAC Packet
+
+   A DOCSIS PDU.
+
+2.12.  MCNS
+
+   "Multimedia Cable Network System".  Generally replaced in usage by
+   DOCSIS.
+
+2.13.  Mini-slot
+
+   See [16].  In general, an interval of time which is allocated by the
+   CMTS to a given CM for that CM to transmit in an upstream direction.
+
+2.14.  QPSK   Quadrature Phase Shift Keying.
+
+   A particular modulation scheme on an RF medium. See [19].
+
+2.15.  QAM   Quadrature Amplitude Modulation.
+
+   A particular modulation scheme on on RF medium.  Usually expressed
+   with a number indicating the size of the modulation constellation
+   (e.g. 16 QAM). See [19], or any other book on digital communications
+   over RF for a complete explanation of this.
+
+2.16.  RF
+
+   Radio Frequency.
+
+2.17.  Symbol-times
+
+   See [16]. A characteristic of the RF modulation scheme.
+
+
+
+
+
+St. Johns                       Standard                        [Page 5]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+2.18.  Upstream
+
+   The direction from the subscriber towards the head-end.
+
+3.  Overview
+
+   This MIB provides a set of objects required for the management of
+   MCNS/DOCSIS compliant Cable Modem (CM) and Cable Modem Termination
+   System (CMTS) RF interfaces.  The specification is derived in part
+   from the parameters and protocols described in DOCSIS Radio Frequency
+   Interface Specification [16].
+
+3.1.  Structure of the MIB
+
+   This MIB is structured as three groups:
+
+   o    Management information pertinent to both Cable Modems (CM) and
+        Cable Modem Termination Systems (CMTS) (docsIfBaseObjects).
+
+   o    Management information pertinent to Cable Modems only
+        (docsIfCmObjects).
+
+   o    Management information pertinent to Cable Modem Termination
+        Systems only (docsIfCmtsObjects).
+
+   Tables within each of these groups group objects functionally - e.g.
+   Quality of Service, Channel characteristics, MAC layer management,
+   etc.  Rows created automatically (e.g. by the device according to the
+   hardware configuration) may and generally will have a mixture of
+   configuration and status objects within them.  Rows that are meant to
+   be created by the management station are generally restricted to
+   configuration (read-create) objects.
+
+3.1.1.  docsIfBaseObjects
+
+   docsIfDownstreamChannelTable - This table describes the active
+   downstream channels for a CMTS and the received downstream channel
+   for a CM.
+
+   docsIfUpstreamChannelTable - This table describes the active upstream
+   channels for a a CMTS and the current upstream transmission channel
+   for a CM.
+
+   docsIfQosProfileTable - This table describes the valid Quality of
+   Service service profiles for the cable data system.
+
+   docsIfSignalQualityTable - This table is used to monitor RF signal
+   quality characteristics of received signals.
+
+
+
+St. Johns                       Standard                        [Page 6]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+3.1.2.  docsIfCmObjects
+
+   docsIfCmMacTable - This table is used to monitor the DOCSIS MAC
+   interface and can be considered an extension to the ifEntry.
+
+   docsIfCmServiceTable - This table describes the upstream service
+   queues available at this CM.  There is a comparable table at the
+   CMTS, docsIfCmtsServiceEntry, which describes the service queues from
+   the point of view of the CMTS.
+
+3.1.3.  docsIfCmtsObjects
+
+   docsIfCmtsStatusTable - This table provides a set of aggregated
+   counters which roll-up values and events that occur on the underlying
+   sub-interfaces.
+
+   docsIfCmtsCmStatusTable - This table is used to hold information
+   about known (e.g. registered) cable modems on the system serviced by
+   this CMTS.
+
+   docsIfCmtsServiceEntry - This table provides access to the
+   information related to upstream service queues.
+
+   docsIfCmtsModulationTable - This table allows control over the
+   modulation profiles for RF channels associated with this CMTS.
+
+   docsIfCmtsMacToCmTable - This table allows fast access into the
+   docsIfCmtsCmTable via a MAC address (of the CM) interface.
+
+3.2.  Relationship to the Interfaces MIB
+
+   This section clarifies the relationship of this MIB to the Interfaces
+   MIB [17].  Several areas of correlation are addressed in the
+   following subsections.  The implementor is referred to the Interfaces
+   MIB document in order to understand the general intent of these
+   areas.
+
+3.2.1.  Layering Model
+
+   An instance of ifEntry exists for each RF Downstream interface, for
+   each RF Upstream interface, and for each RF MAC layer.  The
+   ifStackTable [17] MUST be implemented to identify relationships among
+   sub-interfaces.
+
+
+
+
+
+
+
+
+St. Johns                       Standard                        [Page 7]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+   The following example illustrates a MAC interface with one downstream
+   and two upstream channels.
+
+                               | <== to network layer
+                 +-------------+--------------+
+                 |           RF MAC           |
+                 +----+---------+-----------+-+
+                      |         |           |
+            +---------+---+ +---+-------+ +-+---------+
+            | Downstream1 | | Upstream1 | | Upstream2 |
+            +-------------+ +-----------+ +-----------+
+
+   As can be seen from this example, the RF MAC interface is layered on
+   top of the downstream and upstream interfaces.
+
+   In this example, the assignment of index values could be as follows:
+
+      ifIndex ifType                   Description
+
+      1    docsCableMaclayer(127)   CATV MAC Layer
+      2    docsCableDownstream(128) CATV Downstream interface
+      3    docsCableUpstream(129)   CATV Upstream interface
+      4    docsCableUpstream(129)   CATV Upstream interface
+
+      The corresponding ifStack entries would then be:
+
+           | IfStackHigherLayer | ifStackLowerLayer |
+           |         0          |         1         |
+           |         1          |         2         |
+           |         1          |         3         |
+           |         1          |         4         |
+           |         2          |         0         |
+           |         3          |         0         |
+           |         4          |         0         |
+
+   The same interface model can also be used in Telephony or Telco
+   Return systems.  A pure Telco Return system (Cable Modem as well as
+   Cable Modem Termination System) would not have upstream, but only
+   downstream cable channels.  Systems supporting both Telco Return and
+   cable upstream channels can use the above model without modification.
+
+   Telco Return Upstream channel(s) are handled by the appropriate MIBs,
+   such as PPP or Modem MIBs.
+
+3.2.2.  Virtual Circuits
+
+   This medium does not support virtual circuits and this area is not
+   applicable to this MIB.
+
+
+
+St. Johns                       Standard                        [Page 8]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+3.2.3.  ifTestTable
+
+   The ifTestTable is not supported by this MIB.
+
+3.2.4.  ifRcvAddressTable
+
+   The ifRcvAddressTable is not supported by this MIB.
+
+3.2.5.  ifEntry
+
+   This section documents only the differences from the requirements
+   specified in the Interfaces MIB.  See that MIB for columns omitted
+   from the descriptions below.
+
+3.2.5.1.  ifEntry for Downstream interfaces
+
+   The ifEntry for Downstream interfaces supports the
+   ifGeneralInformationGroup and the ifPacketGroup of the Interfaces
+   MIB.  This is an output only interface at the CMTS and all input
+   status counters - ifIn* - will return zero.  This is an input only
+   interface at the CM and all output status counters - ifOut* - will
+   return zero.
+
+3.2.5.1.1.  ifEntry for Downstream interfaces in Cable Modem Termination
+            Systems
+
+   ifTable           Comments
+   ==============    ===========================================
+   ifIndex           Each RF Cable Downstream interface is represented
+                     by an ifEntry.
+
+   ifType            The IANA value of docsCableDownstream(128).
+
+   ifSpeed           Return the speed of this downstream channel.
+                     The returned value the raw bandwidth in bits/s
+                     of this interface. This is the symbol rate
+                     multiplied with the number of bits per symbol.
+
+   ifPhysAddress     Return an empty string.
+
+   ifAdminStatus     The administrative status of this interface.
+
+   ifOperStatus      The current operational status of this interface.
+
+   ifMtu             The size of the largest frame which can be
+                     sent on this interface, specified in octets.
+                     The value includes the length of the MAC header.
+
+
+
+
+St. Johns                       Standard                        [Page 9]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+   ifInOctets        Return zero.
+
+   ifInUcastPkts     Return zero.
+
+   ifInMulticastPkts Return zero.
+
+   ifInBroadcastPkts Return zero.
+
+   ifInDiscards      Return zero.
+
+   ifInErrors        Return zero.
+
+   ifInUnknownProtos Return zero.
+
+   ifOutOctets       The total number of octets transmitted on this
+                     interface. This includes MAC packets as well as
+                     data packets, and includes the length of the MAC
+                     header.
+
+   ifOutUcastPkts    The number of Unicast packets transmitted on this
+                     interface. This includes MAC packets as well as
+                     data packets.
+
+   ifOutMulticastPkts
+                     Return the number of Multicast packets transmitted
+                     on this interface.
+                     This includes MAC packets as well as data packets.
+
+   ifOutBroadcastPkts
+                     Return the number of broadcast packets transmitted
+                     on this interface.
+                     This includes MAC packets as well as data packets.
+
+   ifOutDiscards     The total number of outbound packets which
+                     were discarded. Possible reasons are:
+                     buffer shortage.
+
+   ifOutErrors       The number of packets which could not be
+                     transmitted due to errors.
+
+   ifPromiscuousMode Return false.
+
+
+
+
+
+
+
+
+
+
+St. Johns                       Standard                       [Page 10]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+3.2.5.1.2.  ifEntry for Downstream interfaces in Cable Modems
+
+   ifTable           Comments
+   ==============    ===========================================
+   ifIndex           Each RF Cable Downstream interface is represented
+                     by an ifEntry.
+
+   ifType            The IANA value of docsCableDownstream(128).
+
+   ifSpeed           Return the speed of this downstream channel.
+                     The returned value the raw bandwidth in bits/s
+                     of this interface. This is the symbol rate
+                     multiplied with the number of bits per symbol.
+
+   ifPhysAddress     Return an empty string.
+
+   ifAdminStatus     The administrative status of this interface.
+
+   ifOperStatus      The current operational status of this interface.
+
+   ifMtu             The size of the largest frame which can be
+                     received from this interface, specified in octets.
+                     The value includes the length of the MAC header.
+
+   ifInOctets        The total number of octets received on this
+                     interface. This includes data packets as well as
+                     MAC layer packets, and includes the length of the
+                     MAC header.
+
+   ifInUcastPkts     The number of Unicast packets received on this
+                     interface. This includes data packets as well as
+                     MAC layer packets.
+
+   ifInMulticastPkts Return the number of Multicast packets received
+                     on this interface. This includes data packets as
+                     well as MAC layer packets.
+
+   ifInBroadcastPkts Return the number of Broadcast packets received
+                     on this interface. This includes data packets
+                     as well as MAC layer packets.
+
+   ifInDiscards      The total number of received packets which have
+                     been discarded.
+                     The possible reasons are: buffer shortage.
+
+   ifInErrors        The number of inbound packets that contained
+                     errors preventing them from being deliverable
+                     to higher layers.
+
+
+
+St. Johns                       Standard                       [Page 11]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+                     Possible reasons are: MAC FCS error.
+
+   ifInUnknownProtos The number of frames with an unknown packet type.
+                     These are MAC frames with an unknown packet type.
+
+   ifOutOctets       Return zero.
+
+   ifOutUcastPkts    Return zero.
+
+   ifOutMulticastPkts
+                     Return zero.
+
+   ifOutBroadcastPkts
+                     Return zero.
+
+   ifOutDiscards     Return zero.
+
+   ifOutErrors       Return zero.
+
+   ifPromiscuousMode Refer to the Interfaces MIB.
+
+3.2.5.2.  ifEntry for Upstream interfaces
+
+   The ifEntry for Upstream interfaces supports the
+   ifGeneralInformationGroup and the ifPacketGroup of the Interfaces
+   MIB.  This is an input only interface at the CMTS and all output
+   status counters - ifOut* - will return zero.  This is an output only
+   interface at the CM and all input status counters - ifIn* - will
+   return zero.
+
+3.2.5.2.1.  ifEntry for Upstream interfaces in Cable Modem Termination
+            Systems
+
+   ifTable           Comments
+   ==============    ===========================================
+   ifIndex           Each RF Cable Upstream interface is represented
+                     by an ifEntry.
+
+   ifType            The IANA value of docsCableUpstream(129).
+
+   ifSpeed           Return the speed of this upstream channel.
+                     The returned value is the raw bandwidth
+                     in bits/s of this interface, regarding the
+                     highest speed modulation profile that is
+                     defined. This is the symbol rate multiplied
+                     with the number of bits per symbol for this
+                     modulation profile.
+
+
+
+
+St. Johns                       Standard                       [Page 12]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+   ifPhysAddress     Return an empty string.
+
+   ifAdminStatus     The administrative status of this interface.
+
+   ifOperStatus      The current operational status of this interface.
+
+   ifMtu             The size of the largest frame which can be
+                     received on this interface, specified in octets.
+                     The value includes the length of the MAC header.
+
+   ifInOctets        The total number of octets received on this
+                     interface. This includes data packets as well as
+                     MAC layer packets, and includes the length of the
+                     MAC header.
+
+   ifInUcastPkts     The number of Unicast packets received on this
+                     interface. This includes data packets as well as
+                     MAC layer packets.
+
+   ifInMulticastPkts Return the number of Multicast packets received
+                     on this interface. This includes data packets as
+                     well as MAC layer packets.
+
+   ifInBroadcastPkts Return the number of Broadcast packets received
+                     on this interface. This includes data packets
+                     as well as MAC layer packets.
+
+   ifInDiscards      The total number of received packets which have
+                     been discarded.
+                     The possible reasons are: buffer shortage.
+
+   ifInErrors        The number of inbound packets that contained
+                     errors preventing them from being deliverable
+                     to higher layers.
+                     Possible reasons are: MAC FCS error.
+
+   ifInUnknownProtos The number of frames with an unknown packet type.
+                     This are MAC frames with an unknown packet type.
+
+   ifOutOctets       Return zero.
+
+   ifOutUcastPkts    Return zero.
+
+   ifOutMulticastPkts
+                     Return zero.
+
+   ifOutBroadcastPkts
+                     Return zero.
+
+
+
+St. Johns                       Standard                       [Page 13]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+   ifOutDiscards     Return zero.
+
+   ifOutErrors       Return zero.
+
+3.2.5.2.2.  ifEntry for Upstream interfaces in Cable Modems
+
+   ifTable           Comments
+   ==============    ===========================================
+   ifIndex           Each RF Cable Upstream interface is represented
+                     by an ifEntry.
+
+   ifType            The IANA value of docsCableUpstream(129).
+
+   ifSpeed           Return the speed of this upstream channel.
+                     The returned value is the raw bandwidth
+                     in bits/s of this interface, regarding the
+                     highest speed modulation profile that is
+                     defined. This is the symbol rate multiplied
+                     with the number of bits per symbol for this
+                     modulation profile.
+
+   ifPhysAddress     Return an empty string.
+
+   ifAdminStatus     The administrative status of this interface.
+
+   ifOperStatus      The current operational status of this interface.
+
+   ifMtu             The size of the largest frame which can be
+                     transmitted on this interface, specified in octets.
+                     The value includes the length of the MAC header.
+
+   ifInOctets        Return zero.
+
+   ifInUcastPkts     Return zero.
+
+   ifInMulticastPkts Return zero.
+
+   ifInBroadcastPkts Return zero.
+
+   ifInDiscards      Return zero.
+
+   ifInErrors        Return zero.
+
+   ifInUnknownProtos Return zero.
+
+
+
+
+
+
+
+St. Johns                       Standard                       [Page 14]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+   ifOutOctets       The total number of octets transmitted on this
+                     interface. This includes MAC packets as well as
+                     data packets, and includes the length of the MAC
+                     header.
+
+   ifOutUcastPkts    The number of Unicast packets transmitted on this
+                     interface. This includes MAC packets as well as
+                     data packets.
+
+   ifOutMulticastPkts
+                     Return the number of Multicast packets transmitted
+                     on this interface.
+                     This includes MAC packets as well as data packets.
+
+   ifOutBroadcastPkts
+                     Return the number of broadcast packets transmitted
+                     on this interface.
+                     This includes MAC packets as well as data packets.
+
+   ifOutDiscards     The total number of outbound packets which
+                     were discarded. Possible reasons are:
+                     buffer shortage.
+
+   ifOutErrors       The number of packets which could not be
+                     transmitted due to errors.
+
+   ifPromiscuousMode Return false.
+
+3.2.5.3.  ifEntry for the MAC Layer
+
+   The ifEntry for the MAC Layer supports the ifGeneralInformationGroup
+   and the ifPacketGroup of the Interfaces MIB.  This interface provides
+   an aggregate view of status for the lower level Downstream and
+   Upstream interfaces.
+
+   ifTable           Comments
+   ==============    ===========================================
+   ifIndex           Each RF Cable MAC layer entity is represented
+                     by an ifEntry.
+
+   ifType            The IANA value of docsCableMaclayer(127).
+
+   ifSpeed           Return zero.
+
+   ifPhysAddress     Return the physical address of this interface.
+
+   ifAdminStatus     The administrative status of this interface.
+
+
+
+
+St. Johns                       Standard                       [Page 15]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+   ifOperStatus      The current operational status of the MAC
+                     layer interface.
+
+   ifHighSpeed       Return zero.
+
+   ifMtu             Return 1500.
+
+   ifInOctets        The total number of data octets received on this
+                     interface, targeted for upper protocol layers.
+
+   ifInUcastPkts     The number of Unicast packets received on this
+                     interface, targeted for upper protocol layers.
+
+   ifInMulticastPkts Return the number of Multicast packets received
+                     on this interface, targeted for upper protocol
+                     layers.
+
+   ifInBroadcastPkts Return the number of Broadcast packets received
+                     on this interface, targeted for upper protocol
+                     layers.
+
+   ifInDiscards      The total number of received packets which have
+                     been discarded.
+                     The possible reasons are: buffer shortage.
+
+   ifInErrors        The number of inbound packets that contained
+                     errors preventing them from being deliverable
+                     to higher layers.
+                     Possible reasons are: data packet FCS error,
+                     invalid MAC header.
+
+   ifInUnknownProtos The number of frames with an unknown packet type.
+                     This is the number of data packets targeted for
+                     upper protocol layers with an unknown packet type.
+
+   ifOutOctets       The total number of octets, received from upper
+                     protocol layers and transmitted on this interface.
+
+   ifOutUcastPkts    The number of Unicast packets, received from upper
+                     protocol layers and transmitted on this interface.
+
+   ifOutMulticastPkts
+                     Return the number of Multicast packets received
+                     from upper protocol layers and transmitted on this
+                     interface.
+
+
+
+
+
+
+St. Johns                       Standard                       [Page 16]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+   ifOutBroadcastPkts
+                     Return the number of broadcast packets received
+                     from upper protocol layers and transmitted on this
+                     interface.
+
+   ifOutDiscards     The total number of outbound packets which
+                     were discarded. Possible reasons are:
+                     buffer shortage.
+
+   ifOutErrors       The number of packets which could not be
+                     transmitted due to errors.
+
+   ifPromiscuousMode Refer to the Interfaces MIB.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+St. Johns                       Standard                       [Page 17]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+4.  Definitions
+
+DOCS-IF-MIB DEFINITIONS ::= BEGIN
+
+  IMPORTS
+        MODULE-IDENTITY,
+        OBJECT-TYPE,
+  -- do not import        BITS,
+        Unsigned32,
+        Integer32,
+        Counter32,
+        TimeTicks,
+        IpAddress,
+        transmission
+                FROM SNMPv2-SMI
+        TEXTUAL-CONVENTION,
+        MacAddress,
+        RowStatus,
+        TruthValue,
+        TimeInterval,
+        TimeStamp
+                FROM SNMPv2-TC
+        OBJECT-GROUP,
+
+        MODULE-COMPLIANCE
+                FROM SNMPv2-CONF
+        ifIndex, InterfaceIndexOrZero
+                FROM IF-MIB;
+
+docsIfMib MODULE-IDENTITY
+        LAST-UPDATED    "9908190000Z" -- August 19, 1999
+        ORGANIZATION    "IETF IPCDN Working Group"
+        CONTACT-INFO
+            "        Michael StJohns
+             Postal: @Home Network
+                     425 Broadway
+                     Redwood City, CA
+                     U.S.A.
+             Phone:  +1 650 569 5368
+             E-mail: stjohns@corp.home.net"
+        DESCRIPTION
+            "This is the MIB Module for MCNS/DOCSIS compliant Radio
+             Frequency (RF) interfaces in Cable Modems (CM) and
+             Cable Modem Termination Systems (CMTS)."
+        REVISION "9908190000Z"
+        DESCRIPTION
+            "Initial Version, published as RFC 2670.
+             Modified by Mike StJohns to fix problems identified by
+
+
+
+St. Johns                       Standard                       [Page 18]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+             the first pass of the MIB doctor.  Of special note,
+             docsIfRangingResp and docsIfCmtsInsertionInterval were
+             obsoleted and replaced by other objects with the same
+             functionality, but more appropriate SYNTAX."
+        ::= { transmission 127 }
+
+-- Textual Conventions
+
+TenthdBmV ::= TEXTUAL-CONVENTION
+        DISPLAY-HINT "d-1"
+        STATUS       current
+        DESCRIPTION
+            "This data type represents power levels that are normally
+             expressed in dBmV. Units are in tenths of a dBmV;
+             for example, 5.1 dBmV will be represented as 51."
+        SYNTAX       Integer32
+
+TenthdB ::= TEXTUAL-CONVENTION
+        DISPLAY-HINT "d-1"
+        STATUS       current
+        DESCRIPTION
+            "This data type represents power levels that are normally
+             expressed in dB. Units are in tenths of a dB;
+             for example, 5.1 dB will be represented as 51."
+        SYNTAX       Integer32
+
+docsIfMibObjects  OBJECT IDENTIFIER ::= { docsIfMib 1 }
+docsIfBaseObjects OBJECT IDENTIFIER ::= { docsIfMibObjects 1 }
+docsIfCmObjects   OBJECT IDENTIFIER ::= { docsIfMibObjects 2 }
+docsIfCmtsObjects OBJECT IDENTIFIER ::= { docsIfMibObjects 3 }
+
+--
+-- BASE GROUP
+--
+
+--
+-- The following table is implemented on both the Cable Modem (CM)
+-- and the Cable Modem Termination System (CMTS).
+--
+
+docsIfDownstreamChannelTable OBJECT-TYPE
+        SYNTAX      SEQUENCE OF DocsIfDownstreamChannelEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "This table describes the attributes of downstream
+             channels (frequency bands)."
+        REFERENCE
+
+
+
+St. Johns                       Standard                       [Page 19]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+            "DOCSIS Radio Frequency Interface Specification,
+             Table 4-12 and Table 4-13."
+        ::= { docsIfBaseObjects 1 }
+
+docsIfDownstreamChannelEntry OBJECT-TYPE
+        SYNTAX      DocsIfDownstreamChannelEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "An entry provides a list of attributes for a single
+             Downstream channel.
+             An entry in this table exists for each ifEntry with an
+             ifType of docsCableDownstream(128)."
+        INDEX { ifIndex }
+        ::= { docsIfDownstreamChannelTable 1 }
+
+DocsIfDownstreamChannelEntry ::= SEQUENCE {
+            docsIfDownChannelId               Integer32,
+            docsIfDownChannelFrequency        Integer32,
+            docsIfDownChannelWidth            Integer32,
+            docsIfDownChannelModulation       INTEGER,
+            docsIfDownChannelInterleave       INTEGER,
+            docsIfDownChannelPower            TenthdBmV
+        }
+
+docsIfDownChannelId OBJECT-TYPE
+        SYNTAX      Integer32 (0..255)
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The Cable Modem Termination System (CMTS) identification
+             of the downstream channel within this particular MAC
+             interface. If the interface is down, the object returns
+             the most current value. If the downstream channel ID is
+             unknown, this object returns a value of 0."
+        ::= { docsIfDownstreamChannelEntry 1 }
+
+docsIfDownChannelFrequency  OBJECT-TYPE
+        SYNTAX      Integer32 (0..1000000000)
+        UNITS       "hertz"
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+            "The center of the downstream frequency associated with
+             this channel. This object will return the current tuner
+             frequency. If a CMTS provides IF output, this object
+             will return 0, unless this CMTS is in control of the
+             final downstream RF frequency.  See the associated
+
+
+
+St. Johns                       Standard                       [Page 20]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+             compliance object for a description of valid frequencies
+             that may be written to this object."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+             Section 4.3.3."
+        ::= { docsIfDownstreamChannelEntry 2 }
+
+docsIfDownChannelWidth  OBJECT-TYPE
+        SYNTAX      Integer32 (0..16000000)
+        UNITS       "hertz"
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+            "The bandwidth of this downstream channel. Most
+             implementations are expected to support a channel width
+             of 6 MHz (North America) and/or 8 MHz (Europe).  See the
+             associated compliance object for a description of the
+             valid channel widths for this object."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+             Table 4-12 and Table 4-13."
+        ::= { docsIfDownstreamChannelEntry 3 }
+
+docsIfDownChannelModulation OBJECT-TYPE
+        SYNTAX      INTEGER {
+            unknown(1),
+            other(2),
+            qam64(3),
+            qam256(4)
+        }
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+            "The modulation type associated with this downstream
+             channel. If the interface is down, this object either
+             returns the configured value (CMTS), the most current
+             value (CM), or the value of unknown(1).  See the
+             associated conformance object for write conditions and
+             limitations. See the reference for specifics on the
+             modulation profiles implied by qam64 and qam256."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+             Section 3.6.2."
+        ::= { docsIfDownstreamChannelEntry 4 }
+
+docsIfDownChannelInterleave OBJECT-TYPE
+        SYNTAX      INTEGER {
+            unknown(1),
+
+
+
+St. Johns                       Standard                       [Page 21]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+            other(2),
+            taps8Increment16(3),
+            taps16Increment8(4),
+            taps32Increment4(5),
+            taps64Increment2(6),
+            taps128Increment1(7)
+        }
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+            "The Forward Error Correction (FEC) interleaving used
+             for this downstream channel.
+             Values are defined as follows:
+             taps8Increment16(3):   protection 5.9/4.1 usec,
+                                    latency .22/.15 msec
+             taps16Increment8(4):   protection 12/8.2 usec,
+                                    latency .48/.33 msec
+             taps32Increment4(5):   protection 24/16 usec,
+                                    latency .98/.68 msec
+             taps64Increment2(6):   protection 47/33 usec,
+                                    latency 2/1.4 msec
+             taps128Increment1(7):  protection 95/66 usec,
+                                    latency 4/2.8 msec
+             If the interface is down, this object either returns
+             the configured value (CMTS), the most current value (CM),
+             or the value of unknown(1).
+             The value of other(2) is returned if the interleave
+             is known but not defined in the above list.
+             See the associated conformance object for write
+             conditions and limitations. See the reference for the FEC
+             configuration described by the setting of this object."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+             Section 4.3.2."
+        ::= { docsIfDownstreamChannelEntry 5 }
+
+docsIfDownChannelPower OBJECT-TYPE
+        SYNTAX      TenthdBmV
+        UNITS       "dBmV"
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+            "At the CMTS, the operational transmit power. At the CM,
+             the received power level. May be set to zero at the CM
+             if power level measurement is not supported.
+             If the interface is down, this object either returns
+             the configured value (CMTS), the most current value (CM)
+             or the value of 0. See the associated conformance object
+
+
+
+St. Johns                       Standard                       [Page 22]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+             for write conditions and limitations. See the reference
+             for recommended and required power levels."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+             Table 4-12 and Table 4-13."
+        ::= { docsIfDownstreamChannelEntry 6 }
+
+--
+-- The following table is implemented on both the CM and the CMTS.
+-- For the CM, only attached channels appear in the table.  For the
+-- CM, this table is read only as well.
+--
+
+docsIfUpstreamChannelTable OBJECT-TYPE
+        SYNTAX      SEQUENCE OF DocsIfUpstreamChannelEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "This table describes the attributes of attached upstream
+             channels (frequency bands)."
+        ::= { docsIfBaseObjects 2 }
+
+docsIfUpstreamChannelEntry OBJECT-TYPE
+        SYNTAX      DocsIfUpstreamChannelEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "List of attributes for a single upstream channel.
+             An entry in this table exists for each ifEntry with an
+             ifType of docsCableUpstream(129)."
+        INDEX { ifIndex }
+        ::= { docsIfUpstreamChannelTable 1 }
+
+DocsIfUpstreamChannelEntry ::= SEQUENCE {
+            docsIfUpChannelId                     Integer32,
+            docsIfUpChannelFrequency              Integer32,
+            docsIfUpChannelWidth                  Integer32,
+            docsIfUpChannelModulationProfile      Unsigned32,
+            docsIfUpChannelSlotSize               Unsigned32,
+            docsIfUpChannelTxTimingOffset         Unsigned32,
+            docsIfUpChannelRangingBackoffStart    Integer32,
+            docsIfUpChannelRangingBackoffEnd      Integer32,
+            docsIfUpChannelTxBackoffStart         Integer32,
+            docsIfUpChannelTxBackoffEnd           Integer32
+        }
+
+docsIfUpChannelId OBJECT-TYPE
+        SYNTAX      Integer32 (0..255)
+
+
+
+St. Johns                       Standard                       [Page 23]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The CMTS identification of the upstream channel."
+        ::= { docsIfUpstreamChannelEntry 1 }
+
+docsIfUpChannelFrequency OBJECT-TYPE
+        SYNTAX      Integer32 (0..1000000000)
+        UNITS       "hertz"
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+            "The center of the frequency band associated with this
+             upstream channel. This object returns 0 if the frequency
+             is undefined or unknown. Minimum permitted upstream
+             frequency is 5,000,000 Hz for current technology.  See
+             the associated conformance object for write conditions
+             and limitations."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+             Table 2-2."
+        ::= { docsIfUpstreamChannelEntry 2 }
+
+docsIfUpChannelWidth OBJECT-TYPE
+        SYNTAX      Integer32 (0..20000000)
+        UNITS       "hertz"
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+            "The bandwidth of this upstream channel. This object
+             returns 0 if the channel width is undefined or unknown.
+             Minimum permitted channel width is 200,000 Hz currently.
+             See the associated conformance object for write conditions
+             and limitations."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+             Table 4-3."
+        ::= { docsIfUpstreamChannelEntry 3 }
+
+docsIfUpChannelModulationProfile OBJECT-TYPE
+        SYNTAX      Unsigned32
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+            "An entry identical to the docsIfModIndex in the
+             docsIfCmtsModulationTable that describes this channel.
+             This channel is further instantiated there by a grouping
+             of interval usage codes which together fully describe the
+
+
+
+St. Johns                       Standard                       [Page 24]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+             channel modulation. This object returns 0 if the
+             docsIfCmtsModulationTable entry does not exist or
+             docsIfCmtsModulationTable is empty. See
+             the associated conformance object for write conditions
+             and limitations."
+        ::= { docsIfUpstreamChannelEntry 4 }
+
+docsIfUpChannelSlotSize OBJECT-TYPE
+        SYNTAX      Unsigned32
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+            "The number of 6.25 microsecond ticks in each upstream mini-
+             slot. Returns zero if the value is undefined or unknown.
+             See the associated conformance object for write
+             conditions and limitations."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+             Section 6.1.2.4."
+        ::= { docsIfUpstreamChannelEntry 5 }
+
+docsIfUpChannelTxTimingOffset OBJECT-TYPE
+        SYNTAX      Unsigned32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "A measure of the current round trip time at the CM, or the
+             maximum round trip time seen by the CMTS.  Used for timing
+             of CM upstream transmissions to ensure synchronized
+             arrivals at the CMTS. Units are in terms of
+             (6.25 microseconds/64)."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+             Section 6.5."
+        ::= { docsIfUpstreamChannelEntry 6 }
+
+docsIfUpChannelRangingBackoffStart OBJECT-TYPE
+        SYNTAX      Integer32 (0..16)
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+            "The initial random backoff window to use when retrying
+             Ranging Requests. Expressed as a power of 2. A value of 16
+             at the CMTS indicates that a proprietary adaptive retry
+             mechanism is to be used. See the associated conformance
+             object for write conditions and limitations."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+
+
+
+St. Johns                       Standard                       [Page 25]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+             Section 6.4.4."
+        ::= { docsIfUpstreamChannelEntry 7 }
+
+docsIfUpChannelRangingBackoffEnd OBJECT-TYPE
+        SYNTAX      Integer32 (0..16)
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+            "The final random backoff window to use when retrying
+             Ranging Requests. Expressed as a power of 2. A value of 16
+             at the CMTS indicates that a proprietary adaptive retry
+             mechanism is to be used. See the associated conformance
+             object for write conditions and limitations."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+             Section 6.4.4."
+        ::= { docsIfUpstreamChannelEntry 8 }
+
+docsIfUpChannelTxBackoffStart OBJECT-TYPE
+        SYNTAX      Integer32 (0..16)
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+            "The initial random backoff window to use when retrying
+             transmissions. Expressed as a power of 2. A value of 16
+             at the CMTS indicates that a proprietary adaptive retry
+             mechanism is to be used. See the associated conformance
+             object for write conditions and limitations."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+             Section 6.4.4."
+        ::= { docsIfUpstreamChannelEntry 9 }
+
+docsIfUpChannelTxBackoffEnd OBJECT-TYPE
+        SYNTAX      Integer32 (0..16)
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+            "The final random backoff window to use when retrying
+             transmissions. Expressed as a power of 2. A value of 16
+             at the CMTS indicates that a proprietary adaptive retry
+             mechanism is to be used. See the associated conformance
+             object for write conditions and limitations."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+             Section 6.4.4."
+        ::= { docsIfUpstreamChannelEntry 10 }
+
+
+
+
+St. Johns                       Standard                       [Page 26]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+-- The following table describes the attributes of each class of
+-- service.  The entries in this table are referenced from the
+-- docsIfServiceEntries.  They exist as a separate table in order to
+-- reduce redundant information in docsIfServiceTable.
+--
+-- This table is implemented at both the CM and the CMTS.
+-- The CM need only maintain entries for the classes of service
+-- referenced by its docsIfServiceTable.
+--
+
+docsIfQosProfileTable OBJECT-TYPE
+        SYNTAX      SEQUENCE OF DocsIfQosProfileEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "Describes the attributes for each class of service."
+        ::= { docsIfBaseObjects 3 }
+
+docsIfQosProfileEntry OBJECT-TYPE
+        SYNTAX      DocsIfQosProfileEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "Describes the attributes for a single class of service.
+
+             If implemented as read-create in the Cable Modem
+             Termination System, creation of entries in this table is
+             controlled by the value of docsIfCmtsQosProfilePermissions.
+
+             If implemented as read-only, entries are created based
+             on information in REG-REQ MAC messages received from
+             Cable Modems (Cable Modem Termination System
+             implementation), or based on information extracted from
+             the TFTP option file (Cable Modem implementation).
+             In the Cable Modem Termination system, read-only entries
+             are removed if no longer referenced by
+             docsIfCmtsServiceTable.
+
+             An entry in this table must not be removed while it is
+             referenced by an entry in docsIfCmServiceTable (Cable Modem)
+             or docsIfCmtsServiceTable (Cable Modem Termination System).
+
+             An entry in this table should not be changeable while
+             it is referenced by an entry in docsIfCmtsServiceTable.
+
+             If this table is created automatically, there should only
+             be a single entry for each Class of Service. Multiple
+             entries with the same Class of Service parameters are not
+
+
+
+St. Johns                       Standard                       [Page 27]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+             recommended."
+        INDEX { docsIfQosProfIndex }
+        ::= { docsIfQosProfileTable 1 }
+
+DocsIfQosProfileEntry ::= SEQUENCE {
+            docsIfQosProfIndex                Integer32,
+            docsIfQosProfPriority             Integer32,
+            docsIfQosProfMaxUpBandwidth       Integer32,
+            docsIfQosProfGuarUpBandwidth      Integer32,
+            docsIfQosProfMaxDownBandwidth     Integer32,
+            docsIfQosProfMaxTxBurst           Integer32,
+            docsIfQosProfBaselinePrivacy      TruthValue,
+            docsIfQosProfStatus               RowStatus
+        }
+
+docsIfQosProfIndex OBJECT-TYPE
+        SYNTAX      Integer32 (1..16383)
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "The index value which uniquely identifies an entry
+             in the docsIfQosProfileTable."
+        ::= { docsIfQosProfileEntry 1 }
+
+docsIfQosProfPriority  OBJECT-TYPE
+        SYNTAX      Integer32 (0..7)
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "A relative priority assigned to this service when
+             allocating bandwidth. Zero indicates lowest priority;
+             and seven indicates highest priority.
+             Interpretation of priority is device-specific.
+             MUST NOT be changed while this row is active."
+        DEFVAL { 0 }
+        ::= { docsIfQosProfileEntry 2 }
+
+docsIfQosProfMaxUpBandwidth OBJECT-TYPE
+        SYNTAX      Integer32 (0..100000000)
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "The maximum upstream bandwidth, in bits per second,
+             allowed for a service with this service class.
+             Zero if there is no restriction of upstream bandwidth.
+             MUST NOT be changed while this row is active."
+        DEFVAL { 0 }
+        ::= { docsIfQosProfileEntry 3 }
+
+
+
+St. Johns                       Standard                       [Page 28]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+docsIfQosProfGuarUpBandwidth OBJECT-TYPE
+        SYNTAX      Integer32 (0..100000000)
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "Minimum guaranteed upstream bandwidth, in bits per second,
+             allowed for a service with this service class.
+             MUST NOT be changed while this row is active."
+        DEFVAL { 0 }
+        ::= { docsIfQosProfileEntry 4 }
+
+docsIfQosProfMaxDownBandwidth OBJECT-TYPE
+        SYNTAX      Integer32 (0..100000000)
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "The maximum downstream bandwidth, in bits per second,
+             allowed for a service with this service class.
+             Zero if there is no restriction of downstream bandwidth.
+             MUST NOT be changed while this row is active."
+        DEFVAL { 0 }
+        ::= { docsIfQosProfileEntry 5 }
+
+docsIfQosProfMaxTxBurst OBJECT-TYPE
+        SYNTAX      Integer32 (0..255)
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "The maximum number of mini-slots that may be requested
+             for a single upstream transmission.
+             A value of zero means there is no limit.
+             MUST NOT be changed while this row is active."
+        DEFVAL { 0 }
+        ::= { docsIfQosProfileEntry 6 }
+
+docsIfQosProfBaselinePrivacy  OBJECT-TYPE
+        SYNTAX      TruthValue
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "Indicates whether Baseline Privacy is enabled for this
+             service class.
+             MUST NOT be changed while this row is active."
+        DEFVAL { false }
+        ::= { docsIfQosProfileEntry 7 }
+
+docsIfQosProfStatus OBJECT-TYPE
+        SYNTAX      RowStatus
+
+
+
+St. Johns                       Standard                       [Page 29]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "This is object is to used to create or delete rows in
+             this table.  This object MUST NOT be changed from active
+             while the row is referenced by the any entry in either
+             docsIfCmServiceTable (on the CM), or the
+             docsIfCmtsServiceTable (on the CMTS)."
+        ::= { docsIfQosProfileEntry 8 }
+
+
+docsIfSignalQualityTable OBJECT-TYPE
+        SYNTAX      SEQUENCE OF DocsIfSignalQualityEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "At the CM, describes the PHY signal quality of downstream
+             channels. At the CMTS, describes the PHY signal quality of
+             upstream channels. At the CMTS, this table may exclude
+             contention intervals."
+        ::= { docsIfBaseObjects 4 }
+
+docsIfSignalQualityEntry OBJECT-TYPE
+        SYNTAX      DocsIfSignalQualityEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "At the CM, describes the PHY characteristics of a
+             downstream channel. At the CMTS, describes the PHY signal
+             quality of an upstream channel.
+             An entry in this table exists for each ifEntry with an
+             ifType of docsCableUpstream(129) for Cable Modem Termination
+             Systems and docsCableDownstream(128) for Cable Modems."
+        INDEX { ifIndex }
+        ::= { docsIfSignalQualityTable 1 }
+
+DocsIfSignalQualityEntry ::= SEQUENCE {
+            docsIfSigQIncludesContention  TruthValue,
+            docsIfSigQUnerroreds          Counter32,
+            docsIfSigQCorrecteds          Counter32,
+            docsIfSigQUncorrectables      Counter32,
+            docsIfSigQSignalNoise         TenthdB,
+            docsIfSigQMicroreflections    Integer32,
+            docsIfSigQEqualizationData    OCTET STRING
+        }
+
+docsIfSigQIncludesContention OBJECT-TYPE
+        SYNTAX      TruthValue
+
+
+
+St. Johns                       Standard                       [Page 30]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "true(1) if this CMTS includes contention intervals in
+             the counters in this table. Always false(2) for CMs."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Section 6.4.4"
+        ::= { docsIfSignalQualityEntry 1 }
+
+docsIfSigQUnerroreds OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Codewords received on this channel without error.
+             This includes all codewords, whether or not they
+             were part of frames destined for this device."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Section 4.2.3 and 4.3.6"
+        ::= { docsIfSignalQualityEntry 2 }
+
+docsIfSigQCorrecteds OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Codewords received on this channel with correctable
+             errors. This includes all codewords, whether or not
+             they were part of frames destined for this device."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Section 4.2.3 and 4.3.6"
+        ::= { docsIfSignalQualityEntry 3 }
+
+docsIfSigQUncorrectables OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Codewords received on this channel with uncorrectable
+             errors. This includes all codewords, whether or not
+             they were part of frames destined for this device."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Section 4.2.3 and 4.3.6"
+        ::= { docsIfSignalQualityEntry 4 }
+
+
+
+St. Johns                       Standard                       [Page 31]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+docsIfSigQSignalNoise OBJECT-TYPE
+        SYNTAX      TenthdB
+        UNITS       "dB"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Signal/Noise ratio as perceived for this channel.
+             At the CM, describes the Signal/Noise of the downstream
+             channel.  At the CMTS, describes the average Signal/Noise
+             of the upstream channel."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Table 2-1 and 2-2"
+        ::= { docsIfSignalQualityEntry 5 }
+
+docsIfSigQMicroreflections OBJECT-TYPE
+        SYNTAX      Integer32 (0..255)
+        UNITS       "dBc"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Total microreflections including in-channel response
+             as perceived on this interface, measured in dBc below
+             the signal level.
+             This object is not assumed to return an absolutely
+             accurate value, but should give a rough indication
+             of microreflections received on this interface.
+             It is up to the implementor to provide information
+             as accurate as possible."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Table 2-1 and 2-2"
+        ::= { docsIfSignalQualityEntry 6 }
+
+docsIfSigQEqualizationData OBJECT-TYPE
+        SYNTAX      OCTET STRING
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "At the CM, returns the equalization data for the downstream
+             channel. At the CMTS, returns the average equalization
+             data for the upstream channel. Returns an empty string
+             if the value is unknown or if there is no equalization
+             data available or defined."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+             Figure 6-23."
+        ::= { docsIfSignalQualityEntry 7 }
+
+
+
+St. Johns                       Standard                       [Page 32]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+--
+-- CABLE MODEM GROUP
+--
+
+-- #######
+
+--
+-- The CM MAC Table
+--
+
+docsIfCmMacTable OBJECT-TYPE
+        SYNTAX      SEQUENCE OF DocsIfCmMacEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "Describes the attributes of each CM MAC interface,
+             extending the information available from ifEntry."
+        ::= { docsIfCmObjects 1 }
+
+docsIfCmMacEntry OBJECT-TYPE
+        SYNTAX      DocsIfCmMacEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "An entry containing objects describing attributes of
+             each MAC entry, extending the information in ifEntry.
+             An entry in this table exists for each ifEntry with an
+             ifType of docsCableMaclayer(127)."
+        INDEX { ifIndex }
+        ::= { docsIfCmMacTable 1 }
+
+DocsIfCmMacEntry ::= SEQUENCE {
+            docsIfCmCmtsAddress           MacAddress,
+            docsIfCmCapabilities          BITS,
+            docsIfCmRangingRespTimeout    TimeTicks,
+            docsIfCmRangingTimeout        TimeInterval
+        }
+
+docsIfCmCmtsAddress OBJECT-TYPE
+        SYNTAX      MacAddress
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Identifies the CMTS that is believed to control this MAC
+             domain. At the CM, this will be the source address from
+             SYNC, MAP, and other MAC-layer messages. If the CMTS is
+             unknown, returns 00-00-00-00-00-00."
+        ::= { docsIfCmMacEntry 1 }
+
+
+
+St. Johns                       Standard                       [Page 33]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+docsIfCmCapabilities OBJECT-TYPE
+        SYNTAX      BITS {
+            atmCells(0),
+            concatenation(1)
+        }
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Identifies the capabilities of the MAC implementation
+             at this interface. Note that packet transmission is
+             always supported. Therefore, there is no specific bit
+             required to explicitely indicate this capability."
+        ::= { docsIfCmMacEntry 2 }
+
+-- This object has been obsoleted and replaced by
+-- docsIfCmRangingTimeout to correct the typing to TimeInterval. New
+-- implementations of the MIB should use docsIfCmRangingTimeout instead.
+
+docsIfCmRangingRespTimeout OBJECT-TYPE
+        SYNTAX      TimeTicks
+        MAX-ACCESS  read-write
+        STATUS      obsolete
+        DESCRIPTION
+            "Waiting time for a Ranging Response packet."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Figure 7-6 and 7-7, timer T3."
+        DEFVAL { 20 }
+        ::= { docsIfCmMacEntry 3 }
+
+docsIfCmRangingTimeout OBJECT-TYPE
+        SYNTAX      TimeInterval
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+            "Waiting time for a Ranging Response packet."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Figure 7-6 and 7-7, timer T3."
+        DEFVAL { 20 }
+        ::= { docsIfCmMacEntry 4 }
+
+--
+-- CM status table.
+-- This table is implemented only at the CM.
+--
+
+docsIfCmStatusTable OBJECT-TYPE
+
+
+
+St. Johns                       Standard                       [Page 34]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+        SYNTAX      SEQUENCE OF DocsIfCmStatusEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "This table maintains a number of status objects
+             and counters for Cable Modems."
+        ::= { docsIfCmObjects 2 }
+
+docsIfCmStatusEntry OBJECT-TYPE
+        SYNTAX      DocsIfCmStatusEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "A set of status objects and counters for a single MAC
+             layer instance in a Cable Modem.
+             An entry in this table exists for each ifEntry with an
+             ifType of docsCableMaclayer(127)."
+        INDEX { ifIndex }
+        ::= { docsIfCmStatusTable 1 }
+
+DocsIfCmStatusEntry ::= SEQUENCE {
+            docsIfCmStatusValue                     INTEGER,
+            docsIfCmStatusCode                      OCTET STRING,
+            docsIfCmStatusTxPower                   TenthdBmV,
+            docsIfCmStatusResets                    Counter32,
+            docsIfCmStatusLostSyncs                 Counter32,
+            docsIfCmStatusInvalidMaps               Counter32,
+            docsIfCmStatusInvalidUcds               Counter32,
+--            docsIfCmStatusInvalidRangingResp        Counter32,
+            docsIfCmStatusInvalidRangingResponses   Counter32,
+--            docsIfCmStatusInvalidRegistrationResp   Counter32,
+            docsIfCmStatusInvalidRegistrationResponses Counter32,
+            docsIfCmStatusT1Timeouts                Counter32,
+            docsIfCmStatusT2Timeouts                Counter32,
+            docsIfCmStatusT3Timeouts                Counter32,
+            docsIfCmStatusT4Timeouts                Counter32,
+            docsIfCmStatusRangingAborteds           Counter32
+        }
+
+docsIfCmStatusValue OBJECT-TYPE
+        SYNTAX      INTEGER {
+            other(1),
+            notReady(2),
+            notSynchronized(3),
+            phySynchronized(4),
+            usParametersAcquired(5),
+            rangingComplete(6),
+            ipComplete(7),
+
+
+
+St. Johns                       Standard                       [Page 35]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+            todEstablished(8),
+            securityEstablished(9),
+            paramTransferComplete(10),
+            registrationComplete(11),
+            operational(12),
+            accessDenied(13)
+        }
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Current Cable Modem connectivity state, as specified
+             in the RF Interface Specification."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+             Chapter 7.2."
+        ::= { docsIfCmStatusEntry 1 }
+
+docsIfCmStatusCode OBJECT-TYPE
+        SYNTAX      OCTET STRING
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Status code for this Cable Modem as defined in the
+             RF Interface Specification. The status code consists
+             of a single character indicating error groups, followed
+             by a two- or three-digit number indicating the status
+             condition."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+             Cable Modem status codes."
+        ::= { docsIfCmStatusEntry 2 }
+
+docsIfCmStatusTxPower OBJECT-TYPE
+        SYNTAX      TenthdBmV
+        UNITS       "dBmV"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The operational transmit power for the attached upstream
+             channel."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Section 4.2.8."
+        ::= { docsIfCmStatusEntry 3 }
+
+docsIfCmStatusResets OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+
+
+
+St. Johns                       Standard                       [Page 36]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+        STATUS      current
+        DESCRIPTION
+            "Number of times the CM reset or initialized
+             this interface."
+        ::= { docsIfCmStatusEntry 4 }
+
+docsIfCmStatusLostSyncs OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Number of times the CM lost synchronization with
+             the downstream channel."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Section 6.5."
+        ::= { docsIfCmStatusEntry 5 }
+
+docsIfCmStatusInvalidMaps OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Number of times the CM received invalid MAP messages."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Section 6.3.2.3 and 6.4.2."
+        ::= { docsIfCmStatusEntry 6 }
+
+docsIfCmStatusInvalidUcds OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Number of times the CM received invalid UCD messages."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Section 6.3.2.2."
+        ::= { docsIfCmStatusEntry 7 }
+
+-- docsIfCmStatusInvalidRangingResp replaced for Counter32
+-- naming requirements
+
+docsIfCmStatusInvalidRangingResponses OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+
+
+
+St. Johns                       Standard                       [Page 37]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+            "Number of times the CM received invalid ranging response
+             messages."
+        ::= { docsIfCmStatusEntry 8 }
+
+-- docsIfCmStatusInvalidRegistrationResp replaced for
+-- Counter32 naming requirements
+docsIfCmStatusInvalidRegistrationResponses OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Number of times the CM received invalid registration
+             response messages."
+        ::= { docsIfCmStatusEntry 9 }
+
+docsIfCmStatusT1Timeouts OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Number of times counter T1 expired in the CM."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Figure 7-3."
+        ::= { docsIfCmStatusEntry 10 }
+
+docsIfCmStatusT2Timeouts OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Number of times counter T2 expired in the CM."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Figure 7-6."
+        ::= { docsIfCmStatusEntry 11 }
+
+docsIfCmStatusT3Timeouts OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Number of times counter T3 expired in the CM."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Figure 7-6 and 7-7."
+        ::= { docsIfCmStatusEntry 12 }
+
+
+
+
+St. Johns                       Standard                       [Page 38]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+docsIfCmStatusT4Timeouts OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Number of times counter T4 expired in the CM."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Figure 7-7."
+        ::= { docsIfCmStatusEntry 13 }
+
+docsIfCmStatusRangingAborteds OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Number of times the ranging process was aborted
+             by the CMTS."
+        ::= { docsIfCmStatusEntry 14 }
+
+--
+-- The Cable Modem Service Table
+--
+
+docsIfCmServiceTable  OBJECT-TYPE
+        SYNTAX      SEQUENCE OF DocsIfCmServiceEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "Describes the attributes of each upstream service queue
+             on a CM."
+        ::= { docsIfCmObjects 3 }
+
+docsIfCmServiceEntry OBJECT-TYPE
+        SYNTAX      DocsIfCmServiceEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "Describes the attributes of an upstream bandwidth service
+             queue.
+             An entry in this table exists for each Service ID.
+             The primary index is an ifIndex with an ifType of
+             docsCableMaclayer(127)."
+        INDEX { ifIndex, docsIfCmServiceId }
+        ::= { docsIfCmServiceTable 1 }
+
+DocsIfCmServiceEntry ::= SEQUENCE {
+            docsIfCmServiceId               Integer32,
+
+
+
+St. Johns                       Standard                       [Page 39]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+            docsIfCmServiceQosProfile       Integer32,
+            docsIfCmServiceTxSlotsImmed     Counter32,
+            docsIfCmServiceTxSlotsDed       Counter32,
+            docsIfCmServiceTxRetries        Counter32,
+
+--            docsIfCmServiceTxExceeded       Counter32,
+            docsIfCmServiceTxExceededs      Counter32,
+            docsIfCmServiceRqRetries        Counter32,
+--            docsIfCmServiceRqExceeded       Counter32
+            docsIfCmServiceRqExceededs      Counter32
+        }
+
+docsIfCmServiceId OBJECT-TYPE
+        SYNTAX      Integer32 (1..16383)
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "Identifies a service queue for upstream bandwidth. The
+             attributes of this service queue are shared between the
+             CM and the CMTS. The CMTS allocates upstream bandwidth
+             to this service queue based on requests from the CM and
+             on the class of service associated with this queue."
+        ::= { docsIfCmServiceEntry 1 }
+
+docsIfCmServiceQosProfile OBJECT-TYPE
+        SYNTAX      Integer32 (0..16383)
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The index in docsIfQosProfileTable describing the quality
+             of service attributes associated with this particular
+             service. If no associated entry in docsIfQosProfileTable
+             exists, this object returns a value of zero."
+        ::= { docsIfCmServiceEntry 2 }
+
+docsIfCmServiceTxSlotsImmed OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The number of upstream mini-slots which have been used to
+             transmit data PDUs in immediate (contention) mode. This
+             includes only those PDUs which are presumed to have
+             arrived at the headend (i.e., those which were explicitly
+             acknowledged.) It does not include retransmission attempts
+             or mini-slots used by Requests."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+
+
+
+St. Johns                       Standard                       [Page 40]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+             Section 6.4."
+        ::= { docsIfCmServiceEntry 3 }
+
+docsIfCmServiceTxSlotsDed OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The number of upstream mini-slots which have been used to
+             transmit data PDUs in dedicated mode (i.e., as a result
+             of a unicast Data Grant)."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Section 6.4."
+        ::= { docsIfCmServiceEntry 4 }
+
+docsIfCmServiceTxRetries OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The number of attempts to transmit data PDUs containing
+             requests for acknowledgment which did not result in
+             acknowledgment."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Section 6.4."
+        ::= { docsIfCmServiceEntry 5 }
+
+-- docsIfCmServiceTxExceeded renamed for Counter32 naming requirements
+docsIfCmServiceTxExceededs OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The number of data PDUs transmission failures due to
+             excessive retries without acknowledgment."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Section 6.4."
+        ::= { docsIfCmServiceEntry 6 }
+
+docsIfCmServiceRqRetries OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The number of attempts to transmit bandwidth requests
+
+
+
+St. Johns                       Standard                       [Page 41]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+             which did not result in acknowledgment."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Section 6.4."
+        ::= { docsIfCmServiceEntry 7 }
+
+
+-- docsIfCmServiceRqExceeded renamed for Counter 32 naming
+-- requirements
+docsIfCmServiceRqExceededs OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The number of requests for bandwidth which failed due to
+             excessive retries without acknowledgment."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Section 6.4."
+        ::= { docsIfCmServiceEntry 8 }
+
+--
+-- CMTS GROUP
+--
+
+--
+-- The CMTS MAC Table
+--
+
+docsIfCmtsMacTable OBJECT-TYPE
+        SYNTAX      SEQUENCE OF DocsIfCmtsMacEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "Describes the attributes of each CMTS MAC interface,
+             extending the information available from ifEntry.
+             Mandatory for all CMTS devices."
+        ::= { docsIfCmtsObjects 1 }
+
+docsIfCmtsMacEntry OBJECT-TYPE
+        SYNTAX      DocsIfCmtsMacEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "An entry containing objects describing attributes of each
+             MAC entry, extending the information in ifEntry.
+             An entry in this table exists for each ifEntry with an
+             ifType of docsCableMaclayer(127)."
+
+
+
+St. Johns                       Standard                       [Page 42]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+        INDEX { ifIndex }
+        ::= { docsIfCmtsMacTable 1 }
+
+DocsIfCmtsMacEntry ::= SEQUENCE {
+            docsIfCmtsCapabilities            BITS,
+            docsIfCmtsSyncInterval            Integer32,
+            docsIfCmtsUcdInterval             Integer32,
+            docsIfCmtsMaxServiceIds           Integer32,
+            docsIfCmtsInsertionInterval       TimeTicks,   -- Obsolete
+            docsIfCmtsInvitedRangingAttempts  Integer32,
+            docsIfCmtsInsertInterval          TimeInterval
+        }
+
+docsIfCmtsCapabilities OBJECT-TYPE
+        SYNTAX      BITS {
+            atmCells(0),
+            concatenation(1)
+        }
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Identifies the capabilities of the CMTS MAC
+             implementation at this interface. Note that packet
+             transmission is always supported. Therefore, there
+             is no specific bit required to explicitely indicate
+             this capability."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Chapter 6."
+        ::= { docsIfCmtsMacEntry 1 }
+
+docsIfCmtsSyncInterval OBJECT-TYPE
+        SYNTAX      Integer32 (1..200)
+        UNITS       "Milliseconds"
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+            "The interval between CMTS transmission of successive SYNC
+             messages at this interface."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+             Section 6.5 and Appendix B."
+        ::= { docsIfCmtsMacEntry 2 }
+
+docsIfCmtsUcdInterval OBJECT-TYPE
+        SYNTAX      Integer32 (1..2000)
+        UNITS       "Milliseconds"
+        MAX-ACCESS  read-write
+
+
+
+St. Johns                       Standard                       [Page 43]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+        STATUS      current
+        DESCRIPTION
+            "The interval between CMTS transmission of successive
+             Upstream Channel Descriptor messages for each upstream
+             channel at this interface."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+             Section 6.5 and Appendix B."
+        ::= { docsIfCmtsMacEntry 3 }
+
+docsIfCmtsMaxServiceIds OBJECT-TYPE
+        SYNTAX     Integer32 (1..16383)
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "The maximum number of service IDs that may be
+             simultaneously active."
+        ::= { docsIfCmtsMacEntry 4 }
+
+
+-- This object has been obsoleted and replaced by
+-- docsIfCmtsInsertInterval to fix a SYNTAX typing problem.  New
+-- implementations of this MIB should use that object instead.
+docsIfCmtsInsertionInterval OBJECT-TYPE
+        SYNTAX      TimeTicks
+        MAX-ACCESS  read-write
+        STATUS      obsolete
+        DESCRIPTION
+            "The amount of time to elapse between each broadcast
+             station maintenance grant. Broadcast station maintenance
+             grants are used to allow new cable modems to join the
+             network. Zero indicates that a vendor-specific algorithm
+             is used instead of a fixed time. Maximum amount of time
+             permitted by the specification is 2 seconds."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+             Appendix B, Ranging Interval."
+        ::= { docsIfCmtsMacEntry 5 }
+
+docsIfCmtsInvitedRangingAttempts OBJECT-TYPE
+        SYNTAX      Integer32 (0..1024)
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+            "The maximum number of attempts to make on invitations
+             for ranging requests. A value of zero means the system
+             should attempt to range forever."
+        REFERENCE
+
+
+
+St. Johns                       Standard                       [Page 44]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+            "DOCSIS Radio Frequency Interface specification,
+             Section 7.2.5 and Appendix B."
+        ::= { docsIfCmtsMacEntry 6 }
+
+docsIfCmtsInsertInterval OBJECT-TYPE
+        SYNTAX      TimeInterval
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+            "The amount of time to elapse between each broadcast
+             station maintenance grant. Broadcast station maintenance
+             grants are used to allow new cable modems to join the
+             network. Zero indicates that a vendor-specific algorithm
+             is used instead of a fixed time. Maximum amount of time
+             permitted by the specification is 2 seconds."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+             Appendix B."
+        ::= { docsIfCmtsMacEntry 7 }
+
+--
+--
+-- CMTS status table.
+--
+
+docsIfCmtsStatusTable OBJECT-TYPE
+        SYNTAX      SEQUENCE OF DocsIfCmtsStatusEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "For the MAC layer, this group maintains a number of
+             status objects and counters."
+        ::= { docsIfCmtsObjects 2 }
+
+docsIfCmtsStatusEntry OBJECT-TYPE
+        SYNTAX      DocsIfCmtsStatusEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "Status entry for a single MAC layer.
+             An entry in this table exists for each ifEntry with an
+             ifType of docsCableMaclayer(127)."
+        INDEX { ifIndex }
+        ::= { docsIfCmtsStatusTable 1 }
+
+DocsIfCmtsStatusEntry ::= SEQUENCE {
+            docsIfCmtsStatusInvalidRangeReqs        Counter32,
+            docsIfCmtsStatusRangingAborteds         Counter32,
+
+
+
+St. Johns                       Standard                       [Page 45]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+            docsIfCmtsStatusInvalidRegReqs          Counter32,
+            docsIfCmtsStatusFailedRegReqs           Counter32,
+            docsIfCmtsStatusInvalidDataReqs         Counter32,
+            docsIfCmtsStatusT5Timeouts              Counter32
+        }
+
+docsIfCmtsStatusInvalidRangeReqs OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "This object counts invalid RNG-REQ messages received on
+             this interface."
+        ::= { docsIfCmtsStatusEntry 1 }
+
+docsIfCmtsStatusRangingAborteds OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "This object counts ranging attempts that were explicitely
+             aborted by the CMTS."
+        ::= { docsIfCmtsStatusEntry 2 }
+
+docsIfCmtsStatusInvalidRegReqs OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "This object counts invalid REG-REQ messages received on
+             this interface."
+        ::= { docsIfCmtsStatusEntry 3 }
+
+docsIfCmtsStatusFailedRegReqs OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "This object counts failed registration attempts, i.e.,
+             authentication failures and class of service failures,
+             on this interface."
+        ::= { docsIfCmtsStatusEntry 4 }
+
+docsIfCmtsStatusInvalidDataReqs OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+
+
+
+St. Johns                       Standard                       [Page 46]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+            "This object counts invalid data request messages
+             received on this interface."
+        ::= { docsIfCmtsStatusEntry 5 }
+
+docsIfCmtsStatusT5Timeouts OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "This object counts the number of times counter T5
+             expired on this interface."
+        ::= { docsIfCmtsStatusEntry 6 }
+
+--
+-- CM status table (within CMTS).
+-- This table is implemented only at the CMTS.
+-- It contains per CM status information available in the CMTS.
+--
+
+docsIfCmtsCmStatusTable OBJECT-TYPE
+        SYNTAX      SEQUENCE OF DocsIfCmtsCmStatusEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "A set of objects in the CMTS, maintained for each
+             Cable Modem connected to this CMTS."
+        ::= { docsIfCmtsObjects 3 }
+
+docsIfCmtsCmStatusEntry OBJECT-TYPE
+        SYNTAX      DocsIfCmtsCmStatusEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "Status information for a single Cable Modem.
+             An entry in this table exists for each Cable Modem
+             that is connected to the CMTS implementing this table."
+        INDEX { docsIfCmtsCmStatusIndex }
+        ::= { docsIfCmtsCmStatusTable 1 }
+
+DocsIfCmtsCmStatusEntry ::= SEQUENCE {
+            docsIfCmtsCmStatusIndex               Integer32,
+            docsIfCmtsCmStatusMacAddress          MacAddress,
+            docsIfCmtsCmStatusIpAddress           IpAddress,
+            docsIfCmtsCmStatusDownChannelIfIndex  InterfaceIndexOrZero,
+            docsIfCmtsCmStatusUpChannelIfIndex    InterfaceIndexOrZero,
+            docsIfCmtsCmStatusRxPower             TenthdBmV,
+            docsIfCmtsCmStatusTimingOffset        Unsigned32,
+            docsIfCmtsCmStatusEqualizationData    OCTET STRING,
+
+
+
+St. Johns                       Standard                       [Page 47]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+            docsIfCmtsCmStatusValue               INTEGER,
+            docsIfCmtsCmStatusUnerroreds          Counter32,
+            docsIfCmtsCmStatusCorrecteds          Counter32,
+            docsIfCmtsCmStatusUncorrectables      Counter32,
+            docsIfCmtsCmStatusSignalNoise         TenthdB,
+            docsIfCmtsCmStatusMicroreflections    Integer32
+        }
+
+docsIfCmtsCmStatusIndex OBJECT-TYPE
+        SYNTAX      Integer32 (1..2147483647)
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "Index value to uniquely identify an entry in this table.
+             For an individual Cable Modem, this index value should
+             not change during CMTS uptime."
+        ::= { docsIfCmtsCmStatusEntry 1 }
+
+docsIfCmtsCmStatusMacAddress OBJECT-TYPE
+        SYNTAX      MacAddress
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "MAC address of this Cable Modem. If the Cable Modem has
+             multiple MAC addresses, this is the MAC address associated
+             with the Cable interface."
+        ::= { docsIfCmtsCmStatusEntry 2 }
+
+docsIfCmtsCmStatusIpAddress OBJECT-TYPE
+        SYNTAX      IpAddress
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "IP address of this Cable Modem. If the Cable Modem has no
+             IP address assigned, or the IP address is unknown, this
+             object returns a value of 0.0.0.0. If the Cable Modem has
+             multiple IP addresses, this object returns the IP address
+             associated with the Cable interface."
+        ::= { docsIfCmtsCmStatusEntry 3 }
+
+docsIfCmtsCmStatusDownChannelIfIndex OBJECT-TYPE
+        SYNTAX      InterfaceIndexOrZero
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "IfIndex of the downstream channel this CM is connected
+             to. If the downstream channel is unknown, this object
+             returns a value of zero."
+
+
+
+St. Johns                       Standard                       [Page 48]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+        ::= { docsIfCmtsCmStatusEntry 4 }
+
+docsIfCmtsCmStatusUpChannelIfIndex OBJECT-TYPE
+        SYNTAX      InterfaceIndexOrZero
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "IfIndex of the upstream channel this CM is connected
+             to. If the upstream channel is unknown, this object
+             returns a value of zero."
+        ::= { docsIfCmtsCmStatusEntry 5 }
+
+docsIfCmtsCmStatusRxPower OBJECT-TYPE
+        SYNTAX      TenthdBmV
+        UNITS       "dBmV"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The receive power as percieved for upstream data from
+             this Cable Modem.
+             If the receive power is unknown, this object returns
+             a value of zero."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+             Table 4-13."
+        ::= { docsIfCmtsCmStatusEntry 6 }
+
+docsIfCmtsCmStatusTimingOffset OBJECT-TYPE
+        SYNTAX      Unsigned32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "A measure of the current round trip time for this CM.
+             Used for timing of CM upstream transmissions to ensure
+             synchronized arrivals at the CMTS. Units are in terms
+             of (6.25 microseconds/64). Returns zero if the value
+             is unknown."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+             Section 6.5."
+        ::= { docsIfCmtsCmStatusEntry 7 }
+
+docsIfCmtsCmStatusEqualizationData OBJECT-TYPE
+        SYNTAX      OCTET STRING
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Equalization data for this CM. Returns an empty string
+
+
+
+St. Johns                       Standard                       [Page 49]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+             if the value is unknown or if there is no equalization
+             data available or defined."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+             Figure 6-23."
+        ::= { docsIfCmtsCmStatusEntry 8 }
+
+docsIfCmtsCmStatusValue OBJECT-TYPE
+        SYNTAX      INTEGER {
+            other(1),
+            ranging(2),
+            rangingAborted(3),
+            rangingComplete(4),
+            ipComplete(5),
+            registrationComplete(6),
+            accessDenied(7)
+        }
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Current Cable Modem connectivity state, as specified
+             in the RF Interface Specification. Returned status
+             information is the CM status as assumed by the CMTS,
+             and indicates the following events:
+             other(1)
+                Any state other than below.
+             ranging(2)
+                The CMTS has received an Initial Ranging Request
+                message from the CM, and the ranging process is not
+                yet complete.
+             rangingAborted(3)
+                The CMTS has sent a Ranging Abort message to the CM.
+             rangingComplete(4)
+                The CMTS has sent a Ranging Complete message to the CM.
+             ipComplete(5)
+                The CMTS has received a DHCP reply message and forwarded
+                it to the CM.
+             registrationComplete(6)
+                The CMTS has sent a Registration Response mesage to
+                the CM.
+             accessDenied(7)
+                The CMTS has sent a Registration Aborted message
+                to the CM.
+             The CMTS only needs to report states it is able to detect."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface Specification,
+             Chapter 7.2."
+        ::= { docsIfCmtsCmStatusEntry 9 }
+
+
+
+St. Johns                       Standard                       [Page 50]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+docsIfCmtsCmStatusUnerroreds OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Codewords received without error from this Cable Modem."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Section 4.2.3"
+        ::= { docsIfCmtsCmStatusEntry 10 }
+
+docsIfCmtsCmStatusCorrecteds OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Codewords received with correctable errors from this
+             Cable Modem."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Section 4.2.3"
+        ::= { docsIfCmtsCmStatusEntry 11 }
+
+docsIfCmtsCmStatusUncorrectables OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Codewords received with uncorrectable errors from this
+             Cable Modem."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Section 4.2.3"
+        ::= { docsIfCmtsCmStatusEntry 12 }
+
+docsIfCmtsCmStatusSignalNoise OBJECT-TYPE
+        SYNTAX      TenthdB
+        UNITS       "dB"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Signal/Noise ratio as perceived for upstream data from
+             this Cable Modem.
+             If the Signal/Noise is unknown, this object returns
+             a value of zero."
+        ::= { docsIfCmtsCmStatusEntry 13 }
+
+docsIfCmtsCmStatusMicroreflections OBJECT-TYPE
+
+
+
+St. Johns                       Standard                       [Page 51]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+        SYNTAX      Integer32 (0..255)
+        UNITS       "dBc"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Total microreflections including in-channel response
+             as perceived on this interface, measured in dBc below
+             the signal level.
+             This object is not assumed to return an absolutely
+             accurate value, but should give a rough indication
+             of microreflections received on this interface.
+             It is up to the implementor to provide information
+             as accurate as possible."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Table 2-1 and 2-2"
+        ::= { docsIfCmtsCmStatusEntry 14 }
+
+--
+-- The CMTS Service Table.
+--
+
+docsIfCmtsServiceTable OBJECT-TYPE
+        SYNTAX      SEQUENCE OF DocsIfCmtsServiceEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "Describes the attributes of upstream service queues
+             in a Cable Modem Termination System."
+        ::= { docsIfCmtsObjects 4 }
+
+docsIfCmtsServiceEntry OBJECT-TYPE
+        SYNTAX      DocsIfCmtsServiceEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "Describes the attributes of a single upstream bandwidth
+             service queue.
+             Entries in this table exist for each ifEntry with an
+             ifType of docsCableMaclayer(127), and for each service
+             queue (Service ID) within this MAC layer.
+             Entries in this table are created with the creation of
+             individual Service IDs by the MAC layer and removed
+             when a Service ID is removed."
+        INDEX { ifIndex, docsIfCmtsServiceId }
+        ::= { docsIfCmtsServiceTable 1 }
+
+DocsIfCmtsServiceEntry ::= SEQUENCE {
+
+
+
+St. Johns                       Standard                       [Page 52]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+            docsIfCmtsServiceId               Integer32,
+            docsIfCmtsServiceCmStatusIndex    Integer32,
+            docsIfCmtsServiceAdminStatus      INTEGER,
+            docsIfCmtsServiceQosProfile       Integer32,
+            docsIfCmtsServiceCreateTime       TimeStamp,
+            docsIfCmtsServiceInOctets         Counter32,
+            docsIfCmtsServiceInPackets        Counter32
+        }
+
+docsIfCmtsServiceId OBJECT-TYPE
+        SYNTAX      Integer32 (1..16383)
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "Identifies a service queue for upstream bandwidth. The
+             attributes of this service queue are shared between the
+             Cable Modem and the Cable Modem Termination System.
+             The CMTS allocates upstream bandwidth to this service
+             queue based on requests from the CM and on the class of
+             service associated with this queue."
+        ::= { docsIfCmtsServiceEntry 1 }
+
+docsIfCmtsServiceCmStatusIndex OBJECT-TYPE
+        SYNTAX      Integer32 (0..65535)
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Pointer to an entry in docsIfCmtsCmStatusTable identifying
+             the Cable Modem using this Service Queue. If multiple
+             Cable Modems are using this Service Queue, the value of
+             this object is zero."
+        ::= { docsIfCmtsServiceEntry 2 }
+
+docsIfCmtsServiceAdminStatus OBJECT-TYPE
+        SYNTAX      INTEGER {
+            enabled(1),
+            disabled(2),
+            destroyed(3) }
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+            "Allows a service class for a particular modem to be
+             suppressed, (re-)enabled, or deleted altogether."
+        ::= { docsIfCmtsServiceEntry 3 }
+
+docsIfCmtsServiceQosProfile OBJECT-TYPE
+        SYNTAX      Integer32 (0..16383)
+        MAX-ACCESS  read-only
+
+
+
+St. Johns                       Standard                       [Page 53]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+        STATUS      current
+        DESCRIPTION
+            "The index in docsIfQosProfileTable describing the quality
+             of service attributes associated with this particular
+             service. If no associated docsIfQosProfileTable entry
+             exists, this object returns a value of zero."
+        ::= { docsIfCmtsServiceEntry 4 }
+
+docsIfCmtsServiceCreateTime OBJECT-TYPE
+
+--      SYNTAX      TimeTicks
+        SYNTAX      TimeStamp
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The value of sysUpTime when this entry was created."
+        ::= { docsIfCmtsServiceEntry 5 }
+
+docsIfCmtsServiceInOctets OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The cumulative number of Packet Data octets received
+             on this Service ID. The count does not include the
+             size of the Cable MAC header"
+        ::= { docsIfCmtsServiceEntry 6 }
+
+docsIfCmtsServiceInPackets OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The cumulative number of Packet Data packets received
+             on this Service ID."
+        ::= { docsIfCmtsServiceEntry 7 }
+
+--
+-- The following table provides upstream channel modulation profiles.
+-- Entries in this table can be
+-- re-used by one or more upstream channels. An upstream channel will
+-- have a modulation profile
+-- for each value of docsIfModIntervalUsageCode.
+--
+
+docsIfCmtsModulationTable OBJECT-TYPE
+        SYNTAX      SEQUENCE OF DocsIfCmtsModulationEntry
+        MAX-ACCESS  not-accessible
+
+
+
+St. Johns                       Standard                       [Page 54]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+        STATUS      current
+        DESCRIPTION
+            "Describes a modulation profile associated with one or more
+             upstream channels."
+        ::= { docsIfCmtsObjects 5 }
+
+docsIfCmtsModulationEntry OBJECT-TYPE
+        SYNTAX      DocsIfCmtsModulationEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "Describes a modulation profile for an Interval Usage Code
+             for one or more upstream channels.
+             Entries in this table are created by the operator. Initial
+             default entries may be created at system initialization
+             time. No individual objects have to be specified in order
+             to create an entry in this table.
+             Note that some objects do not have DEFVALs, but do have
+             calculated defaults and need not be specified during row
+             creation.
+             There is no restriction on the changing of values in this
+             table while their associated rows are active."
+        INDEX { docsIfCmtsModIndex, docsIfCmtsModIntervalUsageCode }
+        ::= { docsIfCmtsModulationTable 1 }
+
+DocsIfCmtsModulationEntry ::= SEQUENCE {
+            docsIfCmtsModIndex                    Integer32,
+            docsIfCmtsModIntervalUsageCode        INTEGER,
+            docsIfCmtsModControl                  RowStatus,
+            docsIfCmtsModType                     INTEGER,
+            docsIfCmtsModPreambleLen              Integer32,
+            docsIfCmtsModDifferentialEncoding     TruthValue,
+            docsIfCmtsModFECErrorCorrection       Integer32,
+            docsIfCmtsModFECCodewordLength        Integer32,
+            docsIfCmtsModScramblerSeed            Integer32,
+            docsIfCmtsModMaxBurstSize             Integer32,
+            docsIfCmtsModGuardTimeSize            Unsigned32,
+            docsIfCmtsModLastCodewordShortened    TruthValue,
+            docsIfCmtsModScrambler                TruthValue
+        }
+
+docsIfCmtsModIndex OBJECT-TYPE
+        SYNTAX       Integer32 (1..2147483647)
+        MAX-ACCESS   not-accessible
+        STATUS      current
+        DESCRIPTION
+             "An index into the Channel Modulation table representing
+              a group of Interval Usage Codes, all associated with the
+
+
+
+St. Johns                       Standard                       [Page 55]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+              same channel."
+        ::= { docsIfCmtsModulationEntry 1 }
+
+docsIfCmtsModIntervalUsageCode OBJECT-TYPE
+        SYNTAX       INTEGER {
+            request(1),
+            requestData(2),
+            initialRanging(3),
+            periodicRanging(4),
+            shortData(5),
+            longData(6)
+        }
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "An index into the Channel Modulation table which, when
+             grouped with other Interval Usage Codes, fully
+             instantiate all modulation sets for a given upstream
+             channel."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Table 6-16."
+        ::= { docsIfCmtsModulationEntry 2 }
+
+docsIfCmtsModControl OBJECT-TYPE
+        SYNTAX      RowStatus
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "Controls and reflects the status of rows in this table."
+        ::= { docsIfCmtsModulationEntry 3 }
+
+docsIfCmtsModType OBJECT-TYPE
+        SYNTAX      INTEGER {
+            other(1),
+            qpsk(2),
+            qam16(3)
+        }
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "The modulation type used on this channel. Returns
+             other(1) if the modulation type is neither qpsk or
+             qam16. See the reference for the modulation profiles
+             implied by qpsk or qam16.  See the conformance object for
+             write conditions and limitations."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+
+
+
+St. Johns                       Standard                       [Page 56]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+             Section 4.2.2."
+        DEFVAL { qpsk }
+        ::= { docsIfCmtsModulationEntry 4 }
+
+docsIfCmtsModPreambleLen OBJECT-TYPE
+        SYNTAX      Integer32 (0..1024)
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "The preamble length for this modulation profile in bits.
+             Default value is the minimum needed by the implementation
+             at the CMTS for the given modulation profile."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Section 4.2.5."
+        ::= { docsIfCmtsModulationEntry 5 }
+
+docsIfCmtsModDifferentialEncoding OBJECT-TYPE
+        SYNTAX      TruthValue
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "Specifies whether or not differential encoding is used
+             on this channel."
+        DEFVAL { false }
+        ::= { docsIfCmtsModulationEntry 6 }
+
+docsIfCmtsModFECErrorCorrection OBJECT-TYPE
+        SYNTAX      Integer32 (0..10)
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "The number of correctable errored bytes (t) used in
+             forward error correction code. The value of 0 indicates
+             no correction is employed. The number of check bytes
+             appended will be twice this value."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Section 4.2.3."
+        DEFVAL { 0 }
+        ::= { docsIfCmtsModulationEntry 7 }
+
+docsIfCmtsModFECCodewordLength OBJECT-TYPE
+        SYNTAX      Integer32 (1..255)
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "The number of data bytes (k) in the forward error
+
+
+
+St. Johns                       Standard                       [Page 57]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+             correction codeword.
+             This object is not used if docsIfCmtsModFECErrorCorrection
+             is zero."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Section 4.2.3."
+        DEFVAL { 32 }
+        ::= { docsIfCmtsModulationEntry 8 }
+
+docsIfCmtsModScramblerSeed OBJECT-TYPE
+        SYNTAX      Integer32 (0..32767)
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "The 15 bit seed value for the scrambler polynomial."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Section 4.2.4."
+        DEFVAL { 0 }
+        ::= { docsIfCmtsModulationEntry 9 }
+
+docsIfCmtsModMaxBurstSize OBJECT-TYPE
+        SYNTAX      Integer32 (0..255)
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "The maximum number of mini-slots that can be transmitted
+             during this channel's burst time. Returns zero if the
+             burst length is bounded by the allocation MAP rather than
+             this profile.
+             Default value is 0 except for shortData, where it is 8."
+        ::= { docsIfCmtsModulationEntry 10 }
+
+docsIfCmtsModGuardTimeSize OBJECT-TYPE
+        SYNTAX      Unsigned32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The number of symbol-times which must follow the end of
+             this channel's burst. Default value is the minimum time
+             needed by the implementation for this modulation profile."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Section 4.2.7."
+        ::= { docsIfCmtsModulationEntry 11 }
+
+docsIfCmtsModLastCodewordShortened OBJECT-TYPE
+        SYNTAX      TruthValue
+
+
+
+St. Johns                       Standard                       [Page 58]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "Indicates if the last FEC codeword is truncated."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Section 4.2.10."
+        DEFVAL { true }
+        ::= { docsIfCmtsModulationEntry 12 }
+
+docsIfCmtsModScrambler OBJECT-TYPE
+        SYNTAX      TruthValue
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "Indicates if the scrambler is employed."
+        REFERENCE
+            "DOCSIS Radio Frequency Interface specification,
+             Section 4.2.4."
+        DEFVAL { false }
+        ::= { docsIfCmtsModulationEntry 13 }
+
+docsIfCmtsQosProfilePermissions OBJECT-TYPE
+        SYNTAX      BITS {
+            createByManagement(0),
+            updateByManagement(1),
+            createByModems(2)
+        }
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+            "This object specifies permitted methods of creating
+             entries in docsIfQosProfileTable.
+             CreateByManagement(0) is set if entries can be created
+             using SNMP. UpdateByManagement(1) is set if updating
+             entries using SNMP is permitted. CreateByModems(2)
+             is set if entries can be created based on information
+             in REG-REQ MAC messages received from Cable Modems.
+             Information in this object is only applicable if
+             docsIfQosProfileTable is implemented as read-create.
+             Otherwise, this object is implemented as read-only
+             and returns CreateByModems(2).
+             Either CreateByManagement(0) or CreateByModems(1)
+             must be set when writing to this object."
+        ::= { docsIfCmtsObjects 6 }
+
+docsIfCmtsMacToCmTable OBJECT-TYPE
+        SYNTAX      SEQUENCE OF DocsIfCmtsMacToCmEntry
+
+
+
+St. Johns                       Standard                       [Page 59]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "This is a table to provide a quick access index into the
+             docsIfCmtsCmStatusTable. There is exactly one row in this
+             table for each row in the docsIfCmtsCmStatusTable. In
+             general, the management station should use this table only
+             to get a pointer into the docsIfCmtsCmStatusTable (which
+             corresponds to the CM's RF interface MAC address), and
+             should not iterate (e.g. GetNext through) this table."
+    ::= { docsIfCmtsObjects 7 }
+
+docsIfCmtsMacToCmEntry OBJECT-TYPE
+        SYNTAX      DocsIfCmtsMacToCmEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "A row in the docsIfCmtsMacToCmTable.
+             An entry in this table exists for each Cable Modem
+             that is connected to the CMTS implementing this table."
+        INDEX   { docsIfCmtsCmMac }
+        ::= {docsIfCmtsMacToCmTable 1 }
+
+DocsIfCmtsMacToCmEntry ::= SEQUENCE {
+                docsIfCmtsCmMac     MacAddress,
+                docsIfCmtsCmPtr     Integer32
+        }
+
+docsIfCmtsCmMac OBJECT-TYPE
+        SYNTAX      MacAddress
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "The RF side MAC address for the referenced CM. (E.g. the
+             interface on the CM that has docsCableMacLayer(127) as
+             its ifType."
+    ::= { docsIfCmtsMacToCmEntry 1 }
+
+docsIfCmtsCmPtr OBJECT-TYPE
+        SYNTAX      Integer32 (1..2147483647)
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "An row index into docsIfCmtsCmStatusTable. When queried
+             with the correct instance value (e.g. a CM's MAC address),
+             returns the index in docsIfCmtsCmStatusTable which
+             represents that CM."
+    ::= { docsIfCmtsMacToCmEntry 2 }
+
+
+
+St. Johns                       Standard                       [Page 60]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+--
+-- notification group is for future extension.
+--
+docsIfNotification OBJECT IDENTIFIER     ::= { docsIfMib 2 }
+
+docsIfConformance  OBJECT IDENTIFIER     ::= { docsIfMib 3 }
+docsIfCompliances  OBJECT IDENTIFIER     ::= { docsIfConformance 1 }
+docsIfGroups       OBJECT IDENTIFIER     ::= { docsIfConformance 2 }
+
+-- compliance statements
+
+docsIfBasicCompliance MODULE-COMPLIANCE
+        STATUS      current
+        DESCRIPTION
+            "The compliance statement for devices that implement
+             MCNS/DOCSIS compliant Radio Frequency Interfaces."
+
+MODULE  -- docsIfMib
+
+-- unconditionally mandatory groups
+MANDATORY-GROUPS {
+        docsIfBasicGroup
+        }
+
+-- conditionally mandatory group
+GROUP docsIfCmGroup
+        DESCRIPTION
+            "This group is implemented only in Cable Modems, not in
+             Cable Modem Termination Systems."
+
+-- conditionally mandatory group
+GROUP docsIfCmtsGroup
+        DESCRIPTION
+            "This group is implemented only in Cable Modem Termination
+             Systems, not in Cable Modems."
+
+OBJECT  docsIfDownChannelFrequency
+    WRITE-SYNTAX Integer32 (54000000..860000000)
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Read-write in Cable Modem Termination Systems;
+             read-only in Cable Modems.  The values above are
+             appropriate for a cable plant using a  Sub-Split channel
+             plan.  If DOCSIS is extended to cover other types of
+             channel plans (and frequency allocations) this object
+             will be modified accordingly."
+
+OBJECT  docsIfDownChannelWidth
+
+
+
+St. Johns                       Standard                       [Page 61]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+        WRITE-SYNTAX Integer32 (6000000)
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "It is conformant to implement this object as read-only.
+             In Cable Modems, this object is always implemented as
+             read-only.  The above value is appropriate for cable
+             plants running under  NTSC (National Television
+             Standards Committee) standards.  If DOCSIS is extended to
+             work with other standard (e.g. European standards), this
+             object will be modified accordingly."
+
+OBJECT  docsIfDownChannelModulation
+        WRITE-SYNTAX INTEGER {
+                               qam64 (3),
+                               qam256 (4)
+                             }
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Read-write in Cable Modem Termination Systems;
+             read-only in Cable Modems."
+
+OBJECT  docsIfDownChannelInterleave
+        WRITE-SYNTAX INTEGER {
+                    taps8Increment16(3),
+                    taps16Increment8(4),
+                    taps32Increment4(5),
+                    taps64Increment2(6),
+                    taps128Increment1(7)
+                     }
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Read-write in Cable Modem Termination Systems;
+             read-only in Cable Modems."
+
+OBJECT  docsIfDownChannelPower
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Read-write in Cable Modem Termination Systems;
+             read-only in Cable Modems."
+
+OBJECT  docsIfUpChannelFrequency
+   WRITE-SYNTAX Integer32 (5000000..42000000)
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Read-write in Cable Modem Termination Systems;
+             read-only in Cable Modems.The values above are
+             appropriate for a cable plant using a  Sub-Split channel
+             plan.  If DOCSIS is extended to cover other types of
+
+
+
+St. Johns                       Standard                       [Page 62]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+             channel plans (and frequency allocations) this object
+             will be modified accordingly."
+
+OBJECT  docsIfUpChannelWidth
+        WRITE-SYNTAX Integer32 (200000..3200000)
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Read-write in Cable Modem Termination Systems;
+             read-only in Cable Modems.The above value is appropriate
+             for cable plants running under  NTSC (National Television
+             Standards Committee) standards.  If DOCSIS is extended to
+             work with other standard (e.g. European standards), this
+             object will be modified accordingly."
+
+OBJECT  docsIfUpChannelModulationProfile
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Read-write in Cable Modem Termination Systems;
+             read-only in Cable Modems."
+
+OBJECT  docsIfUpChannelSlotSize
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "This object is always read-only in Cable Modems.
+             It is compliant to implement this object as read-only
+             in Cable Modem Termination Systems."
+
+OBJECT  docsIfUpChannelRangingBackoffStart
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Read-write in Cable Modem Termination Systems;
+             read-only in Cable Modems."
+
+OBJECT  docsIfUpChannelRangingBackoffEnd
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Read-write in Cable Modem Termination Systems;
+             read-only in Cable Modems."
+
+OBJECT  docsIfUpChannelTxBackoffStart
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Read-write in Cable Modem Termination Systems;
+             read-only in Cable Modems."
+
+OBJECT  docsIfUpChannelTxBackoffEnd
+        MIN-ACCESS  read-only
+        DESCRIPTION
+
+
+
+St. Johns                       Standard                       [Page 63]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+            "Read-write in Cable Modem Termination Systems;
+             read-only in Cable Modems."
+
+OBJECT  docsIfQosProfPriority
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "This object is always read-only in Cable Modems.
+             It is compliant to implement this object as read-only
+             in Cable Modem Termination Systems."
+
+OBJECT  docsIfQosProfMaxUpBandwidth
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "This object is always read-only in Cable Modems.
+             It is compliant to implement this object as read-only
+             in Cable Modem Termination Systems."
+
+OBJECT  docsIfQosProfGuarUpBandwidth
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "This object is always read-only in Cable Modems.
+             It is compliant to implement this object as read-only
+             in Cable Modem Termination Systems."
+
+OBJECT  docsIfQosProfMaxDownBandwidth
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "This object is always read-only in Cable Modems.
+             It is compliant to implement this object as read-only
+             in Cable Modem Termination Systems."
+
+OBJECT  docsIfQosProfMaxTxBurst
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "This object is always read-only in Cable Modems.
+             It is compliant to implement this object as read-only
+             in Cable Modem Termination Systems."
+
+OBJECT  docsIfQosProfBaselinePrivacy
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "This object is always read-only in Cable Modems.
+             It is compliant to implement this object as read-only
+             in Cable Modem Termination Systems."
+
+OBJECT  docsIfQosProfStatus
+        MIN-ACCESS  read-only
+        DESCRIPTION
+
+
+
+St. Johns                       Standard                       [Page 64]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+            "This object is always read-only in Cable Modems.
+             It is compliant to implement this object as read-only
+             in Cable Modem Termination Systems."
+
+OBJECT  docsIfCmtsServiceAdminStatus
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "It is compliant to implement this object as read-only."
+
+OBJECT  docsIfCmtsSyncInterval
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "It is compliant to implement this object as read-only."
+
+OBJECT  docsIfCmtsUcdInterval
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "It is compliant to implement this object as read-only."
+
+OBJECT  docsIfCmtsInsertInterval
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "It is compliant to implement this object as read-only."
+
+OBJECT  docsIfCmtsInvitedRangingAttempts
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "It is compliant to implement this object as read-only."
+
+OBJECT  docsIfCmtsQosProfilePermissions
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "It is compliant to implement this object as read-only."
+
+OBJECT docsIfCmtsModType
+        WRITE-SYNTAX INTEGER {
+                        qpsk (2),
+                        qam16 (3)
+                         }
+        DESCRIPTION
+            "Management station may only set 16QAM or QPSK modulation,
+             but others might be possible based on device configuration."
+
+
+        ::= { docsIfCompliances 1 }
+
+docsIfBasicGroup OBJECT-GROUP
+        OBJECTS {
+
+
+
+St. Johns                       Standard                       [Page 65]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+            docsIfDownChannelId,
+            docsIfDownChannelFrequency,
+            docsIfDownChannelWidth,
+            docsIfDownChannelModulation,
+            docsIfDownChannelInterleave,
+            docsIfDownChannelPower,
+            docsIfUpChannelId,
+            docsIfUpChannelFrequency,
+            docsIfUpChannelWidth,
+            docsIfUpChannelModulationProfile,
+            docsIfUpChannelSlotSize,
+            docsIfUpChannelTxTimingOffset,
+            docsIfUpChannelRangingBackoffStart,
+            docsIfUpChannelRangingBackoffEnd,
+            docsIfUpChannelTxBackoffStart,
+            docsIfUpChannelTxBackoffEnd,
+            docsIfQosProfPriority,
+            docsIfQosProfMaxUpBandwidth,
+            docsIfQosProfGuarUpBandwidth,
+            docsIfQosProfMaxDownBandwidth,
+            docsIfQosProfMaxTxBurst,
+            docsIfQosProfBaselinePrivacy,
+            docsIfQosProfStatus,
+            docsIfSigQIncludesContention,
+            docsIfSigQUnerroreds,
+            docsIfSigQCorrecteds,
+            docsIfSigQUncorrectables,
+            docsIfSigQSignalNoise,
+            docsIfSigQMicroreflections,
+            docsIfSigQEqualizationData
+        }
+        STATUS      current
+        DESCRIPTION
+            "Group of objects implemented in both Cable Modems and
+             Cable Modem Termination Systems."
+        ::= { docsIfGroups 1 }
+
+-- The following  table was modified to correct naming conventions for
+-- Counter32 variables.
+docsIfCmGroup OBJECT-GROUP
+        OBJECTS {
+            docsIfCmCmtsAddress,
+            docsIfCmCapabilities,
+--            docsIfCmRangingRespTimeout,
+            docsIfCmRangingTimeout,
+            docsIfCmStatusValue,
+            docsIfCmStatusCode,
+            docsIfCmStatusTxPower,
+
+
+
+St. Johns                       Standard                       [Page 66]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+            docsIfCmStatusResets,
+            docsIfCmStatusLostSyncs,
+            docsIfCmStatusInvalidMaps,
+            docsIfCmStatusInvalidUcds,
+--            docsIfCmStatusInvalidRangingResp,
+            docsIfCmStatusInvalidRangingResponses,
+--            docsIfCmStatusInvalidRegistrationResp,
+            docsIfCmStatusInvalidRegistrationResponses,
+            docsIfCmStatusT1Timeouts,
+            docsIfCmStatusT2Timeouts,
+            docsIfCmStatusT3Timeouts,
+            docsIfCmStatusT4Timeouts,
+            docsIfCmStatusRangingAborteds,
+            docsIfCmServiceQosProfile,
+            docsIfCmServiceTxSlotsImmed,
+            docsIfCmServiceTxSlotsDed,
+            docsIfCmServiceTxRetries,
+--            docsIfCmServiceTxExceeded,
+            docsIfCmServiceTxExceededs,
+            docsIfCmServiceRqRetries,
+--            docsIfCmServiceRqExceeded
+            docsIfCmServiceRqExceededs
+        }
+        STATUS      current
+        DESCRIPTION
+            "Group of objects implemented in Cable Modems."
+        ::= { docsIfGroups 2 }
+
+docsIfCmtsGroup OBJECT-GROUP
+        OBJECTS {
+            docsIfCmtsCapabilities,
+            docsIfCmtsSyncInterval,
+            docsIfCmtsUcdInterval,
+            docsIfCmtsMaxServiceIds,
+--            docsIfCmtsInsertionInterval,
+            docsIfCmtsInvitedRangingAttempts,
+            docsIfCmtsInsertInterval,
+            docsIfCmtsStatusInvalidRangeReqs,
+            docsIfCmtsStatusRangingAborteds,
+            docsIfCmtsStatusInvalidRegReqs,
+            docsIfCmtsStatusFailedRegReqs,
+            docsIfCmtsStatusInvalidDataReqs,
+            docsIfCmtsStatusT5Timeouts,
+            docsIfCmtsCmStatusMacAddress,
+            docsIfCmtsCmStatusIpAddress,
+            docsIfCmtsCmStatusDownChannelIfIndex,
+            docsIfCmtsCmStatusUpChannelIfIndex,
+            docsIfCmtsCmStatusRxPower,
+
+
+
+St. Johns                       Standard                       [Page 67]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+            docsIfCmtsCmStatusTimingOffset,
+            docsIfCmtsCmStatusEqualizationData,
+            docsIfCmtsCmStatusValue,
+            docsIfCmtsCmStatusUnerroreds,
+            docsIfCmtsCmStatusCorrecteds,
+            docsIfCmtsCmStatusUncorrectables,
+            docsIfCmtsCmStatusSignalNoise,
+            docsIfCmtsCmStatusMicroreflections,
+            docsIfCmtsServiceCmStatusIndex,
+            docsIfCmtsServiceAdminStatus,
+            docsIfCmtsServiceQosProfile,
+            docsIfCmtsServiceCreateTime,
+            docsIfCmtsServiceInOctets,
+            docsIfCmtsServiceInPackets,
+            docsIfCmtsModType,
+            docsIfCmtsModControl,
+            docsIfCmtsModPreambleLen,
+            docsIfCmtsModDifferentialEncoding,
+            docsIfCmtsModFECErrorCorrection,
+            docsIfCmtsModFECCodewordLength,
+            docsIfCmtsModScramblerSeed,
+            docsIfCmtsModMaxBurstSize,
+            docsIfCmtsModGuardTimeSize,
+            docsIfCmtsModLastCodewordShortened,
+            docsIfCmtsModScrambler,
+            docsIfCmtsQosProfilePermissions,
+            docsIfCmtsCmPtr
+        }
+        STATUS      current
+        DESCRIPTION
+            "Group of objects implemented in Cable Modem Termination
+             Systems."
+        ::= { docsIfGroups 3 }
+
+
+docsIfObsoleteGroup OBJECT-GROUP
+     OBJECTS {
+            docsIfCmRangingRespTimeout,
+            docsIfCmtsInsertionInterval
+        }
+        STATUS      obsolete
+        DESCRIPTION
+            "Group of objects obsoleted."
+        ::= { docsIfGroups 4 }
+
+END
+
+
+
+
+
+St. Johns                       Standard                       [Page 68]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+5.  Acknowledgments
+
+   This document was produced by the IPCDN Working Group.  It is based
+   on a document written by Pam Anderson from CableLabs, Wilson Sawyer
+   from BayNetworks, and Rich Woundy from Continental Cablevision.  The
+   original working group editor, Guenter Roeck of cisco Systems, did
+   much of the grunt work of putting the document into its current form.
+
+   Special thanks is also due to Azlina Palmer, who helped a lot
+   reviewing the document.
+
+6.  References
+
+   [1]  Harrington, D., Presuhn, R. and B. Wijnen, "An Architecture for
+        Describing SNMP Management Frameworks", RFC 2571, April 1999.
+
+   [2]  Rose, M. and K. McCloghrie, "Structure and Identification of
+        Management Information for TCP/IP-based Internets", STD 16, RFC
+        1155, May 1990.
+
+   [3]  Rose, M. and K. McCloghrie, "Concise MIB Definitions", STD 16,
+        RFC 1212, March 1991.
+
+   [4]  Rose, M., "A Convention for Defining Traps for use with the
+        SNMP", RFC 1215, March 1991.
+
+   [5]  McCloghrie, K., Perkins, D. and J. Schoenwaelder, "Structure of
+        Management Information for Version 2 (SMIv2)", STD 58, RFC 2578,
+        April 1999.
+
+   [6]  McCloghrie, K., Perkins, D. and J. Schoenwaelder, "Textual
+        Conventions for SMIv2", STD 58, RFC 2579, April 1999.
+
+   [7]  McCloghrie, K., Perkins, D. and J. Schoenwaelder, "Conformance
+        Statements for SMIv2", STD 58, RFC 2580, April 1999.
+
+   [8]  Case, J., Fedor, M., Schoffstall, M. and J. Davin, "Simple
+        Management Protocol", STD 15, RFC 1157, May 1990.
+
+   [9]  Case, J., McCloghrie, K., Rose, M. and S. Waldbusser,
+        "Introduction to Community-based SNMPv2", RFC 1901, January
+        1996.
+
+   [10] Case, J., McCloghrie, K., Rose, M. and S. Waldbusser, "Transport
+        Mappings for Version 2 of the Simple Network Management Protocol
+        (SNMPv2)", RFC 1906, January 1996.
+
+
+
+
+
+St. Johns                       Standard                       [Page 69]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+   [11] Case, J., Harrington D., Presuhn R. and B. Wijnen, "Message
+        Processing and Dispatching for the Simple Network Management
+        Protocol (SNMP)", RFC 2572, April 1999.
+
+   [12] Blumenthal, U. and B. Wijnen, "User-based Security Model (USM)
+        for version 3 of the Simple Network Management Protocol
+        (SNMPv3)", RFC 2574, April 1999.
+
+   [13] Case, J., McCloghrie, K., Rose, M. and S. Waldbusser, "Protocol
+        Operations for Version 2 of the Simple Network Management
+        Protocol (SNMPv2)", RFC 1905, January 1996.
+
+   [14] Levi, D., Meyer, P. and B. Stewart, "SNMP Applications", RFC
+        2573, April 1999.
+
+   [15] Wijnen, B., Presuhn, R. and K. McCloghrie, "View-based Access
+        Control Model (VACM) for the Simple Network Management Protocol
+        (SNMP)", RFC 2575, April 1999.
+
+   [16] "Data-Over-Cable Service Interface Specifications: Cable Modem
+        Radio Frequency Interface Specification SP-RFI-I04-980724",
+        DOCSIS, July 1998,
+        http://www.cablemodem.com/public/pubtechspec/SP-RFI-I04-
+        980724.pdf.
+
+   [17] McCloghrie, K. and F. Kastenholz, "The Interfaces Group MIB
+        using SMIv2", RFC 2233, November 1997.
+
+   [18] StJohns, M. , "Cable Device Management Information Base for
+        DOCSIS Compliant Cable Modems and Cable Modem Termination
+        Systems", RFC2669, August 1999.
+
+   [19] Proakis, John G., "Digital Communications, 3rd Edition",
+        McGraw-Hill, New York, New York, 1995, ISBN 0-07-051726-6
+
+   [20] "Transmission Systems for Interactive Cable Television Services,
+        Annex B", J.112, International Telecommunications Union, March
+        1998.
+
+7.  Security Considerations
+
+   This MIB relates to a system which will provide metropolitan public
+   internet access.  As such, improper manipulation of the objects
+   represented by this MIB may result in denial of service to a large
+   number of end-users.  In addition, manipulation of the
+   docsIfCmServiceQosProfile, docsIfCmtsServerQosProfile, and the
+   elements of docsIfQosProfileTable may allow an end-user to improve
+   their service response or decrease other subscriber service response.
+
+
+
+St. Johns                       Standard                       [Page 70]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+   This MIB does not affect confidentiality, authentication or
+   authorization of services on a cable modem system.  For
+   authentication and authorization, please see the related document
+   "Cable Device Management Information Base for DOCSIS compliant Cable
+   Modems and Cable Modem Termination Systems" [18].  For
+   confidentiality, the working group expects to issue a MIB which
+   describes the management of the DOCSIS Baseline Privacy mechanism.
+
+8.  Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   intellectual property or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; neither does it represent that it
+   has made any effort to identify any such rights.  Information on the
+   IETF's procedures with respect to rights in standards-track and
+   standards-related documentation can be found in BCP-11.  Copies of
+   claims of rights made available for publication and any assurances of
+   licenses to be made available, or the result of an attempt made to
+   obtain a general license or permission for the use of such
+   proprietary rights by implementors or users of this specification can
+   be obtained from the IETF Secretariat.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights which may cover technology that may be required to practice
+   this standard.  Please address the information to the IETF Executive
+   Director.
+
+9.  Author's Address
+
+   Michael StJohns
+   @Home Network
+   425 Broadway
+   Redwood City, CA 94063
+
+   Phone: +1 650 569 5368
+   EMail: stjohns@corp.home.net
+
+
+
+
+
+
+
+
+
+
+
+
+St. Johns                       Standard                       [Page 71]
+
+RFC 2670                DOCSIS RF Interface MIB              August 1999
+
+
+10.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (1999).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+St. Johns                       Standard                       [Page 72]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2670.txt](<www.ietf.org/rfc/rfc2670.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
