### PR TITLE
Archive rfc2934.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2934.txt
+++ b/www.ietf.org/rfc/rfc2934.txt
@@ -1,0 +1,1515 @@
+
+
+
+
+
+
+Network Working Group                                       K. McCloghrie
+Request for Comments: 2934                                  cisco Systems
+Category: Experimental                                       D. Farinacci
+                                                         Procket Networks
+                                                                D. Thaler
+                                                                Microsoft
+                                                                B. Fenner
+                                                                AT&T Labs
+                                                             October 2000
+
+
+              Protocol Independent Multicast MIB for IPv4
+
+Status of this Memo
+
+   This memo defines an Experimental Protocol for the Internet
+   community.  It does not specify an Internet standard of any kind.
+   Discussion and suggestions for improvement are requested.
+   Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2000).  All Rights Reserved.
+
+Abstract
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the Internet community.
+   In particular, it describes managed objects used for managing the
+   Protocol Independent Multicast (PIM) protocol for IPv4.
+
+Table of Contents
+
+   1 Introduction .................................................  2
+   2 The SNMP Network Management Framework ........................  2
+   3 Overview .....................................................  3
+   4 Definitions ..................................................  4
+   5 Security Considerations ...................................... 22
+   6 Intellectual Property Notice ................................. 23
+   7 Acknowledgements ............................................. 23
+   8 Authors' Addresses ........................................... 24
+   9 References ................................................... 24
+   10 Full Copyright Statement .................................... 27
+
+
+
+
+
+
+
+
+McCloghrie, et al.            Experimental                      [Page 1]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+1.  Introduction
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the Internet community.
+   In particular, it describes managed objects used for managing the
+   Protocol Independent Multicast (PIM) protocol [16,17,18,19].  This
+   MIB module is applicable to IPv4 multicast routers which implement
+   PIM.  This MIB does not support management of PIM for other address
+   families, including IPv6.  Such management may be supported by other
+   MIBs.
+
+2.  The SNMP Network Management Framework
+
+   The SNMP Management Framework presently consists of five major
+   components:
+
+   o    An overall architecture, described in RFC 2271 [1].
+
+   o    Mechanisms for describing and naming objects and events for the
+        purpose of management.  The first version of this Structure of
+        Management Information (SMI) is called SMIv1 and described in
+        STD 16, RFC 1155 [2], STD 16, RFC 1212 [3] and RFC 1215 [4].
+        The second version, called SMIv2, is described in STD 58, RFC
+        2578 [5], STD 58, RFC 2579 [6] and STD 58, RFC 2580 [7].
+
+   o    Message protocols for transferring management information.  The
+        first version of the SNMP message protocol is called SNMPv1 and
+        described in STD 15, RFC 1157 [8].  A second version of the SNMP
+        message protocol, which is not an Internet standards track
+        protocol, is called SNMPv2c and described in RFC 1901 [9] and
+        RFC 1906 [10].  The third version of the message protocol is
+        called SNMPv3 and described in RFC 1906 [10], RFC 2572 [11] and
+        RFC 2574 [12].
+
+   o    Protocol operations for accessing management information.  The
+        first set of protocol operations and associated PDU formats is
+        described in STD 15, RFC 1157 [8].  A second set of protocol
+        operations and associated PDU formats is described in RFC 1905
+        [13].
+
+   o    A set of fundamental applications described in RFC 2573 [14] and
+        the view-based access control mechanism described in RFC 2575
+        [15].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  Objects in the MIB are
+   defined using the mechanisms defined in the SMI.
+
+
+
+
+McCloghrie, et al.            Experimental                      [Page 2]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+   This memo specifies a MIB module that is compliant to the SMIv2.  A
+   MIB conforming to the SMIv1 can be produced through the appropriate
+   translations.  The resulting translated MIB must be semantically
+   equivalent, except where objects or events are omitted because no
+   translation is possible (use of Counter64).  Some machine readable
+   information in SMIv2 will be converted into textual descriptions in
+   SMIv1 during the translation process.  However, this loss of machine
+   readable information is not considered to change the semantics of the
+   MIB.
+
+3.  Overview
+
+   This MIB module contains one scalar and eight tables.  Some of the
+   objects in these tables are deprecated.  This MIB contains deprecated
+   objects since they are necessary for managing PIMv1 routers, but
+   PIMv1 itself is obsoleted by PIMv2 [18,19].
+
+   The tables contained in this MIB are:
+
+
+   (1)  The PIM Interface Table contains one row for each of the
+        router's PIM interfaces.
+
+   (2)  The PIM Neighbor Table contains one row for each of the router's
+        PIM neighbors.
+
+   (3)  The PIM IP Multicast Route Table contains one row for each
+        multicast routing entry whose incoming interface is running PIM.
+
+   (4)  The PIM Next Hop Table which contains one row for each outgoing
+        interface list entry in the multicast routing table whose
+        interface is running PIM, and whose state is pruned.
+
+   (5)  The (deprecated) PIM RP Table contains the PIM (version 1)
+        information for IP multicast groups which is common to all RPs
+        of a group.
+
+   (6)  The PIM RP-Set Table contains the PIM (version 2) information
+        for sets of candidate Rendezvous Points (RPs) for IP multicast
+        group addresses with particular address prefixes.
+
+   (7)  The PIM Candidate-RP Table contains the IP multicast groups for
+        which the local router is to advertise itself as a Candidate-RP.
+        If this table is empty, then the local router advertises itself
+        as a Candidate-RP for all groups.
+
+   (8)  The PIM Component Table contains one row for each of the PIM
+        domains to which the router is connected.
+
+
+
+McCloghrie, et al.            Experimental                      [Page 3]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+4.  Definitions
+
+PIM-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, experimental,
+    NOTIFICATION-TYPE,
+    Integer32, IpAddress, TimeTicks  FROM SNMPv2-SMI
+    RowStatus, TruthValue            FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP,
+    NOTIFICATION-GROUP               FROM SNMPv2-CONF
+    ipMRouteGroup, ipMRouteSource,
+    ipMRouteSourceMask, ipMRouteNextHopGroup,
+    ipMRouteNextHopSource, ipMRouteNextHopSourceMask,
+    ipMRouteNextHopIfIndex,
+    ipMRouteNextHopAddress           FROM IPMROUTE-STD-MIB
+    InterfaceIndex                   FROM IF-MIB;
+
+pimMIB MODULE-IDENTITY
+    LAST-UPDATED "200009280000Z" -- September 28, 2000
+    ORGANIZATION "IETF IDMR Working Group."
+    CONTACT-INFO
+            " Dave Thaler
+              Microsoft Corporation
+              One Microsoft Way
+              Redmond, WA  98052-6399
+              US
+
+              Phone: +1 425 703 8835
+              EMail: dthaler@microsoft.com"
+    DESCRIPTION
+            "The MIB module for management of PIM routers."
+    REVISION     "200009280000Z" -- September 28, 2000
+    DESCRIPTION
+            "Initial version, published as RFC 2934."
+    ::= { experimental 61 }
+
+pimMIBObjects OBJECT IDENTIFIER ::= { pimMIB 1 }
+
+pimTraps      OBJECT IDENTIFIER ::= { pimMIBObjects 0 }
+
+pim           OBJECT IDENTIFIER ::= { pimMIBObjects 1 }
+
+pimJoinPruneInterval OBJECT-TYPE
+    SYNTAX     Integer32
+    UNITS      "seconds"
+    MAX-ACCESS read-write
+    STATUS     current
+
+
+
+McCloghrie, et al.            Experimental                      [Page 4]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+    DESCRIPTION
+            "The default interval at which periodic PIM-SM Join/Prune
+            messages are to be sent."
+    ::= { pim 1 }
+
+-- The PIM Interface Table
+
+pimInterfaceTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF PimInterfaceEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The (conceptual) table listing the router's PIM interfaces.
+            IGMP and PIM are enabled on all interfaces listed in this
+            table."
+    ::= { pim 2 }
+
+pimInterfaceEntry OBJECT-TYPE
+    SYNTAX     PimInterfaceEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "An entry (conceptual row) in the pimInterfaceTable."
+    INDEX      { pimInterfaceIfIndex }
+    ::= { pimInterfaceTable 1 }
+
+PimInterfaceEntry ::= SEQUENCE {
+    pimInterfaceIfIndex            InterfaceIndex,
+    pimInterfaceAddress            IpAddress,
+    pimInterfaceNetMask            IpAddress,
+    pimInterfaceMode               INTEGER,
+    pimInterfaceDR                 IpAddress,
+    pimInterfaceHelloInterval      Integer32,
+    pimInterfaceStatus             RowStatus,
+    pimInterfaceJoinPruneInterval  Integer32,
+    pimInterfaceCBSRPreference     Integer32
+}
+
+pimInterfaceIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The ifIndex value of this PIM interface."
+    ::= { pimInterfaceEntry 1 }
+
+pimInterfaceAddress OBJECT-TYPE
+    SYNTAX     IpAddress
+
+
+
+McCloghrie, et al.            Experimental                      [Page 5]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+    MAX-ACCESS read-only
+    STATUS     current
+
+    DESCRIPTION
+            "The IP address of the PIM interface."
+    ::= { pimInterfaceEntry 2 }
+
+pimInterfaceNetMask OBJECT-TYPE
+    SYNTAX     IpAddress
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The network mask for the IP address of the PIM interface."
+    ::= { pimInterfaceEntry 3 }
+
+pimInterfaceMode OBJECT-TYPE
+    SYNTAX     INTEGER { dense(1), sparse(2), sparseDense(3) }
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+            "The configured mode of this PIM interface.  A value of
+            sparseDense is only valid for PIMv1."
+    DEFVAL     { dense }
+    ::= { pimInterfaceEntry 4 }
+
+pimInterfaceDR OBJECT-TYPE
+    SYNTAX     IpAddress
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The Designated Router on this PIM interface.  For point-to-
+            point interfaces, this object has the value 0.0.0.0."
+    ::= { pimInterfaceEntry 5 }
+
+pimInterfaceHelloInterval OBJECT-TYPE
+    SYNTAX     Integer32
+    UNITS      "seconds"
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+            "The frequency at which PIM Hello messages are transmitted
+            on this interface."
+    DEFVAL     { 30 }
+    ::= { pimInterfaceEntry 6 }
+
+pimInterfaceStatus OBJECT-TYPE
+    SYNTAX     RowStatus
+    MAX-ACCESS read-create
+
+
+
+McCloghrie, et al.            Experimental                      [Page 6]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+    STATUS     current
+    DESCRIPTION
+            "The status of this entry.  Creating the entry enables PIM
+            on the interface; destroying the entry disables PIM on the
+            interface."
+    ::= { pimInterfaceEntry 7 }
+
+pimInterfaceJoinPruneInterval OBJECT-TYPE
+    SYNTAX     Integer32
+    UNITS      "seconds"
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+            "The frequency at which PIM Join/Prune messages are
+            transmitted on this PIM interface.  The default value of
+            this object is the pimJoinPruneInterval."
+    ::= { pimInterfaceEntry 8 }
+
+pimInterfaceCBSRPreference OBJECT-TYPE
+    SYNTAX     Integer32 (-1..255)
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+            "The preference value for the local interface as a candidate
+            bootstrap router.  The value of -1 is used to indicate that
+            the local interface is not a candidate BSR interface."
+    DEFVAL     { 0 }
+    ::= { pimInterfaceEntry 9 }
+
+
+-- The PIM Neighbor Table
+
+pimNeighborTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF PimNeighborEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The (conceptual) table listing the router's PIM neighbors."
+    ::= { pim 3 }
+
+pimNeighborEntry OBJECT-TYPE
+    SYNTAX     PimNeighborEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "An entry (conceptual row) in the pimNeighborTable."
+    INDEX      { pimNeighborAddress }
+    ::= { pimNeighborTable 1 }
+
+
+
+McCloghrie, et al.            Experimental                      [Page 7]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+PimNeighborEntry ::= SEQUENCE {
+    pimNeighborAddress      IpAddress,
+    pimNeighborIfIndex      InterfaceIndex,
+    pimNeighborUpTime       TimeTicks,
+    pimNeighborExpiryTime   TimeTicks,
+    pimNeighborMode         INTEGER
+}
+
+pimNeighborAddress OBJECT-TYPE
+    SYNTAX     IpAddress
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The IP address of the PIM neighbor for which this entry
+            contains information."
+    ::= { pimNeighborEntry 1 }
+
+pimNeighborIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The value of ifIndex for the interface used to reach this
+            PIM neighbor."
+    ::= { pimNeighborEntry 2 }
+
+pimNeighborUpTime OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The time since this PIM neighbor (last) became a neighbor
+            of the local router."
+    ::= { pimNeighborEntry 3 }
+
+pimNeighborExpiryTime OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The minimum time remaining before this PIM neighbor will be
+            aged out."
+    ::= { pimNeighborEntry 4 }
+
+pimNeighborMode OBJECT-TYPE
+    SYNTAX     INTEGER { dense(1), sparse(2) }
+    MAX-ACCESS read-only
+    STATUS     deprecated
+
+
+
+McCloghrie, et al.            Experimental                      [Page 8]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+    DESCRIPTION
+            "The active PIM mode of this neighbor.  This object is
+            deprecated for PIMv2 routers since all neighbors on the
+            interface must be either dense or sparse as determined by
+            the protocol running on the interface."
+    ::= { pimNeighborEntry 5 }
+
+--
+-- The PIM IP Multicast Route Table
+--
+
+pimIpMRouteTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF PimIpMRouteEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The (conceptual) table listing PIM-specific information on
+            a subset of the rows of the ipMRouteTable defined in the IP
+            Multicast MIB."
+    ::= { pim 4 }
+
+pimIpMRouteEntry OBJECT-TYPE
+    SYNTAX     PimIpMRouteEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "An entry (conceptual row) in the pimIpMRouteTable.  There
+            is one entry per entry in the ipMRouteTable whose incoming
+            interface is running PIM."
+    INDEX      { ipMRouteGroup, ipMRouteSource, ipMRouteSourceMask }
+    ::= { pimIpMRouteTable 1 }
+
+PimIpMRouteEntry ::= SEQUENCE {
+    pimIpMRouteUpstreamAssertTimer   TimeTicks,
+    pimIpMRouteAssertMetric          Integer32,
+    pimIpMRouteAssertMetricPref      Integer32,
+    pimIpMRouteAssertRPTBit          TruthValue,
+    pimIpMRouteFlags                 BITS
+}
+
+pimIpMRouteUpstreamAssertTimer OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The time remaining before the router changes its upstream
+            neighbor back to its RPF neighbor.  This timer is called the
+            Assert timer in the PIM Sparse and Dense mode specification.
+
+
+
+McCloghrie, et al.            Experimental                      [Page 9]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+            A value of 0 indicates that no Assert has changed the
+            upstream neighbor away from the RPF neighbor."
+    ::= { pimIpMRouteEntry 1 }
+
+pimIpMRouteAssertMetric OBJECT-TYPE
+    SYNTAX     Integer32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The metric advertised by the assert winner on the upstream
+            interface, or 0 if no such assert is in received."
+    ::= { pimIpMRouteEntry 2 }
+
+pimIpMRouteAssertMetricPref OBJECT-TYPE
+    SYNTAX     Integer32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The preference advertised by the assert winner on the
+            upstream interface, or 0 if no such assert is in effect."
+    ::= { pimIpMRouteEntry 3 }
+
+pimIpMRouteAssertRPTBit OBJECT-TYPE
+    SYNTAX     TruthValue
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The value of the RPT-bit advertised by the assert winner on
+            the upstream interface, or false if no such assert is in
+            effect."
+    ::= { pimIpMRouteEntry 4 }
+
+pimIpMRouteFlags OBJECT-TYPE
+    SYNTAX     BITS {
+                  rpt(0),
+                  spt(1)
+               }
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "This object describes PIM-specific flags related to a
+            multicast state entry.  See the PIM Sparse Mode
+            specification for the meaning of the RPT and SPT bits."
+    ::= { pimIpMRouteEntry 5 }
+
+--
+-- The PIM Next Hop Table
+--
+
+
+
+McCloghrie, et al.            Experimental                     [Page 10]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+pimIpMRouteNextHopTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF PimIpMRouteNextHopEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The (conceptual) table listing PIM-specific information on
+            a subset of the rows of the ipMRouteNextHopTable defined in
+            the IP Multicast MIB."
+    ::= { pim 7 }
+
+pimIpMRouteNextHopEntry OBJECT-TYPE
+    SYNTAX     PimIpMRouteNextHopEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "An entry (conceptual row) in the pimIpMRouteNextHopTable.
+            There is one entry per entry in the ipMRouteNextHopTable
+            whose interface is running PIM and whose
+            ipMRouteNextHopState is pruned(1)."
+    INDEX      { ipMRouteNextHopGroup, ipMRouteNextHopSource,
+                 ipMRouteNextHopSourceMask, ipMRouteNextHopIfIndex,
+                 ipMRouteNextHopAddress }
+    ::= { pimIpMRouteNextHopTable 1 }
+
+PimIpMRouteNextHopEntry ::= SEQUENCE {
+    pimIpMRouteNextHopPruneReason       INTEGER
+}
+
+pimIpMRouteNextHopPruneReason OBJECT-TYPE
+    SYNTAX     INTEGER {
+                  other (1),
+                  prune (2),
+                  assert (3)
+               }
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "This object indicates why the downstream interface was
+            pruned, whether in response to a PIM prune message or due to
+            PIM Assert processing."
+    ::= { pimIpMRouteNextHopEntry 2 }
+
+-- The PIM RP Table
+
+pimRPTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF PimRPEntry
+    MAX-ACCESS not-accessible
+    STATUS     deprecated
+
+
+
+McCloghrie, et al.            Experimental                     [Page 11]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+    DESCRIPTION
+            "The (conceptual) table listing PIM version 1 information
+            for the Rendezvous Points (RPs) for IP multicast groups.
+            This table is deprecated since its function is replaced by
+            the pimRPSetTable for PIM version 2."
+    ::= { pim 5 }
+
+pimRPEntry OBJECT-TYPE
+    SYNTAX     PimRPEntry
+    MAX-ACCESS not-accessible
+    STATUS     deprecated
+    DESCRIPTION
+            "An entry (conceptual row) in the pimRPTable.  There is one
+            entry per RP address for each IP multicast group."
+    INDEX      { pimRPGroupAddress, pimRPAddress }
+    ::= { pimRPTable 1 }
+
+PimRPEntry ::= SEQUENCE {
+    pimRPGroupAddress    IpAddress,
+    pimRPAddress         IpAddress,
+    pimRPState           INTEGER,
+    pimRPStateTimer      TimeTicks,
+    pimRPLastChange      TimeTicks,
+    pimRPRowStatus       RowStatus
+}
+
+pimRPGroupAddress OBJECT-TYPE
+    SYNTAX     IpAddress
+    MAX-ACCESS not-accessible
+    STATUS     deprecated
+    DESCRIPTION
+            "The IP multicast group address for which this entry
+            contains information about an RP."
+    ::= { pimRPEntry 1 }
+
+pimRPAddress OBJECT-TYPE
+    SYNTAX     IpAddress
+    MAX-ACCESS not-accessible
+    STATUS     deprecated
+    DESCRIPTION
+            "The unicast address of the RP."
+    ::= { pimRPEntry 2 }
+
+pimRPState OBJECT-TYPE
+    SYNTAX     INTEGER { up(1), down(2) }
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+
+
+
+McCloghrie, et al.            Experimental                     [Page 12]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+            "The state of the RP."
+    ::= { pimRPEntry 3 }
+
+pimRPStateTimer OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+            "The minimum time remaining before the next state change.
+            When pimRPState is up, this is the minimum time which must
+            expire until it can be declared down.  When pimRPState is
+            down, this is the time until it will be declared up (in
+            order to retry)."
+    ::= { pimRPEntry 4 }
+
+pimRPLastChange OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+            "The value of sysUpTime at the time when the corresponding
+            instance of pimRPState last changed its value."
+    ::= { pimRPEntry 5 }
+
+pimRPRowStatus OBJECT-TYPE
+    SYNTAX     RowStatus
+    MAX-ACCESS read-create
+    STATUS     deprecated
+    DESCRIPTION
+            "The status of this row, by which new entries may be
+            created, or old entries deleted from this table."
+    ::= { pimRPEntry 6 }
+
+-- The PIM RP-Set Table
+
+pimRPSetTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF PimRPSetEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The (conceptual) table listing PIM information for
+            candidate Rendezvous Points (RPs) for IP multicast groups.
+            When the local router is the BSR, this information is
+            obtained from received Candidate-RP-Advertisements.  When
+            the local router is not the BSR, this information is
+            obtained from received RP-Set messages."
+    ::= { pim 6 }
+
+
+
+
+McCloghrie, et al.            Experimental                     [Page 13]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+pimRPSetEntry OBJECT-TYPE
+    SYNTAX     PimRPSetEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "An entry (conceptual row) in the pimRPSetTable."
+    INDEX      { pimRPSetComponent, pimRPSetGroupAddress,
+                 pimRPSetGroupMask, pimRPSetAddress }
+    ::= { pimRPSetTable 1 }
+
+PimRPSetEntry ::= SEQUENCE {
+
+    pimRPSetGroupAddress    IpAddress,
+    pimRPSetGroupMask       IpAddress,
+    pimRPSetAddress         IpAddress,
+    pimRPSetHoldTime        Integer32,
+    pimRPSetExpiryTime      TimeTicks,
+    pimRPSetComponent       Integer32
+}
+
+pimRPSetGroupAddress OBJECT-TYPE
+    SYNTAX     IpAddress
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The IP multicast group address which, when combined with
+            pimRPSetGroupMask, gives the group prefix for which this
+            entry contains information about the Candidate-RP."
+    ::= { pimRPSetEntry 1 }
+
+pimRPSetGroupMask OBJECT-TYPE
+    SYNTAX     IpAddress
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The multicast group address mask which, when combined with
+            pimRPSetGroupAddress, gives the group prefix for which this
+            entry contains information about the Candidate-RP."
+    ::= { pimRPSetEntry 2 }
+
+pimRPSetAddress OBJECT-TYPE
+    SYNTAX     IpAddress
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The IP address of the Candidate-RP."
+    ::= { pimRPSetEntry 3 }
+
+
+
+
+McCloghrie, et al.            Experimental                     [Page 14]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+pimRPSetHoldTime OBJECT-TYPE
+    SYNTAX     Integer32 (0..255)
+    UNITS      "seconds"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The holdtime of a Candidate-RP.  If the local router is not
+            the BSR, this value is 0."
+    ::= { pimRPSetEntry 4 }
+
+pimRPSetExpiryTime OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The minimum time remaining before the Candidate-RP will be
+            declared down.  If the local router is not the BSR, this
+            value is 0."
+    ::= { pimRPSetEntry 5 }
+
+pimRPSetComponent OBJECT-TYPE
+    SYNTAX     Integer32 (1..255)
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            " A number uniquely identifying the component.  Each
+            protocol instance connected to a separate domain should have
+            a different index value."
+    ::= { pimRPSetEntry 6 }
+
+--
+-- Note: { pim 8 } through { pim 10 } were used in older versions
+-- of this MIB.  Since some earlier versions of this MIB have been
+-- widely-deployed, these values must not be used in the future,
+-- as long the MIB is rooted under { experimental 61 }.
+--
+
+-- The PIM Candidate-RP Table
+
+pimCandidateRPTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF PimCandidateRPEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The (conceptual) table listing the IP multicast groups for
+            which the local router is to advertise itself as a
+            Candidate-RP when the value of pimComponentCRPHoldTime is
+            non-zero.  If this table is empty, then the local router
+
+
+
+McCloghrie, et al.            Experimental                     [Page 15]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+            will advertise itself as a Candidate-RP for all groups
+            (providing the value of pimComponentCRPHoldTime is non-
+            zero)."
+    ::= { pim 11 }
+
+pimCandidateRPEntry OBJECT-TYPE
+    SYNTAX     PimCandidateRPEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "An entry (conceptual row) in the pimCandidateRPTable."
+    INDEX      { pimCandidateRPGroupAddress,
+                 pimCandidateRPGroupMask }
+    ::= { pimCandidateRPTable 1 }
+
+PimCandidateRPEntry ::= SEQUENCE {
+    pimCandidateRPGroupAddress    IpAddress,
+    pimCandidateRPGroupMask       IpAddress,
+    pimCandidateRPAddress         IpAddress,
+    pimCandidateRPRowStatus       RowStatus
+}
+
+pimCandidateRPGroupAddress OBJECT-TYPE
+    SYNTAX     IpAddress
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The IP multicast group address which, when combined with
+            pimCandidateRPGroupMask, identifies a group prefix for which
+            the local router will advertise itself as a Candidate-RP."
+    ::= { pimCandidateRPEntry 1 }
+
+pimCandidateRPGroupMask OBJECT-TYPE
+    SYNTAX     IpAddress
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The multicast group address mask which, when combined with
+            pimCandidateRPGroupMask, identifies a group prefix for which
+            the local router will advertise itself as a Candidate-RP."
+    ::= { pimCandidateRPEntry 2 }
+
+pimCandidateRPAddress OBJECT-TYPE
+    SYNTAX     IpAddress
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+            "The (unicast) address of the interface which will be
+
+
+
+McCloghrie, et al.            Experimental                     [Page 16]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+            advertised as a Candidate-RP."
+    ::= { pimCandidateRPEntry 3 }
+
+pimCandidateRPRowStatus OBJECT-TYPE
+    SYNTAX     RowStatus
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+            "The status of this row, by which new entries may be
+            created, or old entries deleted from this table."
+    ::= { pimCandidateRPEntry 4 }
+
+-- The PIM Component Table
+
+pimComponentTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF PimComponentEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The (conceptual) table containing objects specific to a PIM
+            domain.  One row exists for each domain to which the router
+            is connected.  A PIM-SM domain is defined as an area of the
+            network over which Bootstrap messages are forwarded.
+            Typically, a PIM-SM router will be a member of exactly one
+            domain.  This table also supports, however, routers which
+            may form a border between two PIM-SM domains and do not
+            forward Bootstrap messages between them."
+    ::= { pim 12 }
+
+pimComponentEntry OBJECT-TYPE
+    SYNTAX     PimComponentEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "An entry (conceptual row) in the pimComponentTable."
+    INDEX      { pimComponentIndex }
+    ::= { pimComponentTable 1 }
+
+PimComponentEntry ::= SEQUENCE {
+    pimComponentIndex              Integer32,
+    pimComponentBSRAddress         IpAddress,
+    pimComponentBSRExpiryTime      TimeTicks,
+    pimComponentCRPHoldTime        Integer32,
+    pimComponentStatus             RowStatus
+}
+
+pimComponentIndex OBJECT-TYPE
+    SYNTAX     Integer32 (1..255)
+
+
+
+McCloghrie, et al.            Experimental                     [Page 17]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "A number uniquely identifying the component.  Each protocol
+            instance connected to a separate domain should have a
+            different index value.  Routers that only support membership
+            in a single PIM-SM domain should use a pimComponentIndex
+            value of 1."
+    ::= { pimComponentEntry 1 }
+
+pimComponentBSRAddress OBJECT-TYPE
+    SYNTAX     IpAddress
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The IP address of the bootstrap router (BSR) for the local
+            PIM region."
+    ::= { pimComponentEntry 2 }
+
+pimComponentBSRExpiryTime OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The minimum time remaining before the bootstrap router in
+            the local domain will be declared down.  For candidate BSRs,
+            this is the time until the component sends an RP-Set
+            message.  For other routers, this is the time until it may
+            accept an RP-Set message from a lower candidate BSR."
+    ::= { pimComponentEntry 3 }
+
+pimComponentCRPHoldTime OBJECT-TYPE
+    SYNTAX     Integer32 (0..255)
+    UNITS      "seconds"
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+            "The holdtime of the component when it is a candidate RP in
+            the local domain.  The value of 0 is used to indicate that
+            the local system is not a Candidate-RP."
+    DEFVAL     { 0 }
+    ::= { pimComponentEntry 4 }
+
+pimComponentStatus OBJECT-TYPE
+    SYNTAX     RowStatus
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+
+
+
+McCloghrie, et al.            Experimental                     [Page 18]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+            "The status of this entry.  Creating the entry creates
+            another protocol instance; destroying the entry disables a
+            protocol instance."
+    ::= { pimComponentEntry 5 }
+
+-- PIM Traps
+
+pimNeighborLoss NOTIFICATION-TYPE
+    OBJECTS {
+       pimNeighborIfIndex
+    }
+    STATUS             current
+    DESCRIPTION
+            "A pimNeighborLoss trap signifies the loss of an adjacency
+            with a neighbor.  This trap should be generated when the
+            neighbor timer expires, and the router has no other
+            neighbors on the same interface with a lower IP address than
+            itself."
+    ::= { pimTraps 1 }
+
+-- conformance information
+
+pimMIBConformance OBJECT IDENTIFIER ::= { pimMIB 2 }
+pimMIBCompliances OBJECT IDENTIFIER ::= { pimMIBConformance 1 }
+pimMIBGroups      OBJECT IDENTIFIER ::= { pimMIBConformance 2 }
+
+
+-- compliance statements
+
+pimV1MIBCompliance MODULE-COMPLIANCE
+    STATUS  deprecated
+    DESCRIPTION
+            "The compliance statement for routers running PIMv1 and
+            implementing the PIM MIB."
+    MODULE  -- this module
+        MANDATORY-GROUPS { pimV1MIBGroup }
+
+    ::= { pimMIBCompliances 1 }
+
+pimSparseV2MIBCompliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+            "The compliance statement for routers running PIM Sparse
+            Mode and implementing the PIM MIB."
+    MODULE  -- this module
+    MANDATORY-GROUPS { pimV2MIBGroup }
+
+    GROUP      pimV2CandidateRPMIBGroup
+
+
+
+McCloghrie, et al.            Experimental                     [Page 19]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+    DESCRIPTION
+            "This group is mandatory if the router is capable of being a
+            Candidate RP."
+
+    OBJECT     pimInterfaceStatus
+    MIN-ACCESS read-only
+    DESCRIPTION
+             "Write access is not required."
+
+    ::= { pimMIBCompliances 2 }
+
+pimDenseV2MIBCompliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+            "The compliance statement for routers running PIM Dense Mode
+            and implementing the PIM MIB."
+    MODULE  -- this module
+
+        MANDATORY-GROUPS { pimDenseV2MIBGroup }
+
+    OBJECT     pimInterfaceStatus
+    MIN-ACCESS read-only
+    DESCRIPTION
+             "Write access is not required."
+
+    ::= { pimMIBCompliances 3 }
+
+-- units of conformance
+
+pimNotificationGroup NOTIFICATION-GROUP
+    NOTIFICATIONS { pimNeighborLoss }
+    STATUS  current
+    DESCRIPTION
+            "A collection of notifications for signaling important PIM
+            events."
+    ::= { pimMIBGroups 1 }
+
+pimV2MIBGroup OBJECT-GROUP
+    OBJECTS { pimJoinPruneInterval, pimNeighborIfIndex,
+              pimNeighborUpTime, pimNeighborExpiryTime,
+              pimInterfaceAddress, pimInterfaceNetMask,
+              pimInterfaceDR, pimInterfaceHelloInterval,
+              pimInterfaceStatus, pimInterfaceJoinPruneInterval,
+              pimInterfaceCBSRPreference, pimInterfaceMode,
+              pimRPSetHoldTime, pimRPSetExpiryTime,
+              pimComponentBSRAddress, pimComponentBSRExpiryTime,
+              pimComponentCRPHoldTime, pimComponentStatus,
+              pimIpMRouteFlags, pimIpMRouteUpstreamAssertTimer
+
+
+
+McCloghrie, et al.            Experimental                     [Page 20]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+            }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects to support management of PIM Sparse
+            Mode (version 2) routers."
+    ::= { pimMIBGroups 2 }
+
+pimDenseV2MIBGroup OBJECT-GROUP
+    OBJECTS { pimNeighborIfIndex,
+              pimNeighborUpTime, pimNeighborExpiryTime,
+              pimInterfaceAddress, pimInterfaceNetMask,
+              pimInterfaceDR, pimInterfaceHelloInterval,
+              pimInterfaceStatus, pimInterfaceMode
+            }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects to support management of PIM Dense
+            Mode (version 2) routers."
+    ::= { pimMIBGroups 5 }
+
+pimV2CandidateRPMIBGroup OBJECT-GROUP
+    OBJECTS { pimCandidateRPAddress,
+              pimCandidateRPRowStatus
+            }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects to support configuration of which
+            groups a router is to advertise itself as a Candidate-RP."
+    ::= { pimMIBGroups 3 }
+
+pimV1MIBGroup OBJECT-GROUP
+    OBJECTS { pimJoinPruneInterval, pimNeighborIfIndex,
+              pimNeighborUpTime, pimNeighborExpiryTime,
+              pimNeighborMode,
+              pimInterfaceAddress, pimInterfaceNetMask,
+              pimInterfaceJoinPruneInterval, pimInterfaceStatus,
+              pimInterfaceMode, pimInterfaceDR,
+              pimInterfaceHelloInterval,
+              pimRPState, pimRPStateTimer,
+              pimRPLastChange, pimRPRowStatus
+            }
+    STATUS  deprecated
+    DESCRIPTION
+            "A collection of objects to support management of PIM
+            (version 1) routers."
+    ::= { pimMIBGroups 4 }
+
+pimNextHopGroup OBJECT-GROUP
+
+
+
+McCloghrie, et al.            Experimental                     [Page 21]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+    OBJECTS { pimIpMRouteNextHopPruneReason }
+    STATUS  current
+    DESCRIPTION
+            "A collection of optional objects to provide per-next hop
+            information for diagnostic purposes.  Supporting this group
+            may add a large number of instances to a tree walk, but the
+            information in this group can be extremely useful in
+            tracking down multicast connectivity problems."
+    ::= { pimMIBGroups 6 }
+
+pimAssertGroup OBJECT-GROUP
+    OBJECTS { pimIpMRouteAssertMetric, pimIpMRouteAssertMetricPref,
+              pimIpMRouteAssertRPTBit }
+    STATUS  current
+    DESCRIPTION
+            "A collection of optional objects to provide extra
+            information about the assert election process.  There is no
+            protocol reason to keep such information, but some
+            implementations may already keep this information and make
+            it available.  These objects can also be very useful in
+            debugging connectivity or duplicate packet problems,
+            especially if the assert winner does not support the PIM and
+            IP Multicast MIBs."
+    ::= { pimMIBGroups 7 }
+
+END
+
+5.  Security Considerations
+
+   This MIB contains readable objects whose values provide information
+   related to multicast routing, including information on the network
+   topology.  There are also a number of objects that have a MAX-ACCESS
+   clause of read-write and/or read-create, which allow an administrator
+   to configure PIM in the router.
+
+   While unauthorized access to the readable objects is relatively
+   innocuous, unauthorized access to the write-able objects could cause
+   a denial of service.  Hence, the support for SET operations in a
+   non-secure environment without proper protection can have a negative
+   effect on network operations.
+
+   SNMPv1 by itself is such an insecure environment.  Even if the
+   network itself is secure (for example by using IPSec), even then,
+   there is no control as to who on the secure network is allowed to
+   access and SET (change/create/delete) the objects in this MIB.
+
+
+
+
+
+
+McCloghrie, et al.            Experimental                     [Page 22]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+   It is recommended that the implementers consider the security
+   features as provided by the SNMPv3 framework.  Specifically, the use
+   of the User-based Security Model RFC 2274 [12] and the View-based
+   Access Control Model RFC 2275 [15] is recommended.
+
+   It is then a customer/user responsibility to ensure that the SNMP
+   entity giving access to this MIB, is properly configured to give
+   access to those objects only to those principals (users) that have
+   legitimate rights to access them.
+
+6.  Intellectual Property Notice
+
+   The IETF takes no position regarding the validity or scope of any
+   intellectual property or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; neither does it represent that it
+   has made any effort to identify any such rights.  Information on the
+   IETF's procedures with respect to rights in standards-track and
+   standards-related documentation can be found in BCP-11.  Copies of
+   claims of rights made available for publication and any assurances of
+   licenses to be made available, or the result of an attempt made to
+   obtain a general license or permission for the use of such
+   proprietary rights by implementers or users of this specification can
+   be obtained from the IETF Secretariat.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights which may cover technology that may be required to practice
+   this standard.  Please address the information to the IETF Executive
+   Director.
+
+7.  Acknowledgements
+
+   This MIB module has been updated based on feedback from the IETF's
+   Inter-Domain Multicast Routing (IDMR) Working Group.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McCloghrie, et al.            Experimental                     [Page 23]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+8.  Authors' Addresses
+
+   Keith McCloghrie
+   cisco Systems, Inc.
+   170 West Tasman Drive
+   San Jose, CA  95134-1706
+
+   Phone: +1 408 526 5260
+   EMail: kzm@cisco.com
+
+
+   Dino Farinacci
+   Procket Networks
+   3850 North First Street
+   San Jose, CA 95134
+
+   Phone: +1 408-954-7909
+   Email: dino@procket.com
+
+
+   Dave Thaler
+   Microsoft Corporation
+   One Microsoft Way
+   Redmond, WA  98052-6399
+
+   Phone: +1 425 703 8835
+   EMail: dthaler@microsoft.com
+
+
+   Bill Fenner
+   AT&T Labs - Research
+   75 Willow Rd.
+   Menlo Park, CA 94025
+
+   Phone: +1 650 330 7893
+   EMail: fenner@research.att.com
+
+9.  References
+
+   [1]  Wijnen, B., Harrington, D. and R. Presuhn, "An Architecture for
+        Describing SNMP Management Frameworks", RFC 2571, April 1999.
+
+   [2]  Rose, M. and K. McCloghrie, "Structure and Identification of
+        Management Information for TCP/IP-based Internets", STD 16, RFC
+        1155, May 1990.
+
+   [3]  Rose, M. and K. McCloghrie, "Concise MIB Definitions", STD 16,
+        RFC 1212, March 1991.
+
+
+
+McCloghrie, et al.            Experimental                     [Page 24]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+   [4]  Rose, M., "A Convention for Defining Traps for use with the
+        SNMP", RFC 1215, March 1991.
+
+   [5]  McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J., Rose,
+        M. and S. Waldbusser, "Structure of Management Information
+        Version 2 (SMIv2)", STD 58, RFC 2578, April 1999.
+
+   [6]  McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J., Rose,
+        M. and S. Waldbusser, "Textual Conventions for SMIv2", STD 58,
+        RFC 2579, April 1999.
+
+   [7]  McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J., Rose,
+        M. and S. Waldbusser, "Conformance Statements for SMIv2", STD
+        58, RFC 2580, April 1999.
+
+   [8]  Case, J., Fedor, M., Schoffstall, M. and J. Davin, "Simple
+        Network Management Protocol", STD 15, RFC 1157, May 1990.
+
+   [9]  Case, J., McCloghrie, K., Rose, M. and S. Waldbusser,
+        "Introduction to Community-based SNMPv2", RFC 1901, January
+        1996.
+
+   [10] Case, J., McCloghrie, K., Rose, M. and S. Waldbusser, "Transport
+        Mappings for Version 2 of the Simple Network Management Protocol
+        (SNMPv2)", RFC 1906, January 1996.
+
+   [11] Case, J., Harrington D., Presuhn R. and B. Wijnen, "Message
+        Processing and Dispatching for the Simple Network Management
+        Protocol (SNMP)", RFC 2572, April 1999.
+
+   [12] Blumenthal, U. and B. Wijnen, "User-based Security Model (USM)
+        for version 3 of the Simple Network Management Protocol
+        (SNMPv3)", RFC 2574, April 1999.
+
+   [13] Case, J., McCloghrie, K., Rose, M. and S. Waldbusser, "Protocol
+        Operations for Version 2 of the Simple Network Management
+        Protocol (SNMPv2)", RFC 1905, January 1996.
+
+   [14] Levi, D., Meyer, P. and B. Stewart, "SNMPv3 Applications", RFC
+        2573, April 1999.
+
+   [15] Wijnen, B., Presuhn, R. and K. McCloghrie, "View-based Access
+        Control Model (VACM) for the Simple Network Management Protocol
+        (SNMP)", RFC 2575, April 1999.
+
+   [16] Deering, S., Estrin, D., Farinacci, D., Jacobson, V., Liu, G.
+        and L. Wei, "Protocol Independent Multicast (PIM): Motivation
+        and Architecture", Work in Progress.
+
+
+
+McCloghrie, et al.            Experimental                     [Page 25]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+   [17] Deering, S., Estrin, D., Farinacci, D., Jacobson, V., Liu, G.
+        and L. Wei, "Protocol Independent Multicast (PIM): Protocol
+        Specification", Work in Progress.
+
+   [18] Estrin, D., Farinacci, D., Helmy, A., Thaler, D., Deering, S.,
+        Handley, M., Jacobson, V., Liu, C., Sharma, P. and L. Wei,
+        "Protocol Independent Multicast - Sparse Mode (PIM-SM): Protocol
+        Specification", RFC 2362, June 1998.
+
+   [19] Deering, S., Estrin, D., Farinacci, D., Jacobson, V., Helmy, A.
+        and L. Wei, "Protocol Independent Multicast Version 2, Dense
+        Mode Specification", Work in Progress.
+
+   [20] McCloghrie, K., Farinacci, D. and D. Thaler, "IPv4 Multicast
+        Routing MIB", RFC 2932, October 2000.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McCloghrie, et al.            Experimental                     [Page 26]
+
+RFC 2934      Protocol Independent Multicast MIB for IPv4   October 2000
+
+
+10.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (2000).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McCloghrie, et al.            Experimental                     [Page 27]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2934.txt](<www.ietf.org/rfc/rfc2934.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
