### PR TITLE
Archive rfc415.txt

### DIFF
--- a/www.ietf.org/rfc/rfc415.txt
+++ b/www.ietf.org/rfc/rfc415.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                          H. Murray
+Request for Comments: 415                    Stanford Research Institute
+NIC: 392                                                29 November 1972
+
+
+                            TENEX BANDWIDTH
+
+   NIC 11584 (RFC 392) BY G. HICKS AND B. WESSLER AT UTAH RECENTLY
+   DISCUSSED THE COST OF USING THE NETWORK.
+
+   I WOULD LIKE TO TAKE THESE SAME TYPES OF NUMBERS AND LOOK AT THEM
+   FROM ANOTHER POINT OF VIEW.  WITHOUT CALCULATING COSTS, LET US
+   CONSIDER ULTIMATE PERFORMANCE OF THE HOSTS.  I WROTE A SIMPLE TENEX
+   PROGRAM THAT SENT ITSELF STRINGS OVER THE NET.  IT USED BIN/BOUT AND
+   THE BUFFERED SEND MODE.   IT COUNTED THINGS, BUT DID NOT PROCESS THE
+   STRING.  WITH SAMPLES OF A MILLION BITS, THE FOLLOWING RESULTS WERE
+   OBTAINED.
+
+   BYTES/SIZE      REAL BAUD       CPU BAUD      CPU NEEDED
+
+     50/36          48.8K           291K          16%
+    100/36          46.5K           309K          15%
+    200/36          52.7K           322K          16%
+    400/36          59.3K           267K          22%
+    800/36          61.1K           279K          21%
+
+     50/8           22.0K           70K           31%
+    100/8           26.7K           76K           35%
+    200/8           29.0K           79K           36%
+    400/8           30.0K           81K           37%
+    800/8           31.9K           78K           40%
+   1600/8           38.1K           64K           59%
+   3200/8           41.8K           59K           70%
+
+   THE FOLLOWING WERE OBTAINED BY USING SIN/SOUT WITHOUT THE BUFFERED
+   MODE.
+
+   BYTES/SIZE      REAL BAUD       CPU BAUD      CPU NEEDED
+     50/36          36K             95K           38%
+    100/36          44K             95K           45%
+    200/36          49K             92K           53%
+    400/36          54K             90K           60%
+
+     50/8           12K             22K           57%
+    100/8           16K             21K           75%
+    200/8           18K             20K           92%
+    400/8           20K             20K           99%
+
+
+
+
+Murray                                                          [Page 1]
+
+RFC 415                     TENEX BANDWIDTH                November 1972
+
+
+   THESE TESTS WERE RUN WITH NO OTHER LOAD ON OUR SYSTEM, AN EARLY
+   VERSION OF 1.29.  THE INPUT AND OUTPUT HALVES OF THE TRANSMISSION
+   HAVE BEEN AVERAGED TOGETHER.  I.E. THE ABOVE BAUD RATES WERE
+   CALCULATED USING 2 MILLION BITS SINCE THE STRINGS WENT OUT AND IN.
+
+OTHER PIECES OF DATA:
+
+   OUR TTY'S AND LPT HAVE ULTIMATE CPU BANDWIDTHS NEAR 15-20 KB.  AT
+   2400 BAUD, A TTY TAKES 15% OF THE CPU.  TELNETS NESTED THREE DEEP ARE
+   ALMOST COMPUTE LIMITED WHEN JUST TYPING THINGS OUT ON A 2400 BAUD
+   TERMINAL.
+
+   AS A ROUGH CALCULATION, THE BANDWIDTH OF THE TIP TAPE TRANSMISSION
+   FEATURE - USING STEVE BUTTERFIELD'S (OF BBN) NETMAG PROGRAM - IS
+   ABOUT 7 KILOBITS/SEC.  ONE TAPE OF ABOUT 6,000 TENEX PAGES TOOK ABOUT
+   4 HOURS TO TRANSMIT.  THIS WAS A FULL TAPE FROM ETAC TO CCA LATE ONE
+   NIGHT WITH NOTHING ELSE RUNNING ON OUR SYSTEM.  ABOUT 30% OF THE CPU
+   IS NEEDED TO MAINTAIN THIS BANDWIDTH.  AGAIN THIS IS ONLY ABOUT 20KB
+   PER CPU SEC.
+
+
+        [This RFC was put into machine readable form for entry]
+    [into the online RFC archives by Helene Morin, Via Genie 12/99]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Murray                                                          [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc415.txt](<www.ietf.org/rfc/rfc415.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
