### PR TITLE
Archive rfc389.txt

### DIFF
--- a/www.ietf.org/rfc/rfc389.txt
+++ b/www.ietf.org/rfc/rfc389.txt
@@ -1,0 +1,112 @@
+
+
+
+
+
+
+NETWORK WORKING GROUP                                    BARBARA NOBLE
+REQUEST FOR COMMENTS #389                                UCLA/CCN
+NIC 11361                                                AUGUST 30, 1972
+CATEGORIES:
+OBSELETES:
+UPDATES: 10264
+
+
+TO:      ARPA NETWORK USERS
+
+TOPIC:   UCLA CAMPUS COMPUTING NETWORK LIAISON STAFF FOR ARPA NETWORK
+
+    The ARPA Network contacts at CCN are:
+
+    1.  Initial Contact - User Relations  Fred Ebrahimi  (213) 825-7548
+
+    2.  ARPA Liaison    - User Services   Barbara Noble  (213) 825-7438
+                                                               825-7548
+
+    3.  Network Technical Liaison         Robert Braden  (213) 825-7518
+
+    4.  Operations Manager                William Tippit (213) 825-7546
+
+    5.  Operations                                       (213) 825-7554
+
+    6.  Consulting                                       (213) 825-7452
+
+Please make initial contact with CCN through these representatives:
+
+    A.  Administrative Matters and General Facility Orientation:
+
+             Fred Ebrahimi, Head - User Relations  (213) 825-7548
+
+        Fred handles administrative matters, such as: charge number
+        applications and funding, and will discuss your application
+        and the facilities and services available at CCN.
+
+    B.  Network Technical Matters:
+
+             Robert Braden, Manager of Programming (213) 825-7518
+
+        Bob handles problems with Network protocol and Network hardware.
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+
+TO:  ARPA NETWORK USERS
+                                                          (continued)
+
+
+When you are using CCN facilities:
+
+    A. Programming problems (JCL, compilers, documentation) and any
+       other problems you may have related to any aspect of using
+       CCN:
+
+             Barbara Noble (213) 825-7438 or 825-7548
+
+             or call a consultant:
+
+             Consulting    (213) 825-7452
+
+             Bob Bell, Head, User Services   (213) 825-7529
+
+       Barbara is the focal point for all of your problems as soon as
+       you begin using our system.  She will attempt to solve your
+       programming problems and to expedite any other matters involv-
+       ing your use of CCN.
+
+    B. Operations:   Schedules, special handling, etc.
+
+             Operations                           (213) 825-7554
+
+             William Tippit, Operations Manager   (213) 825-7546
+
+                        ____________________________
+
+
+
+BBN:hzt
+8/30/72
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                      1/97 ]
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc389.txt](<www.ietf.org/rfc/rfc389.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
