### PR TITLE
Archive rfc433.txt

### DIFF
--- a/www.ietf.org/rfc/rfc433.txt
+++ b/www.ietf.org/rfc/rfc433.txt
@@ -1,0 +1,298 @@
+
+
+
+
+
+
+Network Working Group                              Jon Postel (UCLA-NMC)
+Request for Comments: 433                             Nancy Neigus (BBN)
+NIC 13491                                               22 December 1972
+Categories: Socket Numbers
+References: 349
+
+                       Socket Number List
+
+
+The czar of socket numbers [Jon Postel] has established the
+following assignments for socket numbers used for public
+functions. Note that a socket number is a 40 bit quantity, the
+first 8 bits being the host specification, the next 24 bits being
+site specific, and the last 8 bits being user specified - these
+last 8 bits are called the AEN [it stands for, cleverly enough,
+Another Eightbit Number].
+
+For the assignments here the value in the host field ranges
+across all hosts (unless otherwise specified), the value in the
+24 bit field is zero, and the AEN is indicated here.
+
+General Assignments:
+
+       Sockets         Assignment
+
+       0 - 63          Network Wide Standard Functions
+       64 - 127        Host Specific Functions
+       128 - 239       Reserved for Future Use
+       240 - 255       Any Experimental Function
+
+
+Particular Assignments:
+
+       Socket          Assignment
+
+       1               Telnet
+       3               File Transfer
+       5               Remote Job Entry
+       7               Echo
+       9               Discard
+       19              Character Generator [e.g. TTYTST]
+
+       65              Speech Data Base @ ll-tx-2 (74)
+       67              Datacomputer @ cca (31)
+
+       241             NCP Measurement
+       243             Survey Measurement
+       245             LINK
+
+The specifications for the assigned functions can be found in the
+documents listed here:
+
+
+
+Postel and Neigus                                               [Page 1]
+
+RFC 433                    Socket Number List           22 December 1972
+
+
+               Telnet                  RFC 318
+               File Transfer           RFC 354 & RFC 385
+               Remote Job Entry        RFC 407
+               Echo                    RFC 347
+               Discard                 RFC 348
+               Character Generator     RFC 429
+               Speech Data Base        SUR 37
+               Datacomputer            [Murray @ CCA]
+               NCP Measurment          RFC 388
+               Survey Data             [Kampe @ NMC]
+               LINK                    [Bressler @ BBN]
+
+
+It has come to our attention that there are several hosts
+performing useful public services on sockets which conflict with
+the above scheme. We hope we can resolve this problem with a
+minimum of disruption.
+
+The following is a tabulation of socket numbers together with the
+services offered. This listing is presented as an aid to network
+users. If you know of a socket/function which has been left out
+or an entry which should be corrected or deleted please contact:
+
+                       Jon Postel
+                       3804 Boelter Hall
+                       Computer Science Department
+                       University of California
+                       Los Angeles, CA. 90024
+
+                       Phone: (213) 825-2368
+
+                       NIC Ident = JBP
+
+                               or
+
+                       Nancy Neigus
+                       Bolt Beranek and Newman
+                       50 Moulton Street
+                       Cambridge, Mass. 02139
+
+                       Phone: (617) 661-0100
+
+                       NIC Ident = NJN
+
+
+
+
+
+
+
+
+
+
+
+Postel and Neigus                                               [Page 2]
+
+RFC 433                    Socket Number List           22 December 1972
+
+
+We will be pleased to include socket/function information for
+other than "offical" sockets [e.g Tip News].
+
+   1   UCLA-NMC
+      1   Telnet
+      241 NCP Measurement
+      243 Survey Data
+   2    SRI-ARC
+      1    Telnet
+      3    File Transfer
+      5    Echo
+      7    CPYNET
+      9    SYSTAT
+      13   DATE-TIME
+   3    UCSB
+      1    Telnet
+      5    UCSB RJS [not ARPANET standard]
+      7    Echo
+      9    Discard
+   4    UTAH
+      1    Telnet
+      3    File Transfer
+      5    Echo
+      7    CPYNET
+      9    SYSTAT
+      13   DATE-TIME
+   5    NCC
+   6    MIT-Multics
+      1    Telnet
+   9   Harvard
+      1    Telnet
+      3    Sorry File Transfer
+   10   LL-67
+      1    Telnet
+   11   SAIL
+      1    Telnet
+      3    File Transfer
+   12   ILL-ANTS
+   13   CASE
+      1    Telnet
+      3    File Transfer
+      5    Echo
+      7    CPYNET
+      9    SYSTAT
+      13   DATE-TIME
+   14   CMU
+      1    Telnet
+      3    File Transfer
+   15   ILLIAC-TENEX
+      1    Telnet
+      3    File Transfer
+
+
+
+Postel and Neigus                                               [Page 3]
+
+RFC 433                    Socket Number List           22 December 1972
+
+
+      5    Echo
+      7    CPYNET
+      9    SYSTAT
+      13   DATE-TIME
+   16   NASA-AMES
+      1    Telnet
+      3    File Transfer
+      5    Sorry Remote Job Entry
+      7    Echo
+      9    Discard
+      241 NCP Measurement
+   23   USC-44
+   31   CCA-TENEX
+      1    Telnet
+      3    File Transfer
+      5    Echo
+      9    SYSTAT
+      11   NETSTAT
+   35   UCSD
+      1    Telnet
+   65   UCLA-CCN
+      1    Telnet
+      7    Echo
+      9    Discard
+      11   NETPJS [EBCDIC]
+      13   NETRJS [ASCII]
+      15   NETRJS [TTY]
+   66   SRI-AI
+      1    Telnet
+      3    DATE-TIME
+      5    Echo
+      7    CPYNET
+      9    SYSTAT
+      11   Sorry NETSTAT
+   69   BBN-TENEX (a)
+      1    Telnet
+      3    File Transfer
+      5    Echo
+      7    CPYNET
+      9    SYSTAT
+      13   DATE-TIME
+      15   NETSTAT
+      17   Oneliners
+      3604505 = x'370019' = o'15600031'   TIP News
+   70   MIT-DMCG
+      1    Telnet
+      3    File Transfer
+      7    Network Status
+      9    Discard
+   74   LL-TX-2
+      1    Telnet
+
+
+
+Postel and Neigus                                               [Page 4]
+
+RFC 433                    Socket Number List           22 December 1972
+
+
+   78   CMU-alt
+      1    Telnet
+      3    File Transfer
+   86   ISI-TENEX
+      1    Telnet
+      3    File Transfer
+      5    Echo
+      7    CPYNET
+      9    SYSTAT
+      13   DATE-TIME
+   133  BBN-TENEXB
+      1    Telnet
+      3    File Transfer
+      5    Echo
+      7    CPYNET
+      9    SYSTAT
+      13   DATE-TIME
+      15   NETSTAT
+      17   Oneliners
+   134  MIT-AI
+      1    Telnet
+      3    File Transfer
+   198  MIT-Mathlab
+      1    Telnet
+      3    File Transfer
+
+Following hosts not tested
+
+   7    RAND
+   8    SDC-ADEPT
+   19   NBS-ANTS
+   138  LL-TSP
+
+
+
+
+
+     [ This RFC was put into machine readable form for entry ]
+      [ into the online RFC archives by James Carlson 11/98 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Postel and Neigus                                               [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc433.txt](<www.ietf.org/rfc/rfc433.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
