### PR TITLE
Archive rfc4371.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4371.txt
+++ b/www.ietf.org/rfc/rfc4371.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Network Working Group                                  B. Carpenter, Ed.
+Request for Comments: 4371                                           IBM
+BCP: 101                                                   L. Lynch, Ed.
+Updates: 4071                                                         UO
+Category: Best Current Practice                             January 2006
+
+
+                      BCP 101 Update for IPR Trust
+
+Status of this Memo
+
+   This document specifies an Internet Best Current Practices for the
+   Internet Community, and requests discussion and suggestions for
+   improvements.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2006).
+
+Abstract
+
+   This document updates BCP 101 to take account of the new IETF
+   Intellectual Property Trust.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . . . 1
+   2.  Updates to RFC 4071 . . . . . . . . . . . . . . . . . . . . . . 2
+   3.  Security Considerations . . . . . . . . . . . . . . . . . . . . 2
+   4.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . 2
+   5.  References  . . . . . . . . . . . . . . . . . . . . . . . . . . 3
+       5.1.  Normative References  . . . . . . . . . . . . . . . . . . 3
+       5.2.  Informative References  . . . . . . . . . . . . . . . . . 3
+
+1.  Introduction
+
+   The first version of BCP 101, i.e., RFC 4071 [1], assumed that the
+   vehicle for certain IETF-related Intellectual Property Rights (IPR)
+   would be the Internet Society (ISOC).  Since that time, an IETF Trust
+   has been created to hold such IPR.  This document appropriately
+   updates RFC 4071.
+
+   This update comes into force as soon as it has been approved by the
+   IESG and the IETF Trust Agreement [2] has been formally signed by its
+   Settlors and initial Trustees.
+
+   Terms and abbreviations used in this document are defined in RFC
+   4071.
+
+
+
+Carpenter & Lynch        Best Current Practice                  [Page 1]
+
+RFC 4371                     BCP 101 Update                 January 2006
+
+
+2.  Updates to RFC 4071
+
+   A Trust ("the IETF Trust") has been formed for the purpose of
+   acquiring, holding, maintaining, and licensing certain existing and
+   future intellectual property and other property used in connection
+   with the administration of the IETF.  The Trust was formed by the
+   signatures of its Settlors and initial Trustees.  The Settlors, who
+   contributed initial intellectual property to the Trust, were ISOC and
+   the Corporation for National Research Initiatives.  The Trustees of
+   the IETF Trust are the members of the IAOC, and the Beneficiary of
+   the IETF Trust is the IETF as a whole.
+
+   In its administration of IPR under the terms of BCP 101, the IASA,
+   including the IAD and the IAOC, will treat the IETF Trust rather than
+   ISOC as the proper entity for ownership and licensing of IETF IPR.
+   Specifically, references to ISOC in sections 3.1, 5.3, and 7 of [1]
+   shall be interpreted as referring to the IETF Trust wherever IPR
+   issues are concerned.  The duty to serve as Trustees is added to
+   section 3.2 of [1].
+
+3.  Security Considerations
+
+   This document has no security implications for the Internet.
+
+4.  Acknowledgements
+
+   The members of the IAOC when this document was written were:
+
+      Brian Carpenter
+      Steve Crocker
+      Leslie Daigle
+      Ed Juskevicius
+      Kurtis Lindqvist
+      Lucy Lynch
+      Ray Pelletier
+      Lynn St Amour
+      Jonne Soininen
+
+   Useful comments were received from Harald Alvestrand.  Comments on
+   RFC 4071 by Patrice Lyons assisted in preparing this document.
+
+   This document was produced using the xml2rfc tool [3].
+
+
+
+
+
+
+
+
+
+Carpenter & Lynch        Best Current Practice                  [Page 2]
+
+RFC 4371                     BCP 101 Update                 January 2006
+
+
+5.  References
+
+5.1.  Normative References
+
+   [1]  Austein, R. and B. Wijnen, "Structure of the IETF Administrative
+        Support Activity (IASA)", BCP 101, RFC 4071, April 2005.
+
+   [2]  "IETF Trust Agreement",
+        http://www.ietf.org/trust/IETFtrustAgreement20051208.pdf,
+        December 2005.
+
+5.2.  Informative References
+
+   [3]  Rose, M., "Writing I-Ds and RFCs using XML", RFC 2629,
+        June 1999.
+
+Authors' Addresses
+
+   Brian Carpenter (Ed.)
+   IBM
+   8 Chemin de Blandonnet
+   1214 Vernier
+   Switzerland
+
+   EMail: brc@zurich.ibm.com
+
+
+   Lucy Lynch (Ed.)
+   University of Oregon
+   1225 Kincaid St
+   Eugene, Oregon 97403
+   USA
+
+   Phone: +1 541 346 1774
+   EMail: llynch@darkwing.uoregon.edu
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Carpenter & Lynch        Best Current Practice                  [Page 3]
+
+RFC 4371                     BCP 101 Update                 January 2006
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2006).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is provided by the IETF
+   Administrative Support Activity (IASA).
+
+
+
+
+
+
+
+Carpenter & Lynch        Best Current Practice                  [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4371.txt](<www.ietf.org/rfc/rfc4371.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
