### PR TITLE
Archive rfc309.txt

### DIFF
--- a/www.ietf.org/rfc/rfc309.txt
+++ b/www.ietf.org/rfc/rfc309.txt
@@ -1,0 +1,339 @@
+
+
+
+
+
+
+Network Working Group                               17 March 1972
+Request For Comments # 309                          Abhay Bhushan
+NIC # 9260                                                MIT-MAC
+
+              DATA AND FILE TRANSFER WORKSHOP ANNOUNCEMENT
+              --------------------------------------------
+
+        MIT will host a workshop on Data and File Transfer, Friday,
+   April 14 and Saturday, April 15, 1972.  People have expressed an
+   interest in revising the existing ARPANET Data and File Transfer
+   Protocols (RFC # 264 and RFC # 265), to make them more suitable
+   to fulfill the now better understood ARPANET requirements.
+
+        The objective of this workshop is to arrive at a unified
+   convention for ARPANET data and file transfer.  It is important
+   that we adequately consider the needs of TIP users, DATACOMPUTER
+   users, remote job entry users, and the major ARPANET service
+   systems.
+
+        In addition to the current members of the data and file
+   transfer protocol committee, I have invited a number of
+   interested parties to talk and participate in this workshop.  On
+   the first day's agenda is a list of speakers who have agreed to
+   discuss their respective interests in data and file transfer.  If
+   your interests have not been represented and you would like to
+   give a presentation or discuss a specific area, please contact me
+   (617-864-6900 Ext. 1428).
+
+        Participants are encouraged to have written position papers
+   ready at the time of this meeting.  If possible, these papers
+   should be distributed as NWG/RFCs or informal notes to workshop
+   invitees, prior to the workshop.
+
+        As this meeting is intended to be an intensive workshop,
+   with the second half devoted to a detailed specification of
+   protocol, it will be necessary to limit attendance.  The
+   attendance to this meeting is by invitation only.  A list of
+   invitees is attached.  If you have not been invited, and would
+   like to attend the workshop, please contact me.
+
+        Hotel reservations may be made at Random House, operated by
+   MIT's Real Estate office ($5.00 to $7.00/night), by contacting
+   either me or Sue Pitkin (617-864-6900 Ext. 1450)  before March
+   31st.  If you would prefer other hotel accomodations instead, a
+   convenient hotel is the Fenway motor Hotel (Tel. 617-492-4777).
+
+        Please contact either me or Sue Pitkin if you intend to come.
+
+
+
+
+                                                                [Page 1]
+
+NWG/RFC # 309                                              Abhay Bhushan
+
+
+                                 AGENDA
+                                 ------
+
+   FRIDAY April 14th, 1972
+   -----------------------
+
+        8th Floor Conference Room, MIT Project MAC,
+        545 Technology Square, Cambridge, Mass.
+
+                      Morning Session -- 9:00 a.m.
+                      ----------------------------
+
+   LIST OF SPEAKERS
+
+        Steve Crocker -- ARPA
+             Keynote Address and General Discussion
+
+        Richard Winter -- CCA
+             The DATACOMPUTER and ARPANET Protocols
+
+        William Crowther -- BBN-NET
+             Data and File Transfer to Terminal IMPs
+
+        Robert T. Braden -- UCLA-CCN
+             Remote Job Service on ARPANET -- A Server Viewpoint
+
+        John Heafner -- RAND
+             Remote Job Service on ARPANET -- A User Viewpoint
+
+                                  (LUNCH)
+
+                     Afternoon Session -- 1:30 p.m.
+                     ------------------------------
+
+        Ray Tomlinson -- BBN-TENEX
+             The TENEX View and Experience With "CPYNET"
+
+        Abhay Bhushan -- MIT-MAC
+             Current Data and File Transfer Strategies and
+             Some Measurement Results.
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 2]
+
+NWG/RFC # 309                                              Abhay Bhushan
+
+
+   GROUP DISCUSSION OF DATA TRANSFER PROTOCOL
+
+        Discuss revision and specific changes to the existing data
+   transfer protocol (RFC 264).  See tentative discussion items for
+   DTP on page 4.  You are expected to have read RFC 264 and be
+   familiar with it.
+
+   GROUP DISCUSSION OF FILE TRANSFER PROTOCOL
+
+        Discuss revision and specific changes to the existing file
+   transfer protocol (RFC 265).  See tentative list of discussion
+   items on page 4.  You are expected to have read RFC 265 and be
+   familiar with it.
+
+                             AGENDA (Cont.)
+                             --------------
+
+   SATURDAY April 15,  1972
+   ------------------------
+
+        8th Floor Conference Room, MIT Project MAC,
+        545 Technology Square, Cambridge, Mass.
+
+                      Morning Session -- 9:00 a.m.
+                      ----------------------------
+
+   WORKING SESSION ON DATA AND FILE TRANSFER PROTOCOLS
+
+        Objective is to come up with revised specifications for data
+   and file transfer protocols that fulfill current (existing and
+   anticipated) ARPANET needs.  A unified approach is a desirable
+   goal to strive for.
+
+        Continuation of Friday's discussion of data and file
+   transfer protocols, incorporating specific ideas and changes in
+   the existing protocols.
+
+        Possible formation of a sub-committee whose task is to write
+   the revised specificaitons for DTP and FTP.
+
+                     Afternoon Session -- 1:30 p.m.
+                     ------------------------------
+
+                            (TO BE DECIDED)
+
+
+
+
+
+
+
+                                                                [Page 3]
+
+NWG/RFC # 309                                              Abhay Bhushan
+
+
+                 Tentative List of Items for Discussion
+                 --------------------------------------
+
+   Data Transfer Protocol (DTP)
+   ----------------------------
+
+        - DTP vs TELNET.  Concept of extended TELNET, or
+             allowing use of ASCII in DTP.
+
+        - Error Control and recovery in DTP (use of
+             error checks, restart, etc.)
+
+        - Modes available -- handshake, only one mode, or use
+             of default.
+
+        - Information separator, Aborts, and the Use
+             of Close (NCP-CLS) to Separate Information.
+
+        - Use of DTP with TIPs
+
+        - Use of DTP with DATACOMPUTER
+
+
+   File Transfer Protocol (FTP)
+   ----------------------------
+
+        - Use of ICP, inter-mixing data and control,
+             transferring files to third connections
+             (possibly to different sites)
+
+        - The command language ASCII or codes
+
+        - Handling of data types and physical storage.
+
+        - Handling of descriptors and logical structure
+
+        - Error control and error recovery
+
+        - Use of FTP with TIPs
+
+        - Use of FTP with DATACOMPUTER
+
+        - Uniform Pathnames and the ARPANET virtual file system.
+
+
+
+
+
+
+
+
+                                                                [Page 4]
+
+NWG/RFC # 309                                              Abhay Bhushan
+
+
+                            List of Invitees
+                            ----------------
+   R. T. Braden -- UCLA-CCN , A. Chan -- MIT-DMCG , S. D. Crocker --
+   ARPA , W. Crowther -- BBN-TIP , E. Harslem -- Rand , J. Heafner
+   -- Rand , A. McKenzie -- BBN-NET , J. Melvin -- SRI-ARC (NIC) ,
+   E. Meyer --  MIT-MULTICS , J. Postel -- UCLA-NMC , N. Ryan --
+   MIT-MULTICS , M. Seriff -- MIT-DMCG , R. Sundberg --  Harvard , R.
+   Tomlinson -- BBN-TENEX , R. Watson -- SRI-ARC (NIC) , J. White --
+   UCSB , R. Winter -- CCA
+
+                           Suggested Reading
+                           -----------------
+        It is recommended that prior to the workshop, attendees read
+   the following papers.  This will greatly enhance the success of
+   the workshop.
+
+             1. The Data Trnasfer Protocol, NWG/RFC # 264
+
+             2. The File Transfer Protocol, NWG/RFC # 265
+
+             3. The Use of "Set Data Type" Transaction in File
+                Transfer Protocol, A. Bhushan, NWG/RFC # 294
+
+             4. Using ARPANET Remote Job Entry, E. Harslem, NWG/RFC # 307
+
+             5. NETRJT -- Remote Job Service Protocol for TIPs,
+                R. T. Braden, NWG/RFC # 283
+
+             6. Interim NETRJS Specifications, R. T. Braden, NWG/RFC # 189
+
+             7. User's View of the DATACOMPUTER, R. Winter, NWG/RFC # 219
+
+             8. Data Language, CCA,  NIC # 8208
+
+             9. A Suggested Addition to File Transfer Protocol,
+                A. McKenzie, NWG/RFC # 281
+
+            10. Revision of the Mail Box Protocol, NWG/RFC # 278
+
+            11. Some Experience with File Transfer, H. Brodie,
+                NWG/RFC # 269
+
+            12. ARPANET Specifications for UCSB's Simple-Minded
+                File System, J. White, NWG/RFC # 122
+
+   (In addition please also read any of the position papers
+   distributed prior to the workshop.)
+
+
+
+
+                                                                [Page 5]
+
+NWG/RFC # 309                                              Abhay Bhushan
+
+
+         [ This RFC was put into machine readable form for entry ]
+         [ into the online RFC archives by BBN Corp. under the   ]
+         [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 6]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc309.txt](<www.ietf.org/rfc/rfc309.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
