### PR TITLE
Archive rfc317.txt

### DIFF
--- a/www.ietf.org/rfc/rfc317.txt
+++ b/www.ietf.org/rfc/rfc317.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                         Jon Postel
+Request for Comments: 317                                       UCLA-NMC
+NIC: 9347                                                 March 20, 1972
+
+
+    Official Host-Host Protocol Modification:  Assigned Link Numbers
+
+
+     I.  Links 192,193,194 and 195 (decimal) are assigned for use by the
+         Message Switching Protocol (MSP) experiment.
+
+    II.  Links 159 through 190 (decimal) are assigned for network
+         measurement purposes.  These links are to be used only under
+         the direction of the Network Measurement Center (NMC).  Contact
+         Vint Cerf, (213) 825-2368 for additional information.
+
+   III.  On page 28 of NIC 8246 the link assignment table should read:
+
+         LINK NUMBER            ASSIGNMENT
+
+         0                      Control Link
+
+         2-71                   Available for Connection
+
+         1, 72-158              Reserved--not for current use
+
+         159-191                To be used only for measurement work
+                                under the direction of the Network
+                                Measurement Center at UCLA
+
+         192-195                To be used for the Message Switching
+                                Protocol experiment
+
+         196-255                Available for private experimental use
+
+
+
+
+
+
+
+
+
+        [This RFC was put into machine readable form for entry]
+     [into the online RFC archives by Hélène Morin, Viagénie 10/99]
+
+
+
+
+
+
+Postel                                                          [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc317.txt](<www.ietf.org/rfc/rfc317.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
