### PR TITLE
Archive rfc29.txt

### DIFF
--- a/www.ietf.org/rfc/rfc29.txt
+++ b/www.ietf.org/rfc/rfc29.txt
@@ -1,0 +1,43 @@
+Network Working Group                                   Robert Kahn
+RFC-29                                                  BBN
+                                                        19 January 1970
+
+
+
+
+
+This note is in response to Bill English's Request for Comments:  28.
+
+A "millisecond" clock should be satisfactory for most network measurements.
+Round-trip message transit times typically should be at least on the
+order of tens to hundreds of milliseconds.  The IMP contains a 16-bit
+hardware clock which is incremented every 100 microseconds to allow for
+timing of internal events within the IMP, as for example, during tracing.
+However, most measurements are made using a 25.6 ms. software clock.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+DISTRIBUTION:
+
+A. Bhushan, MIT
+S. Carr. Utah
+G. Cole, SDS
+S. Crocker, UCLA
+K. Fry, MITRE
+J. Heafner, RAND
+B. Kahn, BBN
+T. O'Sullivan, Raytheon
+L. Roberts, ARPA
+P. Rovner, LL
+R. Stoughton, UCSB


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc29.txt](<www.ietf.org/rfc/rfc29.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
