### PR TITLE
Archive rfc363.txt

### DIFF
--- a/www.ietf.org/rfc/rfc363.txt
+++ b/www.ietf.org/rfc/rfc363.txt
@@ -1,0 +1,731 @@
+
+
+
+
+
+
+Network Working Group                         Network Information Center
+Request for Comments: 363                    Stanford Research Institute
+Obsoletes: RFC 329, NIC 9636                               8 August 1972
+NIC: 10605
+
+                       ARPA NETWORK MAILING LISTS
+
+ABSTRACT
+
+   The following are three lists to be used for distribution of Network
+   documents.  List A should be used by sites when they distribute their
+   own documents, to get RFC's to Liaisons as quickly as possible.  All
+   but local mail should be sent Air Mail.  Lists B and C will be used
+   by NIC in making distribution of copies to non-site Network
+   Participants and to Station Agents.
+
+   For phone numbers and lists of names by sites see the Current
+   Directory of Network Participants.
+
+A. INITIAL DISTRIBUTION LIST
+
+   Note:  This list includes all Network Liaisons and others who should
+   receive initial distribution of RFC's, whether sent from NIC or from
+   sites.  They will also receive selected catalogs and other formal
+   documents from NIC.
+
+ABERDEEN
+                                     AMES-67
+Mr. Michael J. Romanelli
+Aberdeen Research                    A. Wayne Hathaway
+and Development Center               Mail Stop 233-9
+Aberdeen Proving Ground              NASA Ames Research Center
+Maryland 21005                       Moffett Field, Calif. 94035
+
+    (301) 278-4574                       (415) 965-6033
+
+AFGWC (see GWC)                      AMES-ILLIAC (see ILLIAC)
+
+AMEC                                 ARPA-TIP
+
+Ralph E. Hall, Jr.                   Steve D. Crocker
+Commanding Officer/USAMERDC          Advanced Research Projects Agency
+SMEFB-BC                             1400 Wilson Boulevard
+Fort Belvoir, Virginia, 22060        Arlington, Virginia  22209
+
+    (703) 664-5511                       (202) 694-5037 or 694 5922
+
+
+
+
+
+Network Information Center                                      [Page 1]
+
+RFC 363                ARPA NETWORK MAILING LISTS            August 1972
+
+
+BBN-NET                              CMU-CC (see CMU-10)
+
+Alex McKenzie                        DCAO
+Bolt Beranek and Newman Inc.
+50 Moulton Street                    Daniel L. Kadunce
+Cambridge, Mass.  02138              Defense Communications Agency
+                                     Operations
+    (617) 491-1850 x441              Attention: Code N-321
+                                     Washington, D. C. 20305
+BBN-TENEX
+                                         (202) 692-2600
+Robert H. Thomas
+Bolt Beranek and Newman Inc          DOCB
+50 Moulton Street
+Cambridge, Mass.  02138              Schuyler Stevenson R-523
+                                     Department of Commerce NOAA
+    (617) 491-1850 x351              325 South Broadway
+                                     Boulder, Colorado 80302
+CASE-10
+                                         (303) 499-1000 x3863
+Dr. Patrick W. Foulk
+Jennings Computing Center            ETAC-TIP
+Room 300, Crawford Hall
+Case Western Reserve University      Capt. George N. Petregal
+10900 Euclid Avenue                  USAF-ETAC
+Cleveland, Ohio  44106               Bldg. 159
+                                     Navy Yard Annex
+    (216) 368-2936                   Washington, D. C. 20333
+
+CCA                                  FNWC
+
+Richard A. Winter                    Dick Reins
+Computer Corporation of America      Fleet Numerical Weather Central
+565 Technology Square                Monterey, Calif. 93
+Cambridge, Mass.  02139
+                                         (408) 646-2201
+    (617) 491-3670
+                                     GWC
+CMU-10
+                                     Lt. John C. Thomas
+Harold R. Van Zoeren                 AF Global Weather Central (DN)
+Carnegie-Mellon University           Offutt Air Force Base
+Computer Science Department          Nebraska 68113
+Schenley Park
+Pittsburgh, Pa.  15213                   (402) 294-5245
+
+    (412)621-2600 x160
+
+
+
+
+Network Information Center                                      [Page 2]
+
+RFC 363                ARPA NETWORK MAILING LISTS            August 1972
+
+
+HARV-10                              LBL
+
+Robert L. Sundberg                   Robert L. Fink
+Harvard University                   Lawrence Berkeley Labs
+Aiken Computation Laboratory         Bldg. 50A, Room 1143
+33 Oxford Street                     Berkeley, California 94720
+Cambridge, Mass.  02138
+                                         (415) 643-2740 x5351
+    (617) 495-4147
+                                     LL-67
+HARV-11
+                                     Joel M. Winett
+Scott Bradner                        Massachusetts Institute of
+Harvard University                   Technology
+Psychology Department                Lincoln Laboratory
+33 Kirkland Street                   244 Wood Street
+Cambridge, Mass.  02138              Lexington, Mass.  02173
+
+    (617) 495-3864                       (617)862-5500 x7474
+
+IBMW                                 LL-TX2
+
+Sol F. Seroussi                      William Kantrowitz
+IBM Watson Research Center           Massachusetts Institute of
+P.O. box 218                         Technology
+Yorktown Heights, New York  10598    Lincoln Laboratory
+                                     244 Wood Street
+    (914) 945-2052                   Lexington, Mass.  02173
+
+ILL-ANTS                                 (617) 862-5500 x7349
+
+Karl C. Kelley                       MIT-DMCG
+University of Illinois
+Center for Advanced Computation      Abhay Bhushan
+Urbana, Illinois  61801              Project Mac Room 208
+                                     545 Technology Square
+    (217)333-8469                    Cambridge, Mass.  02139
+
+ILLIAC                                   (617) 253-1428
+
+John W. McConnell
+NASA Ames Research Center
+Mail Stop 202-10
+Moffett Field, Calif.  94035
+
+    (415)965-5191
+
+
+
+
+
+Network Information Center                                      [Page 3]
+
+RFC 363                ARPA NETWORK MAILING LISTS            August 1972
+
+
+MIT-MULTICS                          PARC-VTS
+
+Mike Padlipsky                       Bob Metcalfe
+Project MAC Room 208                 Xerox PARC
+545 Technology Square                Computer Systems Building
+Cambridge, Mass. 02139               3180 Porter Drive
+                                     Palo Alto, California 94304
+    (617) 253-6006
+                                         (415) 493-1600
+MITRE-TIP
+                                     RADC
+Jerry Powell
+MITRE Corporation                    Thomas F. Lawrence
+Information Systems Dept., W140      Rene Air Development Center (ISIM)
+Westgate Research Park               Griffiss Air Force Base
+McLean, Va.  22101                   Rome, New York  13440
+
+    (703) 893-3500 x2391                 (315) 330-3857 or 330-7834
+
+NBS                                  RAND
+
+Thomas N. Pyke, Jr.                  Eric Harslem
+National Bureau of Standards         Rand Corporation
+Center for Computer Sciences         Computer Science Department
+and Technology                       1700 Main Street
+Washington, D.C.  20234              Santa Monica, Calif.  90406
+
+    (301) 921-2601                       (213) 393-0411 x7606
+
+NIC (see SRI-ARC)                    RAY
+
+PARC-MAXC                            Thomas O'Sullivan
+                                     Raytheon Data Systems
+L. Peter Deutsch                     526 Boston Post Road
+Xerox PARC                           Sudbury, Mass.  01776
+3180 Porter Drive
+Palo Alto, California 94304              (617) 443-9521 x2945
+
+    (415) 493-1600
+
+
+
+
+
+
+
+
+
+
+
+
+Network Information Center                                      [Page 4]
+
+RFC 363                ARPA NETWORK MAILING LISTS            August 1972
+
+
+RUTGERS                              SRI-ARC
+
+Gil Falk                             James E. White
+Department of Computer Science       Stanford Research Institute
+Hill Mathematics Center              Augmentation Research Center
+University Heights Campus            333 Ravenswood Avenue
+Rutgers University                   Menlo Park, Calif.  94025
+New Brunswick, New Jersey 08903
+                                         (415) 329-0740
+    (201) 932-2085
+                                     SRI-ARC
+SAAC-TIP
+                                     Jeanne B. North (for NIC)
+A.D. (Buz) Owen                      Stanford Research Institute
+Teledyne/Geotech                     Augmentation Research Center
+Seismic Analysis Array Center        333 Ravenswood Avenue
+Box 334                              Menlo Park, Calif.  94025
+Alexandria, Va. 22314
+                                         (415) 329-0740
+    (703) 836-3882
+                                     SU-AI
+SCI
+                                     James H. Stein
+Gene Leichner                        Stanford University
+Systems Control, Inc.                Computer Science Dept.
+260 Sheridan Ave.                    AI Project
+Palo Alto. California 94306          Stanford, Calif.  94305
+
+    (415) 327-8823                       (415) 321-2300 x4971
+
+SDC-ADEPT                            SU-HP
+
+Robert E. Long                       Edward A. Feigenbaum
+System Development Corporation       Stanford University,
+2500 Colorado Avenue                 Heuristic Programming
+Santa Monica, Calif.  90406          Serra House
+                                     Stanford, Calif.  94305
+    (213) 393-9411 x6994 or 6119
+                                         (415) 321-2300 x4878
+SRI-AI
+
+B. Michael Wilber
+Stanford Research Institute
+Artificial Intelligence Group
+33 Ravenswood Avenue
+Menlo Park, Calif.  94025
+
+    (415) 326-6200 x4593
+
+
+
+Network Information Center                                      [Page 5]
+
+RFC 363                ARPA NETWORK MAILING LISTS            August 1972
+
+
+UCLA-CCBS                            UHI
+
+Reg E. Martin                        John Davidson
+UCLA - Computer Center for           University of Hawaii
+Behavioral Sciences                  The Aloha System
+Los Angeles, California 90024        2565 The Mall
+                                     Honolulu, Hawaii 96822
+    (213) 825-4822
+                                     USC-44
+UCLA-CCN
+                                     James Pepin
+Robert T. Braden                     University of Southern California
+UCLA - Campus Computing Network      School of Engineering
+Los Angeles, Calif.  90024           Los Angeles, Calif.  90007
+
+    (213) 825-7518                       (213) 746-2240
+
+UCLA-NMC                             USC-ISI
+
+Ari O. Ollikainen                    John Melvin
+UCLA - Network Measurement Center    USC Information Sciences Institute
+Los Angeles, Calif.  90024           4676 Admiralty Way
+                                     Marina Del Rey, Calif. 90291
+    (213) 825-2381 or 825-2368
+                                         (213) 821-0595
+UCSB-MOD75
+                                     UTAH-10
+Ron Stoughton
+University of California             Barry D. Wessler
+at Santa Barbara                     University of Utah
+Computer Research Laboratory         Computer Science/IRL
+Santa Barbara, Calif.  93106         Salt Lake City, Utah  84112
+
+    (805) 961-3793                       (801) 581-8378
+
+UCSD-CC                              Anthony C. Hearn
+                                     University of Utah
+Charles Holland                      Dept. of Physics
+University of California             Salt Lake City, Utah 84112
+at San Diego
+Computer Center                          (801) 581-8378
+La Jolla, Calif.  92037
+
+    (714) 453-2000 x2598
+
+
+
+
+
+
+
+Network Information Center                                      [Page 6]
+
+RFC 363                ARPA NETWORK MAILING LISTS            August 1972
+
+
+B. LIST FOR DISTRIBUTION FROM NIC
+
+   Note: These Network participants will receive all formal Network
+   documents sent from NIC, in the mailing to Liaisons when such is
+   made, otherwise at the time documents are sent to Station Agents.
+
+CHIU                                 EDUCOM
+
+Prof. Robert L. Ashenhurst           John LeGates
+Institute for Computer Research      Old Concord Road
+University of Chicago                Lincoln, Mass. 01773
+Chicago, Illinois 60637
+                                         (617) 259-9450
+    (312) 753-8762
+                                     IFF
+COU
+                                     Hubert Lipinski
+Maurice P. Brown, Director           Institute for the Future
+Office of Computer Coordination      2725 Sand Hill Road, Suite 203
+Council of Ontario Universities      Menlo Park, Calif. 94025
+102 Bloor Street West
+Toronto 181, Ontario                     (415) 854-6322
+
+    (416) 920-6865                   MERIT
+
+CRC                                  E. M.  Aupperle
+                                     MERIT computer Network
+C.D. Shepard                         University of Michigan
+Communications Research Center       1037 N. University Building
+P.O. Box 490                         Ann Arbor, Michigan 48104
+Ottawa, Canada K1N ATB
+                                         (313) 764-9423
+    (613) 996-7051
+                                     NETH
+DART
+                                     Tjaart Schipper
+Prof. Robert F. Hargraves            13 Marijkestraat
+Kiewit Computation Center            Leiderdorp, Netherlands
+Dartmouth University
+Hanover, New Hampshire  03755
+
+    (603) 646-2643 x3755
+
+
+
+
+
+
+
+
+
+Network Information Center                                      [Page 7]
+
+RFC 363                ARPA NETWORK MAILING LISTS            August 1972
+
+
+NPL                                  UBC
+
+Derek Barber                         Dave Tywver
+Computer Science Division            Computing Center
+National Physical Laboratory         University of British Columbia
+Teddington, Middlesex, England       Vancouver 8, Canada
+
+    01-977-3222                          (604) 228-3072
+
+NSF                                  UCI
+
+Dr. D. D. Aufenkamp                  Prof. David Farber
+Office of Computing Activities       Dept. of Information and Computer
+National Science Foundation          Science
+1800 G Street, P.W.                  University of California
+Washington, D. C.  20550             Irvine, Calif.  92664
+
+    (202) 632-7349                       (714) 833-6891
+
+ONR1                                 UKICS
+
+A. Kenneth Showalter                 Prof. Peter Kirstein
+Office of Naval Research             Institute of Computer Science
+Information Systems Programs         University of London
+800 North Quincy Street              44 Gordon Square
+Arlington, Va. 22217                 London, W.C.1, England
+
+    (202) 692-4304                   WASHU
+
+OWENS                                Marianne Pepper
+                                     Washington University
+Dave Liddle                          Computer Systems Laboratory
+Owens Illinois, Inc.                 724 South Euclid Avenue
+Lewis Development Park, Bldg. 30     St. Louis, Mo.  63110
+Perrysberg, Ohio 43551
+                                         (314) 361-7356
+    (419) 242-6543
+                                     WATERU
+SUNY
+                                     Prof. Donald Cowan
+Prof. Art J. Bernstein               Dept. Of Computer Science
+SUNY Stoneybrook                     University of Waterloo
+Dept. Of computer Science            Waterloo, Ontario, Canada
+Stoneybrook, L.I., N.Y.  11790
+                                         (519) 744-6111 x3292
+    (516) 246-4080
+
+
+
+
+
+Network Information Center                                      [Page 8]
+
+RFC 363                ARPA NETWORK MAILING LISTS            August 1972
+
+
+C.  NIC STATION AGENTS
+
+   Note:  Station Agents receive copies from NIC of all documents
+   distributed to Liaisons, as well as documents sent as part of Station
+   collection.  A mailing is made to Station Agents once a week, or
+   oftener when quantity warrants.
+
+ABERDEEN                             BBN-TENEX
+
+Ermalee R. McCauley                  Steve O. Chipman
+Aberdeen Research and Development    Bolt Beranek and Newman Inc.
+Center                               50 Moulton Street
+Aberdeen Proving Ground, Maryland 2  Cambridge, Mass.  02138
+1005
+                                         (617) 491-1850 x356
+    (301) 278-4574
+                                     CASE-10
+AMEC
+                                     John Barden
+Brenda Monroe                        Case Western Reserve University
+Commanding Officer/USAMERDC          Computing and Information Sciences
+SMEFB-BC                             10900 Euclid Ave.
+Fort Belvoir, Virginia, 22060        Cleveland, Ohio  44106
+
+    (703) 664-5511                       (216) 368-4467
+
+AMES-67                              CCA
+
+Stan Golding                         Martha A. Ginsberg
+Mail Stop 233-13                     Computer Corporation of America
+NASA Ames Research Center            565 Technology Square
+Moffett Field, Calif.  94035         Cambridge, Mass.  02139
+
+    (415) 961-1111 x2501                 (617)491-3670
+
+ARPA-TIP                             CMU-10 (see CMU-CC)
+
+Pam J. Klotz                         CMU-CC
+Advanced Research Projects Agency
+1400 Wilson Boulevard                David J. King
+Arlington, Va,  22209                Carnegie-Mellon University
+                                     Computer Science Department
+    (202) 694-5037                   Schenley Park
+                                     Pittsburgh, Pa.  15213
+BBN-NET  (see BBN-TENEX)
+                                         (412) 621-2600 x683
+
+
+
+
+
+Network Information Center                                      [Page 9]
+
+RFC 363                ARPA NETWORK MAILING LISTS            August 1972
+
+
+DCAO                                 HARV-10
+
+Helen D. Young                       Bradley A. Reussow
+Defense Communications Agency        Harvard University
+Operations                           Aiken Computation Laboratory
+Attention: Code N-321                33 Oxford Street
+Washington, D. C. 20305              Cambridge, Mass.  02138
+
+    (202) 692-2600                       (617) 495-4147
+
+DOCB                                 HARV-11
+
+Dorothy A. Reynolds R-522            Craig Fields
+Department of Commerce NOAA          Harvard University
+325 South Broadway                   Psychology Department
+Boulder, Colorado 80302              33 Kirkland Street
+                                     Cambridge, Mass.  02138
+    (303) 499-1000 x3835
+                                         (617) 495-3857
+ETAC-TIP
+                                     ILL-ANTS
+James Shiffrin
+USAF-ETAC                            Katy Howe
+Bldg. 159                            University of Illinois
+Navy Yard Annex                      Advanced Computation Building
+Washington, D.C.  20333              Urbana, Ill.  61801
+
+    (202) 693-3912                       (217) 333-1515
+
+FNWC                                 ILLIAC (see AMES-67)
+
+Judy Scott                           LBL
+Fleet Numerical Weather Central
+Monterey, Calif. 93940               Eric R. Beals
+                                     Lawrence Berkeley Labs
+    (408) 646-2817                   Bldg. 50B, Room 3238B
+                                     Berkeley, California 94720
+GWC
+                                         (415) 843-2740 x5351
+SSgt. James G. Benedict
+AF Global Weather Central
+DOCC/PC HHH
+Offutt Air Force Base,
+                Nebraska 68113
+
+    (402) 294-4671
+
+
+
+
+
+Network Information Center                                     [Page 10]
+
+RFC 363                ARPA NETWORK MAILING LISTS            August 1972
+
+
+LL-67                                PARC-MAXC
+
+Carol J. Mostrom                     Diana Merry
+Massachusetts Institute of           Xerox PARC
+Technology                           3180 Porter Drive
+Lincoln Laboratory                   Palo Alto, California 94304
+244 Wood Street
+Lexington, Mass.  02173                  (415) 493-1600
+
+    (617) 862-5500 x7177             PARC-VTS (see PARC-MAXC)
+
+LL-TX2  (see LL-67)                  RADC
+
+MIT-DMCG                             Robert E. Doane
+
+                                     Rome Air Development Center (ISIM)
+Sue Pitkin                           Griffiss Air Force Base
+Project MAC                          Rome, New York, 1344
+545 Technology square
+Cambridge, Mass.  02139                  (315) 330-7628
+
+    (617) 253-1458                   RAND
+
+MIT-MULTICS (see MIT-DMCG)           Linda M. Connelly
+                                     Rand Corporation
+MITRE-TIP                            Computer Science Department
+                                     1700 Main Street
+Ernest H. Fortman                    Santa Monica, Calif.  90406
+MITRE Corporation
+Information Systems Dept., W150          (213) 393-0411 x7388
+Westgate Research Park
+McLean, Va.  22101                   RAY
+
+    (703) 893-3500 x2523 or 2318     Dan Odom, 1R9
+                                     Raytheon Company
+NBS                                  528 Boston Post Road
+                                     Sudbury, Mass. 01776
+Shirley W. Watkins
+National Bureau of Standards             (617) 442-9521 x2870
+Bldg. 225, Room B216
+Washington, D.C.  20234
+
+    (301) 921-2601
+
+NIC (see SRI-ARC)
+
+
+
+
+
+
+Network Information Center                                     [Page 11]
+
+RFC 363                ARPA NETWORK MAILING LISTS            August 1972
+
+
+RUTGERS                              SRI-AI
+
+Gil Falk                             Maria E. Lemaro
+Department of Computer Science       Stanford Research Institute
+Hill Mathematics Center              Artificial Intelligence Group
+University Heights Campus            333 Ravenswood Avenue
+Rutgers University                   Menlo Park, Calif.  94025
+New Brunswick,New Jersey 08903
+                                         (415) 326-6200 x4618
+    (201) 932-2085
+                                     SRI-ARC
+SAAC-TIP
+                                     Cindy Page
+Ann U. Kerr                          Stanford Research Institute
+Teledyne/Geotech                     Augmentation Research Center
+Seismic Analysis Array Center        333 Ravenswood Ave.
+Box 334                              Menlo Park, Calif.  94025
+Alexandria, Va. 22314
+                                         (415) 329-0740
+    (703) 836-3882
+                                     SU-AI
+SCI
+                                     Barbara A. Barnett
+Faye Baxter                          Stanford University
+Systems Control, Inc.                Artificial Intelligence Project
+260 Sheridan Ave.                    D.C. Power Lab
+Palo Alto. California 94306          Stanford, Calif.  94305
+
+    (415) 327-9333                       (415) 321-2300 x2800 or 4971
+
+SDC-ADEPT                            SU-HP
+
+Janet W. Troxel                      Dee Larson
+System Development Corporation       Stanford University
+Information Processing Information   Heuristic Programming Project
+Center                               Serra House
+2500 Colorado Avenue                 Stanford, Calif.  94305
+Santa Monica, Calif.  90406
+                                         (415) 321-2300 x4878
+    (213) 393-9411 x495 or 534
+
+
+
+
+
+
+
+
+
+
+
+Network Information Center                                     [Page 12]
+
+RFC 363                ARPA NETWORK MAILING LISTS            August 1972
+
+
+UCLA-CCBS                            UCSD-CC
+
+Roberta J. Peeler                    Jerry Fitzsimmons
+UCLA - Computer Center for           University of California
+Behavioral Sciences                  at San Diego
+Los Angeles, California 99024        Computer Center
+                                     La Jolla, Calif.  90037
+    (213) 825-5834
+                                         (714) 453-2000 x2598
+UCLA-CCN
+                                     UHI
+Gloria Jean Maxey
+UCLA - Campus Computing Network      Margaret Iwamoto
+Los Angeles, Calif.  90024           University of Hawaii
+                                     The Aloha System
+    (213) 825-7518                   2565 The Mall
+                                     Honolulu, Hawaii 96822
+UCLA-NMC
+                                     USC-44
+Anita Coley
+UCLA - Network Measurement Center    Linda M. Webster
+Los Angeles, Calif.  90024           University of Southern California
+                                     Olin Hall of Engineering
+    (213) 825-4797                   Room 340
+                                     Los Angeles, Calif.  90007
+UCSB-MOD75
+                                         (213) 746-6379
+Connie Rosewall
+University of California             USC-ISI
+at Santa Barbara
+Computer Research Laboratory         John Heafner
+Santa Barbara, Calif.  93106         University of Southern California
+                                     Information Sciences Institute
+    (805) 961-3221                   4676 Admiralty Way
+                                     Marina Del Rey, Calif. 90291
+
+                                     UTAH-10
+
+                                     Greg Hicks
+                                     University of Utah
+                                     Computer Science Department
+                                     Salt Lake City, Utah  84112
+
+                                         (801) 581-7888
+
+        [This RFC was put into machine readable form for entry]
+    [into the online RFC archives by Helene Morin, Viagenie 12/99]
+
+
+
+
+Network Information Center                                     [Page 13]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc363.txt](<www.ietf.org/rfc/rfc363.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
