### PR TITLE
Archive rfc2933.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2933.txt
+++ b/www.ietf.org/rfc/rfc2933.txt
@@ -1,0 +1,1067 @@
+
+
+
+
+
+
+Network Working Group                                     K. McCloghrie
+Request for Comments: 2933                                cisco Systems
+Category: Standards Track                                  D. Farinacci
+                                                       Procket Networks
+                                                              D. Thaler
+                                                              Microsoft
+                                                           October 2000
+
+
+                 Internet Group Management Protocol MIB
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2000).  All Rights Reserved.
+
+Abstract
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the Internet community.
+   In particular, it describes objects used for managing the Internet
+   Group Management Protocol (IGMP).
+
+Table of Contents
+
+    1 Introduction ................................................  1
+    2 The SNMP Network Management Framework .......................  2
+    3 Overview ....................................................  3
+    4 Definitions .................................................  3
+    5 Security Considerations ..................................... 14
+    6 Intellectual Property Notice ................................ 15
+    7 Acknowledgements ............................................ 15
+    8 Authors' Addresses .......................................... 16
+    9 References .................................................. 17
+   10 Full Copyright Statement .................................... 19
+
+1.  Introduction
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the Internet community.
+   In particular, it describes objects used for managing the Internet
+
+
+
+McCloghrie, et al.          Standards Track                     [Page 1]
+
+RFC 2933         Internet Group Management Protocol MIB     October 2000
+
+
+   Group Management Protocol (IGMP), version 1 [16] or version 2 [17].
+   A future version of this MIB will support IGMP version 3 (currently a
+   work in progress).  All of this MIB module is applicable to IPv4
+   multicast routers; a subset is applicable to hosts implementing IGMP.
+   Since IGMP is specific to IPv4, this MIB does not support management
+   of equivalent functionality for other address families, such as IPv6.
+   Such management may be supported by other MIBs.
+
+2.  The SNMP Network Management Framework
+
+   The SNMP Management Framework presently consists of five major
+   components:
+
+   o    An overall architecture, described in RFC 2571 [1].
+
+   o    Mechanisms for describing and naming objects and events for the
+        purpose of management.  The first version of this Structure of
+        Management Information (SMI) is called SMIv1 and described in
+        STD 16, RFC 1155 [2], STD 16, RFC 1212 [3] and RFC 1215 [4].
+        The second version, called SMIv2, is described in STD 58, RFC
+        2578 [5], STD 58, RFC 2579 [6] and STD 58, RFC 2580 [7].
+
+   o    Message protocols for transferring management information.  The
+        first version of the SNMP message protocol is called SNMPv1 and
+        described in STD 15, RFC 1157 [8].  A second version of the SNMP
+        message protocol, which is not an Internet standards track
+        protocol, is called SNMPv2c and described in RFC 1901 [9] and
+        RFC 1906 [10].  The third version of the message protocol is
+        called SNMPv3 and described in RFC 1906 [10], RFC 2572 [11] and
+        RFC 2574 [12].
+
+   o    Protocol operations for accessing management information.  The
+        first set of protocol operations and associated PDU formats is
+        described in STD 15, RFC 1157 [8].  A second set of protocol
+        operations and associated PDU formats is described in RFC 1905
+        [13].
+
+   o    A set of fundamental applications described in RFC 2573 [14] and
+        the view-based access control mechanism described in RFC 2575
+        [15].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  Objects in the MIB are
+   defined using the mechanisms defined in the SMI.
+
+   This memo specifies a MIB module that is compliant to the SMIv2.  A
+   MIB conforming to the SMIv1 can be produced through the appropriate
+   translations.  The resulting translated MIB must be semantically
+
+
+
+McCloghrie, et al.          Standards Track                     [Page 2]
+
+RFC 2933         Internet Group Management Protocol MIB     October 2000
+
+
+   equivalent, except where objects or events are omitted because no
+   translation is possible (use of Counter64).  Some machine readable
+   information in SMIv2 will be converted into textual descriptions in
+   SMIv1 during the translation process.  However, this loss of machine
+   readable information is not considered to change the semantics of the
+   MIB.
+
+3.  Overview
+
+   This MIB module contains two tables:
+
+   (1)  the IGMP Interface Table which contains one row for each
+        interface on which IGMP is enabled, and
+
+   (2)  the IGMP Cache Table which contains one row for each IP
+        multicast group for which there are members on a particular
+        interface.
+
+   Both tables are intended to be implemented by hosts and routers, but
+   some columnar objects in each table apply only to routers.
+
+4.  Definitions
+
+IGMP-STD-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, mib-2, Counter32, Gauge32,
+    Unsigned32, IpAddress, TimeTicks FROM SNMPv2-SMI
+    RowStatus, TruthValue            FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP  FROM SNMPv2-CONF
+    InterfaceIndexOrZero,
+    InterfaceIndex                   FROM IF-MIB;
+
+igmpStdMIB MODULE-IDENTITY
+    LAST-UPDATED "200009280000Z" -- September 28, 2000
+    ORGANIZATION "IETF IDMR Working Group."
+    CONTACT-INFO
+            " Dave Thaler
+              Microsoft Corporation
+              One Microsoft Way
+              Redmond, WA  98052-6399
+              US
+
+              Phone: +1 425 703 8835
+              EMail: dthaler@microsoft.com"
+    DESCRIPTION
+            "The MIB module for IGMP Management."
+    REVISION     "200009280000Z" -- September 28, 2000
+
+
+
+McCloghrie, et al.          Standards Track                     [Page 3]
+
+RFC 2933         Internet Group Management Protocol MIB     October 2000
+
+
+    DESCRIPTION
+            "Initial version, published as RFC 2933."
+    ::= { mib-2 85 }
+
+
+igmpMIBObjects     OBJECT IDENTIFIER ::= { igmpStdMIB 1 }
+
+--
+--  The IGMP Interface Table
+--
+
+igmpInterfaceTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF IgmpInterfaceEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The (conceptual) table listing the interfaces on which IGMP
+            is enabled."
+    ::= { igmpMIBObjects 1 }
+
+igmpInterfaceEntry OBJECT-TYPE
+    SYNTAX     IgmpInterfaceEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "An entry (conceptual row) representing an interface on
+            which IGMP is enabled."
+    INDEX      { igmpInterfaceIfIndex }
+    ::= { igmpInterfaceTable 1 }
+
+IgmpInterfaceEntry ::= SEQUENCE {
+    igmpInterfaceIfIndex               InterfaceIndex,
+    igmpInterfaceQueryInterval         Unsigned32,
+    igmpInterfaceStatus                RowStatus,
+    igmpInterfaceVersion               Unsigned32,
+    igmpInterfaceQuerier               IpAddress,
+    igmpInterfaceQueryMaxResponseTime  Unsigned32,
+    igmpInterfaceQuerierUpTime         TimeTicks,
+    igmpInterfaceQuerierExpiryTime     TimeTicks,
+    igmpInterfaceVersion1QuerierTimer  TimeTicks,
+    igmpInterfaceWrongVersionQueries   Counter32,
+    igmpInterfaceJoins                 Counter32,
+    igmpInterfaceProxyIfIndex          InterfaceIndexOrZero,
+    igmpInterfaceGroups                Gauge32,
+    igmpInterfaceRobustness            Unsigned32,
+    igmpInterfaceLastMembQueryIntvl    Unsigned32
+}
+
+
+
+
+McCloghrie, et al.          Standards Track                     [Page 4]
+
+RFC 2933         Internet Group Management Protocol MIB     October 2000
+
+
+igmpInterfaceIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The ifIndex value of the interface for which IGMP is
+            enabled."
+    ::= { igmpInterfaceEntry 1 }
+
+igmpInterfaceQueryInterval OBJECT-TYPE
+    SYNTAX     Unsigned32
+    UNITS      "seconds"
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+            "The frequency at which IGMP Host-Query packets are
+            transmitted on this interface."
+    DEFVAL     { 125 }
+    ::= { igmpInterfaceEntry 2 }
+
+igmpInterfaceStatus OBJECT-TYPE
+    SYNTAX     RowStatus
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+            "The activation of a row enables IGMP on the interface.  The
+            destruction of a row disables IGMP on the interface."
+    ::= { igmpInterfaceEntry 3 }
+
+igmpInterfaceVersion OBJECT-TYPE
+    SYNTAX     Unsigned32
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+            "The version of IGMP which is running on this interface.
+            This object can be used to configure a router capable of
+            running either value.  For IGMP to function correctly, all
+            routers on a LAN must be configured to run the same version
+            of IGMP on that LAN."
+    DEFVAL     { 2 }
+    ::= { igmpInterfaceEntry 4 }
+
+igmpInterfaceQuerier OBJECT-TYPE
+    SYNTAX     IpAddress
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The address of the IGMP Querier on the IP subnet to which
+
+
+
+McCloghrie, et al.          Standards Track                     [Page 5]
+
+RFC 2933         Internet Group Management Protocol MIB     October 2000
+
+
+            this interface is attached."
+    ::= { igmpInterfaceEntry 5 }
+
+igmpInterfaceQueryMaxResponseTime OBJECT-TYPE
+    SYNTAX     Unsigned32 (0..255)
+    UNITS      "tenths of seconds"
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+            "The maximum query response time advertised in IGMPv2
+            queries on this interface."
+    DEFVAL     { 100 }
+    ::= { igmpInterfaceEntry 6 }
+
+igmpInterfaceQuerierUpTime OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The time since igmpInterfaceQuerier was last changed."
+    ::= { igmpInterfaceEntry 7 }
+
+igmpInterfaceQuerierExpiryTime OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The amount of time remaining before the Other Querier
+            Present Timer expires.  If the local system is the querier,
+            the value of this object is zero."
+    ::= { igmpInterfaceEntry 8 }
+
+igmpInterfaceVersion1QuerierTimer OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The time remaining until the host assumes that there are no
+            IGMPv1 routers present on the interface.  While this is non-
+            zero, the host will reply to all queries with version 1
+            membership reports."
+    ::= { igmpInterfaceEntry 9 }
+
+igmpInterfaceWrongVersionQueries OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+
+
+
+McCloghrie, et al.          Standards Track                     [Page 6]
+
+RFC 2933         Internet Group Management Protocol MIB     October 2000
+
+
+            "The number of queries received whose IGMP version does not
+            match igmpInterfaceVersion, over the lifetime of the row
+            entry.  IGMP requires that all routers on a LAN be
+            configured to run the same version of IGMP.  Thus, if any
+            queries are received with the wrong version, this indicates
+            a configuration error."
+    ::= { igmpInterfaceEntry 10 }
+
+igmpInterfaceJoins OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of times a group membership has been added on
+            this interface; that is, the number of times an entry for
+            this interface has been added to the Cache Table.  This
+            object gives an indication of the amount of IGMP activity
+            over the lifetime of the row entry."
+    ::= { igmpInterfaceEntry 11 }
+
+igmpInterfaceProxyIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndexOrZero
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+            "Some devices implement a form of IGMP proxying whereby
+            memberships learned on the interface represented by this
+            row, cause IGMP Host Membership Reports to be sent on the
+            interface whose ifIndex value is given by this object.  Such
+            a device would implement the igmpV2RouterMIBGroup only on
+            its router interfaces (those interfaces with non-zero
+            igmpInterfaceProxyIfIndex).  Typically, the value of this
+            object is 0, indicating that no proxying is being done."
+    DEFVAL     { 0 }
+    ::= { igmpInterfaceEntry 12 }
+
+igmpInterfaceGroups OBJECT-TYPE
+    SYNTAX     Gauge32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The current number of entries for this interface in the
+            Cache Table."
+    ::= { igmpInterfaceEntry 13 }
+
+igmpInterfaceRobustness OBJECT-TYPE
+    SYNTAX     Unsigned32 (1..255)
+    MAX-ACCESS read-create
+
+
+
+McCloghrie, et al.          Standards Track                     [Page 7]
+
+RFC 2933         Internet Group Management Protocol MIB     October 2000
+
+
+    STATUS     current
+    DESCRIPTION
+            "The Robustness Variable allows tuning for the expected
+            packet loss on a subnet.  If a subnet is expected to be
+            lossy, the Robustness Variable may be increased.  IGMP is
+            robust to (Robustness Variable-1) packet losses."
+    DEFVAL     { 2 }
+    ::= { igmpInterfaceEntry 14 }
+
+igmpInterfaceLastMembQueryIntvl OBJECT-TYPE
+    SYNTAX     Unsigned32 (0..255)
+    UNITS      "tenths of seconds"
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+            "The Last Member Query Interval is the Max Response Time
+            inserted into Group-Specific Queries sent in response to
+            Leave Group messages, and is also the amount of time between
+            Group-Specific Query messages.  This value may be tuned to
+            modify the leave latency of the network.  A reduced value
+            results in reduced time to detect the loss of the last
+            member of a group.  The value of this object is irrelevant
+            if igmpInterfaceVersion is 1."
+    DEFVAL     { 10 }
+    ::= { igmpInterfaceEntry 15 }
+
+--
+--  The IGMP Cache Table
+--
+
+igmpCacheTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF IgmpCacheEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The (conceptual) table listing the IP multicast groups for
+            which there are members on a particular interface."
+    ::= { igmpMIBObjects 2 }
+
+igmpCacheEntry OBJECT-TYPE
+    SYNTAX     IgmpCacheEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "An entry (conceptual row) in the igmpCacheTable."
+    INDEX      { igmpCacheAddress, igmpCacheIfIndex }
+    ::= { igmpCacheTable 1 }
+
+
+
+
+McCloghrie, et al.          Standards Track                     [Page 8]
+
+RFC 2933         Internet Group Management Protocol MIB     October 2000
+
+
+IgmpCacheEntry ::= SEQUENCE {
+    igmpCacheAddress            IpAddress,
+    igmpCacheIfIndex            InterfaceIndex,
+    igmpCacheSelf               TruthValue,
+    igmpCacheLastReporter       IpAddress,
+    igmpCacheUpTime             TimeTicks,
+    igmpCacheExpiryTime         TimeTicks,
+    igmpCacheStatus             RowStatus,
+    igmpCacheVersion1HostTimer  TimeTicks
+}
+
+igmpCacheAddress OBJECT-TYPE
+    SYNTAX     IpAddress
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The IP multicast group address for which this entry
+            contains information."
+    ::= { igmpCacheEntry 1 }
+
+igmpCacheIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The interface for which this entry contains information for
+            an IP multicast group address."
+    ::= { igmpCacheEntry 2 }
+
+igmpCacheSelf OBJECT-TYPE
+    SYNTAX     TruthValue
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+            "An indication of whether the local system is a member of
+            this group address on this interface."
+    DEFVAL     { true }
+    ::= { igmpCacheEntry 3 }
+
+igmpCacheLastReporter OBJECT-TYPE
+    SYNTAX     IpAddress
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The IP address of the source of the last membership report
+            received for this IP Multicast group address on this
+            interface.  If no membership report has been received, this
+            object has the value 0.0.0.0."
+
+
+
+McCloghrie, et al.          Standards Track                     [Page 9]
+
+RFC 2933         Internet Group Management Protocol MIB     October 2000
+
+
+    ::= { igmpCacheEntry 4 }
+
+igmpCacheUpTime OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The time elapsed since this entry was created."
+    ::= { igmpCacheEntry 5 }
+
+igmpCacheExpiryTime OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The minimum amount of time remaining before this entry will
+            be aged out.  A value of 0 indicates that the entry is only
+            present because igmpCacheSelf is true and that if the router
+            left the group, this entry would be aged out immediately.
+            Note that some implementations may process membership
+            reports from the local system in the same way as reports
+            from other hosts, so a value of 0 is not required."
+    ::= { igmpCacheEntry 6 }
+
+igmpCacheStatus OBJECT-TYPE
+    SYNTAX     RowStatus
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+            "The status of this entry."
+    ::= { igmpCacheEntry 7 }
+
+igmpCacheVersion1HostTimer OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The time remaining until the local router will assume that
+            there are no longer any IGMP version 1 members on the IP
+            subnet attached to this interface.  Upon hearing any IGMPv1
+            Membership Report, this value is reset to the group
+            membership timer.  While this time remaining is non-zero,
+            the local router ignores any IGMPv2 Leave messages for this
+            group that it receives on this interface."
+    ::= { igmpCacheEntry 8 }
+
+-- conformance information
+
+
+
+
+McCloghrie, et al.          Standards Track                    [Page 10]
+
+RFC 2933         Internet Group Management Protocol MIB     October 2000
+
+
+igmpMIBConformance
+               OBJECT IDENTIFIER ::= { igmpStdMIB 2 }
+igmpMIBCompliances
+               OBJECT IDENTIFIER ::= { igmpMIBConformance 1 }
+igmpMIBGroups  OBJECT IDENTIFIER ::= { igmpMIBConformance 2 }
+
+
+-- compliance statements
+
+igmpV1HostMIBCompliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+            "The compliance statement for hosts running IGMPv1 and
+            implementing the IGMP MIB."
+    MODULE  -- this module
+    MANDATORY-GROUPS { igmpBaseMIBGroup }
+
+    OBJECT     igmpInterfaceStatus
+    MIN-ACCESS read-only
+    DESCRIPTION
+             "Write access is not required."
+
+    OBJECT     igmpCacheStatus
+    MIN-ACCESS read-only
+    DESCRIPTION
+             "Write access is not required."
+
+    ::= { igmpMIBCompliances 1 }
+
+igmpV1RouterMIBCompliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+            "The compliance statement for routers running IGMPv1 and
+            implementing the IGMP MIB."
+    MODULE  -- this module
+      MANDATORY-GROUPS { igmpBaseMIBGroup,
+                       igmpRouterMIBGroup
+                     }
+
+    OBJECT     igmpInterfaceStatus
+    MIN-ACCESS read-only
+    DESCRIPTION
+             "Write access is not required."
+    OBJECT     igmpCacheStatus
+    MIN-ACCESS read-only
+    DESCRIPTION
+             "Write access is not required."
+
+
+
+
+McCloghrie, et al.          Standards Track                    [Page 11]
+
+RFC 2933         Internet Group Management Protocol MIB     October 2000
+
+
+    ::= { igmpMIBCompliances 2 }
+
+igmpV2HostMIBCompliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+            "The compliance statement for hosts running IGMPv2 and
+            implementing the IGMP MIB."
+    MODULE  -- this module
+    MANDATORY-GROUPS { igmpBaseMIBGroup,
+                       igmpV2HostMIBGroup
+                     }
+
+    OBJECT     igmpInterfaceStatus
+    MIN-ACCESS read-only
+    DESCRIPTION
+             "Write access is not required."
+
+    OBJECT     igmpCacheStatus
+    MIN-ACCESS read-only
+    DESCRIPTION
+             "Write access is not required."
+
+    ::= { igmpMIBCompliances 3 }
+
+igmpV2RouterMIBCompliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+            "The compliance statement for routers running IGMPv2 and
+            implementing the IGMP MIB."
+    MODULE  -- this module
+    MANDATORY-GROUPS { igmpBaseMIBGroup,
+                       igmpRouterMIBGroup,
+                       igmpV2RouterMIBGroup
+                     }
+
+    OBJECT     igmpInterfaceStatus
+    MIN-ACCESS read-only
+    DESCRIPTION
+             "Write access is not required."
+    OBJECT     igmpCacheStatus
+    MIN-ACCESS read-only
+    DESCRIPTION
+             "Write access is not required."
+
+    ::= { igmpMIBCompliances 4 }
+
+
+-- units of conformance
+
+
+
+McCloghrie, et al.          Standards Track                    [Page 12]
+
+RFC 2933         Internet Group Management Protocol MIB     October 2000
+
+
+igmpBaseMIBGroup OBJECT-GROUP
+    OBJECTS { igmpCacheSelf,
+              igmpCacheStatus, igmpInterfaceStatus
+            }
+    STATUS  current
+    DESCRIPTION
+            "The basic collection of objects providing management of
+            IGMP version 1 or 2."
+    ::= { igmpMIBGroups 1 }
+
+
+igmpRouterMIBGroup OBJECT-GROUP
+    OBJECTS { igmpCacheUpTime, igmpCacheExpiryTime,
+              igmpInterfaceJoins, igmpInterfaceGroups,
+              igmpCacheLastReporter, igmpInterfaceQuerierUpTime,
+              igmpInterfaceQuerierExpiryTime,
+              igmpInterfaceQueryInterval
+            }
+    STATUS  current
+    DESCRIPTION
+            "A collection of additional objects for management of IGMP
+            version 1 or 2 in routers."
+    ::= { igmpMIBGroups 2 }
+
+
+igmpV2HostMIBGroup OBJECT-GROUP
+    OBJECTS { igmpInterfaceVersion1QuerierTimer }
+    STATUS  current
+    DESCRIPTION
+            "A collection of additional objects for management of IGMP
+            version 2 in hosts."
+    ::= { igmpMIBGroups 3 }
+
+igmpHostOptMIBGroup OBJECT-GROUP
+    OBJECTS { igmpCacheLastReporter, igmpInterfaceQuerier }
+    STATUS  current
+    DESCRIPTION
+            "A collection of optional objects for IGMP hosts.
+            Supporting this group can be especially useful in an
+            environment with a router which does not support the IGMP
+            MIB."
+    ::= { igmpMIBGroups 4 }
+
+igmpV2RouterMIBGroup OBJECT-GROUP
+    OBJECTS { igmpInterfaceVersion, igmpInterfaceQuerier,
+              igmpInterfaceQueryMaxResponseTime,
+              igmpInterfaceRobustness,
+              igmpInterfaceWrongVersionQueries,
+
+
+
+McCloghrie, et al.          Standards Track                    [Page 13]
+
+RFC 2933         Internet Group Management Protocol MIB     October 2000
+
+
+              igmpInterfaceLastMembQueryIntvl,
+              igmpCacheVersion1HostTimer
+            }
+    STATUS  current
+    DESCRIPTION
+            "A collection of additional objects for management of IGMP
+            version 2 in routers."
+    ::= { igmpMIBGroups 5 }
+
+igmpV2ProxyMIBGroup OBJECT-GROUP
+    OBJECTS { igmpInterfaceProxyIfIndex }
+    STATUS  current
+    DESCRIPTION
+            "A collection of additional objects for management of IGMP
+            proxy devices."
+    ::= { igmpMIBGroups 6 }
+
+END
+
+5.  Security Considerations
+
+   This MIB contains readable objects whose values provide information
+   related to multicast sessions.  Some of these objects could contain
+   sensitive information.  In particular, the igmpCacheSelf and
+   igmpCacheLastReporter can be used to identify machines which are
+   listening to a given group address.  There are also a number of
+   objects that have a MAX-ACCESS clause of read-write and/or read-
+   create, which allow an administrator to configure IGMP in the router.
+
+   While unauthorized access to the readable objects is relatively
+   innocuous, unauthorized access to the write-able objects could cause
+   a denial of service.  Hence, the support for SET operations in a
+   non-secure environment without proper protection can have a negative
+   effect on network operations.
+
+   SNMPv1 by itself is such an insecure environment.  Even if the
+   network itself is secure (for example by using IPSec), even then,
+   there is no control as to who on the secure network is allowed to
+   access and SET (change/create/delete) the objects in this MIB.
+
+   It is recommended that the implementers consider the security
+   features as provided by the SNMPv3 framework.  Specifically, the use
+   of the User-based Security Model RFC 2574 [12] and the View-based
+   Access Control Model RFC 2575 [15] is recommended.
+
+
+
+
+
+
+
+McCloghrie, et al.          Standards Track                    [Page 14]
+
+RFC 2933         Internet Group Management Protocol MIB     October 2000
+
+
+   It is then a customer/user responsibility to ensure that the SNMP
+   entity giving access to this MIB, is properly configured to give
+   access to those objects only to those principals (users) that have
+   legitimate rights to access them.
+
+6.  Intellectual Property Notice
+
+   The IETF takes no position regarding the validity or scope of any
+   intellectual property or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; neither does it represent that it
+   has made any effort to identify any such rights.  Information on the
+   IETF's procedures with respect to rights in standards-track and
+   standards-related documentation can be found in BCP-11.  Copies of
+   claims of rights made available for publication and any assurances of
+   licenses to be made available, or the result of an attempt made to
+   obtain a general license or permission for the use of such
+   proprietary rights by implementers or users of this specification can
+   be obtained from the IETF Secretariat.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights which may cover technology that may be required to practice
+   this standard.  Please address the information to the IETF Executive
+   Director.
+
+7.  Acknowledgements
+
+   This MIB module was updated based on feedback from the IETF's Inter-
+   Domain Multicast Routing (IDMR) Working Group.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McCloghrie, et al.          Standards Track                    [Page 15]
+
+RFC 2933         Internet Group Management Protocol MIB     October 2000
+
+
+8.  Authors' Addresses
+
+   Keith McCloghrie
+   cisco Systems, Inc.
+   170 West Tasman Drive
+   San Jose, CA  95134-1706
+
+   Phone: +1 408 526 5260
+   EMail: kzm@cisco.com
+
+
+   Dino Farinacci
+   Procket Networks
+   3850 North First Street
+   San Jose, CA 95134
+
+   Phone: +1 408-954-7909
+   Email: dino@procket.com
+
+
+   Dave Thaler
+   Microsoft Corporation
+   One Microsoft Way
+   Redmond, WA  48105-6399
+
+   Phone: +1 425 703 8835
+   EMail: dthaler@microsoft.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McCloghrie, et al.          Standards Track                    [Page 16]
+
+RFC 2933         Internet Group Management Protocol MIB     October 2000
+
+
+9.  References
+
+   [1]  Wijnen, B., Harrington, D. and R. Presuhn, "An Architecture for
+        Describing SNMP Management Frameworks", RFC 2571, April 1999.
+
+   [2]  Rose, M. and K. McCloghrie, "Structure and Identification of
+        Management Information for TCP/IP-based Internets", STD 16, RFC
+        1155, May 1990.
+
+   [3]  Rose, M. and K. McCloghrie, "Concise MIB Definitions", STD 16,
+        RFC 1212, March 1991.
+
+   [4]  Rose, M., "A Convention for Defining Traps for use with the
+        SNMP", RFC 1215, March 1991.
+
+   [5]  McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J., Rose,
+        M. and S. Waldbusser, "Structure of Management Information
+        Version 2 (SMIv2)", STD 58, RFC 2578, April 1999.
+
+   [6]  McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J., Rose,
+        M. and S. Waldbusser, "Textual Conventions for SMIv2", STD 58,
+        RFC 2579, April 1999.
+
+   [7]  McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J., Rose,
+        M. and S. Waldbusser, "Conformance Statements for SMIv2", STD
+        58, RFC 2580, April 1999.
+
+   [8]  Case, J., Fedor, M., Schoffstall, M. and J. Davin, "Simple
+        Network Management Protocol", STD 15, RFC 1157, May 1990.
+
+   [9]  Case, J., McCloghrie, K., Rose, M. and S. Waldbusser,
+        "Introduction to Community-based SNMPv2", RFC 1901, January
+        1996.
+
+   [10] Case, J., McCloghrie, K., Rose, M. and S. Waldbusser, "Transport
+        Mappings for Version 2 of the Simple Network Management Protocol
+        (SNMPv2)", RFC 1906, January 1996.
+
+   [11] Case, J., Harrington D., Presuhn R. and B. Wijnen, "Message
+        Processing and Dispatching for the Simple Network Management
+        Protocol (SNMP)", RFC 2572, April 1999.
+
+   [12] Blumenthal, U. and B. Wijnen, "User-based Security Model (USM)
+        for version 3 of the Simple Network Management Protocol
+        (SNMPv3)", RFC 2574, April 1999.
+
+
+
+
+
+
+McCloghrie, et al.          Standards Track                    [Page 17]
+
+RFC 2933         Internet Group Management Protocol MIB     October 2000
+
+
+   [13] Case, J., McCloghrie, K., Rose, M. and S. Waldbusser, "Protocol
+        Operations for Version 2 of the Simple Network Management
+        Protocol (SNMPv2)", RFC 1905, January 1996.
+
+   [14] Levi, D., Meyer, P. and B. Stewart, "SNMPv3 Applications", RFC
+        2573, April 1999.
+
+   [15] Wijnen, B., Presuhn, R. and K. McCloghrie, "View-based Access
+        Control Model (VACM) for the Simple Network Management Protocol
+        (SNMP)", RFC 2575, April 1999.
+
+   [16] Deering, S., "Host Extensions for IP Multicasting", STD 5, RFC
+        1112, August 1989.
+
+   [17] Fenner, W., "Internet Group Management Protocol, Version 2", RFC
+        2236, November 1997.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McCloghrie, et al.          Standards Track                    [Page 18]
+
+RFC 2933         Internet Group Management Protocol MIB     October 2000
+
+
+10. Full Copyright Statement
+
+   Copyright (C) The Internet Society (2000).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McCloghrie, et al.          Standards Track                    [Page 19]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2933.txt](<www.ietf.org/rfc/rfc2933.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
