### PR TITLE
Archive rfc2957.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2957.txt
+++ b/www.ietf.org/rfc/rfc2957.txt
@@ -1,0 +1,339 @@
+
+
+
+
+
+
+Network Working Group                                           L. Daigle
+Request for Comments: 2957                       Thinking Cat Enterprises
+Category: Informational                                      P. Faltstrom
+                                                       Cisco Systems Inc.
+                                                             October 2000
+
+
+               The application/whoispp-query Content-Type
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard of any kind.  Distribution of this
+   memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2000).  All Rights Reserved.
+
+Abstract
+
+   This document defines the expression of Whois++ protocol (RFC 1835)
+   queries within MIME (Multipurpose Internet Mail Extensions) (RFC
+   2046) media types.  The intention of this document, in conjunction
+   with RFC 2958 is to enable MIME-enabled mail software, and other
+   systems using Internet media types, to carry out Whois++
+   transactions.
+
+1.  MIME Registration Information
+
+   To: iana@isi.edu
+   Subject:  Registration of MIME media type application/whoispp-query
+
+   MIME Type name:         Application
+
+   MIME subtype name:      whoispp-query
+
+   Required parameters:    none
+
+   Optional parameters:    none
+
+   Encoding considerations: Any valid MIME encodings may be used
+
+   Security considerations: This content-type contains purely
+   descriptive information (i.e., no directives).  There are security
+   considerations with regards to the appropriateness (privacy) of
+   information provided through the use of this content-type, and the
+   authenticity of the information so-provided.  This content-type
+
+
+
+Daigle & Faltstrom           Informational                      [Page 1]
+
+RFC 2957         application/whoispp-query Content-Type     October 2000
+
+
+   provides no native mechanisms for authentication.
+
+   Published specification:  this document
+
+   Person & email address to contact for further information:
+
+                           Leslie L. Daigle
+                           leslie@thinkingcat.com
+
+   Intended usage:         common
+
+2.  whoispp-query Syntax
+
+   The following grammar, which uses BNF-like notation as defined in
+   [RFC2234] defines the set of acceptable input to a Whois++ server.
+   As such, it describes the expected structure of a whoispp-query media
+   type object.
+
+   N.B.:  As outlined in the ABNF definition, rule names and string
+   literals are in the US-ASCII character set, and are case-insensitive.
+
+   whois-command   =   ( system-command / terms [":" globalcnstrnts] )
+                       nl
+
+   system-command  =   "constraints" / "describe" / "commands" /
+                       "polled-by" / "polled-for" / "version" / "list" /
+                       "show" [1*sp bytestring] / "help" [1*sp
+                       bytestring] / "?" [bytestring]
+
+   terms           =   and-expr *("or" and-expr)
+
+   and-expr        =   not-expr *("and" not-expr)
+
+   not-expr        =   ["not"] (term / ( "(" terms ")" ))
+
+   term            =   ( generalterm / specificterm / combinedterm )
+                       localcnstrnts
+
+   generalterm     =   bytestring
+
+   specificterm    =   specificname "=" bytestring
+
+   specificname    =   "handle" / "value" / "template"
+
+   combinedterm    =   attributename "=" bytestring
+
+   globalcnstrnts  =   globalcnstrnt *(";" globalcnstrnt)
+
+
+
+
+Daigle & Faltstrom           Informational                      [Page 2]
+
+RFC 2957         application/whoispp-query Content-Type     October 2000
+
+
+   globalcnstrnt   =   "format" "=" format / "maxfull" "=" 1*digit /
+                       "maxhits" "=" 1*digit / "case" "=" casevalue /
+                       "search" "=" searchvalue / opt-globalcnst
+
+   opt-globalcnst  =   "authenticate" "=" auth-method / "language" "="
+                       language / "incharset" "=" characterset /
+                       "outcharset" "=" characterset / "ignore" "="
+                       attriblist / "include" "=" attriblist
+
+   localcnstrnts   =   0*(";" localcnstrnt)
+
+   localcnstrnt    =   "case" "=" casevalue / "search" "=" searchvalue
+
+   format          =   "full" / "abridged" / "handle" / "summary" /
+                       "server-to-ask"
+
+   auth-method     =  bytestring
+
+   language        = <The language code defined in RFC1766 [ALVE95]>
+
+   characterset    =   "us-ascii" / "iso-8859-1" / "iso-8859-2" / "iso-
+                       8859-3" / "iso-8859-4" / "iso-8859-5" / "iso-
+                       8859-6" / "iso-8859-7" / "iso-8859-8" / "iso-
+                       8859-9" / "iso-8859-10" / "UNICODE-1-1-UTF-8" /
+                       "UNICODE-2-0-UTF-8" "UTF-8"
+
+                         ;"UTF-8" is as defined in [RFC2279].  This is
+                         ;the character set label that should be used
+                         ;for UTF encoded information; the labels
+                         ;"UNICODE-2-0-UTF-8" and "UNICODE-1-1-UTF-8"
+                         ;are retained primarily for compatibility with
+                         ;older Whois++ servers (and as outlined in
+                         ;[RFC2279]).
+
+   searchvalue     =   "exact" / "substring" / "regex" / "fuzzy" /
+                       "lstring"
+
+   casevalue       =   "ignore" / "consider"
+
+   bytestring      =   0*charbyte
+
+   attributename   =   1*attrbyte
+
+   attriblist      =   attributename 0*("," attributename)
+
+   charbyte        =   "\" specialbyte / normalbyte
+
+   normalbyte      =   <%d33-255, except specialbyte>
+
+
+
+Daigle & Faltstrom           Informational                      [Page 3]
+
+RFC 2957         application/whoispp-query Content-Type     October 2000
+
+
+   attrbyte        =   <%d33-127 except specialbyte> /
+                                              "\" <specialbyte except
+                       ":" " " tab nl>
+
+   specialbyte     =   " " / tab / "=" / "," / ":" / ";" / "\" /
+                                              "*" / "." / "(" / ")" /
+                       "[" / "]" / "^" /
+                                              "$" / "!" / "?"
+
+   tab             =  %d09
+   sp              =  %d32        ; space
+
+   digit           =   "0" / "1" / "2" / "3" / "4" /
+                                              "5" / "6" / "7" / "8" /
+                       "9"
+
+   nl              =   %d13 %d10   ; CR LF
+
+   NOTE: Blanks that are significant to a query must be escaped.  The
+   following characters, when significant to the query, may be preceded
+   and/or followed by a single blank:
+
+     : ; , ( ) = !
+
+3.  Security Considerations
+
+   Security issues are discussed in section 1.
+
+4.  References
+
+   [ALVE95]  Alvestrand H., "Tags for the Identification of Languages",
+             RFC 1766, March 1995.
+
+   [RFC2234] Crocker, D. and P. Overell,  "Augmented BNF for Syntax
+             Specifications: ABNF", RFC 2234, November 1997.
+
+   [RFC2958] Daigle, L. and P. Faltstrom, "The application/whoispp-
+             response Content-type", RFC 2958, October 2000.
+
+   [RFC1835] Deutsch, P., Schoultz, R., Faltstrom, P. and C.  Weider,
+             "Architecture of the WHOIS++ service", RFC 1835, August
+             1995.
+
+   [RFC2046] Freed, N. and N. Borenstein, "Multipurpose Internet Mail
+             Extensions (MIME) Part Two: Media Types", RFC 2046,
+             November 1996.
+
+
+
+
+
+Daigle & Faltstrom           Informational                      [Page 4]
+
+RFC 2957         application/whoispp-query Content-Type     October 2000
+
+
+   [HARR85]  Harrenstein K., Stahl M. and E. Feinler, "NICNAME/WHOIS",
+             RFC 954, October 1985.
+
+   [POST82]  Postel J., "Simple Mail Transfer Protocol", STD 10, RFC
+             821, August 1982.
+
+   [IIIR]    Weider C. and P. Deutsch, "A Vision of an Integrated
+             Internet Information Service", RFC 1727, December 1994.
+
+   [WINDX]   Weider, C., Fullton, J. and S. Spero, "Architecture of the
+             Whois++ Index Service", RFC 1913, February 1996.
+
+   [RFC2279] Yergeau F., " UTF-8, a transformation format of ISO 10646",
+             RFC 2279, January 1998.
+
+5.  Authors' Addresses
+
+   Leslie L. Daigle
+   Thinking Cat Enterprises
+
+   Email:  leslie@thinkingcat.com
+
+
+   Patrik Faltstrom
+   Cisco Systems Inc
+   170 W Tasman Drive SJ-13/2
+   San Jose CA 95134
+   USA
+
+   EMail: paf@cisco.com
+   URL:   http://www.cisco.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Daigle & Faltstrom           Informational                      [Page 5]
+
+RFC 2957         application/whoispp-query Content-Type     October 2000
+
+
+6.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (2000).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Daigle & Faltstrom           Informational                      [Page 6]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2957.txt](<www.ietf.org/rfc/rfc2957.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
