### PR TITLE
Archive rfc276.txt

### DIFF
--- a/www.ietf.org/rfc/rfc276.txt
+++ b/www.ietf.org/rfc/rfc276.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+NWG/RFC# 276                                  8-NOV-71 09:23 7936
+NIC Course at SRI on Nov. 29, 30              Richard W. Watson
+                                              SRI-ARC
+
+
+NIC Course
+
+
+   The Network Information Center is planning to run a course on
+   the use of its Online System (NLS), including use of the
+   Journal, at SRI.  The dates are to be Nov. 29, 30.
+
+   We particularly would like this course to be for Station
+   Agents or Secretaries who could help others at a site use the
+   NIC and could transcribe documents or messages into NLS.
+   Anyone is welcome, however.  The only restriction is a limit
+   of 12 people.
+
+   Those desiring to attend should contact Dirk Van Nouhuys or
+   Dick Watson at (415) 326-6200 ext. 3370 or 2013.
+
+   We will be glad to make motel reservations for anyone
+   attending.  We usually use the Mermaid Motel in Menlo Park.
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc276.txt](<www.ietf.org/rfc/rfc276.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
