### PR TITLE
Archive rfc2738.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2738.txt
+++ b/www.ietf.org/rfc/rfc2738.txt
@@ -1,0 +1,283 @@
+
+
+
+
+
+
+Network Working Group                                         G. Klyne
+Request for Comments: 2738                        Content Technologies
+Updates: 2533                                            December 1999
+Category: Standards Track
+
+
+      Corrections to "A Syntax for Describing Media Feature Sets"
+
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (1999).  All Rights Reserved.
+
+Abstract
+
+   In RFC 2533, "A Syntax for Describing Media Feature Sets", an
+   expression format is presented for describing media feature
+   capabilities using simple media feature tags.
+
+   This memo contains two corrections to that specification:  one fixes
+   an error in the formal syntax specification, and the other fixes an
+   error in the rules for reducing feature comparison predicates.
+
+Table of Contents
+
+   1. Introduction ............................................2
+      1.1 Terminology and document conventions                 2
+      1.2 Discussion of this document                          2
+   2. Correction to feature expression syntax .................3
+   3. Correction to feature set matching reduction rules ......3
+   4. Security Considerations .................................4
+   5. References ..............................................4
+   6. Author's Address ........................................4
+   7. Full Copyright Statement ................................5
+
+
+
+
+
+
+
+
+
+Klyne                       Standards Track                     [Page 1]
+
+RFC 2738        Corrections to Syntax for Media Features   December 1999
+
+
+1. Introduction
+
+   In RFC 2533, "A Syntax for Describing Media Feature Sets" [1], an
+   expression format is presented for describing media feature
+   capabilities using simple media feature tags.  This provides a format
+   for message handling agents to describe the media feature content of
+   messages that they can handle.  That memo also describes an algorithm
+   for finding the common capabilities expressed by two different
+   feature expressions.
+
+   This memo contains two corrections to that specification:  one fixes
+   an error in the formal syntax specification, and the other fixes an
+   error in the feature set matching algorithm, in the rules for
+   reducing feature comparison predicates.
+
+   The first of these corrections affects the normative content of RFC
+   2533;  the second affects non-normative content.
+
+1.1 Terminology and document conventions
+
+   This specification uses syntax notation and conventions described in
+   RFC 2234, "Augmented BNF for Syntax Specifications: ABNF" [2].
+
+       NOTE:  Comments like this provide additional nonessential
+       information about the rationale behind this document.  Such
+       information is not needed for building a conformant
+       implementation, but may help those who wish to understand the
+       design in greater depth.
+
+1.2 Discussion of this document
+
+   Discussion of this document should take place on the content
+   negotiation and media feature registration mailing list hosted by the
+   Internet Mail Consortium (IMC).
+
+   Please send comments regarding this document to:
+
+       ietf-medfree@imc.org
+
+   To subscribe to this list, send a message with the body 'subscribe'
+   to "ietf-medfree-request@imc.org".
+
+   To see what has gone on before you subscribed, please see the mailing
+   list archive at:
+
+       http://www.imc.org/ietf-medfree/
+
+
+
+
+
+Klyne                       Standards Track                     [Page 2]
+
+RFC 2738        Corrections to Syntax for Media Features   December 1999
+
+
+2. Correction to feature expression syntax
+
+   In section 4.1, RFC 2533 defines the syntax for a "set" expression as
+   follows:
+
+       set        =  attr "=" "[" setentry *( "," setentry ) "]"
+       setentry   =  value "/" range
+
+   The production for 'setentry' should read:
+
+       setentry   =  value / range
+
+   That is: the '/' character is not a character literal, but separates
+   two alternative forms for 'setentry'.  This corrected syntax allows
+   the set expression examples given in section 4.2.5 of RFC 2533, such
+   as:
+
+       ( width=[3,4,6..17/2] )
+
+3. Correction to feature set matching reduction rules
+
+   In section 5.8.2, "Rules for simplifying unordered values", RFC 2533
+   lists the following rewriting rules for simplifying feature tag
+   comparisons with unordered values:
+
+      (LE f a)  (LE f b)      -->  (LE f a),   a=b
+                                   FALSE,      otherwise
+      (LE f a)  (GE f b)      -->  FALSE,      a!=b
+      (LE f a)  (NL f b)      -->  (LE f a)    a!=b
+                                   FALSE,      otherwise
+      (LE f a)  (NG f b)      -->  (LE f a),   a!=b
+                                   FALSE,      otherwise
+
+   The second of these rules is incomplete, and should read:
+
+      (LE f a)  (GE f b)      -->  (LE f a),   a=b
+                                   FALSE,      otherwise
+
+        NOTE:  implementation experience with these rules has
+        suggested a revised feaure set matching algorithm with a
+        more useful set of simplification rules.  Apart from the
+        change noted above, the algorithm given in RFC 2533 has
+        been implemented and shown to work as intended, but the
+        results generated are not always in the most convenient
+        form.  It is planned to test and publish a revised
+        algorithm at a future date.
+
+
+
+
+
+Klyne                       Standards Track                     [Page 3]
+
+RFC 2738        Corrections to Syntax for Media Features   December 1999
+
+
+4. Security Considerations
+
+   Security considerations are discussed in RFC 2533 [1] and related
+   documents.
+
+5. References
+
+   [1]  Klyne, G., "A Syntax for Describing Media Feature Sets", RFC
+        2533, March 1999.
+
+   [2]  Crocker, D. and P. Overell, "Augmented BNF for Syntax
+        Specifications: ABNF", RFC 2234, November 1997.
+
+6. Author's Address
+
+   Graham Klyne
+   Content Technologies Ltd.
+   1220 Parkview
+   Arlington Business Park
+   Theale
+   Reading, RG7 4SA
+   United Kingdom
+
+   Phone: +44 118 930 1300
+   Fax:   +44 118 930 1301
+   EMail: GK@ACM.ORG
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Klyne                       Standards Track                     [Page 4]
+
+RFC 2738        Corrections to Syntax for Media Features   December 1999
+
+
+7.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (1999).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Klyne                       Standards Track                     [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2738.txt](<www.ietf.org/rfc/rfc2738.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
