### PR TITLE
Archive rfc43.txt

### DIFF
--- a/www.ietf.org/rfc/rfc43.txt
+++ b/www.ietf.org/rfc/rfc43.txt
@@ -1,0 +1,66 @@
+
+
+
+
+
+
+Network Working Group                         A. G. Nemeth
+Request for Comments: 43                      M.I.T. Lincoln Laboratory
+                                              8 April 1970
+
+
+                         Proposed Meeting
+
+
+      On Friday, 8 May 1970, at 9:30 AM a meeting at M.I.T. Lincoln
+Laboratory is proposed. A description of LIL (Local Interaction
+Language) for the TSP (Terminal Support Processor) system will be
+presented.
+
+      The purpose of the TSP system is to provide a flexible I/O
+capability for network users. In order to achieve maximum flexibility,
+the system is user-programmable in an interpretable language called
+LIL.
+
+      LIL has the appropriate primitives for manipulating tree
+structures (for interactive graphics) as well as message-oriented
+I/O. The general purpose portion of the language is used to specify
+the I/O handlers and the display structures.
+
+      A discussion of the problems of handling interactive programs
+over the ARPA network will follow.
+
+      This conference is intended as a working group and each host
+should send as few or as many individuals as are actively
+interested. A working document on LIL will be mailed about a week in
+advance to interested individuals.
+
+      Anyone interested in attending and/or receiving the documents
+should contact A. G. Nemeth (x7354) or J. Forgie (x7173) at
+M.I.T. Lincoln Labs, Lexington, Mass. 02173, (617) 862-5500.
+
+
+[This RFC was put into machine readable form for entry into the RFC
+archives by Glenn Forbes Fleming Larratt]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                     December 27, 1996
+
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc43.txt](<www.ietf.org/rfc/rfc43.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
