### PR TITLE
Archive rfc4053.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4053.txt
+++ b/www.ietf.org/rfc/rfc4053.txt
@@ -1,0 +1,1067 @@
+
+
+
+
+
+
+Network Working Group                                      S. Trowbridge
+Request for Comments: 4053                           Lucent Technologies
+BCP: 103                                                      S. Bradner
+Category: Best Current Practice                       Harvard University
+                                                                F. Baker
+                                                           Cisco Systems
+                                                              April 2005
+
+
+    Procedures for Handling Liaison Statements to and from the IETF
+
+Status of This Memo
+
+   This document specifies an Internet Best Current Practices for the
+   Internet Community, and requests discussion and suggestions for
+   improvements.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2005).
+
+Abstract
+
+   This document describes the procedure for proper handling of incoming
+   liaison statements from other standards development organizations
+   (SDOs), consortia, and industry fora, and for generating liaison
+   statements to be transmitted from IETF to other SDOs, consortia and
+   industry fora.  This procedure allows IETF to effectively collaborate
+   with other organizations in the international standards community.
+
+   The IETF expects that liaison statements might come from a variety of
+   organizations, and it may choose to respond to many of those.  The
+   IETF is only obligated to respond if there is an agreed liaison
+   relationship, however.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Trowbridge, et al.       Best Current Practice                  [Page 1]
+
+RFC 4053             Handling of Liaison Statements           April 2005
+
+
+Table of Contents
+
+   1. Introduction ....................................................3
+   2. Liaison Statements and Their Handling ...........................3
+      2.1. Definitions ................................................3
+      2.2. Liaison Statements .........................................4
+           2.2.1. Contents of a Liaison Statement .....................4
+                  2.2.1.1. Envelope Information .......................4
+                  2.2.1.2. Liaison Content ............................5
+      2.3. Addressee Responsibilities .................................6
+      2.4. Lifetime of a Liaison Statement ............................7
+   3. Tools for Handling Liaison Statements ...........................7
+      3.1. Liaison Statements from Other SDOs, Consortia, and
+           Fora to IETF ...............................................7
+           3.1.1. Liaison Statement Submission ........................8
+           3.1.2. Mechanism for Displaying Liaison Statements .........9
+      3.2. Communicating IETF Information to Other SDOs,
+           Consortia, and Fora ........................................9
+           3.2.1. Spontaneously Generating Liaison Statements
+                  to Other ............................................9
+                  3.2.1.1. Transmitting IETF Documents to
+                           Other Organizations .......................10
+                  3.2.1.2. Requests for Information ..................10
+                  3.2.1.3. Requesting Comments on Work in Progress ...11
+                  3.2.1.4. Requests for Other Actions
+                           (Besides Comments on IETF Drafts) .........11
+           3.2.2. Responding to Incoming Liaison Statements ..........11
+                  3.2.2.1. Responding to Requests for Information ....11
+                  3.2.2.2. Responding to Requests for Comments .......12
+                  3.2.2.3. Responding to Request for Action ..........12
+                  3.2.2.4. Generating Liaison Statements .............13
+   4. Security Considerations ........................................13
+   5. Acknowledgements ...............................................14
+   A. Implementation Road map ........................................15
+      A.1. Phase I: Initial Implementation ...........................15
+           A.1.1.   Displays .........................................15
+           A.1.2.   Actions on Submission ............................16
+   B. Phase II: Additional Instrumentation and Responses to
+      Usage Experience ...............................................17
+   Normative References ..............................................17
+
+
+
+
+
+
+
+
+
+
+
+Trowbridge, et al.       Best Current Practice                  [Page 2]
+
+RFC 4053             Handling of Liaison Statements           April 2005
+
+
+1.  Introduction
+
+   This document describes the procedure for generating and handling
+   liaison statements between the IETF and other SDOs, so that IETF can
+   effectively collaborate with other organizations in the international
+   standards community.  These liaison statements are primarily
+   exchanged between IETF and organizations with whom the IAB has
+   created a liaison relationship (see [RFC4052]), although other
+   organizations are not precluded.  The procedures described in this
+   document encompass all liaisons statements received from SDOs,
+   whether or not a formal liaison arrangement is in place between the
+   SDO and the IETF.  The IETF is not obligated to respond to the
+   liaison statement where there is no formal liaison arrangement.
+
+   The implementation of the procedure and supporting tools is occurring
+   in a minimum of three phases.  The initial phase has been the
+   development of a prototype (in the best tradition of "rough consensus
+   and running code"), by Sunny Lee of Foretec, in parallel with the
+   development of this specification.  The second phase is the
+   conversion of that prototype to an operational tool.  This
+   operational tool lacks an automated tracking tool; rather, the
+   liaison manager implements it in his or her own way.  The third phase
+   will include that tracking tool.
+
+   The specific supporting tools and their functionality described in
+   this document are one possible way of providing automated support for
+   the processes described in this document.  Because specific tools and
+   their functionality will change over time, the descriptions in this
+   document are to be considered examples only and are not a normative
+   part of this specification.
+
+2.  Liaison Statements and Their Handling
+
+   Let us first define what a liaison statement is (and is not), and set
+   reasonable expectations.  The expectations in this section are
+   normative for a liaison statement sent by any SDO to the IETF.
+
+2.1.  Definitions
+
+   For purposes of clarity, we use the following definitions:
+
+   Addressee: The Working Group(s) (WG) or other party(s) in the IETF to
+      whom a liaison statement is addressed.
+
+
+
+
+
+
+
+
+Trowbridge, et al.       Best Current Practice                  [Page 3]
+
+RFC 4053             Handling of Liaison Statements           April 2005
+
+
+   Assignee: The person responsible to act on a liaison statement,
+      initially either the person to whom it was addressed or the chair
+      of the group to which it was addressed.  The task may be
+      reassigned to another person in the same or a different group as
+      appropriate.
+
+   Liaison manager: A person designated to act as a manager of the
+      relationship between the IETF and a peer organization to ensure
+      that communication is maintained, is productive, and is timely, as
+      defined by sections 2.2 and 3 in [RFC4052].
+
+   Liaison statement: A letter as described in this document, exchanged
+      between organizations.
+
+2.2.  Liaison Statements
+
+   A Liaison Statement is a business letter sent by one standards
+   organization to another.  These organizations may be at any level
+   (WG, Area, etc.)   Generally, the sender and receiver are peer
+   organizations.  A liaison statement may have any purpose, but
+   generally the purpose is to solicit information, make a comment or
+   request an action.
+
+2.2.1.  Contents of a Liaison Statement
+
+   Liaison statements may be very formal or informal, depending on the
+   rules of the body generating them.  Any liaison statement, however,
+   will always contain certain information, much as an business letter
+   does.  This information will include the following:
+
+2.2.1.1.  Envelope Information
+
+   The following fields detail properties of the liaison statement.
+
+2.2.1.1.1.  From:
+
+   The statement will indicate from what body it originates; for
+   example, it may be from, an IETF WG or Area, an ITU-T Study Group,
+   Working Party, or Question, etc.  In this document, this body is the
+   "sender".
+
+2.2.1.1.2.  To:
+
+   The statement will indicate to which body it is.  In this document,
+   this body is the "addressee".
+
+
+
+
+
+
+Trowbridge, et al.       Best Current Practice                  [Page 4]
+
+RFC 4053             Handling of Liaison Statements           April 2005
+
+
+2.2.1.1.3.  Title:
+
+   The statement will contain a short (usually single line) statement of
+   its context and content.
+
+2.2.1.1.4.  Response Contact:
+
+   The sender will indicate the electronic mail address to which any
+   response should be sent.
+
+2.2.1.1.5.  Technical Contact:
+
+   The sender will indicate one or more electronic mail addresses
+   (persons or lists) that may be contacted for clarification of the
+   liaison statement.
+
+2.2.1.1.6.  Purpose:
+
+   A liaison statement generally has one of three purposes and will
+   clearly state its purpose using one of the following labels:
+
+   For Information: The liaison statement is to inform the addressee of
+      something, and expects no response.
+
+   For Comment: The liaison statement requests commentary from the
+      addressee, usually within a stated time frame.
+
+   For Action: The liaison statement requests that the addressee do
+      something on the sender's behalf, usually within a stated time
+      frame.
+
+   In Response: The liaison statement includes a response to a liaison
+      statement from the peer organization on one or more of its
+      documents and expects no further response.
+
+2.2.1.1.7.  Deadline:
+
+   Liaison statements that request comment or action will indicate when
+   the comment or action is required.  If the addressee cannot
+   accomplish the request within the stated period, courtesy calls for a
+   response offering a more doable deadline or an alternative course of
+   action.
+
+2.2.1.2.  Liaison Content
+
+   The following fields are the substance of the liaison statement.
+   IETF participants use a wide variety of systems, thus document
+   formats that are not universally readable are problematic.  As a
+
+
+
+Trowbridge, et al.       Best Current Practice                  [Page 5]
+
+RFC 4053             Handling of Liaison Statements           April 2005
+
+
+   result, documents enclosed with the body or attachments should be in
+   PDF, W3C HTML (without proprietary extensions), or ASCII text format.
+   If they were originally in a proprietary format such as Microsoft
+   Word, the file may be sent, but should be accompanied by a generally
+   readable file.
+
+2.2.1.2.1.  Body:
+
+   As with any business letter, the liaison statement contains
+   appropriate content explaining the issues or questions at hand.
+
+2.2.1.2.2.  Attachments:
+
+   Attachments, if enclosed, may be in the form of documents sent with
+   the liaison statement or may be URLs to similar documents including
+   Internet Drafts.
+
+2.3.  Addressee Responsibilities
+
+   The responsibilities of the addressee of a liaison statement are the
+   same as the responsibilities of any business letter.  A liaison
+   statement calls for appropriate consideration of its contents, and if
+   a reply is requested and an appropriate relationship exists, a
+   courteous authoritative reply within the expected time frame.  The
+   reply may be that the information was useful or not useful, that the
+   requested action has been accomplished, it will be accomplished by a
+   specified date, it will not be done for a specific reason, an answer
+   to a question posed, or any other appropriate reply.
+
+   A liaison statement, like any other temporary document, must be
+   considered for its relevance, importance, and urgency.
+
+   One hopes that a liaison statement will be sent to the right
+   organization, but this cannot be assured.  An SDO might send a
+   liaison statement to a specific IETF Area whose Area Director (AD)
+   deems it better handled by one of the WGs, or it might be sent to one
+   WG when it should have gone to another.  If a liaison statement
+   arrives that appears misdirected, the assignee should promptly ask
+   the liaison manager to redirect it appropriately.  In some cases, a
+   liaison statement may require consideration by multiple groups within
+   the IETF; in such cases, one assignee takes the lead and
+   responsibility for developing a response.
+
+   Liaison Statements are always important to the body that sent them.
+   Having arrived at the appropriate body, the liaison statement may be
+   more or less important to the addressee depending on its contents and
+   the expertise of the sender.  If the liaison statement seeks to
+   influence the direction of a WG's development, it should receive the
+
+
+
+Trowbridge, et al.       Best Current Practice                  [Page 6]
+
+RFC 4053             Handling of Liaison Statements           April 2005
+
+
+   same consideration that any temporary document receives.  The WG
+   chair may request the sender's contacts to make their case to the
+   IETF WG in the same manner that an author of an internet draft makes
+   his or her case.
+
+   The urgency of a liaison statement is usually reflected in its
+   deadline.  A liaison statement for informational purposes may have no
+   deadline; in such a case, a courteous "thank you" liaison statement
+   is necessary to inform the sender that the liaison statement was
+   received.  The WG may then inform itself of the contents and close
+   the document.  A liaison statement specifying a deadline, however,
+   gives the addressee a finite opportunity to influence the activity of
+   another body; if it fails to react in a timely fashion, it may miss
+   the opportunity.
+
+2.4.  Lifetime of a Liaison Statement
+
+   A liaison statement is a temporary document, much like an internet
+   draft.  If it affects IETF output, the normal expectation is that the
+   resulting RFC will contain relevant information that remains
+   pertinent.  Retaining liaison statements that have been completely
+   dealt with mostly serves to hide new ones and create the appearance
+   of not dealing with them.
+
+   However, unlike an internet draft, liaison statements are often the
+   only record the IETF has of the communication with the peer SDO.  As
+   such, some liaison statements are referred to for relatively long
+   periods of time.
+
+   As a result, the IETF will archive liaison statements that have been
+   fully dealt with, along with any attachments that may have been
+   relevant, but do so in a manner obviously distinct from current
+   liaison statements.
+
+3.  Tools for Handling Liaison Statements
+
+   Some tools have been developed for the IETF.  Development is expected
+   to continue.  This section describes the basic tool and its intended
+   use.
+
+3.1.  Liaison Statements from Other SDOs, Consortia, and Fora to IETF
+
+   The process of handling a liaison statement is more weighty than
+   handling a business letter because it is important to a relationship
+   with another SDO established by the IAB.  To manage liaison
+   statements, the IETF will offer three electronically accessible
+   facilities: a form for submission of liaison statements, a mechanism
+   organizing their contents and making them accessible, and a tracking
+
+
+
+Trowbridge, et al.       Best Current Practice                  [Page 7]
+
+RFC 4053             Handling of Liaison Statements           April 2005
+
+
+   system.  Initially, the tracking system will be a manual procedure
+   used by the liaison manager; in the future, this should be automated.
+
+3.1.1.  Liaison Statement Submission
+
+   The IETF Secretariat will provide an electronic method for submission
+   of liaison statements.
+
+   The liaison statement submission mechanism is a form that requests
+   the information listed in Section 2.2.1 from the user.
+
+   Submission of that information results in the following actions:
+
+   o  creation of a display mechanism containing the envelope data in
+      Section 2.2.1.1 and URLs pointing to the items from
+      Section 2.2.1.2, an indication whether the liaison statement has
+      been replied to, and if so, on what date,
+
+   o  the addition of a URL to the "outstanding liaison statements"
+      summary mechanism,
+
+   o  when an automated tracking system has been implemented, a tickler/
+      status entry in the tracking system, assigned to the relevant
+      chair or AD,
+
+   o  an email to the assignee copying
+
+      *  the liaison statement's technical contacts
+
+      *  The supervisor of the assignee (if it is to a WG, the relevant
+         ADs; if to an AD, the IETF Chair),
+
+      *  The liaison manager for the sending SDO,
+
+      *  an alias associated with the assignee (WG/BOF or other open
+         mailing list, Area Directorate, IESG, IAB, etc.)
+
+      This email should contain the URL to the liaison statement
+      mechanism, text indicating that the liaison statement has arrived,
+      requests appropriate consideration, and if a deadline is
+      specified, a reply by the deadline.
+
+   The assignee has the capability of interacting with the liaison
+   manager and the tracking system (once implemented), including
+   replying, changing dates, reassignment, closing the liaison statement
+   process, etc.
+
+
+
+
+
+Trowbridge, et al.       Best Current Practice                  [Page 8]
+
+RFC 4053             Handling of Liaison Statements           April 2005
+
+
+   The liaison manager or tracking system's "tickle" function
+   periodically reminds the assignee by email that the liaison statement
+   has not yet been closed.  This tickle email copies all of the above
+   except the associated mailing alias.
+
+3.1.2.  Mechanism for Displaying Liaison Statements
+
+   The IETF site contains a section for current liaison statement
+   activity.  This consists of:
+
+   o  A submission mechanism,
+
+   o  A status/management mechanism for each active or recently closed
+      liaison statement, and zero or more associated files.
+
+   The status/management mechanism contains a simple frame, showing the
+   title of the liaison statement, the URL for its mechanism, and the
+   organizations it is from and to.
+
+   The display for liaison statement itself contains:
+
+   o  the liaison statement envelope information (Section 2.2.1),
+
+   o  direct content (Section 2.2.1),
+
+   o  URLs for the various associated files
+
+   o  current status of the liaison statement: to whom it is assigned,
+      its due date, and its status,
+
+   o  pointer to the liaison manager and tracking system entry for the
+      liaison statement.
+
+   o  reply-generation mechanism (see Section 3.2.2.4)
+
+
+3.2.  Communicating IETF Information to Other SDOs, Consortia, and Fora
+
+   This includes liaison statements sent in reply to liaison statements
+   sent by other bodies, and liaison statements being originated by the
+   IETF.
+
+3.2.1.  Spontaneously Generating Liaison Statements to Other
+        Organizations
+
+   Liaison Statements can be generated at a WG, Area, or IETF level to
+   another organization.  The respective (co)chair(s) are responsible
+   for judging the degree of consensus for sending the particular
+
+
+
+Trowbridge, et al.       Best Current Practice                  [Page 9]
+
+RFC 4053             Handling of Liaison Statements           April 2005
+
+
+   liaison statement and deciding the content.  The amount of consensus
+   required to send a liaison statement varies greatly depending on its
+   content.  This section gives some rough guidance about how much
+   consensus should be sought before sending a liaison statement to
+   another organization.
+
+3.2.1.1.  Transmitting IETF Documents to Other Organizations
+
+   The simplest case of approving sending of a liaison statement from
+   IETF is when the information being transmitted consists of an IETF
+   document that has some level of agreement within the IETF.  The
+   process that the document has already gone through to achieve its
+   current status assures the necessary level of consensus.  Any
+   Standards Track RFC (Draft Standard, Proposed Standard, Internet
+   Standard, BCP), and any WG document expected to be placed on the
+   standards track, may be transmitted without concern.
+
+   Informational documents may also be exchanged readily when they
+   represent a WG position or consensus, such as a requirements or
+   architecture document.
+
+   In all cases, the document status must be appropriately noted.  In
+   the case of a WG Internet Draft, it must be clear that the existence
+   of the draft only indicates that the WG has accepted the work item
+   and, as the standard disclaimer says, the actual content can be
+   treated as nothing more than Work in Progress.
+
+   Individually submitted Internet Drafts, Experimental or Historical
+   RFCs, and non-WG informational documents should not be transmitted
+   without developing further consensus within the relevant group, as
+   these documents cannot be truthfully represented as any kind of IETF
+   position.
+
+3.2.1.2.  Requests for Information
+
+   Another type of liaison statement that can be generated without the
+   need for extensive consensus building on the email list is a request
+   for information.  The (co)chairs(s) can generate such a liaison
+   statement when they recognize, from the activities of the group, that
+   some additional information is helpful, for example, to resolve an
+   impasse (i.e., don't waste time arguing over what the real meaning or
+   intent of another SDOs document is, just ask the other SDO and base
+   further work on the "official" answer).
+
+   Other requests for information may request access to certain
+   documents of other organizations that are not publicly available.
+
+
+
+
+
+Trowbridge, et al.       Best Current Practice                 [Page 10]
+
+RFC 4053             Handling of Liaison Statements           April 2005
+
+
+3.2.1.3.  Requesting Comments on Work in Progress
+
+   There may be cases when one feels that a document under development
+   in the IETF may benefit from the input of experts in another relevant
+   SDO, consortium, or forum.  Generally, this is done before the text
+   is "fully cooked" so that input from experts in another organization
+   can be included in the final result.  Comments would generally be
+   solicited for a standards track WG Internet Draft and some level of
+   consensus should be reached on the WG or other open mailing list that
+   it is appropriate to ask another organization for comments on an IETF
+   draft.
+
+3.2.1.4.  Requests for Other Actions (Besides Comments on IETF Drafts)
+
+   There are many other kinds of actions that might reasonably be
+   requested of another organization:
+
+   o  In the case of overlapping or related work in another
+      organization, a request could be made that the other organization
+      change something to align with the IETF work.
+
+   o  A request could be made for another organization to start a new
+      work item (on behalf of IETF).
+
+   o  A request could be made for another organization to stop a work
+      item (presumably because it overlaps or conflicts with other work
+      in the IETF).
+
+   These kinds of requests are quite serious.  They can certainly be
+   made when appropriate, but should only be made when there is the
+   clearest possible consensus within the particular WG, Area, or within
+   the IETF at large.
+
+3.2.2.  Responding to Incoming Liaison Statements
+
+   Any incoming liaison statement that indicates that it is for
+   "Comment" or for "Action" requires a response by the deadline; other
+   liaison statements may also be replied to, although a reply is
+   generally optional.  It is the responsibility of the (co)chair(s) of
+   the addressed organization to ensure that a response is generated by
+   the deadline.
+
+3.2.2.1.  Responding to Requests for Information
+
+   If another organization requests information that can be found in an
+   IETF document of the types indicated in Section 3.2.1.1, this can be
+   transmitted by the (co)chair(s) of the addressed group, indicating
+   the level of agreement for the relevant document.
+
+
+
+Trowbridge, et al.       Best Current Practice                 [Page 11]
+
+RFC 4053             Handling of Liaison Statements           April 2005
+
+
+3.2.2.2.  Responding to Requests for Comments
+
+   If an incoming liaison statement requests comments on a document from
+   another organization, a discussion will occur on the mailing list
+   where participants can provide their comments.
+
+   If a clear consensus is evident from the pattern of comments made to
+   the mailing list, the (co)chair(s) can summarize the conclusions in a
+   reply liaison statement back to the originating organization.
+
+   If no clear consensus is evident from the pattern of comments on the
+   mailing list, or if there is no further discussion, a response is
+   still due to the originator.  A summary of the email comments, or
+   lack of interest in the issue, should be created and sent to the
+   originator, and represented as "collected comments" rather than a
+   consensus of the IETF group to which the liaison statement was
+   addressed.  It is possible to send this kind of a reply even if some
+   of the comments are contradictory.
+
+3.2.2.3.  Responding to Request for Action
+
+   A request for Action is a fairly serious thing.  Examples of the
+   kinds of actions that may be expected are:
+
+   o  In the case of overlapping or related work in another
+      organization, another organization may request that the IETF align
+      its work with that of the other organization.
+
+   o  A request could be made for IETF to undertake a new work item.
+
+   o  A request could be made for IETF to stop a work item (presumably
+      because it overlaps or conflicts with other work in the
+      originating organization).
+
+   Consensus of the receiving group within IETF is clearly necessary to
+   fulfill the request.  Fulfilling the request may require a great deal
+   of time and multiple steps, for example, if initiating or stopping a
+   work item requires a charter change.
+
+   There is, of course, no requirement that IETF perform the action that
+   was requested.  But the request should always be taken seriously, and
+   a response is required.  The originating organization must always be
+   informed of what, if anything, the IETF has decided to do in response
+   to the request.  If the IETF decides not to honor the request, or to
+   honor it with modifications, the response should include the reasons
+   and, if applicable, the alternate course of action.
+
+
+
+
+
+Trowbridge, et al.       Best Current Practice                 [Page 12]
+
+RFC 4053             Handling of Liaison Statements           April 2005
+
+
+   For tasks that require a great deal of time, it may be necessary that
+   several liaison statements be sent back to the originating
+   organization to report the status of the work and the anticipated
+   completion time.  The first of these liaison statements must be
+   generated by the deadline indicated in the incoming liaison
+   statement.
+
+3.2.2.4.  Generating Liaison Statements
+
+   IETF participants, usually WG chairs, ADs, or other officials, need
+   to be able to send liaison statements to other SDOs.  The mechanism
+   described in Section 3.1.2, listing appropriate contacts in other
+   SDOs with which the IAB has established liaison relationships,
+   provides that capability.
+
+   As a convenience, the liaison statement page described in
+   Section 3.1.2 may be used to generate a reply.  If a person (usually
+   a WG chair or an AD) selects "reply", a new liaison statement page is
+   generated from the existing one, reversing the addressing
+   information.  IETF documents should be referenced by URL, such as
+   http://www.ietf.org/internet-drafts/>file< or
+   ftp://ftp.rfc-editor.org/in-notes/>file<.
+
+   The process of generating and approving transmission of liaison
+   statements is a matter of IETF process and is specified in [RFC4052].
+
+4.  Security Considerations
+
+   One of the key considerations in developing this process has been the
+   possibility of a denial of service attack on the IETF and its
+   processes.  Historically, the IETF has not always handled liaison
+   statements effectively, resulting in people working in other
+   organizations becoming frustrated with it.  Various organizations
+   have also used the liaison statement process to impose deadlines on
+   IETF activities, which has been frustrating for all concerned - the
+   IETF because it does not accept such deadlines, and other
+   organizations because they feel ignored.
+
+   For this reason the submission process is automated.  While the IETF
+   cannot rate-limit the submitters, it can manage its internal
+   pipelines.
+
+   This issue is exacerbated by the lack of any authentication on the
+   part of the submitter.  However, the IAB considers it important to be
+   able to accept liaison statements whether or not a liaison
+   relationship exists, so authentication of submitters is not an
+   effective control.
+
+
+
+
+Trowbridge, et al.       Best Current Practice                 [Page 13]
+
+RFC 4053             Handling of Liaison Statements           April 2005
+
+
+5.  Acknowledgements
+
+   This text has been prompted by discussions with numerous individuals
+   within IETF and other SDOs and fora, including Gary Fishman and Bert
+   Wijnen.  It has been developed in cooperation with [RFC4052], which
+   is to say with the express cooperation of the chair of the IAB,
+   Leslie Daigle.  Personal experiences and some "miscues" in
+   coordinating work across ITU-T Study Group 15 and the IETF Sub-IP
+   Area have also motivated this work.  Some drafts addressing
+   individual problems (for example, RFC 3427) make it clear that a more
+   general, consistent solution is needed for dealing with outside
+   organizations.  Certain ideas have been borrowed from these texts.
+
+   Barbara Fuller, Sunny Lee, and Michael Lee developed a prototype and
+   commented in detail on the document.  Their inputs directly resulted
+   in the appendices describing the implementation road map.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Trowbridge, et al.       Best Current Practice                 [Page 14]
+
+RFC 4053             Handling of Liaison Statements           April 2005
+
+
+Appendix A.  Implementation Road Map
+
+   This section documents the development program as of the time of the
+   writing of this document.  It is not normative.
+
+A.1.  Phase I: Initial Implementation
+
+A.1.1.  Displays
+
+   The descriptions of the required displays in Section 3.1.1 and
+   Section 3.1.2 call for two sets of displays: one for the public (for
+   viewing liaison statements), and one for submitters (for managing
+   liaison statements).
+
+   Displays for public view of liaison statements include:
+
+   o  A Liaison Statements Web page that lists all incoming and outgoing
+      liaison statements (specific fields TBD).  The title of each
+      liaison statement is a link to the details page for that liaison
+      statement.
+
+   o  A detail page for each liaison statement that contains:
+
+      *  All of the information specified in the subsections of
+         Section 2.2.1.
+
+      *  Links to all attachments that accompanied the liaison statement
+         or to documents that are mentioned in the statement but were
+         not provided as part of the submission.
+
+      *  Links to all related liaison statements (e.g., replies).
+
+   Displays for submitting and managing liaison statements include:
+
+   o  A summary page that offers mechanisms for:
+
+      *  Creating and submitting a new liaison statement.
+
+      *  Editing a liaison statement that the user has previously
+         created and submitted.
+
+      *  Acting on a liaison statement that has been assigned to the
+         user.
+
+
+
+
+
+
+
+
+Trowbridge, et al.       Best Current Practice                 [Page 15]
+
+RFC 4053             Handling of Liaison Statements           April 2005
+
+
+   o  A template for creating and submitting a liaison statement.  This
+      template allows the user to enter the information specified in
+      Section 2.2.1.  The user is able to access the template at any
+      time (from a list of liaison statements that the user has
+      previously created and submitted), and update and resubmit the
+      information.
+
+   o  A detail page for managing a liaison statement assigned to the
+      user.  This page is similar to the details page available to the
+      public.  However, it also includes:
+
+      *  A mechanism for replying to the liaison statement (initial
+         implementation)
+
+      *  A link to a liaison statement tracking mechanism (future
+         implementation)
+
+A.1.2.  Actions on Submission
+
+   Submission of a liaison statement results in the following actions:
+
+   o  The information is uploaded to the database.
+
+   o  An e-mail message with the content specified in Section 3.1.1 is
+      sent to the addressee with copies to the addresses specified in
+      Section 4.1, and to the Secretariat (as specified in [RFC4052]).
+
+   o  The liaison statement is added to the list on the Liaison
+      Statements Web page.
+
+   o  Two detail pages are created for the liaison statement: one for
+      the public (to view the liaison statement), and one for the sender
+      and the assignee (to manage the liaison statement).
+
+   As specified in Section 3.2.2.4, when a user selects reply on the
+   details page of a liaison statement, a template for creating and
+   submitting a new liaison statement is generated from the existing one
+   that copies "From" to "To" and specifies the respondent as the
+   individual the response is coming "From".  Submission of this reply
+   liaison statement results in the same set of actions as submission of
+   any new liaison statement.  In addition, a link to the details page
+   of this liaison statement is added to the list of related liaison
+   statements on the details pages (both public and management) of the
+   original liaison statement (i.e., the one to which the user replied).
+
+
+
+
+
+
+
+Trowbridge, et al.       Best Current Practice                 [Page 16]
+
+RFC 4053             Handling of Liaison Statements           April 2005
+
+
+Appendix B.  Phase II: Additional Instrumentation and Responses to Usage
+             Experience
+
+   This section is for information, and is not normative.
+
+   The intended features of the future liaison statement tracking system
+   are discussed in Section 3.1.  They include mechanisms for:
+
+   o  Designating an assignee; the assignee is initially a person
+      associated with the body (IAB, IESG, Area, WG, etc.) to which the
+      liaison statement is addressed, but may subsequently be changed by
+      an IETF participant.
+
+   o  Indicating the status of the liaison statement (e.g., actions
+      required, actions taken, etc.  Specific options TBD).
+
+   o  Sending ticklers to the assignee when action is required (with
+      copies to whomever is appropriate).
+
+   o  Changing the status of the liaison statement, the deadline, or
+      other attributes.
+
+   o  Reassigning responsibility.
+
+   o  Closing the liaison statement.
+
+Normative References
+
+   [RFC4052]  Daigle, L., "IAB Processes for Management of Liaison
+              Relationships", RFC 4052, April 2005.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Trowbridge, et al.       Best Current Practice                 [Page 17]
+
+RFC 4053             Handling of Liaison Statements           April 2005
+
+
+Authors' Addresses
+
+   Stephen J. Trowbridge
+   Lucent Technologies
+   1200 West 120th Avenue, Suite 232, Room 34Z07
+   Westminster, Colorado  80234-2795
+   USA
+
+   Phone: +1 303 920 6545
+   Fax:   +1 303 920 6553
+   EMail: sjtrowbridge@lucent.com
+
+
+   Scott Bradner
+   Harvard University
+   29 Oxford St.
+   Cambridge, Massachusetts  02138
+   USA
+
+   Phone: +1 617 495 3864
+   Fax:   +1 617 492 8835
+   EMail: sob@harvard.edu
+
+
+   Fred Baker
+   Cisco Systems
+   1121 Via Del Rey
+   Santa Barbara, California  93117
+   USA
+
+   Phone: +1-408-526-4257
+   Fax:   +1-413-473-2403
+   EMail: fred@cisco.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Trowbridge, et al.       Best Current Practice                 [Page 18]
+
+RFC 4053             Handling of Liaison Statements           April 2005
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2005).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at ietf-
+   ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+Trowbridge, et al.       Best Current Practice                 [Page 19]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4053.txt](<www.ietf.org/rfc/rfc4053.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
