### PR TITLE
Archive rfc416.txt

### DIFF
--- a/www.ietf.org/rfc/rfc416.txt
+++ b/www.ietf.org/rfc/rfc416.txt
@@ -1,0 +1,111 @@
+
+
+
+
+
+
+NETWORK WORKING GROUP                           James C. Norton (SRI-ARC)
+Request for Comments #416                          7-NOV-72
+NIC #12542
+
+THE ARC SYSTEM WILL BE UNAVAILABLE FOR USE DURING THANKSGIVING WEEK
+
+The ARC PDP-10 system will be unavailable for ARC and NIC users
+from Friday, November 17 (6:00 pm PST ) through Sunday, November
+26. (10:00 pm PST).  This will give our hardware team a period of
+nine days to work on equipment with a loss of only three SRI
+working days to users (Monday, Tuesday, and Wednesday.)
+
+This is the Network Information Center's notice to its network
+users of the schedule.
+
+    In addition, a login message will be sent starting about 6
+    November to all users showing schedule.
+
+       It will read something like: "THE ARC/NIC PDP-10 SYSTEM
+      WILL BE UNAVAILABLE FOR USE FROM FRIDAY NOV 17 (6:00 pm
+      PST) THRU SUNDAY NOV 26 (10:00 pm PST) FOR MAJOR HARDWARE
+      WORK AS OUTLINED IN (12542,)".
+
+For those who are interested, the hardware facility work to be
+done during this period will include:
+
+   Removal of the Bryant disk, Bryant disk controller and
+   Cybernex drum-disk interference.
+
+   Moving the Tasker display system and DEC dispack (old and
+   new) equipment to their new locations.
+
+   Having Bryant people run a combination drum maintenance and
+   training session to teach ARC people how to change heads and
+   clean the drum.
+
+   Redoing the power cabling to the drum.
+
+   Putting the new signal cable in between drum and controller.
+
+   Debugging the parity checker.
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+
+   Making a check of all main signal levels in XCORE.
+
+   Debugging the new cable from the parity checker to XCORE.
+
+   Wiring the parity bit through the Cybernex XCORE interface.
+
+   Getting any necessary power wiring done.
+
+   Building a wall for the next dispack location.
+
+
+    [ This RFC was put into machine readable form for entry ]
+    [ into the online RFC archives by BBN Corp. under the   ]
+    [ direction of Alex McKenzie.                      1/97 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc416.txt](<www.ietf.org/rfc/rfc416.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
