### PR TITLE
Archive rfc4424.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4424.txt
+++ b/www.ietf.org/rfc/rfc4424.txt
@@ -1,0 +1,451 @@
+
+
+
+
+
+
+Network Working Group                                          S. Ahmadi
+Request for Comments: 4424                                 February 2006
+Updates: 4348
+Category: Standards Track
+
+
+       Real-Time Transport Protocol (RTP) Payload Format for the
+    Variable-Rate Multimode Wideband (VMR-WB) Extension Audio Codec
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2006).
+
+Abstract
+
+   This document is an addendum to RFC 4348, which specifies the RTP
+   payload format for the Variable-Rate Multimode Wideband (VMR-WB)
+   speech codec.  This document specifies some updates in RFC 4348 to
+   enable support for the new operating mode of VMR-WB standard (i.e.,
+   VMR-WB mode 4).  These updates do not affect the existing modes of
+   VMR-WB already specified in RFC 4348.
+
+   The payload formats and their associated parameters, as well as all
+   provisions, restrictions, use cases, features, etc., that are
+   specified in RFC 4348 are applicable to the new operating mode with
+   no exception.
+
+Table of Contents
+
+   1. Introduction ....................................................2
+   2. Conventions and Acronyms ........................................2
+   3. The Variable-Rate Multimode Wideband (VMR-WB) Extension .........2
+   4. The Necessary Updates in RFC 4348 ...............................4
+   5. Security Considerations .........................................6
+   6. Public Specification ............................................6
+   7. IANA Considerations .............................................7
+   8. References ......................................................7
+      8.1. Normative References .......................................7
+      8.2. Informative References .....................................7
+
+
+
+
+Ahmadi                      Standards Track                     [Page 1]
+
+RFC 4424          VMR-WB Extension RTP Payload Format      February 2006
+
+
+1.  Introduction
+
+   This document is an addendum to RFC 4348 [2] and contains the
+   necessary updates for the support of the new operating mode of 3GPP2
+   VMR-WB standard [1].  The new mode of VMR-WB standard (VMR-WB mode
+   4), although operating at a lower data rate, has similar
+   characteristics and functionalities compared to the existing modes of
+   VMR-WB already included in RFC 4348 (e.g., variable bit rate,
+   narrowband/wideband input/output speech/audio processing capability,
+   continuous and discontinuous transmission, etc.).  Therefore, all
+   provisions and restrictions specified in RFC 4348 are applicable to
+   all modes of the VMR-WB standard including the new mode, which is
+   specified in this document.  As a result, no new media type
+   registration is required.
+
+   The VMR-WB file format for transport of VMR-WB speech data in storage
+   mode applications is specified in [1,4] and includes support for the
+   new mode of operation.
+
+   The following sections provide the necessary updates to RFC 4348 to
+   enable support of VMR-WB mode 4.
+
+2.  Conventions and Acronyms
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [3].
+
+   The following acronyms are used in this document:
+
+      3GPP2  - Third Generation Partnership Project 2
+      CDMA   - Code Division Multiple Access
+      VMR-WB - Variable-Rate Multimode Wideband
+      CMR    - Codec Mode Request
+      DTX    - Discontinuous Transmission
+      RTP    - Real-Time Transport Protocol
+      MIME   - Multipurpose Internet Mail Extensions
+
+3.  The Variable-Rate Multimode Wideband (VMR-WB) Extension
+
+   VMR-WB is the wideband speech-coding standard developed by the Third
+   Generation Partnership Project 2 (3GPP2) for encoding/decoding
+   wideband/narrowband speech content in multimedia services in 3G CDMA
+   cellular systems [1].  VMR-WB is a source-controlled variable-rate
+   multimode wideband speech codec.  It has a number of operating modes,
+   where each mode is a trade-off between voice quality and average data
+   rate.  The operating mode in VMR-WB (as shown in Table 2) is chosen
+   based on the traffic condition of the network and the desired quality
+
+
+
+Ahmadi                      Standards Track                     [Page 2]
+
+RFC 4424          VMR-WB Extension RTP Payload Format      February 2006
+
+
+   of service.  The desired average data rate (ADR) in each mode is
+   obtained by encoding speech frames at permissible rates (as shown in
+   Tables 1 and 3) compliant with CDMA2000 system depending on the
+   instantaneous characteristics of input speech and the maximum and
+   minimum rate constraints imposed by the network operator.
+
+   The capabilities of the VMR-WB codec were extended through the
+   addition of a new mode operating at lower average data rates,
+   resulting in improved system capacity in IP and non-IP networks [1].
+
+   As a result of this extension, certain reserved table entries in RFC
+   4348 are used to include support for the new operating mode.  VMR-WB
+   mode 4 is compliant with all applicable provisions and restrictions
+   specified in RFC 4348 [2].  Note that the existing table entries of
+   RFC 4348 remain unchanged (e.g., frame types) and the original modes
+   of VMR-WB are not affected by these updates.
+
+   The existing flexibility in RFC 4348 for future extensions allows the
+   addition of the new mode without any impact on the interoperability
+   with earlier implementations of RFC 4348.
+
+   The following sections provide the necessary updates that are
+   required to be made in RFC 4348.
+
+   The provisions and considerations for implementation, congestion
+   control, and security remain identical to those specified in RFC
+   4348.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ahmadi                      Standards Track                     [Page 3]
+
+RFC 4424          VMR-WB Extension RTP Payload Format      February 2006
+
+
+4.  The Necessary Updates in RFC 4348
+
+   Table 1 of RFC 4348 is updated as follows:
+
+   +---------------------------+-----------------+---------------+
+   |        Frame Type         | Bits per Packet | Encoding Rate |
+   |                           |   (Frame Size)  |     (kbps)    |
+   +---------------------------+-----------------+---------------+
+   | Full-Rate                 |      266        |     13.3      |
+   | Full-Rate                 |      171        |     8.55      |
+   | Half-Rate                 |      124        |      7.2      |
+   | Half-Rate                 |       80        |      4.0      |
+   | Quarter-Rate              |       54        |      2.7      |
+   | Quarter-Rate              |       40        |      2.0      |
+   | Eighth-Rate               |       20        |      1.0      |
+   | Eighth-Rate               |       16        |      0.8      |
+   | Blank                     |        0        |       -       |
+   | Erasure                   |        0        |       -       |
+   | Full-Rate with Bit Errors |      171        |     8.55      |
+   +---------------------------+-----------------+---------------+
+
+   Table 1: CDMA2000 system permissible frame types and their
+            associated encoding rates
+
+   Note that the new permissible rates correspond to CDMA2000 rate-set I
+   and have been added to the table.
+
+   Table 2 of RFC 4348 is updated as follows to include VMR-WB mode 4
+   and VMR-WB mode 4 with maximum half-rate similar to that described in
+   Section 2.4 of the revised VMR-WB specification [1].
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ahmadi                      Standards Track                     [Page 4]
+
+RFC 4424          VMR-WB Extension RTP Payload Format      February 2006
+
+
+   +-------+----------------------------------------------------------+
+   | CMR   |                 VMR-WB Operating Modes                   |
+   +-------+----------------------------------------------------------+
+   |   0   | VMR-WB mode 3 (AMR-WB interoperable mode at 6.60 kbps)   |
+   |   1   | VMR-WB mode 3 (AMR-WB interoperable mode at 8.85 kbps)   |
+   |   2   | VMR-WB mode 3 (AMR-WB interoperable mode at 12.65 kbps)  |
+   |   3   | VMR-WB mode 2                                            |
+   |   4   | VMR-WB mode 1                                            |
+   |   5   | VMR-WB mode 0                                            |
+   |   6   | VMR-WB mode 2 with maximum half-rate encoding            |
+   |   7   | VMR-WB mode 4                                            |
+   |   8   | VMR-WB mode 4 with maximum half-rate encoding            |
+   | 9-14  | (reserved)                                               |
+   |  15   | No Preference (no mode request is present)               |
+   +-------+----------------------------------------------------------+
+
+   Table 2: List of valid CMR values and their associated VMR-WB
+            operating modes
+
+   Note that CMR values 7 and 8 replace the reserved values in Table 2
+   of RFC 4348.
+
+   Table 3 of RFC 4348 is updated as follows to include new frame types
+   (FTs) associated with VMR-WB mode 4.
+
+   Note that the sizes of the frames are unique and different, allowing
+   for the use of header-free payload format for all modes of operations
+   [2].
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ahmadi                      Standards Track                     [Page 5]
+
+RFC 4424          VMR-WB Extension RTP Payload Format      February 2006
+
+
+   +----+--------------------------------------------+-----------------+
+   | FT |                Encoding Rate               |Frame Size (Bits)|
+   +----+--------------------------------------------+-----------------+
+   | 0  | Interoperable Full-Rate (AMR-WB 6.60 kbps) |      132        |
+   | 1  | Interoperable Full-Rate (AMR-WB 8.85 kbps) |      177        |
+   | 2  | Interoperable Full-Rate (AMR-WB 12.65 kbps)|      253        |
+   | 3  | Full-Rate 13.3 kbps                        |      266        |
+   | 4  | Half-Rate 6.2 kbps                         |      124        |
+   | 5  | Quarter-Rate 2.7 kbps                      |       54        |
+   | 6  | Eighth-Rate 1.0 kbps                       |       20        |
+   | 7  | Full-Rate 8.55 kbps                        |      171        |
+   | 8  | Half-Rate 4.0 kbps                         |       80        |
+   | 9  | CNG (AMR-WB SID)                           |       35        |
+   | 10 | Eighth-Rate 0.8 kbps                       |       16        |
+   | 11 | (reserved)                                 |        -        |
+   | 12 | (reserved)                                 |        -        |
+   | 13 | (reserved)                                 |        -        |
+   | 14 | Erasure (AMR-WB SPEECH_LOST)               |        0        |
+   | 15 | Blank (AMR-WB NO_DATA)                     |        0        |
+   +----+--------------------------------------------+-----------------+
+
+        Table 3: VMR-WB payload frame types for real-time transport
+
+   Note that the new FT types associated with VMR-WB mode 4 replace the
+   reserved entries 7, 8, and 10 in Table 3 of RFC 4348 and there are no
+   changes in the existing entries of Table 3 of RFC 4348.
+
+   The 'mode-set' MIME parameter value 4 is defined to indicate that
+   VMR-WB mode 4 is supported and used.  Note that the active modes of
+   operation are negotiated and agreed by the IP terminals through the
+   offer/answer model provided in Section 9.3 of RFC 4348 [2].
+
+5.  Security Considerations
+
+   Same as RFC 4348.
+
+6.  Public Specification
+
+   The VMR-WB speech codec including the new mode is specified in
+   following 3GPP2 specification C.S0052-A version 1.0.  Transfer
+   methods are specified in RFC 4348.
+
+
+
+
+
+
+
+
+
+
+Ahmadi                      Standards Track                     [Page 6]
+
+RFC 4424          VMR-WB Extension RTP Payload Format      February 2006
+
+
+7.  IANA Considerations
+
+   This document updates the media type registered in [2].  IANA has
+   added this document as reference to that media type registration and
+   has modified the optional parameter mode-set in the registration.
+   Section 9.1 of RFC 4348 [2] reads:
+
+                                     Currently, this list
+            includes modes 0, 1, 2, and 3 [1], but MAY be
+            extended in the future.  If such mode-set is
+            specified during session initiation, the encoder
+            MUST NOT use modes outside of the subset.  If not
+            present, all operating modes in the set 0 to 3 are
+            allowed for the session.
+
+   IANA will change "modes 0, 1, 2 and 3 [1]" to "modes 0, 1, 2, 3, and
+   4 [1] [2]", and change "modes in the set 0 to 3" to "modes in the set
+   0 to 4".  [1] will be the IANA's reference to the original VMR-WB
+   document (3GPP2 C.S0052-A v1.0) and [2] will be IANA's reference to
+   this document (RFC 4424).
+
+8.  References
+
+8.1.  Normative References
+
+   [1]  3GPP2 C.S0052-A v1.0 "Source-Controlled Variable-Rate Multimode
+        Wideband Speech Codec (VMR-WB) Service Options 62 and 63 for
+        Spread Spectrum Systems", 3GPP2 Technical Specification, April
+        2005, http://www.3gpp2.org/.
+
+   [2]  Ahmadi, S., "Real-Time Transport Protocol (RTP) Payload Format
+        for the Variable-Rate Multimode Wideband (VMR-WB) Audio Codec",
+        RFC 4348, January 2006.
+
+   [3]  Bradner, S., "Key words for use in RFCs to Indicate Requirement
+        Levels", BCP 14, RFC 2119, March 1997.
+
+8.2.  Informative References
+
+   [4]  3GPP2 C.S0050-A v1.0 "3GPP2 File Formats for Multimedia
+        Services", 3GPP2 Technical Specification, October 2005,
+        http://www.3gpp2.org/.
+
+Author's Address
+
+   Dr. Sassan Ahmadi
+
+   EMail: sassan.ahmadi@ieee.org
+
+
+
+Ahmadi                      Standards Track                     [Page 7]
+
+RFC 4424          VMR-WB Extension RTP Payload Format      February 2006
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2006).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is provided by the IETF
+   Administrative Support Activity (IASA).
+
+
+
+
+
+
+
+Ahmadi                      Standards Track                     [Page 8]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4424.txt](<www.ietf.org/rfc/rfc4424.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
