### PR TITLE
Archive rfc311.txt

### DIFF
--- a/www.ietf.org/rfc/rfc311.txt
+++ b/www.ietf.org/rfc/rfc311.txt
@@ -1,0 +1,112 @@
+
+
+
+
+
+
+                                                  UCSB Computer
+NETWORK WORKING GROUP                             Research Lab.
+REQUEST FOR COMMENTS # 311                        Roland F. Bryan
+NIC #9341                                         29 February 1972
+
+
+                NEW CONSOLE ATTACHMENTS TO THE UCSB HOST
+
+
+
+   The MLC/360M
+   ---------------
+
+   The UCSB 360-75 is equipped with an interface unit that allows
+   attachment of any type of I/O device to the Multiplexor Channel and
+   for that device to be operated by program control as though it were a
+   standard IBM Control Unit.  The interface, referred to as the
+   Multi-Line Controller/360M (MLC/360M), operates on the Multiplexor
+   Channel and provides 32 independently addressed I/O connections that
+   are grouped into 16 pairs to accommodate full- duplex I/O operation.
+   Each input group has a 16-bit input buffer plus related synchronizing
+   and control logic to make it a stand-alone control unit on the 360
+   channel.  Similarly, each output group has a 32-bit buffer plus logic.
+   Attachment is achieved by connection through a data-set type connector
+   and I/O signal levels conform to EIA standards (RS-232 Spec.).
+
+
+   Both the I/O group hardware and the supporting software for the
+   MLC/360M are readily modified to produce any variations required for
+   attachment and operation of non-standard devices.
+
+
+   Since our primary support was for 201B data-sets at 2400 baud, we
+   first implemented the 16 I/O group pairs to accommodate this type of
+   modem in our time-shared user environment.  The I/O groups have now
+   been variously modified to support a wide range of applications, from
+   300 baud acoustic coupled use to 9600 baud for multi-station classroom
+   operation.
+
+
+
+   New Consoles
+   ---------------
+
+
+   In addition to our standard attachments, which are mostly Culler-Fried
+   graphic display consoles and educational classrooms
+
+
+
+
+                                                                [Page 1]
+
+   using such consoles, we have a Tektronix 4002A and an NIH General
+   Purpose Graphics Terminal (GPGT).
+
+
+   The Tektronix terminal can now be operated on the ARPANET and will
+   provide our users with upper and lower case ASCII for easier operation
+   with other sites.  A report on this console's capability will be
+   forthcoming.
+
+
+   The GPGT was developed by the University of IOWA for use in
+   Bio-Medical applications.  The unit is a delay-line refreshed video
+   display with graphic capability and is the only dynamic type display
+   in use on our host computer at present.  We are evaluating its
+   performance in our On-Line System environment.  Since a user at this
+   terminal is also able to reach into the network, we will have some
+   future comments on its operation for interested persons.
+
+
+
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc311.txt](<www.ietf.org/rfc/rfc311.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
