### PR TITLE
Archive rfc3615.txt

### DIFF
--- a/www.ietf.org/rfc/rfc3615.txt
+++ b/www.ietf.org/rfc/rfc3615.txt
@@ -1,0 +1,283 @@
+
+
+
+
+
+
+Network Working Group                                          J. Gustin
+Request for Comments: 3615                                     A. Goyens
+Category: Informational                                            SWIFT
+                                                          September 2003
+
+
+                A Uniform Resource Name (URN) Namespace
+                     for SWIFT Financial Messaging
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard of any kind.  Distribution of this
+   memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2003).  All Rights Reserved.
+
+Abstract
+
+   This document describes a Uniform Resource Name (URN) namespace that
+   is managed by SWIFT for usage within messages standardized by SWIFT.
+
+1.  Introduction
+
+   SWIFT is an industry-owned cooperative supplying secure, standardised
+   messaging services and interface software to over 7,500 financial
+   institutions in 199 countries.  The SWIFT community includes banks,
+   broker/dealers and investment managers, as well as their market
+   infrastructures in payments, securities, treasury and trade.
+
+   The goal of this namespace is to ensure the stability and uniqueness
+   of the names of various items that are used within the messages
+   exchanged between financial institutions.  SWIFT is one of the
+   principal standardization bodies for financial messages and services.
+   This standardization process identifies the structure and meaning of
+   messages exchanged for various financial services offered by
+   financial institutions.  It is essential that names of items (such as
+   the XML schema describing the message itself) can be used to identify
+   the resource even years after the message has been exchanged.
+
+   The same resource may exist in multiple physical locations, and thus
+   multiple URL's, but only a single URN.
+
+
+
+
+
+
+
+Gustin & Goyens              Informational                      [Page 1]
+
+RFC 3615                  SWIFT URN Namespace             September 2003
+
+
+2.  Specification Template
+
+   Namespace ID:
+
+      "swift"
+
+   Registration Information:
+
+      Version 1
+      Date: 2001-08-01
+
+   Declared registrant of the namespace:
+
+          SWIFT s.c.r.l.
+          Avenue Adele 1
+          B-1310 La Hulpe
+          Belgium
+
+   Declaration of syntactic structures:
+
+      The structure of the Namespace Specific String is a flat space
+      <URN chars> [1] which have no knowable structure outside of the
+      context of the SWIFT community internal resolver.  Future changes
+      to the assignment methods may allow others to assign sub-spaces of
+      the flat namespace but again, this knowledge is only valid
+      internally and should never be inferred or relied upon externally.
+
+   Relevant ancillary Documentation:
+
+      None
+
+   Identifier uniqueness considerations:
+
+      Identifiers are assigned by SWIFT URN Registration that guarantees
+      uniqueness.  This is simply achieved by keeping track of already
+      assigned names and comparing all new proposed names to the
+      database ones.  If the name already exists a new one has to be
+      proposed.
+
+   Identifiers persistence considerations:
+
+      The assignment process guarantees that names are not reassigned.
+      In any case SWIFT URNs are guaranteed to remain valid for 15
+      years.
+
+
+
+
+
+
+
+Gustin & Goyens              Informational                      [Page 2]
+
+RFC 3615                  SWIFT URN Namespace             September 2003
+
+
+   Process of identifiers assignment:
+
+      Names are granted via SWIFT proprietary registration procedures.
+
+   Process for identifier resolution:
+
+      SWIFT URNs are resolved via URN resolvers run under SWIFT
+      responsibility.
+
+   Rules for lexical equivalence:
+
+      No special consideration.
+
+   Conformance with URN syntax:
+
+      No special consideration.
+
+   Validation mechanism:
+
+      None specified.
+
+   Scope:
+
+      This namespace is reserved to the global financial community.
+
+3.  Examples
+
+   The following examples are not guaranteed to be real.  They are
+   listed for pedagogical reasons only.
+
+      urn:swift:xsd:epp$mi.i-2.0
+      urn:swift:type:fin$103
+
+4.  Security Considerations
+
+   Since the URNs in this namespace are opaque there are no additional
+   security considerations other than those normally associated with the
+   use and resolution of URNs in general.
+
+   It is noted however that attempting to resolve a SWIFT URN through a
+   resolver other than the one provided by SWIFT is error prone.  In any
+   case, it is not considered authoritative.
+
+5.  IANA Considerations
+
+   The IANA has registered formal URN namespace 15, to SWIFT within the
+   IANA registry of URN NIDs.
+
+
+
+
+Gustin & Goyens              Informational                      [Page 3]
+
+RFC 3615                  SWIFT URN Namespace             September 2003
+
+
+6.  Normative References
+
+   [1]  Moats, R., "URN Syntax", RFC 2141, May 1997.
+
+   [2]  Daigle, L., van Gulik, D., Iannella, R. and P. Faltstrom,
+        "Uniform Resource Name (URN) Namespace Definition Mechanisms",
+        BCP 66, RFC 3406, October 2002.
+
+7.  Authors' Addresses
+
+   Jean-Marc Gustin
+   SWIFT s.c.r.l.
+   Avenue Adele, 1
+   B1310 La Hulpe
+   Belgium
+
+   EMail: jean-marc.gustin@swift.com
+
+
+   Andre Goyens
+   SWIFT s.c.r.l.
+   Avenue Adele, 1
+   B1310 La Hulpe
+   Belgium
+
+   EMail: andre.goyens@swift.com
+   URI:   http://www.swift.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Gustin & Goyens              Informational                      [Page 4]
+
+RFC 3615                  SWIFT URN Namespace             September 2003
+
+
+8.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (2003).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assignees.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Gustin & Goyens              Informational                      [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc3615.txt](<www.ietf.org/rfc/rfc3615.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
