### PR TITLE
Archive rfc300.txt

### DIFF
--- a/www.ietf.org/rfc/rfc300.txt
+++ b/www.ietf.org/rfc/rfc300.txt
@@ -1,0 +1,507 @@
+
+
+
+
+
+
+Network Working Group
+Request for Comments: 300                                25 January 1972
+Obsoletes: RFC 211  NIC 7191
+NIC 8468
+
+
+                       ARPA NETWORK MAILING LISTS
+
+   The following are three lists to be used for distribution of Network
+   documents.  List A should be used by sites when they distribute their
+   own documents, to get RFC's to Liaisons as quickly as possible.  All
+   but local mail should be sent Air Mail.  Lists B and C will be used
+   by NIC in making distribution of copies to non-site Network
+   participants and to Station Agents.
+
+   For phone numbers and lists of names by sites see the Current
+   Directory of Network Participants.
+
+   (A)                    A.  INITIAL DISTRIBUTION LIST
+
+   Note: This list includes all Network Liaisons and others who should
+   receive initial distribution of RFC's, whether sent from NIC or from
+   sites. They will also receive selected catalogs and other formal
+   documents from NIC.
+
+   AMES-CD                             CMU
+
+   A. Wayne Hathaway                   Harold R. Van Zoeren
+   Mail Stop 233-9                     Carnegie-Mellon University
+   NASA Ames Research Center           Computer Science Department
+   Moffett Field, Calif. 94035         Schenley Park
+                                       Pittsburgh, Pa.  15213
+   AMES-ILLIAC
+   John W. McConnell                   DOCB
+   NASA Ames research Center
+   Mail Stop 202-10                    Schuyler Stevenson R-523
+   Moffett Field, Calif. 94035         Department of Commerce NOAA
+                                       325 South Broadway
+   ARPA                                Boulder, Colorado 80302
+
+   Steve D. Crocker                    HARV
+   Advanced Research Project Agency
+   1400 Wilson Boulevard               Robert L. Sundberg
+   Arlington, Virginia  22209          Harvard University
+                                       Aiken Computation Laboratory
+                                       33 Oxford Street
+                                       Cambridge, Mass.  02138
+
+
+
+
+                                                                [Page 1]
+
+RFC 300               ARPA NETWORK MAILING LISTS            January 1972
+
+
+   BBN-NET                             IBMW
+
+   Alex McKenzie                       Douglas McKay
+   Bolt Beranek and Newman Inc.        IBM Watson Research Center
+   50 Moulton Street                   P.O. Box  218
+   Cambridge, Mass.  02138             Yorktown Heights, New York  10598
+
+   BBN-TENEX                           ILL
+   Robert H. Thomas                    Karl C. Kelley
+   Belt Beranek and Newman Inc.        University of Illinois
+   50 Moulton Street                   Center for Advanced Computation
+   Cambridge, Mass.  02138             Urbana, Illinois 61801
+
+   CASE                                LINC-67
+
+   Dr. Patrick W. Foulk                Joel M. Winett
+   Jennings Computing Center           Massachusetts Institute of
+   Room 306, Crawford Hall             Technology
+   Case Western Reserve University     Lincoln Laboratory
+   10900 Euclid Avenue                 244 Wood Street
+   Cleveland, Ohio  44106              Lexington, Mass.  02173
+
+   CCA                                 LINC-TX2
+
+   Richard A. Winter                   William Kantrowitz
+   Computer Corporation of America     Massachusetts Institute of
+   565 Technology Square               Technology
+   Cambridge, Mass.  02139             Lincoln Laboratory
+                                       244 Wood Street
+   MIT-DMCG                            Lexington, Mass.  02173
+
+   Abhay Bhushan                       SRI-ARC
+   Project MAC  Room 206
+   545 Technology Square               John T. Melvin
+   Cambridge, Mass.  02139             Stanford Research Institute
+                                       Augmentation Research Center
+                                       Menlo Park, Calif.  94025
+   MIT-MULTICS
+                                       Jeanne B. North  (for NIC)
+   see MIT-DMCG                        Stanford Research Institute
+                                       Augmentation Research Center
+                                       333 Ravenswood Avenue
+                                       Menlo Park, Calif. 94025
+
+
+
+
+
+
+
+
+                                                                [Page 2]
+
+RFC 300               ARPA NETWORK MAILING LISTS            January 1972
+
+
+   MITRE                               SU-AI
+
+   Peggy M. Karp                       James A. (Andy) Moorer
+   MITRE Corporation                   Stanford University
+   Information Systems Dept., W140     Computation Center, AI Project
+   Westgate Research Park              Stanford, Calif.  94305
+   McLean, VA  22101
+
+   NBS                                 SU-HP
+
+   Thomas N. Pyke, Jr.                 Edward A. Feigenbaum
+   National Bureau of Standards        Stanford University
+   Center for Computer Sciences and    Heuristic Programming
+   Technology                          Serra House
+   Washington, D.C. 20234              Stanford, Calif.  94305
+
+   NIC                                 UCLA-CCN
+
+   see SRI-ARC                         Robert T. Braden
+                                       University of California at
+   RADC                                Los Angeles
+                                       5308 Math Sciences Building
+   Thomas S. Lawrence                  Los Angeles, Calif.  90024
+   Rome Air Development Center (ISIM)
+   Griffiss Air Force Base
+   Rome, New York  13440
+
+   RAND                                UCLA-NMC
+
+   John F. Heafner                     Ari O. Ollikainen
+   Rand Corporation                    University of California at
+   Computer Science Department         Los Angeles
+   1700 Main Street                    Computer Science Department
+   Santa Monica, Calif.  90406         3732 Boelter Hall
+                                       Los Angeles, Calif.  90024
+
+   RAY                                 UCSB
+
+   Thomas O'Sullivan                   James E. White
+   Raytheon Data Systems               University of California at
+   1415 Boston-Providence Turnpike     Santa Barbara
+   Norwood, Mass.  02062               Computer Research Laboratory
+                                       Santa Barbara, Calif.  90024
+
+
+
+
+
+
+
+
+                                                                [Page 3]
+
+RFC 300               ARPA NETWORK MAILING LISTS            January 1972
+
+
+   SDC                                 UCSD-CC
+
+   Abe S. Landsberg                    Charles Holland
+   System Development Corporation      Computer Center
+   2500 Colorado Avenue                University of California at
+   Santa Monica, Calif.  90406         San Diego
+                                       La Jolla, Calif. 90037
+
+   SRI-AI                              USAF-ETAC
+
+   B. Michael Wilber                   Capt. George N. Petregal
+   Stanford Research Institute         USAF-ETAC
+   Artificial Intelligence Group       Bldg. 159
+   333 Ravenswood Avenue               Navy Yard Annex
+   Menlo Park, Calif.  94025           Washington, D.C. 20333
+
+   USC
+
+   James Pepin
+   University of Southern California
+   School of Engineering
+   Los Angeles, Calif.  90007
+
+   UTAH
+
+   Barry D. Wessler
+   University of Utah
+   Computer Science/IRL
+   Salt Lake City, Utah  84112
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 4]
+
+RFC 300               ARPA NETWORK MAILING LISTS            January 1972
+
+
+   (B)                   B. LIST FOR DISTRIBUTION FROM NIC
+
+
+   Note: These Network participants will receive all formal Network
+   documents sent from NIC, in the mailing to Liaisons when such is
+   made, otherwise at the time documents are sent to Station Agents.
+
+   CCCTF                               WATERU
+
+   C. D. Shepard                       Prof. Donald Cowan
+   Canadian Computer Communications    Dept. of Computer Science
+   Task Force                          University of Waterloo
+   100 Metcalfe Street                 Waterloo, Ontario, Canada
+   4th Floor
+   Ottawa 2, Canada
+
+   DART                                CHIU
+
+   Prof. Robert F. Hargraves           Prof. Robert L. Ashenhurst
+   Kiewit Computation Center           Institute for Computer Research
+   Dartmouth University                University of Chicago
+   Hanover, New Hampshire  03755       Chicago, Illinois  60637
+
+   EDUCOM                              NPL
+
+   John LeGates                        Derek Barber
+   EDUCOM                              Computer Science Division
+   44 School Street                    National Physical Laboratory
+   Boston, Mass.  02108                Teddington, Middlesex, England
+
+   MERIT                               UBC
+
+   E. M. Aupperle                      Dave Tywer
+   MERIT Computer Network              Computing Center
+   University of Michigan              University of British Columbia
+   1037 N. University Building         Vancouver 8, Canada
+   Ann Arbor, Michigan  48104
+
+   NETH                                NSF
+
+   Tjaart Schipper                     Dr. D. D. Aufenkamp
+   13 Marijkestraat                    Office of Computing Activities
+   Leiderdorp, Netherlands             National Science Foundation
+                                       1800 G Street, N.W.
+                                       Washington, D. C. 20550
+
+
+
+
+
+
+                                                                [Page 5]
+
+RFC 300               ARPA NETWORK MAILING LISTS            January 1972
+
+
+   SUNY
+
+   Prof. Art J. Bernstein
+   SUNY Stoneybrook
+   Dept. of Computer Science
+   Stoneybrook, L.I., N.Y.  11790
+
+
+   UCI
+
+   Prof. David Farber
+   Dept. of Information and Computer Science
+   University of California
+   Irvine, Calif.  92664
+
+   UKICS
+
+   Prof. Peter Kirstein
+   Institute of Computer Science
+   University of London
+   44 Gordon Square
+   London, W.C.1, England
+
+   WASHU
+
+   Marianne Pepper
+   Washington University
+   Computer Systems Laboratory
+   724 South Euclid Avenue
+   St. Louis, No.  63110
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 6]
+
+RFC 300               ARPA NETWORK MAILING LISTS            January 1972
+
+
+   (C)                   C.  NIC STATION AGENTS
+
+   Note: Station Agents receive copies from NIC of all documents
+   distributed to Liaisons, as well as documents sent as part of a
+   Station collection.  A mailing is made to Station Agents once a week,
+   or oftener when quantity warrants.
+
+   AMES-CD                             DOCB
+
+   See AMES-ILLIAC                     Dorothy A. Reynolds P-522
+                                       Department of Commerce NOAA
+   AMES-ILLIAC                         325 South Broadway
+                                       Boulder, Colorado 80302
+   Stan Golding
+   Mail Stop 233-13                    ILL
+   NASA Ames Research Center
+   Moffett Field, Calif.  94035        Marcia Trager
+                                       University of Illinois
+   ARPA                                Center for Advanced Computation
+                                       168 Engineering Research
+   Pam J. Klotz                        Laboratory
+   Advanced Research Projects Agency   Urbana, Ill.  61801
+   1400 Wilson Boulevard
+   Arlington, Va.  22209
+
+   BBN-NET                             LINC-67
+
+   see BBN-TENEX                       Carol J. Mostrom
+                                       Massachusetts Institute of
+                                       Technology
+   BBN-TENEX                           Lincoln Laboratory
+                                       244 Wood Street
+   Steve G. Chipman                    Lexington, Mass.  02173
+   Bolt Beranek and Newman Inc.
+   50 Moulton Street                   LINC-TX2
+   Cambridge, Mass.  02138
+                                       see LINC-6
+
+   CASE                                MIT-DMCG
+
+   John Barden                         Frances Y. Knight
+   Case Western Reserve University     Project MAC
+   Computing and Information Sciences  545 Technology Square
+   10900 Euclid Ave.                   Cambridge, Mass.  02139
+   Cleveland, Ohio  44106
+                                       MIT-MULTICS
+
+                                       see MIT-DMCG
+
+
+
+                                                                [Page 7]
+
+RFC 300               ARPA NETWORK MAILING LISTS            January 1972
+
+
+   CCA                                 MITRE
+
+   Martha A. Ginsberg                  Ernest H. Forman
+   Computer Corporation of America     MITRE Corporation
+   565 Technology Square               Information Systems Dept.,
+   Cambridge, Mass.  02139             W150
+                                       Westgate Research Park
+   CMU                                 McLean, Va.  22101
+
+   Nancy R. Teater                     NBS
+   Carnegie-Mellon University
+   Computer Science Department         Mrs. Shirley W. Watkins
+   Schenley Park                       National Bureau of Standards
+   Pittsburgh, Pa.  15213              Bldg. 225, Room B216
+                                       Washington, D.C. 20234
+
+   HARV                                NIC
+
+   Bradley A. Reassow                  see SRI-ARC
+   Harvard University
+   Aiken Computation Laboratory        UCLA-[NMC]
+   33 Oxford Street
+   Cambridge, Mass.  02138             Anita Coley
+                                       University of California at
+   RADC                                Los Angeles
+                                       Computer Science Department
+   Marcelle D. Petell                  3732 Boelter Hall
+   Rome Air Development Center (ISIM)  Los Angeles, Calif.  90024
+   Griffiss Air Force Base
+   Rome, New York  13440
+
+   RAND                                 UCSB
+
+   Linda M. Connelly                    Connie Rosewall
+   Rand Corporation                     University of California at
+   Computer Science Department          Santa Barbara
+   1700 Main Street                     Computer Research Laboratory
+   Santa Monica, Calif.  90406          Santa Barbara, Calif.  93106
+
+   RAY                                  UCSD-CC
+
+   Laura White                          Charles Hollano
+   Raytheon Data Systems                Computer Center
+   1415 Boston-Providence Turnpike      University of California at
+   Norwood, Mass.  02062                San Diego
+                                        La Jolla, Calif.  90037
+
+
+
+
+
+                                                                [Page 8]
+
+RFC 300               ARPA NETWORK MAILING LISTS            January 1972
+
+
+   SDC                                  USAF-ETAC
+
+   Janet W. Troxel                      M/Sgt. Glen Grazier
+   System Development Corporation       USAF-ETAC
+   Information Processing Information   Bldg. 159
+   Center                               Navy Yard Annex
+   2500 Colorado Avenue                 Washington, D. C. 20333
+   Santa Monica, Calif.  90406
+
+   SRI-AI                               USC
+
+   Rilla J. Reynolds                    Linda M. Webster
+   Stanford Research Institute          University of Southern California
+   Artificial Intelligence Group        Olin Hall of Engineering
+   333 Ravenswood Ave.                  Los Angeles, Calif.  90007
+   Menlo Park, Calif.  94025
+
+   SRI-ARC                              UTAH
+
+   Cindy Page                           Gennie L. Cederholm
+   Stanford Research Institute          University of Utah
+   Augmentation Research Center         3154 Merrill Engineering Bldg.
+   333 Ravenswood Ave.                  Salt Lake City, Utah  84112
+   Menlo Park, Calif.  94025
+
+   SU-AI                                SU-HP
+
+   Barbara A. Barnett                   Carol Wilkinson
+   Stanford University                  Stanford University
+   Artificial Intelligence Project      Heuristic Programming Project
+   D.C. Power Lab                       Serra House
+   Stanford, Calif.  94305              Stanford, Calif.  94305
+
+   UCLA-CCN
+
+   Imogen C. Beattie
+   University of California at Los Angeles
+   3531 Boelter Hall
+   Los Angeles, Calif.  90024
+
+
+         [ This RFC was put into machine readable form for entry ]
+        [ into the online RFC archives by Mirsad Todorovac 11/98 ]
+
+
+
+
+
+
+
+
+                                                                [Page 9]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc300.txt](<www.ietf.org/rfc/rfc300.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
