### PR TITLE
Archive rfc3005.txt

### DIFF
--- a/www.ietf.org/rfc/rfc3005.txt
+++ b/www.ietf.org/rfc/rfc3005.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                                          S. Harris
+Request for Comments: 3005                                 Merit Network
+BCP: 45                                                    November 2000
+Category: Best Current Practice
+
+
+                      IETF Discussion List Charter
+
+Status of this Memo
+
+   This document specifies an Internet Best Current Practices for the
+   Internet Community, and requests discussion and suggestions for
+   improvements.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2000).  All Rights Reserved.
+
+Abstract
+
+   The Internet Engineering Task Force (IETF) discussion mailing list
+   furthers the development and specification of Internet technology
+   through discussion of technical issues, and hosts discussions of IETF
+   direction, policy, meetings, and procedures.  As this is the most
+   general IETF mailing list, considerable latitude is allowed.
+   Advertising, whether to solicit business or promote employment
+   opportunities, falls well outside the range of acceptable topics, as
+   do discussions of a personal nature.
+
+Charter for the IETF Discussion List
+
+   The IETF discussion list, ietf@ietf.org, serves two purposes.  It
+   furthers the development and specification of Internet technology
+   through discussion of technical issues.  It also hosts discussions of
+   IETF direction, policy, meetings, and procedures.  As this is the
+   most general IETF mailing list, considerable latitude is allowed.
+   Advertising, whether to solicit business or promote employment
+   opportunities, falls well outside the range of acceptable topics, as
+   do discussions of a personal nature.
+
+   This list is meant for initial discussion only.  Discussions that
+   fall within the area of any working group or well established list
+   should be moved to such more specific forum as soon as this is
+   pointed out, unless the issue is one for which the working group
+   needs wider input or direction.
+
+
+
+
+
+
+Harris                   Best Current Practice                  [Page 1]
+
+RFC 3005              IETF Discussion List Charter         November 2000
+
+
+   In addition to the topics noted above, appropriate postings include:
+
+    - Last Call discussions of proposed protocol actions
+    - Discussion of technical issues that are candidates for IETF work,
+      but do not yet have an appropriate e-mail venue
+    - Discussion of IETF administrative policies
+    - Questions and clarifications concerning IETF meetings
+    - Announcements of conferences, events, or activities that are
+      sponsored or endorsed by the Internet Society or IETF.
+
+   Inappropriate postings include:
+
+    - Unsolicited bulk e-mail
+    - Discussion of subjects unrelated to IETF policy, meetings,
+      activities, or technical concerns
+    - Unprofessional commentary, regardless of the general subject
+    - Announcements of conferences, events, or activities that are not
+      sponsored or endorsed by the Internet Society or IETF.
+
+   The IETF Chair, the IETF Executive Director, or a sergeant-at-arms
+   appointed by the Chair is empowered to restrict posting by a person,
+   or of a thread, when the content is inappropriate and represents a
+   pattern of abuse.  They are encouraged to take into account the
+   overall nature of the postings by an individual and whether
+   particular postings are an aberration or typical.  Complaints
+   regarding their decisions should be referred to the IAB.
+
+Acknowledgements
+
+   Comments by Donald E. Eastlake 3rd and other members of the IETF
+   POISSON working group are gratefully acknowledged.
+
+Author's Address
+
+   Susan R. Harris
+   Merit Network, Inc.
+   4251 Plymouth Rd., Suite C
+   Ann Arbor, MI 48105-2785
+
+   Phone: (734) 936-2100
+   Fax:   (734) 647-3185
+   EMail: srh@merit.edu
+
+
+
+
+
+
+
+
+
+Harris                   Best Current Practice                  [Page 2]
+
+RFC 3005              IETF Discussion List Charter         November 2000
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2000).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Harris                   Best Current Practice                  [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc3005.txt](<www.ietf.org/rfc/rfc3005.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
