### PR TITLE
Archive rfc298.txt

### DIFF
--- a/www.ietf.org/rfc/rfc298.txt
+++ b/www.ietf.org/rfc/rfc298.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Network Working Group                                      E. Westheimer
+Request for Comments: 298                                1 February 1972
+NIC: 8486
+
+                          NETWORK HOST STATUS
+
+
+   This RFC reports on the status of most Network Hosts from January 17
+   to January 28.
+
+   Several Hosts are currently excluded from the daily testing.  These
+   Hosts fall into two categories:
+
+   1) Hosts which are not expected to be functioning on the Network as
+      servers (available for use from other sites) on a regular basis
+      for at least two weeks.  Included here are:
+
+         NETWORK             SITE           COMPUTER
+         ADDRESS
+
+         133                 BBN            PDP-10(B)
+         13                  Case           PDP-10
+         15                  Ames/(Paoli)   ILLIAC/(B6500)
+
+   2) Hosts which are currently intended to be users only.  Included
+      here are the Terminal IMPs, which are presently in the Network
+      (AMES, MITRE, NBS and BBN*).  This category also includes the
+      Network Control Center (Network Address 5) which is used solely
+      for gathering statistics from the Network.  Finally, included
+      among these Hosts are the following:
+
+         NETWORK             SITE           COMPUTER
+         ADDRESS
+
+         7                   Rand           IBM-360/65
+         73                  Harvard        PDP-1
+         12                  Illinois       PDP-11
+         19                  NBS            PDP-11
+
+   NOTE:  During this interval both the UTAH PDP-10 and the RAND PDP-10
+          became Network servers.
+
+   The tables on the next two pages summarize the Host status for this
+   period.
+
+   * The BBN Terminal IMP (Network Address 158) is a prototype and as
+   such is frequently not connected to the Network, but being used to
+   refine and debug the Terminal IMP programs.
+
+
+
+Westheimer                                                      [Page 1]
+
+RFC 298                   NETWORK HOST STATUS              February 1972
+
+
+ADDRESS  SITE           COMPUTER          DATE AND TIME (EASTERN)
+                                        1/17  1/18  1/19  1/20  1/21
+                                        1800  1730  1000  1500  1730
+
+  1      UCLA(NMC)      SIGMA-7         #H     O    #D     O     O
+ 65      UCLA(CCN)      IBM-360/91       O     O    #D     O     O
+  2      SRI(NIC)       PDP-10           O     O     O     O     O
+ 66      SRI(AI)        PDP-10           D     D     D     D     D
+  3      UCSB           IBM-360/75       O     O     O     D     O
+  4      UTAH           PDP-10           T     T    #T     O     O
+ 69      BBN(10X-A)     PDP-10           O     O     D     O     D
+  6      MIT(Multics)   H-645            O     T     O     D     O
+ 70      MIT(DM)        PDP-10           D     D     O     O     D
+ 71      RAND           PDP-10           D     D     O     D     D
+  8      SDC            IBM-360/155     #D    #D    #D    #D    #D
+  9      HARVARD        PDP-10           O    #D    O     #D    #D
+ 10      LINCOLN LABS   IBM-360/67       D     H     T     H     H
+ 74      LINCOLN LABS   TX2             #D    #T    #D     R     O
+ 11      STANFORD       PDP-10           D     D     D     D     D
+ 14      CARNEGIE       PDP-10           H     H     H     H     H
+ 16      AMES           IBM-360/67       D     D     D     D     D
+
+
+ADDRESS  SITE           COMPUTER          DATE AND TIME (EASTERN)
+                                        1/24  1/25  1/26  1/27  1/28
+                                        1430  1630  1730  1300  1530
+
+  1      UCLA(NMC)      SIGMA-7          O     O     O     O     T
+ 65      UCLA(CCN)      IBM-360/91       O     O     O     O     O
+  2      SRI(NIC)       PDP-10           O     O     T     O     O
+ 66      SRI(AI)        PDP-10           D     D     D     D     D
+  3      UCSB           IBM-360/75       O     O     D     O     O
+  4      UTAH           PDP-10           O     O     O     O     O
+ 69      BBN(10X-A)     PDP-10           O     D     O     H     O
+  6      MIT(Multics)   H-645            R     O     D     O     D
+ 70      MIT(DM)        PDP-10           O     D     T     O     H
+ 71      RAND           PDP-10           T     D     D     O     D
+  8      SDC            IBM-360/155     #D    #D    #D    #D    #D
+  9      HARVARD        PDP-10          #R    #R     O     O     O
+ 10      LINCOLN LABS   IBM-360/67       H     D     H     T     H
+ 74      LINCOLN LABS   TX2              O     O     O     O     T
+ 11      STANFORD       PDP-10           D     D     D     D     D
+ 14      CARNEGIE       PDP-10           D     H     H     D     H
+ 16      AMES           IBM-360/67       D     D     D     D     D
+
+
+
+
+
+
+
+Westheimer                                                      [Page 2]
+
+RFC 298                   NETWORK HOST STATUS              February 1972
+
+
+    where
+
+      D = Dead (Destination Host either dead or inaccessible [due to
+      network partitioning or local IMP failure] from the BBN Terminal
+      IMP.)
+
+      H = 1/2 Open (Destination Host opened a connection but then either
+      immediately closed it, or did not respond any further.)
+
+      O = Open (Destination Host opened a connection and was accessible
+      to users.)
+
+      R = Refused (Destination Host returned a CLS to the initial RFC.)
+
+      T = Timed out (Destination Host did not complete the ICP and open
+      a connection within 60 second)
+
+      * The only service currently offered by the UCLA IBM-360/91 is a
+      Network Job Service (NETRJS), however, the BBN Terminal IMP is not
+      equipped to test NETRJS.  We are assuming that initial connection
+      to the NETRJS logger indicated the NETRJS is also functioning.
+
+      #These sites advertise that they may not have their system
+      available at these times
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Westheimer                                                      [Page 3]
+
+RFC 298                   NETWORK HOST STATUS              February 1972
+
+
+                                                            STATUS OR
+   SITE       SITE         COMPUTER      STATUS OR          PREDICTIONS
+   ADDRESS                               PREDICTION         OBTAINED FROM
+
+      1       UCLA         SIGMA-7      Server(#Limited)    John Postel
+     65       UCLA         IBM-360/91   Remote Job Service  Bob Braden
+                                        (Telnet in April)
+      2       SRI(NIC)     PDP-10       Server              John Melvin
+     66       SRI(AI)      PDP-10       "Soon"              Len Chaiten
+      3       UCSB         IBM-360/75   Server              Jim White
+      4       UTAH         PDP-10       Server              Barry Wessler
+     *5       BBN(NCC)     DDP-516      Never               Alex McKenzie
+     69       BBN(TENEX-A) PDP-10       Server              Dan Murphy
+   *133       BBN(TENEX-B) PDP-10       Server(Exper.)      Dan Murphy
+      6       MIT(Multics) H-645        Server              Mike Padlipsky
+     70       MIT(DM)      PDP-10       Server              Bob Bressler
+     *7       RAND         IBM-360/65   User only           Eric Harslem
+     71       RAND         PDP-10       Server              Eric Harslem
+     *8       SDC          IBM-300/155  Server              Bob Long
+      9       HARVARD      PDP-10       Server              Bob Sundberg
+    *73       HARVARD      PDP-1        User only           Bob Sundberg
+     10       LINCOLN      IBM-30/67    "Soon"              Joel Winnet
+     74       LINCOLN      TX-2         Server              Will Kantrowitz
+     11       STANFORD     PDP-10       "Soon"              Andy Moorer
+    *12       ILLINOIS     PDP-11       User only           John Cravits
+    *13       CASE         PDP-10       March               Charles Rose
+     14       CARNEGIE     PDP-10       "Soon"              Hal VanZoeren
+    *15       AMES/(PAOLI) ILLIAC/B6500 September           John McConnell
+     16       AMES         IBM-360/67   "Soon"              Wayne Hathaway
+   *144       AMES         TIP          User only
+   *145       MITRE        TIP          User only
+    *19       NBS          PDP-11       User only           Robert
+                                                                 Rosenthal
+   *147       NBS          TIP          User only
+   *158       BBN          TIP          User only
+                            (Prototype)
+
+   * Host not included in daily testing.
+
+   #The NMC is a research site and would like to have prior arrangement
+   with each user.
+
+
+          [This RFC was put into machine readable form for entry]
+     [into the online RFC archives by Kelly Tardif, Via Genie 10/1999]
+
+
+
+
+
+
+Westheimer                                                      [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc298.txt](<www.ietf.org/rfc/rfc298.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
