### PR TITLE
Archive rfc2880.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2880.txt
+++ b/www.ietf.org/rfc/rfc2880.txt
@@ -1,0 +1,2075 @@
+
+
+
+
+
+
+Network Working Group                                        L. McIntyre
+Request for Comments: 2880                             Xerox Corporation
+Category: Informational                                         G. Klyne
+                                                    Content Technologies
+                                                             August 2000
+
+
+                   Internet Fax T.30 Feature Mapping
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard of any kind.  Distribution of this
+   memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2000).  All Rights Reserved.
+
+Abstract
+
+   This document describes how to map Group 3 fax capability
+   identification bits, described in ITU T.30 [6], into the Internet fax
+   feature schema described in "Content feature schema for Internet fax"
+   [4].
+
+   This is a companion to the fax feature schema document [4], which
+   itself defines a profile of the media feature registration mechanisms
+   [1,2,3], for use in performing capability identification between
+   extended Internet fax systems [5].
+
+Table of Contents
+
+   1. Introduction .............................................3
+      1.1 Organization of this document ........................3
+      1.2 Terminology and document conventions .................3
+      1.3 Discussion of this document ..........................4
+   2. Combining feature tags ...................................4
+      2.1 Relationship to Group 3 fax ..........................5
+      2.2 Feature set descriptions .............................5
+      2.3 Examples .............................................5
+        2.3.1 Data resource example ............................6
+        2.3.2 Recipient capabilities example ...................6
+   3. Survey of media-related T.30 capability bits .............6
+      3.1 DIS/DTC bit 15 (resolution) ..........................6
+      3.2 DIS/DTC bit 16 (MR coding) ...........................7
+      3.3 DIS/DTC bits 17,18 (width) ...........................7
+      3.4 DIS/DTC bits 19,20 (length) ..........................7
+
+
+
+McIntyre & Klyne             Informational                      [Page 1]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+      3.5 DIS/DTC bit 31 (MMR coding) ..........................7
+      3.6 DIS/DTC bit 36 (JBIG multi-level coding) .............8
+      3.7 DIS/DTC bit 37 (plane interleave) ....................8
+      3.8 DIS/DTC bits 41,42,43 (resolution) ...................8
+      3.9 DIS/DTC bits 44,45 (preferred units) .................9
+      3.10 DIS/DTC bit 68 (JPEG) ...............................9
+      3.11 DIS/DTC bit 69 (colour) .............................9
+      3.12 DIS/DTC bit 71 (bits/sample) .......................10
+      3.13 DIS/DTC bit 73 (no subsampling) ....................10
+      3.14 DIS/DTC bit 74 (custom illuminant) .................10
+      3.15 DIS/DTC bit 75 (custom gamut) ......................10
+      3.16 DIS/DTC bits 76,77 (paper size) ....................11
+      3.17 DIS/DTC bit 78 (JBIG bi-level coding) ..............11
+      3.18 DIS/DTC bit 79 (JBIG stripe size) ..................11
+      3.19 DIS/DTC bit 92,93,94 (MRC maximum functional mode) .11
+      3.20 DIS/DTC bit 95 (MRC stripe size) ...................12
+      3.21 DIS/DTC bit 97 (resolution) ........................12
+      3.22 DIS/DTC bit 98 (resolution) ........................12
+   4. Summary of T.30 capability dependencies .................12
+      4.1 Image coding ........................................13
+        4.1.1 Bi-level coding .................................13
+        4.1.2 Multi-level coding ..............................14
+        4.1.3 MRC format ......................................14
+      4.2 Resolution and units ................................15
+      4.3 Colour capabilities .................................17
+      4.4 Document size .......................................18
+   5. Mapping T.30 capabilities to fax feature schema .........18
+      5.1 Image coding ........................................20
+        5.1.1 Bi-level coding .................................20
+        5.1.2 Multi-level coding ..............................21
+        5.1.3 MRC format ......................................23
+      5.2 Resolution and units ................................23
+      5.3 Colour capabilities .................................24
+      5.4 Document size .......................................26
+   6. Examples ................................................26
+      6.1 Common black-and-white fax machine ..................27
+        6.1.1 Corresponding Internet fax capabilities .........29
+      6.2 Full-featured color fax machine .....................30
+   7. Security Considerations .................................34
+   8. Acknowledgements ........................................34
+   9. References ..............................................34
+   10. Authors' Addresses .....................................36
+   Full Copyright Statement ...................................37
+
+
+
+
+
+
+
+
+McIntyre & Klyne             Informational                      [Page 2]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+1. Introduction
+
+   This document describes how to map Group 3 fax capability
+   identification bits, described in ITU T.30 [6], into the Internet fax
+   feature schema described in "Content feature schema for Internet fax"
+   [4].
+
+   This is a companion to the fax feature schema document [4], which
+   itself defines a profile of the media feature registration mechanisms
+   [1,2,3], for use in performing capability identification between
+   extended Internet fax systems [5].
+
+1.1 Organization of this document
+
+   Section 2 introduces the mechanisms that combine feature tag
+   constraints to describe complex recipient capabilities.
+
+   Section 3 surveys Group 3 fax (T.30) capability bits that relate to
+   media handling capabilities.
+
+   Section 4 describes the dependencies between Group 3 fax (T.30)
+   capability bits.  These are presented in a decision table format [16]
+   with descriptive text in place of the action bodies.
+
+   Section 5 describes a formal mechanism for converting Group 3 fax
+   (T.30) capability masks to fax feature schema statements.  The
+   conversion process is driven by the decision tables introduced
+   previously, using fax feature schema statements and combining rules
+   in the action bodies.
+
+   Section 6 presents an example of a Group 3 fax (T.30) capability
+   mask, and uses the formal mechanism described previously to convert
+   that into a corresponding fax feature schema statement.
+
+1.2 Terminology and document conventions
+
+   eifax system
+             is used to describe any software, device or combination
+             of these that conforms to the specification "Extended
+             Facsimile Using Internet Mail" [5].
+
+   Feature   is used as defined in [15].  (See also section 2 of this
+             memo.)
+
+   Feature tag
+             is used as defined in [15].  (See also section 2.)
+
+
+
+
+
+McIntyre & Klyne             Informational                      [Page 3]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+   Feature collection
+             is used as defined in [2].  (See also section 2.)
+
+   Feature set
+             is used as defined in [2].  (See also section 2.)
+
+1.3 Discussion of this document
+
+   Discussion of this document should take place on the Internet fax
+   mailing list hosted by the Internet Mail Consortium (IMC).  Please
+   send comments regarding this document to:
+
+       ietf-fax@imc.org
+
+   To subscribe to this list, send a message with the body 'subscribe'
+   to "ietf-fax-request@imc.org".
+
+   To see what has gone on before you subscribed, please see the mailing
+   list archive at:
+
+       http://www.imc.org/ietf-fax/
+
+2. Combining feature tags
+
+   A fax document can be described by media features.  Any single media
+   feature value can be thought of as just one component of a feature
+   collection that describes some instance of a document (e.g.  a
+   printed fax, a displayed image, etc.).  Such a feature collection
+   consists of a number of media feature tags (each per [1]) and
+   associated feature values.
+
+   A feature set contains a number of feature collections.  Thus, a
+   feature set can describe a number of different fax document
+   instances.  These can correspond to different treatments of a single
+   document (e.g. different resolutions used for printing a given fax),
+   a number of different documents subjected to a common treatment (e.g.
+   the range of different images that can be rendered on a given
+   display), or some combination of these (see examples below).
+
+   Thus, a description of a feature set can describe the rendering
+   requirements of a fax document or the capabilities of a receiving
+   eifax system.
+
+
+
+
+
+
+
+
+
+McIntyre & Klyne             Informational                      [Page 4]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+2.1 Relationship to Group 3 fax
+
+   A "feature tag" can be compared with a single bit in a T.30 DCS
+   frame, describing a specific attribute of a specific fax document.
+
+   A "feature collection" corresponds to a complete T.30 DCS frame,
+   describing a range of attributes of a specific fax document.
+
+   A "feature set" corresponds to a DIS or DTC frame, describing the
+   range of document attributes that can be accepted by a given fax
+   machine.
+
+   Within T.30 DIS/DTC frames, dependencies between the various
+   capabilities are implicit in the definitions of the capabilities.
+   E.g. multi-level coding (DIS/DTC bit 68) requires support for
+   200*200dpi resolution (DIS/DTC bit 15).  In the feature set
+   description framework used by eifax systems [1,2,3,4] such
+   dependencies between different features are expressed explicitly.
+   Later sections of this memo describe how the implicit dependencies of
+   T.30 are expressed using the media feature set notation.
+
+2.2 Feature set descriptions
+
+   The general approach to describing feature sets, described more fully
+   in [2], is to use functions ("predicates") that, when applied to a
+   feature collection value, yield a Boolean value that is TRUE if the
+   feature collection describes an acceptable fax document instance,
+   otherwise FALSE.
+
+                      P(F)
+        P(F) = TRUE <- : -> P(F) = FALSE
+                       :
+            +----------:----------+  This box represents some
+            |          :          |  universe of fax documents (F)
+            | Included : Excluded |  from which some acceptable subset
+            |          :          |  is selected by the predicate P.
+            +----------:----------+
+                       :
+
+2.3 Examples
+
+   In the examples below the following notation is used:
+
+      (x ? y)             tests feature tag 'x' for some relationship
+                          with value 'y'.
+
+      (| p1 p2 ... pn )   represents the logical-OR of predicates 'p1',
+                          'p2' up to 'pn'.
+
+
+
+McIntyre & Klyne             Informational                      [Page 5]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+      (& p1 p2 ... pn )   represents the logical-AND of predicates
+                          'p1', 'p2' up to 'pn'.
+
+2.3.1 Data resource example
+
+   The following expression uses the syntax of [2] to describe a data
+   resource that can be displayed either:
+   (a)  as a 750x500 pixel image using 15 colours, or
+   (b)  at 150dpi on an A4 page.
+
+      (| (& (pix-x=750) (pix-y=500) (color=15) )
+         (& (dpi>=150) (papersize=A4) ) )
+
+2.3.2 Recipient capabilities example
+
+   The following expression describes a receiving system that has:
+   (a)  a screen capable of displaying 640*480 pixels and 16 million
+        colours (24 bits per pixel), 800*600 pixels and 64 thousand
+        colours (16 bits per pixel) or 1024*768 pixels and 256 colours
+        (8 bits per pixel), or
+   (b)  a printer capable of rendering 300dpi on A4 paper.
+
+      (| (& (| (& (pix-x<=640)  (pix-y<=480) (color<=16777216) )
+               (& (pix-x<=800)  (pix-y<=600) (color<=65535) )
+               (& (pix-x<=1024) (pix-y<=768) (color<=256) ) )
+            (media=screen) )
+         (& (dpi=300)
+            (media=stationery) (papersize=A4) ) )
+
+3. Survey of media-related T.30 capability bits
+
+   The following sections refer to T.30 DIS/DTC bits identified and
+   described in Table 2/T.30 and accompanying notes [6].  Bit numbers
+   that are not referenced below are considered to be not related to
+   media features, hence not relevant to the Internet fax feature
+   schema.
+
+         NOTE: some of the DIS/DTC bits identified below are
+         documented in revisions of the T.30 specification that
+         may be not yet publicly available from the ITU.
+
+3.1 DIS/DTC bit 15 (resolution)
+
+   All Group 3 fax systems are required to support a basic resolution of
+   200*100dpi (dots per inch) or 8*3.85dpmm (dots per millimetre).
+
+   Setting this bit indicates additional support for 200*200dpi or
+   8*7.7dpmm.
+
+
+
+McIntyre & Klyne             Informational                      [Page 6]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+   For multi-level images, 200*200dpi is the basic resolution, and this
+   bit must be set.  The other basic resolution options apply to bi-
+   level images only.
+
+   See also: bits 44,45.
+
+3.2 DIS/DTC bit 16 (MR coding)
+
+   All Group 3 fax systems are required to support Modified Huffman (MH)
+   1-dimensional coding for bi-level images.  (A bi-level image is one
+   with just two pixel states such as black and white, as opposed to a
+   grey-scale or colour image.)
+
+   Setting this bit indicates additional support for Modified Read (MR)
+   2-dimensional coding for bi-level images.
+
+   Both MH and MR coding are described in ITU T.4 [7].
+
+   See also: bits 31,78,79.
+
+3.3 DIS/DTC bits 17,18 (width)
+
+   All Group 3 fax systems are required to support 215mm paper width.
+   These bits can be set to indicate additional support for 255mm and
+   303mm paper widths.
+
+   See also: bits 76,77.
+
+3.4 DIS/DTC bits 19,20 (length)
+
+   All Group 3 fax systems are required to support 297mm paper length.
+   These bits can be set to indicate additional support for 364mm and
+   unlimited paper lengths.
+
+   See also: bits 76,77.
+
+3.5 DIS/DTC bit 31 (MMR coding)
+
+   Setting this bit indicates support for Modified Modified Read (MMR)
+   2-dimensional coding for bi-level images, in addition to the required
+   support for MH coding.
+
+   MMR coding is described in ITU T.6 [8].
+
+   See also: bits 16,78,79.
+
+
+
+
+
+
+McIntyre & Klyne             Informational                      [Page 7]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+3.6 DIS/DTC bit 36 (JBIG multi-level coding)
+
+   If multi-level images are to be handled, support for JPEG coding is
+   required (i.e. bit 68 must be set).  Setting bit 36 indicates
+   additional support for JBIG lossless coding of multi-level images.
+
+   JBIG coding for multi-level images is described in ITU T.43 [10] and
+   T.4 Annex G [7].
+
+   See also: bits 68,69.
+
+3.7 DIS/DTC bit 37 (plane interleave)
+
+   Setting this bit indicates support for plane interleave for JBIG-
+   coded multi-level images in addition to stripe interleave, which is
+   standard for JBIG multi-level images.
+
+   JBIG coding for multi-level images is described in ITU T.43 [10] and
+   T.4 Annex G [7].
+
+   See also: bit 36.
+
+3.8 DIS/DTC bits 41,42,43 (resolution)
+
+   Setting these bits indicates support for resolutions in addition to
+   200*100dpi and 200*200dpi, or 8*3.85dpmm and 8*7.7dpmm.  (Or in
+   addition to the basic 200*200dpi resolution when using a multi-level
+   image mode.)
+
+   Bit 41 indicates support for 8*15.4dpmm bi-level images
+   (independently of the settings of bits 44 and 45).
+
+   Bit 42 indicates support for 300*300dpi bi-level images
+   (independently of the settings of bits 44 and 45).  Also applies to
+   multi-level images or MRC mask if bit 97 is set.
+
+   Bit 43 indicates support for 400*400dpi and/or 16*15.4dpmm bi-level
+   images, depending upon the settings of bits 44 and 45.  Also applies
+   to multi-level images or MRC mask if bit 97 is set.
+
+   See also: bits 15,44,45,97.
+
+
+
+
+
+
+
+
+
+
+McIntyre & Klyne             Informational                      [Page 8]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+3.9 DIS/DTC bits 44,45 (preferred units)
+
+   These bits are used to indicate the preferred resolution units for
+   received images.  Because the exact resolution and x/y pixel density
+   measures in dpi or dpmm are slightly different, some image size and
+   aspect ratio distortion may occur if the sender and receiver use
+   different units.
+
+   Even when sender and recipient have different preferred units, image
+   transfer must be accomplished.  For most fax uses, the dpi and dpmm
+   measurements are sufficiently close to each other that the difference
+   is not noticed.
+
+   The preferred units setting affects the detailed interpretation of
+   the following resolutions:
+
+                dpi       dpmm      (dpi equivalent)
+                ---       ----
+      Base      200*100   8*3.85    204*98
+      Bit 15    200*200   8*7.7     204*196
+      Bit 43    400*400   16*15.4   408*391
+
+   But terminals are required to accept the inch- and metric-based
+   measures given above as equivalent, distorting the image if necessary
+   to accommodate the differences.
+
+   See also: bits 15, 43
+
+3.10 DIS/DTC bit 68 (JPEG)
+
+   This bit indicates support for JPEG coding of multi-level images.
+
+   JPEG coding for multi-level images is described in ITU T.81 [12] and
+   T.4 Annex E [7].
+
+   See also: bits 15,69,73
+
+3.11 DIS/DTC bit 69 (colour)
+
+   This bit indicates support for colour images, in addition to just
+   grey-scale.
+
+   Both grey-scale and colour require multi-level coding.  The
+   difference is that grey is single component while colour is multi-
+   component.
+
+   See also: bits 36,68,73.
+
+
+
+
+McIntyre & Klyne             Informational                      [Page 9]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+3.12 DIS/DTC bit 71 (bits/sample)
+
+   Standard support for multi-level images uses 8 bits per sample.
+   Setting this bit indicates additional support for 12 bits per sample.
+
+   For a grey-scale multi-level image, there is just one sample per
+   pixel, giving 256 or 4096 possible pixel values.  For a full colour
+   multi-level image there are three samples per pixel, giving 256^3
+   (16777216) or 4096^3 (6871946736) possible values.
+
+   When related to a mapped colour image, bit 71 also affects the
+   maximum number of entries in the mapping table:  when it is reset, up
+   to 4096 different pixel values can be used;  when set, up to 65536
+   different values can be used.
+
+   See also: bit 68.
+
+3.13 DIS/DTC bit 73 (no subsampling)
+
+   Standard support for JPEG-coded multi-level images uses 4:1:1
+   chrominance subsampling.  That is, for each 4 luminance samples in
+   the image data there is a single chrominance sample.
+
+   Setting this bit indicates that JPEG-coded colour images without
+   subsampling can also be supported.  This is not applicable to JBIG
+   coding (bit 36).
+
+   See also: bits 68,69.
+
+3.14 DIS/DTC bit 74 (custom illuminant)
+
+   Standard support for multi-level images requires use of D50
+   illuminant.  Setting this bit indicates that a custom illuminant also
+   can be supported for multi-level images (both grey-scale and colour).
+   Details of the custom illuminant are contained in the image data.
+
+   Use of a custom illuminant with multi-level images is described in
+   ITU T.4 Annex E [7].
+
+   See also: bits 36,68.
+
+3.15 DIS/DTC bit 75 (custom gamut)
+
+   Standard support for a default colour gamut is required for multi-
+   level images.  Setting this bit indicates that a custom gamut also
+   can be supported for multi-level images (both grey-scale and colour).
+   Details of the custom gamut are contained in the image data.
+
+
+
+
+McIntyre & Klyne             Informational                     [Page 10]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+   The default gamut (L*=[0,100], a*=[-85, 85], b* = [-75, 125]), and
+   use of a custom gamut with multi-level images is described in ITU
+   T.42 [9] and T.4 Annex E [7].
+
+   See also: bits 36,68.
+
+3.16 DIS/DTC bits 76,77 (paper size)
+
+   All Group 3 faxes are required to support A4 paper size.  These bits
+   can be set to indicate additional support for North American letter
+   and legal paper sizes.
+
+   See also: bits 17,18,19,20.
+
+3.17 DIS/DTC bit 78 (JBIG bi-level coding)
+
+   Setting bit 78 indicates support for JBIG coding of bi-level images
+   (using T.85 encoding rules), in addition to the required support for
+   MH coding.
+
+   JBIG coding of bi-level images is described in ITU T.85 [14].
+
+   See also: bits 16,31,79.
+
+3.18 DIS/DTC bit 79 (JBIG stripe size)
+
+   Setting bit 79 (along with bit 78) indicates support for the 'LO'
+   option with JBIG coded bi-level images.  Basic bi-level JBIG coding
+   uses 128 lines per stripe;  the 'LO' option allows other stripe sizes
+   to be used.
+
+   The stripe size is used for all stripes except the last, which may
+   have fewer lines than the indicated value.
+
+   JBIG coding of bi-level images is described in ITU T.85 [14].
+
+   See also: bits 16,31,78.
+
+3.19 DIS/DTC bit 92,93,94 (MRC maximum functional mode)
+
+   If these bits are all zero, then Mixed Raster Content (MRC) coding is
+   not supported.  Otherwise, they represent a number in the range 1-7
+   that indicates an MRC maximum functional mode.
+
+   MRC coding of images is described in ITU T.44 [11] and T.4 Annex H
+   [17].
+
+   See also: bits 68,95.
+
+
+
+McIntyre & Klyne             Informational                     [Page 11]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+3.20 DIS/DTC bit 95 (MRC stripe size)
+
+   Standard support for MRC uses a maximum stripe size of 256 lines.
+   When this bit is set, the maximum stripe size is a full page.
+
+   This bit is meaningful only if bits 92-94 indicate an MRC coding
+   capability.  MRC coding of images is described in ITU T.44 [11] and
+   T.4 Annex H [17].
+
+   See also: bits 92,93,94.
+
+3.21 DIS/DTC bit 97 (resolution)
+
+   Setting this bit indicates that the additional resolutions indicated
+   by bits 42 and 43 may be used for multi-level images and any MRC mask
+   layer.
+
+   When this bit is set, bit 42 implies 300dpi and bit 43 implies 400dpi
+   for multi-level or MRC mask layer images (irrespective of the
+   preferred units indicated by bits 44 and 45).
+
+   See also: bits 42,43,68.
+
+3.22 DIS/DTC bit 98 (resolution)
+
+   Setting this bit indicates that the additional resolution 100*100dpi
+   may be used for multi-level images.
+
+        NOTE: 100dpi is not used for bi-level images, including
+        the MRC mask layer.
+
+   See also: bit 36,68,92-94.
+
+4. Summary of T.30 capability dependencies
+
+   This section contains a number of decision tables that indicate the
+   allowable combinations of T.30 DIS/DTC mask bits.
+
+   Within the decision table bodies, the following symbols are use to
+   indicate values of T.30 DIS/DTC bits:
+
+      0  = bit set to '0'
+      1  = bit set to '1'
+      x  = don't care bit value: may be '0' or '1'
+      *0 = bit must be '0' ('1' is invalid in given combination)
+      *1 = bit must be '1' ('0' is invalid in given combination)
+      #  = bits in row combined to form a numeric value
+
+
+
+
+McIntyre & Klyne             Informational                     [Page 12]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+4.1 Image coding
+
+   MH coding is required as a minimum for Group 3 fax operation.
+
+4.1.1 Bi-level coding
+
+<------- T.30 bits --------->
+15|16|31|36|37|68|69|73|78|79||Description
+--+--+--+--+--+--+--+--+--+--++---------------------------------------
+ x| 0| 0|  |  |  |  |  | 0| 0||Compression = [MH]
+ x| 1| 0|  |  |  |  |  | 0| 0||Compression = [MH,MR]
+ x| 0| 1|  |  |  |  |  | 0| 0||Compression = [MH,MMR]
+ x| 1| 1|  |  |  |  |  | 0| 0||Compression = [MH,MR,MMR]
+ x| 0| 0|  |  |  |  |  | 1| 0||Compression = [MH,T.85]
+ x| 1| 0|  |  |  |  |  | 1| 0||Compression = [MH,MR,T.85]
+ x| 0| 1|  |  |  |  |  | 1| 0||Compression = [MH,MMR,T.85]
+ x| 1| 1|  |  |  |  |  | 1| 0||Compression = [MH,MR,MMR,T.85]
+ x| 0| 0|  |  |  |  |  |*1| 1||Compression = [MH,T.85,T.85LO]
+ x| 1| 0|  |  |  |  |  |*1| 1||Compression = [MH,MR,T.85,T.85LO]
+ x| 0| 1|  |  |  |  |  |*1| 1||Compression = [MH,MMR,T.85,T.85LO]
+ x| 1| 1|  |  |  |  |  |*1| 1||Compression = [MH,MR,MMR,T.85,T.85LO]
+  |  |  |  |  |  |  |  |  |  ||MH     = 1-D per T.4
+  |  |  |  |  |  |  |  |  |  ||MR     = 2-D per T.4
+  |  |  |  |  |  |  |  |  |  ||MMR    = 2-D per T.6
+  |  |  |  |  |  |  |  |  |  ||T.85   = Basic JBIG per T.85
+  |  |  |  |  |  |  |  |  |  ||T.85LO = Optional LO with T.85/JBIG
+  |  |  |  |  |  |  |  |  |  ||(Basic JBIG is 128 lines/stripe;  LO
+  |  |  |  |  |  |  |  |  |  || allows other stripe sizes to be used)
+--+--+--+--+--+--+--+--+--+--++---------------------------------------
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McIntyre & Klyne             Informational                     [Page 13]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+4.1.2 Multi-level coding
+
+   Note: When 37, 69, 73, 79 and 95 are set to "1", the feature
+   represented by "0" is also available.  Example: If plane interleave
+   is available then stripe interleave is also available.
+
+<------- T.30 bits --------->
+15|16|31|36|37|68|69|73|78|79||Description
+--+--+--+--+--+--+--+--+--+--++---------------------------------------
+ x|  |  |*0| x| 0| x| x|  |  ||No grey or colour (no T.43 or JPEG)
+*1|  |  | 0| x| 1| 0| x|  |  ||JPEG, grey scale only
+*1|  |  | 0| x| 1| 1| 0|  |  ||JPEG, full colour, subsampling
+*1|  |  | 0| x| 1| 1| 1|  |  ||JPEG, full colour, no subsampling
+*1|  |  | 1| 0|*1| 0| x|  |  ||T.43, JPEG, grey only, stripe i/l
+*1|  |  | 1| 1|*1| 0| x|  |  ||T.43, JPEG, grey only, plane i/l
+*1|  |  | 1| 0|*1| 1| 0|  |  ||T.43, JPEG, colour, stripe i/l, s/s
+*1|  |  | 1| 0|*1| 1| 1|  |  ||T.43, JPEG, colour, stripe i/l, no s/s
+*1|  |  | 1| 1|*1| 1| 0|  |  ||T.43, JPEG, colour, plane i/l, s/s
+*1|  |  | 1| 1|*1| 1| 1|  |  ||T.43, JPEG, colour, plane i/l, no s/s
+  |  |  |  |  |  |  |  |  |  ||'s/s'    is 4:1:1 L*:a*:b* subsampling
+  |  |  |  |  |  |  |  |  |  ||'No s/s' is 1:1:1 L*:a*:b* subsampling
+  |  |  |  |  |  |  |  |  |  ||'stripe i/l' is stripe interleave
+  |  |  |  |  |  |  |  |  |  ||'plane i/l'  is full-plane interleave
+--+--+--+--+--+--+--+--+--+--++---------------------------------------
+
+4.1.3 MRC format
+
+   Multi-level coders, as indicated above, are used for foreground and
+   background images within an MRC-format document.  Bi-level codes
+   are used for the mask layer.
+
+<---- T.30 bits ------>
+15|92|93|94|95|  |  |  ||Description
+--+--+--+--+--+--+--+--++---------------------------------------
+ x| 0| 0| 0| x|  |  |  ||MRC not accepted
+*1| #| #| #| 0|  |  |  ||MRC level, max strip 256 lines
+*1| #| #| #| 1|  |  |  ||MRC level, max strip full page
+  |  |  |  |  |  |  |  ||### is MRC performance level (1-7, per T.44)
+--+--+--+--+--+--+--+--++---------------------------------------
+
+
+
+
+
+
+
+
+
+
+
+
+McIntyre & Klyne             Informational                     [Page 14]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+4.2 Resolution and units
+
+   Support for bi-level coding at least one of 200*100dpi or 8*3.85dpmm
+   is required in all cases for Group 3 fax conformance.  For multi-
+   level coders (colour/grey) and MRC mask layers the base resolution is
+   200*200dpi (i.e. bit 15 must be set).
+
+   When multi-level coders (JPEG or T.43) or MRC are used, only inch-
+   based square resolutions are available.  However, the base non-square
+   resolution (i.e. 200x100dpi or 8x3.85dpmm) must still be available as
+   a capability for use with the mandatory bi-level coder (MH).  Hence,
+   any references to metric and non-square resolutions in the table
+   below apply only to bi-level coders.
+
+   When describing MRC capabilities, the complete set of usable
+   resolutions is listed.  However, there are some restrictions on their
+   use:  (a) 100dpi resolution can be used only with multi-level images,
+   and (b) any multi-level image resolution is required to be an
+   integral sub-multiple of the applicable mask resolution.
+
+   In the following table:
+      dpi  = dots per inch
+      dpmm = dots per millimetre
+
+   Preferred resolutions are indicated here, even though inch- or mm-
+   based units must be accepted, according to the T.30 protocol [6].
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McIntyre & Klyne             Informational                     [Page 15]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+<------- T.30 bits ------>
+15|41|42|43|44|45|68|97|98||Description
+--+--+--+--+--+--+--+--+--++-----------------------------------------
+ 0|  |  | 0| x| x|  |  |  ||Resolution = base only
+  |  |  |  |  |  |  |  |  ||
+ 1|  |  | 0| 0| 0|  |  |  ||Invalid
+ 1|  |  | 0| 0| 1|  |  |  ||Resolution = 8*3.85dpmm or 8*7.7dpmm
+ 1|  |  | 0| 1| 0|  |  |  ||Resolution = 200*100dpi or 200*200dpi
+ 1|  |  | 0| 1| 1|  |  |  ||Resolution = 8*3.85dpmm or 8*7.7dpmm
+  |  |  |  |  |  |  |  |  ||        or   200*100dpi or 200*200dpi
+  |  |  |  |  |  |  |  |  ||
+ 0|  |  | 1| 0| 0|  |  |  ||Invalid
+ 0|  |  | 1| 0| 1|  |  |  ||Resolution = 8*3.85dpmm or 16*15.4dpmm
+ 0|  |  | 1| 1| 0|  |  |  ||Resolution = 200*100dpi or 400*400dpi
+ 0|  |  | 1| 1| 1|  |  |  ||Resolution = 8*3.85dpmm or 16*15.4dpmm
+  |  |  |  |  |  |  |  |  ||        or   200*100dpi or 400*400dpi
+  |  |  |  |  |  |  |  |  ||
+ 1|  |  | 1| 0| 0|  |  |  ||Invalid
+ 1|  |  | 1| 0| 1|  |  |  ||Resolution = 8*3.85dpmm or 8*7.7dpmm
+  |  |  |  |  |  |  |  |  ||        or   16*15.4dpmm
+ 1|  |  | 1| 1| 0|  |  |  ||Resolution = 200*100dpi or 200*200dpi
+  |  |  |  |  |  |  |  |  ||        or   400*400dpi
+ 1|  |  | 1| 1| 1|  |  |  ||Resolution = 8*7.7dpmm  or 8*7.7dpmm
+  |  |  |  |  |  |  |  |  ||        or   16*15.4dpmm
+  |  |  |  |  |  |  |  |  ||        or   200*100dpi or 200*200dpi
+  |  |  |  |  |  |  |  |  ||        or   400*400dpi
+--+--+--+--+--+--+--+--+--++-----------------------------------------
+  | 0|  |  |  |  |  |  |  ||Resolutions as above
+  | 1|  |  |  |  |  |  |  ||Also supports 8*15.4dpmm (bi-level only)
+  |  |  |  |  |  |  |  |  ||Independent of bits 44,45
+--+--+--+--+--+--+--+--+--++-----------------------------------------
+  |  | 0|  |  |  |  |  |  ||Resolutions as above
+  |  | 1|  |  |  |  |  |  ||Also supports 300*300dpi
+  |  |  |  |  |  |  |  |  ||Independent of bits 44,45
+--+--+--+--+--+--+--+--+--++-----------------------------------------
+  |  |  |  |  |  | x| 0|  ||Resolutions as above
+  |  |  |  |  |  |*1| 1|  ||Also 300*300dpi or 400*400dpi (see below)
+  |  |  |  |  |  |  |  |  ||(Applies colour, grey-scale or MRC mask)
+  |  |  |  |  |  |  |  |  ||(Valid only when bit 42 or 43 is set.)
+  |  |  |  |  |  |  |  |  ||(42 => 300dpi, 43=>400dpi)
+--+--+--+--+--+--+--+--+--++-----------------------------------------
+  |  |  |  |  |  | x|  | 0||Resolutions as above
+  |  |  |  |  |  |*1|  | 1||Also 100*100dpi
+  |  |  |  |  |  |  |  |  ||(Applies colour or grey-scale only)
+  |  |  |  |  |  |  |  |  ||(Independent of bits 44,45)
+--+--+--+--+--+--+--+--+--++-----------------------------------------
+
+
+
+
+
+McIntyre & Klyne             Informational                     [Page 16]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+4.3 Colour capabilities
+
+   Bit 68 (JPEG) is required for any colour/grey scale mode, and bit 36
+   indicates additional T.43 capability.
+
+<------- T.30 bits --->
+36|68|69|71|74|75|  |  ||Description
+--+--+--+--+--+--+--+--++-----------------------------------------
+ 0| 0| x|  |  |  |  |  ||No grey scale or colour
+ x| 1| 0|  |  |  |  |  ||Grey scale only
+ 0| 1| 1|  |  |  |  |  ||Full colour capability (CIE L*a*b*)
+ 1|*1| 1|  |  |  |  |  ||Full and limited colour capability:
+  |  |  |  |  |  |  |  || (CIE L*a*b*, palette, RGB 1 bit/colour
+  |  |  |  |  |  |  |  ||  and CMY(K)1 bit/colour)
+--+--+--+--+--+--+--+--++-----------------------------------------
+  | 0|  | x|  |  |  |  ||
+  | 1|  | 0|  |  |  |  ||8 bits/pixel and up to 4096 palette entries
+  | 1|  | 1|  |  |  |  ||8 or 12 bits/pixel, 65536 palette entries
+--+--+--+--+--+--+--+--++-----------------------------------------
+  | 0|  |  | x|  |  |  ||
+  | 1|  |  | 0|  |  |  ||CIE standard illuminant D50 (per T.42)
+  | 1|  |  | 1|  |  |  ||Custom illuminants (definition provided)
+--+--+--+--+--+--+--+--++-----------------------------------------
+  | 0|  |  |  | x|  |  ||
+  | 1|  |  |  | 0|  |  ||Default gamut (per T.42)
+  | 1|  |  |  | 1|  |  ||Custom gamuts (definition provided)
+--+--+--+--+--+--+--+--++-----------------------------------------
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McIntyre & Klyne             Informational                     [Page 17]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+4.4 Document size
+
+   A4 width (215mm) is required as a minimum for Group 3 fax
+   conformance.  A Group 3 fax machine must always be able to receive
+   an A4 image.
+
+
+<---- T.30 bits ------>
+17|18|19|20|76|77|  |  ||Description
+--+--+--+--+--+--+--+--++-----------------------------------------
+ 0| 0|  |  |  |  |  |  ||Width = 215mm
+ 1| 0|  |  |  |  |  |  ||Width = 215mm or 255mm
+ 0| 1|  |  |  |  |  |  ||Width = 215mm, 255mm or 303mm
+ 1| 1|  |  |  |  |  |  ||Invalid - interpret as (17=0,18=1)
+  |  |  |  |  |  |  |  ||(measurements described as scan line length)
+  |  |  |  |  |  |  |  ||(corresp. inch measurements: T.4 sect 2.2)
+--+--+--+--+--+--+--+--++-----------------------------------------
+  |  | 0| 0|  |  |  |  ||Length = 297mm (A4)
+  |  | 1| 0|  |  |  |  ||Length = 297mm (A4) or 364mm (B4)
+  |  | 0| 1|  |  |  |  ||Length = unlimited
+  |  | 1| 1|  |  |  |  ||Invalid
+--+--+--+--+--+--+--+--++-----------------------------------------
+  |  |  |  | 0| 0|  |  ||Papersize = A4
+  |  |  |  | 1| 0|  |  ||Papersize = A4 or NA-Letter
+  |  |  |  | 0| 1|  |  ||Papersize = A4 or NA-Legal
+  |  |  |  | 1| 1|  |  ||Papersize = A4 or NA-Letter or NA-Legal
+  |  |  |  |  |  |  |  ||(These in addition to paper sizes implied
+  |  |  |  |  |  |  |  || by bits 17-20 above)
+--+--+--+--+--+--+--+--++-----------------------------------------
+
+5. Mapping T.30 capabilities to fax feature schema
+
+   This section follows the structure of the previous section, except
+   that the decision tables are restated with feature set expression
+   mappings in the action stub.  The feature set expressions use media
+   feature tags presented in "Content feature schema for Internet fax"
+   [4].
+
+   To construct a feature set expression corresponding to a collection
+   of DIS frame bits:
+
+   o  Compare the DIS bits with each decision table in the following
+      sections (5.1 to 5.4).  Some decision tables consist of a number
+      of sub-tables separated by horizontal lines.
+
+   o  The DIS bits will match exactly one row from each table or sub-
+      table:  collect the corresponding feature set expression from the
+      action stub (the right hand column of the table).
+
+
+
+McIntyre & Klyne             Informational                     [Page 18]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+   o  In the case of the table in section 5.2, which consists of
+      several sub-tables, combine the feature set expressions from each
+      sub-table with a logical-OR:  (| s1 s2 ... sn ), where 's1', 's2'
+      etc. are the feature set expressions selected from each sub-
+      table.  In this way, a single feature set expression is obtained
+      for the table.
+
+   o  In the case of the tables in sections 5.3 and 5.4, combine the
+      sub-table expressions with a logical-AND:  (& s1 s2 ... sn ).
+
+   o  Combine the feature set expressions for each table as follows:
+
+        (& (| T511 T512 ) T513 T52 T53 T54 )
+
+      where:
+
+      - T511 is the feature set expression obtained from the table in
+        section 5.1.1
+
+      - T512 is obtained from the table in section 5.1.2
+
+      - T513 is obtained from the table in section 5.1.3
+
+      - T52 is obtained from the table in section 5.2
+
+      - T53 is obtained from the table in section 5.3
+
+      - T54 is obtained from the table in section 5.4
+
+   The resulting expression is the feature set expression corresponding
+   to the DIS bits given.  Remember that there may be other capabilities
+   not expressed by the DIS bits that should be incorporated into the
+   final feature expression (e.g. TIFF image file structure).
+
+   To do the reverse transformation, match the feature set to each row
+   of each decision table using the matching algorithm in RFC 2533 [2],
+   and OR together the DIS bit masks for each row whose feature set
+   expression is completely contained by (i.e. is a subset of) that
+   given (where the bit value in a table is 'x', use '0').
+
+   A feature set A is completely contained by B if the feature set match
+   of A and B (obtained by applying the feature set matching algorithm
+   in [2]) is equal to A.
+
+
+
+
+
+
+
+
+McIntyre & Klyne             Informational                     [Page 19]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+5.1 Image coding
+
+5.1.1 Bi-level coding
+
+<------- T.30 bits --------->
+15|16|31|36|37|68|69|73|78|79||Feature set expression
+--+--+--+--+--+--+--+--+--+--++---------------------------------------
+ x| 0| 0|  |  |  |  |  | 0| 0||(& (color=binary)
+  |  |  |  |  |  |  |  |  |  ||   (image-coding=[MH]) )
+ x| 1| 0|  |  |  |  |  | 0| 0||(& (color=binary)
+  |  |  |  |  |  |  |  |  |  ||   (image-coding=[MH,MR])
+ x| 0| 1|  |  |  |  |  | 0| 0||(& (color=binary)
+  |  |  |  |  |  |  |  |  |  ||   (image-coding=[MH,MMR])
+ x| 1| 1|  |  |  |  |  | 0| 0||(& (color=binary)
+  |  |  |  |  |  |  |  |  |  ||   (image-coding=[MH,MR,MMR])
+ x| 0| 0|  |  |  |  |  | 1| 0||(& (color=binary)
+  |  |  |  |  |  |  |  |  |  ||   (image-coding=[MH,JBIG])
+  |  |  |  |  |  |  |  |  |  ||   (image-coding-constraint=JBIG-T85)
+  |  |  |  |  |  |  |  |  |  ||   (JBIG-stripe-size=128) )
+ x| 1| 0|  |  |  |  |  | 1| 0||(& (color=binary)
+  |  |  |  |  |  |  |  |  |  ||   (image-coding=[MH,MR,JBIG])
+  |  |  |  |  |  |  |  |  |  ||   (image-coding-constraint=JBIG-T85)
+  |  |  |  |  |  |  |  |  |  ||   (JBIG-stripe-size=128) )
+ x| 0| 1|  |  |  |  |  | 1| 0||(& (color=binary)
+  |  |  |  |  |  |  |  |  |  ||   (image-coding=[MH,MMR,JBIG])
+  |  |  |  |  |  |  |  |  |  ||   (image-coding-constraint=JBIG-T85)
+  |  |  |  |  |  |  |  |  |  ||   (JBIG-stripe-size=128) )
+ x| 1| 1|  |  |  |  |  | 1| 0||(& (color=binary)
+  |  |  |  |  |  |  |  |  |  ||   (image-coding=[MH,MR,MMR,JBIG])
+  |  |  |  |  |  |  |  |  |  ||   (image-coding-constraint=JBIG-T85)
+  |  |  |  |  |  |  |  |  |  ||   (JBIG-stripe-size=128) )
+ x| 0| 0|  |  |  |  |  |*1| 1||(& (color=binary)
+  |  |  |  |  |  |  |  |  |  ||   (image-coding=[MH,JBIG])
+  |  |  |  |  |  |  |  |  |  ||   (image-coding-constraint=JBIG-T85)
+  |  |  |  |  |  |  |  |  |  ||   (JBIG-stripe-size>=0) )
+ x| 1| 0|  |  |  |  |  |*1| 1||(& (color=binary)
+  |  |  |  |  |  |  |  |  |  ||   (image-coding=[MH,MR,JBIG])
+  |  |  |  |  |  |  |  |  |  ||   (image-coding-constraint=JBIG-T85)
+  |  |  |  |  |  |  |  |  |  ||   (JBIG-stripe-size>=0) )
+ x| 0| 1|  |  |  |  |  |*1| 1||(& (color=binary)
+  |  |  |  |  |  |  |  |  |  ||   (image-coding=[MH,MMR,JBIG])
+  |  |  |  |  |  |  |  |  |  ||   (image-coding-constraint=JBIG-T85)
+  |  |  |  |  |  |  |  |  |  ||   (JBIG-stripe-size>=0) )
+ x| 1| 1|  |  |  |  |  |*1| 1||(& (color=binary)
+  |  |  |  |  |  |  |  |  |  ||   (image-coding=[MH,MR,MMR,JBIG])
+  |  |  |  |  |  |  |  |  |  ||   (image-coding-constraint=JBIG-T85)
+  |  |  |  |  |  |  |  |  |  ||   (JBIG-stripe-size>=0) )
+--+--+--+--+--+--+--+--+--+--++---------------------------------------
+
+
+
+McIntyre & Klyne             Informational                     [Page 20]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+5.1.2 Multi-level coding
+
+<------- T.30 bits --------->
+15|16|31|36|37|68|69|73|78|79||Feature set expression
+--+--+--+--+--+--+--+--+--+--++---------------------------------------
+ x|  |  |*0| x| 0| x| x|  |  ||
+*1|  |  | 0| x| 1| 0| x|  |  ||(& (color=grey)
+  |  |  |  |  |  |  |  |  |  ||   (image-coding=JPEG)
+  |  |  |  |  |  |  |  |  |  ||   (image-coding-constraint=JPEG-T4E) )
+*1|  |  | 0| x| 1| 1| 0|  |  ||(& (color=[grey,full])
+  |  |  |  |  |  |  |  |  |  ||   (image-coding=JPEG)
+  |  |  |  |  |  |  |  |  |  ||   (image-coding-constraint=JPEG-T4E)
+  |  |  |  |  |  |  |  |  |  ||   (& (color=full)
+  |  |  |  |  |  |  |  |  |  ||      (color-subsampling="4:1:1") ) )
+*1|  |  | 0| x| 1| 1| 1|  |  ||(& (color=[grey,full])
+  |  |  |  |  |  |  |  |  |  ||   (image-coding=JPEG)
+  |  |  |  |  |  |  |  |  |  ||   (image-coding-constraint=JPEG-T4E)
+  |  |  |  |  |  |  |  |  |  ||   (& (color=full)
+  |  |  |  |  |  |  |  |  |  ||      (color-subsampling=
+  |  |  |  |  |  |  |  |  |  ||       ["1:1:1","4:1:1"]) ) )
+*1|  |  | 1| 0|*1| 0| x|  |  ||(& (color=grey)
+  |  |  |  |  |  |  |  |  |  ||   (image-coding=[JPEG,JBIG])
+  |  |  |  |  |  |  |  |  |  ||   (image-coding-constraint=
+  |  |  |  |  |  |  |  |  |  ||    [JPEG-T4E,JBIG-T43])
+  |  |  |  |  |  |  |  |  |  ||   (image-interleave=stripe) )
+*1|  |  | 1| 1|*1| 0| x|  |  ||(& (color=grey)
+  |  |  |  |  |  |  |  |  |  ||   (image-coding=[JPEG,JBIG])
+  |  |  |  |  |  |  |  |  |  ||   (image-coding-constraint=
+  |  |  |  |  |  |  |  |  |  ||    [JPEG-T4E,JBIG-T43])
+  |  |  |  |  |  |  |  |  |  ||   (image-interleave=[stripe,plane]) )
+*1|  |  | 1| 0|*1| 1| 0|  |  ||(& (color=[limited,mapped,grey,full])
+  |  |  |  |  |  |  |  |  |  ||   (image-coding=[JPEG,JBIG])
+  |  |  |  |  |  |  |  |  |  ||   (image-coding-constraint=
+  |  |  |  |  |  |  |  |  |  ||    [JPEG-T4E,JBIG-T43])
+  |  |  |  |  |  |  |  |  |  ||   (& (color=full)
+  |  |  |  |  |  |  |  |  |  ||      (color-subsampling="4:1:1"]) )
+  |  |  |  |  |  |  |  |  |  ||   (image-interleave=stripe) )
+*1|  |  | 1| 0|*1| 1| 1|  |  ||(& (color=[limited,mapped,grey,full])
+  |  |  |  |  |  |  |  |  |  ||   (image-coding=[JPEG,JBIG])
+  |  |  |  |  |  |  |  |  |  ||   (image-coding-constraint=
+  |  |  |  |  |  |  |  |  |  ||    [JPEG-T4E,JBIG-T43])
+  |  |  |  |  |  |  |  |  |  ||   (& (color=full)
+  |  |  |  |  |  |  |  |  |  ||      (color-subsampling=
+  |  |  |  |  |  |  |  |  |  ||       ["1:1:1","4:1:1"]) )
+  |  |  |  |  |  |  |  |  |  ||   (image-interleave=stripe) )
+
+
+
+
+
+
+McIntyre & Klyne             Informational                     [Page 21]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+*1|  |  | 1| 1|*1| 1| 0|  |  ||(& (color=[limited,mapped,grey,full])
+  |  |  |  |  |  |  |  |  |  ||   (image-coding=[JPEG,JBIG])
+  |  |  |  |  |  |  |  |  |  ||   (image-coding-constraint=
+  |  |  |  |  |  |  |  |  |  ||    [JPEG-T4E,JBIG-T43])
+  |  |  |  |  |  |  |  |  |  ||   (& (color=full)
+  |  |  |  |  |  |  |  |  |  ||      (color-subsampling="4:1:1"]) )
+  |  |  |  |  |  |  |  |  |  ||   (image-interleave=[stripe,plane]) )
+*1|  |  | 1| 1|*1| 1| 1|  |  ||(& (color=[limited,mapped,grey,full])
+  |  |  |  |  |  |  |  |  |  ||   (image-coding=[JPEG,JBIG])
+  |  |  |  |  |  |  |  |  |  ||   (image-coding-constraint=
+  |  |  |  |  |  |  |  |  |  ||    [JPEG-T4E,JBIG-T43])
+  |  |  |  |  |  |  |  |  |  ||   (& (color=full)
+  |  |  |  |  |  |  |  |  |  ||      (image-coding=JPEG)
+  |  |  |  |  |  |  |  |  |  ||      (color-subsampling=
+  |  |  |  |  |  |  |  |  |  ||       ["1:1:1","4:1:1"]) )
+  |  |  |  |  |  |  |  |  |  ||   (image-interleave=[stripe,plane]) )
+--+--+--+--+--+--+--+--+--+--++---------------------------------------
+15|16|31|36|37|68|69|73|78|79||
+--+--+--+--+--+--+--+--+--+--++---------------------------------------
+
+5.1.3 MRC format
+
+<---- T.30 bits ------>
+15|92|93|94|95|  |  |  ||Feature set expression
+--+--+--+--+--+--+--+--++---------------------------------------
+ x| 0| 0| 0| x|  |  |  ||(MRC-mode=0)
+*1| #| #| #| 0|  |  |  ||(& (MRC-mode<=###)
+  |  |  |  |  |  |  |  ||   (MRC-max-stripe-size=[0..256]) )
+*1| #| #| #| 1|  |  |  ||(& (MRC-mode<=###)
+  |  |  |  |  |  |  |  ||   (MRC-max-stripe-size>=0) )
+--+--+--+--+--+--+--+--++---------------------------------------
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McIntyre & Klyne             Informational                     [Page 22]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+5.2 Resolution and units
+
+<------- T.30 bits ------>
+15|41|42|43|44|45|68|97|98||Feature set expression
+--+--+--+--+--+--+--+--+--++-----------------------------------------
+ 0|  |  | 0|  |  |  |  |  ||(& (color=binary)
+  |  |  |  |  |  |  |  |  ||   (| (& (dpi=200) (dpi-xyratio=200/100) )
+  |  |  |  |  |  |  |  |  ||      (& (dpi=204)
+  |  |  |  |  |  |  |  |  ||         (dpi-xyratio=204/98) ) ) )
+  |  |  |  |  |  |  |  |  ||
+ 1|  |  | 0|  |  |  |  |  ||(| (& (color=binary)
+  |  |  |  |  |  |  |  |  ||      (| (& (dpi=204)
+  |  |  |  |  |  |  |  |  ||            (dpi-xyratio=204/98) )
+  |  |  |  |  |  |  |  |  ||         (& (dpi=204)
+  |  |  |  |  |  |  |  |  ||            (dpi-xyratio=204/196) )
+  |  |  |  |  |  |  |  |  ||         (& (dpi=200)
+  |  |  |  |  |  |  |  |  ||            (dpi-xyratio=200/100) ) ) )
+  |  |  |  |  |  |  |  |  ||   (& (dpi=200) (dpi-xyratio=1) ) )
+ 0|  |  | 1|  |  |  |  |  ||(| (& (color=binary)
+  |  |  |  |  |  |  |  |  ||      (| (& (dpi=204)
+  |  |  |  |  |  |  |  |  ||            (dpi-xyratio=204/98) )
+  |  |  |  |  |  |  |  |  ||         (& (dpi=408)
+  |  |  |  |  |  |  |  |  ||            (dpi-xyratio=408/391) )
+  |  |  |  |  |  |  |  |  ||         (& (dpi=200)
+  |  |  |  |  |  |  |  |  ||            (dpi-xyratio=200/100) ) ) )
+  |  |  |  |  |  |  |  |  ||   (& (dpi=400) (dpi-xyratio=1) ) )
+ 1|  |  | 1|  |  |  |  |  ||(| (& (color=binary)
+  |  |  |  |  |  |  |  |  ||      (| (& (dpi=204)
+  |  |  |  |  |  |  |  |  ||            (dpi-xyratio=204/98) )
+  |  |  |  |  |  |  |  |  ||         (& (dpi=204)
+  |  |  |  |  |  |  |  |  ||            (dpi-xyratio=204/196) )
+  |  |  |  |  |  |  |  |  ||         (& (dpi=408)
+  |  |  |  |  |  |  |  |  ||            (dpi-xyratio=408/391) )
+  |  |  |  |  |  |  |  |  ||         (& (dpi=200)
+  |  |  |  |  |  |  |  |  ||            (dpi-xyratio=200/100) ) ) )
+  |  |  |  |  |  |  |  |  ||   (& (dpi=200) (dpi-xyratio=1) )
+  |  |  |  |  |  |  |  |  ||   (& (dpi=400) (dpi-xyratio=1) ) )
+--+--+--+--+--+--+--+--+--++-----------------------------------------
+  | 0|  |  |  |  |  |  |  ||
+  | 1|  |  |  |  |  |  |  ||(& (color=binary)
+  |  |  |  |  |  |  |  |  ||   (dpi=204)
+  |  |  |  |  |  |  |  |  ||   (dpi-xyratio=204/391) )
+--+--+--+--+--+--+--+--+--++-----------------------------------------
+  |  | 0|  |  |  |  |  |  ||
+  |  | 1|  |  |  |  |  |  ||(& (dpi=300) (dpi-xyratio=1) )
+
+
+
+
+
+
+McIntyre & Klyne             Informational                     [Page 23]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+--+--+--+--+--+--+--+--+--++-----------------------------------------
+  |  | x| x|  |  | x| 0|  ||
+  |  | x| 1|  |  |*1| 1|  ||(& (dpi=400) (dpi-xyratio=1) )
+  |  |*1| 0|  |  |*1| 1|  ||
+--+--+--+--+--+--+--+--+--++-----------------------------------------
+  |  |  |  |  |  | x|  | 0||
+  |  |  |  |  |  |*1|  | 1||(| (color=binary)
+  |  |  |  |  |  |  |  |  ||   (& (color=[limited,mapped,grey,full])
+  |  |  |  |  |  |  |  |  ||      (dpi=100) (dpi-xyratio=1) ) )
+--+--+--+--+--+--+--+--+--++-----------------------------------------
+15|41|42|43|44|45|68|97|98||
+--+--+--+--+--+--+--+--+--++-----------------------------------------
+
+   Note:  all numbers in media feature expressions are integer or
+   rational values;  hence the rational number format (n/m) used here.
+
+   Also note:  the preferred unit bits (44,45) are not tested here, as a
+   Group 3 fax machine must accept and process either form of units for
+   binary images.  All resolutions are expressed in dpi;  here are the
+   metric unit equivalents:
+
+   204  ~= (1728/215)*25.4  ~=  8.04dpmm expressed in dpi
+   408  ~= (3456/215)*25.4  ~= 16.08dpmm expressed in dpi
+    98  ~=  3.85*25.4       ~=  3.85dpmm expressed in dpi
+   196  ~=  7.70*25.4       ~=  7.70dpmm expressed in dpi
+   391  ~= 15.40*25.4       ~= 15.40dpmm expressed in dpi
+
+5.3 Colour capabilities
+
+<------- T.30 bits --->
+36|68|69|71|74|75|  |  ||Feature set expression
+--+--+--+--+--+--+--+--++-----------------------------------------
+ 0| 0| x|  |  |  |  |  ||
+ x| 1| 0|  |  |  |  |  ||(| (color=binary)
+  |  |  |  |  |  |  |  ||   (& (color=grey)
+  |  |  |  |  |  |  |  ||      (color-space=CIELAB) ) )
+ 0| 1| 1|  |  |  |  |  ||(| (color=binary)
+  |  |  |  |  |  |  |  ||   (& (color=[grey,full])
+  |  |  |  |  |  |  |  ||      (color-space=CIELAB) ) )
+ 1|*1| 1|  |  |  |  |  ||(| (color=binary)
+  |  |  |  |  |  |  |  ||   (& (color=limited)
+  |  |  |  |  |  |  |  ||      (color-space=[Device-RGB,Device-CMY])
+  |  |  |  |  |  |  |  ||      (color-levels<=8) )
+  |  |  |  |  |  |  |  ||   (& (color=limited)
+  |  |  |  |  |  |  |  ||      (color-space=Device-CMYK)
+  |  |  |  |  |  |  |  ||      (color-levels<=16) )
+  |  |  |  |  |  |  |  ||   (& (color=[mapped,grey,full])
+  |  |  |  |  |  |  |  ||      (color-space=CIELAB) ) )
+
+
+
+McIntyre & Klyne             Informational                     [Page 24]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+--+--+--+--+--+--+--+--++-----------------------------------------
+  | 0|  | x|  |  |  |  ||
+  | 1|  | 0|  |  |  |  ||(| (color=[binary,limited])
+  |  |  |  |  |  |  |  ||   (& (color=mapped)
+  |  |  |  |  |  |  |  ||      (color-levels<=4096) )
+  |  |  |  |  |  |  |  ||   (& (color=grey)
+  |  |  |  |  |  |  |  ||      (color-levels<=256) )
+  |  |  |  |  |  |  |  ||   (& (color=full)
+  |  |  |  |  |  |  |  ||      (color-levels<=16777216) ) )
+  | 1|  | 1|  |  |  |  ||(| (color=[binary,limited])
+  |  |  |  |  |  |  |  ||   (& (color=mapped)
+  |  |  |  |  |  |  |  ||      (color-levels<=65536) )
+  |  |  |  |  |  |  |  ||   (& (color=grey)
+  |  |  |  |  |  |  |  ||      (color-levels<=4096) )
+  |  |  |  |  |  |  |  ||   (& (color=full)
+  |  |  |  |  |  |  |  ||      (color-levels<=68719476736) ) )
+--+--+--+--+--+--+--+--++-----------------------------------------
+  | 0|  |  | x|  |  |  ||
+  | 1|  |  | 0|  |  |  ||(| (color=[binary,limited])
+  |  |  |  |  |  |  |  ||   (& (color=[mapped,grey,full])
+  |  |  |  |  |  |  |  ||      (color-illuminant=D50) ) )
+  | 1|  |  | 1|  |  |  ||   -- Any color illuminant: D50 or custom
+  |  |  |  |  |  |  |  ||   -- See note below
+--+--+--+--+--+--+--+--++-----------------------------------------
+  | 0|  |  |  | x|  |  ||
+  | 1|  |  |  | 0|  |  ||(| (color=[binary,limited])
+  |  |  |  |  |  |  |  ||   (& (color=grey)
+  |  |  |  |  |  |  |  ||      (CIELAB-L-min>=0)
+  |  |  |  |  |  |  |  ||      (CIELAB-L-max<=100) )
+  |  |  |  |  |  |  |  ||   (& (color=[mapped,full])
+  |  |  |  |  |  |  |  ||      (CIELAB-L-min>=0)
+  |  |  |  |  |  |  |  ||      (CIELAB-L-max<=100)
+  |  |  |  |  |  |  |  ||      (CIELAB-a-min>=-85)
+  |  |  |  |  |  |  |  ||      (CIELAB-a-max<=85)
+  |  |  |  |  |  |  |  ||      (CIELAB-b-min>=-75)
+  |  |  |  |  |  |  |  ||      (CIELAB-b-max<=125) ) )
+  | 1|  |  |  | 1|  |  ||   -- Any color gamut: default or custom
+--+--+--+--+--+--+--+--++-----------------------------------------
+36|68|69|71|74|75|  |  ||Feature set expression
+--+--+--+--+--+--+--+--++-----------------------------------------
+
+      NOTE: the above table assumes the registration of a feature tag
+      for color illuminant, values of which are tokens that are the same
+      as those described by ITU T.4 [7], Annex E, section E.6.7.
+
+
+
+
+
+
+
+McIntyre & Klyne             Informational                     [Page 25]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+5.4 Document size
+
+   A4 width (215mm) is required as a minimum for Group 3 fax
+   conformance.  A Group 3 fax machine must always be able to receive an
+   A4 image.
+
+<---- T.30 bits ------>
+17|18|19|20|76|77|  |  ||Feature set expression
+--+--+--+--+--+--+--+--++-----------------------------------------
+ 0| 0|  |  |  |  |  |  ||(Size-x <= 2150/254)
+ 1| 0|  |  |  |  |  |  ||(Size-x <= 2550/254)
+ x| 1|  |  |  |  |  |  ||(Size-x <= 3030/254)
+--+--+--+--+--+--+--+--++-----------------------------------------
+  |  | 0| 0|  |  |  |  ||(Size-y <= 2970/254)
+  |  | 1| 0|  |  |  |  ||(Size-y <= 3640/254)
+  |  | 0| 1|  |  |  |  ||  -- unlimited
+  |  | 1| 1|  |  |  |  ||  -- invalid
+--+--+--+--+--+--+--+--++-----------------------------------------
+  |  |  |  | 0| 0|  |  ||(Paper-size=A4)
+  |  |  |  | 1| 0|  |  ||(Paper-size=[A4,Letter])
+  |  |  |  | 0| 1|  |  ||(Paper-size=[A4,Legal])
+  |  |  |  | 1| 1|  |  ||(Paper-size=[A4,Letter,Legal])
+--+--+--+--+--+--+--+--++-----------------------------------------
+
+6. Examples
+
+   NOTE:  Although motivated by the requirements of eifax [5], this
+   document is concerned with describing capabilities of Group 3 fax
+   systems [6].  As such, the algorithms do not of themselves create
+   equivalent Internet fax capability statements but, rather, they
+   construct capability expressions that might be incorporated into
+   those for eifax systems.
+
+   This point is illustrated at the end of the first example below where
+   subsection 6.1.1 has been added, which combines T.30 capabilities
+   with an appropriate TIFF file format capability to yield an
+   expression that might be used to describe an Internet fax system.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McIntyre & Klyne             Informational                     [Page 26]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+6.1 Common black-and-white fax machine
+
+   DIS/DTC
+   Bit No.   DIS/DTC bit description                 Value
+   -------   -----------------------                 -----
+   15        R8 x 7.7 lines/mm and/or                1
+             200 x 200 pels/25.4 mm
+   16        Two dimensional coding capability       1
+   17,18     Recording width capabilities:           0,0
+             Scan line length 215 mm + 1%
+   19,20     Recording length capability:            01
+             unlimited
+   31        T.6 (MMR) coding capability             1
+   36        T.43 (JBIG) coding capability           0
+   37        Plane interleave                        0
+   41        Resolution: 8x15.4 dpmm                 0
+   42        Resolution: 300x300 dpi                 1
+   43        Resolution: 16x15.4 dpmm and/or 400x400 0
+             dpi
+   68        JPEG coding: not supported              0
+   69        Full color mode: not supported          0
+   71        12 bits/pel component:  not supported   0
+   73        No subsampling (1:1:1):  not supported  0
+   74        Custom illuminant:  not supported       0
+   75        Custom gamut range:  not supported      0
+   76        North American Letter paper size        1
+             (8.5"x11") capability
+   77        North American Legal paper size         0
+             (8.5"x14") capability:  not supported
+   78        Single-progression sequential coding    0
+             (T.85, bi-level JBIG) basic capability:
+             not supported
+   79        Single-progression sequential coding    0
+             (T.85, bi-level JBIG) optional L0
+             capability for other than 128
+             lines/stripe:  not supported
+   92,93,94  T.44 (Mixed Raster Content) mode:       0,0,0
+             not supported
+   95        Page length maximum stripe size for MRC 0
+             coding:  not supported.
+   97        Multi-level resolution 300x300dpi or    0
+             400x400dpi:  not supported
+   98        Multi-level resolution 100x100dpi:      0
+             not supported
+
+
+
+
+
+
+
+McIntyre & Klyne             Informational                     [Page 27]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+   Following the procedure in section 5, matching these DIS bits
+   against the decision tables in sections 5.1 to 5.4, we get:
+
+      5.1.1  [Bits 16,31,78,79 = 1,1,0,0]
+               (& (color=binary) (image-coding=[MH,MR,MMR]) )
+
+      5.1.2  [Bits 15,36,37,68,69,73 = 1,0,0,0,0,0]
+               -- no capabilities
+
+      5.1.3  [Bits 15,92,93,94,95 = 1,0,0,0,0]
+               (MRC-mode=0)
+
+      5.2    [Bits 15,43 = 1,0]
+               (| (& (color=binary)
+                     (| (& (dpi=204)
+                           (dpi-xyratio=204/98) )
+                        (& (dpi=204)
+                           (dpi-xyratio=204/196) )
+                        (& (dpi=200)
+                           (dpi-xyratio=200/100) ) ) )
+                  (& (dpi=200) (dpi-xyratio=1) ) )
+             [Bit 41 = 0]
+               -- no capabilities
+             [Bit 42 = 1]
+               (& (dpi=300) (dpi-xyratio=1) )
+             [Bits 42,43,68,97 = 0,0,0,0]
+               -- no capabilities
+             [Bits 68,98 = 0,0]
+               -- no capabilities
+
+      5.3    [Bits 36,68,69 = 0,0,0]
+               -- no capabilities
+             [Bits 68,71 = 0,0]
+               -- no capabilities
+             [Bits 68,74 = 0,0]
+               -- no capabilities
+             [Bits 68,75 = 0,0]
+               -- no capabilities
+
+      5.4    [Bits 17,18 = 0,0]
+               (size-x<=2150/254)
+             [Bits 19,20 = 0,1]
+               -- no capability constraint
+             [Bits 76,77 = 1,0]
+               (Paper-size=[A4,Letter])
+
+
+
+
+
+
+McIntyre & Klyne             Informational                     [Page 28]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+   Combining these as indicated in section 5, we get the following.
+   (The initial expression is constructed verbatim per the rules in the
+   first part of section 5, even though it contains some redundancy.)
+
+      (& (| (& (color=binary) (image-coding=[MH,MR,MMR]) ) )
+         (MRC-mode=0)
+         (| (| (& (color=binary)
+                  (| (& (dpi=204) (dpi-xyratio=204/98)  )
+                     (& (dpi=204) (dpi-xyratio=204/196) )
+                     (& (dpi=200) (dpi-xyratio=200/100) ) ) )
+               (& (dpi=200) (dpi-xyratio=1) ) )
+            (& (dpi=300) (dpi-xyratio=1) ) )
+         (& (size-x<=2150/254)
+            (Paper-size=[A4,Letter]) ) )
+
+   This in turn is simplified as follows.  Note that the expression '(&
+   (| (& A B ) ) C ... )' simplifies to just '(& A B C ... )'.
+
+      (& (color=binary)
+         (image-coding=[MH,MR,MMR])
+         (MRC-mode=0)
+         (| (& (dpi=204) (dpi-xyratio=204/98)  )
+            (& (dpi=204) (dpi-xyratio=204/196) )
+            (& (dpi=200) (dpi-xyratio=200/100) )
+            (& (dpi=200) (dpi-xyratio=1) )
+            (& (dpi=300) (dpi-xyratio=1) ) )
+         (size-x<=2150/254)
+         (Paper-size=[A4,Letter]) )
+
+6.1.1 Corresponding Internet fax capabilities
+
+   In the case of an Internet fax device, additional capabilities not
+   described by the T.30 DIS frame should be included;  e.g. the
+   supported TIFF file structure:
+
+      (& (color=binary)
+         (image-file-structure=[TIFF-Limited,TIFF-Minimal])
+         (image-coding=[MH,MR,MMR])
+         (MRC-mode=0)
+         (| (& (dpi=204) (dpi-xyratio=204/98)  )
+            (& (dpi=204) (dpi-xyratio=205/196) )
+            (& (dpi=200) (dpi-xyratio=200/100) )
+            (& (dpi=200) (dpi-xyratio=1) )
+            (& (dpi=300) (dpi-xyratio=1) ) )
+         (size-x<=2150/254)
+         (Paper-size=[A4,Letter]) )
+
+
+
+
+
+McIntyre & Klyne             Informational                     [Page 29]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+6.2 Full-featured color fax machine
+
+   DIS/DTC
+   Bit No.   DIS/DTC bit description                 Value
+   -------   -----------------------                 -----
+   15        R8 x 7.7 lines/mm and/or                1
+             200 x 200 pels/25.4 mm
+   16        Two dimensional coding capability       1
+   17,18     Recording width capabilities:           0,0
+             Scan line length 215 mm + 1%
+   19,20     Recording length capability:            01
+             unlimited
+   31        T.6 (MMR) coding capability             1
+   36        T.43 (JBIG) coding capability           0
+   37        Plane interleave                        0
+   41        Resolution: 8x15.4 dpmm                 1
+   42        Resolution: 300x300 dpi                 0
+   43        Resolution: 16x15.4 dpmm and/or 400x400 1
+             dpi
+   68        JPEG coding: supported                  1
+   69        Full color mode: supported              1
+   71        12 bits/pel component:  not supported   0
+   73        No subsampling (1:1:1):  supported      1
+   74        Custom illuminant:  not supported       0
+   75        Custom gamut range:  not supported      0
+   76        North American Letter paper size        1
+             (8.5"x11") capability
+   77        North American Legal paper size         0
+             (8.5"x14") capability:  not supported
+   78        Single-progression sequential coding    0
+             (T.85, bi-level JBIG) basic capability:
+             not supported
+   79        Single-progression sequential coding    0
+             (T.85, bi-level JBIG) optional L0
+             capability for other than 128
+             lines/stripe:  not supported
+   92,93,94  T.44 (Mixed Raster Content) mode:       0,0,1
+             mode 1 supported
+   95        Page length maximum stripe size for MRC 1
+             coding.
+   97        Multi-level resolution 300x300dpi or    1
+             400x400dpi:  supported
+   98        Multi-level resolution 100x100dpi:      1
+             supported
+
+
+
+
+
+
+
+McIntyre & Klyne             Informational                     [Page 30]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+   Matching these DIS bits against the decision tables in sections 5.1
+   to 5.4, we get:
+
+      5.1.1  [Bits 16,31,78,79 = 1,1,0,0]
+               (& (color=binary) (image-coding=[MH,MR,MMR]) )
+
+      5.1.2  [Bits 15,36,37,68,69,73 = 1,0,0,1,1,1]
+               (& (color=[grey,full])
+                  (image-coding=JPEG)
+                  (image-coding-constraint=JPEG-T4E)
+                  (& (color=full)
+                     (image-coding=JPEG)
+                     (color-subsampling=["1:1:1","4:1:1"]) ) )
+
+      5.1.3  [Bits 15,92,93,94,95 = 1,0,0,1,1]
+               (& (MRC-mode<=1) (MRC-max-stripe-size>=0) )
+
+      5.2    [Bits 15,43 = 1,1]
+               (| (& (color=binary)
+                     (| (& (dpi=204)
+                           (dpi-xyratio=204/98) )
+                        (& (dpi=204)
+                           (dpi-xyratio=204/196) )
+                        (& (dpi=408)
+                           (dpi-xyratio=408/391) )
+                        (& (dpi=200)
+                           (dpi-xyratio=200/100) ) ) )
+                  (& (dpi=200) (dpi-xyratio=1) )
+                  (& (dpi=400) (dpi-xyratio=1) ) )
+             [Bit 41 = 1]
+               (& (color=binary)
+                  (dpi=204) (dpi-xyratio=204/391) )
+             [Bit 42 = 0]
+               -- no capabilities
+             [Bits 42,43,68,97 = 0,1,1,1]
+               (& (dpi=400) (dpi-xyratio=1) )
+             [Bits 68,98 = 1,1]
+               (| (color=binary)
+                  (& (color=[limited,mapped,grey,full])
+                     (dpi=100) (dpi-xyratio=1) ) )
+
+      5.3    [Bits 36,68,69 = 0,1,1]
+               (| (color=binary)
+                  (& (color=[grey,full])
+                     (color-space=CIELAB) ) )
+             [Bits 68,71 = 1,0]
+               (| (color=[binary,limited])
+                  (& (color=mapped)
+
+
+
+McIntyre & Klyne             Informational                     [Page 31]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+                     (color-levels<=4096) )
+                  (& (color=grey)
+                     (color-levels<=256) )
+                  (& (color=full)
+                     (color-levels<=16777216) ) )
+             [Bits 68,74 = 1,0]
+               (| (color=[binary,limited])
+                  (& (color=[mapped,grey,full])
+                     (color-illuminant=D50) ) )
+             [Bits 68,75 = 1,0]
+               (| (color=[binary,limited])
+                  (& (color=grey)
+                     (CIELAB-L-min>=0)
+                     (CIELAB-L-max<=100) )
+                  (& (color=[mapped,full])
+                     (CIELAB-L-min>=0)
+                     (CIELAB-L-max<=100)
+                     (CIELAB-a-min>=-85)
+                     (CIELAB-a-max<=85)
+                     (CIELAB-b-min>=-75)
+                     (CIELAB-b-max<=125) ) )
+
+      5.4    [Bits 17,18 = 0,0]
+               (size-x<=2150/254)
+             [Bits 19,20 = 0,1]
+               -- no capability constraint
+             [Bits 76,77 = 1,0]
+               (Paper-size=[A4,Letter])
+
+   Combining these as indicated in section 5, we get the following:
+
+      (& (| (& (color=binary)
+               (image-coding=[MH,MR,MMR]) )
+            (& (color=[grey,full])
+               (image-coding=JPEG)
+               (image-coding-constraint=JPEG-T4E)
+               (& (color=full)
+                  (image-coding=JPEG)
+                  (color-subsampling=["1:1:1","4:1:1"]) ) )
+         (& (MRC-mode<=1) (MRC-max-stripe-size>=0) )
+         (| (| (& (color=binary)
+                  (| (& (dpi=204) (dpi-xyratio=204/98) )
+                     (& (dpi=204) (dpi-xyratio=204/196) )
+                     (& (dpi=408) (dpi-xyratio=408/391) )
+                     (& (dpi=200) (dpi-xyratio=200/100) ) ) )
+               (& (dpi=200) (dpi-xyratio=1) )
+               (& (dpi=400) (dpi-xyratio=1) ) )
+            (& (color=binary)
+
+
+
+McIntyre & Klyne             Informational                     [Page 32]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+               (dpi=204) (dpi-xyratio=204/391) )
+            (& (dpi=400) (dpi-xyratio=1) )
+            (| (color=binary)
+               (& (color=[limited,mapped,grey,full])
+                  (dpi=100) (dpi-xyratio=1) ) ) )
+         (& (| (color=binary)
+               (& (color=[grey,full]) (color-space=CIELAB) ) )
+            (| (color=[binary,limited])
+               (& (color=mapped) (color-levels<=4096) )
+               (& (color=grey) (color-levels<=256) )
+               (& (color=full) (color-levels<=16777216) ) )
+            (| (color=[binary,limited])
+               (& (color=[mapped,grey,full]) (color-illuminant=D50) ) )
+            (| (color=[binary,limited])
+               (& (color=grey)
+                  (CIELAB-L-min>=0)
+                  (CIELAB-L-max<=100) )
+               (& (color=[mapped,full])
+                  (CIELAB-L-min>=0)
+                  (CIELAB-L-max<=100)
+                  (CIELAB-a-min>=-85)
+                  (CIELAB-a-max<=85)
+                  (CIELAB-b-min>=-75)
+                  (CIELAB-b-max<=125) ) ) )
+         (& (size-x<=2150/254)
+            (Paper-size=[A4,Letter]) ) )
+
+   This in turn simplifies to:
+
+      (| (& (color=binary)
+            (image-coding=[MH,MR,MMR])
+            (MRC-mode<=1) (MRC-max-stripe-size>=0)
+            (| (& (dpi=204) (dpi-xyratio=204/98) )
+               (& (dpi=204) (dpi-xyratio=204/196) )
+               (& (dpi=204) (dpi-xyratio=204/391) )
+               (& (dpi=408) (dpi-xyratio=408/391) )
+               (& (dpi=200) (dpi-xyratio=200/100) )
+               (& (dpi=200) (dpi-xyratio=1) )
+               (& (dpi=400) (dpi-xyratio=1) ) )
+            (size-x<=2150/254)
+            (Paper-size=[A4,Letter]) )
+         (& (color=grey)
+            (image-coding=JPEG)
+            (image-coding-constraint=JPEG-T4E)
+            (MRC-mode<=1) (MRC-max-stripe-size>=0)
+            (dpi=[100,200,400]) (dpi-xyratio=1)
+            (color-space=CIELAB)
+            (color-levels<=256)
+
+
+
+McIntyre & Klyne             Informational                     [Page 33]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+            (color-illuminant=D50)
+            (CIELAB-L-min>=0)
+            (CIELAB-L-max<=100)
+            (size-x<=2150/254)
+            (Paper-size=[A4,Letter]) )
+         (& (color=full)
+            (image-coding=JPEG)
+            (image-coding-constraint=JPEG-T4E)
+            (color-subsampling=["1:1:1","4:1:1"])
+            (MRC-mode<=1) (MRC-max-stripe-size>=0)
+            (dpi=[100,200,400]) (dpi-xyratio=1)
+            (color-space=CIELAB)
+            (color-levels<=16777216)
+            (color-illuminant=D50)
+            (CIELAB-L-min>=0)
+            (CIELAB-L-max<=100)
+            (CIELAB-a-min>=-85)
+            (CIELAB-a-max<=85)
+            (CIELAB-b-min>=-75)
+            (CIELAB-b-max<=125)
+            (size-x<=2150/254)
+            (Paper-size=[A4,Letter]) ) )
+
+7. Security Considerations
+
+   Security considerations are discussed in the fax feature schema
+   description [4].  This memo is not believed to introduce any
+   additional security concerns.
+
+8. Acknowledgements
+
+   The authors gratefully acknowledge the following persons who made
+   comments on earlier versions of this memo:  Mr. Hiroshi Tamura and
+   and Dr. Robert Buckley.
+
+9. References
+
+   [1]  Holtman, K., Mutz, A. and T. Hardie, "Media Feature Tag
+        Registration Procedure", RFC 2506, March 1999.
+
+   [2]  Graham, K., "A syntax for describing media feature sets" RFC
+        2533, March 1999.
+
+   [3]  Masinter, L., Holtman, K., Mutz, A. and D. Wing, "Media Features
+        for Display, Print, and Fax", RFC 2534, March 1999.
+
+   [4]  Klyne, G. and L. McIntyre, "Content Feature Schema for Internet
+        Fax (V2)", RFC 2879, July 2000.
+
+
+
+McIntyre & Klyne             Informational                     [Page 34]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+   [5]  Masinter, L. and D. Wing, "Extended Facsimile Using Internet
+        Mail", RFC 2532, March 1999.
+
+   [6]  "Procedures for document facsimile transmission in the general
+        switched telephone network" ITU-T Recommendation T.30 (1996),
+        including Amendment 1 (1997), Amendment 2 (1997), Amendment 3
+        (1998) and Amendment 4 (1999) International Telecommunications
+        Union
+
+   [7]  "Standardization of Group 3 facsimile terminals for document
+        transmission" ITU-T Recommendation T.4 (1996), including
+        Amendment 1 (1997), Amendment 2 (1997) and Amendment 3 (1999)
+        International Telecommunications Union (Covers basic fax coding
+        formats:  MH, MR; Annex E deals with some color image related
+        matters, including codes for optional custom illuminants.  Annex
+        G deals with some aspects of JBIG encoding of multi-level
+        images.)
+
+   [8]  "Facsimile coding schemes and coding control functions for Group
+        4 facsimile apparatus" ITU Recommendation T.6 International
+        Telecommunications Union (Commonly referred to as the MMR
+        standard; covers extended 2-D fax coding format)
+
+   [9]  "Continuous-tone colour representation method for facsimile"
+        ITU-T Recommendation T.42 (1996) International
+        Telecommunications Union (Covers custom illuminant, gamut)
+
+   [10] "Colour and gray-scale image representation using lossless
+        coding scheme for facsimile" ITU-T Recommendation T.43 (1997)
+        International Telecommunications Union (Covers JBIG for
+        colour/grey images)
+
+   [11] "Mixed Raster Content (MRC)" ITU-T Recommendation T.44 (1999)
+        International Telecommunications Union
+
+   [12] "Information technology - Digital compression and coding of
+        continuous-tone still image - Requirements and guidelines" ITU-T
+        Recommendation T.81 (1992) | ISO/IEC 10918-1:1993 International
+        Telecommunications Union (Commonly referred to as JPEG standard)
+
+   [13] "Information technology - Coded representation of picture and
+        audio information - Progressive bi-level image compression"
+        ITU-T Recommendation T.82 (1993) | ISO/IEC 11544:1993
+        International Telecommunications Union (Commonly referred to as
+        JBIG1 standard)
+
+
+
+
+
+
+McIntyre & Klyne             Informational                     [Page 35]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+   [14] "Application profile for Recommendation T.82 - Progressive bi-
+        level image compression (JBIG1 coding scheme for facsimile
+        apparatus)" ITU-T Recommendation T.85 (1995), including
+        Amendment 1 (1996), Amendment 2 (1997) and Corrigendum 1 (1997)
+        International Telecommunications Union (Covers bi-level JBIG)
+
+   [15] Klyne, G., "Protocol-independent Content Negotiation Framework",
+        RFC 2703, September 1999.
+
+   [16] "Programs from Decision Tables" E. Humbey Macdonald/American
+        Elsevier computer monographs (19), 1973 ISBN 0-444-19569-6/0-
+        356-04126-3 (This is an old title, and may not be still in
+        print.  It contains a number of references to decision table
+        articles published in Communications of the ACM:  August 1967,
+        September 1970, January 1966, November 1966, October 1968,
+        January 1965, February 1964, June 1970, November 1965, June
+        1965, February 1971.)
+
+   [17] "Mixed Raster Content (MRC) mode for G3 facsimile" ITU-T
+        Recommendation T.4, Annex H (1999) International
+        Telecommunications Union (Covers stripe size)
+
+10. Authors' Addresses
+
+   Lloyd McIntyre
+   Xerox Corporation
+   Mailstop PAHV-121
+   3400 Hillview Ave.
+   Palo Alto, CA 94304 USA
+
+   Phone: +1-650-813-6762
+   Fax:   +1-650-845-2340
+   EMail: Lloyd.McIntyre@pahv.xerox.com
+
+
+   Graham Klyne
+   Content Technologies Ltd.
+   1220 Parkview,
+   Arlington Business Park
+   Theale
+   Reading, RG7 4SA
+   United Kingdom
+
+   Phone: +44 118 930 1300
+   Fax:   +44 118 930 1301
+   EMail: GK@ACM.ORG
+
+
+
+
+
+McIntyre & Klyne             Informational                     [Page 36]
+
+RFC 2880           Internet Fax T.30 Feature Mapping         August 2000
+
+
+11.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (2000).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McIntyre & Klyne             Informational                     [Page 37]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2880.txt](<www.ietf.org/rfc/rfc2880.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
