### PR TITLE
Archive rfc395.txt

### DIFF
--- a/www.ietf.org/rfc/rfc395.txt
+++ b/www.ietf.org/rfc/rfc395.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                     John M. McQuillan
+RFC # 395                                 Bolt Beranek and Newman Inc.
+NIC # 11587                               3 October 1972
+Categories: Updates:
+Obsoletes:
+
+                    SWITCH SETTINGS ON IMPS AND TIPS
+                    --------------------------------
+
+This note provides a description of the switches on the front panel of
+IMPs and TIPs that are important to the correct operation of the
+network software.  We have had some difficulty in the past when
+certain of these switches were set incorrectly, This RFC will be
+updated as necessary, to notify site personnel of changes to the
+settings.
+
+A.  516 IMPs
+    --------
+The IMP at your site is a model 516 if it has a gray cabinet and two
+rows of indicator lights on the front panel.  The correct switch
+settings are:
+
+     1.   Sense switches 1,2,3 and 4:  OFF (DOWN)
+     2.   PFI/PFH:  PFI (UP)
+     3.   HALT INH:  OFF (DOWN)
+     4.   W.D.T.:  OFF (DOWN)
+     5.   AUTO RSTRT:  ON (UP)
+     6.   MEMORY PRTCT:  OFF (DOWN)
+
+B.  316 IMPs and TIPs
+    -----------------
+The IMP at your site is a model 316 if it is a TIP or if it is in a
+black cabinet and has one row of indicator lights on the front panel.
+
+     1.  Sense switches 1,2,3,4 OFF  (top half depressed)
+
+Site personnel are requested to keep a copy of this RFC near the IMP
+and to check the switch settings at their IMP.  In addition, the
+Honeywell field engineers who perform preventive maintenance have been
+requested to use this note as a checklist.
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                      1/97 ]
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc395.txt](<www.ietf.org/rfc/rfc395.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
