### PR TITLE
Archive rfc270.txt

### DIFF
--- a/www.ietf.org/rfc/rfc270.txt
+++ b/www.ietf.org/rfc/rfc270.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                        A. McKenzie
+Request for Comments: 270                                            BBN
+NIC: 7818                                                January 1, 1972
+
+
+                    CORRECTION TO BBN REPORT NO. 1822
+
+
+   In the process of generating RFC #271 we have discovered a set of
+   errors in BBN Report No. 1822 (NIC 7958).  The attached page is a
+   corrected version of page 25; in addition the first two lines should
+   be deleted from page 26.  The paragraph at the top of page 25 is
+   changed to show that the Host is NOT marked dead under the stated
+   conditions, and to show that the timeout period is 30 (rather than
+   40) seconds.  In the footnote, the two changes are underlined; these
+   changes also show the timeout period as 30 seconds.  A more formal
+   update to Report 1822 will be distributed eventually.
+
+   Please note that these changes reflect errors in previous versions of
+   Report 1822, _not_ changes to the IMP system.  The timeout period has
+   ALWAYS been 30 seconds and the Host was NEVER marked dead under these
+   conditions.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+          [This RFC was put into machine readable form for entry]
+      [into the online RFC archives by Kelly Tardif, Viagénie 10/99]
+
+
+
+
+
+
+
+
+
+
+
+McKenzie                                                        [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc270.txt](<www.ietf.org/rfc/rfc270.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
