### PR TITLE
Archive rfc347.txt

### DIFF
--- a/www.ietf.org/rfc/rfc347.txt
+++ b/www.ietf.org/rfc/rfc347.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                           Jon Postel
+Request for Comments : 347                      Computer Science
+                                                UCLA-NMC
+NIC  10426                                      30 May 72
+
+Categories: Standard Processes
+
+
+                                Echo Process
+
+
+I suggest that for debugging and measurement purposes those hosts which
+are willing implement an "Echo" process.
+This echo process would listen for a request for connection and execute
+the Initial Connection Protocol (ICP) as specified in NIC 7104 the
+"Current Network Protocols" notebook.  Upon completion of the ICP the
+echo process would wait for data from the network.  When the data is
+received from the network it is echoed at once, (and the buffer space is
+re-allocated).  By echoed I mean that the data received is sent back
+over the network, bit for bit with no modification by the echo process.
+The echo process is terminated by closing the network connections.
+Note that BBN-TENEX has had such an echo process available for use for a
+long time.
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc347.txt](<www.ietf.org/rfc/rfc347.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
