### PR TITLE
Archive rfc351.txt

### DIFF
--- a/www.ietf.org/rfc/rfc351.txt
+++ b/www.ietf.org/rfc/rfc351.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                   David H. Crocker
+Request for Comments: 351                                           UCLA
+NIC 10593                                                    5 June 1972
+
+
+          (Graphics)Information form for the ARPANET Graphics
+                          Resources Notebook:
+
+   Attached is a questionnaire about the state of graphics resources at
+   your site.  As per the last Graphics Protocol Committee meeting, we
+   are attempting to compile such information for an ARPANET Graphics
+   Resources Notebook.
+
+   Please complete the form and return it as soon as possible,
+   preferably as a NIC Journal entry (making it easier for us to
+   manipulate the information) to Dave Crocker (Nic Ident: DHC).
+   Mailing address:
+
+      David Crocker
+      c/o Jon Postel
+      Computer Science Department
+      School of Engineering and Applied Science
+      3804 Boelter Hall
+      University of California
+      Los Angeles, California  90024
+
+   Name of organization and Host number(s):
+
+
+   Mailing address:
+
+
+   Local Graphics Experts (names & phone number):
+
+
+   Local graphics hardware:
+
+
+   Local graphics capabilities:
+
+
+   Limitations/Abilities over the NET (differences from local options):
+
+
+   Default conditions when entering over the NET:
+
+
+
+
+
+
+Crocker                                                         [Page 1]
+
+RFC 351         Info Form for ARPANET Graphics Resources       June 1972
+
+
+   Graphics routines available over the NET (please add explanations
+   about the advantages/appeal of the programs):
+
+
+   Logger & Pre-logger (Net connection(s), login, process-initiation
+   procedures, including all NET-specific actions):
+
+
+   Attention-getting ('escape') signals:
+
+   Graphics demonstration opportunities
+
+
+      Demo account number(s) or procedures:
+
+
+      Demo programs:
+
+
+   Interests & Capabilities:
+
+
+   Additional comments:
+
+
+
+
+
+
+         [ This RFC was put into machine readable form for entry ]
+           [ into the online RFC archives by Bob German 10/99 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Crocker                                                         [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc351.txt](<www.ietf.org/rfc/rfc351.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
