### PR TITLE
Archive rfc289.txt

### DIFF
--- a/www.ietf.org/rfc/rfc289.txt
+++ b/www.ietf.org/rfc/rfc289.txt
@@ -1,0 +1,165 @@
+
+
+
+
+
+
+NWG/RFC #289                                     21-DEC-71 16:29  8295
+What We Hope Is An Official List of Host Names   Richard W. Watson
+                                                 SRI-ARC
+
+   The enclosed is what we hope will be accepted as a list of
+   official formal host names and nicknames.  As no other subject
+   worked on by the NWG has generated so much comment, it is
+   worthwhile to review briefly how this list came into being.
+
+   The need for some standard set of names recognized by NCP's and
+   Telnets and usable on hardcopy to designate a persons affiliation
+   had been recognized for some time and several sets of names were
+   in use.
+
+   Peggy Karp issued the first formal proposal of a set of standard
+   names in RFC 226, NIC 7625.  This proposal was answered by a
+   number of counter proposals and culminated in RFC 247, NIC 7688.
+   People still were not happy with this proposal as names normally
+   associated with hosts or projects were not used.
+
+   At the last NWG meeting a number of people discussed the name
+   problem and agreed that the only reasonable compromise solution
+   was to have both formal names and nicknames and to let the people
+   at the hosts choose their own names within the guideline which the
+   previous dialog had seemed to agree on.
+
+   The guidelines were summarized in RFC 273, NIC 7837 and the NIC
+   agreed to collect and publish the names that the people at each
+   host indicated they desired.  A number of names were received and
+   a tentative list was published as RFC 280, NIC 8060.  More people
+   responded with their desired names or changed the ones in the
+   above list.
+
+   Almost all sites have since responded and the following list
+   resulted.
+
+   I think people should feel free to change their host name when
+   ever the situation warrants.
+
+    Formal Name                    Nickname        Network Address
+
+    AMES-67                                         16
+
+    AMES-ILLIAC                    I4
+
+    AMES-TIP                                       144
+
+    BBN-NCC                        NCC               5
+
+
+
+                                                                [Page 1]
+
+NWG/RFC #289                                21-DEC-71 16:29  8295
+What We Hope Is An Official List of Host Names
+
+    BBN-TENEX                      BBN              69
+
+    BBN-TENEXB                     BBNB            133
+
+    BBN-TESTIP                                     158
+
+    BURR                                            15
+
+    BURR-TEST                                       79
+
+    CASE-10                                         13
+
+    CMU-10                                          14
+
+    ETAC-TIP                                       148
+
+    GWC-TIP                                        152
+
+    HARV-1                         PDP1             73
+
+    HARV-10                        ACL               9
+
+    HARV-11                                        137
+
+    ILL-ANTS                       ANTS             12
+
+    ILL-CAC                        CAC              76
+
+    LL-67                                           10
+
+    LL-TSP                                         138
+
+    LL-TX-2                        TX-2             74
+
+    MCCL-418                                        22
+
+    MIT-AI                                         134
+
+    MIT-DMCG                       DMCG             70
+
+    MIT-MULTICS                    MIT-M             6
+
+    MITRE-TIP                                      145
+
+    NBS-CCST                       NBS              19
+
+
+
+                                                                [Page 2]
+
+NWG/RFC #289                                21-DEC-71 16:29  8295
+What We Hope Is An Official List of Host Names
+
+    NBS-TIP                                        147
+
+    NCAR-7600                                       25
+
+    NCAR-TIP                                       153
+
+    RADC-645                                        18
+
+    RADC-TIP                                       146
+
+    RAND-CSG                                        71
+
+    RAND-RCC                                         7
+
+    SDC-ADEPT                      SDC               8
+
+    SRI-AI                                          66
+
+    SRI-ARC                                          2
+
+    SU-AI                                           11
+
+    TINK-418                                        21
+
+    UCLA-CCN                       CCN              65
+
+    UCLA-NMC                       SEX               1
+
+    UCLA-MOD75                     UCSB              3
+
+    USC-44                                          23
+
+    USC-TIP                                        151
+
+    UTAH-10                                          4
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+                                                                [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc289.txt](<www.ietf.org/rfc/rfc289.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
