### PR TITLE
Archive rfc28.txt

### DIFF
--- a/www.ietf.org/rfc/rfc28.txt
+++ b/www.ietf.org/rfc/rfc28.txt
@@ -1,0 +1,43 @@
+Network Working Group                                   Bill English
+RFC-28                                                  SRI
+                                                        13 January 1970
+
+
+
+
+                          TIME STANDARDS
+
+
+
+
+We are about to install a relatively accurate real-time clock on our
+system.  I would like any comments relative to Network time standards
+for such things as delay measurement so we can decide how good our clock
+should be.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+DISTRIBUTION:
+
+A. Bhushan, MIT
+S. Carr, Utah
+G. Cole, SDS
+S. Crocker, UCLA
+K. Fry, MITRE
+J. Heafner, RAND
+B. Kahn, BB&N
+T. O'Sullivan, Raytheon
+L. Roberts, ARPA
+P. Rovner, LL
+R. Stoughton, UCSB


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc28.txt](<www.ietf.org/rfc/rfc28.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
