### PR TITLE
Archive rfc287.txt

### DIFF
--- a/www.ietf.org/rfc/rfc287.txt
+++ b/www.ietf.org/rfc/rfc287.txt
@@ -1,0 +1,271 @@
+
+
+
+
+
+
+Network Working Group                                   Ellen Westheimer
+Request for Comments: #287                                           BBN
+NIC: #8273                                              22 December 1971
+Categories: F, G.3
+Updates: RFC #267
+Obsoletes: None
+
+                        Status of Network Hosts
+
+     This RFC reports on the status of most Network Hosts from
+December 6 to December 18.  Due to hardware debugging, the BBN
+prototype Terminal IMP (Network Address 158) was unavailable for most
+of the two weeks from November 22 to December 6. There was, therefore,
+no Host status reports for that period.
+
+     Several Hosts are currently excluded from the daily testing.
+These Hosts fall into two categories:
+
+   1) Hosts which are not expected to be functioning on
+      the Network as servers (available for use from
+      other sites) on a regular basis for at least two
+      weeks. Included here are:
+
+   Network
+   Address              Site                Computer
+   -------              ----                --------
+
+     133                BBN                 PDP-10 (B)
+      71                Rand                PDP-10
+      13                Case                PDP-10
+      15                Ames/(Paoli)        ILLIAC/(B6500)
+      16                Ames                IBM-360/67
+
+   2) Hosts which are currently intended to be users only.
+      Included here are the Terminal IMPs, which are
+      presently in the Network (AMES, MITRE, NBS and BBN*).
+      This category also includes the Network Control Center
+      Computer (Network Address 5) which is used solely for
+      gathering statistics from the Network. Finally,
+      included among these Hosts are the following:
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+
+   Network
+   Address              Site                Computer
+   -------              ----                --------
+
+       7                Rand                IBM-360/65
+      73                Harvard             PDP-1
+      12                Illinois            PDP-11
+      19                NBS                 PDP-11
+
+     The NBS Terminal IMP (Network Address 147) was installed in
+Washington at the beginning of December.
+
+     The tables on the next two pages summarize the Host status for this
+period.
+
+----------------
+* The BBN Terminal IMP (Network Address 158) is a prototype and as
+such is frequently not connected to the Network, but being used
+to refine and debug the Terminal IMP programs.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 2]
+
+NETWORK
+ADDRESS SITE          COMPUTER           DAY, DATE AND TIME (EASTERN)
+------- ----          --------           ----------------------------
+                                      M      Tu       W      Th       F
+                                    12/6    12/7    12/8    12/9    12/10
+                                    1300    1700    1300    1300    1630
+
+   1    UCLA          SIGMA-7         D       O       O       H       T
+
+ *65    UCLA          IBM-360/91      H       H       D       H       H
+
+   2    SRI (NIC)     PDP-10          D       T       D       D       D
+
+  66    SRI (AI)      PDP-10          D       D       D       D       D
+
+   3    UCSB          IBM-360/75      O       D       O       R       D
+
+   4    UTAH          PDP-10          T       D       D       D       T
+
+  69    BBN           PDP-10          D       D       D       D       T
+
+   6    MIT (Multics) H-645           O       O       O       T       O
+
+  70    MIT (DM)      PDP-10          O       O       D       D       O
+
+   8    SDC           IBM-360/67     #D      #D      #D      #D      #D
+
+   9    HARVARD       PDP-10          D       T       D       O       D
+
+  10    LINCOLN LAB   IBM-360/67      D       D       D       D       H
+
+  74    LINCOLN LAB   TX2             D       D       D       D       D
+
+  11    STANFORD      PDP-10          D       D       D       D       D
+
+  14    CARNAGIE      PDP-10          D       D       O       D       D
+
+where
+D = Dead (Destination Host either dead or inaccessible [due to network
+    partitioning or local IMP failure] from the BBN Terminal IMP.)
+H = 1/2 Open (Destination Host opened a connection but then either
+    immediately closed it, or did not respond any further.)
+O = Open (Destination Host opened a connection and was accessible to
+    users.)
+R = Refused (Destination Host returned a CLS to the initial RFC.)
+T = Timed out (Destination Host did not complete the ICP and open a
+    connection within 60 seconds.)
+
+
+
+
+                                                                [Page 3]
+
+NETWORK
+ADDRESS SITE          COMPUTER           DAY, DATE AND TIME (EASTERN)
+------- ----          --------           ----------------------------
+                                      M      Tu       W      Th       F
+                                    12/13   12/14   12/15   12/16   12/17
+                                    1300    1700    1700    1600    1400
+                                    1000    1400    1400    1300    1100
+
+   1    UCLA          SIGMA-7         D      #D       D       O       O
+
+ *65    UCLA          IBM-360/91      O      #D       D       O       O
+
+   2    SRI (NIC)     PDP-10          D       D       D       T       O
+
+  66    SRI (AI)      PDP-10          D       D       D       D       D
+
+   3    UCSB          IBM-360/75      T       O       D       O       D
+
+   4    UTAH          PDP-10          D       D       D       D       D
+
+  69    BBN           PDP-10          T       H       H       O       T
+
+   6    MIT (Multics) H-645           O       H       O       D       D
+
+  70    MIT (DM)      PDP-10          D       O       D       O       O
+
+   8    SDC           IBM-360/67     #D      #D      #D      #D      #D
+
+   9    HARVARD       PDP-10          O       D       O       D       T
+
+  10    LINCOLN LAB   IBM-360/67      H       D       H       H       H
+
+  74    LINCOLN LAB   TX2             D       D       D       H       D
+
+  11    STANFORD      PDP-10          D       D       D       D       D
+
+  14    CARNAGIE      PDP-10          D       D       D       D       D
+
+*The only service currently offered by the UCLA IBM-360/91 is a Network
+Job Service (NETRJS); however, the BBN Terminal IMP is not equipped to
+test NETJRS. We are assuming that initial connection to the NETRJS
+logger indicates that NETJRS is also functioning.
+
+# These sites advertise that they may not have their systems available
+at these times.
+
+
+
+
+
+
+                                                                [Page 4]
+
+                                                         "STATUS OR
+NETWORK                                                  PREDICTIONS"
+ADDRESS SITE          COMPUTER    STATUS OR PREDICTION   OBTAINED FROM
+------- ----          --------    --------------------   -------------
+
+   1    UCLA          SIGMA-7     Server                 Jon Postel
+  65    UCLA          IBM-360/91  Remote Job Service
+                                  now, Telnet in April   Bob Braden
+   2    SRI (NIC)     PDP-10      Server                 John Melvin
+  66    SRI (AI)      PDP-10      "Soon"                 Len Chaiten
+   3    UCSB          IBM-360/75  Server                 Jim White
+   4    UTAH          PDP-10      "Soon"                 Barry Wessler
+  *5    BBN (NCC)     DDP-516     Never                  Alex McKenzie
+  69    BBN (TENEX)   PDP-10      Server                 Dan Murphy
+*133    BBN (TENEX-B) PDP-10      Server (Experimental)  Dan Murphy
+   6    MIT (Multics) H-645       Server                 Mike Padlipsky
+  70    MIT (DM)      PDP-10      Server                 Bob Bressler
+  *7    RAND          IBM-360/65  User only              Eric Harslem
+ *71    RAND          PDP-10      January '72            Eric Harslem
+   8    SDC           IBM-360/67  Server                 Bob Long
+   9    HARVARD       PDP-10      Server                 Bob Sundberg
+ *73    HARVARD       PDP-1       User only              Bob Sundberg
+  10    LINCOLN       IBM-360/67  "Soon"                 Joel Winnet
+  74    LINCOLN       TX2         "Soon"                 Tom Barkalow
+  11    STANFORD      PDP-10      "Soon"                 Andy Moorer
+ *12    ILLINOIS      PDP-11      User Only              John Cravits
+ *13    CASE          PDP-10      March '72              Charles Rose
+  14    CARNEGIE      PDP-10      January '72            Hal VanZoeren
+ *15    AMES/(PAOLI)  ILLIAC/
+                       (B6500)    September '62          John McConnel
+ *16    AMES          IBM-360/67  Januray '72            Wayne Hathaway
+*144    AMES          TIP         User only
+*145    MITRE         TIP         User only
+ *19    NBS           PDP-11      User only              Robert Rosenthal
+*147    NBS           TIP         User only
+*158    BBN           TIP
+                      (Prototype) User only
+
+*Host not included in daily testing.
+
+       [ This RFC was put into machine readable form for entry ]
+          [ into the online RFC archives by Daniel Lang 4/97]
+
+
+
+
+
+
+
+
+
+                                                                [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc287.txt](<www.ietf.org/rfc/rfc287.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
