### PR TITLE
Archive rfc4044.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4044.txt
+++ b/www.ietf.org/rfc/rfc4044.txt
@@ -1,0 +1,3867 @@
+
+
+
+
+
+
+Network Working Group                                      K. McCloghrie
+Request for Comments: 4044                            Cisco Systems, Inc
+Obsoletes: 2837                                                 May 2005
+Category: Standards Track
+
+
+                      Fibre Channel Management MIB
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2005).
+
+Abstract
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the Internet community.
+   In particular, it describes managed objects for information related
+   to the Fibre Channel.
+
+Table of Contents
+
+   1.  Introduction .................................................  2
+   2.  The Internet-Standard Management Framework ...................  2
+   3.  Short Overview of the Fibre Channel ..........................  2
+   4.  MIB Overview .................................................  3
+       4.1.  The fcmInstanceBasicGroup Group ........................  3
+       4.2.  The fcmSwitchBasicGroup Group ..........................  4
+       4.3.  The fcmPortBasicGroup Group ............................  4
+       4.4.  The fcmPortStatsGroup Group ............................  4
+       4.5.  The fcmPortClass23StatsGroup Group .....................  4
+       4.6.  The fcmPortLcStatsGroup Group ..........................  4
+       4.7.  The fcmPortClassFStatsGroup Group ......................  4
+       4.8.  The fcmPortErrorsGroup Group ...........................  4
+       4.9.  The fcmSwitchPortGroup Group ...........................  5
+       4.10. The fcmSwitchLoginGroup Group ..........................  5
+       4.11. The fcmLinkBasicGroup Group ............................  5
+   5.  Relationship to Other MIBs ...................................  5
+       5.1.  The Interfaces Group MIB ...............................  5
+       5.2.  Entity MIB .............................................  8
+       5.3.  Host Resources MIB .....................................  9
+
+
+
+McCloghrie                  Standards Track                     [Page 1]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+   6.  Definitions ..................................................  9
+   7.  Acknowledgements ............................................. 57
+   8.  Normative References ......................................... 57
+   9.  Informative References ....................................... 58
+   10. Security Considerations ...................................... 59
+   11. IANA Considerations .......................................... 60
+       11.1. OID Assignment ......................................... 60
+       11.2. FC Port Type Registry .................................. 60
+   12. Comparison to the Fibre Channel Management Integration MIB ... 62
+       12.1. Problems with the Fibre Channel Management Integration
+             MIB .................................................... 62
+       12.2. Detailed Changes ....................................... 62
+   13. Comparison to RFC 2837 ....................................... 67
+
+1.  Introduction
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the Internet community.
+   In particular, it describes managed objects for information related
+   to the Fibre Channel.
+
+2.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This memo specifies a MIB
+   module that is compliant to the SMIv2, which is described in STD 58,
+   RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579] and STD 58, RFC 2580
+   [RFC2580].
+
+3.  Short Overview of the Fibre Channel
+
+   The Fibre Channel (FC) is logically a bidirectional point-to-point
+   serial data channel, structured for high performance capability.  The
+   Fibre Channel provides a general transport vehicle for higher level
+   protocols such as Intelligent Peripheral Interface (IPI) and Small
+   Computer System Interface (SCSI) command sets, the High-Performance
+   Parallel Interface (HIPPI) data framing, IP (Internet Protocol), IEEE
+   802.2, and others.
+
+   Physically, the Fibre Channel is an interconnection of multiple
+   communication points, called N_Ports, interconnected either by a
+
+
+
+McCloghrie                  Standards Track                     [Page 2]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+   switching network, called a Fabric, or by a point-to-point link.  A
+   Fibre Channel "node" consists of one or more N_Ports.  A Fabric may
+   consist of multiple Interconnect Elements, some of which are
+   switches.  An N_Port connects to the Fabric via a port on a switch
+   called an F_Port.  When multiple FC nodes are connected to a single
+   port on a switch via an "Arbitrated Loop" topology, the switch port
+   is called an FL_Port, and the nodes' ports are called NL_Ports.  The
+   term Nx_Port refers to either an N_Port or an NL_port.  The term
+   Fx_Port refers to either an F_Port or an FL_port.  A switch port,
+   which is interconnected to another switch port via an Inter Element
+   Link (IEL), is called an E_Port.  A B_Port connects a bridge device
+   with an E_Port on a switch; a B_Port provides a subset of E_Port
+   functionality.
+
+   Many Fibre Channel components, including the fabric, each node, and
+   most ports, have globally-unique names.  These globally-unique names
+   are typically formatted as World Wide Names (WWNs).  More information
+   on WWNs can be found in [WWN1] and [WWN2].  WWNs are expected to be
+   persistent across agent and unit resets.
+
+   Fibre Channel frames contain 24-bit address identifiers that identify
+   the frame's source and destination ports.  Each FC port has an
+   address identifier and a WWN.  When a fabric is in use, the FC
+   address identifiers are dynamic and are assigned by a switch.
+
+4.  MIB Overview
+
+   This MIB contains the notion of a Fibre Channel management instance,
+   which is defined as a separable managed instance of Fibre Channel
+   functionality.  Fibre Channel functionality may be grouped into Fibre
+   Channel management instances in whatever way is most convenient for
+   the implementation(s).  For example, one such grouping accommodates a
+   single SNMP agent having multiple AgentX [RFC2741] sub-agents, with
+   each sub-agent implementing a different Fibre Channel management
+   instance.  To represent such multiple Fibre Channel management
+   instances within the same SNMP context (see section 3.3.1 of
+   [RFC3411]), all tables in this MIB are INDEX-ed by fcmInstanceIndex,
+   which is defined as an arbitrary integer to uniquely identify a
+   particular Fibre Channel management instance.
+
+   This MIB contains eleven MIB groups, as follows.
+
+4.1.  The fcmInstanceBasicGroup Group
+
+   This group contains basic information about a Fibre Channel managed
+   instance, including its name and description, the Fibre Channel
+   function(s) it performs, and optional pointers to hardware and/or
+   software components.
+
+
+
+McCloghrie                  Standards Track                     [Page 3]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+4.2.  The fcmSwitchBasicGroup Group
+
+   This group contains basic information about a Fibre Channel switch,
+   including its domain-id and whether it is the principal switch of its
+   fabric.
+
+4.3.  The fcmPortBasicGroup Group
+
+   This group contains basic information about a Fibre Channel port,
+   including its port name (WWN), the name of the node (if any) of which
+   it is a part, the type of port, the classes of service it supports,
+   its transmitter and connector types, and the higher level protocols
+   it supports.
+
+   Each Fibre Channel port is represented by an entry in the ifTable
+   (see below).  The tables relating to ports in this MIB are indexed by
+   the port's value of ifIndex.
+
+4.4.  The fcmPortStatsGroup Group
+
+   This group contains traffic statistics, which are not specific to any
+   particular class of service, for Fibre Channel ports.
+
+4.5.  The fcmPortClass23StatsGroup Group
+
+   This group contains traffic statistics that are specific to Class 2
+   or Class 3 traffic on Fibre Channel ports, including class-specific
+   frame and octet counters and counters of busy and reject frames.
+
+4.6.  The fcmPortLcStatsGroup Group
+
+   Some of the statistics in the fcmPortClass23StatsGroup can increase
+   rapidly enough to warrant them being defined using the Counter64
+   syntax.  However, some old SNMP systems do not (yet) support
+   Counter64 objects.  Thus, this group defines low-capacity
+   (Counter32-based) equivalents for the Counter64-based statistics in
+   the fcmPortClass23StatsGroup group.
+
+4.7.  The fcmPortClassFStatsGroup Group
+
+   This group contains traffic statistics that are specific to Class F
+   traffic on the E_Ports of a Fibre Channel switch.
+
+4.8.  The fcmPortErrorsGroup Group
+
+   This group contains counters of various error conditions that can
+   occur on Fibre Channel ports.
+
+
+
+
+McCloghrie                  Standards Track                     [Page 4]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+4.9.  The fcmSwitchPortGroup Group
+
+   This group contains information about ports on a Fibre Channel
+   switch.  For an Fx_Port, it includes the port's timeout values, its
+   hold-time, and its capabilities in terms of maximum and minimum
+   buffer-to-buffer credit allocations, maximum and minimum data field
+   sizes, and support for class 2 and class 3 sequenced delivery.  For
+   an E_Port or B_Port, it includes the buffer-to-buffer credit
+   allocation and data field size.
+
+4.10.  The fcmSwitchLoginGroup Group
+
+   This group contains information, known to a Fibre Channel switch,
+   about its attached/logged-in Nx_Ports and the service parameters that
+   have been agreed with them.
+
+4.11.  The fcmLinkBasicGroup Group
+
+   This group contains information known to a local Fibre Channel
+   management instance, and concerning Fibre Channel links including
+   those which terminate locally.
+
+5.  Relationship to Other MIBs
+
+   This MIB is a replacement for two other MIBs:  RFC 2837, and the
+   Fibre Channel Management Integration MIB which was originally
+   submitted as an Internet Draft to the IETF's IPFC Working Group, and
+   is now available as [MIB-FA].
+
+5.1.  The Interfaces Group MIB
+
+   The Interfaces Group MIB [RFC2863] contains generic information about
+   all lower layer interfaces, i.e., interfaces which are (potentially)
+   below the internet layer.  Thus, each Fibre Channel port should have
+   its own row in the ifTable, and that row will contain the generic
+   information about the interface/port.  The Interfaces Group MIB
+   specifies that additional information which is specific to a
+   particular type of interface media, should be defined in a media-
+   specific MIB.  This MIB is the media-specific MIB for Fibre Channel
+   ports/interfaces.
+
+   Section 4 of [RFC2863] requires that a media-specific MIB clarify how
+   the generic definitions apply for the particular type of media.  The
+   clarifications for Fibre Channel interfaces are as follows.
+
+
+
+
+
+
+
+McCloghrie                  Standards Track                     [Page 5]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+5.1.1.  Layering Model
+
+   The Interfaces Group MIB permits multiple ifTable entries to be
+   defined for interface sub-layers, and for those multiple entries to
+   be arranged in a stack.
+
+   For Fibre Channel interfaces, no sublayers are defined and a Fibre
+   Channel interface will typically have no other ifTable rows stacked
+   on top of it, nor underneath it.
+
+5.1.2.  Virtual Circuits
+
+   This Fibre Channel MIB does not deal with virtual circuits.
+
+5.1.3.  ifRcvAddressTable
+
+   The ifRcvAddressTable does not apply to Fibre Channel interfaces.
+
+5.1.4.  ifType
+
+   The value of ifType for a Fibre Channel interface is 56.
+
+5.1.5.  ifXxxOctets
+
+   The definitions of ifInOctets and ifOutOctets (and similarly,
+   ifHCInOctets and ifHCOutOctets) specify that their values include
+   framing characters.  For Fibre Channel interfaces, they include all
+   the octets contained in frames between the Start-of-Frame and End-
+   of-Frame delimiters (excluding the delimiters).
+
+5.1.6.  Specific Interface Group MIB Objects
+
+   The following table provides specific implementation guidelines for
+   applying the objects defined in the Interfaces Group MIB to Fibre
+   Channel interfaces.  For those objects not listed here, refer to
+   their generic definitions in [RFC2863].  (RFC 2863 takes precedence
+   over these guidelines in the event of any conflict.)
+
+      Object                   Guidelines
+
+      ifType                   56
+
+      ifMtu                    The MTU as seen by a higher layer
+                               protocol, like IP.
+                               That is, when IP is running over the
+                               interface, this object is the size of the
+                               largest IP datagram that can be
+                               sent/received over the interface.
+
+
+
+McCloghrie                  Standards Track                     [Page 6]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+      ifSpeed                  For 1Gbs, this will be 1,000,000,000;
+                               for 2Gbs, it will be 2,000,000,000.  If
+                               auto-negotiation is implemented and
+                               enabled on an interface, and the
+                               interface has not yet negotiated an
+                               operational speed, this object SHOULD
+                               reflect the maximum speed supported by
+                               the interface.
+
+
+      ifPhysAddress            The interface's 24-bit Fibre Channel
+                               Address Identifier, or the zero-length
+                               string if no Address Identifier has been
+                               assigned to the interface.
+
+      ifAdminStatus            Write access is not required, and support
+                               for 'testing' is not required.
+
+      ifOperStatus             Support for 'testing' is not required.
+                               The value 'dormant' has no meaning for
+                               Fibre Channel interfaces.
+
+      ifInOctets               The number of octets of information
+
+      ifHCInOctets             contained in received frames between the
+                               Start-of-Frame and End-of-Frame
+                               delimiters (excluding the delimiters).
+
+      ifInUcastPkts            The number of unicast frames received,
+
+      ifHCInUcastPkts          i.e., the number of Start-of-Frame
+                               delimiters received for unicast frames.
+
+      ifInErrors               The sum for this interface of
+
+                                  fcmPortLossofSynchs
+                                  fcmPortLossofSignals
+                                  fcmPortPrimSeqProtocolErrors
+                                  fcmPortInvalidTxWords
+                                  fcmPortInvalidCRCs
+                                  fcmPortAddressErrors
+                                  fcmPortDelimiterErrors
+                                  fcmPortTruncatedFrames
+                                  fcmPortEncodingDisparityErrors
+
+                               plus any errors in fcmPortOtherErrors
+                               that were input errors.
+
+
+
+
+McCloghrie                  Standards Track                     [Page 7]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+      ifOutOctets              The number of octets of information
+      ifHCOutOctets            contained in transmitted frames between
+                               the Start-of-Frame and End-of-Frame
+                               delimiters (excluding the delimiters).
+
+      ifOutUcastPkts           The number of frames transmitted,
+                               ifHCOutUcastPkts         i.e., the number
+                               of start-of-frame delimiters transmitted
+                               for unicast frames.
+
+      ifOutErrors              This is the number of errors in
+                               fcmPortOtherErrors that were output
+                               errors.
+
+      ifInMulticastPkts        These counters are not incremented
+
+      ifInBroadcastPkts        (unless a proprietary mechanism for
+      ifOutMulticastPkts       multicast/broadcast is supported).
+      ifOutBroadcastPkts
+      ifHCInMulticastPkts
+      ifHCInBroadcastPkts
+      ifHCOutMulticastPkts
+      ifHCOutBroadcastPkts
+
+      ifLinkUpDownTrapEnable   Refer to [RFC2863].  Default is 'enabled'
+
+      ifHighSpeed              The current operational speed of the
+                               interface in millions of bits per second.
+                               For 1Gbs, this will be 1000; for 2Gbs, it
+                               will be 2000.  If auto-negotiation is
+                               implemented and enabled on an interface,
+                               and the interface has not yet negotiated
+                               an operational speed, this object SHOULD
+                               reflect the maximum speed supported by
+                               the interface.
+
+      ifPromiscuousMode        This will normally be 'false'
+
+      ifConnectorPresent       This will normally be 'true'.
+
+5.2.  Entity MIB
+
+   The Entity MIB [RFC2737] contains information about individual
+   physical components and any hierarchical relationship that may exist
+   between them.  Any Fibre Channel management instance with a
+   relationship to a physical component (or to a hierarchy of physical
+   components) will have its value of the fcmInstancePhysicalIndex
+   object contain a pointer to the relevant row in the Entity MIB.  If
+
+
+
+McCloghrie                  Standards Track                     [Page 8]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+   there is no correspondence with a physical component (or said
+   component does not have a row in the Entity MIB), then the value of
+   fcmInstancePhysicalIndex is zero.  (Note that an implementation is
+   not required to support a non-zero value of
+   fcmInstancePhysicalIndex.)
+
+5.3.  Host Resources MIB
+
+   The Host Resources MIB [RFC2790] includes information about installed
+   software modules.  Any Fibre Channel management instance with a
+   correspondence to a software module, will have its value of the
+   fcmInstanceSoftwareIndex object contain a pointer to the relevant row
+   in the Host Resources MIB.  If there is no correspondence to a
+   software module (or said software module does not have a row in the
+   Host Resources MIB), then the value of fcmInstanceSoftwareIndex is
+   zero.  (Note that an agent implementation is not required to support
+   a non-zero value of fcmInstanceSoftwareIndex.)
+
+6.  Definitions
+
+   FC-MGMT-MIB DEFINITIONS ::= BEGIN
+
+   IMPORTS
+       MODULE-IDENTITY, OBJECT-TYPE,
+       Integer32, Unsigned32, Counter32, Counter64, transmission
+                               FROM SNMPv2-SMI
+       MODULE-COMPLIANCE, OBJECT-GROUP
+                               FROM SNMPv2-CONF
+       TruthValue, TEXTUAL-CONVENTION
+                               FROM SNMPv2-TC
+       ifIndex                 FROM IF-MIB
+       SnmpAdminString         FROM SNMP-FRAMEWORK-MIB;
+
+   fcMgmtMIB MODULE-IDENTITY
+       LAST-UPDATED    "200504260000Z"  -- 26 April 2005
+       ORGANIZATION    "IETF IPS (IP-Storage) Working Group"
+       CONTACT-INFO
+               "        Keith McCloghrie
+                        Cisco Systems, Inc.
+                   Tel: +1 408 526-5260
+                E-mail: kzm@cisco.com
+                Postal: 170 West Tasman Drive
+                        San Jose, CA USA 95134
+               "
+       DESCRIPTION
+               "This module defines management information specific to
+               Fibre Channel-attached devices.
+
+
+
+
+McCloghrie                  Standards Track                     [Page 9]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+               Copyright (C) The Internet Society (2005).  This version
+               of this MIB module is part of RFC 4044;  see the RFC
+               itself for full legal notices."
+      REVISION        "200504260000Z"  -- 26 April 2005
+      DESCRIPTION
+              "Initial version of the Fibre Channel Mgmt MIB module."
+     ::= { transmission 56 }
+
+ fcmgmtObjects       OBJECT IDENTIFIER ::= { fcMgmtMIB 1 }
+ fcmgmtNotifications OBJECT IDENTIFIER ::= { fcMgmtMIB 2 }
+ fcmgmtNotifPrefix   OBJECT IDENTIFIER ::= { fcmgmtNotifications 0 }
+ fcmgmtConformance   OBJECT IDENTIFIER ::= { fcMgmtMIB 3 }
+
+ --********************************
+ --  Textual Conventions
+ --
+
+ FcNameIdOrZero ::= TEXTUAL-CONVENTION
+     STATUS current
+     DESCRIPTION
+             "The World Wide Name (WWN) associated with a Fibre Channel
+             (FC) entity.  WWNs were initially defined as 64-bits in
+             length.  The latest definition (for future use) is 128-bits
+             long.  The zero-length string value is used in
+             circumstances in which the WWN is unassigned/unknown."
+    SYNTAX  OCTET STRING (SIZE(0 | 8 | 16))
+
+FcAddressIdOrZero ::= TEXTUAL-CONVENTION
+    STATUS current
+    DESCRIPTION
+            "A Fibre Channel Address ID, a 24-bit value unique within
+            the address space of a Fabric.  The zero-length string value
+            is used in circumstances in which the WWN is
+            unassigned/unknown."
+    SYNTAX  OCTET STRING (SIZE(0 | 3))
+
+FcDomainIdOrZero ::= TEXTUAL-CONVENTION
+    STATUS current
+    DESCRIPTION
+            "The Domain Id (of an FC switch), or zero if the no Domain
+            Id has been assigned."
+    SYNTAX  Integer32 (0..239)
+
+
+
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 10]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+FcPortType ::= TEXTUAL-CONVENTION
+    STATUS current
+    DESCRIPTION
+            "The type of a Fibre Channel port, as indicated by the use
+            of the appropriate value assigned by IANA."
+    REFERENCE
+             "The IANA-maintained registry for
+              Fibre Channel port types (http://www.iana.org/)."
+    SYNTAX   Unsigned32
+
+FcClasses ::= TEXTUAL-CONVENTION
+    STATUS current
+    DESCRIPTION
+            "A set of Fibre Channel classes of service."
+    REFERENCE
+             "Classes of service are described in FC-FS Section 13."
+    SYNTAX   BITS { classF(0), class1(1), class2(2), class3(3),
+                    class4(4), class5(5), class6(6) }
+
+FcBbCredit ::= TEXTUAL-CONVENTION
+    STATUS current
+    DESCRIPTION
+            "The buffer-to-buffer credit of an FC port."
+    SYNTAX     Integer32 (0..32767)
+
+FcBbCreditModel ::= TEXTUAL-CONVENTION
+    STATUS current
+    DESCRIPTION
+            "The buffer-to-buffer credit model of an Fx_Port."
+    SYNTAX    INTEGER { regular(1), alternate (2) }
+
+
+FcDataFieldSize ::= TEXTUAL-CONVENTION
+    STATUS current
+    DESCRIPTION
+            "The Receive Data Field Size associated with an FC port."
+    SYNTAX     Integer32 (128..2112)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 11]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+FcUnitFunctions ::= TEXTUAL-CONVENTION
+    STATUS current
+    DESCRIPTION
+            "A set of functions that a Fibre Channel Interconnect
+            Element or Platform might perform.  A value with no bits set
+            indicates the function(s) are unknown.  The individual bits
+            have the following meanings:
+
+            other - none of the following.
+
+            hub - a device that interconnects L_Ports, but does not
+            operate as an FL_Port.
+
+            switch - a fabric element conforming to the Fibre Channel
+            switch fabric set of standards (e.g., [FC-SW-3]).
+
+            bridge - a device that encapsulates Fibre Channel frames
+            within another protocol (e.g., [FC-BB], FC-BB-2).
+
+            gateway - a device that converts an FC-4 to another protocol
+            (e.g., FCP to iSCSI).
+
+            host - a computer system that provides end users with
+            services such as computation and storage access.
+
+            storageSubsys - an integrated collection of storage
+            controllers, storage devices, and necessary software that
+            provides storage services to one or more hosts.
+
+            storageAccessDev - a device that provides storage management
+            and access for heterogeneous hosts and heterogeneous devices
+            (e.g., medium changer).
+
+            nas - a device that connects to a network and provides file
+            access services.
+
+            wdmux - a device that modulates/demodulates each of several
+            data streams (e.g., Fibre Channel protocol data streams)
+            onto/from a different part of the light spectrum in an
+            optical fiber.
+
+            storageDevice - a disk/tape/etc. device (without the
+            controller and/or software required for it to be a
+            'storageSubsys')."
+    SYNTAX  BITS {
+                other(0),        -- none of the following
+                hub(1),
+                switch(2),
+
+
+
+McCloghrie                  Standards Track                    [Page 12]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+                bridge(3),
+                gateway(4),
+                host(5),
+                storageSubsys(6),
+                storageAccessDev(7),
+                nas(8),
+                wdmux(9),
+                storageDevice(10)
+            }
+
+--********************************
+--  MIB object definitions
+--
+
+fcmInstanceTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF FcmInstanceEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "Information about the local Fibre Channel management
+            instances."
+    ::= { fcmgmtObjects 1 }
+
+fcmInstanceEntry OBJECT-TYPE
+    SYNTAX     FcmInstanceEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "A list of attributes for a particular local Fibre Channel
+            management instance."
+    INDEX { fcmInstanceIndex }
+    ::= { fcmInstanceTable 1 }
+
+FcmInstanceEntry ::=
+    SEQUENCE {
+        fcmInstanceIndex             Unsigned32,
+        fcmInstanceWwn               FcNameIdOrZero,
+        fcmInstanceFunctions         FcUnitFunctions,
+        fcmInstancePhysicalIndex     Integer32,
+        fcmInstanceSoftwareIndex     Integer32,
+        fcmInstanceStatus            INTEGER,
+        fcmInstanceTextName          SnmpAdminString,
+        fcmInstanceDescr             SnmpAdminString,
+        fcmInstanceFabricId          FcNameIdOrZero
+    }
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 13]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+fcmInstanceIndex OBJECT-TYPE
+    SYNTAX     Unsigned32 (1..4294967295)
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "An arbitrary integer value that uniquely identifies this
+            instance amongst all local Fibre Channel management
+            instances.
+
+            It is mandatory to keep this value constant between restarts
+            of the agent, and to make every possible effort to keep it
+            constant across restarts (but note, it is unrealistic to
+            expect it to remain constant across all re-configurations of
+            the local system, e.g., across the replacement of all non-
+            volatile storage)."
+    ::= { fcmInstanceEntry 1 }
+
+fcmInstanceWwn  OBJECT-TYPE
+    SYNTAX     FcNameIdOrZero
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "If the instance has one (or more) WWN(s), then this object
+            contains that (or one of those) WWN(s).
+
+            If the instance does not have a WWN associated with it, then
+            this object contains the zero-length string."
+    ::= { fcmInstanceEntry 2 }
+
+fcmInstanceFunctions OBJECT-TYPE
+    SYNTAX     FcUnitFunctions
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "One (or more) Fibre Channel unit functions being performed
+            by this instance."
+    ::= { fcmInstanceEntry 3 }
+
+fcmInstancePhysicalIndex OBJECT-TYPE
+    SYNTAX     Integer32 (0..2147483647)
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "If this management instance corresponds to a physical
+            component (or to a hierarchy of physical components)
+            identified by the Entity-MIB, then this object's value is
+            the value of the entPhysicalIndex of that component (or of
+            the component at the root of that hierarchy).  If there is
+
+
+
+McCloghrie                  Standards Track                    [Page 14]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+            no correspondence to a physical component (or no component
+            that has an entPhysicalIndex value), then the value of this
+            object is zero."
+    REFERENCE
+        "entPhysicalIndex is defined in the Entity MIB, RFC 2737."
+    ::= { fcmInstanceEntry 4 }
+
+fcmInstanceSoftwareIndex OBJECT-TYPE
+    SYNTAX     Integer32 (0..2147483647)
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "If this management instance corresponds to an installed
+            software module identified in the Host Resources MIB, then
+            this object's value is the value of the hrSWInstalledIndex
+            of that module.  If there is no correspondence to an
+            installed software module (or no module that has a
+            hrSWInstalledIndex value), then the value of this object is
+            zero."
+    REFERENCE
+        "hrSWInstalledIndex is defined in the Host Resources MIB,
+         RFC 2790"
+    ::= { fcmInstanceEntry 5 }
+
+fcmInstanceStatus OBJECT-TYPE
+    SYNTAX     INTEGER {
+                   unknown(1),
+                   ok(2),      -- able to operate correctly
+                   warning(3), -- needs attention
+                   failed(4)   -- something has failed
+               }
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "Overall status of the Fibre Channel entity/entities managed
+            by this management instance.  The value should reflect the
+            most serious status of such entities."
+    ::= { fcmInstanceEntry 6 }
+
+fcmInstanceTextName OBJECT-TYPE
+    SYNTAX     SnmpAdminString (SIZE(0..79))
+    MAX-ACCESS read-write
+    STATUS     current
+    DESCRIPTION
+            "A textual name for this management instance and the Fibre
+            Channel entity/entities that it is managing."
+    ::= { fcmInstanceEntry 7 }
+
+
+
+
+McCloghrie                  Standards Track                    [Page 15]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+fcmInstanceDescr OBJECT-TYPE
+    SYNTAX     SnmpAdminString
+    MAX-ACCESS read-write
+    STATUS     current
+    DESCRIPTION
+            "A textual description of this management instance and the
+            Fibre Channel entity/entities that it is managing."
+    ::= { fcmInstanceEntry 8 }
+
+fcmInstanceFabricId OBJECT-TYPE
+    SYNTAX     FcNameIdOrZero
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The globally unique Fabric Identifier that identifies the
+            fabric to which the Fibre Channel entity/entities managed by
+            this management instance are connected, or, of which they
+            are a part.  This is typically the Node WWN of the principal
+            switch of a Fibre Channel fabric.  The zero-length string
+            indicates that the fabric identifier is unknown (or not
+            applicable).
+
+            In the event that the Fibre Channel entity/entities managed
+            by this management instance is/are connected to multiple
+            fabrics, then this object records the first (known) one."
+    ::= { fcmInstanceEntry 9 }
+
+--********************************
+-- The Fibre Channel Switch Table
+--
+
+fcmSwitchTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF FcmSwitchEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "A table of information about Fibre Channel switches that
+            are managed by Fibre Channel management instances.  Each
+            Fibre Channel management instance can manage one or more
+            Fibre Channel switches."
+    ::= { fcmgmtObjects 2 }
+
+fcmSwitchEntry OBJECT-TYPE
+    SYNTAX     FcmSwitchEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "Information about a particular Fibre Channel switch that is
+
+
+
+McCloghrie                  Standards Track                    [Page 16]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+            managed by the management instance given by
+            fcmInstanceIndex."
+    INDEX { fcmInstanceIndex, fcmSwitchIndex }
+    ::= { fcmSwitchTable 1 }
+
+FcmSwitchEntry ::=
+    SEQUENCE {
+        fcmSwitchIndex         Unsigned32,
+        fcmSwitchDomainId      FcDomainIdOrZero,
+        fcmSwitchPrincipal     TruthValue,
+        fcmSwitchWWN           FcNameIdOrZero
+    }
+
+fcmSwitchIndex OBJECT-TYPE
+    SYNTAX     Unsigned32 (1..4294967295)
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "An arbitrary integer that uniquely identifies a Fibre
+            Channel switch amongst those managed by one Fibre Channel
+            management instance.
+
+            It is mandatory to keep this value constant between restarts
+            of the agent, and to make every possible effort to keep it
+            constant across restarts."
+    ::= { fcmSwitchEntry 1 }
+
+fcmSwitchDomainId OBJECT-TYPE
+    SYNTAX     FcDomainIdOrZero
+    MAX-ACCESS read-write
+    STATUS     current
+    DESCRIPTION
+            "The Domain Id of this switch.  A value of zero indicates
+            that a switch has not (yet) been assigned a Domain Id."
+    ::= { fcmSwitchEntry 2 }
+
+fcmSwitchPrincipal OBJECT-TYPE
+    SYNTAX     TruthValue
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "An indication of whether this switch is the principal
+            switch within its fabric."
+    ::= { fcmSwitchEntry 3 }
+
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 17]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+fcmSwitchWWN  OBJECT-TYPE
+    SYNTAX     FcNameIdOrZero
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The World Wide Name of this switch."
+    ::= { fcmSwitchEntry 4 }
+
+--********************************
+-- The Fibre Channel Port Table
+--
+
+fcmPortTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF FcmPortEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "Information about Fibre Channel ports.  Each Fibre Channel
+            port is represented by one entry in the IF-MIB's ifTable."
+    REFERENCE
+        "RFC 2863, The Interfaces Group MIB, June 2000."
+    ::= { fcmgmtObjects 3 }
+
+fcmPortEntry OBJECT-TYPE
+    SYNTAX     FcmPortEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "Each entry contains information about a specific port."
+    INDEX { ifIndex }
+    ::= { fcmPortTable 1 }
+
+FcmPortEntry ::=
+    SEQUENCE {
+        fcmPortInstanceIndex    Unsigned32,
+        fcmPortWwn              FcNameIdOrZero,
+        fcmPortNodeWwn          FcNameIdOrZero,
+        fcmPortAdminType        FcPortType,
+        fcmPortOperType         FcPortType,
+        fcmPortFcCapClass       FcClasses,
+        fcmPortFcOperClass      FcClasses,
+        fcmPortTransmitterType  INTEGER,
+        fcmPortConnectorType    INTEGER,
+        fcmPortSerialNumber     SnmpAdminString,
+        fcmPortPhysicalNumber   Unsigned32,
+        fcmPortAdminSpeed       INTEGER,
+        fcmPortCapProtocols     BITS,
+        fcmPortOperProtocols    BITS
+
+
+
+McCloghrie                  Standards Track                    [Page 18]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+    }
+
+fcmPortInstanceIndex OBJECT-TYPE
+    SYNTAX     Unsigned32 (1..4294967295)
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The value of fcmInstanceIndex by which the Fibre Channel
+            management instance, which manages this port, is identified
+            in the fcmInstanceTable."
+    ::= { fcmPortEntry 1 }
+
+fcmPortWwn OBJECT-TYPE
+    SYNTAX     FcNameIdOrZero
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The World Wide Name of the port, or the zero-length string
+            if the port does not have a WWN."
+     ::= { fcmPortEntry 2 }
+
+fcmPortNodeWwn OBJECT-TYPE
+    SYNTAX     FcNameIdOrZero
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The World Wide Name of the Node that contains this port, or
+            the zero-length string if the port does not have a node
+            WWN."
+     ::= { fcmPortEntry 3 }
+
+fcmPortAdminType OBJECT-TYPE
+    SYNTAX     FcPortType
+    MAX-ACCESS read-write
+    STATUS     current
+    DESCRIPTION
+            "The administratively desired type of this port."
+    ::= { fcmPortEntry 4 }
+
+fcmPortOperType OBJECT-TYPE
+    SYNTAX     FcPortType
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The current operational type of this port."
+    ::= { fcmPortEntry 5 }
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 19]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+fcmPortFcCapClass OBJECT-TYPE
+    SYNTAX     FcClasses
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The classes of service capability of this port."
+    ::= { fcmPortEntry 6 }
+
+fcmPortFcOperClass OBJECT-TYPE
+    SYNTAX     FcClasses
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The classes of service that are currently operational on
+            this port.  For an FL_Port, this is the union of the classes
+            being supported across all attached NL_Ports."
+    ::= { fcmPortEntry 7 }
+
+fcmPortTransmitterType OBJECT-TYPE
+    SYNTAX     INTEGER {
+        unknown(1),
+        other(2),
+        shortwave850nm(3),
+        longwave1550nm(4),
+        longwave1310nm(5),
+        electrical(6)
+     }
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The technology of the port transceiver."
+    REFERENCE
+        "FC-GS-3, section 6.1.2.2.3"
+    ::= { fcmPortEntry 8 }
+
+fcmPortConnectorType OBJECT-TYPE
+    SYNTAX     INTEGER {
+        unknown(1),
+        other(2),
+        gbic(3),
+        embedded(4),
+        glm(5),
+        gbicSerialId(6),
+        gbicNoSerialId(7),
+        sfpSerialId(8),
+        sfpNoSerialId(9)
+    }
+    MAX-ACCESS read-only
+
+
+
+McCloghrie                  Standards Track                    [Page 20]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+    STATUS     current
+    DESCRIPTION
+            "The module type of the port connector.  This object refers
+            to the hardware implementation of the port.  It will be
+            'embedded' if the hardware equivalent to Gigabit interface
+            card (GBIC) is part of the line card and is unremovable.  It
+            will be 'glm' if it's a gigabit link module (GLM).  It will
+            be 'gbicSerialId' if the GBIC serial id can be read, else it
+            will be 'gbicNoSerialId'.  It will be 'sfpSerialId' if the
+            small form factor (SFP) pluggable GBICs serial id can be
+            read, else it will be 'sfpNoSerialId'."
+    REFERENCE
+        "FC-GS-3, section 6.1.2.2.4"
+    ::= { fcmPortEntry 9 }
+
+fcmPortSerialNumber OBJECT-TYPE
+    SYNTAX      SnmpAdminString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The serial number associated with the port (e.g., for a
+            GBIC).  If not applicable, the object's value is a zero-
+            length string."
+    REFERENCE
+        "FC-GS-3, section 6.1.2.2.4"
+    ::= { fcmPortEntry 10 }
+
+fcmPortPhysicalNumber OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "This is the port's 'Physical Port Number' as defined by
+            GS-3."
+    REFERENCE
+        "FC-GS-3, section 6.1.2.2.5"
+    ::= { fcmPortEntry 11 }
+
+fcmPortAdminSpeed OBJECT-TYPE
+    SYNTAX     INTEGER {
+                   auto(1),
+                   eighthGbs(2),   -- 125Mbs
+                   quarterGbs(3),  -- 250Mbs
+                   halfGbs(4),     -- 500Mbs
+                   oneGbs(5),      --   1Gbs
+                   twoGbs(6),      --   2Gbs
+                   fourGbs(7),     --   4Gbs
+                   tenGbs(8)       --  10Gbs
+
+
+
+McCloghrie                  Standards Track                    [Page 21]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+               }
+    MAX-ACCESS read-write
+    STATUS     current
+    DESCRIPTION
+            "The speed of the interface:
+
+                'auto'        - auto-negotiation
+                'tenGbs'      - 10Gbs
+                'fourGbs'     -  4Gbs
+                'twoGbs'      -  2Gbs
+                'oneGbs'      -  1Gbs
+                'halfGbs'     - 500Mbs
+                'quarterGbs'  - 250Mbs
+                'eighthGbs'   - 125Mbs"
+    ::= { fcmPortEntry 12 }
+
+fcmPortCapProtocols OBJECT-TYPE
+    SYNTAX     BITS {
+                   unknown(0),
+                   loop(1),
+                   fabric(2),
+                   scsi(3),
+                   tcpIp(4),
+                   vi(5),
+                   ficon(6)
+               }
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "A bit mask specifying the higher level protocols that are
+            capable of running over this port.  Note that for generic
+            Fx_Ports, E_Ports, and B_Ports, this object will indicate
+            all protocols."
+    ::= { fcmPortEntry 13 }
+
+fcmPortOperProtocols OBJECT-TYPE
+    SYNTAX     BITS {
+                   unknown(0),
+                   loop(1),
+                   fabric(2),
+                   scsi(3),
+                   tcpIp(4),
+                   vi(5),
+                   ficon(6)
+               }
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+
+
+
+McCloghrie                  Standards Track                    [Page 22]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+            "A bit mask specifying the higher level protocols that are
+            currently operational on this port.  For Fx_Ports, E_Ports,
+            and B_Ports, this object will typically have the value
+            'unknown'."
+    ::= { fcmPortEntry 14 }
+
+--********************************
+-- Port Statistics
+--
+
+fcmPortStatsTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF FcmPortStatsEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "A list of statistics for Fibre Channel ports."
+    ::= { fcmgmtObjects 4 }
+
+fcmPortStatsEntry OBJECT-TYPE
+    SYNTAX     FcmPortStatsEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "An entry containing statistics for a Fibre Channel port.
+            If any counter in this table suffers a discontinuity, the
+            value of ifCounterDiscontinuityTime (defined in the IF-MIB)
+            must be updated."
+    REFERENCE  "The Interfaces Group MIB, RFC 2863, June 2000."
+    AUGMENTS   { fcmPortEntry }
+    ::= { fcmPortStatsTable 1 }
+
+FcmPortStatsEntry ::=
+    SEQUENCE {
+        fcmPortBBCreditZeros       Counter64,
+        fcmPortFullInputBuffers    Counter64,
+        fcmPortClass2RxFrames      Counter64,
+        fcmPortClass2RxOctets      Counter64,
+        fcmPortClass2TxFrames      Counter64,
+        fcmPortClass2TxOctets      Counter64,
+        fcmPortClass2Discards      Counter64,
+        fcmPortClass2RxFbsyFrames  Counter64,
+        fcmPortClass2RxPbsyFrames  Counter64,
+        fcmPortClass2RxFrjtFrames  Counter64,
+        fcmPortClass2RxPrjtFrames  Counter64,
+        fcmPortClass2TxFbsyFrames  Counter64,
+        fcmPortClass2TxPbsyFrames  Counter64,
+        fcmPortClass2TxFrjtFrames  Counter64,
+        fcmPortClass2TxPrjtFrames  Counter64,
+
+
+
+McCloghrie                  Standards Track                    [Page 23]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+        fcmPortClass3RxFrames      Counter64,
+        fcmPortClass3RxOctets      Counter64,
+        fcmPortClass3TxFrames      Counter64,
+        fcmPortClass3TxOctets      Counter64,
+        fcmPortClass3Discards      Counter64,
+        fcmPortClassFRxFrames      Counter32,
+        fcmPortClassFRxOctets      Counter32,
+        fcmPortClassFTxFrames      Counter32,
+        fcmPortClassFTxOctets      Counter32,
+        fcmPortClassFDiscards      Counter32
+    }
+
+fcmPortBBCreditZeros OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of transitions in/out of the buffer-to-buffer
+            credit zero state.  The other side is not providing any
+            credit."
+    ::= { fcmPortStatsEntry 1 }
+
+fcmPortFullInputBuffers OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of occurrences when all input buffers of a port
+            were full and outbound buffer-to-buffer credit transitioned
+            to zero, i.e., there became no credit to provide to other
+            side."
+    ::= { fcmPortStatsEntry 2 }
+
+fcmPortClass2RxFrames OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of Class 2 frames received at this port."
+    ::= { fcmPortStatsEntry 3 }
+
+fcmPortClass2RxOctets OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of octets contained in Class 2 frames received
+            at this port."
+
+
+
+McCloghrie                  Standards Track                    [Page 24]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+    ::= { fcmPortStatsEntry 4 }
+
+fcmPortClass2TxFrames OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of Class 2 frames transmitted out of this port."
+    ::= { fcmPortStatsEntry 5 }
+
+fcmPortClass2TxOctets OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of octets contained in Class 2 frames
+            transmitted out of this port."
+    ::= { fcmPortStatsEntry 6 }
+
+fcmPortClass2Discards OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of Class 2 frames that were discarded upon
+            reception at this port."
+    ::= { fcmPortStatsEntry 7 }
+
+fcmPortClass2RxFbsyFrames OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of times that F_BSY was returned to this port as
+            a result of a Class 2 frame that could not be delivered to
+            the other end of the link.  This can occur when either the
+            fabric or the destination port is temporarily busy.  Note
+            that this counter will never increment for an F_Port."
+    ::= { fcmPortStatsEntry 8 }
+
+fcmPortClass2RxPbsyFrames OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of times that P_BSY was returned to this port as
+            a result of a Class 2 frame that could not be delivered to
+            the other end of the link.  This can occur when the
+
+
+
+McCloghrie                  Standards Track                    [Page 25]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+            destination port is temporarily busy."
+    ::= { fcmPortStatsEntry 9 }
+
+fcmPortClass2RxFrjtFrames OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of times that F_RJT was returned to this port as
+            a result of a Class 2 frame that was rejected by the fabric.
+            Note that this counter will never increment for an F_Port."
+    ::= { fcmPortStatsEntry 10 }
+
+fcmPortClass2RxPrjtFrames OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of times that P_RJT was returned to this port as
+            a result of a Class 2 frame that was rejected at the
+            destination N_Port."
+    ::= { fcmPortStatsEntry 11 }
+
+fcmPortClass2TxFbsyFrames OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of times that F_BSY was generated by this port
+            as a result of a Class 2 frame that could not be delivered
+            because either the Fabric or the destination port was
+            temporarily busy.  Note that this counter will never
+            increment for an N_Port."
+    ::= { fcmPortStatsEntry 12 }
+
+fcmPortClass2TxPbsyFrames OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of times that P_BSY was generated by this port
+            as a result of a Class 2 frame that could not be delivered
+            because the destination port was temporarily busy.  Note
+            that this counter will never increment for an F_Port."
+    ::= { fcmPortStatsEntry 13 }
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 26]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+fcmPortClass2TxFrjtFrames OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of times that F_RJT was generated by this port
+            as a result of a Class 2 frame being rejected by the fabric.
+            Note that this counter will never increment for an N_Port."
+    ::= { fcmPortStatsEntry 14 }
+
+fcmPortClass2TxPrjtFrames OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of times that P_RJT was generated by this port
+            as a result of a Class 2 frame being rejected at the
+            destination N_Port.  Note that this counter will never
+            increment for an F_Port."
+    ::= { fcmPortStatsEntry 15 }
+
+fcmPortClass3RxFrames OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of Class 3 frames received at this port."
+    ::= { fcmPortStatsEntry 16 }
+
+fcmPortClass3RxOctets OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of octets contained in Class 3 frames received
+            at this port."
+    ::= { fcmPortStatsEntry 17 }
+
+fcmPortClass3TxFrames OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of Class 3 frames transmitted out of this port."
+    ::= { fcmPortStatsEntry 18 }
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 27]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+fcmPortClass3TxOctets OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of octets contained in Class 3 frames
+            transmitted out of this port."
+    ::= { fcmPortStatsEntry 19 }
+
+fcmPortClass3Discards OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of Class 3 frames that were discarded upon
+            reception at this port."
+    ::= { fcmPortStatsEntry 20 }
+
+fcmPortClassFRxFrames OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of Class F frames received at this port."
+    ::= { fcmPortStatsEntry 21 }
+
+fcmPortClassFRxOctets OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of octets contained in Class F frames received
+            at this port."
+    ::= { fcmPortStatsEntry 22 }
+
+fcmPortClassFTxFrames OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of Class F frames transmitted out of this port."
+    ::= { fcmPortStatsEntry 23 }
+
+
+
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 28]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+fcmPortClassFTxOctets OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of octets contained in Class F frames
+            transmitted out of this port."
+    ::= { fcmPortStatsEntry 24 }
+
+fcmPortClassFDiscards OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of Class F frames that were discarded upon
+            reception at this port."
+    ::= { fcmPortStatsEntry 25 }
+
+--********************************
+-- Port Low-capacity Statistics
+--
+-- these are Counter32 "low-capacity" counters for systems
+-- that do not support Counter64's
+
+fcmPortLcStatsTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF FcmPortLcStatsEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "A list of Counter32-based statistics for systems that do
+            not support Counter64."
+    ::= { fcmgmtObjects 5 }
+
+fcmPortLcStatsEntry OBJECT-TYPE
+    SYNTAX     FcmPortLcStatsEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "An entry containing low-capacity (i.e., based on Counter32)
+            statistics for a Fibre Channel port.  If any counter in this
+            table suffers a discontinuity, the value of
+            ifCounterDiscontinuityTime (defined in the IF-MIB) must be
+            updated."
+    REFERENCE  "The Interfaces Group MIB, RFC 2863, June 2000."
+    AUGMENTS   { fcmPortEntry }
+    ::= { fcmPortLcStatsTable 1 }
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 29]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+FcmPortLcStatsEntry ::=
+    SEQUENCE {
+        fcmPortLcBBCreditZeros       Counter32,
+        fcmPortLcFullInputBuffers    Counter32,
+        fcmPortLcClass2RxFrames      Counter32,
+        fcmPortLcClass2RxOctets      Counter32,
+        fcmPortLcClass2TxFrames      Counter32,
+        fcmPortLcClass2TxOctets      Counter32,
+        fcmPortLcClass2Discards      Counter32,
+        fcmPortLcClass2RxFbsyFrames  Counter32,
+        fcmPortLcClass2RxPbsyFrames  Counter32,
+        fcmPortLcClass2RxFrjtFrames  Counter32,
+        fcmPortLcClass2RxPrjtFrames  Counter32,
+        fcmPortLcClass2TxFbsyFrames  Counter32,
+        fcmPortLcClass2TxPbsyFrames  Counter32,
+        fcmPortLcClass2TxFrjtFrames  Counter32,
+        fcmPortLcClass2TxPrjtFrames  Counter32,
+        fcmPortLcClass3RxFrames      Counter32,
+        fcmPortLcClass3RxOctets      Counter32,
+        fcmPortLcClass3TxFrames      Counter32,
+        fcmPortLcClass3TxOctets      Counter32,
+        fcmPortLcClass3Discards      Counter32
+    }
+
+fcmPortLcBBCreditZeros OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of transitions in/out of the buffer-to-buffer
+            credit zero state.  The other side is not providing any
+            credit."
+    ::= { fcmPortLcStatsEntry 1 }
+
+fcmPortLcFullInputBuffers OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of occurrences when all input buffers of a port
+            were full and outbound buffer-to-buffer credit transitioned
+            to zero, i.e., there became no credit to provide to other
+            side."
+    ::= { fcmPortLcStatsEntry 2 }
+
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 30]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+fcmPortLcClass2RxFrames OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of Class 2 frames received at this port."
+    ::= { fcmPortLcStatsEntry 3 }
+
+fcmPortLcClass2RxOctets OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of octets contained in Class 2 frames received
+            at this port."
+    ::= { fcmPortLcStatsEntry 4 }
+
+fcmPortLcClass2TxFrames OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of Class 2 frames transmitted out of this port."
+    ::= { fcmPortLcStatsEntry 5 }
+
+fcmPortLcClass2TxOctets OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of octets contained in Class 2 frames
+            transmitted out of this port."
+    ::= { fcmPortLcStatsEntry 6 }
+
+fcmPortLcClass2Discards OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of Class 2 frames that were discarded upon
+            reception at this port."
+    ::= { fcmPortLcStatsEntry 7 }
+
+
+
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 31]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+fcmPortLcClass2RxFbsyFrames OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of times that F_BSY was returned to this port as
+            a result of a Class 2 frame that could not be delivered to
+            the other end of the link.  This can occur when either the
+            fabric or the destination port is temporarily busy.  Note
+            that this counter will never increment for an F_Port."
+    ::= { fcmPortLcStatsEntry 8 }
+
+fcmPortLcClass2RxPbsyFrames OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of times that P_BSY was returned to this port as
+            a result of a Class 2 frame that could not be delivered to
+            the other end of the link.  This can occur when the
+            destination port is temporarily busy."
+    ::= { fcmPortLcStatsEntry 9 }
+
+fcmPortLcClass2RxFrjtFrames OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of times that F_RJT was returned to this port as
+            a result of a Class 2 frame that was rejected by the fabric.
+            Note that this counter will never increment for an F_Port."
+    ::= { fcmPortLcStatsEntry 10 }
+
+fcmPortLcClass2RxPrjtFrames OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of times that P_RJT was returned to this port as
+            a result of a Class 2 frame that was rejected at the
+            destination N_Port."
+    ::= { fcmPortLcStatsEntry 11 }
+
+
+
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 32]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+fcmPortLcClass2TxFbsyFrames OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of times that F_BSY was generated by this port
+            as a result of a Class 2 frame that could not be delivered
+            because either the Fabric or the destination port was
+            temporarily busy.  Note that this counter will never
+            increment for an N_Port."
+    ::= { fcmPortLcStatsEntry 12 }
+
+fcmPortLcClass2TxPbsyFrames OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of times that P_BSY was generated by this port
+            as a result of a Class 2 frame that could not be delivered
+            because the destination port was temporarily busy.  Note
+            that this counter will never increment for an F_Port."
+    ::= { fcmPortLcStatsEntry 13 }
+
+fcmPortLcClass2TxFrjtFrames OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of times that F_RJT was generated by this port
+            as a result of a Class 2 frame being rejected by the fabric.
+            Note that this counter will never increment for an N_Port."
+    ::= { fcmPortLcStatsEntry 14 }
+
+fcmPortLcClass2TxPrjtFrames OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of times that P_RJT was generated by this port
+            as a result of a Class 2 frame being rejected at the
+            destination N_Port.  Note that this counter will never
+            increment for an F_Port."
+    ::= { fcmPortLcStatsEntry 15 }
+
+
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 33]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+fcmPortLcClass3RxFrames OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of Class 3 frames received at this port."
+    ::= { fcmPortLcStatsEntry 16 }
+
+fcmPortLcClass3RxOctets OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of octets contained in Class 3 frames received
+            at this port."
+    ::= { fcmPortLcStatsEntry 17 }
+
+fcmPortLcClass3TxFrames OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of Class 3 frames transmitted out of this port."
+    ::= { fcmPortLcStatsEntry 18 }
+
+fcmPortLcClass3TxOctets OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of octets contained in Class 3 frames
+            transmitted out of this port."
+    ::= { fcmPortLcStatsEntry 19 }
+
+fcmPortLcClass3Discards OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of Class 3 frames that were discarded upon
+            reception at this port."
+    ::= { fcmPortLcStatsEntry 20 }
+
+
+
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 34]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+--********************************
+-- Port Error Counters
+--
+
+fcmPortErrorsTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF FcmPortErrorsEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "Error counters for Fibre Channel ports."
+    ::= { fcmgmtObjects 6 }
+
+fcmPortErrorsEntry OBJECT-TYPE
+    SYNTAX     FcmPortErrorsEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "Error counters for a Fibre Channel port.  If any counter in
+            this table suffers a discontinuity, the value of
+            ifCounterDiscontinuityTime (defined in the IF-MIB) must be
+            updated."
+    REFERENCE  "The Interfaces Group MIB, RFC 2863, June 2000."
+    AUGMENTS   { fcmPortEntry }
+    ::= { fcmPortErrorsTable 1 }
+
+FcmPortErrorsEntry ::=
+    SEQUENCE {
+        fcmPortRxLinkResets             Counter32,
+        fcmPortTxLinkResets             Counter32,
+        fcmPortLinkResets               Counter32,
+        fcmPortRxOfflineSequences       Counter32,
+        fcmPortTxOfflineSequences       Counter32,
+        fcmPortLinkFailures             Counter32,
+        fcmPortLossofSynchs             Counter32,
+        fcmPortLossofSignals            Counter32,
+        fcmPortPrimSeqProtocolErrors    Counter32,
+        fcmPortInvalidTxWords           Counter32,
+        fcmPortInvalidCRCs              Counter32,
+        fcmPortInvalidOrderedSets       Counter32,
+        fcmPortFrameTooLongs            Counter32,
+        fcmPortTruncatedFrames          Counter32,
+        fcmPortAddressErrors            Counter32,
+        fcmPortDelimiterErrors          Counter32,
+        fcmPortEncodingDisparityErrors  Counter32,
+        fcmPortOtherErrors              Counter32
+    }
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 35]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+fcmPortRxLinkResets OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of Link Reset (LR) Primitive Sequences
+            received."
+    ::= { fcmPortErrorsEntry 1 }
+
+fcmPortTxLinkResets OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of Link Reset (LR) Primitive Sequences
+            transmitted."
+    ::= { fcmPortErrorsEntry 2 }
+
+fcmPortLinkResets OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of times the reset link protocol was initiated
+            on this port.  This includes the number of Loop
+            Initialization Primitive (LIP) events on an arbitrated loop
+            port."
+    ::= { fcmPortErrorsEntry 3 }
+
+fcmPortRxOfflineSequences OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of Offline (OLS) Primitive Sequences received at
+            this port."
+    ::= { fcmPortErrorsEntry 4 }
+
+fcmPortTxOfflineSequences OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of Offline (OLS) Primitive Sequences transmitted
+            by this port."
+    ::= { fcmPortErrorsEntry 5 }
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 36]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+fcmPortLinkFailures OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of link failures.  This count is part of FC-PH's
+            Link Error Status Block (LESB)."
+    REFERENCE
+           "FC-PH, rev 4.3, 1 June 1994, section 29.8 [FC-PH]."
+    ::= { fcmPortErrorsEntry 6 }
+
+fcmPortLossofSynchs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of instances of synchronization loss detected at
+            this port.  This count is part of FC-PH's Link Error Status
+            Block (LESB)."
+    REFERENCE
+           "FC-PH, rev 4.3, 1 June 1994, section 29.8."
+    ::= { fcmPortErrorsEntry 7 }
+
+fcmPortLossofSignals OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of instances of signal loss detected at this
+            port.  This count is part of FC-PH's Link Error Status Block
+            (LESB)."
+    REFERENCE
+           "FC-PH, rev 4.3, 1 June 1994, section 29.8."
+    ::= { fcmPortErrorsEntry 8 }
+
+fcmPortPrimSeqProtocolErrors OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of primitive sequence protocol errors detected
+            at this port.  This count is part of FC-PH's Link Error
+            Status Block (LESB)."
+    REFERENCE
+           "FC-PH, rev 4.3, 1 June 1994, section 29.8."
+    ::= { fcmPortErrorsEntry 9 }
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 37]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+fcmPortInvalidTxWords OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of invalid transmission words received at this
+            port.  This count is part of FC-PH's Link Error Status Block
+            (LESB)."
+    REFERENCE
+           "FC-PH, rev 4.3, 1 June 1994, section 29.8."
+    ::= { fcmPortErrorsEntry 10 }
+
+fcmPortInvalidCRCs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of frames received with an invalid CRC.  This
+            count is part of FC-PH's Link Error Status Block (LESB)."
+    REFERENCE
+           "FC-PH, rev 4.3, 1 June 1994, section 29.8."
+    ::= { fcmPortErrorsEntry 11 }
+
+fcmPortInvalidOrderedSets OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of invalid ordered sets received at this port."
+    ::= { fcmPortErrorsEntry 12 }
+
+fcmPortFrameTooLongs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of frames received at this port for which the
+            frame length was greater than what was agreed to in
+            FLOGI/PLOGI.  This could be caused by losing the end of
+            frame delimiter."
+    ::= { fcmPortErrorsEntry 13 }
+
+fcmPortTruncatedFrames OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of frames received at this port for which the
+
+
+
+McCloghrie                  Standards Track                    [Page 38]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+            frame length was less than the minimum indicated by the
+            frame header - normally 24 bytes, but it could be more if
+            the DFCTL field indicates an optional header should have
+            been present."
+    ::= { fcmPortErrorsEntry 14 }
+
+fcmPortAddressErrors OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of frames received with unknown addressing; for
+            example, an unknown SID or DID."
+    ::= { fcmPortErrorsEntry 15 }
+
+fcmPortDelimiterErrors OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of invalid frame delimiters received at this
+            port.  An example is a frame with a class 2 start and a
+            class 3 at the end."
+    ::= { fcmPortErrorsEntry 16 }
+
+fcmPortEncodingDisparityErrors OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of encoding disparity errors received at this
+            port."
+    ::= { fcmPortErrorsEntry 17 }
+
+fcmPortOtherErrors OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of errors that were detected on this port but
+            not counted by any other error counter in this row."
+    ::= { fcmPortErrorsEntry 18 }
+
+
+
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 39]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+--********************************
+-- The Fibre Channel Fx_Port Table
+--
+
+fcmFxPortTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF FcmFxPortEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "Additional information about Fibre Channel ports that is
+            specific to Fx_Ports.  This table will contain one entry for
+            each fcmPortTable entry that represents an Fx_Port."
+    ::= { fcmgmtObjects 7 }
+
+fcmFxPortEntry OBJECT-TYPE
+    SYNTAX     FcmFxPortEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "Each entry contains information about a specific Fx_Port."
+    INDEX { ifIndex }
+    ::= { fcmFxPortTable 1 }
+
+FcmFxPortEntry ::=
+    SEQUENCE {
+        fcmFxPortRatov                  Unsigned32,
+        fcmFxPortEdtov                  Unsigned32,
+        fcmFxPortRttov                  Unsigned32,
+        fcmFxPortHoldTime               Unsigned32,
+        fcmFxPortCapBbCreditMax         FcBbCredit,
+        fcmFxPortCapBbCreditMin         FcBbCredit,
+        fcmFxPortCapDataFieldSizeMax    FcDataFieldSize,
+        fcmFxPortCapDataFieldSizeMin    FcDataFieldSize,
+        fcmFxPortCapClass2SeqDeliv      TruthValue,
+        fcmFxPortCapClass3SeqDeliv      TruthValue,
+        fcmFxPortCapHoldTimeMax         Unsigned32,
+        fcmFxPortCapHoldTimeMin         Unsigned32
+    }
+
+fcmFxPortRatov OBJECT-TYPE
+    SYNTAX      Unsigned32
+    UNITS       "milliseconds"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The Resource_Allocation_Timeout Value configured for this
+            Fx_Port.  This is used as the timeout value for determining
+            when to reuse an Nx_Port resource such as a
+
+
+
+McCloghrie                  Standards Track                    [Page 40]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+            Recovery_Qualifier.  It represents the Error_Detect_Timeout
+            value (see fcmFxPortEdtov) plus twice the maximum time that
+            a frame may be delayed within the Fabric and still be
+            delivered."
+    ::= { fcmFxPortEntry 1 }
+
+fcmFxPortEdtov OBJECT-TYPE
+    SYNTAX      Unsigned32
+    UNITS       "milliseconds"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The Error_Detect_Timeout value configured for this Fx_Port.
+            This is used as the timeout value for detecting an error
+            condition."
+    ::= { fcmFxPortEntry 2 }
+
+fcmFxPortRttov OBJECT-TYPE
+    SYNTAX      Unsigned32
+    UNITS       "milliseconds"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The Receiver_Transmitter_Timeout value of this Fx_Port.
+            This is used by the receiver logic to detect a Loss of
+            Synchronization."
+    ::= { fcmFxPortEntry 3 }
+
+fcmFxPortHoldTime OBJECT-TYPE
+    SYNTAX      Unsigned32
+    UNITS       "microseconds"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The maximum time that this Fx_Port shall hold a frame
+            before discarding the frame if it is unable to deliver the
+            frame.  The value 0 means that this Fx_Port does not support
+            this parameter."
+    ::= { fcmFxPortEntry 4 }
+
+fcmFxPortCapBbCreditMax OBJECT-TYPE
+    SYNTAX      FcBbCredit
+    UNITS       "buffers"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The maximum number of receive buffers that this port is
+            capable of making available for holding frames from attached
+
+
+
+McCloghrie                  Standards Track                    [Page 41]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+            Nx_Port(s)."
+    ::= { fcmFxPortEntry 5 }
+
+fcmFxPortCapBbCreditMin OBJECT-TYPE
+    SYNTAX      FcBbCredit
+    UNITS       "buffers"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The minimum number of receive buffers that this port is
+            capable of making available for holding frames from attached
+            Nx_Port(s)."
+    ::= { fcmFxPortEntry 6 }
+
+fcmFxPortCapDataFieldSizeMax OBJECT-TYPE
+    SYNTAX      FcDataFieldSize
+    UNITS       "bytes"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The maximum size in bytes of the Data Field in a frame that
+            this Fx_Port is capable of receiving from an attached
+            Nx_Port."
+    ::= { fcmFxPortEntry 7 }
+
+fcmFxPortCapDataFieldSizeMin OBJECT-TYPE
+    SYNTAX      FcDataFieldSize
+    UNITS       "bytes"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The minimum size in bytes of the Data Field in a frame that
+            this Fx_Port is capable of receiving from an attached
+            Nx_Port."
+    ::= { fcmFxPortEntry 8 }
+
+fcmFxPortCapClass2SeqDeliv OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "An indication of whether this Fx_Port is capable of
+            supporting Class 2 Sequential Delivery."
+    ::= { fcmFxPortEntry 9 }
+
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 42]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+fcmFxPortCapClass3SeqDeliv OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "An indication of whether this Fx_Port is capable of
+            supporting Class 3 Sequential Delivery."
+    ::= { fcmFxPortEntry 10 }
+
+fcmFxPortCapHoldTimeMax OBJECT-TYPE
+    SYNTAX      Unsigned32
+    UNITS       "microseconds"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The maximum holding time that this Fx_Port is capable of
+            supporting."
+    ::= { fcmFxPortEntry 11 }
+
+fcmFxPortCapHoldTimeMin OBJECT-TYPE
+    SYNTAX      Unsigned32
+    UNITS       "microseconds"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The minimum holding time that this Fx_Port is capable of
+            supporting."
+    ::= { fcmFxPortEntry 12 }
+
+--********************************
+-- The Fibre Channel Inter-Switch Port Table
+--
+
+fcmISPortTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF FcmISPortEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "Additional information about E_Ports, B_Ports, and any
+            other type of Fibre Channel port to which inter-switch links
+            can be connected.  This table will contain one entry for
+            each fcmPortTable entry that represents such a port."
+    ::= { fcmgmtObjects 8 }
+
+
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 43]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+fcmISPortEntry OBJECT-TYPE
+    SYNTAX     FcmISPortEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "Each entry contains information about a specific port
+            connected to an inter-switch link."
+    INDEX { ifIndex }
+    ::= { fcmISPortTable 1 }
+
+FcmISPortEntry ::=
+    SEQUENCE {
+        fcmISPortClassFCredit           FcBbCredit,
+        fcmISPortClassFDataFieldSize    FcDataFieldSize
+    }
+
+fcmISPortClassFCredit OBJECT-TYPE
+    SYNTAX      FcBbCredit
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+            "The maximum number of Class F data frames that can be
+            transmitted by the inter-switch port without receipt of ACK
+            or Link_Response frames."
+    ::= { fcmISPortEntry 1 }
+
+fcmISPortClassFDataFieldSize OBJECT-TYPE
+    SYNTAX      FcDataFieldSize
+    UNITS       "bytes"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The Receive Data Field Size that the inter-switch port has
+            agreed to support for Class F frames to/from this port.  The
+            size specifies the largest Data Field Size for an FT_1
+            frame."
+    ::= { fcmISPortEntry 2 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 44]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+--********************************
+-- The Fabric Login table
+--
+-- This table contains the information held by FC switches
+-- about the Nx_Ports that are logged-in/attached to their
+-- Fx_Ports
+
+fcmFLoginTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF FcmFLoginEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "A table that contains one entry for each Nx_Port logged-
+            in/attached to a particular Fx_Port in the switch.  Each
+            entry contains the services parameters established during
+            the most recent Fabric Login, explicit or implicit.  Note
+            that an Fx_Port may have one or more Nx_Ports attached to
+            it."
+    ::= { fcmgmtObjects 9 }
+
+fcmFLoginEntry OBJECT-TYPE
+    SYNTAX      FcmFLoginEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "An entry containing service parameters established from a
+            successful Fabric Login."
+    INDEX { ifIndex, fcmFLoginNxPortIndex }
+    ::= { fcmFLoginTable 1 }
+
+FcmFLoginEntry ::=
+    SEQUENCE {
+        fcmFLoginNxPortIndex             Unsigned32,
+        fcmFLoginPortWwn                 FcNameIdOrZero,
+        fcmFLoginNodeWwn                 FcNameIdOrZero,
+        fcmFLoginBbCreditModel           FcBbCreditModel,
+        fcmFLoginBbCredit                FcBbCredit,
+        fcmFLoginClassesAgreed           FcClasses,
+        fcmFLoginClass2SeqDelivAgreed    TruthValue,
+        fcmFLoginClass2DataFieldSize     FcDataFieldSize,
+        fcmFLoginClass3SeqDelivAgreed    TruthValue,
+        fcmFLoginClass3DataFieldSize     FcDataFieldSize
+    }
+
+
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 45]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+fcmFLoginNxPortIndex OBJECT-TYPE
+    SYNTAX      Unsigned32 (1..4294967295)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "An arbitrary integer that uniquely identifies an Nx_Port
+            amongst all those attached to the Fx_Port indicated by
+            ifIndex.
+
+            After a value of this object is assigned to a particular
+            Nx_Port, that value can be re-used when and only when it is
+            assigned to the same Nx_Port, or, after a reset of the value
+            of the relevant instance of ifCounterDiscontinuityTime."
+    REFERENCE  "The Interfaces Group MIB, RFC 2863, June 2000."
+    ::= { fcmFLoginEntry 1 }
+
+fcmFLoginPortWwn  OBJECT-TYPE
+    SYNTAX      FcNameIdOrZero
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The port name of the attached Nx_Port, or the zero-length
+            string if unknown."
+    ::= { fcmFLoginEntry 2 }
+
+fcmFLoginNodeWwn  OBJECT-TYPE
+    SYNTAX      FcNameIdOrZero
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The node name of the attached Nx_Port, or the zero-length
+            string if unknown."
+    ::= { fcmFLoginEntry 3 }
+
+fcmFLoginBbCreditModel OBJECT-TYPE
+    SYNTAX      FcBbCreditModel
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The buffer-to-buffer credit model in use by the Fx_Port."
+    ::= { fcmFLoginEntry 4 }
+
+fcmFLoginBbCredit OBJECT-TYPE
+    SYNTAX      FcBbCredit
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The number of buffers available for holding frames to be
+
+
+
+McCloghrie                  Standards Track                    [Page 46]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+            transmitted to the attached Nx_Port.  These buffers are for
+            buffer-to-buffer flow control in the direction from Fx_Port
+            to Nx_Port."
+    ::= { fcmFLoginEntry 5 }
+
+fcmFLoginClassesAgreed OBJECT-TYPE
+    SYNTAX      FcClasses
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The Classes of Service that the Fx_Port has agreed to
+            support for this Nx_Port."
+    ::= { fcmFLoginEntry 6 }
+
+fcmFLoginClass2SeqDelivAgreed OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "An indication of whether the Fx_Port has agreed to support
+            Class 2 sequential delivery for this Nx_Port.  This is only
+            meaningful if Class 2 service has been agreed upon."
+    ::= { fcmFLoginEntry 7 }
+
+fcmFLoginClass2DataFieldSize OBJECT-TYPE
+    SYNTAX      FcDataFieldSize
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The Receive Data Field Size that the Fx_Port has agreed to
+            support for Class 2 frames to/from this Nx_Port.  The size
+            specifies the largest Data Field Size for an FT_1 frame.
+            This is only meaningful if Class 2 service has been agreed
+            upon."
+    ::= { fcmFLoginEntry 8 }
+
+fcmFLoginClass3SeqDelivAgreed OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "An indication of whether the Fx_Port has agreed to support
+            Class 3 sequential delivery for this Nx_Port.  This is only
+            meaningful if Class 3 service has been agreed upon."
+    ::= { fcmFLoginEntry 9 }
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 47]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+fcmFLoginClass3DataFieldSize OBJECT-TYPE
+    SYNTAX      FcDataFieldSize
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The Receive Data Field Size that the Fx_Port has agreed to
+            support for Class 3 frames to/from this Nx_Port.  The size
+            specifies the largest Data Field Size for an FT_1 frame.
+            This is only meaningful if Class 3 service has been agreed
+            upon."
+    ::= { fcmFLoginEntry 10 }
+
+--********************************
+-- The Link table
+--
+-- This table is intended to assist management applications
+-- in determining the topology of the network.  The table
+-- contains any recent information the known to the agent
+-- about Fibre Channel links, not only those that terminate at
+-- a local port but also any others for which information
+-- is known.
+
+fcmLinkTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF FcmLinkEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "A table containing any Fibre Channel link information that
+            is known to local Fibre Channel managed instances.  One end
+            of such a link is typically at a local port, but the table
+            can also contain information on links for which neither end
+            is a local port.
+
+            If one end of a link terminates locally, then that end is
+            termed 'end1'; the other end is termed 'end2'."
+    ::= { fcmgmtObjects 10 }
+
+fcmLinkEntry OBJECT-TYPE
+    SYNTAX      FcmLinkEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "An entry containing information that a particular Fibre
+            Channel managed instance has about a Fibre Channel link.
+
+            The two ends of the link are called 'end1' and 'end2'."
+    INDEX { fcmInstanceIndex, fcmLinkIndex }
+    ::= { fcmLinkTable 1 }
+
+
+
+McCloghrie                  Standards Track                    [Page 48]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+FcmLinkEntry ::=
+   SEQUENCE {
+        fcmLinkIndex               Unsigned32,
+        fcmLinkEnd1NodeWwn         FcNameIdOrZero,
+        fcmLinkEnd1PhysPortNumber  Unsigned32,
+        fcmLinkEnd1PortWwn         FcNameIdOrZero,
+        fcmLinkEnd2NodeWwn         FcNameIdOrZero,
+        fcmLinkEnd2PhysPortNumber  Unsigned32,
+        fcmLinkEnd2PortWwn         FcNameIdOrZero,
+        fcmLinkEnd2AgentAddress    SnmpAdminString,
+        fcmLinkEnd2PortType        FcPortType,
+        fcmLinkEnd2UnitType        FcUnitFunctions,
+        fcmLinkEnd2FcAddressId     FcAddressIdOrZero
+   }
+
+fcmLinkIndex OBJECT-TYPE
+    SYNTAX      Unsigned32 (1..4294967295)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "An arbitrary integer that uniquely identifies one link
+            within the set of links about which a particular managed
+            instance has information."
+    ::= { fcmLinkEntry 1 }
+
+fcmLinkEnd1NodeWwn  OBJECT-TYPE
+    SYNTAX      FcNameIdOrZero
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The node name of end1, or the zero-length string if
+            unknown."
+    ::= { fcmLinkEntry 2 }
+
+fcmLinkEnd1PhysPortNumber OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The physical port number of end1, or zero if unknown."
+    REFERENCE
+        "FC-GS-3, section 6.1.2.2.5"
+    ::= { fcmLinkEntry 3 }
+
+
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 49]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+fcmLinkEnd1PortWwn OBJECT-TYPE
+    SYNTAX      FcNameIdOrZero
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The port WWN of end1, or the zero-length string if unknown.
+            ('end1' is local if this value is equal to the value of
+            fcmPortWwn in one of the rows of the fcmPortTable.)"
+    ::= { fcmLinkEntry 4 }
+
+fcmLinkEnd2NodeWwn  OBJECT-TYPE
+    SYNTAX      FcNameIdOrZero
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The node name of end2, or the zero-length string if
+            unknown."
+    ::= { fcmLinkEntry 5 }
+
+fcmLinkEnd2PhysPortNumber OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The physical port number of end2, or zero if unknown."
+    REFERENCE
+        "FC-GS-3, section 6.1.2.2.5"
+    ::= { fcmLinkEntry 6 }
+
+fcmLinkEnd2PortWwn OBJECT-TYPE
+    SYNTAX      FcNameIdOrZero
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The port WWN of end2, or the zero-length string if
+            unknown."
+    ::= { fcmLinkEntry 7 }
+
+fcmLinkEnd2AgentAddress OBJECT-TYPE
+    SYNTAX      SnmpAdminString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The address of the management agent for the Fibre Channel
+            Interconnect Element or Platform of which end2 is a part.
+            The GS-4 specification provides some information about
+            management agents.  If the address is unknown, the value of
+            this object is the zero-length string."
+
+
+
+McCloghrie                  Standards Track                    [Page 50]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+    REFERENCE
+        "FC-GS-3, section 6.1.2.1.7"
+    ::= { fcmLinkEntry 8 }
+
+fcmLinkEnd2PortType OBJECT-TYPE
+    SYNTAX      FcPortType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The port type of end2."
+    REFERENCE
+        "FC-GS-3, section 6.1.2.2.2"
+    ::= { fcmLinkEntry 9 }
+
+fcmLinkEnd2UnitType OBJECT-TYPE
+    SYNTAX      FcUnitFunctions
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The type of/function(s) performed by the Fibre Channel
+            Interconnect Element or Platform of which end2 is a part."
+    REFERENCE
+        "FC-GS-3, sections 6.1.2.1.2 and 6.1.2.3.2"
+    ::= { fcmLinkEntry 10 }
+
+fcmLinkEnd2FcAddressId OBJECT-TYPE
+    SYNTAX      FcAddressIdOrZero
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The Fibre Channel Address ID of end2, or the zero-length
+            string if unknown."
+    ::= { fcmLinkEntry 11 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 51]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+--********************************
+-- Conformance Section
+--
+
+fcmgmtCompliances OBJECT IDENTIFIER ::= { fcmgmtConformance 1 }
+fcmgmtGroups      OBJECT IDENTIFIER ::= { fcmgmtConformance 2 }
+
+fcmgmtCompliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+            "Describes the requirements for compliance to this Fibre
+            Channel Management MIB."
+    MODULE  -- this module
+        MANDATORY-GROUPS { fcmInstanceBasicGroup,
+                           fcmPortBasicGroup,
+                           fcmPortErrorsGroup }
+
+        GROUP   fcmPortStatsGroup
+        DESCRIPTION
+            "This group is mandatory for all systems that
+            are able to support the Counter64 date type."
+
+        GROUP   fcmPortClass23StatsGroup
+        DESCRIPTION
+            "This group is mandatory only for systems that
+            keep class-specific traffic statistics on Class 2
+            and Class 3 traffic and are able to support the
+            Counter64 date type."
+
+        GROUP   fcmPortClassFStatsGroup
+        DESCRIPTION
+            "This group is mandatory only for FC switches that
+            keep statistics on Class F traffic."
+
+        GROUP   fcmPortLcStatsGroup
+        DESCRIPTION
+            "This group is mandatory only for agents that can not
+            support the Counter64 data type and/or need to provide
+            information accessible by SNMPv1 applications."
+
+        GROUP   fcmSwitchBasicGroup
+        DESCRIPTION
+            "This group is mandatory only for Fibre Channel
+            managed instances that manage Fibre Channel
+            switches."
+
+        GROUP   fcmSwitchPortGroup
+        DESCRIPTION
+
+
+
+McCloghrie                  Standards Track                    [Page 52]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+            "This group is mandatory only for Fibre Channel
+            managed instances that manage Fibre Channel
+            switches."
+
+        GROUP   fcmSwitchLoginGroup
+        DESCRIPTION
+            "This group is mandatory only for Fibre Channel
+            managed instances that manage Fibre Channel
+            switches."
+
+        GROUP fcmLinkBasicGroup
+        DESCRIPTION
+            "This group is optional."
+
+        OBJECT      fcmInstancePhysicalIndex
+        SYNTAX      Integer32 (0)
+        DESCRIPTION
+            "Implementation of a non-zero value is not required."
+
+        OBJECT      fcmInstanceSoftwareIndex
+        SYNTAX      Integer32 (0)
+        DESCRIPTION
+            "Implementation of a non-zero value is not required."
+
+        OBJECT      fcmInstanceTextName
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+        OBJECT      fcmInstanceDescr
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+        OBJECT      fcmPortAdminType
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+        OBJECT      fcmPortAdminSpeed
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+        OBJECT      fcmSwitchDomainId
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+
+
+McCloghrie                  Standards Track                    [Page 53]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+        OBJECT      fcmISPortClassFCredit
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+    ::= { fcmgmtCompliances 1 }
+
+--********************************
+-- Object Groups
+--
+
+fcmInstanceBasicGroup OBJECT-GROUP
+    OBJECTS { fcmInstanceWwn, fcmInstanceFunctions,
+              fcmInstancePhysicalIndex, fcmInstanceSoftwareIndex,
+              fcmInstanceStatus, fcmInstanceTextName,
+              fcmInstanceDescr, fcmInstanceFabricId }
+    STATUS  current
+    DESCRIPTION
+            "Basic information about Fibre Channel managed instances."
+    ::= { fcmgmtGroups 1 }
+
+fcmSwitchBasicGroup OBJECT-GROUP
+    OBJECTS { fcmSwitchDomainId, fcmSwitchPrincipal, fcmSwitchWWN }
+    STATUS  current
+    DESCRIPTION
+            "Basic information about Fibre Channel switches."
+    ::= { fcmgmtGroups 2 }
+
+fcmPortBasicGroup OBJECT-GROUP
+    OBJECTS { fcmPortInstanceIndex, fcmPortWwn, fcmPortNodeWwn,
+              fcmPortAdminType, fcmPortOperType, fcmPortFcCapClass,
+              fcmPortFcOperClass, fcmPortTransmitterType,
+              fcmPortConnectorType, fcmPortSerialNumber,
+              fcmPortPhysicalNumber, fcmPortAdminSpeed,
+              fcmPortCapProtocols, fcmPortOperProtocols }
+    STATUS  current
+    DESCRIPTION
+            "Basic information about Fibre Channel ports."
+    ::= { fcmgmtGroups 3 }
+
+fcmPortStatsGroup OBJECT-GROUP
+    OBJECTS { fcmPortBBCreditZeros, fcmPortFullInputBuffers }
+    STATUS  current
+    DESCRIPTION
+            "Traffic statistics, which are not specific to any one class
+            of service, for Fibre Channel ports."
+    ::= { fcmgmtGroups 4 }
+
+
+
+
+McCloghrie                  Standards Track                    [Page 54]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+fcmPortClass23StatsGroup OBJECT-GROUP
+    OBJECTS { fcmPortClass2RxFrames, fcmPortClass2RxOctets,
+              fcmPortClass2TxFrames, fcmPortClass2TxOctets,
+              fcmPortClass2Discards, fcmPortClass2RxFbsyFrames,
+              fcmPortClass2RxPbsyFrames,
+              fcmPortClass2RxFrjtFrames,
+              fcmPortClass2RxPrjtFrames,
+              fcmPortClass2TxFbsyFrames,
+              fcmPortClass2TxPbsyFrames,
+              fcmPortClass2TxFrjtFrames,
+              fcmPortClass2TxPrjtFrames, fcmPortClass3RxFrames,
+              fcmPortClass3RxOctets, fcmPortClass3TxFrames,
+              fcmPortClass3TxOctets, fcmPortClass3Discards }
+    STATUS  current
+    DESCRIPTION
+            "Traffic statistics for Class 2 and Class 3 traffic on Fibre
+            Channel ports."
+    ::= { fcmgmtGroups 5 }
+
+fcmPortClassFStatsGroup OBJECT-GROUP
+    OBJECTS { fcmPortClassFRxFrames,
+              fcmPortClassFRxOctets,
+              fcmPortClassFTxFrames,
+              fcmPortClassFTxOctets,
+              fcmPortClassFDiscards }
+    STATUS  current
+    DESCRIPTION
+            "Traffic statistics for Class F traffic on Fibre Channel
+            ports."
+    ::= { fcmgmtGroups 6 }
+
+fcmPortLcStatsGroup OBJECT-GROUP
+    OBJECTS { fcmPortLcBBCreditZeros, fcmPortLcFullInputBuffers,
+              fcmPortLcClass2RxFrames, fcmPortLcClass2RxOctets,
+              fcmPortLcClass2TxFrames, fcmPortLcClass2TxOctets,
+              fcmPortLcClass2Discards, fcmPortLcClass3Discards,
+              fcmPortLcClass3RxFrames, fcmPortLcClass3RxOctets,
+              fcmPortLcClass3TxFrames, fcmPortLcClass3TxOctets,
+              fcmPortLcClass2RxFbsyFrames,
+              fcmPortLcClass2RxPbsyFrames,
+              fcmPortLcClass2RxFrjtFrames,
+              fcmPortLcClass2RxPrjtFrames,
+              fcmPortLcClass2TxFbsyFrames,
+              fcmPortLcClass2TxPbsyFrames,
+              fcmPortLcClass2TxFrjtFrames,
+              fcmPortLcClass2TxPrjtFrames }
+    STATUS  current
+    DESCRIPTION
+
+
+
+McCloghrie                  Standards Track                    [Page 55]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+            "Low-capacity (32-bit) statistics for Fibre Channel ports."
+    ::= { fcmgmtGroups 7 }
+
+fcmPortErrorsGroup OBJECT-GROUP
+    OBJECTS { fcmPortRxLinkResets, fcmPortTxLinkResets,
+              fcmPortLinkResets, fcmPortRxOfflineSequences,
+              fcmPortTxOfflineSequences, fcmPortLinkFailures,
+              fcmPortLossofSynchs, fcmPortLossofSignals,
+              fcmPortPrimSeqProtocolErrors, fcmPortInvalidTxWords,
+              fcmPortInvalidCRCs, fcmPortInvalidOrderedSets,
+              fcmPortFrameTooLongs, fcmPortTruncatedFrames,
+              fcmPortAddressErrors, fcmPortDelimiterErrors,
+              fcmPortEncodingDisparityErrors,
+              fcmPortOtherErrors }
+    STATUS  current
+    DESCRIPTION
+            "Error statistics for Fibre Channel ports."
+    ::= { fcmgmtGroups 8 }
+
+fcmSwitchPortGroup OBJECT-GROUP
+    OBJECTS { fcmFxPortRatov, fcmFxPortEdtov, fcmFxPortRttov,
+              fcmFxPortHoldTime, fcmFxPortCapBbCreditMax,
+              fcmFxPortCapBbCreditMin,
+              fcmFxPortCapDataFieldSizeMax,
+              fcmFxPortCapDataFieldSizeMin,
+              fcmFxPortCapClass2SeqDeliv,
+              fcmFxPortCapClass3SeqDeliv,
+              fcmFxPortCapHoldTimeMax,
+              fcmFxPortCapHoldTimeMin,
+              fcmISPortClassFCredit,
+              fcmISPortClassFDataFieldSize }
+    STATUS  current
+    DESCRIPTION
+            "Information about ports on a Fibre Channel switch."
+    ::= { fcmgmtGroups 9 }
+
+fcmSwitchLoginGroup OBJECT-GROUP
+    OBJECTS { fcmFLoginPortWwn, fcmFLoginNodeWwn,
+              fcmFLoginBbCreditModel, fcmFLoginBbCredit,
+              fcmFLoginClassesAgreed,
+              fcmFLoginClass2SeqDelivAgreed,
+              fcmFLoginClass2DataFieldSize,
+              fcmFLoginClass3SeqDelivAgreed,
+              fcmFLoginClass3DataFieldSize }
+    STATUS  current
+    DESCRIPTION
+            "Information known to a Fibre Channel switch about
+            attached/logged-in Nx_Ports."
+
+
+
+McCloghrie                  Standards Track                    [Page 56]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+    ::= { fcmgmtGroups 10 }
+
+fcmLinkBasicGroup OBJECT-GROUP
+    OBJECTS { fcmLinkEnd1NodeWwn , fcmLinkEnd1PhysPortNumber,
+              fcmLinkEnd1PortWwn, fcmLinkEnd2NodeWwn ,
+              fcmLinkEnd2PhysPortNumber, fcmLinkEnd2PortWwn,
+              fcmLinkEnd2AgentAddress, fcmLinkEnd2PortType,
+              fcmLinkEnd2UnitType, fcmLinkEnd2FcAddressId }
+    STATUS  current
+    DESCRIPTION
+            "Information about Fibre Channel links."
+    ::= { fcmgmtGroups 11 }
+
+END
+
+7.  Acknowledgements
+
+   This memo is partly based on the information contained in the
+   original submission of the Fibre Channel Management Integration MIB
+   to the IETF's IPFC Working Group (now available as [MIB-FA]) and
+   obsoletes RFC 2837.
+
+   Feedback has been incorporated into this document based on comments
+   from the following: Sudhir Pendse, SimpleSoft; Steve Senum, Cisco
+   Systems; and Kha Sin Teow, Brocade.
+
+8.  Normative References
+
+   [RFC2434] Narten, T. and H. Alvestrand, "Guidelines for Writing an
+             IANA Considerations Section in RFCs", BCP 26, RFC 2434,
+             October 1998.
+
+   [RFC2578] McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+             "Structure of Management Information Version 2 (SMIv2)",
+             STD 58, RFC 2578, April 1999.
+
+   [RFC2579] McCloghrie, K., Perkins, D., and J. Schoenwaelder, "Textual
+             Conventions for SMIv2", STD 58, RFC 2579, April 1999.
+
+   [RFC2580] McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+             "Conformance Statements for SMIv2", STD 58, RFC 2580, April
+             1999.
+
+   [RFC2737] McCloghrie, K. and A. Bierman, "Entity MIB (Version 2)",
+             RFC 2737, December 1999.
+
+   [RFC2790] Waldbusser, S. and P. Grillo, "Host Resources MIB", RFC
+             2790, March 2000.
+
+
+
+McCloghrie                  Standards Track                    [Page 57]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+   [RFC2863] McCloghrie, K. and F. Kastenholz, "The Interfaces Group
+             MIB", RFC 2863, June 2000.
+
+   [RFC3411] Harrington, D., Presuhn, R., and B. Wijnen, "An
+             Architecture for Describing Simple Network Management
+             Protocol (SNMP) Management Frameworks", STD 62, RFC 3411,
+             December 2002.
+
+   [FC-AL-2] "Fibre Channel - Arbitrated Loop (FC-AL-2)", ANSI INCITS
+             332-1999, 1999.
+
+   [FC-BB]   "Fibre Channel - Backbone (FC-BB)" ANSI INCITS 342-2001,
+             2001.
+
+   [FC-FS]   "Fibre Channel - Framing and Signaling (FC-FS)" ANSI INCITS
+             373-2003, April 2003.
+
+   [FC-GS-3] "Fibre Channel - Generic Services - 3 (FC-GS-3)" ANSI
+             INCITS 348-2001, 2001.
+
+   [FC-MI]   "Fibre Channel - Methodologies for Interconnects Technical
+             Report (FC-MI)" INCITS TR-30-2002, 2002.
+
+   [FC-PH]   "Information Technology - Fibre Channel Physical and
+             Signaling Interface (FC-PH)", ANSI X3.230, 1994.
+
+   [FC-SW-3] "Fibre Channel - Switch Fabric - 3 (FC-SW-3)", ANSI INCITS
+             384-2004, June 2004.
+
+9.  Informative References
+
+   [RFC2741] Daniele, M., Wijnen, B., Ellison, M., and D. Francisco,
+             "Agent Extensibility (AgentX) Protocol Version 1", RFC
+             2741, January 2000.
+
+   [RFC2837] Teow, K., "Definitions of Managed Objects for the Fabric
+             Element in Fibre Channel Standard", RFC 2837, May 2000.
+
+   [RFC3410] Case, J., Mundy, R., Partain, D., and B. Stewart,
+             "Introduction and Applicability Statements for Internet-
+             Standard Management Framework", RFC 3410, December 2002.
+
+   [RFC3433] Bierman, A., Romascanu, D., and K.C. Norseth, "Entity
+             Sensor Management Information Base", RFC 3433, December
+             2002.
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 58]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+   [MIB-FA]  "INCITS Technical Report for Information Technology - Fibre
+             Channel - Management Information Base - FA (MIB-FA)",
+             INCITS, TR-32-2003.
+
+   [WWN1]    Snively, R., "New identifier formats based on IEEE
+             registration", http://standards.ieee.org/regauth/oui/
+             tutorials/fibreformat.html, 16 January 2001.
+
+   [WWN2]    Snively, R., "Use of the IEEE Registration Authority
+             assigned 'company_id' with the ANSI X3.230 FC-PH Fibre
+             Channel specification and its extensions",
+             http://standards.ieee.org/regauth/oui/tutorials/
+             fibrecomp_id.html, 24 February 1997.
+
+10.  Security Considerations
+
+   There are a number of management objects defined in this MIB that
+   have a MAX-ACCESS clause of read-write:
+
+      fcmInstanceTextName
+      fcmInstanceDescr
+      fcmSwitchDomainId
+      fcmPortAdminType
+      fcmPortAdminSpeed
+      fcmISPortClassFCredit
+
+   Such objects may be considered sensitive or vulnerable in some
+   network environments.  For example, the ability to change network
+   topology or network speed may afford an attacker the ability to
+   obtain better performance at the expense of other network users;
+   setting fcmSwitchDomainId to an invalid value could lead to denial of
+   service in some configurations.  The support for SET operations in a
+   non-secure environment without proper protection can have a negative
+   effect on network operations.
+
+   Some of the readable objects in this MIB module (i.e., objects with a
+   MAX-ACCESS other than not-accessible) may be considered sensitive or
+   vulnerable in some network environments.  It is thus important to
+   control even GET and/or NOTIFY access to these objects and possibly
+   to even encrypt the values of these objects when sending them over
+   the network via SNMP.  In particular, these objects provide
+   information on network topology:
+
+      fcmLinkEnd1NodeWwn
+      fcmLinkEnd1PhysPortNumber
+      fcmLinkEnd1PortWwn
+      fcmLinkEnd2NodeWwn
+      fcmLinkEnd2PhysPortNumber
+
+
+
+McCloghrie                  Standards Track                    [Page 59]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+      fcmLinkEnd2PortWwn
+      fcmLinkEnd2AgentAddress
+      fcmLinkEnd2PortType
+      fcmLinkEnd2UnitType
+      fcmLinkEnd2FcAddressId
+
+   SNMP versions prior to SNMPv3 did not include adequate security.
+   Even if the network itself is secure (for example by using IPSec),
+   even then, there is no control as to who on the secure network is
+   allowed to access and GET/SET (read/change/create/delete) the objects
+   in this MIB module.
+
+   It is RECOMMENDED that implementors consider the security features as
+   provided by the SNMPv3 framework (see [RFC3410], section 8),
+   including full support for the SNMPv3 cryptographic mechanisms (for
+   authentication and privacy).
+
+   Further, deployment of SNMP versions prior to SNMPv3 is NOT
+   RECOMMENDED.  Instead, it is RECOMMENDED to deploy SNMPv3 and to
+   enable cryptographic security.  It is then a customer/operator
+   responsibility to ensure that the SNMP entity giving access to an
+   instance of this MIB module is properly configured to give access to
+   the objects only to those principals (users) that have legitimate
+   rights to indeed GET or SET (change/create/delete) them.
+
+11.  IANA Considerations
+
+11.1.  OID Assignment
+
+   IANA has made a MIB OID assignment under the transmission branch.
+   Specifically, transmission 56 has been assigned as the OID for
+   fcMgmtMIB.  This sub-identifier was requested because this MIB
+   contains the media-specific definitions that correspond to the ifType
+   value of fibreChannel(56).
+
+11.2.  FC Port Type Registry
+
+   IANA has established a registry for Fibre Channel Port Types.  The
+   registry is split into disjointed subset ranges:
+
+   1) a 'standard' range for Fibre Channel Port Types that have been
+      standardized by the InterNational Committee for Information
+      Technology Standards (INCITS)'s Technical Committee T11.  This
+      range will be subject to the 'Expert Review' and 'Specification
+      Required' policies described in [RFC2434], with the following
+      provisions:
+
+      -  the Expert Reviewer is to be appointed by the IESG.
+
+
+
+McCloghrie                  Standards Track                    [Page 60]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+      -  the Expert Reviewer shall obtain approval (or rejection) from
+         INCITS Technical Committee T11 via the chair of that Committee.
+         Rejected values shall not be added to the registry.
+
+      -  if the addition is approved, the Expert shall advise IANA of
+         how to record the reference to the T11 specification document
+         that describes the newly added port type(s), and that is
+         considered to be the "other permanent and readily available
+         reference" required by [RFC2434].
+
+   The initial assignments in the 'standard' range will be as follows:
+
+      Assigned
+       Value     Type      Meaning
+      --------   ------    -------
+         1       unknown   for use when the type is not known,
+                           or is "unidentified" as specified in
+                           section 5.1.2.10 of [FC-GS-3]
+         2       other     used for types without assigned values
+         3       --        an obsolete value, not to be re-assigned
+         4       N_Port     see [FC-FS]
+         5       NL_Port    see [FC-FS]
+         6       F_Port     see [FC-FS]
+         7       FL_Port    see [FC-FS]
+         8       E_Port     see [FC-FS]
+         9       B_Port     see [FC-FS]
+        10       G_Port     see [FC-SW-3]
+        11       GL_Port    see [FC-SW-3]
+        12       F/NL_Port  see [FC-AL-2]
+
+   The above range extends up to a maximum of 9,999.
+
+   2) a range assigned under the "Private Use" policy described in
+      [RFC2434] for values intended for private use by one party or
+      among mutually consenting parties.
+      Values in this range extend from 10,000 to 99,999.  IANA will not
+      make any allocations from this range.
+
+   3) values larger than 99,999 are RESERVED.
+
+
+
+
+
+
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 61]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+12.  Comparison to the Fibre Channel Management Integration MIB
+
+12.1.  Problems with the Fibre Channel Management Integration MIB
+
+   The Fibre Channel Management Integration MIB [MIB-FA] had the
+   following major problems:
+
+   -  It wasn't formatted using SMIv2, which is mandatory.
+
+   -  The MIB seemed to have been defined with the notion that it would
+      be the only MIB that a Fibre Channel product will require.  The
+      notion of an agent implementing just a single MIB was abandoned by
+      the IETF in 1992 as being non-scalable.  Rather, a Fibre Channel
+      MIB needed to be another MIB in the continuing series of MIBs
+      defined by the IETF, and thus, it needed to be consistent with its
+      predecessors.  In other words, there are existing MIBs that all
+      SNMP agents must support, even if the support of Fibre Channel
+      interfaces is the only functionality that they have.  Thus, it was
+      essential that the Fibre Channel Integration MIB contained only
+      objects for information that is specific to Fibre Channel.  All
+      objects relevant to non-Fibre Channel environments needed to be
+      removed.  This issue applied to a large fraction of the objects
+      defined in the MIB.
+
+   -  The MIB had some but not complete overlap in functionality with
+      RFC 2837.
+
+   -  Every SNMP agent must implement the ifTable.  The ifTable counters
+      are the MIB objects most well-used by administrators in SNMP
+      management.  SNMP agents need to implement a row in the ifTable
+      for each of their network interfaces, including their Fibre
+      Channel interfaces.  The IF-MIB requires a media-specific MIB to
+      specify how that type of interface uses the ifTable (see section 4
+      in RFC 2863).  [RFC2837] doesn't do that, nor did the Fibre
+      Channel Integration MIB.
+
+   -  It incorrectly used the OCTET STRING syntax (instead of Counter32
+      or Counter64) for counters.
+
+12.2.  Detailed Changes
+
+12.2.1.  Removal of Sensor-Related Objects
+
+   Information about sensors is not specific to Fibre Channel, and
+   therefore should not be in this MIB.  (At the time of writing, the
+   IETF's ENTITY MIB Working Group has produced a first draft of a
+   Sensor MIB, see [RFC3433].)  This removed the need for:
+
+
+
+
+McCloghrie                  Standards Track                    [Page 62]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+      connUnitSensorTable (and all its contents)
+      connUnitNumSensors
+      connUnitSensorStatusChange
+
+12.2.2.  Removal of Trap-registration Objects
+
+   Information about registering "traps" is not specific to Fibre
+   Channel, and therefore should not be in this MIB.  (For similar
+   functionality, see SNMP-NOTIFICATION-MIB and SNMP-TARGET-MIB in RFC
+   2573).  This removed the need for:
+
+      trapMaxClients
+      trapClientCount
+      trapRegTable (and all its contents)
+
+12.2.3.  Removal of Event-Related Objects
+
+   Information about generic events is not specific to Fibre Channel,
+   and therefore should not be in this MIB.  (For similar functionality,
+   see the Event group in RFC 2819 and the Notification Log MIB in RFC
+   3014; the SNMP-NOTIFICATION-MIB provides for the filtering of
+   notifications.)  This removed the need for:
+
+      connUnitEventTable (and all its contents)
+      connUnitEventFilter
+      connUnitNumEvents
+      connUnitMaxEvents
+      connUnitEventCurrID
+      connUnitEventTrap
+
+12.2.4.  Removal of Inventory-Related Information
+
+   Aspects of hardware (physical) components are represented in the
+   Entity MIB (RFC 2737); aspects of software modules are represented in
+   the Host Resources MIB (RFC 2790).  Two new objects provide indexing
+   from this MIB into those MIBs: one having the value of PhysicalIndex
+   (or zero) and the other having the value of hrSWInstalledIndex (or
+   zero).  These replaced the need for:
+
+      connUnitNumports
+      connUnitRevsTable (and all its contents)
+      connUnitNumRevs
+      connUnitPortRevision
+      connUnitPortVendor
+      connUnitProduct
+      connUnitInfo
+      connUnitSn
+      connUnitModuleId
+
+
+
+McCloghrie                  Standards Track                    [Page 63]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+      connUnitVendorId
+      connUnitDeletedTrap
+
+12.2.5.  Removal of Revision Numbers
+
+   The forward/backward compatibility rules of how to evolve MIBs are
+   designed such that MIBs do not have revision numbers.  This removed
+   the need for:
+
+      revisionNumber
+
+12.2.6.  Removal of Other Not FC-Specific Information
+
+   Other information was removed because it was not specific to Fibre
+   Channel:
+
+      systemURL
+      statusChangeTime
+      configurationChangeTime
+      connUnitUrl
+      connUnitUpTime
+      connUnitState
+      connUnitContact
+      connUnitLocation
+      connUnitProxyMaster
+      connUnitControl
+      connUnitStatus
+      connUnitStatusChange
+
+12.2.7.  Clean-up of Ambiguous/Obsolete Definitions
+
+   Some information in the FC Management integration was obsolete or
+   ambiguous:
+
+      statusChangeTime (obsolete)
+      configurationChangeTime (obsolete)
+      connUnitTableChangeTime (obsolete)
+      connUnitStatusChangeTime (obsolete)
+      connUnitConfigurationChangeTime (obsolete)
+      connUnitNumZones (obsolete)
+      connUnitZoneTable (referenced but not defined)
+      connUnitLinkCurrIndex (badly defined)
+
+12.2.8.  Use of an ifTable Entry
+
+   The following objects were removed because they duplicated existing
+   IF-MIB objects:
+
+
+
+
+McCloghrie                  Standards Track                    [Page 64]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+      redundant object                   existing object(s)
+      ----------------                   ------------------
+      connUnitPortStatCountError         ifInErrors & ifOutErrors
+      connUnitPortStatCountTxObjects     ifOutUcastPkts &
+                                         ifHCOutUcastPkts
+      connUnitPortStatCountRxObjects     ifInUcastPkts &
+                                         ifHCInUcastPkts
+      connUnitPortStatCountTxElements    ifOutOctets &
+                                         ifHCOutOctets
+      connUnitPortStatCountRxElements    ifInOctets &
+                                         ifHCInOctets
+      connUnitPortStatCountRxMulticastObjects
+                                         ifInMulticastPkts &
+                                         ifHCInMulticastPkts
+      connUnitPortStatCountTxMulticastObjects
+                                         ifOutMulticastPkts &
+                                         ifHCOutMulticastPkts
+      connUnitPortStatCountRxBroadcastObjects
+                                         ifInBroadcastPkts &
+                                         ifHCInBroadcastPkts
+      connUnitPortStatCountTxBroadcastObjects
+                                         ifOutBroadcastPkts &
+                                         ifHCOutBroadcastPkts
+      connUnitPortFCId                   ifPhysAddress
+      connUnitPortControl                ifAdminStatus
+      connUnitPortState                  ifAdminStatus
+      connUnitPortHWState                ifOperStatus
+      connUnitPortStatus                 ifOperStatus
+      connUnitPortName                   ifAlias
+      connUnitPortStatObject             ifSpecific
+      connUnitNumports                   ifNumber
+      connUnitPortStatusChange           linkUp/linkDown
+
+12.2.9.  Removed Because of AgentX Difficulty
+
+   An AgentX environment [RFC2741] consists of a master agent and
+   several sub-agents.  It is not difficult to implement the same MIB in
+   several such sub-agents if all of the MIB's tables have a common
+   index variable as the first auxiliary object in their INDEX clauses.
+   However, any scalars that the MIB contains pose a problem for the
+   AgentX environment.  All the (remaining) scalars were therefore
+   removed:
+
+      revisionNumber
+      uNumber
+      systemURL
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 65]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+12.2.10.  FC Management Instance
+
+   The term "connectivity unit" was changed to "FC management instance".
+
+   The term "connectivity unit" was not properly defined in [MIB-FA],
+   and its usage provided a confused mixture of indications to the
+   implementor:
+
+      -  the definition of FcUnitType suggested it was functional;
+
+      -  the definition of uNumber suggested it was physical;
+
+      -  the definition of connUnitProduct suggested it was a vendor's
+         product;
+
+      -  etc.
+
+   The common implementation strategy for the "connectivity unit" was
+   which ever grouping provided access to the management functionality
+   the easiest.  (One such grouping accommodates a single SNMP agent
+   having multiple AgentX [RFC2741] sub-agents, each supporting a
+   separate implementation of the MIB.)
+
+   In fact, this scenario is not new; in practice, a "connectivity unit"
+   will have the same semantics as a management "instance" in other
+   MIBs, e.g., the IPS WG's own iSCSI MIB.  For this MIB, its meaning
+   is: "a separable managed instance of Fibre Channel functionality".
+   Given this definition, the "FC management instance" is a better name
+   because it is more accurate and more representative of the definition
+   than is "connectivity unit".
+
+12.2.11.  Counter Syntax
+
+   All packet and octet counters have been changed to be Counter64's
+   (but Counter32 versions of them are also included for use by old
+   agents).  The error counters have been changed to Counter32's.  (In
+   the probably impossible, and at most improbable, circumstances that
+   the rate of occurrence of errors, even on a 10Gbs Fibre Channel
+   interface, might wrap faster than an hour, the fact that errors are
+   occurring will almost certainly be apparent from other MIB objects.)
+
+12.2.12.  Obsolete/Little-Used Fibre Channel Features
+
+   Information relating to Fibre Channel features that are obsolete or
+   not widely-implemented has been deleted.  (For more information, see
+   section 6.2.1 and section 6.2.2 of [FC-MI].)
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 66]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+      -  Class 1 service,
+      -  Intermix Mode,
+      -  Stacked Conn Mode.
+      -  PH version numbers
+
+   Note that with support for Class 1 service being deleted, only class
+   2 now needs F_BSY, F_RJT, P_BSY, and P_RJT counters, and thus they no
+   longer need to be counted for all classes as well as for class 2, and
+   therefore the following objects have been deleted:
+
+      connUnitPortStatCountFBSYFrames
+      connUnitPortStatCountPBSYFrames
+      connUnitPortStatCountFRJTFrames
+      connUnitPortStatCountPRJTFrames
+
+12.3.  Name Server Objects
+
+   A table of Name Server information was present in
+   the Fibre Channel Management Integration MIB [MIB-FA].
+   That information is not currently represented in this MIB
+   because this MIB is already quite large,
+   and a set of Name Server objects are expected to be
+   defined in a separate (new) MIB.
+
+12.4.  Additional Objects
+
+   Support for Class F traffic, including 32-bit octet and frame
+   counters, has been added.
+
+13.  Comparison to RFC 2837
+
+   This MIB is a superset of RFC 2837, except for the following:
+
+   -  the fcFeClass1AccountingGroup group is obsolete,
+
+   -  fcFxPortConnectedNxPort, fcFxPortFcphVersionHigh,
+      fcFxPortFcphVersionLow, fcFxPortFcphVersionAgreed,
+      fcFxPortStackedConnModeAgreed, fcFxPortIntermixSuppAgreed,
+      fcFxPortCapStackedConnMode, and fcFxPortCapIntermix are obsolete,
+
+   -  fcFxPortBbCredit and fcFxPortRxBufSize are per attached Nx_Port,
+
+   -  fcFxPortBbCreditAvailable is ephemeral,
+
+   -  fcFeModuleTable is mostly contained in the entPhysicalTable,
+
+   -  fcFxPortPhysAdminStatus, fcFxPortPhysOperStatus, and
+      fcFxPortPhysLastChange have equivalents in the ifTable.
+
+
+
+McCloghrie                  Standards Track                    [Page 67]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+Author's Address
+
+   Keith McCloghrie
+   Cisco Systems, Inc.
+   170 West Tasman Drive
+   San Jose, CA USA 95134
+
+   Phone: +1 408-526-5260
+   EMail: kzm@cisco.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 68]
+
+RFC 4044              Fibre Channel Management MIB              May 2005
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2005).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at ietf-
+   ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+McCloghrie                  Standards Track                    [Page 69]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4044.txt](<www.ietf.org/rfc/rfc4044.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
