### PR TITLE
Archive rfc41.txt

### DIFF
--- a/www.ietf.org/rfc/rfc41.txt
+++ b/www.ietf.org/rfc/rfc41.txt
@@ -1,0 +1,41 @@
+
+
+
+
+
+
+Network Working Group                           John Melvin
+Request for Comments: 41                        SRI/ARC
+                                                30 March 1970
+
+
+
+               IMP/IMP Teletype Communication
+
+
+
+        I have occasionally found myself in a situatuation in
+Which I see a message from site X on my IMP teletype, but I don't
+know the time and date of the message.
+
+
+        I find this annoying, since a response to it may be in order
+if it is (say) less than an hour old, but not if it is several hours
+old. The situation is not improved by the existence of sites that
+now span all time zones of the U.S. and do not have direct voice
+connection.
+
+
+        It is requested that everyone tag their IMP to IMP tele-
+type messages that cause no response at the receiving IMP.
+
+
+        The transmitting IMP site should use 24 hour time and include
+the time zone designation.
+
+
+   [ This RFC was put into machine readable form for entry ]
+   [ into the online RFC archives by Larry Campbell 7/97   ]
+
+
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc41.txt](<www.ietf.org/rfc/rfc41.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
