### PR TITLE
Archive rfc291.txt

### DIFF
--- a/www.ietf.org/rfc/rfc291.txt
+++ b/www.ietf.org/rfc/rfc291.txt
@@ -1,0 +1,112 @@
+
+
+
+
+
+
+Network Working Group                          14 January 1972
+Request for Comments 291                       D. B. McKay, IBM
+NIC                 8301                       (Area Code 914)- 945-1159
+Categories:  A.2, D.4, D.7
+
+
+                  Data Management Meeting Announcement
+                  ------------------------------------
+
+
+        Mitre will host a Network Data Management Meeting, February 23,
+   24.  As a follow-on from past meetings, the meeting is being held to
+   accomplish two objectives.  As a result of the first data management
+   meeting in Aug- ust, the general consensus was a need to learn about
+   applications of net- work data facilities, and how networks will
+   better help users achieve their objectives.  There are several people
+   that have expressed an inter- est in discussing applications.  The
+   attached schedule is a list of people who have agreed to talk.  If
+   anyone knows of other people interested in discussing applications,
+   please have them contact me.
+
+        Secondly, the meeting will discuss and try to arrive at a
+   specifica- tion for a network data management protocol.  It was
+   decided that the best way to come up with a design would be to discuss
+   a tentative written proposal or proposals.  I will try and have copies
+   of a written proposal available to meeting attendees before the
+   meeting date.  I would like to encourage anyone else interested in
+   submitting a 3rd level protocol for sharing network data to do so.
+
+        The protocol design would hopefully achieve the objectives of a
+   data facility described in stage 2 of RFC-146.
+
+        Since the facilities are limited and the second half of the
+   meeting is to be a working session, it will be necessary to limit the
+   attendance.  First priority will be the people or representatives from
+   groups that have participated in the past two meetings.  I will inform
+   any other people who contact me of any openings.
+
+        All reservations should be made by contacting Mrs. Madeline
+   Cornell at Mitre, Telephone (Area Code 703) 893-3500 Extension 2395 as
+   soon as possible.
+
+
+                                        D. B. McKay
+
+
+   DBM:eb
+
+
+
+
+                                                                [Page 1]
+
+                 LIST OF SPEAKERS FOR FEBRUARY 23, 1972
+                 --------------------------------------
+
+Captain Roger Moore - U.S.Army R&D Command
+
+     Sharing and Accessing of medical files at all specialized locations.
+
+
+
+Dr. John Senior - National Medical Board of Examiners
+
+     Dr. Senior will discuss their need to access all test results at
+     the various medical testing centers across the country.
+
+
+
+Thomas McCauley* - Hughes Aircraft
+
+     Mr. McCauley will discuss applications they are familiar with in
+     their work at Hughes.
+
+
+
+Dick Watson - SRI-NIC
+
+     Mr. Watson will discuss the advantages and the feasibility of dis-
+     tributing parts of NIC through the network.
+
+
+
+Undecided as yet - MITRE
+
+     A discussion of MITRE's work in designing a system for IRS.
+
+
+*Tentative.
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+                                                                [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc291.txt](<www.ietf.org/rfc/rfc291.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
