### PR TITLE
Archive rfc334.txt

### DIFF
--- a/www.ietf.org/rfc/rfc334.txt
+++ b/www.ietf.org/rfc/rfc334.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                     Alex McKenzie
+RFC #334                                  BBN
+NIC 9927                                  1 May 1972
+
+
+                          Network Use on MAY 8
+
+
+
+     Vint Cerf of UCLA Network Measurement Center has just indicated
+to us a requirement to carry out certain performance experiments on
+the network prior to installation of the new IMP software on May 15.
+These experiments are designed to measure network performance under
+heavy traffic load to a single site, and thus may cause the network to
+"lock up" such that _no_ traffic can flow (a problem which the new IMP
+software is de- signed to prevent). Vint has indicated to us that ARPA
+regards these experiments as extremely important in spite of the
+possibility of lockup; we have therefore agreed to assist with the
+experiments and scheduled them for May 8.
+
+     Although we do not know whether these experiments will cause
+lockup, we suggest that sites do not schedule important network work
+for Monday, May 8. We apologize for the lateness of this announcement.
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc334.txt](<www.ietf.org/rfc/rfc334.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
