### PR TITLE
Archive rfc2799.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2799.txt
+++ b/www.ietf.org/rfc/rfc2799.txt
@@ -1,0 +1,1291 @@
+
+
+
+
+
+
+Network Working Group                                          S. Ginoza
+Request for Comments: 2799                                           ISI
+Category: Informational                                   September 2000
+
+
+                      Request for Comments Summary
+
+                         RFC Numbers 2700-2799
+
+Status of This Memo
+
+   This RFC is a slightly annotated list of the 100 RFCs from RFC 2700
+   through RFCs 2799.  This is a status report on these RFCs.  This memo
+   provides information for the Internet community.  It does not specify
+   an Internet standard of any kind.  Distribution of this memo is
+   unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (YEAR).  All Rights Reserved.
+
+Note
+
+   Many RFCs, but not all, are Proposed Standards, Draft Standards, or
+   Standards.  Since the status of these RFCs may change during the
+   standards processing, we note here only that they are on the
+   standards track.  Please see the latest edition of "Internet Official
+   Protocol Standards" for the current state and status of these RFCs.
+   In the following, RFCs on the standards track are marked [STANDARDS-
+   TRACK].
+
+RFC     Author          Date            Title
+---     ------          ----            -----
+
+
+2799    Ginoza                          Request for Comments Summary
+
+This memo.
+
+
+2798    Smith           Apr 2000        Definition of the
+                                        inetOrgPerson LDAP Object
+                                        Class
+
+We define a new object class called inetOrgPerson for use in LDAP and
+X.500 directory services that extends the X.521 standard
+organizationalPerson class to meet these needs.  This memo provides
+information for the Internet community.
+
+
+
+Ginoza                       Informational                      [Page 1]
+
+RFC 2799                  Summary of 2700-2799            September 2000
+
+
+2797    Myers           Apr 2000        Certificate Management
+                                        Messages over CMS
+
+This document defines a Certificate Management protocol using CMS (CMC).
+[STANDARDS TRACK]
+
+
+2796    Bates           Apr 2000        BGP Route Reflection - An
+                                        Alternative to Full Mesh IBGP
+
+This document describes the use and design of a method known as "Route
+Reflection" to alleviate the the need for "full mesh" IBGP.  [STANDARDS
+TRACK]
+
+
+2795    Christey        Mar 2000        The Infinite Monkey Protocol
+                                        Suite (IMPS)
+
+This memo describes a protocol suite which supports an infinite number
+of monkeys that sit at an infinite number of typewriters in order to
+determine when they have either produced the entire works of William
+Shakespeare or a good television show.  This memo provides information
+for the Internet community.
+
+
+2794    Calhoun         Mar 2000        Mobile IP Network Access
+                                        Identifier Extension for IPv4
+
+Our proposal defines a way for the mobile node to identify itself, by
+including the NAI along with the Mobile IP Registration Request.  This
+memo also updates RFC 2290 which specifies the Mobile-IPv4 Configuration
+option for IPCP, by allowing the Mobile Node's Home Address field of
+this option to be zero.  [STANDARDS TRACK]
+
+
+2793    Hellstrom       May 2000        RTP Payload for Text
+                                        Conversation
+
+This memo describes how to carry text conversation session contents in
+RTP packets.  Text conversation session contents are specified in ITU-T
+Recommendation T.140.  [STANDARDS TRACK]
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 2]
+
+RFC 2799                  Summary of 2700-2799            September 2000
+
+
+2792    Blaze           Mar 2000        DSA and RSA Key and Signature
+                                        Encoding for the KeyNote Trust
+                                        Management System
+
+This memo describes RSA and DSA key and signature encoding, and binary
+key encoding for version 2 of the KeyNote trust-management system.  This
+memo provides information for the Internet community.
+
+
+2791    Yu              Jul 2000        Scalable Routing Design
+                                        Principles
+
+This document identifies major factors affecting routing scalability as
+well as basic principles of designing scalable routing for large
+networks.  This memo provides information for the Internet community.
+
+
+2790    Waldbusser      Mar 2000        Host Resources MIB
+
+This memo obsoletes RFC 1514, the "Host Resources MIB".  This memo
+extends that specification by clarifying changes based on implementation
+and deployment experience and documenting the Host Resources MIB in
+SMIv2 format while remaining semantically identical to the existing
+SMIv1-based MIB.  [STANDARDS TRACK]
+
+
+2789    Freed           Mar 2000        Mail Monitoring MIB
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.
+Specifically, this memo extends the basic Network Services Monitoring
+MIB defined in RFC 2788 [16] to allow monitoring of Message Transfer
+Agents (MTAs).  It may also be used to monitor MTA components within
+gateways.  [STANDARDS TRACK]
+
+
+2788    Freed           Mar 2000        Network Services Monitoring
+                                        MIB
+
+This document defines a MIB which contains the elements common to the
+monitoring of any network service application.  [STANDARDS TRACK]
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 3]
+
+RFC 2799                  Summary of 2700-2799            September 2000
+
+
+2787    Jewell          Mar 2000        Definitions of Managed Objects
+                                        for the Virtual Router
+                                        Redundancy Protocol
+
+
+This specification defines an extension to the Management Information
+Base (MIB) for use with SNMP-based network management.  In particular,
+it defines objects for configuring, monitoring, and controlling routers
+that employ the Virtual Router Redundancy Protocol (VRRP).  [STANDARDS
+TRACK]
+
+
+2786    St. Johns       Mar 2000        Diffie-Helman USM Key
+                                        Management Information
+                                        Base and Textual Convention
+
+This memo defines an experimental portion of the Management Information
+Base (MIB) for use with network management protocols the Internet
+community.  In particular, it defines a textual convention for doing
+Diffie-Helman key agreement key exchanges an set of objects which extend
+the usmUserTable to permit the use of DH key exchange in addition to the
+key change method.  This memo defines an Experimental Protocol for the
+Internet community.
+
+
+2785    Zuccherato      Mar 2000        Methods for Avoiding the
+                                        "Small-Subgroup" Attacks on
+                                        the Diffie-Hellman Key
+                                        Agreement Method for S/MIME
+
+This document will describe the situations relevant to implementations
+of S/MIME version 3 in which protection is necessary and the methods
+that can be used to prevent these attacks.  This memo provides
+information for the Internet community.
+
+
+2784    Farinacci       Mar 2000        Generic Routing Encapsulation
+                                        (GRE)
+
+This document specifies a protocol for encapsulation of an arbitrary
+network layer protocol over another arbitrary network layer protocol.
+[STANDARDS TRACK]
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 4]
+
+RFC 2799                  Summary of 2700-2799            September 2000
+
+
+2783    Mogul           Mar 2000        Pulse-Per-Second API for
+                                        UNIX-like Operating Systems,
+                                        Version 1.0
+
+RFC 1589 did not define an API for managing the PPS facility, leaving
+implementors without a portable means for using PPS sources.  This
+document specifies such an API.  This memo provides information for the
+Internet community.
+
+
+2782    Gulbrandsen     Feb 2000        A DNS RR for specifying the
+                                        location of services (DNS SRV)
+
+This document describes a DNS RR which specifies the location of the
+server(s) for a specific protocol and domain.  [STANDARDS TRACK]
+
+
+2781    Hoffman         Feb 2000        UTF-16, an encoding of ISO
+                                        10646
+
+This document describes the UTF-16 encoding of Unicode/ISO-10646,
+addresses the issues of serializing UTF-16 as an octet stream for
+transmission over the Internet, discusses MIME charset naming as
+described in [CHARSET-REG], and contains the registration for three MIME
+charset parameter values: UTF-16BE (big-endian), UTF-16LE (little-
+endian), and UTF-16.  This memo provides information for the Internet
+community.
+
+
+2780    Bradner         Mar 2000        IANA Allocation Guidelines For
+                                        Values In the Internet
+                                        Protocol and Related Headers
+
+This memo provides guidance for the IANA to use in assigning parameters
+for fields in the IPv4, IPv6, ICMP, UDP and TCP protocol headers.  This
+document specifies an Internet Best Current Practices for the Internet
+Community, and requests discussion and suggestions for improvements.
+
+
+2779    Day             Feb 2000        Instant Messaging / Presence
+                                        Protocol Requirements
+
+This document defines a minimal set of requirements that IMPP must meet.
+This memo provides information for the Internet community.
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 5]
+
+RFC 2799                  Summary of 2700-2799            September 2000
+
+
+2778    Day             Feb 2000        A Model for Presence and
+                                        Instant Messaging
+
+
+This document defines an abstract model for a presence and instant
+messaging system.  It defines the various entities involved, defines
+terminology, and outlines the services provided by the system.  This
+memo provides information for the Internet community.
+
+
+2777    Eastlake        Feb 2000        Publicly Verifiable Nomcom
+                                        Random Selection
+
+This document describes a method for making random selections in such a
+way that the unbiased nature of the choice is publicly verifiable.  This
+memo provides information for the Internet community.
+
+
+2776    Handley         Feb 2000        Multicast-Scope Zone
+                                        Announcement Protocol (MZAP)
+
+This document defines a protocol, the Multicast-Scope Zone Announcement
+Protocol (MZAP), for discovering the multicast administrative scope
+zones that are relevant at a particular location.  [STANDARDS TRACK]
+
+
+2775    Carpenter       Feb 2000        Internet Transparency
+
+This document describes the current state of the Internet from the
+architectural viewpoint, concentrating on issues of end-to-end
+connectivity and transparency.
+
+
+2774    Nielsen         Feb 2000        An HTTP Extension Framework
+
+This document describes a generic extension mechanism for HTTP, which is
+designed to address the tension between private agreement and public
+specification and to accommodate extension of applications using HTTP
+clients, servers, and proxies.  This memo defines an Experimental
+Protocol for the Internet community.
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 6]
+
+RFC 2799                  Summary of 2700-2799            September 2000
+
+
+2773    Housley         Feb 2000        Encryption using KEA and
+                                        SKIPJACK
+
+This document defines a method to encrypt a file transfer using the FTP
+specification STD 9, RFC 959, "File Transfer Protocol (FTP)", (October
+1985) and RFC 2228, "FTP Security Extensions" (October 1997).  This memo
+defines an Experimental Protocol for the Internet community.
+
+
+2772    Rockell         Feb 2000        6Bone Backbone Routing
+                                        Guidelines
+
+This document provides a set of guidelines for all 6bone routing
+equipment operators to use as a reference for efficient and stable
+deployment of 6bone routing systems.  This memo provides information for
+the Internet community.
+
+
+2771    Finlayson       Feb 2000        An Abstract API for Multicast
+                                        Address Allocation
+
+This document describes the "abstract service interface" for the dynamic
+multicast address allocation service, as seen by applications.  This
+memo provides information for the Internet community.
+
+
+2770    Meyer           Feb 2000        GLOP Addressing in 233/8
+
+This describes an experimental policy for use of the class D address
+space using 233/8 as the experimental statically assigned subset of the
+class D address space.  This memo defines an Experimental Protocol for
+the Internet community.
+
+
+2769    Villamizar      Feb 2000        Routing Policy System
+                                        Replication
+
+This document addresses the need to distribute data over multiple
+repositories and delegate authority for data subsets to other
+repositories without compromising the authorization model established in
+Routing Policy System Security RFC.  [STANDARDS TRACK]
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 7]
+
+RFC 2799                  Summary of 2700-2799            September 2000
+
+
+2768    Aiken           Feb 2000        Network Policy and Services:
+                                        A Report of a Workshop on
+                                        Middleware
+
+An ad hoc middleware workshop was held at the International Center for
+Advanced Internet Research in December 1998.  The need for a more
+organized framework for middleware R&D was recognized, and a list of
+specific topics needing further work was identified.  This memo provides
+information for the Internet community.
+
+
+2767    Tsuchiya        Feb 2000        Dual Stack Hosts using the
+                                        "Bump-In-the-Stack" Technique
+                                        (BIS)
+
+This memo proposes a mechanism of dual stack hosts using the technique
+called "Bump-in-the-Stack" in the IP security area.  This memo provides
+information for the Internet community.
+
+
+2766    Tsirtsis        Feb 2000        Network Address Translation -
+                                        Protocol Translation (NAT-PT)
+
+This document specifies an IPv4-to-IPv6 transition mechanism, in
+addition to those already specified.  [STANDARDS TRACK]
+
+
+2765    Nordmark        Feb 2000        Stateless IP/ICMP Translation
+                                        Algorithm (SIIT)
+
+This document specifies a transition mechanism algorithm in addition to
+the mechanisms already specified.  [STANDARDS TRACK]
+
+
+2764    Gleeson         Feb 2000        A Framework for IP Based
+                                        Virtual Private Networks
+
+This document describes a framework for Virtual Private Networks (VPNs)
+running across IP backbones.  This memo provides information for the
+Internet community.
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 8]
+
+RFC 2799                  Summary of 2700-2799            September 2000
+
+
+2763    Shen            Feb 2000        Dynamic Hostname Exchange
+                                        Mechanism for IS-IS
+
+This document defines a new TLV which allows the IS-IS routers to flood
+their name to system ID mapping information across the IS-IS network.
+This memo provides information for the Internet community.
+
+
+2762    Rosenberg       Feb 2000        Sampling of the Group
+                                        Membership in RTP
+
+This document discusses mechanisms for sampling of this group membership
+table in order to reduce the memory requirements.  This memo defines an
+Experimental Protocol for the Internet community.
+
+
+2761    Dunn            Feb 2000        Terminology for ATM
+                                        Benchmarking
+
+This memo discusses and defines terms associated with performance
+benchmarking tests and the results of these tests in the context of
+Asynchronous Transfer Mode (ATM) based switching devices.  This memo
+provides information for the Internet community.
+
+
+2760    Allman          Feb 2000        Ongoing TCP Research Related
+                                        to Satellites
+
+This document outlines possible TCP enhancements that may allow TCP to
+better utilize the available bandwidth provided by networks containing
+satellite links.  This memo provides information for the Internet
+community.
+
+
+2759    Zorn            Jan 2000        Microsoft PPP CHAP Extensions,
+                                        Version 2
+
+This document describes version two of Microsoft's PPP CHAP dialect
+(MS-CHAP-V2).  MS-CHAP-V2 is similar to, but incompatible with, MS-CHAP
+version one (MS-CHAP-V1).  This memo provides information for the
+Internet community.
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 9]
+
+RFC 2799                  Summary of 2700-2799            September 2000
+
+
+2758    White           Feb 2000        Definitions of Managed Objects
+                                        for Service Level Agreements
+                                        Performance Monitoring
+
+This memo defines a Management Information Base (MIB) for performance
+monitoring of Service Level Agreements (SLAs) defined via policy
+definitions.  This memo defines an Experimental Protocol for the
+Internet community.
+
+
+2757    Montenegro      Jan 2000        Long Thin Networks
+
+Our goal is to identify a TCP that works for all users, including users
+of long thin networks.  This memo provides information for the Internet
+community.
+
+
+2756    Vixie           Jan 2000        Hyper Text Caching Protocol
+                                        (HTCP/0.0)
+
+This document describes HTCP, a protocol for discovering HTTP caches and
+cached data, managing sets of HTTP caches, and monitoring cache
+activity.  This is an experimental protocol, one among several proposals
+to perform these functions.  This memo defines an Experimental Protocol
+for the Internet community.
+
+
+2755    Chiu            Jan 2000        Security Negotiation for
+                                        WebNFS
+
+This document describes a protocol for a WebNFS client (RFC2054) to
+negotiate the desired security mechanism with a WebNFS server (RFC2055)
+before the WebNFS client falls back to the MOUNT v3 protocol (RFC1813).
+This document is provided so that people can write compatible
+implementations.  This memo provides information for the Internet
+community.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 10]
+
+RFC 2799                  Summary of 2700-2799            September 2000
+
+
+2754    Alaettinoglu    Jan 2000        RPS IANA Issues
+
+RPS Security requires certain RPSL objects in the IRR to be
+hierarchically delegated.  The set of objects that are at the root of
+this hierarchy needs to be created and digitally signed by IANA.  This
+paper presents these seed objects and lists operations required from
+IANA.  This memo provides information for the Internet community.
+
+
+2753    Yavatkar        Jan 2000        A Framework for Policy-based
+                                        Admission Control
+
+This document is concerned with specifying a framework for providing
+policy-based control over admission control decisions.  This memo
+provides information for the Internet community.
+
+
+2752    Yadav           Jan 2000        Identity Representation for
+                                        RSVP
+
+This document describes the representation of identity information in
+POLICY_DATA object for supporting policy based admission control in
+RSVP.  [STANDARDS TRACK]
+
+
+2751    Herzog          Jan 2000        Signaled Preemption Priority
+                                        Policy Element
+
+This document describes a preemption priority policy element for use by
+signaled policy based admission protocols (such as RSVP and COPS).
+[STANDARDS TRACK]
+
+
+2750    Herzog          Jan 2000        RSVP Extensions for Policy
+                                        Control
+
+This memo presents a set of extensions for supporting generic policy
+based admission control in RSVP.  [STANDARDS TRACK]
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 11]
+
+RFC 2799                  Summary of 2700-2799            September 2000
+
+
+2749    Herzog          Jan 2000        COPS usage for RSVP
+
+This document describes usage directives for supporting COPS policy
+services in RSVP environments.  [STANDARDS TRACK]
+
+
+2748    Durham          Jan 2000        The COPS (Common Open Policy
+                                        Service) Protocol
+
+This document describes a simple client/server model for supporting
+policy control over QoS signaling protocols.  [STANDARDS TRACK]
+
+
+2747    Baker           Jan 2000        RSVP Cryptographic
+                                        Authentication
+
+This document describes the format and use of RSVP's INTEGRITY object to
+provide hop-by-hop integrity and authentication of RSVP messages.
+[STANDARDS TRACK]
+
+
+2746    Terzis          Jan 2000        RSVP Operation Over IP Tunnels
+
+This document describes an approach for providing RSVP protocol services
+over IP tunnels.  [STANDARDS TRACK]
+
+
+2745    Terzis          Jan 2000        RSVP Diagnostic Messages
+
+This document specifies the RSVP diagnostic facility, which allows a
+user to collect information about the RSVP state along a path.
+[STANDARDS TRACK]
+
+
+2744    Wray            Jan 2000        Generic Security Service API
+                                        Version 2 : C-bindings
+
+This document specifies C language bindings for Version 2, Update 1 of
+the Generic Security Service Application Program Interface (GSS-API),
+which is described at a language-independent conceptual level in RFC
+2743.  [STANDARDS TRACK]
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 12]
+
+RFC 2799                  Summary of 2700-2799            September 2000
+
+
+2743    Linn            Jan 2000        Generic Security Service
+                                        Application Program Interface
+                                        Version 2, Update 1
+
+This memo obsoletes [RFC-2078], making specific, incremental changes in
+response to implementation experience and liaison requests.  It is
+intended, therefore, that this memo or a successor version thereto will
+become the basis for subsequent progression of the GSS-API specification
+on the standards track.  [STANDARDS TRACK]
+
+
+2742    Heintz          Jan 2000        Definitions of Managed Objects
+                                        for Extensible SNMP Agents
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it describes objects managing SNMP agents that use the Agent
+Extensibility (AgentX) Protocol.  [STANDARDS TRACK]
+
+
+2741    Daniele         Jan 2000        Agent Extensibility (AgentX)
+                                        Protocol Version 1
+
+This memo defines a standardized framework for extensible SNMP agents.
+[STANDARDS TRACK]
+
+
+2740    Coltun          Dec 1999        OSPF for IPv6
+
+This document describes the modifications to OSPF to support version 6
+of the Internet Protocol (IPv6).  [STANDARDS TRACK]
+
+
+2739    Small           Jan 2000        Calendar Attributes for vCard
+                                        and LDAP
+
+This memo defines three mechanisms for obtaining a URI to a user's
+calendar and free/busy time.  [STANDARDS TRACK]
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 13]
+
+RFC 2799                  Summary of 2700-2799            September 2000
+
+
+2738    Klyne           Dec 1999        Corrections to "A Syntax for
+                                        Describing Media Feature Sets"
+
+In RFC 2533, "A Syntax for Describing Media Feature Sets", an expression
+format is presented for describing media feature capabilities using
+simple media feature tags.  This memo contains two corrections to that
+specification:  one fixes an error in the formal syntax specification,
+and the other fixes an error in the rules for reducing feature
+comparison predicates.  [STANDARDS TRACK]
+
+
+2737    McCloghrie      Dec 1999        Entity MIB (Version 2)
+
+This memo defines a portion of the Management Information Base (M for
+use with network management protocols in the Internet communi In
+particular, it describes managed objects used for managing multiple
+logical and physical entities managed by a single SNMP agent.
+[STANDARDS TRACK]
+
+
+2736    Handley         Dec 1999        Guidelines for Writers of RTP
+                                        Payload Format Specifications
+
+This document provides general guidelines aimed at assisting the authors
+of RTP Payload Format specifications in deciding on good formats.  This
+document specifies an Internet Best Current Practices for the Internet
+Community, and requests discussion and suggestions for improvements.
+
+
+2735    Fox             Dec 1999        NHRP Support for Virtual
+                                        Private Networks
+
+
+The NBMA Next Hop Resolution Protocol (NHRP) is used to determine the
+NBMA subnetwork addresses of the "NBMA next hop" towards a public
+internetworking layer address.  This document describes the enhancements
+necessary to enable NHRP to perform the same function for private
+internetworking layer addresses available within the framework of a
+Virtual Private Network (VPN) service on a shared NBMA network.
+[STANDARDS TRACK]
+
+
+2734    Johansson       Dec 1999        IPv4 over IEEE 1394
+
+This document specifies how to use IEEE Std 1394-1995, Standard for a
+High Performance Serial Bus (and its supplements), for the transport of
+Internet Protocol Version 4 (IPv4) datagrams; it defines the necessary
+methods, data structures and codes for that purpose.  [STANDARDS TRACK]
+
+
+
+Ginoza                       Informational                     [Page 14]
+
+RFC 2799                  Summary of 2700-2799            September 2000
+
+
+2733    Rosenberg       Dec 1999        An RTP Payload Format for
+                                        Generic Forward Error
+                                        Correction
+
+This document specifies a payload format for generic forward error
+correction of media encapsulated in RTP.  [STANDARDS TRACK]
+
+
+2732    Hinden          Dec 1999        Format for Literal IPv6
+                                        Addresses in URL's
+
+This document defines the format for literal IPv6 Addresses in URL's for
+implementation in World Wide Web browsers.  [STANDARDS TRACK]
+
+
+2731    Kunze           Dec 1999        Encoding Dublin Core Metadata
+                                        in HTML
+
+The Dublin Core is a small set of metadata elements for describing
+information resources.  This document explains how these elements are
+expressed using the META and LINK tags of HTML.  This memo provides
+information for the Internet community.
+
+
+2730    Hanna           Dec 1999        Multicast Address Dynamic
+                                        Client Allocation Protocol
+                                        (MADCAP)
+
+This document defines a protocol, Multicast Address Dynamic Client
+Allocation Protocol (MADCAP), that allows hosts to request multicast
+addresses from multicast address allocation servers.  [STANDARDS TRACK]
+
+
+2729    Bagnall         Dec 1999        Taxonomy of Communication
+                                        Requirements for Large-scale
+                                        Multicast Applications
+
+The intention of this memo is to define a classification system for the
+communication requirements of any large-scale multicast application
+(LSMA).  This memo provides information for the Internet community.
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 15]
+
+RFC 2799                  Summary of 2700-2799            September 2000
+
+
+2728    Panabaker       Nov 1999        The Transmission of IP Over
+                                        the Vertical Blanking Interval
+                                        of a Television Signal
+
+This document describes a method for broadcasting IP data in a
+unidirectional manner using the vertical blanking interval of television
+signals.  [STANDARDS TRACK]
+
+
+2727    Galvin          Feb 2000        IAB and IESG Selection,
+                                        Confirmation, and Recall
+                                        Process: Operation of the
+                                        Nominating and Recall
+                                        Committees
+
+The process by which the members of the IAB and IESG are selected,
+confirmed, and recalled is specified.  This document is a self-
+consistent, organized compilation of the process as it was known at the
+time of publication.  This document specifies an Internet Best Current
+Practices for the Internet Community, and requests discussion and
+suggestions for improvements.
+
+
+2726    Zsako           Dec 1999        PGP Authentication for RIPE
+                                        Database Updates
+
+This document presents the proposal for a stronger authentication method
+of the updates of the RIPE database based on digital signatures.
+[STANDARDS TRACK]
+
+
+2725    Villamizar      Dec 1999        Routing Policy System Security
+
+The implementation and deployment of a routing policy system must
+maintain some degree of integrity to be of any operational use.  This
+document addresses the need to assure integrity of the data by providing
+an authentication and authorization model.  [STANDARDS TRACK]
+
+
+2724    Handelman       Oct 1999        RTFM: New Attributes for
+                                        Traffic Flow Measurement
+
+This document discusses RTFM flows and the attributes which they can
+have, so as to provide a logical framework for extending the
+architecture by adding new attributes.  This memo defines an
+Experimental Protocol for the Internet community.
+
+
+
+
+
+Ginoza                       Informational                     [Page 16]
+
+RFC 2799                  Summary of 2700-2799            September 2000
+
+
+2723    Brownlee        Oct 1999        SRL: A Language for Describing
+                                        Traffic Flows and Specifying
+                                        Actions for Flow Groups
+
+This document describes a language for specifying rulesets, i.e.
+configuration files which may be loaded into a traffic flow meter so as
+to specify which traffic flows are measured by the meter, and the
+information it will store for each flow.  This memo provides information
+for the Internet community.
+
+
+2722    Brownlee        Oct 1999        Traffic Flow Measurement:
+                                        Architecture
+
+This document provides a general framework for describing network
+traffic flows, presents an architecture for traffic flow measurement and
+reporting, discusses how this relates to an overall network traffic flow
+architecture and indicates how it can be used within the Internet.  This
+memo provides information for the Internet community.
+
+
+2721    Brownlee        Oct 1999        RTFM: Applicability Statement
+
+This document provides an overview covering all aspects of Realtime
+Traffic Flow Measurement, including its area of applicability and its
+limitations.  This memo provides information for the Internet community.
+
+
+2720    Brownlee        Oct 1999        Traffic Flow Measurement:
+                                        Meter MIB
+
+This document defines a Management Information Base (MIB) for use in
+controlling an RTFM Traffic Meter, in particular for specifying the
+flows to be measured.  It also provides an efficient mechanism for
+retrieving flow data from the meter using SNMP.  Security issues
+concerning the operation of traffic meters are summarised.  [STANDARDS
+TRACK]
+
+
+2719    Ong             Oct 1999        Framework Architecture for
+                                        Signaling Transport
+
+This document defines an architecture framework and functional
+requirements for transport of signaling information over IP.  This memo
+provides information for the Internet community.
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 17]
+
+RFC 2799                  Summary of 2700-2799            September 2000
+
+
+2718    Masinter        Nov 1999        Guidelines for new URL Schemes
+
+This document provides guidelines for the definition of new URL schemes.
+This memo provides information for the Internet community.
+
+
+2717    Petke           Nov 1999        Registration Procedures for
+                                        URL Scheme Names
+
+This document defines the process by which new URL scheme names are
+registered.  This document specifies an Internet Best Current Practices
+for the Internet Community, and requests discussion and suggestions for
+improvements.
+
+
+2716    Aboba           Oct 1999        PPP EAP TLS Authentication
+                                        Protocol
+
+The Point-to-Point Protocol (PPP) provides a standard method for
+transporting multi-protocol datagrams over point-to-point links.The
+Extensible Authentication Protocol (EAP) is a PPP extension that
+provides support for additional authentication methods within PPP.  This
+memo defines an Experimental Protocol for the Internet community.
+
+
+2715    Thaler          Oct 1999        Interoperability Rules for
+                                        Multicast Routing Protocols
+
+The rules described in this document will allow efficient interoperation
+among multiple independent multicast routing domains.  This memo
+provides information for the Internet community.
+
+
+2714    Ryan            Oct 1999        Schema for Representing CORBA
+                                        Object References in an LDAP
+                                        Directory
+
+This document defines the schema for representing CORBA object
+references in an LDAP directory.  This memo provides information for the
+Internet community.
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 18]
+
+RFC 2799                  Summary of 2700-2799            September 2000
+
+
+2713    Ryan            Oct 1999        Schema for Representing
+                                        Java(tm) Objects in an
+                                        LDAP Directory
+
+This document defines the schema for representing Java(tm) objects in an
+LDAP directory.  This memo provides information for the Internet
+community.
+
+
+2712    Medvinsky       Oct 1999        Addition of Kerberos Cipher
+                                        Suites to Transport Layer
+                                        Security (TLS)
+
+This document proposes the addition of new cipher suites to the TLS
+protocol to support Kerberos-based authentication.  [STANDARDS TRACK]
+
+
+2711    Partridge       Oct 1999        IPv6 Router Alert Option
+
+This memo describes a new IPv6 Hop-by-Hop Option type that alerts
+transit routers to more closely examine the contents of an IP datagram.
+[STANDARDS TRACK]
+
+
+2710    Deering         Oct 1999        Multicast Listener Discovery
+                                        (MLD) for IPv6
+
+This document specifies the protocol used by an IPv6 router to discover
+the presence of multicast listeners (that is, nodes wishing to receive
+multicast packets) on its directly attached links, and to discover
+specifically which multicast addresses are of interest to those
+neighboring nodes.  [STANDARDS TRACK]
+
+
+2709    Srisuresh       Oct 1999        Security Model with
+                                        Tunnel-mode IPsec for NAT
+                                        Domains
+
+This document describes a security model by which tunnel-mode IPsec
+security can be architected on NAT devices.  This memo provides
+information for the Internet community.
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 19]
+
+RFC 2799                  Summary of 2700-2799            September 2000
+
+
+2708    Bergman         Nov 1999        Job Submission Protocol
+                                        Mapping Recommendations
+                                        for the Job Monitoring MIB
+
+This document defines the recommended mapping for many currently popular
+Job submission protocols to objects and attributes in the Job Monitoring
+MIB.  This memo provides information for the Internet community.
+
+
+2707    Bergman         Nov 1999        Job Monitoring MIB - V1.0
+
+This document provides a printer industry standard SNMP MIB for (1)
+monitoring the status and progress of print jobs (2) obtaining resource
+requirements before a job is processed, (3) monitoring resource
+consumption while a job is being processed and (4) collecting resource
+accounting data after the completion of a job.  This memo provides
+information for the Internet community.
+
+
+2706    Eastlake        Oct 1999        ECML v1: Field Names for
+                                        E-Commerce
+
+
+A standard set of information fields is defined as the first version of
+an Electronic Commerce Modeling Language (ECML) so that this task can be
+more easily automated, for example by wallet software that could fill in
+fields.  This memo provides information for the Internet community.
+
+
+2705    Arango          Oct 1999        Media Gateway Control Protocol
+                                        (MGCP) Version 1.0
+
+This document describes an application programming interface and a
+corresponding protocol (MGCP) for controlling Voice over IP (VoIP)
+Gateways from external call control elements.  MGCP assumes a call
+control architecture where the call control "intelligence" is outside
+the gateways and handled by external call control elements.  This memo
+provides information for the Internet community.
+
+
+2704    Blaze           Sep 1999        The KeyNote Trust-Management
+                                        System Version 2
+
+This memo describes version 2 of the KeyNote trust-management system.It
+specifies the syntax and semantics of KeyNote `assertions', describes
+`action attribute' processing, and outlines the application architecture
+into which a KeyNote implementation can be fit.  This memo provides
+information for the Internet community.
+
+
+
+Ginoza                       Informational                     [Page 20]
+
+RFC 2799                  Summary of 2700-2799            September 2000
+
+
+2703    Klyne           Sep 1999        Protocol-independent Content
+                                        Negotiation Framework
+
+This memo sets out terminology, an abstract framework and goals for
+protocol-independent content negotiation, and identifies some technical
+issues which may need to be addressed.  This memo provides information
+for the Internet community.
+
+
+2702    Awduche         Sep 1999        Requirements for Traffic
+                                        Engineering Over MPLS
+
+This document presents a set of requirements for Traffic Engineering
+over Multiprotocol Label Switching (MPLS).  It identifies the functional
+capabilities required to implement policies that facilitate efficient
+and reliable network operations in an MPLS domain.  This memo provides
+information for the Internet community.
+
+
+2701    Malkin          Sep 1999        Nortel Networks Multi-link
+                                        Multi-node PPP Bundle
+                                        Discovery Protocol
+
+This document specifies a standard way for Multi-link PPP to operate
+across multiple nodes.  This memo provides information for the Internet
+community.
+
+
+2700    Reynolds        Aug 2000        Internet Official Protocol
+                                        Standards
+
+This memo describes the current state of standardization of protocols
+used in the Internet as determined by the Internet Engineering Task
+Force (IETF).  [STANDARDS TRACK]
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 21]
+
+RFC 2799                  Summary of 2700-2799            September 2000
+
+
+Author's Address
+
+   Sandy Ginoza
+   University of Southern California
+   Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone:  (310) 822-1511
+
+   EMail: ginoza@isi.edu
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 22]
+
+RFC 2799                  Summary of 2700-2799            September 2000
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (YEAR).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 23]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2799.txt](<www.ietf.org/rfc/rfc2799.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
