### PR TITLE
Archive rfc2727.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2727.txt
+++ b/www.ietf.org/rfc/rfc2727.txt
@@ -1,0 +1,843 @@
+
+
+
+
+
+
+Network Working Group                                           J. Galvin
+Request for Comments: 2727                              eList eXpress LLC
+BCP: 10                                                     February 2000
+Obsoletes: 2282
+Category: Best Current Practice
+
+
+       IAB and IESG Selection, Confirmation, and Recall Process:
+           Operation of the Nominating and Recall Committees
+
+Status of this Memo
+
+   This document specifies an Internet Best Current Practices for the
+   Internet Community, and requests discussion and suggestions for
+   improvements.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2000).  All Rights Reserved.
+
+Abstract
+
+   The process by which the members of the IAB and IESG are selected,
+   confirmed, and recalled is specified.  This document is a self-
+   consistent, organized compilation of the process as it was known at
+   the time of publication.
+
+Table of Contents
+
+   1 Introduction .................................................    1
+   2 General ......................................................    2
+   3 Nominating Committee Selection ...............................    6
+   4 Nominating Committee Operation ...............................    8
+   5 Member Recall ................................................   11
+   6 Changes From RFC2282 .........................................   12
+   7 Acknowledgements .............................................   13
+   8 Security Considerations ......................................   14
+   9 References ...................................................   14
+   10 Editor's Address ............................................   14
+   11 Full Copyright Statement ....................................   15
+
+1.  Introduction
+
+   This document is a revision of and supercedes RFC2282.  It is a
+   complete specification of the process by which members of the IAB and
+   IESG are selected, confirmed, and recalled as of the date of its
+   approval.  However, these procedures are subject to change and such
+   change takes effect immediately upon its approval, regardless of
+
+
+
+Galvin                   Best Current Practice                  [Page 1]
+
+RFC 2727                 IAB and IESG Selection            February 2000
+
+
+   whether this document has yet been revised.
+
+   The following two assumptions continue to be true of this
+   specification.
+
+   (1)  The Internet Research Task Force (IRTF) and Internet Research
+        Steering Group (IRSG) are not a part of the process described
+        here.
+
+   (2)  The organization (and re-organization) of the IESG is not a part
+        of the process described here.
+
+   The time frames specified here use IETF meetings as a frame of
+   reference.  The time frames assume that the IETF meets at least once
+   per calendar year.  This document specifies time frames relative to
+   the first IETF of the calendar year, or simply "First IETF".
+
+   The remainder of this document is divided into four major topics as
+   follows.
+
+   General This a set of rules and constraints that apply to the
+        selection and confirmation process as a whole.
+
+   Nominating Committee Selection This is the process by which
+        volunteers from the IETF community are recognized to serve on
+        the committee that nominates candidates to serve on the IESG and
+        IAB.
+
+   Nominating Committee Operation This is the set of principles, rules,
+        and constraints that guide the activities of the nominating
+        committee, including the confirmation process.
+
+   Member Recall This is the process by which the behavior of a sitting
+        member of the IESG or IAB may be questioned, perhaps resulting
+        in the removal of the sitting member.
+
+   A final section describes how this document differs from its
+   predecessor: RFC2282.
+
+2.  General
+
+   The following set of rules apply to the selection and confirmation
+   process as a whole.  If necessary, a paragraph discussing the
+   interpretation of each rule is included.
+
+   (1)  The principal functions of the nominating committee are to
+        review the open IESG and IAB positions and to either nominate
+        its incumbent or recruit a superior candidate.
+
+
+
+Galvin                   Best Current Practice                  [Page 2]
+
+RFC 2727                 IAB and IESG Selection            February 2000
+
+
+      The nominating committee does not select the open positions to be
+      reviewed; it is instructed as to which positions to review.
+
+      At a minimum, the nominating committee will be given the title of
+      the position to be reviewed.  The nominating committee may be
+      given a desirable set of qualifications for the candidate
+      nominated to fill each position.
+
+      Incumbents must notify the nominating committee if they do not
+      wish to be nominated.
+
+      The nominating committee does not confirm its candidates; it
+      presents its candidates to the appropriate confirming body as
+      indicated below.
+
+   (2)  The annual selection and confirmation process is expected to be
+        completed within 3 months.
+
+      The annual selection and confirmation process is expected to be
+      completed one month prior to the friday of the week before the
+      First IETF.  It is expected to begin 4 months prior to the Friday
+      of the week before the First IETF.
+
+   (3)  One-half of each of the then current IESG and IAB positions is
+        selected to be reviewed each year.
+
+      The intent of this rule to ensure the review of approximately
+      one-half of each of the sitting IESG and IAB members each year.
+      It is recognized that circumstances may exist that will require
+      the nominating committee to review more or less than one-half of
+      the current positions, e.g., if the IESG or IAB have re-organized
+      prior to this process and created new positions, or if there are
+      an odd number of current positions.
+
+   (4)  Confirmed candidates are expected to serve at least a 2 year
+        term.
+
+      The intent of this rule is to ensure that members of the IESG and
+      IAB serve the number of years that best facilitates the review of
+      one-half of the members each year.
+
+      It is consistent with this rule for the nominating committee to
+      choose one or more of the currently open positions to which it may
+      assign a term greater than 2 years in order to ensure the ideal
+      application of this rule in the future.
+
+
+
+
+
+
+Galvin                   Best Current Practice                  [Page 3]
+
+RFC 2727                 IAB and IESG Selection            February 2000
+
+
+      It is consistent with this rule for the nominating committee to
+      choose one or more of the currently open positions that share
+      responsibilities with other positions (both those being reviewed
+      and those sitting) to which it may assign a term greater than 2
+      years to ensure that all such members will not be reviewed at the
+      same time.
+
+      All sitting member terms end during the First IETF meeting
+      corresponding to the end of the term for which they were
+      confirmed.  All confirmed candidate terms begin during the First
+      IETF meeting corresponding to the beginning of the term for which
+      they were confirmed.  Normally, the confirmed candidate's term
+      begins when the currently sitting member's term ends on the last
+      day of the meeting.  A term may begin or end no sooner than the
+      first day of the meeting and no later than the last day of the
+      meeting as determined by the mutual agreement of the currently
+      sitting member and the confirmed candidate.  The confirmed
+      candidate's term may overlap the sitting member's term during the
+      meeting as determined by their mutual agreement.
+
+   (5)  Mid-term vacancies are filled by the same rules as documented
+        here with four qualifications.  First, the most recently
+        constituted nominating committee is reconvened to nominate a
+        candidate to fill the vacancy.  Second, the selection and
+        confirmation process is expected to be completed within 1 month,
+        with all other time periods otherwise unspecified prorated
+        accordingly.  Third, the confirming body has two weeks from the
+        day it is notified of a candidate to reject the candidate,
+        otherwise the candidate is assumed to have been confirmed.
+        Fourth, the term of the confirmed candidate will be either:
+
+   a. the remainder of the term of the open position if that remainder
+      is not less than one year.
+
+   b. the remainder of the term of the open position plus the next 2
+      year term if that remainder is less than one year.
+
+   (6)  All deliberations and supporting information that relates to
+        specific nominees, candidates, and confirmed candidates are
+        confidential.
+
+      The nominating committee and confirming body members will be
+      exposed to confidential information as a result of their
+      deliberations, their interactions with those they consult, and
+      from those who provide requested supporting information.  All
+      members and all other participants are expected to handle this
+      information in a manner consistent with its sensitivity.
+
+
+
+
+Galvin                   Best Current Practice                  [Page 4]
+
+RFC 2727                 IAB and IESG Selection            February 2000
+
+
+      It is consistent with this rule for current nominating committee
+      members who have served on prior nominating committees to advise
+      the current committee on deliberations and results of the prior
+      committee, as necessary and appropriate.
+
+   (7)  Unless otherwise specified, the advise and consent model is used
+        throughout the process.  This model is characterized as follows.
+
+   a. The IETF Executive Director advises the nominating committee of
+      the IESG and IAB positions to be reviewed.
+
+   b. The nominating committee selects candidates and advises the
+      confirming bodies of them.
+
+   c. The sitting IAB members review the IESG candidates, consenting to
+      some, all, or none.
+
+      If all of the candidates are confirmed, the job of the nominating
+      committee with respect to reviewing the open IESG positions is
+      considered complete.  If some or none of the candidates are
+      confirmed, the nominating committee must reconvene to select
+      alternate candidates for the rejected candidates.  Any additional
+      time required by the nominating committee should not exceed its
+      maximum time allotment.
+
+   d. The Internet Society Board of Trustees reviews the IAB candidates,
+      consenting to some, all, or none.
+
+      If all of the candidates are confirmed, the job of the nominating
+      committee with respect to reviewing the open IAB positions is
+      considered complete.  If some or none of the candidates are
+      confirmed, the nominating committee must reconvene to select
+      alternate candidates for the rejected candidates.  Any additional
+      time required by the nominating committee should not exceed its
+      maximum time allotment.
+
+   e. The confirming bodies decide their consent according to a
+      mechanism of their own choosing, which must ensure that at least
+      one-half of the sitting members agree with the decision.
+
+      At least one-half of the sitting members of the confirming bodies
+      must agree to either confirm or reject each individual nominee.
+      The agreement must be decided within a reasonable timeframe.  The
+      agreement may be decided by conducting a formal vote, by asserting
+      consensus based on informal exchanges (email), or by whatever
+      mechanism is used to conduct the normal business of the confirming
+      body.
+
+
+
+
+Galvin                   Best Current Practice                  [Page 5]
+
+RFC 2727                 IAB and IESG Selection            February 2000
+
+
+3.  Nominating Committee Selection
+
+   The following set of rules apply to the creation of the nominating
+   committee and the selection of its members.
+
+   (1)  The committee comprises at least a non-voting Chair, 10 voting
+        volunteers, and 3 non-voting liaisons.
+
+      Any committee member may propose the addition of a non-voting
+      advisor to participate in some or all of the deliberations of the
+      committee.  The addition must be approved by both the voting and
+      non-voting members of the committee according to its established
+      voting mechanism.  Advisors participate as individuals.
+
+      Any committee member may propose the addition of a non-voting
+      liaison from other unrepresented organizations to participate in
+      some or all of the deliberations of the committee.  The addition
+      must be approved by both the voting and non-voting members of the
+      committee according to its established voting mechanism.  Liaisons
+      participate as representatives of their respective organizations.
+
+      Advisors and liaisons must meet the usual requirements for
+      membership in the nominating committee.  In the case of liaisons
+      the requirements apply to the organization not to the individual.
+
+   (2)  The Internet Society President appoints the non-voting Chair,
+        who must meet the usual requirements for membership in the
+        nominating committee.
+
+      The nominating committee Chair must agree to invest the time
+      necessary to ensure that the nominating committee completes its
+      assigned duties and to perform in the best interests of the IETF
+      community in that role.
+
+   (3)  The Chair obtains the list of IESG and IAB positions to be
+        reviewed and publishes it along with a solicitation for names of
+        volunteers from the IETF community willing to serve on the
+        nominating committee.
+
+      The list of open positions is published with the solicitation to
+      facilitate community members choosing between volunteering for an
+      open position and volunteering for the nominating committee.
+
+      The list and solicitation must be publicized using at least the
+      same mechanism used by the IETF secretariat for its announcements.
+
+   (4)  Members of the IETF community must have attended at least 2 of
+        the last 3 IETF meetings in order to volunteer.
+
+
+
+Galvin                   Best Current Practice                  [Page 6]
+
+RFC 2727                 IAB and IESG Selection            February 2000
+
+
+   (5)  Internet Society Board of Trustees, sitting members of the IAB,
+        and sitting members of the IESG may not volunteer.
+
+   (6)  The Chair announces the pool of volunteers from which the 10
+        voting volunteers will be randomly selected.
+
+      The announcement must be made using at least the same mechanism
+      used by the IETF secretariat for its announcements.
+
+   (7)  The Chair randomly selects the 10 voting volunteers from the
+        pool of names of volunteers using a method that can be
+        independently verified to be unbiased and fair.
+
+      A method is fair if each eligible volunteer is equally likely to
+      be selected.  A method is unbiased if no one can influence its
+      outcome in favor of a specific outcome.
+
+      The method must include an announcement of an enumerated list of
+      the pool of names together with the specific algorithm for how
+      names will be chosen from the list.  The output of the selection
+      algorithm must depend on random data whose value is not known at
+      the time the list and algorithm are announced.
+
+      One possible method is described in [1].
+
+      All announcements must be made using at least the mechanism used
+      by the IETF secretariat for its announcements.
+
+   (8)  The sitting IAB and IESG members each appoint a non-voting
+        liaison to the nominating committee from their current
+        membership who are not sitting in an open position.
+
+   (9)  The Chair of the prior year's nominating committee serves as a
+        non-voting liaison.
+
+      The prior year's Chair may select a designee from a pool composed
+      of the voting members of the prior year's committee and all prior
+      Chairs if the Chair is unavailable.  If the prior year's Chair is
+      unavailable and is unable or unwilling to make such a designation
+      in a timely fashion, the Chair of the current committee may do so.
+
+      Selecting a prior year's committee member as the designee permits
+      the experience of the prior year's deliberations to be readily
+      available to the current committee.  Selecting an earlier prior
+      year Chair as the designee permits the experience of being a Chair
+      as well as that Chair's committee deliberations to be readily
+      available to the current committee.
+
+
+
+
+Galvin                   Best Current Practice                  [Page 7]
+
+RFC 2727                 IAB and IESG Selection            February 2000
+
+
+4.  Nominating Committee Operation
+
+   The following rules apply to the operation of the nominating
+   committee.  If necessary, a paragraph discussing the interpretation
+   of each rule is included.
+
+   The rules are organized approximately in the order in which they
+   would be invoked.
+
+   The term nominee refers to an individual under consideration by the
+   nominating committee.  The term candidate refers to a nominee that
+   has been selected by the nominating committee to be considered for
+   confirmation by a confirming body.  A confirmed candidate is a
+   candidate that has been reviewed and approved by a confirming body.
+
+   (1)  All rules and special circumstances not otherwise specified are
+        at the discretion of the committee.
+
+      Exceptional circumstances will occasionally arise during the
+      normal operation of the nominating committee.  This rule is
+      intended to foster the continued forward progress of the
+      committee.
+
+      Any member of the committee may propose a rule for adoption by the
+      committee.  The rule must be approved by both the voting and non-
+      voting members of the committee according to its established
+      voting mechanism.
+
+      All members of the committee should consider whether the exception
+      is worthy of mention in the next revision of this document and
+      followup accordingly.
+
+   (2)  The Chair must establish and publicize milestones, which must
+        include at least a call for nominations.
+
+      There is a defined time period during which the selection and
+      confirmation process must be completed.  The Chair must establish
+      a set of milestones which, if met in a timely fashion, will result
+      in the completion of the process on time.  The Chair should allow
+      time for iterating the activities of the committee if one or more
+      candidates is not confirmed.
+
+      The milestones must be publicized using at least the same
+      mechanism used by the IETF secretariat for its announcements.
+
+
+
+
+
+
+
+Galvin                   Best Current Practice                  [Page 8]
+
+RFC 2727                 IAB and IESG Selection            February 2000
+
+
+   (3)  The Chair must establish a voting mechanism.
+
+      The committee must be able to objectively determine when a
+      decision has been made during its deliberations.  The criteria for
+      determining closure must be established and known to all members
+      of the nominating committee.
+
+   (4)  At least a quorum of committee members must participate in a
+        vote.  A quorum comprises at least 7 voting members.
+
+   (5)  The Chair may establish a process by which a member of the
+        nominating committee may be recalled.
+
+      The process, if established, must be agreed to by a 3/4 majority
+      of the members of the nominating committee, including the non-
+      voting members since they would be subject to the same process.
+
+   (6)  All members of the nominating committee may participate in all
+        deliberations.
+
+      The emphasis of this rule is that no member, whether voting or
+      non-voting, can be explicitly excluded from any deliberation.
+      However, a member may individually choose not to participate in a
+      deliberation.
+
+   (7)  The Chair announces the open positions to be reviewed and the
+        call for nominees.
+
+      The call for nominees must include a request for comments
+      regarding the past performance of incumbents, which will be
+      considered during the deliberations of the nominating committee.
+
+      The announcements must be publicized using at least the same
+      mechanism used by the IETF secretariat for its announcements.
+
+   (8)  Any member of the IETF community may nominate any member of the
+        IETF community for any open position.
+
+      A self-nomination is permitted.
+
+   (9)  Nominating committee members must not be nominees.
+
+      To be a nominee is to enter the process of being selected as a
+      candidate and confirmed.  Nominating committee members are not
+      eligible to be considered for filling any open position.  They
+      become ineligible as soon as their role is announced to the IETF
+      community and they remain ineligible for the duration of this
+      nominating committee's term.
+
+
+
+Galvin                   Best Current Practice                  [Page 9]
+
+RFC 2727                 IAB and IESG Selection            February 2000
+
+
+   (10) Members of the IETF community who were recalled from any IESG or
+        IAB position during the previous two years must not be nominees.
+
+   (11) The nominating committee selects candidates based on its
+        understanding of the IETF community's consensus of the
+        qualifications required to fill the open positions.
+
+      The intent of this rule is to ensure that the nominating committee
+      consults with a broad base of the IETF community for input to its
+      deliberations.
+
+      The consultations are permitted to include a slate of nominees, if
+      all parties to the consultation agree to observe customary and
+      reasonable rules of confidentiality.
+
+      A broad base of the community should include the existing members
+      of the IAB and IESG, especially sitting members who share
+      responsibilities with open positions, e.g., co-Area Directors.
+
+   (12) Nominees should be advised that they are being considered and
+        must consent to their nomination prior to being confirmed.
+
+      The nominating committee should help nominees provide
+      justification to their employers.
+
+      A nominee's consent must be written (email is acceptable) and
+      include a commitment to provide the resources necessary to fill
+      the open position and an assurance that the nominee will perform
+      the duties of the position for which they are being considered in
+      the best interests of the IETF community.
+
+   (13) The nominating committee advises the confirming bodies of their
+        candidates, specifying a single candidate for each open position
+        and a testament as to how each candidate meets the
+        qualifications of an open position.
+
+      The testament may include a brief resume of the candidate and a
+      summary of the deliberations of the nominating committee.
+
+   (14) With respect to any action to be taken in the context of
+        notifying and announcing confirmed candidates, and notifying
+        rejected nominees and candidates, the action must be valid
+        according to all of the rules specified below prior to its
+        execution.
+
+
+
+
+
+
+
+Galvin                   Best Current Practice                 [Page 10]
+
+RFC 2727                 IAB and IESG Selection            February 2000
+
+
+   a. Up until a candidate is confirmed, the identity of the candidate
+      must be kept confidential.
+
+   b. The identity of all nominees must be kept confidential (except
+      that the nominee may publicize their intentions).
+
+   c. Rejected nominees may be notified as soon as they are rejected.
+
+   d. Rejected candidates may be notified as soon as they are rejected.
+
+   e. Rejected nominees and candidates must be notified prior to
+      announcing confirmed candidates.
+
+   f. Confirmed candidates may be notified and announced as soon as they
+      are confirmed.
+
+      It is consistent with these rules for a nominee to never know if
+      they were a candidate or not.
+
+      It is consistent with these rules for some nominees to be rejected
+      early in the process and for some nominees to be kept as
+      alternates in case a candidate is rejected by a confirming body.
+      In the matter of whether a confirmed candidate was a first choice
+      or an alternate, that information need not ever be disclosed and,
+      in fact, probably never should be.
+
+      It is consistent with these rules for confirmed candidates to be
+      notified and announced as quickly as possible instead of requiring
+      all confirmed candidates to wait until all open positions have
+      been reviewed.
+
+      When consulting with individual members of the IETF community, if
+      all parties to the consultation agree to observe customary and
+      reasonable rules of confidentiality the consultations are
+      permitted to include a slate of nominees.
+
+      The announcements must be publicized using at least the same
+      mechanism used by the IETF secretariat for its announcements.
+
+5.  Member Recall
+
+   The following rules apply to the recall process.  If necessary, a
+   paragraph discussing the interpretation of each rule is included.
+
+   (1)  Anyone may request the recall of any sitting IAB or IESG member,
+        at any time, upon written (email is acceptable) request with
+        justification to the Internet Society President.
+
+
+
+
+Galvin                   Best Current Practice                 [Page 11]
+
+RFC 2727                 IAB and IESG Selection            February 2000
+
+
+   (2)  Internet Society President shall appoint a Recall Committee
+        Chair.
+
+      The Internet Society President must not evaluate the recall
+      request.  It is explicitly the responsibility of the IETF
+      community to evaluate the behavior of its leaders.
+
+   (3)  The recall committee is created according to the same rules as
+        is the nominating committee with the qualifications that the
+        person being investigated and the person requesting the recall
+        must not be a member of the recall committee in any capacity.
+
+   (4)  The recall committee operates according to the same rules as the
+        nominating committee with the qualification that there is no
+        confirmation process.
+
+   (5)  The recall committee investigates the circumstances of the
+        justification for the recall and votes on its findings.
+
+      The investigation must include at least both an opportunity for
+      the member being recalled to present a written statement and
+      consultation with third parties.
+
+   (6)  A 3/4 majority of the members who vote on the question is
+        required for a recall.
+
+   (7)  If a sitting member is recalled the open position is to be
+      filled according to the mid-term vacancy rules.
+
+6.  Changes From RFC2282
+
+   Editorial changes are not described here, only substantive changes.
+   They are listed here in the order in which they appear in the
+   document.
+
+   (1)  The frame of reference for timeframes was changed from the
+        seasonal "Spring IETF" reference to the less geographic and more
+        temporal "First IETF" reference.
+
+   (2)  The terms of the sitting members and their respective confirmed
+        candidates is explicitly permitted to overlap during the First
+        IETF as determined by their mutual agreement.
+
+   (3)  Nominating committee members who have served on prior committees
+        are explicitly permitted to advise the current committee on the
+        deliberations and results of the prior committee.
+
+
+
+
+
+Galvin                   Best Current Practice                 [Page 12]
+
+RFC 2727                 IAB and IESG Selection            February 2000
+
+
+   (4)  The role and opportunity for additional advisors and liaisons to
+        the nominating committee was clarified.
+
+   (5)  A reference to a documented and accepted fair and unbiased
+        mechanism for randomly selecting nominating committee members
+        from the pool of volunteers was added.
+
+   (6)  The option for the prior year's Chair to select a designee to
+        serve as liaison to the current year's committee was clarified
+        to ensure the Chair selected a non-voting liaison from a pool
+        composed of the prior year's voting members and all prior
+        committee Chairs.
+
+   (7)  The responsibility and authority for the activities of the
+        nominating committee rests with the committee as a whole, not
+        with the Chair.  The operation of the committee was clarified to
+        require changes in process and the handling of exceptions to be
+        approved by the committee as a whole as opposed to being at the
+        discretion of the Chair.
+
+   (8)  The rule that prevented nominating committee members from being
+        eligible to be considered for any open position was clarified to
+        explicitly state that the rule applies from the point in time
+        that the committee membership is announced through the entire
+        term of the current committee.
+
+7.  Acknowledgements
+
+   There have been a number of people involved with the development of
+   this document over the years.  A great deal of credit goes to the
+   first three Nominating Committee Chairs:
+
+        1993 - Jeff Case
+
+        1994 - Fred Baker
+
+        1995 - John Curran
+
+   who had the pleasure of operating without the benefit of a documented
+   process.  It was their fine work and oral tradition that became the
+   first version of this document.  Of course we can not overlook the
+   bug discovery burden that each of the Chairs since the first
+   publication have had to endure:
+
+
+
+
+
+
+
+
+Galvin                   Best Current Practice                 [Page 13]
+
+RFC 2727                 IAB and IESG Selection            February 2000
+
+
+        1996 - Guy Almes
+
+        1997 - Geoff Houston
+
+        1998 - Mike St. Johns
+
+        1999 - Donald Eastlake
+
+   Of course the bulk of the credit goes to the members of the POISSON
+   Working Group, previously the POISED Working Group.  The prose here
+   would not be what it is were it not for the attentive and insightful
+   review of its members.  Specific acknowledgement must be extended to
+   Scott Bradner and John Klensin, who have consistently contributed to
+   the improvement of this document throughout its evolution.
+
+8.  Security Considerations
+
+   Any selection, confirmation, or recall process necessarily involves
+   investigation into the qualifications and activities of prospective
+   candidates.  The investigation may reveal confidential or otherwise
+   private information about candidates to those participating in the
+   process.  Each person who participates in any aspect of the process
+   has a responsibility to maintain the confidentiality of any and all
+   information not explicitly identified as suitable for public
+   dissemination.
+
+9.  References
+
+   [1]  Eastlake, D., "Publicly Verifiable Nomcom Random Selection", RFC
+        2777, February 2000.
+
+10.  Editor's Address
+
+   James M. Galvin
+   eList eXpress LLC
+   607 Trixsam Road
+   Sykesville, MD 21784
+
+   EMail: galvin@elistx.com
+
+
+
+
+
+
+
+
+
+
+
+
+Galvin                   Best Current Practice                 [Page 14]
+
+RFC 2727                 IAB and IESG Selection            February 2000
+
+
+11.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (2000).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Galvin                   Best Current Practice                 [Page 15]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2727.txt](<www.ietf.org/rfc/rfc2727.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
