### PR TITLE
Archive rfc3294.txt

### DIFF
--- a/www.ietf.org/rfc/rfc3294.txt
+++ b/www.ietf.org/rfc/rfc3294.txt
@@ -1,0 +1,507 @@
+
+
+
+
+
+
+Network Working Group                                           A. Doria
+Request for Comments: 3294                Lulea University of Technology
+Category: Informational                                       K. Sundell
+                                                         Nortel Networks
+                                                               June 2002
+
+
+        General Switch Management Protocol (GSMP) Applicability
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard of any kind.  Distribution of this
+   memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2002).  All Rights Reserved.
+
+Abstract
+
+   This memo provides an overview of the GSMP (General Switch Management
+   Protocol) and includes information relating to its deployment in a IP
+   network in an MPLS environment.  It does not discuss deployment in an
+   ATM (Asynchronous Transfer Mode) network or in a raw ethernet
+   configuration.
+
+1. Overview
+
+   The General Switch Management Protocol (GSMP) has been available to
+   the IETF community for several years now as informational RFCs.  Both
+   GSMPv1.1 (released in March 1996 as RFC 1987 [2]) and GSMPv2.0
+   (released in August 1998 as RFC 2297 [3]) are available.  Several
+   vendors have implemented GSMPv1.1.
+
+   In V1.1 and V2 GSMP was intended only for use with ATM switches.
+   During the course of the last two years, the GSMP working group has
+   decided to expand the purview of GSMP to the point where it can be
+   used to control a number of different kinds of switch and can thus
+   live up to what its name indicates; a general switch management
+   protocol.  To do this, commands and arguments needed to be
+   generalised and sections needed to be added, discussing the manner in
+   which the generalised protocol could be applied to specific kinds of
+   switches and port types.  In short, the protocol has gone through
+   major changes in the last 24 months.
+
+
+
+
+
+
+Doria & Sundell              Informational                      [Page 1]
+
+RFC 3294                   GSMP Applicability                  June 2002
+
+
+   GSMP provides an interface that can be used to separate the data
+   forwarder from the routing and other control plane protocols such as
+   LDP.  As such it allows service providers to move away from
+   monolithic systems that bundle the control plane and the data plane
+   into a single tightly coupled system - usually in a single chassis.
+   Separating the control components from the forwarding components and
+   using GSMP for switch management, enables service providers to create
+   multi-service systems composed of various vendors equipment.  It also
+   allows for a more dynamic means of adding services to their networks.
+
+   The IETF GSMP working group was established in the routing area
+   because GSMP was being seen as an optional part of the MPLS solution.
+   In a MPLS system, it is possible to run the routing protocols and
+   label distribution protocols on one system while passing data across
+   a generic switch, e.g., an ATM switch.  GSMP provides the switch
+   resource management mechanism needed in such a scenario.
+
+   GSMP has also been selected by the Multiservice Switching Forum (MSF)
+   as its protocol of choice for the Switch Control Interface identified
+   in their architecture.  The MSF is an industry forum which, among its
+   activities establishes their member's requirements and then works
+   with the appropriate standards bodies to foster their goals.  In the
+   case of GSMP, the MSF presented the IETF GSMP Working Group with a
+   set of requirements for GSMP.  The working group has made a
+   determined effort to comply with those requirements in its
+   specifications.
+
+2. GSMP V3 Document Set
+
+   The current version of GSMP is documented in 3 documents:
+
+   -  GSMP: General Switch Management protocol V3 [5]
+
+   -  GSMP-ENCAPS: General Switch Management Protocol (GSMP) Packet
+      Encapsulations for Asynchronous Transfer Mode (ATM), Ethernet and
+      Transmission Control Protocol (TCP) [4]
+
+   -  GSMP-MIB: Definitions of Managed Objects for the General Switch
+      Management Protocol [1]
+
+3. General Description
+
+   The General Switch Management Protocol V3 (GSMPv3) [5], is a general
+      purpose protocol to control a label switch.  GSMP allows a
+      controller to establish and release connections across the switch;
+      add and delete leaves on a multicast connection; reserve
+      resources; manage switch ports; request configuration information;
+      and request statistics.  It also allows the switch to inform the
+
+
+
+Doria & Sundell              Informational                      [Page 2]
+
+RFC 3294                   GSMP Applicability                  June 2002
+
+
+      controller of asynchronous events such as a link going down.  The
+      GSMPv3 protocol is asymmetric, the controller being the master and
+      the switch being the slave.
+
+   A physical switch can be partitioned into many virtual switches.
+      GSMPv3 does not provide support for defining switch partitions.
+      GSMPv3 treats a virtual switch as if it were a physical switch.
+
+   GSMPv3 may be transported in three ways:
+
+      -  GSMPv3 operation across an IP network is specified.
+
+      -  GSMPv3 operation across an ATM virtual channel is specified.
+
+      -  GSMPv3 operation across an Ethernet link is specified.
+
+   Other encapsulations are possible, but have not been defined.
+   Encapsulations are defined in [4].
+
+   A label switch is a frame or cell switch that supports connection
+      oriented switching using the exact match forwarding algorithm
+      based on labels attached to incoming cells or frames.
+
+   A label switch may support multiple label types.  However, each
+      switch port can support only one label type.  The label type
+      supported by a given port is indicated in a port configuration
+      message.  Connections may be established between ports supporting
+      different label types using the adaptation methods.  GSMPv3
+      supports TLV labels similar to those defined in MPLS.  Examples of
+      labels which are defined include ATM, Frame Relay, DS1, DS3, E1,
+      E3, MPLS Generic Labels and MPLS FECs.
+
+   A connection across a switch is formed by connecting an incoming
+      labelled channel to one or more outgoing labelled channels.
+      Connections are generally referenced by the input port on which
+      they arrive and the label values of their incoming labelled
+      channel.  In some messages, connections are referenced by the
+      output port.
+
+   GSMPv3 supports point-to-point and point-to-multipoint connections.
+      A multipoint-to-point connection is specified by establishing
+      multiple point-to-point connections, each of which specifies the
+      same output label.  A multipoint-to-multipoint connection is
+      specified by establishing multiple point-to-multipoint connections
+      each of which specifies a different input label with the same
+      output labels.
+
+
+
+
+
+Doria & Sundell              Informational                      [Page 3]
+
+RFC 3294                   GSMP Applicability                  June 2002
+
+
+   In general a connection is established with a certain quality of
+      service (QoS).  GSMPv3 includes a default QoS Configuration and
+      additionally allows the negotiation of alternative, optional QoS
+      configurations.  The default QoS Configuration includes three QoS
+      Models: a default service model, a simple priority model and a QoS
+      profile model.  GSMPv3 also supports the reservation of resources
+      when the labels are not yet known.  This ability can be used in
+      support of MPLS.
+
+   GSMP contains an adjacency protocol.  The adjacency protocol is used
+      to synchronise states across the link, to negotiate which version
+      of the GSMP protocol to use, to discover the identity of the
+      entity at the other end of a link, and to detect when it changes.
+
+3.1 Switch Partitioning
+
+   In GSMPv3 switch partitioning is static and occurs prior to running
+   the protocol.  The partitions of a physical switch are isolated from
+   each other by the implementation and the controller assumes that the
+   resources allocated to a partition are at all times available to that
+   partition and only that partition.  A partition appears to its
+   controller as a physical label switch.  The resources allocated to a
+   partition appear to the controller as if they were the actual
+   physical resources of a physical switch.  For example if the
+   bandwidth of a port is divided among several partitions, each
+   partition would appear to the controller to have its own independent
+   port with its fixed set of resources.
+
+   GSMPv3 controls a partitioned switch through the use of a partition
+   identifier that is carried in every GSMPv3 message.  Each partition
+   has a one-to-one control relationship with its own logical controller
+   entity (which in the remainder of the document is referred to simply
+   as a controller) and GSMPv3 independently maintains adjacency between
+   each controller-partition pair.
+
+3.2 Switch and controller interactions
+
+   Multiple switches may be controlled by a single controller using
+   multiple instantiations of the protocol over separate control
+   connections.
+
+   Alternatively, multiple controllers can control a single switch.
+   Each controller would establish a control connection to the switch
+   using the adjacency protocol.  The adjacency mechanism maintains a
+   state table indicating the control connections that are being
+   maintained by the same partition.  The switch provides information to
+   the controller group about the number and identity of the attached
+   controllers.  It does nothing, however, to co-ordinate the activities
+
+
+
+Doria & Sundell              Informational                      [Page 4]
+
+RFC 3294                   GSMP Applicability                  June 2002
+
+
+   of the controllers, and will execute all commands as they are
+   received.  It is the controller group's responsibility to co-ordinate
+   its use of the switch.  This mechanism is most commonly used for
+   controller redundancy and load sharing.  Definition of the mechanism
+   by which controllers use to co-ordinate their control is not within
+   GSMPv3's scope.
+
+3.3 Service support
+
+   All GSMPv3 switches support the default QoS Configuration.  A GSMPv3
+   switch may additionally support one or more alternative QoS
+   Configurations.  GSMP includes a negotiation mechanism that allows a
+   controller to select from the QoS configurations that a switch
+   supports.
+
+   The default QoS Configuration includes three models:
+
+      The Service Model is based on service definitions found external
+         to GSMP such as in CR-LDP, Integrated Services or ATM Service
+         Categories.  Each connection is assigned a specific service
+         that defines the handling of the connection by the switch.
+         Additionally, traffic parameters and traffic controls may be
+         assigned to the connection depending on the assigned service.
+
+      In the Simple Abstract Model a connection is assigned a priority
+         when it is established.  It may be assumed that for connections
+         that share the same output port, a cell or frame on a
+         connection with a higher priority is much more likely to exit
+         the switch before a cell or frame on a connection with a lower
+         priority if they are both in the switch at the same time.
+
+      The QoS Profile Model provides a simple mechanism that allows QoS
+         semantics defined externally to GSMP to be assigned to
+         connections.  Each profile is an opaque indicator that has been
+         predefined in the controller and in the switch.
+
+4. Summary of Message Set
+
+   The following table gives a summary of the messages defined in this
+   version of the specification.  It also makes a recommendation of the
+   minimal set of messages that should be supported in an MPLS
+   environment.  These messages will be labelled as "Required", though
+   the service provided by the other messages are essential for the
+   operation of carrier quality controller/switch operations.  GSMPv1.1
+   or GSMPv2 commands that are no longer support are marked as
+   "Obsolete" and should no longer be used.
+
+
+
+
+
+Doria & Sundell              Informational                      [Page 5]
+
+RFC 3294                   GSMP Applicability                  June 2002
+
+
+4.1 Messages Table
+
+   Message Name                      Message Number  Status
+
+   Connection Management Messages
+        Add Branch........................16          Required
+            ATM Specific - VPC............26
+        Delete Tree.......................18
+        Verify Tree.......................19          Obsoleted
+        Delete All Input..................20
+        Delete All Output.................21
+        Delete Branches...................17          Required
+        Move Output Branch................22
+            ATM Specific - VPC............27
+        Move Input Branch.................23
+            ATM Specific - VPC............28
+
+   Port Management Messages
+        Port Management...................32          Required
+        Label Range.......................33
+
+   State and Statistics Messages
+        Connection Activity...............48
+        Port Statistics...................49          Required
+        Connection Statistics.............50
+        QoS Class Statistics..............51          Reserved
+        Report Connection State...........52
+
+   Configuration Messages
+        Switch Configuration..............64          Required
+        Port Configuration................65          Required
+        All Ports Configuration...........66          Required
+        Service Configuration.............67
+
+   Reservation Messages
+        Reservation Request...............70          Required
+        Delete Reservation................71          Required
+        Delete All Reservations...........72
+
+   Event Messages
+        Port Up...........................80
+        Port Down.........................81
+        Invalid Label.....................82
+        New Port..........................83
+        Dead Port.........................84
+
+
+
+
+
+
+Doria & Sundell              Informational                      [Page 6]
+
+RFC 3294                   GSMP Applicability                  June 2002
+
+
+      Abstract and Resource Model Extension Messages
+          Reserved.Message Range.........200-249
+
+      Adjacency Protocol.................10           Required
+
+5. Security Considerations
+
+   The security of GSMP's TCP/IP control channel has been addressed in
+   [4].  For all uses of GSMP over an IP network, it is REQUIRED that
+   GSMP be run over TCP/IP using the security considerations discussed
+   in [4].
+
+References
+
+   [1] Sjostrand, H., Buerkle, J. and B. Srinivasan, "Definitions of
+       Managed Objects for the General Switch Management Protocol
+       (GSMP)", RFC 3295, June 2002.
+
+   [2] Newman, P., Edwards, W., Hinden, R., Hoffman, E., Ching Liaw, F.,
+       Lyon, T. and Minshall, G., "Ipsilon's General Switch Management
+       Protocol Specification Version 1.1", RFC 1987, August 1996.
+
+   [3] Newman, P., Edwards, W., Hinden, R., Hoffman, E., Ching Liaw, F.,
+       Lyon, T. and G. Minshall, "Ipsilon's General Switch Management
+       Protocol Specification Version 2.0", RFC 2297, March 1998.
+
+   [4] Worster, T., Doria, A. and J. Buerkle, "General Switch Management
+       Protocol (GSMP) Packet Encapsulations for Asynchronous Transfer
+       Mode (ATM), Ethernet and Transmission Control Protocol (TCP)",
+       RFC 3293, June 2002.
+
+   [5] Doria, A., Sundell, K., Hellstrand, F. and T. Worster, "General
+       Switch Management Protocol (GSMP) V3", RFC 3292, June 2002.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Doria & Sundell              Informational                      [Page 7]
+
+RFC 3294                   GSMP Applicability                  June 2002
+
+
+Authors' Addresses
+
+   Avri Doria
+   Div. of Computer Communications
+   Lulea University of Technology
+   S-971 87 Lulea
+   Sweden
+
+   Phone: +1 401 663 5024
+   EMail: avri@acm.org
+
+
+   Kenneth Sundell
+   Nortel Networks AB
+   S:t Eriksgatan 115 A
+   P.O. Box 6701
+   SE-113 85 Stockholm Sweden
+
+   EMail: sundell@nortelnetworks.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Doria & Sundell              Informational                      [Page 8]
+
+RFC 3294                   GSMP Applicability                  June 2002
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2002).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Doria & Sundell              Informational                      [Page 9]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc3294.txt](<www.ietf.org/rfc/rfc3294.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
