### PR TITLE
Archive rfc293.txt

### DIFF
--- a/www.ietf.org/rfc/rfc293.txt
+++ b/www.ietf.org/rfc/rfc293.txt
@@ -1,0 +1,167 @@
+
+
+
+
+
+
+Network Working Group                           Ellen Westheimer
+RFC #293                                        BBN
+NIC #8303                                       18 January 1972
+Categories:  F, G.3
+Updates:  RFC 288
+Obsoletes: None
+
+                          NETWORK HOST STATUS
+
+     This RFC reports on the status of most Network Hosts from January
+3 to January 15.
+
+     Several Hosts are currently excluded from the daily testing.
+These Hosts fall into two categories:
+
+1) Hosts which are not expected to be functioning on the Network as
+servers (available for use from other sites) on a regular basis for at
+least two weeks.  Included here are:
+
+       Network
+       Address                Site            Computer
+       -------                ----            --------
+         133                  BBN             PDP-10 (B)
+           8*                 SDC             IBM-370/155
+          13                  Case            PDP-10
+          15                  Ames/(Paoli)    ILLIAC-(B6500)
+
+2) Hosts which are currently intended to be users only.  Included here
+are the Terminal IMPs, which are presently in the Network (AMES,
+MITRE, NBS and BBN**).  This category also includes the Network
+Control Center Computer (Network Address 5) which is used solely for
+gathering statistics from the Network.  Finally, included among these
+Hosts are the following:
+
+       Network
+       Address                Site            Computer
+       -------                ----            --------
+          7                  Rand            IBM-360/65
+         73                  Harvard         PDP-1
+         12                  Illinois        PDP-11
+         19                  NBS             PDP-11
+
+     The tables on the next two pages summarize the Host status for
+this period.
+______________
+
+
+
+
+
+
+                                                                [Page 1]
+
+*The SDC site is currently replacing their IBM 360/67 by an IBM
+370/155.  This site therefore is temporarily without any permanent
+Host on the network, and for this reason was not included in the daily
+testing for the preceding two weeks.
+**The BBN Terminal IMP (Network Address 158) is a prototype and as
+such is frequently not connected to the Network, but being used to
+refine and debug the Terminal IMP programs.
+
+< In the original, the tables on this and the following page were typed >
+< in "landscape" format.  For this online version the tables are        >
+< compressed horizontally to fit on a "portrait"-oriented page          >
+
+                                                              "STATUS OR
+NETWORK                                                       PREDICTION"
+ADDRESS  SITE          COMPUTER      STATUS OR PREDICTION     OBTAINED FROM
+-------  ----          --------      --------------------     -------------
+
+   1     UCLA          SIGMA-7       Server                   Jon Postel
+  65     UCLA          IBM-360/91    Remote Job Service now,  Bob Braden
+                                      Telnet in April
+   2     SRI(NIC)      PDP-10        Server                   John Melvin
+  66     SRI(AI)       PDP-10        "Soon"                   Len Chaiten
+   3     UCSB          IBM-360/75    Server                   Jim White
+  *5     BBN(NCC)      DDP-516       Never                    Barry Wessler
+  69     BBN(TENEX-A)  PDP-10        Server                   Alex McKenzie
+*133     BBN(TENEX-B)  PDP-10        Server(Exper.)           Dan Murphy
+   6     MIT(Multics)  H-645         Server                   Mike Padlipsky
+  70     MIT(DM)       PDP-10        Server                   Bob Bressler
+  *7     RAND          IBM-360/65    User Only                Eric Harslem
+  71     RAND          PDP-10        "Soon"                   Eric Harslem
+  *8     SDC           IBM-360/67    Server                   Bob Long
+   9     HARVARD       PDP-10        Server                   Bob Sundberg
+ *73     HARVARD       PDP-1         User Only                Bob Sundberg
+  10     LINCOLN       IBM-360/67    "Soon"                   Joel Winett
+  74     LINCOLN       TX2           Server                   Will Kantrowitz
+  11     STANFORD      PDP-10        "Soon"                   Andy Moorer
+ *12     ILLINOIS      PDP-11        User Only                John Cravits
+ *13     CASE          PDP-10        March                    Charles Rose
+  14     CARNEGIE      PDP-10        "Soon"                   Hal VanZoeren
+ *15     AMES/(PAOLI)  ILLIAC/(B6500) September               John McConnell
+  16     AMES          IBM-360/67    "Soon"                   Wayne Hathaway
+*144     AMES          TIP            User Only
+*145     MITRE         TIP            User Only
+ *19     NBS           PDP-11         User Only               Robert Rosenthal
+*147     NBS           TIP            User Only
+*158     BBN           TIP(Prototype) User Only
+
+* Host not included in daily testing
+
+
+
+                                                                [Page 2]
+
+NET
+ADDR SITE     COMPUTER             DATE AND TIME (EASTERN)
+---- ----     --------             -----------------------
+
+                          1/3  1/4  1/5  1/6  1/7  1/10 1/11 1/12 1/14 1/15
+                          1700 1330 1200 1800 0900 1730 1030 1030 1800 1000
+ 1  UCLA(NMC) SIGMA-7       O    O   #D    O    O    O    O   #D    O    O
+65  UCLA(CCN) IBM-360/91    O    O    O    D   #D    O    O    O    O    D
+ 2  SRI(NIC)  PDP-10        O   #D    O    O    D    O    O    O    T    O
+66  SRI(AI)   PDP-10        D    D    D    D    D    D    D    D    D    D
+ 3  UCSB      IBM-360/75    D    D   #D    O    O    D    D   #D    D    D
+ 4  UTAH      PDP-10        D    D   #D    O    O    D    D   #D    D    D
+69  BBN(10X-A)PDP-10        O    O    H    O    O    O    O    O    D    T
+ 6  MIT(Multics)H-645       O    D    D    D    O    O    O    D    T    O
+70  MIT(DM)   PDP-10        O    O    O    T    O    O    D    D    O    T
+71  RAND      PDP-10        T    D    D    T    D    D    D    D    D    D
+ 9  HARVARD   PDP-10       #T   #D    O   #D    D   #D    O    T   #D    O
+10  LL        IBM-360/67    D    T    H    D    D    D    H    D    D    H
+74  LL        TX-2          H    H   #D    T    D    O    H   #D    O    O
+11  STANFORD  PDP-10        D    D    D    D    D    D    D    D    D    D
+14  CARNEGIE  PDP-10        D    T    D    D    D    D    D    D    D    H
+16  AMES      IBM-360/67    D    D    D    D    D    D    D    D    D    H
+
+where
+D =  Dead (Destination Host either dead or inaccessible [due to network
+     partitioning or local IMP failure] from the BBN Terminal IMP.)
+
+H =  1/2 Open (Destination Host opened a connection but then either
+     immediately closed it, or did not respond any further.)
+
+O =  Open (Destination Host opened a connection and was accessible to users.)
+
+R =  Refused (Destination Host returned a CLS to the initial RFC.)
+
+T = Timed out (Destination Host did not complete the ICP and open a
+    connection within 60 seconds.
+
+*The only service currently offered by the UCLA IBM-360/91 is a Network Job
+Service (NETRJS), however, the BBN Terminal IMP is not equipped to test
+NETRJS.  We are assuming that initial connection to the NETRJS logger
+indicates that NETRJS is also functioning.
+
+#These sites advertise that they may not have their system available at these
+times.
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+                                                                [Page 3]
+
+        [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc293.txt](<www.ietf.org/rfc/rfc293.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
