### PR TITLE
Archive rfc429.txt

### DIFF
--- a/www.ietf.org/rfc/rfc429.txt
+++ b/www.ietf.org/rfc/rfc429.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+ARPA Network Information Center
+Stanford Research Institute
+Menlo Park, California  94025
+
+NWG/RFC #429                                 Jonathan B. Postel (UCLA-NMC)
+NIC #13281                                   12-DEC-72
+
+
+
+                      Character Generator Process
+
+
+
+I hereby propose that there be a standard process implemented on
+whatever hosts desire which generates character data with out any
+regard to input. In some sense the process is the converse of the
+discard process [RFC 348]. Many hosts have an existing terminal
+testing program [e.g. TTYTST] which would suit this function
+adequately.
+
+This Character Generator process would listen for a request for
+connection and execute the Initial Connection Protocol (ICP) as
+specified in NIC 7104 the "Current Network Protocols" notebook.  Upon
+completion of the ICP the Character Generator process would begin to
+send characters into the network as buffer space is made available .
+The Character Generator process is terminated by closing the
+connections.
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by BBN Corp. under the   ]
+       [ direction of Alex McKenzie.                      1/97 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc429.txt](<www.ietf.org/rfc/rfc429.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
