### PR TITLE
Archive rfc3020.txt

### DIFF
--- a/www.ietf.org/rfc/rfc3020.txt
+++ b/www.ietf.org/rfc/rfc3020.txt
@@ -1,0 +1,2019 @@
+
+
+
+
+
+
+Network Working Group                                            P. Pate
+Request for Comments: 3020                                      B. Lynch
+Category: Standards Track                              Overture Networks
+                                                              K. Rehbehn
+                                                   Megisto Systems, Inc.
+                                                           December 2000
+
+
+                     Definitions of Managed Objects
+                   for Monitoring and Controlling the
+                 UNI/NNI Multilink Frame Relay Function
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2000).  All Rights Reserved.
+
+Abstract
+
+   This memo defines a Management Information Base (MIB) for monitoring
+   and controlling a UNI/NNI Multilink Frame Relay Function as defined
+   in Frame Relay Forum FRF.16.  This MIB also includes conformance and
+   notification information.
+
+Table of Contents
+
+   1 The SNMP Management Framework ................................    2
+   2 Overview .....................................................    3
+   2.1 Multilink Frame Relay Background ...........................    3
+   2.1.1 Terminology ..............................................    4
+   2.1.2 Reference Model ..........................................    5
+   2.2 Structure of the MIB .......................................    5
+   2.2.1 mfrBundleMaxNumBundles ...................................    6
+   2.2.2 mfrBundleNextIndex .......................................    6
+   2.2.3 mfrBundleTable ...........................................    6
+   2.2.4 Bundle-to-ifIndex Mapping Table ..........................    6
+   2.2.5 mfrBundleLinkTable .......................................    6
+   2.3 Relationship With Other MIBS and Tables ....................    7
+   2.3.1 Relationship With Interface Table ........................    7
+   2.3.1.1 Bundle Links ...........................................    7
+   2.3.1.2 Bundles ................................................    7
+
+
+
+Pate, et al.                Standards Track                     [Page 1]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+   2.3.1.3 Mapping Between ifIndex and mfrBundleIndex .............    8
+   2.3.1.4 ifTable Objects ........................................    8
+   2.3.2 Relationship With Interface Stack Table ..................    9
+   2.3.3 Relationship With Frame Relay DTE MIB ....................    9
+   2.3.4 Relationship With Frame Relay Service MIB ................    9
+   2.3.5 Example ..................................................    9
+   2.4 Creation Of Bundles and Bundle Links .......................   11
+   2.4.1 Creation Of Bundles ......................................   11
+   2.4.2 Creation Of Bundle Links .................................   11
+   2.5 Notifications ..............................................   11
+   2.5.1 Bundle ...................................................   11
+   2.5.1.1 linkUp .................................................   12
+   2.5.1.2 linkDown ...............................................   12
+   2.5.2 Bundle Link ..............................................   12
+   2.5.2.1 linkUp .................................................   12
+   2.5.2.2 linkDown ...............................................   12
+   2.5.2.3 mfrMibTrapBundleLinkMismatch ...........................   12
+   3 Object Definitions ...........................................   13
+   4 Acknowledgments ..............................................   32
+   5 References ...................................................   32
+   6 Security Considerations ......................................   34
+   7 Authors' Addresses ...........................................   35
+   8 Full Copyright Statement .....................................   36
+
+1.  The SNMP Management Framework
+
+   The SNMP Management Framework presently consists of five major
+   components:
+
+   o  An overall architecture, described in RFC 2571 [RFC2571].
+
+   o  Mechanisms for describing and naming objects and events for the
+      purpose of management.  The first version of this Structure of
+      Management Information (SMI) is called SMIv1 and described in STD
+      16, RFC 1155 [RFC1155], STD 16, RFC 1212 [RFC1212] and RFC 1215
+      [RFC1215].  The second version, called SMIv2, is described in STD
+      58: RFC 2578 [RFC2578], RFC 2579 [RFC2579] and RFC 2580 [RFC2580].
+
+   o  Message protocols for transferring management information.  The
+      first version of the SNMP message protocol is called SNMPv1 and
+      described in STD 15, RFC 1157 [RFC1157].  A second version of the
+      SNMP message protocol, which is not an Internet standards track
+      protocol, is called SNMPv2c and described in RFC 1901 [RFC1901]
+      and RFC 1906 [RFC1906].  The third version of the message protocol
+      is called SNMPv3 and described in RFC 1906 [RFC1906], RFC 2572
+      [RFC2572] and RFC 2574 [RFC2574].
+
+
+
+
+
+Pate, et al.                Standards Track                     [Page 2]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+   o  Protocol operations for accessing management information.  The
+      first set of protocol operations and associated PDU formats is
+      described in STD 15, RFC 1157 [RFC1157].  A second set of protocol
+      operations and associated PDU formats is described in RFC 1905
+      [RFC1905].
+
+   o  A set of fundamental applications described in RFC 2573 [RFC2573]
+      and the view-based access control mechanism described in RFC 2575
+      [RFC2575].
+
+   A more detailed introduction to the current SNMP Management Framework
+   can be found in RFC 2570 [RFC2570].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  Objects in the MIB are
+   defined using the mechanisms defined in the SMI.
+
+   This memo specifies a MIB module that is compliant to the SMIv2.  A
+   MIB conforming to the SMIv1 can be produced through the appropriate
+   translations.  The resulting translated MIB must be semantically
+   equivalent, except where objects or events are omitted because no
+   translation is possible (use of Counter64).  Some machine readable
+   information in SMIv2 will be converted into textual descriptions in
+   SMIv1 during the translation process.  However, this loss of machine
+   readable information is not considered to change the semantics of the
+   MIB.
+
+2.  Overview
+
+   This document defines a Management Information Base (MIB) for
+   monitoring and controlling the UNI/NNI Multilink Frame Relay
+   function.  The agreement on which this MIB is based was defined and
+   documented by the Frame Relay Forum in the Frame Relay Forum Document
+   FRF.16 [FRF.16].
+
+2.1.  Multilink Frame Relay Background
+
+   Multilink Frame Relay (MFR) for the User-to-Network Interface (UNI)
+   and the Network-to-Network Interface (NNI) provides physical
+   interface emulation for frame relay devices.  The emulated physical
+   interface consists of one or more physical links, called "bundle
+   links", aggregated together into a single "bundle" of bandwidth.
+   This service provides a frame-based inverse multiplexing function,
+   sometimes referred to as an "IMUX".
+
+
+
+
+
+
+
+Pate, et al.                Standards Track                     [Page 3]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+   The bundle provides the same order-preserving service as a physical
+   layer for frames sent on a data link connection.  In addition, the
+   bundle provides support for all Frame Relay services based on UNI and
+   NNI standards.
+
+2.1.1.  Terminology
+
+   Physical Link --    A single physical interface that interconnects
+                       two devices in a frame relay network (e.g., DS1,
+                       DS0, Bearer channel, refer to FRF.14).
+
+   Bundle --           A grouping of one or more physical links using
+                       the formats and procedures of multilink frame
+                       relay.  The bundle operates as a logical
+                       interface function that emulates a single
+                       physical interface to the Q.922 data link layer.
+
+   Bundle Link --      A MFR sub-component that controls operation of
+                       one of the bundle's physical links.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Pate, et al.                Standards Track                     [Page 4]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+2.1.2.  Reference Model
+
++--------------------------+               +--------------------------+
+|   Switching Layer -OR-   |               |   Switching Layer -OR-   |
+| Higher-Level Applications|               | Higher-Level Applications|
++--------------------------+               +--------------------------+
+|          |C-Plane - Q.933|               |          |C-Plane - Q.933|
+| U-Plane  |    (Note 1)   |               | U-Plane  |    (Note 1)   |
+| (Note 3) |---------------|               | (Note 3) |---------------|
+|          |Q.922 (Note 2) |               |          |Q.922 (Note 2) |
++--------------------------+               +--------------------------+
+| Data Link Layer (Q.922)  |               | Data Link Layer (Q.922)  |
++--------------------------+               +--------------------------+
+|       Bundle (B)         |               |       Bundle (B)         |
++--------------------------+               +--------------------------+
+| Bundle | Bundle | Bundle |               | Bundle | Bundle | Bundle |
+|  Link  |  Link  |  Link  |               |  Link  |  Link  |  Link  |
+|  (BL)  |  (BL)  |  (BL)  |               |  (BL)  |  (BL)  |  (BL)  |
++--------+--------+--------+               +--------+--------+--------+
+|Physical|Physical|Physical|               |Physical|Physical|Physical|
+|  (PH)  |  (PH)  |  (PH)  |  __________   |  (PH)  |  (PH)  |  (PH)  |
++----+---+----+---+----+---+ /\          \ +----+---+----+---+----+---+
+     |        |        |    /  \          \      |        |        |
+     |        |        +--------\          \-----+        |        |
+     |        |           /      \          \             |        |
+     |        +-------------------\          \------------+        |
+     |           _________\_______/  Bundle  /_                    |
+     |          /\               /          /  \                   |
+     +------------| Bundle Link /          /    |------------------+
+                \/_____________/          /____/
+                             \/__________/
+
+                   Figure 1: MFR Reference Diagram
+
+
+   Note 1: C-Plane operation as described in Q.933 [Q.933] and FRF.4
+   [FRF.4]
+
+   Note 2: Multiple frame acknowledged information transfer mode as
+   described in Q.922 [Q.922]
+
+   Note 3: Core aspects for use with frame relay bearer service as
+   described in Q.922, Annex A [Q.922]
+
+2.2.  Structure of the MIB
+
+   The UNI/NNI MFR managed objects consist of two scalar objects and
+   three tables.
+
+
+
+Pate, et al.                Standards Track                     [Page 5]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+2.2.1.  mfrBundleMaxNumBundles
+
+   This scalar is used to inform the manager of the maximum number of
+   bundles supported by this device.
+
+2.2.2.  mfrBundleNextIndex
+
+   This scalar is used to assist the manager in selecting a value for
+   mfrBundleIndex during row creation.  It can also be used to avoid
+   race conditions with multiple managers trying to create rows in the
+   table (see RFC 2494 [RFC2494] for one such algorithm).
+
+2.2.3.  mfrBundleTable
+
+   This table provides a means to configure and monitor bundles.  It is
+   indexed by mfrBundleIndex and contains these columns:
+
+      -  mfrBundleIndex                    Integer32
+      -  mfrBundleIfIndex                  InterfaceIndex
+      -  mfrBundleRowStatus                RowStatus
+      -  mfrBundleNearEndName              SnmpAdminString
+      -  mfrBundleFragmentation            INTEGER
+      -  mfrBundleMaxFragSize              Integer32
+      -  mfrBundleTimerHello               INTEGER
+      -  mfrBundleTimerAck                 INTEGER
+      -  mfrBundleCountMaxRetry            INTEGER
+      -  mfrBundleActivationClass          INTEGER
+      -  mfrBundleThreshold                Integer32
+      -  mfrBundleMaxDiffDelay             Integer32
+      -  mfrBundleSeqNumSize               INTEGER
+      -  mfrBundleLinksConfigured          Integer32
+      -  mfrBundleLinksActive              Integer32
+      -  mfrBundleBandwidth                Integer32
+      -  mfrBundleFarEndName               SnmpAdminString
+      -  mfrBundleResequencingErrors       Counter32
+
+2.2.4.  Bundle-to-ifIndex Mapping Table
+
+   This table provides a means to take an ifIndex and find the
+   corresponding mfrBundleIndex.  It is indexed by ifIndex and contains
+   these columns:
+
+      -  mfrBundleIfIndexMapping           Integer32
+
+2.2.5.  mfrBundleLinkTable
+
+   This table provides a means to configure and monitor bundle links.
+   It is indexed by ifIndex and contains these columns:
+
+
+
+Pate, et al.                Standards Track                     [Page 6]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+      -  mfrBundleLinkRowStatus             RowStatus
+      -  mfrBundleLinkConfigBundleIndex     Integer32
+      -  mfrBundleLinkNearEndName           SnmpAdminString
+      -  mfrBundleLinkState                 MfrBundleLinkState
+      -  mfrBundleLinkFarEndName            SnmpAdminString
+      -  mfrBundleLinkFarEndBundleName      SnmpAdminString
+      -  mfrBundleLinkDelay                 Integer32
+      -  mfrBundleLinkFramesControlTx       Counter32
+      -  mfrBundleLinkFramesControlRx       Counter32
+      -  mfrBundleLinkFramesControlInvalid  Counter32
+      -  mfrBundleLinkTimerExpiredCount     Counter32
+      -  mfrBundleLinkLoopbackSuspected     Counter32
+      -  mfrBundleLinkUnexpectedSequence    Counter32
+      -  mfrBundleLinkMismatch              Counter32
+
+2.3.  Relationship With Other MIBS and Tables
+
+2.3.1.  Relationship With Interface Table
+
+2.3.1.1.  Bundle Links
+
+   Each bundle link will appear as an interface in the ifTable.  The
+   ifIndex that appears in the ifTable is used for indexing the bundle
+   link tables in the UNI-NNI MFR MIB.
+
+2.3.1.2.  Bundles
+
+   Each bundle will appear as an interface in the ifTable.  There will
+   be corresponding mfrBundleIndex which may be different than the
+   ifIndex of the bundle.
+
+   The reason is best summarized in RFC 2494 [RFC2494], which describes
+   frame relay bundle of DS0.  It says:
+
+      This table is not indexed by ifIndex because the manager has to
+      choose the index in a createable row and the agent must be allowed
+      to select ifIndex values.
+
+   The rows in the ifEntry table are not createable as they do not have
+   row status.  RFC 2863 [RFC2863] suggests that the ifIndex should be
+   chosen by the agent.  Here is its statement regarding row creation
+   and deletion:
+
+      While some interfaces, for example, most physical interfaces,
+      cannot be created via network management, other interfaces such as
+      logical interfaces sometimes can be.  The ifTable contains only
+      generic information about an interface.  Almost all 'create-able'
+      interfaces have other, media-specific, information through which
+
+
+
+Pate, et al.                Standards Track                     [Page 7]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+      configuration parameters may be supplied prior to creating such an
+      interface.  Thus, the ifTable does not itself support the creation
+      or deletion of an interface (specifically, it has no RowStatus
+      column).  Rather, if a particular interface type supports the
+      dynamic creation and/or deletion of an interface of that type,
+      then that media-specific MIB should include an appropriate
+      RowStatus object (see the ATM LAN-Emulation Client MIB [ATMLANE]
+      for an example of a MIB which does this).  Typically, when such a
+      RowStatus object is created/deleted, then the conceptual row in
+      the ifTable appears/disappears as a by-product, and an ifIndex
+      value (chosen by the agent) is stored in an appropriate object in
+      the media-specific MIB.
+
+   The ATM LAN-Emulation Client MIB [ATMLANE] uses different indices and
+   so does the IMA MIB [ATMIMA].  Looking at the examples we have, and
+   the statements from RFC, it seems better to have two indices.  This
+   gives the SNMP agent implementor the freedom to manage their ifIndex
+   in the way they like.
+
+2.3.1.3.  Mapping Between ifIndex and mfrBundleIndex
+
+   The mfrBundleIfIndexMappingTable is indexed by ifIndex and provides
+   the means to map a given ifIndex into the corresponding
+   mfrBundleIndex.  The mfrBundleIfIndexMapping object in the
+   mfrBundleTable (indexed by mfrBundleIndex) provides the reverse
+   mapping of a mfrBundleIndex to the corresponding ifIndex in the
+   ifTable.
+
+2.3.1.4.  ifTable Objects
+
+   The bundle configuration and status table.  There is a one-to-one
+   correspondence between a bundle and an interface represented in the
+   ifTable.
+
+   The following objects of the ifTable have specific meaning for an MFR
+   bundle:
+
+      ifAdminStatus  -  the bundle admin status
+      ifOperStatus   -  the bundle operational status
+      ifSpeed        -  the current bandwidth of the bundle
+      ifInUcastPkts  -  the number of frames received on the bundle
+      ifOutUcastPkts -  the number of frames transmitted on the bundle
+      ifInErrors     -  frame (not fragment) errors
+      ifOutErrors    -  frame (not fragment) errors
+
+   The following objects of the ifTable have specific meaning for an MFR
+   bundle link:
+
+
+
+
+Pate, et al.                Standards Track                     [Page 8]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+      ifAdminStatus  -  the bundle link admin status
+      ifOperStatus   -  the bundle link operational status
+      ifSpeed        -  the bandwidth of the bundle link interface
+      ifInUcastPkts  -  the number of frames received on the bundle link
+      ifOutUcastPkts -  the number of frames transmitted on the bundle
+                        link
+      ifInErrors     -  frame and fragment errors
+      ifOutErrors    -  frame and fragment errors
+
+2.3.2.  Relationship With Interface Stack Table
+
+   The bundles and bundle links will appear in the ifStackTable defined
+   in RFC 2863 [RFC2863].  Each bundle link will appear a lower layer to
+   its owner bundle.  The bundle will appear as a higher layer to the
+   bundle links and as a lower layer to a frame relay service or UNI.
+
+2.3.3.  Relationship With Frame Relay DTE MIB
+
+   The bundle will have a one-to-one correspondence with a DLCMI or UNI
+   that appear in the DTE MIB tables [RFC2115].
+
+2.3.4.  Relationship With Frame Relay Service MIB
+
+   There is a one-to-one relationship between the MFR bundle and the
+   frame relay service logical port defined in RFC1604 [RFC1604].
+
+2.3.5.  Example
+
+   Figure two shows an example of how the various tables are related.
+   This example shows two bundles composed of 2 T1s each.  The bundles
+   have a mfrBundleIndex of 10 and 20 respectively.
+
+                     +-------------------------+
+                     |   Frame Relay Service   |
+                     +-----+-------------+-----+
+                           |             |
+                     +-----+------+------+-----+
+                     | MFR Bundle | MFR Bundle |
+                     |    10      |     20     |
+                     +--+-----+---+---+-----+--+
+                        |     |       |     |
+                      +-+-+ +-+-+   +-+-+ +-+-+
+                      |T1 | |T1 |   |T1 | |T1 |
+                      +---+ +---+   +-+-+ +---+
+
+          Figure 2: Frame Relay Service Being Carried on 4 T1s
+
+
+
+
+
+Pate, et al.                Standards Track                     [Page 9]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+   The assignment of the ifTable index values could for example be:
+
+      ifIndex |  Description               | ifType
+      --------+----------------------------+----------------------
+         1    |  FrameRelayService         | frameRelayService(44)
+         2    |  MFR Bundle #10            | frf16MfrBundle(163)
+         3    |  MFR Bundle #20            | frf16MfrBundle(163)
+         4    |  ds1 #1/MFR Bundle Link #1 | ds1(18)
+         5    |  ds1 #2/MFR Bundle Link #2 | ds1(18)
+         6    |  ds1 #3/MFR Bundle Link #3 | ds1(18)
+         7    |  ds1 #4/MFR Bundle Link #4 | ds1(18)
+
+   The ifStackTable is then used to show the relationships between the
+   various interfaces.
+
+      HigherLayer | LowerLayer
+      ------------+-----------
+          0       |     1
+          1       |     2
+          1       |     3
+          2       |     4
+          2       |     5
+          3       |     6
+          3       |     7
+          4       |     0
+          5       |     0
+          6       |     0
+          7       |     0
+
+   The mfrBundleIfIndexMappingTable shows the relationship between the
+   ifTable ifIndex and the mfrBundleIndex:
+
+      ifIndex | mfrBundleIfIndexMappingIndex
+      --------+-----------------------------
+         2    |            10
+         3    |            20
+
+   The mfrBundleTable shows the relationship between the mfrBundleIndex
+   and the ifIndex:
+
+      mfrBundleIndex | mfrBundleIfIndex
+      ---------------+-----------------
+              10     |      2
+              20     |      3
+
+
+
+
+
+
+
+Pate, et al.                Standards Track                    [Page 10]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+   The mfrBundleLinkTable shows the relationship between the bundles and
+   bundle links:
+
+      mfrBundleIndex | mfrBundleLinkIfIndex
+      ---------------+---------------------
+             10      |        4
+             10      |        5
+             20      |        6
+             20      |        7
+
+2.4.  Creation Of Bundles and Bundle Links
+
+2.4.1.  Creation Of Bundles
+
+   A new bundle is created by setting a createAndGo(4) value in the
+   mfrBundleRowStatus RowStatus object.  Optionally, an agent could also
+   support setting a value of createAndWait(5) followed by a set to the
+   value active(1).
+
+   When a bundle is created, the agent must create a new interface in
+   the ifTable.  The ifIndex for this new interface is used for the
+   value of mfrBundleIfIndex.
+
+2.4.2.  Creation Of Bundle Links
+
+   A new bundle link is created by setting a createAndGo(4) value in the
+   mfrBundleLinkRowStatus RowStatus object.
+
+   The bundle link is associated with a specific physical interface and
+   uses the ifIndex of the physical interface.  The mfrBundleLinkEntry
+   row objects may be created after or during creation of the physical
+   interface's ifEntry row objects.
+
+   The bundle identified in the object mfrBundleIndex must exist at time
+   of bundle link creation.
+
+2.5.  Notifications
+
+   The linkUp and linkDown traps are defined in RFC 2223 [RFC2223].
+
+2.5.1.  Bundle
+
+   The following SNMP traps are defined for MFR bundles.
+
+
+
+
+
+
+
+
+Pate, et al.                Standards Track                    [Page 11]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+2.5.1.1.  linkUp
+
+   This trap is sent when the ifOperStatus of a bundle transitions from
+   down to up.  This occurs when a sufficient number of links
+   (determined by mfrBundleActivationClass and mfrBundleThreshold) are
+   in the operationally up state.
+
+2.5.1.2.  linkDown
+
+   This trap is sent when the ifOperStatus of a bundle transitions from
+   up to down.  This occurs when a insufficient number of links
+   (determined by mfrBundleActivationClass and mfrBundleThreshold) are
+   in the operationally up state.
+
+2.5.2.  Bundle Link
+
+   The following SNMP traps are defined for MFR bundle links.
+
+2.5.2.1.  linkUp
+
+   This trap is sent when a mfrBundleLinkState object transitions to the
+   value mfrBundleLinkStateUp.
+
+2.5.2.2.  linkDown
+
+   This trap is sent when a mfrBundleLinkState object transitions from
+   the value mfrBundleLinkStateUp.
+
+2.5.2.3.  mfrMibTrapBundleLinkMismatch
+
+   This trap indicates that a bundle link mismatch has been detected.
+   The following objects are reported:
+
+   -  mfrBundleNearEndName:          configured name of near end bundle
+   -  mfrBundleFarEndName:           previously reported name of far
+                                     end bundle
+   -  mfrBundleLinkNearEndName:      configured name of near end bundle
+   -  mfrBundleLinkFarEndName:       reported name of far end bundle
+   -  mfrBundleLinkFarEndBundleName: currently reported name of far
+                                     end bundle
+
+   Note that the configured items may have been configured
+   automatically.  Note also that the mfrBundleLinkMismatch counter is
+   incremented when the trap is sent.
+
+
+
+
+
+
+
+Pate, et al.                Standards Track                    [Page 12]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+3.  Object Definitions
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  Objects in the MIB are
+   defined using the subset of Abstract Syntax Notation One (ASN.1)
+   defined in the SMI.  In particular, each object type is named by an
+   OBJECT IDENTIFIER, an administratively assigned name.  The object
+   type together with an object instance serves to uniquely identify a
+   specific instantiation of the object.  For human convenience, we
+   often use a textual string, termed the descriptor, to refer to the
+   object type.
+
+FR-MFR-MIB DEFINITIONS ::= BEGIN
+
+   IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE, Integer32, Counter32,
+         NOTIFICATION-TYPE, transmission
+         FROM SNMPv2-SMI
+      TEXTUAL-CONVENTION, TestAndIncr, RowStatus
+         FROM SNMPv2-TC
+      MODULE-COMPLIANCE, OBJECT-GROUP, NOTIFICATION-GROUP
+         FROM SNMPv2-CONF
+      SnmpAdminString
+         FROM SNMP-FRAMEWORK-MIB
+      InterfaceIndex, ifIndex
+         FROM IF-MIB;
+
+   mfrMib MODULE-IDENTITY
+      LAST-UPDATED "200011300000Z"
+      ORGANIZATION "IETF Frame Relay Service MIB (frnetmib)
+                    Working Group"
+      CONTACT-INFO
+        "WG Charter:
+             http://www.ietf.org/html.charters/frnetmib-charter.html
+         WG-email:      frnetmib@sunroof.eng.sun.com
+         Subscribe:     frnetmib-request@sunroof.eng.sun.com
+         Email Archive: ftp://ftp.ietf.org/ietf-mail-archive/frnetmib
+
+         Chair:      Andy Malis
+                     Vivace Networks
+         Email:      Andy.Malis@vivacenetworks.com
+
+         WG editor:  Prayson Pate
+                     Overture Networks
+         Email:      prayson.pate@overturenetworks.com
+
+         Co-author:  Bob Lynch
+                     Overture Networks
+
+
+
+Pate, et al.                Standards Track                    [Page 13]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+         EMail:      bob.lynch@overturenetworks.com
+
+         Co-author:  Kenneth Rehbehn
+                     Megisto Systems, Inc.
+         EMail:      krehbehn@megisto.com"
+
+      DESCRIPTION
+         "This is the MIB used to control and monitor the multilink
+          frame relay (MFR) function described in FRF.16."
+
+   -- ---------------------------------------------------------
+   -- ---------------------------------------------------------
+   -- Revision History
+   -- ---------------------------------------------------------
+   -- ---------------------------------------------------------
+
+      REVISION "200011300000Z"
+      DESCRIPTION
+          "Published as RFC 3020."
+
+      ::= { transmission 47 }
+
+   -- ---------------------------------------------------------
+   -- ---------------------------------------------------------
+   -- Textual Conventions
+   -- ---------------------------------------------------------
+   -- ---------------------------------------------------------
+
+   MfrBundleLinkState ::= TEXTUAL-CONVENTION
+      STATUS      current
+      DESCRIPTION
+         "The possible states for a bundle link, as defined in
+          Annex A of FRF.16."
+      REFERENCE "FRF.16 Annex A"
+      SYNTAX  INTEGER {
+         mfrBundleLinkStateAddSent       (1),
+         mfrBundleLinkStateAddRx         (2),
+         mfrBundleLinkStateAddAckRx      (3),
+         mfrBundleLinkStateUp            (4),
+         mfrBundleLinkStateIdlePending   (5),
+         mfrBundleLinkStateIdle          (6),
+         mfrBundleLinkStateDown          (7),
+         mfrBundleLinkStateDownIdle      (8)
+         }
+
+   -- ---------------------------------------------------------
+   -- ---------------------------------------------------------
+   -- Object Identifiers
+
+
+
+Pate, et al.                Standards Track                    [Page 14]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+   -- ---------------------------------------------------------
+   -- ---------------------------------------------------------
+
+   mfrMibScalarObjects     OBJECT IDENTIFIER ::= { mfrMib 1 }
+   mfrMibBundleObjects     OBJECT IDENTIFIER ::= { mfrMib 2 }
+   mfrMibBundleLinkObjects OBJECT IDENTIFIER ::= { mfrMib 3 }
+   mfrMibTraps             OBJECT IDENTIFIER ::= { mfrMib 4 }
+   mfrMibConformance       OBJECT IDENTIFIER ::= { mfrMib 5 }
+
+   mfrMibTrapsPrefix       OBJECT IDENTIFIER ::= { mfrMibTraps 0 }
+
+   mfrMibGroups      OBJECT IDENTIFIER ::= { mfrMibConformance 1 }
+   mfrMibCompliances OBJECT IDENTIFIER ::= { mfrMibConformance 2 }
+
+   -- ---------------------------------------------------------
+   -- ---------------------------------------------------------
+   -- Scalars
+   -- ---------------------------------------------------------
+   -- ---------------------------------------------------------
+
+   mfrBundleMaxNumBundles OBJECT-TYPE
+      SYNTAX  Integer32
+      MAX-ACCESS read-only
+      STATUS  current
+      DESCRIPTION
+         "This object is used to inform the manager of the
+          maximum number of bundles supported by this device."
+      ::= { mfrMibScalarObjects 1 }
+
+   mfrBundleNextIndex OBJECT-TYPE
+      SYNTAX  TestAndIncr
+      MAX-ACCESS read-write
+      STATUS  current
+      DESCRIPTION
+         "This object is used to assist the manager in
+          selecting a value for mfrBundleIndex during row creation
+          in the mfrBundleTable.  It can also be used to avoid race
+          conditions with multiple managers trying to create
+          rows in the table (see RFC 2494 [RFC2494] for one such
+          alogrithm)."
+      REFERENCE "RFC 2494"
+      ::= { mfrMibScalarObjects 2 }
+
+   -- ---------------------------------------------------------
+   -- ---------------------------------------------------------
+   -- Bundle Table
+   -- ---------------------------------------------------------
+   -- ---------------------------------------------------------
+
+
+
+Pate, et al.                Standards Track                    [Page 15]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+   mfrBundleTable OBJECT-TYPE
+      SYNTAX  SEQUENCE OF MfrBundleEntry
+      MAX-ACCESS  not-accessible
+      STATUS  current
+      DESCRIPTION
+         "The bundle configuration and status table.  There
+          is a one-to-one correspondence between a bundle
+          and an interface represented in the ifTable.
+
+          The following objects of the ifTable have specific
+          meaning for an MFR bundle:
+             ifAdminStatus  - the bundle admin status
+             ifOperStatus   - the bundle operational status
+             ifSpeed        - the current bandwidth of the bundle
+             ifInUcastPkts  - the number of frames received
+                              on the bundle
+             ifOutUcastPkts - the number of frames transmitted
+                              on the bundle
+             ifInErrors     - frame (not fragment) errors
+             ifOutErrors    - frame (not fragment) errors
+             "
+      ::= { mfrMibBundleObjects 3 }
+
+   mfrBundleEntry OBJECT-TYPE
+      SYNTAX  MfrBundleEntry
+      MAX-ACCESS  not-accessible
+      STATUS  current
+      DESCRIPTION
+         "An entry in the bundle table."
+      INDEX   { mfrBundleIndex }
+      ::= { mfrBundleTable 1 }
+
+   MfrBundleEntry ::=
+      SEQUENCE {
+         mfrBundleIndex
+            Integer32,
+         mfrBundleIfIndex
+            InterfaceIndex,
+         mfrBundleRowStatus
+            RowStatus,
+         mfrBundleNearEndName
+            SnmpAdminString,
+         mfrBundleFragmentation
+            INTEGER,
+         mfrBundleMaxFragSize
+            Integer32,
+         mfrBundleTimerHello
+            INTEGER,
+
+
+
+Pate, et al.                Standards Track                    [Page 16]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+         mfrBundleTimerAck
+            INTEGER,
+         mfrBundleCountMaxRetry
+            INTEGER,
+         mfrBundleActivationClass
+            INTEGER,
+         mfrBundleThreshold
+            Integer32,
+         mfrBundleMaxDiffDelay
+            Integer32,
+         mfrBundleSeqNumSize
+            INTEGER,
+         mfrBundleMaxBundleLinks
+            Integer32,
+         mfrBundleLinksConfigured
+            Integer32,
+         mfrBundleLinksActive
+            Integer32,
+         mfrBundleBandwidth
+            Integer32,
+         mfrBundleFarEndName
+            SnmpAdminString,
+         mfrBundleResequencingErrors
+            Counter32
+         }
+
+   mfrBundleIndex OBJECT-TYPE
+      SYNTAX  Integer32 (1..2147483647)
+      MAX-ACCESS  not-accessible
+      STATUS  current
+      DESCRIPTION
+         "The index into the table.  While this corresponds
+          to an entry in the ifTable, the value of mfrBundleIndex
+          need not match that of the ifIndex in the ifTable.
+          A manager can use mfrBundleNextIndex to select a unique
+          mfrBundleIndex for creating a new row."
+      ::= { mfrBundleEntry 1 }
+
+   mfrBundleIfIndex OBJECT-TYPE
+      SYNTAX  InterfaceIndex
+      MAX-ACCESS  read-only
+      STATUS  current
+      DESCRIPTION
+         "The value must match an entry in the interface
+          table whose ifType must be set to frf16MfrBundle(163).
+
+          For example: if the value of mfrBundleIfIndex is 10,
+          then a corresponding entry should be present in
+
+
+
+Pate, et al.                Standards Track                    [Page 17]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+          the ifTable with an index of 10 and an ifType of 163."
+      ::= { mfrBundleEntry 2 }
+
+   mfrBundleRowStatus OBJECT-TYPE
+      SYNTAX  RowStatus
+      MAX-ACCESS  read-create
+      STATUS  current
+      DESCRIPTION
+          "The mfrBundleRowStatus object allows create, change,
+           and delete operations on bundle entries."
+      REFERENCE "RFC 1903"
+      ::= { mfrBundleEntry 3 }
+
+   mfrBundleNearEndName OBJECT-TYPE
+      SYNTAX  SnmpAdminString
+      MAX-ACCESS  read-create
+      STATUS  current
+      DESCRIPTION
+         "The configured name of the bundle."
+      REFERENCE "FRF.16 section 3.4.1"
+      ::= { mfrBundleEntry 4 }
+
+   mfrBundleFragmentation OBJECT-TYPE
+      SYNTAX  INTEGER {
+         enable  (1),
+         disable (2)
+         }
+      MAX-ACCESS  read-create
+      STATUS  current
+      DESCRIPTION
+         "Controls whether the bundle performs/accepts
+          fragmentation and re-assembly.  The possible
+          values are:
+
+          enable(1) - Bundle links will fragment frames
+
+          disable(2) - Bundle links will not fragment
+                      frames."
+      DEFVAL { disable }
+      ::= { mfrBundleEntry 5 }
+
+   mfrBundleMaxFragSize OBJECT-TYPE
+      SYNTAX  Integer32 (-1..8184)
+      UNITS "Octets"
+      MAX-ACCESS  read-create
+      STATUS  current
+      DESCRIPTION
+         "The maximum fragment size supported.  Note that this
+
+
+
+Pate, et al.                Standards Track                    [Page 18]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+          is only valid if mfrBundleFragmentation is set to enable(1).
+
+          Zero is not a valid fragment size.
+
+          A bundle that does not support fragmentation must return
+          this object with a value of -1."
+      DEFVAL { -1 }
+      ::= { mfrBundleEntry 6 }
+
+   mfrBundleTimerHello OBJECT-TYPE
+      SYNTAX  INTEGER (1..180)
+      UNITS "Seconds"
+      MAX-ACCESS  read-create
+      STATUS  current
+      DESCRIPTION
+         "The configured MFR Hello Timer value."
+      REFERENCE "FRF.16 section 4.3.8.1"
+      DEFVAL { 10 }
+      ::= { mfrBundleEntry 7 }
+
+   mfrBundleTimerAck OBJECT-TYPE
+      SYNTAX  INTEGER (1..10)
+      UNITS "Seconds"
+      MAX-ACCESS  read-create
+      STATUS  current
+      DESCRIPTION
+         "The configured MFR T_ACK value."
+      REFERENCE "FRF.16 section 4.3.8.2"
+      DEFVAL { 4 }
+      ::= { mfrBundleEntry 8 }
+
+   mfrBundleCountMaxRetry OBJECT-TYPE
+      SYNTAX  INTEGER (1..5)
+      MAX-ACCESS  read-create
+      STATUS  current
+      DESCRIPTION
+         "The MFR N_MAX_RETRY value."
+      REFERENCE "FRF.16 section 4.3.8.3"
+      DEFVAL { 2 }
+      ::= { mfrBundleEntry 9 }
+
+   mfrBundleActivationClass OBJECT-TYPE
+      SYNTAX  INTEGER {
+         mfrBundleActivationClassA (1),
+         mfrBundleActivationClassB (2),
+         mfrBundleActivationClassC (3),
+         mfrBundleActivationClassD (4)
+         }
+
+
+
+Pate, et al.                Standards Track                    [Page 19]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+      MAX-ACCESS  read-create
+      STATUS  current
+      DESCRIPTION
+         "Controls the conditions under which the bundle is activated.
+          The following settings are available:
+
+             mfrBundleActivationClassA(1) - at least one must link up
+             mfrBundleActivationClassB(2) - all links must be up
+             mfrBundleActivationClassC(3) - a certain number must be
+                                            up.  Refer to
+                                            mfrBundleThreshold for
+                                            the required number.
+             mfrBundleActivationClassD(4) - custom (implementation
+                                            specific)."
+      REFERENCE "FRF.16 section 4.2.2.1"
+      DEFVAL { mfrBundleActivationClassA }
+      ::= { mfrBundleEntry 10 }
+
+   mfrBundleThreshold OBJECT-TYPE
+      SYNTAX  Integer32 (-1..2147483647)
+      UNITS "Bundle Links"
+      MAX-ACCESS  read-create
+      STATUS  current
+      DESCRIPTION
+         "Specifies the number of links that must be in operational
+          'up' state before the bundle will transition to an
+          operational up/active state.  If the number of
+          operational 'up' links falls below this value,
+          then the bundle will transition to an inactive
+          state.
+
+          Note - this is only valid when mfrBundleActivationClass
+          is set to mfrBundleActivationClassC or, depending upon the
+          implementation, to mfrBundleActivationClassD.  A bundle that
+          is not set to one of these must return this object with a
+          value of -1."
+      REFERENCE "FRF.16 section 4.2.2.1"
+      DEFVAL { -1 }
+      ::= { mfrBundleEntry 11 }
+
+   mfrBundleMaxDiffDelay OBJECT-TYPE
+      SYNTAX  Integer32 (-1..2147483647)
+      UNITS "Milliseconds"
+      MAX-ACCESS  read-create
+      STATUS  current
+      DESCRIPTION
+         "The maximum delay difference between the bundle
+          links.
+
+
+
+Pate, et al.                Standards Track                    [Page 20]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+          A value of -1 indicates that this object does not contain
+          a valid value"
+      DEFVAL { -1 }
+      ::= { mfrBundleEntry 12 }
+
+   mfrBundleSeqNumSize OBJECT-TYPE
+      SYNTAX  INTEGER {
+          seqNumSize12bit (1),
+          seqNumSize24bit (2)
+          }
+      MAX-ACCESS  read-create
+      STATUS  current
+      DESCRIPTION
+         "Controls whether the standard FRF.12 12-bit
+          sequence number is used or the optional 24-bit
+          sequence number."
+      REFERENCE "FRFTC/99-194"
+      DEFVAL { seqNumSize12bit }
+      ::= { mfrBundleEntry 13 }
+
+   mfrBundleMaxBundleLinks OBJECT-TYPE
+      SYNTAX  Integer32 (1..2147483647)
+      UNITS "Bundle Links"
+      MAX-ACCESS  read-only
+      STATUS  current
+      DESCRIPTION
+         "The maximum number of bundle links supported for
+          this bundle."
+      ::= { mfrBundleEntry 14 }
+
+   mfrBundleLinksConfigured OBJECT-TYPE
+      SYNTAX  Integer32 (1..2147483647)
+      UNITS "Bundle Links"
+      MAX-ACCESS  read-only
+      STATUS  current
+      DESCRIPTION
+         "The number of links configured for the bundle."
+      ::= {  mfrBundleEntry 15 }
+
+   mfrBundleLinksActive OBJECT-TYPE
+      SYNTAX  Integer32 (-1..2147483647)
+      UNITS "Bundle Links"
+      MAX-ACCESS  read-only
+      STATUS  current
+      DESCRIPTION
+         "The number of links that are active."
+      ::= {  mfrBundleEntry 16 }
+
+
+
+
+Pate, et al.                Standards Track                    [Page 21]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+   mfrBundleBandwidth OBJECT-TYPE
+       SYNTAX  Integer32
+       UNITS "Bits/Sec"
+       MAX-ACCESS  read-only
+       STATUS  current
+       DESCRIPTION
+          "The amount of available bandwidth on the bundle"
+       ::= {  mfrBundleEntry 17 }
+
+   mfrBundleFarEndName OBJECT-TYPE
+      SYNTAX  SnmpAdminString
+      MAX-ACCESS  read-only
+      STATUS  current
+      DESCRIPTION
+         "Name of the bundle received from the far end."
+      REFERENCE "FRF.16 section 3.4.1"
+      ::= { mfrBundleEntry 18 }
+
+   mfrBundleResequencingErrors OBJECT-TYPE
+      SYNTAX  Counter32
+      UNITS "Error Events"
+      MAX-ACCESS  read-only
+      STATUS  current
+      DESCRIPTION
+         "A count of the number of resequencing errors.  Each event
+          may correspond to multiple lost frames.  Example:
+          Say sequence number 56, 59 and 60 is received for DLCI 100.
+          It is decided by some means that sequence 57 and 58 is lost.
+          This counter should then be incremented by ONE, even though
+          two frames were lost."
+      ::= { mfrBundleEntry 19 }
+
+   -- ---------------------------------------------------------
+   -- ---------------------------------------------------------
+   -- ifIndex Mapping to Bundle Index Table
+   -- ---------------------------------------------------------
+   -- ---------------------------------------------------------
+
+   mfrBundleIfIndexMappingTable OBJECT-TYPE
+      SYNTAX  SEQUENCE OF MfrBundleIfIndexMappingEntry
+      MAX-ACCESS  not-accessible
+      STATUS  current
+      DESCRIPTION
+          "A table mapping the values of ifIndex to the
+           mfrBundleIndex.  This is required in order to find
+           the mfrBundleIndex given an ifIndex.  The mapping of
+           mfrBundleIndex to ifIndex is provided by the
+           mfrBundleIfIndex entry in the mfrBundleTable."
+
+
+
+Pate, et al.                Standards Track                    [Page 22]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+      ::= { mfrMibBundleObjects 4 }
+
+   mfrBundleIfIndexMappingEntry OBJECT-TYPE
+      SYNTAX  MfrBundleIfIndexMappingEntry
+      MAX-ACCESS  not-accessible
+      STATUS  current
+      DESCRIPTION
+           "Each row describes one ifIndex to mfrBundleIndex mapping."
+    INDEX   { ifIndex }
+    ::= { mfrBundleIfIndexMappingTable 1 }
+
+   MfrBundleIfIndexMappingEntry ::=
+      SEQUENCE {
+        mfrBundleIfIndexMappingIndex
+           Integer32
+        }
+
+   mfrBundleIfIndexMappingIndex OBJECT-TYPE
+      SYNTAX  Integer32 (1..2147483647)
+      MAX-ACCESS  read-only
+      STATUS  current
+      DESCRIPTION
+           "The mfrBundleIndex of the given ifIndex."
+    ::= { mfrBundleIfIndexMappingEntry 2 }
+
+   -- ---------------------------------------------------------
+   -- ---------------------------------------------------------
+   -- Bundle Link Table
+   -- ---------------------------------------------------------
+   -- ---------------------------------------------------------
+
+   mfrBundleLinkTable OBJECT-TYPE
+      SYNTAX  SEQUENCE OF MfrBundleLinkEntry
+      MAX-ACCESS  not-accessible
+      STATUS  current
+      DESCRIPTION
+         "The bundle link configuration and status table.  There
+          is a one-to-one correspondence between a bundle link
+          and a physical interface represented in the ifTable.  The
+          ifIndex of the physical interface is used to index the
+          bundle link table, and to create rows.
+
+          The following objects of the ifTable have specific
+          meaning for an MFR bundle link:
+
+             ifAdminStatus  - the bundle link admin status
+             ifOperStatus   - the bundle link operational
+                              status
+
+
+
+Pate, et al.                Standards Track                    [Page 23]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+             ifSpeed        - the bandwidth of the bundle
+                              link interface
+             ifInUcastPkts  - the number of frames received
+                              on the bundle link
+             ifOutUcastPkts - the number of frames transmitted
+                              on the bundle link
+             ifInErrors     - frame and fragment errors
+             ifOutErrors    - frame and fragment errors"
+      ::= { mfrMibBundleLinkObjects 1 }
+
+   mfrBundleLinkEntry OBJECT-TYPE
+      SYNTAX  MfrBundleLinkEntry
+      MAX-ACCESS  not-accessible
+      STATUS  current
+      DESCRIPTION
+         "An entry in the bundle link table."
+      INDEX   { ifIndex }
+      ::= { mfrBundleLinkTable 1 }
+
+   MfrBundleLinkEntry ::=
+      SEQUENCE {
+         mfrBundleLinkRowStatus
+            RowStatus,
+         mfrBundleLinkConfigBundleIndex
+            Integer32,
+         mfrBundleLinkNearEndName
+            SnmpAdminString,
+         mfrBundleLinkState
+            MfrBundleLinkState,
+         mfrBundleLinkFarEndName
+            SnmpAdminString,
+         mfrBundleLinkFarEndBundleName
+            SnmpAdminString,
+         mfrBundleLinkDelay
+            Integer32,
+         mfrBundleLinkFramesControlTx
+            Counter32,
+         mfrBundleLinkFramesControlRx
+            Counter32,
+         mfrBundleLinkFramesControlInvalid
+            Counter32,
+         mfrBundleLinkTimerExpiredCount
+            Counter32,
+         mfrBundleLinkLoopbackSuspected
+            Counter32,
+         mfrBundleLinkUnexpectedSequence
+            Counter32,
+         mfrBundleLinkMismatch
+
+
+
+Pate, et al.                Standards Track                    [Page 24]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+            Counter32
+         }
+
+   mfrBundleLinkRowStatus OBJECT-TYPE
+      SYNTAX  RowStatus
+      MAX-ACCESS  read-create
+      STATUS  current
+      DESCRIPTION
+         "The mfrBundleLinkRowStatus object allows create, change,
+          and delete operations on mfrBundleLink entries.
+
+          The create operation must fail if no physical interface
+          is associated with the bundle link."
+      ::= { mfrBundleLinkEntry 1 }
+
+   mfrBundleLinkConfigBundleIndex OBJECT-TYPE
+      SYNTAX  Integer32 (1..2147483647)
+      MAX-ACCESS  read-create
+      STATUS  current
+      DESCRIPTION
+         "The mfrBundleLinkConfigBundleIndex object allows
+          the manager to control the bundle to which the bundle
+          link is assigned.  If no value were in this field, then
+          the bundle would remain in NOT_READY rowStatus and be
+          unable to go to active.  With an appropriate mfrBundleIndex
+          in this field, then we could put the mfrBundleLink row in
+          NOT_IN_SERVICE or ACTIVE rowStatus."
+      ::= { mfrBundleLinkEntry 2 }
+
+   mfrBundleLinkNearEndName OBJECT-TYPE
+      SYNTAX  SnmpAdminString
+      MAX-ACCESS  read-create
+      STATUS  current
+      DESCRIPTION
+         "The configured bundle link name that is sent to the far end."
+      ::= { mfrBundleLinkEntry 3 }
+
+   mfrBundleLinkState OBJECT-TYPE
+      SYNTAX  MfrBundleLinkState
+      MAX-ACCESS  read-only
+      STATUS  current
+      DESCRIPTION
+         "Current bundle link state as defined by the MFR protocol
+          described in Annex A of FRF.16."
+      REFERENCE "FRF.16 Annex A"
+      ::= { mfrBundleLinkEntry 4 }
+
+   mfrBundleLinkFarEndName OBJECT-TYPE
+
+
+
+Pate, et al.                Standards Track                    [Page 25]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+      SYNTAX  SnmpAdminString
+      MAX-ACCESS  read-only
+      STATUS  current
+      DESCRIPTION
+         "Name of bundle link received from far end."
+      REFERENCE "FRF.16 section 3.4.2"
+      ::= { mfrBundleLinkEntry 5 }
+
+   mfrBundleLinkFarEndBundleName OBJECT-TYPE
+      SYNTAX  SnmpAdminString
+      MAX-ACCESS  read-only
+      STATUS  current
+      DESCRIPTION
+         "Name of far end bundle for this link received from far end."
+      REFERENCE "FRF.16 section 3.4.1"
+      ::= { mfrBundleLinkEntry 6 }
+
+   mfrBundleLinkDelay OBJECT-TYPE
+      SYNTAX  Integer32 (-1..2147483647)
+      UNITS "Milliseconds"
+      MAX-ACCESS  read-only
+      STATUS  current
+      DESCRIPTION
+         "Current round-trip delay for this bundle link.  The
+          value -1 is returned when an implementation does not
+          support measurement of the bundle link delay."
+      REFERENCE "FRF.16 section 3.4.4"
+      ::= { mfrBundleLinkEntry 7 }
+
+   mfrBundleLinkFramesControlTx OBJECT-TYPE
+      SYNTAX  Counter32
+      UNITS "Frames"
+      MAX-ACCESS  read-only
+      STATUS  current
+      DESCRIPTION
+         "Number of MFR control frames sent."
+      REFERENCE "FRF.16 section 3.2"
+      ::= { mfrBundleLinkEntry 8 }
+
+   mfrBundleLinkFramesControlRx OBJECT-TYPE
+      SYNTAX  Counter32
+      UNITS "Frames"
+      MAX-ACCESS  read-only
+      STATUS  current
+      DESCRIPTION
+         "Number of valid MFR control frames received."
+      REFERENCE "FRF.16 section 3.2"
+      ::= { mfrBundleLinkEntry 9 }
+
+
+
+Pate, et al.                Standards Track                    [Page 26]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+   mfrBundleLinkFramesControlInvalid OBJECT-TYPE
+      SYNTAX  Counter32
+      UNITS "Frames"
+      MAX-ACCESS  read-only
+      STATUS  current
+      DESCRIPTION
+         "The number of invalid MFR control frames received."
+      REFERENCE "FRF.16 section 3.2"
+      ::= { mfrBundleLinkEntry 10 }
+
+   mfrBundleLinkTimerExpiredCount OBJECT-TYPE
+      SYNTAX  Counter32
+      UNITS "Timer Expiration Events"
+      MAX-ACCESS  read-only
+      STATUS  current
+      DESCRIPTION
+         "Number of times the T_HELLO or T_ACK timers expired."
+      REFERENCE "FRF.16 section 4.3.8.1 and 4.3.8.2"
+      ::= { mfrBundleLinkEntry 11 }
+
+   mfrBundleLinkLoopbackSuspected OBJECT-TYPE
+      SYNTAX  Counter32
+      UNITS "Loopback Suspected Events"
+      MAX-ACCESS  read-only
+      STATUS  current
+      DESCRIPTION
+         "The number of times a loopback has been suspected
+          (based upon the use of magic numbers)."
+      REFERENCE "FRF.16 section 4.3.7"
+      ::= { mfrBundleLinkEntry 12 }
+
+   mfrBundleLinkUnexpectedSequence OBJECT-TYPE
+      SYNTAX  Counter32
+      UNITS "Frames"
+      MAX-ACCESS  read-only
+      STATUS  current
+      DESCRIPTION
+         "The number of data MFR frames discarded because the sequence
+          number of the frame for a DLCI was less than (delayed frame)
+          or equal to (duplicate frame) the one expected for that DLCI.
+
+          Example:
+          Say frames with sequence numbers 56, 58, 59 is received for
+          DLCI 100.  While waiting for sequence number 57 another frame
+          with sequence number 58 arrives.  Frame 58 is discarded and
+          the counter is incremented."
+      REFERENCE "FRF.16 section 4.2.3.2"
+      ::= { mfrBundleLinkEntry 13 }
+
+
+
+Pate, et al.                Standards Track                    [Page 27]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+   mfrBundleLinkMismatch OBJECT-TYPE
+      SYNTAX  Counter32
+      UNITS "Bundle Name Mismatch Events"
+      MAX-ACCESS  read-only
+      STATUS  current
+      DESCRIPTION
+         "The number of times that the unit has been notified by the
+          remote peer that the bundle name is inconsistent with other
+          bundle links attached to the far-end bundle."
+      REFERENCE "FRF.16 section 4.3.2.4"
+      ::= { mfrBundleLinkEntry 14 }
+
+   -- ---------------------------------------------------------
+   -- ---------------------------------------------------------
+   -- Notifications/Traps
+   -- ---------------------------------------------------------
+   -- ---------------------------------------------------------
+
+   mfrMibTrapBundleLinkMismatch NOTIFICATION-TYPE
+      OBJECTS {
+         mfrBundleNearEndName,
+         mfrBundleFarEndName,
+         mfrBundleLinkNearEndName,
+         mfrBundleLinkFarEndName,
+         mfrBundleLinkFarEndBundleName
+         }
+      STATUS  current
+      DESCRIPTION
+         "This trap indicates that a bundle link mismatch has
+          been detected.  The following objects are reported:
+
+          mfrBundleNearEndName:    configured name of near end bundle
+
+          mfrBundleFarEndName:     previously reported name of
+                                far end bundle
+
+          mfrBundleLinkNearEndName: configured name of near end bundle
+
+          mfrBundleLinkFarEndName: reported name of far end bundle
+
+          mfrBundleLinkFarEndBundleName: currently reported name of
+                                far end bundle
+
+          Note: that the configured items may have been configured
+                automatically.
+
+          Note: The mfrBundleLinkMismatch counter is incremented when
+                the trap is sent."
+
+
+
+Pate, et al.                Standards Track                    [Page 28]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+      REFERENCE "FRF.16 section 4.3.2.4"
+       ::= { mfrMibTrapsPrefix 1 }
+
+   -- ---------------------------------------------------------
+   -- ---------------------------------------------------------
+   -- Conformance/Compliance
+   -- ---------------------------------------------------------
+   -- ---------------------------------------------------------
+
+   mfrMibCompliance MODULE-COMPLIANCE
+      STATUS      current
+      DESCRIPTION
+         "The compliance statement for equipment that implements
+          the FRF16 MIB.  All of the current groups are mandatory,
+          but a number of objects may be read-only if the
+          implementation does not allow configuration."
+      MODULE -- this module
+      MANDATORY-GROUPS {
+         mfrMibBundleGroup,
+         mfrMibBundleLinkGroup,
+         mfrMibTrapGroup
+         }
+
+      OBJECT     mfrBundleFragmentation
+      MIN-ACCESS read-only
+      DESCRIPTION
+          "Write access is not required, but the value used must be
+           reported."
+
+      OBJECT     mfrBundleMaxFragSize
+      MIN-ACCESS read-only
+      DESCRIPTION
+          "Write access is not required, but the value used must be
+           reported.
+           A value of -1 indicates that the value is not applicable."
+
+      OBJECT     mfrBundleThreshold
+      MIN-ACCESS read-only
+      DESCRIPTION
+          "Write access is not required, but the value used must be
+           reported.
+           A value of -1 indicates that the value is not applicable."
+
+      OBJECT     mfrBundleMaxDiffDelay
+      MIN-ACCESS read-only
+      DESCRIPTION
+          "Write access is not required, but the value used must be
+           reported."
+
+
+
+Pate, et al.                Standards Track                    [Page 29]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+      OBJECT     mfrBundleSeqNumSize
+      MIN-ACCESS read-only
+      DESCRIPTION
+          "Write access is not required, but the value used must be
+           reported.
+           A value of -1 indicates that the value is not applicable."
+
+      ::= { mfrMibCompliances 1 }
+
+   -- ---------------------------------------------------------
+   -- ---------------------------------------------------------
+   -- Units of Conformance
+   -- ---------------------------------------------------------
+   -- ---------------------------------------------------------
+
+
+   mfrMibBundleGroup OBJECT-GROUP
+      OBJECTS {
+         mfrBundleMaxNumBundles,
+         mfrBundleNextIndex,
+         mfrBundleIfIndex,
+         mfrBundleRowStatus,
+         mfrBundleNearEndName,
+         mfrBundleFragmentation,
+         mfrBundleMaxFragSize,
+         mfrBundleTimerHello,
+         mfrBundleTimerAck,
+         mfrBundleCountMaxRetry,
+         mfrBundleActivationClass,
+         mfrBundleThreshold,
+         mfrBundleMaxDiffDelay,
+         mfrBundleMaxBundleLinks,
+         mfrBundleLinksConfigured,
+         mfrBundleLinksActive,
+         mfrBundleBandwidth,
+         mfrBundleSeqNumSize,
+         mfrBundleFarEndName,
+         mfrBundleResequencingErrors,
+         mfrBundleIfIndexMappingIndex
+         }
+      STATUS current
+      DESCRIPTION
+          "Group of objects describing bundles."
+      ::= { mfrMibGroups 1 }
+
+   mfrMibBundleLinkGroup   OBJECT-GROUP
+      OBJECTS {
+         mfrBundleLinkRowStatus,
+
+
+
+Pate, et al.                Standards Track                    [Page 30]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+         mfrBundleLinkConfigBundleIndex,
+         mfrBundleLinkNearEndName,
+         mfrBundleLinkState,
+         mfrBundleLinkFarEndName,
+         mfrBundleLinkFarEndBundleName,
+         mfrBundleLinkDelay,
+         mfrBundleLinkFramesControlTx,
+         mfrBundleLinkFramesControlRx,
+         mfrBundleLinkFramesControlInvalid,
+         mfrBundleLinkTimerExpiredCount,
+         mfrBundleLinkLoopbackSuspected,
+         mfrBundleLinkUnexpectedSequence,
+         mfrBundleLinkMismatch
+         }
+      STATUS current
+      DESCRIPTION
+          "Group of objects describing bundle links."
+      ::= { mfrMibGroups 2 }
+
+   mfrMibTrapGroup NOTIFICATION-GROUP
+      NOTIFICATIONS {
+         mfrMibTrapBundleLinkMismatch
+         }
+      STATUS current
+      DESCRIPTION
+          "Group of objects describing notifications (traps)."
+      ::= { mfrMibGroups 3 }
+
+END
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Pate, et al.                Standards Track                    [Page 31]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+4.  Acknowledgments
+
+   This document was produced by the Frame Relay Service MIB (frnetmib)
+   Working Group in conjunction with the Frame Relay Forum.
+
+5.  References
+
+   [RFC2571] Harrington, D., Presuhn, R. and B. Wijnen, "An Architecture
+             for Describing SNMP Management Frameworks", RFC 2571, April
+             1999.
+
+   [RFC1155] Rose, M. and K. McCloghrie, "Structure and Identification
+             of Management Information for TCP/IP-based Internets", STD
+             16, RFC 1155, May 1990.
+
+   [RFC1212] Rose, M. and K. McCloghrie, "Concise MIB Definitions", STD
+             16, RFC 1212, March 1991.
+
+   [RFC1215] Rose, M., "A Convention for Defining Traps for use with the
+             SNMP", RFC 1215, March 1991.
+
+   [RFC2578] McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J.,
+             Rose, M. and S. Waldbusser, "Structure of Management
+             Information Version 2 (SMIv2)", STD 58, RFC 2578, April
+             1999.
+
+   [RFC2579] McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J.,
+             Rose, M. and S. Waldbusser, "Textual Conventions for
+             SMIv2", STD 58, RFC 2579, April 1999.
+
+   [RFC2580] McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J.,
+             Rose, M. and S. Waldbusser, "Conformance Statements for
+             SMIv2", STD 58, RFC 2580, April 1999.
+
+   [RFC1157] Case, J., Fedor, M., Schoffstall, M. and J. Davin, "Simple
+             Network Management Protocol", STD 15, RFC 1157, May 1990.
+
+   [RFC1901] Case, J., McCloghrie, K., Rose, M. and S. Waldbusser,
+             "Introduction to Community-based SNMPv2", RFC 1901, January
+             1996.
+
+   [RFC1906] Case, J., McCloghrie, K., Rose, M. and S. Waldbusser,
+             "Transport Mappings for Version 2 of the Simple Network
+             Management Protocol (SNMPv2)", RFC 1906, January 1996.
+
+   [RFC2572] Case, J., Harrington D., Presuhn R. and B. Wijnen, "Message
+             Processing and Dispatching for the Simple Network
+             Management Protocol (SNMP)", RFC 2572, April 1999.
+
+
+
+Pate, et al.                Standards Track                    [Page 32]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+   [RFC2574] Blumenthal, U. and B. Wijnen, "User-based Security Model
+             (USM) for version 3 of the Simple Network Management
+             Protocol (SNMPv3)", RFC 2574, April 1999.
+
+   [RFC1905] Case, J., McCloghrie, K., Rose, M. and S. Waldbusser,
+             "Protocol Operations for Version 2 of the Simple Network
+             Management Protocol (SNMPv2)", RFC 1905, January 1996.
+
+   [RFC2573] Levi, D., Meyer, P. and B. Stewart, "SNMPv3 Applications",
+             RFC 2573, April 1999.
+
+   [RFC2575] Wijnen, B., Presuhn, R. and K. McCloghrie, "View-based
+             Access Control Model (VACM) for the Simple Network
+             Management Protocol (SNMP)", RFC 2575, April 1999.
+
+   [RFC2570] Case, J., Mundy, R., Partain, D. and B. Stewart,
+             "Introduction to Version 3 of the Internet-standard Network
+             Management Framework", RFC 2570, April 1999.
+
+   [Q.922]   ITU-T, Recommendation Q.922: "ISDN Data Link Layer
+             Specification For Frame Mode Bearer Services"
+
+   [Q.933]   ITU-T, Recommendation Q.933: "Signalling Specification For
+             Frame Mode Basic Call Control"
+
+   [FRF.4]   R. Cherukuri (ed), FRF.4: "Frame Relay User-to-Network SVC
+             Implementation Agreement" January 5, 1994.
+
+   [FRF.16]  M. Sheehan (ed), FRF.16: "UNI/NNI Multilink Frame Relay
+             Interworking Implementation Agreement" August 20, 1999.
+
+   [RFC1604] Rehbehn, K. and D. Fowler, "Definitions of Managed Objects
+             for Frame Relay Service", RFC 2954, October 2000.
+
+   [RFC2494] Fowler, D., "Definitions of Managed Objects for the DS0 and
+             DS0 Bundle Interface Type", RFC 2494, November 1997.
+
+   [RFC2863] McCloghrie, D. and F. Kastenholz, "The Interfaces Group MIB
+             using SMIv2", RFC 2233, June 2000.
+
+   [ATMLANE] T. Newton, ed., "LAN Emulation Client Management
+             Specification Version 2.0" AF-LANE-0093.000, ATM Forum,
+             October, 1998
+
+   [ATMIMA]  R. Vallee, ed., "Inverse Multiplexing for ATM Specification
+             Version 1.1" (Appendix A) AF-PHY-0086.001, ATM Forum,
+             March, 1999
+
+
+
+
+Pate, et al.                Standards Track                    [Page 33]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+   [RFC2115] Brown, C. and F. Baker, "Management Information Base for
+             Frame Relay DTEs Using SMIv2", RFC 2115, September 1997.
+
+6.  Security Considerations
+
+   There are a number of management objects defined in this MIB that
+   have a MAX-ACCESS clause of read-write and/or read-create.  Such
+   objects may be considered sensitive or vulnerable in some network
+   environments.  The support for SET operations in a non-secure
+   environment without proper protection can have a negative effect on
+   network operations.
+
+   No managed objects in this MIB contain sensitive information.
+
+   SNMPv1 by itself is not a secure environment.  Even if the network
+   itself is secure (for example by using IPSec), even then, there is no
+   control as to who on the secure network is allowed to access and
+   GET/SET (read/change/create/delete) the objects in this MIB.
+
+   It is recommended that the implementers consider the security
+   features as provided by the SNMPv3 framework.  Specifically, the use
+   of the User-based Security Model RFC 2574 [RFC2574] and the View-
+   based Access Control Model RFC 2575 [RFC2575] is recommended.
+
+   It is then a customer/user responsibility to ensure that the SNMP
+   entity giving access to an instance of this MIB, is properly
+   configured to give access to the objects only to those principals
+   (users) that have legitimate rights to indeed GET or SET
+   (change/create/delete) them.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Pate, et al.                Standards Track                    [Page 34]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+7.  Authors' Addresses
+
+   Prayson Pate
+   Overture Networks
+   P. O. Box 14864
+   RTP, NC, USA 27709
+
+   Phone: +1 919 558 2200
+   EMail: prayson.pate@overturenetworks.com
+
+
+   Bob Lynch
+   Overture Networks
+   P. O. Box 14864
+   RTP, NC, USA 27709
+
+   Phone: +1 919 558-2200
+   EMail: bob.lynch@overturenetworks.com
+
+
+   Kenneth Rehbehn
+   Megisto Systems, Inc.
+   20251 Century Boulevard
+   Germantown, MD, USA 20874
+
+   Phone: +1 301 529-4427
+   EMail: krehbehn@megisto.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Pate, et al.                Standards Track                    [Page 35]
+
+RFC 3020               MIB for FRF.16 UNI/NNI MFR          December 2000
+
+
+8.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (2000).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Pate, et al.                Standards Track                    [Page 36]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc3020.txt](<www.ietf.org/rfc/rfc3020.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
