### PR TITLE
Archive rfc288.txt

### DIFF
--- a/www.ietf.org/rfc/rfc288.txt
+++ b/www.ietf.org/rfc/rfc288.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Network Working Group                                      E. Westheimer
+Request for Comments: 288                                            BBN
+NIC: 8274                                                January 6, 1972
+Obsoletes: None
+Updates: 287
+
+
+                          NETWORK HOST STATUS
+
+   This RFC reports on the status of most Network Hosts from December 20
+   to December 30.  (On December 24 and December 31 BBN celebrated
+   Christmas and New Year's Day respectively.)
+
+   During these two weeks the Lincoln Labs TX2 (Network Address 112)
+   became a server.
+
+   Several Hosts are currently excluded from the daily testing.  These
+   Hosts fall into two categories:
+
+      1)  Hosts which are not expected to be functioning on the Network
+      as servers (available for use from other sites) on a regular basis
+      for at least two weeks.  Included here are:
+
+      NETWORK            SITE            COMPUTER
+      ADDRESS
+
+      133                BBN             PDP-10 (B)
+      15                 Case            PDP-10
+      13                 Ames/(Paoli)    ILLIAC/(B6500)
+
+      2)  Hosts which are currently intended to be users only.  Included
+      here are the Terminal IMPs, which are presently in the Network
+      (AMES, MITRE, NBS and BBN*).  This category also includes the
+      Network Control Center Computer (Network Address 5) which is used
+      solely for gathering statistics from the Network.  Finally,
+      included among these Hosts are the following:
+
+      NETWORK             SITE           COMPUTER
+      ADDRESS
+
+      7                   Rand           IBM-360/65
+      73                  Harvard        PDP-1
+      12                  Illinois       PDP-11
+      19                  NBS            PDP-11
+
+
+
+
+
+
+
+Westheimer                                                      [Page 1]
+
+RFC 288                   Network Host Status               January 1972
+
+
+   * The BBN Terminal IMP (Network Address 158) is a prototype and as
+   such is frequently not connected to the Network, but being used to
+   refine and debug the Terminal IMP programs.
+
+   The tables on the next two pages summarize the Host status for this
+   period.
+
+STATUS OR
+NETWORK   SITE         COMPUTER      STATUS OR          PREDICTIONS
+ADDRESS                              PREDICTION         OBTAINED FROM
+
+   1      UCLA         SIGMA-7       Server             John Postel
+  65      UCLA         IBM-360/91    Remote Job Service Bob Braden
+                                     (Telnet in April)
+   2      SRI(NIC)     PDP-10        Server             John Melvin
+  66      SRI(AI)      PDP-10        SOON               Len Chaiten
+   3      UCSB         IBM-360/75    Server             Jim White
+   4      UTAH         PDP-10        SOON               Barry Wessler
+  *5      BBN(NCC)     DDP-516       Never              Alex McKenzie
+  69      BBN(TENEX-A) PDP-10        Server             Dan Murphy
+*133      BBN(TENEX-B) PDP-10        Server(Exper.)     Dan Murphy
+   6      MIT(Multics) H-645         Server             Mike Padlipsky
+  70      MIT(DM)      PDP-10        Server             Bob Bressler
+  *7      RAND         IBM-360/65    User only          Eric Harslem
+  71      RAND         PDP-10        SOON               Eric Harslem
+  *8      SDC          IBM-360/67    Server             Bob Long
+   9      HARVARD      PDP-10        Server             Bob Sundberg
+ *73      HARVARD      PDP-1         User only          Bob Sundberg
+  10      LINCOLN      IBM-360/67    SOON               Joel Winnet
+  74      LINCOLN      TX-2          Server             Tom Barkalow
+  11      STANFORD     PDP-10        SOON               Andy Moorer
+ *12      ILLINOIS     PDP-11        User only          John Cravits
+ *13      CASE         PDP-10        March              Charles Rose
+  14      CARNEGIE     PDP-10        SOON               Hal VanZoeren
+   5      AMES/(PAOLI) ILLIAC        September          John McConnell
+                        (B6500)
+  16      AMES         IBM-360/67    SOON               Wayne Hathaway
+*144      AMES         TIP           User only
+*145      MITRE        TIP           User only
+ *19      NBS          PDP-11        User only          Robert Rosenthal
+*147      NBS          TIP           User only
+*158      BBN          TIP           User only
+                       (Prototype)
+
+* Host not included in daily testing.
+
+
+
+
+
+
+Westheimer                                                      [Page 2]
+
+RFC 288                   Network Host Status               January 1972
+
+
+   ADDRESS   SITE          COMPUTER      DATE AND TIME (EASTERN)
+   NETWORK                               12/20 12/21  12/22 12/23
+                                         1700  1200  1400   1700
+
+    1        UCLA          SIGMA-7          O    #D     O      O
+   65*       UCLA          IBM-360/91       O     O     D      D
+    2        SRI(NIC)      PDP-10           D     O     D      D
+   66        SRI(AI)       PDP-10           D     D     D      D
+    3        UCSB          IBM-360/75       T     D     D      T
+    4        UTAH          PDP-10           O     O     D      D
+   69        BBN           PDP-10           H     O     D      O
+    6        MIT(Multics)  H-645            D     D     D      T
+   70        MIT(DM)       PDP-10           O     O     H      O
+   71        RAND          PDP-10           D     D     D      D
+    8        SDC           IBM-360/67      #D    #D    #D     #D
+    9        HARVARD       PDP-10           D     T     D      D
+   10        LINCOLN LAB   IBM-360/67       H     H     H      D
+   74        LINCOLN LAB   TX2              H     H    #D      T
+   11        STANFORD      PDP-10           D     D     D      D
+   14        CARNEGIE      PDP-10           D     D     D      D
+   16        AMES          IBM-360/67       D     D     D      D
+
+
+   ADDRESS   SITE          COMPUTER      DATE AND TIME (EASTERN)
+   NETWORK                               12/27 12/28 12/29 12/30
+                                         1730  1300  1600  1400
+
+    1        UCLA          SIGMA-7          T    #D     O     O
+   65*       UCLA          IBM-360/91       O     O     O     O
+    2        SRI(NIC)      PDP-10           D     D     D     D
+   66        SRI(AI)       PDP-10           D     D     D     O
+    3        UCSB          IBM-360/75       D     D     D     D
+    4        UTAH          PDP-10           D     D     D     D
+   69        BBN           PDP-10           O     O     O     H
+    6        MIT(Multics)  H-645            O     O     O     O
+   70        MIT(DM)       PDP-10           O     D     O     D
+   71        RAND          PDP-10           D     D     D     D
+    8        SDC           IBM-360/67       H    #D    #D    #D
+    9        HARVARD       PDP-10           T     T     D     T
+   10        LINCOLN LAB   IBM-360/67       D     H     T     T
+   74        LINCOLN LAB   TX2              D     D    #D     H
+   11        STANFORD      PDP-10           D     D     D     D
+   14        CARNEGIE      PDP-10           D     D     D     D
+   16        AMES          IBM-360/67       D     D     D     D
+
+
+
+
+
+
+
+Westheimer                                                      [Page 3]
+
+RFC 288                   Network Host Status               January 1972
+
+
+   where
+
+      D = Dead (Destination Host either dead or inaccessible [due to
+      network partitioning or local IMP failure] from the BBN Terminal
+      IMP.)
+
+      H = 1/2 Open (Destination Host opened a connection but then either
+      immediately closed it, or did not respond any further.)
+
+      O = Open (Destination Host opened a connection and was accessible
+      to users.)
+
+      R = Refused (Destination Host returned a CLS to the initial RFC.)
+
+      T = Timed out (Destination Host did not complete the ICP and open
+      a connection within 60 second)
+
+      * The only service currently offered by the UCLA IBM-360/91 is a
+      Network Job Service (NETRJS), however, the BBN Terminal IMP is not
+      equipped to test NETRJS.  We are assuming that initial connection
+      to the NETRJS logger indicated the NETRJS is also functioning.
+
+      # These sites advertise that they may not have their system
+      available at these times.
+
+
+
+
+
+
+
+
+
+
+
+        [This RFC was put into machine readable form for entry]
+     [into the online RFC archives by Kelly Tardif, Viagénie 10/99]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Westheimer                                                      [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc288.txt](<www.ietf.org/rfc/rfc288.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
