### PR TITLE
Archive rfc3919.txt

### DIFF
--- a/www.ietf.org/rfc/rfc3919.txt
+++ b/www.ietf.org/rfc/rfc3919.txt
@@ -1,0 +1,451 @@
+
+
+
+
+
+
+Network Working Group                                         E. Stephan
+Request for Comments: 3919                            France Telecom R&D
+Category: Informational                                         J. Palet
+                                                             Consulintel
+                                                            October 2004
+
+
+   Remote Network Monitoring (RMON) Protocol Identifiers for IPv6 and
+                 Multi Protocol Label Switching (MPLS)
+
+Status of this Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard of any kind.  Distribution of this
+   memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2004).
+
+Abstract
+
+   This memo defines additional (to those in RFC 2896) protocol
+   identifier examples for IP version 6 and MPLS protocols.  These can
+   be used to produce valid protocolDirTable INDEX encodings, as defined
+   by the Remote Network Monitoring MIB (Management Information Base)
+   Version 2 [RFC2021] and the RMON Protocol Identifier Reference
+   [RFC2895].
+
+   This document contains additional (to those in RFC 2896) protocol
+   identifier macros for well-known protocols.  A conformant
+   implementation of the RMON-2 MIB [RFC2021] can be accomplished
+   without the use of these protocol identifiers, and accordingly, this
+   document does not specify any IETF standard.  It is published to
+   encourage better interoperability between RMON-2 agent
+   implementations, by providing RMON related IPv6 and MPLS protocol
+   information.
+
+Table of Contents
+
+   1.  The Internet-Standard Management Framework . . . . . . . . . .  2
+   2.  Overview . . . . . . . . . . . . . . . . . . . . . . . . . . .  2
+   3.  Relationship to the Remote Network Monitoring MIB. . . . . . .  2
+   4.  MPLS layer protocol identifiers  . . . . . . . . . . . . . . .  2
+   5.  IPv6 Protocols . . . . . . . . . . . . . . . . . . . . . . . .  3
+   6.  Security Considerations  . . . . . . . . . . . . . . . . . . .  5
+   7.  Acknowledgments  . . . . . . . . . . . . . . . . . . . . . . .  5
+   8.  References . . . . . . . . . . . . . . . . . . . . . . . . . .  6
+
+
+
+Stephan & Palet              Informational                      [Page 1]
+
+RFC 3919      RMON Protocol Identifiers for IPv6 and MPLS   October 2004
+
+
+       8.1.  Normative References . . . . . . . . . . . . . . . . . .  6
+       8.2.  Informative References . . . . . . . . . . . . . . . . .  6
+       Authors' Addresses  . . . . . . . . . . . . . . . . . . . . .   7
+       Full Copyright Statement. . . . . . . . . . . .. . . . . . . .  8
+
+1.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [RFC3410].  Managed objects are accessed via a virtual
+   information store, termed the Management Information Base or MIB. MIB
+   objects are generally accessed through the Simple Network Management
+   Protocol (SNMP).  Objects in the MIB are defined using the mechanisms
+   defined in the Structure of Management Information (SMI). This memo
+   specifies a MIB module that is compliant to the SMIv2, which is
+   described in STD 58, RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579]
+   and STD 58, RFC 2580 [RFC2580].
+
+2.  Overview
+
+   This memo defines basic protocol identifiers for IP version 6 and
+   MPLS protocols.
+
+   The "Remote Network Monitoring MIB Protocol Identifier Macros"
+   [RFC2896], defines various protocol identifiers.  The syntax of the
+   protocol identifier descriptor is defined in the RMON Protocol
+   Identifier Reference [RFC2895].  The reader should be familiar with
+   these documents.
+
+   The intent of this document is not to adapt each protocol identifier
+   defined in the RFC 2895 and in the RFC 2896 to IP version 6, but to
+   define protocol identifiers for IP version 6 protocols and for MPLS
+   protocol.
+
+3.  Relationship to the Remote Network Monitoring MIB
+
+   RMON MIB implementations use protocol identifiers to describe
+   unambiguous capabilities in protocolDirTable entries.
+
+4.  MPLS layer protocol identifiers
+
+   This section defines protocol identifiers for MPLS with unambiguous
+   names to distinguish MPLS Unicast from MPLS Multicast.
+
+
+
+
+
+
+
+
+Stephan & Palet              Informational                      [Page 2]
+
+RFC 3919      RMON Protocol Identifiers for IPv6 and MPLS   October 2004
+
+
+-- MPLS unicast
+
+mplsu PROTOCOL-IDENTIFIER
+   PARAMETERS { }
+   ATTRIBUTES { }
+   DESCRIPTION
+                "MPLS Label Stack Encoding."
+
+   CHILDREN
+                "Children of MPLS are not systematically identifiable. "
+   REFERENCE
+                "RFC 3032, MPLS Label Stack Encoding [RFC3032]."
+   ::= {
+                ether2  0x8847, -- RFC 3032 section 5
+                snap    0x8847,
+                802-1Q  0x8847,
+                ppp     0x0281, -- RFC 3032 section 4.3
+   }
+
+-- MPLS multicast
+
+mplsm PROTOCOL-IDENTIFIER
+   PARAMETERS { }
+   ATTRIBUTES { }
+   DESCRIPTION
+                "MPLS Label Stack Encoding."
+   CHILDREN
+                "Children of MPLS are not systematically identifiable."
+   REFERENCE
+                "RFC 3032, MPLS Label Stack Encoding [RFC3032]."
+   ::= {
+                ether2  0x8848, -- RFC 3032 section 5
+                snap    0x8848,
+                802-1Q  0x8848,
+                ppp     0x0283, -- RFC 3032 section 4.3
+   }
+
+5.  IPv6 Protocols
+
+ip6 PROTOCOL-IDENTIFIER
+PARAMETERS {}
+ATTRIBUTES {}
+DESCRIPTION
+        "The protocol identifiers for the Internet Protocol, Version 6
+        [RFC2460]."
+
+
+
+
+
+
+Stephan & Palet              Informational                      [Page 3]
+
+RFC 3919      RMON Protocol Identifiers for IPv6 and MPLS   October 2004
+
+
+CHILDREN
+        "Children of 'ip6' are selected by the value in the Protocol
+        field (one octet), as defined in the PROTOCOL NUMBERS table
+        within the Assigned Numbers Document.
+
+        The value of the Protocol field is encoded in an octet string as
+        [ 0.0.0.a ], where 'a' is the protocol field.
+        Children of 'ip6' are encoded as [ 0.0.0.a ], and named as 'ip6
+        a' where 'a' is the protocol field value.  For example, a
+        protocolDirID-fragment value of:
+          0.0.0.1.0.0.0.41.0.0.0.58
+
+        defines an encapsulation of IPv6-ICMP (ether2.ip6.icmp6)"
+ADDRESS-FORMAT
+        "16 octets of the IPv6 address, in network byte order.  Each ip
+        packet contains two addresses, the source address and the
+        destination address."
+DECODING
+        "Note: ether2.ip.ipip6.udp is a different protocolDirID than
+        ether2.ip6.udp, as identified in the protocolDirTable.  As such,
+        two different local protocol index values will be assigned by
+        the agent. E.g., (full INDEX values shown):
+        ether2.ip.ipip6.udp =
+                        16.0.0.0.1.0.0.8.0.0.0.0.41.0.0.0.17.4.0.0.0.0
+        ether2.ip6.udp =
+                        12.0.0.0.1.0.0.0.41.0.0.0.17.3.0.0.0 "
+REFERENCE
+
+        "RFC 2460 [RFC2460] defines the Internet Protocol version 6; The
+        following URL defines the authoritative repository for the
+        PROTOCOL NUMBERS Table:
+
+          http://www.iana.org/assignments/protocol-numbers"
+::= {
+        ether2     0x86DD,
+        802-1Q     0x86DD,
+        mplsu       41,
+        mplsm       41
+}
+
+ipip6 PROTOCOL-IDENTIFIER
+PARAMETERS { }
+ATTRIBUTES {
+
+   }
+DESCRIPTION
+        "IPv6 in IPv4 Tunneling"
+
+
+
+
+Stephan & Palet              Informational                      [Page 4]
+
+RFC 3919      RMON Protocol Identifiers for IPv6 and MPLS   October 2004
+
+
+CHILDREN
+        "Children of 'ipip6' are selected and encoded in the same manner
+        as children of ip6."
+ADDRESS-FORMAT
+        "The 'ipip6' address format is the same as the IPv6 address
+        format."
+DECODING
+        "Note: ether2.ip.ipip6.udp is a different protocolDirID than
+        ether2.ip6.udp, as identified in the protocolDirTable.  As such,
+        two different local protocol index values will be assigned by
+        the agent. E.g., (full INDEX values shown):
+                ether2.ip.ipip6.udp =
+                        16.0.0.0.1.0.0.8.0.0.0.0.41.0.0.0.17.4.0.0.0.0
+                ether2.ip6.udp =
+                        12.0.0.0.1.0.0.0.41.0.0.0.17.3.0.0.0 "
+REFERENCE
+        "RFC 2473 [RFC2473] defines Generic Packet Tunneling in IPv6
+        Specification."
+::= {
+        ip 41
+}
+
+icmp6 PROTOCOL-IDENTIFIER
+PARAMETERS { }
+ATTRIBUTES { }
+DESCRIPTION
+        "Internet Message Control Protocol for IP Version 6"
+REFERENCE
+        "RFC 2463 [RFC2463] Internet Control Message Protocol (ICMPv6)
+        for the Internet Protocol Version 6 (IPv6) Specification "
+::= {
+        ip6 58,
+        ipip6 58
+}
+
+6.  Security Considerations
+
+   This document contains textual descriptions of well-known networking
+   protocols, not the definition of any networking behavior.  As such,
+   no security considerations are raised by its publication.
+
+7.  Acknowledgments
+
+   The authors would like to acknowledge the European Commission support
+   in the co-funding of the 6QM project, where this work is being
+   developed.
+
+
+
+
+
+Stephan & Palet              Informational                      [Page 5]
+
+RFC 3919      RMON Protocol Identifiers for IPv6 and MPLS   October 2004
+
+
+8.  References
+
+8.1.  Normative References
+
+   [RFC2460]  Deering, S. and R. Hinden, "Internet Protocol, Version 6
+              (IPv6) Specification", RFC 2460, December 1998.
+
+   [RFC2463]  Conta, A. and S. Deering, "Internet Control Message
+              Protocol (ICMPv6) for the Internet Protocol Version 6
+              (IPv6) Specification", RFC 2463, December 1998.
+
+   [RFC2473]  Conta, A. and S. Deering, "Generic Packet Tunneling in
+              IPv6 Specification", RFC 2473, December 1998.
+
+   [RFC2578]  McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+              "Structure of Management Information Version 2 (SMIv2)",
+              STD 58, RFC 2578, April 1999.
+
+   [RFC2579]  McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+              "Textual Conventions for SMIv2", STD 58, RFC 2579, April
+              1999.
+
+   [RFC2580]  McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+              "Conformance Statements for SMIv2", STD 58, RFC 2580,
+              April 1999.
+
+   [RFC2895]  Bierman, A., Bucci, C., and R. Iddon, "Remote Network
+              Monitoring MIB Protocol Identifier Reference", RFC 2895,
+              August 2000.
+
+   [RFC3032]  Rosen, E., Tappan, D., Fedorkow, G., Rekhter, Y.,
+              Farinacci, D., Li, T., and A. Conta, "MPLS Label Stack
+              Encoding", RFC 3032, January 2001.
+
+8.2.  Informative References
+
+   [RFC2021]  Waldbusser, S., "Remote Network Monitoring Management
+              Information Base Version 2 using SMIv2", RFC 2021, January
+              1997.
+
+   [RFC2026]  Bradner, S., "The Internet Standards Process -- Revision
+              3", BCP 9, RFC 2026, October 1996.
+
+   [RFC2896]  Bierman, A., Bucci, C., and R. Iddon, "Remote Network
+              Monitoring MIB Protocol Identifier Macros", RFC 2896,
+              August 2000.
+
+
+
+
+
+Stephan & Palet              Informational                      [Page 6]
+
+RFC 3919      RMON Protocol Identifiers for IPv6 and MPLS   October 2004
+
+
+   [RFC3410]  Case, J., Mundy, R., Partain, D., and B. Stewart,
+              "Introduction and Applicability Statements for Internet-
+              Standard Management Framework", RFC 3410, December 2002.
+
+Authors' Addresses
+
+   Stephan Emile
+   France Telecom R & D
+   2 avenue Pierre Marzin
+   Lannion,   F-22307
+
+   Fax:   +33 2 96 05 18 52
+   EMail: emile.stephan@francetelecom.com
+
+
+   Jordi Palet
+   Consulintel, IPv6 R&D
+   San Jose Artesano, 1
+   Alcobendas, Madrid, Spain  E-28108
+
+   Fax:   +34 91 151 81 98
+   EMail: jordi.palet@consulintel.es
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Stephan & Palet              Informational                      [Page 7]
+
+RFC 3919      RMON Protocol Identifiers for IPv6 and MPLS   October 2004
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2004).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the IETF's procedures with respect to rights in IETF Documents can
+   be found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at ietf-
+   ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+Stephan & Palet              Informational                      [Page 8]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc3919.txt](<www.ietf.org/rfc/rfc3919.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
