### PR TITLE
Archive rfc299.txt

### DIFF
--- a/www.ietf.org/rfc/rfc299.txt
+++ b/www.ietf.org/rfc/rfc299.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                             NIC 8487
+Request for Comments #299
+                                                  Dorothy Hopkin
+                                                  University of Illinois
+                                                  Center for Advanced
+                                                    Computation
+                                                  February 11, 1972
+
+
+                     Information Management System
+                     -----------------------------
+
+        We intend to build an Information Management and Statistical System
+   for the ILLIAC IV.  It is intended to support various areas of research
+   whose problems are ILLIAC IV suited and whose data bases are large.
+
+        This System will include a user language and necessary manipulatory
+   routines for the ILLIAC IV.  It will use the datacomputer for Archival
+   storage and provide the interface to the datacomputer for queries not
+   ILLIAC suited.
+
+        If you have problems involving large amounts of data and wish to
+   learn more about our proposed system or contribute to its development,
+   contact:
+
+                        Dorothy Hopkin
+                        University of Illinois
+                        Center for Advanced Computation
+                        333 Advanced Computation Building
+                        Urbana, Illinois 61801
+
+                        Tel:  (217)  333-8060
+
+                                     or
+
+                              (217)  333-6159
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc299.txt](<www.ietf.org/rfc/rfc299.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
