### PR TITLE
Archive rfc405.txt

### DIFF
--- a/www.ietf.org/rfc/rfc405.txt
+++ b/www.ietf.org/rfc/rfc405.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+NWG/RFC  #405                       AAM 10-OCT-72 13:09 12110
+Correction to RFC 404
+
+This is to correct a typographic error in RFC# 404.  The
+address of the ISI IMP is 22 (decimal), not 86 as was
+erroneously stated.  All other numbers in RFC# 404 were
+correct;  the complete (corrected) text follows:
+
+This week the RAND IMP was temporarily removed from the
+Network and a new IMP was installed at ISI.  Some of the
+people and computers from RAND have moved to ISI, in
+particular the RAND TENEX is now the ISI TENEX.  The address
+of the ISI IMP is 22 (decimal) and the TENEX at ISI is Host
+number one; thus the "Network Address" of the ISI TENEX is 86.
+Sometime early next week the RAND IMP will be re-installed.
+It will still be IMP number 7, and the IBM 360/65 at RAND will
+still be "Network Address" 7.
+
+
+
+
+
+
+
+    [ This RFC was put into machine readable form for entry ]
+    [ into the online RFC archives by BBN Corp. under the   ]
+    [ direction of Alex McKenzie.                      1/97 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc405.txt](<www.ietf.org/rfc/rfc405.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
