### PR TITLE
Archive rfc3816.txt

### DIFF
--- a/www.ietf.org/rfc/rfc3816.txt
+++ b/www.ietf.org/rfc/rfc3816.txt
@@ -1,0 +1,2971 @@
+
+
+
+
+
+
+Network Working Group                                         J. Quittek
+Request for Comments: 3816                                M. Stiemerling
+Category: Standards Track                                            NEC
+                                                          H. Hartenstein
+                                                 University of Karlsruhe
+                                                               June 2004
+
+
+  Definitions of Managed Objects for RObust Header Compression (ROHC)
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2004).
+
+Abstract
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the Internet community.
+   In particular, it describes a set of managed objects that allow
+   monitoring of running instances of RObust Header Compression (ROHC).
+   The managed objects defined in this memo are grouped into three MIB
+   modules.  The ROHC-MIB module defines managed objects shared by all
+   ROHC profiles, the ROHC-UNCOMPRESSED-MIB module defines managed
+   objects specific to the ROHC uncompressed profile, the ROHC-RTP-MIB
+   module defines managed objects specific to the ROHC RTP (Real-Time
+   Transport Protocol) profile, the ROHC UDP (User Datagram Protocol)
+   profile, the ROHC ESP (Encapsulating Security Payload) profile, and
+   the ROHC LLA (Link Layer Assisted) profile.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Quittek, et al.             Standards Track                     [Page 1]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+Table of Contents
+
+   1.  Introduction . . . . . . . . . . . . . . . . . . . . . . . . .  2
+   2.  The Internet-Standard Management Framework . . . . . . . . . .  2
+   3.  Overview . . . . . . . . . . . . . . . . . . . . . . . . . . .  3
+   4.  Structure of the MIB modules . . . . . . . . . . . . . . . . .  3
+       4.1. The ROHC-MIB module . . . . . . . . . . . . . . . . . . .  4
+            4.1.1. rohcChannelTable . . . . . . . . . . . . . . . . .  5
+            4.1.2. rohcInstanceTable. . . . . . . . . . . . . . . . .  5
+            4.1.3. rohcProfileTable . . . . . . . . . . . . . . . . .  6
+            4.1.4. rohcContextTable . . . . . . . . . . . . . . . . .  7
+       4.2. The ROHC-UNCOMPRESSED-MIB module. . . . . . . . . . . . .  8
+            4.2.1. rohcUncmprContextTable . . . . . . . . . . . . . .  8
+       4.3. The ROHC-RTP-MIB module . . . . . . . . . . . . . . . . .  8
+            4.3.1. rohcRtpContextTable. . . . . . . . . . . . . . . .  8
+            4.3.2. rohcPacketSizeTable. . . . . . . . . . . . . . . .  9
+   5.  Definitions  . . . . . . . . . . . . . . . . . . . . . . . . .  9
+   6.  Security Considerations. . . . . . . . . . . . . . . . . . . . 50
+   7.  Acknowledgements . . . . . . . . . . . . . . . . . . . . . . . 51
+   8.  References . . . . . . . . . . . . . . . . . . . . . . . . . . 51
+       8.1. Normative References. . . . . . . . . . . . . . . . . . . 51
+       8.2. Informative References. . . . . . . . . . . . . . . . . . 52
+   9.  Authors' Addresses . . . . . . . . . . . . . . . . . . . . . . 52
+   10. Full Copyright Statement . . . . . . . . . . . . . . . . . . . 53
+
+1.  Introduction
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the Internet community.
+   In particular, it describes a set of managed objects that allow
+   monitoring of running instances of robust header compression.
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in BCP
+   14, RFC 2119 [RFC2119].
+
+2.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This memo specifies a MIB
+
+
+
+Quittek, et al.             Standards Track                     [Page 2]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+   module that is compliant to the SMIv2, which is described in STD 58,
+   RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579] and STD 58, RFC 2580
+   [RFC2580].
+
+3.  Overview
+
+   This section describes the basic model of RObust Header Compression
+   (ROHC, [RFC3095]) used when developing the MIB modules for ROHC
+   described in the following sections.
+
+   ROHC presents a framework for IP header compression that allows
+   flexible adjustment of compression efficiency versus robustness
+   against channel errors depending on the underlying channel
+   characteristics.
+
+   ROHC introduces header compressors/decompressors at the end-points
+   (interfaces) of (wireless) channels on which packets with compressed
+   headers are transferred.  ROHC exploits the temporal redundancy in
+   successive packet headers of a packet flow by storing non-changing
+   fields of the headers as well as reference values of predictably
+   changing fields as context information.  When the context information
+   for a packet flow is also established at the decompressor, only
+   delta-information and unpredictably changing header fields have to be
+   sent over the channel.
+
+   This document specifies MIB modules in order to provide a means for
+   managing ROHC implementations via SNMP and within the IETF management
+   framework.  The objects defined support configuration management,
+   fault management and performance monitoring.
+
+   For configuration management implementation parameters (see Section
+   6.3 of [RFC3095]) and configuration parameters (including the ones
+   specified in Section 5.1.1 of [RFC3095] and in Section 5.1.1 of
+   [RFC3242]) can be verified by using the MIB modules specified below.
+
+   For fault management compressor/decompressor state and mode can be
+   checked.
+
+   For performance management a set of statistics is provided including
+   the number of flows that have used ROHC, the current and long term
+   compression ratio, the number of reinitializations and the number of
+   packets sent or received with different header types.
+
+4.  Structure of the MIB modules
+
+   This section presents the structure of the MIB modules that are
+   specified in Section 5.  Basically, the MIB is structured according
+   to the ROHC architecture described in [RFC3759].
+
+
+
+Quittek, et al.             Standards Track                     [Page 3]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+   ROHC is an evolving technology.  [RFC3095] specifies the header
+   compression framework and four profiles: uncompressed, RTP, UDP, and
+   ESP (Real-Time Transport Protocol, User Datagram Protocol,
+   Encapsulating Security Payload).  [RFC3242] specifies a profile with
+   additional link layer assistance called LLA (Link Layer Assisted).  A
+   profile for compression of TCP (Transmission Control Protocol) flows
+   is under development within the ROHC working group and SCTP (Stream
+   Control Transmission Protocol) compression is being discussed as
+   potential next candidate.  Therefore, the managed objects defined
+   below are structured into three MIB modules: the general ROHC-MIB
+   module and the profile-specific ROHC-UNCOMPRESSED-MIB and ROHC-RTP-
+   MIB modules.  This flexible approach allows to support future
+   profiles each by its own profile-specific module.
+
+   The ROHC-MIB module defines properties of information on ROHC
+   instances, ROHC channels, ROHC profiles, and ROHC compressor and
+   decompressor contexts.  All managed objects in this module are
+   assumed to be shared by all profiles.
+
+   The ROHC-UNCOMPRESSED-MIB module extends the ROHC-MIB by managed
+   objects that are specific to the ROHC uncompressed profile 0x0000
+   defined in [RFC3095].  The ROHC-RTP-MIB module extends the ROHC-MIB
+   by managed objects that are specific to the three profiles defined in
+   [RFC3095] (ROHC RTP profile 0x0001, ROHC UDP profile 0x0002, and ROHC
+   ESP profile 0x0003), and to the ROHC LLA profile 0x0005 defined in
+   [RFC3242].  An analysis of these profiles showed that they are
+   tightly related and can share most of the managed objects in the
+   ROHC-UNCOMPRESSED-MIB module.  Therefore, a joint module for all of
+   them was preferred to individual modules.
+
+   The number of managed objects in the ROHC-UNCOMPRESSED-MIB Module and
+   the ROHC-RTP-MIB Module is rather small.  They contain context state
+   and context mode, and profile-specific context statistics.  It is
+   assumed that MIB modules for future profiles, such as TCP and SCTP,
+   will be similarly small and easy to design.
+
+4.1.  The ROHC-MIB module
+
+   The ROHC-MIB module defines managed objects that are expected to be
+   useful for all current and future ROHC profiles.  Objects in the
+   ROHC-MIB module are arranged into four tables: the rohcChannelTable,
+   the rohcInstanceTable, the rohcProfileTable, and the
+   rohcContextTable.  The managed objects in the first three tables are
+   rather static (except for provided statistics), while the objects in
+   the rohcContextTable are more dynamic.
+
+
+
+
+
+
+Quittek, et al.             Standards Track                     [Page 4]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+   All tables are indexed by the IP interface number and by a numeric
+   channel identifier.  The channel identifier is used for channels to
+   which compressors and decompressors are attached (called ROHC
+   channels in [RFC3759]), as well as for dedicated feedback channels
+   (called ROHC feedback channels in [RFC3759]).  Compressor and
+   decompressor instances are further indexed by their type (either
+   compressor or decompressor).  Contexts are indexed by the same index
+   as their corresponding instance and their individual context
+   identifier (CID).
+
+4.1.1.  rohcChannelTable
+
+   The rohcChannelTable lists all channels used by ROHC instances for
+   transferring compressed packets and/or for giving feedback from the
+   decompressor to the compressor.  Listed channels are either ROHC
+   channels or feedback channels as defined in [RFC3759].  The channels
+   are listed per IP interface.
+
+   The information per channel in the rohcChannelTable includes
+
+   o  the channel ID,
+
+   o  the channel type, either 'notInUse', 'rohc', or
+      'dedicatedFeedback',
+
+   o  the channel for which feedback is provided by this channel (if
+      applicable),
+
+   o  a string for describing the channel, and
+
+   o  the status of the channel being either 'enabled' or 'disabled'.
+
+4.1.2.  rohcInstanceTable
+
+   The rohcInstanceTable defines properties of ROHC compressor instances
+   and ROHC decompressor instances.
+
+   As described in [RFC3759], an instance is associated with exactly one
+   channel and only one instance can be associated with the same
+   channel.  Therefore, the same index consisting of ifIndex and
+   rohcChannelID could have been used for both tables.  But when
+   accessing the rohcInstanceTable (and the rohcContextTable that shares
+   a part of its index with the rohcInstanceTable) there are many cases
+   where either a compressor contexts or a decompressor contexts are of
+   interest.  Therefore, the rohcInstanceType indicating either a
+   compressor or a decompressor was added to the table's index.  This
+   allows listing all compressors without accessing any decompressor.
+
+
+
+
+Quittek, et al.             Standards Track                     [Page 5]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+   Note that still the combination of ifIndex and rohcChannelID uniquely
+   identifies an instance.  It is always possible to directly identify
+   and access the channel corresponding to a given instance.
+
+   The set of instance properties in the rochInstanceTable includes
+
+   o  the vendor of the implementation, version number and description,
+
+   o  the channels used for compressed packets and for feedback,
+
+   o  implementation and configuration properties including clock
+      resolution, maximum context identifier number (MAX_CID), the
+      LARGE_CIDS flag, and the Maximum Reconstructed Reception Unit
+      (MRRU),
+
+   o  the storage time for contexts created by this instance,
+
+   o  the status of the instance (operational or not).
+
+   Optionally, the rohcInstanceTable also contains instance statistics
+   including
+
+   o  the total number of compressed flows,
+
+   o  the current number of compressed flows,
+
+   o  the total number of packets passing this instance
+
+   o  the total number of static Initialization and Refreshes (IRs)
+      passing this instance
+
+   o  the total number of dynamic Initialization and Refreshes (IR-DYNs)
+      passing this instance, and
+
+   o  the total compression ratio achieved on the channel.
+
+   Instances are listed per IP interface.
+
+4.1.3.  rohcProfileTable
+
+   The rohcProfileTable lists available profiles per instance including
+   information on
+
+   o  the profile number,
+
+   o  the vendor and version number, and
+
+   o  a string describing the profile.
+
+
+
+Quittek, et al.             Standards Track                     [Page 6]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+   o  a flag indicating whether or not using this profile has been
+      negotiated with the corresponding (de)compressor.
+
+4.1.4.  rohcContextTable
+
+   The rohcContextTable lists compressor contexts or decompressor
+   contexts per instance and context identifier (CID).  Each row of this
+   table represents a context.  If a new context is created, also a new
+   row in this table is created.  After expiration or termination of a
+   context, the row will continue to exist until the context's storage
+   time expires or until the CID is re-used.  Then the row will be
+   deleted.
+
+   For each context, the following attributes are listed:
+
+   o  the type of context ('compressor' or 'decompressor'), also used as
+      part of the table index,
+
+   o  the CID,
+
+   o  the state of the CID ('unused', 'active', 'expired', or
+      'terminated'), also used as part of the table index,
+
+   o  the used profile,
+
+   o  in case of a decompressor: the decompressor depth, and
+
+   o  the storage time.
+
+   Optionally, context statistics is provided including
+
+   o  activation and deactivation time of the context,
+
+   o  the number of packets sent or received, respectively,
+
+   o  the numbers of IRs and IR-DYNs sent or received, respectively,
+
+   o  the number of feedbacks sent or received, respectively,
+
+   o  in case of a decompressor context: the numbers of decompressor
+      failures and repairs,
+
+   o  the total compression ratio of all packets passing this context,
+
+   o  the total compression ratio of all packet headers compressed in
+      this context,
+
+
+
+
+
+Quittek, et al.             Standards Track                     [Page 7]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+   o  the mean compressed packet size of all packets passing this
+      context,
+
+   o  the mean header size of all compressed headers passing this
+      context,
+
+   o  the compression ratio of the last 16 packets passing this context,
+
+   o  the compression ratio of the last 16 packet headers compressed in
+      this context,
+
+   o  the mean compressed packet size of the last 16 packets passing
+      this context,
+
+   o  the mean header size of the last 16 compressed headers passing
+      this context.
+
+4.2.  The ROHC-UNCOMPRESSED-MIB module
+
+   The ROHC-UNCOMPRESSED-MIB module defines managed objects that are
+   specific to ROHC uncompressed profile (0x0000) specified in
+   [RFC3095].
+
+4.2.1.  rohcUncmprContextTable
+
+   The rohcUncmprContextTable extends the rohcContextTable.  It provides
+   information on state and mode of the compressor for profile 0x0000.
+   Optionally, it also provides a counter of ACK feedbacks sent or
+   received by the context, respectively.
+
+4.3.  The ROHC-RTP-MIB module
+
+   The ROHC-RTP-MIB module defines managed objects that are specific to
+   three profiles specified in [RFC3095] (ROHC RTP profile 0x0001, ROHC
+   UDP profile 0x0002, and ROHC ESP profile 0x0003) and to the ROHC LLA
+   profile 0x0005 specified in [RFC3242].  The ROHC-RTP-MIB contains two
+   tables, the rohcRtpContextTable and the rohcRtpPacketSizeTable.
+
+4.3.1.  rohcRtpContextTable
+
+   The rohcRtpContextTable extends the rohcContextTable.  It provides
+   information on context state and context mode for profiles 0x0001 -
+   0x0003 and 0x0005.  For compressor contexts it optionally contains
+   managed object containing the numbers of allowed and used packet
+   sizes.  As further option, counters of the numbers of ACKs, NACKs,
+   and SNACKs in this context are specified.
+
+
+
+
+
+Quittek, et al.             Standards Track                     [Page 8]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+4.3.2.  rohcPacketSizeTable
+
+   The optional rohcPacketSizeTable lists per compressor context the
+   allowed packet sizes for profiles ROHC RTP, ROHC UDP, ROHC ESP, or
+   the preferred packet sizes for ROHC LLA, respectively.  Allowed
+   packet sizes are marked if they are used.  For preferred packet
+   sizes, it is indicated whether the preferred size applies to NHP
+   only, to RHP only or to all packets.
+
+5.  Definitions
+
+  ROHC-MIB DEFINITIONS ::= BEGIN
+
+  IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE,
+      Unsigned32, Counter32, mib-2
+          FROM SNMPv2-SMI                                -- [RFC2578]
+
+      TEXTUAL-CONVENTION, TruthValue,
+      TimeInterval, DateAndTime
+          FROM SNMPv2-TC                                 -- [RFC2579]
+
+      MODULE-COMPLIANCE, OBJECT-GROUP
+          FROM SNMPv2-CONF                               -- [RFC2580]
+
+      SnmpAdminString
+          FROM SNMP-FRAMEWORK-MIB                        -- [RFC3411]
+
+      ifIndex
+          FROM IF-MIB;                                   -- [RFC2863]
+
+  rohcMIB MODULE-IDENTITY
+      LAST-UPDATED "200406030000Z"  -- June 3, 2004
+      ORGANIZATION "IETF Robust Header Compression Working Group"
+      CONTACT-INFO
+         "WG charter:
+            http://www.ietf.org/html.charters/rohc-charter.html
+
+          Mailing Lists:
+            General Discussion: rohc@ietf.org
+            To Subscribe: rohc-request@ietf.org
+            In Body: subscribe your_email_address
+
+          Editor:
+            Juergen Quittek
+            NEC Europe Ltd.
+            Network Laboratories
+            Kurfuersten-Anlage 36
+
+
+
+Quittek, et al.             Standards Track                     [Page 9]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+            69221 Heidelberg
+            Germany
+            Tel: +49 6221 90511-15
+            EMail: quittek@netlab.nec.de"
+      DESCRIPTION
+          "This MIB module defines a set of basic objects for
+           monitoring and configuring robust header compression.
+           The module covers information about running instances
+           of ROHC (compressors or decompressors) at IP interfaces.
+
+           Information about compressor contexts and decompressor
+           contexts has different structure for different profiles.
+           Therefore it is not provided by this MIB module, but by
+           individual modules for different profiles.
+
+           Copyright (C) The Internet Society (2004). The
+           initial version of this MIB module was published
+           in RFC 3816. For full legal notices see the RFC
+           itself or see:
+           http://www.ietf.org/copyrights/ianamib.html"
+
+      REVISION    "200406030000Z"  -- June 3, 2004
+      DESCRIPTION "Initial version, published as RFC 3816."
+      ::= { mib-2 112 }
+
+  RohcChannelIdentifier ::= TEXTUAL-CONVENTION
+      DISPLAY-HINT "d"
+      STATUS       current
+      DESCRIPTION
+          "A number identifying a channel.
+           The value of 0 must not be used as identifier
+           of an existing channel."
+      SYNTAX       Unsigned32 (1..4294967295)
+
+  RohcChannelIdentifierOrZero ::= TEXTUAL-CONVENTION
+      DISPLAY-HINT "d"
+      STATUS       current
+      DESCRIPTION
+          "A number identifying a channel.
+           The value of 0 is indicates that
+           no channel is identified."
+      SYNTAX       Unsigned32 (0..4294967295)
+
+  RohcCompressionRatio ::= TEXTUAL-CONVENTION
+      DISPLAY-HINT "d"
+      STATUS       current
+      DESCRIPTION
+          "A number indicating a compression ratio over
+
+
+
+Quittek, et al.             Standards Track                    [Page 10]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+           a set of bytes.  The value is defined as
+           1000 * bytes(compressed) / bytes(original)
+           rounded to the next integer value.
+
+           Note that compressed sets of bytes can be larger
+           than the corresponding uncompressed ones.
+           Therefore, the number can be greater than 1000."
+      SYNTAX       Unsigned32
+
+  --
+  -- The groups defined within this MIB module:
+  --
+
+  rohcObjects       OBJECT IDENTIFIER ::= { rohcMIB 1 }
+  rohcConformance   OBJECT IDENTIFIER ::= { rohcMIB 2 }
+
+  --
+  -- The ROHC Instance group lists properties of ROHC
+  -- instances in the rohcInstanceTable, about the channels used
+  -- by the instances in the rohcChanneltable and about the profiles
+  -- available at the instances in the rohcProfileTable.
+  --
+
+  rohcInstanceObjects       OBJECT IDENTIFIER ::= { rohcObjects 1 }
+
+  --
+  -- Channel Table
+  --
+  -- Listing all channels used for ROHC data channel
+  -- and/or as feedback channel.
+  --
+
+  rohcChannelTable OBJECT-TYPE
+      SYNTAX      SEQUENCE OF RohcChannelEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+          "This table lists and describes all ROHC channels
+           per interface."
+      ::= { rohcInstanceObjects 1 }
+
+  rohcChannelEntry OBJECT-TYPE
+      SYNTAX      RohcChannelEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+          "An entry describing a particular script.  Every script that
+           is stored in non-volatile memory is required to appear in
+
+
+
+Quittek, et al.             Standards Track                    [Page 11]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+           this script table.
+
+           Note, that the rohcChannelID identifies the channel
+           uniquely.  The ifIndex is part of the index of this table
+           just in order to allow addressing channels per interface."
+      INDEX { ifIndex, rohcChannelID }
+      ::= { rohcChannelTable 1 }
+
+  RohcChannelEntry ::= SEQUENCE {
+      rohcChannelID               RohcChannelIdentifier,
+      rohcChannelType             INTEGER,
+      rohcChannelFeedbackFor      RohcChannelIdentifierOrZero,
+      rohcChannelDescr            SnmpAdminString,
+      rohcChannelStatus           INTEGER
+  }
+
+  rohcChannelID OBJECT-TYPE
+      SYNTAX      RohcChannelIdentifier
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+          "The locally arbitrary, but unique identifier associated
+           with this channel.  The value is REQUIRED to be unique
+           per ROHC MIB implementation independent of the associated
+           interface.
+
+           The value is REQUIRED to remain constant at least from one
+           re-initialization of the entity's network management system
+           to the next re-initialization.  It is RECOMMENDED that the
+           value persist across such re-initializations."
+      REFERENCE
+          "RFC 3095, Section 5.1.1"
+      ::= { rohcChannelEntry 2 }
+
+  rohcChannelType OBJECT-TYPE
+      SYNTAX      INTEGER {
+                      notInUse(1),
+                      rohc(2),
+                      dedicatedFeedback(3)
+                  }
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "Type of usage of the channel.  A channel might be currently
+           not in use for ROHC or feedback, it might be in use as
+           a ROHC channel carrying packets and optional piggy-backed
+           feedback, or it might be used as a dedicated feedback
+           channel exclusively carrying feedback."
+
+
+
+Quittek, et al.             Standards Track                    [Page 12]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+      ::= { rohcChannelEntry 3 }
+
+  rohcChannelFeedbackFor OBJECT-TYPE
+      SYNTAX      RohcChannelIdentifierOrZero
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "The index of another channel of this interface for which
+           the channel serves as feedback channel.
+
+           If no feedback information is transferred on this channel,
+           then the value of this ID is 0.  If the channel type is set
+           to notInUse(1), then the value of this object must be 0.
+           If the channel type is rohc(2) and the value of this object
+           is a valid channel ID, then feedback information is
+           piggy-backed on the ROHC channel.  If the channel type is
+           dedicatedFeedback(3), then feedback is transferred on this
+           channel and the value of this object MUST be different from
+           0 and MUST identify an existing ROHC channel."
+      REFERENCE
+          "RFC 3095, Section 5.1.1"
+      ::= { rohcChannelEntry 4 }
+
+  rohcChannelDescr OBJECT-TYPE
+      SYNTAX      SnmpAdminString
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "A textual description of the channel."
+      ::= { rohcChannelEntry 5 }
+
+  rohcChannelStatus OBJECT-TYPE
+      SYNTAX      INTEGER {
+                      enabled(1),
+                      disabled(2)
+                  }
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "Status of the channel."
+      ::= { rohcChannelEntry 6 }
+
+  --
+  -- Instances of ROHC
+  --
+  -- This table lists properties of running instances of ROHC
+  -- compressors and decompressors at the managed node.
+  --
+
+
+
+Quittek, et al.             Standards Track                    [Page 13]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+
+  rohcInstanceTable OBJECT-TYPE
+      SYNTAX      SEQUENCE OF RohcInstanceEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+          "This table lists properties of running instances
+           of robust header compressors and decompressors
+           at IP interfaces.  It is indexed by interface number,
+           the type of instance (compressor or decompressor),
+           and the ID of the channel used by the instance as
+           ROHC channel.
+
+           Note that the rohcChannelID uniquely identifies an
+           instance.  The ifIndex and rohcInstanceType are part
+           of the index, because it simplifies accessing instances
+           per interface and for addressing either compressors or
+           decompressors only."
+      ::= { rohcInstanceObjects 2 }
+
+  rohcInstanceEntry OBJECT-TYPE
+      SYNTAX      RohcInstanceEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+          "An entry describing a particular instance
+           of a robust header compressor or decompressor."
+      INDEX { ifIndex, rohcInstanceType, rohcChannelID }
+      ::= { rohcInstanceTable 1 }
+
+  RohcInstanceEntry ::= SEQUENCE {
+      rohcInstanceType               INTEGER,
+      rohcInstanceFBChannelID        RohcChannelIdentifierOrZero,
+      rohcInstanceVendor             OBJECT IDENTIFIER,
+      rohcInstanceVersion            SnmpAdminString,
+      rohcInstanceDescr              SnmpAdminString,
+      rohcInstanceClockRes           Unsigned32,
+      rohcInstanceMaxCID             Unsigned32,
+      rohcInstanceLargeCIDs          TruthValue,
+      rohcInstanceMRRU               Unsigned32,
+      rohcInstanceContextStorageTime TimeInterval,
+      rohcInstanceStatus             INTEGER,
+      rohcInstanceContextsTotal      Counter32,
+      rohcInstanceContextsCurrent    Unsigned32,
+      rohcInstancePackets            Counter32,
+      rohcInstanceIRs                Counter32,
+      rohcInstanceIRDYNs             Counter32,
+      rohcInstanceFeedbacks          Counter32,
+
+
+
+Quittek, et al.             Standards Track                    [Page 14]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+      rohcInstanceCompressionRatio   RohcCompressionRatio
+  }
+
+  rohcInstanceType OBJECT-TYPE
+      SYNTAX      INTEGER {
+                      compressor(1),
+                      decompressor(2)
+                  }
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+          "Type of the instance of ROHC. It is either a
+           compressor instance or a decompressor instance."
+      ::= { rohcInstanceEntry 2 }
+
+  rohcInstanceFBChannelID OBJECT-TYPE
+      SYNTAX      RohcChannelIdentifierOrZero
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "Identifier of the channel used for feedback.
+           If no feedback channel is used, the value of
+           this object is 0 ."
+      REFERENCE
+          "RFC 3095, Section 5.1.1"
+      ::= { rohcInstanceEntry 4 }
+
+  rohcInstanceVendor OBJECT-TYPE
+      SYNTAX      OBJECT IDENTIFIER
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "An object identifier that identifies the vendor who
+           provides the implementation of robust header description.
+           This object identifier SHALL point to the object identifier
+           directly below the enterprise object identifier
+           {1 3 6 1 4 1} allocated for the vendor.  The value must be
+           the object identifier {0 0} if the vendor is not known."
+      ::= { rohcInstanceEntry 5 }
+
+  rohcInstanceVersion OBJECT-TYPE
+      SYNTAX      SnmpAdminString (SIZE (0..32))
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "The version number of the implementation of robust header
+           compression.  The zero-length string shall be used if the
+           implementation does not have a version number.
+
+
+
+Quittek, et al.             Standards Track                    [Page 15]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+
+           It is suggested that the version number consist of one or
+           more decimal numbers separated by dots, where the first
+           number is called the major version number."
+      ::= { rohcInstanceEntry 6 }
+
+  rohcInstanceDescr OBJECT-TYPE
+      SYNTAX      SnmpAdminString
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "A textual description of the implementation."
+      ::= { rohcInstanceEntry 7 }
+
+  rohcInstanceClockRes OBJECT-TYPE
+      SYNTAX      Unsigned32
+      UNITS       "milliseconds"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "This object indicates the system clock resolution in
+           units of milliseconds.  A zero (0) value means that there
+           is no clock available."
+      ::= { rohcInstanceEntry 8 }
+
+  rohcInstanceMaxCID OBJECT-TYPE
+      SYNTAX      Unsigned32 (1..16383)
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "The highest context ID number to be used by the
+           compressor.  Note that this parameter is not coupled to,
+           but in effect further constrained by,
+           rohcChannelLargeCIDs."
+      REFERENCE
+          "RFC 3095, Section 5.1.1"
+      ::= { rohcInstanceEntry 9 }
+
+  rohcInstanceLargeCIDs OBJECT-TYPE
+      SYNTAX      TruthValue
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "When retrieved, this boolean object returns false if
+           the short CID representation (0 bytes or 1 prefix byte,
+           covering CID 0 to 15) is used; it returns true, if the
+           embedded CID representation (1 or 2 embedded CID bytes
+           covering CID 0 to 16383) is used."
+
+
+
+Quittek, et al.             Standards Track                    [Page 16]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+      REFERENCE
+          "RFC 3095, Section 5.1.1"
+      ::= { rohcInstanceEntry 10 }
+
+  rohcInstanceMRRU OBJECT-TYPE
+      SYNTAX      Unsigned32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "Maximum reconstructed reception unit.  This is the
+           size of the largest reconstructed unit in octets that
+           the decompressor is expected to reassemble from
+           segments (see RFC 3095, Section 5.2.5).  Note that this
+           size includes the CRC.  If MRRU is negotiated to be 0,
+           no segment headers are allowed on the channel."
+      REFERENCE
+          "RFC 3095, Section 5.1.1"
+      ::= { rohcInstanceEntry 11 }
+
+  rohcInstanceContextStorageTime OBJECT-TYPE
+      SYNTAX      TimeInterval
+      UNITS       "centi-seconds"
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+          "This object indicates the default maximum amount of time
+           information on a context belonging to this instance is kept
+           as entry in the rohcContextTable after the context is
+           expired or terminated.  The value of this object is used
+           to initialize rohcContexStorageTime object when a new
+           context is created.
+           Changing the value of an rohcInstanceContextStorageTime
+           instance does not affect any entry of the rohcContextTable
+           created previously.
+           ROHC-MIB implementations SHOULD store the set value of this
+           object persistently."
+      DEFVAL { 360000 }
+      ::= { rohcInstanceEntry 12 }
+
+  rohcInstanceStatus OBJECT-TYPE
+      SYNTAX      INTEGER {
+                      enabled(1),
+                      disabled(2)
+                  }
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "Status of the instance of ROHC."
+
+
+
+Quittek, et al.             Standards Track                    [Page 17]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+      ::= { rohcInstanceEntry 13 }
+
+  rohcInstanceContextsTotal OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "Counter of all contexts created by this instance.
+
+           Discontinuities in the value of this counter can
+           occur at re-initialization of the management
+           system, and at other times as indicated by the
+           value of ifCounterDiscontinuityTime."
+      ::= { rohcInstanceEntry 14 }
+
+  rohcInstanceContextsCurrent OBJECT-TYPE
+      SYNTAX      Unsigned32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "Number of currently active contexts created by this
+           instance."
+      ::= { rohcInstanceEntry 15 }
+
+  rohcInstancePackets OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "Counter of all packets passing this instance.
+
+           Discontinuities in the value of this counter can
+           occur at re-initialization of the management
+           system, and at other times as indicated by the
+           value of ifCounterDiscontinuityTime."
+      ::= { rohcInstanceEntry 16 }
+
+  rohcInstanceIRs OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "The number of all IR packets that are either sent
+           or received by this instance.
+
+           Discontinuities in the value of this counter can
+           occur at re-initialization of the management
+           system, and at other times as indicated by the
+
+
+
+Quittek, et al.             Standards Track                    [Page 18]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+           value of ifCounterDiscontinuityTime."
+      REFERENCE
+          "RFC 3095, Section 5.7.7.1"
+      ::= { rohcInstanceEntry 17 }
+
+  rohcInstanceIRDYNs OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "The number of all IR-DYN packets that are either sent
+           or received by this instance.
+
+           Discontinuities in the value of this counter can
+           occur at re-initialization of the management
+           system, and at other times as indicated by the
+           value of ifCounterDiscontinuityTime."
+      REFERENCE
+          "RFC 3095, Section 5.7.7.2"
+      ::= { rohcInstanceEntry 18 }
+
+  rohcInstanceFeedbacks OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "The number of all feedbacks that are either sent
+           or received by this instance.
+
+           Discontinuities in the value of this counter can
+           occur at re-initialization of the management
+           system, and at other times as indicated by the
+           value of ifCounterDiscontinuityTime."
+      ::= { rohcInstanceEntry 19 }
+
+  rohcInstanceCompressionRatio OBJECT-TYPE
+      SYNTAX      RohcCompressionRatio
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "This object indicates the compression ratio so far over all
+           packets on the channel served by this instance.  The
+           compression is computed over all bytes of the IP packets
+           including the IP header but excluding all lower layer
+           headers."
+      ::= { rohcInstanceEntry 20 }
+
+  --
+
+
+
+Quittek, et al.             Standards Track                    [Page 19]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+  -- Profile Table
+  --
+
+  rohcProfileTable OBJECT-TYPE
+      SYNTAX      SEQUENCE OF RohcProfileEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+          "This table lists a set of profiles supported by the
+           instance."
+      REFERENCE
+          "RFC 3095, Section 5.1.1"
+      ::= { rohcInstanceObjects 3 }
+
+  rohcProfileEntry OBJECT-TYPE
+      SYNTAX      RohcProfileEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+          "An entry describing a particular profile supported by
+           the instance.  It is indexed by the rohcChannelID
+           identifying the instance and by the rohcProfile."
+      INDEX { rohcChannelID, rohcProfile }
+      ::= { rohcProfileTable 1 }
+
+  RohcProfileEntry ::= SEQUENCE {
+      rohcProfile            Unsigned32,
+      rohcProfileVendor      OBJECT IDENTIFIER,
+      rohcProfileVersion     SnmpAdminString,
+      rohcProfileDescr       SnmpAdminString,
+      rohcProfileNegotiated  TruthValue
+  }
+
+  rohcProfile OBJECT-TYPE
+      SYNTAX      Unsigned32 (0..65535)
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+          "Identifier of a profile supported.  For a listing of
+           possible profile values, see the IANA registry for
+           'RObust Header Compression (ROHC) Profile Identifiers'
+           at http://www.iana.org/assignments/rohc-pro-ids"
+      ::= { rohcProfileEntry 2 }
+
+  rohcProfileVendor OBJECT-TYPE
+      SYNTAX      OBJECT IDENTIFIER
+      MAX-ACCESS  read-only
+      STATUS      current
+
+
+
+Quittek, et al.             Standards Track                    [Page 20]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+      DESCRIPTION
+          "An object identifier that identifies the vendor who
+           provides the implementation of robust header description.
+           This object identifier SHALL point to the object identifier
+           directly below the enterprise object identifier
+           {1 3 6 1 4 1} allocated for the vendor.  The value must be
+           the object identifier {0 0} if the vendor is not known."
+      ::= { rohcProfileEntry 3 }
+
+  rohcProfileVersion OBJECT-TYPE
+      SYNTAX      SnmpAdminString (SIZE (0..32))
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "The version number of the implementation of robust header
+           compression.  The zero-length string shall be used if the
+           implementation does not have a version number.
+
+           It is suggested that the version number consist of one or
+           more decimal numbers separated by dots, where the first
+           number is called the major version number."
+      ::= { rohcProfileEntry 4 }
+
+  rohcProfileDescr OBJECT-TYPE
+      SYNTAX      SnmpAdminString
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "A textual description of the implementation."
+      ::= { rohcProfileEntry 5 }
+
+  rohcProfileNegotiated OBJECT-TYPE
+      SYNTAX      TruthValue
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "When retrieved, this boolean object returns true
+           if the profile has been negotiated to be used at
+           the instance, i.e., is supported also be the
+           corresponding compressor/decompressor."
+      ::= { rohcProfileEntry 6 }
+
+  --
+  -- Context Table
+  --
+
+  rohcContextTable OBJECT-TYPE
+      SYNTAX      SEQUENCE OF RohcContextEntry
+
+
+
+Quittek, et al.             Standards Track                    [Page 21]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+          "This table lists and describes all compressor contexts
+           per instance."
+      ::= { rohcObjects 2 }
+
+  rohcContextEntry OBJECT-TYPE
+      SYNTAX      RohcContextEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+          "An entry describing a particular compressor context."
+      INDEX {
+          rohcChannelID,
+          rohcContextCID
+      }
+      ::= { rohcContextTable 1 }
+
+  RohcContextEntry ::= SEQUENCE {
+      rohcContextCID                  Unsigned32,
+      rohcContextCIDState             INTEGER,
+      rohcContextProfile              Unsigned32,
+      rohcContextDecompressorDepth    Unsigned32,
+      rohcContextStorageTime          TimeInterval,
+      rohcContextActivationTime       DateAndTime,
+      rohcContextDeactivationTime     DateAndTime,
+      rohcContextPackets              Counter32,
+      rohcContextIRs                  Counter32,
+      rohcContextIRDYNs               Counter32,
+      rohcContextFeedbacks            Counter32,
+      rohcContextDecompressorFailures Counter32,
+      rohcContextDecompressorRepairs  Counter32,
+      rohcContextAllPacketsRatio      RohcCompressionRatio,
+      rohcContextAllHeadersRatio      RohcCompressionRatio,
+      rohcContextAllPacketsMeanSize   Unsigned32,
+      rohcContextAllHeadersMeanSize   Unsigned32,
+      rohcContextLastPacketsRatio     RohcCompressionRatio,
+      rohcContextLastHeadersRatio     RohcCompressionRatio,
+      rohcContextLastPacketsMeanSize  Unsigned32,
+      rohcContextLastHeadersMeanSize  Unsigned32
+  }
+
+  rohcContextCID OBJECT-TYPE
+      SYNTAX      Unsigned32 (0..16383)
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+
+
+
+Quittek, et al.             Standards Track                    [Page 22]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+          "The context identifier (CID) of this context."
+      REFERENCE
+          "RFC 3095, Sections 5.1.1 and 5.1.3"
+      ::= { rohcContextEntry 2 }
+
+  rohcContextCIDState OBJECT-TYPE
+      SYNTAX      INTEGER {
+                      unused(1),
+                      active(2),
+                      expired(3),
+                      terminated(4)
+                  }
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "State of the CID.  When a CID is assigned to a context,
+           its state changes from `unused' to `active'.  The active
+           context may stop operation due to some explicit
+           signalling or after observing no packet for some specified
+           time.  In the first case then the CID state changes to
+           `terminated', in the latter case it changes to `expired'.
+           If the CID is re-used again for another context, the
+           state changes back to `active'."
+      ::= { rohcContextEntry 3 }
+
+  rohcContextProfile OBJECT-TYPE
+      SYNTAX      Unsigned32 (0..65535)
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "Identifier of the profile for this context.
+           The profile is identified by its index in the
+           rohcProfileTable for this instance.  There MUST exist a
+           corresponding entry in the rohcProfileTable using the
+           value of rohcContextProfile as second part of the index
+           (and using the same rohcChannelID as first part of the
+           index)."
+      ::= { rohcContextEntry 4 }
+
+  rohcContextDecompressorDepth OBJECT-TYPE
+      SYNTAX      Unsigned32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "This object indicates whether reverse decompression, for
+           example as described in RFC 3095, Section 6.1, is used
+           on this channel or not, and if used, to what extent.
+
+
+
+
+Quittek, et al.             Standards Track                    [Page 23]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+           Its value is only valid for decompressor contexts, i.e.,
+           if rohcInstanceType has the value decompressor(2).  For
+           compressor contexts where rohcInstanceType has the value
+           compressor(1), the value of this object is irrelevant
+           and MUST be set to zero (0).
+
+           The value of the reverse decompression depth indicates
+           the maximum number of packets that are buffered, and thus
+           possibly be reverse decompressed by the decompressor.
+           A zero (0) value means that reverse decompression is not
+           used."
+      ::= { rohcContextEntry 5 }
+
+  rohcContextStorageTime OBJECT-TYPE
+      SYNTAX      TimeInterval
+      UNITS       "centi-seconds"
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+          "The value of this object specifies how long this row
+           can exist in the rohcContextTable after the
+           rohcContextCIDState switched to expired(3) or
+           terminated(4).  This object returns  the remaining time
+           that the row may exist before it is aged out.  The object
+           is initialized with the value of the  associated
+           rohcContextStorageTime object.  After expiration or
+           termination of the context, the value of this object ticks
+           backwards.  The entry in the rohcContextTable is destroyed
+           when the value reaches 0.
+
+           The value of this object may be set in order to increase or
+           reduce the remaining time that the row may exist.  Setting
+           the value to 0 will destroy this entry as soon as the
+           rochContextCIDState has the value expired(3) or
+           terminated(4).
+
+           Note that there is no guarantee that the row is stored as
+           long as this object indicates.  In case of limited CID
+           space, the instance may re-use a CID before the storage
+           time of the corresponding row in rohcContextTable reaches
+           the value of 0.  In this case the information stored in this
+           row is not anymore available."
+      ::= { rohcContextEntry 6 }
+
+  rohcContextActivationTime OBJECT-TYPE
+      SYNTAX      DateAndTime
+      MAX-ACCESS  read-only
+      STATUS      current
+
+
+
+Quittek, et al.             Standards Track                    [Page 24]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+      DESCRIPTION
+          "The date and time when the context started to be able to
+           compress packets or decompress packets, respectively.
+           The value '0000000000000000'H is returned if the context
+           has not been activated yet."
+      DEFVAL { '0000000000000000'H }
+      ::= { rohcContextEntry 7 }
+
+  rohcContextDeactivationTime OBJECT-TYPE
+      SYNTAX      DateAndTime
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "The date and time when the context stopped being able to
+           compress packets or decompress packets, respectively,
+           because it expired or was terminated for other reasons.
+           The value '0000000000000000'H is returned if the context
+           has not been deactivated yet."
+      DEFVAL { '0000000000000000'H }
+      ::= { rohcContextEntry 8 }
+
+  rohcContextPackets OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "The number of all packets passing this context.
+
+           Discontinuities in the value of this counter can
+           occur at re-initialization of the management
+           system, and at other times as indicated by the
+           value of ifCounterDiscontinuityTime.  For checking
+           ifCounterDiscontinuityTime, the interface index is
+           required.  It can be determined by reading the
+           rohcChannelTable."
+      ::= { rohcContextEntry 9 }
+
+  rohcContextIRs OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "The number of all IR packets sent or received,
+           respectively, by this context.
+
+           Discontinuities in the value of this counter can
+           occur at re-initialization of the management
+           system, and at other times as indicated by the
+
+
+
+Quittek, et al.             Standards Track                    [Page 25]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+           value of ifCounterDiscontinuityTime.  For checking
+           ifCounterDiscontinuityTime, the interface index is
+           required.  It can be determined by reading the
+           rohcChannelTable."
+      REFERENCE
+          "RFC 3095, Section 5.7.7.1"
+      ::= { rohcContextEntry 10 }
+
+  rohcContextIRDYNs OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "The number of all IR-DYN packets sent or received,
+           respectively, by this context.
+
+           Discontinuities in the value of this counter can
+           occur at re-initialization of the management
+           system, and at other times as indicated by the
+           value of ifCounterDiscontinuityTime.  For checking
+           ifCounterDiscontinuityTime, the interface index is
+           required.  It can be determined by reading the
+           rohcChannelTable."
+      REFERENCE
+          "RFC 3095, Section 5.7.7.2"
+      ::= { rohcContextEntry 11 }
+
+  rohcContextFeedbacks OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "The number of all feedbacks sent or received,
+           respectively, by this context.
+
+           Discontinuities in the value of this counter can
+           occur at re-initialization of the management
+           system, and at other times as indicated by the
+           value of ifCounterDiscontinuityTime.  For checking
+           ifCounterDiscontinuityTime, the interface index is
+           required.  It can be determined by reading the
+           rohcChannelTable."
+      ::= { rohcContextEntry 12 }
+
+  rohcContextDecompressorFailures OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+
+
+
+Quittek, et al.             Standards Track                    [Page 26]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+      DESCRIPTION
+          "The number of all decompressor failures so far in this
+           context. The number is only valid for decompressor
+           contexts, i.e., if rohcInstanceType has the value
+           decompressor(2).
+
+           Discontinuities in the value of this counter can
+           occur at re-initialization of the management
+           system, and at other times as indicated by the
+           value of ifCounterDiscontinuityTime.  For checking
+           ifCounterDiscontinuityTime, the interface index is
+           required.  It can be determined by reading the
+           rohcChannelTable."
+      ::= { rohcContextEntry 13 }
+
+  rohcContextDecompressorRepairs OBJECT-TYPE
+      SYNTAX      Counter32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "The number of all context repairs so far in this
+           context.  The number is only valid for decompressor
+           contexts, i.e., if rohcInstanceType has the value
+           decompressor(2).
+
+           Discontinuities in the value of this counter can
+           occur at re-initialization of the management
+           system, and at other times as indicated by the
+           value of ifCounterDiscontinuityTime.  For checking
+           ifCounterDiscontinuityTime, the interface index is
+           required.  It can be determined by reading the
+           rohcChannelTable."
+      ::= { rohcContextEntry 14 }
+
+  rohcContextAllPacketsRatio OBJECT-TYPE
+      SYNTAX      RohcCompressionRatio
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "This object indicates the compression ratio so far over all
+           packets passing this context.  The compression is computed
+           over all bytes of the IP packets including the IP header
+           but excluding all lower layer headers."
+      ::= { rohcContextEntry 15 }
+
+  rohcContextAllHeadersRatio OBJECT-TYPE
+      SYNTAX      RohcCompressionRatio
+      MAX-ACCESS  read-only
+
+
+
+Quittek, et al.             Standards Track                    [Page 27]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+      STATUS      current
+      DESCRIPTION
+          "This object indicates the compression ratio so far over all
+           packet headers passing this context.  The compression is
+           computed over all bytes of all headers that are subject to
+           compression for the used profile."
+      ::= { rohcContextEntry 16 }
+
+  rohcContextAllPacketsMeanSize OBJECT-TYPE
+      SYNTAX      Unsigned32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "This object indicates the mean compressed packet size
+           of all packets passing this context.  The packet size
+           includes the IP header and payload but excludes all lower
+           layer headers.  The mean value is given in byte rounded
+           to the next integer value."
+      ::= { rohcContextEntry 17 }
+
+  rohcContextAllHeadersMeanSize OBJECT-TYPE
+      SYNTAX      Unsigned32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "This object indicates the mean compressed packet header size
+           of all packets passing this context.  The packet header size
+           is the sum of the size of all headers of a packet that are
+           subject to compression for the used profile.  The mean value
+           is given in byte rounded to the next integer value."
+      ::= { rohcContextEntry 18 }
+
+  rohcContextLastPacketsRatio OBJECT-TYPE
+      SYNTAX      RohcCompressionRatio
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "This object indicates the compression ratio
+           concerning the last 16 packets passing this context
+           or concerning all packets passing this context
+           if they are less than 16, so far.  The compression is
+           computed over all bytes of the IP packets including the IP
+           header but excluding all lower layer headers."
+      ::= { rohcContextEntry 19 }
+
+  rohcContextLastHeadersRatio OBJECT-TYPE
+      SYNTAX      RohcCompressionRatio
+      MAX-ACCESS  read-only
+
+
+
+Quittek, et al.             Standards Track                    [Page 28]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+      STATUS      current
+      DESCRIPTION
+          "This object indicates the compression ratio concerning the
+           headers of the last 16 packets passing this context or
+           concerning the headers of all packets passing this context
+           if they are less than 16, so far.  The compression is
+           computed over all bytes of all headers that are subject to
+           compression for the used profile."
+      ::= { rohcContextEntry 20 }
+
+  rohcContextLastPacketsMeanSize OBJECT-TYPE
+      SYNTAX      Unsigned32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "This object indicates the mean compressed packet size
+           concerning the last 16 packets passing this context or
+           concerning all packets passing this context if they are
+           less than 16, so far.  The packet size includes the IP
+           header and payload but excludes all lower layer headers.
+           The mean value is given in byte rounded to the next
+           integer value."
+      ::= { rohcContextEntry 21 }
+
+  rohcContextLastHeadersMeanSize OBJECT-TYPE
+      SYNTAX      Unsigned32
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+          "This object indicates the mean compressed packet header size
+           concerning the last 16 packets passing this context or
+           concerning all packets passing this context if they are
+           less than 16, so far.  The packet header size is the sum of
+           the size of all headers of a packet that are subject to
+           compression for the used profile.  The mean value is given
+           in byte rounded to the next integer value."
+      ::= { rohcContextEntry 22 }
+
+  --
+  -- conformance information
+  --
+
+  rohcCompliances OBJECT IDENTIFIER ::= { rohcConformance 1 }
+  rohcGroups      OBJECT IDENTIFIER ::= { rohcConformance 2 }
+
+  --
+  -- compliance statements
+  --
+
+
+
+Quittek, et al.             Standards Track                    [Page 29]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+
+
+  rohcCompliance MODULE-COMPLIANCE
+      STATUS      current
+      DESCRIPTION
+          "The compliance statement for SNMP entities that implement
+           the ROHC-MIB.
+
+           Note that compliance with this compliance
+           statement requires compliance with the
+           ifCompliance3 MODULE-COMPLIANCE statement of the
+           IF-MIB (RFC2863)."
+      MODULE      -- this module
+      MANDATORY-GROUPS {
+              rohcInstanceGroup, rohcContextGroup
+      }
+      GROUP   rohcStatisticsGroup
+      DESCRIPTION
+         "A compliant implementation does not have to implement
+          the rohcStatisticsGroup."
+      GROUP   rohcTimerGroup
+      DESCRIPTION
+         "A compliant implementation does not have to implement
+          the rohcTimerGroup."
+      OBJECT  rohcInstanceContextStorageTime
+      MIN-ACCESS  read-only
+      DESCRIPTION
+          "A compliant implementation does not have to support changing
+           the value of object rohcInstanceContextStorageTime."
+      OBJECT  rohcContextStorageTime
+      MIN-ACCESS  read-only
+      DESCRIPTION
+          "A compliant implementation does not have to support changing
+           the value of object rohcContextStorageTime."
+      GROUP   rohcContextStatisticsGroup
+      DESCRIPTION
+         "A compliant implementation does not have to implement
+          the rohcContextStatisticsGroup."
+      ::= { rohcCompliances 1 }
+
+  rohcInstanceGroup OBJECT-GROUP
+      OBJECTS {
+          rohcChannelType,
+          rohcChannelFeedbackFor,
+          rohcChannelDescr,
+          rohcChannelStatus,
+          rohcInstanceFBChannelID,
+          rohcInstanceVendor,
+
+
+
+Quittek, et al.             Standards Track                    [Page 30]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+          rohcInstanceVersion,
+          rohcInstanceDescr,
+          rohcInstanceClockRes,
+          rohcInstanceMaxCID,
+          rohcInstanceLargeCIDs,
+          rohcInstanceMRRU,
+          rohcInstanceStatus,
+          rohcProfileVendor,
+          rohcProfileVersion,
+          rohcProfileDescr,
+          rohcProfileNegotiated
+      }
+      STATUS      current
+      DESCRIPTION
+          "A collection of objects providing information about
+           ROHC instances, used channels and available profiles."
+      ::= { rohcGroups 2 }
+
+  rohcStatisticsGroup OBJECT-GROUP
+      OBJECTS {
+          rohcInstanceContextsTotal,
+          rohcInstanceContextsCurrent,
+          rohcInstancePackets,
+          rohcInstanceIRs,
+          rohcInstanceIRDYNs,
+          rohcInstanceFeedbacks,
+          rohcInstanceCompressionRatio
+      }
+      STATUS      current
+      DESCRIPTION
+          "A collection of objects providing ROHC statistics."
+      ::= { rohcGroups 4 }
+
+  rohcContextGroup OBJECT-GROUP
+      OBJECTS {
+          rohcContextCIDState,
+          rohcContextProfile,
+          rohcContextDecompressorDepth
+      }
+      STATUS      current
+      DESCRIPTION
+          "A collection of objects providing information about
+           ROHC compressor contexts and decompressor contexts."
+      ::= { rohcGroups 5 }
+
+  rohcTimerGroup OBJECT-GROUP
+      OBJECTS {
+          rohcInstanceContextStorageTime,
+
+
+
+Quittek, et al.             Standards Track                    [Page 31]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+          rohcContextStorageTime,
+          rohcContextActivationTime,
+          rohcContextDeactivationTime
+
+      }
+      STATUS      current
+      DESCRIPTION
+          "A collection of objects providing statistical information
+           about ROHC compressor contexts and decompressor contexts."
+      ::= { rohcGroups 6 }
+
+  rohcContextStatisticsGroup OBJECT-GROUP
+      OBJECTS {
+          rohcContextPackets,
+          rohcContextIRs,
+          rohcContextIRDYNs,
+          rohcContextFeedbacks,
+          rohcContextDecompressorFailures,
+          rohcContextDecompressorRepairs,
+          rohcContextAllPacketsRatio,
+          rohcContextAllHeadersRatio,
+          rohcContextAllPacketsMeanSize,
+          rohcContextAllHeadersMeanSize,
+          rohcContextLastPacketsRatio,
+          rohcContextLastHeadersRatio,
+          rohcContextLastPacketsMeanSize,
+          rohcContextLastHeadersMeanSize
+      }
+      STATUS      current
+      DESCRIPTION
+          "A collection of objects providing statistical information
+           about ROHC compressor contexts and decompressor contexts."
+      ::= { rohcGroups 7 }
+
+  END
+
+   ROHC-UNCOMPRESSED-MIB DEFINITIONS ::= BEGIN
+
+   IMPORTS
+       MODULE-IDENTITY, OBJECT-TYPE, Counter32, mib-2
+           FROM SNMPv2-SMI                               -- [RFC2578]
+
+       MODULE-COMPLIANCE, OBJECT-GROUP
+           FROM SNMPv2-CONF                              -- [RFC2580]
+
+       rohcChannelID, rohcContextCID
+           FROM ROHC-MIB;
+
+
+
+
+Quittek, et al.             Standards Track                    [Page 32]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+   rohcUncmprMIB MODULE-IDENTITY
+       LAST-UPDATED "200406030000Z"  -- June 3, 2004
+       ORGANIZATION "IETF Robust Header Compression Working Group"
+       CONTACT-INFO
+          "WG charter:
+             http://www.ietf.org/html.charters/rohc-charter.html
+
+           Mailing Lists:
+             General Discussion: rohc@ietf.org
+             To Subscribe: rohc-request@ietf.org
+             In Body: subscribe your_email_address
+
+           Editor:
+             Juergen Quittek
+             NEC Europe Ltd.
+             Network Laboratories
+             Kurfuersten-Anlage 36
+             69221 Heidelberg
+             Germany
+             Tel: +49 6221 90511-15
+             EMail: quittek@netlab.nec.de"
+       DESCRIPTION
+           "This MIB module defines a set of objects for monitoring
+            and configuring RObust Header Compression (ROHC).
+            The objects are specific to ROHC uncompressed
+            (profile 0x0000).
+
+            Copyright (C) The Internet Society (2004). The
+            initial version of this MIB module was published
+            in RFC 3816. For full legal notices see the RFC
+            itself or see:
+            http://www.ietf.org/copyrights/ianamib.html"
+
+       REVISION    "200406030000Z"  -- June 3, 2004
+       DESCRIPTION "Initial version, published as RFC 3816."
+       ::= { mib-2 113 }
+
+   --
+   -- The groups defined within this MIB module:
+   --
+
+   rohcUncmprObjects       OBJECT IDENTIFIER ::= { rohcUncmprMIB 1 }
+   rohcUncmprConformance   OBJECT IDENTIFIER ::= { rohcUncmprMIB 2 }
+
+   --
+   -- Context Table
+   --
+   -- The rohcUncmprContextTable lists all contexts per interface
+
+
+
+Quittek, et al.             Standards Track                    [Page 33]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+   -- and instance.  It extends the rohcContextTable.
+   --
+
+   rohcUncmprContextTable OBJECT-TYPE
+       SYNTAX      SEQUENCE OF RohcUncmprContextEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "This table lists and describes ROHC uncompressed profile
+            specific properties of compressor contexts and
+            decompressor contexts.  It extends the rohcContextTable
+            of the ROHC-MIB module."
+       ::= { rohcUncmprObjects 1 }
+
+   rohcUncmprContextEntry OBJECT-TYPE
+       SYNTAX      RohcUncmprContextEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "An entry describing a particular context."
+       INDEX {
+           rohcChannelID,
+           rohcContextCID
+       }
+       ::= { rohcUncmprContextTable 1 }
+
+   RohcUncmprContextEntry ::= SEQUENCE {
+       rohcUncmprContextState         INTEGER,
+       rohcUncmprContextMode          INTEGER,
+       rohcUncmprContextACKs          Counter32
+   }
+
+   rohcUncmprContextState OBJECT-TYPE
+       SYNTAX      INTEGER {
+                       initAndRefresh(1),
+                       normal(2),
+                       noContext(3),
+                       fullContext(4)
+                   }
+
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "State of the context. States initAndRefresh(1) and normal(2)
+            are states of compressor contexts, states noContext(3)
+            and fullContext(4) are states of decompressor contexts."
+       REFERENCE
+           "RFC 3095, Section 5.10.3"
+
+
+
+Quittek, et al.             Standards Track                    [Page 34]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+       ::= { rohcUncmprContextEntry 3 }
+
+   rohcUncmprContextMode OBJECT-TYPE
+       SYNTAX      INTEGER {
+                       unidirectional(1),
+                       bidirectional(2)
+                   }
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "Mode of the context."
+       REFERENCE
+           "RFC 3095, Section 5.10.3"
+       ::= { rohcUncmprContextEntry 4 }
+
+   rohcUncmprContextACKs OBJECT-TYPE
+       SYNTAX      Counter32
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The number of all positive feedbacks (ACK) sent or
+            received in this context, respectively.
+
+            Discontinuities in the value of this counter can
+            occur at re-initialization of the management
+            system, and at other times as indicated by the
+            value of ifCounterDiscontinuityTime.  For checking
+            ifCounterDiscontinuityTime, the interface index is
+            required.  It can be determined by reading the
+            rohcChannelTable of the ROHC-MIB."
+       REFERENCE
+           "RFC 3095, Section 5.2.1"
+       ::= { rohcUncmprContextEntry 5 }
+
+   --
+   -- conformance information
+   --
+
+   rohcUncmprCompliances OBJECT IDENTIFIER
+       ::= { rohcUncmprConformance 1 }
+   rohcUncmprGroups      OBJECT IDENTIFIER
+       ::= { rohcUncmprConformance 2 }
+
+   --
+   -- compliance statements
+   --
+
+   rohcUncmprCompliance MODULE-COMPLIANCE
+
+
+
+Quittek, et al.             Standards Track                    [Page 35]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+       STATUS      current
+       DESCRIPTION
+           "The compliance statement for SNMP entities that implement
+            the ROHC-UNCOMPRESSED-MIB.
+
+            Note that compliance with this compliance
+            statement requires compliance with the
+            rohcCompliance MODULE-COMPLIANCE statement of the
+            ROHC-MIB and with the ifCompliance3 MODULE-COMPLIANCE
+            statement of the IF-MIB (RFC2863)."
+       MODULE      -- this module
+       MANDATORY-GROUPS {
+               rohcUncmprContextGroup
+       }
+       GROUP   rohcUncmprStatisticsGroup
+       DESCRIPTION
+          "A compliant implementation does not have to implement
+           the rohcUncmprStatisticsGroup."
+       ::= { rohcUncmprCompliances 1 }
+
+   rohcUncmprContextGroup OBJECT-GROUP
+       OBJECTS {
+           rohcUncmprContextState,
+           rohcUncmprContextMode
+       }
+       STATUS      current
+       DESCRIPTION
+           "A collection of objects providing information about
+            ROHC uncompressed compressors and decompressors."
+       ::= { rohcUncmprGroups 1 }
+
+   rohcUncmprStatisticsGroup OBJECT-GROUP
+       OBJECTS {
+           rohcUncmprContextACKs
+       }
+       STATUS      current
+       DESCRIPTION
+           "An object providing context statistics."
+       ::= { rohcUncmprGroups 2 }
+
+   END
+
+   ROHC-RTP-MIB DEFINITIONS ::= BEGIN
+
+   IMPORTS
+       MODULE-IDENTITY, OBJECT-TYPE,
+       Unsigned32, Counter32, mib-2
+           FROM SNMPv2-SMI                               -- [RFC2578]
+
+
+
+Quittek, et al.             Standards Track                    [Page 36]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+       TruthValue
+           FROM SNMPv2-TC                                -- [RFC2579]
+
+       MODULE-COMPLIANCE, OBJECT-GROUP
+           FROM SNMPv2-CONF                              -- [RFC2580]
+
+       rohcChannelID, rohcContextCID
+           FROM ROHC-MIB;                                -- [RFC3816]
+
+   rohcRtpMIB MODULE-IDENTITY
+       LAST-UPDATED "200406030000Z"  -- June 3, 2004
+       ORGANIZATION "IETF Robust Header Compression Working Group"
+       CONTACT-INFO
+          "WG charter:
+             http://www.ietf.org/html.charters/rohc-charter.html
+
+           Mailing Lists:
+             General Discussion: rohc@ietf.org
+             To Subscribe: rohc-request@ietf.org
+             In Body: subscribe your_email_address
+
+           Editor:
+             Juergen Quittek
+             NEC Europe Ltd.
+             Network Laboratories
+             Kurfuersten-Anlage 36
+             69221 Heidelberg
+             Germany
+             Tel: +49 6221 90511-15
+             EMail: quittek@netlab.nec.de"
+       DESCRIPTION
+           "This MIB module defines a set of objects for monitoring
+            and configuring RObust Header Compression (ROHC).
+            The objects are specific to ROHC RTP (profile 0x0001),
+            ROHC UDP (profile 0x0002), and ROHC ESP (profile 0x0003)
+            defined in RFC 3095 and for the ROHC LLA profile (profile
+            0x0005) defined in RFC 3242.
+
+            Copyright (C) The Internet Society (2004). The
+            initial version of this MIB module was published
+            in RFC 3816. For full legal notices see the RFC
+            itself or see:
+            http://www.ietf.org/copyrights/ianamib.html"
+
+       REVISION    "200406030000Z"  -- June 3, 2004
+       DESCRIPTION "Initial version, published as RFC 3816."
+       ::= { mib-2 114 }
+
+
+
+
+Quittek, et al.             Standards Track                    [Page 37]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+   --
+   -- The groups defined within this MIB module:
+   --
+
+   rohcRtpObjects       OBJECT IDENTIFIER ::= { rohcRtpMIB 1 }
+   rohcRtpConformance   OBJECT IDENTIFIER ::= { rohcRtpMIB 2 }
+
+   --
+   -- Context Table
+   --
+   -- The rohcRtpContextTable lists all contexts per interface
+   -- and instance.  It extends the rohcContextTable.
+   --
+
+   rohcRtpContextTable OBJECT-TYPE
+       SYNTAX      SEQUENCE OF RohcRtpContextEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "This table lists and describes RTP profile specific
+            properties of compressor contexts and decompressor
+            contexts.  It extends the rohcContextTable of the
+            ROHC-MIB module."
+       ::= { rohcRtpObjects 1 }
+
+   rohcRtpContextEntry OBJECT-TYPE
+       SYNTAX      RohcRtpContextEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "An entry describing a particular context."
+       INDEX {
+           rohcChannelID,
+           rohcContextCID
+       }
+       ::= { rohcRtpContextTable 1 }
+
+   RohcRtpContextEntry ::= SEQUENCE {
+       rohcRtpContextState             INTEGER,
+       rohcRtpContextMode              INTEGER,
+       rohcRtpContextAlwaysPad         TruthValue,
+       rohcRtpContextLargePktsAllowed  TruthValue,
+       rohcRtpContextVerifyPeriod      Unsigned32,
+       rohcRtpContextSizesAllowed      Unsigned32,
+       rohcRtpContextSizesUsed         Unsigned32,
+       rohcRtpContextACKs              Counter32,
+       rohcRtpContextNACKs             Counter32,
+       rohcRtpContextSNACKs            Counter32,
+
+
+
+Quittek, et al.             Standards Track                    [Page 38]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+       rohcRtpContextNHPs              Counter32,
+       rohcRtpContextCSPs              Counter32,
+       rohcRtpContextCCPs              Counter32,
+       rohcRtpContextPktsLostPhysical  Counter32,
+       rohcRtpContextPktsLostPreLink   Counter32
+   }
+
+   rohcRtpContextState OBJECT-TYPE
+       SYNTAX      INTEGER {
+                       initAndRefresh(1),
+                       firstOrder(2),
+                       secondOrder(3),
+                       noContext(4),
+                       staticContext(5),
+                       fullContext(6)
+                   }
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "State of the context as defined in RFC 3095.  States
+            initAndRefresh(1), firstOrder(2), and secondOrder(3)
+            are states of compressor contexts, states noContext(4),
+            staticContext(5) and fullContext(6) are states of
+            decompressor contexts."
+       REFERENCE
+           "RFC 3095"
+       ::= { rohcRtpContextEntry 3 }
+
+   rohcRtpContextMode OBJECT-TYPE
+       SYNTAX      INTEGER {
+                       unidirectional(1),
+                       optimistic(2),
+                       reliable(3)
+                   }
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "Mode of the context."
+       REFERENCE
+           "RFC 3095, Section 4.4"
+       ::= { rohcRtpContextEntry 4 }
+
+   rohcRtpContextAlwaysPad OBJECT-TYPE
+       SYNTAX      TruthValue
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "Boolean, only applicable to compressor contexts using the
+
+
+
+Quittek, et al.             Standards Track                    [Page 39]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+            LLA profile.  If its value is true, the compressor must
+            pad every RHP packet with a minimum of one octet ROHC
+            padding.
+
+            The value of this object is only valid for LLA profiles,
+            i.e., if the corresponding rohcProfile has a value of
+            0x0005.  If the corresponding rohcProfile has a value
+            other than 0x0005, then this object MUST NOT be
+            instantiated."
+       REFERENCE
+           "RFC 3242, Section 5.1.1"
+       DEFVAL { false }
+       ::= { rohcRtpContextEntry 5 }
+
+   rohcRtpContextLargePktsAllowed OBJECT-TYPE
+       SYNTAX      TruthValue
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "Boolean, only applicable to compressor contexts using the
+            LLA profile.  It specifies how to handle packets that do
+            not fit any of the preferred packet sizes specified.  If
+            its value is true, the compressor must deliver the larger
+            packet as-is and must not use segmentation.  If it is set
+            to false, the ROHC segmentation scheme must be used to
+            split the packet into two or more segments, and each
+            segment must further be padded to fit one of the preferred
+            packet sizes.
+
+            The value of this object is only valid for LLA profiles,
+            i.e., if the corresponding rohcProfile has a value of
+            0x0005.  If the corresponding rohcProfile has a value
+            other than 0x0005, then this object MUST NOT be
+            instantiated."
+       REFERENCE
+           "RFC 3242, Section 5.1.1"
+       DEFVAL { true }
+       ::= { rohcRtpContextEntry 6 }
+
+   rohcRtpContextVerifyPeriod OBJECT-TYPE
+       SYNTAX      Unsigned32
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "This object is only applicable to compressor contexts
+            using the LLA profile.  It specifies the minimum frequency
+            with which a packet validating the context must be sent.
+            This tells the compressor that a packet containing a CRC
+
+
+
+Quittek, et al.             Standards Track                    [Page 40]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+            field must be sent at least once every N packets, where N
+            is the value of the object.  A value of 0 indicates that
+            periodical verifications are disabled.
+
+            The value of this object is only valid for LLA profiles,
+            i.e., if the corresponding rohcProfile has a value of
+            0x0005.  If the corresponding rohcProfile has a value
+            other than 0x0005, then this object MUST NOT be
+            instantiated."
+       REFERENCE
+           "RFC 3242, Section 5.1.1"
+       DEFVAL { 0 }
+       ::= { rohcRtpContextEntry 7 }
+
+   rohcRtpContextSizesAllowed  OBJECT-TYPE
+       SYNTAX      Unsigned32 (1..4294967295)
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The value of this object is only valid for decompressor
+            contexts, i.e., if rohcInstanceType of the corresponding
+            rohcContextEntry has the value decompressor(2).  For
+            compressor contexts where rohcInstanceType has the value
+            compressor(1), this object MUST NOT be instantiated.
+
+            This object contains the number of different packet sizes
+            that may be used in the context."
+       REFERENCE
+           "RFC 3095, Section 6.3.1"
+       ::= { rohcRtpContextEntry 8 }
+
+   rohcRtpContextSizesUsed  OBJECT-TYPE
+       SYNTAX      Unsigned32 (1..4294967295)
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The value of this object is only valid for decompressor
+            contexts, i.e., if rohcInstanceType of the corresponding
+            rohcContextEntry has the value decompressor(2).  For
+            compressor contexts where rohcInstanceType has the value
+            compressor(1), this object MUST NOT be instantiated.
+
+            This object contains the number of different packet sizes
+            that are used in the context."
+       REFERENCE
+           "RFC 3095, Section 6.3.1"
+       ::= { rohcRtpContextEntry 9 }
+
+
+
+
+Quittek, et al.             Standards Track                    [Page 41]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+   rohcRtpContextACKs OBJECT-TYPE
+       SYNTAX      Counter32
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The number of all positive feedbacks (ACK) sent or
+            received in this context, respectively.
+
+            Discontinuities in the value of this counter can
+            occur at re-initialization of the management
+            system, and at other times as indicated by the
+            value of ifCounterDiscontinuityTime.  For checking
+            ifCounterDiscontinuityTime, the interface index is
+            required.  It can be determined by reading the
+            rohcChannelTable of the ROHC-MIB."
+       REFERENCE
+           "RFC 3095, Section 5.2.1."
+       ::= { rohcRtpContextEntry 10 }
+
+   rohcRtpContextNACKs OBJECT-TYPE
+       SYNTAX      Counter32
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The number of all dynamic negative feedbacks (ACK) sent
+            or received in this context, respectively.
+
+            Discontinuities in the value of this counter can
+            occur at re-initialization of the management
+            system, and at other times as indicated by the
+            value of ifCounterDiscontinuityTime.  For checking
+            ifCounterDiscontinuityTime, the interface index is
+            required.  It can be determined by reading the
+            rohcChannelTable of the ROHC-MIB."
+       REFERENCE
+           "RFC 3095, Section 5.2.1."
+       ::= { rohcRtpContextEntry 11 }
+
+   rohcRtpContextSNACKs OBJECT-TYPE
+       SYNTAX      Counter32
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The number of all static negative feedbacks (ACK) sent
+            or received in this context, respectively.
+
+            Discontinuities in the value of this counter can
+            occur at re-initialization of the management
+
+
+
+Quittek, et al.             Standards Track                    [Page 42]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+            system, and at other times as indicated by the
+            value of ifCounterDiscontinuityTime.  For checking
+            ifCounterDiscontinuityTime, the interface index is
+            required.  It can be determined by reading the
+            rohcChannelTable of the ROHC-MIB."
+       REFERENCE
+           "RFC 3095, Section 5.2.1."
+       ::= { rohcRtpContextEntry 12 }
+
+   rohcRtpContextNHPs OBJECT-TYPE
+       SYNTAX      Counter32
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "This object is only applicable to contexts using the
+            LLA profile.  It contains the number of all no-header
+            packets (NHP) sent or received in this context,
+            respectively.
+
+            Discontinuities in the value of this counter can
+            occur at re-initialization of the management
+            system, and at other times as indicated by the
+            value of ifCounterDiscontinuityTime.  For checking
+            ifCounterDiscontinuityTime, the interface index is
+            required.  It can be determined by reading the
+            rohcChannelTable of the ROHC-MIB.
+
+            The value of this object is only valid for LLA profiles,
+            i.e., if the corresponding rohcProfile has a value of
+            0x0005.  If the corresponding rohcProfile has a value
+            other than 0x0005, then this object MUST NOT be
+            instantiated."
+       REFERENCE
+           "RFC 3242, Section 4.1.1."
+       ::= { rohcRtpContextEntry 13 }
+
+   rohcRtpContextCSPs OBJECT-TYPE
+       SYNTAX      Counter32
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "This object is only applicable to contexts using the
+            LLA profile.  It contains the number of all context
+            synchronization packets (CSP) sent or received in this
+            context, respectively.
+
+            Discontinuities in the value of this counter can
+            occur at re-initialization of the management
+
+
+
+Quittek, et al.             Standards Track                    [Page 43]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+            system, and at other times as indicated by the
+            value of ifCounterDiscontinuityTime.  For checking
+            ifCounterDiscontinuityTime, the interface index is
+            required.  It can be determined by reading the
+            rohcChannelTable of the ROHC-MIB.
+
+            The value of this object is only valid for LLA profiles,
+            i.e., if the corresponding rohcProfile has a value of
+            0x0005.  If the corresponding rohcProfile has a value
+            other than 0x0005, then this object MUST NOT be
+            instantiated."
+       REFERENCE
+           "RFC 3242, Section 4.1.2."
+       ::= { rohcRtpContextEntry 14 }
+
+   rohcRtpContextCCPs OBJECT-TYPE
+       SYNTAX      Counter32
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "This object is only applicable to contexts using the
+            LLA profile.  It contains the number of all context check
+            packets (CCP) sent or received in this context,
+            respectively.
+
+            Discontinuities in the value of this counter can
+            occur at re-initialization of the management
+            system, and at other times as indicated by the
+            value of ifCounterDiscontinuityTime.  For checking
+            ifCounterDiscontinuityTime, the interface index is
+            required.  It can be determined by reading the
+            rohcChannelTable of the ROHC-MIB.
+
+            The value of this object is only valid for LLA profiles,
+            i.e., if the corresponding rohcProfile has a value of
+            0x0005.  If the corresponding rohcProfile has a value
+            other than 0x0005, then this object MUST NOT be
+            instantiated."
+       REFERENCE
+           "RFC 3242, Section 4.1.3."
+       ::= { rohcRtpContextEntry 15 }
+
+   rohcRtpContextPktsLostPhysical OBJECT-TYPE
+       SYNTAX      Counter32
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "This object is only applicable to decompressor contexts
+
+
+
+Quittek, et al.             Standards Track                    [Page 44]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+            using the LLA profile.  It contains the number of physical
+            packet losses on the link between compressor and
+            decompressor, that have been indicated to the decompressor.
+
+            Discontinuities in the value of this counter can
+            occur at re-initialization of the management
+            system, and at other times as indicated by the
+            value of ifCounterDiscontinuityTime.  For checking
+            ifCounterDiscontinuityTime, the interface index is
+            required.  It can be determined by reading the
+            rohcChannelTable of the ROHC-MIB.
+
+            The value of this object is only valid for LLA profiles,
+            i.e., if the corresponding rohcProfile has a value of
+            0x0005.  If the corresponding rohcProfile has a value
+            other than 0x0005, then this object MUST NOT be
+            instantiated."
+       REFERENCE
+           "RFC 3242, Section 5.1.2."
+       ::= { rohcRtpContextEntry 16 }
+
+   rohcRtpContextPktsLostPreLink OBJECT-TYPE
+       SYNTAX      Counter32
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "This object is only applicable to decompressor contexts
+            using the LLA profile.  It contains the number of pre-link
+            packet losses on the link between compressor and
+            decompressor, that have been indicated to the decompressor.
+
+            Discontinuities in the value of this counter can
+            occur at re-initialization of the management
+            system, and at other times as indicated by the
+            value of ifCounterDiscontinuityTime.  For checking
+            ifCounterDiscontinuityTime, the interface index is
+            required.  It can be determined by reading the
+            rohcChannelTable of the ROHC-MIB.
+
+            The value of this object is only valid for LLA profiles,
+            i.e., if the corresponding rohcProfile has a value of
+            0x0005.  If the corresponding rohcProfile has a value
+            other than 0x0005, then this object MUST NOT be
+            instantiated."
+       REFERENCE
+           "RFC 3242, Section 5.1.2."
+       ::= { rohcRtpContextEntry 17 }
+
+
+
+
+Quittek, et al.             Standards Track                    [Page 45]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+   --
+   -- Packet Sizes Table
+   --
+   -- The rohcPacketSizeTable lists allowed, preferred, and used
+   -- packet sizes per compressor context.
+
+   rohcRtpPacketSizeTable OBJECT-TYPE
+       SYNTAX      SEQUENCE OF RohcRtpPacketSizeEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "This table lists all allowed, preferred, and used packet
+            sizes per compressor context and channel.
+
+            Note, that the sizes table represents implementation
+            parameters that are suggested by RFC 3095 and/or RFC 3242,
+            but that are not mandatory."
+       ::= { rohcRtpObjects 2 }
+
+   rohcRtpPacketSizeEntry OBJECT-TYPE
+       SYNTAX      RohcRtpPacketSizeEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "An entry of a particular packet size."
+       INDEX {
+           rohcChannelID,
+           rohcContextCID,
+           rohcRtpPacketSize
+       }
+       ::= { rohcRtpPacketSizeTable 1 }
+
+   RohcRtpPacketSizeEntry ::= SEQUENCE {
+       rohcRtpPacketSize                Unsigned32,
+       rohcRtpPacketSizePreferred       TruthValue,
+       rohcRtpPacketSizeUsed            TruthValue,
+       rohcRtpPacketSizeRestrictedType  INTEGER
+   }
+
+   rohcRtpPacketSize OBJECT-TYPE
+       SYNTAX      Unsigned32 (1..4294967295)
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "A packet size used as index."
+       ::= { rohcRtpPacketSizeEntry 3 }
+
+   rohcRtpPacketSizePreferred OBJECT-TYPE
+
+
+
+Quittek, et al.             Standards Track                    [Page 46]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+       SYNTAX      TruthValue
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "This object is only applicable to compressor contexts
+            using the LLA profile.  When retrieved, it will have
+            the value true(1) if the packet size is preferred.
+            Otherwise, its value will be false(2).
+
+            The value of this object is only valid for LLA profiles,
+            i.e., if the corresponding rohcProfile has a value of
+            0x0005.  If the corresponding rohcProfile has a value
+            other than 0x0005, then this object MUST NOT be
+            instantiated."
+       REFERENCE
+            "RFC 3242, Section 5.1.1"
+       ::= { rohcRtpPacketSizeEntry 4 }
+
+   rohcRtpPacketSizeUsed OBJECT-TYPE
+       SYNTAX      TruthValue
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "This object is only applicable to compressor contexts
+            using the UDP, RTP, or ESP profile.  When retrieved,
+            it will have the value true(1) if the packet size is
+            used.  Otherwise, its value will be false(2).
+
+            The value of this object is only valid for UDP, RTP,
+            and ESP profiles, i.e., if the corresponding rohcProfile
+            has a value of either 0x0001, 0x0002 or 0x0003.  If
+            the corresponding rohcProfile has a value other than
+            0x0001, 0x0002 or 0x0003, then this object MUST NOT be
+            instantiated."
+       REFERENCE
+            "RFC 3095, Section 6.3.1"
+       ::= { rohcRtpPacketSizeEntry 5 }
+
+   rohcRtpPacketSizeRestrictedType OBJECT-TYPE
+       SYNTAX      INTEGER {
+                       nhpOnly(1),
+                       rhpOnly(2),
+                       noRestrictions(3)
+                   }
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "This object is only applicable to preferred packet
+
+
+
+Quittek, et al.             Standards Track                    [Page 47]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+            sizes of compressor contexts using the LLA profile.
+            When retrieved, it will indicate whether the packet
+            size is preferred for NHP only, for RHP only, or
+            for both of them.
+
+            The value of this object is only valid for LLA profiles,
+            i.e., if the corresponding rohcProfile has a value of
+            0x0005.  If the corresponding rohcProfile has a value
+            other than 0x0005, then this object MUST NOT be
+            instantiated."
+       REFERENCE
+            "RFC 3242, Section 5.1.1"
+       ::= { rohcRtpPacketSizeEntry 6 }
+   --
+   -- conformance information
+   --
+
+   rohcRtpCompliances OBJECT IDENTIFIER ::= { rohcRtpConformance 1 }
+   rohcRtpGroups      OBJECT IDENTIFIER ::= { rohcRtpConformance 2 }
+
+   --
+   -- compliance statements
+   --
+
+   rohcRtpCompliance MODULE-COMPLIANCE
+       STATUS      current
+       DESCRIPTION
+           "The compliance statement for SNMP entities that implement
+            the ROHC-RTP-MIB.
+
+            Note that compliance with this compliance
+            statement requires compliance with the
+            rohcCompliance MODULE-COMPLIANCE statement of the
+            ROHC-MIB and with the ifCompliance3 MODULE-COMPLIANCE
+            statement of the IF-MIB (RFC2863)."
+       MODULE      -- this module
+       MANDATORY-GROUPS {
+               rohcRtpContextGroup
+       }
+       GROUP   rohcRtpPacketSizesGroup
+       DESCRIPTION
+          "A compliant implementation does not have to implement
+           the rohcRtpPacketSizesGroup."
+       GROUP   rohcRtpStatisticsGroup
+       DESCRIPTION
+          "A compliant implementation does not have to implement
+           the rohcRtpStatisticsGroup."
+       ::= { rohcRtpCompliances 1 }
+
+
+
+Quittek, et al.             Standards Track                    [Page 48]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+   rohcRtpContextGroup OBJECT-GROUP
+       OBJECTS {
+           rohcRtpContextState,
+           rohcRtpContextMode,
+           rohcRtpContextAlwaysPad,
+           rohcRtpContextLargePktsAllowed,
+           rohcRtpContextVerifyPeriod
+       }
+       STATUS      current
+       DESCRIPTION
+           "A collection of objects providing information about
+            ROHC RTP compressors and decompressors."
+       ::= { rohcRtpGroups 1 }
+
+   rohcRtpPacketSizesGroup OBJECT-GROUP
+       OBJECTS {
+           rohcRtpContextSizesAllowed,
+           rohcRtpContextSizesUsed,
+           rohcRtpPacketSizePreferred,
+           rohcRtpPacketSizeUsed,
+           rohcRtpPacketSizeRestrictedType
+       }
+       STATUS      current
+       DESCRIPTION
+           "A collection of objects providing information about
+            allowed and used packet sizes at a ROHC RTP compressor."
+       ::= { rohcRtpGroups 2 }
+
+   rohcRtpStatisticsGroup OBJECT-GROUP
+       OBJECTS {
+           rohcRtpContextACKs,
+           rohcRtpContextNACKs,
+           rohcRtpContextSNACKs,
+           rohcRtpContextNHPs,
+           rohcRtpContextCSPs,
+           rohcRtpContextCCPs,
+           rohcRtpContextPktsLostPhysical,
+           rohcRtpContextPktsLostPreLink
+       }
+       STATUS      current
+       DESCRIPTION
+           "A collection of objects providing ROHC compressor and
+            decompressor statistics."
+       ::= { rohcRtpGroups 3 }
+
+   END
+
+
+
+
+
+Quittek, et al.             Standards Track                    [Page 49]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+6.  Security Considerations
+
+   The managed objects defined by the ROHC-MIB module, the ROHC-
+   UNCOMPRESSED-MIB module and the ROHC-RTP-MIB module do not have a
+   MAX-ACCESS value of read-write and/or read-create except
+   rohcInstanceContextStorageTime and rohcContextStorageTime, both of
+   which have a MAX-ACCESS value of read-write.  These objects determine
+   how long context information is stored after its termination.
+   Unauthorized access to these objects can have one of two negative
+   effects.  If they are set to a value lower than required, e.g., to
+   zero, then context information about past contexts might get lost.
+   If they are set to a very high value, then context information will
+   not be deleted and memory consumption of the agent implementation
+   might become very high.  However, unauthorized access to these
+   objects cannot cause harm to existing ROHC connections nor can it
+   allow manipulation of running instances of ROHC in a malicious way.
+
+   Another security issue is unauthorized access to readable objects in
+   the MIB modules for getting information about existing communication
+   sessions.  It is thus important to control even GET and/or NOTIFY
+   access to these objects and possibly to even encrypt the values of
+   these objects when sending them over the network via SNMP.  However,
+   the only information that might be disclosed is the use of channels.
+   Users and their addresses are not visible in the MIB.  This
+   information can only be mis-used in conjunction with the mis-use of
+   further information.
+
+   SNMP versions prior to SNMPv3 did not include adequate security.
+   Even if the network itself is secure (for example by using IPSec),
+   even then, there is no control as to who on the secure network is
+   allowed to access and GET/SET (read/change/create/delete) the objects
+   in this MIB module.
+
+   It is RECOMMENDED that implementers consider the security features as
+   provided by the SNMPv3 framework (see [RFC3410], section 8),
+   including full support for the SNMPv3 cryptographic mechanisms (for
+   authentication and privacy).
+
+   Further, deployment of SNMP versions prior to SNMPv3 is NOT
+   RECOMMENDED.  Instead, it is RECOMMENDED to deploy SNMPv3 and to
+   enable cryptographic security.  It is then a customer/operator
+   responsibility to ensure that the SNMP entity giving access to an
+   instance of this MIB module is properly configured to give access to
+   the objects only to those principals (users) that have legitimate
+   rights to indeed GET or SET (change/create/delete) them.
+
+
+
+
+
+
+Quittek, et al.             Standards Track                    [Page 50]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+7.  Acknowledgements
+
+   Many thanks to Lars-Erik Jonsson and Mark West for their guidance
+   through the ROHC world and to Ghyslain Pelletier for explaining how
+   the ROHC LLA profile works.  Further thanks to Frank Strauss for his
+   advice on tricky SMI issues.  Special thanks to Mike Heard who acted
+   as MIB doctor.  He studied every tiny detail, raised a long list of
+   issues and helped to significantly improve this document.
+
+8.  References
+
+8.1.  Normative References
+
+
+   [RFC2578]   McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+               "Structure of Management Information Version 2 (SMIv2)",
+               STD 58, RFC 2578, April 1999.
+
+   [RFC2579]   McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+               "Textual Conventions for SMIv2", STD 58, RFC 2579, April
+               1999.
+
+   [RFC2580]   McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+               "Conformance Statements for SMIv2", STD 58, RFC 2580,
+               April 1999.
+
+   [RFC2863]   McCloghrie, K. and F. Kastenholz, "The Interfaces Group
+               MIB", RFC 2863, June 2000.
+
+   [RFC3095]   Bormann, C., Burmeister, C., Degermark, M., Fukushima,
+               H., Hannu, H., Jonsson, L., Hakenberg, R., Koren, T., Le,
+               K., Liu, Z., Martensson, A., Miyazaki, A., Svanbro, K.,
+               Wiebke, T., Yoshimura, T., and H. Zheng, "RObust Header
+               Compression (ROHC): Framework and four profiles: RTP,
+               UDP, ESP, and uncompressed", RFC 3095, July 2001.
+
+   [RFC3242]   Jonsson, L. and G. Pelletier, "RObust Header Compression
+               (ROHC): A Link-Layer Assisted Profile for IP/UDP/RTP",
+               RFC 3242, April 2002.
+
+   [RFC3411]   Harrington, D., Presuhn, R., and B. Wijnen, "An
+               Architecture for Describing Simple Network Management
+               Protocol (SNMP) Management Frameworks", STD 62, RFC 3411,
+               December 2002.
+
+   [RFC3759]   Jonsson, L., "RObust Header Compression (ROHC):
+               Terminology and Channel Mapping Examples", RFC 3759,
+               April 2004.
+
+
+
+Quittek, et al.             Standards Track                    [Page 51]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+8.2.  Informative References
+
+   [RFC3410]   Case, J., Mundy, R., Partain, D., and B. Stewart,
+               "Introduction and Applicability Statements for Internet-
+               Standard Management Framework", RFC 3410, December 2002.
+
+9.  Authors' Addresses
+
+   Juergen Quittek
+   NEC Europe Ltd.
+   Network Laboratories
+   Kurfuersten-Anlage 36
+   69115 Heidelberg
+   Germany
+
+   Phone: +49 6221 90511-15
+   EMail: quittek@netlab.nec.de
+
+
+   Martin Stiemerling
+   NEC Europe Ltd.
+   Network Laboratories
+   Kurfuersten-Anlage 36
+   69115 Heidelberg
+   Germany
+
+   Phone: +49 6221 90511-13
+   EMail: stiemerling@netlab.nec.de
+
+
+   Hannes Hartenstein
+   University of Karlsruhe
+   Computing Center and Institute of Telematics
+   76128 Karlsruhe
+   Germany
+
+   Phone: +49 721 608 8104
+   EMail: hartenstein@rz.uni-karlsruhe.de
+
+
+
+
+
+
+
+
+
+
+
+
+
+Quittek, et al.             Standards Track                    [Page 52]
+
+RFC 3816                        ROHC MIB                       June 2004
+
+
+10.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (2004).  This document is subject
+   to the rights, licenses and restrictions contained in BCP 78, and
+   except as set forth therein, the authors retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at ietf-
+   ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+Quittek, et al.             Standards Track                    [Page 53]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc3816.txt](<www.ietf.org/rfc/rfc3816.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
