### PR TITLE
Archive rfc436.txt

### DIFF
--- a/www.ietf.org/rfc/rfc436.txt
+++ b/www.ietf.org/rfc/rfc436.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                   Mark Krilanovich
+RFC #436                                                UCSB
+NIC #13700                                              Jan. 10 1973
+
+                      Announcement of RJS at UCSB
+
+    There now is resident under socket 5 at UCSB a server program which
+supports a subset of the Remote Job Entry Protocol of RFC #407.  This
+document includes enough information to allow the user to gain access
+to, and use the more basic function of UCSB's RJS.  An RFC containing
+more detailed documentation will be forthcoming shortly.
+
+    The accounting parameters needed to login to RJS are a userid and a
+password, each consisting of one to eight alphameric characters, the
+first of which must be alphabetic.  The userid is, at present,
+completely arbitrary.  The password is arbitrary the first time it is
+used with a particular userid; in subsequent logins with that userid,
+the same password must appear.  Eventually, users will be assigned
+userid-password pairs by UCSB Computer Center.
+
+    The only transmission mode supported currently is T (TELNET-like
+carriage control); any other is treated as T.  The other modes will soon
+be added.  The only disposition supported is the default transmit-and-
+discard; any other is treated as transmit-and discard.  The other
+dispositions may or may not be added later.
+
+    For consistency and user convenience, the command 'INUSER' may be
+substituted for 'INID' and 'OUTPATH' for 'OUT'.  The following commands
+are not as yet implemented: ABORT, ALTER, BACK, HOLD, OP RECOVER,
+RESTART, AND SKIP.  At least some of these will be implemented
+relatively soon.
+
+    In order to accommodate users of TENEX FTP servers, the commands
+'INACCT' and 'OUTACCT' have been added.  These are used to set the
+account number used in the file retrieval and storage operations,
+respectively.  The command 'ACCT' may be used to get both account
+numbers.  If one of these account numbers has not been specified, the
+FTP 'ACCT' command will be omitted from the appropriate file operation.
+These commands have the familiar syntax of <command verb> followed by
+<space> or optionally '-', followed by <parameter> and <CR> <LF>.  The
+<operand> is an account number consisting of one to six alphameric
+characters.
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.             9/99 ]
+
+
+
+
+Krilanovich                                                     [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc436.txt](<www.ietf.org/rfc/rfc436.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
