### PR TITLE
Archive rfc3085.txt

### DIFF
--- a/www.ietf.org/rfc/rfc3085.txt
+++ b/www.ietf.org/rfc/rfc3085.txt
@@ -1,0 +1,339 @@
+
+
+
+
+
+
+Network Working Group                                          A. Coates
+Request for Comments: 3085                                       Reuters
+Category: Informational                                         D. Allen
+                                                                    IPTC
+                                                         D. Rivers-Moore
+                                                                  Rivcom
+                                                              March 2001
+
+
+                   URN Namespace for NewsML Resources
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard of any kind.  Distribution of this
+   memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2001).  All Rights Reserved.
+
+Abstract
+
+   This document describes a URN (Uniform Resource Name) namespace for
+   identifying NewsML NewsItems.  A NewsItem is an information resource
+   that is expressible as a NewsML element within a NewsML document
+   conforming to the NewsML Document Type Declaration (DTD) as defined
+   by the International Press Telecommunications Council (IPTC).
+
+1. Introduction
+
+   NewsML is an XML format for packaging multimedia news resources.  It
+   has been created under the auspices of the International Press
+   Telecommunications Council (IPTC), and version 1.0 was approved by
+   the IPTC on 6 October 2000.
+
+   The same logical NewsItem may exist in multiple physical locations.
+   The NewsML specification allows NewsItems to have multiple URLs, but
+   only a single URN.  It is the latter which then uniquely names the
+   resource.
+
+   This namespace specification is for a formal namespace.
+
+2. Specification Template
+
+   Namespace ID:
+
+      "newsml" requested.
+
+
+
+Coates, et al.               Informational                      [Page 1]
+
+RFC 3085           URN Namespace for NewsML Resources         March 2001
+
+
+   Registration Information:
+
+      Registration Version Number: 1
+      Registration Date: 2000-11-07
+
+   Declared registrant of the namespace:
+
+      David Allen
+      ho73@dial.pipex.com
+      IPTC
+      Royal Albert House
+      Sheet Street
+      Windsor
+      SL4 1BE
+
+   Declaration of structure:
+
+      The identifier has the following ABNF[6] specification:
+
+      NSS = ProviderId ":" DateId ":" NewsItemId ":" RevisionId Update
+      ProviderId = string
+      DateId = date
+      NewsItemId = string
+      RevisionId = posint
+      Update = 0*1( "A" / "U" )
+      date = century year month day
+      century = ( "0" posdig ) / ( posdig DIGIT )
+      year = 1*2DIGIT
+      month = ( 0 posdig ) / ( "1" ( "0" "1" "2" ) )
+      day = ( 0 posdig ) / ( ( "1" / "2" ) DIGIT ) / "30" / "31"
+      string = 1*char
+      char = ALPHA / DIGIT / symbol / escape
+      symbol = "(" / ")" / "+" / "," / "-" / "." / "=" / "@" / ";" /
+        "$" / "_" / "!" / "*" / "'"
+      escape = "%" HEXDIG HEXDIG
+      posint = posdig *DIGIT
+      posdig = "1" / "2" / "3" / "4" / "5" / "6" / "7" / "8" / "9"
+
+      The ProviderId must be an Internet domain name, and must be owned
+         by the organisation creating the NewsML resource and allocating
+         the URN to it, at the date identified by the DateId.
+      DateId is a date in ISO 8601 Basic Format (CCYYMMDD), and must
+         correspond to a date at which the organisation allocating the
+         URN owned the domain name specified in the ProviderId.
+      The NewsItemId must be unique among all NewsItems emanating from
+         the same provider and having the same DateId.
+
+
+
+
+
+Coates, et al.               Informational                      [Page 2]
+
+RFC 3085           URN Namespace for NewsML Resources         March 2001
+
+
+      RevisionId is a positive integer indicating which revision of a
+         given NewsItem this is.  Any positive integer may be used, but
+         it must always be the case that of two instances of a NewsItem
+         that have the same ProviderId, DateId and NewsItemId, the one
+         whose RevisionId has the larger value must be the more recent
+         revision.  A RevisionId of 0 is not permitted.
+      If the NewsItem contains an "Update" element or elements, then
+         Update must be set to "U".  If the NewsItem consists only of a
+         replacement set of NewsManagement data, then Update must be set
+         to "A".  If neither of these is the case, then Update must be
+         suppressed.
+
+   Relevant ancillary documentation:
+
+      None
+
+   Identifier uniqueness considerations:
+
+      The combination of ProviderId and DateId serves to uniquely
+         identify the organisation that is allocating the URN.  That
+         organisation is responsible for ensuring the uniqueness of the
+         DateId/NewsItemId/RevisionId combination.
+
+   Identifier persistence considerations:
+
+      A NewsML URN may only be allocated by an organisation that owns an
+         Internet domain name.  The URN identifies a date on which the
+         organisation owned that domain name.  The combination of date
+         and domain name will serve to uniquely identify that
+         organisation for all time.
+
+   Process of identifier assignment:
+
+      The organisation identified by the ProviderId/DateId combination
+         is responsible for allocating a NewsItemId that is unique among
+         all those that it allocates with that DateId.
+
+   Process of identifier resolution:
+
+      NewsML providers are responsible for the provision of a URN
+         resolution service, if any, for NewsML URNs they have assigned
+         with a valid ProviderId/DateId combination.
+
+   Rules for Lexical Equivalence:
+
+      URNs are lexically equivalent if the ProviderId, DateId,
+         NewsItemId, and RevisionId are all identical (case-insensitive
+         comparison).
+
+
+
+Coates, et al.               Informational                      [Page 3]
+
+RFC 3085           URN Namespace for NewsML Resources         March 2001
+
+
+   Conformance with URN Syntax:
+
+      No special considerations beyond the syntax herein described.
+
+   Validation mechanism:
+
+      Organisations that allocate NewsML URNs are responsible for the
+         provision of a URN validation service, if any, for URNs they
+         have assigned with a valid ProviderId/DateId combination.
+
+   Scope:
+
+      Global
+
+3. Examples
+
+   The following examples are representative of NewsML URNs, but may not
+   refer to actual resources.
+
+   urn:newsml:iptc.org:20001006:NewsMLv1.0:1
+   urn:newsml:reuters.com:20000206:
+              IIMFFH05643_2000-02-06_17-54-01_L06156584:1U
+
+4. Security Considerations
+
+   There are no additional security considerations other than those
+   normally associated with the use and resolution of URNs in general.
+
+References
+
+   [1]  Rivers-Moore, D., "NewsML Version 1.0 Functional Specification",
+        November 2000,
+        <http://www.iptc.org/NewsML/specification/NewsMLv1.0.pdf>.
+
+   [2]  Rivers-Moore, D., "NewsML Version 1.0 DTD", November 2000,
+        <http://www.iptc.org/NewsML/DTD/NewsMLv1.0.dtd>.
+
+   [3]  W3C, XML WG, "Extensible Markup Language (XML) 1.0", February
+        1998, <http://www.w3.org/TR/REC-xml>.
+
+   [4]  Moats, R., "URN Syntax", RFC 2141, May 1997.
+
+   [5]  Daigle, L., van Gulik, D., Iannella, R. and P. Faltstrom, "URN
+        Namespace Definition Mechanisms", RFC 2611, June 1999.
+
+   [6]  Crocker, D. and P. Overell, "Augmented BNF for Syntax
+        Specifications: ABNF", RFC 2234, November 1997.
+
+
+
+
+Coates, et al.               Informational                      [Page 4]
+
+RFC 3085           URN Namespace for NewsML Resources         March 2001
+
+
+Authors' Addresses
+
+   Anthony B. Coates
+   Reuters
+   85 Fleet St
+   London  EC4P 4AJ
+   United Kingdom
+
+   Phone: +44 20 75 42 21 65
+   EMail: tony.coates@reuters.com
+
+
+   David Allen
+   IPTC
+   Royal Albert House
+   Sheet Street
+   Windsor  SL4 1BE
+   United Kingdom
+
+   Phone: +44 17 53 70 50 51
+   EMail: ho73@dial.pipex.com
+
+
+   Daniel Rivers-Moore
+   Rivcom
+   Lotmead Business Village
+   Swindon  SN4 0UY
+   United Kingdom
+
+   Phone: +44 17 93 79 20 00
+   EMail: daniel.rivers-moore@rivcom.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Coates, et al.               Informational                      [Page 5]
+
+RFC 3085           URN Namespace for NewsML Resources         March 2001
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2001).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Coates, et al.               Informational                      [Page 6]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc3085.txt](<www.ietf.org/rfc/rfc3085.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
