### PR TITLE
Archive rfc2699.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2699.txt
+++ b/www.ietf.org/rfc/rfc2699.txt
@@ -1,0 +1,1235 @@
+
+
+
+
+
+
+Network Working Group                                          S. Ginoza
+Request for Comments: 2699                                           ISI
+Category: Informational                                         May 2000
+
+
+                      Request for Comments Summary
+
+                         RFC Numbers 2600-2699
+
+Status of This Memo
+
+   This RFC is a slightly annotated list of the 100 RFCs from RFC 2600
+   through RFCs 2699.  This is a status report on these RFCs.  This memo
+   provides information for the Internet community.  It does not specify
+   an Internet standard of any kind.  Distribution of this memo is
+   unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (1998).  All Rights Reserved.
+
+Note
+
+   Many RFCs, but not all, are Proposed Standards, Draft Standards, or
+   Standards.  Since the status of these RFCs may change during the
+   standards processing, we note here only that they are on the
+   standards track.  Please see the latest edition of "Internet Official
+   Protocol Standards" for the current state and status of these RFCs.
+   In the following, RFCs on the standards track are marked [STANDARDS-
+   TRACK].
+
+RFC     Author          Date            Title
+---     ------          ----            -----
+
+
+2699    Ginoza          Apr 2000        Request for Comments Summary
+
+This memo.
+
+
+2698    Heinanen        Sep 1999        A Two Rate Three Color Marker
+
+This document defines a Two Rate Three Color Marker (trTCM), which can
+be used as a component in a Diffserv traffic conditioner.  This memo
+provides information for the Internet community.
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 1]
+
+RFC 2699                  Summary of 2600-2699                  May 2000
+
+
+2697    Heinanen        Sep 1999        A Single Rate Three Color Marker
+
+This document defines a Single Rate Three Color Marker (srTCM), which
+can be used as component in a Diffserv traffic conditioner.  This memo
+provides information for the Internet community.
+
+
+2696    Weider          Sep 1999        LDAP Control Extension for
+                                        Simple Paged Results
+                                        Manipulation
+
+This document describes an LDAPv3 control extension for simple paging of
+search results.  This memo provides information for the Internet
+community.
+
+
+2695    Chiu            Sep 1999        Authentication Mechanisms for
+                                        ONC RPC
+
+This document describes two authentication mechanisms created by Sun
+Microsystems that are commonly used in conjunction with the ONC Remote
+Procedure Call (ONC RPC Version 2) protocol.  This memo provides
+information for the Internet community.
+
+
+2694    Srisuresh       Sep 1999        DNS extensions to Network
+                                        Address Translators (DNS_ALG)
+
+This document identifies the need for DNS extensions to NATs and
+outlines how a DNS Application Level Gateway (DNS_ALG) can meet the
+need.  This memo provides information for the Internet community.
+
+
+2693    Ellison         Sep 1999        SPKI Certificate Theory
+
+This document gives the theory behind SPKI certificates and ACLs without
+going into technical detail about those structures or their uses.  This
+memo defines an Experimental Protocol for the Internet community.
+
+
+2692    Ellison         Sep 1999        SPKI Requirements
+
+The SPKI Working Group first established a list of things one might want
+to do with certificates (attached at the end of this document), and then
+summarized that list of desires into requirements.  This document
+presents that summary of requirements.  This memo defines an
+Experimental Protocol for the Internet community.
+
+
+
+
+Ginoza                       Informational                      [Page 2]
+
+RFC 2699                  Summary of 2600-2699                  May 2000
+
+
+2691    Bradner         Sep 1999        A Memorandum of Understanding
+                                        for an ICANN Protocol Support
+                                        Organization
+
+This is the text of the Memorandum of Understanding (MoU) that was
+signed by ICANN, the IETF, the ITU-T, W3C and ETSI on July 14, 1999 in
+Oslo. This MoU creates the Protocol Support Organization (PSO) within
+the Internet Corporation for Assigned Names and Numbers (ICANN).  This
+memo provides information for the Internet community.
+
+
+2690    Bradner         Sep 1999        A Proposal for an MOU-Based
+                                        ICANN Protocol Support
+                                        Organization
+
+This is a copy of the proposal for an MOU-based Protocol Supporting
+Organization that was submitted to ICANN on April 23, 1999.  This memo
+provides information for the Internet community.
+
+
+2689    Bormann         Sep 1999        Providing Integrated Services
+                                        over Low-bitrate Links
+
+This document describes an architecture for providing integrated
+services over low-bitrate links, such as modem lines, ISDN B-channels,
+and sub-T1 links.  This memo provides information for the Internet
+community.
+
+
+2688    Jackowski       Sep 1999        Integrated Services Mappings
+                                        for Low Speed Networks
+
+This document defines the service mappings of the IETF Integrated
+Services for low-bitrate links, specifically the controlled load and
+guaranteed services.  [STANDARDS-TRACK]
+
+
+2687    Bormann         Sep 1999        PPP in a Real-time Oriented
+                                        HDLC-like Framing
+
+This document proposes the suspend/resume-oriented solution for the
+real-time encapsulation format part of the architecture.  [STANDARDS-
+TRACK]
+
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 3]
+
+RFC 2699                  Summary of 2600-2699                  May 2000
+
+
+2686    Bormann         Sep 1999        The Multi-Class Extension to
+                                        Multi-Link PPP
+
+This document proposes the fragment-oriented solution for the real-time
+encapsulation format part of the architecture.  [STANDARDS-TRACK]
+
+
+2685    Fox             Sep 1999        Virtual Private Networks
+                                        Identifier
+
+This document proposes a format for a globally unique VPN identifier.
+[STANDARDS-TRACK]
+
+
+2684    Grossman        Sep 1999        Multiprotocol Encapsulation
+                                        over ATM Adaptation Layer 5
+
+This memo replaces RFC 1483.  It describes two encapsulations methods
+for carrying network interconnect traffic over AAL type 5 over  ATM.
+[STANDARDS-TRACK]
+
+
+2683    Leiba           Sep 1999        IMAP4 Implementation
+                                        Recommendations
+
+The IMAP4 specification describes a rich protocol for use in building
+clients and servers for storage, retrieval, and manipulation of
+electronic mail.  Because the protocol is so rich and has so many
+implementation choices, there are often trade-offs that must be made and
+issues that must be considered when designing such clients and servers.
+This document attempts to outline these issues and to make
+recommendations in order to make the end products as interoperable as
+possible.  This memo provides information for the Internet community.
+
+
+2682    Widjaja         Sep 1999        Performance Issues in VC-Merge
+                                        Capable ATM LSRs
+
+This document investigates the impact of VC merging on the additional
+buffer required for the reassembly buffers and other buffers.  This memo
+provides information for the Internet community.
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 4]
+
+RFC 2699                  Summary of 2600-2699                  May 2000
+
+
+2681    Almes           Sep 1999        A Round-trip Delay Metric for IPP
+
+This memo defines a metric for round-trip delay of packets across
+Internet paths.  [STANDARDS-TRACK]
+
+
+2680    Almes           Sep 1999        A One-way Packet Loss Metric
+                                        for IPPM
+
+This memo defines a metric for one-way packet loss across Internet
+paths.  [STANDARDS-TRACK]
+
+
+2679    Almes           Sep 1999        A One-way Delay Metric for IPPM
+
+This memo defines a metric for one-way delay of packets across Internet
+paths.  [STANDARDS-TRACK]
+
+
+2678    Mahdavi         Sep 1999        IPPM Metrics for Measuring
+                                        Connectivity
+
+This memo defines a series of metrics for connectivity between a pair of
+Internet hosts.  [STANDARDS-TRACK]
+
+
+2677    Greene          Sep 1999        Definitions of Managed Objects
+                                        for the NBMA Next Hop
+                                        Resolution Protocol (NHRP)
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.
+[STANDARDS-TRACK]
+
+
+2676    Apostolopoulos  Aug 1999        QoS Routing Mechanisms
+                                        and OSPF Extensions
+
+This memo describes extensions to the OSPF protocol to support QoS
+routes.  The focus of this document is on the algorithms used to compute
+QoS routes and on the necessary modifications to OSPF to support this
+function, e.g., the information needed, its format, how it is
+distributed, and how it is used by the QoS path selection process.  This
+memo defines an Experimental Protocol for the Internet community.
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 5]
+
+RFC 2699                  Summary of 2600-2699                  May 2000
+
+
+2675    Borman          Aug 1999        IPv6 Jumbograms
+
+This document describes the IPv6 Jumbo Payload option, which provides
+the means of specifying such large payload lengths.  It also describes
+the changes needed to TCP and UDP to make use of jumbograms.
+[STANDARDS-TRACK]
+
+
+2674    Bell            Sep 1999        Definitions of Managed Objects
+                                        for Bridges with Traffic
+                                        Classes, Multicast Filtering
+                                        and Virtual LAN Extensions
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP based internets.
+[STANDARDS-TRACK]
+
+
+2673    Crawford        Aug 1999        Binary Labels in the
+                                        Domain Name System
+
+This document defines a "Bit-String Label" which may appear within
+domain names.  This new label type compactly represents a sequence of
+"One-Bit Labels" and enables resource records to be stored at any bit-
+boundary in a binary-named section of the domain name tree.
+[STANDARDS-TRACK]
+
+
+2672    Crawford        Aug 1999        Non-Terminal DNS Name
+                                        Redirection
+
+This document defines a new DNS Resource Record called "DNAME", which
+provides the capability to map an entire subtree of the DNS name space
+to another domain.  [STANDARDS-TRACK]
+
+
+2671    Vixie           Aug 1999        Extension Mechanisms
+                                        for DNS (EDNS0)
+
+The Domain Name System's wire protocol includes a number of fixed fields
+whose range has been or soon will be exhausted and does not allow
+clients to advertise their capabilities to servers.  This document
+describes backward compatible mechanisms for allowing the protocol to
+grow.  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 6]
+
+RFC 2699                  Summary of 2600-2699                  May 2000
+
+
+2670    St. Johns       Aug 1999        Radio Frequency (RF)
+                                        Interface Management
+                                        Information Base for
+                                        MCNS/DOCSIS compliant
+                                        RF interfaces
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it defines a basic set of managed objects for SNMP-based
+management of MCNS/DOCSIS compliant Radio Frequency (RF) interfaces.
+[STANDARDS-TRACK]
+
+
+2669    St. Johns       Aug 1999        DOCSIS Cable Device MIB
+                                        Cable Device Management
+                                        Information Base for
+                                        DOCSIS compliant Cable
+                                        Modems and Cable Modem
+                                        Termination Systems
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it defines a basic set of managed objects for SNMP-based
+management of DOCSIS 1.0 compliant Cable Modems and Cable Modem
+Termination Systems.  [STANDARDS-TRACK]
+
+
+2668    Smith           Sep 1999        Definitions of Managed Objects
+                                        for IEEE 802.3 Medium
+                                        Attachment Units (MAUs)
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.
+[STANDARDS-TRACK]
+
+
+2667    Thaler          Aug 1999        IP Tunnel MIB
+
+This memo defines a Management Information Base (MIB) for use with
+network management protocols in the Internet community.  In particular,
+it describes managed objects used for managing tunnels of any type over
+IPv4 networks.  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 7]
+
+RFC 2699                  Summary of 2600-2699                  May 2000
+
+
+2666    Flick           Sep 1999        Definitions of Object
+                                        Identifiers for Identifying
+                                        Ethernet Chip Sets
+
+This memo defines OBJECT IDENTIFIER values for use with network
+management protocols in the Internet community.  This memo provides
+information for the Internet community.
+
+
+2665    Flick           Sep 1999        Definitions of Managed Objects
+                                        for the Ethernet-like
+                                        Interface Types
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.
+[STANDARDS-TRACK]
+
+
+2664    Plzak           Aug 1999        FYI on Questions and Answers
+                                        Answers to Commonly Asked "New
+                                        Internet User" Questions
+
+This memo provides an overview to the new Internet User.  The intended
+audience is the common Internet user of today, thus it attempts to
+provide a more consumer oriented approach to the Internet rather than
+going into any depth about a topic. This memo provides information for
+the Internet community.
+
+
+2663    Srisuresh       Aug 1999        IP Network Address Translator
+                                        (NAT) Terminology and
+                                        Considerations
+
+This document attempts to describe the operation of NAT devices and the
+associated considerations in general, and to define the terminology used
+to identify various flavors of NAT.  This memo provides information for
+the Internet community.
+
+
+2662    Bathrick        Aug 1999        Definitions of Managed Objects
+                                        for the ADSL Lines
+
+This document defines a standard SNMP MIB for ADSL lines based on the
+ADSL Forum standard data model.  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 8]
+
+RFC 2699                  Summary of 2600-2699                  May 2000
+
+
+2661    Townsley        Aug 1999        Layer Two Tunneling Protocol
+                                        "L2TP"
+
+This document describes the Layer Two Tunneling Protocol (L2TP).
+[STANDARDS-TRACK]
+
+
+2660    Rescorla        Aug 1999        The Secure HyperText Transfer
+                                        Protocol
+
+This memo describes a syntax for securing messages sent using the
+Hypertext Transfer Protocol (HTTP), which forms the basis for the World
+Wide Web.  This memo defines an Experimental Protocol for the Internet
+community.
+
+
+2659    Rescorla        Aug 1999        Security Extensions For HTML
+
+This memo describes a syntax for embedding S-HTTP negotiation parameters
+in HTML documents.  This memo defines an Experimental Protocol for the
+Internet community.
+
+
+2658    McKay           Aug 1999        RTP Payload Format for
+                                        PureVoice(tm) Audio
+
+This document describes the RTP payload format for PureVoice(tm) Audio.
+[STANDARDS-TRACK]
+
+
+2657    Hedberg         Aug 1999        LDAPv2 Client vs. the Index Mesh
+
+LDAPv2 clients as implemented according to RFC 1777 have no notion on
+referral.  The integration between such a client and an Index Mesh, as
+defined by the Common Indexing Protocol, heavily depends on referrals
+and therefore needs to be handled in a special way.  This document
+defines one possible way of doing this.  This memo defines an
+Experimental Protocol for the Internet community.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 9]
+
+RFC 2699                  Summary of 2600-2699                  May 2000
+
+
+2656    Hardie          Aug 1999        Registration Procedures for
+                                        SOIF Template Type
+
+The registration procedure described in this document is specific to
+SOIF template types.  This memo defines an Experimental Protocol for the
+Internet community.
+
+
+2655    Hardie          Aug 1999        CIP Index Object Format for
+                                        SOIF Objects
+
+This document describes SOIF, the Summary Object Interchange Format, as
+an index object type in the context of the CIP framework.  This memo
+defines an Experimental Protocol for the Internet community.
+
+
+2654    Hedberg         Aug 1999        A Tagged Index Object for use
+                                        in the Common Indexing
+                                        Protocol
+
+This document defines a mechanism by which information servers can
+exchange indices of information from their databases by making use of
+the Common Indexing Protocol (CIP).  This document defines the structure
+of the index information being exchanged, as well as the appropriate
+meanings for the headers that are defined in the Common Indexing
+Protocol. This memo defines an Experimental Protocol for the Internet
+community.
+
+
+2653    Allen           Aug 1999        CIP Transport Protocols
+
+This document specifies three protocols for transporting CIP requests,
+responses and index objects, utilizing TCP, mail, and HTTP.
+[STANDARDS-TRACK]
+
+
+2652    Allen           Aug 1999        MIME Object Definitions for
+                                        the Common Indexing Protocol
+                                        (CIP)
+
+This document describes the definitions of those objects as well as the
+methods and requirements needed to define a new index type.
+[STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 10]
+
+RFC 2699                  Summary of 2600-2699                  May 2000
+
+
+2651    Allen           Aug 1999        The Architecture of the Common
+                                        Indexing Protocol (CIP)
+
+This document describes the CIP framework, including its architecture
+and the protocol specifics of exchanging indices.  [STANDARDS-TRACK]
+
+
+2650    Meyer           Aug 1999        Using RPSL in Practice
+
+This document is a tutorial on using the Routing Policy Specification
+Language (RPSL) to describe routing policies in the Internet Routing
+Registry (IRR).  This memo provides information for the Internet
+community.
+
+
+2649    Greenblatt      Aug 1999        An LDAP Control and Schema for
+                                        Holding Operation Signatures
+
+This document describes an LDAP message control which allows for the
+retrieval of digitally signed information. This document defines an LDAP
+v3 based mechanism for signing directory operations in order to create a
+secure journal of changes that have been made to each directory entry.
+This memo defines an Experimental Protocol for the Internet community.
+
+
+2648    Moats           Aug 1999        A URN Namespace for IETF
+                                        Documents
+
+This document proposes the "ietf" namespace, which consists of the RFC
+family of documents (RFCs, STDs, FYIs, and BCPs) developed by the IETF
+and published by the RFC Editor and the minutes of working groups (WG)
+and birds of a feather (BOF) meetings that occur during IETF
+conferences.  [STANDARDS-TRACK]
+
+
+2647    Newman          Aug 1999        Benchmarking Terminology for
+                                        Firewall Performance
+
+This document defines terms used in measuring the performance of
+firewalls. It extends the terminology already used for benchmarking
+routers and switches with definitions specific to firewalls.
+[STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 11]
+
+RFC 2699                  Summary of 2600-2699                  May 2000
+
+
+2646    Gellens         Aug 1999        The Text/Plain Format Parameter
+
+This memo proposes a new parameter to be used with Text/Plain, and, in
+the presence of this parameter, the use of trailing whitespace to
+indicate flowed lines.  This results in an encoding which appears as
+normal Text/Plain in older implementations, since it is in fact normal
+Text/Plain.  [STANDARDS-TRACK]
+
+
+2645    Gellens         Aug 1999        ON-DEMAND MAIL RELAY (ODMR)
+                                        SMTP with Dynamic IP Addresses
+
+This memo proposes a new service, On-Demand Mail Relay (ODMR), which is
+a profile of SMTP, providing for a secure, extensible, easy to implement
+approach to the problem.  [STANDARDS-TRACK]
+
+
+2644    Bradner         Aug 1999        Benchmarking Methodology for
+                                        Network Interconnect Devices
+
+This document discusses and defines a number of tests that may be used
+to describe the performance characteristics of a network interconnecting
+device.  In addition to defining the tests this document also describes
+specific formats for reporting the results of the tests.  This memo
+provides information for the Internet community.
+
+
+2643    Ruffen          Aug 1999        Cabletron's SecureFast VLAN
+                                        Operational Model
+
+Cabletron's SecureFast VLAN (SFVLAN) product implements a distributed
+connection-oriented switching protocol that provides fast forwarding of
+data packets at the MAC layer.  The product uses the concept of virtual
+LANs (VLANs) to determine the validity of call connection requests and
+to scope the broadcast of certain flooded messages.  This memo provides
+information for the Internet community.
+
+
+2642    Kane            Aug 1999        Cabletron's VLS Protocol
+                                        Specification
+
+VLSP provides support for equal-cost multipath routing, and recalculates
+routes quickly in the face of topological changes, utilizing a minimum
+of routing protocol traffic.  This memo provides information for the
+Internet community.
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 12]
+
+RFC 2699                  Summary of 2600-2699                  May 2000
+
+
+2641    Hamilton        Aug 1999        Cabletron's VlanHello Protocol
+                                        Specification
+
+The VlanHello protocol is part of the InterSwitch Message Protocol
+(ISMP) which provides interswitch communication between switches running
+Cabletron's SecureFast VLAN (SFVLAN) product.  Switches use the
+VlanHello protocol to discover their neighboring switches and establish
+the topology of the switch fabric.  This memo provides information for
+the Internet community.
+
+
+2640    Curtin          Jul 1999        Internationalization of the
+                                        File transfer Protocol
+
+This document addresses the internationalization (I18n) of FTP, which
+includes supporting the multiple character sets and languages found
+throughout the Internet community.  This is achieved by extending the
+FTP specification and giving recommendations for proper
+internationalization support.  [STANDARDS-TRACK]
+
+
+2639    Hastings        Jul 1999        Internet Printing
+                                        Protocol/1.0: Implementer's
+                                        Guide
+
+This document contains information that supplements the IPP Model and
+Semantics and the IPP Transport and Encoding documents.  It is intended
+to help implementers understand IPP/1.0 and some of the considerations
+that may assist them in the design of their client and/or IPP object
+implementations.  This memo provides information for the Internet
+community.
+
+
+2638    Nichols         Jul 1999        A Two-bit Differentiated
+                                        Services Architecture for
+                                        the Internet
+
+This document presents a differentiated services architecture for the
+internet.  This memo provides information for the Internet community.
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 13]
+
+RFC 2699                  Summary of 2600-2699                  May 2000
+
+
+2637    Hamzeh          Jul 1999        Point-to-Point Tunneling
+                                        Protocol (PPTP)
+
+This document specifies a protocol which allows the Point to Point
+Protocol (PPP) to be tunneled through an IP network.  This memo provides
+information for the Internet community.
+
+
+2636    Gellens         Jul 1999        Wireless Device Configuration
+                                        (OTASP/OTAPA) via ACAP
+
+This paper describes a viable and attractive means to provide
+OTASP/OTAPA via IS-707, using the ACAP protocol.  This memo provides
+information for the Internet community.
+
+
+2635    Hambridge       Jun 1999        DON'T SPEW A Set of Guidelines
+                                        for Mass Unsolicited Mailings
+                                        and Postings
+
+
+This document explains why mass unsolicited electronic mail messages are
+harmful in the Internetworking community.  This memo provides
+information for the Internet community.
+
+
+2634    Hoffman         Jun 1999        Enhanced Security Services for
+                                        S/MIME
+
+This document describes four optional security service extensions for
+S/MIME.  [STANDARDS-TRACK]
+
+
+2633    Ramsdell        Jun 1999        S/MIME Version 3 Message
+                                        Specification
+
+This document describes a protocol for adding cryptographic signature
+and encryption services to MIME data.  [STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 14]
+
+RFC 2699                  Summary of 2600-2699                  May 2000
+
+
+2632    Ramsdell        Jun 1999        S/MIME Version 3 Certificate
+                                        Handling
+
+S/MIME (Secure/Multipurpose Internet Mail Extensions), provides a method
+to send and receive secure MIME messages. Before using a public key to
+provide security services, the S/MIME agent MUST certify that the public
+key is valid. S/MIME agents MUST use PKIX certificates to validate
+public keys as described in the Internet X.509 Public Key Infrastructure
+(PKIX) Certificate and CRL Profile.  [STANDARDS-TRACK]
+
+
+2631    Rescorla        Jun 1999        Diffie-Hellman Key Agreement
+                                        Method
+
+This document standardizes one particular Diffie-Hellman variant, based
+on the ANSI X9.42 draft, developed by the ANSI X9F1 working group.
+[STANDARDS-TRACK]
+
+
+2630    Housley         Jun 1999        Cryptographic Message Syntax
+
+This document describes the Cryptographic Message Syntax.  This syntax
+is used to digitally sign, digest, authenticate, or encrypt arbitrary
+messages.  [STANDARDS-TRACK]
+
+
+2629    Rose            Jun 1999        Writing I-Ds and RFCs using XML
+
+This memo presents a technique for using XML (Extensible Markup
+Language) as a source format for documents in the Internet-Drafts (I-Ds)
+and Request for Comments (RFC) series.  This memo provides information
+for the Internet community.
+
+
+2628    Smyslov         Jun 1999        Simple Cryptographic Program
+                                        Interface (Crypto API)
+
+This document describes a simple Application Program Interface to
+cryptographic functions.  This memo provides information for the
+Internet community.
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 15]
+
+RFC 2699                  Summary of 2600-2699                  May 2000
+
+
+2627    Wallner         Jun 1999        Key Management for Multicast:
+                                        Issues and Architectures
+
+This report contains a discussion of the difficult problem of key
+management for multicast communication sessions.  It focuses on two main
+areas of concern with respect to key management, which are, initializing
+the multicast group with a common net key and rekeying the multicast
+group.  This memo provides information for the Internet community.
+
+
+2626    Nesser II       Jun 1999        The Internet and the
+                                        Millennium Problem (Year 2000)
+
+The Year 2000 Working Group (WG) has conducted an investigation into the
+millennium problem as it regards Internet related protocols.  This
+investigation only targeted the protocols as documented in the Request
+For Comments Series (RFCs).  This investigation discovered little reason
+for concern with regards to the functionality of the protocols.  A few
+minor cases of older implementations still using two digit years (ala
+RFC 850) were discovered, but almost all Internet protocols were given a
+clean bill of health.  Several cases of "period" problems were
+discovered, where a time field would "roll over" as the size of field
+was reached.  In particular, there are several protocols, which have 32
+bit, signed integer representations of the number of seconds since
+January 1, 1970 which will turn negative at Tue Jan 19 03:14:07 GMT
+2038.  Areas whose protocols will be effected by such problems have been
+notified so that new revisions will remove this limitation.  This memo
+provides information for the Internet community.
+
+
+2625    Rajagopal       Jun 1999        IP and ARP over Fibre Channel
+
+The purpose of this document is to specify a way of encapsulating IP and
+Address Resolution Protocol(ARP) over Fibre Channel and also to describe
+a mechanism(s) for IP address resolution.  [STANDARDS-TRACK]
+
+
+2624    Shepler         Jun 1999        NFS Version 4 Design
+                                        Considerations
+
+This design considerations document is meant to present more detail than
+the working group charter.  Specifically, it presents the areas that the
+working group will investigate and consider while developing a protocol
+specification for NFS version 4.  This memo provides information for the
+Internet community.
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 16]
+
+RFC 2699                  Summary of 2600-2699                  May 2000
+
+
+2623    Eisler          Jun 1999        NFS Version 2 and Version 3
+                                        Security Issues and the NFS
+                                        Protocol's Use of RPCSEC_GSS
+                                        and Kerberos V5
+
+This memorandum clarifies various security issues involving the NFS
+protocol (Version 2 and Version 3 only) and then describes how the
+Version 2 and Version 3 of the NFS protocol use the RPCSEC_GSS security
+flavor protocol and Kerberos V5.  [STANDARDS-TRACK]
+
+
+2622    Alaettinoglu    Jun 1999        Routing Policy Specification
+                                        Language (RPSL)
+
+RPSL allows a network operator to be able to specify routing policies at
+various levels in the Internet hierarchy; for example at the Autonomous
+System (AS) level.  At the same time, policies can be specified with
+sufficient detail in RPSL so that low level router configurations can be
+generated from them.  RPSL is extensible; new routing protocols and new
+protocol features can be introduced at any time.  [STANDARDS-TRACK]
+
+
+2621    Zorn            Jun 1999        RADIUS Accounting Server MIB
+
+This memo defines a set of extensions which instrument RADIUS accounting
+server functions.  This memo provides information for the Internet
+community.
+
+
+2620    Aboba           Jun 1999        RADIUS Accounting Client MIB
+
+This memo defines a set of extensions which instrument RADIUS accounting
+client functions.  This memo provides information for the Internet
+community.
+
+
+2619    Zorn            Jun 1999        RADIUS Authentication Server MIB
+
+This memo defines a set of extensions which instrument RADIUS
+authentication server functions.  [STANDARDS-TRACK]
+
+
+2618    Aboba           Jun 1999        RADIUS Authentication Client MIB
+
+This memo defines a set of extensions which instrument RADIUS
+authentication client functions.  [STANDARDS-TRACK]
+
+
+
+
+
+Ginoza                       Informational                     [Page 17]
+
+RFC 2699                  Summary of 2600-2699                  May 2000
+
+
+2617    Franks          Jun 1999        HTTP Authentication: Basic and
+                                        Digest Access Authentication
+
+This document provides the specification for HTTP's authentication
+framework, the original Basic authentication scheme and a scheme based
+on cryptographic hashes, referred to as "Digest Access Authentication".
+[STANDARDS-TRACK]
+
+
+2616    Fielding        Jun 1999        Hypertext Transfer Protocol --
+                                        HTTP/1.1
+
+HTTP has been in use by the World-Wide Web global information initiative
+since 1990. This specification defines the protocol referred to as
+"HTTP/1.1", and is an update to RFC 2068.  [STANDARDS-TRACK]
+
+
+2615    Malis           Jun 1999        PPP over SONET/SDH
+
+This document describes the use of PPP over Synchronous Optical Network
+(SONET) and Synchronous Digital Hierarchy (SDH) circuits.  [STANDARDS-
+TRACK]
+
+
+2614    Kempf           Jun 1999        An API for Service Location
+
+This document describes standardized APIs for SLP in C and Java.  This
+memo provides information for the Internet community.
+
+
+2613    Waterman        Jun 1999        Remote Network Monitoring MIB
+                                        Extensions for Switched
+                                        Networks Version 1.0
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing remote network monitoring
+devices in switched networks environments.  [STANDARDS-TRACK]
+
+
+2612    Adams           Jun 1999        The CAST-256 Encryption Algorithm
+
+This document describes an existing algorithm that can be used to
+satisfy this requirement.  Included are a description of the cipher and
+the key scheduling algorithm, the s-boxes, and a set of test vectors
+(Appendix A).  This memo provides information for the Internet
+community.
+
+
+
+
+Ginoza                       Informational                     [Page 18]
+
+RFC 2699                  Summary of 2600-2699                  May 2000
+
+
+2611    Daigle          Jun 1999        URN Namespace Definition
+                                        Mechanisms
+
+This document lays out general definitions of and mechanisms for
+establishing URN "namespaces".  This document specifies an Internet Best
+Current Practices for the Internet Community, and requests discussion
+and suggestions for improvements.
+
+
+2610    Perkins         Jun 1999        DHCP Options for Service
+                                        Location Protocol
+
+The Dynamic Host Configuration Protocol provides a framework for passing
+configuration information to hosts on a TCP/IP network.  Entities using
+the Service Location Protocol need to find out the address of Directory
+Agents in order to transact messages.  Another option provides an
+assignment of scope for configuration of SLP User and Service Agents.
+[STANDARDS-TRACK]
+
+
+2609    Guttman         Jun 1999        Service Templates and Service:
+                                        Schemes
+
+This document describes a formal procedure for defining and
+standardizing new service types and attributes for use with the
+"service:" scheme.  [STANDARDS-TRACK]
+
+
+2608    Guttman         Jun 1999        Service Location Protocol,
+                                        Version 2
+
+The Service Location Protocol provides a scalable framework for the
+discovery and selection of network services.  Using this protocol,
+computers using the Internet need little or no static configuration of
+network services for network based applications.  This is especially
+important as computers become more portable, and users less tolerant or
+able to fulfill the demands of network system administration.
+[STANDARDS-TRACK]
+
+
+2607    Aboba           Jun 1999        Proxy Chaining and Policy
+                                        Implementation in Roaming
+
+This document describes how proxy chaining and policy implementation can
+be supported in roaming systems.  This memo provides information for the
+Internet community.
+
+
+
+
+
+Ginoza                       Informational                     [Page 19]
+
+RFC 2699                  Summary of 2600-2699                  May 2000
+
+
+2606    Eastlake        Jun 1999        Reserved Top Level DNS Names
+
+To reduce the likelihood of conflict and confusion, a few top level
+domain names are reserved for use in private testing, as examples in
+documentation, and the like.  In addition, a few second level domain
+names reserved for use as examples are documented.  This document
+specifies an Internet Best Current Practices for the Internet Community,
+and requests discussion and suggestions for improvements.
+
+
+2605    Mansfield       Jun 1999        Directory Server Monitoring MIB
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.
+[STANDARDS-TRACK]
+
+
+2604    Gellens         Jun 1999        Wireless Device Configuration
+                                        (OTASP/OTAPA) via ACAP
+
+This paper describes a viable and attractive means to provide
+OTASP/OTAPA via IS-707, using the ACAP protocol.  This memo provides
+information for the Internet community.
+
+
+2603    Davison         Jun 1999        ILMI-Based Server Discovery
+                                        for NHRP
+
+This memo defines how ILMI-based Server Discovery, which provides a
+method for ATM-attached hosts and routers to dynamically determine the
+ATM addresses of servers, shall be used to locate NHRP servers.
+[STANDARDS-TRACK]
+
+
+2602    Davison         Jun 1999        ILMI-Based Server Discovery
+                                        for MARS
+
+This memo defines how ILMI-based Server Discovery, which provides a
+method for ATM-attached hosts and routers to dynamically determine the
+ATM addresses of servers, shall be used to locate MARS servers.
+[STANDARDS-TRACK]
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 20]
+
+RFC 2699                  Summary of 2600-2699                  May 2000
+
+
+2601    Davison         Jun 1999        ILMI-Based Server Discovery
+                                        for ATMARP
+
+This memo defines how ILMI-based Server Discovery, which provides a
+method for ATM-attached hosts and routers to dynamically determine the
+ATM addresses of servers, shall be used to locate ATMARP servers.
+[STANDARDS-TRACK]
+
+
+2600    Reynolds        Mar 2000        Internet Official Protocol
+                                        Standards
+
+This memo is published by the RFC Editor in accordance with Section 2.1
+of "The Internet Standards Process -- Revision 3", RFC 2026, which
+specifies the rules and procedures by which all Internet standards are
+set.  This memo is prepared by the RFC Editor for the IESG and IAB.
+Please see http://www.rfc-editor.org for later updates to this document.
+[STANDARDS-TRACK]
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Author's Address
+
+   Sandy Ginoza
+   University of Southern California
+   Information Sciences Institute
+   4676 Admiralty Way
+   Marina Del Rey, CA 90292
+
+   Phone: (310) 822-1511
+   EMail: ginoza@isi.edu
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 21]
+
+RFC 2699                  Summary of 2600-2699                  May 2000
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (1998).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 22]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2699.txt](<www.ietf.org/rfc/rfc2699.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
