### PR TITLE
Archive rfc399.txt

### DIFF
--- a/www.ietf.org/rfc/rfc399.txt
+++ b/www.ietf.org/rfc/rfc399.txt
@@ -1,0 +1,112 @@
+
+
+
+
+
+
+RFC #399                                        Mark Krilanovich
+NIC #11917                                      UCSB
+Updates:  122                                   Sept. 26, 1972
+
+                  SMFS Login and Logout
+
+        Two new commands have been added to UCSB's Simple Minded
+File System (SMFS).  They are described below.
+
+
+        Login (LGI)
+        The login command is the means whereby the user
+identifies himself and specifies the account number to which his
+use of SMFS is to be billed.  The user should issue a LGI command
+directly after completing the ICP and before any command
+referencing a file.  The user name and account number specified
+remain in effect until another LGI command is issued, a LGO
+command is issued, or the connection is closed.
+
+        At present, the use of SMFS is not billed, and therefore
+use of the accounting commands is optional.  It is requested,
+however, that users and user processes begin to use this command
+as soon as possible, since we would like to collect statistics on
+SMFS utilization before implementing billing.  Therefore, at
+present the user name can be any name that identfies the user,
+and the account number is completely arbitrary.
+
+        The format of the LGI command is given below.  Note that
+the lengths of the fixed-length fields are given in bits.  The op
+code for LGI is decimal 13.
+
+            8
+        <op code><user name><account number>
+
+The <user name> and <account number> fields are further divided
+as follows:
+
+            8     8*length
+        <length><user name>
+
+where <length> gives the length in 8-bit characters of the <user
+name> or <account number> subfield.  The maximum length of <user
+name> is eight characters and of <account number> is four
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+
+NWG/RFC# 399                           MCK 26-SEP-72 15:15  11917
+SMFS Login and Logout
+
+
+characters.  The <user name> and <account number> fields must
+consist of characters chosen from the same character set as
+filenames.
+
+
+        Logout (LGO)
+        The logout command terminates the association between the
+user and the accounting information specified in the last LGI
+command issued, if any; it does not cause SMFS to close the
+connection.  The user should then issue another LGI command
+before attempting any operation referencing a file.  It is not
+necessary to issue a LGO command before issuing another LGI
+command, or before closing the connection.
+
+        Again, at the present time the LGO command is optional,
+and does not affect the user's ability to reference files.
+
+        The format of the LGO command is as follows:
+
+            8
+        <op code>
+
+The op code for LGO is decimal 14.
+
+
+
+
+
+
+
+    [ This RFC was put into machine readable form for entry ]
+    [ into the online RFC archives by BBN Corp. under the   ]
+    [ direction of Alex McKenzie.                      1/97 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc399.txt](<www.ietf.org/rfc/rfc399.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
