### PR TITLE
Archive rfc4363.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4363.txt
+++ b/www.ietf.org/rfc/rfc4363.txt
@@ -1,0 +1,5547 @@
+
+
+
+
+
+
+Network Working Group                                            D. Levi
+Request for Comments: 4363                               Nortel Networks
+Obsoletes: 2674                                            D. Harrington
+Category: Standards Track                             Effective Software
+                                                            January 2006
+
+
+        Definitions of Managed Objects for Bridges with Traffic
+        Classes, Multicast Filtering, and Virtual LAN Extensions
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2006).
+
+Abstract
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in TCP/IP-based internets.
+   In particular, it defines two MIB modules for managing the
+   capabilities of MAC bridges defined by the IEEE 802.1D-1998 (TM) MAC
+   Bridges and the IEEE 802.1Q-2003 (TM) Virtual LAN (VLAN) standards
+   for bridging between Local Area Network (LAN) segments.  One MIB
+   module defines objects for managing the 'Traffic Classes' and
+   'Enhanced Multicast Filtering' components of IEEE 802.1D-1998 and
+   P802.1t-2001 (TM).  The other MIB module defines objects for managing
+   VLANs, as specified in IEEE 802.1Q-2003, P802.1u (TM), and P802.1v
+   (TM).
+
+   Provisions are made for support of transparent bridging.  Provisions
+   are also made so that these objects apply to bridges connected by
+   subnetworks other than LAN segments.
+
+   This memo supplements RFC 4188 and obsoletes RFC 2674.
+
+
+
+
+
+
+
+
+
+
+Levi & Harrington           Standards Track                     [Page 1]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+Table of Contents
+
+   1. The Internet-Standard Management Framework ......................3
+   2. Overview ........................................................3
+      2.1. Scope ......................................................3
+   3. Structure of MIBs ...............................................4
+      3.1. Structure of Extended Bridge MIB Module ....................5
+           3.1.1. Relationship to IEEE 802.1D-1998 Manageable
+                  Objects .............................................5
+           3.1.2. Relationship to IEEE 802.1Q Manageable Objects ......6
+           3.1.3. The dot1dExtBase Subtree ............................7
+           3.1.4. The dot1dPriority Subtree ...........................7
+           3.1.5. The dot1dGarp Subtree ...............................7
+           3.1.6. The dot1dGmrp Subtree ...............................7
+           3.1.7. The dot1dTpHCPortTable ..............................8
+           3.1.8. The dot1dTpPortOverflowTable ........................8
+      3.2. Structure of Virtual Bridge MIB module .....................8
+           3.2.1. Relationship to IEEE 802.1Q Manageable Objects ......8
+           3.2.2. The dot1qBase Subtree ..............................12
+           3.2.3. The dot1qTp Subtree ................................12
+           3.2.4. The dot1qStatic Subtree ............................12
+           3.2.5. The dot1qVlan Subtree ..............................12
+      3.3. Textual Conventions .......................................12
+      3.4. Relationship to Other MIBs ................................13
+           3.4.1. Relationship to the SNMPv2-MIB .....................13
+           3.4.2. Relationship to the IF-MIB .........................13
+                  3.4.2.1. Layering Model ............................14
+                  3.4.2.2. ifStackTable ..............................15
+                  3.4.2.3. ifRcvAddressTable .........................15
+           3.4.3. Relationship to the BRIDGE-MIB .....................16
+                  3.4.3.1. The dot1dBase Subtree .....................16
+                  3.4.3.2. The dot1dStp Subtree ......................16
+                  3.4.3.3. The dot1dTp Subtree .......................16
+                  3.4.3.4. The dot1dStatic Subtree ...................17
+                  3.4.3.5. Additions to the BRIDGE-MIB ...............17
+   4. Definitions for Extended Bridge MIB ............................18
+   5. Definitions for Virtual Bridge MIB .............................42
+   6. Acknowledgements ...............................................91
+   7. Security Considerations ........................................91
+   8. Normative References ...........................................94
+   9. Informative References .........................................95
+   Appendix A. Email from Tony Jeffrey from IEEE .....................96
+
+
+
+
+
+
+
+
+
+Levi & Harrington           Standards Track                     [Page 2]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+1.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This memo specifies a MIB
+   module that is compliant to the SMIv2, which is described in STD 58,
+   RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579] and STD 58, RFC 2580
+   [RFC2580].
+
+2.  Overview
+
+   A common device present in many networks is the Bridge.  This device
+   is used to connect Local Area Network segments below the network
+   layer.  These devices are often known as 'layer 2 switches'.
+
+   The transparent method of bridging is defined by IEEE 802.1D-1998
+   [802.1D].  Managed objects for transparent bridging are defined in
+   the BRIDGE-MIB [BRIDGE-MIB].
+
+   The original IEEE 802.1D is augmented by IEEE 802.1Q-2003 [802.1Q] to
+   provide support for 'virtual bridged LANs' where a single bridged
+   physical LAN network may be used to support multiple logical bridged
+   LANs, each of which offers a service approximately the same as that
+   defined by IEEE 802.1D.  Such virtual LANs (VLANs) are an integral
+   feature of switched LAN networks.  A VLAN can be viewed as a group of
+   end-stations on multiple LAN segments and can communicate as if they
+   were on a single LAN.  IEEE 802.1Q defines port-based Virtual LANs
+   where membership is determined by the bridge port on which data
+   frames are received, and port-and-protocol-based Virtual LANs where
+   membership is determined by the bridge port on which frames are
+   received and the protocol identifier of the frame.  This memo defines
+   the objects needed for the management of port-based VLANs in bridge
+   entities.
+
+   This memo supplements RFC 4188 [BRIDGE-MIB] and obsoletes RFC 2674
+   [RFC2674].
+
+2.1.  Scope
+
+   The MIB modules defined in this document include a comprehensive set
+   of managed objects that attempts to match the set defined in IEEE
+   802.1D and IEEE 802.1Q.  However, to be consistent with the spirit of
+
+
+
+Levi & Harrington           Standards Track                     [Page 3]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+   the SNMP Framework, a subjective judgement was made to omit the
+   objects from those standards most 'costly' to implement in an agent
+   and least 'essential' for fault and configuration management.  The
+   omissions are described in Section 3 below.
+
+   Historical note:
+
+   The original BRIDGE-MIB [RFC1493] used the following principles for
+   determining inclusion of an object in the BRIDGE-MIB module:
+
+   (1)   Start with a small set of essential objects and add only as
+         further objects are needed.
+
+   (2)   Require that objects be essential for either fault or
+         configuration management.
+
+   (3)   Consider evidence of current use and/or utility.
+
+   (4)   Limit the total number of objects.
+
+   (5)   Exclude objects that are simply derivable from others in this
+         or other MIBs.
+
+   (6)   Avoid causing critical sections to be heavily instrumented.
+         The guideline that was followed is one counter per critical
+         section per layer.
+
+3.  Structure of MIBs
+
+   This document defines objects that supplement those in the BRIDGE-MIB
+   module [BRIDGE-MIB].  Section 3.4.3 of the present document contains
+   some recommendations regarding usage of objects in the BRIDGE-MIB by
+   devices implementing the enhancements defined here.
+
+   An extended bridge MIB module P-BRIDGE-MIB defines managed objects
+   for the traffic class and multicast filtering enhancements defined by
+   IEEE 802.1D-1998 [802.1D], including the Restricted Group
+   Registration control defined by IEEE P802.1t [802.1t].
+
+   A virtual bridge MIB module Q-BRIDGE-MIB defines managed objects for
+   the Virtual LAN bridging enhancements defined by IEEE 802.1Q-2003
+   [802.1Q], including the Restricted VLAN Registration control, defined
+   by IEEE P802.1u [802.1u], and the VLAN Classification by Protocol and
+   Port enhancement, defined by IEEE P802.1v [802.1v].
+
+
+
+
+
+
+
+Levi & Harrington           Standards Track                     [Page 4]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+3.1.  Structure of Extended Bridge MIB Module
+
+   Objects in this MIB are arranged into subtrees.  Each subtree is
+   organized as a set of related objects.  The overall structure and
+   assignment of objects to their subtrees is shown below.
+
+3.1.1.  Relationship to IEEE 802.1D-1998 Manageable Objects
+
+   This section contains a cross-reference to the objects defined in
+   IEEE 802.1D-1998 [802.1D].  It also details those objects that are
+   not considered necessary in this MIB module.
+
+   Some objects defined by IEEE 802.1D-1998 have been included in the
+   virtual bridge MIB module rather than this one: entries in
+   dot1qTpGroupTable, dot1qForwardAllTable, and
+   dot1qForwardUnregisteredTable are required for virtual bridged LANs
+   with additional indexing (e.g., per-VLAN, per-Filtering-Database
+   (per-FDB)) and so are not defined here.  Instead, devices that do not
+   implement virtual bridged LANs but do implement the Extended
+   Forwarding Services defined by IEEE 802.1D (i.e., dynamic learning of
+   multicast group addresses and group service requirements in the
+   filtering database) should implement these tables with a fixed value
+   for dot1qFdbId (the value 1 is recommended) or dot1qVlanIndex (the
+   value 1 is recommended).  Devices that support Extended Filtering
+   Services should support dot1qTpGroupTable, dot1qForwardAllTable, and
+   dot1qForwardUnregisteredTable.
+
+   Extended Bridge MIB Name            IEEE 802.1D-1998 Name
+
+   dot1dExtBase                        Bridge
+     dot1dDeviceCapabilities
+       dot1dExtendedFilteringServices
+       dot1dTrafficClasses
+     dot1dTrafficClassesEnabled
+     dot1dGmrpStatus                    .ApplicantAdministrativeControl
+   dot1dPriority
+     dot1dPortPriorityTable
+       dot1dPortDefaultUserPriority     .UserPriority
+       dot1dPortNumTrafficClasses
+     dot1dUserPriorityRegenTable        .UserPriorityRegenerationTable
+       dot1dUserPriority
+       dot1dRegenUserPriority
+     dot1dTrafficClassTable             .TrafficClassTable
+       dot1dTrafficClassPriority
+       dot1dTrafficClass
+     dot1dPortOutboundAccessPriorityTable
+                                        .OutboundAccessPriorityTable
+   dot1dPortOutboundAccessPriority
+
+
+
+Levi & Harrington           Standards Track                     [Page 5]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+   dot1dGarp
+     dot1dPortGarpTable
+       dot1dPortGarpJoinTime            .JoinTime
+       dot1dPortGarpLeaveTime           .LeaveTime
+       dot1dPortGarpLeaveAllTime        .LeaveAllTime
+   dot1dGmrp
+     dot1dPortGmrpTable
+       dot1dPortGmrpStatus             .ApplicantAdministrativeControl
+       dot1dPortGmrpFailedRegistrations .FailedRegistrations
+       dot1dPortGmrpLastPduOrigin       .OriginatorOfLastPDU
+       dot1dPortRestrictedGroupRegistration
+                                        Restricted Group Registration
+                                        (Ref. IEEE 802.1t 10.3.2.3)
+   dot1dTp
+     dot1dTpHCPortTable
+       dot1dTpHCPortInFrames            .BridgePort.FramesReceived
+       dot1dTpHCPortOutFrames             .ForwardOutBound
+       dot1dTpHCPortInDiscards            .DiscardInbound
+     dot1dTpPortOverflowTable
+       dot1dTpPortInOverflowFrames      .BridgePort.FramesReceived
+       dot1dTpPortOutOverflowFrames       .ForwardOutBound
+       dot1dTpPortInOverflowDiscards      .DiscardInbound
+
+   The following IEEE 802.1D-1998 management objects have not been
+   included in the Bridge MIB for the indicated reasons.
+
+   IEEE 802.1D-1998 Object           Disposition
+
+   Bridge.StateValue                 not considered useful
+   Bridge.ApplicantAdministrativeControl
+                                     not provided per-attribute
+                                     (e.g., per-VLAN, per-Group).
+                                     Only per-{device,port,application}
+                                     control is provided in this MIB.
+
+   notify group registration failure    not considered useful
+     (IEEE 802.1t 14.10.1.2)
+
+3.1.2.  Relationship to IEEE 802.1Q Manageable Objects
+
+   This section contains section number cross-references to manageable
+   objects defined in IEEE 802.1Q-2003 [802.1Q].  These objects have
+   been included in this MIB as they provide a natural fit with the IEEE
+   802.1D objects with which they are co-located.
+
+
+
+
+
+
+
+Levi & Harrington           Standards Track                     [Page 6]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+   Extended Bridge MIB Name            IEEE 802.1Q-2003 Section and Name
+
+   dot1dExtBase                        Bridge
+     dot1dDeviceCapabilities
+       dot1qStaticEntryIndividualPort   5.2 implementation options
+       dot1qIVLCapable
+       dot1qSVLCapable
+       dot1qHybridCapable
+       dot1qConfigurablePvidTagging     12.10.1.1 read bridge vlan
+                                                 config
+       dot1dLocalVlanCapable
+     dot1dPortCapabilitiesTable
+       dot1dPortCapabilities
+         dot1qDot1qTagging              5.2 implementation options
+         dot1qConfigurableAcceptableFrameTypes
+                                        5.2 implementation options
+         dot1qIngressFiltering          5.2 implementation options
+
+3.1.3.  The dot1dExtBase Subtree
+
+   This subtree contains the objects that are applicable to all bridges
+   implementing the traffic class and multicast filtering features of
+   IEEE 802.1D-1998 [802.1D].  It includes per-device configuration of
+   Generic Attribute Registration Protocol (GARP) and GARP Multicast
+   Registration Protocol (GMRP) protocols.
+
+3.1.4.  The dot1dPriority Subtree
+
+   This subtree contains the objects for configuring and reporting
+   status of priority-based queuing mechanisms in a bridge.  This
+   includes per-port user_priority treatment, mapping of user_priority
+   in frames into internal traffic classes, and outbound user_priority
+   and access_priority.
+
+3.1.5.  The dot1dGarp Subtree
+
+   This subtree contains the objects for configuring and reporting on
+   operation of the Generic Attribute Registration Protocol (GARP).
+
+3.1.6.  The dot1dGmrp Subtree
+
+   This subtree contains the objects for configuring and reporting on
+   operation of the GARP Multicast Registration Protocol (GMRP).
+
+
+
+
+
+
+
+
+Levi & Harrington           Standards Track                     [Page 7]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+3.1.7.  The dot1dTpHCPortTable
+
+   This table extends the dot1dTp subtree from the BRIDGE-MIB
+   [BRIDGE-MIB] and contains the objects for reporting port-bridging
+   statistics for high-capacity network interfaces.
+
+3.1.8.  The dot1dTpPortOverflowTable
+
+   This table extends the dot1dTp subtree from the BRIDGE-MIB
+   [BRIDGE-MIB] and contains the objects for reporting the upper bits of
+   port-bridging statistics for high-capacity network interfaces for
+   when 32-bit counters are inadequate.
+
+3.2.  Structure of Virtual Bridge MIB module
+
+   Objects in this MIB are arranged into subtrees.  Each subtree is
+   organized as a set of related objects.  The overall structure and
+   assignment of objects to their subtrees is shown below.  Some
+   manageable objects defined in the BRIDGE-MIB [BRIDGE-MIB] need to be
+   indexed differently when they are used in a VLAN bridging
+   environment: these objects are, therefore, effectively duplicated by
+   new objects with different indexing, which are defined in the Virtual
+   Bridge MIB.
+
+3.2.1.  Relationship to IEEE 802.1Q Manageable Objects
+
+   This section contains section-number cross-references to manageable
+   objects defined in clause 12 of IEEE 802.1Q-2003 [802.1Q].  It also
+   details those objects that are not considered necessary in this MIB
+   module.
+
+   Note: Unlike IEEE 802.1D-1998, IEEE 802.1Q-2003 [802.1Q] did not
+   define exact syntax for a set of managed objects.  The following
+   cross-references indicate the section numbering of the descriptions
+   of management operations from clause 12 in the latter document.
+
+   Virtual Bridge MIB object          IEEE 802.1Q-2003 Reference
+
+   dot1qBase
+     dot1qVlanVersionNumber           12.10.1.1 read bridge vlan config
+     dot1qMaxVlanId                   12.10.1.1 read bridge vlan config
+     dot1qMaxSupportedVlans           12.10.1.1 read bridge vlan config
+     dot1qNumVlans
+     dot1qGvrpStatus                  12.9.2.1/2 read/set garp
+                                                applicant controls
+   dot1qTp
+     dot1qFdbTable
+       dot1qFdbId
+
+
+
+Levi & Harrington           Standards Track                     [Page 8]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+       dot1qFdbDynamicCount           12.7.1.1.3 read filtering d/base
+     dot1qTpFdbTable
+       dot1qTpFdbAddress
+       dot1qTpFdbPort
+       dot1qTpFdbStatus
+     dot1qTpGroupTable                12.7.7.1 read filtering entry
+       dot1qTpGroupAddress
+       dot1qTpGroupEgressPorts
+       dot1qTpGroupLearnt
+     dot1qForwardAllTable             12.7.7.1 read filtering entry
+       dot1qForwardAllPorts
+       dot1qForwardAllStaticPorts
+       dot1qForwardAllForbiddenPorts
+     dot1qForwardUnregisteredTable    12.7.7.1 read filtering entry
+       dot1qForwardUnregisteredPorts
+       dot1qForwardUnregisteredStaticPorts
+       dot1qForwardUnregisteredForbiddenPorts
+   dot1qStatic
+     dot1qStaticUnicastTable          12.7.7.1 create/delete/read
+                                                filtering entry
+                                      12.7.6.1 read permanent database
+       dot1qStaticUnicastAddress
+       dot1qStaticUnicastReceivePort
+       dot1qStaticUnicastAllowedToGoTo
+       dot1qStaticUnicastStatus
+     dot1qStaticMulticastTable        12.7.7.1 create/delete/read
+                                                filtering entry
+                                      12.7.6.1 read permanent database
+       dot1qStaticMulticastAddress
+       dot1qStaticMulticastReceivePort
+       dot1qStaticMulticastStaticEgressPorts
+       dot1qStaticMulticastForbiddenEgressPorts
+       dot1qStaticMulticastStatus
+   dot1qVlan
+     dot1qVlanNumDeletes
+     dot1qVlanCurrentTable            12.10.2.1 read vlan configuration
+                                      12.10.3.5 read VID to FID
+                                                allocations
+                                      12.10.3.6 read FID allocated to
+                                                VID
+                                      12.10.3.7 read VIDs allocated to
+                                                FID
+       dot1qVlanTimeMark
+       dot1qVlanIndex
+       dot1qVlanFdbId
+       dot1qVlanCurrentEgressPorts
+       dot1qVlanCurrentUntaggedPorts
+       dot1qVlanStatus
+
+
+
+Levi & Harrington           Standards Track                     [Page 9]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+       dot1qVlanCreationTime
+     dot1qVlanStaticTable             12.7.7.1/2/3 create/delete/read
+                                                filtering entry
+                                      12.7.6.1 read permanent database
+                                      12.10.2.2 create vlan config
+                                      12.10.2.3 delete vlan config
+       dot1qVlanStaticName            12.4.1.3 set bridge name
+       dot1qVlanStaticEgressPorts
+       dot1qVlanForbiddenEgressPorts
+       dot1qVlanStaticUntaggedPorts
+       dot1qVlanStaticRowStatus
+     dot1qNextFreeLocalVlanIndex
+     dot1qPortVlanTable               12.10.1.1 read bridge vlan
+                                                configuration
+       dot1qPvid                      12.10.1.2 configure PVID values
+       dot1qPortAcceptableFrameTypes  12.10.1.3 configure acceptable
+                                                frame types parameter
+       dot1qPortIngressFiltering      12.10.1.4 configure ingress
+                                                filtering parameters
+       dot1qPortGvrpStatus            12.9.2.2 read/set garp applicant
+                                                controls
+       dot1qPortGvrpFailedRegistrations
+       dot1qPortGvrpLastPduOrigin
+       dot1qPortRestrictedVlanRegistration
+                                      IEEE 802.1u 11.2.3.2.3
+                                           Restricted VLAN Registration
+     dot1qPortVlanStatisticsTable     12.6.1.1 read forwarding port
+                                                counters
+       dot1qTpVlanPortInFrames
+       dot1qTpVlanPortOutFrames
+       dot1qTpVlanPortInDiscards
+       dot1qTpVlanPortInOverflowFrames
+       dot1qTpVlanPortOutOverflowFrames
+       dot1qTpVlanPortInOverflowDiscards
+     dot1qPortVlanHCStatisticsTable   12.6.1.1 read forwarding port
+                                                counters
+       dot1qTpVlanPortHCInFrames
+       dot1qTpVlanPortHCOutFrames
+       dot1qTpVlanPortHCInDiscards
+     dot1qLearningConstraintsTable    12.10.3.1/3/4 read/set/delete
+                                              vlan learning constraints
+                                      12.10.3.2 read vlan learning
+                                              constraints for VID
+       dot1qConstraintVlan
+       dot1qConstraintSet
+       dot1qConstraintType
+       dot1qConstraintStatus
+     dot1qConstraintSetDefault
+
+
+
+Levi & Harrington           Standards Track                    [Page 10]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+     dot1qConstraintTypeDefault
+
+   dot1vProtocol                      IEEE 802.1v Reference:
+     dot1vProtocolGroupTable            8.6.4 Protocol Group Database,
+                                        8.6.2 Protocol Template
+       dot1vProtocolTemplateFrameType
+       dot1vProtocolTemplateProtocolValue
+       dot1vProtocolGroupId             8.6.3 Protocol Group Identifier
+       dot1vProtocolGroupRowStatus
+     dot1vProtocolPortTable             8.4.4 VID Set for each Port
+       dot1vProtocolPortGroupId
+       dot1vProtocolGroupVid
+       dot1vProtocolPortRowStatus
+
+
+   The following IEEE 802.1Q management objects have not been included
+   in the Bridge MIB for the indicated reasons.
+
+      IEEE 802.1Q-2003 Operation          Disposition
+
+      reset bridge (12.4.1.4)             not considered useful
+
+      reset vlan bridge (12.10.1.5)       not considered useful
+
+      read forwarding port counters (12.6.1.1)
+        discard on error details          not considered useful
+
+      read permanent database (12.7.6.1)
+        permanent database size           not considered useful
+        number of static filtering        count rows in
+           entries                          dot1qStaticUnicastTable +
+                                            dot1qStaticMulticastTable
+        number of static VLAN             count rows in
+          registration entries              dot1qVlanStaticTable
+      read filtering entry range          use GetNext operation.
+         (12.7.7.4)
+
+      read filtering database (12.7.1.1)
+        filtering database size           not considered useful
+        number of dynamic group address   count rows applicable to each
+            entries (12.7.1.3)            FDB in dot1dTpGroupTable
+
+      read garp state (12.9.3.1)          not considered useful
+
+      notify vlan registration failure    not considered useful
+        (12.10.1.6)
+
+
+
+
+
+Levi & Harrington           Standards Track                    [Page 11]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+      notify learning constraint violation
+        (12.10.3.10)                      not considered useful
+
+3.2.2.  The dot1qBase Subtree
+
+   This subtree contains the objects that are applicable to all bridges
+   implementing IEEE 802.1Q virtual LANs.
+
+3.2.3.  The dot1qTp Subtree
+
+   This subtree contains objects that control the operation and report
+   the status of transparent bridging.  This includes management of the
+   dynamic Filtering Databases for both unicast and multicast
+   forwarding.  This subtree will be implemented by all bridges that
+   perform destination-address filtering.
+
+3.2.4.  The dot1qStatic Subtree
+
+   This subtree contains objects that control static configuration
+   information for transparent bridging.  This includes management of
+   the static entries in the Filtering Databases for both unicast and
+   multicast forwarding.
+
+3.2.5.  The dot1qVlan Subtree
+
+   This subtree contains objects that control configuration and report
+   status of the Virtual LANs known to a bridge.  This includes
+   management of the statically configured VLANs as well as reporting
+   VLANs discovered by other means (e.g., GARP VLAN Registration
+   Protocol (GVRP)).  It also controls configuration and reports status
+   of per-port objects relating to VLANs and reports traffic statistics.
+   It also provides for management of the VLAN Learning Constraints.
+
+3.3.  Textual Conventions
+
+   Various Working Groups have defined standards-track MIB documents
+   (for example, [RFC2613] and [RFC3318]), that contain objects and
+   Textual Conventions to represent a Virtual Local Area Network
+   Identifier (VLAN-ID) [802.1Q].  New definitions are showing up in
+   various documents (for example, [RFC4323] and [RFC4149]).
+   Unfortunately, the result is a set of different definitions for the
+   same piece of management information.  This may lead to confusion and
+   unnecessary complexity.  In order to address this situation, three
+   new textual conventions are defined in the Q-BRIDGE-MIB, called
+   VlanIdOrAny, VlanIdOrNone, and VlanIdOrAnyOrNone.  These new textual
+   conventions should be (re)used in MIB modules so that they all
+   represent a VLAN-ID in the same way.
+
+
+
+
+Levi & Harrington           Standards Track                    [Page 12]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+   These textual conventions provide a means to specify MIB objects that
+   refer to a specific VLAN, to any VLAN, or to no VLAN.  For an example
+   of how these textual conventions might be used, consider a MIB
+   object, with SYNTAX of VlanIdOrAnyOrNone, that specifies the VLAN on
+   which to accept incoming packets of a particular protocol.  Such an
+   object would allow the device to be configured to accept packets of
+   this protocol received with a specific 802.1q tag value, with any
+   802.1q tag value, or with no 802.1q tag.  Note that a MIB object that
+   is defined using one of these textual conventions should clarify the
+   meaning of 'any VLAN' and/or 'no VLAN' in its DESCRIPTION clause.
+
+3.4.  Relationship to Other MIBs
+
+   As described above, some IEEE 802.1D management objects have not been
+   included in this MIB because they overlap with objects in other MIBs
+   applicable to a bridge implementing this MIB module.
+
+3.4.1.  Relationship to the SNMPv2-MIB
+
+   The SNMPv2-MIB [RFC3418] defines objects that are generally
+   applicable to managed devices.  These objects apply to the device as
+   a whole, irrespective of whether bridging is the device's sole
+   functionality or only a subset of the device's functionality.
+
+   Full support for the 802.1D management objects requires that the
+   SNMPv2-MIB objects sysDescr and sysUpTime be implemented.  Note that
+   compliance to the current SNMPv2-MIB module requires additional
+   objects and notifications to be implemented as specified in RFC 3418
+   [RFC3418].
+
+3.4.2.  Relationship to the IF-MIB
+
+   The IF-MIB, [RFC2863], requires that any MIB that is an adjunct of
+   the IF-MIB clarify specific areas within the IF-MIB.  These areas
+   were intentionally left vague in the IF-MIB in order to avoid over-
+   constraining the MIB, thereby precluding management of certain
+   media-types.
+
+   The IF-MIB enumerates several areas that a media-specific MIB must
+   clarify.  Each of these areas is addressed in a following subsection.
+   The implementor is referred to the IF-MIB in order to understand the
+   general intent of these areas.
+
+   The IF-MIB [RFC2863] defines managed objects for managing network
+   interfaces.  A network interface is considered attached to a
+   'subnetwork'.  (Note that this term is not to be confused with
+   'subnet', which refers to an addressing partitioning scheme used in
+   the Internet suite of protocols.)  The term 'segment' is used in this
+
+
+
+Levi & Harrington           Standards Track                    [Page 13]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+   memo to refer to such a subnetwork, whether it be an Ethernet
+   segment, a 'ring', a WAN link, or even an X.25 virtual circuit.
+
+   Full support for the 802.1D management objects requires that the
+   IF-MIB objects ifIndex, ifType, ifDescr, ifPhysAddress, and
+   ifLastChange are implemented.  Note that compliance to the current
+   IF-MIB module requires additional objects and notifications to be
+   implemented as specified in RFC 2863 [RFC2863].
+
+   Implicit in this Extended Bridge MIB is the notion of ports on a
+   bridge.  Each of these ports is associated with one interface of the
+   'interfaces' subtree (one row in ifTable), and, in most situations,
+   each port is associated with a different interface.  However, there
+   are situations in which multiple ports are associated with the same
+   interface.  An example of such a situation would be several ports
+   each corresponding one-to-one with several X.25 virtual circuits but
+   all on the same interface.
+
+   Each port is uniquely identified by a port number.  A port number has
+   no mandatory relationship to an interface number, but in the simple
+   case a port number will have the same value as the corresponding
+   interface's interface number.  Port numbers are in the range
+   (1..dot1dBaseNumPorts).
+
+   Some entities perform other functionality as well as bridging through
+   the sending and receiving of data on their interfaces.  In such
+   situations, only a subset of the data sent/received on an interface
+   is within the domain of the entity's bridging functionality.  This
+   subset is considered delineated according to a set of protocols, with
+   some protocols being bridged, and other protocols not being bridged.
+   For example, in an entity that exclusively performed bridging, all
+   protocols would be considered bridged, whereas in an entity that
+   performed IP routing on IP datagrams and only bridged other
+   protocols, only the non-IP data would be considered bridged.
+
+   Thus, this Extended Bridge MIB (and in particular, its counters) is
+   applicable only to that subset of the data on an entity's interfaces
+   that is sent/received for a protocol being bridged.  All such data is
+   sent/received via the ports of the bridge.
+
+3.4.2.1.  Layering Model
+
+   This memo assumes the interpretation of the Interfaces Subtree to be
+   in accordance with the IF-MIB [RFC2863], which states that the
+   interfaces table (ifTable) contains information on the managed
+   resource's interfaces and that each sub-layer below the internetwork
+   layer of a network interface is considered an interface.
+
+
+
+
+Levi & Harrington           Standards Track                    [Page 14]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+   This document does not make any assumption that within an entity,
+   VLANs that are instantiated as an entry in dot1qVlanCurrentTable by
+   either management configuration through dot1qVlanStaticTable or by
+   dynamic means (e.g., through GVRP) are also represented by an entry
+   in ifTable.
+
+   Where an entity contains higher-layer protocol entities (e.g.,
+   IP-layer interfaces that transmit and receive traffic to/from a
+   VLAN), these should be represented in the ifTable as interfaces of
+   type propVirtual(53).  Protocol-specific types such as l3ipxvlan(137)
+   should not be used here, since there is no implication that the
+   bridge will perform any protocol filtering before delivering up to
+   these virtual interfaces.
+
+3.4.2.2.  ifStackTable
+
+   In addition, the IF-MIB [RFC2863] defines a table 'ifStackTable' for
+   describing the relationship between logical interfaces within an
+   entity.  It is anticipated that implementors will use this table to
+   describe the binding of (for example) IP interfaces to physical
+   ports, although the presence of VLANs makes the representation less
+   than perfect for showing connectivity.  The ifStackTable cannot
+   represent the full capability of the IEEE 802.1Q VLAN bridging
+   standard, since that makes a distinction between VLAN bindings on
+   'ingress' to and 'egress' from a port: these relationships may or may
+   not be symmetrical whereas Interface MIB Evolution assumes a
+   symmetrical binding for transmit and receive.  This makes it
+   necessary to define other manageable objects for configuring which
+   ports are members of which VLANs.
+
+3.4.2.3.  ifRcvAddressTable
+
+   This table contains all MAC addresses, unicast, multicast, and
+   broadcast, for which an interface will receive packets and forward
+   them up to a higher-layer entity for local consumption.  Note that
+   this does not include addresses for data-link layer control protocols
+   such as Spanning-Tree, GMRP, or GVRP.  The format of the address,
+   contained in ifRcvAddressAddress, is the same as for ifPhysAddress.
+
+   This table does not include unicast or multicast addresses that are
+   accepted for possible forwarding out some other port.  This table is
+   explicitly not intended to provide a bridge address filtering
+   mechanism.
+
+
+
+
+
+
+
+
+Levi & Harrington           Standards Track                    [Page 15]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+3.4.3.  Relationship to the BRIDGE-MIB
+
+   This section defines how objects in the BRIDGE-MIB module
+   [BRIDGE-MIB] should be represented for devices that implement the
+   extensions: some of the old objects are less useful in such devices
+   but must still be implemented for reasons of backwards compatibility.
+
+3.4.3.1.  The dot1dBase Subtree
+
+   This subtree contains objects that are applicable to all types of
+   bridges.  Interpretation of this subtree is unchanged.
+
+3.4.3.2.  The dot1dStp Subtree
+
+   This subtree contains the objects that denote the bridge's state with
+   respect to the Spanning Tree Protocol.  Interpretation of this
+   subtree is unchanged.
+
+3.4.3.3.  The dot1dTp Subtree
+
+   This subtree contains objects that describe the entity's state with
+   respect to transparent bridging.
+
+   In a device operating with a single Filtering Database,
+   interpretation of this subtree is unchanged.
+
+   In a device supporting multiple Filtering Databases, this subtree is
+   interpreted as follows:
+
+   dot1dTpLearnedEntryDiscards
+
+        The number of times that *any* of the FDBs became full.
+
+   dot1dTpAgingTime
+
+        This applies to all Filtering Databases.
+
+   dot1dTpFdbTable
+
+        Report MAC addresses learned on each port, regardless of which
+        Filtering Database they have been learned in.  If an address has
+        been learned in multiple databases on a single port, report it
+        only once.  If an address has been learned in multiple databases
+        on more than one port, report the entry on any one of the valid
+        ports.
+
+
+
+
+
+
+Levi & Harrington           Standards Track                    [Page 16]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+   dot1dTpPortTable
+
+        This table is port-based and is not affected by multiple
+        Filtering Databases or multiple VLANs.  The counters should
+        include frames received or transmitted for all VLANs.  Note that
+        equivalent 64-bit port statistics counters, as well as other
+        objects to represent the upper 32 bits of these counters, are
+        defined in this document for high-capacity network interfaces.
+        These have conformance statements to indicate for which speeds
+        of interface they are required.
+
+3.4.3.4.  The dot1dStatic Subtree
+
+   This optional subtree contains objects that describe the
+   configuration of destination-address filtering.
+
+   In a device operating with a single Filtering Database,
+   interpretation of this subtree is unchanged.
+
+   In a device supporting multiple Filtering Databases, this subtree is
+   interpreted as follows:
+
+   dot1dStaticTable
+
+        Entries read from this table include all static entries from all
+        of the Filtering Databases.  Entries for the same MAC address
+        and receive port in more than one Filtering Database must appear
+        only once, since these are the indices of this table.  This
+        table should be implemented as read-only in devices that support
+        multiple Forwarding Databases.  Instead, write access should be
+        provided through dot1qStaticUnicastTable and
+        dot1qStaticMulticastTable, as defined in this document.
+
+3.4.3.5.  Additions to the BRIDGE-MIB
+
+   To supplement the BRIDGE-MIB [BRIDGE-MIB], this module contains:
+
+   (1)   support for multiple traffic classes and dynamic multicast
+         filtering as per IEEE 802.1D-1998 [802.1D].
+
+   (2)   support for bridged Virtual LANs as per IEEE 802.1Q-2003
+         [802.1Q].
+
+   (3)   support for 64-bit versions of BRIDGE-MIB [BRIDGE-MIB] port
+         counters.
+
+
+
+
+
+
+Levi & Harrington           Standards Track                    [Page 17]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+4.  Definitions for Extended Bridge MIB
+
+P-BRIDGE-MIB DEFINITIONS ::= BEGIN
+
+-- -------------------------------------------------------------
+-- MIB for IEEE 802.1p devices
+-- -------------------------------------------------------------
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Counter32, Integer32, Counter64
+        FROM SNMPv2-SMI
+    TruthValue, TimeInterval, MacAddress, TEXTUAL-CONVENTION
+        FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP
+        FROM SNMPv2-CONF
+    dot1dTp, dot1dTpPort, dot1dBridge,
+    dot1dBasePortEntry, dot1dBasePort
+        FROM BRIDGE-MIB;
+
+pBridgeMIB MODULE-IDENTITY
+    LAST-UPDATED "200601090000Z"
+    ORGANIZATION "IETF Bridge MIB Working Group"
+    CONTACT-INFO
+        "Email:  bridge-mib@ietf.org
+                 ietfmibs@ops.ietf.org
+
+                 David Levi
+         Postal: Nortel Networks
+                 4655 Great America Parkway
+                 Santa Clara, CA 95054
+                 USA
+                 Phone: +1 865 686 0432
+                 Email: dlevi@nortel.com
+
+                 David Harrington
+         Postal: Effective Software
+                 50 Harding Rd.
+                 Portsmouth, NH 03801
+                 USA
+                 Phone: +1 603 436 8634
+                 Email: ietfdbh@comcast.net
+
+                 Les Bell
+         Postal: Hemel Hempstead, Herts. HP2 7YU
+                 UK
+          Email: elbell@ntlworld.com
+
+                 Vivian Ngai
+
+
+
+Levi & Harrington           Standards Track                    [Page 18]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+          Email: vivian_ngai@acm.org
+
+                 Andrew Smith
+         Postal: Beijing Harbour Networks
+                 Jiuling Building
+                 21 North Xisanhuan Ave.
+                 Beijing, 100089
+                 PRC
+            Fax: +1 415 345 1827
+          Email: ah_smith@acm.org
+
+                 Paul Langille
+         Postal: Newbridge Networks
+                 5 Corporate Drive
+                 Andover, MA 01810
+                 USA
+          Phone: +1 978 691 4665
+          Email: langille@newbridge.com
+
+                 Anil Rijhsinghani
+         Postal: Accton Technology Corporation
+                 5 Mount Royal Ave
+                 Marlboro, MA 01752
+                 USA
+          Phone:
+          Email: anil@accton.com
+
+                 Keith McCloghrie
+         Postal: Cisco Systems, Inc.
+                 170 West Tasman Drive
+                 San Jose, CA 95134-1706
+                 USA
+          Phone: +1 408 526 5260
+          Email: kzm@cisco.com"
+    DESCRIPTION
+        "The Bridge MIB Extension module for managing Priority
+        and Multicast Filtering, defined by IEEE 802.1D-1998,
+        including Restricted Group Registration defined by
+        IEEE 802.1t-2001.
+
+        Copyright (C) The Internet Society (2006).  This version of
+        this MIB module is part of RFC 4363; See the RFC itself for
+        full legal notices."
+    REVISION     "200601090000Z"
+    DESCRIPTION
+         "Added dot1dPortRestrictedGroupRegistration.
+          Deprecated pBridgePortGmrpGroup and pBridgeCompliance
+          and added pBridgePortGmrpGroup2 and pBridgeCompliance2."
+
+
+
+Levi & Harrington           Standards Track                    [Page 19]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+    REVISION     "199908250000Z"
+    DESCRIPTION
+         "The Bridge MIB Extension module for managing Priority
+          and Multicast Filtering, defined by IEEE 802.1D-1998.
+
+          Initial version, published as RFC 2674."
+
+    ::= { dot1dBridge 6 }
+
+pBridgeMIBObjects OBJECT IDENTIFIER ::= { pBridgeMIB 1 }
+
+-- -------------------------------------------------------------
+-- Textual Conventions
+-- -------------------------------------------------------------
+
+EnabledStatus ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+        "A simple status value for the object."
+    SYNTAX      INTEGER { enabled(1), disabled(2) }
+
+-- -------------------------------------------------------------
+-- subtrees in the P-BRIDGE MIB
+-- -------------------------------------------------------------
+
+dot1dExtBase    OBJECT IDENTIFIER ::= { pBridgeMIBObjects 1 }
+dot1dPriority   OBJECT IDENTIFIER ::= { pBridgeMIBObjects 2 }
+dot1dGarp       OBJECT IDENTIFIER ::= { pBridgeMIBObjects 3 }
+dot1dGmrp       OBJECT IDENTIFIER ::= { pBridgeMIBObjects 4 }
+
+-- -------------------------------------------------------------
+-- the dot1dExtBase subtree
+-- -------------------------------------------------------------
+
+dot1dDeviceCapabilities OBJECT-TYPE
+    SYNTAX      BITS {
+        dot1dExtendedFilteringServices(0),
+        dot1dTrafficClasses(1),
+        dot1qStaticEntryIndividualPort(2),
+        dot1qIVLCapable(3),
+        dot1qSVLCapable(4),
+        dot1qHybridCapable(5),
+        dot1qConfigurablePvidTagging(6),
+        dot1dLocalVlanCapable(7)
+    }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+
+
+
+Levi & Harrington           Standards Track                    [Page 20]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        "Indicates the optional parts of IEEE 802.1D and 802.1Q
+        that are implemented by this device and are manageable
+        through this MIB.  Capabilities that are allowed on a
+        per-port basis are indicated in dot1dPortCapabilities.
+
+        dot1dExtendedFilteringServices(0),
+                              -- can perform filtering of
+                              -- individual multicast addresses
+                              -- controlled by GMRP.
+        dot1dTrafficClasses(1),
+                              -- can map user priority to
+                              -- multiple traffic classes.
+        dot1qStaticEntryIndividualPort(2),
+                              -- dot1qStaticUnicastReceivePort &
+                              -- dot1qStaticMulticastReceivePort
+                              -- can represent non-zero entries.
+        dot1qIVLCapable(3),   -- Independent VLAN Learning (IVL).
+        dot1qSVLCapable(4),   -- Shared VLAN Learning (SVL).
+        dot1qHybridCapable(5),
+                              -- both IVL & SVL simultaneously.
+        dot1qConfigurablePvidTagging(6),
+                              -- whether the implementation
+                              -- supports the ability to
+                              -- override the default PVID
+                              -- setting and its egress status
+                              -- (VLAN-Tagged or Untagged) on
+                              -- each port.
+        dot1dLocalVlanCapable(7)
+                              -- can support multiple local
+                              -- bridges, outside of the scope
+                              -- of 802.1Q defined VLANs."
+    REFERENCE
+        "ISO/IEC 15802-3 Section 5.2,
+        IEEE 802.1Q/D11 Section 5.2, 12.10.1.1.3/b/2"
+    ::= { dot1dExtBase 1 }
+
+dot1dTrafficClassesEnabled OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "The value true(1) indicates that Traffic Classes are
+        enabled on this bridge.  When false(2), the bridge
+        operates with a single priority level for all traffic.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    DEFVAL      { true }
+
+
+
+Levi & Harrington           Standards Track                    [Page 21]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+    ::= { dot1dExtBase 2 }
+
+dot1dGmrpStatus OBJECT-TYPE
+    SYNTAX      EnabledStatus
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "The administrative status requested by management for
+        GMRP.  The value enabled(1) indicates that GMRP should
+        be enabled on this device, in all VLANs, on all ports
+        for which it has not been specifically disabled.  When
+        disabled(2), GMRP is disabled, in all VLANs and on all
+        ports, and all GMRP packets will be forwarded
+        transparently.  This object affects both Applicant and
+        Registrar state machines.  A transition from disabled(2)
+        to enabled(1) will cause a reset of all GMRP state
+        machines on all ports.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    DEFVAL      { enabled }
+    ::= { dot1dExtBase 3 }
+
+-- -------------------------------------------------------------
+-- Port Capabilities Table
+-- -------------------------------------------------------------
+
+dot1dPortCapabilitiesTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1dPortCapabilitiesEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table that contains capabilities information about
+        every port that is associated with this bridge."
+    ::= { dot1dExtBase 4 }
+
+dot1dPortCapabilitiesEntry OBJECT-TYPE
+    SYNTAX      Dot1dPortCapabilitiesEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A set of capabilities information about this port
+        indexed by dot1dBasePort."
+    AUGMENTS { dot1dBasePortEntry }
+    ::= { dot1dPortCapabilitiesTable 1 }
+
+Dot1dPortCapabilitiesEntry ::=
+    SEQUENCE {
+
+
+
+Levi & Harrington           Standards Track                    [Page 22]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        dot1dPortCapabilities
+            BITS
+    }
+
+dot1dPortCapabilities OBJECT-TYPE
+    SYNTAX      BITS {
+        dot1qDot1qTagging(0),
+        dot1qConfigurableAcceptableFrameTypes(1),
+        dot1qIngressFiltering(2)
+    }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Indicates the parts of IEEE 802.1D and 802.1Q that are
+        optional on a per-port basis, that are implemented by
+        this device, and that are manageable through this MIB.
+
+        dot1qDot1qTagging(0), -- supports 802.1Q VLAN tagging of
+                              -- frames and GVRP.
+        dot1qConfigurableAcceptableFrameTypes(1),
+                              -- allows modified values of
+                              -- dot1qPortAcceptableFrameTypes.
+        dot1qIngressFiltering(2)
+                              -- supports the discarding of any
+                              -- frame received on a Port whose
+                              -- VLAN classification does not
+                              -- include that Port in its Member
+                              -- set."
+    REFERENCE
+        "ISO/IEC 15802-3 Section 5.2,
+        IEEE 802.1Q/D11 Section 5.2"
+    ::= { dot1dPortCapabilitiesEntry 1 }
+
+-- -------------------------------------------------------------
+-- the dot1dPriority subtree
+-- -------------------------------------------------------------
+
+-- -------------------------------------------------------------
+-- Port Priority Table
+-- -------------------------------------------------------------
+
+dot1dPortPriorityTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1dPortPriorityEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table that contains information about every port that
+        is associated with this transparent bridge."
+
+
+
+Levi & Harrington           Standards Track                    [Page 23]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+    ::= { dot1dPriority 1 }
+
+dot1dPortPriorityEntry OBJECT-TYPE
+    SYNTAX      Dot1dPortPriorityEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A list of Default User Priorities for each port of a
+        transparent bridge.  This is indexed by dot1dBasePort."
+    AUGMENTS { dot1dBasePortEntry }
+    ::= { dot1dPortPriorityTable 1 }
+
+Dot1dPortPriorityEntry ::=
+    SEQUENCE {
+        dot1dPortDefaultUserPriority
+            Integer32,
+        dot1dPortNumTrafficClasses
+            Integer32
+    }
+
+dot1dPortDefaultUserPriority OBJECT-TYPE
+    SYNTAX      Integer32 (0..7)
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "The default ingress User Priority for this port.  This
+        only has effect on media, such as Ethernet, that do not
+        support native User Priority.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    ::= { dot1dPortPriorityEntry 1 }
+
+dot1dPortNumTrafficClasses OBJECT-TYPE
+    SYNTAX      Integer32 (1..8)
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "The number of egress traffic classes supported on this
+        port.  This object may optionally be read-only.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    ::= { dot1dPortPriorityEntry 2 }
+
+-- -------------------------------------------------------------
+-- User Priority Regeneration Table
+-- -------------------------------------------------------------
+
+
+
+Levi & Harrington           Standards Track                    [Page 24]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+dot1dUserPriorityRegenTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1dUserPriorityRegenEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A list of Regenerated User Priorities for each received
+        User Priority on each port of a bridge.  The Regenerated
+        User Priority value may be used to index the Traffic
+        Class Table for each input port.  This only has effect
+        on media that support native User Priority.  The default
+        values for Regenerated User Priorities are the same as
+        the User Priorities."
+    REFERENCE
+        "ISO/IEC 15802-3 Section 6.4"
+    ::= { dot1dPriority 2 }
+
+dot1dUserPriorityRegenEntry OBJECT-TYPE
+    SYNTAX      Dot1dUserPriorityRegenEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A mapping of incoming User Priority to a Regenerated
+        User Priority."
+    INDEX   { dot1dBasePort, dot1dUserPriority }
+    ::= { dot1dUserPriorityRegenTable 1 }
+
+Dot1dUserPriorityRegenEntry ::=
+    SEQUENCE {
+        dot1dUserPriority
+            Integer32,
+        dot1dRegenUserPriority
+            Integer32
+    }
+
+dot1dUserPriority OBJECT-TYPE
+    SYNTAX      Integer32 (0..7)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The User Priority for a frame received on this port."
+    ::= { dot1dUserPriorityRegenEntry 1 }
+
+dot1dRegenUserPriority OBJECT-TYPE
+    SYNTAX      Integer32 (0..7)
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "The Regenerated User Priority that the incoming User
+
+
+
+Levi & Harrington           Standards Track                    [Page 25]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        Priority is mapped to for this port.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    ::= { dot1dUserPriorityRegenEntry 2 }
+
+-- -------------------------------------------------------------
+-- Traffic Class Table
+-- -------------------------------------------------------------
+
+dot1dTrafficClassTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1dTrafficClassEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table mapping evaluated User Priority to Traffic
+        Class, for forwarding by the bridge.  Traffic class is a
+        number in the range (0..(dot1dPortNumTrafficClasses-1))."
+    REFERENCE
+        "ISO/IEC 15802-3 Table 7-2"
+    ::= { dot1dPriority 3 }
+
+dot1dTrafficClassEntry OBJECT-TYPE
+    SYNTAX      Dot1dTrafficClassEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "User Priority to Traffic Class mapping."
+    INDEX   { dot1dBasePort, dot1dTrafficClassPriority }
+    ::= { dot1dTrafficClassTable 1 }
+
+Dot1dTrafficClassEntry ::=
+    SEQUENCE {
+        dot1dTrafficClassPriority
+            Integer32,
+        dot1dTrafficClass
+            Integer32
+    }
+
+dot1dTrafficClassPriority OBJECT-TYPE
+    SYNTAX      Integer32 (0..7)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The Priority value determined for the received frame.
+        This value is equivalent to the priority indicated in
+        the tagged frame received, or one of the evaluated
+        priorities, determined according to the media-type.
+
+
+
+Levi & Harrington           Standards Track                    [Page 26]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        For untagged frames received from Ethernet media, this
+        value is equal to the dot1dPortDefaultUserPriority value
+        for the ingress port.
+
+        For untagged frames received from non-Ethernet media,
+        this value is equal to the dot1dRegenUserPriority value
+        for the ingress port and media-specific user priority."
+    ::= { dot1dTrafficClassEntry 1 }
+
+dot1dTrafficClass OBJECT-TYPE
+    SYNTAX      Integer32 (0..7)
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "The Traffic Class the received frame is mapped to.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    ::= { dot1dTrafficClassEntry 2 }
+
+-- -------------------------------------------------------------
+-- Outbound Access Priority Table
+-- -------------------------------------------------------------
+
+dot1dPortOutboundAccessPriorityTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1dPortOutboundAccessPriorityEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table mapping Regenerated User Priority to Outbound
+        Access Priority.  This is a fixed mapping for all port
+        types, with two options for 802.5 Token Ring."
+    REFERENCE
+        "ISO/IEC 15802-3 Table 7-3"
+    ::= { dot1dPriority 4 }
+
+dot1dPortOutboundAccessPriorityEntry OBJECT-TYPE
+    SYNTAX      Dot1dPortOutboundAccessPriorityEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Regenerated User Priority to Outbound Access Priority
+        mapping."
+    INDEX   { dot1dBasePort, dot1dRegenUserPriority }
+    ::= { dot1dPortOutboundAccessPriorityTable 1 }
+
+Dot1dPortOutboundAccessPriorityEntry ::=
+    SEQUENCE {
+
+
+
+Levi & Harrington           Standards Track                    [Page 27]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        dot1dPortOutboundAccessPriority
+            Integer32
+    }
+
+dot1dPortOutboundAccessPriority OBJECT-TYPE
+    SYNTAX      Integer32 (0..7)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The Outbound Access Priority the received frame is
+        mapped to."
+    ::= { dot1dPortOutboundAccessPriorityEntry 1 }
+
+-- -------------------------------------------------------------
+-- the dot1dGarp subtree
+-- -------------------------------------------------------------
+
+-- -------------------------------------------------------------
+-- The GARP Port Table
+-- -------------------------------------------------------------
+
+dot1dPortGarpTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1dPortGarpEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table of GARP control information about every bridge
+        port.  This is indexed by dot1dBasePort."
+    ::= { dot1dGarp 1 }
+
+dot1dPortGarpEntry OBJECT-TYPE
+    SYNTAX      Dot1dPortGarpEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "GARP control information for a bridge port."
+    AUGMENTS { dot1dBasePortEntry }
+    ::= { dot1dPortGarpTable 1 }
+
+Dot1dPortGarpEntry ::=
+    SEQUENCE {
+        dot1dPortGarpJoinTime
+            TimeInterval,
+        dot1dPortGarpLeaveTime
+            TimeInterval,
+        dot1dPortGarpLeaveAllTime
+            TimeInterval
+    }
+
+
+
+Levi & Harrington           Standards Track                    [Page 28]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+dot1dPortGarpJoinTime OBJECT-TYPE
+    SYNTAX      TimeInterval
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "The GARP Join time, in centiseconds.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    DEFVAL      { 20 }
+    ::= { dot1dPortGarpEntry 1 }
+
+dot1dPortGarpLeaveTime OBJECT-TYPE
+    SYNTAX      TimeInterval
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "The GARP Leave time, in centiseconds.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    DEFVAL      { 60 }
+    ::= { dot1dPortGarpEntry 2 }
+
+dot1dPortGarpLeaveAllTime OBJECT-TYPE
+    SYNTAX      TimeInterval
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "The GARP LeaveAll time, in centiseconds.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    DEFVAL      { 1000 }
+    ::= { dot1dPortGarpEntry 3 }
+
+-- -------------------------------------------------------------
+-- The GMRP Port Configuration and Status Table
+-- -------------------------------------------------------------
+
+dot1dPortGmrpTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1dPortGmrpEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table of GMRP control and status information about
+        every bridge port.  Augments the dot1dBasePortTable."
+    ::= { dot1dGmrp 1 }
+
+
+
+Levi & Harrington           Standards Track                    [Page 29]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+dot1dPortGmrpEntry OBJECT-TYPE
+    SYNTAX      Dot1dPortGmrpEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "GMRP control and status information for a bridge port."
+    AUGMENTS { dot1dBasePortEntry }
+    ::= { dot1dPortGmrpTable 1 }
+
+Dot1dPortGmrpEntry ::=
+    SEQUENCE {
+        dot1dPortGmrpStatus
+            EnabledStatus,
+        dot1dPortGmrpFailedRegistrations
+            Counter32,
+        dot1dPortGmrpLastPduOrigin
+            MacAddress,
+        dot1dPortRestrictedGroupRegistration
+            TruthValue
+    }
+
+dot1dPortGmrpStatus OBJECT-TYPE
+    SYNTAX      EnabledStatus
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "The administrative state of GMRP operation on this port.  The
+        value enabled(1) indicates that GMRP is enabled on this port
+        in all VLANs as long as dot1dGmrpStatus is also enabled(1).
+        A value of disabled(2) indicates that GMRP is disabled on
+        this port in all VLANs: any GMRP packets received will
+        be silently discarded, and no GMRP registrations will be
+        propagated from other ports.  Setting this to a value of
+        enabled(1) will be stored by the agent but will only take
+        effect on the GMRP protocol operation if dot1dGmrpStatus
+        also indicates the value enabled(1).  This object affects
+        all GMRP Applicant and Registrar state machines on this
+        port.  A transition from disabled(2) to enabled(1) will
+        cause a reset of all GMRP state machines on this port.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    DEFVAL      { enabled }
+    ::= { dot1dPortGmrpEntry 1 }
+
+dot1dPortGmrpFailedRegistrations OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+
+
+
+Levi & Harrington           Standards Track                    [Page 30]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+    STATUS      current
+    DESCRIPTION
+        "The total number of failed GMRP registrations, for any
+        reason, in all VLANs, on this port."
+    ::= { dot1dPortGmrpEntry 2 }
+
+dot1dPortGmrpLastPduOrigin OBJECT-TYPE
+    SYNTAX      MacAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The Source MAC Address of the last GMRP message
+        received on this port."
+    ::= { dot1dPortGmrpEntry 3 }
+
+dot1dPortRestrictedGroupRegistration OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "The state of Restricted Group Registration on this port.
+         If the value of this control is true(1), then creation
+         of a new dynamic entry is permitted only if there is a
+         Static Filtering Entry for the VLAN concerned, in which
+         the Registrar Administrative Control value is Normal
+         Registration.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    REFERENCE
+        "IEEE 802.1t clause 10.3.2.3, 14.10.1.3."
+    DEFVAL      { false }
+    ::= { dot1dPortGmrpEntry 4 }
+
+-- -------------------------------------------------------------
+--  High-Capacity Port Table for Transparent Bridges
+-- -------------------------------------------------------------
+
+dot1dTpHCPortTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1dTpHCPortEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table that contains information about every high-
+        capacity port that is associated with this transparent
+        bridge."
+    ::= { dot1dTp 5 }
+
+
+
+
+Levi & Harrington           Standards Track                    [Page 31]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+dot1dTpHCPortEntry OBJECT-TYPE
+    SYNTAX      Dot1dTpHCPortEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Statistics information for each high-capacity port of a
+        transparent bridge."
+    INDEX   { dot1dTpPort }
+    ::= { dot1dTpHCPortTable 1 }
+
+Dot1dTpHCPortEntry ::=
+    SEQUENCE {
+        dot1dTpHCPortInFrames
+            Counter64,
+        dot1dTpHCPortOutFrames
+            Counter64,
+        dot1dTpHCPortInDiscards
+            Counter64
+    }
+
+dot1dTpHCPortInFrames OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of frames that have been received by this
+        port from its segment.  Note that a frame received on
+        the interface corresponding to this port is only counted
+        by this object if and only if it is for a protocol being
+        processed by the local bridging function, including
+        bridge management frames."
+    REFERENCE
+        "ISO/IEC 15802-3 Section 14.6.1.1.3"
+    ::= { dot1dTpHCPortEntry 1 }
+
+dot1dTpHCPortOutFrames OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of frames that have been transmitted by this
+        port to its segment.  Note that a frame transmitted on
+        the interface corresponding to this port is only counted
+        by this object if and only if it is for a protocol being
+        processed by the local bridging function, including
+        bridge management frames."
+    REFERENCE
+        "ISO/IEC 15802-3 Section 14.6.1.1.3"
+
+
+
+Levi & Harrington           Standards Track                    [Page 32]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+    ::= { dot1dTpHCPortEntry 2 }
+
+dot1dTpHCPortInDiscards OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Count of valid frames that have been received by this
+        port from its segment that were discarded (i.e.,
+        filtered) by the Forwarding Process."
+    REFERENCE
+        "ISO/IEC 15802-3 Section 14.6.1.1.3"
+    ::= { dot1dTpHCPortEntry 3 }
+
+-- ----------------------------------------------------
+--  Upper part of High-Capacity Port Table for Transparent Bridges
+-- ----------------------------------------------------
+
+dot1dTpPortOverflowTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1dTpPortOverflowEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table that contains the most-significant bits of
+        statistics counters for ports that are associated with this
+        transparent bridge that are on high-capacity interfaces, as
+        defined in the conformance clauses for this table.  This table
+        is provided as a way to read 64-bit counters for agents that
+        support only SNMPv1.
+
+        Note that the reporting of most-significant and
+        least-significant counter bits separately runs the risk of
+        missing an overflow of the lower bits in the interval between
+        sampling.  The manager must be aware of this possibility, even
+        within the same varbindlist, when interpreting the results of
+        a request or asynchronous notification."
+    ::= { dot1dTp 6 }
+
+dot1dTpPortOverflowEntry OBJECT-TYPE
+    SYNTAX      Dot1dTpPortOverflowEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The most significant bits of statistics counters for a high-
+        capacity interface of a transparent bridge.  Each object is
+        associated with a corresponding object in dot1dTpPortTable
+        that indicates the least significant bits of the counter."
+    INDEX   { dot1dTpPort }
+
+
+
+Levi & Harrington           Standards Track                    [Page 33]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+    ::= { dot1dTpPortOverflowTable 1 }
+
+Dot1dTpPortOverflowEntry ::=
+    SEQUENCE {
+        dot1dTpPortInOverflowFrames
+            Counter32,
+        dot1dTpPortOutOverflowFrames
+            Counter32,
+        dot1dTpPortInOverflowDiscards
+            Counter32
+    }
+
+dot1dTpPortInOverflowFrames OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of times the associated dot1dTpPortInFrames
+        counter has overflowed."
+    REFERENCE
+        "ISO/IEC 15802-3 Section 14.6.1.1.3"
+    ::= { dot1dTpPortOverflowEntry 1 }
+
+dot1dTpPortOutOverflowFrames OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of times the associated dot1dTpPortOutFrames
+        counter has overflowed."
+    REFERENCE
+        "ISO/IEC 15802-3 Section 14.6.1.1.3"
+    ::= { dot1dTpPortOverflowEntry 2 }
+
+dot1dTpPortInOverflowDiscards OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of times the associated
+        dot1dTpPortInDiscards counter has overflowed."
+    REFERENCE
+        "ISO/IEC 15802-3 Section 14.6.1.1.3"
+    ::= { dot1dTpPortOverflowEntry 3 }
+
+-- -------------------------------------------------------------
+-- IEEE 802.1p MIB - Conformance Information
+-- -------------------------------------------------------------
+
+
+
+Levi & Harrington           Standards Track                    [Page 34]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+pBridgeConformance OBJECT IDENTIFIER ::= { pBridgeMIB 2 }
+
+pBridgeGroups OBJECT IDENTIFIER ::= { pBridgeConformance 1 }
+
+pBridgeCompliances OBJECT IDENTIFIER
+    ::= { pBridgeConformance 2 }
+
+-- -------------------------------------------------------------
+-- units of conformance
+-- -------------------------------------------------------------
+
+pBridgeExtCapGroup OBJECT-GROUP
+    OBJECTS {
+        dot1dDeviceCapabilities,
+        dot1dPortCapabilities
+    }
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects indicating the optional
+        capabilities of the device."
+    ::= { pBridgeGroups 1 }
+
+pBridgeDeviceGmrpGroup OBJECT-GROUP
+    OBJECTS {
+        dot1dGmrpStatus
+    }
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects providing device-level control
+        for the Multicast Filtering extended bridge services."
+    ::= { pBridgeGroups 2 }
+
+pBridgeDevicePriorityGroup OBJECT-GROUP
+    OBJECTS {
+        dot1dTrafficClassesEnabled
+    }
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects providing device-level control
+        for the Priority services."
+    ::= { pBridgeGroups 3 }
+
+pBridgeDefaultPriorityGroup OBJECT-GROUP
+    OBJECTS {
+        dot1dPortDefaultUserPriority
+    }
+    STATUS      current
+    DESCRIPTION
+
+
+
+Levi & Harrington           Standards Track                    [Page 35]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        "A collection of objects defining the User Priority
+        applicable to each port for media that do not support
+        native User Priority."
+    ::= { pBridgeGroups 4 }
+
+pBridgeRegenPriorityGroup OBJECT-GROUP
+    OBJECTS {
+        dot1dRegenUserPriority
+    }
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects defining the User Priorities
+        applicable to each port for media that support native
+        User Priority."
+    ::= { pBridgeGroups 5 }
+
+pBridgePriorityGroup OBJECT-GROUP
+    OBJECTS {
+        dot1dPortNumTrafficClasses,
+        dot1dTrafficClass
+    }
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects defining the traffic classes
+        within a bridge for each evaluated User Priority."
+    ::= { pBridgeGroups 6 }
+
+pBridgeAccessPriorityGroup OBJECT-GROUP
+    OBJECTS {
+        dot1dPortOutboundAccessPriority
+    }
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects defining the media-dependent
+        outbound access level for each priority."
+    ::= { pBridgeGroups 7 }
+
+pBridgePortGarpGroup OBJECT-GROUP
+    OBJECTS {
+        dot1dPortGarpJoinTime,
+        dot1dPortGarpLeaveTime,
+        dot1dPortGarpLeaveAllTime
+    }
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects providing port level control
+        and status information for GARP operation."
+    ::= { pBridgeGroups 8 }
+
+
+
+Levi & Harrington           Standards Track                    [Page 36]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+pBridgePortGmrpGroup OBJECT-GROUP
+    OBJECTS {
+        dot1dPortGmrpStatus,
+        dot1dPortGmrpFailedRegistrations,
+        dot1dPortGmrpLastPduOrigin
+    }
+    STATUS      deprecated
+    DESCRIPTION
+        "A collection of objects providing port level control
+        and status information for GMRP operation."
+    ::= { pBridgeGroups 9 }
+
+pBridgeHCPortGroup OBJECT-GROUP
+    OBJECTS {
+        dot1dTpHCPortInFrames,
+        dot1dTpHCPortOutFrames,
+        dot1dTpHCPortInDiscards
+    }
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects providing 64-bit statistics
+         counters for high-capacity bridge ports."
+    ::= { pBridgeGroups 10 }
+
+pBridgePortOverflowGroup OBJECT-GROUP
+    OBJECTS {
+        dot1dTpPortInOverflowFrames,
+        dot1dTpPortOutOverflowFrames,
+        dot1dTpPortInOverflowDiscards
+    }
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects providing overflow statistics
+        counters for high-capacity bridge ports."
+    ::= { pBridgeGroups 11 }
+
+pBridgePortGmrpGroup2 OBJECT-GROUP
+    OBJECTS {
+        dot1dPortGmrpStatus,
+        dot1dPortGmrpFailedRegistrations,
+        dot1dPortGmrpLastPduOrigin,
+        dot1dPortRestrictedGroupRegistration
+    }
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects providing port level control
+        and status information for GMRP operation."
+    ::= { pBridgeGroups 12 }
+
+
+
+Levi & Harrington           Standards Track                    [Page 37]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+-- -------------------------------------------------------------
+-- compliance statements
+-- -------------------------------------------------------------
+
+pBridgeCompliance MODULE-COMPLIANCE
+    STATUS  deprecated
+    DESCRIPTION
+        "The compliance statement for device support of Priority
+        and Multicast Filtering extended bridging services."
+
+    MODULE
+        MANDATORY-GROUPS { pBridgeExtCapGroup }
+
+        GROUP       pBridgeDeviceGmrpGroup
+        DESCRIPTION
+            "This group is mandatory for devices supporting the GMRP
+            application, defined by IEEE 802.1D Extended Filtering
+            Services."
+
+        GROUP       pBridgeDevicePriorityGroup
+        DESCRIPTION
+            "This group is mandatory only for devices supporting
+            the priority forwarding operations defined by IEEE
+            802.1D."
+
+        GROUP       pBridgeDefaultPriorityGroup
+        DESCRIPTION
+            "This group is mandatory only for devices supporting
+            the priority forwarding operations defined by the
+            extended bridge services with media types, such as
+            Ethernet, that do not support native User Priority."
+
+        GROUP       pBridgeRegenPriorityGroup
+        DESCRIPTION
+            "This group is mandatory only for devices supporting
+            the priority forwarding operations defined by IEEE 802.1D
+            and that have interface media types that support
+            native User Priority, e.g., IEEE 802.5."
+
+        GROUP       pBridgePriorityGroup
+        DESCRIPTION
+            "This group is mandatory only for devices supporting
+            the priority forwarding operations defined by IEEE 802.1D."
+
+        GROUP       pBridgeAccessPriorityGroup
+        DESCRIPTION
+            "This group is optional and is relevant only for devices
+            supporting the priority forwarding operations defined by
+
+
+
+Levi & Harrington           Standards Track                    [Page 38]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+            IEEE 802.1D and that have interface media types that
+            support native Access Priority, e.g., IEEE 802.5."
+
+        GROUP       pBridgePortGarpGroup
+        DESCRIPTION
+            "This group is mandatory for devices supporting any
+            of the GARP applications: e.g., GMRP, defined by the
+            extended filtering services of 802.1D; or GVRP,
+            defined by 802.1Q (refer to the Q-BRIDGE-MIB for
+            conformance statements for GVRP)."
+
+        GROUP       pBridgePortGmrpGroup
+        DESCRIPTION
+            "This group is mandatory for devices supporting the
+            GMRP application, as defined by IEEE 802.1D Extended
+            Filtering Services."
+
+        GROUP       pBridgeHCPortGroup
+        DESCRIPTION
+            "Support for this group in a device is mandatory for those
+            bridge ports that map to network interfaces that have the
+            value of the corresponding instance of ifSpeed
+            greater than 650,000,000 bits/second."
+
+        GROUP       pBridgePortOverflowGroup
+        DESCRIPTION
+            "Support for this group in a device is mandatory for those
+            bridge ports that map to network interfaces that have the
+            value of the corresponding instance of ifSpeed
+            greater than 650,000,000 bits/second."
+
+        OBJECT      dot1dPortNumTrafficClasses
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+        OBJECT      dot1dTrafficClass
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+        OBJECT      dot1dRegenUserPriority
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+       ::= { pBridgeCompliances 1 }
+
+
+
+
+Levi & Harrington           Standards Track                    [Page 39]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+pBridgeCompliance2 MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+        "The compliance statement for device support of Priority
+        and Multicast Filtering extended bridging services."
+
+    MODULE
+        MANDATORY-GROUPS { pBridgeExtCapGroup }
+
+        GROUP       pBridgeDeviceGmrpGroup
+        DESCRIPTION
+            "This group is mandatory for devices supporting the GMRP
+            application, defined by IEEE 802.1D Extended Filtering
+            Services."
+
+        GROUP       pBridgeDevicePriorityGroup
+        DESCRIPTION
+            "This group is mandatory only for devices supporting
+            the priority forwarding operations defined by IEEE
+            802.1D."
+
+        GROUP       pBridgeDefaultPriorityGroup
+        DESCRIPTION
+            "This group is mandatory only for devices supporting
+            the priority forwarding operations defined by the
+            extended bridge services with media types, such as
+            Ethernet, that do not support native User Priority."
+
+        GROUP       pBridgeRegenPriorityGroup
+        DESCRIPTION
+            "This group is mandatory only for devices supporting
+            the priority forwarding operations defined by IEEE 802.1D
+            and that have interface media types that support
+            native User Priority, e.g., IEEE 802.5."
+
+        GROUP       pBridgePriorityGroup
+        DESCRIPTION
+            "This group is mandatory only for devices supporting
+            the priority forwarding operations defined by IEEE 802.1D."
+
+        GROUP       pBridgeAccessPriorityGroup
+        DESCRIPTION
+            "This group is optional and is relevant only for devices
+            supporting the priority forwarding operations defined by
+            IEEE 802.1D and that have interface media types that
+            support native Access Priority, e.g., IEEE 802.5."
+
+        GROUP       pBridgePortGarpGroup
+
+
+
+Levi & Harrington           Standards Track                    [Page 40]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        DESCRIPTION
+            "This group is mandatory for devices supporting any
+            of the GARP applications: e.g., GMRP, defined by the
+            extended filtering services of 802.1D; or GVRP,
+            defined by 802.1Q (refer to the Q-BRIDGE-MIB for
+            conformance statements for GVRP)."
+
+        GROUP       pBridgePortGmrpGroup2
+        DESCRIPTION
+            "This group is mandatory for devices supporting the
+            GMRP application, as defined by IEEE 802.1D Extended
+            Filtering Services."
+
+        GROUP       pBridgeHCPortGroup
+        DESCRIPTION
+            "Support for this group in a device is mandatory for those
+            bridge ports that map to network interfaces that have the
+            value of the corresponding instance of ifSpeed
+            greater than 650,000,000 bits/second."
+
+        GROUP       pBridgePortOverflowGroup
+        DESCRIPTION
+            "Support for this group in a device is mandatory for those
+            bridge ports that map to network interfaces that have the
+            value of the corresponding instance of ifSpeed
+            greater than 650,000,000 bits/second."
+
+        OBJECT      dot1dPortNumTrafficClasses
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+        OBJECT      dot1dTrafficClass
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+        OBJECT      dot1dRegenUserPriority
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+       ::= { pBridgeCompliances 2 }
+
+END
+
+
+
+
+
+
+Levi & Harrington           Standards Track                    [Page 41]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+5.  Definitions for Virtual Bridge MIB
+
+Q-BRIDGE-MIB DEFINITIONS ::= BEGIN
+
+-- -------------------------------------------------------------
+-- MIB for IEEE 802.1Q Devices
+-- -------------------------------------------------------------
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE,
+    Counter32, Counter64, Unsigned32, TimeTicks, Integer32
+        FROM SNMPv2-SMI
+    RowStatus, TruthValue, TEXTUAL-CONVENTION, MacAddress
+        FROM SNMPv2-TC
+    SnmpAdminString
+        FROM SNMP-FRAMEWORK-MIB
+    MODULE-COMPLIANCE, OBJECT-GROUP
+        FROM SNMPv2-CONF
+    dot1dBridge, dot1dBasePortEntry, dot1dBasePort
+        FROM BRIDGE-MIB
+    EnabledStatus
+        FROM P-BRIDGE-MIB
+    TimeFilter
+        FROM RMON2-MIB;
+
+qBridgeMIB MODULE-IDENTITY
+    LAST-UPDATED "200601090000Z"
+    ORGANIZATION "IETF Bridge MIB Working Group"
+    CONTACT-INFO
+        "Email:  Bridge-mib@ietf.org
+                 ietfmibs@ops.ietf.org
+
+                 David Levi
+         Postal: Nortel Networks
+                 4655 Great America Parkway
+                 Santa Clara, CA 95054
+                 USA
+         Phone:  +1 865 686 0432
+         Email:  dlevi@nortel.com
+
+                 David Harrington
+         Postal: Effective Software
+                 50 Harding Rd.
+                 Portsmouth, NH 03801
+                 USA
+         Phone:  +1 603 436 8634
+         Email:  ietfdbh@comcast.net
+
+
+
+
+Levi & Harrington           Standards Track                    [Page 42]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+                 Les Bell
+         Postal: Hemel Hempstead, Herts. HP2 7YU
+                 UK
+          Email: elbell@ntlworld.com
+
+                 Andrew Smith
+         Postal: Beijing Harbour Networks
+                 Jiuling Building
+                 21 North Xisanhuan Ave.
+                 Beijing, 100089
+                 PRC
+            Fax: +1 415 345 1827
+          Email: ah_smith@acm.org
+
+                 Paul Langille
+         Postal: Newbridge Networks
+                 5 Corporate Drive
+                 Andover, MA 01810
+                 USA
+          Phone: +1 978 691 4665
+          Email: langille@newbridge.com
+
+                 Anil Rijhsinghani
+         Postal: Accton Technology Corporation
+                 5 Mount Royal Ave
+                 Marlboro, MA 01752
+                 USA
+          Phone:
+          Email: anil@accton.com
+
+                 Keith McCloghrie
+         Postal: Cisco Systems, Inc.
+                 170 West Tasman Drive
+                 San Jose, CA 95134-1706
+                 USA
+          Phone: +1 408 526 5260
+          Email: kzm@cisco.com"
+    DESCRIPTION
+        "The VLAN Bridge MIB module for managing Virtual Bridged
+        Local Area Networks, as defined by IEEE 802.1Q-2003,
+        including Restricted Vlan Registration defined by
+        IEEE 802.1u-2001 and Vlan Classification defined by
+        IEEE 802.1v-2001.
+
+        Copyright (C) The Internet Society (2006).  This version of
+        this MIB module is part of RFC 4363; See the RFC itself for
+        full legal notices."
+    REVISION     "200601090000Z"
+
+
+
+Levi & Harrington           Standards Track                    [Page 43]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+    DESCRIPTION
+         "Added Vlan TEXTUAL-CONVENTIONs,
+          dot1qPortRestrictedVlanRegistration, dot1vProtocol subtree,
+          qBridgeClassificationDeviceGroup, qBridgePortGroup2,
+          qBridgeClassificationPortGroup, and qBridgeCompliance2.
+          Clarified dot1qForwardAllStaticPorts,
+          qPortAcceptableFrameTypes, and qBridgeCompliance.
+          Deprecated qBridgePortGroup and qBridgeCompliance."
+
+    REVISION     "199908250000Z"
+    DESCRIPTION
+         "The VLAN Bridge MIB module for managing Virtual Bridged
+        Local Area Networks, as defined by IEEE 802.1Q-1998.
+
+        Initial version, published as RFC 2674."
+
+    ::= { dot1dBridge 7 }
+
+qBridgeMIBObjects OBJECT IDENTIFIER ::= { qBridgeMIB 1 }
+
+-- -------------------------------------------------------------
+-- Textual Conventions
+-- -------------------------------------------------------------
+
+PortList ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+        "Each octet within this value specifies a set of eight
+        ports, with the first octet specifying ports 1 through
+        8, the second octet specifying ports 9 through 16, etc.
+        Within each octet, the most significant bit represents
+        the lowest numbered port, and the least significant bit
+        represents the highest numbered port.  Thus, each port
+        of the bridge is represented by a single bit within the
+        value of this object.  If that bit has a value of '1',
+        then that port is included in the set of ports; the port
+        is not included if its bit has a value of '0'."
+    SYNTAX      OCTET STRING
+
+VlanIndex ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS      current
+    DESCRIPTION
+        "A value used to index per-VLAN tables: values of 0 and
+        4095 are not permitted.  If the value is between 1 and
+        4094 inclusive, it represents an IEEE 802.1Q VLAN-ID with
+        global scope within a given bridged domain (see VlanId
+        textual convention).  If the value is greater than 4095,
+
+
+
+Levi & Harrington           Standards Track                    [Page 44]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        then it represents a VLAN with scope local to the
+        particular agent, i.e., one without a global VLAN-ID
+        assigned to it.  Such VLANs are outside the scope of
+        IEEE 802.1Q, but it is convenient to be able to manage them
+        in the same way using this MIB."
+    SYNTAX      Unsigned32
+
+VlanId ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS      current
+    DESCRIPTION
+        "The VLAN-ID that uniquely identifies a VLAN.  This
+        is the 12-bit VLAN-ID used in the VLAN Tag header.
+        The range is defined by the REFERENCEd specification."
+    REFERENCE
+        "IEEE Std 802.1Q 2003 Edition, Virtual Bridged
+        Local Area Networks."
+    SYNTAX      Integer32 (1..4094)
+
+VlanIdOrAny ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS       current
+    DESCRIPTION
+        "The VLAN-ID that uniquely identifies a specific VLAN,
+        or any VLAN.  The special value of 4095 is used to
+        indicate a wildcard, i.e., any VLAN.  This can be used
+        in any situation where an object or table entry must
+        refer either to a specific VLAN or to any VLAN.
+
+        Note that a MIB object that is defined using this
+        TEXTUAL-CONVENTION should clarify the meaning of
+        'any VLAN' (i.e., the special value 4095)."
+    SYNTAX       Integer32 (1..4094 | 4095)
+
+VlanIdOrNone ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS       current
+    DESCRIPTION
+        "The VLAN-ID that uniquely identifies a specific VLAN,
+        or no VLAN.  The special value of zero is used to
+        indicate that no VLAN-ID is present or used.  This can
+        be used in any situation where an object or a table entry
+        must refer either to a specific VLAN, or to no VLAN.
+
+        Note that a MIB object that is defined using this
+        TEXTUAL-CONVENTION should clarify the meaning of
+        'no VLAN' (i.e., the special value 0)."
+    SYNTAX       Integer32 (0 | 1..4094)
+
+
+
+Levi & Harrington           Standards Track                    [Page 45]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+VlanIdOrAnyOrNone ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS       current
+    DESCRIPTION
+        "The VLAN-ID that uniquely identifies a specific VLAN,
+        any VLAN, or no VLAN.  The special values 0 and 4095
+        have the same meaning as described in the VlanIdOrAny
+        and VlanIdOrNone TEXTUAL-CONVENTIONs.
+
+        Note that a MIB object that is defined using this
+        TEXTUAL-CONVENTION should clarify the meaning of
+        'any VLAN' and 'no VLAN' (i.e., the special values
+        0 and 4095)."
+    SYNTAX       Integer32 (0 | 1..4094 | 4095)
+
+-- -------------------------------------------------------------
+-- subtrees in the Q-BRIDGE MIB
+-- -------------------------------------------------------------
+
+dot1qBase       OBJECT IDENTIFIER ::= { qBridgeMIBObjects 1 }
+dot1qTp         OBJECT IDENTIFIER ::= { qBridgeMIBObjects 2 }
+dot1qStatic     OBJECT IDENTIFIER ::= { qBridgeMIBObjects 3 }
+dot1qVlan       OBJECT IDENTIFIER ::= { qBridgeMIBObjects 4 }
+dot1vProtocol   OBJECT IDENTIFIER ::= { qBridgeMIBObjects 5 }
+
+-- -------------------------------------------------------------
+-- dot1qBase subtree
+-- -------------------------------------------------------------
+
+dot1qVlanVersionNumber OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    version1(1)
+                }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The version number of IEEE 802.1Q that this device
+        supports."
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.10.1.1"
+    ::= { dot1qBase 1 }
+
+dot1qMaxVlanId OBJECT-TYPE
+    SYNTAX      VlanId
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The maximum IEEE 802.1Q VLAN-ID that this device
+
+
+
+Levi & Harrington           Standards Track                    [Page 46]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        supports."
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 9.3.2.3"
+    ::= { dot1qBase 2 }
+
+dot1qMaxSupportedVlans OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The maximum number of IEEE 802.1Q VLANs that this
+        device supports."
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.10.1.1"
+    ::= { dot1qBase 3 }
+
+dot1qNumVlans OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The current number of IEEE 802.1Q VLANs that are
+        configured in this device."
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.7.1.1"
+    ::= { dot1qBase 4 }
+
+dot1qGvrpStatus OBJECT-TYPE
+    SYNTAX      EnabledStatus
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "The administrative status requested by management for
+        GVRP.  The value enabled(1) indicates that GVRP should
+        be enabled on this device, on all ports for which it has
+        not been specifically disabled.  When disabled(2), GVRP
+        is disabled on all ports, and all GVRP packets will be
+        forwarded transparently.  This object affects all GVRP
+        Applicant and Registrar state machines.  A transition
+        from disabled(2) to enabled(1) will cause a reset of all
+        GVRP state machines on all ports.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    DEFVAL      { enabled }
+    ::= { dot1qBase 5 }
+
+-- -------------------------------------------------------------
+
+
+
+Levi & Harrington           Standards Track                    [Page 47]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+-- the dot1qTp subtree
+-- -------------------------------------------------------------
+
+-- -------------------------------------------------------------
+-- the current Filtering Database Table
+-- -------------------------------------------------------------
+
+dot1qFdbTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1qFdbEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table that contains configuration and control
+        information for each Filtering Database currently
+        operating on this device.  Entries in this table appear
+        automatically when VLANs are assigned FDB IDs in the
+        dot1qVlanCurrentTable."
+    ::= { dot1qTp 1 }
+
+dot1qFdbEntry OBJECT-TYPE
+    SYNTAX      Dot1qFdbEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Information about a specific Filtering Database."
+    INDEX   { dot1qFdbId }
+    ::= { dot1qFdbTable 1 }
+
+Dot1qFdbEntry ::=
+    SEQUENCE {
+        dot1qFdbId
+            Unsigned32,
+        dot1qFdbDynamicCount
+            Counter32
+    }
+
+dot1qFdbId OBJECT-TYPE
+    SYNTAX       Unsigned32
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+        "The identity of this Filtering Database."
+    ::= { dot1qFdbEntry 1 }
+
+dot1qFdbDynamicCount OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+
+
+
+Levi & Harrington           Standards Track                    [Page 48]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+    DESCRIPTION
+        "The current number of dynamic entries in this
+        Filtering Database."
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.7.1.1.3"
+    ::= { dot1qFdbEntry 2 }
+
+-- -------------------------------------------------------------
+-- Multiple Forwarding Databases for 802.1Q Transparent Devices
+-- This table is an alternative to the dot1dTpFdbTable,
+-- previously defined for 802.1D devices that only support a
+-- single Forwarding Database.
+-- -------------------------------------------------------------
+
+dot1qTpFdbTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1qTpFdbEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table that contains information about unicast entries
+        for which the device has forwarding and/or filtering
+        information.  This information is used by the
+        transparent bridging function in determining how to
+        propagate a received frame."
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.7.7"
+    ::= { dot1qTp 2 }
+
+dot1qTpFdbEntry OBJECT-TYPE
+    SYNTAX      Dot1qTpFdbEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Information about a specific unicast MAC address for
+        which the device has some forwarding and/or filtering
+        information."
+    INDEX   { dot1qFdbId, dot1qTpFdbAddress }
+    ::= { dot1qTpFdbTable 1 }
+
+Dot1qTpFdbEntry ::=
+    SEQUENCE {
+        dot1qTpFdbAddress
+            MacAddress,
+        dot1qTpFdbPort
+            Integer32,
+        dot1qTpFdbStatus
+            INTEGER
+    }
+
+
+
+Levi & Harrington           Standards Track                    [Page 49]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+dot1qTpFdbAddress OBJECT-TYPE
+    SYNTAX      MacAddress
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A unicast MAC address for which the device has
+        forwarding and/or filtering information."
+    ::= { dot1qTpFdbEntry 1 }
+
+dot1qTpFdbPort OBJECT-TYPE
+    SYNTAX      Integer32 (0..65535)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Either the value '0', or the port number of the port on
+        which a frame having a source address equal to the value
+        of the corresponding instance of dot1qTpFdbAddress has
+        been seen.  A value of '0' indicates that the port
+        number has not been learned but that the device does
+        have some forwarding/filtering information about this
+        address (e.g., in the dot1qStaticUnicastTable).
+        Implementors are encouraged to assign the port value to
+        this object whenever it is learned, even for addresses
+        for which the corresponding value of dot1qTpFdbStatus is
+        not learned(3)."
+    ::= { dot1qTpFdbEntry 2 }
+
+dot1qTpFdbStatus OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    other(1),
+                    invalid(2),
+                    learned(3),
+                    self(4),
+                    mgmt(5)
+                }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The status of this entry.  The meanings of the values
+        are:
+            other(1) - none of the following.  This may include
+                the case where some other MIB object (not the
+                corresponding instance of dot1qTpFdbPort, nor an
+                entry in the dot1qStaticUnicastTable) is being
+                used to determine if and how frames addressed to
+                the value of the corresponding instance of
+                dot1qTpFdbAddress are being forwarded.
+            invalid(2) - this entry is no longer valid (e.g., it
+
+
+
+Levi & Harrington           Standards Track                    [Page 50]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+                was learned but has since aged out), but has not
+                yet been flushed from the table.
+            learned(3) - the value of the corresponding instance
+                of dot1qTpFdbPort was learned and is being used.
+            self(4) - the value of the corresponding instance of
+                dot1qTpFdbAddress represents one of the device's
+                addresses.  The corresponding instance of
+                dot1qTpFdbPort indicates which of the device's
+                ports has this address.
+            mgmt(5) - the value of the corresponding instance of
+                dot1qTpFdbAddress is also the value of an
+                existing instance of dot1qStaticAddress."
+    ::= { dot1qTpFdbEntry 3 }
+
+-- -------------------------------------------------------------
+-- Dynamic Group Registration Table
+-- -------------------------------------------------------------
+
+dot1qTpGroupTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1qTpGroupEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table containing filtering information for VLANs
+        configured into the bridge by (local or network)
+        management, or learned dynamically, specifying the set of
+        ports to which frames received on a VLAN for this FDB
+        and containing a specific Group destination address are
+        allowed to be forwarded."
+    ::= { dot1qTp 3 }
+
+dot1qTpGroupEntry OBJECT-TYPE
+    SYNTAX      Dot1qTpGroupEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Filtering information configured into the bridge by
+        management, or learned dynamically, specifying the set of
+        ports to which frames received on a VLAN and containing
+        a specific Group destination address are allowed to be
+        forwarded.  The subset of these ports learned dynamically
+        is also provided."
+    INDEX   { dot1qVlanIndex, dot1qTpGroupAddress }
+    ::= { dot1qTpGroupTable 1 }
+
+Dot1qTpGroupEntry ::=
+    SEQUENCE {
+        dot1qTpGroupAddress
+
+
+
+Levi & Harrington           Standards Track                    [Page 51]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+            MacAddress,
+        dot1qTpGroupEgressPorts
+            PortList,
+        dot1qTpGroupLearnt
+            PortList
+    }
+
+dot1qTpGroupAddress OBJECT-TYPE
+    SYNTAX      MacAddress
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The destination Group MAC address in a frame to which
+        this entry's filtering information applies."
+    ::= { dot1qTpGroupEntry 1 }
+
+dot1qTpGroupEgressPorts OBJECT-TYPE
+    SYNTAX      PortList
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The complete set of ports, in this VLAN, to which
+        frames destined for this Group MAC address are currently
+        being explicitly forwarded.  This does not include ports
+        for which this address is only implicitly forwarded, in
+        the dot1qForwardAllPorts list."
+    ::= { dot1qTpGroupEntry 2 }
+
+dot1qTpGroupLearnt OBJECT-TYPE
+    SYNTAX      PortList
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The subset of ports in dot1qTpGroupEgressPorts that
+        were learned by GMRP or some other dynamic mechanism, in
+        this Filtering database."
+    ::= { dot1qTpGroupEntry 3 }
+
+-- -------------------------------------------------------------
+-- Service Requirements subtree
+-- -------------------------------------------------------------
+
+dot1qForwardAllTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1qForwardAllEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table containing forwarding information for each
+
+
+
+Levi & Harrington           Standards Track                    [Page 52]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        VLAN, specifying the set of ports to which forwarding of
+        all multicasts applies, configured statically by
+        management or dynamically by GMRP.  An entry appears in
+        this table for all VLANs that are currently
+        instantiated."
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.7.2, 12.7.7"
+    ::= { dot1qTp 4 }
+
+dot1qForwardAllEntry OBJECT-TYPE
+    SYNTAX      Dot1qForwardAllEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Forwarding information for a VLAN, specifying the set
+        of ports to which all multicasts should be forwarded,
+        configured statically by management or dynamically by
+        GMRP."
+    INDEX   { dot1qVlanIndex }
+    ::= { dot1qForwardAllTable 1 }
+
+Dot1qForwardAllEntry ::=
+    SEQUENCE {
+        dot1qForwardAllPorts
+            PortList,
+        dot1qForwardAllStaticPorts
+            PortList,
+        dot1qForwardAllForbiddenPorts
+            PortList
+    }
+
+dot1qForwardAllPorts OBJECT-TYPE
+    SYNTAX      PortList
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The complete set of ports in this VLAN to which all
+        multicast group-addressed frames are to be forwarded.
+        This includes ports for which this need has been
+        determined dynamically by GMRP, or configured statically
+        by management."
+    ::= { dot1qForwardAllEntry 1 }
+
+dot1qForwardAllStaticPorts OBJECT-TYPE
+    SYNTAX      PortList
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+
+
+
+Levi & Harrington           Standards Track                    [Page 53]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        "The set of ports configured by management in this VLAN
+        to which all multicast group-addressed frames are to be
+        forwarded.  Ports entered in this list will also appear
+        in the complete set shown by dot1qForwardAllPorts.  This
+        value will be restored after the device is reset.  This
+        only applies to ports that are members of the VLAN,
+        defined by dot1qVlanCurrentEgressPorts.  A port may not
+        be added in this set if it is already a member of the
+        set of ports in dot1qForwardAllForbiddenPorts.  The
+        default value is a string of ones of appropriate length,
+        to indicate the standard behaviour of using basic
+        filtering services, i.e., forward all multicasts to all
+        ports.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    ::= { dot1qForwardAllEntry 2 }
+
+dot1qForwardAllForbiddenPorts OBJECT-TYPE
+    SYNTAX      PortList
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "The set of ports configured by management in this VLAN
+        for which the Service Requirement attribute Forward All
+        Multicast Groups may not be dynamically registered by
+        GMRP.  This value will be restored after the device is
+        reset.  A port may not be added in this set if it is
+        already a member of the set of ports in
+        dot1qForwardAllStaticPorts.  The default value is a
+        string of zeros of appropriate length.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    ::= { dot1qForwardAllEntry 3 }
+
+dot1qForwardUnregisteredTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1qForwardUnregisteredEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table containing forwarding information for each
+        VLAN, specifying the set of ports to which forwarding of
+        multicast group-addressed frames for which no
+        more specific forwarding information applies.  This is
+        configured statically by management and determined
+        dynamically by GMRP.  An entry appears in this table for
+        all VLANs that are currently instantiated."
+
+
+
+Levi & Harrington           Standards Track                    [Page 54]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.7.2, 12.7.7"
+    ::= { dot1qTp 5 }
+
+dot1qForwardUnregisteredEntry OBJECT-TYPE
+    SYNTAX      Dot1qForwardUnregisteredEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Forwarding information for a VLAN, specifying the set
+        of ports to which all multicasts for which there is no
+        more specific forwarding information shall be forwarded.
+        This is configured statically by management or
+        dynamically by GMRP."
+    INDEX   { dot1qVlanIndex }
+    ::= { dot1qForwardUnregisteredTable 1 }
+
+Dot1qForwardUnregisteredEntry ::=
+    SEQUENCE {
+        dot1qForwardUnregisteredPorts
+            PortList,
+        dot1qForwardUnregisteredStaticPorts
+            PortList,
+        dot1qForwardUnregisteredForbiddenPorts
+            PortList
+    }
+
+dot1qForwardUnregisteredPorts OBJECT-TYPE
+    SYNTAX      PortList
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The complete set of ports in this VLAN to which
+        multicast group-addressed frames for which there is no
+        more specific forwarding information will be forwarded.
+        This includes ports for which this need has been
+        determined dynamically by GMRP, or configured statically
+        by management."
+    ::= { dot1qForwardUnregisteredEntry 1 }
+
+dot1qForwardUnregisteredStaticPorts OBJECT-TYPE
+    SYNTAX      PortList
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "The set of ports configured by management, in this
+        VLAN, to which multicast group-addressed frames for
+        which there is no more specific forwarding information
+
+
+
+Levi & Harrington           Standards Track                    [Page 55]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        are to be forwarded.  Ports entered in this list will
+        also appear in the complete set shown by
+        dot1qForwardUnregisteredPorts.  This value will be
+        restored after the device is reset.  A port may not be
+        added in this set if it is already a member of the set
+        of ports in dot1qForwardUnregisteredForbiddenPorts.  The
+        default value is a string of zeros of appropriate
+        length, although this has no effect with the default
+        value of dot1qForwardAllStaticPorts.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    ::= { dot1qForwardUnregisteredEntry 2 }
+
+dot1qForwardUnregisteredForbiddenPorts OBJECT-TYPE
+    SYNTAX      PortList
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "The set of ports configured by management in this VLAN
+        for which the Service Requirement attribute Forward
+        Unregistered Multicast Groups may not be dynamically
+        registered by GMRP.  This value will be restored after
+        the device is reset.  A port may not be added in this
+        set if it is already a member of the set of ports in
+        dot1qForwardUnregisteredStaticPorts.  The default value
+        is a string of zeros of appropriate length.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    ::= { dot1qForwardUnregisteredEntry 3 }
+
+-- -------------------------------------------------------------
+-- The Static (Destination-Address Filtering) Database
+-- -------------------------------------------------------------
+
+dot1qStaticUnicastTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1qStaticUnicastEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table containing filtering information for Unicast
+        MAC addresses for each Filtering Database, configured
+        into the device by (local or network) management
+        specifying the set of ports to which frames received
+        from specific ports and containing specific unicast
+        destination addresses are allowed to be forwarded.  A
+        value of zero in this table (as the port number from
+
+
+
+Levi & Harrington           Standards Track                    [Page 56]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        which frames with a specific destination address are
+        received) is used to specify all ports for which there
+        is no specific entry in this table for that particular
+        destination address.  Entries are valid for unicast
+        addresses only."
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.7.7,
+        ISO/IEC 15802-3 Section 7.9.1"
+    ::= { dot1qStatic 1 }
+
+dot1qStaticUnicastEntry OBJECT-TYPE
+    SYNTAX      Dot1qStaticUnicastEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Filtering information configured into the device by
+        (local or network) management specifying the set of
+        ports to which frames received from a specific port and
+        containing a specific unicast destination address are
+        allowed to be forwarded."
+    INDEX   {
+        dot1qFdbId,
+        dot1qStaticUnicastAddress,
+        dot1qStaticUnicastReceivePort
+    }
+    ::= { dot1qStaticUnicastTable 1 }
+
+Dot1qStaticUnicastEntry ::=
+    SEQUENCE {
+        dot1qStaticUnicastAddress
+            MacAddress,
+        dot1qStaticUnicastReceivePort
+            Integer32,
+        dot1qStaticUnicastAllowedToGoTo
+            PortList,
+        dot1qStaticUnicastStatus
+            INTEGER
+    }
+
+dot1qStaticUnicastAddress OBJECT-TYPE
+    SYNTAX      MacAddress
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The destination MAC address in a frame to which this
+        entry's filtering information applies.  This object must
+        take the value of a unicast address."
+    ::= { dot1qStaticUnicastEntry 1 }
+
+
+
+Levi & Harrington           Standards Track                    [Page 57]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+dot1qStaticUnicastReceivePort OBJECT-TYPE
+    SYNTAX      Integer32 (0..65535)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Either the value '0' or the port number of the port
+        from which a frame must be received in order for this
+        entry's filtering information to apply.  A value of zero
+        indicates that this entry applies on all ports of the
+        device for which there is no other applicable entry."
+    ::= { dot1qStaticUnicastEntry 2 }
+
+dot1qStaticUnicastAllowedToGoTo OBJECT-TYPE
+    SYNTAX      PortList
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "The set of ports for which a frame with a specific
+        unicast address will be flooded in the event that it
+        has not been learned.  It also specifies the set of
+        ports on which a specific unicast address may be dynamically
+        learned.  The dot1qTpFdbTable will have an equivalent
+        entry with a dot1qTpFdbPort value of '0' until this
+        address has been learned, at which point it will be updated
+        with the port the address has been seen on.  This only
+        applies to ports that are members of the VLAN, defined
+        by dot1qVlanCurrentEgressPorts.  The default value of
+        this object is a string of ones of appropriate length.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    REFERENCE
+        "IEEE 802.1Q/D11 Table 8-5, ISO/IEC 15802-3 Table 7-5"
+    ::= { dot1qStaticUnicastEntry 3 }
+
+dot1qStaticUnicastStatus OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    other(1),
+                    invalid(2),
+                    permanent(3),
+                    deleteOnReset(4),
+                    deleteOnTimeout(5)
+                }
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "This object indicates the status of this entry.
+            other(1) - this entry is currently in use, but
+
+
+
+Levi & Harrington           Standards Track                    [Page 58]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+                the conditions under which it will remain
+                so differ from the following values.
+            invalid(2) - writing this value to the object
+                removes the corresponding entry.
+            permanent(3) - this entry is currently in use
+                and will remain so after the next reset of
+                the bridge.
+            deleteOnReset(4) - this entry is currently in
+                use and will remain so until the next
+                reset of the bridge.
+            deleteOnTimeout(5) - this entry is currently in
+                use and will remain so until it is aged out.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    DEFVAL      { permanent }
+    ::= { dot1qStaticUnicastEntry 4 }
+
+dot1qStaticMulticastTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1qStaticMulticastEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table containing filtering information for Multicast
+        and Broadcast MAC addresses for each VLAN, configured
+        into the device by (local or network) management
+        specifying the set of ports to which frames received
+        from specific ports and containing specific Multicast
+        and Broadcast destination addresses are allowed to be
+        forwarded.  A value of zero in this table (as the port
+        number from which frames with a specific destination
+        address are received) is used to specify all ports for
+        which there is no specific entry in this table for that
+        particular destination address.  Entries are valid for
+        Multicast and Broadcast addresses only."
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.7.7,
+        ISO/IEC 15802-3 Section 7.9.1"
+    ::= { dot1qStatic 2 }
+
+dot1qStaticMulticastEntry OBJECT-TYPE
+    SYNTAX      Dot1qStaticMulticastEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Filtering information configured into the device by
+        (local or network) management specifying the set of
+        ports to which frames received from this specific port
+
+
+
+Levi & Harrington           Standards Track                    [Page 59]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        for this VLAN and containing this Multicast or Broadcast
+        destination address are allowed to be forwarded."
+    INDEX   {
+        dot1qVlanIndex,
+        dot1qStaticMulticastAddress,
+        dot1qStaticMulticastReceivePort
+    }
+    ::= { dot1qStaticMulticastTable 1 }
+
+Dot1qStaticMulticastEntry ::=
+    SEQUENCE {
+        dot1qStaticMulticastAddress
+            MacAddress,
+        dot1qStaticMulticastReceivePort
+            Integer32,
+        dot1qStaticMulticastStaticEgressPorts
+            PortList,
+        dot1qStaticMulticastForbiddenEgressPorts
+            PortList,
+        dot1qStaticMulticastStatus
+            INTEGER
+    }
+
+dot1qStaticMulticastAddress OBJECT-TYPE
+    SYNTAX      MacAddress
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The destination MAC address in a frame to which this
+        entry's filtering information applies.  This object must
+        take the value of a Multicast or Broadcast address."
+    ::= { dot1qStaticMulticastEntry 1 }
+
+dot1qStaticMulticastReceivePort OBJECT-TYPE
+    SYNTAX      Integer32 (0..65535)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Either the value '0' or the port number of the port
+        from which a frame must be received in order for this
+        entry's filtering information to apply.  A value of zero
+        indicates that this entry applies on all ports of the
+        device for which there is no other applicable entry."
+    ::= { dot1qStaticMulticastEntry 2 }
+
+dot1qStaticMulticastStaticEgressPorts OBJECT-TYPE
+    SYNTAX      PortList
+    MAX-ACCESS  read-write
+
+
+
+Levi & Harrington           Standards Track                    [Page 60]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+    STATUS      current
+    DESCRIPTION
+        "The set of ports to which frames received from a
+        specific port and destined for a specific Multicast or
+        Broadcast MAC address must be forwarded, regardless of
+        any dynamic information, e.g., from GMRP.  A port may not
+        be added in this set if it is already a member of the
+        set of ports in dot1qStaticMulticastForbiddenEgressPorts.
+        The default value of this object is a string of ones of
+        appropriate length.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    ::= { dot1qStaticMulticastEntry 3 }
+
+dot1qStaticMulticastForbiddenEgressPorts OBJECT-TYPE
+    SYNTAX      PortList
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "The set of ports to which frames received from a
+        specific port and destined for a specific Multicast or
+        Broadcast MAC address must not be forwarded, regardless
+        of any dynamic information, e.g., from GMRP.  A port may
+        not be added in this set if it is already a member of the
+        set of ports in dot1qStaticMulticastStaticEgressPorts.
+        The default value of this object is a string of zeros of
+        appropriate length.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    ::= { dot1qStaticMulticastEntry 4 }
+
+dot1qStaticMulticastStatus OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    other(1),
+                    invalid(2),
+                    permanent(3),
+                    deleteOnReset(4),
+                    deleteOnTimeout(5)
+                }
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "This object indicates the status of this entry.
+            other(1) - this entry is currently in use, but
+                the conditions under which it will remain
+                so differ from the following values.
+
+
+
+Levi & Harrington           Standards Track                    [Page 61]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+            invalid(2) - writing this value to the object
+                removes the corresponding entry.
+            permanent(3) - this entry is currently in use
+                and will remain so after the next reset of
+                the bridge.
+            deleteOnReset(4) - this entry is currently in
+                use and will remain so until the next
+                reset of the bridge.
+            deleteOnTimeout(5) - this entry is currently in
+                use and will remain so until it is aged out.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    DEFVAL      { permanent }
+    ::= { dot1qStaticMulticastEntry 5 }
+
+-- -------------------------------------------------------------
+-- The Current VLAN Database
+-- -------------------------------------------------------------
+
+dot1qVlanNumDeletes OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of times a VLAN entry has been deleted from
+        the dot1qVlanCurrentTable (for any reason).  If an entry
+        is deleted, then inserted, and then deleted, this
+        counter will be incremented by 2."
+    ::= { dot1qVlan 1 }
+
+dot1qVlanCurrentTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1qVlanCurrentEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table containing current configuration information
+        for each VLAN currently configured into the device by
+        (local or network) management, or dynamically created
+        as a result of GVRP requests received."
+    ::= { dot1qVlan 2 }
+
+dot1qVlanCurrentEntry OBJECT-TYPE
+    SYNTAX      Dot1qVlanCurrentEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Information for a VLAN configured into the device by
+
+
+
+Levi & Harrington           Standards Track                    [Page 62]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        (local or network) management, or dynamically created
+        as a result of GVRP requests received."
+    INDEX   { dot1qVlanTimeMark, dot1qVlanIndex }
+    ::= { dot1qVlanCurrentTable 1 }
+
+Dot1qVlanCurrentEntry ::=
+    SEQUENCE {
+        dot1qVlanTimeMark
+            TimeFilter,
+        dot1qVlanIndex
+            VlanIndex,
+        dot1qVlanFdbId
+            Unsigned32,
+        dot1qVlanCurrentEgressPorts
+            PortList,
+        dot1qVlanCurrentUntaggedPorts
+            PortList,
+        dot1qVlanStatus
+            INTEGER,
+        dot1qVlanCreationTime
+            TimeTicks
+    }
+
+dot1qVlanTimeMark OBJECT-TYPE
+    SYNTAX      TimeFilter
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A TimeFilter for this entry.  See the TimeFilter
+        textual convention to see how this works."
+    ::= { dot1qVlanCurrentEntry 1 }
+
+dot1qVlanIndex OBJECT-TYPE
+    SYNTAX      VlanIndex
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The VLAN-ID or other identifier referring to this VLAN."
+    ::= { dot1qVlanCurrentEntry 2 }
+
+dot1qVlanFdbId OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The Filtering Database used by this VLAN.  This is one
+        of the dot1qFdbId values in the dot1qFdbTable.  This
+        value is allocated automatically by the device whenever
+
+
+
+Levi & Harrington           Standards Track                    [Page 63]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        the VLAN is created: either dynamically by GVRP, or by
+        management, in dot1qVlanStaticTable.  Allocation of this
+        value follows the learning constraints defined for this
+        VLAN in dot1qLearningConstraintsTable."
+    ::= { dot1qVlanCurrentEntry 3 }
+
+dot1qVlanCurrentEgressPorts OBJECT-TYPE
+    SYNTAX      PortList
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The set of ports that are transmitting traffic for
+        this VLAN as either tagged or untagged frames."
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.10.2.1"
+    ::= { dot1qVlanCurrentEntry 4 }
+
+dot1qVlanCurrentUntaggedPorts OBJECT-TYPE
+    SYNTAX      PortList
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The set of ports that are transmitting traffic for
+        this VLAN as untagged frames."
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.10.2.1"
+    ::= { dot1qVlanCurrentEntry 5 }
+
+dot1qVlanStatus OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    other(1),
+                    permanent(2),
+                    dynamicGvrp(3)
+                }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "This object indicates the status of this entry.
+            other(1) - this entry is currently in use, but the
+                conditions under which it will remain so differ
+                from the following values.
+            permanent(2) - this entry, corresponding to an entry
+                in dot1qVlanStaticTable, is currently in use and
+                will remain so after the next reset of the
+                device.  The port lists for this entry include
+                ports from the equivalent dot1qVlanStaticTable
+                entry and ports learned dynamically.
+            dynamicGvrp(3) - this entry is currently in use
+
+
+
+Levi & Harrington           Standards Track                    [Page 64]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+                and will remain so until removed by GVRP.  There
+                is no static entry for this VLAN, and it will be
+                removed when the last port leaves the VLAN."
+    ::= { dot1qVlanCurrentEntry 6 }
+
+dot1qVlanCreationTime OBJECT-TYPE
+    SYNTAX      TimeTicks
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The value of sysUpTime when this VLAN was created."
+    ::= { dot1qVlanCurrentEntry 7 }
+
+-- -------------------------------------------------------------
+-- The Static VLAN Database
+-- -------------------------------------------------------------
+
+dot1qVlanStaticTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1qVlanStaticEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table containing static configuration information for
+        each VLAN configured into the device by (local or
+        network) management.  All entries are permanent and will
+        be restored after the device is reset."
+    ::= { dot1qVlan 3 }
+
+dot1qVlanStaticEntry OBJECT-TYPE
+    SYNTAX      Dot1qVlanStaticEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Static information for a VLAN configured into the
+        device by (local or network) management."
+    INDEX   { dot1qVlanIndex }
+    ::= { dot1qVlanStaticTable 1 }
+
+Dot1qVlanStaticEntry ::=
+    SEQUENCE {
+        dot1qVlanStaticName
+            SnmpAdminString,
+        dot1qVlanStaticEgressPorts
+            PortList,
+        dot1qVlanForbiddenEgressPorts
+            PortList,
+        dot1qVlanStaticUntaggedPorts
+            PortList,
+
+
+
+Levi & Harrington           Standards Track                    [Page 65]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        dot1qVlanStaticRowStatus
+            RowStatus
+    }
+
+dot1qVlanStaticName OBJECT-TYPE
+    SYNTAX      SnmpAdminString (SIZE (0..32))
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+        "An administratively assigned string, which may be used
+        to identify the VLAN."
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.10.2.1"
+    ::= { dot1qVlanStaticEntry 1 }
+
+dot1qVlanStaticEgressPorts OBJECT-TYPE
+    SYNTAX      PortList
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+        "The set of ports that are permanently assigned to the
+        egress list for this VLAN by management.  Changes to a
+        bit in this object affect the per-port, per-VLAN
+        Registrar control for Registration Fixed for the
+        relevant GVRP state machine on each port.  A port may
+        not be added in this set if it is already a member of
+        the set of ports in dot1qVlanForbiddenEgressPorts.  The
+        default value of this object is a string of zeros of
+        appropriate length, indicating not fixed."
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.7.7.3, 11.2.3.2.3"
+    ::= { dot1qVlanStaticEntry 2 }
+
+dot1qVlanForbiddenEgressPorts OBJECT-TYPE
+    SYNTAX      PortList
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+        "The set of ports that are prohibited by management
+        from being included in the egress list for this VLAN.
+        Changes to this object that cause a port to be included
+        or excluded affect the per-port, per-VLAN Registrar
+        control for Registration Forbidden for the relevant GVRP
+        state machine on each port.  A port may not be added in
+        this set if it is already a member of the set of ports
+        in dot1qVlanStaticEgressPorts.  The default value of
+        this object is a string of zeros of appropriate length,
+        excluding all ports from the forbidden set."
+
+
+
+Levi & Harrington           Standards Track                    [Page 66]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.7.7.3, 11.2.3.2.3"
+    ::= { dot1qVlanStaticEntry 3 }
+
+dot1qVlanStaticUntaggedPorts OBJECT-TYPE
+    SYNTAX      PortList
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+        "The set of ports that should transmit egress packets
+        for this VLAN as untagged.  The default value of this
+        object for the default VLAN (dot1qVlanIndex = 1) is a string
+        of appropriate length including all ports.  There is no
+        specified default for other VLANs.  If a device agent cannot
+        support the set of ports being set, then it will reject the
+        set operation with an error.  For example, a
+        manager might attempt to set more than one VLAN to be untagged
+        on egress where the device does not support this IEEE 802.1Q
+        option."
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.10.2.1"
+    ::= { dot1qVlanStaticEntry 4 }
+
+dot1qVlanStaticRowStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+        "This object indicates the status of this entry."
+    ::= { dot1qVlanStaticEntry 5 }
+
+dot1qNextFreeLocalVlanIndex OBJECT-TYPE
+    SYNTAX      Integer32 (0|4096..2147483647)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The next available value for dot1qVlanIndex of a local
+        VLAN entry in dot1qVlanStaticTable.  This will report
+        values >=4096 if a new Local VLAN may be created or else
+        the value 0 if this is not possible.
+
+        A row creation operation in this table for an entry with a local
+        VlanIndex value may fail if the current value of this object
+        is not used as the index.  Even if the value read is used,
+        there is no guarantee that it will still be the valid index
+        when the create operation is attempted; another manager may
+        have already got in during the intervening time interval.
+        In this case, dot1qNextFreeLocalVlanIndex should be re-read
+
+
+
+Levi & Harrington           Standards Track                    [Page 67]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        and the creation re-tried with the new value.
+
+        This value will automatically change when the current value is
+        used to create a new row."
+    ::= { dot1qVlan 4 }
+
+-- -------------------------------------------------------------
+-- The VLAN Port Configuration Table
+-- -------------------------------------------------------------
+
+dot1qPortVlanTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1qPortVlanEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table containing per-port control and status
+        information for VLAN configuration in the device."
+    ::= { dot1qVlan 5 }
+
+dot1qPortVlanEntry OBJECT-TYPE
+    SYNTAX      Dot1qPortVlanEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Information controlling VLAN configuration for a port
+        on the device.  This is indexed by dot1dBasePort."
+    AUGMENTS { dot1dBasePortEntry }
+    ::= { dot1qPortVlanTable 1 }
+
+Dot1qPortVlanEntry ::=
+    SEQUENCE {
+        dot1qPvid
+            VlanIndex,
+        dot1qPortAcceptableFrameTypes
+            INTEGER,
+        dot1qPortIngressFiltering
+            TruthValue,
+        dot1qPortGvrpStatus
+            EnabledStatus,
+        dot1qPortGvrpFailedRegistrations
+            Counter32,
+        dot1qPortGvrpLastPduOrigin
+            MacAddress,
+        dot1qPortRestrictedVlanRegistration
+            TruthValue
+    }
+
+dot1qPvid OBJECT-TYPE
+
+
+
+Levi & Harrington           Standards Track                    [Page 68]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+    SYNTAX      VlanIndex
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "The PVID, the VLAN-ID assigned to untagged frames or
+        Priority-Tagged frames received on this port.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.10.1.1"
+    DEFVAL      { 1 }
+    ::= { dot1qPortVlanEntry 1 }
+
+dot1qPortAcceptableFrameTypes OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    admitAll(1),
+                    admitOnlyVlanTagged(2)
+                }
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "When this is admitOnlyVlanTagged(2), the device will
+        discard untagged frames or Priority-Tagged frames
+        received on this port.  When admitAll(1), untagged
+        frames or Priority-Tagged frames received on this port
+        will be accepted and assigned to a VID based on the
+        PVID and VID Set for this port.
+
+        This control does not affect VLAN-independent Bridge
+        Protocol Data Unit (BPDU) frames, such as GVRP and
+        Spanning Tree Protocol (STP).  It does affect VLAN-
+        dependent BPDU frames, such as GMRP.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.10.1.3"
+    DEFVAL      { admitAll }
+    ::= { dot1qPortVlanEntry 2 }
+
+dot1qPortIngressFiltering OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "When this is true(1), the device will discard incoming
+        frames for VLANs that do not include this Port in its
+
+
+
+Levi & Harrington           Standards Track                    [Page 69]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        Member set.  When false(2), the port will accept all
+        incoming frames.
+
+        This control does not affect VLAN-independent BPDU
+        frames, such as GVRP and STP.  It does affect VLAN-
+        dependent BPDU frames, such as GMRP.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.10.1.4"
+    DEFVAL      { false }
+    ::= { dot1qPortVlanEntry 3 }
+
+dot1qPortGvrpStatus OBJECT-TYPE
+    SYNTAX      EnabledStatus
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "The state of GVRP operation on this port.  The value
+        enabled(1) indicates that GVRP is enabled on this port,
+        as long as dot1qGvrpStatus is also enabled for this
+        device.  When disabled(2) but dot1qGvrpStatus is still
+        enabled for the device, GVRP is disabled on this port:
+        any GVRP packets received will be silently discarded, and
+        no GVRP registrations will be propagated from other
+        ports.  This object affects all GVRP Applicant and
+        Registrar state machines on this port.  A transition
+        from disabled(2) to enabled(1) will cause a reset of all
+        GVRP state machines on this port.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    DEFVAL      { enabled }
+    ::= { dot1qPortVlanEntry 4 }
+
+dot1qPortGvrpFailedRegistrations OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of failed GVRP registrations, for any
+        reason, on this port."
+    ::= { dot1qPortVlanEntry 5 }
+
+dot1qPortGvrpLastPduOrigin OBJECT-TYPE
+    SYNTAX      MacAddress
+    MAX-ACCESS  read-only
+
+
+
+Levi & Harrington           Standards Track                    [Page 70]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+    STATUS      current
+    DESCRIPTION
+        "The Source MAC Address of the last GVRP message
+        received on this port."
+    ::= { dot1qPortVlanEntry 6 }
+
+dot1qPortRestrictedVlanRegistration OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "The state of Restricted VLAN Registration on this port.
+         If the value of this control is true(1), then creation
+         of a new dynamic VLAN entry is permitted only if there
+         is a Static VLAN Registration Entry for the VLAN concerned,
+         in which the Registrar Administrative Control value for
+         this port is Normal Registration.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    REFERENCE
+        "IEEE 802.1u clause 11.2.3.2.3, 12.10.1.7."
+    DEFVAL      { false }
+    ::= { dot1qPortVlanEntry 7 }
+
+-- -------------------------------------------------------------
+-- Per port VLAN Statistics Table
+-- -------------------------------------------------------------
+
+dot1qPortVlanStatisticsTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1qPortVlanStatisticsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table containing per-port, per-VLAN statistics for
+        traffic received.  Separate objects are provided for both the
+        most-significant and least-significant bits of statistics
+        counters for ports that are associated with this transparent
+        bridge.  The most-significant bit objects are only required on
+        high-capacity interfaces, as defined in the conformance clauses
+        for these objects.  This mechanism is provided as a way to read
+        64-bit counters for agents that support only SNMPv1.
+
+        Note that the reporting of most-significant and least-
+        significant counter bits separately runs the risk of missing
+        an overflow of the lower bits in the interval between sampling.
+        The manager must be aware of this possibility, even within the
+        same varbindlist, when interpreting the results of a request or
+
+
+
+Levi & Harrington           Standards Track                    [Page 71]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        asynchronous notification."
+    ::= { dot1qVlan 6 }
+
+dot1qPortVlanStatisticsEntry OBJECT-TYPE
+    SYNTAX      Dot1qPortVlanStatisticsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Traffic statistics for a VLAN on an interface."
+    INDEX   { dot1dBasePort, dot1qVlanIndex }
+    ::= { dot1qPortVlanStatisticsTable 1 }
+
+Dot1qPortVlanStatisticsEntry ::=
+    SEQUENCE {
+        dot1qTpVlanPortInFrames
+            Counter32,
+        dot1qTpVlanPortOutFrames
+            Counter32,
+        dot1qTpVlanPortInDiscards
+            Counter32,
+        dot1qTpVlanPortInOverflowFrames
+            Counter32,
+        dot1qTpVlanPortOutOverflowFrames
+            Counter32,
+        dot1qTpVlanPortInOverflowDiscards
+            Counter32
+    }
+
+dot1qTpVlanPortInFrames OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of valid frames received by this port from
+        its segment that were classified as belonging to this
+        VLAN.  Note that a frame received on this port is
+        counted by this object if and only if it is for a
+        protocol being processed by the local forwarding process
+        for this VLAN.  This object includes received bridge
+        management frames classified as belonging to this VLAN
+        (e.g., GMRP, but not GVRP or STP."
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.6.1.1.3(a)"
+    ::= { dot1qPortVlanStatisticsEntry 1 }
+
+dot1qTpVlanPortOutFrames OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+
+
+
+Levi & Harrington           Standards Track                    [Page 72]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+    STATUS      current
+    DESCRIPTION
+        "The number of valid frames transmitted by this port to
+        its segment from the local forwarding process for this
+        VLAN.  This includes bridge management frames originated
+        by this device that are classified as belonging to this
+        VLAN (e.g., GMRP, but not GVRP or STP)."
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.6.1.1.3(d)"
+    ::= { dot1qPortVlanStatisticsEntry 2 }
+
+dot1qTpVlanPortInDiscards OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of valid frames received by this port from
+        its segment that were classified as belonging to this
+        VLAN and that were discarded due to VLAN-related reasons.
+        Specifically, the IEEE 802.1Q counters for Discard
+        Inbound and Discard on Ingress Filtering."
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.6.1.1.3"
+    ::= { dot1qPortVlanStatisticsEntry 3 }
+
+dot1qTpVlanPortInOverflowFrames OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of times the associated
+        dot1qTpVlanPortInFrames counter has overflowed."
+    REFERENCE
+        "ISO/IEC 15802-3 Section 14.6.1.1.3"
+    ::= { dot1qPortVlanStatisticsEntry 4 }
+
+dot1qTpVlanPortOutOverflowFrames OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of times the associated
+        dot1qTpVlanPortOutFrames counter has overflowed."
+    REFERENCE
+        "ISO/IEC 15802-3 Section 14.6.1.1.3"
+    ::= { dot1qPortVlanStatisticsEntry 5 }
+
+dot1qTpVlanPortInOverflowDiscards OBJECT-TYPE
+
+
+
+Levi & Harrington           Standards Track                    [Page 73]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of times the associated
+        dot1qTpVlanPortInDiscards counter has overflowed."
+    REFERENCE
+        "ISO/IEC 15802-3 Section 14.6.1.1.3"
+    ::= { dot1qPortVlanStatisticsEntry 6 }
+
+dot1qPortVlanHCStatisticsTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1qPortVlanHCStatisticsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table containing per-port, per-VLAN statistics for
+        traffic on high-capacity interfaces."
+    ::= { dot1qVlan 7 }
+
+dot1qPortVlanHCStatisticsEntry OBJECT-TYPE
+    SYNTAX      Dot1qPortVlanHCStatisticsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Traffic statistics for a VLAN on a high-capacity
+        interface."
+    INDEX   { dot1dBasePort, dot1qVlanIndex }
+    ::= { dot1qPortVlanHCStatisticsTable 1 }
+
+Dot1qPortVlanHCStatisticsEntry ::=
+    SEQUENCE {
+        dot1qTpVlanPortHCInFrames
+            Counter64,
+        dot1qTpVlanPortHCOutFrames
+            Counter64,
+        dot1qTpVlanPortHCInDiscards
+            Counter64
+    }
+
+dot1qTpVlanPortHCInFrames OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of valid frames received by this port from
+        its segment that were classified as belonging to this
+        VLAN.  Note that a frame received on this port is
+        counted by this object if and only if it is for a
+
+
+
+Levi & Harrington           Standards Track                    [Page 74]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        protocol being processed by the local forwarding process
+        for this VLAN.  This object includes received bridge
+        management frames classified as belonging to this VLAN
+        (e.g., GMRP, but not GVRP or STP)."
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.6.1.1.3(a)"
+    ::= { dot1qPortVlanHCStatisticsEntry 1 }
+
+dot1qTpVlanPortHCOutFrames OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of valid frames transmitted by this port to
+        its segment from the local forwarding process for this
+        VLAN.  This includes bridge management frames originated
+        by this device that are classified as belonging to this
+        VLAN (e.g., GMRP, but not GVRP or STP)."
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.6.1.1.3(d)"
+    ::= { dot1qPortVlanHCStatisticsEntry 2 }
+
+dot1qTpVlanPortHCInDiscards OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of valid frames received by this port from
+        its segment that were classified as belonging to this
+        VLAN and that were discarded due to VLAN-related reasons.
+        Specifically, the IEEE 802.1Q counters for Discard
+        Inbound and Discard on Ingress Filtering."
+    REFERENCE
+        "IEEE 802.1Q/D11 Section 12.6.1.1.3"
+    ::= { dot1qPortVlanHCStatisticsEntry 3 }
+
+-- -------------------------------------------------------------
+-- The VLAN Learning Constraints Table
+-- -------------------------------------------------------------
+
+dot1qLearningConstraintsTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1qLearningConstraintsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table containing learning constraints for sets of
+        Shared and Independent VLANs."
+    REFERENCE
+
+
+
+Levi & Harrington           Standards Track                    [Page 75]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        "IEEE 802.1Q/D11 Section 12.10.3.1"
+    ::= { dot1qVlan 8 }
+
+dot1qLearningConstraintsEntry OBJECT-TYPE
+    SYNTAX      Dot1qLearningConstraintsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A learning constraint defined for a VLAN."
+    INDEX   { dot1qConstraintVlan, dot1qConstraintSet }
+    ::= { dot1qLearningConstraintsTable 1 }
+
+Dot1qLearningConstraintsEntry ::=
+    SEQUENCE {
+        dot1qConstraintVlan
+            VlanIndex,
+        dot1qConstraintSet
+            Integer32,
+        dot1qConstraintType
+            INTEGER,
+        dot1qConstraintStatus
+            RowStatus
+    }
+
+dot1qConstraintVlan OBJECT-TYPE
+    SYNTAX      VlanIndex
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The index of the row in dot1qVlanCurrentTable for the
+        VLAN constrained by this entry."
+    ::= { dot1qLearningConstraintsEntry 1 }
+
+dot1qConstraintSet OBJECT-TYPE
+    SYNTAX      Integer32 (0..65535)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The identity of the constraint set to which
+        dot1qConstraintVlan belongs.  These values may be chosen
+        by the management station."
+    ::= { dot1qLearningConstraintsEntry 2 }
+
+dot1qConstraintType OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    independent(1),
+                    shared(2)
+                }
+
+
+
+Levi & Harrington           Standards Track                    [Page 76]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+        "The type of constraint this entry defines.
+            independent(1) - the VLAN, dot1qConstraintVlan,
+                uses a filtering database independent from all
+                other VLANs in the same set, defined by
+                dot1qConstraintSet.
+            shared(2) - the VLAN, dot1qConstraintVlan, shares
+                the same filtering database as all other VLANs
+                in the same set, defined by dot1qConstraintSet."
+    ::= { dot1qLearningConstraintsEntry 3 }
+
+dot1qConstraintStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+        "The status of this entry."
+    ::= { dot1qLearningConstraintsEntry 4 }
+
+dot1qConstraintSetDefault OBJECT-TYPE
+    SYNTAX      Integer32 (0..65535)
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "The identity of the constraint set to which a VLAN
+        belongs, if there is not an explicit entry for that VLAN
+        in dot1qLearningConstraintsTable.
+
+        The value of this object MUST be retained across
+        reinitializations of the management system."
+    ::= { dot1qVlan 9 }
+
+dot1qConstraintTypeDefault OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    independent(1),
+                    shared(2)
+                }
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "The type of constraint set to which a VLAN belongs, if
+        there is not an explicit entry for that VLAN in
+        dot1qLearningConstraintsTable.  The types are as defined
+        for dot1qConstraintType.
+
+        The value of this object MUST be retained across
+
+
+
+Levi & Harrington           Standards Track                    [Page 77]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        reinitializations of the management system."
+    ::= { dot1qVlan 10 }
+
+-- -------------------------------------------------------------
+-- dot1vProtocol subtree
+-- -------------------------------------------------------------
+
+dot1vProtocolGroupTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1vProtocolGroupEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table that contains mappings from Protocol
+         Templates to Protocol Group Identifiers used for
+         Port-and-Protocol-based VLAN Classification."
+    REFERENCE
+        "IEEE 802.1v clause 8.6.4"
+    ::= { dot1vProtocol 1 }
+
+dot1vProtocolGroupEntry OBJECT-TYPE
+    SYNTAX      Dot1vProtocolGroupEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A mapping from a Protocol Template to a Protocol
+         Group Identifier."
+    INDEX       { dot1vProtocolTemplateFrameType,
+                  dot1vProtocolTemplateProtocolValue }
+    ::= { dot1vProtocolGroupTable 1 }
+
+Dot1vProtocolGroupEntry ::=
+    SEQUENCE {
+        dot1vProtocolTemplateFrameType
+            INTEGER,
+        dot1vProtocolTemplateProtocolValue
+            OCTET STRING,
+        dot1vProtocolGroupId
+            Integer32,
+        dot1vProtocolGroupRowStatus
+            RowStatus
+    }
+
+dot1vProtocolTemplateFrameType OBJECT-TYPE
+    SYNTAX      INTEGER {
+                  ethernet  (1),
+                  rfc1042   (2),
+                  snap8021H (3),
+                  snapOther (4),
+
+
+
+Levi & Harrington           Standards Track                    [Page 78]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+                  llcOther  (5)
+                }
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The data-link encapsulation format or the
+         'detagged_frame_type' in a Protocol Template."
+    REFERENCE
+        "IEEE 802.1v clause 8.6.2"
+    ::= { dot1vProtocolGroupEntry 1 }
+
+dot1vProtocolTemplateProtocolValue OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE (2 | 5))
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The identification of the protocol above the data-link
+         layer in a Protocol Template.  Depending on the
+         frame type, the octet string will have one of the
+         following values:
+
+         For 'ethernet', 'rfc1042' and 'snap8021H',
+             this is the 16-bit (2-octet) IEEE 802.3 Type Field.
+         For 'snapOther',
+             this is the 40-bit (5-octet) PID.
+         For 'llcOther',
+             this is the 2-octet IEEE 802.2 Link Service Access
+             Point (LSAP) pair: first octet for Destination Service
+             Access Point (DSAP) and second octet for Source Service
+             Access Point (SSAP)."
+    REFERENCE
+        "IEEE 802.1v clause 8.6.2"
+    ::= { dot1vProtocolGroupEntry 2 }
+
+dot1vProtocolGroupId OBJECT-TYPE
+    SYNTAX      Integer32 (0..2147483647)
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+        "Represents a group of protocols that are associated
+         together when assigning a VID to a frame."
+    REFERENCE
+        "IEEE 802.1v clause 8.6.3, 12.10.2.1"
+    ::= { dot1vProtocolGroupEntry 3 }
+
+dot1vProtocolGroupRowStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-create
+
+
+
+Levi & Harrington           Standards Track                    [Page 79]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+    STATUS      current
+    DESCRIPTION
+        "This object indicates the status of this entry."
+    ::= { dot1vProtocolGroupEntry 4 }
+
+dot1vProtocolPortTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1vProtocolPortEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table that contains VID sets used for
+         Port-and-Protocol-based VLAN Classification."
+    REFERENCE
+        "IEEE 802.1v clause 8.4.4"
+    ::= { dot1vProtocol 2 }
+
+dot1vProtocolPortEntry OBJECT-TYPE
+    SYNTAX      Dot1vProtocolPortEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A VID set for a port."
+    INDEX       { dot1dBasePort,
+                  dot1vProtocolPortGroupId }
+    ::= { dot1vProtocolPortTable 1 }
+
+Dot1vProtocolPortEntry ::=
+    SEQUENCE {
+        dot1vProtocolPortGroupId
+            Integer32,
+        dot1vProtocolPortGroupVid
+            Integer32,
+        dot1vProtocolPortRowStatus
+            RowStatus
+    }
+
+dot1vProtocolPortGroupId OBJECT-TYPE
+    SYNTAX      Integer32 (1..2147483647)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Designates a group of protocols in the Protocol
+         Group Database."
+    REFERENCE
+        "IEEE 802.1v clause 8.6.3, 12.10.1.2"
+    ::= { dot1vProtocolPortEntry 1 }
+
+dot1vProtocolPortGroupVid OBJECT-TYPE
+
+
+
+Levi & Harrington           Standards Track                    [Page 80]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+    SYNTAX      Integer32 (1..4094)
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+        "The VID associated with a group of protocols for
+         each port."
+    REFERENCE
+        "IEEE 802.1v clause 8.4.4, 12.10.1.2"
+    ::= { dot1vProtocolPortEntry 2 }
+
+dot1vProtocolPortRowStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+        "This object indicates the status of this entry."
+    ::= { dot1vProtocolPortEntry 3 }
+
+-- -------------------------------------------------------------
+-- IEEE 802.1Q MIB - Conformance Information
+-- -------------------------------------------------------------
+
+qBridgeConformance OBJECT IDENTIFIER ::= { qBridgeMIB 2 }
+
+qBridgeGroups OBJECT IDENTIFIER ::= { qBridgeConformance 1 }
+
+qBridgeCompliances OBJECT IDENTIFIER ::= { qBridgeConformance 2 }
+
+-- -------------------------------------------------------------
+-- units of conformance
+-- -------------------------------------------------------------
+
+qBridgeBaseGroup OBJECT-GROUP
+    OBJECTS {
+        dot1qVlanVersionNumber,
+        dot1qMaxVlanId,
+        dot1qMaxSupportedVlans,
+        dot1qNumVlans,
+        dot1qGvrpStatus
+    }
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects providing device-level control
+        and status information for the Virtual LAN bridge
+        services."
+    ::= { qBridgeGroups 1 }
+
+qBridgeFdbUnicastGroup OBJECT-GROUP
+
+
+
+Levi & Harrington           Standards Track                    [Page 81]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+    OBJECTS {
+        dot1qFdbDynamicCount,
+        dot1qTpFdbPort,
+        dot1qTpFdbStatus
+    }
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects providing information about all
+        unicast addresses, learned dynamically or statically
+        configured by management, in each Filtering Database."
+    ::= { qBridgeGroups 2 }
+
+qBridgeFdbMulticastGroup OBJECT-GROUP
+    OBJECTS {
+        dot1qTpGroupEgressPorts,
+        dot1qTpGroupLearnt
+    }
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects providing information about all
+        multicast addresses, learned dynamically or statically
+        configured by management, in each Filtering Database."
+    ::= { qBridgeGroups 3 }
+
+qBridgeServiceRequirementsGroup OBJECT-GROUP
+    OBJECTS {
+        dot1qForwardAllPorts,
+        dot1qForwardAllStaticPorts,
+        dot1qForwardAllForbiddenPorts,
+        dot1qForwardUnregisteredPorts,
+        dot1qForwardUnregisteredStaticPorts,
+        dot1qForwardUnregisteredForbiddenPorts
+    }
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects providing information about
+        service requirements, learned dynamically or statically
+        configured by management, in each Filtering Database."
+    ::= { qBridgeGroups 4 }
+
+qBridgeFdbStaticGroup OBJECT-GROUP
+    OBJECTS {
+        dot1qStaticUnicastAllowedToGoTo,
+        dot1qStaticUnicastStatus,
+        dot1qStaticMulticastStaticEgressPorts,
+        dot1qStaticMulticastForbiddenEgressPorts,
+        dot1qStaticMulticastStatus
+    }
+
+
+
+Levi & Harrington           Standards Track                    [Page 82]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects providing information about
+        unicast and multicast addresses statically configured by
+        management, in each Filtering Database or VLAN."
+    ::= { qBridgeGroups 5 }
+
+qBridgeVlanGroup OBJECT-GROUP
+    OBJECTS {
+        dot1qVlanNumDeletes,
+        dot1qVlanFdbId,
+        dot1qVlanCurrentEgressPorts,
+        dot1qVlanCurrentUntaggedPorts,
+        dot1qVlanStatus,
+        dot1qVlanCreationTime
+    }
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects providing information about
+        all VLANs currently configured on this device."
+    ::= { qBridgeGroups 6 }
+
+qBridgeVlanStaticGroup OBJECT-GROUP
+    OBJECTS {
+        dot1qVlanStaticName,
+        dot1qVlanStaticEgressPorts,
+        dot1qVlanForbiddenEgressPorts,
+        dot1qVlanStaticUntaggedPorts,
+        dot1qVlanStaticRowStatus,
+        dot1qNextFreeLocalVlanIndex
+    }
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects providing information about
+        VLANs statically configured by management."
+    ::= { qBridgeGroups 7 }
+
+qBridgePortGroup OBJECT-GROUP
+    OBJECTS {
+        dot1qPvid,
+        dot1qPortAcceptableFrameTypes,
+        dot1qPortIngressFiltering,
+        dot1qPortGvrpStatus,
+        dot1qPortGvrpFailedRegistrations,
+        dot1qPortGvrpLastPduOrigin
+    }
+    STATUS      deprecated
+    DESCRIPTION
+
+
+
+Levi & Harrington           Standards Track                    [Page 83]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        "A collection of objects providing port-level VLAN
+        control and status information for all ports."
+    ::= { qBridgeGroups 8 }
+
+qBridgeVlanStatisticsGroup OBJECT-GROUP
+    OBJECTS {
+        dot1qTpVlanPortInFrames,
+        dot1qTpVlanPortOutFrames,
+        dot1qTpVlanPortInDiscards
+    }
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects providing per-port packet
+        statistics for all VLANs currently configured on this
+        device."
+    ::= { qBridgeGroups 9 }
+
+qBridgeVlanStatisticsOverflowGroup OBJECT-GROUP
+    OBJECTS {
+        dot1qTpVlanPortInOverflowFrames,
+        dot1qTpVlanPortOutOverflowFrames,
+        dot1qTpVlanPortInOverflowDiscards
+    }
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects providing overflow counters for
+        per-port packet statistics for all VLANs currently configured
+        on this device for high-capacity interfaces, defined as those
+        that have the value of the corresponding instance of
+        ifSpeed greater than 650,000,000 bits/second."
+    ::= { qBridgeGroups 10 }
+
+qBridgeVlanHCStatisticsGroup OBJECT-GROUP
+    OBJECTS {
+        dot1qTpVlanPortHCInFrames,
+        dot1qTpVlanPortHCOutFrames,
+        dot1qTpVlanPortHCInDiscards
+    }
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects providing per-port packet
+        statistics for all VLANs currently configured on this
+        device for high-capacity interfaces, defined as those
+        that have the value of the corresponding instance of
+        ifSpeed greater than 650,000,000 bits/second."
+    ::= { qBridgeGroups 11 }
+
+qBridgeLearningConstraintsGroup OBJECT-GROUP
+
+
+
+Levi & Harrington           Standards Track                    [Page 84]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+    OBJECTS {
+        dot1qConstraintType,
+        dot1qConstraintStatus
+    }
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects defining the Filtering Database
+        constraints all VLANs have with each other."
+    ::= { qBridgeGroups 12 }
+
+qBridgeLearningConstraintDefaultGroup OBJECT-GROUP
+    OBJECTS {
+        dot1qConstraintSetDefault,
+        dot1qConstraintTypeDefault
+    }
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects defining the default Filtering
+        Database constraints for VLANs that have no specific
+        constraints defined."
+    ::= { qBridgeGroups 13 }
+
+qBridgeClassificationDeviceGroup OBJECT-GROUP
+    OBJECTS {
+        dot1vProtocolGroupId,
+        dot1vProtocolGroupRowStatus
+    }
+    STATUS      current
+    DESCRIPTION
+        "VLAN classification information for the bridge."
+    ::= { qBridgeGroups 14 }
+
+qBridgeClassificationPortGroup OBJECT-GROUP
+    OBJECTS {
+        dot1vProtocolPortGroupVid,
+        dot1vProtocolPortRowStatus
+    }
+    STATUS      current
+    DESCRIPTION
+        "VLAN classification information for individual ports."
+    ::= { qBridgeGroups 15 }
+
+qBridgePortGroup2 OBJECT-GROUP
+    OBJECTS {
+        dot1qPvid,
+        dot1qPortAcceptableFrameTypes,
+        dot1qPortIngressFiltering,
+        dot1qPortGvrpStatus,
+
+
+
+Levi & Harrington           Standards Track                    [Page 85]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        dot1qPortGvrpFailedRegistrations,
+        dot1qPortGvrpLastPduOrigin,
+        dot1qPortRestrictedVlanRegistration
+    }
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects providing port-level VLAN
+        control and status information for all ports."
+    ::= { qBridgeGroups 16 }
+
+-- -------------------------------------------------------------
+-- compliance statements
+-- -------------------------------------------------------------
+
+qBridgeCompliance MODULE-COMPLIANCE
+    STATUS  deprecated
+    DESCRIPTION
+        "The compliance statement for device support of Virtual
+        LAN Bridge services.
+
+        RFC2674 was silent about the expected persistence of the
+        read-write objects in this MIB module.  Applications MUST
+        NOT assume that the values of the read-write objects are
+        persistent across reinitializations of the management
+        system and MUST NOT assume that the values are not
+        persistent across reinitializations of the management
+        system."
+
+    MODULE
+        MANDATORY-GROUPS {
+            qBridgeBaseGroup,
+            qBridgeVlanGroup,
+            qBridgeVlanStaticGroup,
+            qBridgePortGroup
+        }
+
+        GROUP       qBridgeFdbUnicastGroup
+        DESCRIPTION
+            "This group is mandatory for bridges that implement
+            802.1Q transparent bridging."
+
+        GROUP       qBridgeFdbMulticastGroup
+        DESCRIPTION
+            "This group is mandatory for bridges that implement
+            802.1Q transparent bridging."
+
+        GROUP       qBridgeServiceRequirementsGroup
+        DESCRIPTION
+
+
+
+Levi & Harrington           Standards Track                    [Page 86]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+            "This group is mandatory for bridges that implement
+            extended filtering services.  All objects must be
+            read-write if extended-filtering services are
+            enabled."
+
+        GROUP       qBridgeFdbStaticGroup
+        DESCRIPTION
+            "This group is optional."
+
+        GROUP       qBridgeVlanStatisticsGroup
+        DESCRIPTION
+            "This group is optional as there may be significant
+            implementation cost associated with its support."
+
+        GROUP       qBridgeVlanStatisticsOverflowGroup
+        DESCRIPTION
+            "This group is optional as there may be significant
+            implementation cost associated with its support.  It is most
+            relevant for high-capacity interfaces where the SNMP agent
+            supports only SNMPv1."
+
+        GROUP       qBridgeVlanHCStatisticsGroup
+        DESCRIPTION
+            "This group is optional as there may be significant
+            implementation cost associated with its support.  It is most
+            relevant for high-capacity interfaces."
+
+        GROUP       qBridgeLearningConstraintsGroup
+        DESCRIPTION
+            "This group is mandatory for devices implementing
+             both Independent VLAN Learning (IVL) and Shared
+             VLAN Learning (SVL) modes of operation of the
+             filtering database, as defined by IEEE 802.1Q."
+
+        GROUP       qBridgeLearningConstraintDefaultGroup
+        DESCRIPTION
+            "This group is mandatory for devices implementing
+             both Independent VLAN Learning (IVL) and Shared
+             VLAN Learning (SVL) modes of operation of the
+             filtering database, as defined by IEEE 802.1Q."
+
+        OBJECT      dot1qPortAcceptableFrameTypes
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required as this is an optional
+            capability in IEEE 802.1Q."
+
+        OBJECT      dot1qPortIngressFiltering
+
+
+
+Levi & Harrington           Standards Track                    [Page 87]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required as this is an optional
+            capability in IEEE 802.1Q."
+
+        OBJECT      dot1qConstraintSetDefault
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required as this is an optional
+            capability in IEEE 802.1Q."
+
+        OBJECT      dot1qConstraintTypeDefault
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required as this is an optional
+            capability in IEEE 802.1Q."
+
+       ::= { qBridgeCompliances 1 }
+
+qBridgeCompliance2 MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+        "The compliance statement for device support of Virtual
+        LAN Bridge services.
+
+        This document clarifies the persistence requirements for
+        the read-write objects in this MIB module.  All
+        implementations claiming compliance to qBridgeCompliance2
+        MUST retain the values of those read-write objects that
+        specify this requirement."
+
+    MODULE
+        MANDATORY-GROUPS {
+            qBridgeBaseGroup,
+            qBridgeVlanGroup,
+            qBridgeVlanStaticGroup,
+            qBridgePortGroup2
+        }
+
+        GROUP       qBridgeFdbUnicastGroup
+        DESCRIPTION
+            "This group is mandatory for bridges that implement
+            802.1Q transparent bridging."
+
+        GROUP       qBridgeFdbMulticastGroup
+        DESCRIPTION
+            "This group is mandatory for bridges that implement
+            802.1Q transparent bridging."
+
+
+
+Levi & Harrington           Standards Track                    [Page 88]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        GROUP       qBridgeServiceRequirementsGroup
+        DESCRIPTION
+            "This group is mandatory for bridges that implement
+            extended filtering services.  All objects must be
+            read-write if extended-filtering services are
+            enabled."
+
+        GROUP       qBridgeFdbStaticGroup
+        DESCRIPTION
+            "This group is optional."
+
+        GROUP       qBridgeVlanStatisticsGroup
+        DESCRIPTION
+            "This group is optional as there may be significant
+            implementation cost associated with its support."
+
+        GROUP       qBridgeVlanStatisticsOverflowGroup
+        DESCRIPTION
+            "This group is optional as there may be significant
+            implementation cost associated with its support.  It is most
+            relevant for high-capacity interfaces where the SNMP agent
+            supports only SNMPv1."
+
+        GROUP       qBridgeVlanHCStatisticsGroup
+        DESCRIPTION
+            "This group is optional as there may be significant
+            implementation cost associated with its support.  It is most
+            relevant for high-capacity interfaces."
+
+        GROUP       qBridgeLearningConstraintsGroup
+        DESCRIPTION
+            "This group is mandatory for devices implementing
+             both Independent VLAN Learning (IVL) and Shared
+             VLAN Learning (SVL) modes of operation of the
+             filtering database, as defined by IEEE 802.1Q."
+
+        GROUP       qBridgeLearningConstraintDefaultGroup
+        DESCRIPTION
+            "This group is mandatory for devices implementing
+             both Independent VLAN Learning (IVL) and Shared
+             VLAN Learning (SVL) modes of operation of the
+             filtering database, as defined by IEEE 802.1Q."
+
+        GROUP       qBridgeClassificationDeviceGroup
+        DESCRIPTION
+            "This group is mandatory ONLY for devices implementing
+             VLAN Classification as specified in IEEE 802.1v."
+
+
+
+
+Levi & Harrington           Standards Track                    [Page 89]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+        GROUP       qBridgeClassificationPortGroup
+        DESCRIPTION
+            "This group is mandatory ONLY for devices implementing
+             VLAN Classification as specified in IEEE 802.1v."
+
+        OBJECT      dot1qPortAcceptableFrameTypes
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required as this is an optional
+            capability in IEEE 802.1Q."
+
+        OBJECT      dot1qPortIngressFiltering
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required as this is an optional
+            capability in IEEE 802.1Q."
+
+        OBJECT      dot1qConstraintSetDefault
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required as this is an optional
+            capability in IEEE 802.1Q."
+
+        OBJECT      dot1qConstraintTypeDefault
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required as this is an optional
+            capability in IEEE 802.1Q."
+
+        OBJECT      dot1vProtocolGroupId
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required as this is an optional
+            capability in IEEE 802.1v."
+
+        OBJECT      dot1vProtocolGroupRowStatus
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required as this is an optional
+            capability in IEEE 802.1v."
+
+        ::= { qBridgeCompliances 2 }
+
+END
+
+
+
+
+
+
+
+Levi & Harrington           Standards Track                    [Page 90]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+6.  Acknowledgements
+
+   Much of the groundwork for this document was performed by the IEEE
+   802.1 working group during the definition of the IEEE 802.1D updates
+   [802.1D] and IEEE 802.1Q [802.1Q].
+
+   The authors wish to thank the members of the Bridge Working Group,
+   and David Harrington, Anders SW Christensen, Andrew Smith, Paul
+   Langille, Anil Rijhsinghani, and Keith McCloghrie in particular for
+   their comments and suggestions, which improved this effort.
+
+   Editing for the final version was done by David Levi.
+
+   The new textual conventions related to VLAN-IDs were produced as a
+   result of a review of the use of VLAN-ID in several MIB modules.
+   Further investigation found that VLAN-ID objects were defined in a
+   few other MIB modules.  The editor would like to thank all who
+   contributed to the discussion that resulted in these new textual
+   conventions.  Specifically, Bert Wijnen, Les Bell, Andrew Smith, Mike
+   Heard, Randy Presuhn, Dan Romascanu, Eduardo Cardona, Tom Petch,
+   Juergen Schoenwaelder, Richard Woundy, Tony Jeffree, and William
+   Murwin.  We also received input and feedback from IEEE confirming
+   that the values 0 and 4095 are not used for identifying a specific
+   VLAN-ID and so can be used to represent none or a wildcard (see
+   Appendix A).
+
+7.  Security Considerations
+
+   There are a number of management objects defined in this MIB module
+   with a MAX-ACCESS clause of read-write and/or read-create.  Such
+   objects may be considered sensitive or vulnerable in some network
+   environments.  The support for SET operations in a non-secure
+   environment without proper protection can have a negative effect on
+   network operations.  These tables and objects and their
+   sensitivity/vulnerability are described below.
+
+   The following tables and objects in the P-BRIDGE-MIB can be
+   manipulated to interfere with the operation of priority classes.
+   This could, for example, be used to force a reinitialization of state
+   machines, thus causing network instability.  Another possibility
+   would be for an attacker to override established policy on port
+   priorities, thus giving a user (or an attacker) unauthorized
+   preferential treatment.
+
+         dot1dTrafficClassesEnabled
+         dot1dGmrpStatus
+         dot1dPortPriorityTable
+         dot1dUserPriorityRegenTable
+
+
+
+Levi & Harrington           Standards Track                    [Page 91]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+         dot1dTrafficClassTable
+         dot1dPortGarpTable
+         dot1dPortGmrpTable
+
+   The following tables and objects in the Q-BRIDGE-MIB could be
+   manipulated to interfere with the operation of virtual LANs.  This
+   could, for example, be used to force a reinitialization of state
+   machines to cause network instability, or changing the forwarding and
+   filtering policies.
+
+         dot1qGvrpStatus
+         dot1qForwardAllTable
+         dot1qStaticUnicastTable
+         dot1qStaticMulticastTable
+         dot1qVlanStaticTable
+         dot1qPortVlanTable
+         dot1qLearningConstraintsTable
+         dot1vProtocolGroupTable
+         dot1vProtocolPortTable
+
+   Some of the readable objects in this MIB module (i.e., objects with a
+   MAX-ACCESS other than not-accessible) may be considered sensitive or
+   vulnerable in some network environments.  It is thus important to
+   control even GET and/or NOTIFY access to these objects and possibly
+   to even encrypt the values of these objects when sending them over
+   the network via SNMP.  These are the tables and objects and their
+   sensitivity/vulnerability.
+
+   The objects dot1dDeviceCapabilities and dot1dPortCapabilitiesTable in
+   the P-BRIDGE-MIB could be used by an attacker to determine which
+   attacks might be useful to attempt against a given device.
+
+   The following read-only tables and objects in the Q-BRIDGE-MIB could
+   be used by an attacker to determine which attacks might be useful to
+   attempt against a given device, could be used by an attacker to
+   detect whether their attacks are being blocked or filtered, or could
+   be used to understand the logical topology of the network.
+
+         dot1qMaxVlanID
+         dot1qMaxSupportedVlans
+         dot1qNumVlans
+         dot1qFdbTable
+         dot1qTpFdbTable
+         dot1qTpGroupTable
+         dot1qVlanCurrentTable
+         dot1qPortVlanStatisticsTable
+
+
+
+
+
+Levi & Harrington           Standards Track                    [Page 92]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+   SNMP versions prior to SNMPv3 did not include adequate security.
+   Even if the network itself is secure (for example by using IPSec),
+   even then, there is no control as to who on the secure network is
+   allowed to access and GET/SET (read/change/create/delete) the objects
+   in this MIB module.
+
+   It is RECOMMENDED that implementers consider the security features as
+   provided by the SNMPv3 framework (see [RFC3410], section 8),
+   including full support for the SNMPv3 cryptographic mechanisms (for
+   authentication and privacy).
+
+   Further, deployment of SNMP versions prior to SNMPv3 is NOT
+   RECOMMENDED.  Instead, it is RECOMMENDED to deploy SNMPv3 and to
+   enable cryptographic security.  It is then a customer/operator
+   responsibility to ensure that the SNMP entity giving access to an
+   instance of this MIB module is properly configured to give access to
+   the objects only to those principals (users) that have legitimate
+   rights to indeed GET or SET (change/create/delete) them.
+
+8.  Normative References
+
+   [BRIDGE-MIB] Norseth, K. and E. Bell, "Definitions of Managed Objects
+                for Bridges", RFC 4188, September 2005.
+
+   [RFC2578]    McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+                "Structure of Management Information Version 2 (SMIv2)",
+                STD 58, RFC 2578, April 1999.
+
+   [RFC2579]    McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+                "Textual Conventions for SMIv2", STD 58, RFC 2579, April
+                1999.
+
+   [RFC2580]    McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+                "Conformance Statements for SMIv2", STD 58, RFC 2580,
+                April 1999.
+
+   [RFC2674]    Bell, E., Smith, A., Langille, P., Rijhsinghani, A., and
+                K. McCloghrie, "Definitions of Managed Objects for
+                Bridges with Traffic Classes, Multicast Filtering and
+                Virtual LAN Extensions", RFC 2674, August 1999.
+
+   [RFC2863]    McCloghrie, K. and F. Kastenholz, "The Interfaces Group
+                MIB", RFC 2863, June 2000.
+
+   [RFC3418]    Presuhn, R., "Management Information Base (MIB) for the
+                Simple Network Management Protocol (SNMP)", STD 62, RFC
+                3418, December 2002.
+
+
+
+
+Levi & Harrington           Standards Track                    [Page 93]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+   [802.1D]     "Information technology - Telecommunications and
+                information exchange between systems - Local and
+                metropolitan area networks - Common specifications -
+                Part 3: Media Access Control (MAC) Bridges:  Revision.
+                This is a revision of ISO/IEC 10038: 1993, 802.1j-1992
+                and 802.6k-1992.  It incorporates P802.11c, P802.1p and
+                P802.12e."  ISO/IEC 15802-3: 1998.
+
+   [802.1Q]     ANSI/IEEE Standard 802.1Q, "IEEE Standards for Local and
+                Metropolitan Area Networks: Virtual Bridged Local Area
+                Networks", 2003.
+
+   [802.1t]     IEEE 802.1t-2001, "(Amendment to IEEE Standard 802.1D)
+                IEEE Standard for Information technology -
+                Telecommunications and information exchange between
+                systems - Local and metropolitan area networks - Common
+                specifications - Part 3: Media Access Control (MAC)
+                Bridges: Technical and Editorial Corrections".
+
+   [802.1u]     IEEE 802.1u-2001, "(Amendment to IEEE Standard 802.1Q)
+                IEEE Standard for Local and metropolitan area networks -
+                Virtual Bridged Local Area Networks - Amendment 1:
+                Technical and Editorial Corrections".
+
+   [802.1v]     IEEE 802.1v-2001, "(Amendment to IEEE Standard 802.1Q)
+                IEEE Standards for Local and Metropolitan Area Networks:
+                Virtual Bridged Local Area Networks--Amendment 2: VLAN
+                Classification by Protocol and Port".
+
+9.  Informative References
+
+   [RFC1493]    Decker, E., Langille, P., Rijsinghani, A. and K.
+                McCloghrie, "Definitions of Managed Objects for
+                Bridges", RFC 1493, July 1993.
+
+   [RFC4323]    Patrick, M. and W. Murwin, "Data Over Cable System
+                Interface Specification Quality of Service Management
+                Information Base (DOCSIS-QOS MIB)", RFC 4323, January
+                2006.
+
+   [RFC4149]    Kalbfleisch, C., Cole, R., and D. Romascanu, "Definition
+                of Managed Objects for Synthetic Sources for Performance
+                Monitoring Algorithms", RFC 4149, August 2005.
+
+   [RFC2613]    Waterman, R., Lahaye, B., Romascanu, D., and S.
+                Waldbusser, "Remote Network Monitoring MIB Extensions
+                for Switched Networks Version 1.0", RFC 2613, June 1999.
+
+
+
+
+Levi & Harrington           Standards Track                    [Page 94]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+   [RFC3318]    Sahita, R., Hahn, S., Chan, K., and K. McCloghrie,
+                "Framework Policy Information Base", RFC 3318, March
+                2003.
+
+   [RFC3410]    Case, J., Mundy, R., Partain, D., and B. Stewart,
+                "Introduction and Applicability Statements for
+                Internet-Standard Management Framework", RFC 3410,
+                December 2002.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Levi & Harrington           Standards Track                    [Page 95]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+Appendix A.  Email from Tony Jeffrey from IEEE
+
+   -----Original Message-----
+   From: Tony Jeffree [mailto:tony@jeffree.co.uk]
+   Sent: Friday, 6th of June 2003 17:16
+   To: Wijnen, Bert (Bert) [mailto:bwijnen@lucent.com]
+   Subject: RE: VLAn ID
+
+
+   Bert et al -
+
+   We have concluded that the use of 4095 as a wildcard is acceptable
+   to 802.1, and we will make any necessary changes to 802.1Q in due
+   course to relax the current stated restriction.  However, we need
+   to know whether that is all that needs to be done to 802.1Q - i.e.,
+   is there any need to change our definitions of the managed objects
+   in the document (Clause 12) to reflect the interpretation of 4095
+   as a wildcard, or is this simply an issue for the SNMP machinery
+   to handle?
+
+   Regards,
+   Tony
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Levi & Harrington           Standards Track                    [Page 96]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+Authors' Adresses
+
+   David Levi
+   Nortel Networks
+   4655 Great America Parkway
+   Santa Clara, CA 95054
+   USA
+
+   Phone: +1 865 686 0432
+   EMail: dlevi@nortel.com
+
+
+   David Harrington
+   Effective Software
+   50 Harding Rd.
+   Portsmouth, NH 03801
+   USA
+
+   Phone: +1 603 436 8634
+   EMail: ietfdbh@comcast.net
+
+
+   Vivian Ngai
+   Salt lake City, UT
+   USA
+
+   EMail: vivian_ngai@acm.org
+
+
+   Les Bell
+   Hemel Hempstead
+   Herts.  HP2 7YU
+   UK
+
+   EMail: elbell@ntlworld.com
+
+
+   Andrew Smith
+   Beijing Harbour Networks
+   Jiuling Building
+   21 North Xisanhuan Ave.
+   Beijing, 100089
+   PRC
+
+   Fax: +1 415 345 1827
+   EMail: ah_smith@acm.org
+
+
+
+
+
+Levi & Harrington           Standards Track                    [Page 97]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+   Paul Langille
+   Newbridge Networks
+   5 Corporate Drive
+   Andover, MA 01810
+   USA
+
+   Phone: +1 978 691 4665
+   EMail: langille@newbridge.com
+
+
+   Anil Rijhsinghani
+   Accton Technology Corporation
+   5 Mount Royal Ave
+   Marlboro, MA 01752
+   USA
+   EMail: anil@accton.com
+
+
+   Keith McCloghrie
+   Cisco Systems, Inc.
+   170 West Tasman Drive
+   San Jose, CA 95134-1706
+   USA
+
+   Phone: +1 408 526 5260
+   EMail: kzm@cisco.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Levi & Harrington           Standards Track                    [Page 98]
+
+RFC 4363                 Bridge MIB Extensions              January 2006
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2006).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is provided by the IETF
+   Administrative Support Activity (IASA).
+
+
+
+
+
+
+
+Levi & Harrington           Standards Track                    [Page 99]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4363.txt](<www.ietf.org/rfc/rfc4363.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
