### PR TITLE
Archive rfc302.txt

### DIFF
--- a/www.ietf.org/rfc/rfc302.txt
+++ b/www.ietf.org/rfc/rfc302.txt
@@ -1,0 +1,165 @@
+
+
+
+
+
+
+NWG/RFC #302                               UCSB Computer
+NIC  9074                                  Research Laboratory
+                                           Roland F. Bryan
+                                           8 February 1972
+
+
+                         EXERCISING THE ARPANET
+
+
+Questions
+---------
+
+     1.  Can a technically competent person, initially uninformed
+         as to network operation and naive as to the capabilities
+         of various time-shared terminal systems attached to the
+         Network, be able to develop problem solving competence
+         at server sites on the ARPANET?
+
+     2.  What inherent user problems exist that complicate such
+         adaptation?
+
+     3.  Once proficient in the use, what aspects of the various
+         sites limit the usability and what modifications should
+         be considered at both server and user sites to meet
+         various needs?
+
+     4.  Should a user select a given site for composing and
+         editing all of his files for subsequent transfer to
+         other sites for processing or should he learn to compose
+         and edit at each of the sites doing his processing?
+
+     5.  What are the problems in starting cooperating processes
+         at several sites?  How does a user control such
+         processes?
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+
+Obtaining the Answers
+---------------------
+
+     Under the direction of UCSB Professor James Howard, a test
+group of 14 graduate students was formed to pursue the questions
+above, and any other aspect of ARPANET operation that they might
+uncover.
+
+     The test group has been given access to the 16 console On-Line
+System classroom in the E.E. Department at UCSB.  The 16 consoles
+produce graphic and alphanumeric displays and are tied into the
+UCSB Host 360-75 which gains them access to the network.  Old
+style Culler-Fried keyboards are being used which provide a
+limited key set  Jim White has managed to program around most of
+the protocol problems brought about by these keyboards, but some
+still remain.
+
+     Seminars were given to the test group to familiarize them
+with software and hardware aspects of the ARPANET, the local NIC
+file has been made available to the group, and the group has been
+allowed to sign onto the Network to pursue any available system.
+
+     Following the initial period of two weeks, during which the
+group developed some familiarity with the network, the test group
+has been divided into working groups with emphasis as follows:
+
+
+         Patric Timlick      }      BBN-TENEX
+         Dave Stearns        }      BBN-TENEX B
+
+         John Pickens        }      SRI-ARC (NIC)
+         Doug Beaubien       }
+
+         Dave Whittington    }
+         Richard Haraguchi   }      MIT-Multics
+         Maria deGraaf       }      MIT-DMCG
+         Richard Melton      }
+         Su Sung Won         }
+
+         Ronald Varekamp     }
+         Jeoff Benson        }      UCLA-CCN    HARV-10
+         Hasan A. El. Hasan  }      UCLA-NMC    UTAH-10
+         George Engelberg    }      RAND-CSG    LL-67
+         Rodney Skinner      }
+
+
+
+
+
+
+
+                                                                [Page 2]
+
+Some Initial Results
+--------------------
+     The first real encounters with the ARPANET at large produced
+a series of questions and comments.  Test group comments are
+itemized below with additional comments by the author {In braces}.
+We plan subsequent reports on a periodic basis.
+
+     1.  We find that we need further information about access
+         to the NCPs at various sites.  User manuals from the
+         sites might provide this.  {Site response is solicited}
+
+     2.  We sometimes cannot sign into UCLA-NMC directly from
+         UCSB, but can do so readily by way of BBN.  {Protocol?}
+
+     3.  After running a Fortran or PL-1 program at some net
+         location we can only display the results on our consoles
+         but cannot store them as files.  {UCSB programming need?}
+
+     4.  When communications break down how can a user be
+         assured that he is logged out of some remote site?
+         {Need for automatic Log-out?}
+
+     5.  How do we make contact with programmers at other sites
+         to develop cooperative programs for file transfer, etc?
+         {Jim White?}
+
+     6.  Is there a best time of day for operation at each site?
+         Should contact be made with the site operator prior to
+         user sessions?   {Server sites please comment}
+
+     7.  UCLA-NMC has assigned a separate user identification
+         for test group use.  Would other sites prefer to do
+         likewise?  {Comments?}
+
+     8.  Is there information regarding uses made of the
+         various time shared systems by internal users at each
+         site?  Does a bibliography exist to allow contact
+         with such users?  {Check the Resource Notebook}
+
+     9.  MIT-DMCG and BBN provide very good user service,
+         especially the site survey.  Also these sites have
+         good responses to define events.  Can UCSB provide
+         local users with similar information?  {Jim White?}
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+                                                                [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc302.txt](<www.ietf.org/rfc/rfc302.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
