### PR TITLE
Archive rfc286.txt

### DIFF
--- a/www.ietf.org/rfc/rfc286.txt
+++ b/www.ietf.org/rfc/rfc286.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                 E. Forman
+Request for Comments: #286                            MITRE
+NIC #8272                                             21 December 1971
+Categories: G.1 & G.2
+Updates: None
+Obsoletes: None
+
+                   Network Library Information System
+
+        Georgetown University is designing a Learning Resource Center
+   (LRC), part of which may consist of a system to enable computer query
+   (hopefully on-line) of G.U.'s Library holdings.  The ARPA community
+   might be of assistance in either of two ways:
+
+        1.  One or more organizations may have a Library Retrieval
+            System that they would like to share with Georgetown.
+
+        2.  Since there probably are needs for such a system at most
+            organizations, and since it would be highly beneficial
+            for one organization to be able to query other library
+            holdings as well, and subsequently arrange for inter-
+            library loans, the ARPA community might undertake to
+            design a Network Library Information System.
+
+        If sufficient interest in such a system exists, a working group
+   could be set up to establish the necessary protocols and iron out
+   details of the system.
+
+        It is probable that the NIC could provide valuable inputs to such
+   an undertaking and perhaps would serve as a focal point for the system
+   design and operation.
+
+        Please contact me if either:
+
+        1.  You have, or know of a Library Retrieval System that
+            can be shared with Georgetown University,
+
+        2.  Your organization is interested in participating in a
+            Network Library Retrieval System, or
+
+        3.  You are interested in participating in designing such a
+            system.
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc286.txt](<www.ietf.org/rfc/rfc286.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
