### PR TITLE
Archive rfc3273.txt

### DIFF
--- a/www.ietf.org/rfc/rfc3273.txt
+++ b/www.ietf.org/rfc/rfc3273.txt
@@ -1,0 +1,4315 @@
+
+
+
+
+
+
+Network Working Group                                      S. Waldbusser
+Request for Comments: 3273                                     July 2002
+Category: Standards Track
+
+
+     Remote Network Monitoring Management Information Base for High
+                           Capacity Networks
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2002).  All Rights Reserved.
+
+Abstract
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in TCP/IP-based internets.
+   In particular, it defines objects for managing remote network
+   monitoring (RMON) devices for use on high speed networks.  This
+   document contains a MIB Module that defines these new objects and
+   also contains definitions of some updated objects from the RMON-MIB
+   in RFC 2819 and the RMON2-MIB in RFC 2021.
+
+
+Table of Contents
+
+   1  The SNMP Management Framework ............................... 2
+   2  Overview .................................................... 3
+   2.1  Structure of MIB .......................................... 3
+   3  Updates to RMON MIB and RMON2 MIB objects ................... 4
+   4  Conventions ................................................. 6
+   5  Definitions ................................................. 7
+   6  Security Considerations .....................................73
+   7  Acknowledgments .............................................73
+   8  References ..................................................73
+   9  Notices .....................................................75
+   10 Author's Address.............................................76
+   11 Full Copyright Statement.....................................77
+
+
+
+
+
+
+Waldbusser                  Standards Track                     [Page 1]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+1.  The SNMP Management Framework
+
+   The SNMP Management Framework presently consists of five major
+   components:
+
+      o  An overall architecture, described in RFC 2571 [1].
+
+      o  Mechanisms for describing and naming objects and events for the
+         purpose of management.  The first version of this Structure of
+         Management Information (SMI) is called SMIv1 and described in
+         STD 16, RFC 1155 [2], STD 16, RFC 1212 [3], and RFC 1215 [4].
+         The second version, called SMIv2, is described in STD 58, RFC
+         2578 [5], RFC 2579 [6], and RFC 2580 [7].
+
+      o  Message protocols for transferring management information.  The
+         first version of the SNMP message protocol is called SNMPv1 and
+         is described in STD 15, RFC 1157 [8].  A second version of the
+         SNMP message protocol, which is not an Internet standards track
+         protocol, is called SNMPv2c and is described in RFC 1901 [9],
+         and RFC 1906 [10].  The third version of the message protocol
+         is called SNMPv3 and is described in RFC 1906 [10], RFC 2572
+         [11], and RFC 2574 [12].
+
+      o  Protocol operations for accessing management information.  The
+         first set of protocol operations and associated PDU formats is
+         described in STD 15, RFC 1157 [8].  A second set of protocol
+         operations and associated PDU formats is described in RFC 1905
+         [13].
+
+      o  A set of fundamental applications described in RFC 2573 [14]
+         and the view-based access control mechanism described in RFC
+         2575 [15].
+
+   A more detailed introduction to the current SNMP Management Framework
+   can be found in RFC 2570 [22].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  Objects in the MIB are
+   defined using the mechanisms defined in the SMI.
+
+   This memo specifies a MIB module that is compliant to the SMIv2.  A
+   MIB conforming to the SMIv1 can be produced through the appropriate
+   translations.  The resulting translated MIB must be semantically
+   equivalent, except where objects or events are omitted because no
+   translation is possible (use of Counter64).  Some machine readable
+   information in SMIv2 will be converted into textual descriptions in
+
+
+
+
+
+Waldbusser                  Standards Track                     [Page 2]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+   SMIv1 during the translation process.  However, this loss of machine
+   readable information is not considered to change the semantics of the
+   MIB.
+
+2.  Overview
+
+   This document continues the architecture created in the RMON MIB [RFC
+   2819] by supporting high speed networks.
+
+   Remote network monitoring devices, often called monitors or probes,
+   are instruments that exist for the purpose of managing a network.
+   Often these remote probes are stand-alone devices and devote
+   significant internal resources for the sole purpose of managing a
+   network.  An organization may employ many of these devices, one per
+   network segment, to manage its internet.  In addition, these devices
+   may be used for a network management service provider to access a
+   client network, often geographically remote.
+
+   The objects defined in this document are intended as an interface
+   between an RMON agent and an RMON management application and are not
+   intended for direct manipulation by humans.  While some users may
+   tolerate the direct display of some of these objects, few will
+   tolerate the complexity of manually manipulating objects to
+   accomplish row creation.  These functions should be handled by the
+   management application.
+
+2.1  Structure of MIB
+
+   Except for the mediaIndependentTable, each of the tables in this MIB
+   adds high capacity capability to an associated table in the RMON-1
+   MIB or RMON-2 MIB.
+
+   The objects are arranged into the following groups:
+
+      - mediaIndependentGroup
+
+      - etherStatsHighCapacityGroup
+
+      - etherHistoryHighCapacityGroup
+
+      - hostHighCapacityGroup
+
+      - hostTopNHighCapacityGroup
+
+      - matrixHighCapacityGroup
+
+      - captureBufferHighCapacityGroup
+
+
+
+
+Waldbusser                  Standards Track                     [Page 3]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+      - protocolDistributionHighCapacityGroup
+
+      - nlHostHighCapacityGroup
+
+      - nlMatrixHighCapacityGroup
+
+      - nlMatrixTopNHighCapacityGroup
+
+      - alHostHighCapacityGroup
+
+      - alMatrixHighCapacityGroup
+
+      - alMatrixTopNHighCapacityGroup
+
+      - usrHistoryHighCapacityGroup
+
+   These groups are the basic units of conformance.  If a remote
+   monitoring device implements a group, then it must implement all
+   objects in that group.  For example, a managed agent that implements
+   the network layer matrix group must implement the
+   nlMatrixSDHighCapacityTable and the nlMatrixDSHighCapacityTable.
+
+   Implementations of this MIB must also implement the system and
+   interfaces group of MIB-II [16,17].  MIB-II may also mandate the
+   implementation of additional groups.
+
+   These groups are defined to provide a means of assigning object
+   identifiers, and to provide a method for agent implementors to know
+   which objects they must implement.
+
+3.  Updates to RMON MIB and RMON2 MIB objects
+
+   This document extends the enumerations in the following objects from
+   the RMON MIB [18] and the RMON2 MIB [20].
+
+From the RMON MIB:
+
+hostTopNRateBase OBJECT-TYPE
+    SYNTAX     INTEGER {
+                 hostTopNInPkts(1),
+                 hostTopNOutPkts(2),
+                 hostTopNInOctets(3),
+                 hostTopNOutOctets(4),
+                 hostTopNOutErrors(5),
+                 hostTopNOutBroadcastPkts(6),
+                 hostTopNOutMulticastPkts(7),
+                 hostTopNHCInPkts(8),
+                 hostTopNHCOutPkts(9),
+
+
+
+Waldbusser                  Standards Track                     [Page 4]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+                 hostTopNHCInOctets(10),
+                 hostTopNHCOutOctets(11)
+               }
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+        "The variable for each host that the hostTopNRate
+        variable is based upon, as well as a control
+        for the table that the results will be reported in.
+
+        This object may not be modified if the associated
+        hostTopNStatus object is equal to valid(1).
+
+        If this value is less than or equal to 7, when the report
+        is prepared, entries are created in the hostTopNTable
+        associated with this object.
+        If this value is greater than or equal to 8, when the report
+        is prepared, entries are created in the
+        hostTopNHighCapacityTable associated with this object."
+    ::= { hostTopNControlEntry 3 }
+
+From the RMON2 MIB:
+
+nlMatrixTopNControlRateBase OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    nlMatrixTopNPkts(1),
+                    nlMatrixTopNOctets(2),
+                    nlMatrixTopNHighCapacityPkts(3),
+                    nlMatrixTopNHighCapacityOctets(4)
+                }
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+        "The variable for each nlMatrix[SD/DS] entry that the
+        nlMatrixTopNEntries are sorted by, as well as a control
+        for the table that the results will be reported in.
+
+        This object may not be modified if the associated
+        nlMatrixTopNControlStatus object is equal to active(1).
+
+        If this value is less than or equal to 2, when the report
+        is prepared, entries are created in the nlMatrixTopNTable
+        associated with this object.
+        If this value is greater than or equal to 3, when the report
+        is prepared, entries are created in the
+        nlMatrixTopNHighCapacityTable associated with this object."
+    ::= { nlMatrixTopNControlEntry 3 }
+
+
+
+
+Waldbusser                  Standards Track                     [Page 5]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+From the RMON2 MIB:
+
+alMatrixTopNControlRateBase OBJECT-TYPE
+    SYNTAX     INTEGER {
+                  alMatrixTopNTerminalsPkts(1),
+                  alMatrixTopNTerminalsOctets(2),
+                  alMatrixTopNAllPkts(3),
+                  alMatrixTopNAllOctets(4),
+                  alMatrixTopNTerminalsHighCapacityPkts(5),
+                  alMatrixTopNTerminalsHighCapacityOctets(6),
+                  alMatrixTopNAllHighCapacityPkts(7),
+                  alMatrixTopNAllHighCapacityOctets(8)
+               }
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+        "The variable for each alMatrix[SD/DS] entry that the
+        alMatrixTopNEntries are sorted by, as well as the
+        selector of the view of the matrix table that will be
+        used, as well as a control for the table that the results
+        will be reported in.
+
+        The values alMatrixTopNTerminalsPkts,
+        alMatrixTopNTerminalsOctets,
+        alMatrixTopNTerminalsHighCapacityPkts, and
+        alMatrixTopNTerminalsHighCapacityOctets cause collection
+        only from protocols that have no child protocols that are
+        counted.  The values alMatrixTopNAllPkts,
+        alMatrixTopNAllOctets, alMatrixTopNAllHighCapacityPkts, and
+        alMatrixTopNAllHighCapacityOctets cause collection from all
+        alMatrix entries.
+
+        This object may not be modified if the associated
+        alMatrixTopNControlStatus object is equal to active(1)."
+    ::= { alMatrixTopNControlEntry 3 }
+
+For convenience, updated MIB modules containing these objects may be
+found at:
+  ftp://ftp.rfc-editor.org/in-notes/mibs/current.mibs/rmon.mib
+  ftp://ftp.rfc-editor.org/in-notes/mibs/current.mibs/rmon2.mib
+
+4.  Conventions
+
+   The following conventions are used throughout the RMON MIB and its
+   companion documents.
+
+
+
+
+
+
+Waldbusser                  Standards Track                     [Page 6]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119.
+
+   Good Packets
+
+   Good packets are error-free packets that have a valid frame length.
+   For example, on Ethernet, good packets are error-free packets that
+   are between 64 octets long and 1518 octets long.  They follow the
+   form defined in IEEE 802.3 section 3.2.all.  Implementors are urged
+   to consult the appropriate media-specific specifications.
+
+   Bad Packets
+
+   Bad packets are packets that have proper framing and are therefore
+   recognized as packets, but contain errors within the packet or have
+   an invalid length.  For example, on Ethernet, bad packets have a
+   valid preamble and SFD (Start of Frame Delimiter), but have a bad FCS
+   (Frame Check Sequence), or are either shorter than 64 octets or
+   longer than 1518 octets.  Implementors are urged to consult the
+   appropriate media-specific specifications.
+
+5.  Definitions
+
+HC-RMON-MIB DEFINITIONS ::= BEGIN
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Counter32, Integer32,
+        Gauge32, Counter64             FROM SNMPv2-SMI
+    RowStatus, TimeStamp               FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP FROM SNMPv2-CONF
+    rmon, OwnerString, statistics, history, hosts, hostTopN, matrix,
+    etherStatsIndex, etherHistoryIndex, etherHistorySampleIndex,
+    hostIndex, hostAddress, hostTimeIndex, hostTimeCreationOrder,
+    hostTopNReport, hostTopNIndex,
+    matrixSDIndex, matrixSDSourceAddress, matrixSDDestAddress,
+    matrixDSIndex, matrixDSDestAddress, matrixDSSourceAddress,
+    capture, captureBufferControlIndex, captureBufferIndex
+                                    FROM RMON-MIB
+    protocolDirLocalIndex, protocolDistControlIndex,
+    protocolDist, hlHostControlIndex,
+    nlHost, nlHostTimeMark, nlHostAddress,
+    hlMatrixControlIndex, nlMatrix,
+    nlMatrixSDTimeMark, nlMatrixSDSourceAddress, nlMatrixSDDestAddress,
+    nlMatrixDSTimeMark, nlMatrixDSDestAddress, nlMatrixDSSourceAddress,
+    nlMatrixTopNControlIndex, nlMatrixTopNIndex,
+    alHost, alHostTimeMark,
+    alMatrix, alMatrixSDTimeMark, alMatrixDSTimeMark,
+    alMatrixTopNControlIndex, alMatrixTopNIndex,
+
+
+
+Waldbusser                  Standards Track                     [Page 7]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    usrHistory, usrHistoryControlIndex,
+    usrHistorySampleIndex, usrHistoryObjectIndex,
+    rmonConformance, ZeroBasedCounter32, probeConfig
+                                    FROM RMON2-MIB
+    ZeroBasedCounter64, CounterBasedGauge64
+                                    FROM HCNUM-TC;
+
+--  Remote Network Monitoring MIB
+
+hcRMON MODULE-IDENTITY
+    LAST-UPDATED "200205080000Z"    -- May 08, 2002
+    ORGANIZATION "IETF RMON MIB Working Group"
+    CONTACT-INFO
+        "Steve Waldbusser
+
+        Phone: +1-650-948-6500
+        Fax:   +1-650-745-0671
+        Email: waldbusser@nextbeacon.com
+
+        Andy Bierman
+        WG Chair
+        abierman@cisco.com
+
+        RMONMIB WG Mailing List
+        rmonmib@ietf.org
+        http://www.ietf.org/mailman/listinfo/rmonmib"
+    DESCRIPTION
+        "The MIB module for managing remote monitoring
+        device implementations. This MIB module
+        augments the original RMON MIB as specified in
+        RFC 2819 and RFC 1513 and RMON-2 MIB as specified in
+        RFC 2021."
+
+    REVISION "200205080000Z"    -- May 08, 2002
+    DESCRIPTION
+        "The original version of this MIB, published as RFC3273."
+    ::= { rmonConformance 5 }
+
+-- { rmon 1 } through { rmon 20 } are defined in RMON [RFC 2819] and
+-- the Token Ring RMON MIB [RFC 1513] and the RMON-2 MIB [RFC 2021].
+
+mediaIndependentStats  OBJECT IDENTIFIER ::= { rmon 21 }
+
+mediaIndependentTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF MediaIndependentEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+
+
+
+Waldbusser                  Standards Track                     [Page 8]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+        "Media independent statistics for promiscuous monitoring of
+        any media.
+
+        The following table defines media independent statistics that
+        provide information for full and/or half-duplex links as well
+        as high capacity links.
+
+        For half-duplex links, or full-duplex-capable links operating
+        in half-duplex mode, the mediaIndependentIn* objects shall be
+        used and the mediaIndependentOut* objects shall not increment.
+
+        For full-duplex links, the mediaIndependentOut* objects shall
+        be present and shall increment. Whenever possible, the probe
+        should count packets moving away from the closest terminating
+        equipment as output packets. Failing that, the probe should
+        count packets moving away from the DTE as output packets."
+    ::= { mediaIndependentStats 1 }
+
+mediaIndependentEntry OBJECT-TYPE
+    SYNTAX     MediaIndependentEntry
+    MAX-ACCESS not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Media independent statistics for promiscuous monitoring of
+        any media."
+    INDEX { mediaIndependentIndex }
+    ::= { mediaIndependentTable 1 }
+
+MediaIndependentEntry ::= SEQUENCE {
+
+    mediaIndependentIndex                       Integer32,
+    mediaIndependentDataSource                  OBJECT IDENTIFIER,
+    mediaIndependentDropEvents                  Counter32,
+    mediaIndependentDroppedFrames               Counter32,
+    mediaIndependentInPkts                      Counter32,
+    mediaIndependentInOverflowPkts              Counter32,
+    mediaIndependentInHighCapacityPkts          Counter64,
+    mediaIndependentOutPkts                     Counter32,
+    mediaIndependentOutOverflowPkts             Counter32,
+    mediaIndependentOutHighCapacityPkts         Counter64,
+    mediaIndependentInOctets                    Counter32,
+    mediaIndependentInOverflowOctets            Counter32,
+    mediaIndependentInHighCapacityOctets        Counter64,
+    mediaIndependentOutOctets                   Counter32,
+    mediaIndependentOutOverflowOctets           Counter32,
+    mediaIndependentOutHighCapacityOctets       Counter64,
+    mediaIndependentInNUCastPkts                Counter32,
+    mediaIndependentInNUCastOverflowPkts        Counter32,
+
+
+
+Waldbusser                  Standards Track                     [Page 9]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    mediaIndependentInNUCastHighCapacityPkts    Counter64,
+    mediaIndependentOutNUCastPkts               Counter32,
+    mediaIndependentOutNUCastOverflowPkts       Counter32,
+    mediaIndependentOutNUCastHighCapacityPkts   Counter64,
+    mediaIndependentInErrors                    Counter32,
+    mediaIndependentOutErrors                   Counter32,
+    mediaIndependentInputSpeed                  Gauge32,
+    mediaIndependentOutputSpeed                 Gauge32,
+    mediaIndependentDuplexMode                  INTEGER,
+    mediaIndependentDuplexChanges               Counter32,
+    mediaIndependentDuplexLastChange            TimeStamp,
+    mediaIndependentOwner                       OwnerString,
+    mediaIndependentStatus                      RowStatus
+}
+
+mediaIndependentIndex OBJECT-TYPE
+    SYNTAX     Integer32 (1..65535)
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "The value of this object uniquely identifies this
+        mediaIndependent entry."
+    ::= { mediaIndependentEntry 1 }
+
+mediaIndependentDataSource OBJECT-TYPE
+    SYNTAX     OBJECT IDENTIFIER
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+        "This object identifies the source of the data that
+        this mediaIndependent entry is configured to analyze.  This
+        source can be any interface on this device.
+        In order to identify a particular interface, this
+        object shall identify the instance of the ifIndex
+        object, defined in RFC 1213 and RFC 2233 [16,17], for
+        the desired interface.  For example, if an entry
+        were to receive data from interface #1, this object
+        would be set to ifIndex.1.
+
+        The statistics in this group reflect all packets
+        on the local network segment attached to the
+        identified interface.
+
+        An agent may or may not be able to tell if
+        fundamental changes to the media of the interface
+        have occurred and necessitate a deletion of
+        this entry.  For example, a hot-pluggable ethernet
+        card could be pulled out and replaced by a
+
+
+
+Waldbusser                  Standards Track                    [Page 10]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+        token-ring card.  In such a case, if the agent has
+        such knowledge of the change, it is recommended that
+        it delete this entry.
+
+        This object may not be modified if the associated
+        mediaIndependentStatus object is equal to active(1)."
+    ::= { mediaIndependentEntry 2 }
+
+mediaIndependentDropEvents OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS      "Events"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The total number of events in which packets
+        were dropped by the probe due to lack of resources.
+        Note that this number is not necessarily the number of
+        packets dropped; it is just the number of times this
+        condition has been detected."
+    ::= { mediaIndependentEntry 3 }
+
+mediaIndependentDroppedFrames OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+       "The total number of frames which were received by the probe
+        and therefore not accounted for in the
+        mediaIndependentDropEvents, but for which the probe chose not
+        to count for this entry for whatever reason.  Most often, this
+        event occurs when the probe is out of some resources and
+        decides to shed load from this collection.
+
+        This count does not include packets that were not counted
+        because they had MAC-layer errors.
+
+        Note that, unlike the dropEvents counter, this number is the
+        exact number of frames dropped."
+    ::= { mediaIndependentEntry 4 }
+
+mediaIndependentInPkts OBJECT-TYPE
+    SYNTAX      Counter32
+    UNITS       "Packets"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of packets (including bad packets,
+
+
+
+Waldbusser                  Standards Track                    [Page 11]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+        broadcast packets, and multicast packets) received
+        on a half-duplex link or on the inbound connection of a
+        full-duplex link."
+    ::= { mediaIndependentEntry 5 }
+
+mediaIndependentInOverflowPkts OBJECT-TYPE
+    SYNTAX      Counter32
+    UNITS       "Packets"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of times the associated
+        mediaIndependentInPkts counter has overflowed."
+    ::= { mediaIndependentEntry 6 }
+
+mediaIndependentInHighCapacityPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    UNITS       "Packets"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of packets (including bad packets,
+        broadcast packets, and multicast packets) received
+        on a half-duplex link or on the inbound connection of a
+        full-duplex link."
+    ::= { mediaIndependentEntry 7 }
+
+mediaIndependentOutPkts OBJECT-TYPE
+    SYNTAX      Counter32
+    UNITS       "Packets"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of packets (including bad packets,
+        broadcast packets, and multicast packets) received on a
+        full-duplex link in the direction of the network."
+    ::= { mediaIndependentEntry 8 }
+
+mediaIndependentOutOverflowPkts OBJECT-TYPE
+    SYNTAX      Counter32
+    UNITS       "Packets"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of times the associated
+        mediaIndependentOutPkts counter has overflowed."
+    ::= { mediaIndependentEntry 9 }
+
+
+
+
+Waldbusser                  Standards Track                    [Page 12]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+mediaIndependentOutHighCapacityPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    UNITS       "Packets"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of packets (including bad packets,
+        broadcast packets, and multicast packets) received on a
+        full-duplex link in the direction of the network."
+    ::= { mediaIndependentEntry 10 }
+
+mediaIndependentInOctets OBJECT-TYPE
+    SYNTAX      Counter32
+    UNITS       "Octets"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of octets of data (including those in bad
+        packets) received (excluding framing bits but including FCS
+        octets) on a half-duplex link or on the inbound connection of
+        a full-duplex link."
+    ::= { mediaIndependentEntry 11 }
+
+mediaIndependentInOverflowOctets OBJECT-TYPE
+    SYNTAX      Counter32
+    UNITS       "Octets"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of times the associated
+        mediaIndependentInOctets counter has overflowed."
+    ::= { mediaIndependentEntry 12 }
+
+mediaIndependentInHighCapacityOctets OBJECT-TYPE
+    SYNTAX      Counter64
+    UNITS       "Octets"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of octets of data (including those in bad
+        packets) received (excluding framing bits but
+        including FCS octets) on a half-duplex link or on the inbound
+        connection of a full-duplex link."
+    ::= { mediaIndependentEntry 13 }
+
+mediaIndependentOutOctets OBJECT-TYPE
+    SYNTAX      Counter32
+    UNITS       "Octets"
+
+
+
+Waldbusser                  Standards Track                    [Page 13]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of octets of data (including those in bad
+        packets) received on a full-duplex link in the direction of
+        the network (excluding framing bits but including FCS
+        octets)."
+    ::= { mediaIndependentEntry 14 }
+
+mediaIndependentOutOverflowOctets OBJECT-TYPE
+    SYNTAX      Counter32
+    UNITS       "Octets"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of times the associated
+        mediaIndependentOutOctets counter has overflowed."
+    ::= { mediaIndependentEntry 15 }
+
+mediaIndependentOutHighCapacityOctets OBJECT-TYPE
+    SYNTAX      Counter64
+    UNITS       "Octets"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of octets of data (including those in bad
+        packets) received on a full-duplex link in the direction of
+        the network (excluding framing bits but including FCS
+        octets)."
+    ::= { mediaIndependentEntry 16 }
+
+mediaIndependentInNUCastPkts OBJECT-TYPE
+    SYNTAX      Counter32
+    UNITS       "Packets"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of non-unicast packets (including bad
+        packets) received on a half-duplex link or on the inbound
+        connection of a full-duplex link."
+    ::= { mediaIndependentEntry 17 }
+
+mediaIndependentInNUCastOverflowPkts OBJECT-TYPE
+    SYNTAX      Counter32
+    UNITS       "Packets"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+
+
+
+Waldbusser                  Standards Track                    [Page 14]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+        "The number of times the associated
+        mediaIndependentInNUCastPkts counter has overflowed."
+    ::= { mediaIndependentEntry 18 }
+
+mediaIndependentInNUCastHighCapacityPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    UNITS       "Packets"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of non-unicast packets (including bad
+        packets) received on a half-duplex link or on the inbound
+        connection of a full-duplex link."
+    ::= { mediaIndependentEntry 19 }
+
+mediaIndependentOutNUCastPkts OBJECT-TYPE
+    SYNTAX      Counter32
+    UNITS       "Packets"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of non-unicast packets (including bad
+        packets) received on a full-duplex link in the direction of
+        the network."
+    ::= { mediaIndependentEntry 20 }
+
+mediaIndependentOutNUCastOverflowPkts OBJECT-TYPE
+    SYNTAX      Counter32
+    UNITS       "Packets"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of times the associated
+        mediaIndependentOutNUCastPkts counter has overflowed."
+    ::= { mediaIndependentEntry 21 }
+
+mediaIndependentOutNUCastHighCapacityPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    UNITS       "Packets"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of packets (including bad packets)
+        received on a full-duplex link in the direction of the
+        network."
+    ::= { mediaIndependentEntry 22 }
+
+mediaIndependentInErrors OBJECT-TYPE
+
+
+
+Waldbusser                  Standards Track                    [Page 15]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    SYNTAX     Counter32
+    UNITS       "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The total number of bad packets received on a
+        half-duplex link or on the inbound connection of a
+        full-duplex link."
+    ::= { mediaIndependentEntry 23 }
+
+mediaIndependentOutErrors OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS       "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The total number of bad packets received on a full-duplex
+        link in the direction of the network."
+    ::= { mediaIndependentEntry 24 }
+
+mediaIndependentInputSpeed OBJECT-TYPE
+    SYNTAX     Gauge32
+    UNITS      "Kilobits per Second"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The nominal maximum speed in kilobits per second of this
+        half-duplex link or on the inbound connection of this
+        full-duplex link. If the speed is unknown or there is no fixed
+        maximum (e.g. a compressed link), this value shall be zero."
+    ::= { mediaIndependentEntry 25 }
+
+mediaIndependentOutputSpeed OBJECT-TYPE
+    SYNTAX     Gauge32
+    UNITS      "Kilobits per Second"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The nominal maximum speed in kilobits per second of this
+        full-duplex link in the direction of the network. If the speed
+        is unknown, the link is half-duplex, or there is no fixed
+        maximum (e.g. a compressed link), this value shall be zero."
+    ::= { mediaIndependentEntry 26 }
+
+mediaIndependentDuplexMode OBJECT-TYPE
+    SYNTAX     INTEGER {
+                    halfduplex(1),
+                    fullduplex(2)
+
+
+
+Waldbusser                  Standards Track                    [Page 16]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+               }
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The current mode of this link.
+
+        Note that if the link has full-duplex capabilities but
+        is operating in half-duplex mode, this value will be
+        halfduplex(1)."
+    ::= { mediaIndependentEntry 27 }
+
+mediaIndependentDuplexChanges OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS      "Events"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times this link has changed from full-duplex
+        mode to half-duplex mode or from half-duplex mode to
+        full-duplex mode."
+    ::= { mediaIndependentEntry 28 }
+
+mediaIndependentDuplexLastChange OBJECT-TYPE
+    SYNTAX     TimeStamp
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The value of sysUpTime at the time the duplex status
+        of this link last changed."
+    ::= { mediaIndependentEntry 29 }
+
+mediaIndependentOwner OBJECT-TYPE
+    SYNTAX     OwnerString
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+        "The entity that configured this entry and is
+        therefore using the resources assigned to it."
+    ::= { mediaIndependentEntry 30 }
+
+mediaIndependentStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+        "The status of this media independent statistics entry."
+    ::= { mediaIndependentEntry 31 }
+
+
+
+
+Waldbusser                  Standards Track                    [Page 17]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+-- High Capacity extensions for the etherStatsTable
+
+etherStatsHighCapacityTable  OBJECT-TYPE
+
+    SYNTAX     SEQUENCE OF EtherStatsHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-1
+        etherStatsTable."
+    ::= { statistics 7 }
+
+etherStatsHighCapacityEntry  OBJECT-TYPE
+    SYNTAX     EtherStatsHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-1
+        etherStatsEntry. These objects will be created by the agent
+        for all etherStatsEntries it deems appropriate."
+    INDEX { etherStatsIndex }
+    ::= { etherStatsHighCapacityTable 1 }
+
+EtherStatsHighCapacityEntry ::= SEQUENCE {
+    etherStatsHighCapacityOverflowPkts                 Counter32,
+    etherStatsHighCapacityPkts                         Counter64,
+    etherStatsHighCapacityOverflowOctets               Counter32,
+    etherStatsHighCapacityOctets                       Counter64,
+    etherStatsHighCapacityOverflowPkts64Octets         Counter32,
+    etherStatsHighCapacityPkts64Octets                 Counter64,
+    etherStatsHighCapacityOverflowPkts65to127Octets    Counter32,
+    etherStatsHighCapacityPkts65to127Octets            Counter64,
+    etherStatsHighCapacityOverflowPkts128to255Octets   Counter32,
+    etherStatsHighCapacityPkts128to255Octets           Counter64,
+    etherStatsHighCapacityOverflowPkts256to511Octets   Counter32,
+    etherStatsHighCapacityPkts256to511Octets           Counter64,
+    etherStatsHighCapacityOverflowPkts512to1023Octets  Counter32,
+    etherStatsHighCapacityPkts512to1023Octets          Counter64,
+    etherStatsHighCapacityOverflowPkts1024to1518Octets Counter32,
+    etherStatsHighCapacityPkts1024to1518Octets         Counter64
+}
+
+etherStatsHighCapacityOverflowPkts OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+
+
+
+Waldbusser                  Standards Track                    [Page 18]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+        "The number of times the associated etherStatsPkts
+        counter has overflowed."
+    ::= { etherStatsHighCapacityEntry 1 }
+
+etherStatsHighCapacityPkts OBJECT-TYPE
+    SYNTAX     Counter64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The total number of packets (including bad packets,
+        broadcast packets, and multicast packets) received."
+    ::= { etherStatsHighCapacityEntry 2 }
+
+etherStatsHighCapacityOverflowOctets OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated etherStatsOctets
+        counter has overflowed."
+    ::= { etherStatsHighCapacityEntry 3 }
+
+etherStatsHighCapacityOctets OBJECT-TYPE
+    SYNTAX     Counter64
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The total number of octets of data (including
+        those in bad packets) received on the
+        network (excluding framing bits but including
+        FCS octets).
+
+        If the network is half-duplex Fast Ethernet, this
+        object can be used as a reasonable estimate of
+        utilization. If greater precision is desired, the
+        etherStatsHighCapacityPkts and
+        etherStatsHighCapacityOctets objects should be sampled
+        before and after a common interval.  The differences
+        in the sampled values are Pkts and Octets,
+        respectively, and the number of seconds in the
+        interval is Interval.  These values
+        are used to calculate the Utilization as follows:
+
+
+
+
+
+
+Waldbusser                  Standards Track                    [Page 19]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+                        Pkts * (.96 + .64) + (Octets * .08)
+        Utilization = -------------------------------------
+                                Interval * 10,000
+
+        The result of this equation is the value Utilization
+        which is the percent utilization of the ethernet
+        segment on a scale of 0 to 100 percent.
+
+        This table is not appropriate for monitoring full-duplex
+        ethernets. If the network is a full-duplex ethernet and the
+        mediaIndependentTable is monitoring that network, the
+        utilization can be calculated as follows:
+
+        1) Determine the utilization of the inbound path by using
+           the appropriate equation (for ethernet or fast ethernet)
+           to determine the utilization, substituting
+           mediaIndependentInPkts for etherStatsHighCapacityPkts, and
+           mediaIndependentInOctets for etherStatsHighCapacityOctets.
+           Call the resulting utilization inUtilization.
+
+        2) Determine the utilization of the outbound path by using
+           the same equation to determine the utilization, substituting
+           mediaIndependentOutPkts for etherStatsHighCapacityPkts, and
+           mediaIndependentOutOctets for etherStatsHighCapacityOctets.
+           Call the resulting utilization outUtilization.
+
+        3) The utilization is the maximum of inUtilization and
+           outUtilization. This metric shows the amount of percentage
+           of bandwidth that is left before congestion will be
+           experienced on the link."
+    ::= { etherStatsHighCapacityEntry 4 }
+
+etherStatsHighCapacityOverflowPkts64Octets OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated etherStatsPkts64Octets
+        counter has overflowed."
+    ::= { etherStatsHighCapacityEntry 5 }
+
+etherStatsHighCapacityPkts64Octets OBJECT-TYPE
+    SYNTAX     Counter64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+
+
+
+Waldbusser                  Standards Track                    [Page 20]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+        "The total number of packets (including bad
+        packets) received that were 64 octets in length
+        (excluding framing bits but including FCS octets)."
+    ::= { etherStatsHighCapacityEntry 6 }
+
+etherStatsHighCapacityOverflowPkts65to127Octets OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated etherStatsPkts65to127Octets
+        counter has overflowed."
+    ::= { etherStatsHighCapacityEntry 7 }
+
+etherStatsHighCapacityPkts65to127Octets OBJECT-TYPE
+    SYNTAX     Counter64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The total number of packets (including bad
+        packets) received that were between
+        65 and 127 octets in length inclusive
+        (excluding framing bits but including FCS octets)."
+    ::= { etherStatsHighCapacityEntry 8 }
+
+etherStatsHighCapacityOverflowPkts128to255Octets OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated etherStatsPkts128to255Octets
+        counter has overflowed."
+    ::= { etherStatsHighCapacityEntry 9 }
+
+etherStatsHighCapacityPkts128to255Octets OBJECT-TYPE
+    SYNTAX     Counter64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The total number of packets (including bad
+        packets) received that were between
+        128 and 255 octets in length inclusive
+        (excluding framing bits but including FCS octets)."
+    ::= { etherStatsHighCapacityEntry 10 }
+
+
+
+Waldbusser                  Standards Track                    [Page 21]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+etherStatsHighCapacityOverflowPkts256to511Octets OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated etherStatsPkts256to511Octets
+        counter has overflowed."
+    ::= { etherStatsHighCapacityEntry 11 }
+
+etherStatsHighCapacityPkts256to511Octets OBJECT-TYPE
+    SYNTAX     Counter64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The total number of packets (including bad
+        packets) received that were between
+        256 and 511 octets in length inclusive
+        (excluding framing bits but including FCS octets)."
+    ::= { etherStatsHighCapacityEntry 12 }
+
+etherStatsHighCapacityOverflowPkts512to1023Octets OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated
+         etherStatsPkts512to1023Octets counter has overflowed."
+    ::= { etherStatsHighCapacityEntry 13 }
+
+etherStatsHighCapacityPkts512to1023Octets OBJECT-TYPE
+    SYNTAX     Counter64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The total number of packets (including bad
+        packets) received that were between
+        512 and 1023 octets in length inclusive
+        (excluding framing bits but including FCS octets)."
+    ::= { etherStatsHighCapacityEntry 14 }
+
+etherStatsHighCapacityOverflowPkts1024to1518Octets OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+
+
+
+Waldbusser                  Standards Track                    [Page 22]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated
+        etherStatsPkts1024to1518Octets counter has overflowed."
+    ::= { etherStatsHighCapacityEntry 15 }
+
+etherStatsHighCapacityPkts1024to1518Octets OBJECT-TYPE
+    SYNTAX     Counter64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The total number of packets (including bad
+        packets) received that were between
+        1024 and 1518 octets in length inclusive
+        (excluding framing bits but including FCS octets)."
+    ::= { etherStatsHighCapacityEntry 16 }
+
+-- High Capacity extensions for the etherHistoryTable
+
+etherHistoryHighCapacityTable  OBJECT-TYPE
+    SYNTAX     SEQUENCE OF EtherHistoryHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-1
+        etherHistoryTable."
+    ::= { history 6 }
+
+etherHistoryHighCapacityEntry  OBJECT-TYPE
+    SYNTAX     EtherHistoryHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-1
+        etherHistoryEntry. These objects will be created by the agent
+        for all etherHistoryEntries associated with whichever
+        historyControlEntries it deems appropriate. (i.e., either all
+        etherHistoryHighCapacityEntries associated with a particular
+        historyControlEntry will be created, or none of them will
+        be.)"
+    INDEX { etherHistoryIndex, etherHistorySampleIndex }
+    ::= { etherHistoryHighCapacityTable 1 }
+
+EtherHistoryHighCapacityEntry ::= SEQUENCE {
+    etherHistoryHighCapacityOverflowPkts           Gauge32,
+    etherHistoryHighCapacityPkts                   CounterBasedGauge64,
+    etherHistoryHighCapacityOverflowOctets         Gauge32,
+
+
+
+Waldbusser                  Standards Track                    [Page 23]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    etherHistoryHighCapacityOctets                 CounterBasedGauge64
+}
+
+etherHistoryHighCapacityOverflowPkts OBJECT-TYPE
+    SYNTAX     Gauge32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated etherHistoryPkts
+        Gauge overflowed during this sampling interval."
+    ::= { etherHistoryHighCapacityEntry 1 }
+
+etherHistoryHighCapacityPkts OBJECT-TYPE
+    SYNTAX     CounterBasedGauge64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The total number of packets (including bad packets,
+        broadcast packets, and multicast packets) received during
+        this sampling interval."
+    ::= { etherHistoryHighCapacityEntry 2 }
+
+etherHistoryHighCapacityOverflowOctets OBJECT-TYPE
+    SYNTAX     Gauge32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated etherHistoryOctets
+        counter has overflowed during this sampling interval."
+    ::= { etherHistoryHighCapacityEntry 3 }
+
+etherHistoryHighCapacityOctets OBJECT-TYPE
+    SYNTAX     CounterBasedGauge64
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The total number of octets of data (including
+        those in bad packets) received on the
+        network (excluding framing bits but including
+        FCS octets) during this sampling interval."
+    ::= { etherHistoryHighCapacityEntry 4 }
+
+-- High Capacity Extensions for the hostTable
+
+
+
+
+Waldbusser                  Standards Track                    [Page 24]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+hostHighCapacityTable  OBJECT-TYPE
+    SYNTAX     SEQUENCE OF HostHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-1
+        hostTable."
+    ::= { hosts 5 }
+
+hostHighCapacityEntry  OBJECT-TYPE
+    SYNTAX     HostHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-1
+        hostEntry. These objects will be created by the agent
+        for all hostEntries associated with whichever
+        hostControlEntries it deems appropriate. (i.e., either all
+        hostHighCapacityEntries associated with a particular
+        hostControlEntry will be created, or none of them will
+        be.)"
+    INDEX { hostIndex, hostAddress }
+    ::= { hostHighCapacityTable 1 }
+
+HostHighCapacityEntry ::= SEQUENCE {
+    hostHighCapacityInOverflowPkts    Counter32,
+    hostHighCapacityInPkts            Counter64,
+    hostHighCapacityOutOverflowPkts   Counter32,
+    hostHighCapacityOutPkts           Counter64,
+    hostHighCapacityInOverflowOctets  Counter32,
+    hostHighCapacityInOctets          Counter64,
+    hostHighCapacityOutOverflowOctets Counter32,
+    hostHighCapacityOutOctets         Counter64
+}
+
+hostHighCapacityInOverflowPkts OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated hostInPkts
+        counter has overflowed."
+    ::= { hostHighCapacityEntry 1 }
+
+hostHighCapacityInPkts OBJECT-TYPE
+    SYNTAX     Counter64
+    UNITS      "Packets"
+
+
+
+Waldbusser                  Standards Track                    [Page 25]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of good packets transmitted to
+        this address since it was added to the
+        hostHighCapacityTable."
+    ::= { hostHighCapacityEntry 2 }
+
+hostHighCapacityOutOverflowPkts OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated hostOutPkts
+        counter has overflowed."
+    ::= { hostHighCapacityEntry 3 }
+
+hostHighCapacityOutPkts OBJECT-TYPE
+    SYNTAX     Counter64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of packets, including bad packets, transmitted
+        by this address since it was added to the
+        hostHighCapacityTable."
+    ::= { hostHighCapacityEntry 4 }
+
+hostHighCapacityInOverflowOctets OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated hostInOctets
+        counter has overflowed."
+    ::= { hostHighCapacityEntry 5 }
+
+hostHighCapacityInOctets OBJECT-TYPE
+    SYNTAX     Counter64
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets transmitted to this address
+        since it was added to the hostHighCapacityTable (excluding
+        framing bits but including FCS octets), except for
+
+
+
+Waldbusser                  Standards Track                    [Page 26]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+        those octets in bad packets."
+    ::= { hostHighCapacityEntry 6 }
+
+hostHighCapacityOutOverflowOctets OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated hostOutOctets
+        counter has overflowed."
+    ::= { hostHighCapacityEntry 7 }
+
+hostHighCapacityOutOctets OBJECT-TYPE
+    SYNTAX     Counter64
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets transmitted by this address
+        since it was added to the hostHighCapacityTable (excluding
+        framing bits but including FCS octets), including
+        those octets in bad packets."
+    ::= { hostHighCapacityEntry 8 }
+
+-- High Capacity extensions for the hostTimeTable
+
+hostTimeHighCapacityTable  OBJECT-TYPE
+    SYNTAX     SEQUENCE OF HostTimeHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-1
+        hostTimeTable."
+    ::= { hosts 6 }
+
+hostTimeHighCapacityEntry  OBJECT-TYPE
+    SYNTAX     HostTimeHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-1
+        hostTimeEntry. These objects will be created by the agent
+        for all hostTimeEntries associated with whichever
+        hostControlEntries it deems appropriate. (i.e., either all
+        hostTimeHighCapacityEntries associated with a particular
+        hostControlEntry will be created, or none of them will
+        be.)"
+
+
+
+Waldbusser                  Standards Track                    [Page 27]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    INDEX { hostTimeIndex, hostTimeCreationOrder }
+    ::= { hostTimeHighCapacityTable 1 }
+
+HostTimeHighCapacityEntry ::= SEQUENCE {
+    hostTimeHighCapacityInOverflowPkts    Counter32,
+    hostTimeHighCapacityInPkts            Counter64,
+    hostTimeHighCapacityOutOverflowPkts   Counter32,
+    hostTimeHighCapacityOutPkts           Counter64,
+    hostTimeHighCapacityInOverflowOctets  Counter32,
+    hostTimeHighCapacityInOctets          Counter64,
+    hostTimeHighCapacityOutOverflowOctets Counter32,
+    hostTimeHighCapacityOutOctets         Counter64
+}
+
+hostTimeHighCapacityInOverflowPkts OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated hostTimeInPkts
+        counter has overflowed."
+    ::= { hostTimeHighCapacityEntry 1 }
+
+hostTimeHighCapacityInPkts OBJECT-TYPE
+    SYNTAX     Counter64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of good packets transmitted to this address
+        since it was added to the hostTimeHighCapacityTable."
+    ::= { hostTimeHighCapacityEntry 2 }
+
+hostTimeHighCapacityOutOverflowPkts OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated hostTimeOutPkts
+        counter has overflowed."
+    ::= { hostTimeHighCapacityEntry 3 }
+
+hostTimeHighCapacityOutPkts OBJECT-TYPE
+    SYNTAX     Counter64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+
+
+
+Waldbusser                  Standards Track                    [Page 28]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    STATUS     current
+    DESCRIPTION
+        "The number of packets, including bad packets, transmitted
+        by this address since it was added to the
+        hostTimeHighCapacityTable."
+    ::= { hostTimeHighCapacityEntry 4 }
+
+hostTimeHighCapacityInOverflowOctets OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated hostTimeInOctets
+        counter has overflowed."
+    ::= { hostTimeHighCapacityEntry 5 }
+
+hostTimeHighCapacityInOctets OBJECT-TYPE
+    SYNTAX     Counter64
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets transmitted to this address
+        since it was added to the hostTimeHighCapacityTable
+        (excluding framing bits but including FCS octets),
+        except for those octets in bad packets."
+    ::= { hostTimeHighCapacityEntry 6 }
+
+hostTimeHighCapacityOutOverflowOctets OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated hostTimeOutOctets
+        counter has overflowed."
+    ::= { hostTimeHighCapacityEntry 7 }
+
+hostTimeHighCapacityOutOctets OBJECT-TYPE
+    SYNTAX     Counter64
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets transmitted by this address since
+        it was added to the hostTimeTable (excluding framing
+        bits but including FCS octets), including those
+
+
+
+Waldbusser                  Standards Track                    [Page 29]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+        octets in bad packets."
+    ::= { hostTimeHighCapacityEntry 8 }
+
+-- High Capacity Extensions for the hostTopNTable
+
+hostTopNHighCapacityTable  OBJECT-TYPE
+    SYNTAX     SEQUENCE OF HostTopNHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-1
+        hostTopNTable when hostTopNRateBase specifies a High Capacity
+        TopN Report."
+    ::= { hostTopN 3 }
+
+hostTopNHighCapacityEntry  OBJECT-TYPE
+    SYNTAX     HostTopNHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-1
+        hostTopNEntry when hostTopNRateBase specifies a High Capacity
+        TopN Report. These objects will be created by the agent
+        for all hostTopNEntries associated with whichever
+        hostTopNControlEntries have a hostTopNRateBase that specify
+        a high capacity report."
+    INDEX { hostTopNReport, hostTopNIndex }
+    ::= { hostTopNHighCapacityTable 1 }
+
+HostTopNHighCapacityEntry ::= SEQUENCE {
+     hostTopNHighCapacityAddress        OCTET STRING,
+     hostTopNHighCapacityBaseRate       Gauge32,
+     hostTopNHighCapacityOverflowRate   Gauge32,
+     hostTopNHighCapacityRate           CounterBasedGauge64
+}
+
+hostTopNHighCapacityAddress OBJECT-TYPE
+    SYNTAX     OCTET STRING
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+          "The physical address of this host."
+    ::= { hostTopNHighCapacityEntry 1 }
+
+hostTopNHighCapacityBaseRate OBJECT-TYPE
+    SYNTAX     Gauge32
+    MAX-ACCESS read-only
+    STATUS     current
+
+
+
+Waldbusser                  Standards Track                    [Page 30]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    DESCRIPTION
+          "The amount of change in the selected variable
+          during this sampling interval, modulo 2^32.  The
+          selected variable is this host's instance of the
+          object selected by hostTopNRateBase."
+    ::= { hostTopNHighCapacityEntry 2 }
+
+hostTopNHighCapacityOverflowRate OBJECT-TYPE
+    SYNTAX     Gauge32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+          "The amount of change in the selected variable
+          during this sampling interval, divided by 2^32, truncating
+          fractions (i.e., X DIV 2^32).  The selected variable is
+          this host's instance of the object selected by
+          hostTopNRateBase."
+    ::= { hostTopNHighCapacityEntry 3 }
+
+hostTopNHighCapacityRate OBJECT-TYPE
+     SYNTAX     CounterBasedGauge64
+     MAX-ACCESS read-only
+     STATUS     current
+     DESCRIPTION
+          "The amount of change in the selected variable
+          during this sampling interval.  The selected
+          variable is this host's instance of the object
+          selected by hostTopNRateBase."
+     ::= { hostTopNHighCapacityEntry 4 }
+
+-- High Capacity Extensions for the matrixSDTable
+
+matrixSDHighCapacityTable  OBJECT-TYPE
+    SYNTAX     SEQUENCE OF MatrixSDHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-1
+        matrixSDTable."
+    ::= { matrix 5 }
+
+matrixSDHighCapacityEntry  OBJECT-TYPE
+    SYNTAX     MatrixSDHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-1
+        matrixSDEntry. These objects will be created by the agent
+
+
+
+Waldbusser                  Standards Track                    [Page 31]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+        for all matrixSDEntries associated with whichever
+        matrixControlEntries it deems appropriate. (i.e., either all
+        matrixSDHighCapacityEntries associated with a particular
+        matrixControlEntry will be created, or none of them will
+        be.)"
+    INDEX { matrixSDIndex,
+            matrixSDSourceAddress, matrixSDDestAddress }
+    ::= { matrixSDHighCapacityTable 1 }
+
+MatrixSDHighCapacityEntry ::= SEQUENCE {
+    matrixSDHighCapacityOverflowPkts   Counter32,
+    matrixSDHighCapacityPkts           Counter64,
+    matrixSDHighCapacityOverflowOctets Counter32,
+    matrixSDHighCapacityOctets         Counter64
+}
+
+matrixSDHighCapacityOverflowPkts OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated matrixSDPkts
+        counter has overflowed."
+    ::= { matrixSDHighCapacityEntry 1 }
+
+matrixSDHighCapacityPkts OBJECT-TYPE
+    SYNTAX     Counter64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of packets transmitted from the source
+        address to the destination address (this number
+        includes bad packets)."
+    ::= { matrixSDHighCapacityEntry 2 }
+
+matrixSDHighCapacityOverflowOctets OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated matrixSDOctets
+        counter has overflowed."
+    ::= { matrixSDHighCapacityEntry 3 }
+
+matrixSDHighCapacityOctets OBJECT-TYPE
+
+
+
+Waldbusser                  Standards Track                    [Page 32]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    SYNTAX     Counter64
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets (excluding framing bits but
+        including FCS octets) contained in all packets
+        transmitted from the source address to the
+        destination address."
+    ::= { matrixSDHighCapacityEntry 4 }
+
+-- High Capacity extensions for the matrixDSTable
+
+matrixDSHighCapacityTable  OBJECT-TYPE
+    SYNTAX     SEQUENCE OF MatrixDSHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-1
+        matrixDSTable."
+    ::= { matrix 6 }
+
+matrixDSHighCapacityEntry  OBJECT-TYPE
+    SYNTAX     MatrixDSHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-1
+        matrixDSEntry. These objects will be created by the agent
+        for all matrixDSEntries associated with whichever
+        matrixControlEntries it deems appropriate. (i.e., either all
+        matrixDSHighCapacityEntries associated with a particular
+        matrixControlEntry will be created, or none of them will
+        be.)"
+    INDEX { matrixDSIndex,
+            matrixDSDestAddress, matrixDSSourceAddress }
+    ::= { matrixDSHighCapacityTable 1 }
+
+MatrixDSHighCapacityEntry ::= SEQUENCE {
+    matrixDSHighCapacityOverflowPkts   Counter32,
+    matrixDSHighCapacityPkts           Counter64,
+    matrixDSHighCapacityOverflowOctets Counter32,
+    matrixDSHighCapacityOctets         Counter64
+}
+
+matrixDSHighCapacityOverflowPkts OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS      "Packets"
+
+
+
+Waldbusser                  Standards Track                    [Page 33]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated matrixDSPkts
+        counter has overflowed."
+    ::= { matrixDSHighCapacityEntry 1 }
+
+matrixDSHighCapacityPkts OBJECT-TYPE
+    SYNTAX     Counter64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of packets transmitted from the source
+        address to the destination address (this number
+        includes bad packets)."
+    ::= { matrixDSHighCapacityEntry 2 }
+
+matrixDSHighCapacityOverflowOctets OBJECT-TYPE
+    SYNTAX     Counter32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated matrixDSOctets
+        counter has overflowed."
+    ::= { matrixDSHighCapacityEntry 3 }
+
+matrixDSHighCapacityOctets OBJECT-TYPE
+    SYNTAX     Counter64
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets (excluding framing bits
+        but including FCS octets) contained in all packets
+        transmitted from the source address to the
+        destination address."
+    ::= { matrixDSHighCapacityEntry 4 }
+
+-- High Capacity extensions for the captureBufferTable
+
+captureBufferHighCapacityTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF CaptureBufferHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-1
+
+
+
+Waldbusser                  Standards Track                    [Page 34]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+        captureBufferTable."
+    ::= { capture 3 }
+
+captureBufferHighCapacityEntry OBJECT-TYPE
+    SYNTAX     CaptureBufferHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-1
+        captureBufferEntry. These objects will be created by the agent
+        for all captureBufferEntries associated with whichever
+        bufferControlEntries it deems appropriate. (i.e., either all
+        captureBufferHighCapacityEntries associated with a particular
+        bufferControlEntry will be created, or none of them will
+        be.)"
+    INDEX { captureBufferControlIndex, captureBufferIndex }
+    ::= { captureBufferHighCapacityTable 1 }
+
+CaptureBufferHighCapacityEntry ::= SEQUENCE {
+    captureBufferPacketHighCapacityTime     Integer32
+}
+
+captureBufferPacketHighCapacityTime  OBJECT-TYPE
+    SYNTAX      Integer32 (0..999999)
+    UNITS       "nanoseconds"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of nanoseconds that had passed since this capture
+        buffer was first turned on when this packet was captured,
+        modulo 10^6.
+
+        This object is used in conjunction with the
+        captureBufferPacketTime object. This object returns the
+        number of nano-seconds to be added to to number of
+        milli-seconds obtained from the captureBufferPacketTime
+        object, to obtain more accurate inter packet arrival time."
+  ::= { captureBufferHighCapacityEntry 1 }
+
+-- High Capacity extensions for the protocolDistStatsTable
+
+protocolDistStatsHighCapacityTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF ProtocolDistStatsHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-2
+        protocolDistStatsTable."
+
+
+
+Waldbusser                  Standards Track                    [Page 35]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    ::= { protocolDist 3 }
+
+protocolDistStatsHighCapacityEntry OBJECT-TYPE
+    SYNTAX     ProtocolDistStatsHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-2
+        protocolDistStatsTable. These objects will be created by the
+        agent for all protocolDistStatsEntries associated with
+        whichever protocolDistControlEntries it deems appropriate.
+        (i.e., either all protocolDistStatsHighCapacityEntries
+        associated with a particular protocolDistControlEntry will be
+        created, or none of them will be.)"
+    INDEX { protocolDistControlIndex, protocolDirLocalIndex }
+    ::= { protocolDistStatsHighCapacityTable 1 }
+
+ProtocolDistStatsHighCapacityEntry ::= SEQUENCE {
+    protocolDistStatsHighCapacityOverflowPkts   ZeroBasedCounter32,
+    protocolDistStatsHighCapacityPkts           ZeroBasedCounter64,
+    protocolDistStatsHighCapacityOverflowOctets ZeroBasedCounter32,
+    protocolDistStatsHighCapacityOctets         ZeroBasedCounter64
+}
+
+protocolDistStatsHighCapacityOverflowPkts OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated protocolDistStatsPkts
+        counter has overflowed."
+    ::= { protocolDistStatsHighCapacityEntry 1 }
+
+protocolDistStatsHighCapacityPkts OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of packets without errors received of this
+        protocol type.  Note that this is the number of link-layer
+        packets, so if a single network-layer packet is fragmented
+        into several link-layer frames, this counter is incremented
+        several times."
+    ::= { protocolDistStatsHighCapacityEntry 2 }
+
+protocolDistStatsHighCapacityOverflowOctets OBJECT-TYPE
+
+
+
+Waldbusser                  Standards Track                    [Page 36]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    SYNTAX     ZeroBasedCounter32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated protocolDistStatsOctets
+        counter has overflowed."
+    ::= { protocolDistStatsHighCapacityEntry 3 }
+
+protocolDistStatsHighCapacityOctets OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter64
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets in packets received of this protocol
+        type since it was added to the protocolDistStatsTable
+        (excluding framing bits but including FCS octets), except for
+        those octets in packets that contained errors.
+
+        Note this doesn't count just those octets in the particular
+        protocol frames, but includes the entire packet that contained
+        the protocol."
+    ::= { protocolDistStatsHighCapacityEntry 4 }
+
+-- High Capacity extensions for the nlHostTable.
+
+nlHostHighCapacityTable  OBJECT-TYPE
+    SYNTAX     SEQUENCE OF NlHostHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-2
+        nlHostTable."
+    ::= { nlHost 3 }
+
+nlHostHighCapacityEntry  OBJECT-TYPE
+    SYNTAX     NlHostHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-2
+        nlHostEntry. These objects will be created by the agent
+        for all nlHostEntries associated with whichever
+        hlHostControlEntries it deems appropriate. (i.e., either all
+        nlHostHighCapacityEntries associated with a particular
+        hlHostControlEntry will be created, or none of them will
+        be.)"
+
+
+
+Waldbusser                  Standards Track                    [Page 37]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    INDEX { hlHostControlIndex, nlHostTimeMark,
+            protocolDirLocalIndex, nlHostAddress }
+    ::= { nlHostHighCapacityTable 1 }
+
+NlHostHighCapacityEntry ::= SEQUENCE {
+    nlHostHighCapacityInOverflowPkts    ZeroBasedCounter32,
+    nlHostHighCapacityInPkts            ZeroBasedCounter64,
+    nlHostHighCapacityOutOverflowPkts   ZeroBasedCounter32,
+    nlHostHighCapacityOutPkts           ZeroBasedCounter64,
+    nlHostHighCapacityInOverflowOctets  ZeroBasedCounter32,
+    nlHostHighCapacityInOctets          ZeroBasedCounter64,
+    nlHostHighCapacityOutOverflowOctets ZeroBasedCounter32,
+    nlHostHighCapacityOutOctets         ZeroBasedCounter64
+}
+
+nlHostHighCapacityInOverflowPkts OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated nlHostInPkts
+        counter has overflowed."
+    ::= { nlHostHighCapacityEntry 1 }
+
+nlHostHighCapacityInPkts OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of packets without errors transmitted to
+        this address since it was added to the nlHostHighCapacityTable.
+        Note that this is the number of link-layer packets, so if a
+        single network-layer packet is fragmented into several
+        link-layer frames, this counter is incremented several times."
+    ::= { nlHostHighCapacityEntry 2 }
+
+nlHostHighCapacityOutOverflowPkts OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated nlHostOutPkts
+        counter has overflowed."
+    ::= { nlHostHighCapacityEntry 3 }
+
+
+
+
+Waldbusser                  Standards Track                    [Page 38]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+nlHostHighCapacityOutPkts OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of packets without errors transmitted by
+        this address since it was added to the nlHostHighCapacityTable.
+        Note that this is the number of link-layer packets, so if a
+        single network-layer packet is fragmented into several
+        link-layer frames, this counter is incremented several times."
+    ::= { nlHostHighCapacityEntry 4 }
+
+nlHostHighCapacityInOverflowOctets OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated nlHostInOctets
+        counter has overflowed."
+    ::= { nlHostHighCapacityEntry 5 }
+
+nlHostHighCapacityInOctets OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter64
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets transmitted to this address
+        since it was added to the nlHostHighCapacityTable
+        (excluding framing bits but including FCS octets),
+        excluding those octets in packets that contained
+        errors.
+
+        Note this doesn't count just those octets in the
+        particular protocol frames, but includes the entire
+        packet that contained the protocol."
+    ::= { nlHostHighCapacityEntry 6 }
+
+nlHostHighCapacityOutOverflowOctets OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated nlHostOutOctets
+        counter has overflowed."
+
+
+
+Waldbusser                  Standards Track                    [Page 39]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    ::= { nlHostHighCapacityEntry 7 }
+
+nlHostHighCapacityOutOctets OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter64
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets transmitted by this address
+        since it was added to the nlHostHighCapacityTable
+        (excluding framing bits but including FCS octets),
+        excluding those octets in packets that contained
+        errors.
+
+        Note this doesn't count just those octets in the
+        particular protocol frames, but includes the entire
+        packet that contained the protocol."
+    ::= { nlHostHighCapacityEntry 8 }
+
+-- High Capacity extensions for the nlMatrixTable
+
+nlMatrixSDHighCapacityTable  OBJECT-TYPE
+    SYNTAX     SEQUENCE OF NlMatrixSDHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-2
+        nlMatrixTable."
+    ::= { nlMatrix 6 }
+
+nlMatrixSDHighCapacityEntry  OBJECT-TYPE
+    SYNTAX     NlMatrixSDHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-2
+        nlMatrixEntry. These objects will be created by the agent
+        for all nlMatrixSDEntries associated with whichever
+        hlMatrixControlEntries it deems appropriate. (i.e., either all
+        nlMatrixSDHighCapacityEntries associated with a particular
+        hlMatrixControlEntry will be created, or none of them will
+        be.)"
+    INDEX { hlMatrixControlIndex, nlMatrixSDTimeMark,
+            protocolDirLocalIndex,
+            nlMatrixSDSourceAddress, nlMatrixSDDestAddress }
+    ::= { nlMatrixSDHighCapacityTable 1 }
+
+NlMatrixSDHighCapacityEntry ::= SEQUENCE {
+
+
+
+Waldbusser                  Standards Track                    [Page 40]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    nlMatrixSDHighCapacityOverflowPkts   ZeroBasedCounter32,
+    nlMatrixSDHighCapacityPkts           ZeroBasedCounter64,
+    nlMatrixSDHighCapacityOverflowOctets ZeroBasedCounter32,
+    nlMatrixSDHighCapacityOctets         ZeroBasedCounter64
+}
+
+nlMatrixSDHighCapacityOverflowPkts OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated nlMatrixSDPkts
+        counter has overflowed."
+    ::= { nlMatrixSDHighCapacityEntry 1 }
+
+nlMatrixSDHighCapacityPkts OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of packets without errors transmitted from the
+        source address to the destination address since this entry was
+        added to the nlMatrixSDHighCapacityTable.  Note that this is
+        the number of link-layer packets, so if a single network-layer
+        packet is fragmented into several link-layer frames, this
+        counter is incremented several times."
+    ::= { nlMatrixSDHighCapacityEntry 2 }
+
+nlMatrixSDHighCapacityOverflowOctets OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated nlMatrixSDOctets
+        counter has overflowed."
+    ::= { nlMatrixSDHighCapacityEntry 3 }
+
+nlMatrixSDHighCapacityOctets OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter64
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets transmitted from the source address to
+        the destination address since this entry was added to the
+
+
+
+Waldbusser                  Standards Track                    [Page 41]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+        nlMatrixSDHighCapacityTable (excluding framing bits but
+        including FCS octets), excluding those octets in packets that
+        contained errors.
+
+        Note this doesn't count just those octets in the particular
+        protocol frames, but includes the entire packet that contained
+        the protocol."
+    ::= { nlMatrixSDHighCapacityEntry 4 }
+
+-- High Capacity extensions for the nlMatrixDSTable
+
+nlMatrixDSHighCapacityTable  OBJECT-TYPE
+    SYNTAX     SEQUENCE OF NlMatrixDSHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-2
+        nlMatrixDSTable."
+    ::= { nlMatrix 7 }
+
+nlMatrixDSHighCapacityEntry  OBJECT-TYPE
+    SYNTAX     NlMatrixDSHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-2
+        nlMatrixDSEntry. These objects will be created by the agent
+        for all nlMatrixDSEntries associated with whichever
+        hlmatrixControlEntries it deems appropriate. (i.e., either all
+        nlMatrixDSHighCapacityEntries associated with a particular
+        hlMatrixControlEntry will be created, or none of them will
+        be.)"
+    INDEX { hlMatrixControlIndex, nlMatrixDSTimeMark,
+            protocolDirLocalIndex,
+            nlMatrixDSDestAddress, nlMatrixDSSourceAddress }
+    ::= { nlMatrixDSHighCapacityTable 1 }
+
+NlMatrixDSHighCapacityEntry ::= SEQUENCE {
+    nlMatrixDSHighCapacityOverflowPkts   ZeroBasedCounter32,
+    nlMatrixDSHighCapacityPkts           ZeroBasedCounter64,
+    nlMatrixDSHighCapacityOverflowOctets ZeroBasedCounter32,
+    nlMatrixDSHighCapacityOctets         ZeroBasedCounter64
+}
+
+nlMatrixDSHighCapacityOverflowPkts OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+
+
+
+Waldbusser                  Standards Track                    [Page 42]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated nlMatrixDSPkts
+        counter has overflowed."
+    ::= { nlMatrixDSHighCapacityEntry 1 }
+
+nlMatrixDSHighCapacityPkts OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of packets without errors transmitted from the
+        source address to the destination address since this entry was
+        added to the nlMatrixDSHighCapacityTable.  Note that this is
+        the number of link-layer packets, so if a single network-layer
+        packet is fragmented into several link-layer frames, this
+        counter is incremented several times."
+    ::= { nlMatrixDSHighCapacityEntry 2 }
+
+nlMatrixDSHighCapacityOverflowOctets OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated nlMatrixDSOctets
+        counter has overflowed."
+    ::= { nlMatrixDSHighCapacityEntry 3 }
+
+nlMatrixDSHighCapacityOctets OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter64
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets transmitted from the source address
+        to the destination address since this entry was added to the
+        nlMatrixDSHighCapacityTable (excluding framing bits but
+        including FCS octets), excluding those octets in packets that
+        contained errors.
+
+        Note this doesn't count just those octets in the particular
+        protocol frames, but includes the entire packet that contained
+        the protocol."
+    ::= { nlMatrixDSHighCapacityEntry 4 }
+
+-- High Capacity extensions for the nlMatrixTopNTable
+
+
+
+Waldbusser                  Standards Track                    [Page 43]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+nlMatrixTopNHighCapacityTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF NlMatrixTopNHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-2
+        nlMatrixTopNTable when nlMatrixTopNControlRateBase specifies
+        a High Capacity TopN Report."
+    ::= { nlMatrix 8 }
+
+nlMatrixTopNHighCapacityEntry OBJECT-TYPE
+    SYNTAX     NlMatrixTopNHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-2
+        nlMatrixTopNEntry when nlMatrixTopNControlRateBase specifies
+        a High Capacity TopN Report. These objects will be created by
+        the agent for all nlMatrixTopNEntries associated with whichever
+        nlMatrixTopNControlEntries have a nlMatrixTopNControlRateBase
+        that specify a high capacity report."
+    INDEX { nlMatrixTopNControlIndex, nlMatrixTopNIndex }
+    ::= { nlMatrixTopNHighCapacityTable 1 }
+
+NlMatrixTopNHighCapacityEntry ::= SEQUENCE {
+  nlMatrixTopNHighCapacityProtocolDirLocalIndex    Integer32,
+  nlMatrixTopNHighCapacitySourceAddress            OCTET STRING,
+  nlMatrixTopNHighCapacityDestAddress              OCTET STRING,
+  nlMatrixTopNHighCapacityBasePktRate              Gauge32,
+  nlMatrixTopNHighCapacityOverflowPktRate          Gauge32,
+  nlMatrixTopNHighCapacityPktRate                  CounterBasedGauge64,
+  nlMatrixTopNHighCapacityReverseBasePktRate       Gauge32,
+  nlMatrixTopNHighCapacityReverseOverflowPktRate   Gauge32,
+  nlMatrixTopNHighCapacityReversePktRate           CounterBasedGauge64,
+  nlMatrixTopNHighCapacityBaseOctetRate            Gauge32,
+  nlMatrixTopNHighCapacityOverflowOctetRate        Gauge32,
+  nlMatrixTopNHighCapacityOctetRate                CounterBasedGauge64,
+  nlMatrixTopNHighCapacityReverseBaseOctetRate     Gauge32,
+  nlMatrixTopNHighCapacityReverseOverflowOctetRate Gauge32,
+  nlMatrixTopNHighCapacityReverseOctetRate         CounterBasedGauge64
+}
+
+nlMatrixTopNHighCapacityProtocolDirLocalIndex OBJECT-TYPE
+    SYNTAX     Integer32 (1..2147483647)
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The protocolDirLocalIndex of the network layer protocol of
+
+
+
+Waldbusser                  Standards Track                    [Page 44]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+        this entry's network address."
+    ::= { nlMatrixTopNHighCapacityEntry 1 }
+
+nlMatrixTopNHighCapacitySourceAddress OBJECT-TYPE
+    SYNTAX     OCTET STRING
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The network layer address of the source host in this
+        conversation.
+
+        This is represented as an octet string with
+        specific semantics and length as identified
+        by the associated nlMatrixTopNProtocolDirLocalIndex.
+
+        For example, if the protocolDirLocalIndex indicates an
+        encapsulation of ip, this object is encoded as a length
+        octet of 4, followed by the 4 octets of the ip address,
+        in network byte order."
+    ::= { nlMatrixTopNHighCapacityEntry 2 }
+
+nlMatrixTopNHighCapacityDestAddress OBJECT-TYPE
+    SYNTAX     OCTET STRING
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The network layer address of the destination host in this
+        conversation.
+
+        This is represented as an octet string with
+        specific semantics and length as identified
+        by the associated nlMatrixTopNProtocolDirLocalIndex.
+
+        For example, if the nlMatrixTopNProtocolDirLocalIndex
+        indicates an encapsulation of ip, this object is encoded as a
+        length octet of 4, followed by the 4 octets of the ip address,
+        in network byte order."
+    ::= { nlMatrixTopNHighCapacityEntry 3 }
+
+nlMatrixTopNHighCapacityBasePktRate OBJECT-TYPE
+    SYNTAX     Gauge32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of packets seen from the source host
+        to the destination host during this sampling interval,
+        modulo 2^32, counted using the rules for counting the
+
+
+
+Waldbusser                  Standards Track                    [Page 45]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+        nlMatrixSDPkts object."
+    ::= { nlMatrixTopNHighCapacityEntry 4 }
+
+nlMatrixTopNHighCapacityOverflowPktRate OBJECT-TYPE
+    SYNTAX     Gauge32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of packets seen from the source host
+        to the destination host during this sampling interval,
+        divided by 2^32, truncating fractions (i.e., X DIV 2^32),
+        and counted using the rules for counting the
+        nlMatrixSDPkts object."
+    ::= { nlMatrixTopNHighCapacityEntry 5 }
+
+nlMatrixTopNHighCapacityPktRate OBJECT-TYPE
+    SYNTAX     CounterBasedGauge64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of packets seen from the source host to the
+        destination host during this sampling interval, counted
+        using the rules for counting the nlMatrixSDPkts object.
+        If the value of nlMatrixTopNControlRateBase is
+        nlMatrixTopNHighCapacityPkts, this variable will be
+        used to sort this report."
+    ::= { nlMatrixTopNHighCapacityEntry 6 }
+
+nlMatrixTopNHighCapacityReverseBasePktRate OBJECT-TYPE
+    SYNTAX     Gauge32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of packets seen from the destination host to the
+        source host during this sampling interval, modulo 2^32, counted
+        using the rules for counting the nlMatrixSDPkts object (note
+        that the corresponding nlMatrixSDPkts object selected is the
+        one whose source address is equal to nlMatrixTopNDestAddress
+        and whose destination address is equal to
+        nlMatrixTopNSourceAddress.)
+
+        Note that if the value of nlMatrixTopNControlRateBase is equal
+        to nlMatrixTopNHighCapacityPkts, the sort of topN entries is
+        based entirely on nlMatrixTopNHighCapacityPktRate, and not on
+        the value of this object."
+
+
+
+Waldbusser                  Standards Track                    [Page 46]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    ::= { nlMatrixTopNHighCapacityEntry 7 }
+
+nlMatrixTopNHighCapacityReverseOverflowPktRate OBJECT-TYPE
+    SYNTAX     Gauge32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of packets seen from the destination host to the
+        source host during this sampling interval, divided by 2^32,
+        truncating fractions (i.e., X DIV 2^32), and counted
+        using the rules for counting the nlMatrixSDPkts object (note
+        that the corresponding nlMatrixSDPkts object selected is the
+        one whose source address is equal to nlMatrixTopNDestAddress
+        and whose destination address is equal to
+        nlMatrixTopNSourceAddress.)
+
+        Note that if the value of nlMatrixTopNControlRateBase is equal
+        to nlMatrixTopNHighCapacityPkts, the sort of topN entries is
+        based entirely on nlMatrixTopNHighCapacityPktRate, and not on
+        the value of this object."
+    ::= { nlMatrixTopNHighCapacityEntry 8 }
+
+nlMatrixTopNHighCapacityReversePktRate OBJECT-TYPE
+    SYNTAX     CounterBasedGauge64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of packets seen from the destination host to the
+        source host during this sampling interval, counted
+        using the rules for counting the nlMatrixSDPkts object (note
+        that the corresponding nlMatrixSDPkts object selected is the
+        one whose source address is equal to nlMatrixTopNDestAddress
+        and whose destination address is equal to
+        nlMatrixTopNSourceAddress.)
+
+        Note that if the value of nlMatrixTopNControlRateBase is equal
+        to nlMatrixTopNHighCapacityPkts, the sort of topN entries is
+        based entirely on nlMatrixTopNHighCapacityPktRate, and not on
+        the value of this object."
+    ::= { nlMatrixTopNHighCapacityEntry 9 }
+
+nlMatrixTopNHighCapacityBaseOctetRate OBJECT-TYPE
+    SYNTAX     Gauge32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+
+
+
+Waldbusser                  Standards Track                    [Page 47]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    DESCRIPTION
+        "The number of octets seen from the source host to the
+        destination host during this sampling interval, modulo 2^32,
+        counted using the rules for counting the nlMatrixSDOctets
+        object."
+    ::= { nlMatrixTopNHighCapacityEntry 10 }
+
+nlMatrixTopNHighCapacityOverflowOctetRate OBJECT-TYPE
+    SYNTAX     Gauge32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets seen from the source host
+        to the destination host during this sampling interval,
+        divided by 2^32, truncating fractions (i.e., X DIV 2^32),
+        and counted using the rules for counting the
+        nlMatrixSDOctets object."
+    ::= { nlMatrixTopNHighCapacityEntry 11 }
+
+nlMatrixTopNHighCapacityOctetRate OBJECT-TYPE
+    SYNTAX     CounterBasedGauge64
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets seen from the source host
+        to the destination host during this sampling interval,
+        counted using the rules for counting the
+        nlMatrixSDOctets object.
+        If the value of nlMatrixTopNControlRateBase is
+        nlMatrixTopNHighCapacityOctets, this variable will be used
+        to sort this report."
+    ::= { nlMatrixTopNHighCapacityEntry 12 }
+
+nlMatrixTopNHighCapacityReverseBaseOctetRate OBJECT-TYPE
+    SYNTAX     Gauge32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets seen from the destination host to the
+        source host during this sampling interval, modulo 2^32, counted
+        using the rules for counting the nlMatrixSDOctets object (note
+        that the corresponding nlMatrixSDOctets object selected is the
+        one whose source address is equal to nlMatrixTopNDestAddress
+        and whose destination address is equal to
+        nlMatrixTopNSourceAddress.)
+
+
+
+Waldbusser                  Standards Track                    [Page 48]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+        Note that if the value of nlMatrixTopNControlRateBase is equal
+        to nlMatrixTopNHighCapacityOctets, the sort of topN entries is
+        based entirely on nlMatrixTopNHighCapacityOctetRate, and not on
+        the value of this object."
+    ::= { nlMatrixTopNHighCapacityEntry 13 }
+
+nlMatrixTopNHighCapacityReverseOverflowOctetRate OBJECT-TYPE
+    SYNTAX     Gauge32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets seen from the destination host to the
+        source host during this sampling interval, divided by 2^32,
+        truncating fractions (i.e., X DIV 2^32), and counted
+        using the rules for counting the nlMatrixSDOctets object (note
+        that the corresponding nlMatrixSDOctets object selected is the
+        one whose source address is equal to nlMatrixTopNDestAddress
+        and whose destination address is equal to
+        nlMatrixTopNSourceAddress.)
+
+        Note that if the value of nlMatrixTopNControlRateBase is equal
+        to nlMatrixTopNHighCapacityOctets, the sort of topN entries is
+        based entirely on nlMatrixTopNHighCapacityOctetRate, and not on
+        the value of this object."
+    ::= { nlMatrixTopNHighCapacityEntry 14 }
+
+nlMatrixTopNHighCapacityReverseOctetRate OBJECT-TYPE
+    SYNTAX     CounterBasedGauge64
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets seen from the destination host to the
+        source host during this sampling interval, counted
+        using the rules for counting the nlMatrixSDOctets object (note
+        that the corresponding nlMatrixSDOctets object selected is the
+        one whose source address is equal to nlMatrixTopNDestAddress
+        and whose destination address is equal to
+        nlMatrixTopNSourceAddress.)
+
+        Note that if the value of nlMatrixTopNControlRateBase is equal
+        to nlMatrixTopNHighCapacityOctets, the sort of topN entries is
+        based entirely on nlMatrixTopNHighCapacityOctetRate, and not on
+        the value of this object."
+    ::= { nlMatrixTopNHighCapacityEntry 15 }
+
+-- High Capacity extensions for the alHostTable
+
+
+
+Waldbusser                  Standards Track                    [Page 49]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+alHostHighCapacityTable  OBJECT-TYPE
+    SYNTAX     SEQUENCE OF AlHostHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-2
+        alHostTable."
+    ::= { alHost 2 }
+
+alHostHighCapacityEntry  OBJECT-TYPE
+    SYNTAX     AlHostHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-2
+        alHostEntry. These objects will be created by the agent
+        for all alHostEntries associated with whichever
+        hlHostControlEntries it deems appropriate. (i.e., either all
+        alHostHighCapacityEntries associated with a particular
+        hlHostControlEntry will be created, or none of them will
+        be.)"
+    INDEX { hlHostControlIndex, alHostTimeMark,
+            protocolDirLocalIndex, nlHostAddress,
+            protocolDirLocalIndex }
+    ::= { alHostHighCapacityTable 1 }
+
+AlHostHighCapacityEntry ::= SEQUENCE {
+    alHostHighCapacityInOverflowPkts    ZeroBasedCounter32,
+    alHostHighCapacityInPkts            ZeroBasedCounter64,
+    alHostHighCapacityOutOverflowPkts   ZeroBasedCounter32,
+    alHostHighCapacityOutPkts           ZeroBasedCounter64,
+    alHostHighCapacityInOverflowOctets  ZeroBasedCounter32,
+    alHostHighCapacityInOctets          ZeroBasedCounter64,
+    alHostHighCapacityOutOverflowOctets ZeroBasedCounter32,
+    alHostHighCapacityOutOctets         ZeroBasedCounter64
+}
+
+alHostHighCapacityInOverflowPkts OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated alHostInPkts
+        counter has overflowed."
+
+    ::= { alHostHighCapacityEntry 1 }
+
+
+
+
+Waldbusser                  Standards Track                    [Page 50]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+alHostHighCapacityInPkts OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of packets of this protocol type without errors
+        transmitted to this address since it was added to the
+        alHostHighCapacityTable.  Note that this is the number of
+        link-layer packets, so if a single network-layer packet
+        is fragmented into several link-layer frames, this counter
+        is incremented several times."
+    ::= { alHostHighCapacityEntry 2 }
+
+alHostHighCapacityOutOverflowPkts OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated alHostOutPkts
+        counter has overflowed."
+    ::= { alHostHighCapacityEntry 3 }
+
+alHostHighCapacityOutPkts OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of packets of this protocol type without errors
+        transmitted by this address since it was added to the
+        alHostHighCapacityTable.  Note that this is the number of
+        link-layer packets, so if a single network-layer packet
+        is fragmented into several link-layer frames, this counter
+        is incremented several times."
+    ::= { alHostHighCapacityEntry 4 }
+
+alHostHighCapacityInOverflowOctets OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated alHostInOctets
+        counter has overflowed."
+    ::= { alHostHighCapacityEntry 5 }
+
+
+
+
+Waldbusser                  Standards Track                    [Page 51]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+alHostHighCapacityInOctets OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter64
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets transmitted to this address
+        of this protocol type since it was added to the
+        alHostHighCapacityTable (excluding framing bits but
+        including FCS octets), excluding those octets in
+        packets that contained errors.
+
+        Note this doesn't count just those octets in the particular
+        protocol frames, but includes the entire packet that contained
+        the protocol."
+    ::= { alHostHighCapacityEntry 6 }
+
+alHostHighCapacityOutOverflowOctets OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated alHostOutOctets
+        counter has overflowed."
+    ::= { alHostHighCapacityEntry 7 }
+
+alHostHighCapacityOutOctets OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter64
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets transmitted by this address
+        of this protocol type since it was added to the
+        alHostHighCapacityTable (excluding framing bits but
+        including FCS octets), excluding those octets in
+        packets that contained errors.
+
+        Note this doesn't count just those octets in the particular
+        protocol frames, but includes the entire packet that contained
+        the protocol."
+    ::= { alHostHighCapacityEntry 8 }
+
+-- High Capacity extensions for the alMatrixSDTable
+
+alMatrixSDHighCapacityTable  OBJECT-TYPE
+    SYNTAX     SEQUENCE OF AlMatrixSDHighCapacityEntry
+
+
+
+Waldbusser                  Standards Track                    [Page 52]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-2
+        alMatrixSDTable."
+    ::= { alMatrix 5 }
+
+alMatrixSDHighCapacityEntry  OBJECT-TYPE
+    SYNTAX     AlMatrixSDHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-2
+        alMatrixSDEntry. These objects will be created by the agent
+        for all alMatrixSDEntries associated with whichever
+        hlMatrixControlEntries it deems appropriate. (i.e., either all
+        alMatrixSDHighCapacityEntries associated with a particular
+        hlMatrixControlEntry will be created, or none of them will
+        be.)"
+    INDEX { hlMatrixControlIndex, alMatrixSDTimeMark,
+            protocolDirLocalIndex,
+            nlMatrixSDSourceAddress, nlMatrixSDDestAddress,
+            protocolDirLocalIndex }
+    ::= { alMatrixSDHighCapacityTable 1 }
+
+AlMatrixSDHighCapacityEntry ::= SEQUENCE {
+    alMatrixSDHighCapacityOverflowPkts   ZeroBasedCounter32,
+    alMatrixSDHighCapacityPkts           ZeroBasedCounter64,
+    alMatrixSDHighCapacityOverflowOctets ZeroBasedCounter32,
+    alMatrixSDHighCapacityOctets         ZeroBasedCounter64
+}
+
+alMatrixSDHighCapacityOverflowPkts OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated alMatrixSDPkts
+        counter has overflowed."
+    ::= { alMatrixSDHighCapacityEntry 1 }
+
+alMatrixSDHighCapacityPkts OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+
+
+
+Waldbusser                  Standards Track                    [Page 53]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+        "The number of good packets of this protocol type
+        transmitted from the source address to the destination address
+        since this entry was added to the alMatrixSDHighCapacityTable.
+        Note that this is the number of link-layer packets, so if a
+        single network-layer packet is fragmented into several
+        link-layer frames, this counter is incremented several times."
+    ::= { alMatrixSDHighCapacityEntry 2 }
+
+alMatrixSDHighCapacityOverflowOctets OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated alMatrixSDOctets
+        counter has overflowed."
+    ::= { alMatrixSDHighCapacityEntry 3 }
+
+alMatrixSDHighCapacityOctets OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter64
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets in good packets of this protocol type
+        transmitted from the source address to the destination address
+        since this entry was added to the alMatrixSDHighCapacityTable
+        (excluding framing bits but including FCS octets).
+
+        Note this doesn't count just those octets in the particular
+        protocol frames, but includes the entire packet that contained
+        the protocol."
+    ::= { alMatrixSDHighCapacityEntry 4 }
+
+-- High Capacity extensions for the alMatrixDSTable
+
+alMatrixDSHighCapacityTable  OBJECT-TYPE
+    SYNTAX     SEQUENCE OF AlMatrixDSHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-2
+        alMatrixDSTable."
+    ::= { alMatrix 6 }
+
+alMatrixDSHighCapacityEntry  OBJECT-TYPE
+    SYNTAX     AlMatrixDSHighCapacityEntry
+    MAX-ACCESS not-accessible
+
+
+
+Waldbusser                  Standards Track                    [Page 54]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-2
+        alMatrixSDTable. These objects will be created by the agent
+        for all alMatrixDSEntries associated with whichever
+        hlMatrixControlEntries it deems appropriate. (i.e., either all
+        alMatrixDSHighCapacityEntries associated with a particular
+        hlMatrixControlEntry will be created, or none of them will
+        be.)"
+    INDEX { hlMatrixControlIndex, alMatrixDSTimeMark,
+            protocolDirLocalIndex,
+            nlMatrixDSDestAddress, nlMatrixDSSourceAddress,
+            protocolDirLocalIndex }
+    ::= { alMatrixDSHighCapacityTable 1 }
+
+AlMatrixDSHighCapacityEntry ::= SEQUENCE {
+    alMatrixDSHighCapacityOverflowPkts   ZeroBasedCounter32,
+    alMatrixDSHighCapacityPkts           ZeroBasedCounter64,
+    alMatrixDSHighCapacityOverflowOctets ZeroBasedCounter32,
+    alMatrixDSHighCapacityOctets         ZeroBasedCounter64
+}
+
+alMatrixDSHighCapacityOverflowPkts OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated alMatrixDSPkts
+        counter has overflowed."
+    ::= { alMatrixDSHighCapacityEntry 1 }
+
+alMatrixDSHighCapacityPkts OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of good packets of this protocol type
+        transmitted from the source address to the destination address
+        since this entry was added to the alMatrixDSHighCapacityTable.
+        Note that this is the number of link-layer packets, so if a
+        single network-layer packet is fragmented into several
+        link-layer frames, this counter is incremented several times."
+    ::= { alMatrixDSHighCapacityEntry 2 }
+
+alMatrixDSHighCapacityOverflowOctets OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter32
+
+
+
+Waldbusser                  Standards Track                    [Page 55]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times the associated alMatrixDSOctets
+        counter has overflowed."
+    ::= { alMatrixDSHighCapacityEntry 3 }
+
+alMatrixDSHighCapacityOctets OBJECT-TYPE
+    SYNTAX     ZeroBasedCounter64
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets in good packets of this protocol type
+        transmitted from the source address to the destination address
+        since this entry was added to the alMatrixDSHighCapacityTable
+        (excluding framing bits but including FCS octets).
+
+        Note this doesn't count just those octets in the particular
+        protocol frames, but includes the entire packet that contained
+        the protocol."
+    ::= { alMatrixDSHighCapacityEntry 4 }
+
+alMatrixTopNHighCapacityTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF AlMatrixTopNHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-2
+        alMatrixTopNTable when alMatrixTopNControlRateBase specifies
+        a High Capacity TopN Report."
+    ::= { alMatrix 7 }
+
+alMatrixTopNHighCapacityEntry OBJECT-TYPE
+    SYNTAX     AlMatrixTopNHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-2
+        alMatrixTopNEntry when alMatrixTopNControlRateBase specifies
+        a High Capacity TopN Report. These objects will be created by
+        the agent for all alMatrixTopNEntries associated with whichever
+        alMatrixTopNControlEntries have a alMatrixTopNControlRateBase
+        that specify a high capacity report."
+     INDEX { alMatrixTopNControlIndex, alMatrixTopNIndex }
+    ::= { alMatrixTopNHighCapacityTable 1 }
+
+
+
+
+Waldbusser                  Standards Track                    [Page 56]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+AlMatrixTopNHighCapacityEntry ::= SEQUENCE {
+  alMatrixTopNHighCapacityProtocolDirLocalIndex    Integer32,
+  alMatrixTopNHighCapacitySourceAddress            OCTET STRING,
+  alMatrixTopNHighCapacityDestAddress              OCTET STRING,
+  alMatrixTopNHighCapacityAppProtocolDirLocalIndex Integer32,
+  alMatrixTopNHighCapacityBasePktRate              Gauge32,
+  alMatrixTopNHighCapacityOverflowPktRate          Gauge32,
+  alMatrixTopNHighCapacityPktRate                  CounterBasedGauge64,
+  alMatrixTopNHighCapacityReverseBasePktRate       Gauge32,
+  alMatrixTopNHighCapacityReverseOverflowPktRate   Gauge32,
+  alMatrixTopNHighCapacityReversePktRate           CounterBasedGauge64,
+  alMatrixTopNHighCapacityBaseOctetRate            Gauge32,
+  alMatrixTopNHighCapacityOverflowOctetRate        Gauge32,
+  alMatrixTopNHighCapacityOctetRate                CounterBasedGauge64,
+  alMatrixTopNHighCapacityReverseBaseOctetRate     Gauge32,
+  alMatrixTopNHighCapacityReverseOverflowOctetRate Gauge32,
+  alMatrixTopNHighCapacityReverseOctetRate         CounterBasedGauge64
+}
+
+alMatrixTopNHighCapacityProtocolDirLocalIndex OBJECT-TYPE
+    SYNTAX     Integer32 (1..2147483647)
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The protocolDirLocalIndex of the network layer protocol of
+        this entry's network address."
+    ::= { alMatrixTopNHighCapacityEntry 1 }
+
+alMatrixTopNHighCapacitySourceAddress OBJECT-TYPE
+    SYNTAX     OCTET STRING
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The network layer address of the source host in this
+        conversation.
+
+        This is represented as an octet string with
+        specific semantics and length as identified
+        by the associated alMatrixTopNProtocolDirLocalIndex.
+
+        For example, if the alMatrixTopNProtocolDirLocalIndex
+        indicates an encapsulation of ip, this object is encoded as a
+        length octet of 4, followed by the 4 octets of the ip address,
+        in network byte order."
+    ::= { alMatrixTopNHighCapacityEntry 2 }
+
+alMatrixTopNHighCapacityDestAddress OBJECT-TYPE
+    SYNTAX     OCTET STRING
+
+
+
+Waldbusser                  Standards Track                    [Page 57]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The network layer address of the destination host in this
+        conversation.
+
+        This is represented as an octet string with
+        specific semantics and length as identified
+        by the associated alMatrixTopNProtocolDirLocalIndex.
+
+        For example, if the alMatrixTopNProtocolDirLocalIndex
+        indicates an encapsulation of ip, this object is encoded as a
+        length octet of 4, followed by the 4 octets of the ip address,
+        in network byte order."
+    ::= { alMatrixTopNHighCapacityEntry 3 }
+
+alMatrixTopNHighCapacityAppProtocolDirLocalIndex OBJECT-TYPE
+    SYNTAX     Integer32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The type of the protocol counted by this entry."
+    ::= { alMatrixTopNHighCapacityEntry 4 }
+
+alMatrixTopNHighCapacityBasePktRate OBJECT-TYPE
+    SYNTAX     Gauge32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of packets seen of this protocol from the
+        source host to the destination host during this sampling
+        interval, modulo 2^32, counted using the rules for counting
+        the alMatrixSDPkts object."
+    ::= { alMatrixTopNHighCapacityEntry 5 }
+
+alMatrixTopNHighCapacityOverflowPktRate OBJECT-TYPE
+    SYNTAX     Gauge32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of packets seen of this protocol from the source
+        host to the destination host during this sampling interval,
+        divided by 2^32, truncating fractions (i.e., X DIV 2^32),
+        and counted using the rules for counting the
+        alMatrixSDPkts object."
+    ::= { alMatrixTopNHighCapacityEntry 6 }
+
+
+
+Waldbusser                  Standards Track                    [Page 58]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+alMatrixTopNHighCapacityPktRate OBJECT-TYPE
+    SYNTAX     CounterBasedGauge64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of packets seen of this protocol from the source
+        host to the destination host during this sampling interval,
+        counted using the rules for counting the
+        alMatrixSDPkts object.
+        If the value of alMatrixTopNControlRateBase is
+        alMatrixTopNTerminalsPkts, alMatrixTopNAllPkts,
+        alMatrixTopNTerminalsHighCapacityPkts, or
+        alMatrixTopNAllHighCapacityPkts, this variable will be used
+        to sort this report."
+    ::= { alMatrixTopNHighCapacityEntry 7 }
+
+alMatrixTopNHighCapacityReverseBasePktRate OBJECT-TYPE
+    SYNTAX     Gauge32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of packets seen of this protocol from the
+        destination host to the source host during this sampling
+        interval, modulo 2^32, counted using the rules for counting
+        the alMatrixSDPkts object (note that the corresponding
+        alMatrixSDPkts object selected is the one whose source address
+        is equal to alMatrixTopNDestAddress and whose destination
+        address is equal to alMatrixTopNSourceAddress.)"
+    ::= { alMatrixTopNHighCapacityEntry 8 }
+
+alMatrixTopNHighCapacityReverseOverflowPktRate OBJECT-TYPE
+    SYNTAX     Gauge32
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of packets seen of this protocol from the
+        destination host to the source host during this sampling
+        interval, divided by 2^32, truncating fractions
+        (i.e., X DIV 2^32), and counted using the rules for
+        counting the alMatrixSDPkts object (note that the
+        corresponding alMatrixSDPkts object selected is the
+        one whose source address is equal to alMatrixTopNDestAddress
+        and whose destination address is equal to
+        alMatrixTopNSourceAddress.)"
+    ::= { alMatrixTopNHighCapacityEntry 9 }
+
+
+
+Waldbusser                  Standards Track                    [Page 59]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+alMatrixTopNHighCapacityReversePktRate OBJECT-TYPE
+    SYNTAX     CounterBasedGauge64
+    UNITS      "Packets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of packets seen of this protocol from the
+        destination host to the source host during this sampling
+        interval, counted using the rules for counting the
+        alMatrixSDPkts object (note that the corresponding
+        alMatrixSDPkts object selected is the one whose source address
+        is equal to alMatrixTopNDestAddress and whose destination
+        address is equal to alMatrixTopNSourceAddress.)"
+    ::= { alMatrixTopNHighCapacityEntry 10 }
+
+alMatrixTopNHighCapacityBaseOctetRate OBJECT-TYPE
+    SYNTAX     Gauge32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets seen of this protocol from the source host
+        to the destination host during this sampling interval,
+        modulo 2^32, counted using the rules for counting the
+        alMatrixSDOctets object."
+    ::= { alMatrixTopNHighCapacityEntry 11 }
+
+alMatrixTopNHighCapacityOverflowOctetRate OBJECT-TYPE
+    SYNTAX     Gauge32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets seen of this protocol from the source host
+        to the destination host during this sampling interval,
+        divided by 2^32, truncating fractions (i.e., X DIV 2^32),
+        and counted using the rules for counting the
+        alMatrixSDOctets object."
+    ::= { alMatrixTopNHighCapacityEntry 12 }
+
+alMatrixTopNHighCapacityOctetRate OBJECT-TYPE
+    SYNTAX     CounterBasedGauge64
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets seen of this protocol from the source host
+        to the destination host during this sampling interval,
+
+
+
+Waldbusser                  Standards Track                    [Page 60]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+        counted using the rules for counting the
+        alMatrixSDOctets object.
+        If the value of alMatrixTopNControlRateBase is
+        alMatrixTopNTerminalsOctets, alMatrixTopNAllOctets,
+        alMatrixTopNTerminalsHighCapacityOctets, or
+        alMatrixTopNAllHighCapacityOctets, this variable will be used
+        to sort this report."
+    ::= { alMatrixTopNHighCapacityEntry 13 }
+
+alMatrixTopNHighCapacityReverseBaseOctetRate OBJECT-TYPE
+    SYNTAX     Gauge32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets seen of this protocol from the
+        destination host to the source host during this sampling
+        interval, modulo 2^32, counted using the rules for counting
+        the alMatrixSDOctets object (note that the corresponding
+        alMatrixSDOctets object selected is the one whose source
+        address is equal to alMatrixTopNDestAddress and whose
+        destination address is equal to alMatrixTopNSourceAddress.)"
+    ::= { alMatrixTopNHighCapacityEntry 14 }
+
+alMatrixTopNHighCapacityReverseOverflowOctetRate OBJECT-TYPE
+    SYNTAX     Gauge32
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets seen of this protocol from the
+        destination host to the source host during this sampling
+        interval, divided by 2^32, truncating fractions (i.e., X DIV
+        2^32), and counted using the rules for counting the
+        alMatrixSDOctets object (note that the corresponding
+        alMatrixSDOctets object selected is the one whose source
+        address is equal to alMatrixTopNDestAddress and whose
+        destination address is equal to alMatrixTopNSourceAddress.)"
+    ::= { alMatrixTopNHighCapacityEntry 15 }
+
+alMatrixTopNHighCapacityReverseOctetRate OBJECT-TYPE
+    SYNTAX     CounterBasedGauge64
+    UNITS      "Octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets seen of this protocol from the
+        destination host to the source host during this sampling
+
+
+
+Waldbusser                  Standards Track                    [Page 61]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+        interval, counted using the rules for counting the
+        alMatrixSDOctets object (note that the corresponding
+        alMatrixSDOctets object selected is the one whose source
+        address is equal to alMatrixTopNDestAddress and whose
+        destination address is equal to alMatrixTopNSourceAddress.)"
+    ::= { alMatrixTopNHighCapacityEntry 16 }
+
+usrHistoryHighCapacityTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF UsrHistoryHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-2
+        usrHistoryTable."
+        ::= { usrHistory 4 }
+
+usrHistoryHighCapacityEntry OBJECT-TYPE
+    SYNTAX UsrHistoryHighCapacityEntry
+    MAX-ACCESS not-accessible
+    STATUS  current
+    DESCRIPTION
+        "Contains the High Capacity RMON extensions to the RMON-2
+        usrHistoryEntry. These objects will be created by the agent
+        for all usrHistoryEntries associated with whichever
+        usrHistoryControlEntries it deems appropriate. (i.e., either all
+        usrHistoryHighCapacityEntries associated with a particular
+        usrHistoryControlEntry will be created, or none of them will
+        be.)"
+    INDEX { usrHistoryControlIndex, usrHistorySampleIndex,
+            usrHistoryObjectIndex }
+    ::= { usrHistoryHighCapacityTable 1 }
+
+UsrHistoryHighCapacityEntry ::= SEQUENCE {
+    usrHistoryHighCapacityOverflowAbsValue     Gauge32,
+    usrHistoryHighCapacityAbsValue             CounterBasedGauge64
+}
+
+usrHistoryHighCapacityOverflowAbsValue OBJECT-TYPE
+    SYNTAX     Gauge32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The absolute value (i.e. unsigned value) of the
+        user-specified statistic during the last sampling period,
+        divided by 2^32, truncating fractions (i.e., X DIV 2^32).
+        The value during the current sampling period is not made
+        available until the period is completed.
+
+
+
+
+Waldbusser                  Standards Track                    [Page 62]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+        To obtain the true value for this sampling interval, the
+        associated instance of usrHistoryValStatus should be checked,
+        and usrHistoryAbsValue adjusted as necessary.
+
+        If the MIB instance could not be accessed during the sampling
+        interval, then this object will have a value of zero and the
+        associated instance of usrHistoryValStatus will be set to
+        'valueNotAvailable(1)'."
+    ::= { usrHistoryHighCapacityEntry 1 }
+
+usrHistoryHighCapacityAbsValue OBJECT-TYPE
+    SYNTAX CounterBasedGauge64
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The absolute value (i.e. unsigned value) of the
+        user-specified statistic during the last sampling period. The
+        value during the current sampling period is not made available
+        until the period is completed.
+
+        To obtain the true value for this sampling interval, the
+        associated instance of usrHistoryValStatus should be checked,
+        and usrHistoryHighCapacityAbsValue adjusted as necessary.
+
+        If the MIB instance could not be accessed during the sampling
+        interval, then this object will have a value of zero and the
+        associated instance of usrHistoryValStatus will be set to
+        'valueNotAvailable(1)'."
+    ::= { usrHistoryHighCapacityEntry 2 }
+
+--
+-- High Capacity RMON Probe Capabilities
+--
+hcRMONCapabilities OBJECT-TYPE
+    SYNTAX BITS {
+        mediaIndependentGroup(0),
+        etherStatsHighCapacityGroup(1),
+        etherHistoryHighCapacityGroup(2),
+        hostHighCapacityGroup(3),
+        hostTopNHighCapacityGroup(4),
+        matrixHighCapacityGroup(5),
+        captureBufferHighCapacityGroup(6),
+        protocolDistributionHighCapacityGroup(7),
+        nlHostHighCapacityGroup(8),
+        nlMatrixHighCapacityGroup(9),
+        nlMatrixTopNHighCapacityGroup(10),
+        alHostHighCapacityGroup(11),
+        alMatrixHighCapacityGroup(12),
+
+
+
+Waldbusser                  Standards Track                    [Page 63]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+        alMatrixTopNHighCapacityGroup(13),
+        usrHistoryHighCapacityGroup(14)
+    }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "An indication of the High Capacity RMON MIB groups supported
+        on at least one interface by this probe."
+    ::= { probeConfig 16 }
+
+-- Conformance Macros
+
+hcRmonMIBCompliances OBJECT IDENTIFIER ::= { rmonConformance 6 }
+hcRmonMIBGroups      OBJECT IDENTIFIER ::= { rmonConformance 7 }
+
+hcMediaIndependentCompliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+        "Describes the requirements for conformance to the
+        High Capacity Media Independent Group."
+    MODULE  -- this module
+    MANDATORY-GROUPS { mediaIndependentGroup, hcRMONInformationGroup }
+    ::= { hcRmonMIBCompliances 1 }
+
+hcRmon1MIBCompliance MODULE-COMPLIANCE
+    STATUS current
+    DESCRIPTION
+        "Describes the requirements for conformance to the High
+        Capacity RMON-1 MIB"
+    MODULE  -- this module
+        GROUP etherStatsHighCapacityGroup
+        DESCRIPTION
+            "The etherStatsHighCapacityGroup is optional but requires
+            implementation of the rmonEtherStatsGroup."
+
+        GROUP etherHistoryHighCapacityGroup
+        DESCRIPTION
+            "The etherHistoryHighCapacityGroup is optional but
+            requires implementation of the rmonHistoryControlGroup and
+            rmonEthernetHistoryGroup."
+
+        GROUP hostHighCapacityGroup
+        DESCRIPTION
+            "The hostHighCapacityGroup is mandatory when the
+            hostTopNHighCapacityGroup is implemented. This group also
+            requires implementation of the rmonHostGroup."
+
+        GROUP hostTopNHighCapacityGroup
+
+
+
+Waldbusser                  Standards Track                    [Page 64]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+        DESCRIPTION
+            "The hostTopNHighCapacityGroup is optional but requires
+            implementation of the rmonHostTopNGroup."
+
+        GROUP matrixHighCapacityGroup
+        DESCRIPTION
+            "The matrixHighCapacityGroup is optional but requires
+            implementation of the rmonMatrixGroup."
+
+        GROUP captureBufferHighCapacityGroup
+        DESCRIPTION
+            "The captureBufferHighCapacityGroup is optional but
+            requires implementation of the rmonFilterGroup and
+            rmonPacketCaptureGroup."
+
+    MODULE RMON-MIB
+        GROUP rmonEtherStatsGroup
+        DESCRIPTION
+            "The RMON Ethernet Statistics Group is mandatory if the
+            etherStatsHighCapacityGroup is implemented."
+
+        GROUP rmonHistoryControlGroup
+        DESCRIPTION
+            "The RMON History Control Group is mandatory if the
+            etherHistoryHighCapacityGroup is implemented."
+
+        GROUP rmonEthernetHistoryGroup
+        DESCRIPTION
+            "The RMON Ethernet History Group is mandatory if the
+            etherHistoryHighCapacityGroup is implemented."
+
+        GROUP rmonHostGroup
+        DESCRIPTION
+            "The RMON Host Group is mandatory if the
+            hostHighCapacityGroup is implemented."
+
+        GROUP rmonHostTopNGroup
+        DESCRIPTION
+            "The RMON Host Top N Group is mandatory if the
+            hostTopNHighCapacityGroup is implemented."
+
+        GROUP rmonMatrixGroup
+        DESCRIPTION
+            "The RMON Matrix Group is mandatory if the
+            matrixHighCapacityGroup is implemented."
+
+        GROUP rmonFilterGroup
+        DESCRIPTION
+
+
+
+Waldbusser                  Standards Track                    [Page 65]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+            "The RMON Filter Group is mandatory when the
+            captureBufferHighCapacityGroup is implemented."
+
+       GROUP rmonPacketCaptureGroup
+       DESCRIPTION
+            "The RMON Packet Capture Group is mandatory when the
+           captureBufferHighCapacityGroup is implemented."
+    ::= { hcRmonMIBCompliances 2 }
+
+hcRmon2MIBCompliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+        "Describes the requirements for conformance to
+        the High Capacity RMON-2 MIB"
+    MODULE  -- this module
+        MANDATORY-GROUPS { protocolDistributionHighCapacityGroup,
+                           nlHostHighCapacityGroup,
+                           nlMatrixHighCapacityGroup,
+                           nlMatrixTopNHighCapacityGroup,
+                           usrHistoryHighCapacityGroup,
+                           hcRMONInformationGroup }
+    MODULE RMON2-MIB
+        MANDATORY-GROUPS { protocolDirectoryGroup,
+                           protocolDistributionGroup,
+                           addressMapGroup,
+                           nlHostGroup,
+                           nlMatrixGroup,
+                           usrHistoryGroup,
+                           probeInformationGroup }
+
+        GROUP   rmon1EnhancementGroup
+        DESCRIPTION
+            "The rmon1EnhancementGroup is mandatory for systems which
+            implement RMON [RFC2819]"
+    ::= { hcRmonMIBCompliances 3 }
+
+hcRmon2MIBApplicationLayerCompliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+        "Describes the requirements for conformance to
+        the High Capacity RMON-2 MIB with Application Layer
+        Enhancements."
+
+    MODULE  -- this module
+        MANDATORY-GROUPS { protocolDistributionHighCapacityGroup,
+
+                           nlHostHighCapacityGroup,
+                           nlMatrixHighCapacityGroup,
+
+
+
+Waldbusser                  Standards Track                    [Page 66]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+                           nlMatrixTopNHighCapacityGroup,
+                           alHostHighCapacityGroup,
+                           alMatrixHighCapacityGroup,
+                           alMatrixTopNHighCapacityGroup,
+                           usrHistoryHighCapacityGroup,
+                           hcRMONInformationGroup }
+    MODULE RMON2-MIB
+        MANDATORY-GROUPS { protocolDirectoryGroup,
+                           protocolDistributionGroup,
+                           addressMapGroup,
+                           nlHostGroup,
+                           nlMatrixGroup,
+                           alHostGroup,
+                           alMatrixGroup,
+                           usrHistoryGroup,
+                           probeInformationGroup }
+
+        GROUP   rmon1EnhancementGroup
+        DESCRIPTION
+            "The rmon1EnhancementGroup is mandatory for systems which
+            implement RMON [RFC2819]"
+    ::= { hcRmonMIBCompliances 4 }
+
+mediaIndependentGroup OBJECT-GROUP
+    OBJECTS {mediaIndependentDataSource,
+        mediaIndependentDropEvents,
+        mediaIndependentDroppedFrames,
+        mediaIndependentInPkts,
+        mediaIndependentInOverflowPkts,
+        mediaIndependentInHighCapacityPkts,
+        mediaIndependentOutPkts,
+        mediaIndependentOutOverflowPkts,
+        mediaIndependentOutHighCapacityPkts,
+        mediaIndependentInOctets,
+        mediaIndependentInOverflowOctets,
+        mediaIndependentInHighCapacityOctets,
+        mediaIndependentOutOctets,
+        mediaIndependentOutOverflowOctets,
+        mediaIndependentOutHighCapacityOctets,
+        mediaIndependentInNUCastPkts,
+        mediaIndependentInNUCastOverflowPkts,
+        mediaIndependentInNUCastHighCapacityPkts,
+        mediaIndependentOutNUCastPkts,
+        mediaIndependentOutNUCastOverflowPkts,
+        mediaIndependentOutNUCastHighCapacityPkts,
+        mediaIndependentInErrors,
+        mediaIndependentOutErrors,
+        mediaIndependentInputSpeed,
+
+
+
+Waldbusser                  Standards Track                    [Page 67]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+        mediaIndependentOutputSpeed,
+        mediaIndependentDuplexMode,
+        mediaIndependentDuplexChanges,
+        mediaIndependentDuplexLastChange,
+        mediaIndependentOwner,
+        mediaIndependentStatus }
+    STATUS current
+    DESCRIPTION
+        "Collects utilization statistics for any type of network."
+    ::= { hcRmonMIBGroups 1 }
+
+etherStatsHighCapacityGroup OBJECT-GROUP
+    OBJECTS { etherStatsHighCapacityOverflowPkts,
+              etherStatsHighCapacityPkts,
+              etherStatsHighCapacityOverflowOctets,
+              etherStatsHighCapacityOctets,
+              etherStatsHighCapacityOverflowPkts64Octets,
+              etherStatsHighCapacityPkts64Octets,
+              etherStatsHighCapacityOverflowPkts65to127Octets,
+              etherStatsHighCapacityPkts65to127Octets,
+              etherStatsHighCapacityOverflowPkts128to255Octets,
+              etherStatsHighCapacityPkts128to255Octets,
+              etherStatsHighCapacityOverflowPkts256to511Octets,
+              etherStatsHighCapacityPkts256to511Octets,
+              etherStatsHighCapacityOverflowPkts512to1023Octets,
+              etherStatsHighCapacityPkts512to1023Octets,
+              etherStatsHighCapacityOverflowPkts1024to1518Octets,
+              etherStatsHighCapacityPkts1024to1518Octets }
+    STATUS  current
+    DESCRIPTION
+        "Collects utilization statistics for ethernet networks."
+    ::= { hcRmonMIBGroups 2 }
+
+etherHistoryHighCapacityGroup OBJECT-GROUP
+    OBJECTS { etherHistoryHighCapacityOverflowPkts,
+              etherHistoryHighCapacityPkts,
+              etherHistoryHighCapacityOverflowOctets,
+              etherHistoryHighCapacityOctets }
+    STATUS  current
+    DESCRIPTION
+        "Collects utilization statistics for ethernet networks."
+    ::= { hcRmonMIBGroups 3 }
+
+hostHighCapacityGroup OBJECT-GROUP
+    OBJECTS { hostHighCapacityInOverflowPkts,
+              hostHighCapacityInPkts,
+              hostHighCapacityOutOverflowPkts,
+              hostHighCapacityOutPkts,
+
+
+
+Waldbusser                  Standards Track                    [Page 68]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+              hostHighCapacityInOverflowOctets,
+              hostHighCapacityInOctets,
+              hostHighCapacityOutOverflowOctets,
+              hostHighCapacityOutOctets,
+              hostTimeHighCapacityInOverflowPkts,
+              hostTimeHighCapacityInPkts,
+              hostTimeHighCapacityOutOverflowPkts,
+              hostTimeHighCapacityOutPkts,
+              hostTimeHighCapacityInOverflowOctets,
+              hostTimeHighCapacityInOctets,
+              hostTimeHighCapacityOutOverflowOctets,
+              hostTimeHighCapacityOutOctets }
+    STATUS  current
+    DESCRIPTION
+        "Collects utilization and error statistics per host."
+    ::= { hcRmonMIBGroups 4 }
+
+hostTopNHighCapacityGroup OBJECT-GROUP
+    OBJECTS { hostTopNHighCapacityAddress,
+        hostTopNHighCapacityBaseRate,
+        hostTopNHighCapacityOverflowRate,
+        hostTopNHighCapacityRate }
+    STATUS  current
+    DESCRIPTION
+        "Prepares sorted reports of utilization and error statistics
+        per host."
+    ::= { hcRmonMIBGroups 5 }
+
+
+matrixHighCapacityGroup OBJECT-GROUP
+    OBJECTS { matrixSDHighCapacityOverflowPkts,
+              matrixSDHighCapacityPkts,
+              matrixSDHighCapacityOverflowOctets,
+              matrixSDHighCapacityOctets,
+              matrixDSHighCapacityOverflowPkts,
+              matrixDSHighCapacityPkts,
+              matrixDSHighCapacityOverflowOctets,
+              matrixDSHighCapacityOctets }
+    STATUS  current
+    DESCRIPTION
+        "Collects utilization statistics per conversation."
+    ::= { hcRmonMIBGroups 6 }
+
+captureBufferHighCapacityGroup OBJECT-GROUP
+    OBJECTS { captureBufferPacketHighCapacityTime }
+    STATUS  current
+    DESCRIPTION
+        "Provides finer granularity time stamps."
+
+
+
+Waldbusser                  Standards Track                    [Page 69]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+    ::= { hcRmonMIBGroups 7 }
+
+protocolDistributionHighCapacityGroup OBJECT-GROUP
+    OBJECTS { protocolDistStatsHighCapacityOverflowPkts,
+              protocolDistStatsHighCapacityPkts,
+              protocolDistStatsHighCapacityOverflowOctets,
+              protocolDistStatsHighCapacityOctets }
+    STATUS  current
+    DESCRIPTION
+        "Collects the relative amounts of octets and packets for the
+        different protocols detected on a network segment."
+    ::= { hcRmonMIBGroups 8 }
+
+nlHostHighCapacityGroup OBJECT-GROUP
+    OBJECTS { nlHostHighCapacityInOverflowPkts,
+              nlHostHighCapacityInPkts,
+              nlHostHighCapacityOutOverflowPkts,
+              nlHostHighCapacityOutPkts,
+              nlHostHighCapacityInOverflowOctets,
+              nlHostHighCapacityInOctets,
+              nlHostHighCapacityOutOverflowOctets,
+              nlHostHighCapacityOutOctets }
+    STATUS  current
+    DESCRIPTION
+        "Counts the amount of traffic sent from and to each network
+        address discovered by the probe."
+    ::= { hcRmonMIBGroups 9 }
+
+nlMatrixHighCapacityGroup OBJECT-GROUP
+    OBJECTS { nlMatrixSDHighCapacityOverflowPkts,
+              nlMatrixSDHighCapacityPkts,
+              nlMatrixSDHighCapacityOverflowOctets,
+              nlMatrixSDHighCapacityOctets,
+              nlMatrixDSHighCapacityOverflowPkts,
+              nlMatrixDSHighCapacityPkts,
+              nlMatrixDSHighCapacityOverflowOctets,
+              nlMatrixDSHighCapacityOctets }
+    STATUS  current
+    DESCRIPTION
+        "Counts the amount of traffic sent between each pair of
+        network addresses discovered by the probe."
+    ::= { hcRmonMIBGroups 10 }
+
+nlMatrixTopNHighCapacityGroup OBJECT-GROUP
+    OBJECTS { nlMatrixTopNHighCapacityProtocolDirLocalIndex,
+        nlMatrixTopNHighCapacitySourceAddress,
+        nlMatrixTopNHighCapacityDestAddress,
+        nlMatrixTopNHighCapacityBasePktRate,
+
+
+
+Waldbusser                  Standards Track                    [Page 70]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+        nlMatrixTopNHighCapacityOverflowPktRate,
+        nlMatrixTopNHighCapacityPktRate,
+        nlMatrixTopNHighCapacityReverseBasePktRate,
+        nlMatrixTopNHighCapacityReverseOverflowPktRate,
+        nlMatrixTopNHighCapacityReversePktRate,
+        nlMatrixTopNHighCapacityBaseOctetRate,
+        nlMatrixTopNHighCapacityOverflowOctetRate,
+        nlMatrixTopNHighCapacityOctetRate,
+        nlMatrixTopNHighCapacityReverseBaseOctetRate,
+        nlMatrixTopNHighCapacityReverseOverflowOctetRate,
+        nlMatrixTopNHighCapacityReverseOctetRate }
+    STATUS  current
+    DESCRIPTION
+        "Prepares sorted reports of the amount of traffic sent between
+        each pair of network addresses discovered by the probe."
+    ::= { hcRmonMIBGroups 11 }
+
+alHostHighCapacityGroup OBJECT-GROUP
+    OBJECTS { alHostHighCapacityInOverflowPkts,
+              alHostHighCapacityInPkts,
+              alHostHighCapacityOutOverflowPkts,
+              alHostHighCapacityOutPkts,
+              alHostHighCapacityInOverflowOctets,
+              alHostHighCapacityInOctets,
+              alHostHighCapacityOutOverflowOctets,
+              alHostHighCapacityOutOctets }
+    STATUS  current
+    DESCRIPTION
+        "Counts the amount of traffic, by protocol, sent from and to
+        each network address discovered by the probe."
+    ::= { hcRmonMIBGroups 12 }
+
+alMatrixHighCapacityGroup OBJECT-GROUP
+    OBJECTS { alMatrixSDHighCapacityOverflowPkts,
+              alMatrixSDHighCapacityPkts,
+              alMatrixSDHighCapacityOverflowOctets,
+              alMatrixSDHighCapacityOctets,
+              alMatrixDSHighCapacityOverflowPkts,
+              alMatrixDSHighCapacityPkts,
+              alMatrixDSHighCapacityOverflowOctets,
+              alMatrixDSHighCapacityOctets }
+    STATUS  current
+    DESCRIPTION
+        "Counts the amount of traffic, by protocol, sent between each
+        pair of network addresses discovered by the
+        probe."
+    ::= { hcRmonMIBGroups 13 }
+
+
+
+
+Waldbusser                  Standards Track                    [Page 71]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+alMatrixTopNHighCapacityGroup OBJECT-GROUP
+    OBJECTS { alMatrixTopNHighCapacityProtocolDirLocalIndex,
+        alMatrixTopNHighCapacitySourceAddress,
+        alMatrixTopNHighCapacityDestAddress,
+        alMatrixTopNHighCapacityAppProtocolDirLocalIndex,
+        alMatrixTopNHighCapacityBasePktRate,
+        alMatrixTopNHighCapacityOverflowPktRate,
+        alMatrixTopNHighCapacityPktRate,
+        alMatrixTopNHighCapacityReverseBasePktRate,
+        alMatrixTopNHighCapacityReverseOverflowPktRate,
+        alMatrixTopNHighCapacityReversePktRate,
+        alMatrixTopNHighCapacityBaseOctetRate,
+        alMatrixTopNHighCapacityOverflowOctetRate,
+        alMatrixTopNHighCapacityOctetRate,
+        alMatrixTopNHighCapacityReverseBaseOctetRate,
+        alMatrixTopNHighCapacityReverseOverflowOctetRate,
+        alMatrixTopNHighCapacityReverseOctetRate }
+    STATUS  current
+    DESCRIPTION
+        "Prepares sorted reports of the amount of traffic per protocol
+        sent between each pair of network addresses discovered by the
+        probe."
+    ::= { hcRmonMIBGroups 14 }
+
+usrHistoryHighCapacityGroup OBJECT-GROUP
+    OBJECTS { usrHistoryHighCapacityOverflowAbsValue,
+        usrHistoryHighCapacityAbsValue }
+    STATUS  current
+    DESCRIPTION
+        "Provides user-defined collection of historical information
+        from MIB objects on the probe with scalability to statistics
+        from high-capacity networks."
+    ::= { hcRmonMIBGroups 15 }
+
+hcRMONInformationGroup OBJECT-GROUP
+    OBJECTS { hcRMONCapabilities }
+    STATUS  current
+    DESCRIPTION
+        "An indication of the high capacity RMON groups supported on
+        at least one interface by this probe."
+    ::= { hcRmonMIBGroups 16 }
+END
+
+
+
+
+
+
+
+
+
+Waldbusser                  Standards Track                    [Page 72]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+6.  Security Considerations
+
+   In order to implement this MIB, a probe must capture all packets on
+   the locally-attached network, including packets between third
+   parties.  These packets are analyzed to collect network addresses,
+   protocol usage information, and conversation statistics.  Data of
+   this nature may be considered sensitive in some environments.  In
+   such environments the administrator may wish to restrict SNMP access
+   to the probe.
+
+   A probe implementing this MIB is likely to also implement RMON [RFC
+   2819], which includes functions for returning the contents of
+   captured packets, potentially including sensitive user data or
+   passwords.  It is recommended that SNMP access to these functions be
+   restricted.
+
+   There are a number of management objects defined in this MIB that
+   have a MAX-ACCESS clause of read-write and/or read-create.  Such
+   objects may be considered sensitive or vulnerable in some network
+   environments.  The support for SET operations in a non-secure
+   environment without proper protection can have a negative effect on
+   network operations.
+
+   SNMPv1 by itself is not a secure environment.  Even if the network
+   itself is secure (for example by using IPSec), even then, there is no
+   control as to who on the secure network is allowed to access and
+   GET/SET (read/change/create/delete) the objects in this MIB.
+
+   It is recommended that the implementers consider the security
+   features as provided by the SNMPv3 framework.  Specifically, the use
+   of the User-based Security Model RFC 2574 [RFC2574] and the View-
+   based Access Control Model RFC 2575 [RFC2575] is recommended.
+
+   It is then a customer/user responsibility to ensure that the SNMP
+   entity giving access to an instance of this MIB, is properly
+   configured to give access to the objects only to those principals
+   (users) that have legitimate rights to indeed GET or SET
+   (change/create/delete) them.
+
+7.  Acknowledgments
+
+   This document was produced by the IETF Remote Network Monitoring
+   Working Group.
+
+8.  References
+
+   [1]   Harrington, D., Presuhn, R. and B. Wijnen, "An Architecture for
+         Describing SNMP Management Frameworks", RFC 2571, April 1999.
+
+
+
+Waldbusser                  Standards Track                    [Page 73]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+   [2]   Rose, M. and K. McCloghrie, "Structure and Identification of
+         Management Information for TCP/IP-based Internets", STD 16, RFC
+         1155, May 1990.
+
+   [3]   Rose, M. and K. McCloghrie, "Concise MIB Definitions", STD 16,
+         RFC 1212, March 1991.
+
+   [4]   Rose, M., "A Convention for Defining Traps for use with the
+         SNMP", RFC 1215, March 1991.
+
+   [5]   McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J., Rose,
+         M. and S. Waldbusser, "Structure of Management Information
+         Version 2 (SMIv2)", STD 58, RFC 2578, April 1999.
+
+   [6]   McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J., Rose,
+         M. and S. Waldbusser, "Textual Conventions for SMIv2", STD 58,
+         RFC 2579, April 1999.
+
+   [7]   McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J., Rose,
+         M. and S. Waldbusser, "Conformance Statements for SMIv2", STD
+         58, RFC 2580, April 1999.
+
+   [8]   Case, J., Fedor, M., Schoffstall, M. and J. Davin, "Simple
+         Network Management Protocol", STD 15, RFC 1157, May 1990.
+
+   [9]   Case, J., McCloghrie, K., Rose, M. and S. Waldbusser,
+         "Introduction to Community-based SNMPv2", RFC 1901, January
+         1996.
+
+   [10]  Case, J., McCloghrie, K., Rose, M. and S. Waldbusser,
+         "Transport Mappings for Version 2 of the Simple Network
+         Management Protocol (SNMPv2)", RFC 1906, January 1996.
+
+   [11]  Case, J., Harrington D., Presuhn R. and B. Wijnen, "Message
+         Processing and Dispatching for the Simple Network Management
+         Protocol (SNMP)", RFC 2572, April 1999.
+
+   [12]  Blumenthal, U. and B. Wijnen, "User-based Security Model (USM)
+         for version 3 of the Simple Network Management Protocol
+         (SNMPv3)", RFC 2574, April 1999.
+
+   [13]  Case, J., McCloghrie, K., Rose, M. and S. Waldbusser, "Protocol
+         Operations for Version 2 of the Simple Network Management
+         Protocol (SNMPv2)", RFC 1905, January 1996.
+
+   [14]  Levi, D., Meyer, P. and B. Stewart, "SNMPv3 Applications", RFC
+         2573, April 1999.
+
+
+
+
+Waldbusser                  Standards Track                    [Page 74]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+   [15]  Wijnen, B., Presuhn, R. and K. McCloghrie, "View-based Access
+         Control Model (VACM) for the Simple Network Management Protocol
+         (SNMP)", RFC 2575, April 1999.
+
+   [16]  McCloghrie, K. and M. Rose, Editors, "Management Information
+         Base for Network Management of TCP/IP-based internets: MIB-II",
+         STD 17, RFC 1213, March 1991.
+
+   [17]  McCloghrie, K. and F. Kastenholz, "The Interfaces Group MIB",
+         RFC 2863, June 2000.
+
+   [18]  Waldbusser, S., "Remote Network Monitoring MIB", STD 59, RFC
+         2819, May 2000.
+
+   [19]  Waldbusser, S., "Token Ring Extensions to the Remote Network
+         Monitoring MIB", RFC 1513, September 1993.
+
+   [20]  Waldbusser, S., "Remote Network Monitoring Management
+         Information Base Version 2 using SMIv2", RFC 2021, January
+         1997.
+
+   [21]  Case, J., Mundy, R., Partain, D. and B. Stewart, "Introduction
+         to Version 3 of the Internet-standard Network Management
+         Framework, RFC 2570, April 1999.
+
+9.  Notices
+
+   The IETF takes no position regarding the validity or scope of any
+   intellectual property or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; neither does it represent that it
+   has made any effort to identify any such rights.  Information on the
+   IETF's procedures with respect to rights in standards-track and
+   standards-related documentation can be found in BCP-11.  Copies of
+   claims of rights made available for publication and any assurances of
+   licenses to be made available, or the result of an attempt made to
+   obtain a general license or permission for the use of such
+   proprietary rights by implementors or users of this specification can
+   be obtained from the IETF Secretariat.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights which may cover technology that may be required to practice
+   this standard.  Please address the information to the IETF Executive
+   Director.
+
+
+
+
+
+Waldbusser                  Standards Track                    [Page 75]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+10.  Author's Address
+
+   Steve Waldbusser
+
+   Phone:  +1-650-948-6500
+   Fax:    +1-650-745-0671
+   EMail:  waldbusser@nextbeacon.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Waldbusser                  Standards Track                    [Page 76]
+
+RFC 3273          Remote Network Monitoring Management         July 2002
+
+
+11.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (2002).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Waldbusser                  Standards Track                    [Page 77]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc3273.txt](<www.ietf.org/rfc/rfc3273.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
