### PR TITLE
Archive rfc3091.txt

### DIFF
--- a/www.ietf.org/rfc/rfc3091.txt
+++ b/www.ietf.org/rfc/rfc3091.txt
@@ -1,0 +1,339 @@
+
+
+
+
+
+
+Network Working Group                                         H. Kennedy
+Request for Comments: 3091                        University of Michigan
+Category: Informational                                     1 April 2001
+
+
+                      Pi Digit Generation Protocol
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard of any kind.  Distribution of this
+   memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2001).  All Rights Reserved.
+
+Abstract
+
+   This memo defines a protocol to provide the Pi digit generation
+   service (PIgen) used between clients and servers on host computers.
+
+Introduction
+
+   This protocol is intended to provide the Pi digit generation service
+   (PIgen), and be used between clients and servers on host computers.
+   Typically the clients are on workstation hosts lacking local Pi
+   support, and the servers are more capable machines with greater Pi
+   calculation capabilities.  The essential tradeoff is the use of
+   network resources and time instead of local computational cycles.
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+Note
+
+   All digits supplied by implementations of this service are ASCII
+   [US-ASCII] representations of decimal (base 10) numbers following the
+   decimal point in values or approximations of Pi.  There MUST be an
+   implied decimal value of 3 (three) preceding the values provided by
+   the service defined by this protocol.
+
+1.     TCP Based Digit Generator Service
+
+   One REQUIRED PIgen service is defined as a stateless TCP service.  A
+   server listens on TCP port 314159.  Once a connection is established
+   the server sends a stream of data, one digit of Pi at at time,
+
+
+
+Kennedy                      Informational                      [Page 1]
+
+RFC 3091              Pi Digit Generation Protocol          1 April 2001
+
+
+   starting with the most significant digit following the decimal point.
+   Any incoming data MUST be discarded.  This continues until the client
+   closes the connection.
+
+   The data flow over the connection is limited by the normal TCP flow
+   control mechanisms, so there is no concern about the server sending
+   data faster than the client can process it.
+
+   Servers MAY use any appropriate method of Pi digit generation to
+   provide this service, including (but not limited to) table lookup
+   [DIGITS], numerical calculation [FIBPI,PIFFT] and statistical
+   sampling [MCM].  However, the method chosen SHOULD provide a precise
+   value for the digits of Pi generated.
+
+   Implementors of PIgen MUST provide this service to be conditionally
+   compliant with this RFC.
+
+1.1.   Approximate Service
+
+   An OPTIONAL PIgen service is defined as a stateless TCP service.  A
+   server listens on TCP port 220007.  Once a connection is established
+   the server sends a stream of data, one digit of the rational number
+   22/7 at a time, starting with the most significant digit following
+   the decimal point.  Any incoming data MUST be discarded.  This
+   continues until the client closes the connection.
+
+2.     UDP Based Digit Generator Service
+
+   An OPTIONAL PIgen service is defined as a stateless UDP service.  A
+   server listens on UDP port 314159.  When a datagram requesting a
+   specific digit of Pi is received, an answering datagram is sent
+   containing the value of the requested digit of Pi according to the
+   format defined in sections 2.1.1. and 2.1.2.
+
+   The requested digit value MAY be determined by any appropriate method
+   of Pi digit generation.  RECOMMENDED methods include table lookup
+   [DIGITS], or numerical calculation [BBPPA].
+
+2.1.   Packet Format
+
+   The datagram-based components of the PIgen protocol suite all share
+   the following UDP data payload formats (defined in the ABNF of RFC
+   2234 [RFC2234]).
+
+
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 2]
+
+RFC 3091              Pi Digit Generation Protocol          1 April 2001
+
+
+2.1.1. Request Payload Format
+
+   request   = nth_digit
+
+   nth_digit = 1*DIGIT  ; specifying the n-th digit following the
+                        ; decimal point
+
+2.1.2. Reply Payload Format
+
+   reply  = nth_digit ":" DIGIT ; where DIGIT is the value of the n-th
+                                ; digit following the decimal
+                                ; point
+
+2.2.   Approximate Service
+
+   An OPTIONAL PIgen service is defined as a stateless UDP service.  A
+   server listens on UDP port 220007.  When a datagram requesting a
+   specific digit of the rational number 22/7 is received, an answering
+   datagram is sent containing the value of the requested digit of 22/7
+   according to the format defined in sections 2.1.1. and 2.1.2.
+
+3.     IP Multicast Based Digit Generator Service
+
+   An OPTIONAL PIgen service is defined as a stateless UDP service.  A
+   random distribution of digits of Pi are sent using the payload format
+   described in section 2.1.2. to the IP multicast group
+   314.159.265.359.
+
+   There is no request structure.  If a server implementing this
+   component of the protocol suite joins the PIgen multicast group and
+   does not detect a server providing digits within 30 seconds, it MAY
+   elect to become the PIgen multicast provider.
+
+   The PIgen multicast provider generates a random distribution of the
+   digits of Pi and sends them out to the multicast group.  PIgen
+   multicast clients build up a coherent value of Pi by listening to the
+   multicast group over time.
+
+   The randomly selected digit value MAY be determined by any
+   appropriate method of Pi digit generation.  RECOMMENDED methods
+   include table lookup [DIGITS], or numerical calculation [BBPPA].  To
+   ensure an adequately random distribution, a proper random number
+   generator should be used, see [RANDOM] for some examples.
+
+
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 3]
+
+RFC 3091              Pi Digit Generation Protocol          1 April 2001
+
+
+4.   Service Discovery
+
+   Clients SHOULD discover PIgen servers via the DNS SRV algorithm
+   [RFC2782].  The service used is "pigen" and the protocols used are
+   "tcp" and "udp".  Approximate services (sections 1.1. and 2.2.)
+   should be discovered using a service of "pigem".  This allows for
+   central administration of addressing, fallback for failed relays and
+   collectors, and static load balancing.
+
+5.   Security Considerations
+
+   As almost every secure Internet protocol requires a highly accurate
+   value of Pi in order to function correctly, it is imperative that
+   clients only use a trusted PIgen server.  The imminent collapse of
+   the Internet is assured if this guideline is not strictly followed.
+
+6. References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [US-ASCII] Coded Character Set--7-Bit American Standard Code for
+              Information Interchange, ANSI X3.4-1986.
+
+   [DIGITS]   ftp://pi.super-computing.org/pub/pi
+
+   [FIBPI]    Pi and the Fibonacci Numbers
+              http://www.mcs.surrey.ac.uk/Personal/R.Knott/Fibonacci/
+              fibpi.html
+
+   [PIFFT]    Pi Calculation based on FFT and AGM http://momonga.t.u-
+              tokyo.ac.jp/~ooura/pi_fft.html
+
+   [MCM]      The Monte Carlo Method
+              http://www.daimi.aau.dk/~u951581/pi/MonteCarlo/pimc.html
+
+   [BBPPA]    Bailey-Borwien-Plouffe Pi Algorithm
+              http://www.mathsoft.com/asolve/plouffe/plouffe.html
+
+   [RFC2234]  Crocker, D. and P. Overell, "Augmented BNF for Syntax
+              Specifications: ABNF", RFC 2234, November 1997.
+
+   [RANDOM]   Randomness for Crypto http://www.cs.berkeley.edu/~daw/rnd/
+
+   [RFC2782]  Gulbrandsen, A., Vixie, P. and L. Esibov, "A DNS RR for
+              specifying the location of services (DNS SRV)", RFC 2782,
+              February 2000.
+
+
+
+
+Kennedy                      Informational                      [Page 4]
+
+RFC 3091              Pi Digit Generation Protocol          1 April 2001
+
+
+   [CHARGEN]  Postel, J., "Character Generation Protocol", STD 22, RFC
+              864, May 1983.
+
+7. Author's Address
+
+   Hugh Kennedy
+   University of Michigan
+   2281 Bonisteel Blvd.
+   Ann Arbor, MI 48109-2099
+   USA
+
+   EMail: kennedyh@engin.umich.edu
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 5]
+
+RFC 3091              Pi Digit Generation Protocol          1 April 2001
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2001).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kennedy                      Informational                      [Page 6]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc3091.txt](<www.ietf.org/rfc/rfc3091.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
