### PR TITLE
Archive rfc2758.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2758.txt
+++ b/www.ietf.org/rfc/rfc2758.txt
@@ -1,0 +1,3979 @@
+
+
+
+
+
+
+Network Working Group                                            K. White
+Request for Comments: 2758                                      IBM Corp.
+Category: Experimental                                      February 2000
+
+
+           Definitions of Managed Objects for Service Level
+                   Agreements Performance Monitoring
+
+Status of this Memo
+
+   This memo defines an Experimental Protocol for the Internet
+   community.  It does not specify an Internet standard of any kind.
+   Discussion and suggestions for improvement are requested.
+   Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2000).  All Rights Reserved.
+
+Abstract
+
+   This memo defines a Management Information Base (MIB) for performance
+   monitoring of Service Level Agreements (SLAs) defined via policy
+   definitions.  The MIB defined herein focuses on defining a set of
+   objects for monitoring SLAs and not on replication of the content of
+   the policy definitions being monitored.  The goal of the MIB defined
+   within this document is to defined statistics related to a policy
+   rule definition for reporting on the effect that a policy rule has on
+   a system and to defined a method of monitoring this data.
+
+Table of Contents
+
+   1.0  Introduction  . . . . . . . . . . . . . . . . . . . . . . .   2
+   2.0  The SNMP Network Management Framework   . . . . . . . . . .   2
+   3.0  Structure of the MIB  . . . . . . . . . . . . . . . . . . .   3
+   3.1  Scalar objects  . . . . . . . . . . . . . . . . . . . . . .   4
+   3.2  slapmPolicyNameTable  . . . . . . . . . . . . . . . . . . .   5
+   3.3  slapmPolicyRuleStatsTable   . . . . . . . . . . . . . . . .   6
+   3.4  slapmPRMonTable   . . . . . . . . . . . . . . . . . . . . .   6
+   3.5  slapmSubcomponentTable  . . . . . . . . . . . . . . . . . .   8
+   4.0  Definitions   . . . . . . . . . . . . . . . . . . . . . . .   8
+   5.0  Security Considerations   . . . . . . . . . . . . . . . . .  67
+   6.0  Intellectual Property   . . . . . . . . . . . . . . . . . .  67
+   7.0  Acknowledgments   . . . . . . . . . . . . . . . . . . . . .  68
+   8.0  References  . . . . . . . . . . . . . . . . . . . . . . . .  68
+   9.0  Author's Address  . . . . . . . . . . . . . . . . . . . . .  70
+   10.0  Full Copyright Statement   . . . . . . . . . . . . . . . .  71
+
+
+
+
+White                         Experimental                      [Page 1]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+1.0  Introduction
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119, reference
+   [13].
+
+   This document's purpose is to define a MIB module for performance
+   management of Service Level Agreements (SLAs).  It is assumed that an
+   SLA is defined via policy schema definitions.  The policy definitions
+   being modeled with respect to performance management is primarily
+   related to network Quality of Service (QOS).  There are a number of
+   methods that exist for defining and administering policy.  Definition
+   of these methods is considered out side of the scope of this
+   document.
+
+   The MIB module defined within this memo has been modeled using the
+   various versions of the schema definitions being developed within the
+   Policy Framework Working Group in the IETF.  The content of the MIB
+   defined within this memo has evolved along with the Policy Framework
+   Working Group schema definitions.
+
+2.0  The SNMP Network Management Framework
+
+   The SNMP Management Framework presently consists of five major
+   components:
+
+   o  An overall architecture, described in RFC 2571 [7].
+
+   o  Mechanisms for describing and naming objects and events for the
+      purpose of management.  The first version of this Structure of
+      Management Information (SMI) is called SMIv1 and described in STD
+      16, RFC 1155 [14], STD 16, RFC 1212 [15] and RFC 1215 [16].  The
+      second version, called SMIv2, is described in STD 58, RFC 2578
+      [3], STD 58, RFC 2579 [4] and STD 58, RFC 2580 [5].
+
+   o  Message protocols for transferring management information.  The
+      first version of the SNMP message protocol is called SNMPv1 and
+      described in STD 15, RFC 1157 [1].  A second version of the SNMP
+      message protocol, which is not an Internet standards track
+      protocol, is called SNMPv2c and described in RFC 1901 [17] and RFC
+      1906 [18].  The third version of the message protocol is called
+      SNMPv3 and described in RFC 1906 [18], RFC 2572 [8] and RFC 2574
+      [10].
+
+   o  Protocol operations for accessing management information.  The
+      first set of protocol operations and associated PDU formats is
+      described in STD 15, RFC 1157 [1].  A second set of protocol
+
+
+
+White                         Experimental                      [Page 2]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+      operations and associated PDU formats is described in RFC 1905
+      [6].
+
+   o  A set of fundamental applications described in RFC 2573 [9] and
+      the view-based access control mechanism described in RFC 2575
+      [11].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  Objects in the MIB are
+   defined using the mechanisms defined in the SMI.
+
+   This memo specifies a MIB module that is compliant to the SMIv2.  A
+   MIB conforming to the SMIv1 can be produced through the appropriate
+   translations.  The resulting translated MIB must be semantically
+   equivalent, except where objects or events are omitted because no
+   translation is possible (use of Counter64).  Some machine readable
+   information in SMIv2 will be converted into textual descriptions in
+   SMIv1 during the translation process.  However, this loss of machine
+   readable information is not considered to change the semantics of the
+   MIB.
+
+3.0  Structure of the MIB
+
+   The SLAPM-MIB consists of the following components:
+
+   o  scalar objects
+
+   o  slapmPolicyNameTable
+
+   o  slapmPolicyRuleStatsTable (equivalent to the deprecated
+      slapmPolicyStatsTable)
+
+   o  slapmPRMonTable (equivalent to the deprecated
+      slapmPolicyMonitorTable)
+
+   o  slapmSubcomponentTable
+
+   Refer to the compliance statement defined within SLAPM-MIB for a
+   definition of what objects and notifications MUST be implemented by
+   all systems as opposed to those that MUST be implemented by end
+   systems only.
+
+   Initially most of the tables defined by the MIB module within this
+   document where directly indexed using a policy's name and a
+   subordinate traffic profile name.  Over time the structure and
+   resulting naming has grown more complex and as such has exceeded the
+   capacity of being used as a direct MIB table index.  As a result of
+   this the original tables (slapmPolicyStatsTable and
+
+
+
+White                         Experimental                      [Page 3]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+   slapmPolicyMonitorTable) have been deprecated and replaced with new
+   tables that use an Unsigned32 index element instead of "names".  A
+   new table has been defined, slapmPolicyNameTable, that maps the
+   Unsigned32 index to a unique name associated with a given policy rule
+   definition.
+
+3.1  Scalar objects
+
+   Global objects defined within SLAPM-MIB:
+
+   o  slapmSpinLock
+
+      Enables multiple management application access to SLAPM-MIB.  An
+      agent MUST implement the slapmSpinLock object to enable management
+      applications to coordinate their use of the SLAPM-MIB.  Management
+      application use of slapmSpinLock is OPTIONAL.
+
+   o  slapmPolicyCountQueries, slapmPolicyCountAccesses,
+      slapmPolicyCountSuccessAccesses, and slapmPolicyCountNotFounds
+
+      Basic statistics on the amount of policy directory access that has
+      occurred at a system.
+
+   o  slapmPolicyPurgeTime
+
+      Used to prevent the entries in various SLAPM-MIB tables that
+      relate to a policy definition from immediately being deleted when
+      the corresponding policy definition no longer exists.  This gives
+      management applications time to discover this condition and close
+      out any polled based interval data that may be being collected.
+      All dependent slapmPRMonTable entries are also deleted when its
+      parent slapmPolicyRuleStatsEntry is removed.  Refer to the OBJECT
+      description for slapmPolicyPurgeTime for a more precise
+      description of this function.
+
+   o  slapmPolicyTrapEnable
+
+      This object enables or suppresses generation of
+      slapmPolicyRuleDeleted or slapmPolicyRuleMonDeleted notifications.
+
+   o  slapmPolicyTrapFilter
+
+      This object enables suppression of slapmSubcMonitorNotOkay
+      notifications.
+
+
+
+
+
+
+
+White                         Experimental                      [Page 4]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+3.2  slapmPolicyNameTable
+
+   The slapmPolicyNameTable maps a Unsigned32 index to a unique name
+   associated with a given policy rule definition.
+
+   Currently, the core schema definition being worked on within the
+   Policy Framework working group defines five general classes:
+   policyGroup, policyRule, policyCondition, policyTimePeriodCondition,
+   and policyAction.  "Policies can either be used in a stand-alone
+   fashion or aggregated into policy groups to perform more elaborate
+   functions.  Stand-alone policies are called policy rules.  Policy
+   groups are aggregations of policy rules, or aggregations of policy
+   groups, but not both."  Each policy rule consists of a set of
+   conditions and a set of actions.  Policy rules may be aggregated into
+   policy groups.
+
+   "Instances in a directory are identified by distinguished names
+   (DNs), which provide the same type of hierarchical organization that
+   a file system provides in a computer system.  A distinguished name is
+   a sequence of relative distinguished names (RDNs), where an RDN
+   provides a unique identifier for an instance within the context of
+   its immediate superior, in the same way that a filename provides a
+   unique identifier for a file within the context of the folder in
+   which it resides."
+
+   Each of these instances can also be named to fit in with the existing
+   DEN practice with a commonName (cn) attribute as oppose to the
+   classes name attribute.
+
+   "The cn, or commonName, attribute is an X.500 attribute.  It stands
+   for commonName.  It specifies a user-friendly name by which the
+   object is commonly known.  This name may be ambiguous by itself.
+   This name is used in a limited scope (such as an organization).  It
+   conforms to the naming conventions of the country or culture with
+   which it is associated.  CN is used universally in DEN as the naming
+   attribute for a class."
+
+   An slapmPolicyNameEntry contains a single object,
+   slapmPolicyNameOfRule, that contains the unique name associated with
+   a policy rule instance.  An slapmPolicyNameEntry is indexed by a
+   Unsigned32 index, slapmPolicyNameIndex, that is assigned by the
+   implementation of this MIB.
+
+
+
+
+
+
+
+
+
+White                         Experimental                      [Page 5]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+3.3  slapmPolicyRuleStatsTable
+
+   This table is functionally equivalent to the deprecated
+   slapmPolicyStatsTable. The slapmPolicyStatsTable uses the name of
+   both a policy definition and a traffic profile name to index an
+   entry.  The slapmPolicyRuleStatsTable uses an slapmPolicyNameEntry
+   index (Unsigned32) instead.
+
+   The slapmPolicyRuleStatsTable is the main table defined by SLAPM-MIB.
+   The primary index for this table is slapmPolicyNameSystemAddress that
+   enables support of multiple systems from a single policy agent.  The
+   index element, slapmPolicyNameSystemAddress, value must be either the
+   zero-length octet string when at a policy agent only a single system
+   is being support, 4 octets for a ipv4 address, or 16 octets for a
+   ipv6 address.
+
+   It is possible that on a single system multiple policy agent
+   instances exists.  The Entity MIB, refer to [19], should be used to
+   handle the resulting MIBs.
+
+   With respect to slapmPolicyNameSystemAddress one
+   slapmPolicyRuleStatsEntry exists for each policy rule instance.
+   Entries in this table are not administered via SNMP.  An agent
+   implementation for this table MUST reflect its current set of policy
+   rule instances via table entries.  The mechanisms for policy
+   administration are outside of the scope of this memo.
+
+3.4  slapmPRMonTable
+
+   This table is functionally equivalent to the deprecated
+   slapmPolicyMonitorTable. The slapmPolicyMonitorTable uses the name of
+   both a policy definition and a traffic profile name to index an
+   entry.  The slapmPRMonTable uses an slapmPolicyNameEntry index
+   (Unsigned32) instead.
+
+   The slapmPRMonTable provides a method of monitoring the effect of SLA
+   policy being used at a system.  A management application creates an
+   slapmPRMonEntry for each collection that it requires.  The value of
+   the BITS slapmPRMonControl object determines what type of monitoring
+   occurs, at what level to monitor and whether trap support is enabled:
+
+   o  monitorMinRate(0)
+
+      Use the value of slapmPRMonInterval as the interval to determine
+      current traffic in and out rates, using slapmPRMonCurrentInRate
+      and slapmPRMonCurrentOutRate, that can be compared to
+      slapmPRMonMinRateLow for determining when to generate a
+      slapmPolicyRuleMonNotOkay notification.  The notification
+
+
+
+White                         Experimental                      [Page 6]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+      slapmPolicyRuleMonOkay is generated when the problem is resolved.
+      This can be determined by comparing the current rates to
+      slapmPRMonMinRateHigh.
+
+   o  monitorMaxRate(1)
+
+      Use the value of slapmPRMonInterval as the interval to determine
+      current traffic in and out rate, using slapmPRMonCurrentInRate and
+      slapmPRMonCurrentOutRate, that can be compared to
+      slapmPRMonMaxRateHigh for determining when to generate a
+      slapmPolicyRuleMonNotOkay notification. The notification
+      slapmPolicyRuleMonOkay is generated when the problem is resolved.
+      This can be determined by comparing the current rates to
+      slapmPRMonMaxRateLow.
+
+   o  monitorMaxDelay(2)
+
+      Use the value of slapmPRMonInterval as the interval to determine
+      the current delay.  This can be calculated on an aggregate level
+      by averaging the round trip times for all TCP connections
+      associated with the policy definition.  For an individual
+      subcomponent its round trip time can be used directly.  Compare
+      this value to slapmPRMonMaxDelayHigh for determining when to
+      generate a slapmPolicyRuleMonNotOkay notification.  The
+      notification slapmPolicyRuleMonOkay is generated when the problem
+      is resolved.  This can be determined by comparing the current
+      rates to slapmPRMonMaxDelayLow.
+
+      UDP subcomponents don't support max delay monitoring.
+
+   o  enableAggregateTraps(3)
+
+      The slapmPRMonitorControl BITS setting, enableAggregateTraps(3),
+      MUST be set in order for any notifications relating to
+      slapmPolicyRuleStatsTable monitoring to be generated.
+
+   o  enableSubcomponentTraps(4)
+
+      This slapmPRMonControl BITS setting MUST be set in order for any
+      notifications relating to slapmSubcomponetTable monitoring to be
+      generated.  The slapmPRMonControl BITS setting
+      monitorSubcomponents(5) MUST be selected in order for this setting
+      to be allowed.
+
+   o  monitorSubcomponents(5)
+
+      If selected monitor slapmSubcomponentTable entries individually.
+      Note: aggregate policy rule monitoring is always enabled.
+
+
+
+White                         Experimental                      [Page 7]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+   The index element slapmPRMonOwnerIndex is used as the first index in
+   slapmPRMonTable in order to enable SNMP VACM security control.  The
+   slapmPRMonTable is the only table that supports SNMP RowStatus
+   operations.
+
+3.5  slapmSubcomponentTable
+
+   Entries are made into this table for the protocol entities (policy
+   traffic profile subcomponents) to indicate actual policy rule usage,
+   provide general statistics at either a TCP connection or UDP listener
+   level, and enable subcomponent monitoring.
+
+4.0  Definitions
+
+SLAPM-MIB DEFINITIONS ::= BEGIN
+
+   IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE,
+      experimental, Integer32, NOTIFICATION-TYPE,
+      Gauge32, Counter32, Unsigned32
+          FROM SNMPv2-SMI                  -- RFC2578
+      TEXTUAL-CONVENTION, RowStatus,
+      TestAndIncr, DateAndTime
+          FROM SNMPv2-TC                   -- RFC2579
+      MODULE-COMPLIANCE, OBJECT-GROUP,
+      NOTIFICATION-GROUP
+          FROM SNMPv2-CONF                 -- RFC2580
+      SnmpAdminString
+          FROM SNMP-FRAMEWORK-MIB;         -- RFC2571
+
+   slapmMIB MODULE-IDENTITY
+      LAST-UPDATED "200001240000Z"          -- 24 January 2000
+      ORGANIZATION "International Business Machines Corp."
+      CONTACT-INFO
+          "Kenneth White
+
+          International Business Machines Corporation
+          Network Computing Software Division
+          Research Triangle Park, NC, USA
+
+          E-mail: wkenneth@us.ibm.com"
+      DESCRIPTION
+          "The Service Level Agreement Performance Monitoring MIB
+          (SLAPM-MIB) provides data collection and monitoring
+          capabilities for Service Level Agreements (SLAs)
+          policy definitions."
+
+      --  Revision history
+
+
+
+White                         Experimental                      [Page 8]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+      REVISION     "200001240000Z"         -- 24 January 2000
+      DESCRIPTION
+          "This version published as RFC 2758."
+
+      ::= { experimental 88 }
+
+   -- Textual Conventions
+
+   SlapmNameType ::= TEXTUAL-CONVENTION
+      STATUS  deprecated
+      DESCRIPTION
+          "The textual convention for naming entities
+          within this MIB.  The actual contents of an object
+          defined using this textual convention should consist
+          of the distinguished name portion of an name.
+          This is usually the right-most
+          portion of the name.  This convention is necessary,
+          since names within this MIB can be used as index
+          items and an instance identifier is limited to 128
+          subidentifiers.
+
+          This textual convention has been deprecated.  All of the
+          tables defined within this MIB that use this textual
+          convention have been deprecated as well since the method
+          of using a portion of the name (either of a policy
+          definition or of a traffic profile) has been replaced
+          by using an Unsigned32 index.  The new slapmPolicyNameTable
+          would then map the Unsigned32 index to a real name."
+      SYNTAX  SnmpAdminString (SIZE(0..32))
+
+   SlapmStatus ::= TEXTUAL-CONVENTION
+      STATUS  current
+      DESCRIPTION
+          "The textual convention for defining the various
+          slapmPRMonTable (or old slapmPolicyMonitorTable)
+          and the slapmSubcomponentTable states for actual policy
+          rule traffic monitoring."
+      SYNTAX  BITS {
+                     slaMinInRateNotAchieved(0),
+                     slaMaxInRateExceeded(1),
+                     slaMaxDelayExceeded(2),
+                     slaMinOutRateNotAchieved(3),
+                     slaMaxOutRateExceeded(4),
+                     monitorMinInRateNotAchieved(5),
+                     monitorMaxInRateExceeded(6),
+                     monitorMaxDelayExceeded(7),
+                     monitorMinOutRateNotAchieved(8),
+                     monitorMaxOutRateExceeded(9)
+
+
+
+White                         Experimental                      [Page 9]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+                   }
+
+   SlapmPolicyRuleName ::= TEXTUAL-CONVENTION
+      DISPLAY-HINT "1024t"
+      STATUS  current
+      DESCRIPTION
+          "To facilitate internationalization, this TC
+          represents information taken from the ISO/IEC IS
+          10646-1 character set, encoded as an octet string
+          using the UTF-8 character encoding scheme described
+          in RFC 2044.   For strings in 7-bit US-ASCII,
+          there is no impact since the UTF-8 representation
+          is identical to the US-ASCII encoding."
+      SYNTAX  OCTET STRING (SIZE (0..1024))
+
+   -- Top-level structure of the MIB
+
+   slapmNotifications  OBJECT IDENTIFIER ::= { slapmMIB 0 }
+   slapmObjects        OBJECT IDENTIFIER ::= { slapmMIB 1 }
+   slapmConformance    OBJECT IDENTIFIER ::= { slapmMIB 2 }
+
+   -- All scalar objects
+
+   slapmBaseObjects    OBJECT IDENTIFIER ::= { slapmObjects 1 }
+
+   -- Scalar Object Definitions
+
+   slapmSpinLock OBJECT-TYPE
+      SYNTAX      TestAndIncr
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "An advisory lock used to allow cooperating applications
+         to coordinate their use of the contents of this MIB.  This
+         typically occurs when an application seeks to create an
+         new entry or alter an existing entry in
+         slapmPRMonTable (or old slapmPolicyMonitorTable).  A
+         management implementation MAY utilize the slapmSpinLock to
+         serialize its changes or additions.  This usage is not
+         required.   However, slapmSpinLock MUST be supported by
+         agent implementations."
+     ::= { slapmBaseObjects 1 }
+
+   slapmPolicyCountQueries OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+
+
+
+White                         Experimental                     [Page 10]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+         "The total number of times that a policy lookup occurred
+         with respect to a policy agent.
+         This is the number of times that a reference was made to
+         a policy definition at a system and includes the number
+         of times that a policy repository was accessed,
+         slapmPolicyCountAccesses.  The object
+         slapmPolicyCountAccesses should be less than
+         slapmPolicyCountQueries when policy definitions are
+         cached at a system."
+      ::= { slapmBaseObjects 2 }
+
+   slapmPolicyCountAccesses OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "Total number of times that a policy repository was
+          accessed with respect to a policy agent.
+          The value of this object should be less than
+          slapmPolicyCountQueries, since typically policy entries
+          are cached to minimize repository accesses."
+      ::= { slapmBaseObjects 3 }
+
+   slapmPolicyCountSuccessAccesses OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "Total number of successful policy repository accesses
+         with respect to a policy agent."
+      ::= { slapmBaseObjects 4 }
+
+   slapmPolicyCountNotFounds OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "Total number of policy repository accesses,
+         with respect to a policy agent, that
+         resulted in an entry not being located."
+      ::= { slapmBaseObjects 5 }
+
+   slapmPolicyPurgeTime OBJECT-TYPE
+      SYNTAX      Integer32 (0..3600)  -- maximum of 1 hour
+      UNITS       "seconds"
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+
+
+
+White                         Experimental                     [Page 11]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+         "The purpose of this object is to define the amount
+         of time (in seconds) to wait before removing an
+         slapmPolicyRuleStatsEntry (or old slapmPolicyStatsEntry)
+         when a system detects that the associated policy
+         definition has been deleted.  This gives any polling
+         management applications time to complete their last poll
+         before an entry is removed.  An slapmPolicyRuleStatsEntry
+         (or old slapmPolicyStatsEntry) enters the
+         deleteNeeded(3) state via slapmPolicyRuleStatsOperStatus
+         (or old slapmPolicyStatsOperStatus) when a system first
+         detects that the entry needs to be removed.
+
+         Once slapmPolicyPurgeTime has expired for an entry in
+         deleteNeeded(3) state it is removed a long with any
+         dependent slapmPRMonTable (or slapmPolicyMonitorTable)
+         entries.
+
+         A value of 0 for this option disables this function and
+         results in the automatic purging of slapmPRMonTable
+         (or slapmPolicyTable) entries upon transition into
+         deleteNeeded(3) state.
+
+         A slapmPolicyRuleDeleted (or slapmPolicyProfileDeleted)
+         notification is sent when an slapmPolicyRuleStatsEntry (or
+         slapmPolicyStatsEntry) is removed.  Dependent
+         slapmPRMonTable (or slapmPolicyMonitorTable)
+         deletion results in a slapmPolicyRuleMonDeleted (or
+         slapmPolicyMonitorDeleted) notification being sent.
+         These notifications are suppressed if the value of
+         slapmPolicyTrapEnable is disabled(2)."
+      DEFVAL { 900 }  -- 15 minute default purge time
+      ::= { slapmBaseObjects 6 }
+
+   slapmPolicyTrapEnable OBJECT-TYPE
+      SYNTAX      INTEGER { enabled(1), disabled(2) }
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "Indicates whether slapmPolicyRuleDeleted and
+         slapmPolicyRuleMonDeleted (or slapmPolicyProfileDeleted
+         and slapmPolicyMonitorDeleted) notifications should be
+         generated by this system."
+      DEFVAL { disabled }
+      ::= { slapmBaseObjects 7 }
+
+   slapmPolicyTrapFilter   OBJECT-TYPE
+      SYNTAX      Integer32 (0..64)
+      UNITS       "intervals"
+
+
+
+White                         Experimental                     [Page 12]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "The purpose of this object is to suppress unnecessary
+         slapmSubcMonitorNotOkay (or
+         slapmSubcomponentMonitoredEventNotAchieved), for example,
+         notifications.  Basically, a monitored event has to
+         not meet its SLA requirement for the number of
+         consecutive intervals indicated by the value of this
+         object."
+      DEFVAL { 3 }
+      ::= { slapmBaseObjects 8 }
+
+   slapmTableObjects    OBJECT IDENTIFIER ::= { slapmObjects 2 }
+
+   -- Sla Performance Monitoring Policy Statistics Table
+
+   slapmPolicyStatsTable OBJECT-TYPE
+      SYNTAX SEQUENCE OF SlapmPolicyStatsEntry
+      MAX-ACCESS not-accessible
+      STATUS deprecated
+      DESCRIPTION
+          "Provides statistics on all policies known at a
+          system.
+
+          This table has been deprecated and replaced with
+          the slapmPolicyRuleStatsTable.  Older implementations of
+          this MIB are expected to continue their support of this
+          table."
+     ::= { slapmTableObjects 1 }
+
+   slapmPolicyStatsEntry OBJECT-TYPE
+      SYNTAX SlapmPolicyStatsEntry
+      MAX-ACCESS not-accessible
+      STATUS deprecated
+      DESCRIPTION
+          "Defines an entry in the slapmPolicyStatsTable.  This table
+          defines a set of statistics that is kept on a per system,
+          policy and traffic profile basis.  A policy can be
+          defined to contain multiple traffic profiles that map to
+          a single action.
+
+          Entries in this table are not created or deleted via SNMP
+          but reflect the set of policy definitions known at a system."
+      INDEX {
+             slapmPolicyStatsSystemAddress,
+             slapmPolicyStatsPolicyName,
+             slapmPolicyStatsTrafficProfileName
+
+
+
+White                         Experimental                     [Page 13]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+            }
+      ::= { slapmPolicyStatsTable 1 }
+
+   SlapmPolicyStatsEntry ::=
+      SEQUENCE {
+          slapmPolicyStatsSystemAddress      OCTET STRING,
+          slapmPolicyStatsPolicyName         SlapmNameType,
+          slapmPolicyStatsTrafficProfileName SlapmNameType,
+          slapmPolicyStatsOperStatus         INTEGER,
+          slapmPolicyStatsActiveConns        Gauge32,
+          slapmPolicyStatsTotalConns         Counter32,
+          slapmPolicyStatsFirstActivated     DateAndTime,
+          slapmPolicyStatsLastMapping        DateAndTime,
+          slapmPolicyStatsInOctets           Counter32,
+          slapmPolicyStatsOutOctets          Counter32,
+          slapmPolicyStatsConnectionLimit    Integer32,
+          slapmPolicyStatsCountAccepts       Counter32,
+          slapmPolicyStatsCountDenies        Counter32,
+          slapmPolicyStatsInDiscards         Counter32,
+          slapmPolicyStatsOutDiscards        Counter32,
+          slapmPolicyStatsInPackets          Counter32,
+          slapmPolicyStatsOutPackets         Counter32,
+          slapmPolicyStatsInProfileOctets    Counter32,
+          slapmPolicyStatsOutProfileOctets   Counter32,
+          slapmPolicyStatsMinRate            Integer32,
+          slapmPolicyStatsMaxRate            Integer32,
+          slapmPolicyStatsMaxDelay           Integer32
+      }
+
+   slapmPolicyStatsSystemAddress OBJECT-TYPE
+      SYNTAX      OCTET STRING (SIZE(0 | 4 | 16))
+      MAX-ACCESS  not-accessible
+      STATUS      deprecated
+      DESCRIPTION
+         "Address of a system that an Policy definition relates to.
+         A zero length octet string must be used to indicate that
+         only a single system is being represented.
+         Otherwise, the length of the octet string must be
+         4 for an ipv4 address or 16 for an ipv6 address."
+      ::= { slapmPolicyStatsEntry 1 }
+
+   slapmPolicyStatsPolicyName OBJECT-TYPE
+      SYNTAX      SlapmNameType
+      MAX-ACCESS  not-accessible
+      STATUS      deprecated
+      DESCRIPTION
+         "Policy name that this entry relates to."
+      ::= { slapmPolicyStatsEntry 2 }
+
+
+
+White                         Experimental                     [Page 14]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+   slapmPolicyStatsTrafficProfileName OBJECT-TYPE
+      SYNTAX      SlapmNameType
+      MAX-ACCESS  not-accessible
+      STATUS      deprecated
+      DESCRIPTION
+         "The name of a traffic profile that is associated with
+         a policy."
+      ::= { slapmPolicyStatsEntry 3 }
+
+   slapmPolicyStatsOperStatus OBJECT-TYPE
+      SYNTAX      INTEGER {
+                             inactive(1),
+                             active(2),
+                             deleteNeeded(3)
+                          }
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+         "The state of a policy entry:
+
+           inactive(1)      - An policy entry was either defined
+                              by local system definition or
+                              discovered via a directory search
+                              but has not been activated (not
+                              currently being used).
+           active(2)        - Policy entry is being used to affect
+                              traffic flows.
+           deleteNeeded(3)  - Either though local implementation
+                              dependent methods or by discovering
+                              that the directory entry corresponding
+                              to this table entry no longer
+                              exists and slapmPolicyPurgeTime needs
+                              to expire before attempting to remove
+                              the corresponding slapmPolicyStatsEntry
+                              and any dependent slapmPolicyMonitor
+                              table entries.
+         Note: a policy traffic profile in a state other than
+         active(1) is not being used to affect traffic flows."
+      ::= { slapmPolicyStatsEntry 4 }
+
+   slapmPolicyStatsActiveConns OBJECT-TYPE
+      SYNTAX      Gauge32
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+         "The number of active TCP connections that are
+         affected by the corresponding policy entry."
+      ::= { slapmPolicyStatsEntry 5 }
+
+
+
+White                         Experimental                     [Page 15]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+   slapmPolicyStatsTotalConns OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+         "The number of total TCP connections that are
+         affected by the corresponding policy entry."
+      ::= { slapmPolicyStatsEntry 6 }
+
+   slapmPolicyStatsFirstActivated OBJECT-TYPE
+      SYNTAX      DateAndTime
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+         "The timestamp for when the corresponding policy entry
+         is activated.  The value of this object serves as
+         the discontinuity event indicator when polling entries
+         in this table.  The value of this object is updated on
+         transition of slapmPolicyStatsOperStatus into the active(2)
+         state."
+      DEFVAL { '0000000000000000'H }
+      ::= { slapmPolicyStatsEntry 7 }
+
+   slapmPolicyStatsLastMapping OBJECT-TYPE
+      SYNTAX      DateAndTime
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+         "The timestamp for when the last time
+         that the associated policy entry was used."
+      DEFVAL { '0000000000000000'H }
+      ::= { slapmPolicyStatsEntry 8 }
+
+   slapmPolicyStatsInOctets OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+         "The number of octets that was received by IP for an
+         entity that map to this entry."
+      ::= { slapmPolicyStatsEntry 9 }
+
+   slapmPolicyStatsOutOctets OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+         "The number of octets that was transmitted by IP for an
+
+
+
+White                         Experimental                     [Page 16]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+         entity that map to this entry."
+      ::= { slapmPolicyStatsEntry 10 }
+
+   slapmPolicyStatsConnectionLimit OBJECT-TYPE
+      SYNTAX      Integer32
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+         "The limit for the number of active TCP connections that
+         are allowed for this policy definition.  A value of zero
+         for this object implies that a connection limit has not
+         been specified."
+      ::= { slapmPolicyStatsEntry 11 }
+
+   slapmPolicyStatsCountAccepts OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+          "This counter is incremented when a policy action's
+          Permission value is set to Accept and a session
+          (TCP connection) is accepted."
+      ::= { slapmPolicyStatsEntry 12 }
+
+   slapmPolicyStatsCountDenies OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+          "This counter is incremented when a policy action's
+          Permission value is set to Deny and a session is denied,
+          or when a session (TCP connection) is rejected due to a
+          policy's connection limit (slapmPolicyStatsConnectLimit)
+          being reached."
+      ::= { slapmPolicyStatsEntry 13 }
+
+   slapmPolicyStatsInDiscards OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+          "This counter counts the number of in octets discarded.
+          This occurs when an error is detected.  Examples of this
+          are buffer overflow, checksum error, or bad packet
+          format."
+      ::= { slapmPolicyStatsEntry 14 }
+
+   slapmPolicyStatsOutDiscards OBJECT-TYPE
+
+
+
+White                         Experimental                     [Page 17]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+          "This counter counts the number of out octets discarded.
+          Examples of this are buffer overflow, checksum error, or
+          bad packet format."
+      ::= { slapmPolicyStatsEntry 15 }
+
+   slapmPolicyStatsInPackets OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+          "This counter counts the number of in packets received
+          that relate to this policy entry from IP."
+      ::= { slapmPolicyStatsEntry 16 }
+
+   slapmPolicyStatsOutPackets OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+          "This counter counts the number of out packets sent
+          by IP that relate to this policy entry."
+      ::= { slapmPolicyStatsEntry 17 }
+
+   slapmPolicyStatsInProfileOctets OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+          "This counter counts the number of in octets that are
+          determined to be within profile."
+      ::= { slapmPolicyStatsEntry 18 }
+
+   slapmPolicyStatsOutProfileOctets OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+          "This counter counts the number of out octets that are
+          determined to be within profile."
+      ::= { slapmPolicyStatsEntry 19 }
+
+   slapmPolicyStatsMinRate OBJECT-TYPE
+      SYNTAX      Integer32
+      UNITS       "Kilobits per second"
+
+
+
+White                         Experimental                     [Page 18]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+          "The minimum transfer rate defined for this entry."
+      ::= { slapmPolicyStatsEntry 20 }
+
+   slapmPolicyStatsMaxRate OBJECT-TYPE
+      SYNTAX      Integer32
+      UNITS       "Kilobits per second"
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+          "The maximum transfer rate defined for this entry."
+      ::= { slapmPolicyStatsEntry 21 }
+
+   slapmPolicyStatsMaxDelay OBJECT-TYPE
+      SYNTAX      Integer32
+      UNITS       "milliseconds"
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+          "The maximum delay defined for this entry."
+      ::= { slapmPolicyStatsEntry 22 }
+
+   -- SLA Performance Monitoring Policy Monitor Table
+
+   slapmPolicyMonitorTable OBJECT-TYPE
+      SYNTAX SEQUENCE OF SlapmPolicyMonitorEntry
+      MAX-ACCESS not-accessible
+      STATUS     deprecated
+      DESCRIPTION
+          "Provides a method of monitoring policies and their
+          effect at a system.
+
+          This table has been deprecated and replaced with
+          the slapmPRMonTable.  Older implementations of
+          this MIB are expected to continue their support
+          of this table."
+     ::= { slapmTableObjects 2 }
+
+   slapmPolicyMonitorEntry OBJECT-TYPE
+      SYNTAX     SlapmPolicyMonitorEntry
+      MAX-ACCESS not-accessible
+      STATUS     deprecated
+      DESCRIPTION
+          "Defines an entry in the slapmPolicyMonitorTable. This
+          table defines which policies should be monitored on a
+          per policy traffic profile basis."
+
+
+
+White                         Experimental                     [Page 19]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+      INDEX {
+             slapmPolicyMonitorOwnerIndex,
+             slapmPolicyMonitorSystemAddress,
+             slapmPolicyMonitorPolicyName,
+             slapmPolicyMonitorTrafficProfileName
+            }
+      ::= { slapmPolicyMonitorTable 1 }
+
+   SlapmPolicyMonitorEntry ::=
+      SEQUENCE {
+          slapmPolicyMonitorOwnerIndex              SnmpAdminString,
+          slapmPolicyMonitorSystemAddress           OCTET STRING,
+          slapmPolicyMonitorPolicyName              SlapmNameType,
+          slapmPolicyMonitorTrafficProfileName      SlapmNameType,
+          slapmPolicyMonitorControl                 BITS,
+          slapmPolicyMonitorStatus                  SlapmStatus,
+          slapmPolicyMonitorInterval                Integer32,
+          slapmPolicyMonitorIntTime                 DateAndTime,
+          slapmPolicyMonitorCurrentInRate           Gauge32,
+          slapmPolicyMonitorCurrentOutRate          Gauge32,
+          slapmPolicyMonitorMinRateLow              Integer32,
+          slapmPolicyMonitorMinRateHigh             Integer32,
+          slapmPolicyMonitorMaxRateHigh             Integer32,
+          slapmPolicyMonitorMaxRateLow              Integer32,
+          slapmPolicyMonitorMaxDelayHigh            Integer32,
+          slapmPolicyMonitorMaxDelayLow             Integer32,
+          slapmPolicyMonitorMinInRateNotAchieves    Counter32,
+          slapmPolicyMonitorMaxInRateExceeds        Counter32,
+          slapmPolicyMonitorMaxDelayExceeds         Counter32,
+          slapmPolicyMonitorMinOutRateNotAchieves   Counter32,
+          slapmPolicyMonitorMaxOutRateExceeds       Counter32,
+          slapmPolicyMonitorCurrentDelayRate        Gauge32,
+          slapmPolicyMonitorRowStatus               RowStatus
+      }
+
+   slapmPolicyMonitorOwnerIndex OBJECT-TYPE
+      SYNTAX      SnmpAdminString (SIZE(0..16))
+      MAX-ACCESS  not-accessible
+      STATUS      deprecated
+      DESCRIPTION
+         "To facilitate the provisioning of access control by a
+         security administrator using the View-Based Access
+         Control Model (RFC 2575, VACM) for tables in which
+         multiple users may need to independently create or modify
+         entries, the initial index is used as an 'owner index'.
+         Such an initial index has a syntax of SnmpAdminString,
+         and can thus be trivially mapped to a securityName or
+         groupName as defined in VACM, in accordance with a
+
+
+
+White                         Experimental                     [Page 20]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+         security policy.
+
+         All entries in that table belonging to a particular user
+         will have the same value for this initial index.  For a
+         given user's entries in a particular table, the object
+         identifiers for the information in these entries will
+         have the same subidentifiers (except for the 'column'
+         subidentifier) up to the end of the encoded owner index.
+         To configure VACM to permit access to this portion of the
+         table, one would create vacmViewTreeFamilyTable entries
+         with the value of vacmViewTreeFamilySubtree including the
+         owner index portion, and vacmViewTreeFamilyMask
+         'wildcarding' the column subidentifier.  More elaborate
+         configurations are possible."
+      ::= { slapmPolicyMonitorEntry 1 }
+
+   slapmPolicyMonitorSystemAddress OBJECT-TYPE
+      SYNTAX      OCTET STRING (SIZE(0 | 4 | 16))
+      MAX-ACCESS  not-accessible
+      STATUS      deprecated
+      DESCRIPTION
+         "Address of a system that an Policy definition relates to.
+         A zero length octet string can be used to indicate that
+         only a single system is being represented.
+         Otherwise, the length of the octet string should be
+         4 for an ipv4 address and 16 for an ipv6 address."
+      ::= { slapmPolicyMonitorEntry 2 }
+
+   slapmPolicyMonitorPolicyName OBJECT-TYPE
+      SYNTAX      SlapmNameType
+      MAX-ACCESS  not-accessible
+      STATUS      deprecated
+      DESCRIPTION
+         "Policy name that this entry relates to."
+      ::= { slapmPolicyMonitorEntry 3 }
+
+   slapmPolicyMonitorTrafficProfileName OBJECT-TYPE
+      SYNTAX      SlapmNameType
+      MAX-ACCESS  not-accessible
+      STATUS      deprecated
+      DESCRIPTION
+         "The corresponding Traffic Profile name."
+      ::= { slapmPolicyMonitorEntry 4 }
+
+   slapmPolicyMonitorControl OBJECT-TYPE
+      SYNTAX      BITS {
+                        monitorMinRate(0),
+                        monitorMaxRate(1),
+
+
+
+White                         Experimental                     [Page 21]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+                        monitorMaxDelay(2),
+                        enableAggregateTraps(3),
+                        enableSubcomponentTraps(4),
+                        monitorSubcomponents(5)
+                       }
+      MAX-ACCESS  read-create
+      STATUS      deprecated
+      DESCRIPTION
+         "The value of this object determines the type and level
+         of monitoring that is applied to a policy/profile.  The
+         value of this object can't be changed once the table
+         entry that it is a part of is activated via a
+         slapmPolicyMonitorRowStatus transition to active state.
+
+             monitorMinRate(0) - Monitor minimum transfer rate.
+             monitorMaxRate(1) - Monitor maximum transfer rate.
+             monitorMaxDelay(2) - Monitor maximum delay.
+             enableAggregateTraps(3) - The enableAggregateTraps(3)
+                   BITS setting enables notification generation
+                   when monitoring a policy traffic profile as an
+                   aggregate using the values in the corresponding
+                   slapmPolicyStatsEntry.  By default this function
+                   is not enabled.
+             enableSubcomponentTraps(4) - This BITS setting enables
+                   notification generation when monitoring all
+                   subcomponents that are mapped to an corresponding
+                   slapmPolicyStatsEntry.  By default this
+                   function is not enabled.
+             monitorSubcomponents(5) - This BITS setting enables
+                   monitoring of each subcomponent (typically a
+                   TCP connection or UDP listener) individually."
+      DEFVAL   { { monitorMinRate, monitorMaxRate,
+                   monitorMaxDelay } }
+      ::= { slapmPolicyMonitorEntry 5 }
+
+   slapmPolicyMonitorStatus OBJECT-TYPE
+      SYNTAX      SlapmStatus
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+         "The value of this object indicates when a monitored
+         value has not meet a threshold or isn't meeting the
+         defined service level.  The SlapmStatus TEXTUAL-CONVENTION
+         defines two levels of not meeting a threshold.  The first
+         set:
+                     slaMinInRateNotAchieved(0),
+                     slaMaxInRateExceeded(1),
+                     slaMaxDelayExceeded(2),
+
+
+
+White                         Experimental                     [Page 22]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+                     slaMinOutRateNotAchieved(3),
+                     slaMaxOutRateExceeded(4)
+
+         are used to indicate when the SLA as an aggregate is
+         not meeting a threshold while the second set:
+
+                     monitorMinInRateNotAchieved(5),
+                     monitorMaxInRateExceeded(6),
+                     monitorMaxDelayExceeded(7),
+                     monitorMinOutRateNotAchieved(8),
+                     monitorMaxOutRateExceeded(9)
+
+         indicate that at least one subcomponent is not meeting
+         a threshold."
+      ::= { slapmPolicyMonitorEntry 6 }
+
+   slapmPolicyMonitorInterval OBJECT-TYPE
+      SYNTAX      Integer32 (15..86400) -- 15 second min, 24 hour max
+      UNITS       "seconds"
+      MAX-ACCESS  read-create
+      STATUS      deprecated
+      DESCRIPTION
+         "The number of seconds that defines the sample period."
+      DEFVAL   {20}    -- 20 seconds
+      ::= { slapmPolicyMonitorEntry 7 }
+
+   slapmPolicyMonitorIntTime OBJECT-TYPE
+      SYNTAX      DateAndTime
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+         "The timestamp for when the last interval ended."
+      DEFVAL { '0000000000000000'H }
+      ::= { slapmPolicyMonitorEntry 8 }
+
+   slapmPolicyMonitorCurrentInRate OBJECT-TYPE
+      SYNTAX      Gauge32
+      UNITS       "kilobits per second"
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+         "Using the value of the corresponding
+         slapmPolicyMonitorInterval, slapmPolicyStatsInOctets
+         is sampled and then divided by slapmPolicyMonitorInterval
+         to determine the current in transfer rate."
+      ::= { slapmPolicyMonitorEntry 9 }
+
+   slapmPolicyMonitorCurrentOutRate OBJECT-TYPE
+
+
+
+White                         Experimental                     [Page 23]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+      SYNTAX      Gauge32
+      UNITS       "kilobits per second"
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+         "Using the value of the corresponding
+         slapmPolicyMonitorInterval, slapmPolicyStatsOutOctets
+         is sampled and then divided by slapmPolicyMonitorInterval
+         to determine the current out transfer rate."
+      ::= { slapmPolicyMonitorEntry 10 }
+
+   slapmPolicyMonitorMinRateLow OBJECT-TYPE
+      SYNTAX      Integer32
+      UNITS       "kilobits per second"
+      MAX-ACCESS  read-create
+      STATUS      deprecated
+      DESCRIPTION
+         "The threshold for generating a
+         slapmMonitoredEventNotAchieved notification, signalling
+         that a monitored minimum transfer rate has not been meet.
+
+         A slapmMonitoredEventNotAchieved notification is not
+         generated again for an slapmPolicyMonitorEntry until
+         the minimum transfer rate
+         exceeds slapmPolicyMonitorMinRateHigh (a
+         slapmMonitoredEventOkay notification is then transmitted)
+         and then fails below slapmPolicyMonitorMinRateLow.  This
+         behavior reduces the slapmMonitoredEventNotAchieved
+         notifications that are transmitted.
+
+         A value of zero for this object is returned when the
+         slapmPolicyMonitorControl monitorMinRate(0) is not
+         enabled.  When enabled the default value for this object
+         is the min rate value specified in the associated
+         action definition minus 10%.  If the action definition
+         doesn't have a min rate defined then there is no
+         default for this object and a value MUST be specified
+         prior to activating this entry when monitorMinRate(0)
+         is selected.
+
+         Note: The corresponding slapmPolicyMonitorControl
+         BITS setting, enableAggregateTraps(3), MUST be selected in
+         order for any notification relating to this entry to
+         potentially be generated."
+      ::= { slapmPolicyMonitorEntry 11 }
+
+   slapmPolicyMonitorMinRateHigh OBJECT-TYPE
+      SYNTAX      Integer32
+
+
+
+White                         Experimental                     [Page 24]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+      UNITS       "kilobits per second"
+      MAX-ACCESS  read-create
+      STATUS      deprecated
+      DESCRIPTION
+         "The threshold for generating a slapmMonitoredEventOkay
+         notification, signalling that a monitored minimum
+         transfer rate has increased to an acceptable level.
+
+         A value of zero for this object is returned when the
+         slapmPolicyMonitorControl monitorMinRate(0) is not
+         enabled.  When enabled the default value for this object
+         is the min rate value specified in the associated
+         action definition plus 10%.  If the action definition
+         doesn't have a min rate defined then there is no
+         default for this object and a value MUST be specified
+         prior to activating this entry when monitorMinRate(0)
+         is selected.
+
+         Note: The corresponding slapmPolicyMonitorControl
+         BITS setting, enableAggregateTraps(3), MUST be selected
+         in order for any notification relating to this entry to
+         potentially be generated."
+      ::= { slapmPolicyMonitorEntry 12 }
+
+   slapmPolicyMonitorMaxRateHigh OBJECT-TYPE
+      SYNTAX      Integer32
+      UNITS       "kilobits per second"
+      MAX-ACCESS  read-create
+      STATUS      deprecated
+      DESCRIPTION
+         "The threshold for generating a
+         slapmMonitoredEventNotAchieved notification, signalling
+         that a monitored maximum transfer rate has been exceeded.
+
+         A slapmMonitoredEventNotAchieved notification is not
+         generated again for an slapmPolicyMonitorEntry until the
+         maximum transfer rate fails below
+         slapmPolicyMonitorMaxRateLow (a slapmMonitoredEventOkay
+         notification is then transmitted) and then raises above
+         slapmPolicyMonitorMaxRateHigh.  This behavior reduces the
+         slapmMonitoredEventNotAchieved notifications that are
+         transmitted.
+
+         A value of zero for this object is returned when the
+         slapmPolicyMonitorControl monitorMaxRate(1) is not
+         enabled.  When enabled the default value for this object
+         is the max rate value specified in the associated
+         action definition plus 10%.  If the action definition
+
+
+
+White                         Experimental                     [Page 25]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+         doesn't have a max rate defined then there is no
+         default for this object and a value MUST be specified
+         prior to activating this entry when monitorMaxRate(1)
+         is selected.
+
+         Note: The corresponding slapmPolicyMonitorControl
+         BITS setting, enableAggregateTraps(3), MUST be selected in
+         order for any notification relating to this entry to
+         potentially be generated."
+      ::= { slapmPolicyMonitorEntry 13 }
+
+   slapmPolicyMonitorMaxRateLow OBJECT-TYPE
+      SYNTAX      Integer32
+      UNITS       "kilobits per second"
+      MAX-ACCESS  read-create
+      STATUS      deprecated
+      DESCRIPTION
+         "The threshold for generating a slapmMonitoredEventOkay
+         notification, signalling that a monitored maximum
+         transfer rate has fallen to an acceptable level.
+
+         A value of zero for this object is returned when the
+         slapmPolicyMonitorControl monitorMaxRate(1) is not
+         enabled.  When enabled the default value for this object
+         is the max rate value specified in the associated
+         action definition minus 10%.  If the action definition
+         doesn't have a max rate defined then there is no
+         default for this object and a value MUST be specified
+         prior to activating this entry when monitorMaxRate(1)
+         is selected.
+
+         Note: The corresponding slapmPolicyMonitorControl
+         BITS setting, enableAggregateTraps(3), MUST be selected in
+         order for any notification relating to this entry to
+         potentially be generated."
+      ::= { slapmPolicyMonitorEntry 14 }
+
+   slapmPolicyMonitorMaxDelayHigh OBJECT-TYPE
+      SYNTAX      Integer32
+      UNITS       "milliseconds"
+      MAX-ACCESS  read-create
+      STATUS      deprecated
+      DESCRIPTION
+         "The threshold for generating a
+         slapmMonitoredEventNotAchieved notification, signalling
+         that a monitored maximum delay rate has been exceeded.
+
+         A slapmMonitoredEventNotAchieved notification is not
+
+
+
+White                         Experimental                     [Page 26]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+         generated again for an slapmPolicyMonitorEntry until
+         the maximum delay rate falls below
+         slapmPolicyMonitorMaxDelayLow (a slapmMonitoredEventOkay
+         notification is then transmitted) and raises above
+         slapmPolicyMonitorMaxDelayHigh.  This behavior reduces
+         the slapmMonitoredEventNotAchieved notifications that are
+         transmitted.
+
+         A value of zero for this object is returned when the
+         slapmPolicyMonitorControl monitorMaxDelay(4) is not
+         enabled.  When enabled the default value for this object
+         is the max delay value specified in the associated
+         action definition plus 10%.  If the action definition
+         doesn't have a max delay defined then there is no
+         default for this object and a value MUST be specified
+         prior to activating this entry when monitorMaxDelay(4)
+         is selected.
+
+         Note: The corresponding slapmPolicyMonitorControl
+         BITS setting, enableAggregateTraps(3), MUST be selected
+         in order for any notification relating to this entry to
+         potentially be generated."
+      ::= { slapmPolicyMonitorEntry 15 }
+
+   slapmPolicyMonitorMaxDelayLow OBJECT-TYPE
+      SYNTAX      Integer32
+      UNITS       "milliseconds"
+      MAX-ACCESS  read-create
+      STATUS      deprecated
+      DESCRIPTION
+         "The threshold for generating a slapmMonitoredEventOkay
+         notification, signalling that a monitored maximum delay
+         rate has fallen to an acceptable level.
+
+         A value of zero for this object is returned when the
+         slapmPolicyMonitorControl monitorMaxDelay(4) is not
+         enabled.  When enabled the default value for this object
+         is the max delay value specified in the associated
+         action definition minus 10%.  If the action definition
+         doesn't have a max delay defined then there is no
+         default for this object and a value MUST be specified
+         prior to activating this entry when monitorMaxDelay(4)
+         is selected.
+
+         Note: The corresponding slapmPolicyMonitorControl
+         BITS setting, enableAggregateTraps(3), MUST be selected
+         in order for any notification relating to this entry to
+         potentially be generated."
+
+
+
+White                         Experimental                     [Page 27]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+      ::= { slapmPolicyMonitorEntry 16 }
+
+   slapmPolicyMonitorMinInRateNotAchieves OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+          "The number of times that a minimum transfer in rate
+          was not achieved."
+      ::= { slapmPolicyMonitorEntry 17 }
+
+   slapmPolicyMonitorMaxInRateExceeds OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+          "The number of times that a maximum transfer in rate
+          was exceeded."
+      ::= { slapmPolicyMonitorEntry 18 }
+
+   slapmPolicyMonitorMaxDelayExceeds OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+          "The number of times that a maximum delay in rate
+          was exceeded."
+      ::= { slapmPolicyMonitorEntry 19 }
+
+   slapmPolicyMonitorMinOutRateNotAchieves OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+          "The number of times that a minimum transfer out rate
+          was not achieved."
+      ::= { slapmPolicyMonitorEntry 20 }
+
+   slapmPolicyMonitorMaxOutRateExceeds OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+          "The number of times that a maximum transfer out rate
+          was exceeded."
+      ::= { slapmPolicyMonitorEntry 21 }
+
+   slapmPolicyMonitorCurrentDelayRate OBJECT-TYPE
+
+
+
+White                         Experimental                     [Page 28]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+      SYNTAX      Gauge32
+      UNITS       "milliseconds"
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+          "The current delay rate for this entry.  This is
+          calculated by taking the average of the TCP
+          round trip times for all associating
+          slapmSubcomponentTable entries within a interval."
+      ::= { slapmPolicyMonitorEntry 22 }
+
+   slapmPolicyMonitorRowStatus  OBJECT-TYPE
+      SYNTAX       RowStatus
+      MAX-ACCESS   read-create
+      STATUS       deprecated
+      DESCRIPTION
+        "This object allows entries to be created and deleted
+         in the slapmPolicyMonitorTable.  An entry in this table
+         is deleted by setting this object to destroy(6).
+
+         Removal of a corresponding (same policy and traffic profile
+         names) slapmPolicyStatsEntry has the side effect of the
+         automatic deletion an entry in this table."
+      ::= { slapmPolicyMonitorEntry 23 }
+
+   -- Subcomponent Table
+
+   slapmSubcomponentTable OBJECT-TYPE
+       SYNTAX      SEQUENCE OF SlapmSubcomponentEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+            "Defines a table to provide information on the
+            individually components that are mapped to
+            a policy rule (or old traffic profile).
+
+            The indexing for this table is designed to support
+            the use of an SNMP GET-NEXT operation using only
+            the remote address and remote port as a way for
+            a management station to retrieve the table entries
+            relating to a particular client."
+       ::= { slapmTableObjects 3 }
+
+   slapmSubcomponentEntry OBJECT-TYPE
+       SYNTAX      SlapmSubcomponentEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+
+
+
+White                         Experimental                     [Page 29]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+            "Describes a particular subcomponent entry.  This
+            table does not have an OwnerIndex as
+            part of its indexing since this table's contents
+            is intended to span multiple users."
+       INDEX {
+               slapmSubcomponentRemAddress,
+               slapmSubcomponentRemPort,
+               slapmSubcomponentLocalAddress,
+               slapmSubcomponentLocalPort
+             }
+       ::= { slapmSubcomponentTable 1 }
+
+   SlapmSubcomponentEntry ::=
+       SEQUENCE {
+            slapmSubcomponentRemAddress            OCTET STRING,
+            slapmSubcomponentRemPort               Integer32,
+            slapmSubcomponentLocalAddress          OCTET STRING,
+            slapmSubcomponentLocalPort             Integer32,
+            slapmSubcomponentProtocol              INTEGER,
+            slapmSubcomponentSystemAddress         OCTET STRING,
+            slapmSubcomponentPolicyName            SlapmNameType,
+            slapmSubcomponentTrafficProfileName    SlapmNameType,
+            slapmSubcomponentLastActivity          DateAndTime,
+            slapmSubcomponentInOctets              Counter32,
+            slapmSubcomponentOutOctets             Counter32,
+            slapmSubcomponentTcpOutBufferedOctets  Counter32,
+            slapmSubcomponentTcpInBufferedOctets   Counter32,
+            slapmSubcomponentTcpReXmts             Counter32,
+            slapmSubcomponentTcpRoundTripTime      Integer32,
+            slapmSubcomponentTcpRoundTripVariance  Integer32,
+            slapmSubcomponentInPdus                Counter32,
+            slapmSubcomponentOutPdus               Counter32,
+            slapmSubcomponentApplName              SnmpAdminString,
+            slapmSubcomponentMonitorStatus         SlapmStatus,
+            slapmSubcomponentMonitorIntTime        DateAndTime,
+            slapmSubcomponentMonitorCurrentInRate  Gauge32,
+            slapmSubcomponentMonitorCurrentOutRate Gauge32,
+            slapmSubcomponentPolicyRuleIndex       Unsigned32
+         }
+
+   slapmSubcomponentRemAddress OBJECT-TYPE
+      SYNTAX      OCTET STRING (SIZE(0 | 4 | 16))
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "Indicate the remote address of a subcomponent.
+         A remote address can be either an ipv4 address in which
+         case 4 octets are required or as an ipv6 address that
+
+
+
+White                         Experimental                     [Page 30]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+         requires 16 octets.  The value of this subidentifier
+         is a zero length octet string when this entry relates
+         to a UDP listener."
+      ::= { slapmSubcomponentEntry 1 }
+
+   slapmSubcomponentRemPort OBJECT-TYPE
+      SYNTAX      Integer32(0..65535)
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "Indicate the remote port of a subcomponent.
+         The value of this subidentifier
+         is 0 when this entry relates to a UDP listener."
+      ::= { slapmSubcomponentEntry 2 }
+
+   slapmSubcomponentLocalAddress OBJECT-TYPE
+      SYNTAX      OCTET STRING (SIZE(4 | 16))
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "Indicate the local address of a subcomponent.
+         A local address can be either an ipv4 address in which
+         case 4 octets are required or as an ipv6 address that
+         requires 16 octets."
+      ::= { slapmSubcomponentEntry 3 }
+
+   slapmSubcomponentLocalPort OBJECT-TYPE
+      SYNTAX      Integer32(0..65535)
+      MAX-ACCESS  not-accessible
+
+      STATUS      current
+      DESCRIPTION
+         "Indicate the local port of a subcomponent."
+      ::= { slapmSubcomponentEntry 4 }
+
+   slapmSubcomponentProtocol OBJECT-TYPE
+      SYNTAX      INTEGER {
+                             udpListener(1),
+                             tcpConnection(2)
+                          }
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "Indicate the protocol in use that identifies the
+         type of subcomponent."
+      ::= { slapmSubcomponentEntry 5 }
+
+   slapmSubcomponentSystemAddress OBJECT-TYPE
+
+
+
+White                         Experimental                     [Page 31]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+      SYNTAX      OCTET STRING (SIZE(0 | 4 | 16))
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "Address of a system that an Policy definition relates to.
+         A zero length octet string can be used to indicate that
+         only a single system is being represented.
+         Otherwise, the length of the octet string should be
+         4 for an ipv4 address and 16 for an ipv6 address."
+      ::= { slapmSubcomponentEntry 6 }
+
+   slapmSubcomponentPolicyName OBJECT-TYPE
+      SYNTAX      SlapmNameType
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+         "Policy name that this entry relates to.
+
+         This object, along with slapmSubcomponentTrafficProfileName,
+         have been replaced with the use of an unsigned integer
+         index that is mapped to an slapmPolicyNameEntry to actually
+         identify policy naming."
+      ::= { slapmSubcomponentEntry 7 }
+
+   slapmSubcomponentTrafficProfileName OBJECT-TYPE
+      SYNTAX      SlapmNameType
+      MAX-ACCESS  read-only
+      STATUS      deprecated
+      DESCRIPTION
+         "The corresponding traffic profile name.
+
+         This object, along with slapmSubcomponentProfileName,
+         have been replaced with the use of an unsigned integer
+         index that is mapped to an slapmPolicyNameEntry to
+         actually identify policy naming."
+      ::= { slapmSubcomponentEntry 8 }
+
+  slapmSubcomponentLastActivity OBJECT-TYPE
+      SYNTAX      DateAndTime
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "The date and timestamp of when this entry was last used."
+      DEFVAL { '0000000000000000'H }
+      ::= { slapmSubcomponentEntry 9 }
+
+   slapmSubcomponentInOctets OBJECT-TYPE
+       SYNTAX      Counter32
+
+
+
+White                         Experimental                     [Page 32]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The number of octets received from IP for this
+           connection."
+       ::= { slapmSubcomponentEntry 10 }
+
+   slapmSubcomponentOutOctets OBJECT-TYPE
+       SYNTAX      Counter32
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The number of octets sent to IP for this connection."
+       ::= { slapmSubcomponentEntry 11 }
+
+   slapmSubcomponentTcpOutBufferedOctets OBJECT-TYPE
+       SYNTAX      Counter32
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "Number of outgoing octets buffered.  The value
+           of this object is zero when the entry is not
+           for a TCP connection."
+       ::= { slapmSubcomponentEntry 12 }
+
+   slapmSubcomponentTcpInBufferedOctets OBJECT-TYPE
+       SYNTAX      Counter32
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "Number of incoming octets buffered.  The value
+           of this object is zero when the entry is not
+           for a TCP connection."
+       ::= { slapmSubcomponentEntry 13 }
+
+   slapmSubcomponentTcpReXmts OBJECT-TYPE
+       SYNTAX      Counter32
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "Number of retransmissions.  The value
+           of this object is zero when the entry is not
+           for a TCP connection."
+       ::= { slapmSubcomponentEntry 14 }
+
+   slapmSubcomponentTcpRoundTripTime OBJECT-TYPE
+       SYNTAX       Integer32
+       UNITS        "milliseconds"
+
+
+
+White                         Experimental                     [Page 33]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+           "The amount of time that has elapsed, measured in
+           milliseconds, from when the last TCP segment was
+           transmitted by the TCP Stack until the ACK was
+           received.
+
+           The value of this object is zero when the entry is not
+           for a TCP connection."
+       ::= { slapmSubcomponentEntry 15 }
+
+   slapmSubcomponentTcpRoundTripVariance OBJECT-TYPE
+       SYNTAX       Integer32
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+           "Round trip time variance.
+
+           The value of this object is zero when the entry is not
+           for a TCP connection."
+       ::= { slapmSubcomponentEntry 16 }
+
+   slapmSubcomponentInPdus OBJECT-TYPE
+       SYNTAX       Counter32
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+           "The number of protocol related data units transferred
+           inbound:
+
+             slapmSubcomponentProtocol    PDU Type
+
+                  udpListener(1)          UDP datagrams
+                  tcpConnection(2)        TCP segments"
+       ::= { slapmSubcomponentEntry 17 }
+
+   slapmSubcomponentOutPdus OBJECT-TYPE
+       SYNTAX       Counter32
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+           "The number of protocol related data units transferred
+           outbound:
+
+             slapmSubcomponentProtocol    PDU Type
+
+                  udpListener(1)          UDP datagrams
+
+
+
+White                         Experimental                     [Page 34]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+                  tcpConnection(2)        TCP segments"
+       ::= { slapmSubcomponentEntry 18 }
+
+   slapmSubcomponentApplName OBJECT-TYPE
+       SYNTAX       SnmpAdminString (SIZE(0..32))
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+           "The application name associated with this entry if known,
+           otherwise a zero-length octet string is returned as the
+           value of this object."
+       ::= { slapmSubcomponentEntry 19 }
+
+   slapmSubcomponentMonitorStatus OBJECT-TYPE
+      SYNTAX      SlapmStatus
+      MAX-ACCESS  read-only
+      STATUS       current
+      DESCRIPTION
+         "The value of this object indicates when a monitored
+         value has exceeded a threshold or isn't meeting the
+         defined service level.  Only the following SlapmStatus
+         BITS setting can be reported here:
+
+                     monitorMinInRateNotAchieved(5),
+                     monitorMaxInRateExceeded(6),
+                     monitorMaxDelayExceeded(7),
+                     monitorMinOutRateNotAchieved(8),
+                     monitorMaxOutRateExceeded(9)
+
+         This object only has meaning when an corresponding
+         slapmPolicyMonitorEntry exists with the
+         slapmPolicyMonitorControl BITS setting
+         monitorSubcomponents(5) enabled."
+      ::= { slapmSubcomponentEntry 20 }
+
+   slapmSubcomponentMonitorIntTime OBJECT-TYPE
+      SYNTAX      DateAndTime
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "The timestamp for when the last interval ended.
+
+         This object only has meaning when an corresponding
+         slapmPRMonEntry (or old slapmPolicyMonitorEntry)
+         exists with the slapmPRMonControl (or
+         slapmPolicyMonitorControl) BITS setting
+         monitorSubcomponents(5) enabled.  All of the
+         octets returned when monitoring is not in effect
+
+
+
+White                         Experimental                     [Page 35]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+         must be zero."
+      DEFVAL { '0000000000000000'H }
+      ::= { slapmSubcomponentEntry 21 }
+
+   slapmSubcomponentMonitorCurrentInRate OBJECT-TYPE
+      SYNTAX      Gauge32
+      UNITS       "kilobits per second"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "Using the value of the corresponding
+         slapmPRMonInterval (or slapmPolicyMonitorInterval),
+         slapmSubcomponentStatsInOctets
+         is divided by slapmSubcomponentMonitorInterval to determine
+         the current in transfer rate.
+
+         This object only has meaning when an corresponding
+         slapmPRMonEntry (or slapmPolicyMonitorEntry)
+         exists with the slapmPRMonControl (or
+         slapmPolicyMonitorControl) BITS setting
+         monitorSubcomponents(5) enabled.  The value of this
+         object is zero when monitoring is not in effect."
+      ::= { slapmSubcomponentEntry 22 }
+
+   slapmSubcomponentMonitorCurrentOutRate OBJECT-TYPE
+      SYNTAX      Gauge32
+      UNITS       "kilobits per second"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "Using the value of the corresponding slapmPRMonInterval (or
+         slapmPolicyMonitorInterva)l, slapmSubcomponentStatsOutOctets
+         is divided by slapmPRMonInterval (or
+         slapmPolicyMonitorInterval) to determine the
+         current out transfer rate.
+
+         This object only has meaning when an corresponding
+         slapmPRMonEntry (or slapmPolicyMonitorEntry) exists with
+         the slapmPRMonControl (or slapmPolicyMonitorControl)
+         BITS setting monitorSubcomponents(5) enabled.  The value
+         of this object is zero when monitoring is not in effect."
+      ::= { slapmSubcomponentEntry 23 }
+
+  slapmSubcomponentPolicyRuleIndex OBJECT-TYPE
+     SYNTAX      Unsigned32 (0..4294967295)
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+
+
+
+White                         Experimental                     [Page 36]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+        "Points to an slapmPolicyNameEntry when combined with
+        slapmSubcomponentSystemAddress to indicate the
+        policy naming that relates to this entry.
+
+        A value of 0 for this object MUST be returned when
+        the corresponding slapmSubcomponentEntry has no
+        policy rule associated with it."
+     ::= { slapmSubcomponentEntry 24 }
+
+   -- Table that maps an unsigned integer index to whatever
+   -- names a policy rule.
+
+   slapmPolicyNameTable OBJECT-TYPE
+      SYNTAX SEQUENCE OF SlapmPolicyNameEntry
+      MAX-ACCESS not-accessible
+      STATUS current
+      DESCRIPTION
+          "Provides the mapping between a policy index as a
+          unsigned 32 bit integer and the unique name associated
+          with a policy rule."
+     ::= { slapmTableObjects 4 }
+
+   slapmPolicyNameEntry OBJECT-TYPE
+      SYNTAX SlapmPolicyNameEntry
+      MAX-ACCESS not-accessible
+      STATUS current
+      DESCRIPTION
+          "Defines an entry in the slapmPolicyNameTable."
+      INDEX {
+             slapmPolicyNameSystemAddress,
+             slapmPolicyNameIndex
+            }
+      ::= { slapmPolicyNameTable 1 }
+
+   SlapmPolicyNameEntry ::=
+      SEQUENCE {
+          slapmPolicyNameSystemAddress   OCTET STRING,
+          slapmPolicyNameIndex           Unsigned32,
+          slapmPolicyNameOfRule          SlapmPolicyRuleName
+      }
+
+   slapmPolicyNameSystemAddress OBJECT-TYPE
+      SYNTAX      OCTET STRING (SIZE(0 | 4 | 16))
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "Address of a system that an Policy rule definition relates
+         to.  A zero length octet string must be used to indicate
+
+
+
+White                         Experimental                     [Page 37]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+         that only a single system is being represented.
+         Otherwise, the length of the octet string must be
+         4 for an ipv4 address or 16 for an ipv6 address."
+      ::= { slapmPolicyNameEntry 1 }
+
+   slapmPolicyNameIndex OBJECT-TYPE
+      SYNTAX      Unsigned32 (1..4294967295)
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+          "A locally arbitrary, but unique identifier associated
+          with this table entry.  This value is not expected to
+          remain constant across reIPLs."
+      ::= { slapmPolicyNameEntry 2 }
+
+   slapmPolicyNameOfRule OBJECT-TYPE
+      SYNTAX      SlapmPolicyRuleName
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "The unique name that identifies a policy rule definition."
+      ::= { slapmPolicyNameEntry 3 }
+
+   -- Sla Performance Monitoring Policy Rule Statistics Table
+
+   slapmPolicyRuleStatsTable OBJECT-TYPE
+      SYNTAX SEQUENCE OF SlapmPolicyRuleStatsEntry
+      MAX-ACCESS not-accessible
+      STATUS current
+      DESCRIPTION
+          "Provides statistics on a per system and a per policy
+          rule basis."
+     ::= { slapmTableObjects 5 }
+
+   slapmPolicyRuleStatsEntry OBJECT-TYPE
+      SYNTAX SlapmPolicyRuleStatsEntry
+      MAX-ACCESS not-accessible
+      STATUS current
+      DESCRIPTION
+          "Defines an entry in the slapmPolicyRuleStatsTable.
+          This table defines a set of statistics that is kept
+          on a per system and per policy rule basis.
+
+          Entries in this table are not created or deleted via SNMP
+          but reflect the set of policy rule definitions known
+          at a system."
+      INDEX {
+             slapmPolicyNameSystemAddress,
+
+
+
+White                         Experimental                     [Page 38]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+             slapmPolicyNameIndex
+            }
+      ::= { slapmPolicyRuleStatsTable 1 }
+
+   SlapmPolicyRuleStatsEntry ::=
+      SEQUENCE {
+          slapmPolicyRuleStatsOperStatus     INTEGER,
+          slapmPolicyRuleStatsActiveConns    Gauge32,
+          slapmPolicyRuleStatsTotalConns     Counter32,
+          slapmPolicyRuleStatsLActivated     DateAndTime,
+          slapmPolicyRuleStatsLastMapping    DateAndTime,
+          slapmPolicyRuleStatsInOctets       Counter32,
+          slapmPolicyRuleStatsOutOctets      Counter32,
+          slapmPolicyRuleStatsConnLimit      Unsigned32,
+          slapmPolicyRuleStatsCountAccepts   Counter32,
+          slapmPolicyRuleStatsCountDenies    Counter32,
+          slapmPolicyRuleStatsInDiscards     Counter32,
+          slapmPolicyRuleStatsOutDiscards    Counter32,
+          slapmPolicyRuleStatsInPackets      Counter32,
+          slapmPolicyRuleStatsOutPackets     Counter32,
+          slapmPolicyRuleStatsInProOctets    Counter32,
+          slapmPolicyRuleStatsOutProOctets   Counter32,
+          slapmPolicyRuleStatsMinRate        Unsigned32,
+          slapmPolicyRuleStatsMaxRate        Unsigned32,
+          slapmPolicyRuleStatsMaxDelay       Unsigned32,
+          slapmPolicyRuleStatsTotalRsvpFlows Counter32,
+          slapmPolicyRuleStatsActRsvpFlows   Gauge32
+      }
+
+   slapmPolicyRuleStatsOperStatus OBJECT-TYPE
+      SYNTAX      INTEGER {
+                             inactive(1),
+                             active(2),
+                             deleteNeeded(3)
+                          }
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "The state of a policy entry:
+
+           inactive(1)      - An policy entry was either defined
+                              by local system definition or
+                              discovered via
+                              a directory search but has not been
+                              activated (not currently being used).
+           active(2)        - Policy entry is being used to affect
+                              traffic flows.
+           deleteNeeded(3)  - Either though local implementation
+
+
+
+White                         Experimental                     [Page 39]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+                              dependent methods or by discovering
+                              that the directory entry corresponding
+                              to this table entry no longer
+                              exists and slapmPolicyPurgeTime needs
+                              to expire before attempting to remove
+                              the corresponding slapmPolicyStatsEntry
+                              and any dependent slapmPolicyMonitor
+                              table entries.
+         Note: a policy rule in a state other than
+         active(2) is not being used to affect traffic flows."
+      ::= { slapmPolicyRuleStatsEntry 1 }
+
+   slapmPolicyRuleStatsActiveConns OBJECT-TYPE
+      SYNTAX      Gauge32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "The number of active TCP connections that are
+         affected by the corresponding policy entry."
+      ::= { slapmPolicyRuleStatsEntry 2 }
+
+   slapmPolicyRuleStatsTotalConns OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "The number of total TCP connections that are
+         affected by the corresponding policy entry."
+      ::= { slapmPolicyRuleStatsEntry 3 }
+
+   slapmPolicyRuleStatsLActivated OBJECT-TYPE
+      SYNTAX      DateAndTime
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "The timestamp for when the corresponding policy entry
+         was last activated.  The value of this object serves as
+         the discontinuity event indicator when polling entries
+         in this table.  The value of this object is updated on
+         transition of slapmPolicyRuleStatsOperStatus into the
+         active(2) state."
+      DEFVAL { '0000000000000000'H }
+      ::= { slapmPolicyRuleStatsEntry 4 }
+
+   slapmPolicyRuleStatsLastMapping OBJECT-TYPE
+      SYNTAX      DateAndTime
+      MAX-ACCESS  read-only
+      STATUS      current
+
+
+
+White                         Experimental                     [Page 40]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+      DESCRIPTION
+         "The timestamp for when the last time
+         that the associated policy entry was used."
+      DEFVAL { '0000000000000000'H }
+      ::= { slapmPolicyRuleStatsEntry 5 }
+
+   slapmPolicyRuleStatsInOctets OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "The number of octets that was received by IP for an
+         entity that map to this entry."
+      ::= { slapmPolicyRuleStatsEntry 6 }
+
+   slapmPolicyRuleStatsOutOctets OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "The number of octets that was transmitted by IP for an
+         entity that map to this entry."
+      ::= { slapmPolicyRuleStatsEntry 7 }
+
+   slapmPolicyRuleStatsConnLimit OBJECT-TYPE
+      SYNTAX      Unsigned32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "The limit for the number of active TCP connections that
+         are allowed for this policy definition.  A value of zero
+         for this object implies that a connection limit has not
+         been specified."
+      ::= { slapmPolicyRuleStatsEntry 8 }
+
+   slapmPolicyRuleStatsCountAccepts OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "This counter is incremented when a policy action's
+          Permission value is set to Accept and a session
+          (TCP connection) is accepted."
+      ::= { slapmPolicyRuleStatsEntry 9 }
+
+   slapmPolicyRuleStatsCountDenies OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+
+
+
+White                         Experimental                     [Page 41]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+      STATUS      current
+      DESCRIPTION
+          "This counter is incremented when a policy action's
+          Permission value is set to Deny and a session is denied,
+          or when a session (TCP connection) is rejected due to a
+          policy's connection limit (slapmPolicyRuleStatsConnectLimit)
+          being reached."
+      ::= { slapmPolicyRuleStatsEntry 10 }
+
+   slapmPolicyRuleStatsInDiscards OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "This counter counts the number of in octets discarded.
+          This occurs when an error is detected.  Examples of this
+          are buffer overflow, checksum error, or bad packet
+          format."
+      ::= { slapmPolicyRuleStatsEntry 11 }
+
+   slapmPolicyRuleStatsOutDiscards OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "This counter counts the number of out octets discarded.
+          Examples of this are buffer overflow, checksum error, or
+          bad packet format."
+      ::= { slapmPolicyRuleStatsEntry 12 }
+
+   slapmPolicyRuleStatsInPackets OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "This counter counts the number of in packets received
+          that relate to this policy entry from IP."
+      ::= { slapmPolicyRuleStatsEntry 13 }
+
+   slapmPolicyRuleStatsOutPackets OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "This counter counts the number of out packets sent
+          by IP that relate to this policy entry."
+      ::= { slapmPolicyRuleStatsEntry 14 }
+
+
+
+
+White                         Experimental                     [Page 42]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+   slapmPolicyRuleStatsInProOctets OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "This counter counts the number of in octets that are
+          determined to be within profile."
+      ::= { slapmPolicyRuleStatsEntry 15 }
+
+   slapmPolicyRuleStatsOutProOctets OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "This counter counts the number of out octets that are
+          determined to be within profile."
+      ::= { slapmPolicyRuleStatsEntry 16 }
+
+   slapmPolicyRuleStatsMinRate OBJECT-TYPE
+      SYNTAX      Unsigned32
+      UNITS       "Kilobits per second"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "The minimum transfer rate defined for this entry."
+      ::= { slapmPolicyRuleStatsEntry 17 }
+
+   slapmPolicyRuleStatsMaxRate OBJECT-TYPE
+      SYNTAX      Unsigned32
+      UNITS       "Kilobits per second"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "The maximum transfer rate defined for this entry."
+      ::= { slapmPolicyRuleStatsEntry 18 }
+
+   slapmPolicyRuleStatsMaxDelay OBJECT-TYPE
+      SYNTAX      Unsigned32
+      UNITS       "milliseconds"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "The maximum delay defined for this entry."
+      ::= { slapmPolicyRuleStatsEntry 19 }
+
+   slapmPolicyRuleStatsTotalRsvpFlows OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+
+
+
+White                         Experimental                     [Page 43]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+      STATUS      current
+      DESCRIPTION
+         "Total number of RSVP flows that have be activated."
+      ::= { slapmPolicyRuleStatsEntry 20 }
+
+   slapmPolicyRuleStatsActRsvpFlows OBJECT-TYPE
+      SYNTAX      Gauge32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "Current number of active RSVP flows."
+      ::= { slapmPolicyRuleStatsEntry 21 }
+
+   -- SLA Performance Monitoring Policy Rule Monitor Table
+
+   slapmPRMonTable OBJECT-TYPE
+      SYNTAX SEQUENCE OF SlapmPRMonEntry
+      MAX-ACCESS not-accessible
+      STATUS current
+      DESCRIPTION
+          "Provides a method of monitoring policies and their
+          effect at a system."
+     ::= { slapmTableObjects 6 }
+
+   slapmPRMonEntry OBJECT-TYPE
+      SYNTAX SlapmPRMonEntry
+      MAX-ACCESS not-accessible
+      STATUS current
+      DESCRIPTION
+          "Defines an entry in the slapmPRMonTable. This
+          table defines which policies should be monitored on a
+          per policy rule basis.
+
+          An attempt to set any read-create object defined within an
+          slapmPRMonEntry while the value of slapmPRMonRowStatus is
+          active(1) will result in an inconsistentValue error."
+      INDEX {
+             slapmPRMonOwnerIndex,
+             slapmPRMonSystemAddress,
+             slapmPRMonIndex
+            }
+      ::= { slapmPRMonTable 1 }
+
+   SlapmPRMonEntry ::=
+      SEQUENCE {
+          slapmPRMonOwnerIndex              SnmpAdminString,
+          slapmPRMonSystemAddress           OCTET STRING,
+          slapmPRMonIndex                   Unsigned32,
+
+
+
+White                         Experimental                     [Page 44]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+          slapmPRMonControl                 BITS,
+          slapmPRMonStatus                  SlapmStatus,
+          slapmPRMonInterval                Unsigned32,
+          slapmPRMonIntTime                 DateAndTime,
+          slapmPRMonCurrentInRate           Gauge32,
+          slapmPRMonCurrentOutRate          Gauge32,
+          slapmPRMonMinRateLow              Unsigned32,
+          slapmPRMonMinRateHigh             Unsigned32,
+          slapmPRMonMaxRateHigh             Unsigned32,
+          slapmPRMonMaxRateLow              Unsigned32,
+          slapmPRMonMaxDelayHigh            Unsigned32,
+          slapmPRMonMaxDelayLow             Unsigned32,
+          slapmPRMonMinInRateNotAchieves    Counter32,
+          slapmPRMonMaxInRateExceeds        Counter32,
+          slapmPRMonMaxDelayExceeds         Counter32,
+          slapmPRMonMinOutRateNotAchieves   Counter32,
+          slapmPRMonMaxOutRateExceeds       Counter32,
+          slapmPRMonCurrentDelayRate        Gauge32,
+          slapmPRMonRowStatus               RowStatus
+      }
+
+   slapmPRMonOwnerIndex OBJECT-TYPE
+      SYNTAX      SnmpAdminString (SIZE(0..16))
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "To facilitate the provisioning of access control by a
+         security administrator using the View-Based Access
+         Control Model (RFC 2575, VACM) for tables in which
+         multiple users may need to independently create or modify
+         entries, the initial index is used as an 'owner index'.
+         Such an initial index has a syntax of SnmpAdminString,
+         and can thus be trivially mapped to a securityName or
+         groupName as defined in VACM, in accordance with a
+         security policy.
+
+         All entries in that table belonging to a particular user
+         will have the same value for this initial index.  For a
+         given user's entries in a particular table, the object
+         identifiers for the information in these entries will
+         have the same subidentifiers (except for the 'column'
+         subidentifier) up to the end of the encoded owner index.
+         To configure VACM to permit access to this portion of the
+         table, one would create vacmViewTreeFamilyTable entries
+         with the value of vacmViewTreeFamilySubtree including the
+         owner index portion, and vacmViewTreeFamilyMask
+         'wildcarding' the column subidentifier.  More elaborate
+         configurations are possible."
+
+
+
+White                         Experimental                     [Page 45]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+      ::= { slapmPRMonEntry 1 }
+
+   slapmPRMonSystemAddress OBJECT-TYPE
+      SYNTAX      OCTET STRING (SIZE(0 | 4 | 16))
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "Address of a system that an Policy definition relates to.
+         A zero length octet string can be used to indicate that
+         only a single system is being represented.
+         Otherwise, the length of the octet string should be
+         4 for an ipv4 address and 16 for an ipv6 address."
+      ::= { slapmPRMonEntry 2 }
+
+   slapmPRMonIndex OBJECT-TYPE
+      SYNTAX      Unsigned32
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "An slapmPolicyNameTable index, slapmPolicyNameIndex,
+         that points to the unique name associated with a
+         policy rule definition."
+      ::= { slapmPRMonEntry 3 }
+
+   slapmPRMonControl OBJECT-TYPE
+      SYNTAX      BITS {
+                        monitorMinRate(0),
+                        monitorMaxRate(1),
+                        monitorMaxDelay(2),
+                        enableAggregateTraps(3),
+                        enableSubcomponentTraps(4),
+                        monitorSubcomponents(5)
+                       }
+      MAX-ACCESS  read-create
+      STATUS      current
+      DESCRIPTION
+         "The value of this object determines the type and level
+         of monitoring that is applied to a policy rule.  The
+         value of this object can't be changed once the table
+         entry that it is a part of is activated via a
+         slapmPRMonRowStatus transition to active state.
+
+             monitorMinRate(0) - Monitor minimum transfer rate.
+             monitorMaxRate(1) - Monitor maximum transfer rate.
+             monitorMaxDelay(2) - Monitor maximum delay.
+             enableAggregateTraps(3) - The enableAggregateTraps(3)
+                   BITS setting enables notification generation
+                   when monitoring a policy rule as an
+
+
+
+White                         Experimental                     [Page 46]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+                   aggregate using the values in the corresponding
+                   slapmPRMonStatsEntry.  By default this function
+                   is not enabled.
+             enableSubcomponentTraps(4) - This BITS setting enables
+                   notification generation when monitoring all
+                   subcomponents that are mapped to an corresponding
+                   slapmPRMonStatsEntry.  By default this
+                   function is not enabled.
+             monitorSubcomponents(5) - This BITS setting enables
+                   monitoring of each subcomponent (typically a
+                   TCP connection or UDP listener) individually."
+      DEFVAL   { { monitorMinRate, monitorMaxRate,
+                   monitorMaxDelay } }
+      ::= { slapmPRMonEntry 4 }
+
+   slapmPRMonStatus OBJECT-TYPE
+      SYNTAX      SlapmStatus
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "The value of this object indicates when a monitored
+         value has not meet a threshold or isn't meeting the
+         defined service level.  The SlapmStatus TEXTUAL-CONVENTION
+         defines two levels of not meeting a threshold.  The first
+         set:
+                     slaMinInRateNotAchieved(0),
+                     slaMaxInRateExceeded(1),
+                     slaMaxDelayExceeded(2),
+                     slaMinOutRateNotAchieved(3),
+                     slaMaxOutRateExceeded(4)
+
+         are used to indicate when the SLA as an aggregate is
+         not meeting a threshold while the second set:
+
+                     monitorMinInRateNotAchieved(5),
+                     monitorMaxInRateExceeded(6),
+                     monitorMaxDelayExceeded(7),
+                     monitorMinOutRateNotAchieved(8),
+                     monitorMaxOutRateExceeded(9)
+
+         indicate that at least one subcomponent is not meeting
+         a threshold."
+      ::= { slapmPRMonEntry 5 }
+
+   slapmPRMonInterval OBJECT-TYPE
+      SYNTAX      Unsigned32 (15..86400) -- 15 second min, 24 hour max
+      UNITS       "seconds"
+      MAX-ACCESS  read-create
+
+
+
+White                         Experimental                     [Page 47]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+      STATUS      current
+      DESCRIPTION
+         "The number of seconds that defines the sample period."
+      DEFVAL   {20}    -- 20 seconds
+      ::= { slapmPRMonEntry 6 }
+
+   slapmPRMonIntTime OBJECT-TYPE
+      SYNTAX      DateAndTime
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "The timestamp for when the last interval ended."
+      DEFVAL { '0000000000000000'H }
+      ::= { slapmPRMonEntry 7 }
+
+   slapmPRMonCurrentInRate OBJECT-TYPE
+      SYNTAX      Gauge32
+      UNITS       "kilobits per second"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "Using the value of the corresponding
+         slapmPRMonInterval, slapmPolicyRuleStatsInOctets
+         is sampled and then divided by slapmPRMonInterval
+         to determine the current in transfer rate."
+      ::= { slapmPRMonEntry 8 }
+
+   slapmPRMonCurrentOutRate OBJECT-TYPE
+      SYNTAX      Gauge32
+      UNITS       "kilobits per second"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "Using the value of the corresponding
+         slapmPolicyMonInterval, slapmPolicyRuleStatsOutOctets
+         is sampled and then divided by slapmPRMonInterval
+         to determine the current out transfer rate."
+      ::= { slapmPRMonEntry 9 }
+
+   slapmPRMonMinRateLow OBJECT-TYPE
+      SYNTAX      Unsigned32
+      UNITS       "kilobits per second"
+      MAX-ACCESS  read-create
+      STATUS      current
+      DESCRIPTION
+         "The threshold for generating a
+         slapmPolicyRuleMonNotOkay notification, signalling
+         that a monitored minimum transfer rate has not been meet.
+
+
+
+White                         Experimental                     [Page 48]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+         A slapmPolicyRuleMonNotOkay notification is not
+         generated again for an slapmPRMonEntry until
+         the minimum transfer rate
+         exceeds slapmPRMonMinRateHigh (a
+         slapmPolicyRuleMonOkay notification is then transmitted)
+         and then fails below slapmPRMonMinRateLow.  This
+         behavior reduces the slapmPolicyRuleMonNotOkay
+         notifications that are transmitted.
+
+         A value of zero for this object is returned when the
+         slapmPRMonControl monitorMinRate(0) is not
+         enabled.  When enabled the default value for this object
+         is the min rate value specified in the associated
+         action definition minus 10%.  If the action definition
+         doesn't have a min rate defined then there is no
+         default for this object and a value MUST be specified
+         prior to activating this entry when monitorMinRate(0)
+         is selected.
+
+         Note: The corresponding slapmPRMonControl
+         BITS setting, enableAggregateTraps(3), MUST be selected in
+         order for any notification relating to this entry to
+         potentially be generated."
+      ::= { slapmPRMonEntry 10 }
+
+   slapmPRMonMinRateHigh OBJECT-TYPE
+      SYNTAX      Unsigned32
+      UNITS       "kilobits per second"
+      MAX-ACCESS  read-create
+      STATUS      current
+      DESCRIPTION
+         "The threshold for generating a slapmPolicyRuleMonOkay
+         notification, signalling that a monitored minimum
+         transfer rate has increased to an acceptable level.
+
+         A value of zero for this object is returned when the
+         slapmPRMonControl monitorMinRate(0) is not
+         enabled.  When enabled the default value for this object
+         is the min rate value specified in the associated
+         action definition plus 10%.  If the action definition
+         doesn't have a min rate defined then there is no
+         default for this object and a value MUST be specified
+         prior to activating this entry when monitorMinRate(0)
+         is selected.
+
+         Note: The corresponding slapmPRMonControl
+         BITS setting, enableAggregateTraps(3), MUST be selected
+         in order for any notification relating to this entry to
+
+
+
+White                         Experimental                     [Page 49]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+         potentially be generated."
+      ::= { slapmPRMonEntry 11 }
+
+   slapmPRMonMaxRateHigh OBJECT-TYPE
+      SYNTAX      Unsigned32
+      UNITS       "kilobits per second"
+      MAX-ACCESS  read-create
+      STATUS      current
+      DESCRIPTION
+         "The threshold for generating a
+         slapmPolicyRuleMonNotOkay notification, signalling
+         that a monitored maximum transfer rate has been exceeded.
+
+         A slapmPolicyRuleNotOkay notification is not
+         generated again for an slapmPRMonEntry until the
+         maximum transfer rate fails below
+         slapmPRMonMaxRateLow (a slapmPolicyRuleMonOkay
+         notification is then transmitted) and then raises above
+         slapmPRMonMaxRateHigh.  This behavior reduces the
+         slapmPolicyRuleMonNotOkay notifications that are
+         transmitted.
+
+         A value of zero for this object is returned when the
+         slapmPRMonControl monitorMaxRate(1) is not
+         enabled.  When enabled the default value for this object
+         is the max rate value specified in the associated
+         action definition plus 10%.  If the action definition
+         doesn't have a max rate defined then there is no
+         default for this object and a value MUST be specified
+         prior to activating this entry when monitorMaxRate(1)
+         is selected.
+
+         Note: The corresponding slapmPRMonControl
+         BITS setting, enableAggregateTraps(3), MUST be selected in
+         order for any notification relating to this entry to
+         potentially be generated."
+      ::= { slapmPRMonEntry 12 }
+
+   slapmPRMonMaxRateLow OBJECT-TYPE
+      SYNTAX      Unsigned32
+      UNITS       "kilobits per second"
+      MAX-ACCESS  read-create
+      STATUS      current
+      DESCRIPTION
+         "The threshold for generating a slapmPolicyRuleMonOkay
+         notification, signalling that a monitored maximum
+         transfer rate has fallen to an acceptable level.
+
+
+
+
+White                         Experimental                     [Page 50]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+         A value of zero for this object is returned when the
+         slapmPRMonControl monitorMaxRate(1) is not
+         enabled.  When enabled the default value for this object
+         is the max rate value specified in the associated
+         action definition minus 10%.  If the action definition
+         doesn't have a max rate defined then there is no
+         default for this object and a value MUST be specified
+         prior to activating this entry when monitorMaxRate(1)
+         is selected.
+
+         Note: The corresponding slapmPRMonControl
+         BITS setting, enableAggregateTraps(3), MUST be selected in
+         order for any notification relating to this entry to
+         potentially be generated."
+      ::= { slapmPRMonEntry 13 }
+
+   slapmPRMonMaxDelayHigh OBJECT-TYPE
+      SYNTAX      Unsigned32
+      UNITS       "milliseconds"
+      MAX-ACCESS  read-create
+      STATUS      current
+      DESCRIPTION
+         "The threshold for generating a
+         slapmPolicyRuleMonNotOkay notification, signalling
+         that a monitored maximum delay rate has been exceeded.
+
+         A slapmPolicyRuleMonNotOkay notification is not
+         generated again for an slapmPRMonEntry until
+         the maximum delay rate falls below
+         slapmPRMonMaxDelayLow (a slapmPolicyRuleMonOkay
+         notification is then transmitted) and raises above
+         slapmPRMonMaxDelayHigh.  This behavior reduces
+         the slapmPolicyRuleMonNotOkay notifications that are
+         transmitted.
+
+         A value of zero for this object is returned when the
+         slapmPRMonControl monitorMaxDelay(4) is not
+         enabled.  When enabled the default value for this object
+         is the max delay value specified in the associated
+         action definition plus 10%.  If the action definition
+         doesn't have a max delay defined then there is no
+         default for this object and a value MUST be specified
+         prior to activating this entry when monitorMaxDelay(4)
+         is selected.
+
+         Note: The corresponding slapmPRMonControl
+         BITS setting, enableAggregateTraps(3), MUST be selected
+         in order for any notification relating to this entry to
+
+
+
+White                         Experimental                     [Page 51]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+         potentially be generated."
+      ::= { slapmPRMonEntry 14 }
+
+   slapmPRMonMaxDelayLow OBJECT-TYPE
+      SYNTAX      Unsigned32
+      UNITS       "milliseconds"
+      MAX-ACCESS  read-create
+      STATUS      current
+      DESCRIPTION
+         "The threshold for generating a slapmPolicyRuleMonOkay
+         notification, signalling that a monitored maximum delay
+         rate has fallen to an acceptable level.
+
+         A value of zero for this object is returned when the
+         slapmPRMonControl monitorMaxDelay(4) is not
+         enabled.  When enabled the default value for this object
+         is the max delay value specified in the associated
+         action definition minus 10%.  If the action definition
+         doesn't have a max delay defined then there is no
+         default for this object and a value MUST be specified
+         prior to activating this entry when monitorMaxDelay(4)
+         is selected.
+
+         Note: The corresponding slapmPRMonControl
+         BITS setting, enableAggregateTraps(3), MUST be selected
+         in order for any notification relating to this entry to
+         potentially be generated."
+      ::= { slapmPRMonEntry 15 }
+
+   slapmPRMonMinInRateNotAchieves OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "The number of times that a minimum transfer in rate
+          was not achieved."
+      ::= { slapmPRMonEntry 16 }
+
+   slapmPRMonMaxInRateExceeds OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "The number of times that a maximum transfer in rate
+          was exceeded."
+      ::= { slapmPRMonEntry 17 }
+
+   slapmPRMonMaxDelayExceeds OBJECT-TYPE
+
+
+
+White                         Experimental                     [Page 52]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "The number of times that a maximum delay in rate
+          was exceeded."
+      ::= { slapmPRMonEntry 18 }
+
+   slapmPRMonMinOutRateNotAchieves OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "The number of times that a minimum transfer out rate
+          was not achieved."
+      ::= { slapmPRMonEntry 19 }
+
+   slapmPRMonMaxOutRateExceeds OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "The number of times that a maximum transfer out rate
+          was exceeded."
+      ::= { slapmPRMonEntry 20 }
+
+   slapmPRMonCurrentDelayRate OBJECT-TYPE
+      SYNTAX      Gauge32
+      UNITS       "milliseconds"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "The current delay rate for this entry.  This is
+          calculated by taking the average of the TCP
+          round trip times for all associating
+          slapmSubcomponentTable entries within a interval."
+      ::= { slapmPRMonEntry 21 }
+
+   slapmPRMonRowStatus  OBJECT-TYPE
+      SYNTAX       RowStatus
+      MAX-ACCESS   read-create
+      STATUS       current
+      DESCRIPTION
+        "This object allows entries to be created and deleted
+         in the slapmPRMonTable.  An entry in this table
+         is deleted by setting this object to destroy(6).
+
+         Removal of an corresponding (same policy index)
+
+
+
+White                         Experimental                     [Page 53]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+         slapmPolicyRuleStatsEntry has the side effect of the
+         automatic deletion an entry in this table.
+
+         Note that an attempt to set any read-create object
+         defined within an slapmPRMonEntry while the value
+         of slapmPRMonRowStatus is active(1) will result in
+         an inconsistentValue error."
+      ::= { slapmPRMonEntry 22 }
+
+   -- Notifications
+
+   slapmMonitoredEventNotAchieved NOTIFICATION-TYPE
+      OBJECTS {
+          slapmPolicyMonitorIntTime,
+          slapmPolicyMonitorControl,
+          slapmPolicyMonitorStatus,
+          slapmPolicyMonitorStatus,
+          slapmPolicyMonitorCurrentInRate,
+          slapmPolicyMonitorCurrentOutRate,
+          slapmPolicyMonitorCurrentDelayRate
+      }
+      STATUS  deprecated
+      DESCRIPTION
+         "This notification is generated when an monitored event
+         is not achieved with respect to threshold.  This
+         applies only towards monitoring a policy traffic
+         profile as an aggregate via an associating
+         slapmPolicyStatsEntry.  The value
+         of slapmPolicyMonitorControl can be examined to
+         determine what is being monitored.  The first
+         slapmPolicyMonitorStatus value supplies the current
+         monitor status while the 2nd value supplies the
+         previous status.
+
+         Note: The corresponding slapmPolicyMonitorControl
+         BITS setting, enableAggregateTraps(3), MUST be
+         selected in order for this notification to
+         potentially be generated."
+      ::= { slapmNotifications 1 }
+
+   slapmMonitoredEventOkay NOTIFICATION-TYPE
+      OBJECTS {
+          slapmPolicyMonitorIntTime,
+          slapmPolicyMonitorControl,
+          slapmPolicyMonitorStatus,
+          slapmPolicyMonitorStatus,
+          slapmPolicyMonitorCurrentInRate,
+          slapmPolicyMonitorCurrentOutRate,
+
+
+
+White                         Experimental                     [Page 54]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+          slapmPolicyMonitorCurrentDelayRate
+      }
+      STATUS  deprecated
+      DESCRIPTION
+         "This notification is generated when a monitored
+         event has improved to an acceptable level.  This
+         applies only towards monitoring a policy traffic
+         profile as an aggregate via an associating
+         slapmPolicyStatsEntry.  The value
+         of slapmPolicyMonitorControl can be examined to
+         determine what is being monitored.  The first
+         slapmPolicyMonitorStatus value supplies the current
+         monitor status while the 2nd value supplies the
+         previous status.
+
+         Note: The corresponding slapmPolicyMonitorControl
+         BITS setting, enableAggregateTraps(3), MUST be
+         selected in order for this notification to
+         potentially be generated."
+      ::= { slapmNotifications 2 }
+
+   slapmPolicyProfileDeleted NOTIFICATION-TYPE
+      OBJECTS {
+          slapmPolicyStatsActiveConns,
+          slapmPolicyStatsTotalConns,
+          slapmPolicyStatsFirstActivated,
+          slapmPolicyStatsLastMapping,
+          slapmPolicyStatsInOctets,
+          slapmPolicyStatsOutOctets,
+          slapmPolicyStatsConnectionLimit,
+          slapmPolicyStatsCountAccepts,
+          slapmPolicyStatsCountDenies,
+          slapmPolicyStatsInDiscards,
+          slapmPolicyStatsOutDiscards,
+          slapmPolicyStatsInPackets,
+          slapmPolicyStatsOutPackets,
+          slapmPolicyStatsInProfileOctets,
+          slapmPolicyStatsOutProfileOctets,
+          slapmPolicyStatsMinRate,
+          slapmPolicyStatsMaxRate,
+          slapmPolicyStatsMaxDelay
+      }
+      STATUS  deprecated
+      DESCRIPTION
+         "A slapmPolicyDeleted notification is sent when a
+         slapmPolicyStatsEntry is deleted if the value of
+         slapmPolicyTrapEnable is enabled(1)."
+      ::= { slapmNotifications 3 }
+
+
+
+White                         Experimental                     [Page 55]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+   slapmPolicyMonitorDeleted NOTIFICATION-TYPE
+      OBJECTS {
+          slapmPolicyMonitorStatus,
+          slapmPolicyMonitorInterval,
+          slapmPolicyMonitorIntTime,
+          slapmPolicyMonitorCurrentInRate,
+          slapmPolicyMonitorCurrentOutRate,
+          slapmPolicyMonitorCurrentDelayRate,
+          slapmPolicyMonitorMinRateLow,
+          slapmPolicyMonitorMinRateHigh,
+          slapmPolicyMonitorMaxRateHigh,
+          slapmPolicyMonitorMaxRateLow,
+          slapmPolicyMonitorMaxDelayHigh,
+          slapmPolicyMonitorMaxDelayLow,
+          slapmPolicyMonitorMinInRateNotAchieves,
+          slapmPolicyMonitorMaxInRateExceeds,
+          slapmPolicyMonitorMaxDelayExceeds,
+          slapmPolicyMonitorMinOutRateNotAchieves,
+          slapmPolicyMonitorMaxOutRateExceeds
+      }
+      STATUS  deprecated
+      DESCRIPTION
+         "A slapmPolicyMonitorDeleted notification is sent when a
+         slapmPolicyMonitorEntry is deleted if the value of
+         slapmPolicyTrapEnable is enabled(1)."
+      ::= { slapmNotifications 4 }
+
+   slapmSubcomponentMonitoredEventNotAchieved NOTIFICATION-TYPE
+      OBJECTS {
+          slapmSubcomponentSystemAddress,
+          slapmSubcomponentPolicyName,
+          slapmSubcomponentTrafficProfileName,
+          slapmSubcomponentMonitorStatus,
+          slapmSubcomponentMonitorStatus,
+          slapmSubcomponentMonitorIntTime,
+          slapmSubcomponentMonitorCurrentInRate,
+          slapmSubcomponentMonitorCurrentOutRate,
+          slapmSubcomponentTcpRoundTripTime
+      }
+      STATUS  deprecated
+      DESCRIPTION
+         "This notification is generated when a monitored value
+         does not achieved a threshold specification.  This
+         applies only towards monitoring the individual components
+         of a policy traffic profile.  The value of the
+         corresponding slapmPolicyMonitorControl can be examined
+         to determine what is being monitored.  The first
+         slapmSubcomponentMonitorStatus value supplies the current
+
+
+
+White                         Experimental                     [Page 56]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+         monitor status while the 2nd value supplies the
+         previous status.
+
+         Note: The corresponding slapmPolicyMonitorControl
+         BITS setting, enableSubcomponentTraps(4), MUST be selected
+         in order for this notification to potentially be generated."
+      ::= { slapmNotifications 5 }
+
+   slapmSubcomponentMonitoredEventOkay NOTIFICATION-TYPE
+      OBJECTS {
+          slapmSubcomponentSystemAddress,
+          slapmSubcomponentPolicyName,
+          slapmSubcomponentTrafficProfileName,
+          slapmSubcomponentMonitorStatus,
+          slapmSubcomponentMonitorStatus,
+          slapmSubcomponentMonitorIntTime,
+          slapmSubcomponentMonitorCurrentInRate,
+          slapmSubcomponentMonitorCurrentOutRate,
+          slapmSubcomponentTcpRoundTripTime
+      }
+      STATUS  deprecated
+      DESCRIPTION
+         "This notification is generated when a monitored value
+         has reached an acceptable level.
+
+         Note: The corresponding slapmPolicyMonitorControl
+         BITS setting, enableSubcomponentTraps(3), MUST be
+         selected in order for this notification to potentially
+         be generated."
+      ::= { slapmNotifications 6 }
+
+   slapmPolicyRuleMonNotOkay NOTIFICATION-TYPE
+      OBJECTS {
+          slapmPRMonIntTime,
+          slapmPRMonControl,
+          slapmPRMonStatus,
+          slapmPRMonStatus,
+          slapmPRMonCurrentInRate,
+          slapmPRMonCurrentOutRate,
+          slapmPRMonCurrentDelayRate
+      }
+      STATUS  current
+      DESCRIPTION
+         "This notification is generated when an monitored event
+         is not achieved with respect to a threshold.  This
+         applies only towards monitoring a policy rule
+         as an aggregate via an associating
+         slapmPolicyRuleStatsEntry.  The value
+
+
+
+White                         Experimental                     [Page 57]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+         of slapmPRMonControl can be examined to
+         determine what is being monitored.  The first
+         slapmPRMonStatus value supplies the current
+         monitor status while the 2nd value supplies the
+         previous status.
+
+         Note: The corresponding slapmPRMonControl
+         BITS setting, enableAggregateTraps(3), MUST be
+         selected in order for this notification to
+         potentially be generated."
+      ::= { slapmNotifications 7 }
+
+   slapmPolicyRuleMonOkay NOTIFICATION-TYPE
+      OBJECTS {
+          slapmPRMonIntTime,
+          slapmPRMonControl,
+          slapmPRMonStatus,
+          slapmPRMonStatus,
+          slapmPRMonCurrentInRate,
+          slapmPRMonCurrentOutRate,
+          slapmPRMonCurrentDelayRate
+      }
+      STATUS  current
+      DESCRIPTION
+         "This notification is generated when a monitored
+         event has improved to an acceptable level.  This
+         applies only towards monitoring a policy rule
+         as an aggregate via an associating
+         slapmPolicyRuleStatsEntry.  The value
+         of slapmPRMonControl can be examined to
+         determine what is being monitored.  The first
+         slapmPRMonStatus value supplies the current
+         monitor status while the 2nd value supplies the
+         previous status.
+
+         Note: The corresponding slapmPRMonControl
+         BITS setting, enableAggregateTraps(3), MUST be
+         selected in order for this notification to
+         potentially be generated."
+      ::= { slapmNotifications 8 }
+
+   slapmPolicyRuleDeleted NOTIFICATION-TYPE
+      OBJECTS {
+          slapmPolicyRuleStatsActiveConns,
+          slapmPolicyRuleStatsTotalConns,
+          slapmPolicyRuleStatsLActivated,
+          slapmPolicyRuleStatsLastMapping,
+          slapmPolicyRuleStatsInOctets,
+
+
+
+White                         Experimental                     [Page 58]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+          slapmPolicyRuleStatsOutOctets,
+          slapmPolicyRuleStatsConnLimit,
+          slapmPolicyRuleStatsCountAccepts,
+          slapmPolicyRuleStatsCountDenies,
+          slapmPolicyRuleStatsInDiscards,
+          slapmPolicyRuleStatsOutDiscards,
+          slapmPolicyRuleStatsInPackets,
+          slapmPolicyRuleStatsOutPackets,
+          slapmPolicyRuleStatsInProOctets,
+          slapmPolicyRuleStatsOutProOctets,
+          slapmPolicyRuleStatsMinRate,
+          slapmPolicyRuleStatsMaxRate,
+          slapmPolicyRuleStatsMaxDelay,
+          slapmPolicyRuleStatsTotalRsvpFlows,
+          slapmPolicyRuleStatsActRsvpFlows
+      }
+      STATUS  current
+      DESCRIPTION
+         "A slapmPolicyRuleDeleted notification is sent when a
+         slapmPolicyRuleStatsEntry is deleted if the value of
+         slapmPolicyTrapEnable is enabled(1)."
+      ::= { slapmNotifications 9 }
+
+   slapmPolicyRuleMonDeleted NOTIFICATION-TYPE
+      OBJECTS {
+          slapmPRMonControl,
+          slapmPRMonStatus,
+          slapmPRMonInterval,
+          slapmPRMonIntTime,
+          slapmPRMonCurrentInRate,
+          slapmPRMonCurrentOutRate,
+          slapmPRMonCurrentDelayRate,
+          slapmPRMonMinRateLow,
+          slapmPRMonMinRateHigh,
+          slapmPRMonMaxRateHigh,
+          slapmPRMonMaxRateLow,
+          slapmPRMonMaxDelayHigh,
+          slapmPRMonMaxDelayLow,
+          slapmPRMonMinInRateNotAchieves,
+          slapmPRMonMaxInRateExceeds,
+          slapmPRMonMaxDelayExceeds,
+          slapmPRMonMinOutRateNotAchieves,
+          slapmPRMonMaxOutRateExceeds
+      }
+      STATUS  current
+      DESCRIPTION
+         "A slapmPolicyRuleMonDeleted notification is sent when a
+         slapmPRMonEntry is deleted if the value of
+
+
+
+White                         Experimental                     [Page 59]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+         slapmPolicyTrapEnable is enabled(1)."
+      ::= { slapmNotifications 10 }
+
+   slapmSubcMonitorNotOkay NOTIFICATION-TYPE
+      OBJECTS {
+          slapmSubcomponentSystemAddress,
+          slapmSubcomponentPolicyRuleIndex,
+          slapmPRMonControl,
+          slapmSubcomponentMonitorStatus,
+          slapmSubcomponentMonitorStatus,
+          slapmSubcomponentMonitorIntTime,
+          slapmSubcomponentMonitorCurrentInRate,
+          slapmSubcomponentMonitorCurrentOutRate,
+          slapmSubcomponentTcpRoundTripTime
+      }
+      STATUS  current
+      DESCRIPTION
+         "This notification is generated when a monitored value
+         does not achieved a threshold specification.  This
+         applies only towards monitoring the individual components
+         of a policy rule.  The value of the
+         corresponding slapmPRMonControl can be examined
+         to determine what is being monitored.  The first
+         slapmSubcomponentMonitorStatus value supplies the current
+         monitor status while the 2nd value supplies the
+         previous status.
+
+         Note: The corresponding slapmPRMonControl
+         BITS setting, enableSubcomponentTraps(4), MUST be selected
+         in order for this notification to potentially be generated."
+      ::= { slapmNotifications 11 }
+
+   slapmSubcMonitorOkay NOTIFICATION-TYPE
+      OBJECTS {
+          slapmSubcomponentSystemAddress,
+          slapmSubcomponentPolicyRuleIndex,
+          slapmPRMonControl,
+          slapmSubcomponentMonitorStatus,
+          slapmSubcomponentMonitorStatus,
+          slapmSubcomponentMonitorIntTime,
+          slapmSubcomponentMonitorCurrentInRate,
+          slapmSubcomponentMonitorCurrentOutRate,
+          slapmSubcomponentTcpRoundTripTime
+      }
+
+      STATUS  current
+      DESCRIPTION
+         "This notification is generated when a monitored value
+
+
+
+White                         Experimental                     [Page 60]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+         has reached an acceptable level.
+
+         Note: The corresponding slapmPRMonControl
+         BITS setting, enableSubcomponentTraps(3), MUST be
+         selected in order for this notification to potentially
+         be generated."
+      ::= { slapmNotifications 12 }
+
+   -- Conformance information
+   -- Compliance statements
+
+   slapmCompliances OBJECT IDENTIFIER ::= { slapmConformance 1 }
+   slapmGroups      OBJECT IDENTIFIER ::= { slapmConformance 2 }
+
+   -- Compliance statements
+
+   slapmCompliance MODULE-COMPLIANCE
+      STATUS  current
+      DESCRIPTION
+              "The compliance statement for the SLAPM-MIB."
+      MODULE  -- this module
+          MANDATORY-GROUPS {
+                              slapmBaseGroup2,
+                              slapmNotGroup2
+                           }
+          GROUP slapmEndSystemGroup2
+          DESCRIPTION
+              "The contents of this group is required by end-system
+              implementations."
+          GROUP slapmEndSystemNotGroup2
+          DESCRIPTION
+              "The contents of this group is required by end-system
+              implementations."
+          GROUP slapmBaseGroup
+          DESCRIPTION
+              "The contents of this group has been deprecated in favor
+              of the new slapmBaseGroup2.  Older implementations of this
+              MIB would continue its support of the contents of this
+              group."
+          GROUP slapmNotGroup
+          DESCRIPTION
+              "The contents of this group has been deprecated in favor
+              of the new slapmNotGroup2.  Older implementations of this
+              MIB would continue its support of the contents of
+              this group."
+          GROUP slapmOptionalGroup
+          DESCRIPTION
+              "The contents of this group has been deprecated."
+
+
+
+White                         Experimental                     [Page 61]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+          GROUP slapmEndSystemGroup
+          DESCRIPTION
+              "The contents of this group has been deprecated in favor
+              of the new slapmEndSystemGroup2.  Older implementations
+              of this MIB would continue its support of the
+              contents of this group."
+          GROUP slapmEndSystemNotGroup
+          DESCRIPTION
+              "The contents of this group has been deprecated in favor
+              of the new slapmEndSystemNotGroup2.  Older
+              implementations of this MIB would continue its support
+              of the contents of this group."
+      ::= { slapmCompliances 1 }
+
+   -- MIB groupings
+
+   slapmBaseGroup OBJECT-GROUP
+     OBJECTS {
+               slapmSpinLock,
+               slapmPolicyCountQueries,
+               slapmPolicyCountAccesses,
+               slapmPolicyCountSuccessAccesses,
+               slapmPolicyCountNotFounds,
+               slapmPolicyPurgeTime,
+               slapmPolicyTrapEnable,
+               slapmPolicyStatsOperStatus,
+               slapmPolicyStatsActiveConns,
+               slapmPolicyStatsFirstActivated,
+               slapmPolicyStatsLastMapping,
+               slapmPolicyStatsInOctets,
+               slapmPolicyStatsOutOctets,
+               slapmPolicyStatsConnectionLimit,
+               slapmPolicyStatsTotalConns,
+               slapmPolicyStatsCountAccepts,
+               slapmPolicyStatsCountDenies,
+               slapmPolicyStatsInDiscards,
+               slapmPolicyStatsOutDiscards,
+               slapmPolicyStatsInPackets,
+               slapmPolicyStatsOutPackets,
+               slapmPolicyStatsMinRate,
+               slapmPolicyStatsMaxRate,
+               slapmPolicyStatsMaxDelay,
+               slapmPolicyMonitorControl,
+               slapmPolicyMonitorStatus,
+               slapmPolicyMonitorInterval,
+               slapmPolicyMonitorIntTime,
+               slapmPolicyMonitorCurrentInRate,
+               slapmPolicyMonitorCurrentOutRate,
+
+
+
+White                         Experimental                     [Page 62]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+               slapmPolicyMonitorMinRateLow,
+               slapmPolicyMonitorMinRateHigh,
+               slapmPolicyMonitorMaxRateHigh,
+               slapmPolicyMonitorMaxRateLow,
+               slapmPolicyMonitorMaxDelayHigh,
+               slapmPolicyMonitorMaxDelayLow,
+               slapmPolicyMonitorMinInRateNotAchieves,
+               slapmPolicyMonitorMaxInRateExceeds,
+               slapmPolicyMonitorMaxDelayExceeds,
+               slapmPolicyMonitorMinOutRateNotAchieves,
+               slapmPolicyMonitorMaxOutRateExceeds,
+               slapmPolicyMonitorCurrentDelayRate,
+               slapmPolicyMonitorRowStatus
+              }
+    STATUS deprecated
+    DESCRIPTION
+        "The group of objects defined by this MIB that are
+        required for all implementations to be compliant."
+    ::= { slapmGroups 1 }
+
+   slapmOptionalGroup OBJECT-GROUP
+     OBJECTS {
+               slapmPolicyStatsInProfileOctets,
+               slapmPolicyStatsOutProfileOctets
+             }
+    STATUS deprecated
+    DESCRIPTION
+        "The group of objects defined by this MIB that are
+        optional."
+    ::= { slapmGroups 2 }
+
+   slapmEndSystemGroup OBJECT-GROUP
+     OBJECTS {
+               slapmPolicyTrapFilter,
+               slapmSubcomponentProtocol,
+               slapmSubcomponentSystemAddress,
+               slapmSubcomponentPolicyName,
+               slapmSubcomponentTrafficProfileName,
+               slapmSubcomponentLastActivity,
+               slapmSubcomponentInOctets,
+               slapmSubcomponentOutOctets,
+               slapmSubcomponentTcpOutBufferedOctets,
+               slapmSubcomponentTcpInBufferedOctets,
+               slapmSubcomponentTcpReXmts,
+               slapmSubcomponentTcpRoundTripTime,
+               slapmSubcomponentTcpRoundTripVariance,
+               slapmSubcomponentInPdus,
+               slapmSubcomponentOutPdus,
+
+
+
+White                         Experimental                     [Page 63]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+               slapmSubcomponentApplName,
+               slapmSubcomponentMonitorStatus,
+               slapmSubcomponentMonitorIntTime,
+               slapmSubcomponentMonitorCurrentOutRate,
+               slapmSubcomponentMonitorCurrentInRate
+             }
+     STATUS  deprecated
+     DESCRIPTION
+         "The group of objects defined by this MIB that are
+         required for end system implementations."
+     ::= { slapmGroups 3 }
+
+   slapmNotGroup NOTIFICATION-GROUP
+     NOTIFICATIONS {
+               slapmMonitoredEventNotAchieved,
+               slapmMonitoredEventOkay,
+               slapmPolicyProfileDeleted,
+               slapmPolicyMonitorDeleted
+             }
+     STATUS  deprecated
+     DESCRIPTION
+         "The group of notifications defined by this MIB that MUST
+         be implemented."
+     ::= { slapmGroups 4 }
+
+   slapmEndSystemNotGroup NOTIFICATION-GROUP
+     NOTIFICATIONS {
+               slapmSubcomponentMonitoredEventNotAchieved,
+               slapmSubcomponentMonitoredEventOkay
+             }
+     STATUS  deprecated
+     DESCRIPTION
+         "The group of objects defined by this MIB that are
+         required for end system implementations."
+     ::= { slapmGroups 5 }
+
+   slapmBaseGroup2 OBJECT-GROUP
+     OBJECTS {
+               slapmSpinLock,
+               slapmPolicyCountQueries,
+               slapmPolicyCountAccesses,
+               slapmPolicyCountSuccessAccesses,
+               slapmPolicyCountNotFounds,
+               slapmPolicyPurgeTime,
+               slapmPolicyTrapEnable,
+               slapmPolicyNameOfRule,
+               slapmPolicyRuleStatsOperStatus,
+               slapmPolicyRuleStatsActiveConns,
+
+
+
+White                         Experimental                     [Page 64]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+               slapmPolicyRuleStatsTotalConns,
+               slapmPolicyRuleStatsLActivated,
+               slapmPolicyRuleStatsLastMapping,
+               slapmPolicyRuleStatsInOctets,
+               slapmPolicyRuleStatsOutOctets,
+               slapmPolicyRuleStatsConnLimit,
+               slapmPolicyRuleStatsCountAccepts,
+               slapmPolicyRuleStatsCountDenies,
+               slapmPolicyRuleStatsInDiscards,
+               slapmPolicyRuleStatsOutDiscards,
+               slapmPolicyRuleStatsInPackets,
+               slapmPolicyRuleStatsOutPackets,
+               slapmPolicyRuleStatsInProOctets,
+               slapmPolicyRuleStatsOutProOctets,
+               slapmPolicyRuleStatsMinRate,
+               slapmPolicyRuleStatsMaxRate,
+               slapmPolicyRuleStatsMaxDelay,
+               slapmPolicyRuleStatsTotalRsvpFlows,
+               slapmPolicyRuleStatsActRsvpFlows,
+               slapmPRMonControl,
+               slapmPRMonStatus,
+               slapmPRMonInterval,
+               slapmPRMonIntTime,
+               slapmPRMonCurrentInRate,
+               slapmPRMonCurrentOutRate,
+               slapmPRMonMinRateLow,
+               slapmPRMonMinRateHigh,
+               slapmPRMonMaxRateHigh,
+               slapmPRMonMaxRateLow,
+               slapmPRMonMaxDelayHigh,
+               slapmPRMonMaxDelayLow,
+               slapmPRMonMinInRateNotAchieves,
+               slapmPRMonMaxInRateExceeds,
+               slapmPRMonMaxDelayExceeds,
+               slapmPRMonMinOutRateNotAchieves,
+               slapmPRMonMaxOutRateExceeds,
+               slapmPRMonCurrentDelayRate,
+               slapmPRMonRowStatus
+              }
+    STATUS current
+    DESCRIPTION
+        "The group of objects defined by this MIB that are
+        required for all implementations to be compliant."
+    ::= { slapmGroups 6 }
+
+   slapmEndSystemGroup2 OBJECT-GROUP
+     OBJECTS {
+               slapmPolicyTrapFilter,
+
+
+
+White                         Experimental                     [Page 65]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+               slapmSubcomponentProtocol,
+               slapmSubcomponentSystemAddress,
+               slapmSubcomponentLastActivity,
+               slapmSubcomponentInOctets,
+               slapmSubcomponentOutOctets,
+               slapmSubcomponentTcpOutBufferedOctets,
+               slapmSubcomponentTcpInBufferedOctets,
+               slapmSubcomponentTcpReXmts,
+               slapmSubcomponentTcpRoundTripTime,
+               slapmSubcomponentTcpRoundTripVariance,
+               slapmSubcomponentInPdus,
+               slapmSubcomponentOutPdus,
+               slapmSubcomponentApplName,
+               slapmSubcomponentMonitorStatus,
+               slapmSubcomponentMonitorIntTime,
+               slapmSubcomponentMonitorCurrentOutRate,
+               slapmSubcomponentMonitorCurrentInRate,
+               slapmSubcomponentPolicyRuleIndex
+             }
+     STATUS  current
+     DESCRIPTION
+         "The group of objects defined by this MIB that are
+         required for end system implementations."
+     ::= { slapmGroups 7 }
+
+   slapmNotGroup2 NOTIFICATION-GROUP
+     NOTIFICATIONS {
+               slapmPolicyRuleMonNotOkay,
+               slapmPolicyRuleMonOkay,
+               slapmPolicyRuleDeleted,
+               slapmPolicyRuleMonDeleted
+             }
+     STATUS  current
+     DESCRIPTION
+         "The group of notifications defined by this MIB that MUST
+         be implemented."
+     ::= { slapmGroups 8 }
+
+   slapmEndSystemNotGroup2 NOTIFICATION-GROUP
+     NOTIFICATIONS {
+               slapmSubcMonitorNotOkay,
+               slapmSubcMonitorOkay
+             }
+     STATUS  current
+     DESCRIPTION
+         "The group of objects defined by this MIB that are
+         required for end system implementations."
+     ::= { slapmGroups 9 }
+
+
+
+White                         Experimental                     [Page 66]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+END
+
+5.0  Security Considerations
+
+   Certain management information in the MIB defined by this document
+   may be considered sensitive in some network environments.  Therefore,
+   authentication of received SNMP requests and controlled access to
+   management information SHOULD be employed in such environments.  The
+   method for this authentication is a function of the SNMP
+   Administrative Framework, and has not been expanded by this MIB.
+
+   To facilitate the provisioning of access control by a security
+   administrator using the View-Based Access Control Model (VACM)
+   defined in RFC 2575 [11] for tables in which multiple users may need
+   to independently create or modify entries, the initial index is used
+   as an "owner index" (refer to slapmPRMonOwnerIndex in an
+   slapmPRMonEntry).  Such an initial index has a syntax of
+   SnmpAdminString, and can thus be trivially mapped to a securityName
+   or groupName as defined in VACM, in accordance with a security
+   policy.
+
+   All entries in related tables belonging to a particular user will
+   have the same value for this initial index.  For a given user's
+   entries in a particular table, the object identifiers for the
+   information in these entries will have the same subidentifiers
+   (except for the "column" subidentifier) up to the end of the encoded
+   owner index. To configure VACM to permit access to this portion of
+   the table, one would create vacmViewTreeFamilyTable entries with the
+   value of vacmViewTreeFamilySubtree including the owner index portion,
+   and vacmViewTreeFamilyMask "wildcarding" the column subidentifier.
+   More elaborate configurations are possible.  The VACM access control
+   mechanism described above provides control
+
+   It is RECOMMENDED that the slapmPRMonTable (equivalent to the
+   deprecated slapmPolicyMonitorTable) and the slapmSubcomponentTable
+   not be supported in insecure environments.
+
+6.0  Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   intellectual property or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; neither does it represent that it
+   has made any effort to identify any such rights.  Information on the
+   IETF's procedures with respect to rights in standards-track and
+   standards-related documentation can be found in BCP-11.  Copies of
+   claims of rights made available for publication and any assurances of
+
+
+
+White                         Experimental                     [Page 67]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+   licenses to be made available, or the result of an attempt made to
+   obtain a general license or permission for the use of such
+   proprietary rights by implementers or users of this specification can
+   be obtained from the IETF Secretariat.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights which may cover technology that may be required to practice
+   this standard.  Please address the information to the IETF Executive
+   Director.
+
+7.0  Acknowledgments
+
+   This document is an individual submission and not the product of any
+   IETF working group.  Special thanks should be given to Robert Moore
+   of IBM for his numerous reviews.
+
+8.0  References
+
+   [1]  Case, J., Fedor, M., Schoffstall, M. and J. Davin, "Simple
+        Network Management Protocol", STD 15, RFC 1157, May 1990.
+
+   [2]  McCloghrie, K. and M. Rose, Editors, "Management Information
+        Base for Network Management of TCP/IP-based internets: MIB-II",
+        STD 17, RFC 1213, March 1991.
+
+   [3]  McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J., Rose,
+        M.  and S. Waldbusser, "Structure of Management Information
+        Version 2 (SMIv2)", STD 58, RFC 2578, April 1999.
+
+   [4]  McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J., Rose,
+        M.  and S. Waldbusser, "Textual Conventions for SMIv2", STD 58,
+        RFC 2579, April 1999.
+
+   [5]  McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J., Rose,
+        M.  and S. Waldbusser, "Conformance Statements for SMIv2", STD
+        58, RFC 2580, April 1999.
+
+   [6]  Case, J., McCloghrie, K., Rose, M. and Waldbusser, S., "Protocol
+        Operations for Version 2 of the Simple Network Management
+        Protocol (SNMPv2)", RFC 1905, January 1996.
+
+   [7]  Harrington D., Presuhn, R. and B. Wijnen,  "An Architecture for
+        Describing SNMP Management Frameworks", RFC 2571, April 1999.
+
+   [8]  Case, J., Harrington D., Presuhn, R. and B. Wijnen, "Message
+        Processing and Dispatching for the Simple Network Management
+        Protocol (SNMP)", RFC 2572, April 1999.
+
+
+
+White                         Experimental                     [Page 68]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+   [9]  Levi D., Meyer P. and B. Stewart, "SNMPv3 Applications", RFC
+        2573, April 1999.
+
+   [10] Blumenthal, U. and B. Wijnen, "User-based Security Model (USM)
+        for version 3 of the Simple Network Management Protocol
+        (SNMPv3)", RFC 2574, April 1999.
+
+   [11] Wijnen, B., Presuhn, R. and K. McCloghrie, "View-based Access
+        Control Model (VACM) for the Simple Network Management Protocol
+        (SNMP)", RFC 2575, April 1999.
+
+   [12] Hovey, R. and S. Bradner, "The Organizations Involved in the
+        IETF Standards Process", BCP 11, RFC 2028, October 1996.
+
+   [13] Bradner, S., "Key words for use in RFCs to Indicate Requirement
+        Levels", BCP 14, RFC 2119, March 1997.
+
+   [14] Rose, M. and K. McCloghrie, "Structure and Identification of
+        Management Information for TCP/IP-based Internets", STD 16, RFC
+        1155, May 1990.
+
+   [15] Rose, M. and K. McCloghrie, "Concise MIB Definitions", STD 16,
+        RFC 1212, March 1991.
+
+   [16] Rose, M., "A Convention for Defining Traps for use with the
+        SNMP", RFC 1215, March 1991.
+
+   [17] Case, J., McCloghrie, K., Rose, M. and S. Waldbusser,
+        "Introduction to Community-based SNMPv2", RFC 1901, January
+        1996.
+
+   [18] Case, J., McCloghrie, K., Rose, M. and S. Waldbusser, "Transport
+        Mappings for Version 2 of the Simple Network Management Protocol
+        (SNMPv2)", RFC 1906, January 1996.
+
+   [19] McCloghrie, K. and A. Bierman, "Entity MIB using SMIv2", RFC
+        2037, October 1996.
+
+   [20] Bradner, S., "The Internet Standards Process -- Revision 3", BCP
+        9, RFC 2026, October 1996.
+
+
+
+
+
+
+
+
+
+
+
+White                         Experimental                     [Page 69]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+9.0  Author's Address
+
+   Kenneth D. White
+   Dept. BRQA/Bldg. 501/G114
+   IBM Corporation
+   P.O.Box 12195
+   3039 Cornwallis
+   Research Triangle Park, NC 27709, USA
+
+   EMail: wkenneth@us.ibm.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+White                         Experimental                     [Page 70]
+
+RFC 2758                       SLAPM-MIB                   February 2000
+
+
+10.0  Full Copyright Statement
+
+   Copyright (C) The Internet Society (2000).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+White                         Experimental                     [Page 71]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2758.txt](<www.ietf.org/rfc/rfc2758.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
