### PR TITLE
Archive rfc356.txt

### DIFF
--- a/www.ietf.org/rfc/rfc356.txt
+++ b/www.ietf.org/rfc/rfc356.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                 R. Alter
+Request for Comments # 356            Bolt Beranek and Newman Inc.
+NIC # 10598                           June 21, 1972
+Categories:
+Updates:
+Obsoletes:
+
+                      ARPA NETWORK CONTROL CENTER
+
+1.  Schedule
+    --------
+The NCC operations staff has recently been augmented so that the NCC
+is now manned 24 hours per day, 7 days per week. Please be sure to
+contact the NCC in case of any IMP/TIP or Network problems, at any
+time of the day or night.
+
+2.  NCC Phone Number
+    ----------------
+In the past we have been informed that persons trying to reach the NCC
+have occasionally received busy signals.  In an effort to change that,
+we have installed a new set of phone numbers for the NCC.  The new
+phone number for the Network Control Center is (617) 661-0100. Please
+post this new phone number prominently near IMPs and inform all
+concerned parties of this new phone number.  (The old phone number
+will also continue to operate, for a while.)
+
+Hereafter, if you receive a busy signal (please distinguish from the
+"fast busy signal", meaning "busy circuits"), then please persist, but
+also please be sure to inform the operator when you do reach him of
+the the fact that you received a busy signal.
+
+3.  Mail to the NCC should be addressed to:
+    --------------------------------------
+
+                   ARPA Network Control Center
+                   c/o Bolt Beranek and Newman Inc.
+                   50 Moulton Street
+                   Cambridge, Massachusetts 02138
+
+cc:  Honeywell Field Service Managers
+     R. Kerrian (Honeywell)
+     K. Stanley (Long Lines)
+     NCC contacts at sites not having Station Agents
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                      1/97 ]
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc356.txt](<www.ietf.org/rfc/rfc356.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
