### PR TITLE
Archive rfc3595.txt

### DIFF
--- a/www.ietf.org/rfc/rfc3595.txt
+++ b/www.ietf.org/rfc/rfc3595.txt
@@ -1,0 +1,339 @@
+
+
+
+
+
+
+Network Working Group                                          B. Wijnen
+Request for Comments: 3595                           Lucent Technologies
+Category: Standards Track                                 September 2003
+
+
+                Textual Conventions for IPv6 Flow Label
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2003).  All Rights Reserved.
+
+Abstract
+
+   This MIB module defines textual conventions to represent the commonly
+   used IPv6 Flow Label.  The intent is that these textual conventions
+   (TCs) will be imported and used in MIB modules that would otherwise
+   define their own representations.
+
+Table of Contents
+
+   1.  Introduction . . . . . . . . . . . . . . . . . . . . . . . . .  2
+   2.  The Internet-Standard Management Framework . . . . . . . . . .  2
+   3.  Definitions  . . . . . . . . . . . . . . . . . . . . . . . . .  2
+   4.  Security Considerations  . . . . . . . . . . . . . . . . . . .  4
+   5.  Intellectual Property Statement. . . . . . . . . . . . . . . .  4
+   6.  References . . . . . . . . . . . . . . . . . . . . . . . . . .  4
+       6.1.  Normative References . . . . . . . . . . . . . . . . . .  4
+       6.2.  Informative References . . . . . . . . . . . . . . . . .  5
+   7.  Acknowledgments  . . . . . . . . . . . . . . . . . . . . . . .  5
+   8.  Author's Address . . . . . . . . . . . . . . . . . . . . . . .  5
+   9.  Full Copyright Statement . . . . . . . . . . . . . . . . . . .  6
+
+
+
+
+
+
+
+
+
+
+
+
+Wijnen                      Standards Track                     [Page 1]
+
+RFC 3595        Textual Conventions for IPv6 Flow Label   September 2003
+
+
+1.  Introduction
+
+   Several standards-track MIB modules have defined objects to represent
+   an IPv6 Flow Label (sometimes referred to as Flow ID) [RFC2460]
+   [FLOWLABEL] and IPv6 Flow Label filters.  Unfortunately the result is
+   a set of different definitions for the same piece of management
+   information.  This may lead to confusion and unnecessary complexity.
+
+   This document defines a set of textual conventions (TCs) that can and
+   should be (re-)used in MIB modules, so that they all represent an
+   IPv6 Flow Label in the same way.  In fact, PIB modules can and should
+   also use these TCs when they need to represent an IPv6 Flow label.
+
+2.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This memo specifies a MIB
+   module that is compliant to the SMIv2, which is described in STD 58,
+   RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579] and STD 58, RFC 2580
+   [RFC2580].
+
+3.  Definitions
+
+   IPV6-FLOW-LABEL-MIB DEFINITIONS ::= BEGIN
+
+   IMPORTS
+
+       MODULE-IDENTITY, mib-2, Integer32           FROM SNMPv2-SMI
+       TEXTUAL-CONVENTION                          FROM SNMPv2-TC;
+
+   ipv6FlowLabelMIB   MODULE-IDENTITY
+
+       LAST-UPDATED  "200308280000Z"  -- 28 August 2003
+       ORGANIZATION  "IETF Operations and Management Area"
+       CONTACT-INFO  "Bert Wijnen (Editor)
+                      Lucent Technologies
+                      Schagen 33
+                      3461 GL Linschoten
+                      Netherlands
+
+
+
+
+
+Wijnen                      Standards Track                     [Page 2]
+
+RFC 3595        Textual Conventions for IPv6 Flow Label   September 2003
+
+
+                      Phone: +31 348-407-775
+                      EMail: bwijnen@lucent.com
+
+                      Send comments to <mibs@ops.ietf.org>.
+                     "
+       DESCRIPTION   "This MIB module provides commonly used textual
+                      conventions for IPv6 Flow Labels.
+
+                      Copyright (C) The Internet Society (2003).  This
+                      version of this MIB module is part of RFC 3595,
+                      see the RFC itself for full legal notices.
+                     "
+       -- Revision History
+
+       REVISION      "200308280000Z"  -- 28 August 2003
+       DESCRIPTION   "Initial version, published as RFC 3595."
+
+       ::= { mib-2 103 }
+
+   IPv6FlowLabel      ::= TEXTUAL-CONVENTION
+       DISPLAY-HINT  "d"
+       STATUS         current
+       DESCRIPTION   "The flow identifier or Flow Label in an IPv6
+                      packet header that may be used to discriminate
+                      traffic flows.
+                     "
+       REFERENCE     "Internet Protocol, Version 6 (IPv6) specification,
+                      section 6.  RFC 2460.
+                     "
+       SYNTAX         Integer32 (0..1048575)
+
+   IPv6FlowLabelOrAny ::= TEXTUAL-CONVENTION
+       DISPLAY-HINT  "d"
+       STATUS         current
+       DESCRIPTION   "The flow identifier or Flow Label in an IPv6
+                      packet header that may be used to discriminate
+                      traffic flows.  The value of -1 is used to
+                      indicate a wildcard, i.e. any value.
+                     "
+       SYNTAX         Integer32 (-1 | 0..1048575)
+
+   END
+
+
+
+
+
+
+
+
+
+Wijnen                      Standards Track                     [Page 3]
+
+RFC 3595        Textual Conventions for IPv6 Flow Label   September 2003
+
+
+4.  Security Considerations
+
+   The MIB module contained in this memo does not define any management
+   objects.  Instead, it defines a set of textual conventions which may
+   be used by other MIB modules to define management objects.
+
+   Meaningful security considerations can only be written for MIB
+   modules that define concrete management objects.  This document has
+   therefore no impact on the security of the Internet.
+
+5.  Intellectual Property Statement
+
+   The IETF takes no position regarding the validity or scope of any
+   intellectual property or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; neither does it represent that it
+   has made any effort to identify any such rights.  Information on the
+   IETF's procedures with respect to rights in standards-track and
+   standards-related documentation can be found in BCP-11.  Copies of
+   claims of rights made available for publication and any assurances of
+   licenses to be made available, or the result of an attempt made to
+   obtain a general license or permission for the use of such
+   proprietary rights by implementors or users of this specification can
+   be obtained from the IETF Secretariat.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights which may cover technology that may be required to practice
+   this standard.  Please address the information to the IETF Executive
+   Director.
+
+6.  References
+
+6.1.  Normative References
+
+   [RFC2460]   Deering, S. and R. Hinden, "Internet Protocol, Version 6
+               (IPv6) Specification", RFC 2460, December 1998.
+
+   [RFC2578]   McCloghrie, K., Perkins, D. and Schoenwaelder, "Structure
+               of Management Information Version 2 (SMIv2)", STD 58, RFC
+               2578, April 1999.
+
+   [RFC2579]   McCloghrie, K., Perkins, D. and J. Schoenwaelder,"Textual
+               Conventions for SMIv2", STD 58, RFC 2579, April 1999.
+
+
+
+
+
+
+Wijnen                      Standards Track                     [Page 4]
+
+RFC 3595        Textual Conventions for IPv6 Flow Label   September 2003
+
+
+   [RFC2580]   McCloghrie, K., Perkins, D. and J. Schoenwaelder,
+               "Conformance Statements for SMIv2", STD 58, RFC 2580,
+               April 1999.
+
+6.2.  Informative References
+
+   [FLOWLABEL] Carpenter, B., Conta, A., Deering, S. and J. Rajahalme,
+               "IPv6 Flow Label Specification", Work in Progress.
+
+   [RFC3410]   Case, J., Mundy, R., Partain, D. and B. Stewart,
+               "Introduction and Applicability Statements for Internet-
+               Standard Management Framework", RFC 3410, December 2002.
+
+7.  Acknowledgments
+
+   This document was produced as a result of a review of the use of
+   FlowID in a PIB module and a MIB module.  Further investigation found
+   that FlowID and FlowLabel objects were defined in a few other MIB
+   modules.  The editor would like to thank all who contributed to the
+   discussion that resulted in this document, particularly Juergen
+   Schoenwaelder for finding and reporting most of the other MIB modules
+   that were using/defining a FlowLabel object.  Juergen also suggested
+   the very first direction for a common TC for these objects.  Further
+   contributions were received from Fred Baker, Dan Romascanu, Kwok Ho
+   Chan, Margaret Wasserman, Brian Carpenter, Andy Bierman, Randy
+   Presuhn, Branislav Meandzija, Brian Williams, Ravi Sahita.  We also
+   received initial input from 3GPP that expressed the requirement to be
+   able to specify a wildcard for FlowID or FlowLabel.  Further helpful
+   review comments were received from Brian Carpenter, John Loughney,
+   Pekka Savola.
+
+8.  Author's Address
+
+   Bert Wijnen
+   Lucent Technologies
+   Schagen 33
+   3461 GL Linschoten
+   Netherlands
+
+   Phone: +31-348-407-775
+   EMail: bwijnen@lucent.com
+
+
+
+
+
+
+
+
+
+
+Wijnen                      Standards Track                     [Page 5]
+
+RFC 3595        Textual Conventions for IPv6 Flow Label   September 2003
+
+
+9.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (2003).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assignees.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Wijnen                      Standards Track                     [Page 6]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc3595.txt](<www.ietf.org/rfc/rfc3595.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
