### PR TITLE
Archive rfc3184.txt

### DIFF
--- a/www.ietf.org/rfc/rfc3184.txt
+++ b/www.ietf.org/rfc/rfc3184.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Network Working Group                                          S. Harris
+Request for Comments: 3184                                 Merit Network
+BCP: 54                                                     October 2001
+Category: Best Current Practice
+
+
+                      IETF Guidelines for Conduct
+
+Status of this Memo
+
+   This document specifies an Internet Best Current Practices for the
+   Internet Community, and requests discussion and suggestions for
+   improvements.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2001).  All Rights Reserved.
+
+Abstract
+
+   This document provides a set of guidelines for personal interaction
+   in the Internet Engineering Task Force.  The Guidelines recognize the
+   diversity of IETF participants, emphasize the value of mutual
+   respect, and stress the broad applicability of our work.
+
+1. Introduction
+
+   The work of the IETF relies on cooperation among a broad cultural
+   diversity of peoples, ideas, and communication styles.  The
+   Guidelines for Conduct inform our interaction as we work together to
+   develop multiple, interoperable technologies for the Internet.  All
+   IETF participants aim to abide by these Guidelines as we build
+   consensus in person, at IETF meetings, and in e-mail.  If conflicts
+   arise, we resolve them according to the procedures outlined in BCP
+   25.[1]
+
+2. Principles of Conduct
+
+   1. IETF participants extend respect and courtesy to their colleagues
+      at all times.
+
+      IETF participants come from diverse origins and backgrounds and
+      are equipped with multiple capabilities and ideals.  Regardless of
+      these individual differences, participants treat their colleagues
+      with respect as persons--especially when it is difficult to agree
+      with them.  Seeing from another's point of view is often
+      revealing, even when it fails to be compelling.
+
+
+
+
+Harris                   Best Current Practice                  [Page 1]
+
+RFC 3184              IETF Guidelines for Conduct           October 2001
+
+
+      English is the de facto language of the IETF, but it is not the
+      native language of many IETF participants.  Native English
+      speakers attempt to speak clearly and a bit slowly and to limit
+      the use of slang in order to accommodate the needs of all
+      listeners.
+
+   2. IETF participants develop and test ideas impartially, without
+      finding fault with the colleague proposing the idea.
+
+      We dispute ideas by using reasoned argument, rather than through
+      intimidation or ad hominem attack.  Or, said in a somewhat more
+      IETF-like way:
+
+            "Reduce the heat and increase the light"
+
+   3. IETF participants think globally, devising solutions that meet the
+      needs of diverse technical and operational environments.
+
+      The goal of the IETF is to maintain and enhance a working, viable,
+      scalable, global Internet, and the problems we encounter are
+      genuinely very difficult.  We understand that "scaling is the
+      ultimate problem" and that many ideas quite workable in the small
+      fail this crucial test.  IETF participants use their best
+      engineering judgment to find the best solution for the whole
+      Internet, not just the best solution for any particular network,
+      technology, vendor, or user.  We follow the intellectual property
+      guidelines outlined in BCP 9.[2]
+
+   4. Individuals who attend Working Group meetings are prepared to
+      contribute to the ongoing work of the group.
+
+      IETF participants who attend Working Group meetings read the
+      relevant Internet-Drafts, RFCs, and e-mail archives beforehand, in
+      order to familiarize themselves with the technology under
+      discussion.  This may represent a challenge for newcomers, as e-
+      mail archives can be difficult to locate and search, and it may
+      not be easy to trace the history of longstanding Working Group
+      debates.  With that in mind, newcomers who attend Working Group
+      meetings are encouraged to observe and absorb whatever material
+      they can, but should not interfere with the ongoing process of the
+      group.  Working Group meetings run on a very limited time
+      schedule, and are not intended for the education of individuals.
+      The work of the group will continue on the mailing list, and many
+      questions would be better expressed on the list in the months that
+      follow.
+
+
+
+
+
+
+Harris                   Best Current Practice                  [Page 2]
+
+RFC 3184              IETF Guidelines for Conduct           October 2001
+
+
+3. Security Considerations
+
+   IETF participants review each Internet protocol for security
+   concerns, and these concerns are incorporated in the description of
+   each protocol.
+
+4. Acknowledgements
+
+   Mike O'Dell wrote the first draft of the Guidelines for Conduct, and
+   many of his thoughts, statements, and observations are included in
+   this version.  Many useful editorial comments were supplied by Dave
+   Crocker.  Members of the POISSON Working Group provided many
+   significant additions to the text.
+
+5. References
+
+   [1] Bradner, S., "IETF Working Group Guidelines and Procedures",
+       BCP 25, RFC 2418, September 1998.
+
+   [2] Bradner, S., "The Internet Standards Process -- Revision 3",
+       BCP 9, RFC 2026, October 1996.
+
+6. Author's Address
+
+   Susan Harris
+   Merit Network, Inc.
+   4251 Plymouth Rd., Suite 2000
+   Ann Arbor, MI 48105-2785
+
+   EMail: srh@merit.edu
+   Phone: (734) 936-2100
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Harris                   Best Current Practice                  [Page 3]
+
+RFC 3184              IETF Guidelines for Conduct           October 2001
+
+
+7. Full Copyright Statement
+
+   Copyright (C) The Internet Society (2001).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Harris                   Best Current Practice                  [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc3184.txt](<www.ietf.org/rfc/rfc3184.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
