### PR TITLE
Archive rfc366.txt

### DIFF
--- a/www.ietf.org/rfc/rfc366.txt
+++ b/www.ietf.org/rfc/rfc366.txt
@@ -1,0 +1,218 @@
+
+
+
+
+
+
+Network Working Group                            Ellen Westheimer
+NIC # 11013                                      BBN
+RFC # 366                                        11 July 1972
+Categories:  F. G.3
+Updates:  RFC #362
+Obsoletes:  None
+
+                          NETWORK HOST STATUS
+
+     This RFC reports on the status of most Network Hosts from June 19
+to June 30.
+
+     No testing was done on June 20 due to an attempt to install the
+new IMP system.
+
+     Several Hosts are currently excluded from the daily testing as
+they are presently intended to be users only. Included here are the
+Terminal IMPs, which are presently in the Network (AMES, MITRE, RADC,
+NBS, ETAC, USC, GWC, NOAA, SAAC, ARPA, and BBN*).  This category also
+includes the Network Control Center computer (Network address 5) which
+is used solely for gathering statistics from the Network. Finally,
+included among these Hosts are the following:
+          Network
+          Address            Site                 Computer
+          -------            ----                 --------
+
+              7             Rand                  IBM - 360/65
+             73             Harvard               PDP-1
+            138             Lincoln               TSP
+             12             Illinois              PDP-11
+             19             NBS                   PDP-11
+             23             USC                   IBM-360/44
+
+     The tables on the next two pages summarize the Host status
+for this period.
+
+_______________
+*The BBN Terminal IMP (Network Address 158) is a prototype and as
+such is frequently not connected to the Network, but being used
+to refine and debug the Terminal IMP programs.
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+
+NO.    SITE                        DATE AND TIME (EASTERN)
+---    ----                        -----------------------
+                    6/19  6/21  6/22  6/23  6/26  6/27  6/28  6/29  6/30
+                    1700  1830  1530  1300  1600  1400  1400  1600  1530
+  1    UCLA-NMC       O     O     O     O     O     D     H     O     O
+ 65    UCLA-CCN*      O     O     O     T     O     O     O     O     O
+  2    SRI-ARC        O     O     O     O     D     O     O     D     D
+ 66    SRI-AI         D     D     D     D     D     D    #D     D     O
+  3    UCSB-MOD75     O     O     O     O     O     O     O     O     O
+  4    UTAH-10        O     O     O     D     O     O     D     H     D
+ 69    BBN-TENEX      O     O     O     T     O     O     O     F     O
+133    BBN-TENEXB    #D    #D    #D    #D    #D    #D    #D    #D    #D
+  6    MIT-MULTICS    O     D     O     O     O     O     O     O     D
+ 70    MIT-DMCG       O     F     O     O     O     F     H     O     O
+134    MIT-AI         H     H     H     O     O     O     O     O     O
+194    MIT-ML         H     H     H     O     H     H     D     H     H
+ 71    RAND-CSG       O     O     O     H     O     D     O     O     O
+  8    SDC-ADEPT      D     D    #D    #D     D    #D    #D     D    #D
+  9    HARVARD-10    #D    #D     O     O     O     O     O     O     O
+ 10    L.L.-360       H     T     H     H     H     T     H     H     H
+ 74    L.L.-TX-2      T     O     R     D     O     O    #D     O     O
+ 11    STANFORD-AI    O     O     O     O     O     O     O     T     O
+ 13    CASE           D     D     D     D     D     D     D     D     D
+ 14    CMU-10         O     O     O     O     O     O     D     D     O
+ 15    AMES-ILLIAC    O     O     O     O     O     D     O     O     T
+ 16    AMES-67        D     D     D     D     D     D     D     D     D
+
+D = Dead (Destination Host either dead or inaccessible [due to network
+    partitioning or local IMP failure] from the BBN Terminal IMP.)
+
+F = Full (Destination Host opened a connection, informed user that all
+    Network ports were in use, and immediately closed the connection.)
+
+H = 1/2 Open (Destination Host opened a connection but then either
+    immediately closed it, or did not respond any further.)
+
+O = Open (Destination Host opened a connection and was accessible to users.)
+
+R = Refused (Destination Host returned a CLS to the initial RFC.)
+
+T = Timed out (Destination Host did not complete the ICP and open a
+    connection within 60 seconds.)
+_______________
+*The only service currently offered by the UCLA IBM-360/91 is a Network
+ Job Service (NETRJS), however, the BBN Terminal IMP is not equipped to
+ test NETRJS. We are assuming that initial connection to the NETRJS
+ logger indicates that NETRJS is also functioning.
+#These sites advertise that they may not have their system available
+ at these times.
+
+
+                                                                 [Page 2]
+
+STATUS OR
+ SITE                                                         PREDICTIONS
+ADDRESS  SITE           COMPUTER      STATUS OR PREDICTION   OBTAINED FROM
+-------  ----           --------      --------------------   -------------
+   1     UCLA           SIGMA-7       Server #Limited        Jon Postel
+  65     UCLA           IBM-360/91    NETRJS now             Bob Braden
+                                      (Telnet in June)
+   2     SRI (NIC)      PDP10         Server                 Jim White
+  66     SRI (AI)       PDP-10        Server                 Len Chaiten
+   3     UCSB           IBM-360/75    Server                 Ron Stoughton
+   4     UTAH           PDP-10        Server                 Barry Wessler
+  *5     BBN (NCC)      DDP-516       Server                 Alex McKenzie
+  69     BBN (TENEX-A)  PDP-10        Server                 Dan Murphy
+ 133     BBN (TENEX-B)  PDP-10        Server (Exper.)        Dan Murphy
+   6     MIT (Multics)  H-645         Server                 Mike Padlipsky
+  70     MIT (DM)       PDP-10        Server                 Bob Bressler
+ 134     MIT (AI)       PDP-10        Server                 Jeff Rubin
+ 198     MIT (ML)       PDP-10        Server                 Jeff Rubin
+  *7     RAND           IBM-360/65    User Only              Eric Harslem
+  71     RAND           PDP-10        Server                 Eric Harslem
+   8     SDC            IBM-370/155   Server                 Bob Long
+   9     HARVARD        PDP-10        Server                 Bob Sundberg
+ *73     HARVARD        PDP-1         User Only              Bob Sundberg
+  10     LINCOLN        IBM-360/67    "Soon"                 Joel Winett
+  74     LINCOLN        TX-2          Server                 Will Kantrowitz
+*138     LINCOLN        TSP           User Only              Tom Barkelow
+  11     STANFORD       PDP-10        Server                 Andy Moorer
+ *12     ILLINOIS       PDP-11        User Only              John Cravits
+  13     CASE           PDP-10        July                   Charles Rose
+  14     CARNEGIE       PDP-10        Server                 Hal VanZoeren
+  15     AMES           ILLIAC        Server                 John McConnell
+                        (PDP-10)
+  16     AMES           IBM-360/67    "Soon"                 Wayne Hathaway
+*144     AMES           TIP           User Only
+*145     MITRE          TIP           User Only
+*146     RADC           TIP           User Only
+ *19     NBS            PDP-11        User Only              Robert Rosenthal
+*147     NBS            TIP           User Only
+*148     ETAC           TIP           User Only
+ *23     USC            IBM-360/44    User Now               James Pepin
+*151     USC            TIP           User Only
+*152     GWC            TIP           User Only
+*153     NOAA           TIP           User Only
+*154     SAAC           TIP           User Only
+*156     ARPA           TIP           User Only
+*158     BBN            TIP           User Only
+                        (Prototype)
+_______________
+
+
+
+                                                                [Page 3]
+
+*Host not included in daily testing.
+#The NMC is a research site and would like
+ to have prior arrangement with each user.
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                      1/97 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+9
+
+
+                                                                [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc366.txt](<www.ietf.org/rfc/rfc366.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
