### PR TITLE
Archive rfc3000.txt

### DIFF
--- a/www.ietf.org/rfc/rfc3000.txt
+++ b/www.ietf.org/rfc/rfc3000.txt
@@ -1,0 +1,2411 @@
+
+
+
+
+
+
+Network Working Group                    Internet Engineering Task Force
+Request for Comments: 3000                                   J. Reynolds
+Obsoletes: 2900                                                R. Braden
+STD: 1                                                         S. Ginoza
+Category: Standards Track                                      L. Shiota
+                                                                 Editors
+                                                           November 2001
+
+
+                  Internet Official Protocol Standards
+
+Status of this Memo
+
+   This memo is an Internet Standard.  Distribution of this memo is
+   unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2001).  All Rights Reserved.
+
+Abstract
+
+   This memo contains a snapshot of the state of standardization of
+   protocols used in the Internet as of October 25, 2001.  It lists
+   official protocol standards and Best Current Practice RFCs; it is not
+   a complete index to the RFC series.  The latest version of this memo
+   is designated STD 1.
+
+Table of Contents
+
+   1.  Overview . . . . . . . . . . . . . . . . . . . . . . . . .   2
+   2.  Contacts . . . . . . . . . . . . . . . . . . . . . . . . .   2
+   2.1.  Internet-Related Organizations . . . . . . . . . . . . .   2
+   2.2.  Request for Comments Editor (RFC Editor) Web Pages . . .   2
+   2.3   Retrieval using FTP  . . . . . . . . . . . . . . . . . .   3
+   2.4   Search and Retrieval Using Email . . . . . . . . . . . .   4
+   3.  Current Technical Specifications . . . . . . . . . . . . .   5
+   3.1.  Standard Protocols Ordered by STD  . . . . . . . . . . .   5
+   3.2.  Standard Protocols Ordered by RFC  . . . . . . . . . . .   8
+   3.3.  Draft Standard Protocols . . . . . . . . . . . . . . . .  11
+   3.4.  Proposed Standard Protocols  . . . . . . . . . . . . . .  14
+   3.5.  Best Current Practice by BCP . . . . . . . . . . . . . .  32
+   3.6.  Best Current Practice by RFC . . . . . . . . . . . . . .  34
+   3.7.  Experimental Protocols . . . . . . . . . . . . . . . . .  36
+   3.8.  Historic Protocols . . . . . . . . . . . . . . . . . . .  40
+   4.  Security Considerations  . . . . . . . . . . . . . . . . .  42
+   5.  Editors' Addresses . . . . . . . . . . . . . . . . . . . .  42
+   6.  Full Copyright Statement . . . . . . . . . . . . . . . . .  43
+
+
+
+IETF                        Standards Track                     [Page 1]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+1.  Overview
+
+   This memo contains a snapshot of the state of standardization of
+   protocols used in the Internet, as determined by the Internet
+   Engineering Task Force (IETF).  It is a October 25, 2001 snapshot of
+   the current official protocol standards list and the Best Current
+   Practice list, which is updated daily and is available from the RFC
+   Editor Web site.
+
+   The RFC Editor publishes Request for Comments (RFC) documents that
+   are the output of the IETF process or are submitted individually via
+   electronic mail.  Further information about the RFC series is
+   contained in section 2.1, RFC 2026 and at http://www.rfc-editor.org.
+
+   This memo is published by the RFC Editor for the IESG and IAB in
+   accordance with Section 2.1 of "The Internet Standards Process --
+   Revision 3", RFC 2026, which specifies the rules and procedures by
+   which all Internet standards are set.  Sections 3.1 - 3.6 of this
+   memo contain the lists of protocols in each stage of standardization
+   - Standard, Draft Standard, Proposed Standard, Experimental,
+   Historic, as well as Best Current Practice documents.  Protocols that
+   are new to this document or have been moved from one protocol level
+   to another, or that differ from the previous edition of this document
+   are marked with an asterisk.  Informational RFCs are not included.
+   This memo lists the current standards track, Best Current Practice,
+   Experimental, and Historic protocols; it is not a complete index to
+   RFCs.
+
+2.  Resources
+
+   This section contains important contact information, for reference.
+
+2.1.  Internet-Related Organizations
+
+   Internet Architecture Board (IAB) Contact: www.iab.org
+
+   Internet Engineering Task Force (IETF) Contact: www.ietf.org
+
+   Internet Research Task Force (IRTF) Contact: www.irtf.org
+
+   Internet Assigned Numbers Authority (IANA) Contact: www.iana.org
+
+2.2.  Request for Comments Editor (RFC Editor) Web Pages
+
+   The RFC Editor maintains the official repository of all RFCs and
+   indexes to them.  The RFC Editor web site is:
+
+      http://www.rfc-editor.org.
+
+
+
+IETF                        Standards Track                     [Page 2]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+   At this URL, a user can:
+
+   (a) Obtain the current "Internet Official Protocol Standards" list.
+       See:
+
+         http://www.rfc-editor.org/rfcxx00.html
+
+       This hyper-linked listing is updated daily.
+
+   (b) Retrieve the latest version of this STD 1 memo.  See:
+
+         http://www.rfc-editor.org/go.html, and select STD and "1".
+
+   (c) Retrieve text of any RFC.  See:
+
+         http://www.rfc-editor.org/go.html
+
+   (d) Search for RFCs by category.  See:
+
+         http://www.rfc-editor.org/category.html
+
+   (e) Search the RFC index for document number, author, title, and/or
+       keywords, and retrieve the text of any matching documents.  See:
+
+         http://www.rfc-editor.org/rfcsearch.html
+
+   RFC information can also be retrieved using FTP or email.
+
+2.3 Retrieval using FTP
+
+   RFC-related files may be copied via FTP from the FTP.RFC-EDITOR.ORG
+   computer using the FTP username "anonymous" and password
+   "name@host.domain".  An FTP user can:
+
+   (a) Retrieve the latest version of this STD 1 memo.
+
+         File: "in-notes/std/std1.txt"
+
+   (b) Retrieve text of any RFC.
+
+       File: "in-notes/rfcnnnn.txt" will retrieve the ASCII version.
+       Some RFCs also have secondary Postscript and/or PDF versions,
+       available from File: "in-notes/rfcnnnn.ps" and/or
+       "in-notes/rfcnnnn.pdf", respectively.
+
+       Here "nnnn" is a 1-4 digit RFC number, with no leading zeros.
+
+
+
+
+
+IETF                        Standards Track                     [Page 3]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+2.4 Search and Retrieval Using Email
+
+   To use the RFC Editor's email-based RFC-INFO service, send a request
+   to:
+
+      RFC-INFO@RFC-EDITOR.ORG
+
+   In the message body, include your information request.  For example,
+   the following message bodies may be used.
+
+   (a) To retrieve the latest version of this STD 1 memo:
+
+         Retrieve: STD
+            Doc-ID: STD0001
+
+   (b) To retrieve ASCII text of any RFC:
+
+         Retrieve: RFC
+            Doc-ID: RFCnnnn
+
+       Here "nnnn" must be filled with leading zeros to 4 digits.
+
+   (c) The RFC-INFO@RFC-EDITOR.ORG server provides other capabilities,
+       e.g., search and retrieval based on author, title, and/or
+       keyword.  For more information, send the following message body
+       to the server:
+
+         help: help
+
+   The server will email back the results.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+IETF                        Standards Track                     [Page 4]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+3.  Current Technical Specifications
+
+3.1.  Standard Protocols Ordered by STD
+
+Mnemonic   Title                                               RFC# STD#
+------------------------------------------------------------------------
+--------   Internet Official Protocol Standards                3000   1*
+--------   Assigned Numbers                                    1700   2
+--------   Requirements for Internet Hosts - Communication     1122   3
+              Layers
+--------   Requirements for Internet Hosts - Application       1123   3
+              and Support
+--------   [Reserved for Router Requirements.  See RFC 1812.]         4
+IP         Internet Protocol                                    791   5
+ICMP       Internet Control Message Protocol                    792   5
+---------  Broadcasting Internet Datagrams                      919   5
+---------  Broadcasting Internet datagrams in the presence      922   5
+              of subnets
+--------   Internet Standard Subnetting Procedure               950   5
+IGMP       Host extensions for IP multicasting                 1112   5
+UDP        User Datagram Protocol                               768   6
+TCP        Transmission Control Protocol                        793   7
+TELNET     Telnet Protocol Specification                        854   8
+TELNET     Telnet Option Specifications                         855   8
+FTP        File Transfer Protocol                               959   9
+SMTP       Simple Mail Transfer Protocol                        821  10
+SMTP-SIZE  SMTP Service Extension for Message Size Declaration 1870  10
+MAIL       Standard for the format of ARPA Internet text        822  11
+              messages
+NTP        [Reserved for Network Time Protocol (NTP).  See RFC       12
+              305.]
+DOMAIN     Domain names - concepts and facilities              1034  13
+DOMAIN     Domain names - implementation and specification     1035  13
+--------   [Was Mail Routing and the Domain System.  Now             14
+              Historic.]
+SNMP       Simple Network Management Protocol (SNMP)           1157  15
+SMI        Structure and identification of management          1155  16
+              information for TCP/IP-based internets
+Concise-MI Concise MIB definitions                             1212  16
+MIB-II     Management Information Base for Network Management  1213  17
+              of TCP/IP-based internets:MIB-II
+EGP        [Was Exterior Gateway Protocol (RFC 904).  Now            18
+              Historic.]
+NETBIOS    Protocol standard for a NetBIOS service on          1001  19
+              a TCP/UDP transport: Concepts and methods
+NETBIOS    Protocol standard for a NetBIOS service on          1002  19
+              a TCP/UDP transport: Detailed specifications
+ECHO       Echo Protocol                                        862  20
+
+
+
+IETF                        Standards Track                     [Page 5]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+DISCARD    Discard Protocol                                     863  21
+CHARGEN    Character Generator Protocol                         864  22
+QUOTE      Quote of the Day Protocol                            865  23
+USERS      Active users                                         866  24
+DAYTIME    Daytime Protocol                                     867  25
+TIME       Time Protocol                                        868  26
+TOPT-BIN   Telnet Binary Transmission                           856  27
+TOPT-ECHO  Telnet Echo Option                                   857  28
+TOPT-SUPP  Telnet Suppress Go Ahead Option                      858  29
+TOPT-STAT  Telnet Status Option                                 859  30
+TOPT-TIM   Telnet Timing Mark Option                            860  31
+TOPT-EXTOP Telnet Extended Options: List Option                 861  32
+TFTP       The TFTP Protocol (Revision 2)                      1350  33
+RIP1       [Was Routing Information Protocol (RIP).  Replaced        34
+              by STD 56.]
+TP-TCP     ISO transport services on top of the TCP:           1006  35
+              Version 3
+IP-FDDI    Transmission of IP and ARP over FDDI Networks       1390  36
+ARP        Ethernet Address Resolution Protocol: Or converting  826  37
+              network protocol addresses to 48.bit Ethernet
+              address for transmission on Ethernet hardware
+RARP       Reverse Address Resolution Protocol                  903  38
+IP-ARPA    [Was BBN Report 1822 (IMP/Host Interface).  Now           39
+              Historic.]
+IP-WB      Host Access Protocol specification                   907  40
+IP-E       Standard for the transmission of IP datagrams        894  41
+              over Ethernet networks
+IP-EE      Standard for the transmission of IP datagrams        895  42
+              over experimental Ethernet networks
+IP-IEEE    Standard for the transmission of IP datagrams       1042  43
+              over IEEE 802 networks
+IP-DC      DCN local-network protocols                          891  44
+IP-HC      Internet Protocol on Network System's HYPERchannel: 1044  45
+              Protocol specification
+IP-ARC     Transmitting IP traffic over ARCNET networks        1201  46
+IP-SLIP    Nonstandard for transmission of IP datagrams        1055  47
+              over serial lines: SLIP
+IP-NETBIOS Standard for the transmission of IP datagrams       1088  48
+              over NetBIOS networks
+IP-IPX     Standard for the transmission of 802.2 packets      1132  49
+              over IPX networks
+ETHER-MIB  Definitions of Managed Objects for the Ethernet-    1643  50
+              like Interface Types
+PPP        The Point-to-Point Protocol (PPP)                   1661  51
+PPP-HDLC   PPP in HDLC-like Framing                            1662  51
+IP-SMDS    Transmission of IP datagrams over the SMDS Service  1209  52
+POP3       Post Office Protocol - Version 3                    1939  53
+OSPF2      OSPF Version 2                                      2328  54
+
+
+
+IETF                        Standards Track                     [Page 6]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+IP-FR      Multiprotocol Interconnect over Frame Relay         2427  55
+RIP2       RIP Version 2                                       2453  56
+RIP2-APP   RIP Version 2 Protocol Applicability Statement      1722  57
+SMIv2      Structure of Management Information Version         2578  58
+              2 (SMIv2)
+CONV-MIB   Textual Conventions for SMIv2                       2579  58
+CONF-MIB   Conformance Statements for SMIv2                    2580  58
+RMON-MIB   Remote Network Monitoring Management Information    2819  59
+              Base
+SMTP-Pipe  SMTP Service Extension for Command Pipelining       2920  60
+ONE-PASS   A One-Time Password System                          2289  61
+
+   [Note: an asterisk at the end of a line indicates a change from the
+   previous edition of this document.]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+IETF                        Standards Track                     [Page 7]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+3.2.  Standard Protocols Ordered by RFC
+
+Mnemonic   Title                                               STD# RFC#
+------------------------------------------------------------------------
+--------   Internet Official Protocol Standards                 1* 3000*
+SMTP-Pipe  SMTP Service Extension for Command Pipelining       60  2920
+RMON-MIB   Remote Network Monitoring Management Information    59  2819
+              Base
+CONF-MIB   Conformance Statements for SMIv2                    58  2580
+CONV-MIB   Textual Conventions for SMIv2                       58  2579
+SMIv2      Structure of Management Information Version         58  2578
+              2 (SMIv2)
+RIP2       RIP Version 2                                       56  2453
+IP-FR      Multiprotocol Interconnect over Frame Relay         55  2427
+OSPF2      OSPF Version 2                                      54  2328
+ONE-PASS   A One-Time Password System                          61  2289
+POP3       Post Office Protocol - Version 3                    53  1939
+SMTP-SIZE  SMTP Service Extension for Message Size Declaration 10  1870
+RIP2-APP   RIP Version 2 Protocol Applicability Statement      57  1722
+--------   Assigned Numbers                                     2  1700
+PPP-HDLC   PPP in HDLC-like Framing                            51  1662
+PPP        The Point-to-Point Protocol (PPP)                   51  1661
+ETHER-MIB  Definitions of Managed Objects for the Ethernet-    50  1643
+              like Interface Types
+IP-FDDI    Transmission of IP and ARP over FDDI Networks       36  1390
+TFTP       The TFTP Protocol (Revision 2)                      33  1350
+MIB-II     Management Information Base for Network Management  17  1213
+              of TCP/IP-based internets:MIB-II
+Concise-MI Concise MIB definitions                             16  1212
+IP-SMDS    Transmission of IP datagrams over the SMDS Service  52  1209
+IP-ARC     Transmitting IP traffic over ARCNET networks        46  1201
+SNMP       Simple Network Management Protocol (SNMP)           15  1157
+SMI        Structure and identification of management          16  1155
+              information for TCP/IP-based internets
+IP-IPX     Standard for the transmission of 802.2 packets      49  1132
+              over IPX networks
+--------   Requirements for Internet Hosts - Application        3  1123
+              and Support
+--------   Requirements for Internet Hosts - Communication      3  1122
+              Layers
+IGMP       Host extensions for IP multicasting                  5  1112
+IP-NETBIOS Standard for the transmission of IP datagrams       48  1088
+              over NetBIOS networks
+IP-SLIP    Nonstandard for transmission of IP datagrams        47  1055
+              over serial lines: SLIP
+IP-HC      Internet Protocol on Network System's HYPERchannel: 45  1044
+              Protocol specification
+
+
+
+
+IETF                        Standards Track                     [Page 8]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+IP-IEEE    Standard for the transmission of IP datagrams       43  1042
+              over IEEE 802 networks
+DOMAIN     Domain names - implementation and specification     13  1035
+DOMAIN     Domain names - concepts and facilities              13  1034
+TP-TCP     ISO transport services on top of the TCP:           35  1006
+              Version 3
+NETBIOS    Protocol standard for a NetBIOS service on          19  1002
+              a TCP/UDP transport: Detailed specifications
+NETBIOS    Protocol standard for a NetBIOS service on          19  1001
+              a TCP/UDP transport: Concepts and methods
+FTP        File Transfer Protocol                               9   959
+--------   Internet Standard Subnetting Procedure               5   950
+---------  Broadcasting Internet datagrams in the presence      5   922
+              of subnets
+---------  Broadcasting Internet Datagrams                      5   919
+IP-WB      Host Access Protocol specification                  40   907
+RARP       Reverse Address Resolution Protocol                 38   903
+IP-EE      Standard for the transmission of IP datagrams       42   895
+              over experimental Ethernet networks
+IP-E       Standard for the transmission of IP datagrams       41   894
+              over Ethernet networks
+IP-DC      DCN local-network protocols                         44   891
+TIME       Time Protocol                                       26   868
+DAYTIME    Daytime Protocol                                    25   867
+USERS      Active users                                        24   866
+QUOTE      Quote of the Day Protocol                           23   865
+CHARGEN    Character Generator Protocol                        22   864
+DISCARD    Discard Protocol                                    21   863
+ECHO       Echo Protocol                                       20   862
+TOPT-EXTOP Telnet Extended Options: List Option                32   861
+TOPT-TIM   Telnet Timing Mark Option                           31   860
+TOPT-STAT  Telnet Status Option                                30   859
+TOPT-SUPP  Telnet Suppress Go Ahead Option                     29   858
+TOPT-ECHO  Telnet Echo Option                                  28   857
+TOPT-BIN   Telnet Binary Transmission                          27   856
+TELNET     Telnet Option Specifications                         8   855
+TELNET     Telnet Protocol Specification                        8   854
+ARP        Ethernet Address Resolution Protocol: Or converting 37   826
+              network protocol addresses to 48.bit Ethernet
+              address for transmission on Ethernet hardware
+MAIL       Standard for the format of ARPA Internet text       11   822
+              messages
+SMTP       Simple Mail Transfer Protocol                       10   821
+TCP        Transmission Control Protocol                        7   793
+
+
+
+
+
+
+
+IETF                        Standards Track                     [Page 9]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+ICMP       Internet Control Message Protocol                    5   792
+IP         Internet Protocol                                    5   791
+UDP        User Datagram Protocol                               6   768
+
+   [Note: an asterisk at the end of a line indicates a change from the
+   previous edition of this document.]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+IETF                        Standards Track                    [Page 10]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+3.3.  Draft Standard Protocols
+
+Mnemonic   Title                                                   RFC#
+------------------------------------------------------------------------
+RADIUS     Remote Authentication Dial In User Service (RADIUS)     2865
+INTERGRMIB The Interfaces Group MIB                                2863
+--------   Host Resources MIB                                      2790
+--------   HTTP Authentication: Basic and Digest Access            2617
+              Authentication
+HTTP       Hypertext Transfer Protocol -- HTTP/1.1                 2616
+VACM-SNMP  View-based Access Control Model (VACM) for              2575
+              the Simple Network Management Protocol (SNMP)
+USM-SNMPV3 User-based Security Model (USM) for version             2574
+              3 of the Simple Network Management Protocol (SNMPv3)
+SNMP-APP   SNMP Applications                                       2573
+MPD-SNMP   Message Processing and Dispatching for the              2572
+              Simple Network Management Protocol (SNMP)
+ARCH-SNMP  An Architecture for Describing SNMP Management          2571
+              Frameworks
+ICMPv6     Internet Control Message Protocol (ICMPv6)              2463
+              for the Internet Protocol Version 6 (IPv6)
+              Specification
+IPV6-AUTO  IPv6 Stateless Address Autoconfiguration                2462
+IPV6-ND    Neighbor Discovery for IP Version 6 (IPv6)              2461
+IPV6       Internet Protocol, Version 6 (IPv6) Specification       2460
+URI-GEN    Uniform Resource Identifiers (URI): Generic Syntax      2396
+IARP       Inverse Address Resolution Protocol                     2390
+TN3270E    TN3270 Enhancements                                     2355
+TFTP-Opt   TFTP Timeout Interval and Transfer Size Options         2349
+TFTP-Blk   TFTP Blocksize Option                                   2348
+TFTP-Ext   TFTP Option Extension                                   2347
+UTF-8      UTF-8, a transformation format of ISO 10646             2279
+DHCP-BOOTP DHCP Options and BOOTP Vendor Extensions                2132
+DHCP       Dynamic Host Configuration Protocol                     2131
+FRAME-MIB  Management Information Base for Frame Relay             2115
+              DTEs Using SMIv2
+IP-HIPPI   IP over HIPPI                                           2067
+MIME-CONF  Multipurpose Internet Mail Extensions (MIME)            2049
+              Part Five: Conformance Criteria and Examples
+MIME-MSG   MIME (Multipurpose Internet Mail Extensions)            2047
+              Part Three: Message Header Extensions for
+              Non-ASCII Text
+MIME-MEDIA Multipurpose Internet Mail Extensions (MIME)            2046
+              Part Two: Media Types
+MIME       Multipurpose Internet Mail Extensions (MIME)            2045
+              Part One: Format of Internet Message Bodies
+PPP-CHAP   PPP Challenge Handshake Authentication Protocol (CHAP)  1994
+PPP-MP     The PPP Multilink Protocol (MP)                         1990
+
+
+
+IETF                        Standards Track                    [Page 11]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+PPP-LINK   PPP Link Quality Monitoring                             1989
+SNMPv2-MIB Management Information Base for Version 2               1907
+              of the Simple Network Management Protocol (SNMPv2)
+TRANS-MIB  Transport Mappings for Version 2 of the Simple          1906
+              Network Management Protocol (SNMPv2)
+OPS-MIB    Protocol Operations for Version 2 of the Simple         1905
+              Network Management Protocol (SNMPv2)
+CON-MD5    The Content-MD5 Header Field                            1864
+OSPF-MIB   OSPF Version 2 Management Information Base              1850
+XDR        XDR: External Data Representation Standard              1832
+--------   The String Representation of Standard Attribute         1778
+              Syntaxes
+--------   Lightweight Directory Access Protocol                   1777
+BGP-4-APP  Application of the Border Gateway Protocol              1772
+              in the Internet
+BGP-4      A Border Gateway Protocol 4 (BGP-4)                     1771
+PPP-DNCP   The PPP DECnet Phase IV Control Protocol (DNCP)         1762
+802.5-MIB  IEEE 802.5 MIB using SMIv2                              1748
+RIP2-MIB   RIP Version 2 MIB Extension                             1724
+SIP-MIB    Definitions of Managed Objects for SMDS Interfaces      1694
+              using SMIv2
+--------   Definitions of Managed Objects for Parallel-            1660
+              printer-like Hardware Devices using SMIv2
+--------   Definitions of Managed Objects for RS-232-              1659
+              like Hardware Devices using SMIv2
+--------   Definitions of Managed Objects for Character            1658
+              Stream Devices using SMIv2
+BGP-4-MIB  Definitions of Managed Objects for the Fourth           1657
+              Version of the Border Gateway Protocol (BGP-
+              4) using SMIv2
+--------   SMTP Service Extension for 8bit-MIMEtransport           1652
+OSI-NSAP   Guidelines for OSI NSAP Allocation in the Internet      1629
+ISO-TS-ECH An Echo Function for CLNP (ISO 8473)                    1575
+DECNET-MIB DECnet Phase IV MIB Extensions                          1559
+--------   Clarifications and Extensions for the Bootstrap         1542
+              Protocol
+DHCP-BOOTP Interoperation Between DHCP and BOOTP                   1534
+BRIDGE-MIB Definitions of Managed Objects for Bridges              1493
+IP-X.25    Multiprotocol Interconnect on X.25 and ISDN             1356
+              in the Packet Mode
+NTPV3      Network Time Protocol (Version 3) Specification,        1305
+              Implementation
+FINGER     The Finger User Information Protocol                    1288
+IP-MTU     Path MTU discovery                                      1191
+--------   Proposed Standard for the Transmission of               1188
+              IP Datagrams over FDDI Networks
+
+
+
+
+
+IETF                        Standards Track                    [Page 12]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+TOPT-LINE  Telnet Linemode Option                                  1184
+NICNAME    NICNAME/WHOIS                                            954
+BOOTP      Bootstrap Protocol                                       951
+
+   [Note: an asterisk at the end of a line indicates a change from the
+   previous edition of this document.]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+IETF                        Standards Track                    [Page 13]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+3.4.  Proposed Standard Protocols
+
+Mnemonic   Title                                                    RFC#
+------------------------------------------------------------------------
+--------   Reuse of CMS Content Encryption Keys                    3185*
+--------   Aggregation of RSVP for IPv4 and IPv6 Reservations      3175*
+IPCOMP     IP Payload Compression Protocol (IPComp)                3173*
+--------   The Addition of Explicit Congestion Notification        3168*
+              (ECN) to IP
+--------   Definitions of Managed Objects for the Delegation       3165*
+              of Management Scripts
+--------   RADIUS and IPv6                                         3162*
+TSA        Internet X.509 Public Key Infrastructure Time-Stamp     3161*
+              Protocol (TSP)
+PIB        Structure of Policy Provisioning Information (SPPI)     3159*
+MIME-PGP   MIME Security with OpenPGP                              3156*
+--------   PPP Multiplexing                                        3153*
+--------   Transmission of IPv6 Packets over IEEE 1394 Networks    3146*
+--------   L2TP Disconnect Cause Information                       3145
+--------   Remote Monitoring MIB Extensions for Interface          3144*
+              Parameters Monitoring
+--------   Per Hop Behavior Identification Codes                   3140
+--------   The Congestion Manager                                  3124
+--------   Extensions to IPv6 Neighbor Discovery for Inverse       3122
+              Discovery Specification
+--------   A More Loss-Tolerant RTP Payload Format for MP3 Audio   3119
+--------   Authentication for DHCP Messages                        3118
+--------   Mobile IP Vendor/Organization-Specific Extensions       3115
+--------   Service Location Protocol Modifications for IPv6        3111
+--------   RSA/SHA-1 SIGs and RSA KEYs in the Domain Name          3110
+              System (DNS)
+--------   Conventions for the use of the Session Description      3108
+              Protocol (SDP) for ATM Bearer Connections
+SDP        Carrying Label Information in BGP-4                     3107
+RSVP       RSVP Cryptographic Authentication -- Updated Message    3097
+              Type Value
+--------   RObust Header Compression (ROHC): Framework and         3095
+              four profiles
+--------   DNS Security Extension Clarification on Zone Status     3090
+COPS-PR    COPS Usage for Policy Provisioning (COPS-PR)            3084
+--------   Mapping the BEEP Core onto TCP                          3081
+BEEP       The Blocks Extensible Exchange Protocol Core            3080
+--------   A Link-Layer Tunneling Mechanism for Unidirectional     3077
+              Links
+--------   XML-Signature Syntax and Processing                     3075
+--------   DHC Load Balancing Algorithm                            3074
+L2TP-FR    Layer Two Tunneling Protocol (L2TP) over Frame Relay    3070
+--------   An Anycast Prefix for 6to4 Relay Routers                3068
+
+
+
+IETF                        Standards Track                    [Page 14]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+BGP-ASC    Autonomous System Confederations for BGP                3065
+--------   LDAP Password Modify Extended Operation                 3062
+CIM        Policy Core Information Model -- Version 1              3060
+              Specification
+SLPv2      Attribute List Extension for the Service Location       3059
+              Protocol
+--------   ISDN Q.921-User Adaptation Layer                        3057
+--------   Connection of IPv6 Domains via IPv4 Clouds              3056
+--------   Management Information Base for the PINT Services       3055
+              Architecture
+--------   TN3270E Service Location and Session Balancing          3049
+--------   RTP Payload Format for ITU-T Recommendation G.722.1     3047
+--------   DHCP Relay Agent Information Option                     3046
+--------   Enhancing TCP's Loss Recovery Using Limited Transmit    3042
+--------   Privacy Extensions for Stateless Address                3041
+              Autoconfiguration in IPv6
+--------   Internet X.509 Public Key Infrastructure Qualified      3039
+              Certificates Profile
+--------   VCID Notification over ATM link for LDP                 3038
+--------   LDP Specification                                       3036
+--------   MPLS using LDP and ATM VC Switching                     3035
+--------   Use of Label Switching on Frame Relay Networks          3034
+              Specification
+--------   The Assignment of the Information Field and Protocol    3033
+              Identifier in the Q.2941 Generic Identifier
+              and Q.2957 User-to-user Signaling for the Internet
+              Protocol
+--------   MPLS Label Stack Encoding                               3032
+MPLS       Multiprotocol Label Switching Architecture              3031
+--------   SMTP Service Extensions for Transmission of Large       3030
+              and Binary MIME Messages
+--------   Sieve: A Mail Filtering Language                        3028
+--------   Reverse Tunneling for Mobile IP, revised                3024
+--------   XML Media Types                                         3023
+--------   Using 31-Bit Prefixes on IPv4 Point-to-Point Links      3021
+--------   Definitions of Managed Objects for Monitoring and       3020
+              Controlling the UNI/NNI Multilink Frame Relay
+              Function
+--------   IP Version 6 Management Information Base for The        3019
+              Multicast Listener Discovery Protocol
+--------   XML DTD for Roaming Access Phone Book                   3017
+--------   RTP Payload Format for MPEG-4 Audio/Visual Streams      3016
+MEGACO     Megaco Protocol Version 1.0                             3015
+--------   Notification Log MIB                                    3014
+--------   Mobile IPv4 Challenge/Response Extensions               3012
+--------   The IPv4 Subnet Selection Option for DHCP               3011
+NFSv4      NFS version 4 Protocol                                  3010
+--------   Registration of parityfec MIME types                    3009
+
+
+
+IETF                        Standards Track                    [Page 15]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+DNSSEC     Domain Name System Security (DNSSEC) Signing Authority  3008
+--------   Secure Domain Name System (DNS) Dynamic Update          3007
+--------   Integrated Services in the Presence of Compressible     3006
+              Flows
+--------   The User Class Option for DHCP                          3004
+--------   The audio/mpeg Media Type                               3003
+--------   Specification of the Null Service Type                  2997
+--------   Format of the RSVP DCLASS Object                        2996
+--------   Computing TCP's Retransmission Timer                    2988
+--------   Registration of Charset and Languages Media Features    2987
+              Tags
+--------   Use of the CAST-128 Encryption Algorithm in CMS         2984
+--------   Distributed Management Expression MIB                   2982
+--------   Event MIB                                               2981
+--------   The SIP INFO Method                                     2976
+--------   IMAP4 ID extension                                      2971
+--------   HTTP State Management Mechanism                         2965
+--------   RSVP Refresh Overhead Reduction Extensions              2961
+--------   Stream Control Transmission Protocol                    2960
+--------   Real-Time Transport Protocol Management Information     2959
+              Base
+--------   Definitions of Managed Objects for Monitoring and       2955
+              Controlling the Frame Relay/ATM PVC Service
+              Interworking Function
+FR-MIB     Definitions of Managed Objects for Frame Relay Service  2954
+--------   Telnet Encryption: CAST-128 64 bit Cipher Feedback      2950
+--------   Telnet Encryption: CAST-128 64 bit Output Feedback      2949
+--------   Telnet Encryption: DES3 64 bit Output Feedback          2948
+--------   Telnet Encryption: DES3 64 bit Cipher Feedback          2947
+--------   Telnet Data Encryption Option                           2946
+--------   The SRP Authentication and Key Exchange System          2945
+--------   Telnet Authentication: SRP                              2944
+--------   TELNET Authentication Using DSA                         2943
+--------   Telnet Authentication: Kerberos Version 5               2942
+TOPT-AUTH  Telnet Authentication Option                            2941
+--------   Definitions of Managed Objects for Common Open          2940
+              Policy Service (COPS) Protocol Clients
+--------   Identifying Composite Media Features                    2938
+--------   The Name Service Search Option for DHCP                 2937
+IOTP-HTTP  Internet Open Trading Protocol (IOTP) HTTP Supplement   2935
+--------   Internet Group Management Protocol MIB                  2933
+--------   IPv4 Multicast Routing MIB                              2932
+--------   DNS Request and Transaction Signatures ( SIG(0)s )      2931
+TKEY-RR    Secret Key Establishment for DNS (TKEY RR)              2930
+--------   Definitions of Managed Objects for Remote Ping,         2925
+              Traceroute, and Lookup Operations
+--------   List-Id: A Structured Field and Namespace for the       2919
+              Identification of Mailing Lists
+
+
+
+IETF                        Standards Track                    [Page 16]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+--------   Route Refresh Capability for BGP-4                      2918
+--------   E.164 number and DNS                                    2916
+NAPTR      The Naming Authority Pointer (NAPTR) DNS Resource       2915
+              Record
+--------   MIME Content Types in Media Feature Expressions         2913
+--------   Indicating Media Features for MIME Content              2912
+IPP-M-S    Internet Printing Protocol/1.1: Model and Semantics     2911
+IPP-E-T    Internet Printing Protocol/1.1: Encoding and Transport  2910
+--------   MADCAP Multicast Scope Nesting State Option             2907
+RMON-MIB   Remote Network Monitoring MIB Protocol Identifier       2895
+              Reference
+--------   Router Renumbering for IPv6                             2894
+TRANS-IPV6 Transition Mechanisms for IPv6 Hosts and Routers        2893
+--------   LDAP Control Extension for Server Side Sorting          2891
+              of Search Results
+--------   Key and Sequence Number Extensions to GRE               2890
+SACK       An Extension to the Selective Acknowledgement (SACK)    2883
+              Option for TCP
+--------   Content Feature Schema for Internet Fax (V2)            2879
+PPP-BCP    PPP Bridging Control Protocol (BCP)                     2878
+--------   Diffie-Hellman Proof-of-Possession Algorithms           2875
+--------   DNS Extensions to Support IPv6 Address Aggregation      2874
+              and Renumbering
+--------   TCP Processing of the IPv4 Precedence Field             2873
+--------   Application and Sub Application Identity Policy         2872
+              Element for Use with RSVP
+--------   The Inverted Stack Table Extension to the Interfaces    2864
+              Group MIB
+--------   RTP Payload Format for Real-Time Pointers               2862
+MEXT-BGP4  Multiprotocol Extensions for BGP-4                      2858
+--------   The Use of HMAC-RIPEMD-160-96 within ESP and AH         2857
+--------   Textual Conventions for Additional High Capacity        2856
+              Data Types
+--------   DHCP for IEEE 1394                                      2855
+--------   Generic Security Service API Version 2 : Java Bindings  2853
+--------   Deliver By SMTP Service Extension                       2852
+--------   Textual Conventions for Internet Network Addresses      2851
+LDIF       The LDAP Data Interchange Format (LDIF) - Technical     2849
+              Specification
+--------   The PINT Service Protocol: Extensions to SIP and        2848
+              SDP for IP Access to Telephone Call Services
+LIPKEY     LIPKEY - A Low Infrastructure Public Key Mechanism      2847
+              Using SPKM
+--------   GSTN Address Element Extensions in E-mail Services      2846
+TSIG       Secret Key Transaction Authentication for DNS (TSIG)    2845
+--------   Capabilities Advertisement with BGP-4                   2842
+--------   Definitions of Managed Objects for the Fabric Element   2837
+              in Fibre Channel Standard
+
+
+
+IETF                        Standards Track                    [Page 17]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+GSN        IP and ARP over HIPPI-6400 (GSN)                        2835
+--------   ARP and IP Broadcast over HIPPI-800                     2834
+--------   RTP Payload for DTMF Digits, Telephony Tones and        2833
+              Telephony Signals
+--------   Using Digest Authentication as a SASL Mechanism         2831
+LDAP       Lightweight Directory Access Protocol (v3): Extension   2830
+              for Transport Layer Security
+--------   Authentication Methods for LDAP                         2829
+MAIL       Internet Message Format                                 2822
+SMTP       Simple Mail Transfer Protocol                           2821
+--------   Integrated Service Mappings on IEEE 802 Networks        2815
+--------   SBM (Subnet Bandwidth Manager): A Protocol for          2814
+              RSVP-based Admission Control over IEEE 802-
+              style networks
+--------   URLs for Telephone Calls                                2806
+--------   Certificate Management Messages over CMS                2797
+--------   BGP Route Reflection - An Alternative to Full Mesh      2796
+              IBGP
+--------   Mobile IP Network Access Identifier Extension for IPv4  2794
+--------   RTP Payload for Text Conversation                       2793
+--------   Mail Monitoring MIB                                     2789
+--------   Network Services Monitoring MIB                         2788
+--------   Definitions of Managed Objects for the Virtual          2787
+              Router Redundancy Protocol
+GRE        Generic Routing Encapsulation (GRE)                     2784
+DNS-SRV    A DNS RR for specifying the location of services        2782
+              (DNS SRV)
+MZAP       Multicast-Scope Zone Announcement Protocol (MZAP)       2776
+RPSL       Routing Policy System Replication                       2769
+NAT-PT     Network Address Translation - Protocol Translation      2766
+              (NAT-PT)
+SIIT       Stateless IP/ICMP Translation Algorithm (SIIT)          2765
+--------   Identity Representation for RSVP                        2752
+RSVP       Signaled Preemption Priority Policy Element             2751
+--------   RSVP Extensions for Policy Control                      2750
+--------   COPS usage for RSVP                                     2749
+COPS       The COPS (Common Open Policy Service) Protocol          2748
+--------   RSVP Cryptographic Authentication                       2747
+--------   RSVP Operation Over IP Tunnels                          2746
+--------   RSVP Diagnostic Messages                                2745
+--------   Generic Security Service API Version 2 : C-bindings     2744
+--------   Generic Security Service Application Program Interface  2743
+              Version 2, Update 1
+SNMP       Definitions of Managed Objects for Extensible SNMP      2742
+              Agents
+--------   Agent Extensibility (AgentX) Protocol Version 1         2741
+--------   OSPF for IPv6                                           2740
+--------   Calendar Attributes for vCard and LDAP                  2739
+
+
+
+IETF                        Standards Track                    [Page 18]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+--------   Corrections to "A Syntax for Describing Media Feature   2738
+              Sets"
+--------   Entity MIB (Version 2)                                  2737
+--------   NHRP Support for Virtual Private Networks               2735
+--------   IPv4 over IEEE 1394                                     2734
+--------   An RTP Payload Format for Generic Forward Error         2733
+              Correction
+--------   Format for Literal IPv6 Addresses in URL's              2732
+MADCAP     Multicast Address Dynamic Client Allocation Protocol    2730
+              (MADCAP)
+--------   The Transmission of IP Over the Vertical Blanking       2728
+              Interval of a Television Signal
+--------   PGP Authentication for RIPE Database Updates            2726
+--------   Routing Policy System Security                          2725
+--------   Traffic Flow Measurement: Meter MIB                     2720
+TLS        Addition of Kerberos Cipher Suites to Transport         2712
+              Layer Security (TLS)
+--------   IPv6 Router Alert Option                                2711
+MLD-IPv6   Multicast Listener Discovery (MLD) for IPv6             2710
+--------   Integrated Services Mappings for Low Speed Networks     2688
+--------   PPP in a Real-time Oriented HDLC-like Framing           2687
+--------   The Multi-Class Extension to Multi-Link PPP             2686
+VPNI       Virtual Private Networks Identifier                     2685
+--------   Multiprotocol Encapsulation over ATM Adaptation         2684
+              Layer 5
+--------   A Round-trip Delay Metric for IPPM                      2681
+--------   A One-way Packet Loss Metric for IPPM                   2680
+--------   A One-way Delay Metric for IPPM                         2679
+IPPM-MET   IPPM Metrics for Measuring Connectivity                 2678
+NHRP-MIB   Definitions of Managed Objects for the NBMA Next        2677
+              Hop Resolution Protocol (NHRP)
+--------   IPv6 Jumbograms                                         2675
+--------   Definitions of Managed Objects for Bridges with         2674
+              Traffic Classes, Multicast Filtering and Virtual
+              LAN Extensions
+DNS        Binary Labels in the Domain Name System                 2673
+--------   Non-Terminal DNS Name Redirection                       2672
+EDNS0      Extension Mechanisms for DNS (EDNS0)                    2671
+--------   Radio Frequency (RF) Interface Management Information   2670
+              Base for MCNS/DOCSIS compliant RF interfaces
+--------   DOCSIS Cable Device MIB Cable Device Management         2669
+              Information Base for DOCSIS compliant Cable
+              Modems and Cable Modem Termination Systems
+MAU-MIB    Definitions of Managed Objects for IEEE 802.3 Medium    2668
+              Attachment Units (MAUs)
+--------   IP Tunnel MIB                                           2667
+--------   Definitions of Managed Objects for the Ethernet-        2665
+              like Interface Types
+
+
+
+IETF                        Standards Track                    [Page 19]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+--------   Definitions of Managed Objects for the ADSL Lines       2662
+L2TP       Layer Two Tunneling Protocol "L2TP"                     2661
+--------   RTP Payload Format for PureVoice(tm) Audio              2658
+--------   CIP Transport Protocols                                 2653
+--------   MIME Object Definitions for the Common Indexing         2652
+              Protocol (CIP)
+CIP        The Architecture of the Common Indexing Protocol (CIP)  2651
+--------   The Text/Plain Format Parameter                         2646
+ODMR-SMTP  ON-DEMAND MAIL RELAY (ODMR) SMTP with Dynamic IP        2645
+              Addresses
+--------   Internationalization of the File Transfer Protocol      2640
+--------   Enhanced Security Services for S/MIME                   2634
+--------   S/MIME Version 3 Message Specification                  2633
+--------   S/MIME Version 3 Certificate Handling                   2632
+--------   Diffie-Hellman Key Agreement Method                     2631
+--------   Cryptographic Message Syntax                            2630
+--------   IP and ARP over Fibre Channel                           2625
+--------   NFS Version 2 and Version 3 Security Issues and         2623
+              the NFS Protocol's Use of RPCSEC_GSS and Kerberos
+              V5
+RPSL       Routing Policy Specification Language (RPSL)            2622
+--------   RADIUS Authentication Server MIB                        2619
+--------   RADIUS Authentication Client MIB                        2618
+--------   PPP over SONET/SDH                                      2615
+--------   Remote Network Monitoring MIB Extensions for Switched   2613
+              Networks Version 1.0
+--------   DHCP Options for Service Location Protocol              2610
+--------   Service Templates and Service: Schemes                  2609
+SLP        Service Location Protocol, Version 2                    2608
+--------   Directory Server Monitoring MIB                         2605
+--------   ILMI-Based Server Discovery for NHRP                    2603
+--------   ILMI-Based Server Discovery for MARS                    2602
+--------   ILMI-Based Server Discovery for ATMARP                  2601
+--------   An Expedited Forwarding PHB                             2598
+--------   Assured Forwarding PHB Group                            2597
+--------   Use of Language Codes in LDAP                           2596
+--------   Using TLS with IMAP, POP3 and ACAP                      2595
+--------   Definitions of Managed Objects for WWW Services         2594
+--------   Definitions of Managed Objects for Scheduling           2591
+              Management Operations
+--------   Transmission of IPv6 Packets over Frame Relay Networks  2590
+              Specification
+LDAPv3     Lightweight Directory Access Protocol (v3): Extensions  2589
+              for Dynamic Directory Services
+--------   Internet X.509 Public Key Infrastructure LDAPv2 Schema  2587
+--------   Internet X.509 Public Key Infrastructure Operational    2585
+              Protocols: FTP and HTTP
+
+
+
+
+IETF                        Standards Track                    [Page 20]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+--------   Definitions of Managed Objects for APPN/HPR in          2584
+              IP Networks
+TCP-CC     TCP Congestion Control                                  2581
+SNMP       Coexistence between Version 1, Version 2, and Version   2576
+              3 of the Internet-standard Network Management
+              Framework
+APP-MIB    Application Management MIB                              2564
+--------   DHCP Option to Disable Stateless Auto-Configuration     2563
+              in IPv4 Clients
+TN2370E-RT Definitions of Protocol and Managed Objects for         2562
+              TN3270E Response Time Collection Using SMIv2
+              (TN3270E-RT-MIB)
+--------   Base Definitions of Managed Objects for TN3270E         2561
+              Using SMIv2
+PKIX       X.509 Internet Public Key Infrastructure Online         2560
+              Certificate Status Protocol - OCSP
+--------   Internet X.509 Public Key Infrastructure Operational    2559
+              Protocols - LDAPv2
+--------   Definitions of Managed Objects for the SONET/SDH        2558
+              Interface Type
+MHTML      MIME Encapsulation of Aggregate Documents, such         2557
+              as HTML (MHTML)
+--------   SMTP Service Extension for Authentication               2554
+--------   Use of BGP-4 Multiprotocol Extensions for IPv6          2545
+              Inter-Domain Routing
+SIP        SIP: Session Initiation Protocol                        2543
+DHK-DNS    Storage of Diffie-Hellman Keys in the Domain Name       2539
+              System (DNS)
+SC-DNS     Storing Certificates in the Domain Name System (DNS)    2538
+--------   RSA/MD5 KEYs and SIGs in the Domain Name System (DNS)   2537
+--------   DSA KEYs and SIGs in the Domain Name System (DNS)       2536
+DNS-SECEXT Domain Name System Security Extensions                  2535
+--------   Media Features for Display, Print, and Fax              2534
+--------   A Syntax for Describing Media Feature Sets              2533
+--------   Extended Facsimile Using Internet Mail                 2532
+--------   Indicating Supported Media Features Using Extensions    2530
+              to DSN and MDN
+--------   Transmission of IPv6 over IPv4 Domains without          2529
+              Explicit Tunnels
+--------   Reserved IPv6 Subnet Anycast Addresses                  2526
+WEBDAV     HTTP Extensions for Distributed Authoring -- WEBDAV     2518
+ATM-MIBMAN Definitions of Managed Objects for ATM Management       2515
+ATM-TC-OID Definitions of Textual Conventions and OBJECT-          2514
+              IDENTITIES for ATM Management
+--------   Managed Objects for Controlling the Collection          2513
+              and Storage of Accounting Information for
+              Connection-Oriented Networks
+--------   Accounting Information for ATM Networks                 2512
+
+
+
+IETF                        Standards Track                    [Page 21]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+X.509-CRMF Internet X.509 Certificate Request Message Format       2511
+PKICMP     Internet X.509 Public Key Infrastructure Certificate    2510
+              Management Protocols
+IPCOM-PPP  IP Header Compression over PPP                          2509
+--------   Compressing IP/UDP/RTP Headers for Low-Speed Serial     2508
+              Links
+--------   IP Header Compression                                   2507
+--------   Transmission of IPv6 Packets over ARCnet Networks       2497
+DS3-E3-MIB Definitions of Managed Object for the DS3/E3 Interface  2496
+              Type
+--------   Definitions of Managed Objects for the DS1, E1,         2495
+              DS2 and E2 Interface Types
+--------   Definitions of Managed Objects for the DS0 and          2494
+              DS0 Bundle Interface Type
+--------   Textual Conventions for MIB Modules Using Performance   2493
+              History Based on 15 Minute Intervals
+IPv6ATMNET IPv6 over ATM Networks                                  2492
+IPv6-NBMA  IPv6 over Non-Broadcast Multiple Access (NBMA)          2491
+              networks
+--------   SMTP Service Extension for Secure SMTP over TLS         2487
+NAI        The Network Access Identifier                           2486
+--------   DHCP Option for The Open Group's User Authentication    2485
+              Protocol
+--------   PPP LCP Internationalization Configuration Option       2484
+--------   Gateways and MIME Security Multiparts                   2480
+--------   The Simple and Protected GSS-API Negotiation Mechanism  2478
+--------   Message Submission                                      2476
+--------   Definition of the Differentiated Services Field         2474
+              (DS Field) in the IPv4 and IPv6 Headers
+--------   Generic Packet Tunneling in IPv6 Specification          2473
+IPv6-PPP   IP Version 6 over PPP                                   2472
+--------   Transmission of IPv6 Packets over Token Ring Networks   2470
+--------   Transmission of IPv6 Packets over FDDI Networks         2467
+ICMPv6-MIB Management Information Base for IP Version 6: ICMPv6    2466
+              Group
+--------   Management Information Base for IP Version 6: Textual   2465
+              Conventions and General Group
+--------   Transmission of IPv6 Packets over Ethernet Networks     2464
+--------   Internet X.509 Public Key Infrastructure Certificate    2459
+              and CRL Profile
+EBN-MIB    Definitions of Managed Objects for Extended Border      2457
+              Node
+--------   Definitions of Managed Objects for APPN TRAPS           2456
+APPN-MIB   Definitions of Managed Objects for APPN                 2455
+--------   IP Version 6 Management Information Base for the        2454
+              User Datagram Protocol
+--------   IP Version 6 Management Information Base for the        2452
+              Transmission Control Protocol
+
+
+
+IETF                        Standards Track                    [Page 22]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+--------   The ESP CBC-Mode Cipher Algorithms                      2451
+POP3-EXT   POP3 Extension Mechanism                                2449
+IMIP       iCalendar Message-Based Interoperability Protocol       2447
+              (iMIP)
+ITIP       iCalendar Transport-Independent Interoperability        2446
+              Protocol (iTIP) Scheduling Events, BusyTime,
+              To-dos and Journal Entries
+ICALENDAR  Internet Calendaring and Scheduling Core Object         2445
+              Specification (iCalendar)
+OTP-SASL   The One-Time-Password SASL Mechanism                    2444
+--------   OpenPGP Message Format                                  2440
+--------   BGP Route Flap Damping                                  2439
+--------   RTP Payload Format for JPEG-compressed Video            2435
+--------   RTP Payload Format for BT.656 Video Encoding            2431
+--------   RTP Payload Format for the 1998 Version of ITU-         2429
+              T Rec. H.263 Video (H.263+)
+--------   FTP Extensions for IPv6 and NATs                        2428
+MIME-VCARD vCard MIME Directory Profile                            2426
+TXT-DIR    A MIME Content-Type for Directory Information           2425
+CONT-DUR   Content Duration MIME Header Definition                 2424
+MIME-VPIM  VPIM Voice Message MIME Sub-type Registration           2423
+MIME-ADPCM Toll Quality Voice - 32 kbit/s ADPCM MIME Sub-type      2422
+              Registration
+MIME-VP2   Voice Profile for Internet Mail - version 2             2421
+3DESE      The PPP Triple-DES Encryption Protocol (3DESE)          2420
+DESE-bis   The PPP DES Encryption Protocol, Version 2 (DESE-bis)   2419
+--------   Definitions of Managed Objects for Multicast over       2417
+              UNI 3.0/3.1 based ATM Networks
+---------  The NULL Encryption Algorithm and Its Use With IPsec    2410
+IKE        The Internet Key Exchange (IKE)                         2409
+ISAKMP     Internet Security Association and Key Management        2408
+              Protocol (ISAKMP)
+ISAKMPSEC  The Internet IP Security Domain of Interpretation       2407
+              for ISAKMP
+ESP        IP Encapsulating Security Payload (ESP)                 2406
+ESPDES-CBC The ESP DES-CBC Cipher Algorithm With Explicit IV       2405
+--------   The Use of HMAC-SHA-1-96 within ESP and AH              2404
+--------   The Use of HMAC-MD5-96 within ESP and AH                2403
+IP-AUTH    IP Authentication Header                                2402
+IPSEC      Security Architecture for the Internet Protocol         2401
+DATA-URL   The "data" URL scheme                                   2397
+CIDMID-URL Content-ID and Message-ID Uniform Resource Locators     2392
+--------   Feature negotiation mechanism for the File Transfer     2389
+              Protocol
+--------   Returning Values from Forms: multipart/form-data        2388
+MIME-RELAT The MIME Multipart/Related Content-type                 2387
+--------   Protection of BGP Sessions via the TCP MD5 Signature    2385
+              Option
+
+
+
+IETF                        Standards Track                    [Page 23]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+POP-URL    POP URL Scheme                                          2384
+--------   Interoperation of Controlled-Load Service and           2381
+              Guaranteed Service with ATM
+--------   RSVP over ATM Implementation Requirements               2380
+--------   An IPv6 Aggregatable Global Unicast Address Format      2374
+--------   IP Version 6 Addressing Architecture                    2373
+TIPV3      Transaction Internet Protocol Version 3.0               2371
+OSPF-LSA   The OSPF Opaque LSA Option                              2370
+--------   The Use of URLs as Meta-Syntax for Core Mail List       2369
+              Commands and their Transport through Message
+              Header Fields
+URLMAILTO  The mailto URL scheme                                   2368
+PPP-AAL    PPP Over AAL5                                           2364
+PPP-FUNI   PPP Over FUNI                                           2363
+IMAP4UIDPL IMAP4 UIDPLUS extension                                 2359
+IMAP4NAME  IMAP4 Namespace                                         2342
+VRRP       Virtual Router Redundancy Protocol                      2338
+NHRP-SCSP  A Distributed NHRP Service Using SCSP                   2335
+SCSP       Server Cache Synchronization Protocol (SCSP)            2334
+--------   NHRP Protocol Applicability Statement                   2333
+NHRP       NBMA Next Hop Resolution Protocol (NHRP)                2332
+UNI-SIG    ATM Signalling Support for IP over ATM - UNI Signalling 2331
+              4.0 Update
+SDP        SDP: Session Description Protocol                       2327
+RTSP       Real Time Streaming Protocol (RTSP)                     2326
+IPOA-MIB   Definitions of Managed Objects for Classical IP         2320
+              and ARP Over ATM Using SMIv2 (IPOA-MIB)
+DNS-NCACHE Negative Caching of DNS Queries (DNS NCACHE)            2308
+SMFAX-IM   A Simple Mode of Facsimile Using Internet Mail          2305
+MINFAX-IM  Minimal FAX address format in Internet Mail             2304
+MIN-PSTN   Minimal PSTN address format in Internet Mail            2303
+TIFF       Tag Image File Format (TIFF) - image/tiff MIME          2302
+              Sub-type Registration
+FFIF       File Format for Internet Fax                            2301
+EMF-MDN    An Extensible Message Format for Message Disposition    2298
+              Notifications
+OR-ADD     Representing the O/R Address hierarchy in the X.500     2294
+              Directory Information Tree
+SUBTABLE   Representing Tables and Subtrees in the X.500 Directory 2293
+--------   Mobile-IPv4 Configuration Option for PPP IPCP           2290
+SLM-APP    Definitions of System-Level Managed Objects for         2287
+              Applications
+PPP-EAP    PPP Extensible Authentication Protocol (EAP)            2284
+--------   Definitions of Managed Objects for IEEE 802.12          2266
+              Repeater Devices
+--------   A Summary of the X.500(96) User Schema for use          2256
+              with LDAPv3
+LDAP-URL   The LDAP URL Format                                     2255
+
+
+
+IETF                        Standards Track                    [Page 24]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+STR-LDAP   The String Representation of LDAP Search Filters        2254
+LDAP3-UTF8 Lightweight Directory Access Protocol (v3): UTF-        2253
+              8 String Representation of Distinguished Names
+LDAP3-ATD  Lightweight Directory Access Protocol (v3): Attribute   2252
+              Syntax Definitions
+LDAPV3     Lightweight Directory Access Protocol (v3)              2251
+RTP-MPEG   RTP Payload Format for MPEG1/MPEG2 Video                2250
+---------  Using Domains in LDAP/X.500 Distinguished Names         2247
+--------   The TLS Protocol Version 1.0                            2246
+SASL-ANON  Anonymous SASL Mechanism                                2245
+ACAP       ACAP -- Application Configuration Access Protocol       2244
+OTP-ER     OTP Extended Responses                                  2243
+NETWAREIP  NetWare/IP Domain Name and Information                  2242
+DHCP-NDS   DHCP Options for Novell Directory Services              2241
+HPR-MIB    Definitions of Managed Objects for HPR using SMIv2      2238
+IGMP       Internet Group Management Protocol, Version 2           2236
+ABNF       Augmented BNF for Syntax Specifications: ABNF           2234
+DLUR-MIB   Definitions of Managed Objects for DLUR using SMIv2     2232
+MIME-EXT   MIME Parameter Value and Encoded Word Extensions:       2231
+              Character Sets, Languages, and Continuations
+FTPSECEXT  FTP Security Extensions                                 2228
+---------  Simple Hit-Metering and Usage-Limiting for HTTP         2227
+---------  IP Broadcast over ATM Networks                          2226
+IP-ATM     Classical IP and ARP over ATM                           2225
+SASL       Simple Authentication and Security Layer (SASL)         2222
+IMAP4LOGIN IMAP4 Login Referrals                                   2221
+---------  A Common Schema for the Internet White Pages Service    2218
+---------  General Characterization Parameters for Integrated      2215
+              Service Network Elements
+---------  Integrated Services Management Information Base         2214
+              Guaranteed Service Extensions using SMIv2
+---------  Integrated Services Management Information Base         2213
+              using SMIv2
+GQOS       Specification of Guaranteed Quality of Service          2212
+---------  Specification of the Controlled-Load Network Element    2211
+              Service
+RSVP-IS    The Use of RSVP with IETF Integrated Services           2210
+RSVP-IPSEC RSVP Extensions for IPSEC Data Flows                    2207
+RSVP-MIB   RSVP Management Information Base using SMIv2            2206
+RSVP       Resource ReSerVation Protocol (RSVP) -- Version         2205
+              1 Functional Specification
+RPCSEC-GSS RPCSEC_GSS Protocol Specification                       2203
+RTP-RAD    RTP Payload for Redundant Audio Data                    2198
+IMAPPOPAU  IMAP/POP AUTHorize Extension for Simple Challenge/      2195
+           Response
+IMAP4MAIL  IMAP4 Mailbox Referrals                                 2193
+IMAP-URL   IMAP URL Scheme                                         2192
+---------  RTP Payload Format for H.263 Video Streams              2190
+
+
+
+IETF                        Standards Track                    [Page 25]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+---------  Communicating Presentation Information in Internet      2183
+              Messages: The Content-Disposition Header Field
+DNS-CLAR   Clarifications to the DNS Specification                 2181
+IMAP4-IDLE IMAP4 IDLE command                                      2177
+SLP        Service Location Protocol                               2165
+---------  Use of an X.500/LDAP directory to support MIXER         2164
+              address mapping
+DNS-MCGAM  Using the Internet DNS to Distribute MIXER Conformant   2163
+              Global Address Mapping (MCGAM)
+---------  Carrying PostScript in X.400 and MIME                   2160
+---------  A MIME Body Part for FAX                                2159
+---------  X.400 Image Body Parts                                  2158
+---------  Mapping between X.400 and RFC-822/MIME Message Bodies   2157
+MIXER      MIXER (Mime Internet X.400 Enhanced Relay): Mapping     2156
+              between X.400 and RFC 822/MIME
+MAIL-SERV  Mailbox Names for Common Services, Roles and Functions  2142
+URN-SYNTAX URN Syntax                                              2141
+DNS-UPDATE Dynamic Updates in the Domain Name System (DNS UPDATE)  2136
+DC-MIB     Dial Control Management Information Base using SMIv2    2128
+ISDN-MIB   ISDN Management Information Base using SMIv2            2127
+ITOT       ISO Transport Service on top of TCP (ITOT)              2126
+BAP-BACP   The PPP Bandwidth Allocation Protocol (BAP) / The       2125
+              PPP Bandwidth Allocation Control Protocol (BACP)
+VEMMI-URL  VEMMI URL Specification                                 2122
+ROUT-ALERT IP Router Alert Option                                  2113
+802.3-MIB  Definitions of Managed Objects for IEEE 802.3 Repeater  2108
+              Devices using SMIv2
+PPP-NBFCP  The PPP NetBIOS Frames Control Protocol (NBFCP)         2097
+TABLE-MIB  IP Forwarding Table MIB                                 2096
+RIP-TRIG   Triggered Extensions to RIP to Support Demand Circuits  2091
+IMAP4-LIT  IMAP4 non-synchronizing literals                        2088
+IMAP4-QUO  IMAP4 QUOTA extension                                   2087
+IMAP4-ACL  IMAP4 ACL extension                                     2086
+HMAC-MD5   HMAC-MD5 IP Authentication with Replay Prevention       2085
+RIP2-MD5   RIP-2 MD5 Authentication                                2082
+RIPNG-IPV6 RIPng for IPv6                                          2080
+URI-ATT    Definition of an X.500 Attribute Type and an Object     2079
+              Class to Hold Uniform Resource Identifiers (URIs)
+MIME-MODEL The Model Primary Content Type for Multipurpose         2077
+              Internet Mail Extensions
+IMAPV4     Internet Message Access Protocol - Version 4rev1        2060
+URLZ39.50  Uniform Resource Locators for Z39.50                    2056
+SNANAU-APP Definitions of Managed Objects for APPC using SMIv2     2051
+PPP-SNACP  The PPP SNA Control Protocol (SNACP)                    2043
+SMTP-ENH   SMTP Service Extension for Returning Enhanced Error     2034
+              Codes
+RTP-H.261  RTP Payload Format for H.261 Video Streams              2032
+RTP-CELLB  RTP Payload Format of Sun's CellB Video Encoding        2029
+
+
+
+IETF                        Standards Track                    [Page 26]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+SPKM       The Simple Public-Key GSS-API Mechanism (SPKM)          2025
+DLSW-MIB   Definitions of Managed Objects for Data Link Switching  2024
+              using SMIv2
+MULTI-UNI  Support for Multicast over UNI 3.0/3.1 based ATM        2022
+              Networks
+RMON-MIB   Remote Network Monitoring Management Information        2021
+              Base Version 2 using SMIv2
+802.12-MIB IEEE 802.12 Interface MIB                               2020
+TCP-ACK    TCP Selective Acknowledgement Options                   2018
+URL-ACC    Definition of the URL MIME External-Body Access-Type    2017
+MIME-PGP   MIME Security with Pretty Good Privacy (PGP)            2015
+MIB-UDP    SNMPv2 Management Information Base for the User         2013
+              Datagram Protocol using SMIv2
+MIB-TCP    SNMPv2 Management Information Base for the Transmission 2012
+              Control Protocol using SMIv2
+MIB-IP     SNMPv2 Management Information Base for the Internet     2011
+              Protocol using SMIv2
+MOBILEIPMI The Definitions of Managed Objects for IP Mobility      2006
+              Support using SMIv2
+--------   Applicability Statement for IP Mobility Support         2005
+MINI-IP    Minimal Encapsulation within IP                         2004
+IPENCAPIP  IP Encapsulation within IP                              2003
+MOBILEIPSU IP Mobility Support                                     2002
+BGP-COMM   BGP Communities Attribute                               1997
+DNS-NOTIFY A Mechanism for Prompt Notification of Zone Changes     1996
+              (DNS NOTIFY)
+DNS-IZT    Incremental Zone Transfer in DNS                        1995
+SMTP-ETRN  SMTP Service Extension for Remote Message Queue         1985
+              Starting
+SNA        Serial Number Arithmetic                                1982
+MTU-IPV6   Path MTU Discovery for IP version 6                     1981
+PPP-FRAME  PPP in Frame Relay                                      1973
+PPP-ECP    The PPP Encryption Control Protocol (ECP)               1968
+GSSAPI-KER The Kerberos Version 5 GSS-API Mechanism                1964
+PPP-CCP    The PPP Compression Control Protocol (CCP)              1962
+GSSAPI-SOC GSS-API Authentication Method for SOCKS Version 5       1961
+AUTH-SOCKS Username/Password Authentication for SOCKS V5           1929
+SOCKSV5    SOCKS Protocol Version 5                                1928
+WHOIS++M   How to Interact with a Whois++ Mesh                     1914
+WHOIS++A   Architecture of the Whois++ Index Service               1913
+DSN        An Extensible Message Format for Delivery Status        1894
+              Notifications
+EMS-CODE   Enhanced Mail System Status Codes                       1893
+MIME-RPT   The Multipart/Report Content Type for the Reporting     1892
+              of Mail System Administrative Messages
+SMTP-DSN   SMTP Service Extension for Delivery Status              1891
+              Notifications
+
+
+
+
+IETF                        Standards Track                    [Page 27]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+RTP-AV     RTP Profile for Audio and Video Conferences with        1890
+              Minimal Control
+RTP        RTP: A Transport Protocol for Real-Time Applications    1889
+DNS-IPV6   DNS Extensions to support IP version 6                  1886
+MIME-Sec   MIME Object Security Services                           1848
+MIME-Encyp Security Multiparts for MIME: Multipart/Signed          1847
+              and Multipart/Encrypted
+WHOIS++    Architecture of the WHOIS++ service                     1835
+--------   Binding Protocols for ONC RPC Version 2                 1833
+RPC        RPC: Remote Procedure Call Protocol Specification       1831
+              Version 2
+--------   The ESP DES-CBC Transform                               1829
+--------   IP Authentication using Keyed MD5                       1828
+--------   Requirements for IP Version 4 Routers                   1812
+URL        Relative Uniform Resource Locators                      1808
+CLDAP      Connection-less Lightweight X.500 Directory Access      1798
+              Protocol
+OSPF-DC    Extending OSPF to Support Demand Circuits               1793
+OSI-Dir    Using the OSI Directory to Achieve User Friendly        1781
+              Naming
+MIME-EDI   MIME Encapsulation of EDI Objects                       1767
+XNSCP      The PPP XNS IDP Control Protocol (XNSCP)                1764
+BVCP       The PPP Banyan Vines Control Protocol (BVCP)            1763
+Print-MIB  Printer MIB                                             1759
+ATM        ATM Signaling Support for IP over ATM                   1755
+IPNG       The Recommendation for the IP Next Generation Protocol  1752
+802.5-SSR  IEEE 802.5 Station Source Routing MIB using SMIv2       1749
+SDLCSMIv2  Definitions of Managed Objects for SNA Data Link        1747
+              Control (SDLC) using SMIv2
+AT-MIB     AppleTalk Management Information Base II                1742
+MacMIME    MIME Encapsulation of Macintosh Files - MacMIME         1740
+URL        Uniform Resource Locators (URL)                         1738
+POP3-AUTH  POP3 AUTHentication command                             1734
+IMAP4-AUTH IMAP4 Authentication Mechanisms                         1731
+RDBMS-MIB  Relational Database Management System (RDBMS)           1697
+              Management Information Base (MIB) using SMIv2
+MODEM-MIB  Modem Management Information Base (MIB) using SMIv2     1696
+TMUX       Transport Multiplexing Protocol (TMux)                  1692
+SNANAU-MIB Definitions of Managed Objects for SNA NAUs using       1666
+              SMIv2
+PPP-TRANS  PPP Reliable Transmission                               1663
+--------   Postmaster Convention for X.400 Operations              1648
+UPS-MIB    UPS Management Information Base                         1628
+PPP-ISDN   PPP over ISDN                                           1618
+DNS-R-MIB  DNS Resolver MIB Extensions                             1612
+DNS-S-MIB  DNS Server MIB Extensions                               1611
+PPP-X25    PPP in X.25                                             1598
+OSPF-NSSA  The OSPF NSSA Option                                    1587
+
+
+
+IETF                        Standards Track                    [Page 28]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+OSPF-Multi Multicast Extensions to OSPF                            1584
+RIP-DC     Extensions to RIP to Support Demand Circuits            1582
+TOPT-ENVIR Telnet Environment Option                               1572
+PPP-LCP    PPP LCP Extensions                                      1570
+CIPX       Compressing IPX Headers Over WAN Media (CIPX)           1553
+IPXCP      The PPP Internetworking Packet Exchange Control         1552
+              Protocol (IPXCP)
+SRB-MIB    Definitions of Managed Objects for Source Routing       1525
+              Bridges
+CIDR-STRA  Classless Inter-Domain Routing (CIDR): an Address       1519
+              Assignment and Aggregation Strategy
+CIDR-ARCH  An Architecture for IP Address Allocation with CIDR     1518
+CIDR       Applicability Statement for the Implementation          1517
+              of Classless Inter-Domain Routing (CIDR)
+--------   Definitions of Managed Objects for IEEE 802.3 Medium    1515
+              Attachment Units (MAUs)
+--------   Token Ring Extensions to the Remote Network Monitoring  1513
+              MIB
+FDDI-MIB   FDDI Management Information Base                        1512
+KERBEROS   The Kerberos Network Authentication Service (V5)        1510
+--------   X.400 Use of Extended Character Sets                    1502
+HARPOON    Rules for downgrading messages from X.400/88 to         1496
+              X.400/84 when MIME content-types are present
+              in the messages
+Equiv      Equivalences between 1988 X.400 and RFC-822 Message     1494
+              Bodies
+IDPR       Inter-Domain Policy Routing Protocol Specification:     1479
+              Version 1
+IDPR-ARCH  An Architecture for Inter-Domain Policy Routing         1478
+PPP/Bridge The Definitions of Managed Objects for the Bridge       1474
+              Network Control Protocol of the Point-to-Point
+              Protocol
+PPP/IPMIB  The Definitions of Managed Objects for the IP Network   1473
+              Control Protocol of the Point-to-Point Protocol
+PPP/SECMIB The Definitions of Managed Objects for the Security     1472
+              Protocols of the Point-to-Point Protocol
+PPP/LCPMIB The Definitions of Managed Objects for the Link         1471
+              Control Protocol of the Point-to-Point Protocol
+IP-TR-MC   IP Multicast over Token-Ring Local Area Networks        1469
+X25-MIB    SNMP MIB extension for Multiprotocol Interconnect       1461
+              over X.25
+SNMPv2     Introduction to version 2 of the Internet-standard      1441
+              Network Management Framework
+PEM-KEY    Privacy Enhancement for Internet Electronic Mail:       1424
+              Part IV
+PEM-ALG    Privacy Enhancement for Internet Electronic Mail:       1423
+              Part III
+
+
+
+
+IETF                        Standards Track                    [Page 29]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+PEM-CKM    Privacy Enhancement for Internet Electronic Mail:       1422
+              Part II
+PEM-ENC    Privacy Enhancement for Internet Electronic Mail:       1421
+              Part I
+SNMP-IPX   SNMP over IPX                                           1420
+SNMP-AT    SNMP over AppleTalk                                     1419
+SNMP-OSI   SNMP over OSI                                           1418
+FTP        FTP-FTAM Gateway Specification                          1415
+IDENT-MIB  Identification MIB                                      1414
+IDENT      Identification Protocol                                 1413
+---------  Default Route Advertisement In BGP2 and BGP3 Version    1397
+              of The Border Gateway Protocol
+SNMP-X.25  SNMP MIB Extension for the X.25 Packet Layer            1382
+SNMP-LAPB  SNMP MIB Extension for X.25 LAPB                        1381
+PPP-ATCP   The PPP AppleTalk Control Protocol (ATCP)               1378
+PPP-OSINLC The PPP OSI Network Layer Control Protocol (OSINLCP)    1377
+TOPT-RFC   Telnet Remote Flow Control Option                       1372
+--------   Applicability Statement for OSPF                        1370
+PPP-IPCP   The PPP Internet Protocol Control Protocol (IPCP)       1332
+--------   X.400 1988 to 1984 downgrading                          1328
+TCP-EXT    TCP Extensions for High Performance                     1323
+NETFAX     A File Format for the Exchange of Images in the         1314
+              Internet
+FDDI-MIB   FDDI Management Information Base                        1285
+--------   Encoding Network Addresses to Support Operation         1277
+              over Non-OSI Lower Layers
+--------   Replication and Distributed Operations extensions       1276
+              to provide an Internet Directory using X.500
+--------   The COSINE and Internet X.500 Schema                    1274
+BGP-MIB    Definitions of Managed Objects for the Border Gateway   1269
+              Protocol: Version 3
+ICMP-ROUT  ICMP Router Discovery Messages                          1256
+STD-MIBs   Reassignment of experimental MIBs to standard MIBs      1239
+IPX-IP     Tunneling IPX traffic through IP networks               1234
+IS-IS      Use of OSI IS-IS for routing in TCP/IP and dual         1195
+              environments
+IP-CMPRS   Compressing TCP/IP headers for low-speed serial links   1144
+TOPT-XDL   Telnet X display location option                        1096
+TOPT-TERM  Telnet terminal-type option                             1091
+TOPT-TS    Telnet terminal speed option                            1079
+TOPT-NAWS  Telnet window size option                               1073
+TOPT-X.3   Telnet X.3 PAD option                                   1053
+TOPT-DATA  Telnet Data Entry Terminal option: DODIIS               1043
+              implementation
+TOPT-3270  Telnet 3270 regime option                               1041
+NNTP       Network News Transfer Protocol                           977
+TOPT-TLN   Telnet terminal location number option                   946
+TOPT-OM    Output marking Telnet option                             933
+
+
+
+IETF                        Standards Track                    [Page 30]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+TOPT-TACAC TACACS user identification Telnet option                 927
+TOPT-EOR   Telnet end of record option                              885
+TOPT-SNDL  Telnet send-location option                              779
+TOPT-SUPO  Telnet SUPDUP-Output option                              749
+TOPT-SUP   Telnet SUPDUP option                                     736
+TOPT-BYTE  Revised Telnet byte macro option                         735
+TOPT-LOGO  Telnet logout option                                     727
+TOPT-REM   Remote Controlled Transmission and Echoing Telnet        726
+              option
+TOPT-EXT   Telnet extended ASCII option                             698
+
+   [Note: an asterisk at the end of a line indicates a change from the
+   previous edition of this document.]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+IETF                        Standards Track                    [Page 31]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+3.5.  Best Current Practice by BCP
+
+Mnemonic   Title                                               RFC# BCP#
+------------------------------------------------------------------------
+-------- Best Current Practices                                1818  1
+-------- Addendum to RFC 1602 -- Variance Procedure            1871  2
+-------- Variance for The PPP Connection Control Protocol      1915  3
+            and The PPP Encryption Control Protocol
+-------- An Appeal to the Internet Community to Return         1917  4
+            Unused IP Networks (Prefixes) to the IANA
+-------- Address Allocation for Private Internets              1918  5
+-------- Guidelines for creation, selection, and               1930  6
+            registration of an Autonomous System (AS)
+-------- Implications of Various Address Allocation            2008  7
+            Policies for Internet Routing
+-------- IRTF Research Group Guidelines and Procedures         2014  8
+-------- The Internet Standards Process -- Revision 3          2026  9
+-------- IAB and IESG Selection, Confirmation, and Recall      2727  10
+            Process: Operation of the Nominating and Recall
+            Committees
+-------- The Organizations Involved in the IETF Standards      2028  11
+            Process
+-------- Internet Registry IP Allocation Guidelines            2050  12
+-------- Multipurpose Internet Mail Extensions (MIME) Part     2048  13
+            Four: Registration Procedures
+-------- Key words for use in RFCs to Indicate Requirement     2119  14
+            Levels
+-------- Deployment of the Internet White Pages Service        2148  15
+-------- Selection and Operation of Secondary DNS Servers      2182  16
+-------- Use of DNS Aliases for Network Services               2219  17
+-------- IETF Policy on Character Sets and Languages           2277  18
+-------- IANA Charset Registration Procedures                  2978  19
+-------- Classless IN-ADDR.ARPA delegation                     2317  20
+-------- Expectations for Computer Security Incident           2350  21
+            Response
+-------- Guide for Internet Standards Writers                  2360  22
+-------- Administratively Scoped IP Multicast                  2365  23
+-------- RSVP over ATM Implementation Guidelines               2379  24
+-------- IETF Working Group Guidelines and Procedures          2418  25
+-------- Guidelines for Writing an IANA Considerations         2434  26
+            Section in RFCs
+-------- Advancement of MIB specifications on the IETF         2438  27
+            Standards Track
+-------- Enhancing TCP Over Satellite Channels using           2488  28
+            Stanard Mechanisms
+
+
+
+
+
+
+IETF                        Standards Track                    [Page 32]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+-------- Procedure for Defining New DHCP Options               2489  29
+-------- Anti-Spam Recommendations for SMTP MTAs               2505  30
+-------- Media Feature Tag Registration Procedure              2506  31
+-------- Reserved Top Level DNS Names                          2606  32
+-------- URN Namespace Definition Mechanisms                   2611  33
+-------- Changing the Default for Directed Broadcasts in       2644  34
+            Routers
+-------- Registration Procedures for URL Scheme Names          2717  35
+-------- Guidelines for Writers of RTP Payload Format          2736  36
+            Specifications
+-------- IANA Allocation Guidelines For Values In the          2780  37
+            Internet Protocol and Related Headers
+-------- Network Ingress Filtering: Defeating Denial of        2827  38
+            Service Attacks which employ IP Source Address
+            Spoofing
+-------- Charter of the Internet Architecture Board (IAB)      2850  39
+-------- Root Name Server Operational Requirements             2870  40
+-------- Congestion Control Principles                         2914  41
+-------- Domain Name System (DNS) IANA Considerations          2929  42
+-------- Procedures and IANA Guidelines for Definition of      2939  43
+            New DHCP Options and Message Types
+-------- Use of HTTP State Management                          2964  44
+-------- IETF Discussion List Charter                          3005  45
+-------- Recommended Internet Service Provider Security        3013  46
+            Services and Procedures
+-------- Tags for the Identification of Languages              3066  47
+-------- End-to-end Performance Implications of Slow Links     3150  48*
+-------- Delegation of IP6.ARPA                                3152  49*
+-------- End-to-end Performance Implications of Links with     3155  50*
+            Errors
+-------- IANA Guidelines for IPv4 Multicast Address            3171  51*
+            Assignments
+-------- Management Guidelines & Operational Requirements      3172  52*
+            for the Address and Routing Parameter Area
+            Domain ("arpa")
+-------- GLOP Addressing in 233/8                              3180  53*
+-------- IETF Guidelines for Conduct                           3184  54*
+
+   [Note: an asterisk at the end of a line indicates a change from the
+   previous edition of this document.]
+
+
+
+
+
+
+
+
+
+
+
+IETF                        Standards Track                    [Page 33]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+3.6.  Best Current Practice by RFC
+
+Mnemonic   Title                                               BCP# RFC#
+------------------------------------------------------------------------
+-------- IETF Guidelines for Conduct                           54  3184*
+-------- GLOP Addressing in 233/8                              53  3180*
+-------- Management Guidelines & Operational Requirements      52  3172*
+            for the Address and Routing Parameter Area Domain
+            ("arpa")
+-------- IANA Guidelines for IPv4 Multicast Address            51  3171*
+            Assignments
+-------- End-to-end Performance Implications of Links with     50  3155*
+            Errors
+-------- Delegation of IP6.ARPA                                49  3152*
+-------- End-to-end Performance Implications of Slow Links     48  3150*
+-------- Tags for the Identification of Languages              47  3066
+-------- Recommended Internet Service Provider Security        46  3013
+            Services and Procedures
+-------- IETF Discussion List Charter                          45  3005
+-------- IANA Charset Registration Procedures                  19  2978
+-------- Use of HTTP State Management                          44  2964
+-------- Procedures and IANA Guidelines for Definition of      43  2939
+            New DHCP Options and Message Types
+-------- Domain Name System (DNS) IANA Considerations          42  2929
+-------- Congestion Control Principles                         41  2914
+-------- Root Name Server Operational Requirements             40  2870
+-------- Charter of the Internet Architecture Board (IAB)      39  2850
+-------- Network Ingress Filtering: Defeating Denial of        38  2827
+            Service Attacks which employ IP Source Address
+            Spoofing
+-------- IANA Allocation Guidelines For Values In the          37  2780
+            Internet Protocol and Related Headers
+-------- Guidelines for Writers of RTP Payload Format          36  2736
+            Specifications
+-------- IAB and IESG Selection, Confirmation, and Recall      10  2727
+            Process: Operation of the Nominating and Recall
+            Committees
+-------- Registration Procedures for URL Scheme Names          35  2717
+-------- Changing the Default for Directed Broadcasts in       34  2644
+            Routers
+-------- URN Namespace Definition Mechanisms                   33  2611
+-------- Reserved Top Level DNS Names                          32  2606
+-------- Media Feature Tag Registration Procedure              31  2506
+-------- Anti-Spam Recommendations for SMTP MTAs               30  2505
+-------- Procedure for Defining New DHCP Options               29  2489
+-------- Enhancing TCP Over Satellite Channels using           28  2488
+            Standard Mechanisms
+
+
+
+
+IETF                        Standards Track                    [Page 34]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+-------- Advancement of MIB specifications on the IETF         27  2438
+            Standards Track
+-------- Guidelines for Writing an IANA Considerations         26  2434
+            Section in RFCs
+-------- IETF Working Group Guidelines and Procedures          25  2418
+-------- RSVP over ATM Implementation Guidelines               24  2379
+-------- Administratively Scoped IP Multicast                  23  2365
+-------- Guide for Internet Standards Writers                  22  2360
+-------- Expectations for Computer Security Incident           21  2350
+            Response
+-------- Classless IN-ADDR.ARPA delegation                     20  2317
+-------- IETF Policy on Character Sets and Languages           18  2277
+-------- Use of DNS Aliases for Network Services               17  2219
+-------- Selection and Operation of Secondary DNS Servers      16  2182
+-------- Deployment of the Internet White Pages Service        15  2148
+-------- Key words for use in RFCs to Indicate Requirement     14  2119
+            Levels
+-------- Internet Registry IP Allocation Guidelines            12  2050
+-------- Multipurpose Internet Mail Extensions (MIME) Part     13  2048
+            Four: Registration Procedures
+-------- The Organizations Involved in the IETF Standards      11  2028
+            Process
+-------- The Internet Standards Process -- Revision 3          9  2026
+-------- IRTF Research Group Guidelines and Procedures         8  2014
+-------- Implications of Various Address Allocation            7  2008
+            Policies for Internet Routing
+-------- Guidelines for creation, selection, and               6  1930
+            registration of an Autonomous System (AS)
+-------- Address Allocation for Private Internets              5  1918
+-------- An Appeal to the Internet Community to Return         4  1917
+            Unused IP Networks (Prefixes) to the IANA
+-------- Variance for The PPP Connection Control Protocol      3  1915
+            and The PPP Encryption Control Protocol
+-------- Addendum to RFC 1602 -- Variance Procedure            2  1871
+-------- Best Current Practices                                1  1818
+
+   [Note: an asterisk at the end of a line indicates a change from the
+   previous edition of this document.]
+
+
+
+
+
+
+
+
+
+
+
+
+
+IETF                        Standards Track                    [Page 35]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+3.7.  Experimental Protocols
+
+Mnemonic   Title                                                   RFC#
+------------------------------------------------------------------------
+SMX        Script MIB Extensibility Protocol Version 1.1           3179*
+--------   A DNS RR Type for Lists of Address Prefixes (APL RR)    3123*
+--------   OpenLDAP Root Service An experimental LDAP referral     3088
+              service
+--------   Notification and Subscription for SLP                   3082
+--------   MPLS Loop Prevention Mechanism                          3063
+--------   Internet X.509 Public Key Infrastructure Data           3029
+              Validation and Certification Server Protocols
+--------   Unified Memory Space Protocol Specification             3018
+SAP        Session Announcement Protocol                           2974
+--------   Protocol Independent Multicast MIB for IPv4             2934
+MASC       The Multicast Address-Set Claim (MASC) Protocol         2909
+--------   Generic AAA Architecture                                2903
+--------   TCP Congestion Window Validation                        2861
+TSWTCM     A Time Sliding Window Three Colour Marker (TSWTCM)      2859
+--------   OSPF over ATM and Proxy-PAR                             2844
+PPP-SDL    PPP over Simple Data Link (SDL) using SONET/SDH         2823
+              with ATM-like framing
+--------   Diffie-Helman USM Key Management Information Base       2786
+              and Textual Convention
+--------   An HTTP Extension Framework                             2774
+--------   Encryption using KEA and SKIPJACK                       2773
+--------   GLOP Addressing in 233/8                                2770
+--------   Sampling of the Group Membership in RTP                 2762
+--------   Definitions of Managed Objects for Service Level        2758
+              Agreements Performance Monitoring
+HTCP       Hyper Text Caching Protocol (HTCP/0.0)                  2756
+--------   RTFM: New Attributes for Traffic Flow Measurement       2724
+--------   PPP EAP TLS Authentication Protocol                     2716
+--------   SPKI Certificate Theory                                 2693
+--------   SPKI Requirements                                       2692
+--------   QoS Routing Mechanisms and OSPF Extensions              2676
+--------   The Secure HyperText Transfer Protocol                  2660
+--------   Security Extensions For HTML                            2659
+--------   LDAPv2 Client vs. the Index Mesh                        2657
+--------   Registration Procedures for SOIF Template Types         2656
+--------   CIP Index Object Format for SOIF Objects                2655
+--------   A Tagged Index Object for use in the Common Indexing    2654
+              Protocol
+--------   An LDAP Control and Schema for Holding Operation        2649
+              Signatures
+--------   The NewReno Modification to TCP's Fast Recovery         2582
+              Algorithm
+--------   Mapping between LPD and IPP Protocols                   2569
+
+
+
+IETF                        Standards Track                    [Page 36]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+IPP-RAT    Rationale for the Structure of the Model and Protocol   2568
+              for the Internet Printing Protocol
+IPP-DG     Design Goals for an Internet Printing Protocol          2567
+DNS-INFO   Detached Domain Name System (DNS) Information           2540
+PHOTURIS-E  Photuris: Extended Schemes and Attributes              2523
+PHOTURIS-S Photuris: Session-Key Management Protocol               2522
+ICMP-SEC   ICMP Security Failures Messages                         2521
+NHRP-MNHCS NHRP with Mobile NHCs                                   2520
+--------   URI Resolution Services Necessary for URN Resolution    2483
+--------   IPv6 Testing Address Allocation                         2471
+MARS-SCSP  A Distributed MARS Service Using SCSP                   2443
+TCP-WIN    Increasing TCP's Initial Window                         2414
+PIM-SM     Protocol Independent Multicast-Sparse Mode              2362
+              PIM-SM): Protocol Specification
+--------   Domain Names and Company Name Retrieval                 2345
+RTP-MPEG   RTP Payload Format for Bundled MPEG                     2343
+--------   Intra-LIS IP multicast among routers over ATM           2337
+              using Sparse Mode PIM
+--------   The Safe Response Header Field                          2310
+LDAP-NIS   An Approach for Using LDAP as a Network Information     2307
+              Service
+HTTP-RVSA  HTTP Remote Variant Selection Algorithm -- RVSA/1.0     2296
+TCN-HTTP   Transparent Content Negotiation in HTTP                 2295
+TOPT-COMPO Telnet Com Port Control Option                          2217
+--------   Core Based Trees (CBT) Multicast Routing Architecture   2201
+--------   Core Based Trees (CBT version 2) Multicast Routing      2189
+--------   A Trivial Convention for using HTTP in URN Resolution   2169
+--------   Resolution of Uniform Resource Identifiers using        2168
+              the Domain Name System
+MAP-MAIL   MaXIM-11 - Mapping between X.400 / Internet mail        2162
+              and  Mail-11 mail
+MIME-ODA   A MIME Body Part for ODA                                2161
+OSPF-DIG   OSPF with Digital Signatures                            2154
+IP-SCSI    Encapsulating IP with the Small Computer System         2143
+              Interface
+X.500-NAME Managing the X.500 Root Naming Context                  2120
+GKMP-ARCH  Group Key Management Protocol (GKMP) Architecture       2094
+GKMP-SPEC  Group Key Management Protocol (GKMP) Specification      2093
+TFTP-MULTI TFTP Multicast Option                                   2090
+IP-Echo    IP Echo Host Service                                    2075
+TOPT-CHARS TELNET CHARSET Option                                   2066
+URAS       Uniform Resource Agents (URAs)                          2016
+GPS-AR     GPS-Based Addressing and Routing                        2009
+ETFTP      Experiments with a Simple File Transfer Protocol        1986
+              for Radio Links using Enhanced Trivial File
+              Transfer Protocol (ETFTP)
+BGP-RR     BGP Route Reflection An alternative to full mesh IBGP   1966
+SMKD       Scalable Multicast Key Distribution                     1949
+
+
+
+IETF                        Standards Track                    [Page 37]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+SNMPV2SM   User-based Security Model for SNMPv2                    1910
+SNMPV2AI   An Administrative Infrastructure for SNMPv2             1909
+SNMPV2CB   Introduction to Community-based SNMPv2                  1901
+--------   OSI NSAPs and IPv6                                      1888
+DNS-LOC    A Means for Expressing Location Information in          1876
+              the Domain Name System
+SGML-MT    SGML Media Types                                        1874
+CONT-MT    Message/External-Body Content-ID Access Type            1873
+UNARP      ARP Extension - UNARP                                   1868
+BGP-IDRP   A BGP/IDRP Route Server alternative to a full           1863
+              mesh routing
+ESP3DES    The ESP Triple DES Transform                            1851
+--------   SMTP 521 Reply Code                                     1846
+--------   SMTP Service Extension for Checkpoint/Restart           1845
+ST2        Internet Stream Protocol Version 2 (ST2) Protocol       1819
+              Specification - Version ST2+
+--------   Communicating Presentation Information in Internet      1806
+              Messages: The Content-Disposition Header
+--------   Schema Publishing in X.500 Directory                    1804
+--------   MHS use of the X.500 Directory to support MHS Routing   1801
+--------   Class A Subnet Experiment                               1797
+TCP/IPXMIB TCP/IPX Connection Mib Specification                    1792
+--------   TCP And UDP Over IPX Networks With Fixed Path MTU       1791
+ICMP-DM    ICMP Domain Name Messages                               1788
+CLNP-MULT  Host Group Extensions for CLNP Multicasting             1768
+OSPF-OVFL  OSPF Database Overflow                                  1765
+RWP        Remote Write Protocol - Version 1.0                     1756
+NARP       NBMA Address Resolution Protocol (NARP)                 1735
+DNS-ENCODE DNS Encoding of Geographical Location                   1712
+TCP-POS    An Extension to TCP : Partial Order Service             1693
+T/TCP      T/TCP -- TCP Extensions for Transactions Functional     1644
+              Specification
+MIME-UNI   Using Unicode with MIME                                 1641
+FOOBAR     FTP Operation Over Big Address Records (FOOBAR)         1639
+X500-CHART Charting Networks in the X.500 Directory                1609
+X500-DIR   Representing IP Information in the X.500 Directory      1608
+SNMP-DPI   Simple Network Management Protocol Distributed          1592
+              Protocol Interface Version 2.0
+CLNP-TUBA  Use of ISO CLNP in TUBA Environments                    1561
+REM-PRINT  Principles of Operation for the TPC.INT Subdomain:      1528
+              Remote Printing -- Technical Procedures
+DASS       DASS - Distributed Authentication Security Service      1507
+EHF-MAIL   Encoding Header Field for Internet Messages             1505
+RAP        RAP: Internet Route Access Protocol                     1476
+TP-IX      TP/IX: The Next Internet                                1475
+
+
+
+
+
+
+IETF                        Standards Track                    [Page 38]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+--------   Routing Coordination for X.400 MHS Services Within      1465
+              a Multi Protocol / Multi Network Environment
+              Table Format V3 for Static Routing
+--------   Using the Domain Name System To Store Arbitrary         1464
+              String Attributes
+IRCP       Internet Relay Chat Protocol                            1459
+SIFT       SIFT/UFT: Sender-Initiated/Unsolicited File Transfer    1440
+DIR-ARP    Directed ARP                                            1433
+TEL-SPX    Telnet Authentication: SPX                              1412
+TEL-KER    Telnet Authentication: Kerberos Version 4               1411
+TRACE-IP   Traceroute Using an IP Option                           1393
+DNS-IP     An Experiment in DNS Based IP Routing                   1383
+RMCP       Remote Mail Checking Protocol                           1339
+MSP2       Message Send Protocol 2                                 1312
+DSLCP      Dynamically Switched Link Control Protocol              1307
+--------   X.500 and Domains                                       1279
+IN-ENCAP   Scheme for an internet encapsulation protocol:          1241
+              Version 1
+CLNS-MIB   CLNS MIB for use with Connectionless Network Protocol   1238
+              (ISO 8473) and End System to Intermediate
+              System (ISO 9542)
+CFDP       Coherent File Distribution Protocol                     1235
+IP-AX.25   Internet protocol encapsulation of AX.25 frames         1226
+ALERTS     Techniques for managing asynchronously generated alerts 1224
+MPP        Message Posting Protocol (MPP)                          1204
+SNMP-BULK  Bulk Table Retrieval with the SNMP                      1187
+DNS-RR     New DNS RR Definitions                                  1183
+IMAP2      Interactive Mail Access Protocol: Version 2             1176
+NTP-OSI    Network Time Protocol (NTP) over the OSI Remote         1165
+              Operations Service
+DMF-MAIL   Digest message format                                   1153
+RDP        Version 2 of the Reliable Data Protocol (RDP)           1151
+--------   Standard for the transmission of IP datagrams           1149
+              on avian carriers
+TCP-ACO    TCP alternate checksum options                          1146
+--------   The Q Method of Implementing TELNET Option Negotiation  1143
+IP-DVMRP   Distance Vector Multicast Routing Protocol              1075
+VMTP       VMTP: Versatile Message Transaction Protocol            1045
+COOKIE-JAR Distributed-protocol authentication scheme              1004
+NETBLT     NETBLT: A bulk data transfer protocol                    998
+IRTP       Internet Reliable Transaction Protocol functional        938
+              and interface specification
+LDP        Loader Debugger Protocol                                 909
+RDP        Reliable Data Protocol                                   908
+
+   [Note: an asterisk at the end of a line indicates a change from the
+   previous edition of this document.]
+
+
+
+
+IETF                        Standards Track                    [Page 39]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+3.8.  Historic Protocols
+
+Mnemonic   Title                                                   RFC#
+------------------------------------------------------------------------
+IP-MAC     IP Authentication using Keyed SHA1 with Interleaved     2841
+              Padding (IP-MAC)
+L2F        Cisco Layer Two Forwarding (Protocol) "L2F"             2341
+IPV6-UNI   An IPv6 Provider-Based Unicast Address Format           2073
+HTML-INT   Internationalization of the Hypertext Markup Language   2070
+--------   A Proposed Extension to HTML : Client-Side Image Maps   1980
+HTML-TBL   HTML Tables                                             1942
+IPV6-Addr  IP Version 6 Addressing Architecture                    1884
+--------   Form-based File Upload in HTML                          1867
+HTML       Hypertext Markup Language - 2.0                         1866
+BGP4-IDRP  BGP4/IDRP for IP---OSPF Interaction                     1745*
+--------   Definitions of Managed Objects for the Ethernet-        1623
+              like Interface Types
+--------   Manager-to-Manager Management Information Base          1451
+--------   Party MIB for version 2 of the Simple Network           1447
+              Management Protocol (SNMPv2)
+--------   Security Protocols for version 2 of the Simple          1446
+              Network Management Protocol (SNMPv2)
+--------   Administrative Model for version 2 of the Simple        1445
+              Network Management Protocol (SNMPv2)
+TOPT-ENVIR Telnet Environment Option                               1408
+BGP-OSPF   BGP OSPF Interaction                                    1403*
+SNMP-PARTY Definitions of Managed Objects for Administration       1353
+              of SNMP Parties
+SNMP-SEC   SNMP Security Protocols                                 1352
+SNMP-ADMIN SNMP Administrative Model                               1351
+--------   Application of the Border Gateway Protocol in           1268
+              the Internet
+BGP3       Border Gateway Protocol 3 (BGP-3)                       1267
+OSI-UDP    OSI connectionless transport services on top of         1240
+              UDP: Version 1
+802.4-MIP  IEEE 802.4 Token Bus MIB                                1230
+SNMP-MUX   SNMP MUX protocol and MIB                               1227
+OIM-MIB-II OSI internet management: Management Information Base    1214
+IMAP3      Interactive Mail Access Protocol: Version 3             1203
+CMOT       Common Management Information Services and Protocols    1189
+              for the Internet (CMOT and CMIP)
+--------   Application of the Border Gateway Protocol in           1164
+              the Internet
+BGP        Border Gateway Protocol (BGP)                           1163
+MIB-I      Management Information Base for network management      1156
+              of TCP/IP-based internets
+--------   Mapping between full RFC 822 and RFC 822 with           1137
+              restricted encoding
+
+
+
+IETF                        Standards Track                    [Page 40]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+--------   Privacy enhancement for Internet electronic mail:       1115
+              Part III - algorithms, modes, and identifiers
+--------   Privacy enhancement for Internet electronic mail:       1114
+              Part II - certificate-based key management
+--------   Privacy enhancement for Internet electronic mail:       1113
+              Part I - message encipherment and authentication
+              procedures
+IPSO       U.S. Department of Defense Security Options for         1108
+              the Internet Protocol
+RIP        Routing Information Protocol                            1058
+---------  Standard for the transmission of IP datagrams           1051
+              and ARP packets over ARCNET networks
+SUN-RPC    RPC: Remote Procedure Call Protocol specification       1050
+CONTENT    Content-type header field for Internet messages         1049
+NFILE      NFILE - a file access protocol                          1037
+SGMP       Simple Gateway Monitoring Protocol                      1028
+HEMS       High-level Entity Management System (HEMS)              1021
+--------   Requirements for Internet gateways                      1009
+STATSRV    Statistics server                                        996
+HOSTNAME   Hostname Server                                          953
+POP2       Post Office Protocol: Version 2                          937
+HFEP       Proposed Host-Front End Protocol                         929
+RATP       Reliable Asynchronous Transfer Protocol (RATP)           916
+THINWIRE   Thinwire protocol for connecting personal computers      914
+              to the Internet
+SFTP       Simple File Transfer Protocol                            913
+EGP        Exterior Gateway Protocol formal specification           904
+HMP        Host Monitoring Protocol                                 869
+GGP        DARPA Internet gateway                                   823
+RTELNET    Remote User Telnet service                               818
+CLOCK      DCNET Internet Clock Service                             778
+MPM        Internet Message Protocol                                759
+NETRJS     NETRJS Protocol                                          740
+SUPDUP     SUPDUP Protocol                                          734
+TOPT-OLD   Telnet output linefeed disposition                       658
+TOPT-OVTD  Telnet output vertical tab disposition option            657
+TOPT-OVT   Telnet output vertical tabstops option                   656
+TOPT-OFD   Telnet output formfeed disposition option                655
+TOPT-OHTD  Telnet output horizontal tab disposition option          654
+TOPT-OHT   Telnet output horizontal tabstops option                 653
+TOPT-OCRD  Telnet output carriage-return disposition option         652
+NETED      NETED: A Common Editor for the ARPA Network              569
+RJE        Remote Job Entry Protocol                                407
+
+   [Note: an asterisk at the end of a line indicates a change from the
+   previous edition of this document.]
+
+
+
+
+
+IETF                        Standards Track                    [Page 41]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+4.  Security Coniderations
+
+   This memo does not affect the technical security of the Internet, but
+   it does cite a number of important security specifications.
+
+5.  Editors' Addresses
+
+   Joyce K. Reynolds
+   USC/Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone: +1 310-822-1511
+   Fax:   +1 310-823-6714
+   EMail: JKRey@ISI.EDU
+
+
+   Robert Braden
+   USC/Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone: +1 310-822-1511
+   Fax:   +1 310-823-6714
+   EMail: Braden@ISI.EDU
+
+
+   Sandy Ginoza
+   USC/Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone: +1 310-822-1511
+   Fax:   +1 310-823-6714
+   EMail: Ginoza@ISI.EDU
+
+
+   Lorrie Shiota
+   USC/Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone: +1 310-822-1511
+   Fax:   +1 310-823-6714
+   EMail: Shiota@ISI.EDU
+
+
+
+
+
+
+IETF                        Standards Track                    [Page 42]
+
+RFC 3000                   Internet Standards              November 2001
+
+
+6.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (2001).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+IETF                        Standards Track                    [Page 43]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc3000.txt](<www.ietf.org/rfc/rfc3000.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
