### PR TITLE
Archive rfc443.txt

### DIFF
--- a/www.ietf.org/rfc/rfc443.txt
+++ b/www.ietf.org/rfc/rfc443.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                                        A. McKenzie
+Request for Comments: 443                                            BBN
+NIC: 13899                                               18 January 1973
+Updates: RFC 422
+
+
+                   Traffic Statistics (December 1972)
+
+   Attached are the Host traffic statistics for the month of December
+   1972.
+
+   AAM/jm
+                            HOST THROUGHPUT SUMMARY
+                                (PACKETS OUTPUT)
+
+                                  DECEMBER 1972
+
+                       MISSING DATA FOR 2, 3, 4, 8, 15, 20
+
+                       INTER-    INTRA-            AVG. DAILY
+                        NODE      NODE      TOTAL   INTERNODE   DAYS
+
+   UCLA  HOST 1        181141     57162    238303
+   UCLA  HOST 2        668578     44616    713194
+                     --------  --------  --------
+                       849719    101778    951497       33989     25
+
+   SRI   HOST 1       1396436     17556   1413992
+   SRI   HOST 2         31365      3836     35201
+                     --------  --------  --------
+                      1427801     21392   1449193       57112     25
+
+   UCSB  HOST 1        545166    173928    719094       21807     25
+
+   UTAH  HOST 1        536453     35616    572069       21458     25
+
+   BBN   HOST 2       2424250    373106   2797356
+   BBN   HOST 3        108384     29878    138262
+   BBN   HOST 4        153239        37    153276
+                     --------  --------  --------
+                      2685873    403021   3088894      107435     25
+
+   MIT   HOST 1         48752     13998     62740
+   MIT   HOST 2        482445    224148    706593
+   MIT   HOST 3        401599    373678    775277
+   MIT   HOST 4        201840    439670    641510
+                     --------  --------  --------
+                      1134636   1051484   2186120       45385     25
+
+
+
+McKenzie                                                        [Page 1]
+
+RFC 443            Traffic Statistics (December 1972)       January 1973
+
+
+
+   RAND  HOST 1        264812        86    264898       10592     25
+
+   SDC   HOST 1         27964      4416     32380        1119     25
+
+   HARV  HOST 1        299236    397614    696850
+   HARV  HOST 2         23247    315178    338425
+                     --------  --------  --------
+                       322483    712792   1035275       12899     25
+
+   LINC  HOST 1         10158      1104     11262
+   LINC  HOST 2         28589     67907     96496
+   LINC  HOST 3           578      4512      5090
+                     --------  --------  --------
+                        39325     73523    112848        1573     25
+
+   STAN  HOST 1       1015835     13196   1029031       40633     25
+
+   ILL   HOST 1        386634       280    386914       15465     25
+
+   CASE  HOST 1        221014     28570    249584        8841     25
+
+   CARN  HOST 1        317017    217871    534888
+   CARN  HOST 2        265575    193101    458676
+                     --------  --------  --------
+                       582592    410972    993564       23304     25
+
+   AMES2 HOST 1       2811857     28592   2840449      112474     25
+
+   AMES1 HOST 1         57368     14650     72018
+   AMES1 HOST 3       4384317     18336   4402653
+                     --------  --------  --------
+                      4441685     32986   4474671      177667     25
+
+   MITRE HOST 3       1091812        51   1091863       43672     25
+
+   ROME  HOST 3        487923        25    487948       19517     25
+
+   NBS   HOST 1           738        24       762
+   NBS   HOST 3        921496        92    921588
+                     --------  --------  --------
+                       922234       116    922350       36889     25
+
+   ETAC  HOST 3        878406       416    878822       35136     25
+
+   TINK HAD NO TRAFFIC
+
+   ISI   HOST 2       4176170     46977   4223147      167047     25
+
+
+
+McKenzie                                                        [Page 2]
+
+RFC 443            Traffic Statistics (December 1972)       January 1973
+
+
+
+   USC   HOST 1         13611    151120    164731
+   USC   HOST 3        922350    146673   1069023
+                     --------  --------  --------
+                       935961    297793   1233754       37438     25
+
+   GWC   HOST 3         15327        76     15403         613     25
+
+   NOAA  HOST 3         58916     29885     88801        2357     25
+
+   SAAC  HOST 3        209321       538    209859        8373     25
+
+   BELV HAD NO TRAFFIC
+
+   ARPA  HOST 1             0    180178    180178
+   ARPA  HOST 3        155445    177439    332884
+                     --------  --------  --------
+                       155445    357617    513062        6218     25
+
+   ABER HAD NO TRAFFIC
+
+   BBN T HOST 3        640257      3939    644196       25610     25
+
+   CCA   HOST 1        383002    318035    701037
+   CCA   HOST 3        875814    148241   1024055
+                     --------  --------  --------
+                      1258816    466276   1725092       50353     25
+
+   XEROX HAD NO TRAFFIC
+
+   UCSD  HOST 1        328825      4186    333011       13153     25
+
+   HAW T HOST 3         36487     38789     75270        3317     11
+
+   ------------------------------------
+
+   TOTAL             28489750   4339316
+
+   DAILY AVERAGE      1139590    173573
+
+   AVERAGE PER          34079      5191
+   NODE-DAY
+
+   PACKETS/MESSAGES (INTERNODE)     1.06
+
+         [ This RFC was put into machine readable form for entry ]
+          [ into the online RFC archives by George Bauer 11/97 ]
+
+
+
+
+McKenzie                                                        [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc443.txt](<www.ietf.org/rfc/rfc443.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
