### PR TITLE
Archive rfc3199.txt

### DIFF
--- a/www.ietf.org/rfc/rfc3199.txt
+++ b/www.ietf.org/rfc/rfc3199.txt
@@ -1,0 +1,1347 @@
+
+
+
+
+
+
+Network Working Group                                          S. Ginoza
+Request for Comments: 3199                                           ISI
+Category: Informational                                    February 2003
+
+
+                      Request for Comments Summary
+
+                         RFC Numbers 3100-3199
+
+Status of This Memo
+
+   This RFC is a slightly annotated list of the 100 RFCs from RFC 3100
+   through RFCs 3199.  This is a status report on these RFCs.  This memo
+   provides information for the Internet community.  It does not specify
+   an Internet standard of any kind.  Distribution of this memo is
+   unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2003).  All Rights Reserved.
+
+Note
+
+   Many RFCs, but not all, are Proposed Standards, Draft Standards, or
+   Standards.  Since the status of these RFCs may change during the
+   standards processing, we note here only that they are on the
+   standards track.  Please see the latest edition of "Internet Official
+   Protocol Standards" for the current state and status of these RFCs.
+   In the following, RFCs on the standards track are marked [STANDARDS-
+   TRACK].
+
+RFC     Author          Date            Title
+---     ------          ----            -----
+
+
+3199    Ginoza          Feb 2003        Request for Comments Summary
+
+This memo.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 1]
+
+RFC 3199                  Summary of 3100-3199             February 2003
+
+
+3198    Westerinen      Nov 2001        Terminology for Policy-Based
+                                        Management
+
+This document is a glossary of policy-related terms.  It provides
+abbreviations, explanations, and recommendations for use of these terms.
+The intent is to improve the comprehensibility and consistency of
+writing that deals with network policy, particularly Internet Standards
+documents (ISDs).  This memo provides information for the Internet
+community.
+
+
+3197    Austein         Nov 2001        Applicability Statement for
+                                        DNS MIB Extensions
+
+This document explains why, after more than six years as proposed
+standards, the DNS Server and Resolver MIB extensions were never
+deployed, and recommends retiring these MIB extensions by moving them to
+Historical status.  This memo provides information for the Internet
+community.
+
+
+3196    Hastings        Nov 2001        Internet Printing
+                                        Protocol/1.1: Implementor's
+                                        Guide
+
+This document is one of a set of documents, which together describe all
+aspects of a new Internet Printing Protocol (IPP).  This memo provides
+information for the Internet community.
+
+
+3195    New             Nov 2001        Reliable Delivery for syslog
+
+The BSD Syslog Protocol describes a number of service options related to
+propagating event messages.  This memo describes two mappings of the
+syslog protocol to TCP connections, both useful for reliable delivery of
+event messages.  [STANDARDS TRACK]
+
+
+3194    Durand          Nov 2001        The Host-Density Ratio for
+                                        Address Assignment Efficiency:
+                                        An update on the H ratio
+
+This document provides an update on the "H ratio" defined in RFC 1715.
+It defines a new ratio which the authors claim is easier to understand.
+This memo provides information for the Internet community.
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 2]
+
+RFC 3199                  Summary of 3100-3199             February 2003
+
+
+3193    Patel           Nov 2001        Securing L2TP using IPsec
+
+This document discusses how L2TP (Layer Two Tunneling Protocol) may
+utilize IPsec to provide for tunnel authentication, privacy protection,
+integrity checking and replay protection. Both the voluntary and
+compulsory tunneling cases are discussed.  [STANDARDS TRACK]
+
+
+3192    Allocchio       Oct 2001        Minimal FAX address format in
+                                        Internet Mail
+
+This memo describes a simple method of encoding Global Switched
+Telephone Network (GSTN) addresses of facsimile devices in the local-
+part of Internet email addresses.  [STANDARDS TRACK]
+
+
+3191    Allocchio       Oct 2001        Minimal GSTN address format in
+                                        Internet Mail
+
+This memo describes a simple method of encoding Global Switched
+Telephone Network (GSTN) addresses (commonly called "telephone numbers")
+in the local-part of Internet email addresses, along with an extension
+mechanism to allow encoding of additional standard attributes needed for
+email gateways to GSTN-based services.  [STANDARDS TRACK]
+
+
+3190    Kobayashi       Jan 2002        RTP Payload Format for 12-bit
+                                        DAT Audio and 20- and 24-bit
+                                        Linear Sampled Audio
+
+This document specifies a packetization scheme for encapsulating 12-bit
+nonlinear, 20-bit linear, and 24-bit linear audio data streams using the
+Real-time Transport Protocol (RTP).  This document also specifies the
+format of a Session Description Protocol (SDP) parameter to indicate
+when audio data is preemphasized before sampling.  The parameter may be
+used with other audio payload formats, in particular L16 (16-bit
+linear).  [STANDARDS TRACK]
+
+
+3189    Kobayashi       Jan 2002        RTP Payload Format for DV
+                                        (IEC 61834) Video
+
+This document specifies the packetization scheme for encapsulating the
+compressed digital video data streams commonly known as "DV" into a
+payload format for the Real-Time Transport Protocol (RTP).  [STANDARDS
+TRACK]
+
+
+
+
+
+Ginoza                       Informational                      [Page 3]
+
+RFC 3199                  Summary of 3100-3199             February 2003
+
+
+3188    Hakala          Oct 2001        Using National Bibliography
+                                        Numbers as Uniform Resource
+                                        Names
+
+This document discusses how national bibliography numbers (persistent
+and unique identifiers assigned by the national libraries) can be
+supported within the URN (Uniform Resource Names) framework and the
+syntax for URNs defined in RFC 2141.  Much of the discussion is based on
+the ideas expressed in RFC 2288.  This memo provides information for the
+Internet community.
+
+
+3187    Hakala          Oct 2001        Using International Standard
+                                        Book Numbers as Uniform
+                                        Resource Names
+
+This document discusses how International Standard Book Numbers (ISBN)
+can be supported within the URN (Uniform Resource Names) framework and
+the syntax for URNs defined in RFC 2141.  Much of the discussion below
+is based on the ideas expressed in RFC 2288.  This memo provides
+information for the Internet community.
+
+
+3186    Shimizu         Dec 2001        MAPOS/PPP Tunneling mode
+
+This document specifies tunneling configuration over MAPOS (Multiple
+Access Protocol over SONET/SDH) networks.  Using this mode, a MAPOS
+network can provide transparent point-to-point link for PPP over
+SONET/SDH (Packet over SONET/SDH, POS) without any additional overhead.
+This memo provides information for the Internet community.
+
+
+3185    Farrell         Oct 2001        Reuse of CMS Content
+                                        Encryption Keys
+
+This document describes a way to include a key identifier in a CMS
+(Cryptographic Message Syntax) enveloped data structure, so that the
+content encryption key can be re-used for further enveloped data
+packets.  [STANDARDS TRACK]
+
+
+3184    Harris          Oct 2001        IETF Guidelines for Conduct
+
+This document provides a set of guidelines for personal interaction in
+the Internet Engineering Task Force.  This document specifies an
+Internet Best Current Practices for the Internet Community, and requests
+discussion and suggestions for improvements.
+
+
+
+
+Ginoza                       Informational                      [Page 4]
+
+RFC 3199                  Summary of 3100-3199             February 2003
+
+
+3183    Dean            Oct 2001        Domain Security Services using
+                                        S/MIME
+
+This document describes how the S/MIME (Secure/Multipurpose Internet
+Mail Extensions) protocol can be processed and generated by a number of
+components of a communication system, such as message transfer agents,
+guards and gateways to deliver security services.  These services are
+collectively referred to as 'Domain Security Services'.  This memo
+defines an Experimental Protocol for the Internet community.
+
+
+3182    Yadav           Oct 2001        Identity Representation for
+                                        RSVP
+
+This document describes the representation of identity information in
+POLICY_DATA object for supporting policy based admission control in the
+Resource ReSerVation Protocol (RSVP).  The goal of identity
+representation is to allow a process on a system to securely identify
+the owner and the application of the communicating process (e.g., user
+id) and convey this information in RSVP messages (PATH or RESV) in a
+secure manner.  We describe the encoding of identities as RSVP policy
+element.  We describe the processing rules to generate identity policy
+elements for multicast merged flows.  [STANDARDS TRACK]
+
+
+3181    Herzog          Oct 2001        Signaled Preemption Priority
+                                        Policy Element
+
+This document describes a preemption priority policy element for use by
+signaled policy based admission protocols (such as the Resource
+ReSerVation Protocol (RSVP) and Common Open Policy Service (COPS).
+[STANDARDS TRACK]
+
+
+3180    Meyer           Sep 2001        GLOP Addressing in 233/8
+
+This document defines the policy for the use of 233/8 for statically e
+assigned multicast addresses.  This document specifies an Internet Best
+Current Practices for the Internet Community, and requests discussion
+and suggestions for improvements.
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 5]
+
+RFC 3199                  Summary of 3100-3199             February 2003
+
+
+3179    Schoenwaelder   Oct 2001        Script MIB Extensibility
+                                        Protocol Version 1.1
+
+The Script MIB extensibility protocol (SMX) defined in this memo
+separates language specific runtime systems from language independent
+Script MIB implementations.  The IETF Script MIB defines an interface
+for the delegation of management functions based on the Internet
+management framework.  This memo defines an Experimental Protocol for
+the Internet community.
+
+
+3178    Hagino          Oct 2001        IPv6 Multihoming Support at
+                                        Site Exit Routers
+
+The document describes a mechanism for basic IPv6 multihoming support,
+and its operational requirements.  This memo provides information for
+the Internet community.
+
+
+3177    IAB             Sep 2001        IAB/IESG Recommendations on
+                                        IPv6 Address Allocations to
+                                        Sites
+
+This document provides recommendations to the addressing registries
+(APNIC, ARIN and RIPE-NCC) on policies for assigning IPv6 address blocks
+to end sites.  In particular, it recommends the assignment of /48 in the
+general case, /64 when it is known that one and only one subnet is
+needed and /128 when it is absolutely known that one and only one device
+is connecting.
+
+
+3176    Phaal           Sep 2001        InMon Corporation's sFlow: A
+                                        Method for Monitoring Traffic
+                                        in Switched and Routed Networks
+
+This memo defines InMon Corporation's sFlow system.  sFlow is a
+technology for monitoring traffic in data networks containing switches
+and routers.  In particular, it defines the sampling mechanisms
+implemented in an sFlow Agent for monitoring traffic, the sFlow MIB for
+controlling the sFlow Agent, and the format of sample data used by the
+sFlow Agent when forwarding data to a central data collector.  This memo
+provides information for the Internet community.
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 6]
+
+RFC 3199                  Summary of 3100-3199             February 2003
+
+
+3175    Baker           Sep 2001        Aggregation of RSVP for IPv4
+                                        and IPv6 Reservations
+
+This document describes the use of a single RSVP (Resource ReSerVation
+Protocol) reservation to aggregate other RSVP reservations across a
+transit routing region, in a manner conceptually similar to the use of
+Virtual Paths in an ATM (Asynchronous Transfer Mode) network.  It
+proposes a way to dynamically create the aggregate reservation, classify
+the traffic for which the aggregate reservation applies, determine how
+much bandwidth is needed to achieve the requirement, and recover the
+bandwidth when the sub-reservations are no longer required.  It also
+contains recommendations concerning algorithms and policies for
+predictive reservations.  [STANDARDS TRACK]
+
+
+3174    Eastlake        Sep 2001        US Secure Hash Algorithm 1
+                                        (SHA1)
+
+The purpose of this document is to make the SHA-1 (Secure Hash Algorithm
+1) hash algorithm conveniently available to the Internet community.
+This memo provides information for the Internet community.
+
+
+3173    Shacham         Sep 2001        IP Payload Compression
+                                        Protocol (IPComp)
+
+This document describes a protocol intended to provide lossless
+compression for Internet Protocol datagrams in an Internet environment.
+[STANDARDS TRACK]
+
+
+3172    Huston          Sep 2001        Management Guidelines &
+                                        Operational Requirements for
+                                        the Address and Routing
+                                        Parameter Area Domain ("arpa")
+
+This memo describes the management and operational requirements for the
+address and routing parameter area ("arpa") domain.  This document
+specifies an Internet Best Current Practices for the Internet Community,
+and requests discussion and suggestions for improvements.
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 7]
+
+RFC 3199                  Summary of 3100-3199             February 2003
+
+
+3171    Albanna         Aug 2001        IANA Guidelines for IPv4
+                                        Multicast Address Assignments
+
+This memo provides guidance for the Internet Assigned Numbers Authority
+(IANA) in assigning IPv4 multicast addresses.  This document specifies
+an Internet Best Current Practices for the Internet Community, and
+requests discussion and suggestions for improvements.
+
+
+3170    Quinn           Sep 2001        IP Multicast Applications:
+                                        Challenges and Solutions
+
+This document describes the challenges involved with designing and
+implementing multicast applications.  It is an introductory guide for
+application developers that highlights the unique considerations of
+multicast applications as compared to unicast applications.  This memo
+provides information for the Internet community.
+
+
+3169    Beadles         Sep 2001        Criteria for Evaluating
+                                        Network Access Server
+                                        Protocols
+
+This document defines requirements for protocols used by Network Access
+Servers (NAS).  This memo provides information for the Internet
+community.
+
+
+3168    Ramakrishnan    Sep 2001        The Addition of Explicit
+                                        Congestion Notification (ECN)
+                                        to IP
+
+This memo specifies the incorporation of ECN (Explicit Congestion
+Notification) to TCP and IP, including ECN's use of two bits in the IP
+header.  [STANDARDS TRACK]
+
+
+3167    Meyer           Aug 2001        Request to Move RFC 1745 to
+                                        Historic Status
+
+RFC 1745, "BGP4/IDRP for IP---OSPF Interaction", describes technology
+which was never deployed in the public internet.  This document requests
+that RFC 1745 be moved to Historic status.  This memo provides
+information for the Internet community.
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 8]
+
+RFC 3199                  Summary of 3100-3199             February 2003
+
+
+3166    Meyer           Aug 2001        Request to Move RFC 1403 to
+                                        Historic Status
+
+RFC 1403, "BGP OSPF Interaction", describes technology which is no
+longer used.  This document requests that RFC 1403 be moved to Historic
+status.  This memo provides information for the Internet community.
+
+
+3165    Levi            Aug 2001        Definitions of Managed Objects
+                                        for the Delegation of
+                                        Management Scripts
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  In
+particular, it describes a set of managed objects that allow the
+delegation of management scripts to distributed managers.  [STANDARDS
+TRACK]
+
+
+3164    Lonvick         Aug 2001        The BSD syslog Protocol
+
+This document describes the observed behavior of the syslog protocol.
+This memo provides information for the Internet community.
+
+
+3163    Zuccherato      Aug 2001        ISO/IEC 9798-3 Authentication
+                                        SASL Mechanism
+
+This document defines a SASL (Simple Authentication and Security Layer)
+authentication mechanism based on ISO/IEC 9798-3 and FIPS PUB 196 entity
+authentication.  This memo defines an Experimental Protocol for the
+Internet community.
+
+
+3162    Aboba           Aug 2001        RADIUS and IPv6
+
+This document specifies the operation of RADIUS (Remote Authentication
+Dial In User Service) when run over IPv6 as well as the RADIUS
+attributes used to support IPv6 network access.  [STANDARDS TRACK]
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                      [Page 9]
+
+RFC 3199                  Summary of 3100-3199             February 2003
+
+
+3161    Adams           Aug 2001        Internet X.509 Public Key
+                                        Infrastructure Time-Stamp
+                                        Protocol (TSP)
+
+This document describes the format of a request sent to a Time Stamping
+Authority (TSA) and of the response that is returned.  It also
+establishes several security-relevant requirements for TSA operation,
+with regards to processing requests to generate responses.  [STANDARDS
+TRACK]
+
+
+3160    Harris          Aug 2001        The Tao of IETF - A Novice's
+                                        Guide to the Internet
+                                        Engineering Task Force
+
+This document describes the inner workings of IETF meetings and Working
+Groups, discusses organizations related to the IETF, and introduces the
+standards process.  This memo provides information for the Internet
+community.
+
+
+3159    McCloghrie      Aug 2001        Structure of Policy
+                                        Provisioning Information
+                                        (SPPI)
+
+This document, the Structure of Policy Provisioning Information (SPPI),
+defines the adapted subset of SNMP's Structure of Management Information
+(SMI) used to write Policy Information Base (PIB) modules.  [STANDARDS
+TRACK]
+
+
+3158    Perkins         Aug 2001        RTP Testing Strategies
+
+This memo describes a possible testing strategy for RTP (real-time
+transport protocol) implementations.  This memo provides information for
+the Internet community.
+
+
+3157    Arsenault       Aug 2001        Securely Available Credentials
+                                        - Requirements
+
+This document describes requirements to be placed on Securely Available
+Credentials (SACRED) protocols.  This memo provides information for the
+Internet community.
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 10]
+
+RFC 3199                  Summary of 3100-3199             February 2003
+
+
+3156    Elkins          Aug 2001        MIME Security with OpenPGP
+
+This document describes how the OpenPGP Message Format can be used to
+provide privacy and authentication using the Multipurpose Internet Mail
+Extensions (MIME) security content types described in RFC 1847.
+[STANDARDS TRACK]
+
+
+3155    Dawkins         Aug 2001        End-to-end Performance
+                                        Implications of Links with
+                                        Errors
+
+This document discusses the specific TCP mechanisms that are problematic
+in environments with high uncorrected error rates, and discusses what
+can be done to mitigate the problems without introducing intermediate
+devices into the connection.  This document specifies an Internet Best
+Current Practices for the Internet Community, and requests discussion
+and suggestions for improvements.
+
+
+3154    Kempf           Aug 2001        Requirements and Functional
+                                        Architecture for an IP Host
+                                        Alerting Protocol
+
+This document develops an architecture and a set of requirements needed
+to support alerting of hosts that are in dormant mode.  The architecture
+and requirements are designed to guide development of an IP protocol for
+alerting dormant IP mobile hosts, commonly called paging.  This memo
+provides information for the Internet community.
+
+
+3153    Pazhyannur      Aug 2001        PPP Multiplexing
+
+This document describes a method to reduce the PPP (Point-to-Point
+Protocol) framing overhead used to transport small packets over slow
+links.  [STANDARDS TRACK]
+
+
+3152    Bush            Aug 2001        Delegation of IP6.ARPA
+
+This document discusses the need for delegation of the IP6.ARPA DNS
+zone, and specifies a plan for the technical operation thereof.  This
+document specifies an Internet Best Current Practices for the Internet
+Community, and requests discussion and suggestions for improvements.
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 11]
+
+RFC 3199                  Summary of 3100-3199             February 2003
+
+
+3151    Walsh           Aug 2001        A URN Namespace for Public
+                                        Identifiers
+
+This document describes a URN (Uniform Resource Name) namespace that is
+designed to allow Public Identifiers to be expressed in URI (Uniform
+Resource Identifiers) syntax.  This memo provides information for the
+Internet community.
+
+
+3150    Dawkins         Jul 2001        End-to-end Performance
+                                        Implications of Slow Links
+
+This document makes performance-related recommendations for users of
+network paths that traverse "very low bit-rate" links.  This document
+specifies an Internet Best Current Practices for the Internet Community,
+and requests discussion and suggestions for improvements.
+
+
+3149    Srinath         Sep 2001        MGCP Business Phone Packages
+
+This document describes a collection of MGCP (Media Gateway Control
+Protocol) packages that can be used to take advantage of the feature
+keys and displays on digital business phones and IP-Phones.  This memo
+provides information for the Internet community.
+
+
+3148    Mathis          Jul 2001        A Framework for Defining
+                                        Empirical Bulk Transfer
+                                        Capacity Metrics
+
+This document defines a framework for standardizing multiple BTC (Bulk
+Transport Capacity) metrics that parallel the permitted transport
+diversity.  This memo provides information for the Internet community.
+
+
+3147    Christian       Jul 2001        Generic Routing Encapsulation
+                                        over CLNS Networks
+
+This document proposes a method for transporting an arbitrary protocol
+over a CLNS (Connectionless Network Service) network using GRE (Generic
+Routing Encapsulation).  This may then be used as a method to tunnel
+IPv4 or IPv6 over CLNS.  This memo provides information for the Internet
+community.
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 12]
+
+RFC 3199                  Summary of 3100-3199             February 2003
+
+
+3146    Fujisawa        Oct 2001        Transmission of IPv6 Packets
+                                        over IEEE 1394 Networks
+
+
+This document describes the frame format for transmission of IPv6
+packets and the method of forming IPv6 link-local addresses and
+statelessly autoconfigured addresses on IEEE1394 networks.  [STANDARDS
+TRACK]
+
+
+3145    Verma           Jul 2001        L2TP Disconnect Cause
+                                        Information
+
+This document provides an extension to the Layer 2 Tunneling Protocol
+("L2TP"), a mechanism for tunneling Point-to-Point Protocol (PPP)
+sessions.  [STANDARDS TRACK]
+
+
+3144    Romascanu       Aug 2001        Remote Monitoring MIB
+                                        Extensions for Interface
+                                        Parameters Monitoring
+
+This memo defines a portion of the Management Information Base (MIB) for
+use with network management protocols in the Internet community.  The
+document proposes an extension to the Remote Monitoring MIB with a
+method of sorting the interfaces of a monitored device according to
+values of parameters specific to this interface.  [STANDARDS TRACK]
+
+
+3143    Cooper          Jun 2001        Known HTTP Proxy/Caching
+                                        Problems
+
+This document catalogs a number of known problems with World Wide Web
+(WWW) (caching) proxies and cache servers.  The goal of the document is
+to provide a discussion of the problems and proposed workarounds, and
+ultimately to improve conditions by illustrating problems.  This memo
+provides information for the Internet community.
+
+
+3142    Hagino          Jun 2001        An IPv6-to-IPv4 Transport
+                                        Relay Translator
+
+The document describes an IPv6-to-IPv4 transport relay translator (TRT).
+This memo provides information for the Internet community.
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 13]
+
+RFC 3199                  Summary of 3100-3199             February 2003
+
+
+3141    Hiller          Jun 2001        CDMA2000 Wireless Data
+                                        Requirements for AAA
+
+This memo specifies cdma2000 wireless data AAA (Authentication,
+Authorization, Accounting) requirements associated with third generation
+wireless architecture that supports roaming among service providers for
+traditional PPP and Mobile IP services.  This memo provides information
+for the Internet community.
+
+
+3140    Black           Jun 2001        Per Hop Behavior
+                                        Identification Codes
+
+This document defines a 16 bit encoding mechanism for the identification
+of differentiated services Per Hop Behaviors in protocol messages.  It
+replaces RFC 2836.  [STANDARDS TRACK]
+
+
+3139    Sanchez         Jun 2001        Requirements for Configuration
+                                        Management of IP-based
+                                        Networks
+
+This memo discusses different approaches to configure networks and
+identifies a set of configuration management requirements for IP-based
+networks.  This memo provides information for the Internet community.
+
+
+3138    Meyer           Jun 2001        Extended Assignments in 233/8
+
+This memo provides describes the mapping of the GLOP addresses
+corresponding to the private AS space.  This memo provides information
+for the Internet community.
+
+
+3137    Retana          Jun 2001        OSPF Stub Router Advertisement
+
+This memo describes a backward-compatible technique that may be used by
+OSPF (Open Shortest Path First) implementations to advertise
+unavailability to forward transit traffic or to lower the preference
+level for the paths through such a router.  This memo provides
+information for the Internet community.
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 14]
+
+RFC 3199                  Summary of 3100-3199             February 2003
+
+
+3136    Slutsman        Jun 2001        The SPIRITS Architecture
+
+This document describes the architecture for supporting SPIRITS
+services, which are those originating in the PSTN (Public Switched
+Telephone Network)and necessitating the interactions between the PSTN
+and the Internet.  This memo provides information for the Internet
+community.
+
+
+3135    Border          Jun 2001        Performance Enhancing Proxies
+                                        Intended to Mitigate
+                                        Link-Related Degradations
+
+
+This document is a survey of Performance Enhancing Proxies (PEPs) often
+employed to improve degraded TCP performance caused by characteristics
+of specific link environments, for example, in satellite, wireless WAN,
+and wireless LAN environments.  This memo provides information for the
+Internet community.
+
+
+3134    Dunn            Jun 2001        Terminology for ATM ABR
+                                        Benchmarking
+
+This memo discusses and defines terms associated with performance
+benchmarking tests and the results of these tests in the context of
+Asynchronous Transfer Mode (ATM) based switching devices supporting ABR
+(Available Bit Rate).  This memo provides information for the Internet
+community.
+
+
+3133    Dunn            Jun 2001        Terminology for Frame Relay
+                                        Benchmarking
+
+This memo discusses and defines terms associated with performance
+benchmarking tests and the results of these tests in the context of
+frame relay switching devices.  This memo provides information for the
+Internet community.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 15]
+
+RFC 3199                  Summary of 3100-3199             February 2003
+
+
+3132    Kempf           Jun 2001        Dormant Mode Host Alerting
+                                        ("IP Paging") Problem
+                                        Statement
+
+This memo describes paging, assesses the need for IP paging, and
+presents a list of recommendations for Seamoby charter items regarding
+work on paging.  This memo provides information for the Internet
+community.
+
+
+3131    Bradner         Jun 2001        3GPP2-IETF Standardization
+                                        Collaboration
+
+This document describes the standardization collaboration between 3GPP2
+and IETF.  This memo provides information for the Internet community.
+
+
+3130    Lewis           Jun 2001        Notes from the
+                                        State-Of-The-Technology:
+                                        DNSSEC
+
+This is a memo of a DNSSEC (Domain Name System Security Extensions)
+status meeting.  This memo provides information for the Internet
+community.
+
+
+3129    Thomas          Jun 2001        Requirements for Kerberized
+                                        Internet Negotiation of Keys
+
+The goal of this document is to produce a streamlined, fast, easily
+managed, and cryptographically sound protocol without requiring public
+key.  This memo provides information for the Internet community.
+
+
+3128    Miller          Jun 2001        Protection Against a Variant
+                                        of the Tiny Fragment Attack
+
+This document discusses how RFC 1858 compliant filters can be vulnerable
+to a variant of the "Tiny Fragment Attack" described in section 3.1 of
+the RFC.  This document describes the attack and recommends corrective
+action.  This memo provides information for the Internet community.
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 16]
+
+RFC 3199                  Summary of 3100-3199             February 2003
+
+
+3127    Mitton          Jun 2001        Authentication, Authorization,
+                                        and Accounting: Protocol
+                                        Evaluation
+
+This memo represents the process and findings of the Authentication,
+Authorization, and Accounting Working Group (AAA WG) panel evaluating
+protocols proposed against the AAA Network Access Requirements, RFC
+2989.  This memo provides information for the Internet community.
+
+
+3126    Pinkas          Sep 2001        Electronic Signature Formats
+                                        for long term electronic
+                                        signatures
+
+This document defines the format of an electronic signature that can
+remain valid over long periods.  This includes evidence as to its
+validity even if the signer or verifying party later attempts to deny
+(i.e., repudiates the validity of the signature).  This memo provides
+information for the Internet community.
+
+
+3125    Ross            Sep 2001        Electronic Signature Policies
+
+This document defines signature policies for electronic signatures.  A
+signature policy is a set of rules for the creation and validation of an
+electronic signature, under which the validity of signature can be
+determined.  A given legal/contractual context may recognize a
+particular signature policy as meeting its requirements.  This memo
+defines an Experimental Protocol for the Internet community.
+
+
+3124    Balakrishnan    Jun 2001        The Congestion Manager
+
+This document describes the Congestion Manager (CM), an end-system
+module that enables an ensemble of multiple concurrent streams from a
+sender destined to the same receiver and sharing the same congestion
+properties to perform proper congestion avoidance and control, and
+allows applications to easily adapt to network congestion.  [STANDARDS
+TRACK]
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 17]
+
+RFC 3199                  Summary of 3100-3199             February 2003
+
+
+3123    Koch            Jun 2001        A DNS RR Type for Lists of
+                                        Address Prefixes (APL RR)
+
+The Domain Name System (DNS) is primarily used to translate domain names
+into IPv4 addresses using A RRs (Resource Records).  Several approaches
+exist to describe networks or address ranges.  This document specifies a
+new DNS RR type "APL" for address prefix lists.  This memo defines an
+Experimental Protocol for the Internet community.
+
+
+3122    Conta           Jun 2001        Extensions to IPv6 Neighbor
+                                        Discovery for Inverse
+                                        Discovery Specification
+
+This memo describes extensions to the IPv6 Neighbor Discovery that allow
+a node to determine and advertise an IPv6 address corresponding to a
+given link-layer address.  [STANDARDS TRACK]
+
+
+3121    Best            Jun 2001        A URN Namespace for OASIS
+
+This document describes a URN (Uniform Resource Name) namespace that is
+engineered by the Organization for the Advancement of Structured
+Information Standards (OASIS) for naming persistent resources published
+by OASIS (such as OASIS Standards, XML (Extensible Markup Language)
+Document Type Definitions, XML Schemas, Namespaces, Stylesheets, and
+other documents).  This memo provides information for the Internet
+community.
+
+
+3120    Best            Jun 2001        A URN Namespace for XML.org
+
+This document describes a URN (Uniform Resource Name) namespace that is
+engineered by the Organization for the Advancement of Structured
+Information Standards (OASIS) for naming persistent resources stored in
+the XML.org repository (such as XML (Extensible Markup Language)
+Document Type Definitions, XML Schemas, Namespaces, Stylesheets, and
+other documents).  This memo provides information for the Internet
+community.
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 18]
+
+RFC 3199                  Summary of 3100-3199             February 2003
+
+
+3119    Finlayson       Jun 2001        A More Loss-Tolerant RTP
+                                        Payload Format for MP3 Audio
+
+This document describes a RTP (Real-Time Protocol) payload format for
+transporting MPEG (Moving Picture Experts Group) 1 or 2, layer III audio
+(commonly known as "MP3").  This format is an alternative to that
+described in RFC 2250, and performs better if there is packet loss.
+[STANDARDS TRACK]
+
+
+3118    Droms           Jun 2001        Authentication for DHCP
+                                        Messages
+
+
+This document defines a new Dynamic Host Configuration Protocol (DHCP)
+option through which authorization tickets can be easily generated and
+newly attached hosts with proper authorization can be automatically
+configured from an authenticated DHCP server.  [STANDARDS TRACK]
+
+
+3117    Rose            Nov 2001        On the Design of Application
+                                        Protocols
+
+This memo describes the design principles for the Blocks eXtensible
+eXchange Protocol (BXXP).  This memo provides information for the
+Internet community.
+
+
+3116    Dunn    Jun 2001        Methodology for ATM Benchmarking
+
+This document discusses and defines a number of tests that may be used
+to describe the performance characteristics of ATM (Asynchronous
+Transfer Mode) based switching devices.  In addition to defining the
+tests this document also describes specific formats for reporting the
+results of the tests.  This memo provides information for the Internet
+community.
+
+
+3115    Dommety         Apr 2001        Mobile IP
+                                        Vendor/Organization-Specific
+                                        Extensions
+
+This document defines two new extensions to Mobile IP.  These extensions
+will facilitate equipment vendors and organizations to make specific use
+of these extensions as they see fit for research or deployment purposes.
+[STANDARDS TRACK]
+
+
+
+
+
+Ginoza                       Informational                     [Page 19]
+
+RFC 3199                  Summary of 3100-3199             February 2003
+
+
+3114    Nicolls         May 2002        Implementing Company
+                                        Classification Policy with the
+                                        S/MIME Security Label
+
+This document discusses how company security policy for data
+classification can be mapped to the S/MIME security label.  Actual
+policies from three companies provide worked examples.  This memo
+provides information for the Internet community.
+
+
+3113    Rosenbrock      Jun 2001        3GPP-IETF Standardization
+                                        Collaboration
+
+This document describes the standardization collaboration between 3GPP
+and IETF.  This memo provides information for the Internet community.
+
+
+3112    Zeilenga        May 2001        LDAP Authentication Password
+                                        Schema
+
+This document describes schema in support of user/password
+authentication in a LDAP (Lightweight Directory Access Protocol)
+directory including the authPassword attribute type.  This memo provides
+information for the Internet community.
+
+
+3111    Guttman         May 2001        Service Location Protocol
+                                        Modifications for IPv6
+
+This document defines the Service Location Protocol Version 2's (SLPv2)
+use over IPv6 networks.  Since this protocol relies on UDP and TCP, the
+changes to support its use over IPv6 are minor.  [STANDARDS TRACK]
+
+
+3110    Eastlake 3rd    May 2001        RSA/SHA-1 SIGs and RSA KEYs in
+                                        the Domain Name System (DNS)
+
+This document describes how to produce RSA/SHA1 SIG resource records
+(RRs) in Section 3 and, so as to completely replace RFC 2537, describes
+how to produce RSA KEY RRs in Section 2.  [STANDARDS TRACK]
+
+3109    Braden          May 2001        Request to Move STD 39 to
+                                        Historic Status
+
+This memo changes the status of STD 39, BBN Report 1822, "Specification
+of the Interconnection of a Host and an IMP", from Standard to Historic.
+This memo provides information for the Internet community.
+
+
+
+
+Ginoza                       Informational                     [Page 20]
+
+RFC 3199                  Summary of 3100-3199             February 2003
+
+
+3108    Kumar           May 2001        Conventions for the use of the
+                                        Session Description Protocol
+                                        (SDP) for ATM Bearer
+                                        Connections
+
+This document describes conventions for using the Session Description
+Protocol (SDP) described in RFC 2327 for controlling ATM Bearer
+Connections, and any associated ATM Adaptation Layer (AAL).  The AALs
+addressed are Type 1, Type 2 and Type 5.  [STANDARDS TRACK]
+
+
+3107    Rekhter         May 2001        Carrying Label Information in
+                                        BGP-4
+
+This document specifies the way in which the label mapping information
+for a particular route is piggybacked in the same Border Gateway
+Protocol (BGP) Update message that is used to distribute the route
+itself.  [STANDARDS TRACK]
+
+
+3106    Eastlake        Apr 2001        ECML v1.1: Field
+                                        Specifications for E-Commerce
+
+
+Customers are frequently required to enter substantial amounts of
+information at an Internet merchant site in order to complete a purchase
+or other transaction, especially the first time they go there.  A
+standard set of information fields is defined as the first version of an
+Electronic Commerce Modeling Language (ECML) so that this task can be
+more easily automated, for example by wallet software that could fill in
+fields.  Even for the manual data entry case, customers will be less
+confused by varying merchant sites if a substantial number adopt these
+standard fields.  In addition, some fields are defined for merchant to
+consumer communication.  This memo provides information for the Internet
+community.
+
+
+3105    Kempf           Oct 2001        Finding an RSIP Server with
+                                        SLP
+
+This document contains an SLP service type template that describes the
+advertisements made by RSIP servers for their services.  This memo
+defines an Experimental Protocol for the Internet community.
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 21]
+
+RFC 3199                  Summary of 3100-3199             February 2003
+
+
+3104    Montenegro      Oct 2001        RSIP Support for End-to-end
+                                        IPsec
+
+This document proposes mechanisms that enable Realm Specific IP (RSIP)
+to handle end-to-end IPsec (IP Security).  This memo defines an
+Experimental Protocol for the Internet community.
+
+
+3103    Borella         Oct 2001        Realm Specific IP: Protocol
+                                        Specification
+
+This document presents a protocol with which to implement Realm Specific
+IP (RSIP).  The protocol defined herein allows negotiation of resources
+between an RSIP host and gateway, so that the host can lease some of the
+gateway's addressing parameters in order to establish a global network
+presence.  This protocol is designed to operate on the application layer
+and to use its own TCP or UDP port.  In particular, the protocol allows
+a gateway to allocate addressing and control parameters to a host such
+that a flow policy can be enforced at the gateway.  This memo defines an
+Experimental Protocol for the Internet community.
+
+
+3102    Borella         Oct 2001        Realm Specific IP: Framework
+
+This document examines the general framework of Realm Specific IP
+(RSIP).  RSIP is intended as a alternative to NAT in which the end-to-
+end integrity of packets is maintained.  We focus on implementation
+issues, deployment scenarios, and interaction with other layer-three
+protocols.  This memo defines an Experimental Protocol for the Internet
+community.
+
+
+3101    Murphy          Jan 2003        The OSPF Not-So-Stubby Area
+                                        (NSSA) Option
+
+This memo documents an optional type of Open Shortest Path First (OSPF)
+area that is somewhat humorously referred to as a "not-so-stubby" area
+(or NSSA).  NSSAs are similar to the existing OSPF stub area
+configuration option but have the additional capability of importing AS
+external routes in a limited fashion.
+
+The OSPF NSSA Option was originally defined in RFC 1587.  The functional
+differences between this memo and RFC 1587 are explained in Appendix F.
+All differences, while expanding capability, are backward-compatible in
+nature.  Implementations of this memo and of RFC 1587 will interoperate.
+[STANDARDS TRACK]
+
+
+
+
+
+Ginoza                       Informational                     [Page 22]
+
+RFC 3199                  Summary of 3100-3199             February 2003
+
+
+3100                                    Never Issued
+
+RFC 3100 was never issued.
+
+Security Considerations
+
+   Security issues are not discussed in this memo.
+
+Author's Address
+
+   Sandy Ginoza
+   University of Southern California
+   Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   Phone:  (310) 822-1511
+
+   EMail: ginoza@isi.edu
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 23]
+
+RFC 3199                  Summary of 3100-3199             February 2003
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2003).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ginoza                       Informational                     [Page 24]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc3199.txt](<www.ietf.org/rfc/rfc3199.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
