### PR TITLE
Archive rfc3526.txt

### DIFF
--- a/www.ietf.org/rfc/rfc3526.txt
+++ b/www.ietf.org/rfc/rfc3526.txt
@@ -1,0 +1,563 @@
+
+
+
+
+
+
+Network Working Group                                         T. Kivinen
+Request for Comments: 3526                                       M. Kojo
+Category: Standards Track                    SSH Communications Security
+                                                                May 2003
+
+
+         More Modular Exponential (MODP) Diffie-Hellman groups
+                    for Internet Key Exchange (IKE)
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2003).  All Rights Reserved.
+
+Abstract
+
+   This document defines new Modular Exponential (MODP) Groups for the
+   Internet Key Exchange (IKE) protocol.  It documents the well known
+   and used 1536 bit group 5, and also defines new 2048, 3072, 4096,
+   6144, and 8192 bit Diffie-Hellman groups numbered starting at 14.
+   The selection of the primes for theses groups follows the criteria
+   established by Richard Schroeppel.
+
+Table of Contents
+
+   1.   Introduction. . . . . . . . . . . . . . . . . . . . . . .  2
+   2.   1536-bit MODP Group . . . . . . . . . . . . . . . . . . .  3
+   3.   2048-bit MODP Group . . . . . . . . . . . . . . . . . . .  3
+   4.   3072-bit MODP Group . . . . . . . . . . . . . . . . . . .  4
+   5.   4096-bit MODP Group . . . . . . . . . . . . . . . . . . .  5
+   6.   6144-bit MODP Group . . . . . . . . . . . . . . . . . . .  6
+   7.   8192-bit MODP Group . . . . . . . . . . . . . . . . . . .  6
+   8.   Security Considerations . . . . . . . . . . . . . . . . .  8
+   9.   IANA Considerations . . . . . . . . . . . . . . . . . . .  8
+   10.  Normative References. . . . . . . . . . . . . . . . . . .  8
+   11.  Non-Normative References. . . . . . . . . . . . . . . . .  8
+   12.  Authors' Addresses  . . . . . . . . . . . . . . . . . . .  9
+   13.  Full Copyright Statement. . . . . . . . . . . . . . . . . 10
+
+
+
+
+
+
+Kivinen & Kojo              Standards Track                     [Page 1]
+
+RFC 3526           MODP Diffie-Hellman groups for IKE           May 2003
+
+
+1.  Introduction
+
+   One of the important protocol parameters negotiated by Internet Key
+   Exchange (IKE) [RFC-2409] is the Diffie-Hellman "group" that will be
+   used for certain cryptographic operations.  IKE currently defines 4
+   groups.  These groups are approximately as strong as a symmetric key
+   of 70-80 bits.
+
+   The new Advanced Encryption Standard (AES) cipher [AES], which has
+   more strength, needs stronger groups.  For the 128-bit AES we need
+   about a 3200-bit group [Orman01].  The 192 and 256-bit keys would
+   need groups that are about 8000 and 15400 bits respectively.  Another
+   source [RSA13] [Rousseau00] estimates that the security equivalent
+   key size for the 192-bit symmetric cipher is 2500 bits instead of
+   8000 bits, and the equivalent key size 256-bit symmetric cipher is
+   4200 bits instead of 15400 bits.
+
+   Because of this disagreement, we just specify different groups
+   without specifying which group should be used with 128, 192 or 256-
+   bit AES.  With current hardware groups bigger than 8192-bits being
+   too slow for practical use, this document does not provide any groups
+   bigger than 8192-bits.
+
+   The exponent size used in the Diffie-Hellman must be selected so that
+   it matches other parts of the system.  It should not be the weakest
+   link in the security system.  It should have double the entropy of
+   the strength of the entire system, i.e., if you use a group whose
+   strength is 128 bits, you must use more than 256 bits of randomness
+   in the exponent used in the Diffie-Hellman calculation.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kivinen & Kojo              Standards Track                     [Page 2]
+
+RFC 3526           MODP Diffie-Hellman groups for IKE           May 2003
+
+
+2.  1536-bit MODP Group
+
+   The 1536 bit MODP group has been used for the implementations for
+   quite a long time, but was not defined in RFC 2409 (IKE).
+   Implementations have been using group 5 to designate this group, we
+   standardize that practice here.
+
+   The prime is: 2^1536 - 2^1472 - 1 + 2^64 * { [2^1406 pi] + 741804 }
+
+   Its hexadecimal value is:
+
+      FFFFFFFF FFFFFFFF C90FDAA2 2168C234 C4C6628B 80DC1CD1
+      29024E08 8A67CC74 020BBEA6 3B139B22 514A0879 8E3404DD
+      EF9519B3 CD3A431B 302B0A6D F25F1437 4FE1356D 6D51C245
+      E485B576 625E7EC6 F44C42E9 A637ED6B 0BFF5CB6 F406B7ED
+      EE386BFB 5A899FA5 AE9F2411 7C4B1FE6 49286651 ECE45B3D
+      C2007CB8 A163BF05 98DA4836 1C55D39A 69163FA8 FD24CF5F
+      83655D23 DCA3AD96 1C62F356 208552BB 9ED52907 7096966D
+      670C354E 4ABC9804 F1746C08 CA237327 FFFFFFFF FFFFFFFF
+
+   The generator is: 2.
+
+3.  2048-bit MODP Group
+
+   This group is assigned id 14.
+
+   This prime is: 2^2048 - 2^1984 - 1 + 2^64 * { [2^1918 pi] + 124476 }
+
+   Its hexadecimal value is:
+
+      FFFFFFFF FFFFFFFF C90FDAA2 2168C234 C4C6628B 80DC1CD1
+      29024E08 8A67CC74 020BBEA6 3B139B22 514A0879 8E3404DD
+      EF9519B3 CD3A431B 302B0A6D F25F1437 4FE1356D 6D51C245
+      E485B576 625E7EC6 F44C42E9 A637ED6B 0BFF5CB6 F406B7ED
+      EE386BFB 5A899FA5 AE9F2411 7C4B1FE6 49286651 ECE45B3D
+      C2007CB8 A163BF05 98DA4836 1C55D39A 69163FA8 FD24CF5F
+      83655D23 DCA3AD96 1C62F356 208552BB 9ED52907 7096966D
+      670C354E 4ABC9804 F1746C08 CA18217C 32905E46 2E36CE3B
+      E39E772C 180E8603 9B2783A2 EC07A28F B5C55DF0 6F4C52C9
+      DE2BCBF6 95581718 3995497C EA956AE5 15D22618 98FA0510
+      15728E5A 8AACAA68 FFFFFFFF FFFFFFFF
+
+   The generator is: 2.
+
+
+
+
+
+
+
+
+Kivinen & Kojo              Standards Track                     [Page 3]
+
+RFC 3526           MODP Diffie-Hellman groups for IKE           May 2003
+
+
+4.  3072-bit MODP Group
+
+   This group is assigned id 15.
+
+   This prime is: 2^3072 - 2^3008 - 1 + 2^64 * { [2^2942 pi] + 1690314 }
+
+   Its hexadecimal value is:
+
+      FFFFFFFF FFFFFFFF C90FDAA2 2168C234 C4C6628B 80DC1CD1
+      29024E08 8A67CC74 020BBEA6 3B139B22 514A0879 8E3404DD
+      EF9519B3 CD3A431B 302B0A6D F25F1437 4FE1356D 6D51C245
+      E485B576 625E7EC6 F44C42E9 A637ED6B 0BFF5CB6 F406B7ED
+      EE386BFB 5A899FA5 AE9F2411 7C4B1FE6 49286651 ECE45B3D
+      C2007CB8 A163BF05 98DA4836 1C55D39A 69163FA8 FD24CF5F
+      83655D23 DCA3AD96 1C62F356 208552BB 9ED52907 7096966D
+      670C354E 4ABC9804 F1746C08 CA18217C 32905E46 2E36CE3B
+      E39E772C 180E8603 9B2783A2 EC07A28F B5C55DF0 6F4C52C9
+      DE2BCBF6 95581718 3995497C EA956AE5 15D22618 98FA0510
+      15728E5A 8AAAC42D AD33170D 04507A33 A85521AB DF1CBA64
+      ECFB8504 58DBEF0A 8AEA7157 5D060C7D B3970F85 A6E1E4C7
+      ABF5AE8C DB0933D7 1E8C94E0 4A25619D CEE3D226 1AD2EE6B
+      F12FFA06 D98A0864 D8760273 3EC86A64 521F2B18 177B200C
+      BBE11757 7A615D6C 770988C0 BAD946E2 08E24FA0 74E5AB31
+      43DB5BFC E0FD108E 4B82D120 A93AD2CA FFFFFFFF FFFFFFFF
+
+   The generator is: 2.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kivinen & Kojo              Standards Track                     [Page 4]
+
+RFC 3526           MODP Diffie-Hellman groups for IKE           May 2003
+
+
+5.  4096-bit MODP Group
+
+   This group is assigned id 16.
+
+   This prime is: 2^4096 - 2^4032 - 1 + 2^64 * { [2^3966 pi] + 240904 }
+
+   Its hexadecimal value is:
+
+      FFFFFFFF FFFFFFFF C90FDAA2 2168C234 C4C6628B 80DC1CD1
+      29024E08 8A67CC74 020BBEA6 3B139B22 514A0879 8E3404DD
+      EF9519B3 CD3A431B 302B0A6D F25F1437 4FE1356D 6D51C245
+      E485B576 625E7EC6 F44C42E9 A637ED6B 0BFF5CB6 F406B7ED
+      EE386BFB 5A899FA5 AE9F2411 7C4B1FE6 49286651 ECE45B3D
+      C2007CB8 A163BF05 98DA4836 1C55D39A 69163FA8 FD24CF5F
+      83655D23 DCA3AD96 1C62F356 208552BB 9ED52907 7096966D
+      670C354E 4ABC9804 F1746C08 CA18217C 32905E46 2E36CE3B
+      E39E772C 180E8603 9B2783A2 EC07A28F B5C55DF0 6F4C52C9
+      DE2BCBF6 95581718 3995497C EA956AE5 15D22618 98FA0510
+      15728E5A 8AAAC42D AD33170D 04507A33 A85521AB DF1CBA64
+      ECFB8504 58DBEF0A 8AEA7157 5D060C7D B3970F85 A6E1E4C7
+      ABF5AE8C DB0933D7 1E8C94E0 4A25619D CEE3D226 1AD2EE6B
+      F12FFA06 D98A0864 D8760273 3EC86A64 521F2B18 177B200C
+      BBE11757 7A615D6C 770988C0 BAD946E2 08E24FA0 74E5AB31
+      43DB5BFC E0FD108E 4B82D120 A9210801 1A723C12 A787E6D7
+      88719A10 BDBA5B26 99C32718 6AF4E23C 1A946834 B6150BDA
+      2583E9CA 2AD44CE8 DBBBC2DB 04DE8EF9 2E8EFC14 1FBECAA6
+      287C5947 4E6BC05D 99B2964F A090C3A2 233BA186 515BE7ED
+      1F612970 CEE2D7AF B81BDD76 2170481C D0069127 D5B05AA9
+      93B4EA98 8D8FDDC1 86FFB7DC 90A6C08F 4DF435C9 34063199
+      FFFFFFFF FFFFFFFF
+
+   The generator is: 2.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kivinen & Kojo              Standards Track                     [Page 5]
+
+RFC 3526           MODP Diffie-Hellman groups for IKE           May 2003
+
+
+6.  6144-bit MODP Group
+
+   This group is assigned id 17.
+
+   This prime is: 2^6144 - 2^6080 - 1 + 2^64 * { [2^6014 pi] + 929484 }
+
+   Its hexadecimal value is:
+
+   FFFFFFFF FFFFFFFF C90FDAA2 2168C234 C4C6628B 80DC1CD1 29024E08
+   8A67CC74 020BBEA6 3B139B22 514A0879 8E3404DD EF9519B3 CD3A431B
+   302B0A6D F25F1437 4FE1356D 6D51C245 E485B576 625E7EC6 F44C42E9
+   A637ED6B 0BFF5CB6 F406B7ED EE386BFB 5A899FA5 AE9F2411 7C4B1FE6
+   49286651 ECE45B3D C2007CB8 A163BF05 98DA4836 1C55D39A 69163FA8
+   FD24CF5F 83655D23 DCA3AD96 1C62F356 208552BB 9ED52907 7096966D
+   670C354E 4ABC9804 F1746C08 CA18217C 32905E46 2E36CE3B E39E772C
+   180E8603 9B2783A2 EC07A28F B5C55DF0 6F4C52C9 DE2BCBF6 95581718
+   3995497C EA956AE5 15D22618 98FA0510 15728E5A 8AAAC42D AD33170D
+   04507A33 A85521AB DF1CBA64 ECFB8504 58DBEF0A 8AEA7157 5D060C7D
+   B3970F85 A6E1E4C7 ABF5AE8C DB0933D7 1E8C94E0 4A25619D CEE3D226
+   1AD2EE6B F12FFA06 D98A0864 D8760273 3EC86A64 521F2B18 177B200C
+   BBE11757 7A615D6C 770988C0 BAD946E2 08E24FA0 74E5AB31 43DB5BFC
+   E0FD108E 4B82D120 A9210801 1A723C12 A787E6D7 88719A10 BDBA5B26
+   99C32718 6AF4E23C 1A946834 B6150BDA 2583E9CA 2AD44CE8 DBBBC2DB
+   04DE8EF9 2E8EFC14 1FBECAA6 287C5947 4E6BC05D 99B2964F A090C3A2
+   233BA186 515BE7ED 1F612970 CEE2D7AF B81BDD76 2170481C D0069127
+   D5B05AA9 93B4EA98 8D8FDDC1 86FFB7DC 90A6C08F 4DF435C9 34028492
+   36C3FAB4 D27C7026 C1D4DCB2 602646DE C9751E76 3DBA37BD F8FF9406
+   AD9E530E E5DB382F 413001AE B06A53ED 9027D831 179727B0 865A8918
+   DA3EDBEB CF9B14ED 44CE6CBA CED4BB1B DB7F1447 E6CC254B 33205151
+   2BD7AF42 6FB8F401 378CD2BF 5983CA01 C64B92EC F032EA15 D1721D03
+   F482D7CE 6E74FEF6 D55E702F 46980C82 B5A84031 900B1C9E 59E7C97F
+   BEC7E8F3 23A97A7E 36CC88BE 0F1D45B7 FF585AC5 4BD407B2 2B4154AA
+   CC8F6D7E BF48E1D8 14CC5ED2 0F8037E0 A79715EE F29BE328 06A1D58B
+   B7C5DA76 F550AA3D 8A1FBFF0 EB19CCB1 A313D55C DA56C9EC 2EF29632
+   387FE8D7 6E3C0468 043E8F66 3F4860EE 12BF2D5B 0B7474D6 E694F91E
+   6DCC4024 FFFFFFFF FFFFFFFF
+
+   The generator is: 2.
+
+7.  8192-bit MODP Group
+
+   This group is assigned id 18.
+
+   This prime is: 2^8192 - 2^8128 - 1 + 2^64 * { [2^8062 pi] + 4743158 }
+
+
+
+
+
+
+
+Kivinen & Kojo              Standards Track                     [Page 6]
+
+RFC 3526           MODP Diffie-Hellman groups for IKE           May 2003
+
+
+   Its hexadecimal value is:
+
+      FFFFFFFF FFFFFFFF C90FDAA2 2168C234 C4C6628B 80DC1CD1
+      29024E08 8A67CC74 020BBEA6 3B139B22 514A0879 8E3404DD
+      EF9519B3 CD3A431B 302B0A6D F25F1437 4FE1356D 6D51C245
+      E485B576 625E7EC6 F44C42E9 A637ED6B 0BFF5CB6 F406B7ED
+      EE386BFB 5A899FA5 AE9F2411 7C4B1FE6 49286651 ECE45B3D
+      C2007CB8 A163BF05 98DA4836 1C55D39A 69163FA8 FD24CF5F
+      83655D23 DCA3AD96 1C62F356 208552BB 9ED52907 7096966D
+      670C354E 4ABC9804 F1746C08 CA18217C 32905E46 2E36CE3B
+      E39E772C 180E8603 9B2783A2 EC07A28F B5C55DF0 6F4C52C9
+      DE2BCBF6 95581718 3995497C EA956AE5 15D22618 98FA0510
+      15728E5A 8AAAC42D AD33170D 04507A33 A85521AB DF1CBA64
+      ECFB8504 58DBEF0A 8AEA7157 5D060C7D B3970F85 A6E1E4C7
+      ABF5AE8C DB0933D7 1E8C94E0 4A25619D CEE3D226 1AD2EE6B
+      F12FFA06 D98A0864 D8760273 3EC86A64 521F2B18 177B200C
+      BBE11757 7A615D6C 770988C0 BAD946E2 08E24FA0 74E5AB31
+      43DB5BFC E0FD108E 4B82D120 A9210801 1A723C12 A787E6D7
+      88719A10 BDBA5B26 99C32718 6AF4E23C 1A946834 B6150BDA
+      2583E9CA 2AD44CE8 DBBBC2DB 04DE8EF9 2E8EFC14 1FBECAA6
+      287C5947 4E6BC05D 99B2964F A090C3A2 233BA186 515BE7ED
+      1F612970 CEE2D7AF B81BDD76 2170481C D0069127 D5B05AA9
+      93B4EA98 8D8FDDC1 86FFB7DC 90A6C08F 4DF435C9 34028492
+      36C3FAB4 D27C7026 C1D4DCB2 602646DE C9751E76 3DBA37BD
+      F8FF9406 AD9E530E E5DB382F 413001AE B06A53ED 9027D831
+      179727B0 865A8918 DA3EDBEB CF9B14ED 44CE6CBA CED4BB1B
+      DB7F1447 E6CC254B 33205151 2BD7AF42 6FB8F401 378CD2BF
+      5983CA01 C64B92EC F032EA15 D1721D03 F482D7CE 6E74FEF6
+      D55E702F 46980C82 B5A84031 900B1C9E 59E7C97F BEC7E8F3
+      23A97A7E 36CC88BE 0F1D45B7 FF585AC5 4BD407B2 2B4154AA
+      CC8F6D7E BF48E1D8 14CC5ED2 0F8037E0 A79715EE F29BE328
+      06A1D58B B7C5DA76 F550AA3D 8A1FBFF0 EB19CCB1 A313D55C
+      DA56C9EC 2EF29632 387FE8D7 6E3C0468 043E8F66 3F4860EE
+      12BF2D5B 0B7474D6 E694F91E 6DBE1159 74A3926F 12FEE5E4
+      38777CB6 A932DF8C D8BEC4D0 73B931BA 3BC832B6 8D9DD300
+      741FA7BF 8AFC47ED 2576F693 6BA42466 3AAB639C 5AE4F568
+      3423B474 2BF1C978 238F16CB E39D652D E3FDB8BE FC848AD9
+      22222E04 A4037C07 13EB57A8 1A23F0C7 3473FC64 6CEA306B
+      4BCBC886 2F8385DD FA9D4B7F A2C087E8 79683303 ED5BDD3A
+      062B3CF5 B3A278A6 6D2A13F8 3F44F82D DF310EE0 74AB6A36
+      4597E899 A0255DC1 64F31CC5 0846851D F9AB4819 5DED7EA1
+      B1D510BD 7EE74D73 FAF36BC3 1ECFA268 359046F4 EB879F92
+      4009438B 481C6CD7 889A002E D5EE382B C9190DA6 FC026E47
+      9558E447 5677E9AA 9E3050E2 765694DF C81F56E8 80B96E71
+      60C980DD 98EDD3DF FFFFFFFF FFFFFFFF
+
+   The generator is: 2.
+
+
+
+
+Kivinen & Kojo              Standards Track                     [Page 7]
+
+RFC 3526           MODP Diffie-Hellman groups for IKE           May 2003
+
+
+8.  Security Considerations
+
+   This document describes new stronger groups to be used in IKE.  The
+   strengths of the groups defined here are always estimates and there
+   are as many methods to estimate them as there are cryptographers.
+   For the strength estimates below we took the both ends of the scale
+   so the actual strength estimate is likely between the two numbers
+   given here.
+
+   +--------+----------+---------------------+---------------------+
+   | Group  | Modulus  | Strength Estimate 1 | Strength Estimate 2 |
+   |        |          +----------+----------+----------+----------+
+   |        |          |          | exponent |          | exponent |
+   |        |          | in bits  | size     | in bits  | size     |
+   +--------+----------+----------+----------+----------+----------+
+   |   5    | 1536-bit |       90 |     180- |      120 |     240- |
+   |  14    | 2048-bit |      110 |     220- |      160 |     320- |
+   |  15    | 3072-bit |      130 |     260- |      210 |     420- |
+   |  16    | 4096-bit |      150 |     300- |      240 |     480- |
+   |  17    | 6144-bit |      170 |     340- |      270 |     540- |
+   |  18    | 8192-bit |      190 |     380- |      310 |     620- |
+   +--------+----------+---------------------+---------------------+
+
+9.  IANA Considerations
+
+   IKE [RFC-2409] defines 4 Diffie-Hellman Groups, numbered 1 through 4.
+
+   This document defines a new group 5, and new groups from 14 to 18.
+   Requests for additional assignment are via "IETF Consensus" as
+   defined in RFC 2434 [RFC-2434].  Specifically, new groups are
+   expected to be documented in a Standards Track RFC.
+
+10.  Normative References
+
+   [RFC-2409]   Harkins, D. and D. Carrel, "The Internet Key Exchange
+                (IKE)", RFC 2409, November 1998.
+
+   [RFC-2434]   Narten, T. and H. Alvestrand, "Guidelines for Writing an
+                IANA Considerations Section in RFCs", BCP 26, RFC 2434,
+                October 1998.
+
+11.  Non-Normative References
+
+   [AES]        NIST, FIPS PUB 197, "Advanced Encryption Standard
+                (AES)," November 2001.
+                http://csrc.nist.gov/publications/fips/fips197/fips-
+                197.{ps,pdf}
+
+
+
+
+Kivinen & Kojo              Standards Track                     [Page 8]
+
+RFC 3526           MODP Diffie-Hellman groups for IKE           May 2003
+
+
+   [RFC-2412]   Orman, H., "The OAKLEY Key Determination Protocol", RFC
+                2412, November 1998.
+
+   [Orman01]    Orman, H. and P. Hoffman, "Determining Strengths For
+                Public Keys Used For Exchanging Symmetric Keys", Work in
+                progress.
+
+   [RSA13]      Silverman, R. "RSA Bulleting #13: A Cost-Based Security
+                Analysis of Symmetric and Asymmetric Key Lengths", April
+                2000, http://www.rsasecurity.com/rsalabs/bulletins/
+                bulletin13.html
+
+   [Rousseau00] Rousseau, F. "New Time and Space Based Key Size
+                Equivalents for RSA and Diffie-Hellman", December 2000,
+                http://www.sandelman.ottawa.on.ca/ipsec/2000/12/
+                msg00045.html
+
+12.  Authors' Addresses
+
+   Tero Kivinen
+   SSH Communications Security Corp
+   Fredrikinkatu 42
+   FIN-00100 HELSINKI
+   Finland
+
+   EMail: kivinen@ssh.fi
+
+
+   Mika Kojo
+   HELSINKI
+   Finland
+
+   EMail: mika.kojo@helsinki.fi
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kivinen & Kojo              Standards Track                     [Page 9]
+
+RFC 3526           MODP Diffie-Hellman groups for IKE           May 2003
+
+
+13.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (2003).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kivinen & Kojo              Standards Track                    [Page 10]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc3526.txt](<www.ietf.org/rfc/rfc3526.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
