### PR TITLE
Archive rfc278.txt

### DIFF
--- a/www.ietf.org/rfc/rfc278.txt
+++ b/www.ietf.org/rfc/rfc278.txt
@@ -1,0 +1,222 @@
+
+
+
+
+
+
+NWG/RFC# 278                            RWW 17-NOV-71 14:12  8056
+Revision of the Mail Box Protocol
+
+NETWORK WORKING GROUP             Abhay Bhushan, MIT-DMCG
+Request for Comments #278         Bob Braden, UCLA-CCN
+NIC 8056                          Eric Harslem, RAND
+Categories: A.5, O.7              John Heafner, RAND
+Obsoletes RFC 221, NIC 7612       Alex McKenzie, BBN-NET
+                                  John Melvin, SRI-ARC
+                                  Bob Sundberg, HARV
+                                  Dick Watson, SRI-ARC
+                                  Jim White, UCSB
+                                  17-Nov-1971
+
+                   REVISION OF THE MAIL BOX PROTOCOL
+
+   The file transfer committee met and discussed the Mail Box Protocol
+   RFC 221, NIC 7612.  The potential utility for the mechanism was
+   confirmed and a couple of changes suggested.  We first give the
+   changes and then restate the Protocol.
+
+                                  CHANGES
+
+   1) The Mail Box Protocol is only to allow ASCII stings of text
+   formatted for a network standard line printer rather than allowing
+   other data types.
+
+   2) A new command is to be added to the File Transfer Protocol called
+   "Append With Create" which appends to a file if the file exists, and
+   creates a file if it does not exist.
+
+   3) The standard path name for the mailbox is to be, using conventional
+   metalanguage symbols,
+
+      "MAIL" <separator> ("PRINTER"/<ident>)
+
+      <separator> is the ASCII GS, octal 035.  The semantics of
+      the above are the following:
+
+      <ident> is a NIC IDENT
+
+      "MAIL" <separator> "PRINTER" would be interpreted by the
+      receiving site as meaning Append With Create the
+      transmitted file to a bulk mail file to be printed or
+      directly output it to a printer.
+
+      "MAIL" <separator> <ident> would be interpreted to mean
+      either
+
+
+
+
+                                                                [Page 1]
+
+NWG/RFC# 278                            RWW 17-NOV-71 14:12  8056
+Revision of the Mail Box Protocol
+
+         1) The same as "MAIL" <separator> "PRINTER" i.e., ignore
+         <ident> or
+
+         2) Append With Create the following file to a file
+         specifically for the person designated by <ident> for
+         either online access or printing or both.
+
+   The problem of delivering mail to TIPs was discussed.
+
+   At the moment TIPs support only the Telnet Protocol, but it is planned
+   to support the Data Transfer Protocol.  TIPs will have an ASCII line
+   printer available as an optional device.  People desiring to send a
+   mail item to a TIP with a printer can open a standard published socket
+   and transmit to it with Telnet Protocol now, later also with the Data
+   Transfer Protocol.  The NIC's plans with regard to TIPs is not to do
+   automatic network delivery to them.  Messages to people using TIPs can
+   be sent to them through the NIC and will be delivered as with everyone
+   else directly to the person's initial file at the NIC. The TIP user
+   can read the item online or obtain a hardcopy at his terminal with the
+   Output Device Teletype command of NLS.
+
+                           MAIL BOX PROTOCOL
+
+   The Mail Box Protocol will use established network conventions,
+   specifically the Network Control Program, Initial Connection Protocol,
+   Data Transfer Protocol, and File Transfer Protocol (as described in
+   current Network Protocols, NIC 7104).
+
+   The transmission is to be Network ASCII.  The standard receiving mail
+   printer is assumed to have a print line 72 characters wide, and a page
+   of 66 lines.  The new line convention will be carriage return (Hex
+   per the Telnet Protocol, RFC 158, NIC 6768.  The standard printer will
+   accept form feed character (Hex '0C') (Octal '014') as meaning move
+   paper to the top of a new page.
+
+   It is the sender's responsibility to control the length of the print
+   line and page.  If more than 72 characters per line are sent, or if
+   more than 66 line are sent without a form feed, then the receiving
+   site can handle these situations as appropriate for them.  These
+   conventions can be changed by control codes as described below.  At
+   the head of the message or document sent there is to be two copies of
+   an initial address string each terminated by a form feed.  This
+   address string is to contain the sender's name and address, and the
+
+
+
+
+
+
+                                                                [Page 2]
+
+NWG/RFC# 278                            RWW 17-NOV-71 14:12 8056
+Revision of the Mail Box Protocol
+
+   receiver's name and address formatted in some reasonable, easy-to read
+   form for a clerk to read and distribute.  Comments could also be
+   included in the address string.  The requirements for two copies are
+   to make one readable from a fan fold paper stack without effort.
+
+   Initial Connection
+
+   Initial Connection will be as per the Official Initial Connection
+   Protocol, Document #2, NIC 7101, to the standard File Transfer socket
+   #3.
+
+   File Transfer
+
+   The mail item (file) to be transferred would be transferred according
+   to the File Transfer Protocol.
+
+   As per the File Transfer Protocol, a file (mail item) can be sent in
+   more than one data transaction as defined in the Data Transfer
+   Protocol.  End of file is indicated by the file separator (as defined
+   in Data Transfer Protocol) or by closing the connection.
+
+   Order of Transactions
+
+   The only basic operation required is an Append With Create
+
+                   Append With Create Request
+
+     (Mailer) User -------------------->  Server (Mail Box)
+
+                          <File -  data>
+
+                      -------------------->
+
+                     End of File indication
+
+                      -------------------->
+
+                           Acknowledge
+
+                      <--------------------
+
+   The data type default is network ASCII.  The Standard line printer
+   default is as defined above.  Other control transactions can be used.
+
+                    CONTROL TRANSACTIONS TO BE USED
+
+
+
+
+                                                                [Page 3]
+
+NWG/RFC# 278                            RWW 17-NOV-71 14:12 8056
+Revision of the Mail Box Protocol
+
+      OP CODE
+
+     Hex     Octal
+
+      09       011      Error or unsuccessful terminate
+
+      0A      012      Acknowledge or successful terminate
+
+      05      005       Append With Create request (add to
+                        existing file or create file if
+                        none exists)
+
+      5A      132       Change printer control settings
+
+                              ERROR CODES
+
+   All error codes defined in the file Transfer Protocol could be
+   returned.
+
+                         PRINTER CONTROL CODES
+
+     Hex     Octal
+
+      D1      321       Meaning: Set line width to 72 characters
+
+      D2      322       Meaning: Use the full width of your printer
+
+      03      323       Meaning: Set page size to 66 line
+
+      04      324       Meaning: Set page size to infinite
+
+   Other virtual printer control codes can be added in the future.
+
+   Other classes of control codes can be added as the need arises.
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc278.txt](<www.ietf.org/rfc/rfc278.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
