### PR TITLE
Archive rfc348.txt

### DIFF
--- a/www.ietf.org/rfc/rfc348.txt
+++ b/www.ietf.org/rfc/rfc348.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                           Jon Postel
+Request for Comments : 348                      Computer Science
+                                                UCLA-NMC
+NIC : 10427                                     30 May 72
+
+Categories : Standard Processes
+
+
+
+                            Discard Process
+
+
+
+I suggest that for debugging and measurement purposes those hosts which
+are willing implement a "Discard" process.
+
+This discard process would listen for a request for connection and
+execute the Initial Connection Protocol (ICP) as specified in NIC 7104
+the "Current Network Protocols" notebook.  Upon completion of the ICP
+the discard process would wait for data from the network.  When data is
+received from the network it is discarded at once, (and the buffer space
+is re-allocated).  The discard process is terminated by closing the
+network connections.
+
+
+
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc348.txt](<www.ietf.org/rfc/rfc348.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
