### PR TITLE
Archive rfc378.txt

### DIFF
--- a/www.ietf.org/rfc/rfc378.txt
+++ b/www.ietf.org/rfc/rfc378.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                                        A. McKenzie
+Request for Comments: 378                                            BBN
+NIC #11120                                                10 August 1972
+
+
+                     Traffic Statistics (July 1972)
+
+   For several months BBN has been supplying ARPA with a monthly summary
+   of "Host packets output."  In response to questions from several
+   sites, ARPA has agreed to allow us to publish these statistics in RFC
+   form also.  Attached are the traffic statistics for the month of July
+   1972.
+
+   Please note that the numbers given are either monthly totals or
+   overall averages (i.e., based on 24 hours per day, seven days a
+   week).  Thus, these numbers are not useful in determining peak
+   traffic conditions.
+
+                          HOST THROUGHPUT SUMMARY
+                             (PACKETS OUTPUT)
+
+                                JULY  1972
+
+                            MISSING DATA FOR 17
+
+                     INTER-    INTRA-               AVG. DAILY
+                      NODE      NODE      TOTAL      INTERNODE    DAYS
+
+   UCLA  HOST 1      100083     74730    174813
+   UCLA  HOST 2     1168305     78751   1247056
+   UCLA  HOST 3       33544     11950     45494
+                   --------   -------  --------
+                    1301932    165431   1467363          43398      30
+
+   SRI   HOST 1      952543    343616   1296159
+   SRI   HOST 2      140338      4798    145136
+                   --------   -------  --------
+                    1092881    348414   1441295          36429      30
+
+   UCSB  HOST 1      340463    271366    611829          11349      30
+
+   UTAH  HOST 1      597722   2019417   2617139          19924      30
+
+   BBN   HOST 2     2190851    434235   2625086
+   BBN   HOST 3         105       188       293
+   BBN   HOST 4       78153      7697     85850
+                   --------   -------  --------
+                    2269109    442120   2711229          75637      30
+
+
+
+McKenzie                                                        [Page 1]
+
+RFC 378                    Traffic Statistics                August 1972
+
+
+   MIT   HOST 1      106692     36493    143185
+   MIT   HOST 2      262648    642765    905413
+   MIT   HOST 3      393534   3061353   3454887
+   MIT   HOST 4      132621    800019    932640
+                   --------   -------  --------
+                     895495   4540630   5436125          29850      30
+
+   RAND  HOST 1      145953      7753    153706
+   RAND  HOST 2     1117688   2767974   3885662
+                   --------   -------  --------
+                    1263641   2775727   4039368          42121      30
+
+   SDC   HOST 1         871       623      1494             29      30
+
+   HARV  HOST 1      184616     63963    248579
+   HARV  HOST 2        9771     17938     27709
+                   --------   -------  --------
+                     194387     81901    276288           6480      30
+
+   LINC  HOST 1        5470      2897      8367
+   LINC  HOST 2       20431     34736     55167
+   LINC  HOST 3           0    136843    136843
+                   --------   -------  --------
+                      25901    174476    200377            863      30
+
+   STAN  HOST 1      453402     43346    496748          15113      30
+
+   ILL   HOST 1      199597       481    200078           6653      30
+
+   CASE  HOST 1          49        13        62              2      30
+
+   CARN  HOST 1      175067     58896    233963
+   CARN  HOST 2           0        12        12
+   CARN  HOST 4           1         0         1
+                   --------   -------  --------
+                     175068     58908    233976           5836      30
+
+   AMES2 HOST 1      876411      8700    885111          29214      30
+
+   AMES1 HOST 1       29969     37857     67826
+   AMES1 HOST 3     2081967     35898   2117865
+                   --------   -------  --------
+                    2111936     73755   2185691          70398      30
+
+   MITRE HOST 3      555380        34    555414          18513      30
+
+   ROME  HOST 3      315960        32    315992          10532      30
+
+
+
+
+McKenzie                                                        [Page 2]
+
+RFC 378                    Traffic Statistics                August 1972
+
+
+   NBS   HOST 1       15965       287     16252
+   NBS   HOST 3      531756       172    531928
+                   --------   -------  --------
+                     547721       459    548180          18257      30
+
+   ETAC  HOST 3      150462       175    150637           5015      30
+
+   TINK  HOST 1           0    159872    159872              0      30
+
+   MC CL HAD NO TRAFFIC
+
+   USC   HOST 3      783376      5232    788608          26113      30
+
+   GWC   HOST 3       70982        52     71034           2366      30
+
+   NOAA  HOST 3       44504        24     44528           1483      30
+
+   SAAC  HOST 3        5909        20      5929            197      30
+
+   BELV HAD NO TRAFFIC
+
+   ARPA  HOST 1           0    335053    335053
+   ARPA  HOST 3       68838     50071    118909
+                   --------   -------  --------
+                      68838    385124    453962           2295      30
+
+   BBN T HOST 3      714884   2268976   2983860          23829      30
+
+   --------------------------------------------
+   TOTAL           15056880  13825310
+
+   DAILY AVERAGE     501896    460844
+
+   AVERAGE PER        17307     15891
+   NODE-DAY
+
+   PACKETS/MESSAGE (INTERNODE)    1.09
+
+
+
+         [ This RFC was put into machine readable form for entry ]
+           [ into the online RFC archives by Bob German 10/99 ]
+
+
+
+
+
+
+
+
+
+McKenzie                                                        [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc378.txt](<www.ietf.org/rfc/rfc378.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
