### PR TITLE
Archive rfc3827.txt

### DIFF
--- a/www.ietf.org/rfc/rfc3827.txt
+++ b/www.ietf.org/rfc/rfc3827.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Network Working Group                                          K. Sarcar
+Request for Comments: 3827                        Sun Microsystems, Inc.
+Category: Informational                                        June 2004
+
+
+                    Additional Snoop Datalink Types
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard of any kind.  Distribution of this
+   memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2004).
+
+Abstract
+
+   The snoop file format provides a way to store and exchange datalink
+   layer packet traces.  This document describes extensions to this file
+   format to support new media.
+
+1.  Introduction
+
+   [RFC1761] defines the snoop file format used to store captured
+   network packets for tools that capture, display, and interpret
+   network traffic.  The file format specifies a header containing the
+   Datalink Type field that identifies the network's datalink type.
+   This document defines new values for this field, as well as an IANA
+   registry for future datalink types.
+
+2.  New Datalink Types
+
+   In addition to the Datalink Type codes listed in [RFC1761], this
+   document defines the following type codes for the corresponding
+   media:
+
+             Datalink Type           Code
+             -------------           ----
+
+             Fibre Channel           16
+             ATM                     17
+             ATM Classical IP        18
+             IP over Infiniband      26
+
+   The IP over Infiniband packet format is described in [IPoIB].
+
+
+
+
+Sarcar                       Informational                      [Page 1]
+
+RFC 3827            Additional Snoop Datalink Types            June 2004
+
+
+3.  IANA Considerations
+
+   This document created a new IANA registry named "Snoop Datalink
+   Types" to hold the various possible 32-bit (4 octet) snoop datalink
+   types.  This new registry holds the values previously defined in
+   [RFC1761] and tabulated below:
+
+             Datalink Type           Code
+             -------------           ----
+
+             IEEE 802.3              0
+             IEEE 802.4 Token Bus    1
+             IEEE 802.5 Token Ring   2
+             IEEE 802.6 Metro Net    3
+             Ethernet                4
+             HDLC                    5
+             Character Synchronous   6
+             IBM Channel-to-Channel  7
+             FDDI                    8
+             Other                   9
+
+   Additionally, the new registry also holds the values defined above in
+   section 2 of this document.
+
+   All new allocations and assignments to this registry starting from
+   code 27 will follow the First Come First Served policy outlined in
+   [BCP0026].  Type codes up to 26 not defined by this section of the
+   document (10-15 and 19-25) are considered reserved.
+
+4.  Security Considerations
+
+   The addition of new datalink type codes to the existing file format
+   poses no known security risks.
+
+5.  Acknowledgements
+
+   The author would like to thank Jim Carlson, Brent Callaghan, and Bill
+   Strahm for meticulously reviewing this document.
+
+6.  References
+
+6.1.  Normative References
+
+   [RFC1761] Callaghan, B. and R. Gilligan, "Snoop Version 2 Packet
+             Capture File Format", RFC 1761, February 1995.
+
+
+
+
+
+
+Sarcar                       Informational                      [Page 2]
+
+RFC 3827            Additional Snoop Datalink Types            June 2004
+
+
+   [BCP0026] Narten, T. and H. Alvestrand, "Guidelines for Writing an
+             IANA Considerations Section in RFCs", BCP 26, RFC 2434,
+             October 1998.
+
+6.2.  Informative References
+
+   [IPoIB]   Kashyap, V. and H.K. Chu, "IP encapsulation and address
+             resolution over InfiniBand networks", Work in Progress,
+             April 2003.
+
+7.  Author's Address
+
+   Kanoj Sarcar
+   Sun Microsystems, Inc.
+   14 Network Circle
+   Bldg 14, MPK14-333
+   Menlo Park, CA  94025
+
+   Phone: 1-650-786-4785
+   EMail: kanoj.sarcar@sun.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Sarcar                       Informational                      [Page 3]
+
+RFC 3827            Additional Snoop Datalink Types            June 2004
+
+
+8.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (2004).  This document is subject
+   to the rights, licenses and restrictions contained in BCP 78, and
+   except as set forth therein, the authors retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at ietf-
+   ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+Sarcar                       Informational                      [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc3827.txt](<www.ietf.org/rfc/rfc3827.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
