### PR TITLE
Archive rfc27.txt

### DIFF
--- a/www.ietf.org/rfc/rfc27.txt
+++ b/www.ietf.org/rfc/rfc27.txt
@@ -1,0 +1,149 @@
+Network Working Group                                         S. Crocker
+Request for Comments: 27                                            UCLA
+                                                           9 December 69
+
+
+
+                        DOCUMENTATION CONVENTIONS
+
+
+
+
+This note is a revision of NWG/RFC 10, 16, and 24.
+
+The Network Working Group consists of interested people from existing
+or potential ARPA network sites.  Membership is not closed.
+
+The Network Working Group (NWG) is concerned with the HOST software,
+the strategies for using the network, and initial experience with the
+network.
+
+Documentation of the NWG's effort is through notes such as this.  Notes
+may be produced at any site by anybody and included in this series.
+
+
+CONTENT
+
+The content of a NWG note may be any thought, suggestion, etc. related
+to the HOST software or other aspect of the network.  Notes are
+encouraged to be timely rather than polished.  Philosophical positions
+without examples or other specifics, specific suggestions or
+implementation techniques without introductory or background
+explication, and explicit questions without any attempted answers are
+all acceptable.  The minimum length for a NWG note is one sentence.
+
+These standards (or lack of them) are stated explicitly for two
+reasons.  First, there is a tendency to view a written statement as
+ipso facto authoritative, and we hope to promote the exchange and
+discussion of considerably less than authoritative ideas.  Second,
+there is a natural hesitancy to publish something unpolished, and we
+hope to ease this inhibition.
+
+FORM
+
+Every NWG note should bear the following information:
+
+        1.  "Network Working Group"
+            "Request for Comments: X" (X underscored)
+              where X is a serial number.  Serial numbers are assigned
+              by Steve Crocker at UCLA.
+
+        2.  Author and affiliation
+
+        3.  Date
+
+        4.  Title
+            The title need not be unique.
+
+DISTRIBUTION
+
+One copy only will be sent from the author's site to:
+
+        1.  Abhai Bhushan, MIT
+        2.  Steve Carr, Utah
+        3.  Gerry Cole, SDS
+        4.  Steve Crocker, UCLA
+        5.  Bill English, SRI
+        6.  Kim Fry, MITRE
+        7.  John Haefner, RAND
+        8.  Bob Kahn, BB&N
+        9.  Thomas O'Sullivan, Raytheon
+       10.  Larry Roberts, ARPA
+       11.  Paul Rovner, LL
+       12.  Ron Stoughton, UCSB
+
+Reproduction, if desired, may be handled locally.
+
+ADDRESSES
+
+Below are the most current addressed I have.  Please correct as
+necessary:
+
+
+        Abhai Bhushan                   MIT
+        Room 807 - Project MAC          (617) 864-6900 X5857
+        545 Technology Square
+        Cambridge, Mass. 02139
+
+        Steve Carr                      Utah
+        Computer Science Dept.          (801) 322-8224
+        University of Utah
+        Salt Lake City, Utah  84112
+
+        Gerry Cole                      SDC
+        7842 Croyden                    2500 Colorado
+        Los Angeles, Calif. 90024       Santa Monica, Calif 90406
+                                        (213) 393-9411, X6l35
+                                                        X6019 (Sec'y)
+
+        Steve Crocker                   UCLA
+        3732 Boelter Hall               (213) 825-4864
+        UCLA                                  825-2543 (Sec'y)
+        Los Angeles, Calif. 90024
+
+        Bill English                    SRI
+        Stanford Research Institute     (415) 326-6200
+        333 Ravenswood                  
+        Menlo Park, Calif. 94025
+
+        Kim Fry                         MITRE
+        The MITRE Corp                  (703) 893-3500, X355
+        Westgate Research Park                          X318
+        McLean, Va. 22101
+
+        John Heafner                    RAND
+        The Rand Corporation            (213) 393-0411
+        1700 Main Street
+        Santa Monica, Calif. 90406
+
+        Robert Kahn                     BB&N
+        Bolt, Beranek and Newman        (617) 491-1850
+        50 Moulton St.
+        Cambridge, Mass. 02138
+
+        Thomas O'Sullivan               Raytheon
+        Raytheon Company                (617) 899-8400
+        Equipment Division Headquarters
+        40 Second Ave.
+        Waltham, Mass. 02l54
+
+        Larry Roberts                   ARPA
+        ODS/ARPA                        (202) OX7-8663
+        3D167                                 OX7-8654
+        Washington, D.C.  2030l
+
+        Paul D. Rovner                  LL
+        Mass. Inst. of Tech.            (617) 562-5500 X7211
+        Lincoln Laboratory B-115                      
+        P.O. Box 73
+        Lexington, Mass 02173
+
+        Ron Stoughton                   UCSB
+        Computer Research Lab           (805) 961-3221
+        UCSB
+        Santa Barbara, Calif. 93106
+
+
+
+
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc27.txt](<www.ietf.org/rfc/rfc27.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
