### PR TITLE
Archive rfc361.txt

### DIFF
--- a/www.ietf.org/rfc/rfc361.txt
+++ b/www.ietf.org/rfc/rfc361.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                              Bob Bressler
+Request for Comments:  361                         MIT-DMCG
+NIC:  10603                                        5 July 1972
+
+
+     In response to RFCs 347 and 348, ECHO and DISCARD, MIT-DMCG
+(Host 106) now has deamon processes that will respond to RFCs on
+sockets 7 and 9.
+
+     A few administrative type decisions were made, to which I
+would like to solicit comments.
+
+     First, if our machine is too full to support another deamon
+process, the pro-offered connection will be refused;  that is, a
+CLS will be sent in response to the RFC on socket 7 or 9.
+Second, if no activity takes place for two consecutive minutes
+(no characters received on input, or output blocked waiting for
+allocation), the connection will be aborted.
+
+     Does anyone see the need or desirability for the third
+service in this set:  a random character generator?  Many systems
+provide programs like "TTYTST" available over the standard login
+connection, but there would be no difficulty in creating a server
+connection (like ECHO) offering just this limited service.  I'm
+sure that it would be useful for new NCPs, as well as statistics
+gathering.
+
+
+
+
+
+
+
+
+
+
+    [ This RFC was put into machine readable form for entry ]
+    [ into the online RFC archives by BBN Corp. under the   ]
+    [ direction of Alex McKenzie.                      1/97 ]
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc361.txt](<www.ietf.org/rfc/rfc361.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
