### PR TITLE
Archive rfc4156.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4156.txt
+++ b/www.ietf.org/rfc/rfc4156.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Network Working Group                                         P. Hoffman
+Request for Comments: 4156                                VPN Consortium
+Category: Historic                                           August 2005
+
+
+                          The wais URI Scheme
+
+Status of This Memo
+
+   This memo defines a Historic Document for the Internet community.  It
+   does not specify an Internet standard of any kind.  Distribution of
+   this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2005).
+
+Abstract
+
+   This document specifies the wais Uniform Resource Identifier (URI)
+   scheme that was originally specified in RFC 1738.  The purpose of
+   this document is to allow RFC 1738 to be made obsolete while keeping
+   the information about the scheme on standards track.
+
+
+1.  Introduction
+
+   URIs were previously defined in RFC 2396 [RFC2396], which was updated
+   by RFC 3986 [RFC3986].  Those documents also specify how to define
+   schemes for URIs.
+
+   The first definitions for many URI schemes appeared in RFC 1738
+   [RFC1738].  Because that document has been made obsolete, this
+   document copies the wais URI scheme from it to allow that material to
+   remain on standards track.
+
+
+2.  Scheme Definition
+
+   The WAIS URL scheme is used to designate WAIS databases, searches, or
+   individual documents available from a WAIS database.  The WAIS
+   protocol is described in RFC 1625 [RFC1625].  Although the WAIS
+   protocol is based on Z39.50-1988, the WAIS URL scheme is not intended
+   for use with arbitrary Z39.50 services.
+
+   Historical note: The WAIS protocol was not widely implemented and
+   almost no WAIS servers are in use today.
+
+
+
+
+Hoffman                         Historic                        [Page 1]
+
+RFC 4156                  The wais URI Scheme                August 2005
+
+
+   A WAIS URL takes one of the following forms:
+
+      wais://<host>:<port>/<database>
+      wais://<host>:<port>/<database>?<search>
+      wais://<host>:<port>/<database>/<wtype>/<wpath>
+
+   If :<port> is omitted, the port defaults to 210.  The first form
+   designates a WAIS database that is available for searching.  The
+   second form designates a particular search. <database> is the name of
+   the WAIS database being queried.
+
+   The third form designates a particular document, within a WAIS
+   database, to be retrieved.  In this form <wtype> is the WAIS
+   designation of the type of the object.  Many WAIS implementations
+   require that a client know the "type" of an object prior to
+   retrieval; the type is returned along with the internal object
+   identifier in the search response.  The <wtype> is included in the
+   URL in order to give the client interpreting the URL adequate
+   information to actually retrieve the document.
+
+   The <wpath> of a WAIS URL consists of the WAIS document-id.  The WAIS
+   document-id should be treated opaquely; it may only be decomposed by
+   the server that issued it.
+
+3.  Security Considerations
+
+   Many security considerations for URI schemes are discussed in
+   [RFC3986].  There are no security considerations listed in [RFC1625],
+   but it should be noted that there is no privacy nor authentication
+   specified in the WAIS protocol.
+
+4.  Informative References
+
+   [RFC1738]  Berners-Lee, T., Masinter, L., and M. McCahill, "Uniform
+              Resource Locators (URL)", RFC 1738, December 1994.
+
+   [RFC2396]  Berners-Lee, T., Fielding, R., and L. Masinter, "Uniform
+              Resource Identifiers (URI): Generic Syntax", RFC 2396,
+              August 1998.
+
+   [RFC3986]  Berners-Lee, T., Fielding, R., and L. Masinter, "Uniform
+              Resource Identifier (URI): Generic Syntax", STD 66,
+              RFC 3986, January 2005.
+
+   [RFC1625]  St. Pierre, M., Fullton, J., Gamiel, K., Goldman, J.,
+              Kahle, B., Kunze, J., Morris, H., and F. Schiettecatte,
+              "WAIS over Z39.50-1988", RFC 1625, June 1994.
+
+
+
+
+Hoffman                         Historic                        [Page 2]
+
+RFC 4156                  The wais URI Scheme                August 2005
+
+
+Author's Address
+
+   Paul Hoffman
+   VPN Consortium
+   127 Segre Place
+   Santa Cruz, CA  95060
+   US
+
+   EMail: paul.hoffman@vpnc.org
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hoffman                         Historic                        [Page 3]
+
+RFC 4156                  The wais URI Scheme                August 2005
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2005).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at ietf-
+   ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+Hoffman                         Historic                        [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4156.txt](<www.ietf.org/rfc/rfc4156.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
