### PR TITLE
Archive rfc335.txt

### DIFF
--- a/www.ietf.org/rfc/rfc335.txt
+++ b/www.ietf.org/rfc/rfc335.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                        UCSB Computer
+NIC #9928                                    Research Lab.
+RFC #335                                     Roland F. Bryan
+                                             1 May 1972
+
+
+
+                         NEW INTERFACE-IMP/360
+
+
+
+     The former interface to the network for our 360-75 was replaced
+by a production unit similar to the NASA- AMES and USC versions.  This
+controller went into operation 1 May 1972.
+
+     We would be pleased to hear of any difficulties network users
+encounter, while operating with UCSB, that might be related to this
+unit.
+
+     Thank you.
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc335.txt](<www.ietf.org/rfc/rfc335.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
