### PR TITLE
Archive rfc425.txt

### DIFF
--- a/www.ietf.org/rfc/rfc425.txt
+++ b/www.ietf.org/rfc/rfc425.txt
@@ -1,0 +1,54 @@
+
+
+Network Working Group                                       Bob Bressler  (BBN)
+Request for Comments:  425                                             Dec 1972
+NIC #13010
+
+
+
+
+                   "But my NCP costs $500 a day..."
+
+
+Now that networking is becoming commonplace, people are beginning to measure 
+the cost of their network software and network use.  A not insignificant 
+portion of this use turns out to be random prodding and poking of one system
+by another.  An example of this is the "Survey" mechanism that many sites are
+constructing to see "who's up."  Several systems have noted that this one
+mechanism alone accounts for a log of their overhead, and is not chargeable to
+any given user.
+
+In response to this particular problem, MIT-DMCG and UCLA-NMC, who have both
+been doing surveys for some time, have agreed upon a standard format for host
+survey data and will make it available to the network community.  They will be
+joined by a third site, and will provide a standard socket to obtain this
+information.  The data will be a concise character stream so as to be both
+human and machine readable.
+
+The exact format of the data and the socket number will be forthcoming.
+
+The intent of all this is for all other sites to stop surveying on their own
+and get this data from one of the participating "Official Surveyors" either
+prompted by a user's request or on a periodic basis, whatever they wish.
+
+This should, itself, help considerably to eliminate a lot of the network
+'noise factor.'  But, in addition, we should all try to be more aware of the
+cost of this type of traffic and try to avoid repeated interactions with a
+given Host without some expressed consent - be it an account number of some
+specific experiment.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+BB/ph


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc425.txt](<www.ietf.org/rfc/rfc425.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
