### PR TITLE
Archive rfc3934.txt

### DIFF
--- a/www.ietf.org/rfc/rfc3934.txt
+++ b/www.ietf.org/rfc/rfc3934.txt
@@ -1,0 +1,283 @@
+
+
+
+
+
+
+Network Working Group                                       M. Wasserman
+Request for Comments: 3934                                    ThingMagic
+Updates: 2418                                               October 2004
+BCP: 94
+Category: Best Current Practice
+
+
+   Updates to RFC 2418 Regarding the Management of IETF Mailing Lists
+
+Status of this Memo
+
+   This document specifies an Internet Best Current Practices for the
+   Internet Community, and requests discussion and suggestions for
+   improvements.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2004).
+
+Abstract
+
+   This document is an update to RFC 2418 that gives WG chairs explicit
+   responsibility for managing WG mailing lists.  In particular, it
+   gives WG chairs the authority to temporarily suspend the mailing list
+   posting privileges of disruptive individuals.
+
+Table of Contents
+
+   1.  Introduction . . . . . . . . . . . . . . . . . . . . . . . . .  2
+   2.  Specific Changes to RFC 2418 . . . . . . . . . . . . . . . . .  2
+   3.  Security Considerations  . . . . . . . . . . . . . . . . . . .  3
+   4.  Acknowledgements . . . . . . . . . . . . . . . . . . . . . . .  3
+   5.  References . . . . . . . . . . . . . . . . . . . . . . . . . .  3
+       5.1.  Normative References . . . . . . . . . . . . . . . . . .  3
+       5.2.  Informative References . . . . . . . . . . . . . . . . .  3
+   6.  Author's Address . . . . . . . . . . . . . . . . . . . . . . .  4
+   7.  Full Copyright Statement . . . . . . . . . . . . . . . . . . .  5
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Wasserman                Best Current Practice                  [Page 1]
+
+RFC 3934             Mailing List Management Update         October 2004
+
+
+1.  Introduction
+
+   As written, RFC 2418 [RFC2418] gives WG chairs more authority to
+   manage face-to-face discussions than to manage mailing list
+   discussions.  In face-to-face meetings, the WG chair has the
+   authority "to refuse to grant the floor to any individual who is
+   unprepared or otherwise covering inappropriate material, or who, in
+   the opinion of the Chair, is disrupting the WG process."  However,
+   RFC 2418 does not give the WG Chair the authority to suspend the
+   mailing list posting privileges of an individual who is similarly
+   disrupting WG mailing list discussions.  RFC 2418 explicitly requires
+   full IESG approval for this action.
+
+   This document is an update to RFC 2418, section 3.2.  It gives WG
+   chairs the authority to temporarily suspend the posting privileges of
+   disruptive individuals without IESG approval.
+
+2.  Specific Changes to RFC 2418
+
+   The following paragraphs supersede the last paragraph of RFC 2418,
+   section 3.2:
+
+   As in face-to-face sessions, occasionally one or more individuals may
+   engage in behavior on a mailing list that, in the opinion of the WG
+   chair, is disruptive to the WG process.  Unless the disruptive
+   behavior is severe enough that it must be stopped immediately, the WG
+   chair should attempt to discourage the disruptive behavior by
+   communicating directly with the offending individual.  If the
+   behavior persists, the WG chair should send at least one public
+   warning on the WG mailing list.  As a last resort and typically after
+   one or more explicit warnings and consultation with the responsible
+   Area Director, the WG chair may suspend the mailing list posting
+   privileges of the disruptive individual for a period of not more than
+   30 days.  Even while posting privileges are suspended, the individual
+   must not be prevented from receiving messages posted to the list.
+   Like all other WG chair decisions, any suspension of posting
+   privileges is subject to appeal, as described in RFC 2026 [RFC2026].
+
+   This mechanism is intended to permit a WG chair to suspend posting
+   privileges of a disruptive individual for a short period of time.
+   This mechanism does not permit WG chairs to suspend an individual's
+   posting privileges for a period longer than 30 days regardless of the
+   type or severity of the disruptive incident.  However, further
+   disruptive behavior by the same individual will be considered
+   separately and may result in further warnings or suspensions.  Other
+   methods of mailing list control, including longer suspensions, must
+
+
+
+
+
+Wasserman                Best Current Practice                  [Page 2]
+
+RFC 3934             Mailing List Management Update         October 2004
+
+
+   be carried out in accordance with other IETF-approved procedures.
+   See BCP 83 [RFC3683] for one set of procedures already defined and
+   accepted by the community.
+
+3.  Security Considerations
+
+   This document describes a modification to the IETF process for
+   managing mailing list discussions.  It has no security
+   considerations.
+
+4.  Acknowledgements
+
+   This document reflects a discussion that was held on the MPOWR
+   mailing list in December 2003 and January 2004.  In particular, the
+   following people contributed ideas that influenced this document:
+   Harald Alvestrand, Dave Crocker, James Kempf, and John Klensin.
+
+   This document was written with the xml2rfc tool described in RFC 2629
+   [RFC2629].
+
+5.  References
+
+5.1.  Normative References
+
+   [RFC2026]  Bradner, S., "The Internet Standards Process -- Revision
+              3", BCP 9, RFC 2026, October 1996.
+
+   [RFC2418]  Bradner, S., "IETF Working Group Guidelines and
+              Procedures", BCP 25, RFC 2418, September 1998.
+
+5.2.  Informative References
+
+   [RFC2629]  Rose, M., "Writing I-Ds and RFCs using XML", RFC 2629,
+              June 1999.
+
+   [RFC3683]  Rose, M., "A Practice for Revoking Posting Rights to IETF
+              Mailing Lists", BCP 83, RFC 3683, March 2004.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Wasserman                Best Current Practice                  [Page 3]
+
+RFC 3934             Mailing List Management Update         October 2004
+
+
+6.  Author's Address
+
+   Margaret Wasserman
+   ThingMagic
+   One Broadway, 14th Floor
+   Cambridge, MA  02142
+   USA
+
+   Phone: +1 617 758 4177
+   EMail: margaret@thingmagic.com
+   URI:   http://www.thingmagic.com/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Wasserman                Best Current Practice                  [Page 4]
+
+RFC 3934             Mailing List Management Update         October 2004
+
+
+7.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (2004).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and at www.rfc-editor.org, and except as set
+   forth therein, the authors retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the ISOC's procedures with respect to rights in ISOC Documents can
+   be found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at ietf-
+   ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+Wasserman                Best Current Practice                  [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc3934.txt](<www.ietf.org/rfc/rfc3934.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
