### PR TITLE
Archive rfc391.txt

### DIFF
--- a/www.ietf.org/rfc/rfc391.txt
+++ b/www.ietf.org/rfc/rfc391.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                                        A. McKenzie
+Request for Comments: 391                              15 September 1972
+Updates: 378 NIC: 11583
+
+
+                    TRAFFIC STATISTICS (August 1972)
+
+ABSTRACT
+
+   Attached are the network traffic statistics for the month of August
+   1972.
+
+
+   AAM/jm
+
+   Attach.
+
+                INTER-    INTRA-            AVG. DAILY  DAYS
+                 NODE      NODE      TOTAL   INTERNODE
+
+USLA    HOST 1   163800    187696    351496
+UCLA    HOST 2  1189956    308725   1498681
+UCLA    HOST 3   483386      6107    489493
+                -------    ------   -------
+                1837142    502528   2339670     59263     31
+
+SRI     HOST 1  1708465    120157   1828622
+SRI     HOST 2    32837      7006     39843
+SRI     HOST 4    83904         0     83904
+                -------    ------   -------
+                1825206    127163   1952369     58878     31
+
+UCSB    HOST 1   368992    452967    821959     11903     31
+
+UTAH    HOST 1   692757    107679    800436     22347     31
+
+BBN     HOST 2  2909317    777743   3687060
+BBN     HOST 3      590         0       590
+BBN     HOST 4   168313       587    168900
+                -------    ------   -------
+                3078220    778330   3856550     99297     31
+
+
+
+
+
+
+
+
+
+
+McKenzie                                                        [Page 1]
+
+RFC  391                   TRAFFIC STATISTICS             September 1972
+
+
+MIT     HOST 1   129409     44873    174282
+MIT     HOST 2   372686    703650   1076336
+MIT     HOST 3   529621   1432866   1962487
+MIT     HOST 4     9224    622039    714286
+                -------    ------   -------
+                 112396   2803428   3927391     36257     31
+
+RAND    HOST 1   249521     57302    306823
+RAND    HOST 2  1977168     81451   2058619
+                -------    ------   -------
+                2226689    138753   2365442     71829     31
+
+SDC     HOST 1     2330      1384      3714        75     31
+
+HARV    HOST 1   334219     91043    425262
+HARV    HOST 2     2917     71129     74046
+                 ------    ------    ------
+                 337136    162172    499308     10875     31
+
+LINC    HOST 1    10972      1451     12423
+LINC    HOST 2   135328    325462    460790
+LINC    HOST 3       16       896       912
+                 ------   -------    ------
+                 146316    327809    474125      4720     31
+
+STAN    HOST 1   405796     41438    447234     13090     31
+
+ILL     HOST 1   466698       583    467281     15055     31
+
+CASE    HOST 1      842      1118      1960        27     31
+
+CARN    HOST 1   194751    225985    420736
+CARN    HOST 2        1       112       113
+                 ------    ------    ------
+                 194752    226097    420849      6282     31
+
+AMES2   HOST1    846623    409571   1256194     27310     31
+
+AMES1   HOST 1   117040     42766    159806
+AMES1   HOST 3  2934129     36211   2970340
+                -------     -----  -------
+                3051169     78977   3130146     98425     31
+
+MITRE   HOST 3  1066597      2674   1069271     34406     31
+
+ROME    HOST 3   553392       589    553981     17851     31
+
+
+
+
+
+McKenzie                                                        [Page 2]
+
+RFC  391                   TRAFFIC STATISTICS             September 1972
+
+
+NBS     HOST 1     8183       250      8433
+NBS     HOST 3   645719       186    645905
+                 ------      ----   -------
+                 653902       436    654338     21094     31
+
+ETAC    HOST 3   298495        38    298533      9629     31
+
+TINK HAD NO TRAFFIC                                       31
+
+MC CL HAD NO TRAFFIC                                      31
+
+USC     HOST 3   835516     20973    856489     26952     31
+
+GWC     HOST 3   146321        58    146379      4720     31
+
+NOAA    HOST 3    75601        49     75650      2439     31
+
+SAAC    HOST 3    60755      2293     63048      1960     31
+
+BELV HAD NO TRAFFIC                                       31
+
+ARPA    HOST 1        0    229859    229859
+ARPA    HOST 3   143722    221448    365170
+                 -------   ------   -------
+                 143722    451307    595029      4636     31
+
+BBN T   HOST 3   718636   2288135   3006771     23182     31
+----------------------------------
+
+TOTAL          21157570    8926549
+
+DAILY AVERAGE    682502     287953
+
+AVERAGE PER       23535       9929
+NODE-DAY
+PACKETS/MESSAGES (INTERNODE) 1.09
+
+
+        [This RFC was put into machine readable form for entry]
+    [into the online RFC archives by Helene Morin, Via Genie 12/99]
+
+
+
+
+
+
+
+
+
+
+
+McKenzie                                                        [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc391.txt](<www.ietf.org/rfc/rfc391.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
