### PR TITLE
Archive rfc34.txt

### DIFF
--- a/www.ietf.org/rfc/rfc34.txt
+++ b/www.ietf.org/rfc/rfc34.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                            Bill English   SRI/ARC
+Request for Comments No. 34                      26 February 1970
+
+
+SOME BRIEF PRELIMINARY NOTES ON THE ARC CLOCK
+
+The ARC clock system provides a time reference that is written into the
+core memory of the XDS 940 Computer. There are two types of time
+information available--absolute and relative.
+
+The absolute time is written into two adjacent words of core with the
+following format:
+
+   First word --
+
+      Bits 0 thru 7 contain the month code in straight binary with a
+      range of 1 to 12
+
+      Bits 8 thru 15 contain the day code in straight binary with a
+      range of 1 to 31
+
+      Bits 16 thru 23 contain the year code in straight binary with
+      range of 0 to 99
+
+   Second word --
+
+      Bits 00 thru 7 contain the hour code written in straight binary
+      with a range of 0 to 23
+
+      Bits 8 thru 15 contain the minute code written in straight binary
+      with a range of 0 to 60
+
+      Bits 16 thru 23 contain the second code written in straight binary
+      with range ofr 0 to 60
+
+These 2 words are written once each second.  It is anticipated that the
+accuracy of the initial setting will be on the order of 1 second, as
+referred to WWV, and that the oscillator drift rate will not account for
+an accumlated error of more than 1 second every 250 days.  The
+oscillator and clock are provided with standby power in order to
+maintain the accuracy of the system.  Because of variable delays in time
+required to obtain access to the 940 core memory, it is anticipated that
+the short-term accuracy will be on the order of 10 to 20 microseconds.
+
+The relative time, which is written into one word of core memory, is
+simply the contents of a 24 bit binary accumulator.  The rate at which
+the accumulator is updated can be chosen to be either once very 100
+micro seconds or once every millisecond.  In either case the core
+
+
+
+                                                                [Page 1]
+
+RFC 34              Prelimary Notes on the ARC Clock       February 1970
+
+
+location is written each time the accumulator is updated.  As above the
+short-term accuracy will be about 10 to 20 microseconds and the long-
+term accuracy will be the equivalent of one second every 250 days.
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Katsunori Tanaka 1/98 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc34.txt](<www.ietf.org/rfc/rfc34.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
