### PR TITLE
Archive rfc3638.txt

### DIFF
--- a/www.ietf.org/rfc/rfc3638.txt
+++ b/www.ietf.org/rfc/rfc3638.txt
@@ -1,0 +1,283 @@
+
+
+
+
+
+
+Network Working Group                                           J. Flick
+Request for Comments: 3638                       Hewlett-Packard Company
+Obsoletes: 1643                                                 C. Heard
+Category: Informational                                       Consultant
+                                                          September 2003
+
+
+            Applicability Statement for Reclassification of
+                      RFC 1643 to Historic Status
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard of any kind.  Distribution of this
+   memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2003).  All Rights Reserved.
+
+Abstract
+
+   This memo recommends that RFC 1643 be reclassified as an Historic
+   document and provides the supporting motivation for that
+   recommendation.
+
+1.  Details
+
+   STD 50, RFC 1643 [RFC1643], "Definitions of Managed Objects for the
+   Ethernet-like Interface Types", and its SMIv2 equivalent, RFC 1650
+   [RFC1650], are applicable to half-duplex 10 Mb/s Ethernet interfaces
+   only.  Subsequent to the 1994 publication of these documents, 100
+   Mb/s, 1000 Mb/s, and 10 Gb/s Ethernet interface types have been
+   developed, and full-duplex operation at 10 Mb/s has been
+   standardized.  Updates to RFC 1650 have been produced to accommodate
+   these new technologies [RFC2358] [RFC2665] [RFC2666] [RFC3635].
+   These updates define new MIB objects to supplement those defined in
+   RFC 1643 and RFC 1650 and in addition deprecate some of the objects
+   in RFC 1643 and RFC 1650 that are no longer considered useful.  They
+   also levy a requirement for implementations of the EtherLike-MIB to
+   support the MAU-MIB [RFC2239] [RFC2668] [RFC3636] as well.
+
+
+
+
+
+
+
+
+
+
+Flick & Heard                Informational                      [Page 1]
+
+RFC 3638              RFC 1643 to Historic Status         September 2003
+
+
+   RFC 1643 is an obsolete specification, overtaken by events.  Its
+   SMIv2 equivalent, RFC 1650, was officially retired in 1998.  New
+   implementations -- even those that support only half-duplex 10 Mb/s
+   interfaces -- should comply with in the latest version of the
+   specification, currently RFC 3635 [RFC3635] and RFC 2666 [RFC2666],
+   instead of RFC 1643.  It is therefore recommended that RFC 1643 be
+   reclassified as an Historic document.
+
+2.  Effect on Other Standards Track Documents
+
+   Reclassification of RFC 1643 will have no impact on the status of any
+   standards track RFC because no standards track RFC cites it as a
+   normative reference.  An RFC content search made with the tools
+   available at http://www.rfc-editor.org reveals the following
+   standards track documents that cite RFC 1643:
+
+      Document               Title
+      --------               -----
+
+      RFC 2020         IEEE 802.12 Interface MIB
+
+      RFC 2358         Definitions of Managed Objects for the
+                       Ethernet-like Interface Types
+
+      RFC 2665         Definitions of Managed Objects for the
+                       Ethernet-like Interface Types
+
+      RFC 2720         Traffic Flow Measurement: Meter MIB
+
+      RFC 3635         Definitions of Managed Objects for the
+                       Ethernet-like Interface Types
+
+   RFC 2020 [RFC2020] contains DOT12-IF-MIB, which is the MIB module for
+   managing IEEE 802.12 100VG-AnyLAN interfaces.  It refers to RFC 1643
+   in the context of an admonition not to implement the EtherLike-MIB
+   for any interface where the DOT12-IF-MIB is implemented.
+
+   RFC 2358 [RFC2358], RFC 2665 [RFC2665], and RFC 3635 [RFC3635] all
+   contain updated versions of the EtherLike-MIB.  They refer to RFC
+   1643 in the context of explaining the history of the EtherLike-MIB,
+   and the citation in RFC 3635 is explicitly listed as a non-normative
+   reference.
+
+   RFC 2720 [RFC2720] contains the FLOW-METER-MIB.  It refers to RFC
+   1643 only in an ASN.1 comment in the MIB module.  Omission of that
+   comment would not preclude correct implementation of the MIB module.
+
+   Clearly, none of these citations are normative.
+
+
+
+Flick & Heard                Informational                      [Page 2]
+
+RFC 3638              RFC 1643 to Historic Status         September 2003
+
+
+3.  Security Considerations
+
+   Reclassification of RFC 1643 will not, in and of itself, have any
+   effect on the security of the Internet.
+
+4.  Normative References
+
+   [RFC1643]   Kastenholz, F., "Definitions of Managed Objects for the
+               Ethernet-like Interface Types", STD 50, RFC 1643, July
+               1994.
+
+   [RFC1650]   Kastenholz, F., "Definitions of Managed Objects for the
+               Ethernet-like Interface Types using SMIv2", RFC 1650,
+               August 1994.
+
+   [RFC2020]   Flick, J., "IEEE 802.12 Interface MIB", RFC 2020, October
+               1996.
+
+   [RFC2239]   de Graaf, K., Romascanu, D., McMaster, D., McCloghrie, K.
+               and S. Roberts, "Definitions of Managed Objects for IEEE
+               802.3 Medium Attachment Units (MAUs) using SMIv2", RFC
+               2239, November 1997.
+
+   [RFC2358]   Flick, J. and J. Johnson, "Definitions of Managed Objects
+               for the Ethernet-like Interface Types", RFC 2358, June
+               1998.
+
+   [RFC2665]   Flick, J. and J. Johnson, "Definitions of Managed Objects
+               for the Ethernet-like Interface Types", RFC 2665, August
+               1999.
+
+   [RFC2666]   Flick, J., "Definitions of Object Identifiers for
+               Identifying Ethernet Chip Sets", RFC 2666, August 1999.
+
+   [RFC2668]   Smith, A., Flick, J., deGraaf, K., Romascanu, D.,
+               McMaster, D., McCloghrie, K. and S. Roberts, "Definitions
+               of Managed Objects for IEEE 802.3 Medium Attachment Units
+               (MAUs)", RFC 2668, August 1999.
+
+   [RFC2720]   Brownlee, N., "Traffic Flow Measurement: Meter MIB", RFC
+               2720, October 1999.
+
+   [RFC3635]   Flick, J., "Definitions of Managed Objects for the
+               Ethernet-like Interface Types", RFC 3635, September 2003.
+
+
+
+
+
+
+
+Flick & Heard                Informational                      [Page 3]
+
+RFC 3638              RFC 1643 to Historic Status         September 2003
+
+
+   [RFC3636]   Flick, J., "Definitions of Managed Objects for IEEE 802.3
+               Medium Attachment Units (MAUs)", RFC 3636, September
+               2003.
+
+5.  Authors' Addresses
+
+   John Flick
+   Hewlett-Packard Company
+   8000 Foothills Blvd.  M/S 5557
+   Roseville, CA 95747-5557
+   USA
+
+   Phone: +1 916 785 4018
+   Fax:   +1 916 785 1199
+   EMail: johnf@rose.hp.com
+
+
+   C. M. Heard
+   600 Rainbow Dr. #141
+   Mountain View, CA 94041-2542
+   USA
+
+   Phone: +1 650 964 8391
+   EMail: heard@pobox.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Flick & Heard                Informational                      [Page 4]
+
+RFC 3638              RFC 1643 to Historic Status         September 2003
+
+
+6.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (2003).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assignees.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Flick & Heard                Informational                      [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc3638.txt](<www.ietf.org/rfc/rfc3638.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
