### PR TITLE
Archive rfc353.txt

### DIFF
--- a/www.ietf.org/rfc/rfc353.txt
+++ b/www.ietf.org/rfc/rfc353.txt
@@ -1,0 +1,283 @@
+
+
+
+
+
+
+Network Working Group                                   Ellen Westheimer
+Request for Comments: 353                                            BBN
+NIC #10595                                                  12 June 1972
+Categories:  F, G.3
+Updates: RFC #344
+Obsoletes: None
+
+
+                          NETWORK HOST STATUS
+
+   This RFC reports on the status of most Network Hosts from May 22 to
+   June 2.
+
+   No testing was done on Memorial Day, which Massachusetts celebrated
+   on May 29.  No testing was done on May 31 and June 1 due to an
+   attempt to install the new IMP system.
+
+   Three new terminal IMPs were installed during this interval.  On June
+   1, Terminal IMP #155 was installed at Fort Belvoir in Fairfax,
+   Virginia; on June 3, Terminal IMP #154 was installed at SAAC (Seismic
+   Array Analysis Center) in Alexandria, Virginia; and on June 5,
+   Terminal IMP #153 was installed at NOAA (National Oceanic Analysis
+   Agency) in Boulder, Colorado.
+
+   Several Hosts are currently excluded from the daily testing.  These
+   Hosts fall into two categories:
+
+    1) Hosts which are not expected to be functioning on the Network as
+       servers (available for use from other sites) on a regular basis
+       for at least two weeks.  The only Host in this category is the
+       PDP-10 at Case (Network address 13).
+
+      2) Hosts which are currently intended to be users only.  Included
+       here are the Terminal IMPs, which are presently in the Network
+       (AMES, MITRE, NBS, ETAC, USC, GWC, NOAA, SAAC, BELVOIR, and
+       BBN*).  This category also includes the Network Control Center
+
+
+
+
+
+   ___________
+   *The BBN Terminal IMP (Network Address 158) is a prototype and as
+   such is frequently not connected to the Network, but being used
+   to refine and debug the Terminal IMP programs.
+
+
+
+
+
+
+Westheimer                                                      [Page 1]
+
+RFC 353                   NETWORK HOST STATUS                  June 1972
+
+
+   computer (Network address 5) which is used solely for gathering
+   statistics from the Network.  Finally, included among these Hosts are
+   the following:
+
+         Network
+         Address               Site                Computer
+         -------               ----                --------
+             7               Rand                  IBM-360/65
+            73               Harvard               PDP-1
+            12               Illinois              PDP-11
+            19               NBS                   PDP-11
+            23               USC                   IBM-360/44
+
+   The tables on the next two pages summarize the Host status for this
+   period.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Westheimer                                                      [Page 2]
+
+RFC 353                   NETWORK HOST STATUS                  June 1972
+
+
+                                                        STATUS OR
+ SITE                                                   PREDICTIONS
+ADDRESS SITE          COMPUTER    STATUS OR PREDICTION  OBTAINED FROM
+
+   1    UCLA          SIGMA-7     Server #Limited       Jon Postel
+  65    UCLA          IBM-360/91  NETRJS now            Bob Braden
+                                  (Telnet in June)
+   2    SRI (NIC)     PDP-10      Server                Jim White
+  66    SRI (AI)      PDP-10      Server                Len Chaiten
+   3    UCSB          IBM-360/75  Server                Ron Stoughton
+   4    UTAH          PDP-10      Server                Barry Wessler
+  *5    BBN (NCC)     DDP-516     Never                 Alex McKenzie
+  69    BBN (TENEX-A) PDP-10      Server                Dan Murphy
+ 133    BBN (TENEX-B) PDP-10      Server (Exper.)       Dan Murphy
+   6    MIT (Multics) H-645       Server                Mike Padlipsky
+  70    MIT (DM)      PDP-10      Server                Bob Bressler
+ 134    MIT (AI)      PDP-10      Server                Jeff Rubin
+  *7    RAND          IBM-360/65  User Only             Eric Harslem
+  71    RAND          PDP-10      Server                Eric Harslem
+   8    SDC           IBM-370/155 Server                Bob Long
+   9    HARVARD       PDP-10      Server                Bob Sundberg
+ *73    HARVARD       PDP-1       User Only             Bob Sundberg
+  10    LINCOLN       IBM-360/67  "Soon"                Joel Winett
+  74    LINCOLN       TX-2        Server                Will Kantrowitz
+  11    STANFORD      PDP-10      Server                Andy Moorer
+ *12    ILLINOIS      PDP-11      User Only             John Cravitz
+ *13    CASE          PDP-10      June                  Charles Rose
+  14    CARNEGIE      PDP-10      Server                Hal VanZoeren
+  15    AMES          ILLIAC      Server                John McConnell
+                      (B6500)
+  16    AMES          IBM-360/67  "Soon"                Wayne Hathaway
+*144    AMES          TIP         User Only
+*145    MITRE         TIP         User Only
+ *19    NBS           PDP-11      User Only             Robert Rosenthal
+*147    NBS           TIP         User Only
+*148    ETAC          TIP         User Only
+ *23    USC           IBM-360/44  User Now              James Pepin
+*151    USC           TIP         User Only
+*152    GWC           TIP         User Only
+*153    NOAA          TIP         User Only
+*154    SAAC          TIP         User Only
+*155    BELVOIR       TIP         User Only
+*158    BBN           TIP         User Only
+                      (Prototype)
+_________
+*Host not included in daily testing
+#The NMC is a research site and would like to have prior arrangement
+with each user.
+
+
+
+Westheimer                                                      [Page 3]
+
+RFC 353                   NETWORK HOST STATUS                  June 1972
+
+
+   NO.   SITE                   DATE AND TIME (EASTERN)
+   ---   ----             5/22  5/23  5/24  5/25  5/26  5/30  6/2
+                          1700  1800  1300  1300  1600  1430  1300
+     1   UCLA-NMC           O     O     T     D     D     O     D
+    65   UCLA-CCN*          O     O     O     O     D     O     D
+     2   SRI-ARC            O     O     O     O     O     O     O
+    66   SRI-AI             O     D     O     D     D     D     D
+     3   UCSB-MOD75         O     O     D     O     O     O     O
+     4   UTAH-10            O     O     O     O     O     D     D
+    69   BBN-TENEX          D     O     O     O     O     O     O
+   133   BBN-TENEXB         O     O     O     O    #T     O    #D
+     6   MIT-MULTICS        D     O     O     O     O     O     O
+    70   MIT-DMCG           O     H     O     O     O     O     O
+   134   MIT-AI             D     T     D     D     T     H     H
+    71   RAND-CSG           D     D     D     D     O     D     O
+     8   SDC-ADEPT          H     D    #D    #D     H    #D    #D
+     9   HARVARD-10         O     O     O     O     O     O     O
+    10   L.L.-360           D     D     D     H     H     H     H
+    74   L.L.-TX-2          O     O    #D     D     D     O     O
+    11   STANFORD-AI        O     O     O     H     O     D     D
+    14   CMU-10             D     O     D     O     O     O     O
+    15   AMES-ILLIAC        T     T     T     T     T     T     T
+    16   AMES-67            D     T     D     D     D     D     D
+
+   where
+   D = Dead (Destination Host either dead or inaccessible [due to
+       network partitioning or local IMP failure] from the BBN Terminal
+       IMP.)
+   F = Full (Destination Host opened a connection, informed user that
+       all Network ports were in use, and immediately closed the
+       connection.)
+   H = 1/2 Open (Destination Host opened a connection but then either
+       immediately closed it, or did not respond any further.)
+   O = Open (Destination opened a connection and was accessible to us.
+   R = Refused (Destination Host returned a CLS to the initial RFC.)
+   T = Timed out (Destination Host did not complete the ICP and open a
+       connection within 60 seconds.)
+   __________
+   *The only service currently offered by the UCLA IBM-360/91 is a Network
+   Job Service (NETRJS), however, the BBN Terminal IMP is not equipped to
+   test NETRJS.  We are assuming that initial connection to the NETRJS
+   logger indicates that NETRJS is also functioning.
+
+   #These sites advertise that they may not have their system available at
+   these times.
+
+            [ This RFC was put into machine readable form for entry ]
+              [ into the online RFC archives by Bob German 10/99 ]
+
+
+
+Westheimer                                                      [Page 4]
+
+RFC 353                   NETWORK HOST STATUS                  June 1972
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Westheimer                                                      [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc353.txt](<www.ietf.org/rfc/rfc353.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
