### PR TITLE
Archive rfc4265.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4265.txt
+++ b/www.ietf.org/rfc/rfc4265.txt
@@ -1,0 +1,339 @@
+
+
+
+
+
+
+Network Working Group                                      B. Schliesser
+Request for Comments: 4265                         SAVVIS Communications
+Category: Standards Track                                      T. Nadeau
+                                                     Cisco Systems, Inc.
+                                                           November 2005
+
+
+                 Definition of Textual Conventions for
+                Virtual Private Network (VPN) Management
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2005).
+
+Abstract
+
+   This document describes Textual Conventions used for managing Virtual
+   Private Networks (VPNs).
+
+Table of Contents
+
+   1. Introduction ....................................................1
+      1.1. Conventions Used in This Document ..........................2
+   2. The Internet-Standard Management Framework ......................2
+   3. VPN-TC-STD-MIB ..................................................2
+      3.1. Description ................................................2
+      3.2. Definitions ................................................2
+   4. Security Considerations .........................................4
+   5. IANA Considerations for VPN-TC-STD-MIB ..........................4
+   6. References ......................................................4
+      6.1. Normative References .......................................4
+      6.2. Informative References .....................................5
+
+1.  Introduction
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the Internet community.
+   In particular, it defines Textual Conventions used in Virtual Private
+   Networks (VPNs) and IETF VPN-related MIBs.
+
+
+
+
+Schliesser & Nadeau         Standards Track                     [Page 1]
+
+RFC 4265                     VPN-TC-STD-MIB                November 2005
+
+
+1.1.  Conventions Used in This Document
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC-2119 [RFC2119].
+
+2.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This memo specifies a MIB
+   module that is compliant to the SMIv2, which is described in STD 58,
+   RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579] and STD 58, RFC 2580
+   [RFC2580].
+
+3.  VPN-TC-STD-MIB
+
+3.1.  Description
+
+   The VPN-TC-STD-MIB defines a Textual Convention for the Global VPN
+   Identifier, or VPN-ID, as specified in [RFC2685].  The purpose of a
+   VPN-ID is to uniquely identify a VPN.  It MUST be 7 octets in length,
+   and SHOULD be comprised of a 3 octet Organizationally Unique
+   Identifier (OUI) that uniquely identifies the VPN Authority, followed
+   by a 4 octet value assigned by the VPN Authority that uniquely
+   identifies the VPN within the context of the OUI.
+
+3.2.  Definitions
+
+   VPN-TC-STD-MIB DEFINITIONS ::= BEGIN
+
+   IMPORTS
+       MODULE-IDENTITY, mib-2
+           FROM SNMPv2-SMI
+
+       TEXTUAL-CONVENTION
+           FROM SNMPv2-TC;
+
+   vpnTcMIB MODULE-IDENTITY
+       LAST-UPDATED "200511150000Z"  -- 15 November 2005
+       ORGANIZATION
+           "Layer 3 Virtual Private Networks (L3VPN) Working Group."
+
+
+
+Schliesser & Nadeau         Standards Track                     [Page 2]
+
+RFC 4265                     VPN-TC-STD-MIB                November 2005
+
+
+       CONTACT-INFO
+           "Benson Schliesser
+            bensons@savvis.net
+
+            Thomas D. Nadeau
+            tnadeau@cisco.com
+
+            This TC MIB is a product of the PPVPN
+            http://www.ietf.org/html.charters/ppvpn-charter.html
+            and subsequently the L3VPN
+            http://www.ietf.org/html.charters/l3vpn-charter.html
+            working groups.
+
+            Comments and discussion should be directed to
+            l3vpn@ietf.org"
+       DESCRIPTION
+           "This MIB contains TCs for VPNs.
+
+            Copyright (C) The Internet Society (2005).  This version
+            of this MIB module is part of RFC 4265;  see the RFC
+            itself for full legal notices."
+       -- Revision history.
+       REVISION "200511150000Z"  -- 15 November 2005
+       DESCRIPTION "Initial version, published as RFC 4265."
+       ::= { mib-2 129 }
+
+   -- definition of textual conventions
+
+   VPNId ::= TEXTUAL-CONVENTION
+       STATUS current
+       DESCRIPTION
+           "The purpose of a VPN-ID is to uniquely identify a VPN.
+            The Global VPN Identifier format is:
+            3 octet VPN Authority, Organizationally Unique Identifier
+            followed by 4 octet VPN index identifying VPN according
+            to OUI"
+       REFERENCE
+           "Fox, B. and Gleeson, B., 'Virtual Private Networks
+            Identifier', RFC 2685, September 1999."
+       SYNTAX    OCTET STRING (SIZE (7))
+
+   VPNIdOrZero ::= TEXTUAL-CONVENTION
+       STATUS            current
+       DESCRIPTION
+           "This textual convention is an extension of the
+            VPNId textual convention that defines a non-zero-length
+            OCTET STRING to identify a physical entity.  This extension
+            permits the additional value of a zero-length OCTET STRING.
+
+
+
+Schliesser & Nadeau         Standards Track                     [Page 3]
+
+RFC 4265                     VPN-TC-STD-MIB                November 2005
+
+
+            The semantics of the value zero-length OCTET STRING are
+            object-specific and must therefore be defined
+            as part of the description of any object that uses this
+            syntax.  Examples of usage of this extension are
+            situations where none or all VPN IDs need to be
+            referenced."
+       SYNTAX    OCTET STRING (SIZE (0 | 7))
+
+   END
+
+4.  Security Considerations
+
+   This module does not define any management objects.  Instead, it
+   defines a set of textual conventions that may be used by other MIB
+   modules to define management objects.
+
+   Meaningful security considerations can only be written in the MIB
+   modules that define management objects.  Therefore, this document has
+   no impact on the security of the Internet.
+
+5.  IANA Considerations for VPN-TC-STD-MIB
+
+   The IANA has assigned { mib-2 129 } to the VPN-TC-STD-MIB module
+   specified in this document.
+
+6.  References
+
+6.1.  Normative References
+
+   [RFC2119] Bradner, S., "Key words for use in RFCs to Indicate
+             Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2578] McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+             "Structure of Management Information Version 2 (SMIv2)",
+             STD 58, RFC 2578, April 1999.
+
+   [RFC2579] McCloghrie, K., Perkins, D., and J. Schoenwaelder, "Textual
+             Conventions for SMIv2", STD 58, RFC 2579, April 1999.
+
+   [RFC2580] McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+             "Conformance Statements for SMIv2", STD 58, RFC 2580, April
+             1999.
+
+   [RFC2685] Fox, B. and B. Gleeson, "Virtual Private Networks
+             Identifier", RFC 2685, September 1999.
+
+
+
+
+
+
+Schliesser & Nadeau         Standards Track                     [Page 4]
+
+RFC 4265                     VPN-TC-STD-MIB                November 2005
+
+
+6.2.  Informative References
+
+   [RFC3410] Case, J., Mundy, R., Partain, D., and B. Stewart,
+             "Introduction and Applicability Statements for Internet-
+             Standard Management Framework", RFC 3410, December 2002.
+
+Authors' Addresses
+
+   Benson Schliesser
+   SAVVIS Communications
+   1 Savvis Parkway
+   Saint Louis, MO 63017
+   USA
+
+   Phone: +1-314-628-7036
+   EMail: bensons@savvis.net
+
+
+   Thomas D. Nadeau
+   Cisco Systems
+   1414 Massachusetts Ave.
+   Boxborough, MA 01719
+
+   Phone: +1-978-244-3051
+   EMail: tnadeau@cisco.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schliesser & Nadeau         Standards Track                     [Page 5]
+
+RFC 4265                     VPN-TC-STD-MIB                November 2005
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2005).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at ietf-
+   ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+Schliesser & Nadeau         Standards Track                     [Page 6]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4265.txt](<www.ietf.org/rfc/rfc4265.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
