### PR TITLE
Archive rfc2955.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2955.txt
+++ b/www.ietf.org/rfc/rfc2955.txt
@@ -1,0 +1,2187 @@
+
+
+
+
+
+
+Network Working Group                                         K. Rehbehn
+Request for Comments: 2955                               Megisto Systems
+Category: Standards Track                                    O. Nicklass
+                                           RAD Data Communications, Ltd.
+                                                            G. Mouradian
+                                                               AT&T Labs
+                                                            October 2000
+
+
+                     Definitions of Managed Objects
+                   for Monitoring and Controlling the
+           Frame Relay/ATM PVC Service Interworking Function
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2000).  All Rights Reserved.
+
+Abstract
+
+   This memo defines a Management Information Base (MIB) to configure,
+   monitor, and control a service interworking function (IWF) for
+   Permanent Virtual Connections (PVC) between Frame Relay and
+   Asynchronous Transfer Mode (ATM) technologies.
+
+Table of Contents
+
+   1. The SNMP Management Framework ...............................   2
+   2. Conventions .................................................   3
+   3. Overview ....................................................   3
+   3.1 Frame Relay/ATM Service Interworking Background ............   4
+   3.2 Structure of the MIB .......................................   4
+   3.3 Relationship to Other MIBs .................................   5
+   3.3.1 Frame Relay Service MIB ..................................   6
+   3.3.2 Frame Relay DTE MIB ......................................   6
+   3.3.3 ATM MIB ..................................................   6
+   3.3.4 IF MIB ...................................................   7
+   3.4 Point to Multipoint Considerations .........................   7
+   3.5 Theory of Operation ........................................   7
+   3.5.1 Creation Process .........................................   7
+   3.5.2 Destruction Process ......................................  10
+
+
+
+Rehbehn, et al.             Standards Track                     [Page 1]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+   3.5.3 Modification Process .....................................  11
+   4. Object Definitions ..........................................  11
+   4.1 The FR/ATM PVC Service IWF Connection Group ................  13
+   4.2 The FR/ATM PVC Service IWF Connection Descriptor Group .....  21
+   5. Augmentation of ATM MIB VCL Endpoint Entry (atmVclEntry) ....  27
+   6. Frame Relay/ATM PVC Service Interworking NOTIFICATION .......  29
+   7. Conformance Information .....................................  29
+   7.1 Compliance Statement For Equipment .........................  29
+   7.2 Compliance Statement For Service (CNM Interface) ...........  30
+   7.3 Units of Conformance .......................................  32
+   7.3.1 Basic FR/ATM IWF PVC Connection Group ....................  32
+   7.3.2 FR/ATM IWF PVC Connection Descriptor Group ...............  32
+   7.3.3 ATM MIB VCL Endpoint Table Augmentation ..................  33
+   7.3.4 Notification Group .......................................  33
+   8. Acknowledgments .............................................  34
+   9. References ..................................................  34
+   10. Security Considerations ....................................  36
+   11. Authors' Addresses .........................................  37
+   12. Intellectual Property Rights ...............................  38
+   13. Full Copyright Statement ...................................  39
+
+1.  The SNMP Management Framework
+
+   The SNMP Management Framework presently consists of five major
+   components:
+
+   o  An overall architecture, described in RFC 2571 [1].
+
+   o  Mechanisms for describing and naming objects and events for the
+      purpose of management.  The first version of this Structure of
+      Management Information (SMI) is called SMIv1 and described in STD
+      16, RFC 1155 [2], STD 16, RFC 1212 [3] and RFC 1215 [4].  The
+      second version, called SMIv2, is described in STD 58, RFC 2578
+      [5], STD 58, RFC 2579 [6] and STD 58, RFC 2580 [7].
+
+   o  Message protocols for transferring management information.  The
+      first version of the SNMP message protocol is called SNMPv1 and
+      described in STD 15, RFC 1157 [8].  A second version of the SNMP
+      message protocol, which is not an Internet standards track
+      protocol, is called SNMPv2c and described in RFC 1901 [9] and RFC
+      1906 [10].  The third version of the message protocol is called
+      SNMPv3 and described in RFC 1906 [10], RFC 2572 [11] and RFC 2574
+      [12].
+
+
+
+
+
+
+
+
+Rehbehn, et al.             Standards Track                     [Page 2]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+   o  Protocol operations for accessing management information.  The
+      first set of protocol operations and associated PDU formats is
+      described in STD 15, RFC 1157 [8].  A second set of protocol
+      operations and associated PDU formats is described in RFC 1905
+      [13].
+
+   o  A set of fundamental applications described in RFC 2573 [14] and
+      the view-based access control mechanism described in RFC 2575
+      [15].
+
+   A more detailed introduction to the current SNMP Management Framework
+   can be found in RFC 2570 [16].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  Objects in the MIB are
+   defined using the mechanisms defined in the SMI.
+
+   This memo specifies a MIB module that is compliant to the SMIv2.  A
+   MIB conforming to the SMIv1 can be produced through the appropriate
+   translations.  The resulting translated MIB must be semantically
+   equivalent, except where objects or events are omitted because no
+   translation is possible (use of Counter64).  Some machine readable
+   information in SMIv2 will be converted into textual descriptions in
+   SMIv1 during the translation process.  However, this loss of machine
+   readable information is not considered to change the semantics of the
+   MIB.
+
+2.  Conventions
+
+   The keywords MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD,
+   SHOULD NOT, RECOMMENDED, NOT RECOMMENDED, MAY, and OPTIONAL, when
+   they appear in this document, are to be interpreted as described in
+   RFC 2119 [23].
+
+3.  Overview
+
+   This document defines a Management Information Base (MIB) for
+   monitoring and controlling a service interworking function (IWF) for
+   Permanent Virtual Connections (PVC) between Frame Relay and
+   Asynchronous Transfer Mode (ATM) technologies.  The agreements on
+   which this MIB is based were reached jointly by the Frame Relay Forum
+   and the ATM Forum and are documented in the Frame Relay Forum
+   Document FRF.8 [17].
+
+
+
+
+
+
+
+
+Rehbehn, et al.             Standards Track                     [Page 3]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+3.1.  Frame Relay/ATM Service Interworking Background
+
+   Frame relay to ATM interworking is a function that exchanges Protocol
+   Data Units (PDU) between a frame relay service user and an ATM
+   service user. Two types of interworking functions are specified for
+   frame relay and ATM permanent virtual connection (PVC) service users:
+   network interworking and service interworking.
+
+   Network interworking provides PDU forwarding between frame relay
+   service users inter-connected by an ATM service. Both endpoints are
+   frame relay PVCs. Frame Relay to ATM PVC Network Interworking is
+   defined in [20].
+
+   Service interworking provides PDU forwarding so that the ATM service
+   user performs no frame relaying service-specific functions and the
+   frame relay service user performs no ATM service-specific functions.
+   Optionally, the service IWF translates particular higher layer
+   protocols to satisfy the requirements of end-systems.  Frame Relay to
+   ATM PVC Service Interworking is defined in [17].
+
+   This MIB describes management objects used to provision, monitor, and
+   control a Frame Relay/ATM PVC Service IWF.
+
+   FRF.8 [17] does not address point-to-multipoint applications of the
+   IWF.  Implementations MAY provide support for point-to-multipoint
+   capability using this MIB.
+
+   Consult FRF.8 [17] for more details on the operation of a Frame
+   Relay/ATM PVC Service IWF.
+
+3.2.  Structure of the MIB
+
+   The Frame Relay/ATM PVC Service IWF managed objects are organized as
+   follows:
+
+   (1) FR/ATM PVC Service IWF cross-connect table,
+
+   (2) Connection description table, and
+
+   (3) Notification object
+
+   The IWF cross-connect table contains one or more rows for each
+   inter-worked connection.  Each inter-worked connection is uniquely
+   identified by the frAtmIwfConnIndex object. In the case of point-to-
+   point, a single row is present.  In the case of point-to-multipoint,
+   one row exists for each multipoint destination.  Index objects for
+   the ATM port, VPI, VCI, frame relay port, and frame relay DLCI
+   distinguish the constituent rows used in a point-to-multipoint case.
+
+
+
+Rehbehn, et al.             Standards Track                     [Page 4]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+   Each inter-worked connection has attributes governing behavior of the
+   IWF.  These attributes describe how the IWF should transform a PDU
+   during the forwarding process and provide rules for:
+
+   (1) Mapping the ATM CLP bit to frame relay DE bit
+
+   (2) Mapping the ATM congestion notification bit to frame relay
+       congestion bits
+
+   (3) Mapping higher protocol encapsulations between ATM and frame
+       relay
+
+   (4) Performing fragmentation and reassembly
+
+   (5) Performing ARP translation between ATM and frame relay
+
+   Typically, most connections share the same attributes.  The
+   attributes are represented in this MIB by the connection description
+   table.  Each row of the connection description table contains the
+   attribute settings common to one or more inter-worked connections.
+   One example would be full mapping and translation.  All cross-connect
+   table entries that require full mapping and translation services set
+   the frAtmIwfConnectionDescriptor object to the index value for the
+   connection description table row that contains objects set to values
+   that provide full mapping and translation services.
+
+   A notification object provides cross-connect status change alerts.
+
+3.3.  Relationship to Other MIBs
+
+   The Frame Relay/ATM PVC Service IWF MIB describes the cross-
+   connections between frame relay and ATM service users.  Each PVC
+   endpoint is provisioned and managed with a technology-specific MIB as
+   described below.
+
+   Each technology-specific MIB has a table of PVC endpoints (indexed by
+   ifIndex and logical link address such as the DLCI or VPI/VCI).  In
+   the absence of interworking, two endpoints are cross-connected via a
+   technology-specific cross connect table (e.g., the
+   atmVcCrossConnectTable in the ATM MIB).  However, a connection
+   between a frame relay endpoint and an ATM endpoint requires a cross-
+   connect in the ATM IWF MIB.
+
+   The following sections describe the relationship between the
+   technology-specific MIBs and the FR/ATM PVC Service IWF MIB.
+
+
+
+
+
+
+Rehbehn, et al.             Standards Track                     [Page 5]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+3.3.1.  Frame Relay Service MIB
+
+   Frame relay PVC endpoints are provisioned as rows in the Frame Relay
+   Services MIB [19] endpoint table.
+
+   Each frame relay PVC endpoint is described in the frPVCEndptTable.  A
+   connection between two frame relay endpoints is described by an entry
+   in the frame relay PVC cross-connect table frPVCConnectTable.  The
+   frPVCEndptConnectIdentifier object of each endpoint points to the
+   frPVCConnectTable cross-connect table row for the connection.
+
+   In the case of an inter-worked connection, the
+   frPVCEndptConnectIdentifier object is set to zero.  Instead, the
+   frPVCEndptAtmIwfConnIndex object is set to the index of the FR/ATM
+   IWF cross-connect table row.
+
+   The frame relay PVC cross-connect table (frPVCConnectTable) does not
+   contain an entry for the FR/ATM inter-worked connection.
+
+   Note that the frPVCEndptConnectIdentifier and
+   frPVCEndptAtmIwfConnIndex objects are set by the system as a side-
+   effect of cross-connect establishment.  Consequently, these objects
+   are read-only.
+
+3.3.2.  Frame Relay DTE MIB
+
+   The Frame Relay DTE MIB described in [24] has no relevance to the
+   FR/ATM PVC Service IWF MIB.
+
+3.3.3.  ATM MIB
+
+   ATM PVC endpoints are provisioned as rows in the ATM MIB [21] virtual
+   connection link table.
+
+   Each ATM connection endpoint is described in the atmVclTable.  A
+   connection between two ATM endpoints is described by an entry in the
+   ATM VCL cross-connect table atmVcCrossConnectTable.  The
+   atmVclCrossConnectIdentifier object of each endpoint points to the
+   atmVcCrossConnectTable row for the connection.
+
+   In the case of an inter-worked connection, the
+   atmVclCrossConnectIdentifier object is set to zero.  Instead, the
+   frAtmIwfVclCrossConnectIdentifier object in the frAtmIwfVclEntry is
+   set to the index of the applicable FR/ATM IWF cross-connect table
+   row.
+
+
+
+
+
+
+Rehbehn, et al.             Standards Track                     [Page 6]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+   Note that the frAtmIwfVclCrossConnectIdentifier object is defined not
+   in the ATM MIB but in Section 5 of this MIB.  Specifically, the
+   object is defined as a column object in a table that AUGMENTs the ATM
+   MIB VCL table.
+
+   The ATM VCL cross-connect table (atmVcCrossConnectTable) does not
+   contain an entry for the inter-worked connection.
+
+   Note that the atmVclCrossConnectIdentifier and
+   frAtmIwfVclCrossConnectIdentifier objects are set by the system as a
+   side-effect of cross-connect establishment.  Consequently, these
+   objects are read-only.
+
+3.3.4.  IF MIB
+
+   The ifIndex defined in the IF MIB [22] identifies the specific frame
+   relay and ATM endpoint interfaces.  The values frAtmIwfConnAtmPort
+   and frAtmIwfConnFrPort are used in this MIB as components in the
+   index list for the frAtmIwfConnectionTable rows.
+
+3.4.  Point to Multipoint Considerations
+
+   This MIB supports IWF implementations providing point-to-multipoint
+   functionality. All rows of the cross-connect table indexed by the
+   same frAtmIwfConnIndex MUST utilize the same
+   frAtmIwfConnectionDescriptor value.
+
+   A group of cross-connect table entries indexed by the same
+   frAtmIwfConnIndex value MUST agree on which service the multipoint
+   operation is offered. Two cases are possible:
+
+   (1) Many frame relay PVCs cross-connected to one ATM PVC, or
+
+   (2) One frame relay PVC cross-connected to many ATM PVCs
+
+3.5.  Theory of Operation
+
+3.5.1.  Creation Process
+
+   Multiple steps are required to create a frame relay to ATM cross-
+   connection.  First, rows must be created in the following tables:
+
+   (1) The Frame Relay Service MIB frPVCEndptTable
+
+   (2) The ATM MIB atmVclTable
+
+   (3) The FR/ATM Service IWF MIB frAtmIwfConnectionDescriptorTable
+
+
+
+
+Rehbehn, et al.             Standards Track                     [Page 7]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+   (4) The FR/ATM Service IWF MIB frAtmIwfConnectionTable
+
+   Second, the newly created rows are cross-linked.
+
+   Finally, the administrative and operational status objects are set to
+   'up(1)'.
+
+   A step-by-step example is provided to illustrate the creation
+   process.  In this example, the term "Manager" refers to a network
+   management system that issues SNMP protocol actions to an "Agent".
+   The agent is integrated with the system that implements the frame
+   relay to ATM service IWF.  In this example, the following cross-
+   connection is created:
+
+                  +-----------------------------------+
+   +---------+    |       FR/ATM PVC Service IWF      |
+   | Frame   |    |   ------------------------------  |    +-----------+
+   | Relay   |  +--------> frAtmIwfConnIndex K <--------+  |   ATM     |
+   |Endpoint |  | |               V                   | |  | Endpoint  |
+   | ------- |  | |               |                   | |  | --------- |
+   | DLCI X  |  | |  +------------+                   | |  |VPI.VCI Q.R|
+   |  on     |<-+ |  |                                | +->|    on     |
+   |ifIndex Y|    |  V                                |    | ifIndex S |
+   +---------+    |frAtmIwfConnectionDescriptorIndex L|    +-----------+
+                  +-----------------------------------+
+
+   Step 1 - Create the frame relay PVC endpoint
+
+   a) Manager requests creation of a new row in the frPVCEndptTable
+
+   b) Agent receives management request to create a row in
+      frPVCEndptTable for the frame relay side
+
+   c) A new row is created in frPVCEndptTable as follows:
+
+      -  frPVCEndptConnectIdentifier initialized to zero
+
+      -  frPVCEndptAtmIwfConnIndex initialized to zero
+
+      -  remaining row objects initialized as needed for DLCI X on
+         ifIndex Y
+
+   Step 2 - Create the ATM PVC endpoint
+
+   a) Agent receives management request to create a row in atmVclTable
+      for the ATM side
+
+
+
+
+
+Rehbehn, et al.             Standards Track                     [Page 8]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+   b) A new row is created in atmVclTable and frAtmIwfVclTable (the
+      AUGMENT to the atmVclTable) as follows:
+
+      -  atmVclCrossConnectIdentifier initialized to zero
+
+      -  frAtmIwfVclCrossConnectIdentifier initialized to zero
+
+      -  atmVclConnKind initialized to pvc(1)
+
+      -  remaining row objects initialized as needed for VPI.VCI Q.R on
+         ifIndex S
+
+   Step 3 - Create the FR/ATM connection descriptor
+
+   a) If an existing connection descriptor is appropriate for the new
+      connection, go to Step 4 using the selected connection descriptor
+      index value L
+
+   b) Manager requests a new connection descriptor index value by
+      reading frAtmIwfConnectionDescriptorIndexNext from the agent
+
+   c) Agent receives GET request for
+      frAtmIwfConnectionDescriptorIndexNext and responds with the next
+      available value L
+
+   d) Manager requests a new connection descriptor row entry using the
+      value L as the index
+
+   e) Agent receives SET request to create the
+      frAtmIwfConnectionDescriptorTable row entry causes the system to
+      create a row in the table.
+
+   Step 4 - Create the FR/ATM cross-connect
+
+   a) Manager requests a new cross-connect index value by reading
+      frAtmIwfConnIndexNext from the agent
+
+   b) Agent receives GET request for frAtmIwfConnIndexNext and responds
+      with the next available value K
+
+   c) Manager requests a new cross-connect row entry using the value K
+      as the index
+
+   d) Agent receives SET request to create the frAtmIwfConnectionTable
+      row entry (note: the frame relay and ATM PVC endpoints MUST exist
+      and be specified as part of the index fields for the row
+      'K.S.Q.R.Y.X')
+
+
+
+
+Rehbehn, et al.             Standards Track                     [Page 9]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+   e) System creates a row in frAtmIwfConnectionTable for the following
+      indices:
+
+      -  frAtmIwfConnIndex of K
+
+      -  frAtmIwfConnAtmPort of S
+
+      -  frAtmIwfConnVpi of Q
+
+      -  frAtmIwfConnVci of R
+
+      -  frAtmIwfConnFrPort of Y
+
+      -  frAtmIwfConnDlci of X
+
+      -  frAtmIwfConnectionDescriptor of L
+
+   Step 5 - The system sets the frame relay PVC endpoint and ATM VCL
+   endpoint to point to the FR/ATM cross-connect row (as a side-effect
+   of Step 4).
+
+   a) System sets frPVCEndptAtmIwfConnIndex to K
+
+   b) System sets frAtmIwfVclCrossConnectIdentifier to K
+
+   Step 6 - Manager signals activation by issuing a SET for the
+   frAtmIwfConnAdminStatus object using the value of 'up(1)'
+
+   Step 7 - Agent receives SET request for frAtmIwfConnAdminStatus and
+   executes internal system mechanisms to activate each PVC segment and
+   the IWF cross-connect. The successful activation permits the agent to
+   respond with 'up(1)' when a GET request is received for the following
+   fields:
+
+      -  frAtmIwfConnAtm2FrOperStatus
+
+      -  frAtmIwfConnFr2AtmOperStatus
+
+      -  atmVclOperStatus (Note: there is no comparable FRS MIB object)
+
+3.5.2.  Destruction Process
+
+   Destruction of the frame relay to ATM cross-connection is initiated
+   by the network management system.  The agent's processing of the
+   request stimulates implementation-specific system clean-up actions.
+   Following removal of the row in the cross-connection table, the
+   frAtmIwfVclCrossConnectIdentifier in the frAtmIwfVclTable (AUGMENT of
+
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 10]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+   the ATM MIB endpoint table) and frPVCEndptAtmIwfConnIndex in the
+   Frame Relay Service MIB endpoint table are both re-initialized to
+   zero.
+
+   A step-by-step example is provided to illustrate the destruction
+   process.
+
+   Step 1 - Manager requests destruction of an existing row in the
+   frAtmIwfConnectionTable by setting frAtmIwfConnRowStatus to
+   destroy(6)
+
+   Step 2 - Agent receives the SET request and performs implementation-
+   specific system clean-up actions for the cross-connection row
+
+   Step 3 - System updates the relevant cross connect information for
+   the frame relay PVC endpoint by setting frPVCEndptAtmIwfConnIndex to
+   0
+
+   Step 4 - System updates the relevant cross connect information for
+   the ATM PVC endpoint as follows:
+
+   a) System sets frAtmIwfVclCrossConnectIdentifier to 0
+
+   b) System sets atmVclOperStatus to 'down(2)' (Note: there is no
+      comparable FRS MIB object)
+
+   Following the destruction of the FR/ATM cross-connection entry, the
+   manager MAY set the frPVCConnectRowStatus and/or atmVclRowStatus to
+   destroy(6) the associated endpoint entries.
+
+3.5.3.  Modification Process
+
+   At the discretion of the agent, a FR/ATM cross-connect may be
+   reconfigured by adding and/or deleting leafs to/from the IWF topology
+   as per the FR/ATM IWF cross-connect creation/destruction procedures.
+   Reconfiguration of traffic/service category parameter values requires
+   release of the FR/ATM IWF cross-connect before those parameter values
+   may be changed for individual frame relay or ATM endpoint segments.
+
+4.  Object Definitions
+
+FR-ATM-PVC-SERVICE-IWF-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+              MODULE-IDENTITY, OBJECT-TYPE,
+              NOTIFICATION-TYPE,
+              mib-2, Integer32, Counter32             FROM SNMPv2-SMI
+
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 11]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+              RowStatus, TimeStamp                    FROM SNMPv2-TC
+
+              MODULE-COMPLIANCE, OBJECT-GROUP,
+              NOTIFICATION-GROUP                      FROM SNMPv2-CONF
+
+              AtmVpIdentifier, AtmVcIdentifier        FROM ATM-TC-MIB
+
+              atmVclEntry                             FROM ATM-MIB
+
+              InterfaceIndex                          FROM IF-MIB;
+
+         frAtmIwfMIB MODULE-IDENTITY
+             LAST-UPDATED "200009280000Z" -- September 28, 2000
+             ORGANIZATION "IETF Frame Relay Service MIB Working Group"
+             CONTACT-INFO
+                 "WG Charter:
+                    http://www.ietf.org/html.charters/frnetmib-charter
+                  WG-email:
+                    frnetmib@sunroof.eng.sun.com
+                  Subscribe:
+                    frnetmib-request@sunroof.eng.sun.com
+                  Email Archive:
+                    ftp://ftp.ietf.org/ietf-mail-archive/frnetmib
+
+                  Chair:      Andy Malis
+                              Vivace Networks, Inc.
+                  Email:      Andy.Malis@vivacenetworks.com
+
+                  WG editor:  Kenneth Rehbehn
+                              Megisto Systems, Inc.
+                  Email:      krehbehn@megisto.com
+
+                  Co-author:  Orly Nicklass
+                              RAD Data Communications Ltd.
+                  EMail:      orly_n@rad.co.il
+
+                  Co-author:  George Mouradian
+                              AT&T Labs
+                  EMail:      gvm@att.com"
+
+             DESCRIPTION
+                     "The MIB module for monitoring and controlling the
+                     Frame Relay/ATM PVC Service Interworking
+                     Function."
+
+             --
+             -- Revision History
+             --
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 12]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+             REVISION "200009280000Z"
+             DESCRIPTION
+                  "Published as RFC 2955"
+
+         ::= { mib-2 86 }
+
+         --
+         -- Object Identifiers
+         --
+            frAtmIwfMIBObjects      OBJECT IDENTIFIER
+                                         ::= { frAtmIwfMIB 1 }
+
+            frAtmIwfTraps           OBJECT IDENTIFIER
+                                         ::= { frAtmIwfMIB 2 }
+            frAtmIwfTrapsPrefix     OBJECT IDENTIFIER
+                                         ::= { frAtmIwfTraps 0 }
+
+            frAtmIwfConformance     OBJECT IDENTIFIER
+                                         ::= { frAtmIwfMIB 3 }
+            frAtmIwfGroups          OBJECT IDENTIFIER
+                                         ::= { frAtmIwfConformance 1 }
+            frAtmIwfCompliances     OBJECT IDENTIFIER
+                                         ::= { frAtmIwfConformance 2 }
+
+         --
+         --  The FR/ATM PVC Service IWF Group
+         --
+         --      The Frame Relay/ATM PVC Service Interworking Function
+         --      Connection Table contains all connections utilizing
+         --      the interworking function.
+         --
+
+         frAtmIwfConnIndexNext OBJECT-TYPE
+              SYNTAX         Integer32 (0..2147483647)
+              MAX-ACCESS     read-only
+              STATUS         current
+              DESCRIPTION
+                     "This object contains an appropriate value to be
+                     used for frAtmIwfConnIndex  when creating entries
+                     in the frAtmIwfConnectionTable. The value 0
+                     indicates that no unassigned entries are
+                     available. To obtain the frAtmIwfConnIndexNext
+                     value for a new entry, the manager issues a
+                     management protocol retrieval operation to obtain
+                     the current value of this object.  After each
+                     retrieval, the agent should modify the value to
+                     the next unassigned index."
+              ::= { frAtmIwfMIBObjects 1 }
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 13]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+         frAtmIwfConnectionTable OBJECT-TYPE
+             SYNTAX      SEQUENCE OF FrAtmIwfConnectionEntry
+             MAX-ACCESS  not-accessible
+             STATUS      current
+             DESCRIPTION
+                     "A table in which each row represents a Frame
+                     Relay/ATM interworking connection."
+             ::= { frAtmIwfMIBObjects 2 }
+
+         frAtmIwfConnectionEntry OBJECT-TYPE
+             SYNTAX      FrAtmIwfConnectionEntry
+             MAX-ACCESS  not-accessible
+             STATUS      current
+             DESCRIPTION
+                     "The FrAtmIwfConnectionEntry provides an entry for
+                     an interworking connection between a frame relay
+                     PVC and one or more ATM PVCs, or an ATM PVC and
+                     one or more frame relay PVCs.  A single frame
+                     relay PVC connected to a single ATM PVC is
+                     referred to as a `point-to-point' connection and
+                     is represented by a single row in the FR/ATM IWF
+                     Connection Table.  The case of a single frame
+                     relay PVC connected to multiple ATM PVCs (or
+                     single ATM PVC connected to multiple frame relay
+                     PVCs) is referred to as a `point-to-multipoint'
+                     connection and is represented by multiple rows in
+                     the FR/ATM IWF Connection Table.
+
+                     The object frAtmIwfConnIndex uniquely identifies
+                     each point-to-point or point-to-multipoint
+                     connection.  The manager obtains the
+                     frAtmIwfConnIndex value by reading the
+                     frAtmIwfConnIndexNext object.
+
+                     After a frAtmIwfConnIndex is assigned for the
+                     connection, the manager creates one or more rows
+                     in the Cross Connect Table; one for each cross-
+                     connection between the frame relay PVC and an ATM
+                     PVC. In the case of `point-to-multipoint'
+                     connections, all rows are indexed by the same
+                     frAtmIwfConnIndex value and MUST refer to the same
+                     frame relay PVC or ATM PVC respectively.  An entry
+                     can be created only when at least one pair of
+                     frame relay and ATM PVCs exist.
+
+                     A row can be established by one-step set-request
+                     with all required parameter values and
+                     frAtmIwfConnRowStatus set to createAndGo(4). The
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 14]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+                     Agent should perform all error checking as needed.
+                     A pair of cross-connected PVCs, as identified by a
+                     particular value of the indexes, is released by
+                     setting frAtmIwfConnRowStatus to destroy(6). The
+                     Agent may release all associated resources. The
+                     manager may remove the related PVCs thereafter.
+                     Indexes are persistent across reboots of the
+                     system."
+             INDEX   { frAtmIwfConnIndex,
+                       frAtmIwfConnAtmPort,
+                       frAtmIwfConnVpi,
+                       frAtmIwfConnVci,
+                       frAtmIwfConnFrPort,
+                       frAtmIwfConnDlci
+                     }
+             ::= { frAtmIwfConnectionTable 1 }
+
+         FrAtmIwfConnectionEntry ::=
+             SEQUENCE {
+                 frAtmIwfConnIndex                      Integer32,
+                 frAtmIwfConnAtmPort                    InterfaceIndex,
+                 frAtmIwfConnVpi                        AtmVpIdentifier,
+                 frAtmIwfConnVci                        AtmVcIdentifier,
+                 frAtmIwfConnFrPort                     InterfaceIndex,
+                 frAtmIwfConnDlci                       Integer32,
+                 frAtmIwfConnRowStatus                  RowStatus,
+                 frAtmIwfConnAdminStatus                INTEGER,
+                 frAtmIwfConnAtm2FrOperStatus           INTEGER,
+                 frAtmIwfConnAtm2FrLastChange           TimeStamp,
+                 frAtmIwfConnFr2AtmOperStatus           INTEGER,
+                 frAtmIwfConnFr2AtmLastChange           TimeStamp,
+                 frAtmIwfConnectionDescriptor           Integer32,
+                 frAtmIwfConnFailedFrameTranslate       Counter32,
+                 frAtmIwfConnOverSizedFrames            Counter32,
+                 frAtmIwfConnFailedAal5PduTranslate     Counter32,
+                 frAtmIwfConnOverSizedSDUs              Counter32,
+                 frAtmIwfConnCrcErrors                  Counter32,
+                 frAtmIwfConnSarTimeOuts                Counter32
+         }
+
+         frAtmIwfConnIndex  OBJECT-TYPE
+             SYNTAX      Integer32  (1..2147483647)
+             MAX-ACCESS  not-accessible
+             STATUS      current
+             DESCRIPTION
+                     "A unique value for each point-to-point or point-
+                     to-multipoint connection.  The manager obtains the
+                     frAtmIwfConnIndex value by reading the
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 15]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+                     frAtmIwfConnIndexNext object.  A point-to-
+                     multipoint connection will be represented in the
+                     frAtmIwfConnectionTable with multiple entries that
+                     share the same frAtmIwfConnIndex value."
+             ::= { frAtmIwfConnectionEntry 1 }
+
+         frAtmIwfConnAtmPort OBJECT-TYPE
+             SYNTAX      InterfaceIndex
+             MAX-ACCESS  not-accessible
+             STATUS      current
+             DESCRIPTION
+                     "The index in the ifTable that identifies the ATM
+                     port for this interworking connection."
+             ::= { frAtmIwfConnectionEntry 2 }
+
+         frAtmIwfConnVpi OBJECT-TYPE
+             SYNTAX      AtmVpIdentifier
+             MAX-ACCESS  not-accessible
+             STATUS      current
+             DESCRIPTION
+                     "The VPI of the ATM PVC end point for this
+                      interworking connection."
+             ::= { frAtmIwfConnectionEntry 3 }
+
+         frAtmIwfConnVci OBJECT-TYPE
+             SYNTAX      AtmVcIdentifier
+             MAX-ACCESS  not-accessible
+             STATUS      current
+             DESCRIPTION
+                     "The VCI of the ATM PVC end point for this
+                     interworking
+                      connection."
+             ::= { frAtmIwfConnectionEntry 4 }
+
+         frAtmIwfConnFrPort OBJECT-TYPE
+             SYNTAX      InterfaceIndex
+             MAX-ACCESS  not-accessible
+             STATUS      current
+             DESCRIPTION
+                     "The index in the ifTable that identifies the
+                     frame relay port for this interworking
+                     connection."
+             ::= { frAtmIwfConnectionEntry 5 }
+
+         frAtmIwfConnDlci OBJECT-TYPE
+             SYNTAX      Integer32 (16..4194303)
+             MAX-ACCESS  not-accessible
+             STATUS      current
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 16]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+             DESCRIPTION
+                     "The DLCI that identifies the frame relay PVC end
+                     point for this interworking connection."
+             ::= { frAtmIwfConnectionEntry 6 }
+
+         frAtmIwfConnRowStatus OBJECT-TYPE
+             SYNTAX      RowStatus
+             MAX-ACCESS  read-create
+             STATUS      current
+             DESCRIPTION
+                     "The table row may be created with
+                     'createAndWait(5)' or 'createAndGo(4)'.
+                     To activate a connection entry, a valid connection
+                     descriptor MUST be established in the
+                     frAtmIwfConnectionDescriptor object.
+
+                     This object is set to 'destroy(6)' to delete the
+                     table row.  Before the table row is destroyed, the
+                     OperStatus/AdminStatus of the corresponding
+                     endpoints MUST be 'down(2)'.  The deactivation of
+                     the ATM endpoint MAY occur as a side-effect of
+                     deleting the FR/ATM IWF cross-connection table
+                     row.  Otherwise, 'destroy(6)' operation MUST fail
+                     (error code 'inconsistentValue')."
+             ::= { frAtmIwfConnectionEntry 7 }
+
+         frAtmIwfConnAdminStatus OBJECT-TYPE
+             SYNTAX      INTEGER { up(1), down(2) }
+             MAX-ACCESS  read-create
+             STATUS      current
+             DESCRIPTION
+                     "The desired operational state for this FR/ATM
+                     interworked connection.
+
+                     up(1)       = Activate the connection. Before the
+                                   activation can be completed, the
+                                   OperStatus/AdminStatus of the
+                                   corresponding endpoints MUST be
+                                   'up(1)'.  The activation of the
+                                   corresponding endpoints MAY occur as
+                                   a side-effect of activating the
+                                   FR/ATM IWF cross-connection.
+
+                     down(2)     = Deactivate the connection. Before
+                                   the deactivation can be completed,
+                                   the atmVclAdminStatus of the
+                                   corresponding ATM endpoint MUST be
+                                   'down(2)'.  The deactivation of the
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 17]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+                                   ATM endpoint MAY occur as a
+                                   side-effect of deactivating the
+                                   FR/ATM IWF cross-connection."
+             ::= { frAtmIwfConnectionEntry 8 }
+
+         frAtmIwfConnAtm2FrOperStatus     OBJECT-TYPE
+             SYNTAX      INTEGER { up(1), down(2) }
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                     "The current operational state of this
+                     interworking connection in the ATM to frame
+                     relay direction."
+             ::= { frAtmIwfConnectionEntry 9 }
+
+         frAtmIwfConnAtm2FrLastChange  OBJECT-TYPE
+             SYNTAX      TimeStamp
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                     "The value of sysUpTime at the time this
+                     interworking connection entered its current
+                     operational state in the ATM to FR direction.  If
+                     the current state was entered prior to the last
+                     re-initialization of the local network management
+                     subsystem, then this object contains a zero
+                     value."
+             ::= { frAtmIwfConnectionEntry 10 }
+
+         frAtmIwfConnFr2AtmOperStatus     OBJECT-TYPE
+             SYNTAX      INTEGER { up(1), down(2) }
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                     "The current operational state of this
+                     interworking connection in the frame relay
+                     to ATM direction."
+             ::= { frAtmIwfConnectionEntry 11 }
+
+         frAtmIwfConnFr2AtmLastChange  OBJECT-TYPE
+             SYNTAX      TimeStamp
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                     "The value of sysUpTime at the time this
+                     interworking connection entered its current
+                     operational state in the FR to ATM direction.  If
+                     the current state was entered prior to the last
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 18]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+                     re-initialization of the local network management
+                     subsystem, then this object contains a zero
+                     value."
+             ::= { frAtmIwfConnectionEntry 12 }
+
+         frAtmIwfConnectionDescriptor  OBJECT-TYPE
+             SYNTAX      Integer32
+             MAX-ACCESS  read-create
+             STATUS      current
+             DESCRIPTION
+                     "The value represents a pointer to the relevant
+                     descriptor in the IWF descriptor table.  An
+                     attempt to set this value to an inactive or non-
+                     existent row in the Connection Descriptor Table
+                     MUST fail (error code 'inconsistentValue')."
+             ::= { frAtmIwfConnectionEntry 13 }
+
+         frAtmIwfConnFailedFrameTranslate OBJECT-TYPE
+             SYNTAX      Counter32
+             UNITS       "Frames"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                     "This object counts the number of frames discarded
+                     by the IWF because, while operating in Translation
+                     Mode, the IWF is unable to decode the incoming
+                     frame payload header according to the mapping
+                     rules. (i.e., payload header not recognized by the
+                     IWF).
+
+                     Frame relay frames are received in the frame relay
+                     to ATM direction of the PVC.
+
+                     When operating in Transparent Mode, the IWF MUST
+                     return noSuchInstance."
+                       REFERENCE
+                                "FRF.8 [17], Section 5.3.1"
+                       ::= { frAtmIwfConnectionEntry 14 }
+
+         frAtmIwfConnOverSizedFrames OBJECT-TYPE
+             SYNTAX      Counter32
+             UNITS       "Frames"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                     "Count of frames discarded by the IWF because the
+                     frame is too large to be processed by the AAL5
+                     segmentation procedure.  Specifically, the frame
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 19]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+                     does not conform to the size specified in the
+                     atmVccAal5CpcsTransmitSduSize object associated
+                     with the atmVclEntry at the ATM endpoint.
+                     Frame relay frames are received in the frame relay
+                     to ATM direction of the PVC."
+                       REFERENCE
+                                "ATM MIB [21], atmVclTable
+                                 FRF.8 [17], 5.3.1.4"
+                       ::= { frAtmIwfConnectionEntry 15 }
+
+         frAtmIwfConnFailedAal5PduTranslate OBJECT-TYPE
+             SYNTAX      Counter32
+             UNITS       "PDUs"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                     "This attribute counts the number of AAL5 PDUs
+                     discarded by the IWF because, while operating in
+                     Translation Mode, the IWF is unable to decode the
+                     incoming AAL5 PDU payload header according to the
+                     mapping rules. (i.e., payload header not
+                     recognized by the IWF).
+
+                     AAL5 PDUs are received in the ATM to frame relay
+                     direction of the PVC.
+
+                     When operating in Transparent Mode, the IWF MUST
+                     return noSuchInstance."
+                       REFERENCE
+                                "FRF.8 [17], Section 5.3.1"
+                       ::= { frAtmIwfConnectionEntry 16 }
+
+         frAtmIwfConnOverSizedSDUs OBJECT-TYPE
+             SYNTAX      Counter32
+             UNITS       "SDUs"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                     "Count of AAL5 SDUs discarded by the IWF because
+                     the SDU is too large to be forwarded on the frame
+                     relay segment of the connection.  Specifically,
+                     the frame does not conform to the size specified
+                     in the frLportFragSize object of the FRS MIB [19].
+
+                     AAL5 PDUs are received in the ATM to frame relay
+                     direction of the PVC."
+                       REFERENCE
+                                "FRS MIB [19], frLportTable
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 20]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+                                 FRF.8 [17], 5.3.1.4"
+                       ::= { frAtmIwfConnectionEntry 17 }
+
+         frAtmIwfConnCrcErrors OBJECT-TYPE
+             SYNTAX      Counter32
+             UNITS       "PDUs"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                     "The number of AAL5 CPCS PDUs received with CRC-32
+                     errors on this AAL5 VCC at the IWF.
+
+                     AAL5 PDUs are received in the ATM to frame relay
+                     direction of the PVC."
+                       REFERENCE
+                                "ATM MIB [21], atmVclTable"
+                       ::= { frAtmIwfConnectionEntry 18 }
+
+         frAtmIwfConnSarTimeOuts OBJECT-TYPE
+             SYNTAX      Counter32
+             UNITS       "PDUs"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                     "The number of partially re-assembled AAL5 CPCS
+                     PDUs which were discarded on this AAL5 VCC at the
+                     IWF because they were not fully re-assembled
+                     within the required time period.  If the re-
+                     assembly timer is not supported, then this object
+                     contains a zero value.
+
+                     AAL5 PDUs are received in the ATM to frame relay
+                     direction of the PVC."
+                       REFERENCE
+                                "ATM MIB [21], atmVclTable"
+                       ::= { frAtmIwfConnectionEntry 19 }
+
+         --
+         -- The FR/ATM PVC Service IWF Connection Descriptor Group
+         --
+         --     The Frame Relay/ATM PVC Service Interworking Function
+         --     Connection Descriptor table.  A descriptor provides the
+         --     attributes for a type of interworked connection.
+         --
+
+         frAtmIwfConnectionDescriptorIndexNext OBJECT-TYPE
+              SYNTAX      Integer32 (0..2147483647)
+              MAX-ACCESS  read-only
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 21]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+              STATUS      current
+              DESCRIPTION
+                     "This object contains an appropriate value to be
+                     used for frAtmIwfConnectionDescriptorIndex  when
+                     creating entries in the
+                     frAtmIwfConnectionDescriptorTable. The value 0
+                     indicates that no unassigned entries are
+                     available. To obtain the
+                     frAtmIwfConnectionDescriptorIndexNext value for a
+                     new entry, the manager issues a management
+                     protocol retrieval operation to obtain the current
+                     value of this object.  After each retrieval, the
+                     agent should modify the value to the next
+                     unassigned index."
+              ::= { frAtmIwfMIBObjects 3 }
+
+         frAtmIwfConnectionDescriptorTable OBJECT-TYPE
+             SYNTAX      SEQUENCE OF FrAtmIwfConnectionDescriptorEntry
+             MAX-ACCESS  not-accessible
+             STATUS      current
+             DESCRIPTION
+                     "A table in which each row represents a descriptor
+                     for one type of Frame Relay/ATM interworking
+                     connection.  A descriptor may be assigned to zero
+                     or more FR/ATM PVC service IWF connections."
+             ::= { frAtmIwfMIBObjects 4 }
+
+         frAtmIwfConnectionDescriptorEntry OBJECT-TYPE
+             SYNTAX      FrAtmIwfConnectionDescriptorEntry
+             MAX-ACCESS  not-accessible
+             STATUS      current
+             DESCRIPTION
+                     "An entry for a descriptor in an interworking
+                     connection between a frame relay PVC and an ATM
+                     PVC."
+             INDEX   { frAtmIwfConnectionDescriptorIndex  }
+             ::= { frAtmIwfConnectionDescriptorTable 1 }
+
+         FrAtmIwfConnectionDescriptorEntry ::=
+             SEQUENCE {
+                 frAtmIwfConnectionDescriptorIndex      Integer32,
+                 frAtmIwfConnDescriptorRowStatus        RowStatus,
+                 frAtmIwfConnDeToClpMappingMode         INTEGER,
+                 frAtmIwfConnClpToDeMappingMode         INTEGER,
+                 frAtmIwfConnCongestionMappingMode      INTEGER,
+                 frAtmIwfConnEncapsulationMappingMode   INTEGER,
+                 frAtmIwfConnEncapsulationMappings      BITS,
+                 frAtmIwfConnFragAndReassEnabled        INTEGER,
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 22]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+                 frAtmIwfConnArpTranslationEnabled      INTEGER
+         }
+
+         frAtmIwfConnectionDescriptorIndex OBJECT-TYPE
+             SYNTAX      Integer32 (1..2147483647)
+             MAX-ACCESS  not-accessible
+             STATUS      current
+             DESCRIPTION
+                     "A unique value to identify a descriptor in the
+                     table "
+             ::= { frAtmIwfConnectionDescriptorEntry 1 }
+
+         frAtmIwfConnDescriptorRowStatus OBJECT-TYPE
+             SYNTAX      RowStatus
+             MAX-ACCESS  read-create
+             STATUS      current
+             DESCRIPTION
+                     "The status of this table row.  This object is
+                     used to create or delete an entry in the
+                     descriptor table.
+
+                     Creation of the row requires a row index (see
+                     frAtmIwfConnectionDescriptorIndexNext).  If not
+                     explicitly set or in existence, all other columns
+                     of the row will be created and initialized to the
+                     default value.  During creation, this object MAY
+                     be set to 'createAndGo(4)' or 'createAndWait(5)'.
+                     The object MUST contain the value 'active(1)'
+                     before any connection table entry references the
+                     row.
+
+                     To destroy a row in this table, this object is set
+                     to the 'destroy(6)' action.  Row destruction MUST
+                     fail (error code 'inconsistentValue') if any
+                     connection references the row."
+             ::= { frAtmIwfConnectionDescriptorEntry 2 }
+
+         frAtmIwfConnDeToClpMappingMode OBJECT-TYPE
+             SYNTAX      INTEGER {
+                            mode1(1),
+                            mode2Const0(2),
+                            mode2Const1(3)
+                         }
+             MAX-ACCESS  read-create
+             STATUS      current
+             DESCRIPTION
+                     "This object describes which mode of translation
+                     is in use for loss priority mapping in the frame
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 23]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+                     relay to ATM direction.
+
+                     mode1(1)        = the DE field in the Q.922 core
+                                       frame shall be mapped to the ATM
+                                       CLP field of every cell
+                                       generated by the segmentation
+                                       process of the AAL5 PDU
+                                       containing the information of
+                                       that frame.
+
+                     mode2Contst0(2) = the ATM CLP field of every cell
+                                       generated by the segmentation
+                                       process of the AAL5 PDU
+                                       containing the information of
+                                       that frame shall be set to
+                                       constant 0.
+
+                     mode2Contst1(3) = the ATM CLP field of every cell
+                                       generated by the segmentation
+                                       process of the AAL5 PDU
+                                       containing the information of
+                                       that frame shall be set to
+                                       constant 1."
+             REFERENCE
+                      "FRF.8 [17], Section 4.2.1"
+             DEFVAL { mode1 }
+             ::= { frAtmIwfConnectionDescriptorEntry 3 }
+
+         frAtmIwfConnClpToDeMappingMode OBJECT-TYPE
+             SYNTAX      INTEGER {
+                           mode1(1),
+                           mode2Const0(2),
+                           mode2Const1(3)
+                         }
+             MAX-ACCESS  read-create
+             STATUS      current
+             DESCRIPTION
+                     "This object describes which mode of translation
+                     is in use for loss priority mapping in the ATM to
+                     frame relay direction.
+
+                     mode1(1)       = if one or more cells in a frame
+                                      has its CLP field set, the DE
+                                      field of the Q.922 core frame
+                                      should be set.
+
+                     mode2Const0(2) = the DE field of the Q.922 core
+                                      frame should be set to the
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 24]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+                                      constant 0.
+
+                     mode2Const1(3) = the DE field of the Q.922 core
+                                      frame should be set to the
+                                      constant 1."
+             REFERENCE
+                      "FRF.8 [17], Section 4.2.2"
+             DEFVAL { mode1 }
+             ::= { frAtmIwfConnectionDescriptorEntry 4 }
+
+         frAtmIwfConnCongestionMappingMode OBJECT-TYPE
+             SYNTAX      INTEGER {
+                            mode1(1),
+                            mode2(2)
+                         }
+             MAX-ACCESS  read-create
+             STATUS      current
+             DESCRIPTION
+                     "This object describes which mode of translation
+                     is in use for forward congestion indication
+                     mapping in the frame relay to ATM direction.
+
+                     mode1(1) = The FECN field in the Q.922 core frame
+                                shall be mapped to the ATM EFCI field
+                                of every cell generated by the
+                                segmentation process of the AAL5 PDU
+                                containing the information of that
+                                frame.
+
+                     mode2(2) = The FECN field in the Q.922 core frame
+                                shall not be mapped to the ATM EFCI
+                                field of cells generated by the
+                                segmentation process of the AAL5 PDU
+                                containing the information of that
+                                frame. The EFCI field is always set to
+                                'congestion not experienced'.
+
+                     In both of the modes above, if there is congestion
+                     in the forward direction in the ATM layer within
+                     the IWF, then the IWF can set the EFCI field to
+                     'congestion experienced'."
+             REFERENCE
+                         "FRF.8 [17], Section 4.3.1.1"
+             DEFVAL      { mode1 }
+             ::= { frAtmIwfConnectionDescriptorEntry 5 }
+
+         frAtmIwfConnEncapsulationMappingMode OBJECT-TYPE
+             SYNTAX      INTEGER {
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 25]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+                            transparentMode(1),
+                            translationMode(2),
+                            translationModeAll(3)
+                         }
+             MAX-ACCESS  read-create
+             STATUS      current
+             DESCRIPTION
+                     "This object indicates whether the mapping of
+                     upper layer protocol encapsulation is enabled on
+                     this interworking connection.
+
+                     transparentMode(1) = Forward the encapsulations
+                                          unaltered.
+
+                     translationMode(2) = Perform mapping between the
+                                          two encapsulations due to the
+                                          incompatibilities of the two
+                                          methods. Mapping is provided
+                                          for a subset of the potential
+                                          encapsulations as itemized in
+                                          frAtmIwfConnEncapsulationMapp
+                                          ings.
+
+                     translationModeAll(3) = Perform mapping between
+                                          the two encapsulations due to
+                                          the incompatibilities of the
+                                          two methods. All
+                                          encapsulations are
+                                          translated."
+             REFERENCE
+                         "FRF.8 [17], Section 5.3"
+             DEFVAL      { transparentMode }
+             ::= { frAtmIwfConnectionDescriptorEntry 6 }
+
+         frAtmIwfConnEncapsulationMappings OBJECT-TYPE
+             SYNTAX      BITS {
+                    none (0),
+                    bridgedPdus(1),
+                    bridged802dot6(2),
+                    bPdus(3),
+                    routedIp(4),
+                    routedOsi(5),
+                    otherRouted(6),
+                    x25Iso8202(7),
+                    q933q2931(8) }
+             MAX-ACCESS  read-create
+             STATUS      current
+             DESCRIPTION
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 26]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+                     "If upper layer protocol encapsulation mapping is
+                     enabled on this interworking connection, then this
+                     attribute enumerates which of the encapsulation
+                     mappings are supported.
+
+                     none(0)           = Transparent mode operation
+                     bridgedPdus(1)    = PID: 0x00-01,-07,-02 or -08
+                     bridged802dot6(2) = PID: 0x00-0B
+                     bPdus(3)          = PID: 0x00-0E or -0F
+                     routedIp(4)       = NLPID: OxCC
+                     routedOsi(5)      = NLPID: Ox81, 0x82 or 0x83
+                     otherRouted(6)    = Other routed protocols
+                     x25Iso8202(7)     = X25
+                     q933q2931(8)      = Q.933 and Q.2931"
+             REFERENCE
+                         "FRF.8 [17], Section 5.3.1"
+             DEFVAL      { { none } }
+             ::= { frAtmIwfConnectionDescriptorEntry 7 }
+
+         frAtmIwfConnFragAndReassEnabled OBJECT-TYPE
+             SYNTAX      INTEGER { enabled(1),  disabled(2)}
+             MAX-ACCESS  read-create
+             STATUS      current
+             DESCRIPTION
+                     "The attribute indicates whether fragmentation and
+                     reassembly is enabled for this connection."
+             REFERENCE
+                         "FRF.8 [17], Section 5.3.1.4"
+             DEFVAL      { disabled }
+             ::= { frAtmIwfConnectionDescriptorEntry 8 }
+
+         frAtmIwfConnArpTranslationEnabled OBJECT-TYPE
+             SYNTAX      INTEGER { enabled(1),  disabled(2)}
+             MAX-ACCESS  read-create
+             STATUS      current
+             DESCRIPTION
+                     "The attribute indicates whether ARP translation
+                     is enabled for this connection."
+             REFERENCE
+                         "FRF.8 [17], Section 5.4"
+             DEFVAL      { disabled }
+             ::= { frAtmIwfConnectionDescriptorEntry 9 }
+
+         --
+         -- Augmentation of ATM MIB VCL Endpoint Table (atmVclTable)
+         --
+         frAtmIwfVclTable OBJECT-TYPE
+             SYNTAX      SEQUENCE OF FrAtmIwfVclEntry
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 27]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+             MAX-ACCESS  not-accessible
+             STATUS      current
+             DESCRIPTION
+                     "The FR/ATM IWF VCL Table augments the ATM MIB VCL
+                     Endpoint table."
+             ::= { frAtmIwfMIBObjects 5 }
+
+         frAtmIwfVclEntry OBJECT-TYPE
+             SYNTAX      FrAtmIwfVclEntry
+             MAX-ACCESS  not-accessible
+             STATUS      current
+             DESCRIPTION
+                     "Entries in this table are created only by the
+                     agent. One entry exists for each ATM VCL managed
+                     by the agent."
+             AUGMENTS    { atmVclEntry }
+             ::= { frAtmIwfVclTable 1 }
+
+         FrAtmIwfVclEntry ::= SEQUENCE {
+             frAtmIwfVclCrossConnectIdentifier    Integer32
+         }
+
+         frAtmIwfVclCrossConnectIdentifier OBJECT-TYPE
+             SYNTAX      Integer32  (1..2147483647)
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                     "This object contains the index value of the
+                     FR/ATM cross-connect table entry used to link the
+                     ATM VCL with a frame relay PVC.
+
+                     Each row of the atmVclTable that is not cross-
+                     connected with a frame relay PVC MUST return the
+                     value zero when this object is read.
+
+                     In the case of (frame relay) point to (ATM)
+                     multipoint, multiple ATM VCLs will have the same
+                     value of this object, and all their cross-
+                     connections are identified by entries that are
+                     indexed by the same value of
+                     frAtmIwfVclCrossConnectIdentifier in the
+                     frAtmIwfConnectionTable of this MIB module.
+
+                     The value of this object is initialized by the
+                     agent after the associated entries in the
+                     frAtmIwfConnectionTable have been created."
+             ::= { frAtmIwfVclEntry 1 }
+
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 28]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+         --
+         -- Frame Relay/ATM PVC Service Interworking NOTIFICATION
+         --
+
+         frAtmIwfConnStatusChange NOTIFICATION-TYPE
+             OBJECTS {   frAtmIwfConnAdminStatus,
+                         frAtmIwfConnAtm2FrOperStatus,
+                         frAtmIwfConnFr2AtmOperStatus
+                      }
+             STATUS      current
+             DESCRIPTION
+                     "An indication that the status of this
+                     interworking connection has changed."
+             ::= { frAtmIwfTrapsPrefix 1 }
+
+         --
+         -- Conformance Information
+         --
+
+         --
+         -- Compliance Statement For Equipment
+         --
+
+         frAtmIwfEquipmentCompliance MODULE-COMPLIANCE
+             STATUS      current
+             DESCRIPTION
+                     "The compliance statement for equipment that
+                     implements the FR/ATM Interworking MIB."
+
+             MODULE -- this module
+                 MANDATORY-GROUPS { frAtmIwfBasicGroup,
+                                    frAtmIwfConnectionDescriptorGroup,
+                                    frAtmIwfAtmVclTableAugmentGroup,
+                                    frAtmIwfNotificationsGroup }
+
+                 OBJECT      frAtmIwfConnDeToClpMappingMode
+                 SYNTAX      INTEGER { mode1(1) }
+                 DESCRIPTION
+                     "Only support for Mode 1 is REQUIRED."
+
+                 OBJECT      frAtmIwfConnClpToDeMappingMode
+                 SYNTAX      INTEGER { mode1(1) }
+                 DESCRIPTION
+                     "Only support for Mode 1 is REQUIRED."
+
+                 OBJECT      frAtmIwfConnCongestionMappingMode
+                 SYNTAX      INTEGER { mode1(1) }
+                 DESCRIPTION
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 29]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+                     "Only support for Mode 1 is REQUIRED."
+
+                 OBJECT      frAtmIwfConnEncapsulationMappingMode
+                 SYNTAX      INTEGER { transparentMode(1) }
+                 DESCRIPTION
+                     "Support for Translation Mode is OPTIONAL."
+
+                 OBJECT      frAtmIwfConnEncapsulationMappings
+                 SYNTAX      BITS { none(0) }
+                 DESCRIPTION
+                     "The IWF may provide one, some or none of the
+                     encapsulation translations defined in section
+                     5.3.1 of FRF.8 [17]."
+
+                 OBJECT      frAtmIwfConnFragAndReassEnabled
+                 SYNTAX      INTEGER { disabled(2) }
+                 DESCRIPTION
+                     "Only support for Mode 1 is REQUIRED."
+
+                 OBJECT      frAtmIwfConnArpTranslationEnabled
+                 SYNTAX      INTEGER { disabled(2) }
+                 DESCRIPTION
+                     "Support for ARP Translation is NOT REQUIRED."
+
+             ::= { frAtmIwfCompliances 1 }
+
+         --
+         -- Compliance Statement For Service (CNM Interface)
+         --
+
+         frAtmIwfServiceCompliance MODULE-COMPLIANCE
+             STATUS  current
+             DESCRIPTION
+                     "The compliance statement for a CNM interface that
+                     implements the FR/ATM Interworking MIB."
+
+             MODULE  -- this module
+                 MANDATORY-GROUPS { frAtmIwfBasicGroup,
+                                    frAtmIwfConnectionDescriptorGroup,
+                                    frAtmIwfAtmVclTableAugmentGroup,
+                                    frAtmIwfNotificationsGroup }
+
+                 --
+                 -- Exceptions for each object type implemented for a
+                 -- CNM view of the FR/ATM Interworking MIB
+                 --
+                 OBJECT      frAtmIwfConnAdminStatus
+                 MIN-ACCESS  read-only
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 30]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+                 DESCRIPTION
+                     "Write access is not REQUIRED."
+
+                 OBJECT      frAtmIwfConnDeToClpMappingMode
+                 SYNTAX      INTEGER { mode1(1) }
+                 MIN-ACCESS  read-only
+                 DESCRIPTION
+                     "Support for Mode 1 is REQUIRED.  Other modes are
+                     OPTIONAL.  Write access is NOT REQUIRED."
+
+                 OBJECT      frAtmIwfConnClpToDeMappingMode
+                 SYNTAX      INTEGER { mode1(1) }
+                 MIN-ACCESS  read-only
+                 DESCRIPTION
+                     "Support for Mode 1 is REQUIRED.  Other modes are
+                     OPTIONAL.  Write access is NOT REQUIRED."
+
+                 OBJECT      frAtmIwfConnCongestionMappingMode
+                 SYNTAX      INTEGER { mode1(1) }
+                 MIN-ACCESS  read-only
+                 DESCRIPTION
+                     "Support for Mode 1 is REQUIRED.  Other modes are
+                     OPTIONAL.  Write access is NOT REQUIRED."
+
+                 OBJECT      frAtmIwfConnEncapsulationMappingMode
+                 SYNTAX      INTEGER { transparentMode(1) }
+                 MIN-ACCESS  read-only
+                 DESCRIPTION
+                     "Support for Transparent Mode is REQUIRED.
+                     Translation Mode is OPTIONAL.  Write access is not
+                     required."
+
+                 OBJECT      frAtmIwfConnEncapsulationMappings
+                 SYNTAX      BITS { none(0) }
+                 MIN-ACCESS  read-only
+                 DESCRIPTION
+                     "The IWF may provide one, some or none of the
+                     encapsulation translations defined in section
+                     5.3.1 of FRF.8 [17]. Write access is not
+                     required."
+
+                 OBJECT      frAtmIwfConnFragAndReassEnabled
+                 SYNTAX      INTEGER { disabled(2) }
+                 MIN-ACCESS  read-only
+                 DESCRIPTION
+                     "Support for Fragmentation and Reassembly is NOT
+                     REQUIRED.  Write access is not required."
+
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 31]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+                 OBJECT      frAtmIwfConnArpTranslationEnabled
+                 SYNTAX      INTEGER { disabled(2) }
+                 MIN-ACCESS  read-only
+                 DESCRIPTION
+                     "Support for ARP Translation is not required.
+                     Write access is not required."
+
+                 OBJECT      frAtmIwfConnRowStatus
+                 MIN-ACCESS  read-only
+                 DESCRIPTION
+                     "Write access is not required."
+
+             ::= { frAtmIwfCompliances 2 }
+
+         --
+         -- Units of Conformance
+         --
+
+         --
+         -- Basic FR/ATM IWF PVC Connection Group
+         --
+         frAtmIwfBasicGroup    OBJECT-GROUP
+             OBJECTS { frAtmIwfConnIndexNext,
+                       frAtmIwfConnAdminStatus,
+                       frAtmIwfConnAtm2FrOperStatus,
+                       frAtmIwfConnAtm2FrLastChange,
+                       frAtmIwfConnFr2AtmOperStatus,
+                       frAtmIwfConnFr2AtmLastChange,
+                       frAtmIwfConnectionDescriptor,
+                       frAtmIwfConnFailedFrameTranslate,
+                       frAtmIwfConnOverSizedFrames,
+                       frAtmIwfConnFailedAal5PduTranslate,
+                       frAtmIwfConnOverSizedSDUs,
+                       frAtmIwfConnCrcErrors,
+                       frAtmIwfConnSarTimeOuts,
+                       frAtmIwfConnRowStatus }
+             STATUS  current
+             DESCRIPTION
+                     "The collection of basic objects for configuration
+                     and control of FR/ATM interworking connections."
+             ::= { frAtmIwfGroups 1 }
+
+         --
+         -- FR/ATM IWF PVC Connection Descriptor Group
+         --
+
+         frAtmIwfConnectionDescriptorGroup    OBJECT-GROUP
+             OBJECTS {
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 32]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+                 frAtmIwfConnectionDescriptorIndexNext,
+                 frAtmIwfConnDeToClpMappingMode,
+                 frAtmIwfConnClpToDeMappingMode,
+                 frAtmIwfConnCongestionMappingMode,
+                 frAtmIwfConnEncapsulationMappingMode,
+                 frAtmIwfConnEncapsulationMappings,
+                 frAtmIwfConnFragAndReassEnabled,
+                 frAtmIwfConnArpTranslationEnabled,
+                 frAtmIwfConnDescriptorRowStatus
+                 }
+             STATUS  current
+             DESCRIPTION
+                     "The collection of basic objects for specification
+                     of FR/ATM interworking connection descriptors."
+             ::= { frAtmIwfGroups 2 }
+
+         --
+         -- ATM MIB VCL Endpoint Table Augmentation Group
+         --
+
+         frAtmIwfAtmVclTableAugmentGroup    OBJECT-GROUP
+             OBJECTS {
+                 frAtmIwfVclCrossConnectIdentifier
+                 }
+             STATUS  current
+             DESCRIPTION
+                     "The ATM MIB VCL Endpoint Table AUGMENT object
+                     contained in the FR/ATM PVC Service Interworking
+                     MIB."
+             ::= { frAtmIwfGroups 3 }
+
+         --
+         -- Notification Group
+         --
+
+         frAtmIwfNotificationsGroup NOTIFICATION-GROUP
+             NOTIFICATIONS { frAtmIwfConnStatusChange }
+             STATUS  current
+             DESCRIPTION
+                     "The notification for FR/ATM interworking status
+                     change."
+             ::= { frAtmIwfGroups 4 }
+         END
+
+
+
+
+
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 33]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+8.  Acknowledgments
+
+   This document was produced by the Frame Relay Service MIB Working
+   Group.
+
+   The Editors thank Bert Wijnen, Kaj Tesink, Keith McCloghrie, and
+   David Perkins for providing many helpful comments and suggestions.
+
+9.  References
+
+   [1]  Harrington, D., Presuhn, R. and B. Wijnen, "An Architecture for
+        Describing SNMP Management Frameworks", RFC 2571, April 1999.
+
+   [2]  Rose, M. and K. McCloghrie, "Structure and Identification of
+        Management Information for TCP/IP-based Internets", STD 16, RFC
+        1155, May 1990.
+
+   [3]  Rose, M. and K. McCloghrie, "Concise MIB Definitions", STD 16,
+        RFC 1212, March 1991.
+
+   [4]  Rose, M., "A Convention for Defining Traps for use with the
+        SNMP", RFC 1215, March 1991.
+
+   [5]  McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J., Rose,
+        M. and S. Waldbusser, "Structure of Management Information
+        Version 2 (SMIv2)", STD 58, RFC 2578, April 1999.
+
+   [6]  McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J., Rose,
+        M. and S. Waldbusser, "Textual Conventions for SMIv2", STD 58,
+        RFC 2579, April 1999.
+
+   [7]  McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J., Rose,
+        M. and S. Waldbusser, "Conformance Statements for SMIv2", STD
+        58, RFC 2580, April 1999.
+
+   [8]  Case, J., Fedor, M., Schoffstall, M. and J. Davin, "Simple
+        Network Management Protocol", STD 15, RFC 1157, May 1990.
+
+   [9]  Case, J., McCloghrie, K., Rose, M. and S. Waldbusser,
+        "Introduction to Community-based SNMPv2", RFC 1901, January
+        1996.
+
+   [10] Case, J., McCloghrie, K., Rose, M. and S. Waldbusser, "Transport
+        Mappings for Version 2 of the Simple Network Management Protocol
+        (SNMPv2)", RFC 1906, January 1996.
+
+
+
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 34]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+   [11] Case, J., Harrington D., Presuhn R. and B. Wijnen, "Message
+        Processing and Dispatching for the Simple Network Management
+        Protocol (SNMP)", RFC 2572, April 1999.
+
+   [12] Blumenthal, U. and B. Wijnen, "User-based Security Model (USM)
+        for version 3 of the Simple Network Management Protocol
+        (SNMPv3)", RFC 2574, April 1999.
+
+   [13] Case, J., McCloghrie, K., Rose, M. and S. Waldbusser, "Protocol
+        Operations for Version 2 of the Simple Network Management
+        Protocol (SNMPv2)", RFC 1905, January 1996.
+
+   [14] Levi, D., Meyer, P. and B. Stewart, "SNMPv3 Applications", RFC
+        2573, April 1999.
+
+   [15] Wijnen, B., Presuhn, R. and K. McCloghrie, "View-based Access
+        Control Model (VACM) for the Simple Network Management Protocol
+        (SNMP)", RFC 2575, April 1999.
+
+   [16] Case, J., Mundy, R., Partain, D. and B. Stewart, "Introduction
+        to Version 3 of the Internet-standard Network Management
+        Framework", RFC 2570, April 1999.
+
+   [17] Frame Relay/ATM PVC Service Interworking Implementation
+        Agreement, Frame Relay Forum, Document Number FRF.8.1, March,
+        2000.
+
+   [18] Noto, M., Spiegel, E. and K. Tesink, "Definitions of Textual
+        Conventions and OBJECT-IDENTITIES for ATM Management", RFC 2514,
+        February 1999.
+
+   [19] Rehbehn, K. and D. Fowler, "Definitions of Managed Objects for
+        Frame Relay Service", RFC 2954, October 2000.
+
+   [20] Frame Relay/ATM PVC Network Interworking Implementation
+        Agreement, Frame Relay Forum, Document Number FRF.5, December
+        20, 1994.
+
+   [21] Tesink, K., "Definitions of Managed Objects for ATM Management",
+        RFC 2515, February 1999.
+
+   [22] McCloghrie, K. and F. Kastenholz, "The Interfaces Group MIB",
+        RFC 2863, June 2000.
+
+   [23] Bradner, S., "Key words for use in RFCs to Indicate Requirement
+        Levels", BCP 14, RFC 2119, March 1997.
+
+
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 35]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+   [24] Brown, C. and F. Baker, "Management Information Base for Frame
+        Relay DTEs Using SMIv2", RFC 2115, September 1997.
+
+10.  Security Considerations
+
+   There are a number of management objects defined in this MIB that
+   have a MAX-ACCESS clause of read-write and/or read-create.  Such
+   objects may be considered sensitive or vulnerable in some network
+   environments.  The support for SET operations in a non-secure
+   environment without proper protection can have a negative effect on
+   network operations.
+
+   No managed objects in this MIB contain sensitive information.
+
+   SNMPv1 by itself is not a secure environment.  Even if the network
+   itself is secure (for example by using IPSec), even then, there is no
+   control as to who on the secure network is allowed to access and
+   GET/SET (read/change/create/delete) the objects in this MIB.
+
+   It is recommended that the implementers consider the security
+   features as provided by the SNMPv3 framework.  Specifically, the use
+   of the User-based Security Model RFC 2574 [12] and the View-based
+   Access Control Model RFC 2575 [15] is recommended.
+
+   It is then a customer/user responsibility to ensure that the SNMP
+   entity giving access to an instance of this MIB, is properly
+   configured to give access to the objects only to those principals
+   (users) that have legitimate rights to indeed GET or SET
+   (change/create/delete) them.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 36]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+11.  Authors' Addresses
+
+   Kenneth Rehbehn
+   Megisto Systems, Inc.
+   20251 Century Boulevard
+   Germantown, MD, USA 20874
+
+   Phone: +1 (301) 515-3672
+   EMail: krehbehn@megisto.com
+
+
+   Orly Nicklass
+   RAD Data Communications, Ltd.
+   12 Hanechoshet St.
+   Tel Aviv 69710
+   Israel
+
+   Phone: +972 (3) 6459588
+   EMail: orly_n@rad.co.il
+
+
+   George Mouradian
+   AT&T Labs,  Room 1G-325
+   101 Crawfords Corner Road
+   Holmdel, NJ  USA  07733
+
+   Phone: +1 908 949 7671
+   EMail: gvm@att.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 37]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+12.  Intellectual Property Rights
+
+   The IETF takes no position regarding the validity or scope of any
+   intellectual property or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; neither does it represent that it
+   has made any effort to identify any such rights.  Information on the
+   IETF's procedures with respect to rights in standards-track and
+   standards-related documentation can be found in BCP-11.  Copies of
+   claims of rights made available for publication and any assurances of
+   licenses to be made available, or the result of an attempt made to
+   obtain a general license or permission for the use of such
+   proprietary rights by implementors or users of this specification can
+   be obtained from the IETF Secretariat.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights which may cover technology that may be required to practice
+   this standard.  Please address the information to the IETF Executive
+   Director.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 38]
+
+RFC 2955           FR to ATM Service Interworking MIB       October 2000
+
+
+13.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (2000).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rehbehn, et al.             Standards Track                    [Page 39]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2955.txt](<www.ietf.org/rfc/rfc2955.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
