### PR TITLE
Archive rfc3.txt

### DIFF
--- a/www.ietf.org/rfc/rfc3.txt
+++ b/www.ietf.org/rfc/rfc3.txt
@@ -1,0 +1,80 @@
+Network Working Group                                                 4689
+RFC-3                                                           April 1969
+                                                             Steve Crocker
+                                                                      UCLA
+
+
+                        DOCUMENTATION CONVENTIONS
+
+
+
+The Network Working Group seems to consist of Steve Carr of Utah, Jeff
+Rulifson and Bill Duvall at SRI, and Steve Crocker and Gerard Deloche
+at UCLA.  Membership is not closed.
+
+The Network Working Group (NWG) is concerned with the HOST software, the
+strategies for using the network, and initial experiments with the network.
+
+Documentation of the NWG's effort is through notes such as this.  Notes
+may be produced at any site by anybody and included in this series.
+                        
+
+CONTENT
+
+The content of a NWG note may be any thought, suggestion, etc. related to
+the HOST software or other aspect of the network.  Notes are encouraged to
+be timely rather than polished.  Philosophical positions without examples
+or other specifics, specific suggestions or implementation techniques
+without introductory or background explication, and explicit questions
+without any attempted answers are all acceptable.  The minimum length for 
+a NWG note is one sentence.
+
+These standards (or lack of them) are stated explicitly for two reasons.
+First, there is a tendency to view a written statement as ipso facto 
+authoritative, and we hope to promote the exchange and discussion of 
+considerably less than authoritative ideas.  Second, there is a natural
+hesitancy to publish something unpolished, and we hope to ease this
+inhibition.
+
+FORM
+
+Every NWG note should bear the following information:
+
+        1.  "Network Working Group"
+            "Request for Comments:" x
+            where x is a serial number.
+            Serial numbers are assigned by Bill Duvall at SRI
+
+        2.  Author and affiliation
+
+        3.  Date
+
+        4.  Title.  The title need not be unique.
+
+DISTRIBUTION
+
+One copy only will be sent from the author's site to"
+
+        1.  Bob Kahn, BB&N
+        2.  Larry Roberts, ARPA
+        3.  Steve Carr, UCLA
+        4.  Jeff Rulifson, UTAH
+        5.  Ron Stoughton, UCSB
+        6.  Steve Crocker, UCLA
+
+Reproduction if desired may be handled locally.  
+
+OTHER NOTES
+
+Two notes (1 & 2) have been written so far.  These are both titled HOST
+Software and are by Steve Crocker and Bill Duvall, separately.
+
+Other notes planned are on
+
+        1.  Network Timetable
+        2.  The Philosophy of NIL
+        3.  Specifications for NIL
+        4.  Deeper Documentation of HOST Software.
+
+
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc3.txt](<www.ietf.org/rfc/rfc3.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
