### PR TITLE
Archive rfc398.txt

### DIFF
--- a/www.ietf.org/rfc/rfc398.txt
+++ b/www.ietf.org/rfc/rfc398.txt
@@ -1,0 +1,112 @@
+
+
+
+
+
+
+NWG/RFC #398                                        John R. Pickens
+UCSB Online Graphics                                Edward D. Faeh
+NIC 11911                                           UCSB
+                                                    22 Sept 72
+
+At present, users with TEKTRONIX or IMLAC terminals or with systems
+that support the proposed level 0 graphics protocol can access UCSB
+graphics.  Listed below are the ICP sockets for the currently
+supported terminals and protocols.  Any detailed questions about or
+problems with a particular protocol should be directed to Ed Faeh
+(805-961-4047).
+
+   Socket                       Supports
+
+   x'701'               IMLAC with special software designed
+                        by Jerry Powell (MITRE Corp.).
+                        Graphics is sent over a simplex
+                        connection to the IMLAC.  Alphanumerics
+                        are sent over a TELNET-like connection
+                        to a separate device.  The IMLAC
+                        software can be loaded from MIT-DMCG.
+
+   x'703'               IMLAC with 80x80 display grid
+                        and Standard Text and Edit Package.
+                        Some IMLACs have a 64x64 display grid.
+                        Therefore, the choice may be made in
+                        the near future to format the
+                        graphics output from this connection
+                        for the smaller grid resolution so
+                        that both terminal types may be handled.
+                        Display resolution is limited with
+                        this terminal configuration as
+                        normal UCSB terminals have 1024x1024
+                        grid.  Nevertheless, meaningful
+                        displays are obtained even at the
+                        lower resolutions.
+
+   x'705'               Current Level 0 graphics protocol.
+
+   x'707'               Same as x'701' but with special
+                        UCSB online keyboard as input.
+                        This configuration averts the
+                        necessity of spelling out online
+                        operators.
+
+   x'709'               Same as x'705' but with special
+                        UCSB online keyboard as input.
+
+
+
+
+                                                                [Page 1]
+
+NWG/RFC# 398                        JRP EDF 22-SEP-72 16:25  11911
+UCSB OnLine Graphics
+
+
+   x'801'               TEKTRONIX terminals.  Models 4002-A
+                        4010, and T-4002 have been tested
+                        successfully.  Presumably all other
+                        4002 compatible terminals will also work.
+
+The primary problems that will be encountered by the network user
+center about display formatting.  For historical reasons (i.e.  only
+one type of terminal in house ) no means were included in the system
+to facilitate terminal independent random positioning of alphanumeric
+output.  Thus, a program which draws and labels a graph neatly on one
+terminal might label like a kindergartener on other terminals.
+Nevertheless, this problem can be minimized with careful programming
+and efforts are underway to provide at least minimal alphanumeric
+device independence.
+
+Users interested in experimenting with online graphics should contact
+John Pickens (805-961-3454), Glen Davis (805-961-2462), or Mark
+Krilonovich (805-961-3454).  Suggestions and criticisms of all aspects
+of the UCSB OnLine - Network User interface are desired.
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                      1/97 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc398.txt](<www.ietf.org/rfc/rfc398.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
