### PR TITLE
Archive rfc3276.txt

### DIFF
--- a/www.ietf.org/rfc/rfc3276.txt
+++ b/www.ietf.org/rfc/rfc3276.txt
@@ -1,0 +1,3699 @@
+
+
+
+
+
+
+Network Working Group                                             B. Ray
+Request for Comments: 3276                        PESA Switching Systems
+Category: Standards Track                                        R. Abbi
+                                                                 Alcatel
+                                                                May 2002
+
+
+ Definitions of Managed Objects for High Bit-Rate DSL - 2nd generation
+         (HDSL2) and Single-Pair High-Speed Digital Subscriber
+                           Line (SHDSL) Lines
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2002).  All Rights Reserved.
+
+Abstract
+
+   This document defines a portion of the Management Information Base
+   (MIB) module for use with network management protocols in the
+   Internet community.  In particular, it describes objects used for
+   managing High Bit-Rate DSL - 2nd generation (HDSL2) and Single-Pair
+   High-Speed Digital Subscriber Line (SHDSL) interfaces.
+
+Table of Contents
+
+   1.   Introduction .............................................  2
+   2.   The SNMP Network Management Framework ....................  2
+   3.   Introduction .............................................  3
+   3.1  Relationship of the HDSL2/SHDSL Line MIB to other MIBs ...  3
+   3.2  IANA Considerations ......................................  5
+   4.   Conventions used in the MIB ..............................  5
+   4.1  Naming Conventions .......................................  5
+   4.2  Textual Conventions ......................................  6
+   4.3  Structure ................................................  7
+   4.4  Counters, Interval Buckets and Thresholds ................ 10
+   4.5  Profiles ................................................. 11
+   4.6  Notifications ............................................ 12
+   5.   Conformance and Compliance ............................... 14
+   6.   Definitions .............................................. 14
+   7.   Security Considerations .................................. 60
+
+
+
+Ray & Abbi                  Standards Track                     [Page 1]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   8.   Acknowledgments .......................................... 62
+   9.   References ............................................... 63
+   10.  Intellectual Property Notice ............................. 65
+   11.  Authors' Addresses ....................................... 65
+   12.  Full Copyright Statement ................................. 66
+
+1. Introduction
+
+   This document defines a portion of the Management Information Base
+   (MIB) module for use with network management protocols in the
+   Internet community.  In particular, it describes objects used for
+   managing High Bit-Rate DSL - 2nd generation (HDSL2) [18] and Single-
+   Pair High-Speed Digital Subscriber Line (SHDSL) interfaces [19].
+
+2.  The SNMP Management Framework
+
+   The SNMP Management Framework presently consists of five major
+   components:
+
+   o  An overall architecture, described in RFC 2571 [1].
+
+   o  Mechanisms for describing and naming objects and events for the
+      purpose of management.  The first version of this Structure of
+      Management Information (SMI) is called SMIv1 and is described in
+      STD 16, RFC 1155 [2], STD 16, RFC 1212 [3], and RFC 1215 [4].  The
+      second version, called SMIv2, is described in STD 58, RFC 2578
+      [5], RFC 2579 [6], and RFC 2580 [7].
+
+   o  Message protocols for transferring management information.  The
+      first version of the SNMP message protocol is called SNMPv1 and is
+      described in STD 15, RFC 1157 [8].  A second version of the SNMP
+      message protocol, which is not an Internet standards track
+      protocol, is called SNMPv2c and described is in RFC 1901 [9] and
+      RFC 1906 [10].  The third version of the message protocol is
+      called SNMPv3 and is described in RFC 1906 [10], RFC 2572 [11],
+      and RFC 2574 [12].
+
+   o  Protocol operations for accessing management information.  The
+      first set of protocol operations and associated PDU formats is
+      described in STD 15, RFC 1157 [8].  A second set of protocol
+      operations and associated PDU formats is described in RFC 1905
+      [13].
+
+   o  A set of fundamental applications described in RFC 2573 [14] and
+      the view-based access control mechanism described in RFC 2575
+      [15].
+
+
+
+
+
+Ray & Abbi                  Standards Track                     [Page 2]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   A more detailed introduction to the current SNMP Management Framework
+   can be found in RFC 2570 [16].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  Objects in the MIB are
+   defined using the mechanisms defined in the SMI.
+
+   This memo specifies a MIB module that is compliant to the SMIv2.  A
+   MIB conforming to the SMIv1 can be produced through the appropriate
+   translations.  The resulting translated MIB must be semantically
+   equivalent, except where objects or events are omitted because no
+   translation is possible (use of Counter64).  Some machine readable
+   information in SMIv2 will be converted into textual descriptions in
+   SMIv1 during the translation process.  However, this loss of machine
+   readable information is not considered to change the semantics of the
+   MIB.
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [17].
+
+3.  Introduction
+
+   This document describes an SNMP MIB for managing HDSL2/SHDSL Lines.
+   These definitions are based upon the specifications for the HDSL2 and
+   SHDSL Embedded Operations Channel (EOC) as defined in ANSI
+   T1E1.4/2000-006 [18] and ITU G.991.2 [19].
+
+   The MIB is located in the MIB tree under MIB 2 transmission, as
+   discussed in the MIB-2 Integration (RFC 1213 [20] and RFC 2863 [21])
+   section of this document.
+
+3.1.  Relationship of the HDSL2/SHDSL Line MIB to other MIBs
+
+   This section outlines the relationship of this MIB with other MIBs
+   described in RFCs.  Specifically, IF-MIB as presented in RFC 2863
+   [21] is discussed.
+
+3.1.1  General IF-MIB Integration (RFC 2863)
+
+   The HDSL2/SHDSL Line MIB specifies the detailed attributes of a data
+   interface.  As such, it needs to integrate with RFC 2863 [21].  The
+   IANA has assigned the following ifTypes to HDSL2 and SHDSL:
+
+
+
+
+
+
+
+
+Ray & Abbi                  Standards Track                     [Page 3]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   IANAifType ::= TEXTUAL-CONVENTION
+       ...
+   SYNTAX INTEGER {
+       ...
+       hdsl2 (168), -- High Bit-Rate DSL, 2nd generation
+       shdsl (169), -- Multirate HDSL2
+       ...
+       }
+
+   Note that the ifFixedLengthGroup from RFC 2863 [21] MUST be supported
+   and that the ifRcvAddressGroup does not apply to this MIB.
+
+3.1.2  Usage of ifTable
+
+   The MIB branch identified by this ifType contains tables appropriate
+   for this interface type.  Most such tables extend the ifEntry table,
+   and are indexed by ifIndex.  For interfaces in systems implementing
+   this MIB, those table entries indexed by ifIndex MUST be persistent.
+
+   The following attributes are part of the mandatory ifGeneral group in
+   RFC 2863 [21], and are not duplicated in the HDSL2/SHDSL Line MIB.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ray & Abbi                  Standards Track                     [Page 4]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   ===================================================================
+       ifIndex                  Interface index.
+
+       ifDescr                  See interfaces MIB [21].
+
+       ifType                   hdsl2(168) or shdsl(169).
+
+       ifSpeed                  Set as appropriate.
+                                (This is fixed at 1552000 for HDSL2
+                                lines)
+
+       ifPhysAddress            This object MUST have an octet string
+                                with zero length.
+
+       ifAdminStatus            See interfaces MIB [21].
+
+       ifOperStatus             See interfaces MIB [21].
+
+       ifLastChange             See interfaces MIB [21].
+
+       ifName                   See interfaces MIB [21].
+
+       ifLinkUpDownTrapEnable   Default to enabled(1).
+
+       ifHighSpeed              Set as appropriate.
+                                (For HDSL2 lines, this is fixed at 2)
+
+       ifConnectorPresent       Set as appropriate.
+
+   ===================================================================
+                   Figure 1: Use of ifTable Objects
+
+3.2 IANA Considerations
+
+   The HDSL2-SHDSL-LINE-MIB module requires the allocation of a single
+   object identifier for its MODULE-IDENTITY.  The IANA has allocated
+   this object identifier in the transmission subtree (48), defined in
+   the SNMPv2-SMI MIB module.
+
+4.  Conventions used in the MIB
+
+4.1.  Naming Conventions
+
+   A.  xtuC refers to a central site terminal unit;
+       H2TU-C for HDSL2, or STU-C for SHDSL.
+   B.  xtuR refers to a remote site terminal unit;
+       H2TU-R for HDSL2, or STU-R for SHDSL.
+   C.  xtu refers to a terminal unit; either an xtuC or xtuR.
+
+
+
+Ray & Abbi                  Standards Track                     [Page 5]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   D.  xru refer to a regenerator unit;
+       H2RU for HDSL2, or SRU for SHDSL.
+   E.  xU refers to any HDSL2/SHDSL unit; either an xtu or xru.
+   F.  CRC is cyclic redundancy check [19].
+   G.  ES means errored second [19].
+   H.  LOSW means loss of sync word [19].
+   I.  LOSWS means LOSW seconds [19].
+   J.  SES means severely errored second [19].
+   K.  SNR means signal-to-noise ratio [19].
+   L.  UAS means unavailable second [19].
+
+4.2.  Textual Conventions
+
+   The following textual conventions are defined to reflect the line
+   topology in the MIB (further discussed in the following section) and
+   to define the behavior of the statistics to be maintained by an
+   agent.
+
+   o   Hdsl2ShdslUnitId:
+
+   Attributes with this syntax uniquely identify each unit in a
+   HDSL2/SHDSL span.  It mirrors the EOC addressing mechanism:
+
+   xtuC(1)                - CO terminal unit
+   xtuR(2)                - CPE terminal unit
+   xru1(3) .. xru8(10)    - regenerators, numbered from
+                             central office side
+   o   Hdsl2ShdslUnitSide:
+
+   Attributes with this syntax reference the two sides of a unit:
+
+   networkSide(1)   - N in figure 2, below
+   customerSide(2)  - C in figure 2, below
+
+   o   Hdsl2ShdslWirePair:
+
+   Attributes with this syntax reference the wire-pairs connecting the
+   units:
+
+   wirePair1(1)   - First pair for HDSL2/SHDSL.
+
+   wirePair2(2)   - Optional second pair for SHDSL only.
+
+   o   Hdsl2ShdslTransmissionModeType:
+
+   Attributes with this syntax specify the regional setting for a SHDSL
+   line.  Specified as a BITS construct, the two mode types are:
+
+
+
+
+Ray & Abbi                  Standards Track                     [Page 6]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   region1   - ITU-T G.991.2 Annex A
+   region2   - ITU-T G.991.2 Annex B
+
+   o   Hdsl2ShdslPerfCurrDayCount:
+
+   Attributes with this syntax define the behavior of the 1-day (24
+   hour) gauges found in the MIB.
+
+   o   Hdsl2Shdsl1DayIntervalCount:
+
+   Attributes with this syntax define the behavior of the 1-day (24
+   hour) interval counters found in the MIB.
+
+   o   Hdsl2ShdslPerfTimeElapsed:
+
+   Attributes with this syntax define the behavior of the elapsed time
+   counters found in the MIB.
+
+   o   Hdsl2ShdslPerfIntervalThreshold:
+
+   Attributes with this syntax define the behavior of the alarm
+   thresholds found in the MIB.
+
+   o   Hdsl2ShdslClockReferenceType
+
+   Attributes with this syntax define the clock references for the
+   HDSL2/SHDSL span.
+
+4.3.  Structure
+
+   The MIB is structured into following MIB groups:
+
+   o   Span Configuration Group:
+
+   This group supports MIB objects for configuring parameters for the
+   HDSL2/SHDSL span.  It contains the following table:
+
+      - hdsl2ShdslSpanConfTable
+
+   o   Span Status Group:
+
+   This group supports MIB objects for retrieving span status
+   information.  It contains the following table:
+
+      - hdsl2ShdslSpanStatusTable
+
+
+
+
+
+
+Ray & Abbi                  Standards Track                     [Page 7]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   o   Unit Inventory Group:
+
+   This group supports MIB objects for retrieving unit inventory
+   information about units in HDSL2/SHDSL lines via the EOC. It contains
+   the following table:
+
+      - hdsl2ShdslInventoryTable
+
+   o   Segment Endpoint Configuration Group:
+
+   This group supports MIB objects for configuring parameters for the
+   HDSL2/SHDSL segment endpoints.  It contains the following table:
+
+      - hdsl2ShdslEndpointConfTable
+
+   o   Segment Endpoint Current Status/Performance Group:
+
+   This group supports MIB objects that provide the current
+   status/performance information relating to segment endpoints.  It
+   contains the following table:
+
+      - hdsl2ShdslEndpointCurrTable
+
+   o   Segment Endpoint 15-Minute Interval Status/Performance Group:
+
+   This group supports MIB objects that provide historic
+   status/performance information relating to segment endpoints in 15-
+   minute intervals.  It contains the following table:
+
+      - hdsl2Shdsl15MinIntervalTable
+
+   o   Segment Endpoint 1-Day Interval Status/Performance Group:
+
+   This group supports MIB objects that provide historic
+   status/performance information relating to segment endpoints in 1-day
+   intervals.  It contains the following table:
+
+      - hdsl2Shdsl1DayIntervalTable
+
+   o   Maintenance Group:
+
+   This group supports MIB objects for performing maintenance operations
+   such as loopbacks for HDSL2/SHDSL lines.  It contains the following
+   table(s):
+
+      - hdsl2ShdslEndpointMaintTable
+      - hdsl2ShdslUnitMaintTable
+
+
+
+
+Ray & Abbi                  Standards Track                     [Page 8]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   o   Span Configuration Profile Group:
+
+   This group supports MIB objects for defining configuration profiles
+   for HDSL2/SHDSL Spans.  It contains the following table:
+
+      - hdsl2ShdslSpanConfProfileTable
+
+   o   Segment Endpoint Alarm Configuration Profile Group:
+
+   This group supports MIB objects for defining alarm configuration
+   profiles for HDSL2/SHDSL Segment Endpoints.  It contains the
+   following table:
+
+      - hdsl2ShdslEndpointAlarmConfProfileTable
+
+   o   Notifications Group:
+
+   This group defines the notifications supported for HDSL2/SHDSL lines:
+
+      - hdsl2ShdslLoopAttenCrossing
+      - hdsl2ShdslSNRMarginCrossing
+      - hdsl2ShdslPerfESThresh
+      - hdsl2ShdslPerfSESThresh
+      - hdsl2ShdslPerfCRCanomaliesThresh
+      - hdsl2ShdslPerfLOSWSThresh
+      - hdsl2ShdslPerfUASThresh
+      - hdsl2ShdslSpanInvalidNumRepeaters
+      - hdsl2ShdslLoopbackFailure
+      - hdsl2ShdslpowerBackoff
+      - hdsl2ShdsldeviceFault
+      - hdsl2ShdsldcContinuityFault
+      - hdsl2ShdslconfigInitFailure
+      - hdsl2ShdslprotocolInitFailure
+      - hdsl2ShdslnoNeighborPresent
+      - hdsl2ShdslLocalPowerLoss
+
+4.3.1  Line Topology
+
+   An HDSL2/SHDSL Line consists of a minimum of two units - xtuC (the
+   central termination unit) and an xtuR (the remote termination unit).
+   The line may optionally support up to 8 repeater/regenerator units
+   (xru) as shown in the figure below.
+
+
+
+
+
+
+
+
+
+Ray & Abbi                  Standards Track                     [Page 9]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+    <-- Network Side                            Customer Side -->
+
+    |</////////////////// HDSL2/SHDSL Span ////////////////////>|
+
+            <~~~>       <~~~> HDSL2/SHDSL Segments  <~~~>
+
+    +-------+   +-------+   +-------+       +-------+   +-------+
+    +       C=1=N       C=1=N       C=..1..=N       C=1=N       +
+    | xtuC  |   |  xru1 |   |  xru2 |       |  xru8 |   |  xtuR |
+    +       C=2=N       C=2=N       C=..2..=N       C=2=N       +
+    +-------+   +-------+   +-------+       +-------+   +-------+
+
+    Key:  <////> HDSL2/SHDSL Span
+          <~~~~> HDSL2/SHDSL Segment
+          =1=    HDSL2/SHDSL wire-pair-1
+          =2=    SHDSL optional wire-pair-2 (Not applicable to HDSL2)
+          C      Customer Side Segment Endpoint (modem)
+          N      Network Side Segment Endpoint (modem)
+
+
+          Figure 2: General topology for an HDSL2/SHDSL Line
+
+4.4.  Counters, Interval Buckets and Thresholds
+
+   For SNR Margin, Loop Attenuation, ES, SES, CRC anomalies, LOSW, and
+   UAS, there are event counters, current 15-minute and 0 to 96 15-
+   minute history bucket(s) of "interval-counters", as well as current
+   and 0 to 30 previous 1-day interval-counter(s).  Each current 15-
+   minute event bucket has an associated threshold notification.
+
+   Unlike RFC 2493 [22] and RFC 2662 [23], there is no representation in
+   the MIB for invalid buckets.  In those cases where the data for an
+   interval is suspect or known to be invalid, the agent MUST NOT report
+   the interval.  If the current 15-minute event bucket is determined to
+   be invalid, notifications based upon the value of the event bucket
+   MUST NOT be generated.
+
+   Not reporting an interval will result in holes in the associated
+   table.  For example, the table, hdsl2Shdsl15MinIntervalTable, is
+   indexed by { ifIndex, hdsl2ShdslInvIndex, hdsl2ShdslEndpointSide,
+   hdsl2ShdslEndpointWirePair, hdsl2Shdsl15MinIntervalNumber}.  If
+   interval 12 is determined to be invalid but intervals 11 and 13 are
+   valid, a Get Next operation on the indices .1.1.1.1.11 would return
+   indices .1.1.1.1.13.
+
+
+
+
+
+
+
+Ray & Abbi                  Standards Track                    [Page 10]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   There is no requirement for an agent to ensure a fixed relationship
+   between the start of a fifteen minute interval and any wall clock;
+   however some implementations may align the fifteen minute intervals
+   with quarter hours.  Likewise, an implementation may choose to align
+   one day intervals with the start of a day.
+
+   Counters are not reset when an xU is reinitialized, only when the
+   agent is reset or reinitialized (or under specific request outside
+   the scope of this MIB).
+
+4.5.  Profiles
+
+   As a managed node can handle a large number of xUs, (e.g., hundreds
+   or perhaps thousands of lines), provisioning every parameter on every
+   xU may become burdensome.  Moreover, most lines are provisioned
+   identically with the same set of parameters.  To simplify the
+   provisioning process, this MIB makes use of profiles.  A profile is a
+   set of parameters that can be shared by multiple lines using the same
+   configuration.
+
+   The following profiles are used in this MIB:
+
+   o  Span Configuration Profiles - Span configuration profiles contain
+      parameters for configuring HDSL2/SHDSL spans.  They are defined in
+      the hdsl2ShdslSpanConfProfileTable.  Since span configuration
+      parameters are only applicable for SHDSL, the support for span
+      configuration profiles are optional for HDSL2 interfaces.
+
+      Note that the configuration of the span dictates the behavior for
+      each individual segment end point in the span.  If a different
+      configuration is provisioned for any given segment end point
+      within the span, the new configuration for this segment end point
+      will override the span configuration for this segment end point
+      only.
+
+   o  Segment Endpoint Alarm Configuration Profiles - These profiles
+      contain parameters for configuring alarm thresholds for
+      HDSL2/SHDSL segment endpoints.  These profiles are defined in the
+      hdsl2ShdslEndpointAlarmConfProfileTable.
+
+      The index value for this profile is a locally-unique
+      administratively assigned name for the profile having the textual
+      convention `SnmpAdminString' (RFC 2571 [1]).
+
+   One or more lines may be configured to share parameters of a single
+   profile (e.g., hdsl2ShdslEndpointAlarmConfProfile = `silver') by
+   setting its hdsl2ShdslEndpointAlarmConfProfile objects to the value
+   of this profile.  If a change is made to the profile, all lines that
+
+
+
+Ray & Abbi                  Standards Track                    [Page 11]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   refer to it will be reconfigured to the changed parameters.  Before a
+   profile can be deleted or taken out of service it must be first
+   unreferenced from all associated lines.
+
+   Implementations MUST provide a default profile whose name is `DEFVAL'
+   for each profile type.  The values of the associated parameters will
+   be vendor specific unless otherwise indicated in this document.
+   Before a line's profiles have been set, these profiles will be
+   automatically used by setting hdsl2ShdslEndpointAlarmConfProfile and
+   hdsl2ShdslSpanConfProfile to `DEFVAL' where appropriate.  This
+   default profile name, 'DEFVAL', is considered reserved in the context
+   of profiles defined in this MIB.
+
+   Profiles are created, assigned, and deleted dynamically using the
+   profile name and profile row status in each of the four profile
+   tables.
+
+   Profile changes MUST take effect immediately.  These changes MAY
+   result in a restart (hard reset or soft restart) of the units on the
+   line.
+
+4.6.  Notifications
+
+   The ability to generate the SNMP notifications coldStart/WarmStart
+   (per [21]) which are per agent (e.g., per Digital Subscriber Line
+   Access Multiplexer, or DSLAM, in such a device), and linkUp/linkDown
+   (per [21]) which are per interface (i.e., HDSL2/SHDSL line) is
+   required.
+
+   A linkDown notification MAY be generated whenever any of ES, SES, CRC
+   Anomaly, LOSW, or UAS event occurs.  The corresponding linkUp
+   notification MAY be sent when all link failure conditions are
+   cleared.
+
+   The notifications defined in this MIB are for initialization failure
+   and for the threshold crossings associated with the following events:
+   ES, SES, CRC Anomaly, LOSW, and UAS.  Each threshold has its own
+   enable/threshold value.  When that value is 0, the notification is
+   disabled.
+
+   The hdsl2ShdslEndpointCurrStatus is a bitmask representing all
+   outstanding error conditions associated with a particular Segment
+   Endpoint.  Note that since status of remote endpoints is obtained via
+   the EOC, this information may be unavailable for units that are
+   unreachable via EOC during a line error condition.  Therefore, not
+   all conditions may always be included in its current status.
+   Notifications corresponding to the bit fields in this object are
+   defined.
+
+
+
+Ray & Abbi                  Standards Track                    [Page 12]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   Two alarm conditions, SNR Margin Alarm and Loop Attenuation Alarm,
+   are organized in a manner slightly different from that implied in the
+   EOC specifications.  In the MIB, these alarm conditions are tied to
+   the two thresholds hdsl2ShdslEndpointThreshSNRMargin and
+   hdsl2ShdslEndpointThreshLoopAttenuation found in the
+   hdsl2ShdslEndpointAlarmConfProfileTable.  In the EOC, the alarm
+   conditions associated with these thresholds are per-unit.  In the
+   MIB, these alarm conditions are per-endpoint.  For terminal units,
+   this has no impact.  For repeaters, this implies an implementation
+   variance where the agent in the terminal unit is responsible for
+   detecting a threshold crossing.  As the reporting of a repeater
+   detected alarm condition to the polling terminal unit occurs in the
+   same EOC message as the reporting of the current SNR Margin and Loop
+   Attenuation values, it is anticipated that this will have very little
+   impact on agent implementation.
+
+   A threshold notification occurs whenever the corresponding current
+   15-minute interval error counter becomes equal to, or exceeds the
+   threshold value.  One notification may be sent per interval per
+   interface.  Since the current 15-minute counter is reset to 0 every
+   15 minutes, and if the condition persists, the notification may recur
+   as  often as every 15 minutes.  For example, to get a notification
+   whenever a "loss of" event occurs (but at most once every 15
+   minutes), set the corresponding threshold to 1.  The agent will
+   generate a notification when the event originally occurs.
+
+   Note that the Network Management System, or NMS, may receive a
+   linkDown notification, as well, if enabled (via
+   ifLinkUpDownTrapEnable [21]).  At the beginning of the next 15 minute
+   interval, the counter is reset.  When the first second goes by and
+   the event occurs, the current interval bucket will be 1, which equals
+   the threshold, and the notification will be sent again.
+
+   A hdsl2ShdslSpanInvalidNumRepeaters notification may be generated
+   following completion of the discovery phase if the number of
+   repeaters discovered on the line differs from the number of repeaters
+   specified in hdsl2ShdslSpanConfNumRepeaters.  For those conditions
+   where the number of provisioned repeaters is greater than those
+   encountered during span discovery, all table entries associated with
+   the nonexistent repeaters are to be discarded.  For those conditions
+   where the number of provisioned repeaters is less than those
+   encountered during span discovery, additional table entries are to be
+   created using the default span configuration profile.
+
+
+
+
+
+
+
+
+Ray & Abbi                  Standards Track                    [Page 13]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+5.  Conformance and Compliance
+
+   For both HDSL2 and SHDSL lines, the following group(s) are mandatory:
+
+      hdsl2ShdslSpanConfGroup
+      hdsl2ShdslSpanStatusGroup
+      hdsl2ShdslInventoryGroup
+      hdsl2ShdslEndpointConfGroup
+      hdsl2Shdsl15MinIntervalGroup
+      hdsl2Shdsl1DayIntervalGroup
+      hdsl2ShdslMaintenanceGroup
+      hdsl2ShdslEndpointAlarmConfGroup
+      hdsl2ShdslNotificationGroup
+
+   For HDSL2 lines, the following group(s) are optional:
+
+      hdsl2ShdslSpanConfProfileGroup
+      hdsl2ShdslSpanShdslStatusGroup
+
+6.  Definitions
+
+HDSL2-SHDSL-LINE-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+MODULE-IDENTITY,
+OBJECT-TYPE,
+Counter32,
+Unsigned32,
+Gauge32,
+NOTIFICATION-TYPE,
+Integer32,
+transmission                  FROM SNMPv2-SMI
+RowStatus,
+TEXTUAL-CONVENTION            FROM SNMPv2-TC
+ifIndex                       FROM IF-MIB
+PerfCurrentCount,
+PerfIntervalCount             FROM PerfHist-TC-MIB
+SnmpAdminString               FROM SNMP-FRAMEWORK-MIB
+MODULE-COMPLIANCE,
+OBJECT-GROUP,
+NOTIFICATION-GROUP            FROM SNMPv2-CONF;
+
+hdsl2ShdslMIB MODULE-IDENTITY
+    LAST-UPDATED "200205090000Z" -- May 9, 2002
+    ORGANIZATION "ADSLMIB Working Group"
+    CONTACT-INFO "WG-email:  adslmib@ietf.org
+               Info:      https://www1.ietf.org/mailman/listinfo/adslmib
+               Chair:     Mike Sneed
+
+
+
+Ray & Abbi                  Standards Track                    [Page 14]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+               Postal:    P.O. Box 37324
+                          Raleigh NC 27627-7324
+               Email:     sneedmike@hotmail.com
+
+               Co-editor: Bob Ray
+                          PESA Switching Systems, Inc.
+               Postal:    330-A Wynn Drive
+                          Huntsville, AL 35805 USA
+               Email:     rray@pesa.com
+               Phone:     +1 256 726 9200 ext. 142
+
+               Co-editor: Rajesh Abbi
+                          Alcatel USA
+               Postal:    2912 Wake Forest Road
+                          Raleigh, NC 27609-7860 USA
+
+               Email:     Rajesh.Abbi@alcatel.com
+               Phone:     +1 919 850 6194
+              "
+
+DESCRIPTION
+     "This MIB module defines a collection of objects for managing
+      HDSL2/SHDSL lines.  An agent may reside at either end of the
+      line, however the MIB is designed to require no management
+      communication between the modems beyond that inherent in the
+      low-level EOC line protocol as defined in ANSI T1E1.4/2000-006
+      (for HDSL2 lines), or in ITU G.991.2 (for SHDSL lines)."
+ REVISION "200205090000Z" -- May 9, 2002
+ DESCRIPTION "Initial version, published as RFC 3276."
+
+ ::= { transmission 48 }
+
+hdsl2ShdslMibObjects OBJECT IDENTIFIER ::= { hdsl2ShdslMIB 1 }
+
+-- Textual Conventions used in this MIB
+--
+
+Hdsl2ShdslPerfCurrDayCount ::= TEXTUAL-CONVENTION
+   STATUS    current
+   DESCRIPTION
+     "A gauge associated with interface performance measurements in
+      a current 1-day (24 hour) measurement interval.
+
+      The value of this gauge starts at zero at the beginning of an
+      interval and is increased when associated events occur, until
+      the end of the 1-day interval.  At that time the value of the
+      gauge is stored in the previous 1-day history interval, as
+      defined in a companion object of type
+
+
+
+Ray & Abbi                  Standards Track                    [Page 15]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+      Hdsl2Shdsl1DayIntevalCount, and the current interval gauge
+      is restarted at zero.
+
+      In the case where the agent has no valid data available for
+      this interval the corresponding object instance is not
+      available and upon a retrieval request a corresponding error
+      message shall be returned to indicate that this instance does
+      not exist.  Please note that zero is a valid value."
+   SYNTAX  Gauge32
+
+Hdsl2Shdsl1DayIntervalCount ::= TEXTUAL-CONVENTION
+   STATUS    current
+   DESCRIPTION
+     "A counter associated with interface performance measurements
+      during the most previous 1-day (24 hour) measurement interval.
+      The value of this gauge is equal to the value of the current
+      day gauge, as defined in a companion object of type
+      Hdsl2ShdslPerfCurrDayCount, at the end of its most recent
+      interval.
+
+      In the case where the agent has no valid data available for
+      this interval the corresponding object instance is not
+      available and upon a retrieval request a corresponding error
+      message shall be returned to indicate that this instance does
+      not exist."
+   SYNTAX  Gauge32
+
+Hdsl2ShdslPerfTimeElapsed ::= TEXTUAL-CONVENTION
+   STATUS    current
+   DESCRIPTION
+     "The number of seconds that have elapsed since the beginning of
+      the current measurement period.  If, for some reason, such as
+      an adjustment in the system's time-of-day clock or the addition
+      of a leap second, the current interval exceeds the maximum
+      value, the agent will return the maximum value.
+
+      For 15 minute intervals, the range is limited to (0..899).
+      For 24 hour intervals, the range is limited to (0..86399)."
+   SYNTAX    Unsigned32(0..86399)
+
+Hdsl2ShdslPerfIntervalThreshold ::= TEXTUAL-CONVENTION
+   STATUS    current
+   DESCRIPTION
+     "This convention defines a range of values that may be set in
+      a fault threshold alarm control.  As the number of seconds in
+      a 15-minute interval numbers at most 900, objects of this type
+      may have a range of 0...900, where the value of 0 disables the
+      alarm."
+
+
+
+Ray & Abbi                  Standards Track                    [Page 16]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   SYNTAX    Unsigned32(0..900)
+
+Hdsl2ShdslUnitId ::= TEXTUAL-CONVENTION
+   STATUS    current
+   DESCRIPTION
+     "This is the unique identification for all units in a
+      HDSL2/SHDSL Span.  It is based on the EOC unit addressing
+      scheme with reference to the xtuC."
+   SYNTAX    INTEGER
+           {
+           xtuC(1),
+           xtuR(2),
+           xru1(3),
+           xru2(4),
+           xru3(5),
+           xru4(6),
+           xru5(7),
+           xru6(8),
+           xru7(9),
+           xru8(10)
+           }
+
+Hdsl2ShdslUnitSide ::= TEXTUAL-CONVENTION
+   STATUS    current
+   DESCRIPTION
+     "This is the referenced side of a HDSL2/SHDSL unit - Network
+      or Customer side.  The side facing the Network is the Network
+      side, while the side facing the Customer is the Customer side."
+   SYNTAX    INTEGER
+           {
+           networkSide(1),
+           customerSide(2)
+           }
+
+Hdsl2ShdslWirePair ::= TEXTUAL-CONVENTION
+   STATUS    current
+   DESCRIPTION
+     "This is the referenced pair of wires in a HDSL2/SHDSL Segment.
+      HDSL2 only supports a single pair (wirePair1), while SHDSL
+      supports an optional second pair (wirePair2)."
+   SYNTAX    INTEGER
+           {
+           wirePair1(1),
+           wirePair2(2)
+           }
+
+Hdsl2ShdslTransmissionModeType ::= TEXTUAL-CONVENTION
+   STATUS    current
+
+
+
+Ray & Abbi                  Standards Track                    [Page 17]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   DESCRIPTION
+     "Contains the regional setting of the HDSL2/SHDSL span,
+     represented as a bit-map of possible settings. The various
+     bit positions are:
+
+     Bit   Meaning      Description
+     1     region 1     Indicates ITU-T G.991.2 Annex A.
+     2     region 2     Indicates ITU-T G.991.2 Annex B."
+   SYNTAX      BITS
+           {
+           region1(0),
+           region2(1)
+           }
+
+Hdsl2ShdslClockReferenceType ::= TEXTUAL-CONVENTION
+   STATUS    current
+   DESCRIPTION
+     "The various STU-C symbol clock references for the
+     HDSL2/SHDSL span, represented as an enumeration."
+   SYNTAX    INTEGER
+          {
+          localClk(1),          -- Mode-1 per G991.2
+          networkClk(2),        -- Mode-2 per G991.2
+          dataOrNetworkClk(3),  -- Mode-3a per G991.2
+          dataClk(4)            -- Mode-3b per G991.2
+          }
+
+-- Span Configuration Group
+--
+
+hdsl2ShdslSpanConfTable OBJECT-TYPE
+   SYNTAX     SEQUENCE OF Hdsl2ShdslSpanConfEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+     "This table supports overall configuration of HDSL2/SHDSL
+      Spans.  Entries in this table MUST be maintained in a
+      persistent manner."
+   ::= { hdsl2ShdslMibObjects 1 }
+
+hdsl2ShdslSpanConfEntry OBJECT-TYPE
+   SYNTAX      Hdsl2ShdslSpanConfEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+     "An entry in the hdsl2ShdslSpanConfTable.  Each entry
+      represents the complete Span in a single HDSL2/SHDSL line.
+      It is indexed by the ifIndex of the associated HDSL2/SHDSL
+
+
+
+Ray & Abbi                  Standards Track                    [Page 18]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+      line."
+   INDEX { ifIndex }
+   ::= { hdsl2ShdslSpanConfTable 1 }
+
+Hdsl2ShdslSpanConfEntry ::=
+   SEQUENCE
+   {
+   hdsl2ShdslSpanConfNumRepeaters          Unsigned32,
+   hdsl2ShdslSpanConfProfile               SnmpAdminString,
+   hdsl2ShdslSpanConfAlarmProfile          SnmpAdminString
+   }
+
+   hdsl2ShdslSpanConfNumRepeaters OBJECT-TYPE
+   SYNTAX      Unsigned32(0..8)
+   UNITS       "repeaters"
+   MAX-ACCESS  read-write
+   STATUS      current
+   DESCRIPTION
+     "This object provisions the number of repeaters/regenerators
+     in this HDSL2/SHDSL Span."
+   ::= { hdsl2ShdslSpanConfEntry 1 }
+
+hdsl2ShdslSpanConfProfile OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  read-write
+   STATUS      current
+   DESCRIPTION
+     "This object is a pointer to a span configuration profile in
+     the hdsl2ShdslSpanConfProfileTable, which applies to this span.
+     The value of this object is the index of the referenced profile
+     in the hdsl2ShdslSpanConfProfileTable.  Note that span
+     configuration profiles are only applicable to SHDSL lines.
+
+     HDSL2 lines MUST reference the default profile, 'DEFVAL'.
+     By default, this object will have the value 'DEFVAL' (the index
+     of the default profile).
+
+     Any attempt to set this object to a value that is not the value
+     of the index for an active entry in the profile table,
+     hdsl2ShdslSpanConfProfileTable, MUST be rejected."
+   ::= { hdsl2ShdslSpanConfEntry 2 }
+
+hdsl2ShdslSpanConfAlarmProfile OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  read-write
+   STATUS      current
+   DESCRIPTION
+     "This object is a pointer to an Alarm configuration profile in
+
+
+
+Ray & Abbi                  Standards Track                    [Page 19]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+     the hdsl2ShdslEndpointAlarmConfProfileTable.  The value of this
+     object is the index of the referenced profile in the
+     hdsl2ShdslEndpointAlarmConfProfileTable.  The alarm threshold
+     configuration in the referenced profile will be used by default
+     for all segment endpoints in this span.  Individual endpoints
+     may override this profile by explicitly specifying some other
+     profile in the hdsl2ShdslEndpointConfTable.  By default, this
+     object will have the value 'DEFVAL' (the index of the default
+     profile).
+
+     Any attempt to set this object to a value that is not the value
+     of the index for an active entry in the profile table,
+     hdsl2ShdslEndpointAlarmConfProfileTable, MUST be rejected."
+   ::= { hdsl2ShdslSpanConfEntry 3 }
+
+-- Span Status Group
+--
+
+hdsl2ShdslSpanStatusTable OBJECT-TYPE
+   SYNTAX     SEQUENCE OF Hdsl2ShdslSpanStatusEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+     "This table provides overall status information of
+      HDSL2/SHDSL spans.  This table contains live data from
+      equipment.  As such, it is NOT persistent."
+   ::= { hdsl2ShdslMibObjects 2 }
+
+hdsl2ShdslSpanStatusEntry OBJECT-TYPE
+   SYNTAX      Hdsl2ShdslSpanStatusEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+     "An entry in the hdsl2ShdslSpanStatusTable.  Each entry
+      represents the complete span in a single HDSL2/SHDSL line.
+      It is indexed by the ifIndex of the associated HDSL2/SHDSL
+      line."
+   INDEX { ifIndex }
+   ::= { hdsl2ShdslSpanStatusTable 1 }
+
+Hdsl2ShdslSpanStatusEntry ::=
+   SEQUENCE
+   {
+   hdsl2ShdslStatusNumAvailRepeaters        Unsigned32,
+   hdsl2ShdslStatusMaxAttainableLineRate    Unsigned32,
+   hdsl2ShdslStatusActualLineRate           Unsigned32,
+   hdsl2ShdslStatusTransmissionModeCurrent
+             Hdsl2ShdslTransmissionModeType
+
+
+
+Ray & Abbi                  Standards Track                    [Page 20]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   }
+
+hdsl2ShdslStatusNumAvailRepeaters OBJECT-TYPE
+   SYNTAX      Unsigned32(0..8)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "Contains the actual number of repeaters/regenerators
+      discovered in this HDSL2/SHDSL span."
+   ::= { hdsl2ShdslSpanStatusEntry 1 }
+
+hdsl2ShdslStatusMaxAttainableLineRate OBJECT-TYPE
+   SYNTAX      Unsigned32(0..4112000)
+   UNITS       "bps"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "Contains the maximum attainable line rate in this HDSL2/SHDSL
+      span.  This object provides the maximum rate the line is
+      capable of achieving.  This is based upon measurements made
+      during line probing."
+   ::= { hdsl2ShdslSpanStatusEntry 2 }
+
+hdsl2ShdslStatusActualLineRate OBJECT-TYPE
+   SYNTAX      Unsigned32(0..4112000)
+   UNITS       "bps"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "Contains the actual line rate in this HDSL2/SHDSL span.  This
+     should equal ifSpeed."
+   ::= { hdsl2ShdslSpanStatusEntry 3 }
+
+hdsl2ShdslStatusTransmissionModeCurrent OBJECT-TYPE
+   SYNTAX      Hdsl2ShdslTransmissionModeType
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "Contains the current Power Spectral Density (PSD) regional
+      setting of the HDSL2/SHDSL span."
+   ::= { hdsl2ShdslSpanStatusEntry 4 }
+
+-- Unit Inventory Group
+--
+
+hdsl2ShdslInventoryTable OBJECT-TYPE
+   SYNTAX     SEQUENCE OF Hdsl2ShdslInventoryEntry
+   MAX-ACCESS not-accessible
+
+
+
+Ray & Abbi                  Standards Track                    [Page 21]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   STATUS     current
+   DESCRIPTION
+     "This table supports retrieval of unit inventory information
+      available via the EOC from units in a HDSL2/SHDSL line.
+
+      Entries in this table are dynamically created during the
+      line discovery process.  The life cycle for these entries
+      is as follows:
+
+         - xtu discovers a device, either a far-end xtu or an xru
+         - an inventory table entry is created for the device
+         - the line goes down for whatever reason
+         - inventory table entries for unreachable devices are
+           destroyed.
+
+      As these entries are created/destroyed dynamically, they
+      are NOT persistent."
+   ::= { hdsl2ShdslMibObjects 3 }
+
+hdsl2ShdslInventoryEntry OBJECT-TYPE
+   SYNTAX      Hdsl2ShdslInventoryEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+     "An entry in the hdsl2ShdslInventoryTable.  Each entry
+      represents inventory information for a single unit in a
+      HDSL2/SHDSL line.  It is indexed by the ifIndex of the
+      HDSL2/SHDSL line and the Hdsl2ShdslUnitId of the
+      associated unit."
+   INDEX { ifIndex, hdsl2ShdslInvIndex }
+   ::= { hdsl2ShdslInventoryTable 1 }
+
+Hdsl2ShdslInventoryEntry ::=
+   SEQUENCE
+   {
+   hdsl2ShdslInvIndex                      Hdsl2ShdslUnitId,
+   hdsl2ShdslInvVendorID                   OCTET STRING,
+   hdsl2ShdslInvVendorModelNumber          OCTET STRING,
+   hdsl2ShdslInvVendorSerialNumber         OCTET STRING,
+   hdsl2ShdslInvVendorEOCSoftwareVersion   Integer32,
+   hdsl2ShdslInvStandardVersion            Integer32,
+   hdsl2ShdslInvVendorListNumber           OCTET STRING,
+   hdsl2ShdslInvVendorIssueNumber          OCTET STRING,
+   hdsl2ShdslInvVendorSoftwareVersion      OCTET STRING,
+   hdsl2ShdslInvEquipmentCode              OCTET STRING,
+   hdsl2ShdslInvVendorOther                OCTET STRING,
+   hdsl2ShdslInvTransmissionModeCapability
+                         Hdsl2ShdslTransmissionModeType
+
+
+
+Ray & Abbi                  Standards Track                    [Page 22]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   }
+
+hdsl2ShdslInvIndex OBJECT-TYPE
+   SYNTAX      Hdsl2ShdslUnitId
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "Each entry in this table corresponds to a physical element
+      in a HDSL2/SHDSL Span.  It is based on the EOC unit addressing
+      scheme with reference to the xtuC."
+   ::= { hdsl2ShdslInventoryEntry 1 }
+
+hdsl2ShdslInvVendorID OBJECT-TYPE
+   SYNTAX      OCTET STRING(SIZE(8))
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "Vendor ID as reported in an Inventory Response message."
+   ::= { hdsl2ShdslInventoryEntry 2 }
+
+hdsl2ShdslInvVendorModelNumber OBJECT-TYPE
+   SYNTAX      OCTET STRING(SIZE(12))
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "Vendor model number as reported in an Inventory Response
+      message."
+   ::= { hdsl2ShdslInventoryEntry 3 }
+
+hdsl2ShdslInvVendorSerialNumber OBJECT-TYPE
+   SYNTAX      OCTET STRING(SIZE(12))
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "Vendor serial number as reported in an Inventory Response
+      message."
+   ::= { hdsl2ShdslInventoryEntry 4 }
+
+hdsl2ShdslInvVendorEOCSoftwareVersion OBJECT-TYPE
+   SYNTAX      Integer32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "Vendor EOC version as reported in a Discovery Response
+      message."
+   ::= { hdsl2ShdslInventoryEntry 5 }
+
+hdsl2ShdslInvStandardVersion OBJECT-TYPE
+
+
+
+Ray & Abbi                  Standards Track                    [Page 23]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   SYNTAX      Integer32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "Version of the HDSL2/SHDSL standard implemented, as reported
+      in an Inventory Response message."
+   ::= { hdsl2ShdslInventoryEntry 6 }
+
+hdsl2ShdslInvVendorListNumber OBJECT-TYPE
+   SYNTAX      OCTET STRING(SIZE(3))
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "Vendor list number as reported in an Inventory Response
+      message."
+   ::= { hdsl2ShdslInventoryEntry 7 }
+
+hdsl2ShdslInvVendorIssueNumber OBJECT-TYPE
+   SYNTAX      OCTET STRING(SIZE(2))
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "Vendor issue number as reported in an Inventory Response
+      message."
+   ::= { hdsl2ShdslInventoryEntry 8 }
+
+hdsl2ShdslInvVendorSoftwareVersion OBJECT-TYPE
+   SYNTAX      OCTET STRING(SIZE(6))
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "Vendor software version as reported in an Inventory Response
+      message."
+   ::= { hdsl2ShdslInventoryEntry 9 }
+
+hdsl2ShdslInvEquipmentCode OBJECT-TYPE
+   SYNTAX      OCTET STRING(SIZE(10))
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "Equipment code conforming to ANSI T1.213, Coded Identification
+      of Equipment Entities."
+   ::= { hdsl2ShdslInventoryEntry 10 }
+
+hdsl2ShdslInvVendorOther OBJECT-TYPE
+   SYNTAX      OCTET STRING(SIZE(12))
+   MAX-ACCESS  read-only
+   STATUS      current
+
+
+
+Ray & Abbi                  Standards Track                    [Page 24]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   DESCRIPTION
+     "Other vendor information as reported in an Inventory Response
+      message."
+   ::= { hdsl2ShdslInventoryEntry 11 }
+
+hdsl2ShdslInvTransmissionModeCapability OBJECT-TYPE
+   SYNTAX      Hdsl2ShdslTransmissionModeType
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "Contains the transmission mode capability of the SHDSL unit."
+   ::= { hdsl2ShdslInventoryEntry 12 }
+
+-- Segment Endpoint Configuration Group
+--
+
+hdsl2ShdslEndpointConfTable OBJECT-TYPE
+   SYNTAX      SEQUENCE OF Hdsl2ShdslEndpointConfEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+     "This table supports configuration parameters for segment
+      endpoints in a HDSL2/SHDSL line.  As this table is indexed
+      by ifIndex, it MUST be maintained in a persistent manner."
+   ::= { hdsl2ShdslMibObjects 4 }
+
+hdsl2ShdslEndpointConfEntry OBJECT-TYPE
+   SYNTAX      Hdsl2ShdslEndpointConfEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+     "An entry in the hdsl2ShdslEndpointConfTable.  Each entry
+      represents a single segment endpoint in a HDSL2/SHDSL line.
+      It is indexed by the ifIndex of the HDSL2/SHDSL line, the
+      UnitId of the associated unit, the side of the unit, and the
+      wire-pair of the associated modem."
+   INDEX { ifIndex, hdsl2ShdslInvIndex, hdsl2ShdslEndpointSide,
+           hdsl2ShdslEndpointWirePair}
+   ::= { hdsl2ShdslEndpointConfTable 1 }
+
+Hdsl2ShdslEndpointConfEntry ::=
+   SEQUENCE
+   {
+   hdsl2ShdslEndpointSide                   Hdsl2ShdslUnitSide,
+   hdsl2ShdslEndpointWirePair               Hdsl2ShdslWirePair,
+   hdsl2ShdslEndpointAlarmConfProfile       SnmpAdminString
+   }
+
+
+
+
+Ray & Abbi                  Standards Track                    [Page 25]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+hdsl2ShdslEndpointSide OBJECT-TYPE
+   SYNTAX      Hdsl2ShdslUnitSide
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+     "The side of the unit associated with this segment endpoint -
+      Network/Customer side - as per the Hdsl2ShdslUnitSide textual
+      convention."
+   ::= { hdsl2ShdslEndpointConfEntry 1 }
+
+hdsl2ShdslEndpointWirePair OBJECT-TYPE
+   SYNTAX      Hdsl2ShdslWirePair
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+     "The wire-pair of the modem associated with this segment
+      endpoint as per the Hdsl2ShdslWirePair textual convention."
+   ::= { hdsl2ShdslEndpointConfEntry 2 }
+
+hdsl2ShdslEndpointAlarmConfProfile OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(0..32))
+   MAX-ACCESS  read-write
+   STATUS      current
+   DESCRIPTION
+     "This object configures the alarm threshold values to be used
+      for this segment endpoint.  The values are obtained from the
+      alarm configuration profile referenced by this object.  The
+      value of this object is the index of the referenced profile in
+      the hdsl2ShdslEndpointAlarmConfProfileTable, or NULL (a zero-
+      length SnmpAdminString).  If the value is a zero-length
+      SnmpAdminString, the endpoint uses the default Alarm
+      Configuration Profile for the associated span as per the
+      hdsl2ShdslSpanConfAlarmProfile object in the
+      hdsl2ShdslSpanConfTable.  The default value of this object is
+      a zero-length SnmpAdminString.
+
+      Any attempt to set this object to a value that is not the value
+      of the index for an active entry in the profile table,
+      hdsl2ShdslEndpointAlarmConfProfileTable, MUST be rejected."
+   ::= { hdsl2ShdslEndpointConfEntry 3 }
+
+-- Segment Endpoint Current Status/Performance Group
+--
+
+hdsl2ShdslEndpointCurrTable OBJECT-TYPE
+   SYNTAX      SEQUENCE OF Hdsl2ShdslEndpointCurrEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+
+
+
+Ray & Abbi                  Standards Track                    [Page 26]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   DESCRIPTION
+     "This table contains current status and performance information
+      for segment endpoints in HDSL2/SHDSL Lines.  As with other
+      tables in this MIB indexed by ifIndex, entries in this table
+      MUST be maintained in a persistent manner."
+   ::= { hdsl2ShdslMibObjects 5 }
+
+hdsl2ShdslEndpointCurrEntry OBJECT-TYPE
+   SYNTAX      Hdsl2ShdslEndpointCurrEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+     "An entry in the hdsl2ShdslEndpointCurrTable.  Each entry
+     contains status and performance information relating to a
+     single segment endpoint.  It is indexed by the ifIndex of the
+     HDSL2/SHDSL line, the UnitId of the associated unit, the side
+     of the unit, and the wire-pair of the associated modem."
+   INDEX { ifIndex, hdsl2ShdslInvIndex, hdsl2ShdslEndpointSide,
+           hdsl2ShdslEndpointWirePair }
+   ::= { hdsl2ShdslEndpointCurrTable 1 }
+
+Hdsl2ShdslEndpointCurrEntry ::=
+   SEQUENCE
+   {
+   hdsl2ShdslEndpointCurrAtn                Integer32,
+   hdsl2ShdslEndpointCurrSnrMgn             Integer32,
+   hdsl2ShdslEndpointCurrStatus             BITS,
+   hdsl2ShdslEndpointES                     Counter32,
+   hdsl2ShdslEndpointSES                    Counter32,
+   hdsl2ShdslEndpointCRCanomalies           Counter32,
+   hdsl2ShdslEndpointLOSWS                  Counter32,
+   hdsl2ShdslEndpointUAS                    Counter32,
+   hdsl2ShdslEndpointCurr15MinTimeElapsed
+                             Hdsl2ShdslPerfTimeElapsed,
+   hdsl2ShdslEndpointCurr15MinES            PerfCurrentCount,
+   hdsl2ShdslEndpointCurr15MinSES           PerfCurrentCount,
+   hdsl2ShdslEndpointCurr15MinCRCanomalies  PerfCurrentCount,
+   hdsl2ShdslEndpointCurr15MinLOSWS         PerfCurrentCount,
+   hdsl2ShdslEndpointCurr15MinUAS           PerfCurrentCount,
+   hdsl2ShdslEndpointCurr1DayTimeElapsed
+                             Hdsl2ShdslPerfTimeElapsed,
+   hdsl2ShdslEndpointCurr1DayES
+                             Hdsl2ShdslPerfCurrDayCount,
+   hdsl2ShdslEndpointCurr1DaySES
+                             Hdsl2ShdslPerfCurrDayCount,
+   hdsl2ShdslEndpointCurr1DayCRCanomalies
+                             Hdsl2ShdslPerfCurrDayCount,
+   hdsl2ShdslEndpointCurr1DayLOSWS
+
+
+
+Ray & Abbi                  Standards Track                    [Page 27]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+                             Hdsl2ShdslPerfCurrDayCount,
+   hdsl2ShdslEndpointCurr1DayUAS
+                             Hdsl2ShdslPerfCurrDayCount
+   }
+
+hdsl2ShdslEndpointCurrAtn OBJECT-TYPE
+   SYNTAX      Integer32(-127..128)
+   UNITS       "dB"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "The current loop attenuation for this endpoint as reported in
+      a Network or Customer Side Performance Status message."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2ShdslEndpointCurrEntry 1 }
+
+hdsl2ShdslEndpointCurrSnrMgn OBJECT-TYPE
+   SYNTAX      Integer32(-127..128)
+   UNITS       "dB"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "The current SNR margin for this endpoint as reported in a
+      Status Response/SNR message."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2ShdslEndpointCurrEntry 2 }
+
+hdsl2ShdslEndpointCurrStatus OBJECT-TYPE
+   SYNTAX      BITS
+               {
+               noDefect(0),
+               powerBackoff(1),
+               deviceFault(2),
+               dcContinuityFault(3),
+               snrMarginAlarm(4),
+               loopAttenuationAlarm(5),
+               loswFailureAlarm(6),
+               configInitFailure(7),
+               protocolInitFailure(8),
+               noNeighborPresent(9),
+               loopbackActive(10)
+               }
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "Contains the current state of the endpoint.  This is a
+     bitmap of possible conditions. The various bit positions
+     are:
+
+
+
+Ray & Abbi                  Standards Track                    [Page 28]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+     noDefect               There no defects on the line.
+
+     powerBackoff           Indicates enhanced Power Backoff.
+
+     deviceFault            Indicates a vendor-dependent
+                            diagnostic or self-test fault
+                            has been detected.
+
+     dcContinuityFault      Indicates vendor-dependent
+                            conditions that interfere with
+                            span powering such as short and
+                            open circuits.
+
+     snrMarginAlarm         Indicates that the SNR margin
+                            has dropped below the alarm threshold.
+
+     loopAttenuationAlarm   Indicates that the loop attenuation
+                            exceeds the alarm threshold.
+
+     loswFailureAlarm       Indicates a forward LOSW alarm.
+
+     configInitFailure      Endpoint failure during initialization
+                            due to paired endpoint not able to
+                            support requested configuration.
+
+     protocolInitFailure    Endpoint failure during initialization
+                            due to incompatible protocol used by
+                            the paired endpoint.
+
+     noNeighborPresent      Endpoint failure during initialization
+                            due to no activation sequence detected
+                            from paired endpoint.
+
+     loopbackActive         A loopback is currently active at this
+                            Segment Endpoint.
+
+     This is intended to supplement ifOperStatus.  Note that there
+     is a 1-1 relationship between the status bits defined in this
+     object and the notification thresholds defined elsewhere in
+     this MIB."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2ShdslEndpointCurrEntry 3 }
+
+hdsl2ShdslEndpointES OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+
+
+
+Ray & Abbi                  Standards Track                    [Page 29]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   DESCRIPTION
+     "Count of Errored Seconds (ES) on this endpoint since the xU
+      was last restarted."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2ShdslEndpointCurrEntry 4 }
+
+hdsl2ShdslEndpointSES OBJECT-TYPE
+   SYNTAX       Counter32
+   UNITS        "seconds"
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+     "Count of Severely Errored Seconds (SES) on this endpoint
+      since the xU was last restarted."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2ShdslEndpointCurrEntry 5 }
+
+hdsl2ShdslEndpointCRCanomalies OBJECT-TYPE
+   SYNTAX       Counter32
+   UNITS        "detected CRC Anomalies"
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+     "Count of CRC anomalies on this endpoint since the xU was
+      last restarted."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2ShdslEndpointCurrEntry 6 }
+
+hdsl2ShdslEndpointLOSWS OBJECT-TYPE
+   SYNTAX       Counter32
+   UNITS        "seconds"
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+     "Count of Loss of Sync Word (LOSW) Seconds on this endpoint
+      since the xU was last restarted."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2ShdslEndpointCurrEntry 7 }
+
+hdsl2ShdslEndpointUAS OBJECT-TYPE
+   SYNTAX       Counter32
+   UNITS        "seconds"
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+     "Count of Unavailable Seconds (UAS) on this endpoint since
+      the xU was last restarted."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+
+
+
+Ray & Abbi                  Standards Track                    [Page 30]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   ::= { hdsl2ShdslEndpointCurrEntry 8 }
+
+hdsl2ShdslEndpointCurr15MinTimeElapsed OBJECT-TYPE
+   SYNTAX       Hdsl2ShdslPerfTimeElapsed
+   UNITS        "seconds"
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+     "Total elapsed seconds in the current 15-minute interval."
+   ::= { hdsl2ShdslEndpointCurrEntry 9 }
+
+hdsl2ShdslEndpointCurr15MinES OBJECT-TYPE
+   SYNTAX       PerfCurrentCount
+   UNITS        "seconds"
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+     "Count of Errored Seconds (ES) in the current 15-minute
+      interval."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2ShdslEndpointCurrEntry 10 }
+
+hdsl2ShdslEndpointCurr15MinSES OBJECT-TYPE
+   SYNTAX       PerfCurrentCount
+   UNITS        "seconds"
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+     "Count of Severely Errored Seconds (SES) in the current
+      15-minute interval."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2ShdslEndpointCurrEntry 11 }
+
+hdsl2ShdslEndpointCurr15MinCRCanomalies OBJECT-TYPE
+   SYNTAX       PerfCurrentCount
+   UNITS        "detected CRC Anomalies"
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+     "Count of CRC anomalies in the current 15-minute interval."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2ShdslEndpointCurrEntry 12 }
+
+hdsl2ShdslEndpointCurr15MinLOSWS OBJECT-TYPE
+   SYNTAX       PerfCurrentCount
+   UNITS        "seconds"
+   MAX-ACCESS   read-only
+   STATUS       current
+
+
+
+Ray & Abbi                  Standards Track                    [Page 31]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   DESCRIPTION
+     "Count of Loss of Sync Word (LOSW) Seconds in the current
+      15-minute interval."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2ShdslEndpointCurrEntry 13 }
+
+hdsl2ShdslEndpointCurr15MinUAS OBJECT-TYPE
+   SYNTAX       PerfCurrentCount
+   UNITS        "seconds"
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+     "Count of Unavailable Seconds (UAS) in the current 15-minute
+      interval."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2ShdslEndpointCurrEntry 14 }
+
+hdsl2ShdslEndpointCurr1DayTimeElapsed OBJECT-TYPE
+   SYNTAX       Hdsl2ShdslPerfTimeElapsed
+   UNITS        "seconds"
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+     "Number of seconds that have elapsed since the beginning of
+      the current 1-day interval."
+   ::= { hdsl2ShdslEndpointCurrEntry 15 }
+
+hdsl2ShdslEndpointCurr1DayES OBJECT-TYPE
+   SYNTAX       Hdsl2ShdslPerfCurrDayCount
+   UNITS        "seconds"
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+     "Count of Errored Seconds (ES) during the current day as
+      measured by hdsl2ShdslEndpointCurr1DayTimeElapsed."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2ShdslEndpointCurrEntry 16 }
+
+hdsl2ShdslEndpointCurr1DaySES OBJECT-TYPE
+   SYNTAX       Hdsl2ShdslPerfCurrDayCount
+   UNITS        "seconds"
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+     "Count of Severely Errored Seconds (SES) during the current
+      day as measured by hdsl2ShdslEndpointCurr1DayTimeElapsed."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2ShdslEndpointCurrEntry 17 }
+
+
+
+Ray & Abbi                  Standards Track                    [Page 32]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+hdsl2ShdslEndpointCurr1DayCRCanomalies OBJECT-TYPE
+   SYNTAX       Hdsl2ShdslPerfCurrDayCount
+   UNITS        "detected CRC Anomalies"
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+     "Count of CRC anomalies during the current day as measured
+      by hdsl2ShdslEndpointCurr1DayTimeElapsed."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2ShdslEndpointCurrEntry 18 }
+
+hdsl2ShdslEndpointCurr1DayLOSWS OBJECT-TYPE
+   SYNTAX       Hdsl2ShdslPerfCurrDayCount
+   UNITS        "seconds"
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+     "Count of Loss of Sync Word (LOSW) Seconds during the current
+      day as measured by hdsl2ShdslEndpointCurr1DayTimeElapsed."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2ShdslEndpointCurrEntry 19 }
+
+hdsl2ShdslEndpointCurr1DayUAS OBJECT-TYPE
+   SYNTAX       Hdsl2ShdslPerfCurrDayCount
+   UNITS        "seconds"
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+     "Count of Unavailable Seconds (UAS) during the current day as
+      measured by hdsl2ShdslEndpointCurr1DayTimeElapsed."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2ShdslEndpointCurrEntry 20 }
+
+-- Segment Endpoint 15-Minute Interval Status/Performance Group
+--
+
+hdsl2Shdsl15MinIntervalTable OBJECT-TYPE
+   SYNTAX      SEQUENCE OF Hdsl2Shdsl15MinIntervalEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+     "This table provides one row for each HDSL2/SHDSL endpoint
+      performance data collection interval.  This table contains
+      live data from equipment.  As such, it is NOT persistent."
+   ::= { hdsl2ShdslMibObjects 6 }
+
+hdsl2Shdsl15MinIntervalEntry OBJECT-TYPE
+   SYNTAX      Hdsl2Shdsl15MinIntervalEntry
+
+
+
+Ray & Abbi                  Standards Track                    [Page 33]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+     "An entry in the hdsl2Shdsl15MinIntervalTable."
+   INDEX { ifIndex, hdsl2ShdslInvIndex, hdsl2ShdslEndpointSide,
+           hdsl2ShdslEndpointWirePair, hdsl2Shdsl15MinIntervalNumber}
+   ::= { hdsl2Shdsl15MinIntervalTable 1 }
+
+Hdsl2Shdsl15MinIntervalEntry ::=
+   SEQUENCE
+   {
+   hdsl2Shdsl15MinIntervalNumber         Unsigned32,
+   hdsl2Shdsl15MinIntervalES             PerfIntervalCount,
+   hdsl2Shdsl15MinIntervalSES            PerfIntervalCount,
+   hdsl2Shdsl15MinIntervalCRCanomalies   PerfIntervalCount,
+   hdsl2Shdsl15MinIntervalLOSWS          PerfIntervalCount,
+   hdsl2Shdsl15MinIntervalUAS            PerfIntervalCount
+   }
+
+hdsl2Shdsl15MinIntervalNumber OBJECT-TYPE
+   SYNTAX      Unsigned32(1..96)
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+     "Performance Data Interval number. 1 is the the most recent
+      previous interval; interval 96 is 24 hours ago. Intervals
+      2..96 are optional."
+   ::= { hdsl2Shdsl15MinIntervalEntry 1 }
+
+hdsl2Shdsl15MinIntervalES OBJECT-TYPE
+   SYNTAX      PerfIntervalCount
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "Count of Errored Seconds (ES) during the interval."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2Shdsl15MinIntervalEntry 2 }
+
+hdsl2Shdsl15MinIntervalSES OBJECT-TYPE
+   SYNTAX      PerfIntervalCount
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "Count of Severely Errored Seconds (SES) during the interval."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2Shdsl15MinIntervalEntry 3 }
+
+
+
+Ray & Abbi                  Standards Track                    [Page 34]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+hdsl2Shdsl15MinIntervalCRCanomalies OBJECT-TYPE
+   SYNTAX      PerfIntervalCount
+   UNITS       "detected CRC Anomalies"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "Count of CRC anomalies during the interval."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2Shdsl15MinIntervalEntry 4 }
+
+hdsl2Shdsl15MinIntervalLOSWS OBJECT-TYPE
+   SYNTAX      PerfIntervalCount
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "Count of Loss of Sync Word (LOSW) Seconds during the
+      interval."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2Shdsl15MinIntervalEntry 5 }
+
+hdsl2Shdsl15MinIntervalUAS OBJECT-TYPE
+   SYNTAX      PerfIntervalCount
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "Count of Unavailable Seconds (UAS) during the interval."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2Shdsl15MinIntervalEntry 6 }
+
+-- Segment Endpoint 1-Day Interval Status/Performance Group
+--
+
+hdsl2Shdsl1DayIntervalTable OBJECT-TYPE
+   SYNTAX      SEQUENCE OF Hdsl2Shdsl1DayIntervalEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+     "This table provides one row for each HDSL2/SHDSL endpoint
+      performance data collection interval.  This table contains
+      live data from equipment.  As such, it is NOT persistent."
+   ::= { hdsl2ShdslMibObjects 7 }
+
+hdsl2Shdsl1DayIntervalEntry OBJECT-TYPE
+   SYNTAX      Hdsl2Shdsl1DayIntervalEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+
+
+
+Ray & Abbi                  Standards Track                    [Page 35]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   DESCRIPTION
+     "An entry in the hdsl2Shdsl1DayIntervalTable."
+   INDEX { ifIndex, hdsl2ShdslInvIndex, hdsl2ShdslEndpointSide,
+           hdsl2ShdslEndpointWirePair, hdsl2Shdsl1DayIntervalNumber }
+   ::= { hdsl2Shdsl1DayIntervalTable 1 }
+
+Hdsl2Shdsl1DayIntervalEntry ::=
+   SEQUENCE
+   {
+   hdsl2Shdsl1DayIntervalNumber         Unsigned32,
+   hdsl2Shdsl1DayIntervalMoniSecs       Hdsl2ShdslPerfTimeElapsed,
+   hdsl2Shdsl1DayIntervalES             Hdsl2Shdsl1DayIntervalCount,
+   hdsl2Shdsl1DayIntervalSES            Hdsl2Shdsl1DayIntervalCount,
+   hdsl2Shdsl1DayIntervalCRCanomalies   Hdsl2Shdsl1DayIntervalCount,
+   hdsl2Shdsl1DayIntervalLOSWS          Hdsl2Shdsl1DayIntervalCount,
+   hdsl2Shdsl1DayIntervalUAS            Hdsl2Shdsl1DayIntervalCount
+   }
+
+hdsl2Shdsl1DayIntervalNumber OBJECT-TYPE
+   SYNTAX      Unsigned32(1..30)
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+     "History Data Interval number. Interval 1 is the the most
+      recent previous day; interval 30 is 30 days ago. Intervals
+      2..30 are optional."
+   ::= { hdsl2Shdsl1DayIntervalEntry 1 }
+
+hdsl2Shdsl1DayIntervalMoniSecs OBJECT-TYPE
+   SYNTAX       Hdsl2ShdslPerfTimeElapsed
+   UNITS        "seconds"
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+     "The amount of time in the 1-day interval over which the
+      performance monitoring information is actually counted.
+      This value will be the same as the interval duration except
+      in a situation where performance monitoring data could not
+      be collected for any reason."
+   ::= { hdsl2Shdsl1DayIntervalEntry 2 }
+
+hdsl2Shdsl1DayIntervalES OBJECT-TYPE
+   SYNTAX       Hdsl2Shdsl1DayIntervalCount
+   UNITS        "seconds"
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+     "Count of Errored Seconds (ES) during the 1-day interval as
+
+
+
+Ray & Abbi                  Standards Track                    [Page 36]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+      measured by hdsl2Shdsl1DayIntervalMoniSecs."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2Shdsl1DayIntervalEntry 3 }
+
+hdsl2Shdsl1DayIntervalSES OBJECT-TYPE
+   SYNTAX       Hdsl2Shdsl1DayIntervalCount
+   UNITS        "seconds"
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+     "Count of Severely Errored Seconds (SES) during the 1-day
+      interval as measured by hdsl2Shdsl1DayIntervalMoniSecs."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2Shdsl1DayIntervalEntry 4 }
+
+hdsl2Shdsl1DayIntervalCRCanomalies OBJECT-TYPE
+   SYNTAX       Hdsl2Shdsl1DayIntervalCount
+   UNITS        "detected CRC Anomalies"
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+     "Count of CRC anomalies during the 1-day interval as
+      measured by hdsl2Shdsl1DayIntervalMoniSecs."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2Shdsl1DayIntervalEntry 5 }
+
+hdsl2Shdsl1DayIntervalLOSWS OBJECT-TYPE
+   SYNTAX       Hdsl2Shdsl1DayIntervalCount
+   UNITS        "seconds"
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+     "Count of Loss of Sync Word (LOSW) Seconds during the 1-day
+      interval as measured by hdsl2Shdsl1DayIntervalMoniSecs."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2Shdsl1DayIntervalEntry 6 }
+
+hdsl2Shdsl1DayIntervalUAS OBJECT-TYPE
+   SYNTAX       Hdsl2Shdsl1DayIntervalCount
+   UNITS        "seconds"
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+     "Count of Unavailable Seconds (UAS) during the 1-day interval
+      as measured by hdsl2Shdsl1DayIntervalMoniSecs."
+   REFERENCE   "HDSL2 Section 7.5.3.7; SHDSL Section 9.5.5.7"
+   ::= { hdsl2Shdsl1DayIntervalEntry 7 }
+
+
+
+
+Ray & Abbi                  Standards Track                    [Page 37]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+-- Maintenance Group
+--
+
+hdsl2ShdslEndpointMaintTable OBJECT-TYPE
+   SYNTAX      SEQUENCE OF Hdsl2ShdslEndpointMaintEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+     "This table supports maintenance operations (eg. loopbacks)
+      to be performed on HDSL2/SHDSL segment endpoints.  This table
+      contains live data from equipment.  As such, it is NOT
+      persistent."
+   ::= { hdsl2ShdslMibObjects 8 }
+
+hdsl2ShdslEndpointMaintEntry OBJECT-TYPE
+   SYNTAX      Hdsl2ShdslEndpointMaintEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+     "An entry in the hdsl2ShdslEndpointMaintTable.  Each entry
+      corresponds to a single segment endpoint, and is indexed by the
+      ifIndex of the HDSL2/SHDSL line, the UnitId of the associated
+      unit and the side of the unit."
+   INDEX { ifIndex, hdsl2ShdslInvIndex, hdsl2ShdslEndpointSide }
+   ::= { hdsl2ShdslEndpointMaintTable 1 }
+
+Hdsl2ShdslEndpointMaintEntry ::=
+   SEQUENCE
+   {
+   hdsl2ShdslMaintLoopbackConfig      INTEGER,
+   hdsl2ShdslMaintTipRingReversal     INTEGER,
+   hdsl2ShdslMaintPowerBackOff        INTEGER,
+   hdsl2ShdslMaintSoftRestart         INTEGER
+   }
+
+hdsl2ShdslMaintLoopbackConfig OBJECT-TYPE
+   SYNTAX      INTEGER
+               {
+               noLoopback(1),
+               normalLoopback(2),
+               specialLoopback(3)
+               }
+   MAX-ACCESS  read-write
+   STATUS      current
+   DESCRIPTION
+     "This object controls configuration of loopbacks for the
+      associated segment endpoint.  The status of the loopback
+      is obtained via the hdsl2ShdslEndpointCurrStatus object."
+
+
+
+Ray & Abbi                  Standards Track                    [Page 38]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   ::= { hdsl2ShdslEndpointMaintEntry 1 }
+
+hdsl2ShdslMaintTipRingReversal OBJECT-TYPE
+   SYNTAX      INTEGER
+               {
+               normal(1),
+               reversed(2)
+               }
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "This object indicates the state of the tip/ring pair at the
+      associated segment endpoint."
+   ::= { hdsl2ShdslEndpointMaintEntry 2 }
+
+hdsl2ShdslMaintPowerBackOff OBJECT-TYPE
+   SYNTAX      INTEGER
+               {
+               default(1),
+               enhanced(2)
+               }
+   MAX-ACCESS  read-write
+   STATUS      current
+   DESCRIPTION
+     "This object configures the receiver at the associated
+      segment endpoint to operate in default or enhanced power
+      backoff mode."
+   ::= { hdsl2ShdslEndpointMaintEntry 3 }
+
+hdsl2ShdslMaintSoftRestart OBJECT-TYPE
+   SYNTAX      INTEGER
+               {
+               ready(1),
+               restart(2)
+               }
+   MAX-ACCESS  read-write
+   STATUS      current
+   DESCRIPTION
+     "This object enables the manager to trigger a soft restart
+      of the modem at the associated segment endpoint.  The manager
+      may only set this object to the 'restart(2)' value, which
+      initiates a restart.  The agent will perform a restart after
+      approximately 5 seconds.  Following the 5 second period, the
+      agent will restore the object to the 'ready(1)' state."
+   ::= { hdsl2ShdslEndpointMaintEntry 4 }
+
+hdsl2ShdslUnitMaintTable OBJECT-TYPE
+   SYNTAX      SEQUENCE OF Hdsl2ShdslUnitMaintEntry
+
+
+
+Ray & Abbi                  Standards Track                    [Page 39]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+     "This table supports maintenance operations for units in a
+      HDSL2/SHDSL line.  Entries in this table MUST be maintained
+      in a persistent manner."
+   ::= { hdsl2ShdslMibObjects 9 }
+
+hdsl2ShdslUnitMaintEntry OBJECT-TYPE
+   SYNTAX      Hdsl2ShdslUnitMaintEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+     "An entry in the hdsl2ShdslUnitMaintTable.  Each entry
+      corresponds to a single unit, and is indexed by the ifIndex
+      of the HDSL2/SHDSL line and the UnitId of the associated
+      unit."
+   INDEX { ifIndex, hdsl2ShdslInvIndex  }
+   ::= { hdsl2ShdslUnitMaintTable 1 }
+
+Hdsl2ShdslUnitMaintEntry ::=
+   SEQUENCE
+   {
+   hdsl2ShdslMaintLoopbackTimeout     Integer32,
+   hdsl2ShdslMaintUnitPowerSource     INTEGER
+   }
+
+hdsl2ShdslMaintLoopbackTimeout OBJECT-TYPE
+   SYNTAX      Integer32(0..4095)
+   UNITS       "minutes"
+   MAX-ACCESS  read-write
+   STATUS      current
+   DESCRIPTION
+     "This object configures the timeout value for loopbacks
+      initiated at segments endpoints contained in the associated
+      unit.  A value of 0 disables the timeout."
+   ::= { hdsl2ShdslUnitMaintEntry 1 }
+
+hdsl2ShdslMaintUnitPowerSource OBJECT-TYPE
+   SYNTAX      INTEGER
+               {
+               local(1),
+               span(2)
+               }
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+     "This object indicates the DC power source being used by the
+
+
+
+Ray & Abbi                  Standards Track                    [Page 40]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+      associated unit."
+   ::= { hdsl2ShdslUnitMaintEntry 2 }
+
+-- Span Configuration Profile Group
+--
+
+hdsl2ShdslSpanConfProfileTable OBJECT-TYPE
+   SYNTAX      SEQUENCE OF Hdsl2ShdslSpanConfProfileEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+     "This table supports definitions of span configuration
+      profiles for SHDSL lines.  HDSL2 does not support these
+      configuration options.  This table MUST be maintained
+      in a persistent manner."
+   ::= { hdsl2ShdslMibObjects 10 }
+
+hdsl2ShdslSpanConfProfileEntry OBJECT-TYPE
+   SYNTAX      Hdsl2ShdslSpanConfProfileEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+     "Each entry corresponds to a single span configuration
+      profile.  Each profile contains a set of span configuration
+      parameters.  The configuration parameters in a profile are
+      applied to those lines referencing that profile (see the
+      hdsl2ShdslSpanConfProfile object).  Profiles may be
+      created/deleted using the row creation/deletion mechanism
+      via hdsl2ShdslSpanConfProfileRowStatus.  If an active
+      entry is referenced in hdsl2ShdslSpanConfProfile, the
+      entry MUST remain active until all references are removed."
+   INDEX { IMPLIED hdsl2ShdslSpanConfProfileName }
+   ::= { hdsl2ShdslSpanConfProfileTable 1 }
+
+Hdsl2ShdslSpanConfProfileEntry ::=
+   SEQUENCE
+   {
+   hdsl2ShdslSpanConfProfileName               SnmpAdminString,
+   hdsl2ShdslSpanConfWireInterface             INTEGER,
+   hdsl2ShdslSpanConfMinLineRate               Unsigned32,
+   hdsl2ShdslSpanConfMaxLineRate               Unsigned32,
+   hdsl2ShdslSpanConfPSD                       INTEGER,
+   hdsl2ShdslSpanConfTransmissionMode
+                                   Hdsl2ShdslTransmissionModeType,
+   hdsl2ShdslSpanConfRemoteEnabled             INTEGER,
+   hdsl2ShdslSpanConfPowerFeeding              INTEGER,
+   hdsl2ShdslSpanConfCurrCondTargetMarginDown  Integer32,
+   hdsl2ShdslSpanConfWorstCaseTargetMarginDown Integer32,
+
+
+
+Ray & Abbi                  Standards Track                    [Page 41]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   hdsl2ShdslSpanConfCurrCondTargetMarginUp    Integer32,
+   hdsl2ShdslSpanConfWorstCaseTargetMarginUp   Integer32,
+   hdsl2ShdslSpanConfUsedTargetMargins         BITS,
+   hdsl2ShdslSpanConfReferenceClock
+                                   Hdsl2ShdslClockReferenceType,
+   hdsl2ShdslSpanConfLineProbeEnable           INTEGER,
+   hdsl2ShdslSpanConfProfileRowStatus          RowStatus
+   }
+
+hdsl2ShdslSpanConfProfileName OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+     "This object is the unique index associated with this profile.
+      Entries in this table are referenced via the object
+      hdsl2ShdslSpanConfProfile in Hdsl2ShdslSpanConfEntry."
+   ::= { hdsl2ShdslSpanConfProfileEntry 1 }
+
+hdsl2ShdslSpanConfWireInterface OBJECT-TYPE
+   SYNTAX      INTEGER
+               {
+               twoWire(1),
+               fourWire(2)
+               }
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "This object configures the two-wire or optional four-wire
+      operation for SHDSL Lines."
+   DEFVAL      { twoWire }
+   ::= { hdsl2ShdslSpanConfProfileEntry 2 }
+
+hdsl2ShdslSpanConfMinLineRate OBJECT-TYPE
+   SYNTAX      Unsigned32(0..4112000)
+   UNITS       "bps"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "This object configures the minimum transmission rate for
+      the associated SHDSL Line in bits-per-second (bps).  If
+      the minimum line rate equals the maximum line rate
+      (hdsl2ShdslSpanMaxLineRate), the line rate is considered
+      'fixed'.  If the minimum line rate is less than the maximum
+      line rate, the line rate is considered 'rate-adaptive'."
+   DEFVAL      { 1552000 }
+   ::= { hdsl2ShdslSpanConfProfileEntry 3 }
+
+
+
+
+Ray & Abbi                  Standards Track                    [Page 42]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+hdsl2ShdslSpanConfMaxLineRate OBJECT-TYPE
+   SYNTAX      Unsigned32(0..4112000)
+   UNITS       "bps"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "This object configures the maximum transmission rate for
+      the associated SHDSL Line in bits-per-second (bps).  If
+      the minimum line rate equals the maximum line rate
+      (hdsl2ShdslSpanMaxLineRate), the line rate is considered
+      'fixed'.  If the minimum line rate is less than the maximum
+      line rate, the line rate is considered 'rate-adaptive'."
+   DEFVAL      { 1552000 }
+   ::= { hdsl2ShdslSpanConfProfileEntry 4 }
+
+hdsl2ShdslSpanConfPSD OBJECT-TYPE
+   SYNTAX      INTEGER
+               {
+               symmetric(1),
+               asymmetric(2)
+               }
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "This object configures use of symmetric/asymmetric PSD (Power
+      Spectral Density) Mask for the associated SHDSL Line.  Support
+      for symmetric PSD is mandatory for all supported data rates.
+      Support for asymmetric PSD is optional."
+   DEFVAL      { symmetric }
+   ::= { hdsl2ShdslSpanConfProfileEntry 5 }
+
+hdsl2ShdslSpanConfTransmissionMode OBJECT-TYPE
+   SYNTAX      Hdsl2ShdslTransmissionModeType
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "This object specifies the regional setting for the SHDSL
+      line."
+   DEFVAL      { { region1 } }
+   ::= { hdsl2ShdslSpanConfProfileEntry 6 }
+
+hdsl2ShdslSpanConfRemoteEnabled OBJECT-TYPE
+   SYNTAX      INTEGER
+               {
+               enabled(1),
+               disabled(2)
+               }
+   MAX-ACCESS  read-create
+
+
+
+Ray & Abbi                  Standards Track                    [Page 43]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   STATUS      current
+   DESCRIPTION
+     "This object enables/disables support for remote management
+      of the units in a SHDSL line from the STU-R via the EOC."
+   DEFVAL      { enabled }
+   ::= { hdsl2ShdslSpanConfProfileEntry 7 }
+
+hdsl2ShdslSpanConfPowerFeeding OBJECT-TYPE
+   SYNTAX      INTEGER
+               {
+               noPower(1),
+               powerFeed(2),
+               wettingCurrent(3)
+               }
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "This object enables/disables support for optional power
+      feeding in a SHDSL line."
+   DEFVAL      { noPower }
+   ::= { hdsl2ShdslSpanConfProfileEntry 8 }
+
+hdsl2ShdslSpanConfCurrCondTargetMarginDown OBJECT-TYPE
+   SYNTAX      Integer32(-10..21)
+   UNITS       "dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "This object specifies the downstream current condition target
+      SNR margin for a SHDSL line.  The SNR margin is the difference
+      between the desired SNR and the actual SNR.  Target SNR margin
+      is the desired SNR margin for a unit."
+   DEFVAL      { 0 }
+   ::= { hdsl2ShdslSpanConfProfileEntry 9 }
+
+hdsl2ShdslSpanConfWorstCaseTargetMarginDown OBJECT-TYPE
+   SYNTAX      Integer32(-10..21)
+   UNITS       "dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "This object specifies the downstream worst case target SNR
+      margin for a SHDSL line.  The SNR margin is the difference
+      between the desired SNR and the actual SNR.  Target SNR
+      margin is the desired SNR margin for a unit."
+   DEFVAL      { 0 }
+   ::= { hdsl2ShdslSpanConfProfileEntry 10 }
+
+
+
+
+Ray & Abbi                  Standards Track                    [Page 44]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+hdsl2ShdslSpanConfCurrCondTargetMarginUp OBJECT-TYPE
+   SYNTAX      Integer32(-10..21)
+   UNITS       "dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "This object specifies the upstream current condition target
+      SNR margin for a SHDSL line.  The SNR margin is the difference
+      between the desired SNR and the actual SNR.  Target SNR margin
+      is the desired SNR margin for a unit."
+   DEFVAL      { 0 }
+   ::= { hdsl2ShdslSpanConfProfileEntry 11 }
+
+hdsl2ShdslSpanConfWorstCaseTargetMarginUp OBJECT-TYPE
+   SYNTAX      Integer32(-10..21)
+   UNITS       "dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "This object specifies the upstream worst case target SNR
+      margin for a SHDSL line.  The SNR margin is the difference
+      between the desired SNR and the actual SNR.  Target SNR margin
+      is the desired SNR margin for a unit."
+   DEFVAL      { 0 }
+   ::= { hdsl2ShdslSpanConfProfileEntry 12 }
+
+hdsl2ShdslSpanConfUsedTargetMargins OBJECT-TYPE
+   SYNTAX      BITS
+               {
+               currCondDown(0),
+               worstCaseDown(1),
+               currCondUp(2),
+               worstCaseUp(3)
+               }
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "Contains indicates whether a target SNR margin is enabled or
+      disabled.  This is a bit-map of possible settings.  The
+      various bit positions are:
+
+      currCondDown     current condition downstream target SNR
+                       margin enabled
+
+      worstCaseDown    worst case downstream target SNR margin
+                       enabled
+
+      currCondUp       current condition upstream target SNR
+
+
+
+Ray & Abbi                  Standards Track                    [Page 45]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+                       margin enabled
+
+      worstCaseUp      worst case upstream target SNR margin
+                       enabled."
+   DEFVAL      { { currCondDown } }
+   ::= { hdsl2ShdslSpanConfProfileEntry 13 }
+
+hdsl2ShdslSpanConfReferenceClock OBJECT-TYPE
+   SYNTAX      Hdsl2ShdslClockReferenceType
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "This object configures the clock reference for the STU-C
+     in a SHDSL Line."
+   DEFVAL      { localClk }
+   ::= { hdsl2ShdslSpanConfProfileEntry 14 }
+
+hdsl2ShdslSpanConfLineProbeEnable OBJECT-TYPE
+   SYNTAX      INTEGER
+               {
+               disable(1),
+               enable(2)
+               }
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "This object enables/disables support for Line Probe of
+     the units in a SHDSL line.  When Line Probe is enabled, the
+     system performs Line Probing to find the best possible
+     rate.  If Line probe is disabled, the rate adaptation phase
+     is skipped to shorten set up time."
+   DEFVAL      { disable }
+   ::= { hdsl2ShdslSpanConfProfileEntry 15 }
+
+hdsl2ShdslSpanConfProfileRowStatus OBJECT-TYPE
+   SYNTAX      RowStatus
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "This object controls creation/deletion of the associated
+      entry in this table per the semantics of RowStatus.  If an
+      active entry is referenced in hdsl2ShdslSpanConfProfile, the
+      entry MUST remain active until all references are removed."
+   ::= { hdsl2ShdslSpanConfProfileEntry 16 }
+
+-- Segment Endpoint Alarm Configuration Profile group
+--
+
+
+
+
+Ray & Abbi                  Standards Track                    [Page 46]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+hdsl2ShdslEndpointAlarmConfProfileTable OBJECT-TYPE
+   SYNTAX      SEQUENCE OF Hdsl2ShdslEndpointAlarmConfProfileEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+     "This table supports definitions of alarm configuration
+      profiles for HDSL2/SHDSL segment endpoints.  This table
+      MUST be maintained in a persistent manner."
+   ::= { hdsl2ShdslMibObjects 11 }
+
+hdsl2ShdslEndpointAlarmConfProfileEntry OBJECT-TYPE
+   SYNTAX      Hdsl2ShdslEndpointAlarmConfProfileEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+     "Each entry corresponds to a single alarm configuration profile.
+      Each profile contains a set of parameters for setting alarm
+      thresholds for various performance attributes monitored at
+      HDSL2/SHDSL segment endpoints.  Profiles may be created/deleted
+      using the row creation/deletion mechanism via
+      hdsl2ShdslEndpointAlarmConfProfileRowStatus.  If an active
+      entry is referenced in either hdsl2ShdslSpanConfAlarmProfile
+      or hdsl2ShdslEndpointAlarmConfProfile, the entry MUST remain
+      active until all references are removed."
+   INDEX { IMPLIED hdsl2ShdslEndpointAlarmConfProfileName }
+   ::= { hdsl2ShdslEndpointAlarmConfProfileTable 1 }
+
+Hdsl2ShdslEndpointAlarmConfProfileEntry ::=
+   SEQUENCE
+   {
+   hdsl2ShdslEndpointAlarmConfProfileName       SnmpAdminString,
+   hdsl2ShdslEndpointThreshLoopAttenuation      Integer32,
+   hdsl2ShdslEndpointThreshSNRMargin            Integer32,
+   hdsl2ShdslEndpointThreshES
+               Hdsl2ShdslPerfIntervalThreshold,
+   hdsl2ShdslEndpointThreshSES
+               Hdsl2ShdslPerfIntervalThreshold,
+   hdsl2ShdslEndpointThreshCRCanomalies         Integer32,
+   hdsl2ShdslEndpointThreshLOSWS
+               Hdsl2ShdslPerfIntervalThreshold,
+   hdsl2ShdslEndpointThreshUAS
+               Hdsl2ShdslPerfIntervalThreshold,
+   hdsl2ShdslEndpointAlarmConfProfileRowStatus  RowStatus
+   }
+
+hdsl2ShdslEndpointAlarmConfProfileName OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  not-accessible
+
+
+
+Ray & Abbi                  Standards Track                    [Page 47]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   STATUS      current
+   DESCRIPTION
+     "This object is the unique index associated with this profile."
+   ::= { hdsl2ShdslEndpointAlarmConfProfileEntry 1 }
+
+hdsl2ShdslEndpointThreshLoopAttenuation OBJECT-TYPE
+   SYNTAX      Integer32(-127..128)
+   UNITS       "dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "This object configures the loop attenuation alarm threshold.
+      When the current value of hdsl2ShdslEndpointCurrAtn reaches
+      or exceeds this threshold, a hdsl2ShdslLoopAttenCrossing
+      MAY be generated."
+   DEFVAL      { 0 }
+   ::= { hdsl2ShdslEndpointAlarmConfProfileEntry 2 }
+
+hdsl2ShdslEndpointThreshSNRMargin OBJECT-TYPE
+   SYNTAX      Integer32(-127..128)
+   UNITS       "dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "This object configures the SNR margin alarm threshold.
+      When the current value of hdsl2ShdslEndpointCurrSnrMgn
+      reaches or drops below this threshold, a
+      hdsl2ShdslSNRMarginCrossing MAY be generated."
+   DEFVAL      { 0 }
+   ::= { hdsl2ShdslEndpointAlarmConfProfileEntry 3 }
+
+hdsl2ShdslEndpointThreshES OBJECT-TYPE
+   SYNTAX      Hdsl2ShdslPerfIntervalThreshold
+   UNITS       "seconds"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "This object configures the threshold for the number of
+      errored seconds (ES) within any given 15-minute performance
+      data collection interval.  If the value of errored seconds
+      in a particular 15-minute collection interval reaches/
+      exceeds this value, a hdsl2ShdslPerfESThresh MAY be
+      generated.  At most one notification will be sent per
+      interval per endpoint."
+   DEFVAL      { 0 }
+   ::= { hdsl2ShdslEndpointAlarmConfProfileEntry 4 }
+
+hdsl2ShdslEndpointThreshSES OBJECT-TYPE
+
+
+
+Ray & Abbi                  Standards Track                    [Page 48]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   SYNTAX      Hdsl2ShdslPerfIntervalThreshold
+   UNITS       "seconds"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "This object configures the threshold for the number of
+      severely errored seconds (SES) within any given 15-minute
+      performance data collection interval.  If the value of
+      severely errored seconds in a particular 15-minute collection
+      interval reaches/exceeds this value, a hdsl2ShdslPerfSESThresh
+      MAY be generated.  At most one notification will be sent per
+      interval per endpoint."
+   DEFVAL      { 0 }
+   ::= { hdsl2ShdslEndpointAlarmConfProfileEntry 5 }
+
+hdsl2ShdslEndpointThreshCRCanomalies OBJECT-TYPE
+   SYNTAX      Integer32
+   UNITS       "detected CRC Anomalies"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "This object configures the threshold for the number of
+      CRC anomalies within any given 15-minute performance data
+      collection interval.  If the value of CRC anomalies in a
+      particular 15-minute collection interval reaches/exceeds
+      this value, a hdsl2ShdslPerfCRCanomaliesThresh MAY be
+      generated.  At most one notification will be sent per
+      interval per endpoint."
+   DEFVAL      { 0 }
+   ::= { hdsl2ShdslEndpointAlarmConfProfileEntry 6 }
+
+hdsl2ShdslEndpointThreshLOSWS OBJECT-TYPE
+   SYNTAX      Hdsl2ShdslPerfIntervalThreshold
+   UNITS       "seconds"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "This object configures the threshold for the number of
+      Loss of Sync Word (LOSW) Seconds within any given 15-minute
+      performance data collection interval.  If the value of LOSW
+      in a particular 15-minute collection interval reaches/exceeds
+      this value, a hdsl2ShdslPerfLOSWSThresh MAY be generated.
+      At most one notification will be sent per interval per
+      endpoint."
+   DEFVAL      { 0 }
+   ::= { hdsl2ShdslEndpointAlarmConfProfileEntry 7 }
+
+hdsl2ShdslEndpointThreshUAS OBJECT-TYPE
+
+
+
+Ray & Abbi                  Standards Track                    [Page 49]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   SYNTAX      Hdsl2ShdslPerfIntervalThreshold
+   UNITS       "seconds"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "This object configures the threshold for the number of
+      unavailable seconds (UAS) within any given 15-minute
+      performance data collection interval.  If the value of UAS
+      in a particular 15-minute collection interval reaches/exceeds
+      this value, a hdsl2ShdslPerfUASThresh MAY be generated.
+      At most one notification will be sent per interval per
+      endpoint."
+   DEFVAL      { 0 }
+   ::= { hdsl2ShdslEndpointAlarmConfProfileEntry 8 }
+
+hdsl2ShdslEndpointAlarmConfProfileRowStatus OBJECT-TYPE
+   SYNTAX      RowStatus
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "This object controls creation/deletion of the associated
+      entry in this table as per the semantics of RowStatus.
+      If an active entry is referenced in either
+      hdsl2ShdslSpanConfAlarmProfile or
+      hdsl2ShdslEndpointAlarmConfProfile, the entry MUST remain
+      active until all references are removed."
+   ::= { hdsl2ShdslEndpointAlarmConfProfileEntry 9 }
+
+-- Notifications Group
+--
+
+hdsl2ShdslNotifications OBJECT IDENTIFIER ::= { hdsl2ShdslMIB 0 }
+
+hdsl2ShdslLoopAttenCrossing NOTIFICATION-TYPE
+   OBJECTS
+   {
+   hdsl2ShdslEndpointCurrAtn,
+   hdsl2ShdslEndpointThreshLoopAttenuation
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the loop attenuation
+      threshold (as per the hdsl2ShdslEndpointThreshLoopAttenuation
+      value) has been reached/exceeded for the HDSL2/SHDSL segment
+      endpoint."
+   ::= { hdsl2ShdslNotifications 1 }
+
+hdsl2ShdslSNRMarginCrossing NOTIFICATION-TYPE
+
+
+
+Ray & Abbi                  Standards Track                    [Page 50]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   OBJECTS
+   {
+
+   hdsl2ShdslEndpointCurrSnrMgn,
+   hdsl2ShdslEndpointThreshSNRMargin
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the SNR margin threshold (as
+      per the hdsl2ShdslEndpointThreshSNRMargin value) has been
+      reached/exceeded for the HDSL2/SHDSL segment endpoint."
+   ::= { hdsl2ShdslNotifications 2 }
+
+hdsl2ShdslPerfESThresh NOTIFICATION-TYPE
+   OBJECTS
+   {
+   hdsl2ShdslEndpointCurr15MinES,
+   hdsl2ShdslEndpointThreshES
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the errored seconds threshold
+      (as per the hdsl2ShdslEndpointThreshES value) has been reached/
+      exceeded for the HDSL2/SHDSL segment endpoint."
+   ::= { hdsl2ShdslNotifications 3 }
+
+hdsl2ShdslPerfSESThresh NOTIFICATION-TYPE
+   OBJECTS
+   {
+   hdsl2ShdslEndpointCurr15MinSES,
+   hdsl2ShdslEndpointThreshSES
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the severely errored seconds
+      threshold (as per the hdsl2ShdslEndpointThreshSES value) has
+      been reached/exceeded for the HDSL2/SHDSL Segment Endpoint."
+   ::= { hdsl2ShdslNotifications 4 }
+
+hdsl2ShdslPerfCRCanomaliesThresh NOTIFICATION-TYPE
+   OBJECTS
+   {
+   hdsl2ShdslEndpointCurr15MinCRCanomalies,
+   hdsl2ShdslEndpointThreshCRCanomalies
+   }
+   STATUS    current
+   DESCRIPTION
+     "This notification indicates that the CRC anomalies threshold
+
+
+
+Ray & Abbi                  Standards Track                    [Page 51]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+      (as per the hdsl2ShdslEndpointThreshCRCanomalies value) has
+      been reached/exceeded for the HDSL2/SHDSL Segment Endpoint."
+   ::= { hdsl2ShdslNotifications 5 }
+
+hdsl2ShdslPerfLOSWSThresh NOTIFICATION-TYPE
+   OBJECTS
+   {
+
+   hdsl2ShdslEndpointCurr15MinLOSWS,
+   hdsl2ShdslEndpointThreshLOSWS
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the LOSW seconds threshold
+      (as per the hdsl2ShdslEndpointThreshLOSWS value) has been
+      reached/exceeded for the HDSL2/SHDSL segment endpoint."
+   ::= { hdsl2ShdslNotifications 6 }
+
+hdsl2ShdslPerfUASThresh NOTIFICATION-TYPE
+   OBJECTS
+   {
+   hdsl2ShdslEndpointCurr15MinUAS,
+   hdsl2ShdslEndpointThreshUAS
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the unavailable seconds
+      threshold (as per the hdsl2ShdslEndpointThreshUAS value) has
+      been reached/exceeded for the HDSL2/SHDSL segment endpoint."
+   ::= { hdsl2ShdslNotifications 7 }
+
+hdsl2ShdslSpanInvalidNumRepeaters NOTIFICATION-TYPE
+   OBJECTS
+   {
+   hdsl2ShdslSpanConfNumRepeaters
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that a mismatch has been detected
+      between the number of repeater/regenerator units configured
+      for a HDSL2/SHDSL line via the hdsl2ShdslSpanConfNumRepeaters
+      object and the actual number of repeater/regenerator units
+      discovered via the EOC."
+   ::= { hdsl2ShdslNotifications 8 }
+
+hdsl2ShdslLoopbackFailure NOTIFICATION-TYPE
+   OBJECTS
+   {
+
+
+
+Ray & Abbi                  Standards Track                    [Page 52]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   hdsl2ShdslMaintLoopbackConfig
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that an endpoint maintenance
+      loopback command failed for an HDSL2/SHDSL segment."
+   ::= { hdsl2ShdslNotifications 9 }
+
+hdsl2ShdslpowerBackoff NOTIFICATION-TYPE
+   OBJECTS
+   {
+   hdsl2ShdslEndpointCurrStatus
+   }
+   STATUS    current
+   DESCRIPTION
+     "This notification indicates that the bit setting for
+      powerBackoff in the hdsl2ShdslEndpointCurrStatus object for
+      this endpoint has changed."
+   ::= { hdsl2ShdslNotifications 10 }
+
+hdsl2ShdsldeviceFault NOTIFICATION-TYPE
+   OBJECTS
+   {
+   hdsl2ShdslEndpointCurrStatus
+   }
+   STATUS    current
+   DESCRIPTION
+     "This notification indicates that the bit setting for
+      deviceFault in the hdsl2ShdslEndpointCurrStatus object for
+      this endpoint has changed."
+   ::= { hdsl2ShdslNotifications 11 }
+
+hdsl2ShdsldcContinuityFault NOTIFICATION-TYPE
+   OBJECTS
+   {
+   hdsl2ShdslEndpointCurrStatus
+   }
+   STATUS    current
+   DESCRIPTION
+     "This notification indicates that the bit setting for
+      dcContinuityFault in the hdsl2ShdslEndpointCurrStatus object
+      for this endpoint has changed."
+   ::= { hdsl2ShdslNotifications 12 }
+
+hdsl2ShdslconfigInitFailure NOTIFICATION-TYPE
+   OBJECTS
+   {
+   hdsl2ShdslEndpointCurrStatus
+
+
+
+Ray & Abbi                  Standards Track                    [Page 53]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   }
+   STATUS    current
+   DESCRIPTION
+     "This notification indicates that the bit setting for
+      configInitFailure in the hdsl2ShdslEndpointCurrStatus object
+      for this endpoint has changed."
+   ::= { hdsl2ShdslNotifications 13 }
+
+hdsl2ShdslprotocolInitFailure NOTIFICATION-TYPE
+   OBJECTS
+   {
+   hdsl2ShdslEndpointCurrStatus
+   }
+   STATUS    current
+   DESCRIPTION
+     "This notification indicates that the bit setting for
+      protocolInitFailure in the hdsl2ShdslEndpointCurrStatus
+      object for this endpoint has changed."
+   ::= { hdsl2ShdslNotifications 14 }
+
+hdsl2ShdslnoNeighborPresent NOTIFICATION-TYPE
+   OBJECTS
+   {
+   hdsl2ShdslEndpointCurrStatus
+   }
+   STATUS    current
+   DESCRIPTION
+     "This notification indicates that the bit setting for
+      noNeighborPresent in the hdsl2ShdslEndpointCurrStatus object
+      for this endpoint has changed."
+   ::= { hdsl2ShdslNotifications 15 }
+
+hdsl2ShdslLocalPowerLoss NOTIFICATION-TYPE
+   OBJECTS
+   {
+   hdsl2ShdslInvVendorID
+   }
+   STATUS    current
+   DESCRIPTION
+     "This notification indicates impending unit failure due to
+      loss of local power (last gasp)."
+   ::= { hdsl2ShdslNotifications 16 }
+
+-- conformance information
+--
+
+hdsl2ShdslConformance OBJECT IDENTIFIER ::= { hdsl2ShdslMIB 3 }
+hdsl2ShdslGroups      OBJECT IDENTIFIER ::=
+
+
+
+Ray & Abbi                  Standards Track                    [Page 54]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+             { hdsl2ShdslConformance 1 }
+hdsl2ShdslCompliances OBJECT IDENTIFIER ::=
+             { hdsl2ShdslConformance 2 }
+
+-- agent compliance statements
+
+hdsl2ShdslLineMibCompliance MODULE-COMPLIANCE
+   STATUS  current
+   DESCRIPTION
+     "The section outlines compliance requirements for this MIB."
+   MODULE
+   MANDATORY-GROUPS
+   {
+   hdsl2ShdslSpanConfGroup,
+   hdsl2ShdslSpanStatusGroup,
+   hdsl2ShdslInventoryGroup,
+   hdsl2ShdslEndpointConfGroup,
+   hdsl2ShdslEndpointCurrGroup,
+   hdsl2Shdsl15MinIntervalGroup,
+   hdsl2Shdsl1DayIntervalGroup,
+   hdsl2ShdslMaintenanceGroup,
+   hdsl2ShdslEndpointAlarmConfGroup,
+   hdsl2ShdslNotificationGroup
+   }
+
+GROUP  hdsl2ShdslInventoryShdslGroup
+   DESCRIPTION
+     "Support for this group is only required for implementations
+     supporting SHDSL lines."
+
+GROUP  hdsl2ShdslSpanShdslStatusGroup
+   DESCRIPTION
+     "Support for this group is only required for implementations
+     supporting SHDSL lines."
+
+GROUP  hdsl2ShdslSpanConfProfileGroup
+   DESCRIPTION
+     "Support for this group is only required for implementations
+     supporting SHDSL lines."
+
+   ::= { hdsl2ShdslCompliances 1 }
+
+-- units of conformance
+--
+
+hdsl2ShdslSpanConfGroup OBJECT-GROUP
+   OBJECTS
+   {
+
+
+
+Ray & Abbi                  Standards Track                    [Page 55]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   hdsl2ShdslSpanConfNumRepeaters,
+   hdsl2ShdslSpanConfProfile,
+   hdsl2ShdslSpanConfAlarmProfile
+   }
+   STATUS      current
+   DESCRIPTION
+     "This group supports objects for configuring span related
+      parameters for HDSL2/SHDSL lines."
+   ::= { hdsl2ShdslGroups 1 }
+
+hdsl2ShdslSpanStatusGroup OBJECT-GROUP
+   OBJECTS
+   {
+   hdsl2ShdslStatusNumAvailRepeaters
+   }
+   STATUS      current
+   DESCRIPTION
+     "This group supports objects for retrieving span related
+      status for HDSL2/SHDSL lines."
+   ::= { hdsl2ShdslGroups 2 }
+
+hdsl2ShdslInventoryShdslGroup OBJECT-GROUP
+   OBJECTS
+   {
+   hdsl2ShdslInvTransmissionModeCapability
+   }
+   STATUS      current
+   DESCRIPTION
+     "This group supports objects for retrieving SHDSL-specific
+      inventory information."
+   ::= { hdsl2ShdslGroups 3 }
+
+hdsl2ShdslSpanShdslStatusGroup OBJECT-GROUP
+   OBJECTS
+   {
+   hdsl2ShdslStatusMaxAttainableLineRate,
+   hdsl2ShdslStatusActualLineRate,
+   hdsl2ShdslStatusTransmissionModeCurrent
+   }
+   STATUS      current
+   DESCRIPTION
+     "This group supports objects for retrieving SHDSL-specific
+      span related status."
+   ::= { hdsl2ShdslGroups 4 }
+
+hdsl2ShdslInventoryGroup OBJECT-GROUP
+   OBJECTS
+   {
+
+
+
+Ray & Abbi                  Standards Track                    [Page 56]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   hdsl2ShdslInvVendorID,
+   hdsl2ShdslInvVendorModelNumber,
+   hdsl2ShdslInvVendorSerialNumber,
+   hdsl2ShdslInvVendorEOCSoftwareVersion,
+   hdsl2ShdslInvStandardVersion,
+   hdsl2ShdslInvVendorListNumber,
+   hdsl2ShdslInvVendorIssueNumber,
+   hdsl2ShdslInvVendorSoftwareVersion,
+   hdsl2ShdslInvEquipmentCode,
+   hdsl2ShdslInvVendorOther
+   }
+   STATUS      current
+   DESCRIPTION
+     "This group supports objects that provide unit inventory
+      information about the units in HDSL2/SHDSL lines."
+   ::= { hdsl2ShdslGroups 5 }
+
+hdsl2ShdslEndpointConfGroup OBJECT-GROUP
+   OBJECTS
+   {
+   hdsl2ShdslEndpointCurrAtn
+   }
+   STATUS      current
+   DESCRIPTION
+     "This group supports objects for configuring parameters for
+      segment endpoints in HDSL2/SHDSL lines."
+   ::= { hdsl2ShdslGroups 6 }
+
+hdsl2ShdslEndpointCurrGroup OBJECT-GROUP
+   OBJECTS
+   {
+   hdsl2ShdslEndpointCurrAtn,
+   hdsl2ShdslEndpointCurrSnrMgn,
+   hdsl2ShdslEndpointCurrStatus,
+   hdsl2ShdslEndpointES,
+   hdsl2ShdslEndpointSES,
+   hdsl2ShdslEndpointCRCanomalies,
+   hdsl2ShdslEndpointLOSWS,
+   hdsl2ShdslEndpointUAS,
+   hdsl2ShdslEndpointCurr15MinTimeElapsed,
+   hdsl2ShdslEndpointCurr15MinES,
+   hdsl2ShdslEndpointCurr15MinSES,
+   hdsl2ShdslEndpointCurr15MinCRCanomalies,
+   hdsl2ShdslEndpointCurr15MinLOSWS,
+   hdsl2ShdslEndpointCurr15MinUAS,
+   hdsl2ShdslEndpointCurr1DayTimeElapsed,
+   hdsl2ShdslEndpointCurr1DayES,
+   hdsl2ShdslEndpointCurr1DaySES,
+
+
+
+Ray & Abbi                  Standards Track                    [Page 57]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   hdsl2ShdslEndpointCurr1DayCRCanomalies,
+   hdsl2ShdslEndpointCurr1DayLOSWS,
+   hdsl2ShdslEndpointCurr1DayUAS
+   }
+   STATUS      current
+   DESCRIPTION
+     "This group supports objects which provide current status and
+      performance measurements relating to segment endpoints in
+      HDSL2/SHDSL lines."
+   ::= { hdsl2ShdslGroups 7 }
+
+hdsl2Shdsl15MinIntervalGroup OBJECT-GROUP
+   OBJECTS
+   {
+   hdsl2Shdsl15MinIntervalES,
+   hdsl2Shdsl15MinIntervalSES,
+   hdsl2Shdsl15MinIntervalCRCanomalies,
+   hdsl2Shdsl15MinIntervalLOSWS,
+   hdsl2Shdsl15MinIntervalUAS
+   }
+   STATUS      current
+   DESCRIPTION
+     "This group supports objects which maintain historic
+      performance measurements relating to segment endpoints in
+      HDSL2/SHDSL lines in 15-minute intervals."
+   ::= { hdsl2ShdslGroups 8 }
+
+hdsl2Shdsl1DayIntervalGroup OBJECT-GROUP
+   OBJECTS
+   {
+   hdsl2Shdsl1DayIntervalMoniSecs,
+   hdsl2Shdsl1DayIntervalES,
+   hdsl2Shdsl1DayIntervalSES,
+   hdsl2Shdsl1DayIntervalCRCanomalies,
+   hdsl2Shdsl1DayIntervalLOSWS,
+   hdsl2Shdsl1DayIntervalUAS
+   }
+   STATUS      current
+   DESCRIPTION
+     "This group supports objects which maintain historic
+      performance measurements relating to segment endpoints in
+      HDSL2/SHDSL lines in 1-day intervals."
+   ::= { hdsl2ShdslGroups 9 }
+
+hdsl2ShdslMaintenanceGroup OBJECT-GROUP
+   OBJECTS
+   {
+   hdsl2ShdslMaintLoopbackConfig,
+
+
+
+Ray & Abbi                  Standards Track                    [Page 58]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   hdsl2ShdslMaintTipRingReversal,
+   hdsl2ShdslMaintPowerBackOff,
+   hdsl2ShdslMaintSoftRestart,
+   hdsl2ShdslMaintLoopbackTimeout,
+   hdsl2ShdslMaintUnitPowerSource
+   }
+   STATUS      current
+   DESCRIPTION
+     "This group supports objects that provide support for
+      maintenance actions for HDSL2/SHDSL lines."
+   ::= { hdsl2ShdslGroups 10 }
+
+hdsl2ShdslEndpointAlarmConfGroup OBJECT-GROUP
+   OBJECTS
+   {
+   hdsl2ShdslEndpointAlarmConfProfile,
+   hdsl2ShdslEndpointThreshLoopAttenuation,
+   hdsl2ShdslEndpointThreshSNRMargin,
+   hdsl2ShdslEndpointThreshES,
+   hdsl2ShdslEndpointThreshSES,
+   hdsl2ShdslEndpointThreshCRCanomalies,
+   hdsl2ShdslEndpointThreshLOSWS,
+   hdsl2ShdslEndpointThreshUAS,
+   hdsl2ShdslEndpointAlarmConfProfileRowStatus
+   }
+   STATUS      current
+   DESCRIPTION
+     "This group supports objects that allow configuration of alarm
+      thresholds for various performance parameters for HDSL2/SHDSL
+      lines."
+   ::= { hdsl2ShdslGroups 11 }
+
+hdsl2ShdslNotificationGroup NOTIFICATION-GROUP
+   NOTIFICATIONS
+   {
+   hdsl2ShdslLoopAttenCrossing,
+   hdsl2ShdslSNRMarginCrossing,
+   hdsl2ShdslPerfESThresh,
+   hdsl2ShdslPerfSESThresh,
+   hdsl2ShdslPerfCRCanomaliesThresh,
+   hdsl2ShdslPerfLOSWSThresh,
+   hdsl2ShdslPerfUASThresh,
+   hdsl2ShdslSpanInvalidNumRepeaters,
+   hdsl2ShdslLoopbackFailure,
+   hdsl2ShdslpowerBackoff,
+   hdsl2ShdsldeviceFault,
+   hdsl2ShdsldcContinuityFault,
+   hdsl2ShdslconfigInitFailure,
+
+
+
+Ray & Abbi                  Standards Track                    [Page 59]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   hdsl2ShdslprotocolInitFailure,
+   hdsl2ShdslnoNeighborPresent,
+   hdsl2ShdslLocalPowerLoss
+   }
+   STATUS      current
+   DESCRIPTION
+     "This group supports notifications of significant conditions
+     associated with HDSL2/SHDSL lines."
+   ::= { hdsl2ShdslGroups 12 }
+
+hdsl2ShdslSpanConfProfileGroup OBJECT-GROUP
+   OBJECTS
+   {
+   hdsl2ShdslSpanConfWireInterface,
+   hdsl2ShdslSpanConfMinLineRate,
+   hdsl2ShdslSpanConfMaxLineRate,
+   hdsl2ShdslSpanConfPSD,
+   hdsl2ShdslSpanConfTransmissionMode,
+   hdsl2ShdslSpanConfRemoteEnabled,
+   hdsl2ShdslSpanConfPowerFeeding,
+   hdsl2ShdslSpanConfCurrCondTargetMarginDown,
+   hdsl2ShdslSpanConfWorstCaseTargetMarginDown,
+   hdsl2ShdslSpanConfCurrCondTargetMarginUp,
+   hdsl2ShdslSpanConfWorstCaseTargetMarginUp,
+   hdsl2ShdslSpanConfUsedTargetMargins,
+   hdsl2ShdslSpanConfReferenceClock,
+   hdsl2ShdslSpanConfLineProbeEnable,
+   hdsl2ShdslSpanConfProfileRowStatus
+   }
+   STATUS      current
+   DESCRIPTION
+     "This group supports objects that constitute configuration
+      profiles for configuring span related parameters in SHDSL
+      lines."
+   ::= { hdsl2ShdslGroups 13 }
+END
+
+7.  Security Considerations
+
+   Blocking unauthorized access to the HDSL2-SHDSL MIB via the element
+   management system is outside the scope of this document.  It should
+   be noted that access to the MIB permits the unauthorized entity to
+   modify the profiles (section 6.4) such that both subscriber service
+   and network operations can be interfered with.  Subscriber service
+   can be altered by modifying any of a number of service
+   characteristics such as rate partitioning and maximum transmission
+   rates.  Network operations can be impacted by modification of
+   notification thresholds such as SES thresholds.
+
+
+
+Ray & Abbi                  Standards Track                    [Page 60]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   There are a number of managed objects in this MIB that may be
+   considered to contain sensitive information.  Access to these objects
+   would allow an intruder to obtain information about which vendor's
+   equipment is in use on the network.  Further, such information is
+   considered sensitive in many environments for competitive reasons.
+
+   These identifying objects in the inventory group are:
+
+   - hdsl2ShdslInvVendorID
+   - hdsl2ShdslInvVendorModelNumber
+   - hdsl2ShdslInvVendorSerialNumber
+   - hdsl2ShdslInvVendorEOCSoftwareVersion
+   - hdsl2ShdslInvStandardVersion
+   - hdsl2ShdslInvVendorListNumber
+   - hdsl2ShdslInvVendorIssueNumber
+   - hdsl2ShdslInvVendorSoftwareVersion
+   - hdsl2ShdslInvEquipmentCode
+   - hdsl2ShdslInvVendorOther
+   - hdsl2ShdslInvTransmissionModeCapability
+
+   Therefore, it may be important in some environments to control read
+   access to these objects and possibly to even encrypt the values of
+   these object when sending them over the network via SNMP.  Not all
+   versions of SNMP provide features for such a secure environment.
+
+   It is recommended that the implementors consider the security
+   features as provided by the SNMPv3 framework.  Specifically, the use
+   of the User-based Security Model RFC 2574 [12] and the View-based
+   Access Control Model RFC 2575 [15] are recommended.
+
+   It is then the customer/user's responsibility to ensure that the SNMP
+   entity giving access to an instance of this MIB, is properly
+   configured to give access to those objects only to those principals
+   (users) that have legitimate rights to access them.
+
+   HDSL2-SHDSL layer connectivity from the xtuR will permit the
+   subscriber to manipulate both the HDSL2-SHDSL link directly and the
+   HDSL2-SHDSL embedded  operations channel (EOC) for their own loop.
+   For example, unchecked or unfiltered fluctuations initiated by the
+   subscriber could generate sufficient notifications to potentially
+   overwhelm either the management interface to the network or the
+   element manager.
+
+   It should be noted that interface indices in this MIB are maintained
+   persistently.  VACM data relating to these should be stored
+   persistently.
+
+
+
+
+
+Ray & Abbi                  Standards Track                    [Page 61]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   There are a number of management objects defined in this MIB that
+   have a MAX-ACCESS clause of read-write and/or read-create.  Such
+   objects may be considered sensitive or vulnerable in some network
+   environments.  The support for SET operations in a non-secure
+   environment without proper protection can have a negative effect on
+   network operations.
+
+8.  Acknowledgments
+
+   The authors are deeply grateful to the authors of the ADSL LINE MIB
+   (RFC 2662 [23]), Gregory Bathrick and Faye Ly, as much of the text
+   and structure of this document originates in their documents.
+
+   The authors are also grateful to the authors of FR MFR MIB (RFC 3020
+   [24]), Prayson Pate, Bob Lynch, and Kenneth Rehbehn, as the majority
+   of the Security Considerations section was lifted from their
+   document.
+
+   The authors also acknowledge the importance of the contributions and
+   suggestions regarding interface indexing structures received from
+   David Horton of CITR.
+
+   Other contributions were received from the following:
+
+      Philip Bergstresser (Adtran)
+      Steve Blackwell (Centillium)
+      Umberto Bonollo (NEC Australia)
+      Yagal Hachmon (RAD)
+      Mark Johnson (Red Point)
+      Sharon Mantin (Orckit)
+      Moti Morgenstern (ECI)
+      Raymond Murphy (Ericsson)
+      Lee Nipper (Verilink)
+      Randy Presuhn (BMC Software)
+      Katy Sherman (Orckit)
+      Mike Sneed (ECI)
+      Jon Turney (DSL Solutions)
+      Aron Wahl (Memotec)
+      Bert Wijnen (Lucent)
+      Michael Wrobel (Memotec)
+
+
+
+
+
+
+
+
+
+
+
+Ray & Abbi                  Standards Track                    [Page 62]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+9.  References
+
+   [1]   Harrington, D., Presuhn, R. and B. Wijnen, "An Architecture for
+         Describing SNMP Management Frameworks", RFC 2571, April 1999.
+
+   [2]   Rose, M. and K. McCloghrie, "Structure and Identification of
+         Management Information for TCP/IP-based Internets", STD 16, RFC
+         1155, May 1990.
+
+   [3]   Rose, M. and K. McCloghrie, "Concise MIB Definitions", STD 16,
+         RFC 1212, March 1991.
+
+   [4]   Rose, M., "A Convention for Defining Traps for use with the
+         SNMP", RFC 1215, March 1991.
+
+   [5]   McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J., Rose,
+         M. and S. Waldbusser, "Structure of Management Information
+         Version 2 (SMIv2)", STD 58, RFC 2578, April 1999.
+
+   [6]   McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J., Rose,
+         M. and S. Waldbusser, "Textual Conventions for SMIv2", STD 58,
+         RFC 2579, April 1999.
+
+   [7]   McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J., Rose,
+         M. and S. Waldbusser, "Conformance Statements for SMIv2", STD
+         58, RFC 2580, April 1999.
+
+   [8]   Case, J., Fedor, M., Schoffstall, M. and J. Davin, "Simple
+         Network Management Protocol", STD 15, RFC 1157, May 1990.
+
+   [9]   Case, J., McCloghrie, K., Rose, M. and S. Waldbusser,
+         "Introduction to Community-based SNMPv2", RFC 1901, January
+         1996.
+
+   [10]  Case, J., McCloghrie, K., Rose, M. and S. Waldbusser,
+         "Transport Mappings for Version 2 of the Simple Network
+         Management Protocol (SNMPv2)", RFC 1906, January 1996.
+
+   [11]  Case, J., Harrington D., Presuhn, R. and B. Wijnen, "Message
+         Processing and Dispatching for the Simple Network Management
+         Protocol (SNMP)", RFC 2572, April 1999.
+
+   [12]  Blumenthal, U. and B. Wijnen, "User-based Security Model (USM)
+         for version 3 of the Simple Network Management Protocol
+         (SNMPv3)", RFC 2574, April 1999.
+
+
+
+
+
+
+Ray & Abbi                  Standards Track                    [Page 63]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+   [13]  Case, J., McCloghrie, K., Rose, M. and S. Waldbusser, "Protocol
+         Operations for Version 2 of the Simple Network Management
+         Protocol (SNMPv2)", RFC 1905, January 1996.
+
+   [14]  Levi, D., Meyer, P. and B. Stewart, "SNMPv3 Applications", RFC
+         2573, April 1999.
+
+   [15]  Wijnen, B., Presuhn, R. and K. McCloghrie, "View-based Access
+         Control Model (VACM) for the Simple Network Management Protocol
+         (SNMP)", RFC 2575, April 1999.
+
+   [16]  Case, J., Mundy, R., Partain, D. and B. Stewart, "Introduction
+         to Version 3 of the Internet-standard Network Management
+         Framework", RFC 2570, April 1999.
+
+   [17]  Bradner, S., "Key Words for use in RFCs to Indicate Requirement
+         Levels", BCP 14, RFC 2119, March 1997.
+
+   [18]  American National Standards Institute, ANSI T1E1.4/2000-006,
+         February 2000.
+
+   [19]  Blackwell, S., Editor, "Single-Pair High-Speed Digital
+         Subscriber Line (SHDSL) Transceivers", ITU-T Draft G.991.2,
+         April 2000.
+
+   [20]  McCloghrie, K. and M. Rose, M., "Management Information Base
+         for Network Management of TCP/IP-based internets: MIB-II", STD
+         17, RFC 1213, March 1991.
+
+   [21]  McCloghrie, K. and F. Kastenholz, "The Interfaces Group MIB",
+         RFC 2863, June 2000.
+
+   [22]  Tesink, K., "Textual Conventions for MIB Modules Using
+         Performance History Based on 15 Minute Intervals", RFC 2493,
+         January 1999.
+
+   [23]  Bathrick, G. and F. Ly, "Definitions of Managed Objects for the
+         ADSL Lines", RFC 2662, August 1999.
+
+   [24]  Pate, P., Lynch, B. and K. Rehbehn, "Definitions of Managed
+         Objects for Monitoring and Controlling the UNI/NNI Multilink
+         Frame Relay Function", RFC 3020, December 2000.
+
+   [25]  American National Standards Institute, "Coded Identification of
+         Equipment Entities of the North American Telecommunications
+         System for the Purpose of Information Exchange", T1.213-2001.
+
+
+
+
+
+Ray & Abbi                  Standards Track                    [Page 64]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+10.  Intellectual Property Notice
+
+   The IETF takes no position regarding the validity or scope of any
+   intellectual property or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; neither does it represent that it
+   has made any effort to identify any such rights.  Information on the
+   IETF's procedures with respect to rights in standards-track and
+   standards-related documentation can be found in BCP-11.  Copies of
+   claims of rights made available for publication and any assurances of
+   licenses to be made available, or the result of an attempt made to
+   obtain a general license or permission for the use of such
+   proprietary rights by implementors or users of this specification can
+   be obtained from the IETF Secretariat.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights which may cover technology that may be required to practice
+   this standard.  Please address the information to the IETF Executive
+   Director.
+
+11.  Authors' Addresses
+
+   Bob Ray
+   PESA Switching Systems, Inc.
+   330-A Wynn Drive
+   Huntsville, AL 35805 USA
+
+   Phone: +1 256 726 9200 ext. 142
+   Fax: +1 256 726 9271
+   EMail: rray@pesa.com
+
+   Rajesh Abbi
+   Alcatel USA
+   2912 Wake Forest Road
+   Raleigh, NC 27609-7860 USA
+
+   Phone: +1 919-850-6194
+   Fax:   +1 919-850-6670
+   EMail: Rajesh.Abbi@alcatel.com
+
+
+
+
+
+
+
+
+
+
+Ray & Abbi                  Standards Track                    [Page 65]
+
+RFC 3276                  HDSL2-SHDSL-LINE MIB                  May 2002
+
+
+12.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (2002).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ray & Abbi                  Standards Track                    [Page 66]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc3276.txt](<www.ietf.org/rfc/rfc3276.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
