### PR TITLE
Archive rfc314.txt

### DIFF
--- a/www.ietf.org/rfc/rfc314.txt
+++ b/www.ietf.org/rfc/rfc314.txt
@@ -1,0 +1,58 @@
+
+
+
+
+
+
+NIC 9344                                                  Ira Cotton
+NWG/RFC# 314                                              Mitre
+Next Network Graphics Working Group Meeting               14 March 1972
+
+Network Graphics Working Group Meeting
+
+   The next network graphics working group meeting has definitely
+   been scheduled for April 16-18 at The Mitre Corporation,
+   McLean, Virginia.
+
+   Please advise Ira Cotton at Mitre as soon as possible if you
+   plan to attend.
+
+      His phone number is (703) 893-3500 x2887.
+
+      Address is The Mitre Corporation, McLean, Virginia, 22101.
+
+      Home phone number (for panic use): (202) 785-1624.
+
+   A block of rooms has been reserved at the Tysons Corner
+   Holiday Inn which is approximately 1 mile from Mitre (see
+   attached map) on route 123.
+
+      These rooms are $19 for a single.
+
+      Please reserve your room as soon as possible with Ira.
+
+      The phone number of the Holiday Inn is (703) 893-2100.
+
+   The meeting will convene at 6 PM on Sunday evening at Mitre.
+   We will have the normal facilities for slides and viewgraphs.
+   Please make any requests for special equipment (e.g., movie
+   projector) in advance.
+
+      Mitre has a TIP, several teletypes, a Datapoint 3300, and a
+      2741.
+
+      In addition, we have an Imlac on loan.
+
+   If there is sufficient interest, a banquet will be arranged at
+   a local inn.
+
+   Washington should be very attractive at this time of year with
+   the cherry trees in bloom. I look forward to seeing all of you
+   again!
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+                                                                [Page 1]


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc314.txt](<www.ietf.org/rfc/rfc314.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
