### PR TITLE
Archive rfc349.txt

### DIFF
--- a/www.ietf.org/rfc/rfc349.txt
+++ b/www.ietf.org/rfc/rfc349.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                           Jon Postel
+Request for Comments : 349                      Computer Science
+                                                UCLA-NMC
+NIC : 10428                                     30 May 72
+
+Categories : Socket Numbers
+References : RFC's 322, 204
+
+
+                    Proposed Standard Socket Numbers
+
+I propose that there be a czar (me ?) who hands out official socket
+numbers for use by standard protocols.  This czar should also keep track
+of and publish a list of those socket numbers where host specific
+services can be obtained.  I further suggest that the initial allocation
+be as follows:
+        Sockets         Assignment
+        0-63            Network wide standard functions
+        64-127          Host specific functions
+        128-239         Reserved for future use
+        240-255         Any experimental function
+
+and within the network wide standard functions the following particular
+assignment be made:
+        Socket          Assignment
+           1            Telnet
+           3            File Transfer
+           5            Remote Job Entry
+           7            Echo
+           9            Discard
+
+these socket numbers (decimal) are to be used for the socket called "L"
+in the official Initial Connection protocol (ICP) as specified in NIC
+7104 the "Current Network Protocols" notebook.
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc349.txt](<www.ietf.org/rfc/rfc349.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
