### PR TITLE
Archive rfc4069.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4069.txt
+++ b/www.ietf.org/rfc/rfc4069.txt
@@ -1,0 +1,1067 @@
+
+
+
+
+
+
+Network Working Group                                           M. Dodge
+Request for Comments: 4069                                   ECI Telecom
+Category: Standards Track                                         B. Ray
+                                                  PESA Switching Systems
+                                                                May 2005
+
+
+                Definitions of Managed Object Extensions
+       for Very High Speed Digital Subscriber Lines (VDSL) Using
+              Single Carrier Modulation (SCM) Line Coding
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2005).
+
+Abstract
+
+   This document defines a portion of the Management Information Base
+   (MIB) module for use with network management protocols in the
+   Internet community.  In particular, it describes objects used for
+   managing the Line Code Specific parameters of Very High Speed Digital
+   Subscriber Line (VDSL) interfaces using Single Carrier Modulation
+   (SCM) Line Coding.  It is an optional extension to the VDSL-LINE-MIB,
+   RFC 3728, which handles line code independent objects.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Dodge & Ray                 Standards Track                     [Page 1]
+
+RFC 4069                 VDSL-LINE-EXT-SCM-MIB                  May 2005
+
+
+Table of Contents
+
+   1.  The Internet-Standard Management Framework .............. ....  2
+   2.  Overview .....................................................  2
+       2.1.  Relationship of this MIB Module to Other MIB Modules ...  3
+       2.2.  Conventions Used in the MIB Module .....................  3
+       2.3.  Structure ..........................  ..................  3
+       2.4.  Persistence ............................................  4
+   3.  Conformance and Compliance ...................................  5
+   4.  Definitions ..................................................  5
+   5.  Acknowledgements ............................................. 14
+   6.  Security Considerations ...................................... 14
+   7.  IANA Considerations .......................................... 16
+   8.  References ................................................... 16
+       8.1.  Normative References ................................... 16
+       8.2.  Informative References ................................. 17
+
+1.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This memo specifies a MIB
+   module that is compliant to the SMIv2, which is described in STD 58,
+   RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579] and STD 58, RFC 2580
+   [RFC2580].
+
+2.  Overview
+
+   This document describes an SNMP MIB module for managing the Line Code
+   Dependent, Physical Medium Dependent (PMD) Layer of SCM VDSL Lines.
+   These definitions are based upon the specifications for VDSL as
+   defined in T1E1, European Telecommunications Standards Institute
+   (ETSI), and International Telecommunication Union (ITU) documentation
+   [T1E1311, T1E1011, T1E1013, ETSI2701, ETSI2702, ITU9931, ITU9971].
+   Additionally the protocol-dependent (and line-code dependent)
+   management framework for VDSL lines specified by the Digital
+   Subscriber Line Forum (DSLF) has been taken into consideration
+   [DSLFTR57] and [DSLFWT96].
+
+
+
+
+
+
+
+Dodge & Ray                 Standards Track                     [Page 2]
+
+RFC 4069                 VDSL-LINE-EXT-SCM-MIB                  May 2005
+
+
+   The MIB module is located in the MIB tree under MIB-2 transmission.
+
+   The key words "MUST", "MUST NOT", "RECOMMENDED", and "SHOULD" in this
+   document are to be interpreted as described in [RFC2119].
+
+2.1.  Relationship of this MIB Module to Other MIB Modules
+
+   The relationship of the VDSL Line MIB module to other MIB modules, in
+   particular to the IF-MIB presented in RFC 2863 [RFC2863], is
+   discussed in the VDSL-LINE-MIB, RFC 3728 [RFC3728].  This section
+   outlines the relationship of this VDSL Line Extension MIB to the
+   VDSL-LINE-MIB, RFC 3728 [RFC3728].
+
+2.2.  Conventions Used in the MIB Module
+
+2.2.1.  Naming Conventions
+
+   A.  Vtuc -- VDSL transceiver unit at near (Central) end of line
+   B.  Vtur -- VDSL transceiver unit at Remote end of line
+   C.  Vtu  -- One of either Vtuc or Vtur
+   D.  Curr -- Current
+   F.  Atn  -- Attenuation
+   J.  LCS  -- Line Code Specific
+   K.  Max  -- Maximum
+   Q.  Mgn  -- Margin
+   S.  PSD  -- Power Spectral Density
+   T.  Rx   -- Receive
+   T.  Snr  -- Signal to Noise Ratio
+   U.  Tx   -- Transmit
+
+2.3.  Structure
+
+   The SCM VDSL Line Extension MIB contains the following MIB group:
+
+   o   vdslSCMGroup :
+
+   This group supports MIB objects for defining configuration profiles
+   and for monitoring individual bands of Single Carrier Modulation
+   (SCM) VDSL modems.  It contains the following tables:
+
+      - vdslLineSCMConfProfileTxBandTable
+      - vdslSCMPhysBandTable
+
+   If the SCM VDSL Line Extension MIB is implemented then all objects in
+   this group MUST be implemented.
+
+   Figure 1 below displays the relationship of the tables in the
+   vdslSCMGroup to the vdslGroup and to the ifEntry:
+
+
+
+Dodge & Ray                 Standards Track                     [Page 3]
+
+RFC 4069                 VDSL-LINE-EXT-SCM-MIB                  May 2005
+
+
+      ifEntry(ifType=97)  ----> vdslLineTableEntry 1:(0..1)
+
+       vdslLineTableEntry (vdslLineCoding=SCM)
+             ----> vdslPhysTableEntry 1:(0..2)
+                 ----> vdslSCMPhysBandTable 1:(0..5)
+
+       vdslLineConfProfileEntry(vdslLineConfProfileName)
+                     ----> vdslLineSCMConfProfileBandTable 1:(0..5)
+
+                       Figure 1: Table Relationships
+
+   When the object vdslLineCoding is set to SCM, vdslLineConfProfileName
+   is used as the index to vdslLineSCMConfProfileBandTable.  The
+   existence of an entry in any of the tables of the vdslSCMGroup is
+   optional.
+
+2.4.  Persistence
+
+   All read-create objects defined in this MIB module SHOULD be stored
+   persistently.  Following is an exhaustive list of these persistent
+   objects:
+
+      vdslLineSCMConfProfileBandId
+      vdslLineSCMConfProfileBandUsage
+      vdslLineSCMConfProfileBandCenterFrequency
+      vdslLineSCMConfProfileBandSymbolRate
+      vdslLineSCMConfProfileBandConstellationSize
+      vdslLineSCMConfProfileBandTransmitPSDLevel
+      vdslLineSCMConfProfileBandRowStatus
+      vdslLineSCMPhysBandId
+      vdslLineSCMPhysBandUsage
+      vdslLineSCMPhysBandCurrPSDLevel
+      vdslLineSCMPhysBandCurrSymbolRate
+      vdslLineSCMPhysBandCurrConstellationSize
+      vdslLineSCMPhysBandCurrCenterFrequency
+      vdslLineSCMPhysBandPerformanceBandId
+      vdslLineSCMPhysBandPerformanceBandUsage
+      vdslLineSCMPhysBandPerformanceBandSnrMgn
+      vdslLineSCMPhysBandPerformanceBandAtn
+
+   Note also that the interface indices in this MIB are maintained
+   persistently.  View-based Access Control Model (VACM) data relating
+   to these SHOULD be stored persistently as well [RFC3415].
+
+
+
+
+
+
+
+
+Dodge & Ray                 Standards Track                     [Page 4]
+
+RFC 4069                 VDSL-LINE-EXT-SCM-MIB                  May 2005
+
+
+3.  Conformance and Compliance
+
+   An SCM based VDSL agent does not have to implement this MIB to be
+   compliant with RFC 3728 [RFC3728].  If the SCM VDSL Line Extension
+   MIB is implemented then the following group is mandatory:
+
+      -  vdslSCMGroup
+
+4.  Definitions
+
+   VDSL-LINE-EXT-SCM-MIB DEFINITIONS ::= BEGIN
+
+   IMPORTS
+
+   MODULE-IDENTITY,
+   OBJECT-TYPE,
+   Integer32,
+   transmission,
+   Unsigned32                      FROM SNMPv2-SMI         -- [RFC2578]
+   TEXTUAL-CONVENTION,
+   TruthValue,
+   RowStatus                       FROM SNMPv2-TC          -- [RFC2579]
+   MODULE-COMPLIANCE,
+   OBJECT-GROUP                    FROM SNMPv2-CONF        -- [RFC2580]
+   ifIndex                         FROM IF-MIB             -- [RFC2863]
+   vdslLineConfProfileName         FROM VDSL-LINE-MIB;     -- [RFC3728]
+
+   vdslExtSCMMIB MODULE-IDENTITY
+      LAST-UPDATED "200504280000Z" --     April 28, 2005
+      ORGANIZATION "ADSLMIB Working Group"
+      CONTACT-INFO "WG-email:  adslmib@ietf.org
+            Info:      https://www1.ietf.org/mailman/listinfo/adslmib
+
+            Chair:     Mike Sneed
+                       Sand Channel Systems
+            Postal:    P.O. Box 37324
+                       Raleigh NC 27627-732
+            Email:     sneedmike@hotmail.com
+            Phone:     +1 206 600 7022
+
+            Co-Chair/Co-editor:
+                       Bob Ray
+                       PESA Switching Systems, Inc.
+            Postal:    330-A Wynn Drive
+                       Huntsville, AL 35805
+                       USA
+            Email:     rray@pesa.com
+            Phone:     +1 256 726 9200 ext.  142
+
+
+
+Dodge & Ray                 Standards Track                     [Page 5]
+
+RFC 4069                 VDSL-LINE-EXT-SCM-MIB                  May 2005
+
+
+            Co-editor: Menachem Dodge
+                       ECI Telecom Ltd.
+            Postal:    30 Hasivim St.
+                       Petach Tikva 49517,
+                       Israel
+            Email:     mbdodge@ieee.org
+            Phone:     +972 3 926 8421
+           "
+
+   DESCRIPTION
+      "The VDSL-LINE-MIB found in RFC 3728 defines objects for the
+      management of a pair of VDSL transceivers at each end of the VDSL
+      line.  The VDSL-LINE-MIB configures and monitors the line code
+      independent parameters (TC layer) of the VDSL line.  This MIB
+      module is an optional extension of the VDSL-LINE-MIB and defines
+      objects for configuration and monitoring of the line code specific
+      (LCS) elements (PMD layer) for VDSL lines using SCM coding.  The
+      objects in this extension MIB MUST NOT be used for VDSL lines
+      using Multiple Carrier Modulation (MCM) line coding.  If an object
+      in this extension MIB is referenced by a line which does not use
+      SCM, it has no effect on the operation of that line.
+
+      Naming Conventions:
+
+         Vtuc -- VDSL transceiver at near (Central) end of line
+         Vtur -- VDSL transceiver at Remote end of line
+         Vtu  -- One of either Vtuc or Vtur
+         Curr -- Current
+         Atn  -- Attenuation
+         LCS  -- Line Code Specific
+         Max  -- Maximum
+         Mgn  -- Margin
+         PSD  -- Power Spectral Density
+         Rx   -- Receive
+         Snr  -- Signal to Noise Ratio
+         Tx   -- Transmit
+
+      Copyright (C) The Internet Society (2005).  This version
+      of this MIB module is part of RFC 4069: see the RFC
+      itself for full legal notices."
+              REVISION "200504280000Z" --     April 28, 2005
+              DESCRIPTION "Initial version, published as RFC 4069."
+          ::= { transmission 228 }
+
+          vdslLineExtSCMMib    OBJECT IDENTIFIER ::= { vdslExtSCMMIB 1 }
+          vdslLineExtSCMMibObjects OBJECT IDENTIFIER ::=
+                                                 { vdslLineExtSCMMib 1 }
+   --
+
+
+
+Dodge & Ray                 Standards Track                     [Page 6]
+
+RFC 4069                 VDSL-LINE-EXT-SCM-MIB                  May 2005
+
+
+   -- textual conventions used in this MIB
+   --
+
+   VdslSCMBandId ::= TEXTUAL-CONVENTION
+       STATUS       current
+       DESCRIPTION
+          "This data type is used as the syntax for the VDSL SCM Band
+           Identity.  Attributes with this syntax identify the SCM Band
+           referred to.  Specified as an INTEGER, the possible values
+           are:
+
+           optionalBand (1)  -- the optional Band range [25kHz - 138kHz]
+           firstDownstreamBand (2)  -- first Downstream Band
+           firstUpstreamBand (3)    -- first Upstream Band
+           secondDownstreamBand (4) -- second Downstream Band
+           secondUpstreamBand (5)   -- second Upstream Band
+           thirdDownstreamBand (6)  -- third Downstream Band
+           thirdUpstreamBand (7)    -- third Upstream Band"
+
+
+       SYNTAX      INTEGER       {  optionalBand (1),
+                                    firstDownstreamBand (2),
+                                    firstUpstreamBand (3),
+                                    secondDownstreamBand (4),
+                                    secondUpstreamBand (5),
+                                    thirdDownstreamBand (6),
+                                    thirdUpstreamBand(7) }
+
+   --
+   -- Single carrier modulation (SCM) configuration profile tables
+   --
+
+   vdslLineSCMConfProfileBandTable OBJECT-TYPE
+       SYNTAX       SEQUENCE OF VdslLineSCMConfProfileBandEntry
+       MAX-ACCESS   not-accessible
+       STATUS       current
+       DESCRIPTION
+          "This table contains transmit band descriptor configuration
+           information for a VDSL line.  Each entry in this table
+           reflects the configuration for one of possibly many bands
+           of a single carrier modulation (SCM) VDSL line.  For each
+           profile which is associated with a VDSL line using SCM
+           line coding, five entries in this table will exist, one for
+           each of the five bands.  Bands which are not in use will be
+           marked as unused.  These entries are defined by a manager
+           and can be used to configure the VDSL line.  If an entry in
+
+
+
+
+
+Dodge & Ray                 Standards Track                     [Page 7]
+
+RFC 4069                 VDSL-LINE-EXT-SCM-MIB                  May 2005
+
+
+           this table is referenced by a line which does not use SCM,
+           it has no effect on the operation of that line."
+       ::= { vdslLineExtSCMMibObjects 1 }
+
+   vdslLineSCMConfProfileBandEntry OBJECT-TYPE
+       SYNTAX       VdslLineSCMConfProfileBandEntry
+       MAX-ACCESS   not-accessible
+       STATUS       current
+       DESCRIPTION
+          "Each entry consists of a list of parameters that
+           represents the configuration of a single carrier
+           modulation VDSL modem transmit band.
+
+           A default profile with an index of 'DEFVAL', will
+           always exist and its parameters will be set to vendor
+           specific values, unless otherwise specified in this
+           document.
+
+           All read-create objects defined in this MIB module SHOULD be
+           stored persistently."
+
+       INDEX { vdslLineConfProfileName,
+        vdslLineSCMConfProfileBandId }
+       ::= { vdslLineSCMConfProfileBandTable 1 }
+
+   VdslLineSCMConfProfileBandEntry ::=
+       SEQUENCE
+          {
+          vdslLineSCMConfProfileBandId                VdslSCMBandId,
+          vdslLineSCMConfProfileBandInUse             TruthValue,
+          vdslLineSCMConfProfileBandCenterFrequency   Unsigned32,
+          vdslLineSCMConfProfileBandSymbolRate        Unsigned32,
+          vdslLineSCMConfProfileBandConstellationSize Unsigned32,
+          vdslLineSCMConfProfileBandTransmitPSDLevel  Unsigned32,
+          vdslLineSCMConfProfileBandRowStatus         RowStatus
+          }
+
+   vdslLineSCMConfProfileBandId OBJECT-TYPE
+       SYNTAX      VdslSCMBandId
+       MAX-ACCESS  not-accessible
+       STATUS  current
+       DESCRIPTION
+          "The BandId for this entry, which specifies which band
+           is being referred to."
+       ::= { vdslLineSCMConfProfileBandEntry 1 }
+
+
+
+
+
+
+Dodge & Ray                 Standards Track                     [Page 8]
+
+RFC 4069                 VDSL-LINE-EXT-SCM-MIB                  May 2005
+
+
+   vdslLineSCMConfProfileBandInUse OBJECT-TYPE
+       SYNTAX       TruthValue
+       MAX-ACCESS   read-create
+       STATUS  current
+       DESCRIPTION
+          "Indicates whether this band is in use.
+           If set to True this band is in use."
+       ::= { vdslLineSCMConfProfileBandEntry 2 }
+
+   vdslLineSCMConfProfileBandCenterFrequency OBJECT-TYPE
+       SYNTAX       Unsigned32
+       UNITS        "Hz"
+       MAX-ACCESS   read-create
+       STATUS       current
+       DESCRIPTION
+          "Specifies the center frequency in Hz"
+       REFERENCE    "T1E1.4/2000-011R3"    -- Part 2, SCM
+       ::= { vdslLineSCMConfProfileBandEntry 3 }
+
+   vdslLineSCMConfProfileBandSymbolRate OBJECT-TYPE
+       SYNTAX       Unsigned32
+       UNITS        "baud"
+       MAX-ACCESS   read-create
+       STATUS       current
+       DESCRIPTION
+          "The requested symbol rate in baud."
+       REFERENCE    "T1E1.4/2000-011R3"    -- Part 2, SCM
+       ::= { vdslLineSCMConfProfileBandEntry 4 }
+
+   vdslLineSCMConfProfileBandConstellationSize OBJECT-TYPE
+       SYNTAX       Unsigned32 (0..16)
+       UNITS        "log2"
+       MAX-ACCESS   read-create
+       STATUS       current
+       DESCRIPTION
+          "Specifies the constellation size."
+       REFERENCE    "T1E1.4/2000-011R3"    -- Part 2, SCM
+       ::= { vdslLineSCMConfProfileBandEntry 5 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+Dodge & Ray                 Standards Track                     [Page 9]
+
+RFC 4069                 VDSL-LINE-EXT-SCM-MIB                  May 2005
+
+
+   vdslLineSCMConfProfileBandTransmitPSDLevel OBJECT-TYPE
+       SYNTAX       Unsigned32
+       UNITS        "-0.25 dBm/Hz"
+       MAX-ACCESS   read-create
+       STATUS       current
+       DESCRIPTION
+          "The requested transmit power spectral density for the VDSL
+           modem.  The Actual value in -0.25 dBm/Hz."
+       REFERENCE    "T1E1.4/2000-011R3"    -- Part 2, SCM
+       ::= { vdslLineSCMConfProfileBandEntry 6  }
+
+   vdslLineSCMConfProfileBandRowStatus OBJECT-TYPE
+       SYNTAX       RowStatus
+       MAX-ACCESS   read-create
+       STATUS       current
+       DESCRIPTION
+          "This object is used to create a new row or modify or
+           delete an existing row in this table.
+
+           A profile activated by setting this object to `active'.
+           When `active' is set, the system will validate the profile.
+
+           None of the columns in this row may be modified while the
+           row is in the `active' state.
+
+           Before a profile can be deleted or taken out of
+           service, (by setting this object to `destroy' or
+           `notInService') it must be first unreferenced
+           from all associated lines."
+
+       ::= { vdslLineSCMConfProfileBandEntry 7 }
+
+   --
+   -- SCM physical band
+   --
+
+   vdslLineSCMPhysBandTable OBJECT-TYPE
+       SYNTAX       SEQUENCE OF VdslLineSCMPhysBandEntry
+       MAX-ACCESS   not-accessible
+       STATUS       current
+       DESCRIPTION
+          "This table provides one row for each SCM Vtu band.  This
+           table is read only as it reflects the current physical
+           parameters of each band.  For each ifIndex which is
+           associated with a VDSL line using SCM line coding, five
+           entries in this table will exist, one for each of the
+           five bands.  Bands which are not in use will be marked
+           as unused."
+
+
+
+Dodge & Ray                 Standards Track                    [Page 10]
+
+RFC 4069                 VDSL-LINE-EXT-SCM-MIB                  May 2005
+
+
+       ::= { vdslLineExtSCMMibObjects 2 }
+
+   vdslLineSCMPhysBandEntry OBJECT-TYPE
+       SYNTAX        VdslLineSCMPhysBandEntry
+       MAX-ACCESS    not-accessible
+       STATUS        current
+       DESCRIPTION
+          "An entry in the vdslLineSCMPhysBandTable."
+       INDEX { ifIndex,
+               vdslLineSCMPhysBandId  }
+       ::= { vdslLineSCMPhysBandTable 1 }
+
+   VdslLineSCMPhysBandEntry ::=
+       SEQUENCE
+           {
+           vdslLineSCMPhysBandId                    VdslSCMBandId,
+           vdslLineSCMPhysBandInUse                 TruthValue,
+           vdslLineSCMPhysBandCurrCenterFrequency   Unsigned32,
+           vdslLineSCMPhysBandCurrSymbolRate        Unsigned32,
+           vdslLineSCMPhysBandCurrConstellationSize Unsigned32,
+           vdslLineSCMPhysBandCurrPSDLevel          Unsigned32,
+           vdslLineSCMPhysBandCurrSnrMgn            Integer32,
+           vdslLineSCMPhysBandCurrAtn               Unsigned32
+           }
+
+   vdslLineSCMPhysBandId OBJECT-TYPE
+       SYNTAX      VdslSCMBandId
+       MAX-ACCESS  not-accessible
+       STATUS  current
+       DESCRIPTION
+           "The BandId for this entry, which specifies which band
+            is being referred to."
+       ::= { vdslLineSCMPhysBandEntry 1 }
+
+   vdslLineSCMPhysBandInUse OBJECT-TYPE
+       SYNTAX      TruthValue
+       MAX-ACCESS  read-only
+       STATUS  current
+       DESCRIPTION
+          "Indicates whether this band is in use.
+           If set to True this band is in use."
+       ::= { vdslLineSCMPhysBandEntry 2 }
+
+
+
+
+
+
+
+
+
+Dodge & Ray                 Standards Track                    [Page 11]
+
+RFC 4069                 VDSL-LINE-EXT-SCM-MIB                  May 2005
+
+
+   vdslLineSCMPhysBandCurrCenterFrequency OBJECT-TYPE
+       SYNTAX       Unsigned32
+       UNITS        "Hz"
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+          "The current center frequency in Hz for this band."
+       REFERENCE    "T1E1.4/2000-011R3"    -- Part 2, SCM
+       ::= { vdslLineSCMPhysBandEntry 3 }
+
+   vdslLineSCMPhysBandCurrSymbolRate    OBJECT-TYPE
+       SYNTAX       Unsigned32
+       UNITS        "baud"
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+          "The current value of the symbol rate in baud for this
+           band."
+      REFERENCE    "T1E1.4/2000-011R3"    -- Part 2, SCM
+      ::= { vdslLineSCMPhysBandEntry 4 }
+
+   vdslLineSCMPhysBandCurrConstellationSize OBJECT-TYPE
+       SYNTAX       Unsigned32 (0..16)
+       UNITS        "log2"
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+          "The current constellation size on this band."
+       REFERENCE    "T1E1.4/2000-011R3"    -- Part 2, SCM
+       ::= { vdslLineSCMPhysBandEntry 5 }
+
+   vdslLineSCMPhysBandCurrPSDLevel    OBJECT-TYPE
+       SYNTAX       Unsigned32
+       UNITS        "- 0.25 dBm/Hz"
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+          "The transmit power spectral density for the
+           VDSL modem."
+       REFERENCE    "T1E1.4/2000-011R3"    -- Part 2, SCM
+       ::= { vdslLineSCMPhysBandEntry 6 }
+
+
+
+
+
+
+
+
+
+
+Dodge & Ray                 Standards Track                    [Page 12]
+
+RFC 4069                 VDSL-LINE-EXT-SCM-MIB                  May 2005
+
+
+   vdslLineSCMPhysBandCurrSnrMgn OBJECT-TYPE
+       SYNTAX        Integer32
+       UNITS         "0.25 dB"
+       MAX-ACCESS    read-only
+       STATUS        current
+       DESCRIPTION
+          "Noise margin as seen by this Vtu and band with respect
+           to its received signal in 0.25 dB."
+       ::= { vdslLineSCMPhysBandEntry 7 }
+
+   vdslLineSCMPhysBandCurrAtn OBJECT-TYPE
+       SYNTAX        Unsigned32 (0..255)
+       UNITS         "0.25 dB"
+       MAX-ACCESS    read-only
+       STATUS        current
+       DESCRIPTION
+          "Measured difference in the total power transmitted by
+           the peer Vtu on this band and the total power received
+           by this Vtu on this band in 0.25 dB."
+       ::= { vdslLineSCMPhysBandEntry 8 }
+
+   -- conformance information
+
+   vdslLineExtSCMConformance OBJECT IDENTIFIER ::=
+                                               { vdslLineExtSCMMib 2 }
+   vdslLineExtSCMGroups OBJECT IDENTIFIER ::=
+                                       { vdslLineExtSCMConformance 1 }
+   vdslLineExtSCMCompliances OBJECT IDENTIFIER ::=
+                                       { vdslLineExtSCMConformance 2 }
+
+   vdslLineExtSCMMibCompliance MODULE-COMPLIANCE
+       STATUS  current
+       DESCRIPTION
+          "The compliance statement for SNMP entities which
+           manage VDSL interfaces."
+
+       MODULE  -- this module
+
+       MANDATORY-GROUPS
+       {
+         vdslLineExtSCMGroup
+       }
+
+       ::= { vdslLineExtSCMCompliances 1 }
+
+
+
+
+
+
+
+Dodge & Ray                 Standards Track                    [Page 13]
+
+RFC 4069                 VDSL-LINE-EXT-SCM-MIB                  May 2005
+
+
+   -- units of conformance
+
+   vdslLineExtSCMGroup    OBJECT-GROUP
+       OBJECTS
+           {
+           vdslLineSCMConfProfileBandInUse,
+           vdslLineSCMConfProfileBandTransmitPSDLevel,
+           vdslLineSCMConfProfileBandSymbolRate,
+           vdslLineSCMConfProfileBandConstellationSize,
+           vdslLineSCMConfProfileBandCenterFrequency,
+           vdslLineSCMConfProfileBandRowStatus,
+           vdslLineSCMPhysBandInUse,
+           vdslLineSCMPhysBandCurrPSDLevel,
+           vdslLineSCMPhysBandCurrSymbolRate,
+           vdslLineSCMPhysBandCurrConstellationSize,
+           vdslLineSCMPhysBandCurrCenterFrequency,
+           vdslLineSCMPhysBandCurrSnrMgn,
+           vdslLineSCMPhysBandCurrAtn
+
+           }
+       STATUS      current
+       DESCRIPTION
+          "A collection of objects providing configuration
+           information for a VDSL line based upon single carrier
+           modulation modem."
+       ::= { vdslLineExtSCMGroups 1 }
+
+   END
+
+5.  Acknowledgments
+
+   This document contains many definitions taken from an early version
+   of the VDSL MIB [RFC3728].  As such, any credit for the text found
+   within should be fully attributed to the authors of that document.
+
+6.  Security Considerations
+
+   There are a number of management objects defined in this MIB module
+   with a MAX-ACCESS clause of read-create.  Such objects may be
+   considered sensitive or vulnerable in some network environments.  The
+   support for SET operations in a non-secure environment without proper
+   protection can have a negative effect on network operations.  These
+   are the tables and objects and their sensitivity/vulnerability:
+
+      vdslLineSCMConfProfileBandTable
+      vdslLineSCMConfProfileBandInUse,
+      vdslLineSCMConfProfileBandTransmitPSDLevel,
+      vdslLineSCMConfProfileBandSymbolRate,
+
+
+
+Dodge & Ray                 Standards Track                    [Page 14]
+
+RFC 4069                 VDSL-LINE-EXT-SCM-MIB                  May 2005
+
+
+      vdslLineSCMConfProfileBandConstellationSize,
+      vdslLineSCMConfProfileBandCenterFrequency,
+      vdslLineSCMConfProfileBandRowStatus
+
+   VDSL layer connectivity from the Vtur will permit the subscriber to
+   manipulate both the VDSL link directly and the VDSL embedded
+   operations channel (EOC) for their own loop.  For example, unchecked
+   or unfiltered fluctuations initiated by the subscriber could generate
+   sufficient notifications to potentially overwhelm either the
+   management interface to the network or the element manager.
+
+   Additionally, allowing write access to configuration data may allow
+   an end-user to increase their service levels or affect other end-
+   users in either a positive or negative manner.  For this reason, the
+   tables and objects listed above should be considered to contain
+   sensitive information.
+
+   Some of the readable objects in this MIB module (i.e., objects with a
+   MAX-ACCESS other than not-accessible) may be considered sensitive or
+   vulnerable in some network environments.  It is thus important to
+   control even GET and/or NOTIFY access to these objects and possibly
+   to even encrypt the values of these objects when sending them over
+   the network via SNMP.  These are the tables and objects and their
+   sensitivity/vulnerability:
+
+      vdslLineSCMPhysBandInUse,
+      vdslLineSCMPhysBandCurrPSDLevel,
+      vdslLineSCMPhysBandCurrSymbolRate,
+      vdslLineSCMPhysBandCurrConstellationSize,
+      vdslLineSCMPhysBandCurrCenterFrequency,
+      vdslLineSCMPhysBandCurrSnrMgn,
+      vdslLineSCMPhysBandCurrAtn
+
+   Read access of the physical band parameters may provide knowledge to
+   an end-user that would allow malicious behavior, for example the
+   application of an intentional interference on one or all of the
+   physical bands in use.
+
+   SNMP versions prior to SNMPv3 did not include adequate security.
+   Even if the network itself is secure (for example by using IPSec),
+   even then, there is no control as to who on the secure network is
+   allowed to access and GET/SET (read/change/create/delete) the objects
+   in this MIB module.
+
+   It is RECOMMENDED that implementers consider the security features as
+   provided by the SNMPv3 framework (see [RFC3410], section 8),
+   including full support for the SNMPv3 cryptographic mechanisms (for
+   authentication and privacy).
+
+
+
+Dodge & Ray                 Standards Track                    [Page 15]
+
+RFC 4069                 VDSL-LINE-EXT-SCM-MIB                  May 2005
+
+
+   Further, deployment of SNMP versions prior to SNMPv3 is NOT
+   RECOMMENDED.  Instead, it is RECOMMENDED to deploy SNMPv3 and to
+   enable cryptographic security.  It is then a customer/operator
+   responsibility to ensure that the SNMP entity giving access to an
+   instance of a MIB module is properly configured to give access to the
+   objects only to those principals (users) that have legitimate rights
+   to indeed GET or SET (change/create/delete) them.
+
+7.  IANA Considerations
+
+   The IANA has assigned the transmission value 228 to VDSL-LINE-EXT-
+   SCM-MIB.
+
+8.  References
+
+8.1.  Normative References
+
+   [DSLFTR57] DSL Forum TR-057, "VDSL Network Element Management",
+              February 2003.
+
+   [DSLFWT96] DSL Forum WT-096, "SCM Specific Managed Objects In VDSL
+              Network Elements".
+
+   [ETSI2701] ETSI TS 101 270-1 V1.2.1, "Transmission and Multiplexing
+              (TM); Access transmission systems on metallic access
+              cables; Very high speed Digital Subscriber Line (VDSL);
+              Part 1: Functional requirements", October 1999.
+
+   [ETSI2702] ETSI TS 101 270-2 V1.1.1, "Transmission and Multiplexing
+              (TM); Access transmission systems on metallic access
+              cables; Very high speed Digital Subscriber Line (VDSL);
+              Part 1: Transceiver specification", February 2001.
+
+   [ITU9931]  ITU-T G.993.1, "Very-high-speed digital subscriber line
+              foundation", November 2001.
+
+   [ITU9971]  ITU-T G.997.1, "Physical layer management for Digital
+              Subscriber Line (DSL) Transceivers", July 1999.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2578]  McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+              "Structure of Management Information Version 2 (SMIv2)",
+              STD 58, RFC 2578, April 1999.
+
+
+
+
+
+
+Dodge & Ray                 Standards Track                    [Page 16]
+
+RFC 4069                 VDSL-LINE-EXT-SCM-MIB                  May 2005
+
+
+   [RFC2579]  McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+              "Textual Conventions for SMIv2", STD 58, RFC 2579, April
+              1999.
+
+   [RFC2580]  McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+              "Conformance Statements for SMIv2", STD 58, RFC 2580,
+              April 1999.
+
+   [RFC2863]  McCloghrie, K. and F. Kastenholz, "The Interfaces Group
+              MIB", RFC 2863, June 2000.
+
+   [RFC3728]  Ray, B. and R. Abbi, "Definitions of Managed Objects for
+              Very High Speed Digital Subscriber Lines (VDSL)", RFC
+              3728, February 2004.
+
+   [T1E1311]  ANSI T1E1.4/2001-311, "Very-high-bit-rate Digital
+              Subscriber Line (VDSL) Metallic Interface, Part 1:
+              Functional Requirements and Common Specification",
+              February 2001.
+
+   [T1E1011]  ANSI T1E1.4/2001-011R3, "VDSL Metallic Interface, Part 2:
+              Technical Specification for a Single-Carrier Modulation
+              (SCM) Transceiver", November 2001.
+
+   [T1E1013]  ANSI T1E1.4/2001-013R4, "VDSL Metallic Interface, Part 3:
+              Technical Specification for a Multi-Carrier Modulation
+              (MCM) Transceiver", November 2000.
+
+8.2.  Informative References
+
+   [RFC3415]  Wijnen, B., Presuhn, R., and K. McCloghrie, "View-based
+              Access Control Model (VACM) for the Simple Network
+              Management Protocol (SNMP)", STD 62, RFC 3415, December
+              2002.
+
+   [RFC3410]  Case, J., Mundy, R., Partain, D., and B. Stewart,
+              "Introduction and Applicability Statements for Internet-
+              Standard Management Framework", RFC 3410, December 2002.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Dodge & Ray                 Standards Track                    [Page 17]
+
+RFC 4069                 VDSL-LINE-EXT-SCM-MIB                  May 2005
+
+
+Authors' Addresses
+
+   Menachem Dodge
+   ECI Telecom Ltd.
+   30 Hasivim St.
+   Petach Tikva 49517,
+   Israel
+
+   Phone: +972 3 926 8421
+   Fax:   +972 3 928 7342
+   EMail: mbdodge@ieee.org
+
+
+   Bob Ray
+   PESA Switching Systems, Inc.
+   330-A Wynn Drive
+   Huntsville, AL 35805
+   USA
+
+   Phone: +1 256 726 9200 ext.  142
+   Fax:   +1 256 726 9271
+   EMail: rray@pesa.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Dodge & Ray                 Standards Track                    [Page 18]
+
+RFC 4069                 VDSL-LINE-EXT-SCM-MIB                  May 2005
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2005).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at ietf-
+   ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+Dodge & Ray                 Standards Track                    [Page 19]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4069.txt](<www.ietf.org/rfc/rfc4069.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
