### PR TITLE
Archive rfc3440.txt

### DIFF
--- a/www.ietf.org/rfc/rfc3440.txt
+++ b/www.ietf.org/rfc/rfc3440.txt
@@ -1,0 +1,2019 @@
+
+
+
+
+
+
+Network Working Group                                              F. Ly
+Request for Comments: 3440                             Pedestal Networks
+Category: Standards Track                                    G. Bathrick
+                                                                   Nokia
+                                                           December 2002
+
+
+                Definitions of Extension Managed Objects
+                for Asymmetric Digital Subscriber Lines
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2002).  All Rights Reserved.
+
+Abstract
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the Internet community.
+   In particular, it describes additional managed objects used for
+   managing Asymmetric Digital Subscriber Line (ADSL) interfaces not
+   covered by the ADSL Line MIB (RFC 2662).
+
+Table of Contents
+
+   1.  The Internet-Standard Management Framework ................. 2
+   2.  Introduction ............................................... 2
+   3.  Relationship of ADSL LINE EXTENSION MIB with standard MIBs . 2
+   4.  Conventions used in the MIB ................................ 2
+   5.  Conformance and Compliance ................................. 6
+   6.  Definitions ................................................ 6
+   7.  Acknowledgments ............................................31
+   8.  References .................................................31
+   9.  Security Considerations ....................................32
+   10. Intellectual Property Notice ...............................34
+   11. Authors' Addresses .........................................35
+   12. Full Copyright Statement ...................................36
+
+
+
+
+
+
+
+Ly & Bathrick               Standards Track                     [Page 1]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+1.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This memo specifies a MIB
+   module that is compliant to the SMIv2, which is described in STD 58,
+   RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579] and STD 58, RFC 2580
+   [RFC2580].
+
+2.  Introduction
+
+   The purpose of this memo is to define a supplemental set of managed
+   objects that is not covered by the ADSL Line MIB as defined in
+   [RFC2662].  This memo addresses the additional objects defined in ITU
+   G.997.1 [ITU G.997.1].
+
+3.  Relationship of ADSL Line Extension MIB with standard MIBs
+
+   This section outlines the relationship of the ADSL Line Extension MIB
+   with other MIBs described in RFCs and in their various degrees of
+   standardization.  In regards to these relationships, the ADSL Line
+   Extension MIB follows conventions as used by the ADSL Line MIB with
+   one exception.  The value of the RFC 2863 object, ifOperstatus, SHALL
+   be down(2) when the ADSL line interface is in power state L3, as
+   defined in ITU G.992.1 [ITU G.992.1], which means no power.  Its
+   value shall be up(1) if the ADSL line interface is in power state L0
+   (power on) [ITU G.992.1] or L1 (reduced power).  Power Status L2 [ITU
+   G.992.1] is not applicable.
+
+4.  Conventions used in the MIB
+
+4.1  Structure
+
+   The MIB is organized to follow the same structure of the ADSL Line
+   MIB [RFC2662].
+
+
+
+
+
+
+
+
+
+
+Ly & Bathrick               Standards Track                     [Page 2]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+4.2  Additional Managed Objects
+
+   Objects specific to the management of ADSL G.Lite as defined in ITU
+   G.992.2 [ITU G.992.2] are:
+
+   - ADSL Transceiver Unit - Central Office End (ATU-C)
+     Transmission System and Line Mode
+   - Power Management
+   - Counters for Fast Retrains and Failed Fast Retrains
+   - Counters for Severe Error Second-line and Unavailable Second
+   - Alternative profile configuration for the Dual line mode
+     interface
+
+   Besides the management of G.Lite, another object has been added in
+   order to manage the ADSL line profile.  The object is the line mode
+   configuration.
+
+4.2.1 ATU-C ADSL Transmission System Parameters and Line Mode
+
+   The adslLineConfigTable needs to be extended to cover control of the
+   ATU-C ADSL Transmission system.  Three objects are defined to monitor
+   and configure the transmission mode as well as the actual line mode:
+
+     - Capability
+     - Configuration
+     - Actual Status
+
+   Transmission modes can further determine the line mode of the ADSL
+   interface.  For example, if g9921PotsNonOverlapped(2) is the actual
+   value of the ADSL interface, the interface is operating in Full rate
+   ADSL.  If the interface is set to g9922PotsOverlapped(9), the
+   interface is operating in G.Lite mode.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ly & Bathrick               Standards Track                     [Page 3]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+   The transmission mode and the corresponding line mode are defined as:
+
+        Transmission mode                        Line Mode
+        ----------------------------------------------------------
+        Regional Std. (ANSI T1.413)              Full
+           [ANSI T1.413]
+        Regional Std. (ETSI DTS/TM06006)         Full
+           [ETSI DTS/TM06006]
+        G.992.1 [ITU G992.1] POTS non-overlapped Full
+        G.992.1 POTS overlapped                  Full
+        G.992.1 Integrated Services Digital
+           Network (ISDN) non-overlapped         Full
+        G.992.1 ISDN overlapped                  Full
+        G.992.1 TCM-ISDN non-overlapped          Full
+        G.992.1 TCM-ISDN overlapped              Full
+        G.992.2 POTS non-overlapped              G.Lite
+        G.992.2 POTS overlapped                  G.Lite
+        G.992.2 with TCM-ISDN                    G.Lite
+            non-overlapped
+        G.992.2 with TCM-ISDN overlapped         G.Lite
+        G.992.1 TCM-ISDN symmetric               Full
+
+                Table 1: Transmission Mode and Line Mode
+
+   In case more than one bit is configured for an ADSL interface and
+   both Full and G.Lite modes are selected, the interface is said to be
+   configured in the dual mode.  Only one bit can be set in the Actual
+   object that reflects the actual mode of transmission as well as the
+   line mode.
+
+4.2.2 Power Management
+
+   There are three possible power states for each managed ADSL interface
+   operating in the G.Lite mode.  L0 is power on, L1 is power on but
+   reduced and L3 is power off.  Power state cannot be configured by an
+   operator but it can be viewed via the ifOperStatus object for the
+   managed ADSL interface.  The value of the object ifOperStatus is set
+   to down(2) if the ADSL interface is in power state L3 and is set to
+   up(1) if the ADSL line interface is in power state L0 or L1.
+
+   An ADSL line power state, if the interface is operating in the G.Lite
+   mode, can also be monitored by the adslLineGlitePowerState object
+   defined in the ADSL Line Extension table.  The value of the object
+   enumerates the three power states attainable by the managed
+   interface.
+
+
+
+
+
+
+Ly & Bathrick               Standards Track                     [Page 4]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+4.2.3 Fast Retrain Parameters
+
+   Section 7.4.15 [ITU G.997.1] specifies fast retrain parameters.  Fast
+   retrain parameters include two counters: fast retrain count and
+   failed fast retrain count.  These two counters have been added to all
+   performance tables.
+
+4.2.4 Counters for Severely Errored Second-line and Unavailable
+      Seconds-line
+
+   ITU G.997.1 sections 6.2.1.1.7 and 6.2.1.1.9 specify two counters
+   that are not covered by the ADSL Line MIB [RFC2662].  These two
+   counters (severely errored seconds-line and unavailable seconds-line)
+   are added to all the performance tables.
+
+   Unavailable seconds counts the cumulative number of seconds in which
+   the interface was unavailable during the measured period.  This
+   counter does not include the seconds in which unavailability was
+   caused solely by fast retrains and failed fast retrains.  Fast
+   retrains and failed fast retrains are considered to be part of the
+   normal network operation and thus are not counted as unavailable
+   errors.
+
+4.2.5  Counters, Interval Buckets and Thresholds
+
+   For physical-level events, there are counters, current 15-minute and
+   one (up to 96) 15-minute history bucket(s) of "interval-counters", as
+   well as current and previous 1-day interval-counters.   Threshold
+   notification can be configured for each physical-layer current 15-
+   minute bucket.
+
+   There is no requirement for an agent to ensure fixed relationship
+   between the start of a fifteen minute and any wall clock; however
+   some implementations may align the fifteen-minute intervals with
+   quarter hours.  Likewise, an implementation may choose to align one
+   day intervals with start of a day.
+
+   Separate tables are provided for the 96 interval-counters.  They are
+   indexed by {ifIndex, AdslAtu*IntervalNumber}.
+
+   Counters are not reset when an ATU-C or ATU-R is reinitialized, only
+   when the agent is reset or reinitialized (or under specific request
+   outside the scope of this MIB).
+
+   The 15-minute event counters are of the type PerfCurrentCount and
+   PerfIntervalCount.  The 1-day event counters are of the type
+   AdslPerfCurrDayCount and AdslPerfPrevDayCount.  Both 15-minute and 1-
+   day time elapsed counters are of the type AdslPerfTimeElapsed.
+
+
+
+Ly & Bathrick               Standards Track                     [Page 5]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+4.2.6 Alternative profile configuration for the dual line mode interface
+
+   The object, adslLineConfProfileDualLite, is used only when the
+   interface (the ADSL line and, if applicable, channel) is configured
+   as dual mode, that is, the object adslLineTransAtucConfig is
+   configured with one or more full-rate modes and one or more G.Lite
+   modes.
+
+   The object adslLineConfProfile defined in ADSL-MIB [RFC2662] is used
+   as the primary full-rate profile.  The newly added object in this MIB
+   module, adslLineConfProfileDualLite, is used to describe and
+   configure the G.Lite profile.  Note that if one or more full-rate
+   modes are configured, or only G.Lite modes are configured, only the
+   original full-rate profile is needed.  The dual-mode profile object
+   is only needed when both full-rate and G.Lite profiles are needed.
+   In this case, it will be set to the value of adslLineConfProfile when
+   'dynamic' profiles are implemented.
+
+   When 'static' profiles are implemented, however, similar to the case
+   of the object, adslLineConfProfileName [RFC2662], this object's value
+   will need to algorithmically represent the line.  In this case, the
+   value of the line's ifIndex plus a value indicating the line mode
+   type (e.g., G.Lite, Full-rate) will be used.  Therefore, the
+   profile's name is a string of the concatenation of the ifIndex and
+   one of the following values: Full or Lite.  This string will be
+   fixed-length (i.e., 14) with leading zero(s).  For example, the
+   profile name for ifIndex that equals '15' and is a full rate line
+   will be '0000000015Full'.
+
+5.  Conformance and Compliance
+
+   See the conformance and compliance statements within the information
+   module.
+
+6.  Definitions
+
+ADSL-LINE-EXT-MIB DEFINITIONS ::= BEGIN
+
+   IMPORTS
+      Counter32,
+      Integer32,
+      NOTIFICATION-TYPE,
+      MODULE-IDENTITY,
+      OBJECT-TYPE                       FROM SNMPv2-SMI
+      MODULE-COMPLIANCE, OBJECT-GROUP,
+      NOTIFICATION-GROUP                FROM SNMPv2-CONF
+      TEXTUAL-CONVENTION                FROM SNMPv2-TC
+      PerfCurrentCount,
+
+
+
+Ly & Bathrick               Standards Track                     [Page 6]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+      PerfIntervalCount                 FROM PerfHist-TC-MIB
+      AdslPerfCurrDayCount,
+      AdslPerfPrevDayCount              FROM ADSL-TC-MIB
+      SnmpAdminString                   FROM SNMP-FRAMEWORK-MIB
+      adslLineAlarmConfProfileEntry,
+      adslLineConfProfileEntry,
+      adslAturIntervalEntry,
+      adslAturPerfDataEntry,
+      adslAtucIntervalEntry,
+      adslAtucPerfDataEntry,
+      adslLineEntry,
+      adslMIB                           FROM ADSL-LINE-MIB
+      ;
+
+   adslExtMIB MODULE-IDENTITY
+
+   LAST-UPDATED "200212100000Z"  -- 10 Dec 2002
+
+   ORGANIZATION "IETF ADSL MIB Working Group"
+
+   CONTACT-INFO
+         "
+          Faye Ly
+          Pedestal Networks
+          6503 Dumbarton Circle,
+          Fremont, CA 94555
+          Tel: +1 510-578-0158
+          Fax: +1 510-744-5152
+          E-Mail: faye@pedestalnetworks.com
+
+          Gregory Bathrick
+          Nokia Networks
+          2235 Mercury Way,
+          Fax: +1 707-535-7300
+          E-Mail: greg.bathrick@nokia.com
+
+          General Discussion:adslmib@ietf.org
+          To Subscribe: https://www1.ietf.org/mailman/listinfo/adslmib
+          Archive: https://www1.ietf.org/mailman/listinfo/adslmib
+          "
+   DESCRIPTION
+           "Copyright (C) The Internet Society (2002). This version of
+           this MIB module is part of RFC 3440; see the RFC itself for
+           full legal notices.
+
+           This MIB Module is a supplement to the ADSL-LINE-MIB
+           [RFC2662]."
+
+
+
+
+Ly & Bathrick               Standards Track                     [Page 7]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+   REVISION     "200212100000Z"  -- 10 dec 2002
+   DESCRIPTION  "Initial Version, published as RFC 3440. This MIB
+                 module supplements the ADSL-LINE-MIB [RFC2662]."
+          ::= { adslMIB 3 }
+
+       adslExtMibObjects  OBJECT IDENTIFIER ::= { adslExtMIB 1 }
+
+       AdslTransmissionModeType ::= TEXTUAL-CONVENTION
+           STATUS       current
+           DESCRIPTION
+               "A set of ADSL line transmission modes, with one bit
+                per mode.  The notes (F) and (L) denote Full-Rate
+                and G.Lite respectively:
+                  Bit 00 : Regional Std. (ANSI T1.413) (F)
+                  Bit 01 : Regional Std. (ETSI DTS/TM06006) (F)
+                  Bit 02 : G.992.1 POTS non-overlapped (F)
+                  Bit 03 : G.992.1 POTS overlapped (F)
+                  Bit 04 : G.992.1 ISDN non-overlapped (F)
+                  Bit 05 : G.992.1 ISDN overlapped (F)
+                  Bit 06 : G.992.1 TCM-ISDN non-overlapped (F)
+                  Bit 07 : G.992.1 TCM-ISDN overlapped (F)
+                  Bit 08 : G.992.2 POTS non-overlapped (L)
+                  Bit 09 : G.992.2 POTS overlapped (L)
+                  Bit 10 : G.992.2 with TCM-ISDN non-overlapped (L)
+                  Bit 11 : G.992.2 with TCM-ISDN overlapped (L)
+                  Bit 12 : G.992.1 TCM-ISDN symmetric (F)
+               "
+           SYNTAX      BITS {
+               ansit1413(0),
+               etsi(1),
+               q9921PotsNonOverlapped(2),
+               q9921PotsOverlapped(3),
+               q9921IsdnNonOverlapped(4),
+               q9921isdnOverlapped(5),
+               q9921tcmIsdnNonOverlapped(6),
+               q9921tcmIsdnOverlapped(7),
+               q9922potsNonOverlapeed(8),
+               q9922potsOverlapped(9),
+               q9922tcmIsdnNonOverlapped(10),
+               q9922tcmIsdnOverlapped(11),
+               q9921tcmIsdnSymmetric(12)
+           }
+
+         adslLineExtTable   OBJECT-TYPE
+             SYNTAX          SEQUENCE OF AdslLineExtEntry
+             MAX-ACCESS      not-accessible
+             STATUS          current
+             DESCRIPTION
+
+
+
+Ly & Bathrick               Standards Track                     [Page 8]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+                 "This table is an extension of RFC 2662.  It
+                  contains ADSL line configuration and
+                  monitoring information. This includes the ADSL
+                  line's capabilities and actual ADSL transmission
+                  system."
+         ::= { adslExtMibObjects 17 }
+
+         adslLineExtEntry   OBJECT-TYPE
+             SYNTAX          AdslLineExtEntry
+             MAX-ACCESS      not-accessible
+             STATUS          current
+             DESCRIPTION
+                 "An entry extends the adslLineEntry defined in
+                  [RFC2662].  Each entry corresponds to an ADSL
+                  line."
+             AUGMENTS { adslLineEntry }
+         ::= { adslLineExtTable 1 }
+
+         AdslLineExtEntry ::=
+             SEQUENCE {
+             adslLineTransAtucCap        AdslTransmissionModeType,
+             adslLineTransAtucConfig     AdslTransmissionModeType,
+             adslLineTransAtucActual     AdslTransmissionModeType,
+             adslLineGlitePowerState     INTEGER,
+             adslLineConfProfileDualLite SnmpAdminString
+             }
+
+         adslLineTransAtucCap OBJECT-TYPE
+             SYNTAX      AdslTransmissionModeType
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "The transmission modes, represented by a
+                  bitmask that the ATU-C is capable of
+                  supporting.  The modes available are limited
+                  by the design of the equipment."
+             REFERENCE "Section 7.3.2 ITU G.997.1"
+         ::= { adslLineExtEntry 1 }
+
+         adslLineTransAtucConfig OBJECT-TYPE
+             SYNTAX      AdslTransmissionModeType
+             MAX-ACCESS  read-write
+             STATUS      current
+
+             DESCRIPTION
+                 "The transmission modes, represented by a bitmask,
+                  currently enabled by the ATU-C.  The manager can
+                  only set those modes that are supported by the
+
+
+
+Ly & Bathrick               Standards Track                     [Page 9]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+                  ATU-C.  An ATU-C's supported modes are provided by
+                  AdslLineTransAtucCap."
+             REFERENCE "Section 7.3.2 ITU G.997.1"
+         ::= { adslLineExtEntry 2 }
+
+         adslLineTransAtucActual OBJECT-TYPE
+             SYNTAX      AdslTransmissionModeType
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "The actual transmission mode of the ATU-C.
+                  During ADSL line initialization, the ADSL
+                  Transceiver Unit - Remote terminal end (ATU-R)
+                  will determine the mode used for the link.
+                  This value will be limited a single transmission
+                  mode that is a subset of those modes enabled
+                  by the ATU-C and denoted by
+                  adslLineTransAtucConfig. After an initialization
+                  has occurred, its mode is saved as the 'Current'
+                  mode and is persistence should the link go
+                  down. This object returns 0 (i.e. BITS with no
+                  mode bit set) if the mode is not known."
+             REFERENCE "Section 7.3.2 ITU G.997.1 "
+         ::= { adslLineExtEntry 3 }
+
+         adslLineGlitePowerState OBJECT-TYPE
+             SYNTAX      INTEGER {
+                         none(1),
+                         l0(2),          -- L0 Power on
+                         l1(3),          -- L1 Power on but reduced
+                         l3(4)           -- L3 Power off
+                         }
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "The value of this object specifies the power
+                  state of this interface.  L0 is power on, L1 is
+                  power on but reduced and L3 is power off.  Power
+                  state cannot be configured by an operator but it
+                  can be viewed via the ifOperStatus object for the
+                  managed ADSL interface.  The value of the object
+                  ifOperStatus is set to down(2) if the ADSL
+                  interface is in power state L3 and is set to up(1)
+                  if the ADSL line interface is in power state L0 or
+                  L1. If the object adslLineTransAtucActual is set to
+                  a G.992.2 (G.Lite)-type transmission mode, the
+                  value of this object will be one of the valid power
+                  states: L0(2), L1(3), or L3(4).  Otherwise, its
+
+
+
+Ly & Bathrick               Standards Track                    [Page 10]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+                  value will be none(1)."
+         ::= { adslLineExtEntry 4 }
+
+         adslLineConfProfileDualLite OBJECT-TYPE
+             SYNTAX SnmpAdminString
+             MAX-ACCESS  read-write
+             STATUS current
+             DESCRIPTION
+                 "This object extends the definition an ADSL line and
+                  associated channels (when applicable) for cases
+                  when it is configured in dual mode, and operating
+                  in a G.Lite-type mode as denoted by
+                  adslLineTransAtucActual.  Dual mode exists when the
+                  object, adslLineTransAtucConfig, is configured with
+                  one or more full-rate modes and one or more G.Lite
+                  modes simultaneously.
+
+                  When 'dynamic' profiles are implemented, the value
+                  of object is equal to the index of the applicable
+                  row in the ADSL Line Configuration Profile Table,
+                  AdslLineConfProfileTable defined in ADSL-MIB
+                  [RFC2662].
+
+                  In the case when dual-mode has not been enabled,
+                  the value of the object will be equal to the value
+                  of the object adslLineConfProfile [RFC2662].
+
+                  When `static' profiles are implemented, in much
+                  like the case of the object,
+                  adslLineConfProfileName [RFC2662], this object's
+                  value will need to algorithmically represent the
+                  characteristics of the line.  In this case, the
+                  value of the line's ifIndex plus a value indicating
+                  the line mode type (e.g., G.Lite, Full-rate) will
+                  be used. Therefore, the profile's name is a string
+                  concatenating the ifIndex and one of the follow
+                  values: Full or Lite. This string will be
+                  fixed-length (i.e., 14) with leading zero(s).  For
+                  example, the profile name for ifIndex that equals
+                  '15' and is a full rate line, it will be
+                  '0000000015Full'."
+             REFERENCE "Section 5.4 Profiles, RFC 2662"
+         ::= { adslLineExtEntry 5 }
+
+         adslAtucPerfDataExtTable   OBJECT-TYPE
+
+             SYNTAX          SEQUENCE OF AdslAtucPerfDataExtEntry
+             MAX-ACCESS      not-accessible
+
+
+
+Ly & Bathrick               Standards Track                    [Page 11]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+             STATUS          current
+             DESCRIPTION
+                 "This table extends adslAtucPerfDataTable [RFC2662]
+                  with additional ADSL physical line counter
+                  information such as unavailable seconds-line and
+                  severely errored seconds-line."
+         ::= { adslExtMibObjects 18 }
+
+         adslAtucPerfDataExtEntry   OBJECT-TYPE
+             SYNTAX          AdslAtucPerfDataExtEntry
+             MAX-ACCESS      not-accessible
+             STATUS          current
+             DESCRIPTION
+                 "An entry extends the adslAtucPerfDataEntry defined
+                  in [RFC2662].  Each entry corresponds to an ADSL
+                  line."
+         AUGMENTS { adslAtucPerfDataEntry }
+         ::= { adslAtucPerfDataExtTable 1 }
+
+         AdslAtucPerfDataExtEntry ::=
+             SEQUENCE {
+             adslAtucPerfStatFastR            Counter32,
+             adslAtucPerfStatFailedFastR      Counter32,
+             adslAtucPerfStatSesL             Counter32,
+             adslAtucPerfStatUasL             Counter32,
+             adslAtucPerfCurr15MinFastR       PerfCurrentCount,
+             adslAtucPerfCurr15MinFailedFastR PerfCurrentCount,
+             adslAtucPerfCurr15MinSesL        PerfCurrentCount,
+             adslAtucPerfCurr15MinUasL        PerfCurrentCount,
+             adslAtucPerfCurr1DayFastR        AdslPerfCurrDayCount,
+             adslAtucPerfCurr1DayFailedFastR  AdslPerfCurrDayCount,
+             adslAtucPerfCurr1DaySesL         AdslPerfCurrDayCount,
+             adslAtucPerfCurr1DayUasL         AdslPerfCurrDayCount,
+             adslAtucPerfPrev1DayFastR        AdslPerfPrevDayCount,
+             adslAtucPerfPrev1DayFailedFastR  AdslPerfPrevDayCount,
+             adslAtucPerfPrev1DaySesL         AdslPerfPrevDayCount,
+             adslAtucPerfPrev1DayUasL         AdslPerfPrevDayCount
+         }
+
+         adslAtucPerfStatFastR OBJECT-TYPE
+             SYNTAX      Counter32
+             UNITS       "line retrains"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "The value of this object reports the count of
+                  the number of fast line bs since last
+                  agent reset."
+
+
+
+Ly & Bathrick               Standards Track                    [Page 12]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+             REFERENCE "ITU G.997.1 Section 7.4.15.1 "
+         ::= { adslAtucPerfDataExtEntry 1 }
+
+         adslAtucPerfStatFailedFastR OBJECT-TYPE
+             SYNTAX      Counter32
+             UNITS       "line retrains"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "The value of this object reports the count of
+                  the number of failed fast line retrains since
+                  last agent reset."
+             REFERENCE "ITU G.997.1 Section 7.4.15.2 "
+         ::= { adslAtucPerfDataExtEntry 2 }
+
+         adslAtucPerfStatSesL OBJECT-TYPE
+             SYNTAX      Counter32
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "The value of this object reports the count of
+                  the number of severely errored seconds-line since
+                  last agent reset."
+             REFERENCE "ITU G.997.1 Section 7.2.1.1.7 "
+         ::= { adslAtucPerfDataExtEntry 3 }
+
+         adslAtucPerfStatUasL OBJECT-TYPE
+             SYNTAX      Counter32
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "The value of this object reports the count of
+                  the number of unavailable seconds-line since
+                  last agent reset."
+             REFERENCE "ITU G.997.1 Section 7.2.1.1.9 "
+         ::= { adslAtucPerfDataExtEntry 4 }
+
+         adslAtucPerfCurr15MinFastR OBJECT-TYPE
+             SYNTAX      PerfCurrentCount
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "For the current 15-minute interval,
+                  adslAtucPerfCurr15MinFastR reports the current
+                  number of seconds during which there have been
+
+
+
+Ly & Bathrick               Standards Track                    [Page 13]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+                  fast retrains."
+             REFERENCE "ITU G.997.1 Section 7.4.15.1 "
+         ::= { adslAtucPerfDataExtEntry 5 }
+
+         adslAtucPerfCurr15MinFailedFastR   OBJECT-TYPE
+             SYNTAX      PerfCurrentCount
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "For the current 15-minute interval,
+                  adslAtucPerfCurr15MinFailedFastR reports the
+                  current number of seconds during which there
+                  have been failed fast retrains."
+             REFERENCE "ITU G.997.1 Section 7.4.15.2 "
+         ::= { adslAtucPerfDataExtEntry 6 }
+
+         adslAtucPerfCurr15MinSesL OBJECT-TYPE
+             SYNTAX      PerfCurrentCount
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "For the current 15-minute interval,
+                  adslAtucPerfCurr15MinSesL reports the current
+                  number of seconds during which there have been
+                  severely errored seconds-line."
+             REFERENCE "ITU G.997.1 Section 7.2.1.1.7 "
+         ::= { adslAtucPerfDataExtEntry 7 }
+
+         adslAtucPerfCurr15MinUasL   OBJECT-TYPE
+             SYNTAX      PerfCurrentCount
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "For the current 15-minute interval,
+                  adslAtucPerfCurr15MinUasL reports the current
+                  number of seconds during which there have been
+                  unavailable seconds-line."
+             REFERENCE "ITU G.997.1 Section 7.2.1.1.9 "
+         ::= { adslAtucPerfDataExtEntry 8 }
+
+         adslAtucPerfCurr1DayFastR    OBJECT-TYPE
+             SYNTAX      AdslPerfCurrDayCount
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+
+
+
+Ly & Bathrick               Standards Track                    [Page 14]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+             DESCRIPTION
+                 "For the current day as measured by
+                  adslAtucPerfCurr1DayTimeElapsed [RFC2662],
+                  adslAtucPerfCurr1DayFastR reports the number
+                  of seconds during which there have been
+                  fast retrains."
+             REFERENCE "ITU G.997.1 Section 7.4.15.1 "
+         ::= { adslAtucPerfDataExtEntry 9 }
+
+         adslAtucPerfCurr1DayFailedFastR    OBJECT-TYPE
+             SYNTAX      AdslPerfCurrDayCount
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "For the current day as measured by
+                  adslAtucPerfCurr1DayTimeElapsed [RFC2662],
+                  adslAtucPerfCurr1DayFailedFastR reports the
+                  number of seconds during which there have been
+                  failed fast retrains."
+             REFERENCE "ITU G.997.1 Section 7.4.15.2 "
+         ::= { adslAtucPerfDataExtEntry 10 }
+
+         adslAtucPerfCurr1DaySesL    OBJECT-TYPE
+             SYNTAX      AdslPerfCurrDayCount
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "For the current day as measured by
+                  adslAtucPerfCurr1DayTimeElapsed [RFC2662],
+                  adslAtucPerfCurr1DaySesL reports the
+                  number of seconds during which there have been
+                  severely errored seconds-line."
+             REFERENCE "ITU G.997.1 Section 7.2.1.1.7 "
+         ::= { adslAtucPerfDataExtEntry 11 }
+
+         adslAtucPerfCurr1DayUasL    OBJECT-TYPE
+             SYNTAX      AdslPerfCurrDayCount
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "For the current day as measured by
+                  adslAtucPerfCurr1DayTimeElapsed [RFC2662],
+                  adslAtucPerfCurr1DayUasL reports the
+                  number of seconds during which there have been
+                  unavailable seconds-line."
+
+
+
+Ly & Bathrick               Standards Track                    [Page 15]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+             REFERENCE "ITU G.997.1 Section 7.2.1.1.9 "
+         ::= { adslAtucPerfDataExtEntry 12 }
+
+         adslAtucPerfPrev1DayFastR     OBJECT-TYPE
+             SYNTAX      AdslPerfPrevDayCount
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "For the previous day, adslAtucPerfPrev1DayFastR
+                  reports the number of seconds during which there
+                  were fast retrains."
+             REFERENCE "ITU G.997.1 Section 7.4.15.1 "
+         ::= { adslAtucPerfDataExtEntry 13 }
+
+         adslAtucPerfPrev1DayFailedFastR OBJECT-TYPE
+             SYNTAX      AdslPerfPrevDayCount
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "For the previous day,
+                  adslAtucPerfPrev1DayFailedFastR reports the number
+                  of seconds during which there were failed fast
+                  retrains."
+             REFERENCE "ITU G.997.1 Section 7.4.15.2 "
+         ::= { adslAtucPerfDataExtEntry 14 }
+
+         adslAtucPerfPrev1DaySesL     OBJECT-TYPE
+             SYNTAX      AdslPerfPrevDayCount
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "For the previous day, adslAtucPerfPrev1DaySesL
+                  reports the number of seconds during which there
+                  were severely errored seconds-line."
+             REFERENCE "ITU G.997.1 Section 7.2.1.1.7 "
+         ::= { adslAtucPerfDataExtEntry 15 }
+
+         adslAtucPerfPrev1DayUasL OBJECT-TYPE
+             SYNTAX      AdslPerfPrevDayCount
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "For the previous day, adslAtucPerfPrev1DayUasL
+                  reports the number of seconds during which there
+
+
+
+Ly & Bathrick               Standards Track                    [Page 16]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+                  were unavailable seconds-line."
+             REFERENCE "ITU G.997.1 Section 7.2.1.1.9 "
+         ::= { adslAtucPerfDataExtEntry 16 }
+
+         adslAtucIntervalExtTable   OBJECT-TYPE
+             SYNTAX          SEQUENCE OF AdslAtucIntervalExtEntry
+             MAX-ACCESS      not-accessible
+             STATUS          current
+             DESCRIPTION
+                 "This table provides one row for each ATU-C
+                  performance data collection interval for
+                  ADSL physical interfaces whose
+                  IfEntries' ifType is equal to adsl(94)."
+         ::= { adslExtMibObjects 19 }
+
+         adslAtucIntervalExtEntry   OBJECT-TYPE
+             SYNTAX          AdslAtucIntervalExtEntry
+             MAX-ACCESS      not-accessible
+             STATUS          current
+             DESCRIPTION     "An entry in the
+                              adslAtucIntervalExtTable."
+             AUGMENTS        { adslAtucIntervalEntry }
+         ::= { adslAtucIntervalExtTable 1 }
+
+         AdslAtucIntervalExtEntry ::=
+             SEQUENCE {
+             adslAtucIntervalFastR            PerfIntervalCount,
+             adslAtucIntervalFailedFastR      PerfIntervalCount,
+             adslAtucIntervalSesL             PerfIntervalCount,
+             adslAtucIntervalUasL             PerfIntervalCount
+             }
+
+         adslAtucIntervalFastR OBJECT-TYPE
+             SYNTAX      PerfIntervalCount
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "For the current interval, adslAtucIntervalFastR
+                  reports the current number of seconds during which
+                  there have been fast retrains."
+         ::= { adslAtucIntervalExtEntry 1 }
+
+         adslAtucIntervalFailedFastR OBJECT-TYPE
+             SYNTAX      PerfIntervalCount
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+
+
+
+Ly & Bathrick               Standards Track                    [Page 17]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+             DESCRIPTION
+                 "For the each interval, adslAtucIntervalFailedFastR
+                  reports the number of seconds during which
+                  there have been failed fast retrains."
+         ::= { adslAtucIntervalExtEntry 2 }
+
+         adslAtucIntervalSesL OBJECT-TYPE
+             SYNTAX      PerfIntervalCount
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "For the each interval, adslAtucIntervalSesL
+                  reports the number of seconds during which
+                  there have been severely errored seconds-line."
+         ::= { adslAtucIntervalExtEntry 3 }
+
+         adslAtucIntervalUasL OBJECT-TYPE
+             SYNTAX      PerfIntervalCount
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "For the each interval, adslAtucIntervalUasL
+                  reports the number of seconds during which
+                  there have been unavailable seconds-line."
+         ::= { adslAtucIntervalExtEntry 4 }
+
+         adslAturPerfDataExtTable   OBJECT-TYPE
+             SYNTAX          SEQUENCE OF AdslAturPerfDataExtEntry
+             MAX-ACCESS      not-accessible
+             STATUS          current
+             DESCRIPTION
+                 "This table contains ADSL physical line counters
+                  not defined in the adslAturPerfDataTable
+                  from the ADSL-LINE-MIB [RFC2662]."
+         ::= { adslExtMibObjects 20 }
+
+         adslAturPerfDataExtEntry   OBJECT-TYPE
+             SYNTAX          AdslAturPerfDataExtEntry
+             MAX-ACCESS      not-accessible
+             STATUS          current
+             DESCRIPTION
+                 "An entry extends the adslAturPerfDataEntry defined
+                  in [RFC2662].  Each entry corresponds to an ADSL
+                  line."
+             AUGMENTS { adslAturPerfDataEntry }
+         ::= { adslAturPerfDataExtTable 1 }
+
+
+
+Ly & Bathrick               Standards Track                    [Page 18]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+         AdslAturPerfDataExtEntry ::=
+             SEQUENCE {
+             adslAturPerfStatSesL             Counter32,
+             adslAturPerfStatUasL             Counter32,
+             adslAturPerfCurr15MinSesL        PerfCurrentCount,
+             adslAturPerfCurr15MinUasL        PerfCurrentCount,
+             adslAturPerfCurr1DaySesL         AdslPerfCurrDayCount,
+             adslAturPerfCurr1DayUasL         AdslPerfCurrDayCount,
+             adslAturPerfPrev1DaySesL         AdslPerfPrevDayCount,
+             adslAturPerfPrev1DayUasL         AdslPerfPrevDayCount
+         }
+
+         adslAturPerfStatSesL OBJECT-TYPE
+             SYNTAX      Counter32
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "The value of this object reports the count of
+                  severely errored second-line since the last agent
+                  reset."
+             REFERENCE "ITU G.997.1 Section 7.2.1.1.7 "
+         ::= { adslAturPerfDataExtEntry 1 }
+
+         adslAturPerfStatUasL OBJECT-TYPE
+             SYNTAX      Counter32
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "The value of this object reports the count of
+                  unavailable seconds-line since the last agent
+                  reset."
+             REFERENCE "ITU G.997.1 Section 7.2.1.2.9 "
+         ::= { adslAturPerfDataExtEntry 2 }
+
+         adslAturPerfCurr15MinSesL OBJECT-TYPE
+             SYNTAX      PerfCurrentCount
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "For the current 15-minute interval,
+                  adslAturPerfCurr15MinSesL reports the current
+                  number of seconds during which there have been
+                  severely errored seconds-line."
+
+             REFERENCE "ITU G.997.1 Section 7.2.1.2.7 "
+
+
+
+Ly & Bathrick               Standards Track                    [Page 19]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+         ::= { adslAturPerfDataExtEntry 3 }
+
+         adslAturPerfCurr15MinUasL   OBJECT-TYPE
+             SYNTAX      PerfCurrentCount
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "For the current 15-minute interval,
+                  adslAturPerfCurr15MinUasL reports the current
+                  number of seconds during which there have been
+                  available seconds-line."
+             REFERENCE "ITU G.997.1 Section 7.2.1.2.9 "
+         ::= { adslAturPerfDataExtEntry 4 }
+
+         adslAturPerfCurr1DaySesL    OBJECT-TYPE
+             SYNTAX      AdslPerfCurrDayCount
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "For the current day as measured by
+                  adslAturPerfCurr1DayTimeElapsed [RFC2662],
+                  adslAturPerfCurr1DaySesL reports the
+                  number of seconds during which there have been
+                  severely errored seconds-line."
+             REFERENCE "ITU G.997.1 Section 7.2.1.2.7 "
+         ::= { adslAturPerfDataExtEntry 5 }
+
+         adslAturPerfCurr1DayUasL    OBJECT-TYPE
+             SYNTAX      AdslPerfCurrDayCount
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "For the current day as measured by
+                  adslAturPerfCurr1DayTimeElapsed [RFC2662],
+                  adslAturPerfCurr1DayUasL reports the
+                  number of seconds during which there have been
+                  unavailable seconds-line."
+             REFERENCE "ITU G.997.1 Section 7.2.1.2.9 "
+         ::= { adslAturPerfDataExtEntry 6 }
+
+         adslAturPerfPrev1DaySesL     OBJECT-TYPE
+             SYNTAX      AdslPerfPrevDayCount
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+
+
+
+Ly & Bathrick               Standards Track                    [Page 20]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+             DESCRIPTION
+                 "For the previous day, adslAturPerfPrev1DaySesL
+                  reports the number of seconds during which there
+                  were severely errored seconds-line."
+             REFERENCE "ITU G.997.1 Section 7.2.1.2.7 "
+         ::= { adslAturPerfDataExtEntry 7 }
+
+         adslAturPerfPrev1DayUasL OBJECT-TYPE
+             SYNTAX      AdslPerfPrevDayCount
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "For the previous day, adslAturPerfPrev1DayUasL
+                  reports the number of seconds during which there
+                  were severely errored seconds-line."
+             REFERENCE "ITU G.997.1 Section 7.2.1.2.9 "
+         ::= { adslAturPerfDataExtEntry 8 }
+
+         adslAturIntervalExtTable   OBJECT-TYPE
+             SYNTAX          SEQUENCE OF AdslAturIntervalExtEntry
+             MAX-ACCESS      not-accessible
+             STATUS          current
+             DESCRIPTION
+                 "This table provides one row for each ATU-R
+                  performance data collection interval for
+                  ADSL physical interfaces whose
+                  IfEntries' ifType is equal to adsl(94)."
+         ::= { adslExtMibObjects 21 }
+
+         adslAturIntervalExtEntry   OBJECT-TYPE
+             SYNTAX          AdslAturIntervalExtEntry
+             MAX-ACCESS      not-accessible
+             STATUS          current
+             DESCRIPTION     "An entry in the
+                              adslAturIntervalExtTable."
+             AUGMENTS        { adslAturIntervalEntry }
+         ::= { adslAturIntervalExtTable 1 }
+
+         AdslAturIntervalExtEntry ::=
+             SEQUENCE {
+             adslAturIntervalSesL             PerfIntervalCount,
+             adslAturIntervalUasL             PerfIntervalCount
+             }
+
+         adslAturIntervalSesL OBJECT-TYPE
+             SYNTAX      PerfIntervalCount
+             UNITS       "seconds"
+
+
+
+Ly & Bathrick               Standards Track                    [Page 21]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "For the each interval, adslAturIntervalSesL
+                  reports the number of seconds during which
+                  there have been severely errored seconds-line."
+         ::= { adslAturIntervalExtEntry 1 }
+
+         adslAturIntervalUasL OBJECT-TYPE
+             SYNTAX      PerfIntervalCount
+             UNITS       "seconds"
+             MAX-ACCESS  read-only
+             STATUS      current
+             DESCRIPTION
+                 "For the each interval, adslAturIntervalUasL
+                  reports the number of seconds during which
+                  there have been unavailable seconds-line."
+         ::= { adslAturIntervalExtEntry 2 }
+
+         adslConfProfileExtTable   OBJECT-TYPE
+             SYNTAX          SEQUENCE OF AdslConfProfileExtEntry
+             MAX-ACCESS      not-accessible
+             STATUS          current
+             DESCRIPTION
+                 "The adslConfProfileExtTable extends the ADSL line
+                  profile configuration information in the
+                  adslLineConfProfileTable from the ADSL-LINE-MIB
+                  [RFC2662] by adding the ability to configure the
+                  ADSL physical line mode."
+         ::= { adslExtMibObjects 22 }
+
+         adslConfProfileExtEntry   OBJECT-TYPE
+             SYNTAX          AdslConfProfileExtEntry
+             MAX-ACCESS      not-accessible
+             STATUS          current
+             DESCRIPTION
+                 "An entry extends the adslLineConfProfileEntry
+                  defined in [RFC2662].  Each entry corresponds to an
+                  ADSL line profile."
+             AUGMENTS { adslLineConfProfileEntry }
+         ::= { adslConfProfileExtTable 1 }
+
+         AdslConfProfileExtEntry ::=
+             SEQUENCE {
+                 adslConfProfileLineType  INTEGER
+             }
+
+         adslConfProfileLineType OBJECT-TYPE
+
+
+
+Ly & Bathrick               Standards Track                    [Page 22]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+             SYNTAX      INTEGER {
+                 noChannel (1),        -- no channels exist
+                 fastOnly (2),         -- only fast channel exists
+                 interleavedOnly (3),  -- only interleaved channel
+                                       -- exist
+                 fastOrInterleaved (4),-- either fast or interleaved
+                                       -- channels can exist, but
+                                       -- only one at any time
+                 fastAndInterleaved (5)-- both the fast channel and
+                                       -- the interleaved channel
+                                       -- exist
+                 }
+             MAX-ACCESS  read-create
+             STATUS      current
+             DESCRIPTION
+                 "This object is used to configure the ADSL physical
+                  line mode.  It has following valid values:
+
+                  noChannel(1), when no channels exist.
+                  fastOnly(2), when only fast channel exists.
+                  interleavedOnly(3), when only interleaved channel
+                      exist.
+                  fastOrInterleaved(4), when either fast or
+                      interleaved channels can exist, but only one
+                      at any time.
+                  fastAndInterleaved(5), when both the fast channel
+                      and the interleaved channel exist.
+
+                  In the case when no value has been set, the default
+                  Value is noChannel(1).
+                  "
+             DEFVAL { fastOnly }
+         ::= { adslConfProfileExtEntry 1 }
+
+         adslAlarmConfProfileExtTable   OBJECT-TYPE
+             SYNTAX          SEQUENCE OF AdslAlarmConfProfileExtEntry
+             MAX-ACCESS      not-accessible
+             STATUS          current
+             DESCRIPTION
+                 "This table extends the
+                  adslLineAlarmConfProfileTable and provides
+                  threshold parameters for all the counters defined
+                  in this MIB module."
+         ::= { adslExtMibObjects 23 }
+
+         adslAlarmConfProfileExtEntry   OBJECT-TYPE
+             SYNTAX          AdslAlarmConfProfileExtEntry
+             MAX-ACCESS      not-accessible
+
+
+
+Ly & Bathrick               Standards Track                    [Page 23]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+             STATUS          current
+             DESCRIPTION
+                 "An entry extends the adslLineAlarmConfProfileTable
+                  defined in [RFC2662].  Each entry corresponds to
+                  an ADSL alarm profile."
+             AUGMENTS { adslLineAlarmConfProfileEntry }
+         ::= { adslAlarmConfProfileExtTable 1 }
+
+         AdslAlarmConfProfileExtEntry ::=
+             SEQUENCE {
+             adslAtucThreshold15MinFailedFastR     Integer32,
+             adslAtucThreshold15MinSesL            Integer32,
+             adslAtucThreshold15MinUasL            Integer32,
+             adslAturThreshold15MinSesL            Integer32,
+             adslAturThreshold15MinUasL            Integer32
+         }
+
+         adslAtucThreshold15MinFailedFastR   OBJECT-TYPE
+             SYNTAX      Integer32(0..900)
+             UNITS       "seconds"
+             MAX-ACCESS  read-create
+             STATUS      current
+             DESCRIPTION
+                 "The first time the value of the corresponding
+                  instance of adslAtucPerfCurr15MinFailedFastR
+                  reaches or exceeds this value within a given
+                  15-minute performance data collection period,
+                  an adslAtucFailedFastRThreshTrap  notification
+                  will be generated. The value '0' will disable
+                  the notification. The default value of this
+                  object is '0'."
+             DEFVAL { 0 }
+         ::= { adslAlarmConfProfileExtEntry 1 }
+
+         adslAtucThreshold15MinSesL OBJECT-TYPE
+             SYNTAX      Integer32(0..900)
+             UNITS       "seconds"
+             MAX-ACCESS  read-create
+             STATUS      current
+             DESCRIPTION
+                 "The first time the value of the corresponding
+                  instance of adslAtucPerf15MinSesL reaches or
+                  exceeds this value within a given 15-minute
+                  performance data collection period, an
+                  adslAtucSesLThreshTrap notification will be
+                  generated. The value '0' will disable the
+                  notification.  The default value of this
+                  object is '0'."
+
+
+
+Ly & Bathrick               Standards Track                    [Page 24]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+             DEFVAL { 0 }
+
+         ::= { adslAlarmConfProfileExtEntry 2 }
+
+         adslAtucThreshold15MinUasL OBJECT-TYPE
+             SYNTAX      Integer32(0..900)
+             UNITS       "seconds"
+             MAX-ACCESS  read-create
+             STATUS      current
+             DESCRIPTION
+                 "The first time the value of the corresponding
+                  instance of adslAtucPerf15MinUasL reaches or
+                  exceeds this value within a given 15-minute
+                  performance data collection period, an
+                  adslAtucUasLThreshTrap notification will be
+                  generated. The value '0' will disable the
+                  notification.  The default value of this
+                  object is '0'."
+             DEFVAL { 0 }
+         ::= { adslAlarmConfProfileExtEntry 3 }
+
+         adslAturThreshold15MinSesL OBJECT-TYPE
+             SYNTAX      Integer32(0..900)
+             UNITS       "seconds"
+             MAX-ACCESS  read-create
+             STATUS      current
+             DESCRIPTION
+                 "The first time the value of the corresponding
+                  instance of adslAturPerf15MinSesL reaches or
+                  exceeds this value within a given 15-minute
+                  performance data collection period, an
+                  adslAturSesLThreshTrap notification will be
+                  generated. The value '0' will disable the
+                  notification.  The default value of this
+                  object is '0'."
+             DEFVAL { 0 }
+         ::= { adslAlarmConfProfileExtEntry 4 }
+
+         adslAturThreshold15MinUasL OBJECT-TYPE
+             SYNTAX      Integer32(0..900)
+             UNITS       "seconds"
+             MAX-ACCESS  read-create
+             STATUS      current
+             DESCRIPTION
+                 "The first time the value of the corresponding
+                  instance of adslAturPerf15MinUasL reaches or
+                  exceeds this value within a given 15-minute
+                  performance data collection period, an
+
+
+
+Ly & Bathrick               Standards Track                    [Page 25]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+                  adslAturUasLThreshTrap notification will be
+                  generated. The value '0' will disable the
+                  notification.  The default value of this
+                  object is '0'."
+             DEFVAL { 0 }
+
+         ::= { adslAlarmConfProfileExtEntry 5 }
+
+  --   definitions
+
+   adslExtTraps OBJECT IDENTIFIER ::= { adslExtMibObjects 24 }
+
+   adslExtAtucTraps OBJECT IDENTIFIER ::= { adslExtTraps 1 }
+
+   adslExtAtucTrapsPrefix OBJECT IDENTIFIER ::= { adslExtAtucTraps 0 }
+
+         adslAtucFailedFastRThreshTrap      NOTIFICATION-TYPE
+             OBJECTS { adslAtucPerfCurr15MinFailedFastR }
+             STATUS  current
+             DESCRIPTION
+                 "Failed Fast Retrains 15-minute threshold reached."
+         ::= { adslExtAtucTrapsPrefix 1 }
+
+         adslAtucSesLThreshTrap      NOTIFICATION-TYPE
+             OBJECTS { adslAtucPerfCurr15MinSesL }
+             STATUS  current
+             DESCRIPTION
+                 "Severely errored seconds-line 15-minute threshold
+                  reached."
+         ::= { adslExtAtucTrapsPrefix 2 }
+
+         adslAtucUasLThreshTrap      NOTIFICATION-TYPE
+             OBJECTS { adslAtucPerfCurr15MinUasL }
+             STATUS  current
+             DESCRIPTION
+                 "Unavailable seconds-line 15-minute threshold
+                  reached."
+         ::= { adslExtAtucTrapsPrefix 3 }
+
+
+   adslExtAturTraps OBJECT IDENTIFIER ::= { adslExtTraps 2 }
+
+   adslExtAturTrapsPrefix OBJECT IDENTIFIER ::= { adslExtAturTraps 0 }
+
+         adslAturSesLThreshTrap      NOTIFICATION-TYPE
+             OBJECTS { adslAturPerfCurr15MinSesL }
+             STATUS  current
+             DESCRIPTION
+
+
+
+Ly & Bathrick               Standards Track                    [Page 26]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+                 "Severely errored seconds-line 15-minute threshold
+                  reached."
+         ::= { adslExtAturTrapsPrefix 1 }
+
+         adslAturUasLThreshTrap      NOTIFICATION-TYPE
+             OBJECTS { adslAturPerfCurr15MinUasL }
+             STATUS  current
+             DESCRIPTION
+                 "Unavailable seconds-line 15-minute threshold
+                  reached."
+         ::= { adslExtAturTrapsPrefix 2 }
+
+
+   -- conformance information
+
+   adslExtConformance OBJECT IDENTIFIER ::= { adslExtMIB 2 }
+
+   adslExtGroups OBJECT IDENTIFIER ::= { adslExtConformance 1 }
+   adslExtCompliances OBJECT IDENTIFIER ::= { adslExtConformance 2 }
+
+         -- ATU-C agent compliance statements
+
+         adslExtLineMibAtucCompliance MODULE-COMPLIANCE
+             STATUS  current
+             DESCRIPTION
+                 "The compliance statement for SNMP entities which
+                  represent ADSL ATU-C interfaces."
+
+             MODULE  -- this module
+             MANDATORY-GROUPS
+                {
+                adslExtLineGroup,
+                adslExtLineConfProfileControlGroup,
+                adslExtLineAlarmConfProfileGroup
+                }
+
+             GROUP       adslExtAtucPhysPerfCounterGroup
+             DESCRIPTION
+                 "This group is optional.  Implementations which
+                  require continuous ATU-C physical event counters
+                  should implement this group."
+
+             GROUP       adslExtAturPhysPerfCounterGroup
+             DESCRIPTION
+                 "This group is optional.  Implementations which
+                  require continuous ATU-R physical event counters
+                  should implement this group."
+
+
+
+
+Ly & Bathrick               Standards Track                    [Page 27]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+             GROUP   adslExtNotificationsGroup
+             DESCRIPTION
+           "This group is optional.  Implementations which
+                  support TCA (Threshold Crossing Alert) should
+                  implement this group."
+
+             OBJECT      adslAtucThreshold15MinFailedFastR
+             MIN-ACCESS  read-write
+             DESCRIPTION
+                 "Read-write access is applicable only when
+                  static profiles as defined in ADSL Line MIB
+                  [RFC2662] are implemented."
+
+             OBJECT      adslAtucThreshold15MinSesL
+             MIN-ACCESS  read-write
+             DESCRIPTION
+                 "Read-write access is applicable only when
+                  static profiles as defined in ADSL Line MIB
+                  [RFC2662] are implemented."
+
+             OBJECT      adslAtucThreshold15MinUasL
+             MIN-ACCESS  read-write
+             DESCRIPTION
+                 "Read-write access is applicable only when
+                  static profiles as defined in ADSL Line MIB
+                  [RFC2662] are implemented."
+
+             OBJECT      adslAturThreshold15MinSesL
+             MIN-ACCESS  read-write
+             DESCRIPTION
+                 "Read-write access is applicable only when
+                  static profiles as defined in ADSL Line MIB
+                  [RFC2662] are implemented."
+
+             OBJECT      adslAturThreshold15MinUasL
+             MIN-ACCESS  read-write
+             DESCRIPTION
+                 "Read-write access is applicable only when
+                  static profiles as defined in ADSL Line MIB
+                  [RFC2662] are implemented."
+
+             OBJECT      adslLineConfProfileDualLite
+             MIN-ACCESS  read-only
+             DESCRIPTION
+                 "Read-only access is applicable only when
+                  static profiles as defined in ADSL Line MIB
+                  [RFC2662] are implemented."
+
+
+
+
+Ly & Bathrick               Standards Track                    [Page 28]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+         ::= { adslExtCompliances 1 }
+
+         -- units of conformance
+         adslExtLineGroup    OBJECT-GROUP
+             OBJECTS {
+                 adslLineConfProfileDualLite,
+                 adslLineTransAtucCap,
+                 adslLineTransAtucConfig,
+                 adslLineTransAtucActual,
+                 adslLineGlitePowerState
+                }
+             STATUS     current
+             DESCRIPTION
+                 "A collection of objects providing extended
+                 configuration information about an ADSL Line."
+         ::= { adslExtGroups 1 }
+
+         adslExtAtucPhysPerfCounterGroup OBJECT-GROUP
+             OBJECTS {
+                 adslAtucPerfStatFastR,
+                 adslAtucPerfStatFailedFastR,
+                 adslAtucPerfCurr15MinFastR,
+                 adslAtucPerfCurr15MinFailedFastR,
+                 adslAtucPerfCurr1DayFastR,
+                 adslAtucPerfCurr1DayFailedFastR,
+                 adslAtucPerfPrev1DayFastR,
+                 adslAtucPerfPrev1DayFailedFastR,
+                 adslAtucPerfStatSesL,
+                 adslAtucPerfStatUasL,
+                 adslAtucPerfCurr15MinSesL,
+                 adslAtucPerfCurr15MinUasL,
+                 adslAtucPerfCurr1DaySesL,
+                 adslAtucPerfCurr1DayUasL,
+                 adslAtucPerfPrev1DaySesL,
+                 adslAtucPerfPrev1DayUasL,
+                 adslAtucIntervalFastR,
+                 adslAtucIntervalFailedFastR,
+                 adslAtucIntervalSesL,
+                 adslAtucIntervalUasL
+                }
+             STATUS     current
+             DESCRIPTION
+                 "A collection of objects providing raw performance
+                 counts on an ADSL Line (ATU-C end)."
+         ::= { adslExtGroups 2 }
+
+         adslExtAturPhysPerfCounterGroup OBJECT-GROUP
+             OBJECTS {
+
+
+
+Ly & Bathrick               Standards Track                    [Page 29]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+                 adslAturPerfStatSesL,
+                 adslAturPerfStatUasL,
+                 adslAturPerfCurr15MinSesL,
+                 adslAturPerfCurr15MinUasL,
+                 adslAturPerfCurr1DaySesL,
+                 adslAturPerfCurr1DayUasL,
+                 adslAturPerfPrev1DaySesL,
+                 adslAturPerfPrev1DayUasL,
+                 adslAturIntervalSesL, adslAturIntervalUasL
+                }
+             STATUS     current
+             DESCRIPTION
+                 "A collection of objects providing raw performance
+                 counts on an ADSL Line (ATU-C end)."
+         ::= { adslExtGroups 3 }
+
+         adslExtLineConfProfileControlGroup OBJECT-GROUP
+             OBJECTS {
+                 adslConfProfileLineType
+                }
+             STATUS     current
+             DESCRIPTION
+                 "A collection of objects providing profile
+                 control for the ADSL system."
+         ::= { adslExtGroups 4 }
+
+         adslExtLineAlarmConfProfileGroup OBJECT-GROUP
+             OBJECTS {
+                    adslAtucThreshold15MinFailedFastR,
+                    adslAtucThreshold15MinSesL,
+                    adslAtucThreshold15MinUasL,
+                    adslAturThreshold15MinSesL,
+                    adslAturThreshold15MinUasL
+                }
+             STATUS     current
+             DESCRIPTION
+                 "A collection of objects providing alarm profile
+                 control for the ADSL system."
+         ::= { adslExtGroups 5 }
+
+         adslExtNotificationsGroup NOTIFICATION-GROUP
+             NOTIFICATIONS {
+                 adslAtucFailedFastRThreshTrap,
+                 adslAtucSesLThreshTrap,
+                 adslAtucUasLThreshTrap,
+                 adslAturSesLThreshTrap,
+                 adslAturUasLThreshTrap
+             }
+
+
+
+Ly & Bathrick               Standards Track                    [Page 30]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+             STATUS        current
+             DESCRIPTION
+                 "The collection of ADSL extension notifications."
+            ::= { adslExtGroups 6 }
+
+END
+
+7.  Acknowledgments
+
+   This document is a product of the ADSL MIB Working Group.
+
+8.  References
+
+8.1 Normative References
+
+   [ANSI T1.413]      American National Standards Institute, ANSI
+                      T1.413, Issue 2, "Standards Project for Interfaces
+                      Relating to Carrier to Customer Connection of ADSL
+                      Equipment", 1998.
+
+   [ETSI DTS/TM06006] European Telecommunications Standards Institute
+                      "ADSL European Specific Requirements", November
+                      2000.
+
+   [ITU G.992.1]      ITU-T Telecommunication Standardization Sector,
+                      "Asymmetric digital subscriber line (ADSL)
+                      transceivers", June 1999.
+
+   [ITU G.992.2]      ITU-T Telecommunication Standardization Sector,
+                      "Splitterless asymmetric digital subscriber line
+                      (ADSL) transceivers", June 1999.
+
+   [ITU G.997.1]      ITU-T Telecommunication Standardization Sector,
+                      "Physical Layer Management of Digital Subscriber
+                      Transceivers", June 1999.
+
+   [RFC2026]          Bradner S., "The Internet Standards Process -
+                      Revision 3", BCP 9, RFC 2026, October 1996.
+
+   [RFC2028]          Hovey R. and  S. Bradner, "The Organizations
+                      Involved in the IETF Standards Process", BCP 11,
+                      RFC 2028, October 1996.
+
+   [RFC2493]          Tesink, K., "Textual Conventions for MIB Modules
+                      Using Performance History Based on 15 Minute
+                      Intervals" RFC 2493, January 1999.
+
+
+
+
+
+Ly & Bathrick               Standards Track                    [Page 31]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+   [RFC2578]          McCloghrie, K., Perkins, D., Schoenwaelder, J.,
+                      Case, J., Rose, M. and S. Waldbusser, "Structure
+                      of Management Information Version 2 (SMIv2)", STD
+                      58, RFC 2578, April 1999.
+
+   [RFC2579]          McCloghrie, K., Perkins, D., Schoenwaelder, J.,
+                      Case, J., Rose, M. and S. Waldbusser, "Textual
+                      Conventions for SMIv2", STD 58, RFC 2579, April
+                      1999.
+
+   [RFC2580]          McCloghrie, K., Perkins, D., Schoenwaelder, J.,
+                      Case, J., Rose, M. and S. Waldbusser, "Conformance
+                      Statements for SMIv2", STD 58, RFC 2580, April
+                      1999.
+
+   [RFC2662]          Bathrick, G. and F. Ly, "Definitions of Managed
+                      Objects for the ADSL Lines", RFC 2662, May 1999.
+
+   [RFC2863]          McCloghrie, K. and F. Kastenholz, "The Interfaces
+                      Group MIB", RFC 2863, June 2000.
+
+   [RFC3414]          Blumenthal, U. and B. Wijnen, "User-based Security
+                      Model (USM) for version 3 of the Simple Network
+                      Management Protocol (SNMPv3)", STD 62, RFC 3414,
+                      December 2002.
+
+   [RFC3415]          Wijnen, B., Presuhn, R. and K. McCloghrie, "View-
+                      based Access Control Model (VACM) for the Simple
+                      Network Management Protocol (SNMP)", STD 62, RFC
+                      3415, December 2002.
+
+8.2 Informative References
+
+   [RFC3410]          Case, J., Mundy, R., Partain, D. and B. Stewart,
+                      "Introduction and Applicability Statements for
+                      Internet-Standard Management Framework", RFC 3410,
+                      December 2002.
+
+9.  Security Considerations
+
+   The following security matters should be considered when implementing
+   this MIB.
+
+   1) Blocking unauthorized access to the ADSL MIB via the element
+      management system is outside the scope of this document.  It
+      should be noted that access to the MIB permits the unauthorized
+      entity to modify the profiles (section 6.4) such that both
+      subscriber service and network operations can be interfered with.
+
+
+
+Ly & Bathrick               Standards Track                    [Page 32]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+      Subscriber service can be altered by modifying any of a number of
+      service characteristics such as rate partitioning and maximum
+      transmission rates.  Network operations can be impacted by
+      modifying notification thresholds such as Signal-to-Noise Ratio
+      (SNR) margins.
+
+   2) SNMPv1 by itself is such an insecure environment.  Even if the
+      network itself is secure (for example by using IPSec), there is no
+      control over who on the secure network is allowed to access and
+      GET (read) the objects in this MIB.  It is recommended that the
+      implementors consider the security features as provided by the
+      SNMPv3 framework.   Specifically, the use of the User-based
+      Security Model STD 62, RFC 3414 [RFC3414] and the View-based
+      Access Control Model STD 62, RFC 3415 [RFC3415] is recommended.
+
+      It is then a customer/user responsibility to ensure that the SNMP
+      entity giving access to an instance of this MIB, is properly
+      configured to give access to only those objects, and to those
+      principals (users) that have legitimate rights to access them.
+
+   3) The profile mechanism presented in this document requires specific
+      attention.  The implementor of this MIB has a choice of
+      implementing either 'static' or 'dynamic' profiles.  This decision
+      must be consistent with the implementation of RFC 2662.
+
+      In the case of 'static' profiles, the elements of the profile are
+      read-write, as opposed to read-create when 'dynamic' profiles are
+      implemented:
+
+         - adslConfProfileLineType,
+         - adslAtucThreshold15MinFailedFastR,
+         - adslAtucThreshold15MinSesL,
+         - adslAtucThreshold15MinUasL,
+         - adslAturThreshold15MinSesL, and
+         - adslAturThreshold15MinUasL.
+
+      This decision also impacts the mechanics of the index,
+      adslLineConfProfileDualLite.  When 'static' profiles are
+      implemented, its value is algorithmically set by the system and
+      its value is based on the ifIndex.  Hence it is not guaranteed
+      across system reboots.  Similar to the handling of
+      adslLineConfProfile [RFC2662], the implementor of this MIB must
+      ensure that the profile object values associated with these
+      indices are maintained across system reboots.
+
+
+
+
+
+
+
+Ly & Bathrick               Standards Track                    [Page 33]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+      In the case of dynamic profiles, this object is set by the SNMP
+      manager.  The implementor of this MIB may want to provide a view
+      of the profile on a customer-by-customer standpoint, but should be
+      cautious of the dynamic nature of these objects.
+
+      4) ADSL layer connectivity from the ATU-R will permit the
+      subscriber to manipulate both the ADSL link directly and the ADSL
+      overhead control channel(AOC)/embedded operations channel (EOC)
+      for their own loop.  For example,  unchecked or unfiltered
+      fluctuations initiated by the subscriber could generate sufficient
+      notifications to potentially overwhelm either the management
+      interface to the network or the element manager.  Other attacks
+      affecting the ATU-R portions of the MIB may also be possible.
+
+10. Intellectual Property Notice
+
+   The IETF takes no position regarding the validity or scope of any
+   intellectual property or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; neither does it represent that it
+   has made any effort to identify any such rights.  Information on the
+   IETF's procedures with respect to rights in standards-track and
+   standards-related documentation can be found in BCP-11 [RFC2028].
+   Copies of claims of rights made available for publication and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementors or users of this
+   specification can be obtained from the IETF Secretariat.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to practice
+   this standard.  Please address the information to the IETF Executive
+   Director.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ly & Bathrick               Standards Track                    [Page 34]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+11.  Authors' Addresses
+
+   Faye Ly
+   Pedestal Networks
+   6503 Dumbarton Circle,
+   Fremont, CA 94555
+
+   Phone: +1 510-578-0158
+   Fax:   +1 510-744-5152
+   EMail: faye@pedestalnetworks.com
+
+   Gregory Bathrick
+   Nokia Networks
+   2235 Mercury Way,
+   Santa Rosa, CA 95405
+
+   Phone: +1 707-362-1125
+   Fax:   +1 707-535-7300
+   EMail: greg.bathrick@nokia.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ly & Bathrick               Standards Track                    [Page 35]
+
+RFC 3440                ADSL Line Extension MIB            December 2002
+
+
+12.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (2002).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ly & Bathrick               Standards Track                    [Page 36]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc3440.txt](<www.ietf.org/rfc/rfc3440.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
