### PR TITLE
Archive rfc2899.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2899.txt
+++ b/www.ietf.org/rfc/rfc2899.txt
@@ -1,0 +1,1235 @@
+
+
+
+
+
+
+Network Working Group                                          S. Ginoza
+Request for Comments: 2899                                           ISI
+Category: Informational                                         May 2001
+
+
+                      Request for Comments Summary
+
+                         RFC Numbers 2800-2899
+
+Status of This Memo
+
+   This RFC is a slightly annotated list of the 100 RFCs from RFC 2800
+   through RFCs 2899.  This is a status report on these RFCs.  This memo
+   provides information for the Internet community.  It does not specify
+   an Internet standard of any kind.  Distribution of this memo is
+   unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2001).  All Rights Reserved.
+
+Note
+
+   Many RFCs, but not all, are Proposed Standards, Draft Standards, or
+   Standards.  Since the status of these RFCs may change during the
+   standards processing, we note here only that they are on the
+   standards track.  Please see the latest edition of "Internet Official
+   Protocol Standards" for the current state and status of these RFCs.
+   In the following, RFCs on the standards track are marked [STANDARDS-
+   TRACK].
+
+RFC     Author          Date            Title
+---     ------          ----            -----
+
+2899    Ginoza          May 2001        Request for Comments Summary
+
+This memo.
+
+
+2898    Kaliski         Sep 2000        PKCS #5: Password-Based
+                                        Cryptography Specification
+                                        Version 2.0
+
+This document provides recommendations for the implementation of
+password-based cryptography, covering key derivation functions,
+encryption schemes, message-authentication schemes, and ASN.1 syntax
+identifying the techniques.  This memo provides information for the
+Internet community.
+
+
+
+Ginoza                       Informational                      [Page 1]
+
+RFC 2899                  Summary of 2800-2899                  May 2001
+
+
+2897    Cromwell        Aug 2000        Proposal for an MGCP Advanced
+                                        Audio Package
+
+This document is a proposal to add a new event/signal package to the
+MGCP (Media Gateway Control Protocol) protocol to control an ARF (Audio
+Resource Function) which may reside on a Media Gateway or specialized
+Audio Server.  This memo provides information for the Internet
+community.
+
+
+2896    Bierman         Aug 2000        Remote Network Monitoring MIB
+                                        Protocol Identifier Macros
+
+This memo contains various protocol identifier examples, which can be
+used to produce valid protocolDirTable INDEX encodings, as defined by
+the Remote Network Monitoring MIB and the RMON Protocol Identifier
+Reference.  This memo provides information for the Internet community.
+
+
+2895    Bierman         Aug 2000        Remote Network Monitoring MIB
+                                        Protocol Identifier Reference
+
+This memo defines a notation describing protocol layers in a protocol
+encapsulation, specifically for use in encoding INDEX values for the
+protocolDirTable, found in the RMON-2 MIB.  [STANDARDS TRACK]
+
+
+2894    Crawford        Aug 2000        Router Renumbering for IPv6
+
+This document defines a mechanism called Router Renumbering ("RR") which
+allows address prefixes on routers to be configured and reconfigured
+almost as easily as the combination of Neighbor Discovery and Address
+Autoconfiguration works for hosts.  [STANDARDS TRACK]
+
+
+2893    Gilligan        Aug 2000        Transition Mechanisms for IPv6
+                                        Hosts and Routers
+
+This document specifies IPv4 compatibility mechanisms that can be
+implemented by IPv6 hosts and routers.  [STANDARDS TRACK]
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 2]
+
+RFC 2899                  Summary of 2800-2899                  May 2001
+
+
+2892    Tsiang          Aug 2000        The Cisco SRP MAC Layer
+                                        Protocol
+
+This document specifies the MAC layer protocol, "Spatial Reuse Protocol"
+(SRP) for use with ring based media.  This is a second version of the
+protocol (V2).  This memo provides information for the Internet
+community.
+
+
+2891    Howes           Aug 2000        LDAP Control Extension for
+                                        Server Side Sorting of Search
+                                        Results
+
+This document describes two LDAPv3 control extensions for server side
+sorting of search results.  These controls allows a client to specify
+the attribute types and matching rules a server should use when
+returning the results to an LDAP search request.  [STANDARDS TRACK]
+
+
+2890    Dommety         Sep 2000        Key and Sequence Number
+                                        Extensions to GRE
+
+This document describes extensions by which two fields, Key and Sequence
+Number, can be optionally carried in the GRE Header.  [STANDARDS TRACK]
+
+
+2889    Mandeville      Aug 2000        Benchmarking Methodology for
+                                        LAN Switching Devices
+
+This document is intended to provide methodology for the benchmarking of
+local area network (LAN) switching devices.  This memo provides
+information for the Internet community.
+
+
+2888    Srisuresh       Aug 2000        Secure Remote Access with L2TP
+
+The objective of this document is to extend security characteristics of
+IPsec to remote access users, as they dial-in through the Internet.
+This memo provides information for the Internet community.
+
+
+2887    Handley         Aug 2000        The Reliable Multicast Design
+                                        Space for Bulk Data Transfer
+
+This document provides an overview of the design space and the ways in
+which application constraints affect possible solutions.  This memo
+provides information for the Internet community.
+
+
+
+
+Ginoza                       Informational                      [Page 3]
+
+RFC 2899                  Summary of 2800-2899                  May 2001
+
+
+2886    Taylor          Sep 2000        Megaco Errata
+
+This document records the errors found in the Megaco/H.248 protocol
+document, along with the changes proposed in the text of that document
+to resolve them.  [STANDARDS TRACK]
+
+
+2885    Cuervo          Sep 2000        Megaco Protocol version 0.8
+
+This document is common text with Recommendation H.248 as redetermined
+in Geneva, February 2000.  It must be read in conjunction with the
+Megaco Errata, RFC 2886.  [STANDARDS TRACK]
+
+
+2884    Hadi Salim      Jul 2000        Performance Evaluation of
+                                        Explicit Congestion
+                                        Notification (ECN) in IP
+                                        Networks
+
+This memo presents a performance study of the Explicit Congestion
+Notification (ECN) mechanism in the TCP/IP protocol using our
+implementation on the Linux Operating System.  This memo provides
+information for the Internet community.
+
+
+2883    Floyd           Jul 2000        An Extension to the Selective
+                                        Acknowledgement (SACK) Option
+                                        for TCP
+
+This note defines an extension of the Selective Acknowledgement (SACK)
+Option for TCP.  [STANDARDS TRACK]
+
+
+2882    Mitton          Jul 2000        Network Access Servers
+                                        Requirements: Extended RADIUS
+                                        Practices
+
+This document describes current practices implemented in NAS products
+that go beyond the scope of the RADIUS (Remote Authentication Dial In
+User Service) RFCs 2138, 2139.  This memo provides information for the
+Internet community.
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 4]
+
+RFC 2899                  Summary of 2800-2899                  May 2001
+
+
+2881    Mitton          Jul 2000        Network Access Server
+                                        Requirements Next Generation
+                                        (NASREQNG) NAS Model
+
+This document describes the terminology and gives a model of typical
+Network Access Server (NAS).  This memo provides information for the
+Internet community.
+
+
+2880    McIntyre        Aug 2000        Internet Fax T.30 Feature
+                                        Mapping
+
+This document describes how to map Group 3 fax capability identification
+bits, described in ITU T.30, into the Internet fax feature schema
+described in "Content feature schema for Internet fax".  This memo
+provides information for the Internet community.
+
+
+2879    Klyne           Aug 2000        Content Feature Schema for
+                                        Internet Fax (V2)
+
+This document defines a content media feature schema for Internet fax.
+[STANDARDS TRACK]
+
+
+2878    Higashiyama     Jul 2000        PPP Bridging Control Protocol
+                                        (BCP)
+
+This document defines the Network Control Protocol for establishing and
+configuring Remote Bridging for PPP links.  [STANDARDS TRACK]
+
+
+2877    Murphy, Jr.     Jul 2000        5250 Telnet Enhancements
+
+This memo describes the interface to the IBM 5250 Telnet server that
+allows client Telnet to request a Telnet terminal or printer session
+using a specific device name.  This memo provides information for the
+Internet community.
+
+
+2876    Pawling         Jul 2000        Use of the KEA and SKIPJACK
+                                        Algorithms in CMS
+
+This document describes the conventions for using the Key Exchange
+Algorithm (KEA) and SKIPJACK encryption algorithm in conjunction with
+the Cryptographic Message Syntax [CMS] enveloped-data and encrypted-
+data content types.  This memo provides information for the Internet
+community.
+
+
+
+Ginoza                       Informational                      [Page 5]
+
+RFC 2899                  Summary of 2800-2899                  May 2001
+
+
+2875    Prafullchandra  Jul 2000        Diffie-Hellman
+                                        Proof-of-Possession Algorithms
+
+This document describes two methods for producing an integrity check
+value from a Diffie-Hellman key pair.  [STANDARDS TRACK]
+
+
+2874    Crawford        Jul 2000        DNS Extensions to Support IPv6
+                                        Address Aggregation and
+                                        Renumbering
+
+This document defines changes to the Domain Name System to support
+renumberable and aggregatable IPv6 addressing.  [STANDARDS TRACK]
+
+
+2873    Xiao            Jun 2000        TCP Processing of the IPv4
+                                        Precedence Field
+
+This memo describes a conflict between TCP and DiffServ on the use of
+the three leftmost bits in the TOS octet of an IPv4 header.  [STANDARDS
+TRACK]
+
+
+2872    Bernet          Jun 2000        Application and Sub
+                                        Application Identity Policy
+                                        Element for Use with RSVP
+
+RSVP signaling messages typically include policy data objects, which in
+turn contain policy elements.  Policy elements may describe user and/or
+application information, which may be used by RSVP aware network
+elements to apply appropriate policy decisions to a traffic flow.  This
+memo details the usage of policy elements that provide application
+information.  [STANDARDS TRACK]
+
+
+2871    Rosenberg       Jun 2000        A Framework for Telephony
+                                        Routing over IP
+
+This document serves as a framework for Telephony Routing over IP
+(TRIP), which supports the discovery and exchange of IP telephony
+gateway routing tables between providers.  This memo provides
+information for the Internet community.
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 6]
+
+RFC 2899                  Summary of 2800-2899                  May 2001
+
+
+2870    Bush            Jun 2000        Root Name Server Operational
+                                        Requirements
+
+The primary focus of this document is to provide guidelines for
+operation of the root name servers.  This document specifies an Internet
+Best Current Practices for the Internet Community, and requests
+discussion and suggestions for improvements.
+
+
+2869    Rigney          Jun 2000        RADIUS Extensions
+
+This document describes additional attributes for carrying
+authentication, authorization and accounting information between a
+Network Access Server (NAS) and a shared Accounting Server using the
+Remote Authentication Dial In User Service (RADIUS) protocol described
+in RFC 2865 and RFC 2866.  This memo provides information for the
+Internet community.
+
+
+2868    Zorn            Jun 2000        RADIUS Attributes for Tunnel
+                                        Protocol Support
+
+This document defines a set of RADIUS (Remote Authentication Dial In
+User Service) attributes designed to support the provision of compulsory
+tunneling in dial-up networks.  This memo provides information for the
+Internet community.
+
+
+2867    Zorn            Jun 2000        RADIUS Accounting
+                                        Modifications for Tunnel
+                                        Protocol Support
+
+This document defines new RADIUS (Remote Authentication Dial In User
+Service) accounting Attributes and new values for the existing Acct-
+Status-Type Attribute designed to support the provision of compulsory
+tunneling in dial-up networks.  This memo provides information for the
+Internet community.
+
+
+2866    Rigney          Jun 2000        RADIUS Accounting
+
+This document describes a protocol for carrying accounting information
+between a Network Access Server and a shared Accounting Server.  This
+memo provides information for the Internet community.
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 7]
+
+RFC 2899                  Summary of 2800-2899                  May 2001
+
+
+2865    Rigney          Jun 2000        Remote Authentication Dial In
+                                        User Service (RADIUS)
+
+This document describes a protocol for carrying authentication,
+authorization, and configuration information between a Network Access
+Server which desires to authenticate its links and a shared
+Authentication Server.  [STANDARDS TRACK]
+
+
+2864    McCloghrie      Jun 2000        The Inverted Stack Table
+                                        Extension to the Interfaces
+                                        Group MIB
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it describes managed objects which provide an inverted
+mapping of the interface stack table used for managing network
+interfaces.  [STANDARDS TRACK]
+
+
+2863    McCloghrie      Jun 2000        The Interfaces Group MIB
+
+This memo discusses the 'interfaces' group of MIB-II, especially the
+experience gained from the definition of numerous media-specific MIB
+modules for use in conjunction with the 'interfaces' group for managing
+various sub-layers beneath the internetwork-layer.  It specifies
+clarifications to, and extensions of, the architectural issues within
+the MIB-II model of the 'interfaces' group.  [STANDARDS TRACK]
+
+
+2862    Civanlar        Jun 2000         RTP Payload Format for
+                                         Real-Time Pointers
+
+This document describes an RTP payload format for transporting the
+coordinates of a dynamic pointer that may be used during a presentation.
+[STANDARDS TRACK]
+
+
+2861    Handley         Jun 2000        TCP Congestion Window
+                                        Validation
+
+This document describes a simple modification to TCP's congestion
+control algorithms to decay the congestion window cwnd after the
+transition from a sufficiently-long application-limited period, while
+using the slow-start threshold ssthresh to save information about the
+previous value of the congestion window.  This memo defines an
+Experimental Protocol for the Internet community.
+
+
+
+
+Ginoza                       Informational                      [Page 8]
+
+RFC 2899                  Summary of 2800-2899                  May 2001
+
+
+2860    Carpenter       Jun 2000        Memorandum of Understanding
+                                        Concerning the Technical Work
+                                        of the Internet Assigned
+                                        Numbers Authority
+
+This document places on record the text of the Memorandum of
+Understanding concerning the technical work of the IANA that was signed
+on March 1, 2000 between the IETF and ICANN, and ratified by the ICANN
+Board on March 10, 2000.  This memo provides information for the
+Internet community.
+
+
+2859    Fang            Jun 2000        A Time Sliding Window Three
+                                        This memo defines a Time
+
+This memo defines a Time Sliding Window Three Colour Marker (TSWTCM),
+which can be used as a component in a Diff-Serv traffic conditioner.
+This memo defines an Experimental Protocol for the Internet community.
+
+
+2858    Bates           Jun 2000        Multiprotocol Extensions for
+                                        BGP-4
+
+This document defines extensions to BGP-4 to enable it to carry routing
+information for multiple Network Layer protocols (e.g., IPv6, IPX,
+etc...).  [STANDARDS TRACK]
+
+
+2857    Keromytis       Jun 2000        The Use of HMAC-RIPEMD-160-96
+                                        within ESP and AH
+
+This memo describes the use of the HMAC algorithm in conjunction with
+the RIPEMD-160 algorithm as an authentication mechanism within the
+revised IPSEC Encapsulating Security Payload (ESP) and the revised IPSEC
+Authentication Header (AH).  [STANDARDS TRACK]
+
+
+2856    Bierman         Jun 2000        Textual Conventions for
+                                        Additional High Capacity Data
+                                        Types
+
+This memo specifies new textual conventions for additional high capacity
+data types, intended for SNMP implementations which already support the
+Counter64 data type.  [STANDARDS TRACK]
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 9]
+
+RFC 2899                  Summary of 2800-2899                  May 2001
+
+
+2855    Fujisawa        Jun 2000        DHCP for IEEE 1394
+
+This memo describes specific usage of some fields of DHCP (Dynamic Host
+Configuration Protocol) messages.  IEEE Std 1394-1995 is a standard for
+a High Performance Serial Bus.  Since 1394 uses a different link-layer
+addressing method than conventional IEEE802/Ethernet, the usage of some
+fields must be clarified to achieve interoperability.  [STANDARDS TRACK]
+
+
+2854    Connolly        Jun 2000        The 'text/html' Media Type
+
+This document summarizes the history of HTML development, and defines
+the "text/html" MIME type by pointing to the relevant W3C
+recommendations.  This memo provides information for the Internet
+community.
+
+
+2853    Kabat           Jun 2000        Generic Security Service API
+                                        Version 2 : Java Bindings
+
+This document specifies the Java bindings for GSS-API (Generic Security
+Service Application Program Interface) which is described at a language
+independent conceptual level in RFC 2743.  [STANDARDS TRACK]
+
+
+2852    Newman          Jun 2000        Deliver By SMTP Service
+                                        Extension
+
+This memo defines a mechanism whereby a SMTP client can request, when
+transmitting a message to a SMTP server, that the server deliver the
+message within a prescribed period of time.  [STANDARDS TRACK]
+
+
+2851    Daniele         Jun 2000        Textual Conventions for
+                                        Internet Network Addresses
+
+This MIB module defines textual conventions to represent commonly used
+Internet network layer addressing information.  [STANDARDS TRACK]
+
+
+2850    IAB             May 2000        Charter of the Internet
+                                        Architecture Board (IAB)
+
+This memo documents the composition, selection, roles, and organization
+of the Internet Architecture Board.  It replaces RFC 1601.  This
+document specifies an Internet Best Current Practices for the Internet
+Community, and requests discussion and suggestions for improvements.
+
+
+
+
+Ginoza                       Informational                     [Page 10]
+
+RFC 2899                  Summary of 2800-2899                  May 2001
+
+
+2849    Good            Jun 2000        The LDAP Data Interchange
+                                        Format (LDIF) - Technical
+                                        Specification
+
+This document describes a file format suitable for describing directory
+information or modifications made to directory information.  [STANDARDS
+TRACK]
+
+
+2848    Petrack         Jun 2000        The PINT Service Protocol:
+                                        Extensions to SIP and SDP for
+                                        IP Access to Telephone Call
+                                        Services
+
+This document contains the specification of the PINT Service Protocol
+1.0, which defines a protocol for invoking certain telephone services
+from an IP network.  [STANDARDS TRACK]
+
+
+2847    Eisler          Jun 2000        LIPKEY - A Low Infrastructure
+                                        Public Key Mechanism Using SPKM
+
+This memorandum describes a method whereby one can use GSS-API (Generic
+Security Service Application Program Interface)  to supply a secure
+channel between a client and server, authenticating the client with a
+password, and a server with a public key certificate.  [STANDARDS TRACK]
+
+
+2846    Allocchio       Jun 2000        GSTN Address Element
+                                        Extensions in E-mail Services
+
+This memo defines a full syntax for a specific application in which
+there is a need to represent GSTN (Global Switched Telephone Network)
+addressing and Internet addressing.  [STANDARDS TRACK]
+
+
+2845    Vixie           May 2000        Secret Key Transaction
+                                        Authentication for DNS (TSIG)
+
+This protocol allows for transaction level authentication using shared
+secrets and one way hashing.  It can be used to authenticate dynamic
+updates as coming from an approved client, or to authenticate responses
+as coming from an approved recursive name server.  [STANDARDS TRACK]
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 11]
+
+RFC 2899                  Summary of 2800-2899                  May 2001
+
+
+2844    Przygienda      May 2000        OSPF over ATM and Proxy-PAR
+
+This memo specifies, for OSPF implementors and users, mechanisms
+describing how the protocol operates in ATM networks over PVC (Permanent
+Virtual Connections) and SVC (Switched Virtual Circuit) meshes with the
+presence of Proxy-PAR (PNNI Augmented Routing).  This memo defines an
+Experimental Protocol for the Internet community.
+
+
+2843    Droz            May 2000        Proxy-PAR
+
+The intention of this document is to provide general information about
+Proxy-PAR (PNNI Augmented Routing).  [STANDARDS TRACK]
+
+
+2842    Chandra         May 2000        Capabilities Advertisement
+                                        with BGP-4
+
+This document defines new Optional Parameter, called Capabilities, that
+is expected to facilitate introduction of new capabilities in BGP by
+providing graceful capability advertisement without requiring that BGP
+peering be terminated.  [STANDARDS TRACK]
+
+
+2841    Metzger         Nov 2000        IP Authentication using Keyed
+                                        SHA1 with Interleaved Padding
+                                        (IP-MAC)
+
+This document describes the use of keyed SHA1 (Secure Hash Algorithm)
+with the IP Authentication Header.  This memo defines a Historic
+Document for the Internet community.
+
+
+2840    Altman          May 2000        TELNET KERMIT OPTION
+
+This document describes an extension to the Telnet protocol to allow the
+negotiation, coordination, and use of the Kermit file transfer and
+management protocol over an existing Telnet protocol connection.  This
+memo provides information for the Internet community.
+
+
+2839    da Cruz         May 2000        Internet Kermit Service
+
+This document describes a new file transfer service for the Internet
+based on Telnet Protocol for option negotiation and Kermit Protocol for
+file transfer and management.  This memo provides information for the
+Internet community.
+
+
+
+
+Ginoza                       Informational                     [Page 12]
+
+RFC 2899                  Summary of 2800-2899                  May 2001
+
+
+2838    Zigmond         May 2000        Uniform Resource Identifiers
+                                        for Television Broadcasts
+
+This document describes a widely-implemented URI scheme, as World-Wide
+Web browsers are starting to appear on a variety of consumer electronic
+devices, such as television sets and television set-top boxes, which are
+capable of receiving television programming from either terrestrial
+broadcast, satellite broadcast, or cable.  In this context there is a
+need to reference television broadcasts using the URI format described
+in RFC 2396.  This memo provides information for the Internet community.
+
+
+2837    Teow            May 2000        Definitions of Managed Objects
+                                        for the Fabric Element in
+                                        Fibre Channel Standard
+
+This memo defines an extension to the Management Information Base (MIB)
+for use with network management protocols in TCP/IP-based internets.  In
+particular, it defines the objects for managing the operations of the
+Fabric Element portion of the Fibre Channel Standards.  [STANDARDS
+TRACK]
+
+
+2836    Brim            May 2000        Per Hop Behavior
+                                        Identification Codes
+
+This document defines a binary encoding to uniquely identify PHBs (Per
+Hop Behaviors) and/or sets of PHBs in protocol messages.  [STANDARDS
+TRACK]
+
+
+2835    Pittet          May 2000        IP and ARP over HIPPI-6400
+                                        (GSN)
+
+This document further specifies a method for resolving IP addresses to
+HIPPI-6400 (High-Performance Parallel Interface) hardware addresses
+(HARP) and for emulating IP broadcast in a logical IP subnet (LIS) as a
+direct extension of HARP.  Furthermore, it is the goal of this memo to
+define a IP and HARP that will allow interoperability for HIPPI-800 and
+HIPPI-6400 equipment both broadcast and non-broadcast capable networks.
+[STANDARDS TRACK]
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 13]
+
+RFC 2899                  Summary of 2800-2899                  May 2001
+
+
+2834    Pittet          May 2000        ARP and IP Broadcast over
+                                        HIPPI-800
+
+This document specifies a method for resolving IP addresses to ANSI
+High-Performance Parallel Interface (HIPPI) hardware addresses and for
+emulating IP broadcast in a logical IP subnet (LIS) as a direct
+extension of HARP (hardware addresses).  This memo defines a HARP that
+will interoperate between HIPPI-800 and HIPPI-6400 (also known as
+Gigabyte System Network, GSN).  This document (when combined with RFC
+2067 "IP over HIPPI") obsoletes RFC 1374.  [STANDARDS TRACK]
+
+
+2833    Schulzrinne     May 2000        RTP Payload for DTMF Digits,
+                                        Telephony Tones and Telephony
+                                        Signals
+
+This memo describes how to carry dual-tone multifrequency (DTMF)
+signaling, other tone signals and telephony events in RTP packets.
+[STANDARDS TRACK]
+
+
+2832    Hollenbeck      May 2000        NSI Registry Registrar
+                                        Protocol (RRP) Version 1.1.0
+
+This document describes a protocol for the registration and management
+of second level domain names and associated name servers in both generic
+Top Level Domains (gTLDs) and country code Top Level Domains (ccTLDs).
+This memo provides information for the Internet community.
+
+
+2831    Leach           May 2000        Using Digest Authentication as
+                                        a SASL Mechanism
+
+This specification defines how HTTP Digest Authentication can be used as
+a SASL mechanism for any protocol that has a SASL (Simple Authentication
+and Security Layer) profile.  [STANDARDS TRACK]
+
+
+2830    Hodges          May 2000        Lightweight Directory Access
+                                        Protocol (v3): Extension for
+                                        Transport Layer Security
+
+This document defines the "Start Transport Layer Security (TLS)
+Operation" for LDAP.  [STANDARDS TRACK]
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 14]
+
+RFC 2899                  Summary of 2800-2899                  May 2001
+
+
+2829    Wahl            May 2000        Authentication Methods for
+                                        LDAP
+
+This document specifies particular combinations of security mechanisms
+which are required and recommended in LDAP implementations.  [STANDARDS
+TRACK]
+
+
+2828    Shirey          May 2000        Internet Security Glossary
+
+This Glossary provides abbreviations, explanations, and recommendations
+for use of information system security terminology.  This memo provides
+information for the Internet community.
+
+
+2827    Ferguson        May 2000        Network Ingress Filtering:
+                                        Defeating Denial of Service
+                                        Attacks which employ IP Source
+                                        Address Spoofing
+
+This paper discusses a simple, effective, and straightforward method for
+using ingress traffic filtering to prohibit DoS (Denial of Service)
+attacks which use forged IP addresses to be propagated from 'behind' an
+Internet Service Provider's (ISP) aggregation point.  This document
+specifies an Internet Best Current Practices for the Internet Community,
+and requests discussion and suggestions for improvements.
+
+
+2826    IAB             May 2000        IAB Technical Comment on the
+                                        Unique DNS Root
+
+This document discusses the existence of a globally unique public name
+space in the Internet called the DNS (Domain Name System).  This name
+space is a hierarchical name space derived from a single, globally
+unique root.  It is a technical constraint inherent in the design of the
+DNS.  One root must be supported by a set of coordinated root servers
+administered by a unique naming authority.  It is not technically
+feasible for there to be more than one root in the public DNS.  This
+memo provides information for the Internet community.
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 15]
+
+RFC 2899                  Summary of 2800-2899                  May 2001
+
+
+2825    IAB             May 2000        A Tangled Web: Issues of I18N,
+                                        Domain Names, and the Other
+                                        Internet protocols
+
+This document is a statement by the Internet Architecture Board.  It is
+not a protocol specification, but an attempt to clarify the range of
+architectural issues that the internationalization of domain names
+faces.  This memo provides information for the Internet community.
+
+
+2824    Lennox          May 2000        Call Processing Language
+                                        Framework and Requirements
+
+This document describes an architectural framework we call a processing
+language, as a simple and standardized way for implementing and
+deploying Internet telephony.  A large number of the services we wish to
+make possible for Internet telephony require fairly elaborate
+combinations of signalling operations, often in network devices, to
+complete.  It also outlines requirements for such a language.  This memo
+provides information for the Internet community.
+
+
+2823    Carlson         May 2000        PPP over Simple Data Link
+                                        (SDL) using SONET/SDH with
+                                        ATM-like framing
+
+This document extends methods found in the Point-to-Point Protocol (PPP)
+and RFCs 1662 and 2615 to include a new encapsulation for PPP called
+Simple Data Link (SDL).  SDL provides a standard method for transporting
+multi-protocol datagrams over point-to-point links, and RFCs 1662 and
+2615 provide a means to carry PPP over Synchronous Optical Network
+(SONET) and Synchronous Digital Hierarchy (SDH) circuits.  SDL provides
+a very low overhead alternative to HDLC-like encapsulation, and can also
+be used on SONET/SDH links.  This memo defines an Experimental Protocol
+for the Internet community.
+
+
+2822    Resnick         Apr 2001        Internet Message Format
+
+This document specifies a syntax for text messages that are sent between
+computer users, within the framework of "electronic mail" messages.
+[STANDARDS TRACK]
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 16]
+
+RFC 2899                  Summary of 2800-2899                  May 2001
+
+
+2821    Klensin         Apr 2001        Simple Mail Transfer Protocol
+
+This document is a self-contained specification of the basic protocol
+for the Internet electronic mail transport.  [STANDARDS TRACK]
+
+
+2820    Stokes          May 2000        Access Control Requirements
+                                        for LDAP
+
+This document describes the fundamental requirements of an access
+control list (ACL) model for the Lightweight Directory Application
+Protocol (LDAP) directory service.  This memo provides information for
+the Internet community.
+
+
+2819    Waldbusser      May 2000        Remote Network Monitoring
+                                        Management Information Base
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP-based internets.  In
+particular, it defines objects for managing remote network monitoring
+devices.  [STANDARDS TRACK]
+
+
+2818    Rescorla        May 2000        HTTP Over TLS
+
+
+This memo describes how to use Transport Layer Security (TLS) to secure
+Hypertext Transfer Protocol (HTTP) connections over the Internet.  This
+memo provides information for the Internet community.
+
+
+2817    Khare           May 2000        Upgrading to TLS Within
+                                        HTTP/1.1
+
+This memo explains how to use the Upgrade mechanism in HTTP/1.1 to
+initiate Transport Layer Security (TLS) over an existing TCP connection.
+[STANDARDS TRACK]
+
+
+2816    Ghanwani        May 2000        A Framework for Integrated
+                                        Services Over Shared and
+                                        Switched IEEE 802 LAN
+                                        Technologies
+
+This memo describes a framework for supporting IETF Integrated Services
+on shared and switched LAN infrastructure.  This memo provides
+information for the Internet community.
+
+
+
+Ginoza                       Informational                     [Page 17]
+
+RFC 2899                  Summary of 2800-2899                  May 2001
+
+
+2815    Seaman          May 2000        Integrated Service Mappings on
+                                        IEEE 802 Networks
+
+This document describes mappings of IETF Integrated Services over LANs
+built from IEEE 802 network segments which may be interconnected by IEEE
+802.1D MAC Bridges (switches).  [STANDARDS TRACK]
+
+
+2814    Yavatkar        May 2000        SBM (Subnet Bandwidth
+                                        Manager): A Protocol for
+                                        RSVP-based Admission Control
+                                        over IEEE 802-style networks
+
+This document describes a signaling method and protocol for RSVP-based
+admission control over IEEE 802-style LANs.  [STANDARDS TRACK]
+
+
+2813    Kalt            Apr 2000        Internet Relay Chat: Server
+                                        Protocol
+
+This document defines the protocol used by servers to talk to each
+other.  This memo provides information for the Internet community.
+
+
+2812    Kalt            Apr 2000        Internet Relay Chat: Client
+                                        Protocol
+
+This document defines the Client Protocol, and assumes that the reader
+is familiar with the IRC Architecture.  This memo provides information
+for the Internet community.
+
+
+2811    Kalt            Apr 2000        Internet Relay Chat: Channel
+                                        Management
+
+This document specifies how channels, their characteristics and
+properties are managed by IRC servers.  This memo provides information
+for the Internet community.
+
+
+2810    Kalt            Apr 2000        Internet Relay Chat:
+                                        Architecture
+
+This document is an update describing the architecture of the current
+IRC protocol and the role of its different components.  Other documents
+describe in detail the protocol used between the various components
+defined here.  This memo provides information for the Internet
+community.
+
+
+
+Ginoza                       Informational                     [Page 18]
+
+RFC 2899                  Summary of 2800-2899                  May 2001
+
+
+2809    Aboba           Apr 2000        Implementation of L2TP
+                                        Compulsory Tunneling via
+                                        RADIUS
+
+This document discusses implementation issues arising in the
+provisioning of compulsory tunneling in dial-up networks using the L2TP
+(Layer Two Tunneling Protocol) protocol.  This memo provides information
+for the Internet community.
+
+
+2808    Nystrom         Apr 2000        The SecurID(r) SASL Mechanism
+
+This document defines a SASL (Simple Authentication and Security Layer)
+authentication mechanism using SecurID (a hardware token card product
+(or software emulation thereof) produced by RSA Security Inc., which is
+used for end-user authentication), thereby providing a means for such
+tokens to be used in SASL environments.  This mechanism is only is only
+for authentication, and has no effect on the protocol encoding and is
+not designed to provide integrity or confidentiality services.  This
+memo provides information for the Internet community.
+
+
+2807    Reagle          Jul 2000        XML Signature Requirements
+
+This document lists the design principles, scope, and requirements for
+the XML Digital Signature specification.  It includes requirements as
+they relate to the signature syntax, data model, format, cryptographic
+processing, and external requirements and coordination.  This memo
+provides information for the Internet community.
+
+
+2806    Vaha-Sipila     Apr 2000        URLs for Telephone Calls
+
+
+This document specifies URL (Uniform Resource Locator) schemes "tel",
+"fax" and "modem" for specifying the location of a terminal in the phone
+network and the connection types (modes of operation) that can be used
+to connect to that entity.  [STANDARDS TRACK]
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 19]
+
+RFC 2899                  Summary of 2800-2899                  May 2001
+
+
+2805    Greene          Apr 2000        Media Gateway Control Protocol
+                                        Architecture and Requirements
+
+This document describes protocol requirements for the Media Gateway
+Control Protocol between a Media Gateway Controller and a Media Gateway.
+This memo provides information for the Internet community.
+
+
+2804    IAB             May 2000        IETF Policy on Wiretapping
+
+This document describes the position that the Internet Engineering Task
+Force (IETF) has taken regarding the inclusion into IETF standards-track
+documents of functionality designed to facilitate wiretapping.  This
+memo explains what the IETF thinks the question means, why its answer is
+"no", and what that answer means.  This memo provides information for
+the Internet community.
+
+
+2803    Maruyama        Apr 2000        Digest Values for DOM (DOMHASH)
+
+This memo defines a clear and unambiguous definition of digest (hash)
+values of the XML objects regardless of the surface string variation of
+XML.  This memo provides information for the Internet community.
+
+
+2802    Davidson        Apr 2000        Digital Signatures for the
+                                        v1.0 Internet Open Trading
+                                        Protocol (IOTP)
+
+This document describes the syntax and procedures for the computation
+and verification of digital signatures for use within Version 1.0 of the
+Internet Open Trading Protocol (IOTP).  This memo provides information
+for the Internet community.
+
+
+2801    Burdett         Apr 2000        Internet Open Trading Protocol
+                                        - IOTP Version 1.0
+
+This document discusses the Internet Open Trading Protocol (IOTP) and
+its provision of an interoperable framework for Internet commerce.  This
+memo provides information for the Internet community.
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 20]
+
+RFC 2899                  Summary of 2800-2899                  May 2001
+
+
+2800    Reynolds        May 2001        Internet Official Protocol
+                                        Standards
+
+This memo contains a snapshot of the state of standardization of
+protocols used in the Internet as of April 17, 2001.  It lists only
+official protocol standards RFCs; it is not a complete index to the RFC
+series.  [STANDARDS TRACK]
+
+Security Considerations
+
+   This memo does not affect the technical security of the Internet, but
+   may cite important security specifications.
+
+Author's Address
+
+   Sandy Ginoza
+   University of Southern California
+   Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone:  (310) 822-1511
+
+   EMail: ginoza@isi.edu
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 21]
+
+RFC 2899                  Summary of 2800-2899                  May 2001
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2001).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 22]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2899.txt](<www.ietf.org/rfc/rfc2899.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
