### PR TITLE
Archive rfc290.txt

### DIFF
--- a/www.ietf.org/rfc/rfc290.txt
+++ b/www.ietf.org/rfc/rfc290.txt
@@ -1,0 +1,843 @@
+
+
+
+
+
+
+Network Working Group                                   Alvin P. Mullery
+Request for Comments: 290               Thomas J. Watson Research Center
+Updates: RFC 243                                        January 11, 1972
+NIC: 8300
+
+
+           COMPUTER NETWORKS AND DATE SHARING: A BIBLIOGRAPHY
+
+
+   Abstract.  The bibliography is broken into seven subject areas -
+   general data structures, data description, data conversion, data
+   management, data security, data transmission, and computer network
+   design.  Two of these areas, general data structures and data
+   management, cover a very broad range of subjects: however, in these
+   two areas, only entries that seem to be specially pertinent to
+   computer networks and data sharing are included.  The bibliography
+   also contains an index of authors.
+
+
+   A. GENERAL DATA STRUCTURES
+
+   1.  F.D. Anzelmo, "A Data-Storage Format for Information System
+       Files," IEEE Trans. Computers, vol. C-20, p. 39-43, January 1971.
+
+   2.  E. F. Codd, "A Relational Model of Data for Large Shared Data
+       Banks," Comm. ACM, vol 13, p. 377-387, June, 1970.
+
+   3.  C.T. Davies, "A Logical Concept for the Control and Management of
+       Data", AR-0803-00
+
+   4.  J. Barley, "Toward on Understanding of Data Structures," 1970 ACM
+       SIGFIDET Workshop on Data Description and Access, p. 1-40,
+       November, 1970.
+
+   5.  M. Kay and S. Y. W. Su, "The MIND System:  The Structure of the
+       Semantic File," Rand Corp. Rept. RM-6265/3-PR, June 1970.
+
+   6.  S. E. Madnick and J.W. Alsop II, "A Modular Approach to File
+       System Design," 1969 Spring Joint Computer Conf., AFIPS Proc.,
+       vol. 34, p. 1-13, 1969.
+
+   7.  W. C. McGee, "File Structures for Generalized Data Management,"
+       Pro. IFIPS Congress 68, p. 1233, 1968.
+
+   8.  P. D. Rovner and J. A. Feldman, "The LEAP Language and Data
+       Structure," Proc IFIPS Congress 68, p. 579 1968.
+
+
+
+
+
+Mullery                                                         [Page 1]
+
+RFC 290     Computer Networks and Data Sharing Bibliography January 1972
+
+
+   B. DATA DESCRIPTION
+
+   1.  R. E. Bleier, "Data Definition Standardization," 1970 ACM
+       SIGFIDET Workshop on Data Description and Access, p. 68-86,
+       November 1970.
+
+   2.  T. H. Bonn, "A Standard for Computer Networks," Computer, vol. 4,
+       p. 10-14, May/June, 1971.
+
+   3.  "Data Base Task Group Report," CODASYL Program Language
+       Committee.
+
+   4.  "IBM Data Base Task Group Representative Minority Report,"
+       CODASYL Program Language Committee, Oct. 17, 1969.
+
+   5.  C. J. Date and P. Hopewell, "File Definition and Logical Data
+       Independence," 1971 ACM SIGFIDET Workshop on Data Description,
+       Access, and Control, p. 117-138, November 1971.
+
+   6.  C. J. Date and P. Hopewell, "Storage Structure and Physical Data
+       Independence," 1971 ACM SIGFIDET Workshop on Data Description,
+       Access, and Control, p. 139-169, November 1971.
+
+   7.  J. B. Dennis, "On the Exchange of Information," 1970 ACM SIGFIDET
+       Workshop on Data Description and Access, p. 41-67, November, 1970
+
+   8.  M. Donaldson, S. Robinovitz, and B. Wolfe, "Proposed MICIS
+       Standard for Data Description," Michigan Interuniversity
+       Committee on Information Systems, Dec. 4, 1970.
+
+   9.  M. Ellis and K. Nelson, "A Data Description Language for
+       Hierarchical Data Files," 1970 ACM SIGFIDET Workshop on Data
+       Description and Access, p. 87-107, November 1970
+
+   10. D. Evans and A. Van Dam, "Data Structure Programming Language,"
+       Proc. IFIP Congress 68, p. 557-564, 1968.
+
+   11. G. A. Gibson, "Draft: Data Description Language," fdt (a
+       publication of the ACM Special Interest Committee on File
+       Description and Translation), vol. 1, p. 9-13, 10 August 1969.
+
+   12. L. V. Haibt and A. P. Mullery, "Data Descriptive Language for
+       Shared Data," IBM Research Report RC3476, August 1971.
+
+   13. A. W. Holt, "Information System Theory Project," Applied Data
+       Research, Princeton, Rept. ADR-REF-6606, Sept. 1968.
+
+
+
+
+
+Mullery                                                         [Page 2]
+
+RFC 290     Computer Networks and Data Sharing Bibliography January 1972
+
+
+   14. G. J. Lipovsky,  "The Architecture of a Large Distributed Logic
+       Associative Memory," Univ. of Illinois, Urbana, Report R-424,
+       July 1969 (contains a discussion of representation structures
+       suitable for describing complex data bases).
+
+   15. C. N. Mooers, "A Standard Method for the Description of External
+       Data Formats," part IV of "Standards for User Procedures and Data
+       Formats in Automatic Information Systems and Networks," Zator
+       Co., Cambridge Mass., Aug. 28, 1967.
+
+   16. C. N. Mooers, "Data Descriptive Languages," fdt (a publication of
+       the ACM Special Interest Committee on File Description and
+       Translation), vol. 1 p. 31-36, 10 August 1969.
+
+   17. H. R. Morse, "Efficiency and the Use of Data Definition
+       Techniques," fdt (a publication of the ACM Special Interest
+       Committee on File Description and Translation), vol. 1, p. 20-23,
+       10 August 1969.
+
+   18. M. Schaefer, "User's Guide for DBL:  General Description," System
+       Development Corporation, Santa Monica, Calif., Rept. TM-
+       3870/001/01, September, 1969.
+
+   19. D. P. Smith, "A Data Description Facility," Moore School, Univ.
+       of Penn., AD-703244, April 1970.
+
+   20. D. P. Smith, "A Manual with Examples for the Data Description
+       Language (DDL)," Moore School, Univ. of Penn., AD-726707, April
+       1971.
+
+   21. T. A. Standish, "A Data Definition Facility for Programming
+       Languages," Carnegie Institute of Technology, AD-658042, May 18,
+       1967.
+
+   22. B. Wegbreit, " The Treatment of Data Types in EL1," Technical
+       Report, Division of Engineering and Applied Physics, Harvard
+       Univ., May 1971.
+
+   23. B. Wegbreit, "The ECL Programming System," Technical Report
+       Division of Engineering and Applied Physics, Harvard Univ., May
+       1971.
+
+
+
+
+
+
+
+
+
+
+Mullery                                                         [Page 3]
+
+RFC 290     Computer Networks and Data Sharing Bibliography January 1972
+
+
+   C. DATA CONVERSION
+
+   1.  R. D. Anderson, E. F. Harslem, J. F. Heafner, V. Cerf, J. Madden,
+       R. Metcalfe, A. Shoshani, J. White, and D. Wood, "The Data
+       Reconfiguration Service - - An Experiment in Adaptable,
+       Process/Process Communication," Proc. ACM/IEEE Second Symposium
+       on Problems in the Optimization of Data Communication Systems, p.
+       1-9, October 1971.
+
+   2.  K. Sattley, R. E. Millstein, S. Marshall, "On Program
+       Transferability," Applied Data Research, Inc., Rept. RADC-TR-70-
+       217, Nov. 1970.
+
+   3.  M. Schaefer, "DBL - A Language for Converting Data Bases,"
+       Datamation, vol. 16, p. 123, June 1970.
+
+
+   D. DATA MANAGEMENT
+
+   1.  W. W. Chu, "Optimal File Allocation in a Multiple Computer
+       System," IEEE Trans. Computers, vol. c-18, p. 885-889, October
+       1969.
+
+   2.  E. G. Coffman, J. J. Elphick, and A. Shoshani, "System
+       Deadlocks," Computing Surveys, vol. 3, no. 2, p. 67, June 1971.
+
+   3.  J. M. Daniels and L. D. Irwin, "Memory Protection in
+       Multiprocessor Computer Systems," Auburn Univ. Rept. THEMIS-AU-
+       T-17, November, 1970.
+
+   4.  A. N. Habermann, "Prevention of System Deadlocks," Comm. ACM, vol
+       12, no. 7, p. 373-385, July 1969.
+
+   5.  J. W. Havender, "Avoiding Deadlock in Multitasking Systems," IBM
+       Systems Journal, vol. 7, no. 2, 1968.
+
+   6.  P. G. Hebalkar, "A Graph Model for Analysis of Deadlock
+       Prevention in Systems with Parallel Computations," IBM Research
+       Report RC3367, April 22, 1971.
+
+   7.  B. W. Lawpson, "A Scheduling Philosophy for Multi-Processing
+       Systems," Comm. ACM, vol. 11, p. 347-360, May, 1968.
+
+   8.  T. Marill and K. Curewitz, "Network Data Handling System,"
+       Computer Corporation of America, Cambridge, Mass., August 1971.
+
+
+
+
+
+
+Mullery                                                         [Page 4]
+
+RFC 290     Computer Networks and Data Sharing Bibliography January 1972
+
+
+   9.  J. E. Murphy, "Resource Allocation with Interlock Detection in a
+       Multi-Task System," 1968 Fall Joint Computer Conference.  AFIPS
+       Proc., vol. 33, p. 1169-1176, 1968
+
+   10. P. J. Owens, "Phase II, A Data Management System Model," IBM
+       Research Rept. RJ665, Jan. 29 1970.
+
+   11. M. E. Senko, V. Y. Lum, P. J. Woens, "A File Organization
+       Evaluation Model (FOREM)," Proc IFIP Congress 68, August, 1968.
+
+   12. A. Shoshani and A. J. Bernstein, "Synchronization in a Parallel-
+       Accessed Data Base," Comm. ACM, vol 13, p. 604-607, Nov. 1969.
+
+   13. A. J. Strnad, "The Relational Approach to the Management of Data
+       Bases," MIT Project MAC Rept. Mac-TM-23, April 1971.
+
+   14. V. K. M. Whitney, "A Study of Optimal File Assignment and
+       Communication Network configuration in Remote-Access Computer
+       Message Processing and Communication Systems," SEL Technical
+       Report No. 48, System Engineering Lab, Dept. of Elect. Engin.,
+       University of Michigan, September, 1970.
+
+
+   E. DATA SECURITY
+
+   1.  P. Baran, "On Distributed Communications: IX. Security, Secrecy,
+       and Tamper-Free Considerations," The RAND Corporation, AD-444839,
+       August 1964.
+
+   2.  P. S. Browne and D. Steinauer, "A Model for Access Control," 1971
+       ACM SIGFIDET Workshop on Data Description, Access, and Control,
+       p. 241-262, November 1971.
+
+   3.  A. I. Dean, Jr., "Data Privacy and Integrity Requirements for
+       Online Data Management System," 1971 ACM SIGFIDET Workshop on
+       Data Description, Access, and Control, p. 279-298, November 1971.
+
+   4.  T. D. Friedman, "The Authorization Problem in Shared Files," IBM
+       Systems Journal, vol. 9, no. 4, p. 258-280, 1970.
+
+   5.  R. M. Graham, "Protection in an Information Processing Utility,"
+       comm. ACM, vol 1, no. 5, p. 365-369, May 1968.
+
+   6.  L. J. Hoffman, "Computers and Privacy:  A Survey," Computing
+       Surveys, vol. 1, no. 2, p. 85-103,  1969.
+
+   7.  L. J. Hoffman, "The Formulary Model for Access Control and
+       Privacy in Computer Systems," SLAC Report No. 117, May 1970.
+
+
+
+Mullery                                                         [Page 5]
+
+RFC 290     Computer Networks and Data Sharing Bibliography January 1972
+
+
+   8.  B. W. Lampson, "Dynamic Protection Structures," 1969 Fall Joint
+       Computer Conference, AFIPS Proc., vol 35, p. 27-38, 1969.
+
+   9.  R. C. Owens, Jr., "Evaluation of Access Authorization
+       Characteristics of Derived Data Sets," 1971 ACM SIGFIDET Workshop
+       on Data Description, Access, and Control, p. 263-278, November
+       1971.
+
+   10. P. L. Peck, Jr., "Survey of Applicable Safeguards for Insuring
+       the Integrity of Information in the Data Processing Environment,"
+       MITRE Rept. MTP356, MITRE Corp., McLean, Va., June 1971.
+
+   11. B. Peters, "Security Considerations in a Multiprogrammed Computer
+       System," 1967 Spring Joint Computer Conference, AFIPS Proc., vol
+       30, p. 283-286, 1967.
+
+   12. L. H. Saltzer and M. D. Schroeder, "A Hardware Architecture for
+       Implementing Protection Rings," Third ACM Symposium on Operating
+       Systems, October 1970.
+
+   13. R. O. Skatrud, " A Consideration of the Application of
+       Cryptographic Techniques to Data Processing," 1969 Fall Joint
+       Computer Conference, AFIPS Proc. Vol 35, p. 111-117, 1969.
+
+   14. R. Turn and H. E. Petersen, "Security of Computerized Information
+       Systems," Rand Corp. Rept. P-4405, July 1970.
+
+   15. W. H. Ware, "Security and Privacy in Computer Systems," 1967
+       Spring Joint Computer Conference, AFIPS Proc., vol 30, p. 279-
+       282, 1967.
+
+   16. W. H. Ware, "Security and Privacy:  Similarities and
+       Differences," 1967 Spring Joint Computer Conference, AFIPS Proc.,
+       vol 30, p. 283-290, 1967.
+
+
+   F. DATA TRANSMISSION
+
+   1.  "Proposed Character Set for Roman alphabet and Romanized Non-
+       Roman Alphabets" American Standards Institute Document x3.2/836,
+       May 29, 1969.
+
+   2.  P. Baran, "On Distributed Communication Networks," IEEE Trans. On
+       Communication Systems, vol. CS-12, no. 1, p. 1-9, March 1964.
+
+   3.  K. A. Bartlett, "Transmission Control in a Local Data Network,"
+       Proc. IFIP Congress 68, p. 704-708, August 1968.
+
+
+
+
+Mullery                                                         [Page 6]
+
+RFC 290     Computer Networks and Data Sharing Bibliography January 1972
+
+
+   4.  "Final Report of the Electronic Industries Association Committee
+       on Netting Computer Systems," Marc Bendick, Chairman, System Dev.
+       Corp. Rept. SP-3514, May, 1970.
+
+   5.  "Computer Netting, Standardization, and Systems Management,"
+       Computer Netting Committee, Defense Communications Council,
+       Electronic Industries Association, I. Bialick, Chairman,
+       September 15, 1969.
+
+   6.  A. K. Bhushan and R. H. Stotz, "Procedures and Standards for
+       Intercomputer Communication," 1968 Spring Joint Computer Conf.,
+       AFIPS Proc., vol 32 pp 95-104, 1968.
+
+   7.  S. Carr, S. Crocker, V. Cerf. "Host-Host Communication Protocol
+       in the ARPA Network," 1970 Spring Joint Computer Conf., AFIPS
+       Proc., vol 36, p. 589-598, 1970.
+
+   8.  "Data Transmission Network Computer-to Computer Study," Computer
+       Sciences Corporation, Falls Church, Va., 1971.
+
+   9.  D. W. Davies, "Communication Networks to Serve Rapid-response
+       Computers," Proc IFIP Congress 68, p. 650-656, August 1968.
+
+   10. D. W. Davies, "The Principles of a Data Communication Network for
+       Computers and Remote Peripherals," Proc IFIP Congress 69, p.
+       709-714, August 1968.
+
+   11. D. R. Doll, "Topology and Transmission Rate Considerations in the
+       Design of Centralized Computer Communication Networks," Proc.
+       1970 IEEE International Conference on Communications, p. 19.17-
+       19.27, 1970.
+
+   12. H. Frank, "Analysis and Optimization of Store-and Forward
+       Computer Networks," Network Analysis Corporation, AD-707438, June
+       15, 1970.
+
+   13. M. E. Jacobs, "Standard Format for Data Exchange," Special
+       Libraries, vol. 59, pp 258-260, April 1968.
+
+   14. D. Karp and S. Seroussi, "A Communications Interface for Computer
+       Networks," IBM Research Report No. RC3417, June 1971.
+
+   15. J. L. Little, "Some Evolving Conventions and Standards for
+       Character Information Coded in Six, Seven, and Eight Bits," NBS
+       Technical Note 478, May 1969.
+
+
+
+
+
+
+Mullery                                                         [Page 7]
+
+RFC 290     Computer Networks and Data Sharing Bibliography January 1972
+
+
+   16. J. L. Little and C. N. Mooers, "Standards for User Procedures and
+       Data Formats in Automated Information Systems and Networks," 1968
+       Spring Joint Computer Conf., AFIPS Proc., vol 32 pp 89-94, 1968.
+
+   17. A. K. Olefir, B. F. Kipurov, D. M. Frumin, and L. P. Yukhnevich,
+       "A System for Data Exchange between two Computers," Foreign
+       Technology Division, Wright Patterson AFB, Rept. FTD-HT-23-438-
+       68, November 7, 1969.
+
+   18. R. A. Scantlebury and P. T. Wilkinson, "The Design of a Switching
+       System to Allow Remote Access to Computer Services by Other
+       Computers and Terminal Devices," Proc. ACM/IEEE Second Symposium
+       on Problems in the Optimization of Data Communication Systems, p.
+       160-165, October 1971.
+
+   19. P. J. Trafton, H. A. Blank, and N. F. McAllister, "Data
+       Transmission Network Computer-to Computer Study," Proc. ACM/IEEE
+       Second Symposium on Problems in the Optimization of Data
+       Communication Systems, p. 183-191, October 1971.
+
+   20. P. T. Wilkinson and R. A. Scantlebury, "The Control Functions in
+       a Local Data Network," Proc IFIP Congress 68, p. 734-738, August
+       1968.
+
+
+   G. COMPUTER NETWORK DESIGN
+
+   1.  V. I. Belyakov-Bodin and Yu. I. Torgov, "On the Structure of a
+       Heterogeneous Computing System, Controlled by a Large Digital
+       Computer," Foreign Technology Division, Wright-Patterson AFB
+       Rept. FTD-HT-23-1450-68, AD699640, October 1, 1969.
+
+   2.  A. A. Benvenuto, et al., "System Load Sharing Study," The MITRE
+       Corporation, Rept. MTR-5062, 1969.
+
+   3.  "Interface Message Processor:  Specifications for the
+       Interconnection of a Host and an IMP." Bolt, Baranek and Newman,
+       Inc., Rept. 1822, February 1971.
+
+   4.  E. K. Bowden, Sr., "Priority Assignment in a Network of
+       Computers," IEEE Trans. Computers, vol. C-18 p. 1021-1026, Nov.
+       1969.
+
+   5.  I. Cohen, "Control of Data Processor Networks," 1970 IEEE
+       International Conference on Communications, p. 19.28-19.34, 1970.
+
+
+
+
+
+
+Mullery                                                         [Page 8]
+
+RFC 290     Computer Networks and Data Sharing Bibliography January 1972
+
+
+   6.  G. D. Cole, "Performance Measurements on the ARPA Computer
+       Network," Proc. ACM/IEEE Second Symposium on Problems in the
+       Optimization of Data Communication Systems, p. 39-45, October
+       1971.
+
+   7.  P. R. Cox, "General System Organisation of Multi-Processor
+       Configurations," Software 70, Sheffield England, p. 33-40, April
+       1970.
+
+   8.  D. R. Doll, "Efficient Allocation of Resources in Centralized
+       Computer Communication Network Design," PhD Thesis, Univ. of
+       Michigan, System Engineering Laboratory, Tech. Rept. 02641-1-T,
+       June 1969.
+
+   9 . D. J. Farber and K. C. Larson, "The System Architecture of the
+       Distributed Computer System - an Informal Description," Univ. of
+       California, Irvine Technical Report No. 11, September 1971.
+
+   10. H. Frank, I. T. Frisch, and W. S. Chou, "Topological
+       Considerations in the Design of the ARPA Network," 1970 Spring
+       Joint Computer Conf., AFIPS Proc., vol. 36, p. 581-587, 1970.
+
+   11. H. Frank, I. T. Frisch, W. S. Chou, and R. Van Slyke, "Optimal
+       Design of Centralized Computer Networks," Proc. 1970 IEEE
+       International Communications Conference, p. 19.1-19.10, 1970.
+
+   12. H. Frank, I. T. Frisch, R. Van Slyke, and W. S. Chou, "Optimal
+       Design of Centralized Computer Networks," Networks, vol 1, no. 1,
+       p. 43-57, 1971.  (Same paper as previous entry.)
+
+   13. D. Fredericksen and R. W. Ryniker, "A Computer Network Interface
+       for OS/MVT," IBM Research Report RC3317, April 1971.
+
+   14. R. C. Gunderson and J. O. Johnson, "Engineering Design and
+       Implementation of a Multi-Computer Data Processing System for a
+       Navy Command and Control Center," Proc. 7th International
+       Convention on Military Electronics, Western Periodicals, North
+       Hollywood Calif., 1963.
+
+   15. R. M. Hamaker, "Distributed Computer Systems,"
+       Telecommunications, vol. 4, p. 25-30, March 1970.
+
+   16. E. Hansler, G. K. McAuliffe, R. S. Wilkov, "Reliability
+       Considerations in Centralized Computer Networks," IBM Research
+       Report RC3354, May 1971.
+
+
+
+
+
+
+Mullery                                                         [Page 9]
+
+RFC 290     Computer Networks and Data Sharing Bibliography January 1972
+
+
+   17. F. Heart, R. Kahn, S. Ornstein, W. Crowther, and D. Walden, "The
+       Interface Message Processor for the ARPA Computer Network," 1970
+       Spring Joint Computer Conference, AFIPS proc. Vol 36, p. 551-567,
+       1970.
+
+   18. W. G. Howe and T. R. Kibler, "Control Concepts of a Logical
+       Network Machine," IBM Research Report RC3331, April 1971.
+
+   19. R. E. Kahn and W. R. Crowther, "Flow Control in a Resource-
+       Sharing Computer Network," Proc. ACM/IEEE Second Symposium on
+       Problems in the Optimization of Data Communication Systems, p.
+       108-116, October 1971.
+
+   20. R. E. Kahn and W. R. Crowther, " A Study of the ARPA Network
+       Design and Performance," Bolt, Beranek and Newman, Inc.,
+       Cambridge, Mass, Report BBN-2161, August 1971.
+
+   21. L Kleinrock, "Analytic and Simulation Methods in Computer Network
+       Design," 1970 Spring Joint Computer Conf., AFIPS Proc., vol. 36,
+       p. 569-579, 1970.
+
+   22. L Kleinrock, "Models for Computer Networks," Proc. 1969 IEEE
+       International Conf. on Communications, p. 21.9-21.16, June 1969.
+
+   23. D. E. Lawrence, "A Proposed Computer Network for the Australian
+       National University," Computer Centre, The Australian National
+       University, Canberra, Report No. 38, August 1971.
+
+   24. A. L. Leiner, W. A. Notz, J. L. Smith, and A. Weinberger, "PILOT,
+       A New Multiple Computer System," J. ACM, vol 6, p. 315-335, July
+       1959.
+
+   25. T. Marill and L. G. Roberts, "Toward a Cooperative Network of
+       Time-Shared Computers,"  1966 Fall Joint Computer Conference,
+       AFIPS Proc., vol 29, p. 425-431, 1966.
+
+   26. D. B. McKay and D. P. Karp, "Network/440 - - IBM Research
+       Computer Sciences Department Computer Network," IBM Research
+       Report RC 3431, July 1971.
+
+   27. D. B. McKay and D. P. Karp, "A Network/440 Protocol Concept," IBM
+       Research Report RC 3432, July 1971.
+
+   28. D. B. McKay and D. P. Karp, J. W. Meyer, and R. S. Nachbar,
+       "Exploratory Research on Netting at IBM," IBM  Research Report
+       RC3486, June 1971.
+
+
+
+
+
+Mullery                                                        [Page 10]
+
+RFC 290     Computer Networks and Data Sharing Bibliography January 1972
+
+
+   29. S. F. Mendicino, "The Lawrence Radiation Laboratory Octopus,"
+       Lawrence Radiation Lab Rept. UCRL-73149, April 1971.
+
+   30. "An Experimental Computer Network," MIT Lexington, Rept. ESD-TR-
+       69-74, March 1969.
+
+   31. S. S. Patil, "Coordination of Asynchronous Events," MIT Project
+       MAC Rept. MAC-TR-72, June 1970.
+
+   32. P. L. Peck, "The Implications of ADP Networking Standards for
+       Operations Research," Mitre Corp., McLean, Va., Rept. MTP333, AD
+       696675, June 1696.
+
+   33. J. L. Redding, "Computer Network Simulator," Naval Ship Research
+       and Development Center Rept. NSRDC 3650, September 1971.
+
+   34. L. G. Roberts, and B. D. Wessler, "Computer Network Development
+       to Achieve Resource Sharing," 1970 Spring Joint Computer Conf.,
+       AFIPS Proc., vol. 36, p. 543-549, 1970.
+
+   35. J. J. Russell and D. C. Knight, "Communication and Systems
+       Development in the C. S. I. R. O. (Commonwealth Scientific and
+       Industrial Research Organization) Network," Proc, 3rd Australian
+       Computer Conference, p. 384-386, 1966.
+
+   36. R. M. Rutledge, A. L. Vareha, L. C. Varian, A. H. Weis, S. F.
+       Seroussi, J. W. Meyer, J. F. Jaffee, and M. A. K. Angell, "An
+       Interactive Network of Time-Sharing Computers," Proc. 24th
+       National Conference, A. C. M. Publication p-69, p. 431-442, 1969.
+
+   37. J. F. Sherlock, "The Simulation of a Multi-Computer System," IEEE
+       Trans. Computers, v. C-19, p. 1114-1117, Nov. 1970.
+
+   38. A. Shoshani and E. G. Coffman, "Sequencing Tasks in Multi-
+       Process, Multiple Resource Systems to Avoid Deadlocks," Proc.
+       11th Annual Symposium on Switching and Automata Theory, p. 225-
+       233, Oct. 1970.
+
+   39. A. H. Weis, "Distributed Network Activity at IBM, "IBM Research
+       Report RC3392, June 1971.
+
+
+
+
+
+
+
+
+
+
+
+Mullery                                                        [Page 11]
+
+RFC 290     Computer Networks and Data Sharing Bibliography January 1972
+
+
+   AUTHOR INDEX
+
+       J. H. Alsop II . . . . . . . . . . . . . . . . . . . .  A6
+       R. D. Anderson . . . . . . . . . . . . . . . . . . . .  C1
+       M. A. K. Angell. . . . . . . . . . . . . . . . . . . . G36
+       F. D. Anzelmo  . . . . . . . . . . . . . . . . . . . .  A1
+       ASI  . . . . . . . . . . . . . . . . . . . . . . . . .  F1
+
+       P. Baran . . . . . . . . . . . . . . . . . . . . . . E1,F2
+       K.A. Bartlett. . . . . . . . . . . . . . . . . . . . .  F3
+       V. I. Belyakov-Bodin . . . . . . . . . . . . . . . . .  G1
+       M. Bendick . . . . . . . . . . . . . . . . . . . . . .  F4
+       A. A. Benvenuto. . . . . . . . . . . . . . . . . . . .  G2
+       A. J. Bernstein. . . . . . . . . . . . . . . . . . . . D12
+       A. K. Bhushan  . . . . . . . . . . . . . . . . . . . .  F6
+       I. Bialick . . . . . . . . . . . . . . . . . . . . . .  F5
+       H. A. Blank. . . . . . . . . . . . . . . . . . . . . . F19
+       R. E. Bleier . . . . . . . . . . . . . . . . . . . . .  B1
+       Bolt, Baranek and Newman . . . . . . . . . . . . . . .  G3
+       T. H. Bonn . . . . . . . . . . . . . . . . . . . . . .  B2
+       E. K. Bowden, Sr . . . . . . . . . . . . . . . . . . .  G4
+       P. S. Browne . . . . . . . . . . . . . . . . . . . . .  E2
+
+       S. Carr  . . . . . . . . . . . . . . . . . . . . . . .  F7
+       V. Cerf  . . . . . . . . . . . . . . . . . . . . . .C1, F7
+       W. S. Chou  . . . . . . . . . . . . . . . . . .G10,G11,G12
+       W. W. Chu . . . . . . . . . . . . . . . . . . . . . .   D1
+       CODASYL . . . . . . . . . . . . . . . . . . . . . .  B3,B4
+       E. F. Codd  . . . . . . . . . . . . . . . . . . . . .   A2
+       E. G. Coffman . . . . . . . . . . . . . . . . . . . D2,G38
+       I. Cohen  . . . . . . . . . . . . . . . . . . . . . .   G5
+       G. D. Cole  . . . . . . . . . . . . . . . . . . . . . . G6
+       Computer Sciences Corp. . . . . . . . . . . . . . . . . F8
+       P. R. Cox   . . . . . . . . . . . . . . . . . . . . . . G7
+       S. Crocker  . . . . . . . . . . . . . . . . . . . . . . F7
+       W. Crowther . . . . . . . . . . . . . . . . .  G17,G19,G20
+       K. Curewitz  . . . . . . . . . . . . . . . . . . . . .  D8
+
+       J. M. Daniels  . . . . . . . . . . . . . . . . . . . .  D3
+       C. J. Date  . . . . . . . . . . . . . . . . . . . .  B5,B6
+       C. T. Davies  . . . . . . . . . . . . . . . . . . . .   A3
+       D. W. Davies  . . . . . . . . . . . . . . . . . . . F9,F10
+       A. L. Dean, Jr  . . . . . . . . . . . . . . . . . . . . E3
+       J. B. Dennis  . . . . . . . . . . . . . . . . . . . . . B7
+       D. R. Doll  . . . . . . . . . . . . . . . . . . . . F11,G8
+       M. Donaldson  . . . . . . . . . . . . . . . . . . . . . B8
+
+
+
+
+
+Mullery                                                        [Page 12]
+
+RFC 290     Computer Networks and Data Sharing Bibliography January 1972
+
+
+       J. Earley  . . . . . . . . . . . . . . . . . . . . . .  A4
+       M. Ellis . . . . . . . . . . . . . . . . . . . . . . .  B9
+       M. J. Elphick  . . . . . . . . . . . . . . . . . . . .  D2
+       D. Evans . . . . . . . . . . . . . . . . . . . . . . . B10
+
+       J. A. Feldman  . . . . . . . . . . . . . . . . . . . .  A8
+       H. Frank . . . . . . . . . . . . . . . . . F12,G10,G11,G12
+       D. Fredericksen  . . . . . . . . . . . . . . . . . . . G13
+       T. D. Friedman . . . . . . . . . . . . . . . . . . . .  E4
+       I. T. Frisch . . . . . . . . . . . . . . . . . G10,G11,G12
+       D.M. Frumin  . . . . . . . . . . . . . . . . . . . . . F17
+       G. A. Gibson . . . . . . . . . . . . . . . . . . . . . B11
+       R. M. Graham . . . . . . . . . . . . . . . . . . . . .  E5
+       R. C. Gunderson  . . . . . . . . . . . . . . . . . . . G14
+
+       A. N. Haberman . . . . . . . . . . . . . . . . . . . .  D4
+       L. Haibt . . . . . . . . . . . . . . . . . . . . . . . B12
+       R. M. Hammaker . . . . . . . . . . . . . . . . . . . . G15
+       E. Hansler . . . . . . . . . . . . . . . . . . . . . . G16
+       E. F. Harslem  . . . . . . . . . . . . . . . . . . . .  C1
+       J. W. Havender . . . . . . . . . . . . . . . . . . . .  D5
+       J. F. Heafner. . . . . . . . . . . . . . . . . . . . .  C1
+       F. Heart . . . . . . . . . . . . . . . . . . . . . . . G17
+       P. G. Hebalkar . . . . . . . . . . . . . . . . . . . .  D6
+       L. J. Hoffman  . . . . . . . . . . . . . . . . . . . E6,E7
+       A. W. Holt . . . . . . . . . . . . . . . . . . . . . . B13
+       P. Hopewell. . . . . . . . . . . . . . . . . . . . . B5,B6
+
+       J. D. Irwin  . . . . . . . . . . . . . . . . . . . . .  D3
+
+       M. E. Jacobs . . . . . . . . . . . . . . . . . . . . . F13
+       J. F. Jaffee . . . . . . . . . . . . . . . . . . . . . G36
+       J. O. Johnson. . . . . . . . . . . . . . . . . . . . . G14
+
+       R. Kahn . . . . . . . . . . . . . . . . . . . .G17,G19,G20
+       D. Karp . . . . . . . . . . . . . . . . . .F14,G26,G27,G28
+       M. Kay. . . . . . . . . . . . . . . . . . . . . . . . . A5
+       B. F. Kipurov . . . . . . . . . . . . . . . . . . . .  F17
+       L. Kleinrock. . . . . . . . . . . . . . . . . . . .G21,G22
+       D. C. Knight  . . . . . . . . . . . . . . . . . . . . .G35
+
+       B. W. Lampson . . . . . . . . . . . . . . . . . . . .D7,E8
+       D. E. Lawrence. . . . . . . . . . . . . . . . . . . .  G23
+       A. L. Leiner. . . . . . . . . . . . . . . . . . . . .  G24
+       G. J. Lipovsky  . . . . . . . . . . . . . . . . . . .  B14
+       J. L. Little  . . . . . . . . . . . . . . . . . . .F15,F16
+       V. U. Lum . . . . . . . . . . . . . . . . . . . . . .  D11
+
+
+
+
+Mullery                                                        [Page 13]
+
+RFC 290     Computer Networks and Data Sharing Bibliography January 1972
+
+
+       J. Madden . . . . . . . . . . . . . . . . . . . . . . . C1
+       S. E. Madnick . . . . . . . . . . . . . . . . . . . . . A6
+       T. Marill . . . . . . . . . . . . . . . . . . . . . D8,G25
+       S. Marshall . . . . . . . . . . . . . . . . . . . . . . C2
+       N. F. McAllister  . . . . . . . . . . . . . . . . . . .F19
+       G. K. McAuliffe . . . . . . . . . . . . . . . . . . . .G16
+       W. C. McGee . . . . . . . . . . . . . . . . . . . . . . A7
+       D. B. McKay . . . . . . . . . . . . . . . . . .G26,G27,G28
+       S. F. Mendicino . . . . . . . . . . . . . . .  . . . . G29
+       R. Metcalf  . . . . . . . . . . . . . . . . . . . . . . C1
+       R. E. Millstein . . . . . . . . . . . . . . . . . . . . C2
+       MIT . . . . . . . . . . . . . . . . . . . . . . . . . .G30
+       C. N. Mooers. . . . . . . . . . . . . . . . . .B15,B16,F16
+       H. R. Morse . . . . . . . . . . . . . . . . . . . . .  B17
+       A. P. Mullery . . . . . . . . . . . . . . . . . . . .  B12
+       J. E. Murphy. . . . . . . . . . . . . . . . . . . . .   D9
+
+       R. S. Nachbar . . . . . . . . . . . . . . . . . . . .  G28
+       K. Nelson . . . . . . . . . . . . . . . . . . . . . .   B9
+       W. A. Notz. . . . . . . . . . . . . . . . . . . . . .  G24
+
+       A. K. Olefir. . . . . . . . . . . . . . . . . . . . .  F17
+       S. Ornstein . . . . . . . . . . . . . . . . . . . . .  G17
+       P. J. Owens . . . . . . . . . . . . . . . . . . . .D10,D11
+       R. C. Owens, Jr.. . . . . . . . . . . . . . . . . . . . E9
+
+       S. S. Patil . . . . . . . . . . . . . . . . . . . . .  G31
+       P. L. Peck, Jr. . . . . . . . . . . . . . . . . .  E10,G32
+       B. Peters . . . . . . . . . . . . . . . . . . . . . .  E11
+       H. E. Petersen. . . . . . . . . . . . . . . . . . . .  E14
+
+       J. L. Redding . . . . . . . . . . . . . . . . . . . .  G33
+       L. G. Roberts . . . . . . . . . . . . . . . . . .  G25,G34
+       S. Robinovitz . . . . . . . . . . . . . . . . . . . . . B8
+       P. D. Rovner  . . . . . . . . . . . . . . . . . . . . . A8
+       J. J. Russel  . . . . . . . . . . . . . . . . . . . .  G35
+       R. M. Rutledge. . . . . . . . . . . . . . . . . . . .  G36
+       R. W. Ryniker . . . . . . . . . . . . . . . . . . . .  G13
+
+       J. H. Saltzer . . . . . . . . . . . . . . . . . . . .  E12
+       K. Sattley. . . . . . . . . . . . . . . . . . . . . . . C2
+       R. A. Scantlebury . . . . . . . . . . . . . . . . .F18,F20
+       M. Shaefer. . . . . . . . . . . . . . . . . . . . . B18,C3
+       M. D. Schroeder . . . . . . . . . . . . . . . . . . .  E12
+       M. E. Senko . . . . . . . . . . . . . . . . . . . . .  D11
+       S. Seroussi . . . . . . . . . . . . . . . . . . . .F14,G36
+       J. F. Sherlock. . . . . . . . . . . . . . . . . . . .  G37
+       A. Shoshani . . . . . . . . . . . . . . . . .C1,D2,D12,G38
+
+
+
+Mullery                                                        [Page 14]
+
+RFC 290     Computer Networks and Data Sharing Bibliography January 1972
+
+
+       R. O. Skatrud . . . . . . . . . . . . . . . . . . . .  E13
+       D. P. Smith . . . . . . . . . . . . . . . . . . . .B19,B20
+       J. L. Smith . . . . . . . . . . . . . . . . . . . . .  G24
+       T. A. Standish. . . . . . . . . . . . . . . . . . . .  B21
+       D. Steinauer. . . . . . . . . . . . . . . . . . . . . . E2
+       R. H. Stotz . . . . . . . . . . . . . . . . . . . . . . F6
+       A. J. Strnad. . . . . . . . . . . . . . . . . . . . . .D13
+       S. Y. W. Su . . . . . . . . . . . . . . . . . . . . . . A5
+
+       Yu. I. Torgov . . . . . . . . . . . . . . . . . . . . . G1
+       P. J. Trafton . . . . . . . . . . . . . . . . . . . .  F19
+       R. Turn . . . . . . . . . . . . . . . . . . . . . . .  E14
+
+       A. VanDam . . . . . . . . . . . . . . . . . . . . . .  B10
+       R. R. VanSlyke  . . . . . . . . . . . . . . . . .  G11,G12
+       A. L. Vareha . . . . . . . . . . . . . . . . . . . . . G36
+       L. C. Varian . . . . . . . . . . . . . . . . . . . . . G36
+
+
+       W. H. Ware . . . . . . . . . . . . . . . . . . . . E15,E16
+       B. Wegbreit . . . . . . . . . . . . . . . . . . .  B22,B23
+       A. Weinberger . . . . . . . . . . . . . . . . . . . .  G24
+       A. H. Weis . . . . . . . . . . . . . . . . . . . . G36,G39
+       B. D. Wessler  . . . . . . . . . . . . . . . . . . . . G34
+       J. White . . . . . . . . . . . . . . . . . . . . . . .  C1
+       V. K. M. Whitney . . . . . . . . . . . . . . . . . . . D14
+       P. T. Wilkinson . . . . . . . . . . . . . . . . . F18, F20
+       R. S. Wilkov  . . . . . . . . . . . . . . . . . . . .  G16
+       B. Wolfe  . . . . . . . . . . . . . . . . . . . . . . . B8
+       D. Wood . . . . . . . . . . . . . . . . . . . . . . . . C1
+
+       L. P. Yukhnevich  . . . . . . . . . . . . . . . . . .  F17
+
+
+
+
+        [This RFC was put into machine readable form for entry]
+     [into the online RFC archives by Kelly Tardif, Viagénie 10/99]
+
+
+
+
+
+
+
+
+
+
+
+
+
+Mullery                                                        [Page 15]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc290.txt](<www.ietf.org/rfc/rfc290.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
