### PR TITLE
Archive rfc3011.txt

### DIFF
--- a/www.ietf.org/rfc/rfc3011.txt
+++ b/www.ietf.org/rfc/rfc3011.txt
@@ -1,0 +1,395 @@
+
+
+
+
+
+
+Network Working Group                                          G. Waters
+Request for Comments: 3011                               Nortel Networks
+Category: Standards Track                                  November 2000
+
+
+               The IPv4 Subnet Selection Option for DHCP
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2000).  All Rights Reserved.
+
+Abstract
+
+   This memo defines a new Dynamic Host Configuration Protocol (DHCP)
+   option for selecting the subnet on which to allocate an address.
+   This option would override a DHCP server's normal methods of
+   selecting the subnet on which to allocate an address for a client.
+
+Table of Contents
+
+   1. Introduction..................................................1
+   1.1. Motivational Example........................................2
+   2. Subnet Selection Option Definition............................3
+   3. Intellectual Property.........................................4
+   4. IANA Considerations...........................................4
+   5. Acknowledgements..............................................5
+   6. Security Considerations.......................................5
+   7. References....................................................5
+   8. Editor's Addresses............................................6
+   9. Full Copyright Statement......................................7
+
+1. Introduction
+
+   The Dynamic Host Configuration Protocol (DHCP) [RFC2131] provides a
+   framework for passing configuration information to hosts on a TCP/IP
+   network.  RFC 2132 [RFC2132] specifies DHCP option configuration
+   information that may be carried in DHCP packets to/from the DHCP
+   server and the DHCP client.  This document specifies a new DHCP
+   option.
+
+
+
+
+Waters                      Standards Track                     [Page 1]
+
+RFC 3011                Subnet Selection Option            November 2000
+
+
+   To select the subnet on which to allocate an address, the DHCP server
+   determines the subnet from which the request originated, and then
+   selects an address on the originating subnet or on a subnet that is
+   on the same network segment as the originating subnet.  The subnet
+   from which the request originates can be determined by:
+
+   o Using the subnet address of the giaddr field in the DHCP packet
+     header, or if the giaddr field is zero;
+
+   o Using the subnet address of the local interface on which the DHCP
+     server received the packet.
+
+   This memo defines a new DHCP option, the subnet selection option,
+   which allows the DHCP client to specify the subnet on which to
+   allocate an address.  This option takes precedence over the methods
+   that the DHCP server uses to determine the subnet on which to select
+   an address.
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+1.1. Motivational Example
+
+   An example of where this option could be useful is in a device (e.g.:
+   a RAS device) that is allocating addresses on behalf of its clients.
+   In this case the device would be allocating addresses through DHCP
+   and then managing those addresses among its clients.
+
+   In this scenario, the device is connected to a private "internal"
+   network on which the DHCP server would be located.  The device is
+   also connected to one or more service providing "external" networks
+   (i.e.: the networks that the device's clients are connected to).
+   Furthermore, the internal network is not IP connected to the external
+   networks, although inside the device there is connectivity between
+   the internal and external networks (e.g.: though the backplane).
+
+   Recall that the device is allocating addresses for its clients on the
+   external networks and that there is no IP connectivity between the
+   internal network and the external networks.  The DHCP requests cannot
+   originate from the external networks since packets cannot be routed
+   between the external network and the internal network.  Thus, the
+   DHCP requests must originate from the internal network.  The problem
+   with originating the DHCP requests from the internal network is that
+   the DHCP server will allocate addresses on the internal network's
+   subnet, when what is required are addresses on the external subnets.
+   The subnet selection option provides a solution to this problem.
+
+
+
+
+Waters                      Standards Track                     [Page 2]
+
+RFC 3011                Subnet Selection Option            November 2000
+
+
+   The device would send its DHCP request on the internal subnet, but
+   would include the subnet selection option containing the address of
+   the external subnet on which it requires the address.  The subnet
+   selection option instructs the DHCP server to allocate the address on
+   the requested subnet as opposed to the normal operation of allocating
+   the address on the subnet from which the DHCP request originated.
+
+2. Subnet Selection Option Definition
+
+   The subnet selection option is a DHCP option.  The option contains a
+   single IPv4 address that is the address of a subnet.  The value for
+   the subnet address is determined by taking any IPv4 address on the
+   subnet and ANDing that address with the subnet mask (i.e.: the
+   network and subnet bits are left alone and the remaining (address)
+   bits are set to zero).  When the DHCP server is configured to respond
+   to this option, is allocating an address, and this option is present
+   then the DHCP server MUST allocate the address on either:
+
+   o the subnet specified in the subnet selection option, or;
+
+   o a subnet on the same network segment as the subnet specified in the
+     subnet selection option.
+
+   The format of the option is:
+
+        Code   Len        IPv4 Address
+       +-----+-----+-----+-----+-----+-----+
+       | 118 |  4  | A1  | A2  | A3  | A4  |
+       +-----+-----+-----+-----+-----+-----+
+
+   Servers configured to support this option MUST return an identical
+   copy of the option to any client that sends it, regardless of whether
+   or not the client requests the option in a parameter request list.
+   Clients using this option MUST discard DHCPOFFER or DHCPACK packets
+   that do not contain this option.
+
+   This option does not require changes to operations or features of the
+   DHCP server other than to select the subnet on which to allocate an
+   address.  For example, the handling of DHCPDISCOVER for an unknown
+   subnet should continue to operate unchanged.
+
+   When this option is present and the server is configured to support
+   this option, the server MUST NOT offer an address that is not on the
+   requested subnet or network segment.  Servers that do not understand
+   this option will allocate an address using their normal algorithms
+   and will not return this option in the DHCPOFFER or DHCPACK.  In this
+   case the client will discard the DHCPOFFER or DHCPACK.  Servers that
+   understand this option but are administratively configured to ignore
+
+
+
+Waters                      Standards Track                     [Page 3]
+
+RFC 3011                Subnet Selection Option            November 2000
+
+
+   the option MUST ignore the option, use their normal algorithms to
+   allocate an address, and MUST NOT return this option in the DHCPOFFER
+   or DHCPACK.  In this case the client will discard the DHCPOFFER or
+   DHCPACK.
+
+   During an address renew, the DHCP server may send a DHCPACK directly
+   to the allocated address, however packets from the DHCP server may
+   not be routable to the address.  Thus, in all packets that the DHCP
+   client sends that contain the subnet selection option, the giaddr
+   field in the BOOTP header MUST be set to an IPv4 address on which the
+   DHCP client will accept DHCP packets (e.g.: the address on the subnet
+   connected to the internal network).
+
+   The IPv4 address to which a DHCP server sends a reply to MUST be the
+   same as it would chose when this option is not present.
+
+3. Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   intellectual property or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; neither does it represent that it
+   has made any effort to identify any such rights.  Information on the
+   IETF's procedures with respect to rights in standards-track and
+   standards-related documentation can be found in BCP-11.
+
+   Copies of claims of rights made available for publication and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF Secretariat.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights which may cover technology that may be required to practice
+   this standard.  Please address the information to the IETF Executive
+   Director.
+
+4. IANA Considerations
+
+   IANA has assigned a value of 118 for the DHCP option code described
+   in this document.
+
+
+
+
+
+
+
+
+Waters                      Standards Track                     [Page 4]
+
+RFC 3011                Subnet Selection Option            November 2000
+
+
+5. Acknowledgements
+
+   This document is the result of work undertaken the by DHCP working
+   group.  Thanks to Ted Lemon, Tim Aston and Ralph Droms for their
+   helpful comments in this work.
+
+   W. Mark Townsley and Pratik Gupta originally published a subnet
+   selection option Internet Draft in July 1997. The work in this
+   document was not based on the original work but it does achieve the
+   same goals.
+
+6. Security Considerations
+
+   DHCP currently provides no authentication or security mechanisms.
+   Potential exposures to attack are discussed is section 7 of the
+   protocol specification [RFC2131].
+
+   The subnet selection option allows for the DHCP client to specify the
+   subnet on which to allocate an address.  This would allow a client to
+   perform a more complete address-pool exhaustion attack since the
+   client would no longer be restricted to attacking address-pools on
+   just its local subnet.
+
+   Servers that implement the subnet selection option MUST by default
+   disable use of the feature; it must specifically be enabled through
+   configuration.  Moreover, a server SHOULD provide the ability to
+   selectively enable use of the feature under restricted conditions,
+   e.g., by enabling use of the option only from explicitly configured
+   client-ids, enabling its use only by clients on a particular subnet,
+   or restricting the subnets (as indicated in the subnet selection
+   option) from which addresses may be requested.
+
+7. References
+
+   [RFC2119] Bradner, S., "Key words for use in RFCs to Indicate
+             Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2131] Droms, R. "Dynamic Host Configuration Protocol", RFC 2131,
+             March 1997.
+
+   [RFC2132] Alexander, S. and R. Droms, "DHCP Options and BOOTP Vendor
+             Extensions", RFC 2132, March 1997.
+
+
+
+
+
+
+
+
+
+Waters                      Standards Track                     [Page 5]
+
+RFC 3011                Subnet Selection Option            November 2000
+
+
+8. Editor's Address
+
+   Glenn Waters
+   Nortel Networks
+   310-875 Carling Avenue,
+   Ottawa, Ontario K1S 5P1
+   Canada
+
+   Phone:  +1 613-765-0249
+   EMail:  gww@nortelnetworks.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Waters                      Standards Track                     [Page 6]
+
+RFC 3011                Subnet Selection Option            November 2000
+
+
+9.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (2000).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Waters                      Standards Track                     [Page 7]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc3011.txt](<www.ietf.org/rfc/rfc3011.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
