### PR TITLE
Archive rfc2999.txt

### DIFF
--- a/www.ietf.org/rfc/rfc2999.txt
+++ b/www.ietf.org/rfc/rfc2999.txt
@@ -1,0 +1,1291 @@
+
+
+
+
+
+
+Network Working Group                                          S. Ginoza
+Request for Comments: 2999                                           ISI
+Category: Informational                                      August 2001
+
+
+                      Request for Comments Summary
+
+                         RFC Numbers 2900-2999
+
+Status of This Memo
+
+   This RFC is a slightly annotated list of the 100 RFCs from RFC 2900
+   through RFCs 2999.  This is a status report on these RFCs.  This memo
+   provides information for the Internet community.  It does not specify
+   an Internet standard of any kind.  Distribution of this memo is
+   unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2001).  All Rights Reserved.
+
+Note
+
+   Many RFCs, but not all, are Proposed Standards, Draft Standards, or
+   Standards.  Since the status of these RFCs may change during the
+   standards processing, we note here only that they are on the
+   standards track.  Please see the latest edition of "Internet Official
+   Protocol Standards" for the current state and status of these RFCs.
+   In the following, RFCs on the standards track are marked [STANDARDS-
+   TRACK].
+
+RFC     Author          Date            Title
+---     ------          ----            -----
+
+2999    Ginoza          Aug 2001        Request for Comments Summary
+
+This memo.
+
+
+2998    Bernet          Nov 2000        A Framework for Integrated
+                                        Services Operation over
+                                        Diffserv Networks
+
+This document describes a framework by which Integrated Services may be
+supported over Diffserv networks.  This memo provides information for
+the Internet community.
+
+
+
+
+
+Ginoza                       Informational                      [Page 1]
+
+RFC 2999                  Summary of 2900-2999               August 2001
+
+
+2997    Bernet          Nov 2000        Specification of the Null
+                                        Service Type
+
+The Null Service allows applications to identify themselves to network
+Quality of Service (QoS) policy agents, using RSVP signaling.  However,
+it does not require them to specify resource requirements. QoS policy
+agents in the network respond by applying QoS policies appropriate for
+the application (as determined by the network administrator).  This mode
+of RSVP usage is particularly applicable to networks that combine
+differentiated service (diffserv) QoS mechanisms with RSVP signaling.
+In this environment, QoS policy agents may direct the signaled
+application's traffic to a particular diffserv class of service.
+[STANDARDS TRACK]
+
+
+2996    Bernet          Nov 2000        Format of the RSVP DCLASS
+                                        Object
+
+This document specifies the format of the DCLASS object and briefly
+discusses its use.  [STANDARDS TRACK]
+
+
+2995    Lu              Nov 2000        Pre-SPIRITS Implementations of
+                                        PSTN-initiated Services
+
+This document describes four existing implementations of SPIRITS-like
+services from Korea Telecom, Lucent Technologies, NEC, and Telia in
+cooperation with Nortel Networks.  SPIRITS-like services are those
+originating in the Public Switched Telephone Network (PSTN) and
+necessitating the interactions of the Internet and PSTN.  This memo
+provides information for the Internet community.
+
+
+2994    Ohta            Nov 2000        A Description of the MISTY1
+                                        Encryption Algorithm
+
+This document describes a secret-key cryptosystem MISTY1, which is block
+cipher with a 128-bit key, a 64-bit block and a variable number of
+rounds.  It documents the algorithm description including key scheduling
+part and data randomizing part.  This memo provides information for the
+Internet community.
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 2]
+
+RFC 2999                  Summary of 2900-2999               August 2001
+
+
+2993    Hain            Nov 2000        Architectural Implications of
+                                        NAT
+
+This document discusses some of the architectural implications and
+guidelines for implementations of Network Address Translation (NAT).
+This memo provides information for the Internet community.
+
+
+2992    Hopps           Nov 2000        Analysis of an Equal-Cost
+                                        Multi-Path Algorithm
+
+Equal-cost multi-path (ECMP) is a routing technique for routing packets
+along multiple paths of equal cost.  The forwarding engine identifies
+paths by next-hop.  When forwarding a packet the router must decide
+which next-hop (path) to use.  This document gives an analysis of one
+method for making that decision.  The analysis includes the performance
+of the algorithm and the disruption caused by changes to the set of
+next-hops.  This memo provides information for the Internet community.
+
+
+2991    Thaler          Nov 2000        Multipath Issues in Unicast
+                                        and Multicast Next-Hop
+                                        Selection
+
+The effect of multipath routing on a forwarder is that the forwarder
+potentially has several next-hops for any given destination and must use
+some method to choose which next-hop should be used for a given data
+packet.  This memo summarizes current practices, problems, and
+solutions.  This memo provides information for the Internet community.
+
+
+2990    Huston          Nov 2000        Next Steps for the IP QoS
+                                        Architecture
+
+This document highlights the outstanding architectural issues relating
+to the deployment and use of QoS mechanisms within internet networks,
+noting those areas where further standards work may assist with the
+deployment of QoS internets.  This document is the outcome of a
+collaborative exercise on the part of the Internet Architecture Board.
+This memo provides information for the Internet community.
+
+
+2989    Aboba           Nov 2000        Criteria for Evaluating AAA
+                                        Protocols for Network Access
+
+This document represents a summary of Authentication, Authorization,
+Accounting (AAA) protocol requirements for network access.  This memo
+provides information for the Internet community.
+
+
+
+Ginoza                       Informational                      [Page 3]
+
+RFC 2999                  Summary of 2900-2999               August 2001
+
+
+2988    Paxson          Nov 2000        Computing TCP's Retransmission
+                                        Timer
+
+This document defines the standard algorithm that Transmission Control
+Protocol (TCP) senders are required to use to compute and manage their
+retransmission timer.  [STANDARDS TRACK]
+
+
+2987    Hoffman         Nov 2000        Registration of Charset and
+                                        Languages Media Features Tags
+
+This document contains the registration for two media feature tags:
+"charset" and "language".  [STANDARDS TRACK]
+
+
+2986    Nystrom         Nov 2000        PKCS #10: Certification
+                                        Request Syntax Specification
+                                        Version 1.7
+
+This memo represents a republication of PKCS #10 v1.7 from RSA
+Laboratories' Public-Key Cryptography Standards (PKCS) series, and
+change control is retained within the PKCS process.  The body of this
+document, except for the security considerations section, is taken
+directly from the PKCS #9 v2.0 or the PKCS #10 v1.7 document.  This memo
+provides information for the Internet community.
+
+
+2985    Nystrom         Nov 2000        PKCS #9: Selected Object
+                                        Classes and Attribute Types
+                                        Version 2.0
+
+This memo represents a republication of PKCS #9 v2.0 from RSA
+Laboratories' Public-Key Cryptography Standards (PKCS) series, and
+change control is retained within the PKCS process.  The body of this
+document, except for the security considerations section, is taken
+directly from that specification.  This memo provides information for
+the Internet community.
+
+
+2984    Adams           Oct 2000        Use of the CAST-128 Encryption
+                                        Algorithm in CMS
+
+This document specifies how to incorporate CAST-128 into the S/MIME
+Cryptographic Message Syntax (CMS) as an additional algorithm for
+symmetric encryption.  [STANDARDS TRACK]
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 4]
+
+RFC 2999                  Summary of 2900-2999               August 2001
+
+
+2983    Black           Oct 2000        Differentiated Services and
+                                        Tunnels
+
+This document considers the interaction of Differentiated Services
+(diffserv) with IP tunnels of various forms.  This memo provides
+information for the Internet community.
+
+
+2982    Kavasseri       Oct 2000        Distributed Management
+                                        Expression MIB
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it describes managed objects used for managing expressions
+of MIB objects.  [STANDARDS TRACK]
+
+
+2981    Kavasseri       Oct 2000        Event MIB
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it describes managed objects that can be used to manage and
+monitor MIB objects and take action through events.  [STANDARDS TRACK]
+
+
+2980    Barber          Oct 2000        Common NNTP Extensions
+
+In this document, a number of popular extensions to the Network News
+Transfer Protocol (NNTP) protocol defined in RFC 977 are documented and
+discussed.  While this document is not intended to serve as a standard
+of any kind, it will hopefully serve as a reference document for future
+implementers of the NNTP protocol.  This memo provides information for
+the Internet community.
+
+
+2979    Freed           Oct 2000        Behavior of and Requirements
+                                        for Internet Firewalls
+
+This memo defines behavioral characteristics of and interoperability
+requirements for Internet firewalls.  This memo provides information for
+the Internet community.
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 5]
+
+RFC 2999                  Summary of 2900-2999               August 2001
+
+
+2978    Freed           Oct 2000        IANA Charset Registration
+                                        Procedures
+
+Multipurpose Internet Mail Extensions (MIME) and various other Internet
+protocols are capable of using many different charsets.  This in turn
+means that the ability to label different charsets is essential.  This
+document specifies an Internet Best Current Practices for the Internet
+Community, and requests discussion and suggestions for improvements.
+
+
+2977    Glass           Oct 2000        Mobile IP Authentication,
+                                        Authorization, and Accounting
+                                        Requirements
+
+This document contains the requirements which would have to be supported
+by a AAA service to aid in providing Mobile IP services.  This memo
+provides information for the Internet community.
+
+
+2976    Donovan         Oct 2000        The SIP INFO Method
+
+This document proposes an extension to the Session Initiation Protocol
+(SIP).  This extension adds the INFO method to the SIP protocol.  The
+intent of the INFO method is to allow for the carrying of session
+related control information that is generated during a session.
+[STANDARDS TRACK]
+
+
+2975    Aboba           Oct 2000        Introduction to Accounting
+                                        Management
+
+This document describes and discusses the issues involved in the design
+of the modern accounting systems.  The field of Accounting Management is
+concerned with the collection the collection of resource consumption
+data for the purposes of capacity and trend analysis, cost allocation,
+auditing, and billing.  This memo provides information for the Internet
+community.
+
+
+2974    Handley         Oct 2000        Session Announcement Protocol
+
+This document describes version 2 of the multicast session directory
+announcement protocol, Session Announcement Protocol (SAP), and the
+related issues affecting security and scalability that should be taken
+into account by implementors.  This memo defines an Experimental
+Protocol for the Internet community.
+
+
+
+
+
+Ginoza                       Informational                      [Page 6]
+
+RFC 2999                  Summary of 2900-2999               August 2001
+
+
+2973    Balay           Oct 2000        IS-IS Mesh Groups
+
+This document describes a mechanism to reduce redundant packet
+transmissions for the Intermediate System to Intermediate System (IS-IS)
+Routing protocol, as described in ISO 10589.  This memo provides
+information for the Internet community.
+
+
+2972    Popp            Oct 2000        Context and Goals for Common
+                                        Name Resolution
+
+This document establishes the context and goals for a Common Name
+Resolution Protocol.  This memo provides information for the Internet
+community.
+
+
+2971    Showalter       Oct 2000        IMAP4 ID extension
+
+This document describes an ID extension which will enable Internet
+Message Access Protocol - Version 4rev1 (IMAP4rev1) to advertise what
+program a client or server uses to provide service.  The ID extension
+allows the server and client to exchange identification information on
+their implementation in order to make bug reports and usage statistics
+more complete.   [STANDARDS TRACK]
+
+
+2970    Daigle          Oct 2000        Architecture for Integrated
+                                        Directory Services - Result
+                                        from TISDAG
+
+Drawing from experiences with the TISDAG (Technical Infrastructure for
+Swedish Directory Access Gateways) project, this document outlines an
+approach to providing the necessary infrastructure for integrating such
+widely-scattered servers into a single service, rather than attempting
+to mandate a single protocol and schema set for all participating
+servers to use.  This memo provides information for the Internet
+community.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 7]
+
+RFC 2999                  Summary of 2900-2999               August 2001
+
+
+2969    Eklof           Oct 2000        Wide Area Directory Deployment
+                                        - Experiences from TISDAG
+
+This document catalogues some of the experiences gained in developing
+the necessary infrastructure for a national (i.e., multi-organizational)
+directory service and pilot deployment of the service in an environment
+with off-the-shelf directory service products.  This memo provides
+information for the Internet community.
+
+
+2968    Daigle          Oct 2000        Mesh of Multiple DAG servers -
+                                        Results from TISDAG
+
+This document defines the basic principle for establishing a mesh, that
+interoperating services should exchange index objects, according to the
+architecture of the mesh (e.g., hierarchical, or graph-like, preferably
+without loops!).  The Common Indexing Protocol (CIP) is designed to
+facilitate the creation not only of query referral indexes, but also of
+meshes of (loosely) affiliated referral indexes.  The purpose of such a
+mesh of servers is to implement some kind of distributed sharing of
+indexing and/or searching tasks across different servers.  So far, the
+TISDAG (Technical Infrastructure for Swedish Directory Access Gateways)
+project has focused on creating a single referral index; the obvious
+next step is to integrate that into a larger set of interoperating
+services.  This memo provides information for the Internet community.
+
+
+2967    Daigle          Oct 2000        TISDAG - Technical
+                                        Infrastructure for Swedish
+                                        Directory Access Gateways
+
+The overarching goal of this project is to develop the necessary
+technical infrastructure to provide a single-access-point service for
+searching for whitepages information on Swedish Internet users.  This
+memo provides information for the Internet community.
+
+
+2966    Li              Oct 2000        Domain-wide Prefix
+                                        Distribution with Two-Level
+                                        IS-IS
+
+This document describes extensions to the Intermediate System to
+Intermediate System (IS-IS) protocol to support optimal routing within a
+two-level domain.  This memo provides information for the Internet
+community.
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 8]
+
+RFC 2999                  Summary of 2900-2999               August 2001
+
+
+2965    Kristol         Oct 2000        HTTP State Management
+                                        Mechanism
+
+This document specifies a way to create a stateful session with
+Hypertext Transfer Protocol (HTTP) requests and responses.  [STANDARDS
+TRACK]
+
+
+2964    Moore           Oct 2000        Use of HTTP State Management
+
+This memo identifies specific uses of Hypertext Transfer Protocol (HTTP)
+State Management protocol which are either (a) not recommended by the
+IETF, or (b) believed to be harmful, and discouraged.  This memo also
+details additional privacy considerations which are not covered by the
+HTTP State Management protocol specification.  This document specifies
+an Internet Best Current Practices for the Internet Community, and
+requests discussion and suggestions for improvements.
+
+
+2963    Bonaventure     Oct 2000        A Rate Adaptive Shaper for
+                                        Differentiated Services
+
+This memo describes several Rate Adaptive Shapers (RAS) that can be used
+in combination with the single rate Three Color Markers (srTCM) and the
+two rate Three Color Marker (trTCM) described in RFC2697 and RFC2698,
+respectively.  This memo provides information for the Internet
+community.
+
+
+2962    Raz             Oct 2000           An SNMP Application Level
+                                           Gateway for Payload Address
+                                           Translation
+
+This document describes the ALG (Application Level Gateway) for the SNMP
+(Simple Network Management Protocol) by which IP (Internet Protocol)
+addresses in the payload of SNMP packets are statically mapped from one
+group to another.  This memo provides information for the Internet
+community.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 9]
+
+RFC 2999                  Summary of 2900-2999               August 2001
+
+
+2961    Berger          Apr 2001        RSVP Refresh Overhead
+                                        Reduction Extensions
+
+This document describes a number of mechanisms that can be used to
+reduce processing overhead requirements of refresh messages, eliminate
+the state synchronization latency incurred when an RSVP (Resource
+ReserVation Protocol) message is lost and, when desired, refreshing
+state without the transmission of whole refresh messages.  [STANDARDS
+TRACK]
+
+
+2960    Stewart         Oct 2000        Stream Control Transmission
+                                        Protocol
+
+This document describes the Stream Control Transmission Protocol (SCTP).
+[STANDARDS TRACK]
+
+
+2959    Baugher         Oct 2000        Real-Time Transport Protocol
+                                        Management Information Base
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.
+[STANDARDS TRACK]
+
+
+2958    Daigle          Oct 2000        The application/whoispp-
+                                        response Content-type
+
+The intention of this document, in conjunction with RFC 2957, is to
+enable MIME-enabled mail software, and other systems using Internet
+media types, to carry out Whois++ transactions.  This memo provides
+information for the Internet community.
+
+
+2957    Daigle          Oct 2000        The application/whoispp-query
+                                        Content-Type
+
+The intention of this document, in conjunction with RFC 2958, is to
+enable MIME-enabled mail software, and other systems using Internet
+media types, to carry out Whois++ transactions.  This memo provides
+information for the Internet community.
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 10]
+
+RFC 2999                  Summary of 2900-2999               August 2001
+
+
+2956    Kaat            Oct 2000        Overview of 1999 IAB Network
+                                        Layer Workshop
+
+This document is an overview of a workshop held by the Internet
+Architecture Board (IAB) on the Internet Network Layer architecture
+hosted by SURFnet in Utrecht, the Netherlands on 7-9 July 1999.  The
+goal of the workshop was to understand the state of the network layer
+and its impact on continued growth and usage of the Internet.  This memo
+provides information for the Internet community.
+
+
+2955    Rehbehn         Oct 2000        Definitions of Managed Objects
+                                        for Monitoring and Controlling
+                                        the Frame Relay/ATM PVC Service
+                                        Interworking Function
+
+This memo defines a Management Information Base (MIB) to configure,
+monitor, and control a service interworking function (IWF) for Permanent
+Virtual Connections (PVC) between Frame Relay and Asynchronous Transfer
+Mode (ATM) technologies.  [STANDARDS TRACK]
+
+
+2954    Rehbehn         Oct 2000        Definitions of Managed Objects
+                                        for Frame Relay Service
+
+This memo defines an extension to the Management Information Base (MIB)
+for use with network management protocols in Transmission Control
+Protocol/Internet Protocol-based (TCP/IP) internets.  In particular, it
+defines objects for managing the frame relay service.  [STANDARDS TRACK]
+
+
+2953    Ts'o            Sep 2000        Telnet Encryption: DES 64 bit
+                                        Output Feedback
+
+This document specifies how to use the data encryption standard (DES)
+encryption algorithm in output feedback mode with the telnet encryption
+option.  This memo provides information for the Internet community.
+
+
+2952    Ts'o            Sep 2000        Telnet Encryption: DES 64 bit
+                                        Cipher Feedback
+
+This document specifies how to use the DES encryption algorithm in
+cipher feedback mode with the telnet encryption option.  This memo
+provides information for the Internet community.
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 11]
+
+RFC 2999                  Summary of 2900-2999               August 2001
+
+
+2951    Housley         Sep 2000        TELNET Authentication Using
+                                        KEA and SKIPJACK
+
+This document defines a method to authenticate TELNET using the Key
+Exchange Algorithm (KEA), and encryption of the TELNET stream using
+SKIPJACK.  This memo provides information for the Internet community.
+
+
+2950    Altman          Sep 2000        Telnet Encryption: CAST-128 64
+                                        bit Cipher Feedback
+
+This document specifies how to use the CAST-128 encryption algorithm in
+cipher feedback mode with the telnet encryption option.  Two key sizes
+are defined: 40 bit and 128 bit.  [STANDARDS TRACK]
+
+
+2949    Altman          Sep 2000        Telnet Encryption: CAST-128 64
+                                        bit Output Feedback
+
+This document specifies how to use the CAST-128 encryption algorithm in
+output feedback mode with the telnet encryption option.  Two key sizes
+are defined: 40 bit and 128 bit.  [STANDARDS TRACK]
+
+
+2948    Altman          Sep 2000        Telnet Encryption: DES3 64 bit
+                                        Output Feedback
+
+This document specifies how to use the Triple-DES (data encryption
+standard) encryption algorithm in output feedback mode with the telnet
+encryption option.  [STANDARDS TRACK]
+
+
+2947    Altman          Sep 2000        Telnet Encryption: DES3 64 bit
+                                        Cipher Feedback
+
+This document specifies how to use the Triple-DES (data encryption
+standard) encryption algorithm in cipher feedback mode with the telnet
+encryption option.  [STANDARDS TRACK]
+
+
+2946    Ts'o            Sep 2000        Telnet Data Encryption Option
+
+This document describes a the telnet encryption option as a generic
+method of providing data confidentiality services for the telnet data
+stream.  [STANDARDS TRACK]
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 12]
+
+RFC 2999                  Summary of 2900-2999               August 2001
+
+
+2945    Wu              Sep 2000        The SRP Authentication and Key
+                                        Exchange System
+
+This document describes a cryptographically strong network
+authentication mechanism known as the Secure Remote Password (SRP)
+protocol.  [STANDARDS TRACK]
+
+
+2944    Wu              Sep 2000        Telnet Authentication: SRP
+
+This document specifies an authentication scheme for the Telnet protocol
+under the framework described in RFC 2941, using the Secure Remote
+Password Protocol (SRP) authentication mechanism.  [STANDARDS TRACK]
+
+
+2943    Housley         Sep 2000        TELNET Authentication Using
+                                        DSA
+
+This document defines a telnet authentication mechanism using the
+Digital Signature Algorithm (DSA).  It relies on the Telnet
+Authentication Option.  [STANDARDS TRACK]
+
+
+2942    Ts'o            Sep 2000        Telnet Authentication:
+                                        Kerberos Version 5
+
+This document describes how Kerberos Version 5 is used with the telnet
+protocol.   It describes an telnet authentication suboption to be used
+with the telnet authentication option.  [STANDARDS TRACK]
+
+
+2941    Ts'o            Sep 2000        Telnet Authentication Option
+
+This document describes the authentication option to the telnet protocol
+as a generic method for negotiating an authentication type and mode
+including whether encryption should be used and if credentials should be
+forwarded.  [STANDARDS TRACK]
+
+
+2940    Smith           Oct 2000        Definitions of Managed Objects
+                                        for Common Open Policy Service
+                                        (COPS) Protocol Clients
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in TCP/IP based internets.  In
+particular it defines objects for managing a client of the Common Open
+Policy Service (COPS) protocol.  [STANDARDS TRACK]
+
+
+
+
+Ginoza                       Informational                     [Page 13]
+
+RFC 2999                  Summary of 2900-2999               August 2001
+
+
+2939    Droms           Sep 2000        Procedures and IANA Guidelines
+                                        for Definition of New DHCP
+                                        Options and Message Types
+
+This document describes the procedure for defining new DHCP options and
+message types.  This document specifies an Internet Best Current
+Practices for the Internet Community, and requests discussion and
+suggestions for improvements.
+
+
+2938    Klyne           Sep 2000        Identifying Composite Media
+                                        Features
+
+This document describes an abbreviated format for a composite media
+feature set, based upon a hash of the feature expression describing that
+composite.  [STANDARDS TRACK]
+
+
+2937    Smith           Sep 2000        The Name Service Search Option
+                                        for DHCP
+
+This document defines a new Dynamic Host Configuration Protocol (DHCP)
+option which is passed from the DHCP Server to the DHCP Client to
+specify the order in which name services should be consulted when
+resolving hostnames and other information.  [STANDARDS TRACK]
+
+
+2936    Eastlake        Sep 2000        HTTP MIME Type Handler
+                                        Detection
+
+Entities composing web pages to provide services over the Hypertext
+Transfer Protocol (HTTP) frequently have the problem of not knowing what
+Multipurpose Internet Mail Extensions (MIME) types have handlers
+installed at a user's browser.  This document summarizes reasonable
+techniques to solve this problem for most of the browsers actually
+deployed on the Internet as of early 2000.  This memo provides
+information for the Internet community.
+
+
+2935    Eastlake        Sep 2000        Internet Open Trading Protocol
+                                        (IOTP) HTTP Supplement
+
+The goal of mapping to the transport layer is to ensure that the
+underlying XML documents are carried successfully between the various
+parties.  This document describes that mapping for the Hyper Text
+Transport Protocol (HTTP), Versions 1.0 and 1.1.  [STANDARDS TRACK]
+
+
+
+
+
+Ginoza                       Informational                     [Page 14]
+
+RFC 2999                  Summary of 2900-2999               August 2001
+
+
+2934    McCloghrie      Oct 2000        Protocol Independent Multicast
+                                        MIB for IPv4
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it describes managed objects used for managing the Protocol
+Independent Multicast (PIM) protocol for IPv4.  This memo defines an
+Experimental Protocol for the Internet community.
+
+
+2933    McCloghrie      Oct 2000        Internet Group Management
+                                        Protocol MIB
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it describes objects used for managing the Internet Group
+Management Protocol (IGMP).  [STANDARDS TRACK]
+
+
+2932    McCloghrie      Oct 2000        IPv4 Multicast Routing MIB
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it describes managed objects used for managing IP Multicast
+Routing for IPv4, independent of the specific multicast routing protocol
+in use.  [STANDARDS TRACK]
+
+
+2931    Eastlake        Sep 2000        DNS Request and Transaction
+                                        Signatures ( SIG(0)s )
+
+This document describes the minor but non-interoperable changes in
+Request and Transaction signature resource records ( SIG(0)s ) that
+implementation experience has deemed necessary.  [STANDARDS TRACK]
+
+
+2930    Eastlake        Sep 2000        Secret Key Establishment for
+                                        DNS (TKEY RR)
+
+This document describes a Transaction Key (TKEY) RR that can be used in
+a number of different modes to establish shared secret keys between a
+DNS resolver and server.  [STANDARDS TRACK]
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 15]
+
+RFC 2999                  Summary of 2900-2999               August 2001
+
+
+2929    Eastlake        Sep 2000        Domain Name System (DNS) IANA
+                                        Considerations
+
+This document discusses the Internet Assigned Number Authority (IANA)
+parameter assignment considerations given for the allocation of Domain
+Name System (DNS) classes, Resource Record (RR) types, operation codes,
+error codes, etc.  This document specifies an Internet Best Current
+Practices for the Internet Community, and requests discussion and
+suggestions for improvements.
+
+
+2928    Hinden          Sep 2000        Initial IPv6 Sub-TLA ID
+                                        Assignments
+
+This document defines initial assignments of IPv6 Sub-Top-Level
+Aggregation Identifiers (Sub-TLA ID) to the Address Registries.  This
+memo provides information for the Internet community.
+
+
+2927    Wahl            Sep 2000        MIME Directory Profile for
+                                        LDAP Schema
+
+This document defines a multipurpose internet mail extensions (MIME)
+directory profile for holding a lightweight directory access protocol
+(LDAP) schema.  This memo provides information for the Internet
+community.
+
+
+2926    Kempf           Sep 2000        Conversion of LDAP Schemas to
+                                        and from SLP Templates
+
+This document describes a procedure for mapping between Service Location
+Protocol (SLP) service advertisements and lightweight directory access
+protocol (LDAP) descriptions of services.  This memo provides
+information for the Internet community.
+
+
+2925    White           Sep 2000        Definitions of Managed Objects
+                                        for Remote Ping, Traceroute,
+                                        and Lookup Operations
+
+This memo defines Management Information Bases (MIBs) for performing
+remote ping, traceroute and lookup operations at a remote host.
+[STANDARDS TRACK]
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 16]
+
+RFC 2999                  Summary of 2900-2999               August 2001
+
+
+2924    Brownlee        Sep 2000        Accounting Attributes and
+                                        Record Formats
+
+This document summarises Internet Engineering Task Force (IETF) and
+International Telecommunication Union (ITU-T) documents related to
+Accounting.  This memo provides information for the Internet community.
+
+
+2923    Lahey           Sep 2000        TCP Problems with Path MTU
+                                        Discovery
+
+This memo catalogs several known Transmission Control Protocol (TCP)
+implementation problems dealing with Path Maximum Transmission Unit
+Discovery (PMTUD), including the long-standing black hole problem,
+stretch acknowlegements (ACKs) due to confusion between Maximum Segment
+Size (MSS) and segment size, and MSS advertisement based on PMTU.  This
+memo provides information for the Internet community.
+
+
+2922    Bierman         Sep 2000        Physical Topology MIB
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it describes managed objects used for managing physical
+topology identification and discovery.  This memo provides information
+for the Internet community.
+
+
+2921    Fink            Sep 2000        6BONE pTLA and pNLA Formats
+                                        (pTLA)
+
+This memo defines how the 6bone uses the 3FFE::/16 IPv6 address prefix,
+allocated in RFC 2471, "IPv6 Testing Address Allocation", to create
+pseudo Top-Level Aggregation Identifiers (pTLA's) and pseudo Next-Level
+Aggregation Identifiers (pNLA's).  This memo provides information for
+the Internet community.
+
+
+2920    Freed           Sep 2000        SMTP Service Extension for
+                                        Command Pipelining
+
+This memo defines an extension to the Simple Mail Transfer Protocol
+(SMTP) service whereby a server can indicate the extent of its ability
+to accept multiple commands in a single Transmission Control Protocol
+(TCP) send operation.  [STANDARDS TRACK]
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 17]
+
+RFC 2999                  Summary of 2900-2999               August 2001
+
+
+2919    Chandhok        Mar 2001        List-Id: A Structured Field
+                                        and Namespace for the
+                                        Identification of Mailing
+                                        Lists
+
+Software that handles electronic mailing list messages (servers and user
+agents) needs a way to reliably identify messages that belong to a
+particular mailing list.  With the advent of list management headers, it
+has become even more important to provide a unique identifier for a
+mailing list regardless of the particular host that serves as the list
+processor at any given time.  [STANDARDS TRACK]
+
+
+2918    Chen            Sep 2000        Route Refresh Capability for
+                                        BGP-4
+
+
+This document defines a new Border Gateway Protocol (BGP) capability
+termed 'Route Refresh Capability', which would allow the dynamic
+exchange of route refresh request between BGP speakers and subsequent
+re-advertisement of the respective Adj-RIB-Out.  [STANDARDS TRACK]
+
+
+2917    Muthukrishnan   Sep 2000        A Core MPLS IP VPN
+                                        Architecture
+
+This memo presents an approach for building core Virtual Private Network
+(VPN) services in a service provider's MPLS backbone.  This memo
+provides information for the Internet community.
+
+
+2916    Faltstrom       Sep 2000        E.164 number and DNS
+
+This document discusses the use of the Domain Name System (DNS) for
+storage of E.164 numbers.  [Standards Track]
+
+
+2915    Mealling        Sep 2000        The Naming Authority Pointer
+                                        (NAPTR) DNS Resource Record
+
+This document describes a Domain Name System (DNS) resource record which
+specifies a regular expression based rewrite rule that, when applied to
+an existing string, will produce a new domain label or Uniform Resource
+Identifier (URI).  [STANDARDS TRACK]
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 18]
+
+RFC 2999                  Summary of 2900-2999               August 2001
+
+
+2914    Floyd           Sep 2000        Congestion Control Principles
+
+The goal of this document is to explain the need for congestion control
+in the Internet, and to discuss what constitutes correct congestion
+control.  This document specifies an Internet Best Current Practices for
+the Internet Community, and requests discussion and suggestions for
+improvements.
+
+
+2913    Klyne           Sep 2000        MIME Content Types in Media
+                                        Feature Expressions
+
+This memo defines a media feature tag whose value is a Multipurpose
+Internet Mail Extensions (MIME) content type.  [STANDARDS TRACK]
+
+
+2912    Klyne           Sep 2000        Indicating Media Features for
+                                        MIME Content
+
+This memo defines a Multipurpose Internet Mail Extensions (MIME) '
+Content-features:' header that can be used to annotate a MIME message
+part using this expression format, and indicates some ways it might be
+used.  [STANDARDS TRACK]
+
+
+2911    Hastings        Sep 2000        Internet Printing
+                                        Protocol/1.1: Model and
+                                        Semantics
+
+This document is one of a set of documents, which together describe all
+aspects of a new Internet Printing Protocol (IPP).  [STANDARDS TRACK]
+
+
+2910    Herriot         Sep 2000        Internet Printing
+                                        Protocol/1.1: Encoding and
+                                        Transport
+
+This document is one of a set of documents, which together describe all
+aspects of a new Internet Printing Protocol (IPP).  [STANDARDS TRACK]
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 19]
+
+RFC 2999                  Summary of 2900-2999               August 2001
+
+
+2909    Radoslavov      Sep 2000        The Multicast Address-Set
+                                        Claim (MASC) Protocol
+
+This document describes the Multicast Address-Set Claim (MASC) protocol
+which can be used for inter-domain multicast address set allocation.
+This memo defines an Experimental Protocol for the Internet community.
+
+
+2908    Thaler          Sep 2000        The Internet Multicast Address
+                                        Allocation Architecture
+
+This document proposes a multicast address allocation architecture
+(MALLOC) for the Internet.  This memo provides information for the
+Internet community.
+
+
+2907    Kermode         Sep 2000        MADCAP Multicast Scope Nesting
+                                        State Option
+
+This document defines a new option to the Multicast Address Dynamic
+Client Allocation Protocol (MADCAP) to support nested scoping.
+[STANDARDS TRACK]
+
+
+2906    Farrell         Aug 2000        AAA Authorization Requirements
+
+
+This document specifies the requirements that Authentication
+Authorization Accounting (AAA) protocols must meet in order to support
+authorization services in the Internet.  This memo provides information
+for the Internet community.
+
+
+2905    Vollbrecht      Aug 2000        AAA Authorization Application
+                                        Examples
+
+This memo describes several examples of applications requiring
+authorization.  This memo provides information for the Internet
+community.
+
+
+2904    Vollbrecht      Aug 2000        AAA Authorization Framework
+
+This memo serves as the base requirements for Authorization of Internet
+Resources and Services (AIRS).  It presents an architectural framework
+for understanding the authorization of Internet resources and services
+and derives requirements for authorization protocols.  This memo
+provides information for the Internet community.
+
+
+
+Ginoza                       Informational                     [Page 20]
+
+RFC 2999                  Summary of 2900-2999               August 2001
+
+
+2903    de Laat         Aug 2000        Generic AAA Architecture
+
+This memo proposes an Authentication, Authorization, Accounting (AAA)
+architecture that would incorporate a generic AAA server along with an
+application interface to a set of Application Specific Modules that
+could perform application specific AAA functions.  This memo defines an
+Experimental Protocol for the Internet community.
+
+
+2902    Deering         Aug 2000        Overview of the 1998 IAB
+                                        Routing Workshop
+
+This document is an overview of a Routing workshop held by the Internet
+Architecture Board (IAB) during March 25-27, 1998.  This memo provides
+information for the Internet community.
+
+
+2901    Wenzel          Aug 2000        Guide to Administrative
+                                        Procedures of the Internet
+                                        Infrastructure
+
+This document describes the administrative procedures for networks
+seeking to connect to the global Internet.  This memo provides
+information for the Internet community.
+
+
+2900    Reynolds        Aug 2001        Internet Official Protocol
+                                        Standards
+
+This memo contains a snapshot of the state of standardization of
+protocols used in the Internet as of July 17, 2001.  It lists official
+protocol standards and Best Current Practice RFCs; it is not a complete
+index to the RFC series.  This memo is an Internet Standard.
+
+Security Considerations
+
+   This memo does not affect the technical security of the Internet, but
+   may cite important security specifications.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 21]
+
+RFC 2999                  Summary of 2900-2999               August 2001
+
+
+Author's Address
+
+   Sandy Ginoza
+   University of Southern California
+   Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone:  (310) 822-1511
+
+   EMail: ginoza@isi.edu
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 22]
+
+RFC 2999                  Summary of 2900-2999               August 2001
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2001).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 23]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc2999.txt](<www.ietf.org/rfc/rfc2999.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
