### PR TITLE
Archive rfc408.txt

### DIFF
--- a/www.ietf.org/rfc/rfc408.txt
+++ b/www.ietf.org/rfc/rfc408.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+NWG/RFC 408                                        Buzz Owen (SAAC-TIP)
+NIC #12390                                         Jon Postel  (UCLA-NMC)
+                                                   25 October 1972
+
+                                NETBANK
+
+The following idea for a protocol (or service) is offered as an
+aid to network use for new users:
+
+   a single billing and account creation and validation system,
+   so that a manager of a "goal oriented project" could:
+
+      authorize a set of user's ids to gain access to and utilize
+      resources at the entire or a specified subset of the server
+      hosts.
+
+      create a set of accounts which the users will expend, and
+      which will be used as the breakdown for a single bill to be
+      presented to the project manager.
+
+   the idea is that the project manager would be required to go
+   through the initialization process of introducing himself,
+   verifying the existence of funding, etc. only once, and,
+
+   the idea would also encourage server hosts to implement
+   systems for which usage might be projected to start at low
+   levels and grow, by allowing funded hacking by project members
+   in a controlled manner.
+
+   this would require an option at login for the prospective user
+   to indicate the server should check the "netbank" facility at
+   the system currently hosting it.
+
+
+
+    [ This RFC was put into machine readable form for entry ]
+    [ into the online RFC archives by BBN Corp. under the   ]
+    [ direction of Alex McKenzie.                      1/97 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc408.txt](<www.ietf.org/rfc/rfc408.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
