### PR TITLE
Archive rfc402.txt

### DIFF
--- a/www.ietf.org/rfc/rfc402.txt
+++ b/www.ietf.org/rfc/rfc402.txt
@@ -1,0 +1,899 @@
+
+
+
+
+
+
+Network Working Group                         Network Information Center
+Request for Comments: 402                    Stanford Research Institute
+Obsoletes: 363                                           26 October 1972
+NIC: 19924
+
+
+                       ARPA NETWORK MAILING LISTS
+
+ABSTRACT
+
+   The following are three lists to be used for distribution of Network
+   documents.  List A should be used by sites when they distribute their
+   own documents, to get RFC's to Liaisons as quickly as possible.  All
+   but local mail should be sent Air Mail.  Lists B and C will be used
+   by NIC in making distribution of copies to non-site Network
+   Participants and to Station Agents.
+
+
+A. NETWORK LIAISON GROUP
+
+   Note:  This list includes all Network Liaisons and others who should
+   receive initial distribution of RFC's, whether sent from NIC or from
+   sites.  They will also receive selected catalogs and other formal
+   documents from NIC.
+
+ABERDEEN
+
+Mr. Michael J. Romanelli
+Aberdeen Research and Development Center
+Aberdeen Proving Ground, Maryland 21005
+
+      (301) 278-4574                AMES-67
+
+AFETR                               A. Wayne Hathaway
+                                    Mail Stop 233-9
+Michael B. Young                    NASA Ames Research Center
+Air Force Eastern Test Range        Moffett Field, Calif.  94035
+ATTN: ENLE
+Patrick Air Force Base, Florida 32925    (415) 965-6033
+
+      (305) 494-2681                AMES-ILLIAC (see ILLIAC)
+
+
+
+
+
+
+
+
+
+
+Network Information Center                                      [Page 1]
+
+RFC 402                ARPA NETWORK MAILING LISTS           October 1972
+
+
+ARPA-TIP                             CCA
+
+Steve D. Crocker                     Richard A. Winter
+Advanced Research Projects Agency    Computer Corporation of America
+1400 Wilson Boulevard                565 Technology Square
+Arlington, Virginia  22209           Cambridge, Mass.  02139
+
+      (202) 694-5037 or 694 5922           (617) 491-3670
+
+BBN-NET                              CMU-10A
+
+Alex McKenzie                        Harold R. Van Zoeren
+Bolt Beranek and Newman Inc.         Carnegie-Mellon University
+50 Moulton Street                    Computer Science Department
+Cambridge, Mass.  02138              Schenley Park
+                                     Pittsburgh, Pa.  15213
+      (617) 491-1850 x441
+                                           (412)621-2600 x160
+BBN-TENEX
+                                     CMU-10B
+Robert H. Thomas                     (see CMU-10A)
+Bolt Beranek and Newman Inc
+50 Moulton Street                    DCAO
+Cambridge, Mass.  02138
+                                     Daniel L. Kadunce
+      (617) 491-1850 x351            Defense Communications Agency
+                                                              Operations
+BELVOIR                              Attention: Code N-321
+                                     Washington, D. C. 20305
+Sam McCutchen
+Commanding Officer/USAMERDC                (202) 692-2600
+SMEFB-BC
+Fort Belvoir, Virginia, 22060        DOCB
+
+      (703) 664-5013                 Schuyler Stevenson R-523
+                                     Department of Commerce NOAA
+CASE-10                              325 South Broadway
+                                     Boulder, Colorado 80302
+Patrick W. Foulk
+Jennings Computing Center                  (303) 499-1000 x3863
+Room 306, Crawford Hall
+Case Western Reserve University
+10900 Euclid Avenue
+Cleveland, Ohio  44106
+
+      (216) 368-2936
+
+
+
+
+
+Network Information Center                                      [Page 2]
+
+RFC 402                ARPA NETWORK MAILING LISTS           October 1972
+
+
+ETAC-TIP                             IBMW
+
+Capt. George N. Petregal             Sol F. Seroussi
+USAF-ETAC                            IBM Watson Research Center
+Bldg. 159                            P.O. box 218
+Navy Yard Annex                      Yorktown Heights, Pew York  10598
+Washington, D. C. 20333
+                                           (914) 945-2052
+      (202) 693-3911 or 693-3912
+                                     ILL-ANTS
+FNWC
+                                     Jascov Meir
+Dick Reins                           University of Illinois
+Fleet Numerical Weather Central      Advanced Computation Building
+Monterey, Calif. 93940               Urbana, Illinois  61801
+
+      (408) 646-2201                       (217)333-8469
+
+GWC                                  ILLIAC
+
+Lt. John C. Thomas                   John W. McConnell
+AF Global Weather Central (DN)       NASA Ames Research Center
+Offutt Air Force Base,               Mail Stop 202-10
+                     Nebraska 68113  Moffett Field, Calif.  94035
+
+                                           (415) 965-5191 or 961-6340
+      (402) 294-5245
+                                     LBL
+HARV-10
+                                     Robert L. Fink
+Bradley A. Reussow                   Lawrence Berkeley Labs
+Harvard University                   Bldg. 50A, Room 1143
+Aiken Computation Laboratory         Berkeley, California 94720
+33 Oxford Street
+Cambridge, Mass.  02138                    (415) 643-2740 x5351
+
+      (617) 495-4147                 LL-67
+
+HARV-11                              Joel M. Winett
+                                     Massachusetts Institute of
+Scott Bradner                                                 Technology
+Harvard University                   Lincoln Laboratory
+Psychology Department                244 Wood Street
+33 Kirkland Street                   Lexington, Mass.  02173
+Cambridge, Mass.  02138
+                                           (617)862-5500 x7474
+      (617) 495-3864
+
+
+
+
+Network Information Center                                      [Page 3]
+
+RFC 402                ARPA NETWORK MAILING LISTS           October 1972
+
+
+LL-TX-2                              NBS
+
+William Kantrowitz                   Thomas N. Pyke, Jr.
+Massachusetts Institute of           National Bureau of Standards
+                         Technology  Bldg. 225, Room B216
+Lincoln Laboratory                   Washington, D.C.  20234
+244 Wood Street
+Lexington, Mass.  02173                    (301) 921-2601
+
+      (617) 862-5500 x7349           NIC
+                                     see SRI-ARC
+MIT-DMCG
+                                     PARC-MAXC
+Abhay Bhushan
+Project Mac Room 208                 L. Peter Deutsch
+545 Technology Square                Xerox PARC
+Cambridge, Mass.  02139              3180 Porter Drive
+                                     Palo Alto, California 94304
+      (617) 253-1428
+                                           (415) 493-1600
+MIT-MULTICS
+                                     PARC-VTS
+Mike Padlipsky
+Project MAC Room 208                 Bob Metcalfe
+545 Technology Square                Xerox PARC
+Cambridge, Mass. 02139               Computer Systems Building
+                                     3180 Porter Drive
+      (617) 253-6006                 Palo Alto, California 94304
+
+MITRE-TIP                                  (415) 493-1600
+
+Jerry Powell                         RADC
+MITRE Corporation
+Information Systems Dept., W140      Thomas F. Lawrence
+Westgate Research Park               Rene Air Development Center (ISIM)
+McLean, Va.  22101                   Griffiss Air Force Base
+                                     Rome, New York  13440
+      (703) 893-3500 x2887
+                                           (315) 330-3857 or 330-7834
+
+
+
+
+
+
+
+
+
+
+
+
+Network Information Center                                      [Page 4]
+
+RFC 402                ARPA NETWORK MAILING LISTS           October 1972
+
+
+RAND                                 SDC-ADEPT
+
+Eric Harslem                         Arie Shoshani
+Rand Corporation                     System Development Corporation
+Computer Science Department          2500 Colorado Avenue
+1700 Main Street                     Santa Monica, Calif.  90406
+Santa Monica, Calif.  90406
+                                            (213) 393-9411 x7122
+      (213) 393-0411 x7606
+                                     SRI-AI
+RAY
+                                     B. Michael Wilber
+Thomas O'Sullivan, 1-ML-17           Stanford Research Institute
+Raytheon Company                     Artificial Intelligence Group
+528 Boston Post Road                 33 Ravenswood Avenue
+Sudbury, Mass.  01776                Menlo Park, Calif.  94025
+
+      (617) 443-9521 x2945                 (415) 326-6200 x4593
+
+RUTGERS                              SRI-ARC
+
+Gil Falk                             James E. White
+Department of Computer Science       Stanford Research Institute
+Hill Mathematics Center              Augmentation Research Center
+University Heights Campus            333 Ravenswood Avenue
+Rutgers University                   Menlo Park, Calif.  94025
+New Brunswick,New Jersey 08903
+                                           (415) 329-0740
+      (201) 932-2085
+                                     Jeanne B. North (for NIC)
+SAAC-TIP                             Stanford Research Institute
+                                     Augmentation Research Center
+A.D. (Buz) Owen                      333 Ravenswood Avenue
+Teledyne/Geotech                     Menlo Park, Calif.  94025
+Seismic Analysis Array Center
+Box 334                                    (415)329-0740
+Alexandria, Va. 22314
+                                     SU-AI
+      (703) 836-3882 x278
+                                     James H. Stein
+SCI                                  Stanford University
+                                     Computer Science Dept.
+Gene Leichner                        AI Project
+Systems Control, Inc.                Stanford, Calif.  94305
+260 Sheridan Ave.
+Palo Alto. California 94306                (415) 321-2300 x4971
+
+      (415) 327-8823
+
+
+
+Network Information Center                                      [Page 5]
+
+RFC 402                ARPA NETWORK MAILING LISTS           October 1972
+
+
+SU-HP                                UCSD-CC
+
+Edward A. Feigenbaum                 James Madden
+Stanford University,                 Computer Center
+Heuristic Programming                University of California
+Serra House                                                 at San Diego
+Stanford, Calif.  94305              La Jolla, Calif.  92037
+
+      (415) 321-2300 x4878                 (714) 453-2000 x2598
+
+UCLA-CCBS                            UHI
+
+Reg E. Martin                        John Davidson
+UCLA                                 University of Hawaii
+Center for Computer-based            The Aloha System
+                 Behavioral Studies  2565 The Mall
+405 Hilgard Avenue                   Honolulu, Hawaii 96822
+Los Angeles, Calif. 90024
+                                           (808) 944-7455
+      (213) 825-0841
+                                     USC-44
+UCLA-CCN
+                                     James Pepin
+Robert T. Braden                     University of Southern California
+UCLA - Campus Computing Network      School of Engineering
+Los Angeles, Calif.  90024           Los Angeles, Calif.  90007
+
+      (213) 825-7518                       (213) 746-2240
+
+UCLA-NMC                             USC-ISI
+
+Ari O. Ollikainen                    John Melvin
+UCLA - Network Measurement Center    USC Information Sciences Institute
+Los Angeles, Calif.  90024           4676 Admiralty Way
+                                     Marina Del Rey, Calif. 90291
+      (213) 825-2381 or 825-2368
+                                           (213) 822-1511
+UCSB-MOD75
+
+Ron Stoughton
+University of California
+                   at Santa Barbara
+Computer Research Laboratory
+Santa Barbara, Calif.  93106
+
+      (805) 961-3793
+
+
+
+
+
+Network Information Center                                      [Page 6]
+
+RFC 402                ARPA NETWORK MAILING LISTS           October 1972
+
+
+UTAH-10                              WECOM
+
+Barry D. Wessler                     Jim Hurt
+University of Utah                   Headquarters USA Weapons Command
+Computer Science/IRL                 Attention: SWERR-R
+Salt Lake City, Utah  84112          Rock Island, Illinois 61201
+
+      (801) 581-6507                       (309) 794-4143
+
+Anthony C. Hearn
+University of Utah
+Dept. of Physics
+Salt Lake City, Utah 84112
+
+      (801) 581-8502
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Network Information Center                                      [Page 7]
+
+RFC 402                ARPA NETWORK MAILING LISTS           October 1972
+
+
+B. LIST FOR DISTRIBUTION FROM NIC
+
+   Note: These Network participants will receive all formal Network
+   documents sent from NIC, in the mailing to Liaisons when such is
+   made, otherwise at the time documents are sent to Station Agents.
+
+CHIU                                 EDUCOM
+
+Robert L. Ashenhurst                 John LeGates
+Institute for Computer Research      Old Concord Road
+University of Chicago                Lincoln, Mass. 01773
+Chicago, Illinois 60637
+                                           (617) 259-9458
+      (312) 753-8762
+                                     IFF
+COU
+                                     Hubert Lipinski
+Maurice P. Brown, Director           Institute for the Future
+Office of Computer Coordination      2725 Sand Hill Road, Suite 203
+Council of Ontario Universities      Menlo Park, Calif. 94025
+102 Bloor Street West
+Toronto 181, Ontario                       (415) 854-6322
+
+      (416) 920-6865                 MERIT
+
+CRC                                  E. M.  Aupperle
+                                     MERIT Computer Network
+C.D. Shepard                         University of Michigan
+Communications Research Center       1037 N. University Building
+P.O. Box 490                         Ann Arbor, Michigan 48104
+Ottawa, Canada K1N ATB
+                                           (313) 764-9423
+      (613) 996-7051
+                                     NAC
+DART
+                                     Richard M. Van Slyke
+Robert F. Hargraves                  Network Analysis Corporation
+Kiewit Computation Center            Beechwood, Old Tappan Road
+Dartmouth University                 Glen Cove, New York 11542
+Hanover, New Hampshire  03755 (603)
+                                           (516) 671-9580
+      (603) 646-2643 x3755
+
+
+
+
+
+
+
+
+
+Network Information Center                                      [Page 8]
+
+RFC 402                ARPA NETWORK MAILING LISTS           October 1972
+
+
+NETH                                 SUNY
+
+Tjaart Schipper                      Art J. Bernstein
+13 Marijkestraat                     SUNY Stonybrook
+Leiderdorp, Netherlands              Dept. Of computer Science
+NPL                                  Stony Brook, L.I., N.Y.  11790
+
+Derek Barber                               (516) 246-4080
+Computer Science Division
+National Physical Laboratory
+Teddington, Middlesex, England       UBC
+
+      01-977-3222                    Dave Tywver
+                                     Computing Center
+NSF                                  University of British Columbia
+                                     Vancouver 8, Canada
+Dr. D. D. Aufenkamp
+Office of Computing Activities             (604) 228-3072
+National Science Foundation
+1800 G Street, P.W.                  UCI
+Washington, D. C.  20550
+                                     David Farber
+      (202) 632-7349                 Dept. of Information and
+                                                        Computer Science
+ONR1                                 University of California
+                                     Irvine, Calif.  92664
+A. Kenneth Showalter
+Office of Naval Research                   (714) 833-6891
+Information Systems Programs
+800 North Quincy Street              UKICS
+Arlington, Va. 22217
+                                     Peter Kirstein
+      (202) 692-4304                 Institute of computer Science
+                                     University of London
+OWENS                                44 Gordon Square
+                                     London, W.C.1, England
+Dave Liddle
+Owens Illinois, Inc.                 UMICH
+Lewis Development Park, Bldg. 30
+Perrysberg, Ohio 43551               Michael O'Malley
+                                     University of Michigan
+      (419) 242-6543                 Phonetics Laboratory
+                                     180 Frieze Building
+                                     Ann Arbor, Michigan 48104
+
+                                           (313) 764-5334
+
+
+
+
+
+Network Information Center                                      [Page 9]
+
+RFC 402                ARPA NETWORK MAILING LISTS           October 1972
+
+
+UNIVAC                               WASHU
+
+Ted Lee                              Marianne Pepper
+Mail Station #8901                   Washington University
+UNIVAC                               Computer Systems Laboratory
+P.O. Box 3525                        724 South Euclid Avenue
+St. Paul, Minnesota 55165            St. Louis, Mo.  63110
+
+      (612) 456-2434                       (314) 361-7356
+
+USWARC                               WATERU
+
+Louis F. Dixon                       Prof. Donald Cowan
+Director, ADP Support Division       Dept. Of Computer Science
+US Army War College                  University of Waterloo
+Carlisle Barracks, Pa. 17013         Waterloo, Ontario, Canada
+
+      (717) 245-4304                       (519) 744-6111 x3292
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Network Information Center                                     [Page 10]
+
+RFC 402                ARPA NETWORK MAILING LISTS           October 1972
+
+
+C. NIC STATION AGENTS
+
+   Note:  Station Agents receive copies from NIC of all documents
+   distributed to Liaisons, as well as documents sent as part of Station
+   collection.  A mailing is made to Station Agents once a week, or
+   oftener when quantity warrants.
+
+ABERDEEN                             BBN-TENEX
+
+Ermalee R. McCauley                  Steve G. Chipman
+Aberdeen Research and                Bolt Beranek and Newman Inc.
+                 Development Center  50 Moulton Street
+Aberdeen Proving Ground,             Cambridge, Mass.  02138
+                     Maryland 21005
+                                           (617) 491-1850 x358
+      (301) 278-4574
+                                     BELVOIR
+AFETR
+                                     Brenda Monroe
+Jane Moody                           Commanding Officer/USAMERDC
+Air Force Eastern Test Range         SMEFB-BC
+ATTN: ENLE                           Fort Belvoir, Virginia, 22060
+Patrick Air Force Base,
+                      Florida 32925        (703) 664-5511
+
+      (305) 494-2966                 CASE-10
+
+AMES-67                              John Barden
+                                     Case Western Reserve University
+Stan Golding                         Computing and Information Sciences
+Mail Stop 233-13                     10900 Euclid Ave.
+NASA Ames Research Center            Cleveland, Ohio  44106
+Moffet Field, Calif.  94035
+                                           (216) 368-4467
+      (415) 965-6035
+                                     CCA
+ARPA-TIP
+                                     Martha A. Ginsberg
+Pam J. Klotz                         Computer Corporation of America
+Advanced Research Projects Agency    565 Technology Square
+1400 Wilson Boulevard                Cambridge, Mass.  02139
+Arlington, Va,  22209
+                                           (617) 491-3670
+      (202) 694-5037
+                                     CMU-10A
+BBN-NET                              (see CMU-10B)
+(see BBN-TENEX)
+
+
+
+
+Network Information Center                                     [Page 11]
+
+RFC 402                ARPA NETWORK MAILING LISTS           October 1972
+
+
+CMU-10B                              GWC
+
+David J. King                        James G. Benedict
+Carnegie-Mellon University           AF Global Weather Central
+Computer Science Department          DOCC/PC HHH
+Schenley Park                        Offutt Air Force Base,
+Pittsburgh, Pa.  15213                                    Nebraska 68113
+                                           (402) 294-4671
+      (412) 621-2600 x683
+DCAO                                 HARV-10
+
+Helen D. Young                       Terry Sack
+Defense Communications Agency        Harvard University
+                         Operations  Aiken Computation Laboratory
+Attention: Code N-321                33 Oxford Street
+Washington, D. C. 20305              Cambridge, Mass.  02138
+
+      (202) 692-2600                       (617) 495-4117
+
+DOCB                                 HARV-11
+
+Dorothy A. Reynolds R-522            Craig Fields
+Department of Commerce NOAA          Harvard University
+325 South Broadway                   Psychology Department
+Boulder, Colorado 80302              33 Kirkland Street
+                                     Cambridge, Mass.  02138
+      (303) 499-1000 x3835
+                                           (617) 495-3857
+ETAC-TIP
+                                     ILL-ANTS
+James Shiffrin
+USAF-ETAC                            Kathy Beaman
+Bldg. 159                            University of Illinois
+Navy Yard Annex                      Advanced Computation Building
+Washington, D.C.  20333              Urbana, Ill.  61801
+
+      (202) 693-3912                       (217) 333-1515
+
+FNWC                                 ILLIAC
+
+Toni McHale                          Harry Colman
+Fleet Numerical Weather Central      Institute for Advanced Computation
+Monterey, Calif. 93940               Documentation Center
+                                     1095 Duane Avenue
+      (408) 646-2817                 Sunnyvale, Calif. 94086
+
+                                           (408) 735-0990
+
+
+
+
+Network Information Center                                     [Page 12]
+
+RFC 402                ARPA NETWORK MAILING LISTS           October 1972
+
+
+LBL                                  NBS
+
+Eric R. Beals                        Shirley W. Watkins
+Lawrence Berkeley Labs               National Bureau of Standards
+Bldg. 50B, Room 3238B                Bldg. 225, Room B216
+Berkeley, California 94720           Washington, D.C.  20234
+
+      (415) 843-2740 x5351                 (301) 921-2601
+
+LL-67                                NIC (see SRI-ARC)
+
+Carol J. Mostrom                     PARC-MAXC
+Massachusetts Institute
+                      of Technology  Diana Merry
+Lincoln Laboratory                   Xerox PARC
+244 Wood Street                      3180 Porter Drive
+Lexington, Mass.  02173              Palo Alto, California 94304
+
+      (617) 862-5500 x7177                 (415) 493-1600
+
+LL-TX2 (see LL-67)                   PARC-VTS (see PARC-MAXC)
+
+MIT-DMCG                             RADC
+
+Sue Pitkin                           Robert E. Doane
+Project MAC                          Rome Air Development Center (ISIM)
+545 Technology square                Griffiss Air Force Base
+Cambridge, Mass.  02139              Rome, New York, 13440
+
+      (617) 253-1458                       (315) 330-7628
+
+MIT-MULTICS                          RAND
+(see MIT-DMCG)
+                                     Linda M. Connelly
+MITRE-TIP                            Rand Corporation
+                                     Computer Science Department
+Ernest H. Forman                     1700 Main Street
+MITRE Corporation                    Santa Monica, Calif.  90406
+Information Systems Dept., W150
+Westgate Research Park                     (213) 393-0411 x7388
+McLean, Va.  22101
+
+      (703) 893-3500 x2397
+
+
+
+
+
+
+
+
+Network Information Center                                     [Page 13]
+
+RFC 402                ARPA NETWORK MAILING LISTS           October 1972
+
+
+RAY
+                                     SDC-ADEPT
+Dan Odom, 1R9
+Raytheon Company                     Janet W. Troxel
+528 Boston Post Road                 System Development Corporation
+Sudbury, Mass. 01776                 Information Processing Information
+                                                                  Center
+      (617) 442-9521 x2870           2500 Colorado Avenue
+                                     Santa Monica, Calif.  90406
+RUTGERS
+                                           (213) 393-9411 x495 or 534
+Gil Falk
+Department of Computer Science       SRI-AI
+Hill Mathematics Center
+University Heights Campus            Maria E. Lemaro
+Rutgers University                   Stanford Research Institute
+New Brunswick,New Jersey 08903       Artificial Intelligence Group
+                                     333 Ravenswood Avenue
+      (201) 932-2085                 Menlo Park, Calif.  94025
+
+SAAC-TIP                                   (415) 326-6200 x4618
+
+Lucy C. Gilliard                     SRI-ARC
+Teledyne/Geotech
+Seismic Analysis Array Center        Susan R. Lee
+Box 334                              Stanford Research Institute
+Alexandria, Va. 22314                Augmentation Research Center
+                                     333 Ravenswood Ave.
+      (703) 836-3882 x295            Menlo Park, Calif.  94025
+
+SCI                                        (415)329-0740
+
+Faye Baxter                          SU-AI
+Systems Control, Inc.
+260 Sheridan Ave.                    Barbara A. Barnett
+Palo Alto. California 94306          Stanford University
+                                     Artificial Intelligence Project
+      (415) 327-9333                 D.C. Power Lab
+                                     Stanford, Calif.  94305
+
+                                           (415) 321-2300 x2800 or 4971
+
+
+
+
+
+
+
+
+
+
+Network Information Center                                     [Page 14]
+
+RFC 402                ARPA NETWORK MAILING LISTS           October 1972
+
+
+SU-HP                                UCSD-CC
+
+Dee Larson                           Jerry Fitzsimmons
+Stanford University                  University of California
+Heuristic Programming Project                               at San Diego
+Serra House                          Computer Center
+Stanford, Calif.  94305              La Jolla, Calif.  90037
+
+      (415) 321-2300 x4878                 (714) 453-2000 x1933
+
+UCLA-CCBS                            UHI
+
+Roberta J. Peeler                    Margaret Iwamoto
+UCLA                                 University of Hawaii
+Center for Computer-based            THE ALOHA SYSTEM
+                 Behavioral Studies  2565 The Mall
+Los Angeles, California 99024        Honolulu, Hawaii 96822
+
+      (213) 825-0841                       (808) 944-7455
+
+UCLA-CCN                             USC-44
+
+Gloria Jean Maxey                    Linda M. Webster
+UCLA - Campus Computing Network      University of Southern California
+Los Angeles, Calif.  90024           Olin Hall of Engineering
+                                     Room 340
+      (213) 825-7518                 Los Angeles, Calif.  90007
+
+UCLA-NMC                                   (213) 746-6379
+
+Anita Coley                          USC-ISI
+UCLA - Network Measurement Center
+Los Angeles, Calif.  90024           John Heafner
+                                     University of Souther California
+      (213) 825-4797                 Information Sciences Institute
+                                     4676 Admiralty Way
+UCSB-MOD75                           Marina Del Rey, Calif. 90291
+
+Connie Rosewall                            (213) 822-1511
+University of California
+                   at Santa Barbara
+Computer Research Laboratory
+Santa Barbara, Calif.  93106
+
+      (805) 961-3221
+
+
+
+
+
+
+Network Information Center                                     [Page 15]
+
+RFC 402                ARPA NETWORK MAILING LISTS           October 1972
+
+
+UTAH-10                              WECOM
+
+Greg Hicks                           Gary Blunck
+University of Utah                   Hdqt. USA Weapons Command
+Computer Science Department          Attention: SWERR-R
+Salt Lake City, Utah  84112          Rock Island, Illinois 61201
+
+      (801) 581-7888                       (309) 794-4143
+
+
+        [This RFC was put into machine readable form for entry]
+   [into the online RFC archives by Helene Morin, Via Genie 12/1999]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Network Information Center                                     [Page 16]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc402.txt](<www.ietf.org/rfc/rfc402.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
