### PR TITLE
Archive rfc280.txt

### DIFF
--- a/www.ietf.org/rfc/rfc280.txt
+++ b/www.ietf.org/rfc/rfc280.txt
@@ -1,0 +1,165 @@
+
+
+
+
+
+
+NWG/RFC# 280                                17-NOV-71 15:57  8060
+A Draft Set of Host Names                   Richard W. Watson
+                                            SRI-ARC
+
+The enclosed list of host names is a draft.  The hosts with an *
+next to them indicated that this is the name they desired.  The
+others are names assigned.  If I do not hear from representatives
+at the hosts to change or correct the names in this list by
+December 3, I will publish a list which we all can consider
+official.
+
+ Formal Name                    Nickname         Network Address
+
+*AMES-ILLIAC                    I4
+
+*AMES-67                                          16
+
+*AMES-TIP                                        144
+
+*BBN-NCC                        NCC                5
+
+*BBN-TESTIP                                      158
+
+*CMU-10                                           14
+
+*MIT-DMCG                       DMCG              70
+
+*MIT-MULTICS                    MIT-M              6
+
+*MITRE-TIP                                       145
+
+*RAND-CSG                                         71
+
+*RAND-RCC                                          7
+
+*SRI-AI                                           66
+
+*SRI-ARC                        NIC                2
+
+*UCLA-CCN                       CCN               65
+
+*UCLA-NMC                       SEX                1
+
+*UCSB-MOD75                     MOD75              3
+
+*USC-44                                           23
+
+BBN-TENEX                       TENEX             69
+
+
+
+                                                                [Page 1]
+
+NWG/RFC# 280                                17-NOV-71 15:57  8060
+A Draft Set of Host Names
+
+
+BBN-TENEXB                                       133
+
+BURR                                              15
+
+BURR-TEST                                         79
+
+CASE-10                                           13
+
+ETAC-TIP                                         148
+
+GWC-TIP                                          152
+
+HARV-1                                            73
+
+HARV-10                                            9
+
+HARV-11                                          137
+
+ILL-11                                            12
+
+ILL-6500                                          76
+
+LL-67                                             10
+
+LL-TSP                                           138
+
+LL-TX2                                            74
+
+MCCL-418                                          22
+
+MIT-AI                                           134
+
+NBS-11                                            19
+
+NBS-TIP                                          147
+
+NCAR-7600                                         25
+
+NCAR-TIP                                         153
+
+RADC-645                                          18
+
+
+
+
+
+
+                                                                [Page 2]
+
+NWG/RFC# 280                                17-NOV-71 15:57  8060
+A Draft Set of Host Names
+
+
+RADC-TIP                                         146
+
+SDC-75                                             8
+
+SU-SAIL                                           11
+
+TINK-418                                          21
+
+USC-TIP                                          151
+
+UTAH-10                                            4
+
+
+
+
+
+
+
+
+
+
+
+
+    [ This RFC was put into machine readable form for entry ]
+    [ into the online RFC archives by BBN Corp. under the   ]
+    [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc280.txt](<www.ietf.org/rfc/rfc280.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
