### PR TITLE
Archive rfc4143.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4143.txt
+++ b/www.ietf.org/rfc/rfc4143.txt
@@ -1,0 +1,283 @@
+
+
+
+
+
+
+Network Working Group                                          K. Toyoda
+Request for Comments: 4143                                           PCC
+Category: Standards Track                                     D. Crocker
+                                                             Brandenburg
+                                                           November 2005
+
+
+          Facsimile Using Internet Mail (IFAX) Service of ENUM
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2005).
+
+Abstract
+
+   This document describes the functional specification and definition
+   of the ENUM Naming Authority Pointer (NAPTR) record for IFax service.
+   IFax is "facsimile using Internet mail".  For this use, the Domain
+   Name System (DNS) returns the email address of the referenced IFax
+   system.  This mechanism allows email-based fax communication to use
+   telephone numbers instead of requiring the sender to already know the
+   recipient email address.
+
+1.   Functional Specification
+
+   An IFax client makes a [ENUMbis] DNS query, using the target system's
+   telephone number.  The returned NAPTR record specifies an email
+   address to be used for reaching the target system.  The email address
+   is then used in accordance with Simple Mode of Facsimile using
+   Internet Mail [RFC3965], Extended Facsimile using Internet Mail
+   [RFC2532], or Full Mode Fax Profile for Internet Mail [FFPIM] is
+   applied.
+
+   The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "MAY"
+   in this document are to be interpreted as defined in "Key words for
+   use in RFCs to Indicate Requirement Levels" [KEYWORDS].
+
+
+
+
+
+
+
+Toyoda & Crocker            Standards Track                     [Page 1]
+
+RFC 4143                  IFAX service of ENUM             November 2005
+
+
+2.  IFax Service Registration
+
+   Service Name : "E2U+ifax"
+
+   Type: "ifax"
+
+   Subtype: "mailto"
+
+   URI Scheme: "mailto"
+   The URI Scheme is "mailto" because facsimile is a profile of standard
+   Internet mail and uses standard Internet mail addressing.
+
+   Functional Specification: See section 1
+
+   Security Considerations: See section 3
+
+   Intended usage: COMMON
+
+   Author: Kiyoshi Toyoda (toyoda.kiyoshi@jp.panasonic.com)
+           Dave Crocker (dcrocker@bbiw.net)
+
+3.  Security Considerations
+
+   DNS, as used by ENUM, is a globally distributed database.  Thus, any
+   information stored in it is visible to anyone anonymously.  Although
+   this is not qualitatively different from publication in a telephone
+   directory, it does expose the data subject to automatic data
+   collection without any indication that this has been done or by whom.
+
+   Data harvesting by third parties is often used to generate lists of
+   targets for unrequested information; in short, the lists are used to
+   address "spam".  The publication of a telephone number in ENUM,
+   especially when it is an associated Internet fax service, may be used
+   to send "junk faxes", for example.
+
+   In the case of electronic mail, users subscribed to mailing lists can
+   have "sacrificial" email accounts.  These special-purpose addresses
+   help the user filter out unrequested email.  This is not so easy with
+   published telephone numbers.  The PSTN E.164 number assignment
+   process is much more involved and less flexible; usually a single
+   E.164 number (or a fixed range of numbers) is associated with each
+   PSTN access.  Thus, it is not possible to use a "sacrificial" phone
+   number.
+
+   Due to the implications of publishing data in a globally accessible
+   database, as a principle, the data subject MUST give explicit
+   informed consent to data being published in ENUM.
+
+
+
+
+Toyoda & Crocker            Standards Track                     [Page 2]
+
+RFC 4143                  IFAX service of ENUM             November 2005
+
+
+   Internet Fax is based on existing use of Internet mail.  Developers
+   and users should also consider the Security Consideration sections in
+   [RFC3965] and [RFC2532].
+
+   In addition to the specific security considerations given above, the
+   Security Considerations section of [ENUMbis] applies to this
+   document.
+
+4.  Example
+
+   The following is an example of the use of IFax service in a NAPTR
+   record.
+
+      $ORIGIN 4.3.2.1.6.7.9.8.6.4.e164.arpa
+        IN NAPTR 10 10 "u" "E2U+ifax:mailto"
+                               "!^.*$!mailto:toyo@example.com!"
+
+5.  IANA Considerations
+
+   This specification creates a DNS NAPTR registration, according to the
+   terms specified in [ENUMbis].
+
+   The registration details are contained in section 2, Fax Service
+   Registration.
+
+6.  References
+
+6.1.  Normative References
+
+   [KEYWORDS] Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [ENUMbis]  Faltstrom, P. and M. Mealling, "The E.164 to Uniform
+              Resource Identifiers (URI) Dynamic Delegation Discovery
+              System (DDDS) Application (ENUM)", RFC 3761, April 2004.
+
+   [RFC3965]  Toyoda, K., Ohno, H., Murai, J., and D. Wing, "A Simple
+              Mode of Facsimile Using Internet Mail", RFC 3965, December
+              2004.
+
+   [RFC2532]  Masinter, L. and D. Wing, " Extended Facsimile Using
+              Internet Mail", RFC 2532, March 1999.
+
+   [FFPIM]    Crocker, D. and G. Klyne, "Full-mode Fax Profile for
+              Internet Mail (FFPIM)", RFC 4142, November 2005.
+
+
+
+
+
+
+Toyoda & Crocker            Standards Track                     [Page 3]
+
+RFC 4143                  IFAX service of ENUM             November 2005
+
+
+Authors' Addresses
+
+   Kiyoshi Toyoda
+   Research and Development Laboratory
+   Panasonic Communications Co., Ltd.
+   4-1-62 Minoshima Hakata-ku, Fukuoka 812-8531 Japan
+
+   Phone: +81-50-3380-5181
+   EMail: toyoda.kiyoshi@jp.panasonic.com
+
+
+   Dave Crocker
+   Brandenburg InternetWorking
+   675 Spruce Drive
+   Sunnyvale, CA  94086  USA
+
+   Phone: +1.408.246.8253
+   EMail: dcrocker@bbiw.net
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Toyoda & Crocker            Standards Track                     [Page 4]
+
+RFC 4143                  IFAX service of ENUM             November 2005
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2005).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at ietf-
+   ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+Toyoda & Crocker            Standards Track                     [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4143.txt](<www.ietf.org/rfc/rfc4143.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
