### PR TITLE
Archive rfc350.txt

### DIFF
--- a/www.ietf.org/rfc/rfc350.txt
+++ b/www.ietf.org/rfc/rfc350.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+NWG/RFC# 350                                              R.M. Stoughton
+User Accounts for UCSB On-line System                     UCSB
+NIC 10549                                                 18-May-72
+
+        For the past year UCSB has provided free use of the UCSB
+        On-line System to Network sites.  Recharges for this
+        service are being paid for by the Computer Research Lab
+        with funds out of our current ARPA contract.  Connect
+        time for the month of April totaled 152 hours.
+
+        Presently, all users are running on the same account:
+        User Number=196, ID Code=57372, User Name=ARPA.  As
+        such, it is difficult to monitor the amount of use by
+        each site.  Consequently, we are changing the login
+        procedure for Network users, effective 1 June 72.
+
+        Commencing June 1, the new login parameters will be:
+
+           User Number=196
+           ID=57372
+           User Name=<site destination>
+           Job Name=<your name> (NIC ID will suffice).
+
+        The appropriate site designation is listed at the end of
+        this RFC for each affilliation presently connected to
+        the ARPA network.  Any site omitted from this list which
+        plans on running at UCSB should contact me at (805)
+        961-3793.
+
+        Network users of the UCSB On-line System are reminded
+        that these free accounts are provided for Network
+        experimentation.  We also encourage use of this service
+        on a casual basis inorder that users unfamiliar with the
+        Culler-Fried System may acquaint themselves with some of
+        the facilities available.  However, sites intending to
+        use the system on a production basis are requested to
+        open a private account to which computer charges can be
+        billed.
+
+        We will also continue to provide free remote batch
+        support on a limited basis.  Again, this service is
+        provided as a convenience to Network sites who are
+        attempting to implement and debug Network software.
+        Sites submitting production jobs will be expected to
+        open a Computer Center account and pay for computer
+        charges billed to that account.
+
+
+
+
+
+                                                                [Page 1]
+
+
+
+NWG/RFC# 350                                RMS 18-MAY-72 15:38  10549
+User Accounts for UCSB On-Line System
+
+              Affilliation     Network    Site Designation
+                               Address    (User Name)
+
+              AMES-67          16         AMES
+
+              AMES-ILLIAC      ?          AMES
+
+              AMES-TIP         144        AMES
+
+              BBN-NCC          5          BBN
+
+              BBN-TENEX        69         BBN
+
+              BBN-TENEXB       133        BBN
+
+              BBN-TESTIP       158        BBN
+
+              BURR             15         BURR
+
+              BURR-TEST        79         BURR
+
+              CASE-10          13         CASE
+
+              CMU-10           14         CMU
+
+              ETAC-TIP         148        ETAC
+
+              GWC-TIP          152        GWC
+
+              HARV-1           73         HARV
+
+              HARV-10          9          HARV
+
+              HARV-11          137        HARV
+
+              ILL-ANTS         12         ILL
+
+              ILL-CAC          76         ILL
+
+              LL-67            10         LL
+
+              LL-TSP           138        LL
+
+              LL-TX-2          74         LL
+
+              MCCL-418         22         MCCL
+
+              MIT-AI           134        MIT
+
+
+                                                                [Page 2]
+
+NWG/RFC# 350                                RMS 18-MAY-72 15:38  10549
+User Accounts for UCSB On-Line System
+
+              MIT-DMCG         70         MIT
+
+              MIT-MULTICS      6          MIT
+
+              MITRE-TIP        145        MITRE
+
+              NBS-CCST         19         NBS
+
+              NBS-TIP          147        NBS
+
+              NCAR-7600        25         NCAR
+
+              NCAR-TIP         153        NCAR
+
+              RADC-645         18         RADC
+
+              RADC-TIP         146        RADC
+
+              RAND-CSG         71         RAND
+
+              RAND-RCC         7          RAND
+
+              SDC-ADEPT        8          SDC
+
+              SRI-AI           66         SRI
+
+              SRI-ARC          2          SRI
+
+              SU-AI            11         SU
+
+              TINK-418         21         TINK
+
+              UCLA-CNN         65         UCLA
+
+              UCLA-NMC         1          UCLA
+
+              UCSB-75          3          UCSB
+
+              USC-44           23         USC
+
+              USC-TIP          151        USC
+
+              UTAH-1O          4          UTAH
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                   12/96   ]
+
+
+
+                                                                [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc350.txt](<www.ietf.org/rfc/rfc350.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
