### PR TITLE
Archive rfc352.txt

### DIFF
--- a/www.ietf.org/rfc/rfc352.txt
+++ b/www.ietf.org/rfc/rfc352.txt
@@ -1,0 +1,165 @@
+
+
+
+
+
+
+NWG/RFC #352                                      David H. Crocker
+NIC 10594                                         UCLA
+                                                  5 June 1972
+
+                       TIP SITE INFORMATION FORM
+
+
+
+(tips) Information form about ARPANET TIPS:
+
+
+   We are attempting to provide additional information for TIP
+   users of the NET.  The availability of such information should
+   allow more flexibility to TIP users and thereby make NET use
+   easier.
+
+   Please complete the form and return it as soon as possible,
+   preferably as a NIC Journal entry (making it easier for us to
+   manipulate the information) to Dave Crocker (Nic ident: DHC).
+   Mailing address:
+
+      David Crocker
+      c/o Jon Postel
+      Computer Science Department
+      School of Engineering and Applied Science
+      3804 Boelter Hall
+      University of California
+      Los Angeles, California 90024
+
+
+
+
+
+
+
+
+
+    [ This RFC was put into machine readable form for entry ]
+    [ into the online RFC archives by BBN Corp. under the   ]
+    [ direction of Alex McKenzie.                      1/97 ]
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+
+NWG/RFC# 352                            DHC 5-JUN-72 16:11  10594
+TIP site information form
+
+   Name of organization & pseudo-host number:
+
+
+   Regular Host computer(s) associated with the same
+   organization:
+
+
+   Mailing address of organization:
+
+
+   Local person responsible for TIP operations:
+
+      Name:
+
+
+      Telephone:
+
+
+      Alternate person(s):
+
+
+   Operator (if any)
+
+      Name(s):
+
+
+      Hours of operator coverage:
+
+
+      Telephone:
+
+
+      Thru the NET:
+
+
+   TIP options & special features:
+
+      Mag tape / /      Printer / /       Card reader / /
+
+
+      other: -------------------------------------------
+
+
+   Scheduled down-time:
+
+
+
+
+                                                                [Page 2]
+
+NWG/RFC# 352                            DHC 5-JUN-72 16:11  10594
+TIP site information form
+
+
+
+   Additional comments:
+
+
+
+
+
+
+   Ports:
+
+
+      TIP address       Terminal-type or dial-up phone number:
+      (port num.)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc352.txt](<www.ietf.org/rfc/rfc352.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
