### PR TITLE
Archive rfc322.txt

### DIFF
--- a/www.ietf.org/rfc/rfc322.txt
+++ b/www.ietf.org/rfc/rfc322.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                         V. Cerf
+Request for Comments #322                                     J. Postel
+NIC #9609                                                     UCLA-NMC
+                                                              26 March 72
+
+                       Well Known Socket Numbers
+
+     The Network Measurement Group would like to establish a network
+standard socket number for a Process Discard service (not all HOSTs need
+cooperate.) To do this, it is necessary to know which sockets at each
+HOST have already been allocated to standard network functions.
+
+     At all HOSTs which permit login for services, socket 1 is the
+Network Logger on which ICP may be performed.
+
+     We would like to catalog other sockets which are supposed to be
+well-known, so we would appreciate having a note or phone call from each
+HOST Technical Liaison describing the function and socket numbers of
+network service programs at each HOST.  The catalog will be published and
+we would recommend that it be maintained at NIC.
+
+
+                            Dr. Vint Cerf or Jon Postel
+                            3804 Boelter Hall
+                            UCLA Computer Science Department
+                            Los Angeles, California 90024
+
+                            (213) 825-4864   Vint
+
+                            (213) 825-4733   Jon
+
+                            (213) 825-2368   Secretary
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc322.txt](<www.ietf.org/rfc/rfc322.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
