### PR TITLE
Archive rfc434.txt

### DIFF
--- a/www.ietf.org/rfc/rfc434.txt
+++ b/www.ietf.org/rfc/rfc434.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                              Alexander A. McKenzie
+RFC 434                                            BBN-NET
+NIC 13658                                          January 4, 1973
+
+
+                    IMP/TIP MEMORY RETROFIT SCHEDULE
+
+   During the first several months of 1973 we will be retrofitting each
+   IMP and TIP with additional core memory.  At the end of the retrofit
+   program, the memory sizes of the various machines will be as follows:
+
+      IMP (516 or 316) - 16K words
+
+      TIP - 28K words
+
+      TIP with magnetic Tape Option - 32K words
+
+   In addition, the expansion of the TIP core memory will necessitate
+   enlarging the TIP to two cabinets.
+
+   Listed below is the preliminary schedule for these retrofits.  We
+   have arranged this schedule to coincide with the usual monthly
+   Preventive Maintenance at each site so as to minimize user
+   inconvenience, but the work required will frequently require the
+   machines to be down longer than normal.  I will issue additional
+   RFC's updating this schedule as necessary.
+
+   Any site which anticipate difficulty with the expansion of TIP size,
+   and thus the floor space requirement, should contact Hawley Rising
+   (BBN) at
+      (617)491-1850 ext. 473
+   All dates given below are in the form (month/day)
+
+   Xerox (1/3)
+   SAAC (1/4)
+   MIT (1/8)
+   MITRE (1/9)
+   Harvard (1/15)
+   RAND (1/16)
+   ARPA (1/16)
+   NBS (1/17)
+   AMES TIP (1/24)
+   Lincoln (1/24)
+   Utah (2/1)
+   UCSB (2/6)
+   Belvoir (2/8)
+   NOAA (2/12)
+   USC (2/13)
+
+
+
+McKenzie                                                        [Page 1]
+
+RFC 434            IMP/TIP Memory Retrofit Schedule        January 1973
+
+
+   Stanford (2/14)
+   ETAC (2/15)
+   Aberdeen (2/22)
+   ISI (2/22)
+   Case (2/26)
+   SRI (3/7)
+   Rome (3/14)
+   FNWC (3/15)
+   UCLA (3/19)
+   CCA (3/20)
+   AMES IMP (3/21)
+   GWC (3/22)
+   Carnegie (4/4)
+   SDC (4/17)
+   Illinois (4/18)
+
+
+         [ This RFC was put into machine readable form for entry ]
+         [ into the online RFC archives by Alex McKenzie with    ]
+         [ support from GTE, formerly BBN Corp.             9/99 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McKenzie                                                        [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc434.txt](<www.ietf.org/rfc/rfc434.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
