### PR TITLE
Archive rfc2850.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2850.txt
+++ b/www.ietf.org/rfc/rfc2850.txt
@@ -1,0 +1,451 @@
+
+
+
+
+
+
+Network Working Group                        Internet Architecture Board
+Request for Comments: 2850                          B. Carpenter, Editor
+Obsoletes: 1601                                                 May 2000
+BCP: 39
+Category: Best Current Practice
+
+
+            Charter of the Internet Architecture Board (IAB)
+
+Status of this Memo
+
+   This document specifies an Internet Best Current Practices for the
+   Internet Community, and requests discussion and suggestions for
+   improvements.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2000).  All Rights Reserved.
+
+Abstract
+
+   This memo documents the composition, selection, roles, and
+   organization of the Internet Architecture Board. It replaces RFC
+   1601.
+
+Table of Contents:
+
+   1. IAB Membership...............................................2
+   1.1  Selection of full IAB members..............................2
+   1.2 Ex-Officio and Liaison members..............................2
+   2.  The Role of the IAB.........................................3
+   2.1 Architectural oversight in more detail......................4
+   3. IAB Organization.............................................5
+   3.1 IAB chair...................................................5
+   3.2 Executive Director..........................................5
+   3.3 Selection of the IRTF chair.................................5
+   3.4 Liaisons within the IETF....................................5
+   3.5 Decision taking.............................................6
+   3.6 Openness and confidentiality................................6
+   Security Considerations.........................................6
+   Summary of Changes from RFC 1601................................6
+   References......................................................7
+   Author's Address................................................7
+   Full Copyright Statement........................................8
+
+
+
+
+
+
+
+IAB                      Best Current Practice                  [Page 1]
+
+RFC 2850                      IAB Charter                       May 2000
+
+
+1. IAB Membership
+
+   The Internet Architecture Board (IAB) shall consist of thirteen full
+   members, composed of the chair of the Internet Engineering Task Force
+   (IETF), and of twelve sitting members.  The IETF chair, who is also
+   the chair of the Internet Engineering Steering Group (IESG), may
+   participate in all official IAB actions except the approval of IESG
+   members and appeals against IESG decisions. Ex-officio and liaison
+   members of the IAB may also attend IAB meetings but shall not
+   participate in determination of official actions.
+
+   Members of the IAB shall serve as individuals, and not as
+   representatives of any company, agency, or other organization.
+   Members of the IAB shall owe no fiduciary duty of loyalty or care to
+   IAB, IETF, IRTF or IESG.
+
+1.1  Selection of full IAB members
+
+   Full IAB members, including the IETF chair, are selected and
+   appointed according to the procedures defined in [BCP 10] . Normally,
+   six sitting members are appointed each year to sit for two years, and
+   the IETF chair is appointed every two years.
+
+   There is no limit to the number of terms that a member of the IAB may
+   serve, subject to the process defined by [BCP 10].
+
+   Mid-term vacancies are filled as defined in [BCP 10] and do not
+   affect the IAB's power to take decisions.
+
+1.2 Ex-Officio and Liaison members
+
+   Ex-officio and liaison members of the IAB have no standing to
+   participate in IAB decisions but are expected to participate in IAB
+   discussions as appropriate to their roles.  However, an ex-officio
+   position may be held by a full member, who does not thereby lose his
+   or her standing to participate in IAB decisions.
+
+   The chair of the Internet Research Task Force (IRTF) is an ex-officio
+   member of the IAB. The IAB has an Executive Director who is an ex-
+   officio member of the IAB.
+
+   The Internet Society, the RFC Editor, the IANA and the IESG each
+   appoints a liaison member to the IAB. These liaison positions may not
+   be held by a full member of the IAB.
+
+   Vacancies in the liaison and ex officio positions do not affect the
+   IAB's power to take decisions.
+
+
+
+
+IAB                      Best Current Practice                  [Page 2]
+
+RFC 2850                      IAB Charter                       May 2000
+
+
+2.  The Role of the IAB
+
+   The IAB is chartered both as a committee of the IETF and as an
+   advisory body of the Internet Society.  Its responsibilities include:
+
+   (a) IESG Appointment
+
+   The IETF nominating committee established under [BCP 10] annually
+   provides a list of candidates for vacant IESG seats and for the IETF
+   Chair if vacant. The IAB reviews the candidates, consenting to some,
+   all, or none.
+
+   (b) Architectural Oversight
+
+   The IAB provides oversight of the architecture for the protocols and
+   procedures used by the Internet. This point is expanded in Section
+   2.1 below.
+
+   (c) Standards Process Oversight and Appeal
+
+   The IAB provides oversight of the process used to create Internet
+   Standards [BCP 9].
+
+   The IAB serves as an appeal board for complaints of improper
+   execution of the standards process, with powers defined in [BCP 9].
+
+   (d) RFC Series and IANA
+
+   The RFC Editor executes editorial management and publication of the
+   IETF "Request for Comment" (RFC) document series, which is the
+   permanent document repository of the IETF.  The RFC series
+   constitutes the archival publication channel for Internet Standards
+   and for other contributions by the Internet research and engineering
+   community. RFCs are available free of charge to anyone via the
+   Internet. The IAB must approve the appointment of an organization to
+   act as RFC Editor and the general policy followed by the RFC Editor.
+
+   The Internet Assigned Numbers Authority (IANA) administers various
+   protocol parameters used by IETF protocols, delegating this
+   administration as appropriate. The IAB must approve the appointment
+   of an organization to act as IANA on behalf of the IETF. The IANA
+   takes technical direction on IETF protocols from the IESG.
+
+   (e) ISOC Liaison
+
+   The IAB acts as a source of advice and guidance to the Board of
+   Trustees and Officers of the Internet Society concerning technical,
+   architectural, procedural, and (where appropriate) policy matters
+
+
+
+IAB                      Best Current Practice                  [Page 3]
+
+RFC 2850                      IAB Charter                       May 2000
+
+
+   pertaining to the Internet and its enabling technologies. If
+   necessary the IAB may convene panels of knowledgeable people, hold
+   hearings, and otherwise pursue the investigation of specific
+   questions or topics presented to it by the Internet Society.
+
+   (f) External Liaison
+
+   The IAB acts as representative of the interests of the IETF and the
+   Internet Society in technical liaison relationships with other
+   organizations concerned with standards and other technical and
+   organizational issues relevant to the world-wide Internet. Liaisons
+   are kept as informal as possible and must be of demonstrable value in
+   improving the quality of IETF specifications.  Individual members of
+   the IETF are appointed as liaisons to other organizations by the IAB
+   or IESG as appropriate.
+
+2.1 Architectural oversight in more detail
+
+   A major role of the IAB is long range planning and coordination
+   between different areas of IETF activity.  The IAB, both collectively
+   and on an individual basis, is expected to pay attention to important
+   long-term issues in the Internet, and to make sure that these issues
+   are brought to the attention of the group(s) that are in a position
+   to address them.  It is also expected to play a role in assuring that
+   the people responsible for evolving the Internet and its technology
+   are aware of the essential elements of the Internet architecture.
+
+   IAB members pay special attention to emerging activities in the IETF
+   and to "Birds of a Feather" sessions at IETF meetings.  The IAB
+   assists the IESG in evaluating such activities and in determining
+   whether an IETF or an IRTF group is more appropriate.  When a new
+   IETF working group is proposed, the IESG will forward a preliminary
+   version of the charter to the IAB for review of architectural
+   consistency and integrity.  The IAB shall review these proposed
+   charters and give feedback to the IESG as appropriate.
+
+   Pursuant to the architectural oversight function, the IAB sponsors
+   and organizes the Internet Research Task Force (IRTF) [BCP 8].  The
+   IAB reviews proposed IRTF groups.
+
+   The IAB will convene invitational workshops to perform in-depth
+   reviews of particular architectural issues.  Such reviews may include
+   consideration of relevant IETF and IRTF activities, and of work in
+   other organizations, and for this purpose the workshop may invite
+   presentations by qualified parties on the design goals and decisions,
+   technology choices, and other pertinent aspects of these activities.
+   The results of such a review will be a report which may give advice
+   to the IETF community and the IESG.
+
+
+
+IAB                      Best Current Practice                  [Page 4]
+
+RFC 2850                      IAB Charter                       May 2000
+
+
+   The IAB may organize ad hoc bodies of independent technical experts
+   to adjudicate technical disputes.
+
+3. IAB Organization
+
+3.1 IAB chair
+
+   The members of the IAB shall select one of its full members to serve
+   as the chair of the IAB, with all of the duties and responsibilities
+   normally associated with such a position.  The term of the IAB chair
+   shall be one year, with no restriction on renewal.  The chair of the
+   IAB may be removed at any time by the affirmative vote of two-thirds
+   of the members of the IAB, or as a result of his or her departure
+   from the IAB.
+
+   The chair of the IAB shall have the authority to manage the
+   activities and meetings of the IAB.
+
+3.2 Executive Director
+
+   The chair of the IAB shall have the authority to appoint an honorary
+   Executive Director (ExecD) for a one-year renewable term, and to
+   remove him or her. The ExecD shall administer the internal operation
+   of the IAB, e.g., organization of meetings and reporting of their
+   results.
+
+   The ExecD is an ex-officio member as defined in Section 1.2.
+
+3.3 Selection of the IRTF chair
+
+   The IAB shall have the authority to appoint the chair of the Internet
+   Research Task Force (IRTF) for a two-year renewable term, and to
+   remove him or her. The IRTF chair shall be responsible for the
+   management and organization of the IRTF according to [BCP 8].
+
+   The IRTF chair is an ex-officio member as defined in Section 1.2.
+
+3.4 Liaisons within the IETF
+
+   The chair of the IAB and another full IAB member (other than the IETF
+   chair), to be selected by the IAB, shall serve as liaisons to the
+   IESG. In addition, the IESG will appoint one of its members (other
+   than the IETF chair) to serve as a liaison to the IAB.  The IESG
+   liaison may attend IAB meetings.
+
+   Vacancies in these liaison seats have no effect on the IAB's or the
+   IESG's powers to make decisions.
+
+
+
+
+IAB                      Best Current Practice                  [Page 5]
+
+RFC 2850                      IAB Charter                       May 2000
+
+
+3.5 Decision taking
+
+   The IAB attempts to reach all decisions unanimously.  If unanimity
+   cannot be achieved, the chair may conduct informal polls to determine
+   consensus.  The IAB may make decisions and take action if at least
+   seven full members concur and there are no more than two dissents.
+
+   The IAB may reach decisions by face to face meeting, teleconference,
+   Internet communication, or any combination of the above.
+
+3.6 Openness and confidentiality
+
+   The IAB publishes minutes of all its meetings on the Internet, and
+   conducts an open meeting at every IETF meeting. It publishes all its
+   findings as RFCs, Internet Drafts or messages to the IETF mailing
+   list. However, discussion of personnel matters and possibly legal and
+   financial matters may sometimes be required to be kept confidential,
+   and the chair may, with the consent of the full members, exclude
+   liaison and ex officio members from such discussions.
+
+   Specifically, the IAB makes use of the second level domain iab.org
+   and the URL http://www.iab.org to publish information.
+
+Security Considerations
+
+   This memo does not raise any known security threats.
+
+Summary of Changes from RFC 1601
+
+   This document replaces [RFC 1601]. The principal change is the
+   removal of material now covered in [BCP 8], [BCP 9] and [BCP 10],
+   with many consequent editorial changes.  Additional changes are:
+
+      - description of decision making when unanimity cannot be achieved
+      - note on openness and confidentiality
+      - addition of liaison seats for the Internet Society and the IANA
+      - revised text concerning the IANA and the RFC Editor
+      - clarifications following legal review
+
+
+
+
+
+
+
+
+
+
+
+
+
+IAB                      Best Current Practice                  [Page 6]
+
+RFC 2850                      IAB Charter                       May 2000
+
+
+References
+
+   [RFC 1601]  Huitema, C., "Charter of the Internet Architecture Board
+               (IAB)", RFC 1601, March 1994.
+
+   [BCP 8]     Weinrib, A., and J. Postel, "IRTF Research Group
+               Guidelines and Procedures", BCP 8, RFC 2014, October
+               1996.
+
+   [BCP 9]     Bradner, S., "The Internet Standards Process -- Revision
+               3", BCP 9, RFC 2026, October 1996.
+
+   [BCP 10]    Galvin, J., "IAB and IESG Selection, Confirmation, and
+               Recall Process: Operation of the Nominating and Recall
+               Committees", BCP 10, RFC 2282, February 1998.
+
+Author's Address
+
+   Brian E. Carpenter
+   IBM
+   c/o iCAIR
+   Suite 150
+   1890 Maple Avenue
+   Evanston IL 60201
+   USA
+
+   EMail: brian@icair.org
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+IAB                      Best Current Practice                  [Page 7]
+
+RFC 2850                      IAB Charter                       May 2000
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2000).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+IAB                      Best Current Practice                  [Page 8]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2850.txt](<www.ietf.org/rfc/rfc2850.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
