### PR TITLE
Archive rfc4438.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4438.txt
+++ b/www.ietf.org/rfc/rfc4438.txt
@@ -1,0 +1,2019 @@
+
+
+
+
+
+
+Network Working Group                                         C. DeSanti
+Request for Comments: 4438                                    V. Gaonkar
+Category: Standards Track                                     H.K. Vivek
+                                                           K. McCloghrie
+                                                           Cisco Systems
+                                                                  S. Gai
+                                                                 Retired
+                                                              April 2006
+
+
+                     Fibre Channel Name Server MIB
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2006).
+
+Abstract
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the Internet community.
+   In particular, it describes managed objects for information related
+   to the Name Server function of a Fibre Channel network.  The Fibre
+   Channel Name Server provides a means for Fibre Channel ports to
+   register and discover Fibre Channel names and attributes.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                     [Page 1]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+Table of Contents
+
+   1. Introduction ....................................................3
+   2. The Internet-Standard Management Framework ......................3
+   3. Short Overview of Fibre Channel .................................3
+   4. Relationship to Other MIBs ......................................5
+   5. MIB Overview ....................................................5
+      5.1. Fibre Channel Management Instance ..........................5
+      5.2. Name Server Information Subset .............................5
+      5.3. Fabric Index ...............................................6
+      5.4. The MIB Groups .............................................6
+           5.4.1. The t11NsDBGroup Group ..............................6
+           5.4.2. Three Statistics Groups .............................7
+           5.4.3. The t11NsNotifyGroup Group ..........................7
+           5.4.4. The t11NsNotifyControlGroup Group ...................7
+      5.5. The Actual Values of Objects ...............................7
+   6. The T11-FC-NAME-SERVER-MIB Module ...............................8
+   7. Acknowledgements ...............................................31
+   8. Normative References ...........................................32
+   9. Informative References .........................................33
+   10. IANA Considerations ...........................................33
+   11. Security Considerations .......................................33
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                     [Page 2]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+1.  Introduction
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the Internet community.
+   In particular, it describes managed objects for information related
+   to the Fibre Channel network's Name Server function, which provides a
+   means for Fibre Channel ports to register and discover Fibre Channel
+   attributes.  Such attributes include names, addresses, types,
+   features, etc., at various protocol layers.
+
+2.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This memo specifies a MIB
+   module that is compliant to the SMIv2, which is described in STD 58,
+   RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579] and STD 58, RFC 2580
+   [RFC2580].
+
+3.  Short Overview of Fibre Channel
+
+   The Fibre Channel (FC) is logically a bidirectional point-to-point
+   serial data channel, structured for high performance.  Fibre Channel
+   provides a general transport vehicle for higher-level protocols such
+   as Small Computer System Interface (SCSI) command sets, the High-
+   Performance Parallel Interface (HIPPI) data framing, IP (Internet
+   Protocol), IEEE 802.2, and others.
+
+   Physically, Fibre Channel is an interconnection of multiple
+   communication points, called N_Ports, interconnected either by a
+   switching network, called a Fabric, or by a point-to-point link.  A
+   Fibre Channel "node" consists of one or more N_Ports.  A Fabric may
+   consist of multiple Interconnect Elements, some of which are
+   switches.  An N_Port connects to the Fabric via a port on a switch
+   called an F_Port.  When multiple FC nodes are connected to a single
+   port on a switch via an "Arbitrated Loop" topology, the switch port
+   is called an FL_Port, and the nodes' ports are called NL_Ports.  The
+   term Nx_Port is used to refer to either an N_Port or an NL_Port.  The
+   term Fx_Port is used to refer to either an F_Port or an FL_Port.  A
+   switch port, which is interconnected to another switch port via an
+
+
+
+
+
+DeSanti, et al.             Standards Track                     [Page 3]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+   Inter-Switch Link (ISL), is called an E_Port.  A B_Port connects a
+   bridge device with an E_Port on a switch; a B_Port provides a subset
+   of E_Port functionality.
+
+   Many Fibre Channel components, including the Fabric, each node, and
+   most ports, have globally-unique names.  These globally-unique names
+   are typically formatted as World Wide Names (WWNs).  More information
+   on WWNs can be found in [FC-FS].  WWNs are expected to be persistent
+   across agent and unit resets.
+
+   Fibre Channel frames contain 24-bit address identifiers, which
+   identify the frame's source and destination ports.  Each FC port has
+   both an address identifier and a WWN.  When a fabric is in use, the
+   FC address identifiers are dynamic and are assigned by a switch.
+   Each octet of a 24-bit address represents a level in an address
+   hierarchy, with a Domain_ID being the highest level of the hierarchy.
+
+   The Fibre Channel Name Server provides a way for N_Ports and NL_Ports
+   to register and discover Fibre Channel attributes.  Such attributes
+   include names, addresses, types, features, etc., at various protocol
+   layers, including upper layer protocols specific to Fibre Channel
+   (which are sometimes called "FC-4s").  Communication with the Name
+   Server is via Fibre Channel's CT (Common Transport for Generic
+   Services) using "Information Units" (called CT_IUs) as either
+   requests, responses, or unsolicited.
+
+   Registrations may be performed by a third party.  However, the Name
+   Server may refuse such third-party registration for unspecified
+   reasons.  Once registered, the attributes are made available to
+   requestors.
+
+   Requestors could learn about new registrations via periodic polling
+   of the Name Server, but such polling would generate a considerable
+   overhead.  To avoid this overhead, the Registered State Change
+   Notification (RSCN) mechanism defined in FC-FS [FC-FS] allows an
+   Nx_Port to register to receive an RSCN whenever an event occurs that
+   may affect the state of other Nx_Port(s), including changes in the
+   information registered with the Name Server.
+
+   The Fibre Channel Name Server is defined in the FC-GS specification,
+   The latest specification is [FC-GS-4]; the previous version was
+   [FC-GS-3].
+
+
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                     [Page 4]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+4.  Relationship to Other MIBs
+
+   The first standardized MIB for Fibre Channel [RFC2837] was focused on
+   Fibre Channel switches.  It was obsoleted by the more generic Fibre
+   Channel Management MIB [FC-MGMT], which defines basic information for
+   Fibre Channel hosts and switches, including extensions to the
+   standard IF-MIB [IF-MIB] for Fibre Channel interfaces.
+
+   This MIB extends beyond [FC-MGMT] to cover the functionality, in
+   Fibre Channel switches, of providing Fibre Channel's Name Server
+   function.
+
+   This MIB also imports some common textual conventions from
+   T11-TC-MIB, defined in [FC-FAM-MIB].
+
+5.  MIB Overview
+
+   This MIB module provides the means for monitoring the operation of,
+   and configuring some parameters of, one or more instances of Fibre
+   Channel Name Server functionality.  (Note that there are no
+   definitions in this MIB module of "managed actions" that can be
+   invoked via SNMP.)
+
+5.1.  Fibre Channel Management Instance
+
+   A Fibre Channel management instance is defined in [FC-MGMT] as a
+   separable managed instance of Fibre Channel functionality.  Fibre
+   Channel functionality may be grouped into Fibre Channel management
+   instances in whatever way is most convenient for the
+   implementation(s).  For example, one such grouping accommodates a
+   single SNMP agent having multiple AgentX [RFC2741] sub-agents, with
+   each sub-agent implementing a different Fibre Channel management
+   instance.
+
+   The object, fcmInstanceIndex, is IMPORTed from the FC-MGMT-MIB
+   [FC-MGMT] as the index value to uniquely identify each Fibre Channel
+   management instance within the same SNMP context ([RFC3411], section
+   3.3.1).
+
+5.2.  Name Server Information Subset
+
+   In addition to allowing for multiple Fibre Channel management
+   instances, this MIB is based on the notion that the information
+   registered with the Name Server is available as one or more subsets.
+   The MIB allows the different subsets to be accessed either:
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                     [Page 5]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+      - via different SNMP agents/contexts,
+      - via different Fibre Channel management instances within the
+        same SNMP agent/context, and/or
+      - via the same Fibre Channel management instance within the
+        same SNMP agent/context.
+
+   The union of these subsets (across all agents/contexts in the
+   network) represents the total set of information registered with the
+   Name Server.  Note that the intersection of the subsets is often
+   non-empty, and the use of the term "subset" does not preclude any
+   subset from containing the complete set of Name Server information.
+   Each of these subsets is identified using an index value called a
+   Name Server Information Subset Index.
+
+   Thus, all objects in this MIB are in tables that are INDEXed by at
+   least fcmInstanceIndex and t11NsInfoSubsetIndex, where the latter
+   contains a Name Server Information Subset Index value.
+
+5.3.  Fabric Index
+
+   The [FC-SW-3] standard for an interconnecting Fabric consisting of
+   multiple Fabric Switch elements describes the operation of a single
+   Fabric in a physical infrastructure.  The current [FC-SW-4] standard
+   also supports the operation of multiple Virtual Fabrics operating
+   within one (or more) physical infrastructures.  In such a scenario,
+   each Fabric has, of course, its own management instrumentation.  In
+   order to accommodate this scenario, this MIB module defines all
+   Fabric-related information in tables that are INDEXed by an arbitrary
+   integer, named a "Fabric Index".  In a Fabric that is conformant to
+   [FC-SW-3], the value of this Fabric Index will always be 1.
+
+5.4.  The MIB Groups
+
+   This section describes the six MIB groups contained in the MIB.
+
+5.4.1.  The t11NsDBGroup Group
+
+   This group contains information about the operation of the Name
+   Server function acting upon a Name Server Information Subset,
+   including an indication of whether such operation is performed local
+   to a particular Fibre Channel switch, or independently of a Fibre
+   Channel switch.  It also contains the information currently
+   registered in a particular Name Server Information Subset.
+
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                     [Page 6]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+5.4.2.  Three Statistics Groups
+
+   There are three groups of Name Server statistics objects:
+
+        t11NsRequestStatsGroup -- stats about requests
+        t11NsRscnStatsGroup    -- stats about (Name Server) RSCNs
+        t11NsRejectStatsGroup  -- stats about rejects
+
+   Each of these groups is conditionally mandatory; specifically, each
+   group contains objects for particular statistics such that
+   implementation of the group is mandatory only for an implementation
+   that counts/captures the group's particular statistics.
+
+   The intent here is not to force implementations to capture these
+   statistics, but rather to have all implementations that do capture
+   them, provide access to them via the same MIB objects.
+
+5.4.3.  The t11NsNotifyGroup Group
+
+   This group contains a set of notifications that provide for
+   monitoring the rejections of Name Server Registration Requests.
+
+5.4.4.  The t11NsNotifyControlGroup Group
+
+   This group contains objects for controlling the generation of, and
+   for information to be included in, the notifications defined in the
+   t11NsNotifyGroup group.
+
+5.5.  The Actual Values of Objects
+
+   The objects defined in the t11NsRegTable represent the values
+   registered with the Name Server.  The SNMP agent MUST report the
+   actual values, even if they are incorrectly formatted.  This is the
+   reason why, for example, the two objects that represent IP addresses,
+   t11NsNodeIpAddress and t11NsPortIpAddress, have the SYNTAX of OCTET
+   STRING, so that they are able to represent invalid values (which
+   could not be represented using InetAddressType and InetAddress).
+
+   Similarly, each set of (t11NsRejectReasonCode, t11NsRejReasonCodeExp,
+   t11NsRejReasonVendorCode) objects must hold the values of the actual
+   reject, explanation, and vendor-specific codes that were present in
+   the generated Reject message (the "Reject CT_IU"), irrespective of
+   whether or not such code values were appropriate.
+
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                     [Page 7]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+6.  The T11-FC-NAME-SERVER-MIB Module
+
+T11-FC-NAME-SERVER-MIB DEFINITIONS ::= BEGIN
+
+-- The MIB for management of the Fibre Channel functionality which
+-- implements the Name Server function.
+
+IMPORTS
+    MODULE-IDENTITY,OBJECT-TYPE,
+    NOTIFICATION-TYPE, Unsigned32,
+    Counter32, Integer32, mib-2   FROM SNMPv2-SMI         -- [RFC2578]
+    MODULE-COMPLIANCE, OBJECT-GROUP,
+    NOTIFICATION-GROUP            FROM SNMPv2-CONF        -- [RFC2580]
+    SnmpAdminString               FROM SNMP-FRAMEWORK-MIB -- [RFC3411]
+    TruthValue, TEXTUAL-CONVENTION,
+    TimeStamp                     FROM SNMPv2-TC          -- [RFC2579]
+    fcmInstanceIndex, FcPortType,
+    FcAddressIdOrZero, FcClasses,
+    FcNameIdOrZero                FROM FC-MGMT-MIB        -- [FC-MGMT]
+    T11FabricIndex                FROM T11-TC-MIB      -- [FC-FAM-MIB]
+    t11FamLocalSwitchWwn
+                      FROM T11-FC-FABRIC-ADDR-MGR-MIB; -- [FC-FAM-MIB]
+
+t11FcNameServerMIB  MODULE-IDENTITY
+    LAST-UPDATED "200603020000Z"
+    ORGANIZATION "T11"
+    CONTACT-INFO
+            "     Claudio DeSanti
+                  Cisco Systems, Inc.
+                  170 West Tasman Drive
+                  San Jose, CA 95134 USA
+                  Phone: +1 408 853-9172
+                  EMail: cds@cisco.com
+
+                  Keith McCloghrie
+                  Cisco Systems, Inc.
+                  170 West Tasman Drive
+                  San Jose, CA USA 95134
+                  Phone: +1 408-526-5260
+                  EMail: kzm@cisco.com"
+    DESCRIPTION
+           "The MIB module for the management of the functionality,
+           which realizes the FC-GS-4 requirements for Name
+           Server (NS).
+
+           Copyright (C) The Internet Society (2006).  This version of
+           this MIB module is part of RFC 4438; see the RFC itself for
+           full legal notices."
+
+
+
+DeSanti, et al.             Standards Track                     [Page 8]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+    REVISION    "200603020000Z"
+    DESCRIPTION
+           "Initial version of this MIB module, published as RFC 4438."
+    ::= { mib-2 135 }
+
+t11NsNotifications    OBJECT IDENTIFIER ::= { t11FcNameServerMIB 0 }
+t11NsMIBObjects       OBJECT IDENTIFIER ::= { t11FcNameServerMIB 1 }
+t11NsMIBConformance   OBJECT IDENTIFIER ::= { t11FcNameServerMIB 2 }
+t11NsStatus           OBJECT IDENTIFIER ::= { t11NsMIBObjects 1 }
+t11NsStatistics       OBJECT IDENTIFIER ::= { t11NsMIBObjects 2 }
+
+-- Textual Conventions
+
+T11NsGs4RejectReasonCode ::= TEXTUAL-CONVENTION
+    STATUS    current
+    DESCRIPTION
+        "The FC-GS-4 reject reason code for a request.
+
+         none(1)
+             - no error.
+         invalidCmdCode(2)
+             - request contained an invalid command code.
+         invalidVerLevel(3)
+             - request contained an invalid version number.
+         logicalError(4)
+             - there was a logical error.
+         invalidIUSize(5)
+             - the CT_IU (Information Unit) size was invalid.
+         logicalBusy(6)
+             - the module is busy.
+         protocolError(7)
+             - there was a protocol error.
+         unableToPerformCmdReq(8)
+             - the command specified in the req could not be
+               executed.  The details of exactly what failed
+               will be in the corresponding reason code
+               explanation.
+         cmdNotSupported(9)
+             - the command is not supported.
+         serverNotAvailable(10)
+             - the identified server was not available.
+         couldNotEstabSession(11)
+             - a server session could not be established.
+         vendorError(12)
+             - a vendor-specific error."
+    REFERENCE
+          "ANSI INCITS 387-2004, Fibre Channel - Generic
+           Services-4 (FC-GS-4), section 4.4.3."
+
+
+
+DeSanti, et al.             Standards Track                     [Page 9]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+    SYNTAX  INTEGER {
+              none(1),
+              invalidCmdCode(2),
+              invalidVerLevel(3),
+              logicalError(4),
+              invalidIUSize(5),
+              logicalBusy(6),
+              protocolError(7),
+              unableToPerformCmdReq(8),
+              cmdNotSupported(9),
+              serverNotAvailable(10),
+              couldNotEstabSession(11),
+              vendorError(12)
+            }
+
+T11NsRejReasonCodeExpl ::= TEXTUAL-CONVENTION
+    STATUS    current
+    DESCRIPTION
+        "The reject reason code explanation:
+
+         noAdditionalExplanation(1)
+             - no additional explanation.
+         portIdentifierNotRegistered(2)
+             - Port Identifier not registered.
+         portNameNotRegistered(3)
+             - Port Name not registered.
+         nodeNameNotRegistered(4)
+             - Node Name not registered.
+         classOfServiceNotRegistered(5)
+             - Class of Service not registered.
+         nodeIpAddressNotRegistered(6)
+             - 'IP Address (Node)' value not registered.
+         ipaNotRegistered(7)
+             - Initial Process Associator (IPA) not registered.
+         fc4TypeNotRegistered(8)
+             - FC-4 TYPEs not registered.
+         symbolicPortNameNotRegistered(9)
+             - Symbolic Port Name not registered.
+         symbolicNodeNameNotRegistered(10)
+             - Symbolic Node Name not registered.
+         portTypeNotRegistered(11)
+             - 'Port Type' not registered.
+         portIpAddressNotRegistered(12)
+             - 'IP Address (Port)' value not registered.
+         fabricPortNameNotRegistered(13)
+             - Fabric Port Name not registered.
+         hardAddressNotRegistered(14)
+             - 'Hard Address' not registered.
+
+
+
+DeSanti, et al.             Standards Track                    [Page 10]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+         fc4DescriptorNotRegistered(15)
+             - FC-4 Descriptor not registered.
+         fc4FeaturesNotRegistered(16)
+             - FC-4 Features not registered.
+         accessDenied(17)
+             - Access denied.
+         unacceptablePortIdentifier(18)
+             - Unacceptable Port Identifier.
+         databaseEmpty(19)
+             - Database is empty.
+         noObjectRegInSpecifiedScope(20)
+             - no object has been registered in the specified
+               scope.
+         domainIdNotPresent(21)
+             - Domain ID not present.
+         portIdNotPresent(22)
+             - Port number not present.
+         noDeviceAttached(23)
+             - No device attached.
+         authorizationException(24)
+             - Authorization Exception.
+         authenticationException(25)
+             - Authentication Exception.
+         databaseFull(26)
+             - Database full."
+    REFERENCE
+          "ANSI INCITS 387-2004, Fibre Channel - Generic
+           Services-4 (FC-GS-4), sections 4.4.4 and 5.2.4"
+    SYNTAX  INTEGER {
+              noAdditionalExplanation(1),
+              portIdentifierNotRegistered(2),
+              portNameNotRegistered(3),
+              nodeNameNotRegistered(4),
+              classOfServiceNotRegistered(5),
+              nodeIpAddressNotRegistered(6),
+              ipaNotRegistered(7),
+              fc4TypeNotRegistered(8),
+              symbolicPortNameNotRegistered(9),
+              symbolicNodeNameNotRegistered(10),
+              portTypeNotRegistered(11),
+              portIpAddressNotRegistered(12),
+              fabricPortNameNotRegistered(13),
+              hardAddressNotRegistered(14),
+              fc4DescriptorNotRegistered(15),
+              fc4FeaturesNotRegistered(16),
+              accessDenied(17),
+              unacceptablePortIdentifier(18),
+              databaseEmpty(19),
+
+
+
+DeSanti, et al.             Standards Track                    [Page 11]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+              noObjectRegInSpecifiedScope(20),
+              domainIdNotPresent(21),
+              portIdNotPresent(22),
+              noDeviceAttached(23),
+              authorizationException(24),
+              authenticationException(25),
+              databaseFull(26)
+           }
+
+--
+-- Information about a Name Server Information Subset
+--
+
+t11NsInfoSubsetTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF T11NsInfoSubsetEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+           "This table contains one entry for each Name Server
+           Information Subset within each Fibre Channel
+           management instance."
+    ::= { t11NsStatus 1 }
+
+t11NsInfoSubsetEntry OBJECT-TYPE
+    SYNTAX        T11NsInfoSubsetEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+           "This entry contains information about operations
+           on a particular Name Server Information Subset
+           within the Fibre Channel management instance
+           identified by fcmInstanceIndex."
+    INDEX { fcmInstanceIndex, t11NsInfoSubsetIndex }
+    ::= { t11NsInfoSubsetTable 1 }
+
+T11NsInfoSubsetEntry ::= SEQUENCE {
+    t11NsInfoSubsetIndex                 Unsigned32,
+    t11NsInfoSubsetSwitchIndex           Unsigned32,
+    t11NsInfoSubsetTableLastChange       TimeStamp,
+    t11NsInfoSubsetNumRows               Integer32,
+    t11NsInfoSubsetTotalRejects          Counter32,
+    t11NsInfoSubsetRejReqNotfyEnable     TruthValue
+}
+
+t11NsInfoSubsetIndex OBJECT-TYPE
+    SYNTAX        Unsigned32 (1..4294967295)
+    MAX-ACCESS    not-accessible
+    STATUS        current
+
+
+
+DeSanti, et al.             Standards Track                    [Page 12]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+    DESCRIPTION
+           "An arbitrary integer value that uniquely identifies
+           this Name Server Information Subset amongst all others
+           within the same Fibre Channel management instance.
+
+           It is mandatory to keep this value constant between
+           restarts of the agent and to make every possible
+           effort to keep it constant across such restarts."
+    ::= { t11NsInfoSubsetEntry 1 }
+
+t11NsInfoSubsetSwitchIndex OBJECT-TYPE
+    SYNTAX        Unsigned32 (0..4294967295)
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The value of this object is zero when operations
+           upon this Name Server Information Subset do not occur
+           at a local Fibre Channel switch; otherwise, it is
+           non-zero and identifies the local switch.
+
+           The switch identified by a non-zero value of this
+           object is the same switch as is identified by the
+           same value of fcmSwitchIndex."
+    REFERENCE
+           "fcmSwitchIndex is defined in the FC-MGMT-MIB module"
+    ::= { t11NsInfoSubsetEntry 2 }
+
+t11NsInfoSubsetTableLastChange OBJECT-TYPE
+    SYNTAX        TimeStamp
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The value of sysUpTime at the time of the last update
+           to any entry in the t11NsRegTable with the same values
+           of fcmInstanceIndex and t11NsInfoSubsetIndex.  This
+           includes creation of an entry, deletion of an entry, or
+           modification of an existing entry.  If no such update
+           has taken place since the last re-initialization of the
+           local network management subsystem, then this object
+           contains a zero value."
+    ::= { t11NsInfoSubsetEntry 3 }
+
+t11NsInfoSubsetNumRows OBJECT-TYPE
+    SYNTAX        Integer32 (0..2147483647)
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The number of Nx_Ports currently registered in this
+
+
+
+DeSanti, et al.             Standards Track                    [Page 13]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+           Name Server Information Subset, i.e., the number of
+           rows in the t11NsRegTable with the same values of
+           fcmInstanceIndex and t11NsInfoSubsetIndex."
+    ::= { t11NsInfoSubsetEntry 4 }
+
+t11NsInfoSubsetTotalRejects OBJECT-TYPE
+    SYNTAX        Counter32
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The total number of (CT_IU) Requests for Name Server
+           functions that were rejected for inclusion in this
+           Name Server Information Subset, across all Fabrics
+           for which it contains information.
+
+           This counter has no discontinuities other than those
+           that all Counter32s have when sysUpTime=0."
+    ::= { t11NsInfoSubsetEntry 5 }
+
+t11NsInfoSubsetRejReqNotfyEnable OBJECT-TYPE
+    SYNTAX        TruthValue
+    MAX-ACCESS    read-write
+    STATUS        current
+    DESCRIPTION
+           "This object indicates whether 't11NsRejectRegNotify'
+           notifications are generated by rejections of requests
+           to register information in this Name Server Information
+           Subset.
+
+           If value of this object is 'true', then the
+           notification is generated when a request is rejected.
+           If it is 'false', the notification is not generated.
+
+           The persistence of values of this object across an
+           agent reboot is implementation-dependent."
+    DEFVAL { false }
+    ::= { t11NsInfoSubsetEntry 6 }
+
+--
+-- Registered Port Information
+--
+
+t11NsRegTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF T11NsRegEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+           "This table contains entries for all Nx_Ports registered
+
+
+
+DeSanti, et al.             Standards Track                    [Page 14]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+           in the identified Name Server Information Subsets across
+           all Fabrics for which such subsets contain information."
+    ::= { t11NsStatus 2 }
+
+t11NsRegEntry OBJECT-TYPE
+    SYNTAX T11NsRegEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+           "An entry containing information about an Nx_Port
+           represented by t11NsRegPortIdentifier that is registered
+           with a Name Server Information Subset (identified by
+           t11NsInfoSubsetIndex) within the Fibre Channel management
+           instance (identified by fcmInstanceIndex) on the Fabric
+           (identified by t11NsRegFabricIndex)."
+    INDEX { fcmInstanceIndex, t11NsInfoSubsetIndex,
+            t11NsRegFabricIndex, t11NsRegPortIdentifier }
+    ::= { t11NsRegTable 1 }
+
+T11NsRegEntry ::= SEQUENCE {
+    t11NsRegFabricIndex            T11FabricIndex,
+    t11NsRegPortIdentifier         FcAddressIdOrZero,
+    t11NsRegPortName               FcNameIdOrZero,
+    t11NsRegNodeName               FcNameIdOrZero,
+    t11NsRegClassOfSvc             FcClasses,
+    t11NsRegNodeIpAddress          OCTET STRING,
+    t11NsRegProcAssoc              OCTET STRING,
+    t11NsRegFc4Type                OCTET STRING,
+    t11NsRegPortType               FcPortType,
+    t11NsRegPortIpAddress          OCTET STRING,
+    t11NsRegFabricPortName         FcNameIdOrZero,
+    t11NsRegHardAddress            FcAddressIdOrZero,
+    t11NsRegSymbolicPortName       SnmpAdminString,
+    t11NsRegSymbolicNodeName       SnmpAdminString,
+    t11NsRegFc4Features            OCTET STRING
+    }
+
+t11NsRegFabricIndex OBJECT-TYPE
+    SYNTAX               T11FabricIndex
+    MAX-ACCESS           not-accessible
+    STATUS               current
+    DESCRIPTION
+           "A unique index value that uniquely identifies a
+           particular Fabric.
+
+           In a Fabric conformant to SW-3, only a single Fabric can
+           operate within a single physical infrastructure, and thus,
+           the value of this Fabric Index will always be 1.
+
+
+
+DeSanti, et al.             Standards Track                    [Page 15]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+           However, it is possible that future standards will define
+           how multiple Fabrics, each with its own management
+           instrumentation, could operate within one (or more) physical
+           infrastructures.  To allow for this future possibility, this
+           index value is used to uniquely identify a particular
+           Fabric within a physical infrastructure."
+    ::= { t11NsRegEntry 1 }
+
+t11NsRegPortIdentifier OBJECT-TYPE
+    SYNTAX               FcAddressIdOrZero
+    MAX-ACCESS           not-accessible
+    STATUS               current
+    DESCRIPTION
+           "The Fibre Channel Address Identifier of this Nx_Port.
+           If no Port Identifier has been registered, then the
+           value of this object is the zero-length string."
+    ::= { t11NsRegEntry 2 }
+
+t11NsRegPortName OBJECT-TYPE
+    SYNTAX        FcNameIdOrZero
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The Port_Name (WWN) of this Nx_Port.
+           If this object has not been registered, then its value
+           is the zero-length string."
+    DEFVAL {''H}
+    ::= { t11NsRegEntry 3 }
+
+t11NsRegNodeName OBJECT-TYPE
+    SYNTAX        FcNameIdOrZero
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The Node_Name (WWN) of this Nx_Port.
+           If this object has not been registered, then its value
+           is the zero-length string."
+    DEFVAL {''H}
+    ::= { t11NsRegEntry 4 }
+
+t11NsRegClassOfSvc OBJECT-TYPE
+    SYNTAX        FcClasses
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The class of service indicator.  This object is an
+           array of bits that contain a bit map of the classes of
+           service supported by the associated port.  If a bit in
+
+
+
+DeSanti, et al.             Standards Track                    [Page 16]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+           this object is 1, it indicates that the class of
+           service is supported by the associated port.  When a
+           bit is set to 0, it indicates that no class of service
+           is supported by this Nx_Port.
+
+           If this object has not been not registered for a port,
+           then the instance for that port is not instantiated."
+    ::= { t11NsRegEntry 5 }
+
+t11NsRegNodeIpAddress OBJECT-TYPE
+    SYNTAX        OCTET STRING (SIZE (0 | 16))
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The IP address of the node of this Nx_Port, in
+           network-byte order, either as a 32-bit IPv4 address or
+           a 128-bit IPv6 address.  For the former, the leftmost 96 bits
+           (12 bytes) should contain x'00 00 00 00 00 00 00 00 00 00 FF
+           FF', and the IPv4 address should be present in the rightmost
+           32 bits.
+
+           Note that the value of this object is the IP address value
+           that is received in the FC-GS-4 message Register IP address
+           (Node) RIP_NN.  It is not validated against any IP address
+           format.
+
+           If no 'IP address (Node)' has been registered, then the
+           value of this object is the zero-length string."
+    REFERENCE
+          "ANSI INCITS 387-2004, Fibre Channel - Generic
+           Services-4 (FC-GS-4)"
+    DEFVAL  { ''H }
+    ::= { t11NsRegEntry 6 }
+
+t11NsRegProcAssoc OBJECT-TYPE
+    SYNTAX        OCTET STRING (SIZE (0 | 8))
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The Fibre Channel Initial Process Associator (IPA).
+
+           If no 'Initial Process Associator' has been registered,
+           then the value of this object is the zero-length string."
+    REFERENCE
+          "ANSI INCITS 387-2004, Fibre Channel - Generic
+           Services-4 (FC-GS-4)"
+    DEFVAL  { ''H }
+    ::= { t11NsRegEntry 7 }
+
+
+
+DeSanti, et al.             Standards Track                    [Page 17]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+t11NsRegFc4Type OBJECT-TYPE
+    SYNTAX        OCTET STRING (SIZE (0 | 32))
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The FC-4 protocol types supported by this Nx_Port.
+           This is an array of 256 bits.  Each bit in the array
+           corresponds to a Type value as defined by Fibre Channel
+           standards and contained in the Type field of the frame
+           header.  The order of the bits in the 256-bit (32-byte)
+           value is the same as defined in FC-GS-4, section 5.2.3.8,
+           and represented in network-byte order.
+
+           If no 'FC-4 TYPEs' has been registered, then the
+           value of this object is the zero-length string."
+    REFERENCE
+           "ANSI INCITS 387-2004, Fibre Channel - Generic
+           Services-4 (FC-GS-4), section 5.2.3.8."
+    DEFVAL  { ''H }
+    ::= { t11NsRegEntry 8 }
+
+t11NsRegPortType OBJECT-TYPE
+    SYNTAX        FcPortType
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The port type of this port.
+
+           If no 'Port Type' has been registered, then the value
+           of this object is unidentified and is represented by
+           the value 'unknown'."
+    DEFVAL  { 1 }                -- 'unknown', see [FC-MGMT]
+    ::= { t11NsRegEntry 9 }
+
+t11NsRegPortIpAddress OBJECT-TYPE
+    SYNTAX        OCTET STRING (SIZE (0 | 16))
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The value that Fibre Channel calls an 'IP Address (Port)'
+           that represents the IP address of the associated port.
+           The value is either in 32-bit IPv4 format or 128-bit IPv6
+           format, in network-byte order.  When this object contains an
+           IPv4 address, the leftmost 96 bits (12 bytes) should contain
+           x'00 00 00 00 00 00 00 00 00 00 FF FF'.  The IPv4 address
+           should be present in the rightmost 32 bits.
+
+           Note that the value of this object is the IP address value
+
+
+
+DeSanti, et al.             Standards Track                    [Page 18]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+           that is received in the FC-GS-4 message Register IP address
+           (Port) RIPP_ID.  It is not validated against any IP address
+           format.
+
+           If no 'IP address (Port)' has been registered, then the
+           value of this object is the zero-length string."
+    REFERENCE
+           "ANSI INCITS 387-2004, Fibre Channel - Generic
+           Services-4, (FC-GS-4)"
+    DEFVAL {''H}
+    ::= { t11NsRegEntry 10 }
+
+t11NsRegFabricPortName OBJECT-TYPE
+    SYNTAX        FcNameIdOrZero
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The Fabric Port Name (WWN) of the Fx_Port to which
+           this Nx_Port is attached.
+
+           If no 'Fabric Port Name' has been registered, then the
+           value of this object is the zero-length string."
+    DEFVAL {''H}
+    ::= { t11NsRegEntry 11 }
+
+t11NsRegHardAddress OBJECT-TYPE
+    SYNTAX        FcAddressIdOrZero
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The format of this object is identical to the format
+           of Hard Address defined in the Discover Address (ADISC)
+           Extended Link Service (FC-FS).
+
+           Hard Address is the 24-bit NL_Port identifier that
+           consists of:
+             - the 8-bit Domain_ID in the most significant byte
+             - the 8-bit Area_ID in the next most significant
+               byte
+             - the 8-bit AL-PA (Arbitrated Loop Physical Address)
+               which an NL_Port attempts acquire during FC-AL
+               initialization in the least significant byte.
+
+           If the port is not an NL_Port, or if it is an NL_Port
+           but does not have a hard address, then all bits are
+           reported as zeros.
+
+           If no 'Hard Address' has been registered, then the
+
+
+
+DeSanti, et al.             Standards Track                    [Page 19]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+           value of this object is the zero-length string."
+    DEFVAL {''H}
+    ::= { t11NsRegEntry 12 }
+
+t11NsRegSymbolicPortName OBJECT-TYPE
+    SYNTAX        SnmpAdminString (SIZE (0..255))
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The user-defined name of this port.
+
+           If no 'Symbolic Port Name' has been registered, then
+           the value of this object is the zero-length string."
+    DEFVAL {''H}
+    ::= { t11NsRegEntry 13 }
+
+t11NsRegSymbolicNodeName OBJECT-TYPE
+    SYNTAX        SnmpAdminString (SIZE (0..255))
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The user-defined name of the node of this port.
+
+           If no 'Symbolic Node Name' has been registered, then
+           the value of this object is the zero-length string."
+    DEFVAL {''H}
+    ::= { t11NsRegEntry 14 }
+
+
+t11NsRegFc4Features OBJECT-TYPE
+    SYNTAX        OCTET STRING (SIZE (0 | 128))
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The FC-4 Features associated with FC-4 Types on this
+           port encoded as a 128-byte value in network-byte order,
+           or the zero-length string if no 'FC-4 Features' have been
+           registered.
+
+           Section 5.2.3.15 of FC-GS-4 is the authoritative
+           definition of the format of the 128-byte value,
+           i.e., if different, FC-GS-4 takes precedence over the
+           following description:
+
+           The 128-byte value is an array of 4-bit values, one for
+           each FC-4 Type value, positioned as follows: the 5 most
+           significant bits of a Type value identify where it appears
+           within the 128-byte value, specifically, within which word:
+
+
+
+DeSanti, et al.             Standards Track                    [Page 20]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+                 - Word 0 (of the 128-byte value) contains information
+                   related to Types '00' through '07';
+                 - Word 1 contains information related to Types
+                   '08' through 0F';
+                 - and so forth, up to Word 31, which contains
+                   information related to Types 'F8' through 'FF'.
+
+           The least significant of the eight 4-bit values in each
+           Word represents an FC-4 Type with 000 as its 3 least
+           significant bits, and most significant 4-bit value in
+           each Word represents an FC-4 Type with 111 as its 3 least
+           significant bits."
+    REFERENCE
+           "ANSI INCITS 387-2004, Fibre Channel - Generic
+           Services-4 (FC-GS-4), section 5.2.3.15."
+    DEFVAL {''H}
+    ::= { t11NsRegEntry 15 }
+
+
+--
+-- Registered FC-4 Descriptors
+--
+
+t11NsRegFc4DescriptorTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF T11NsRegFc4DescriptorEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+           "This table contains entries for all FC-4 Descriptors
+           registered in the identified Name Server Information
+           Subsets across all Fabrics for which such subsets
+           contain information."
+    ::= { t11NsStatus 3 }
+
+t11NsRegFc4DescriptorEntry OBJECT-TYPE
+    SYNTAX        T11NsRegFc4DescriptorEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+           "An entry in the t11NsRegFc4DescriptorTable,
+           containing information about an FC-4 Descriptor
+           that is associated with a particular FC-4 Type
+           value.  The particular FC-4 Descriptor was
+           registered by an Nx_Port (identified by
+           t11NsRegPortIdentifier) in a Name Server Information
+           Subset (identified by t11NsInfoSubsetIndex) within
+           the Fibre Channel management instance (identified by
+           fcmInstanceIndex) on the Fabric (identified by
+
+
+
+DeSanti, et al.             Standards Track                    [Page 21]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+           t11NsRegFabricIndex).
+
+           If no FC-4 Descriptors have been registered
+           for a particular port, then there will be no
+           entries in this table for that port."
+    INDEX { fcmInstanceIndex, t11NsInfoSubsetIndex,
+            t11NsRegFabricIndex, t11NsRegPortIdentifier,
+            t11NsRegFc4TypeValue }
+    ::= { t11NsRegFc4DescriptorTable 1 }
+
+T11NsRegFc4DescriptorEntry ::= SEQUENCE {
+    t11NsRegFc4TypeValue           Unsigned32,
+    t11NsRegFc4Descriptor          OCTET STRING
+}
+
+t11NsRegFc4TypeValue OBJECT-TYPE
+    SYNTAX          Unsigned32 (0..255)
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+           "An integer value that identifies an FC-4 Type value
+           (representing a particular protocol type, as specified
+           in FC-FS) for which an FC-4 Descriptor has been
+           registered.
+
+           An instance of this object contains a 'Type value'
+           that corresponds to a '1' bit in the value of the
+           t11NsRegFc4Type registered for the same port;
+           this correspondence is as specified in FC-GS-4."
+    REFERENCE
+           "ANSI INCITS 387-2004, Fibre Channel - Generic
+              Services-4 (FC-GS-4), section 5.2.3.8, and
+           ANSI INCITS 373-2003, Fibre Channel - Framing and
+              Signaling (FC-FS), section 9.6, Table 29."
+    ::= { t11NsRegFc4DescriptorEntry 1 }
+
+t11NsRegFc4Descriptor OBJECT-TYPE
+    SYNTAX        OCTET STRING (SIZE (0..255))
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The FC-4 Descriptor value that has been registered
+           for the particular port on the particular Fabric, and
+           for the FC-4 Type represented by the corresponding
+           value of t11NsRegFc4TypeIndex.
+
+           The format of an FC-4 Descriptor is dependent on the
+           corresponding FC-4 Type value, but is represented in
+
+
+
+DeSanti, et al.             Standards Track                    [Page 22]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+           network-byte order."
+    REFERENCE
+           "ANSI INCITS 387-2004, Fibre Channel - Generic
+           Services-4 (FC-GS-4), section 5.2.5.42"
+    ::= { t11NsRegFc4DescriptorEntry 2 }
+
+
+--
+-- Name Server per-Fabric Statistics
+--
+
+t11NsStatsTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF T11NsStatsEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+           "This table contains per-Fabric state and statistics
+           for operations upon the identified Name Server
+           Information Subsets."
+    ::= { t11NsStatistics 1 }
+
+t11NsStatsEntry OBJECT-TYPE
+    SYNTAX        T11NsStatsEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+           "An entry in this table contains state and statistics
+           for operations upon a Name Server Information Subset
+           (identified by t11NsInfoSubsetIndex) within the Fibre
+           Channel management instance (identified by
+           fcmInstanceIndex) on the Fabric (identified by
+           t11NsRegFabricIndex)."
+    INDEX { fcmInstanceIndex, t11NsInfoSubsetIndex,
+            t11NsRegFabricIndex }
+    ::= { t11NsStatsTable 1 }
+
+T11NsStatsEntry ::=  SEQUENCE {
+    t11NsInGetReqs                Counter32,
+    t11NsOutGetReqs               Counter32,
+    t11NsInRegReqs                Counter32,
+    t11NsInDeRegReqs              Counter32,
+    t11NsInRscns                  Counter32,
+    t11NsOutRscns                 Counter32,
+    t11NsRejects                  Counter32,
+    t11NsDatabaseFull             TruthValue
+ }
+
+t11NsInGetReqs OBJECT-TYPE
+
+
+
+DeSanti, et al.             Standards Track                    [Page 23]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+    SYNTAX        Counter32
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The total number of (CT_IU) Get Requests
+           received requesting information from this Name
+           Server Information Subset on this Fabric.
+
+           This counter has no discontinuities other than those
+           that all Counter32s have when sysUpTime=0."
+    ::= { t11NsStatsEntry 1 }
+
+t11NsOutGetReqs OBJECT-TYPE
+    SYNTAX        Counter32
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The total number of (CT_IU) Get Requests sent in
+           order to obtain information needed in this Name Server
+           Information Subset on this Fabric.
+
+           This counter has no discontinuities other than those
+           that all Counter32s have when sysUpTime=0."
+    ::= { t11NsStatsEntry 2 }
+
+t11NsInRegReqs OBJECT-TYPE
+    SYNTAX        Counter32
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The total number of (CT_IU) Registration Requests
+           received to register information in the Name Server
+           Information Subset on this Fabric.
+
+           This counter has no discontinuities other than those
+           that all Counter32s have when sysUpTime=0."
+    ::= { t11NsStatsEntry 3 }
+
+t11NsInDeRegReqs OBJECT-TYPE
+    SYNTAX        Counter32
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The total number of (CT_IU) De-registration Requests
+           received to de-register information from this Name Server
+           Information Subset on this Fabric.
+
+           This counter has no discontinuities other than those
+
+
+
+DeSanti, et al.             Standards Track                    [Page 24]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+           that all Counter32s have when sysUpTime=0."
+    ::= { t11NsStatsEntry 4 }
+
+t11NsInRscns OBJECT-TYPE
+    SYNTAX        Counter32
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The total number of received RSCNs, indicating
+           Name Server-related changes relating to this Name
+           Server Information Subset on this Fabric.
+
+           This counter has no discontinuities other than those
+           that all Counter32s have when sysUpTime=0."
+    ::= { t11NsStatsEntry 5 }
+
+t11NsOutRscns OBJECT-TYPE
+    SYNTAX        Counter32
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The total number of transmitted RSCNs, indicating
+           Name Server-related changes relating to this Name
+           Server Information Subset on this Fabric.
+
+           This counter has no discontinuities other than those
+           that all Counter32s have when sysUpTime=0."
+    ::= { t11NsStatsEntry 6 }
+
+t11NsRejects OBJECT-TYPE
+    SYNTAX        Counter32
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The total number of CT_IU Requests for Name
+           Server functions on this Name Server Information
+           Subset on this Fabric that were rejected.
+
+           This counter has no discontinuities other than those
+           that all Counter32s have when sysUpTime=0."
+    ::= { t11NsStatsEntry 7 }
+
+t11NsDatabaseFull OBJECT-TYPE
+    SYNTAX        TruthValue
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "An indication of whether the database containing this
+
+
+
+DeSanti, et al.             Standards Track                    [Page 25]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+           Name Server Information Subset is full.  This object is
+           set to 'true' only if the Name Server is unable to allocate
+           space for a new entry for the corresponding Fabric, and it is
+           set to 'false' whenever an existing entry is deleted for the
+           corresponding Fabric."
+    ::= { t11NsStatsEntry 8 }
+
+--
+-- Reject information objects
+--
+
+t11NsRejectTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF T11NsRejectEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+           "This table contains information about the most recent
+           Name Server Registration Request failures for various
+           ports on various Fabrics.
+
+           If no information is available about the most recent
+           rejection of a Registration Request on a particular port
+           on a particular Fabric, then there will no entry in this
+           table for that port and Fabric.
+
+           When a t11NsRejectRegNotify notification is sent for
+           such a Registration Request failure, the values of the
+           objects in the relevant entry of this table are updated
+           immediately prior to generating the notification."
+    ::= { t11NsStatus 4 }
+
+t11NsRejectEntry OBJECT-TYPE
+    SYNTAX T11NsRejectEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+           "An entry containing information about the most recent
+           rejection of a request to register information in the Name
+           Server Information Subset (identified by
+           t11NsInfoSubsetIndex) within the Fibre Channel management
+           instance (identified by fcmInstanceIndex) for a particular
+           port (identified by t11NsRegPortIdentifier) on a particular
+           Fabric (identified by t11NsRegFabricIndex)."
+    INDEX { fcmInstanceIndex, t11NsInfoSubsetIndex,
+            t11NsRegFabricIndex, t11NsRegPortIdentifier }
+    ::= { t11NsRejectTable 1 }
+
+T11NsRejectEntry ::= SEQUENCE {
+
+
+
+DeSanti, et al.             Standards Track                    [Page 26]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+    t11NsRejectCtCommandString   OCTET STRING,
+    t11NsRejectReasonCode        T11NsGs4RejectReasonCode,
+    t11NsRejReasonCodeExp        T11NsRejReasonCodeExpl,
+    t11NsRejReasonVendorCode     OCTET STRING
+}
+
+t11NsRejectCtCommandString OBJECT-TYPE
+    SYNTAX        OCTET STRING (SIZE (0..255))
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The binary content of the Registration Request,
+           formatted as an octet string (in network byte
+           order) containing the CT_IU, as described in
+           Table 2 of [FC-GS-4] (including the preamble),
+           which was most recently rejected for the particular
+           Name Server Information Subset on the particular port
+           on the particular Fabric.
+
+           This object contains the zero-length string
+           if and when the CT-IU's content is unavailable.
+
+           When the length of this object is 255 octets, it
+           contains the first 255 octets of the CT-IU (in
+           network-byte order)."
+    ::= { t11NsRejectEntry 1 }
+
+t11NsRejectReasonCode OBJECT-TYPE
+    SYNTAX        T11NsGs4RejectReasonCode
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "A registration reject reason code.  This object
+           contains the reason code of the most recent Name
+           Server Registration Request failure for the
+           particular port on the particular Fabric."
+    ::= { t11NsRejectEntry 2 }
+
+t11NsRejReasonCodeExp OBJECT-TYPE
+    SYNTAX        T11NsRejReasonCodeExpl
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "A registration reject reason code explanation.  This
+           object contains the reason code explanation of the most
+           recent Name Server Registration Request failure for the
+           particular port on the particular Fabric."
+    ::= { t11NsRejectEntry 3 }
+
+
+
+DeSanti, et al.             Standards Track                    [Page 27]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+t11NsRejReasonVendorCode OBJECT-TYPE
+    SYNTAX        OCTET STRING (SIZE(1))
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "A registration reject vendor-specific code.  This
+           object contains the vendor-specific code of the most
+           recent Name Server Registration Request failure for the
+           particular port on the particular Fabric."
+    ::= { t11NsRejectEntry 4 }
+
+
+--
+-- Notifications
+--
+
+t11NsRejectRegNotify NOTIFICATION-TYPE
+    OBJECTS   { t11FamLocalSwitchWwn,
+                t11NsRegPortName, t11NsRejectCtCommandString,
+                t11NsRejectReasonCode, t11NsRejReasonCodeExp,
+                t11NsRejReasonVendorCode }
+    STATUS    current
+    DESCRIPTION
+           "This notification is generated whenever a request to
+           register information in a Name Server Information
+           Subset (for which the corresponding instance of
+           t11NsInfoSubsetRejReqNotfyEnable is 'true') is
+           rejected on a particular Fabric for a particular Nx_Port.
+
+           The value of t11FamLocalSwitchWwn indicates the
+           WWN of the switch that received the request.
+           (If the WWN is unavailable, the value is set to
+           the zero-length string.)
+
+           The value of t11NsRejectCtCommandString indicates
+           the rejected request, and the values of
+           t11NsRejectReasonCode, t11NsRejReasonCodeExp, and
+           t11NsRejReasonVendorCode indicate the reason for
+           the rejection.
+
+           The value of t11NsRegPortName represents the Port Name
+           if it is able to be extracted out of the Registration
+           Request, or otherwise the value as currently registered
+           on the port."
+    ::= { t11NsNotifications 1 }
+
+--
+-- Conformance
+
+
+
+DeSanti, et al.             Standards Track                    [Page 28]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+--
+
+t11NsMIBCompliances OBJECT IDENTIFIER ::= {t11NsMIBConformance 1}
+t11NsMIBGroups      OBJECT IDENTIFIER ::= {t11NsMIBConformance 2}
+
+t11NsMIBCompliance MODULE-COMPLIANCE
+    STATUS    current
+    DESCRIPTION
+           "The compliance statement for entities that
+           implement the Fibre Channel Name Server."
+    MODULE MANDATORY-GROUPS {t11NsDBGroup,
+                             t11NsNotifyControlGroup,
+                             t11NsNotifyGroup}
+
+      OBJECT t11NsInfoSubsetRejReqNotfyEnable
+      MIN-ACCESS read-only
+      DESCRIPTION
+             "Write access is not required."
+
+      GROUP t11NsRequestStatsGroup
+      DESCRIPTION
+             "This group is mandatory only for an implementation
+             that captures statistics related to Name Server
+             requests."
+
+      GROUP t11NsRscnStatsGroup
+      DESCRIPTION
+             "This group is mandatory only for an implementation
+             that captures statistics related to Name
+             Server-related RSCNs."
+
+      GROUP t11NsRejectStatsGroup
+      DESCRIPTION
+             "This group is mandatory only for an implementation
+             that captures statistics related to Name Server
+             rejects."
+
+    ::= { t11NsMIBCompliances 1 }
+
+-- Units of conformance
+
+t11NsDBGroup        OBJECT-GROUP
+    OBJECTS { t11NsInfoSubsetSwitchIndex,
+              t11NsInfoSubsetTableLastChange,
+              t11NsInfoSubsetNumRows,
+              t11NsRegPortName,
+              t11NsRegNodeName,
+              t11NsRegClassOfSvc,
+
+
+
+DeSanti, et al.             Standards Track                    [Page 29]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+              t11NsRegNodeIpAddress,
+              t11NsRegProcAssoc,
+              t11NsRegFc4Type,
+              t11NsRegPortType,
+              t11NsRegPortIpAddress,
+              t11NsRegFabricPortName,
+              t11NsRegHardAddress,
+              t11NsRegSymbolicPortName,
+              t11NsRegSymbolicNodeName,
+              t11NsRegFc4Features,
+              t11NsRegFc4Descriptor }
+    STATUS current
+    DESCRIPTION
+           "A collection of objects for monitoring the information
+           registered in a Name Server Information Subset."
+    ::= { t11NsMIBGroups 1 }
+
+t11NsRequestStatsGroup OBJECT-GROUP
+    OBJECTS { t11NsInGetReqs,
+              t11NsOutGetReqs,
+              t11NsInRegReqs,
+              t11NsInDeRegReqs,
+              t11NsDatabaseFull}
+    STATUS current
+    DESCRIPTION
+           "A collection of objects for displaying Name
+           Server statistics and state for Name Server requests."
+    ::= { t11NsMIBGroups 2 }
+
+t11NsRscnStatsGroup OBJECT-GROUP
+    OBJECTS { t11NsInRscns,
+              t11NsOutRscns }
+    STATUS current
+    DESCRIPTION
+           "A collection of objects for displaying Name
+           Server statistics for Name Server-related RSCNs."
+    ::= { t11NsMIBGroups 3 }
+
+t11NsRejectStatsGroup OBJECT-GROUP
+    OBJECTS { t11NsInfoSubsetTotalRejects,
+              t11NsRejects }
+    STATUS current
+    DESCRIPTION
+           "A collection of objects for displaying Name
+           Server statistics for rejects."
+    ::= { t11NsMIBGroups 4 }
+
+t11NsNotifyControlGroup  OBJECT-GROUP
+
+
+
+DeSanti, et al.             Standards Track                    [Page 30]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+    OBJECTS { t11NsRejectCtCommandString,
+              t11NsRejectReasonCode,
+              t11NsRejReasonCodeExp,
+              t11NsRejReasonVendorCode,
+              t11NsInfoSubsetRejReqNotfyEnable }
+    STATUS current
+    DESCRIPTION
+           "A collection of notification control and
+           notification information objects for monitoring
+           rejections of Name Server registrations."
+    ::= { t11NsMIBGroups 5 }
+
+t11NsNotifyGroup        NOTIFICATION-GROUP
+    NOTIFICATIONS {t11NsRejectRegNotify }
+    STATUS current
+    DESCRIPTION
+           "A collection of notifications for monitoring
+           rejections of Name Server registrations."
+    ::= { t11NsMIBGroups 6 }
+
+END
+
+7.  Acknowledgements
+
+   This document began life as a work item of the INCITS Task Group
+   T11.5.  We wish to acknowledge the many contributions and comments
+   from the INCITS Technical Committee T11, including the following:
+
+      T11 Chair: Robert Snively, Brocade
+      T11 Vice Chair: Claudio DeSanti, Cisco Systems
+      T11.5 Chair: Roger Cummings, Symantec
+      T11.5 members, especially:
+          Ken Hirata, Emulex
+          Scott Kipp, McData
+          Michael O'Donnell, McData
+          Elizabeth G. Rodriguez, Dot Hill
+          Steven L. Wilson, Brocade
+          Bob Nixon, Emulex
+
+   Thanks also to Orly Nicklass of RAD Data Communications, Bert Wijnen
+   of Lucent, and those members of the IMSS WG who provided review
+   comments.
+
+
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 31]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+8.  Normative References
+
+   [RFC2578]    McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+                "Structure of Management Information Version 2 (SMIv2)",
+                STD 58, RFC 2578, April 1999.
+
+   [RFC2579]    McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+                "Textual Conventions for SMIv2", STD 58, RFC 2579, April
+                1999.
+
+   [RFC2580]    McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+                "Conformance Statements for SMIv2", STD 58, RFC 2580,
+                April 1999.
+
+   [RFC3411]    Harrington, D., Presuhn, R., and B. Wijnen, "An
+                Architecture for Describing Simple Network Management
+                Protocol (SNMP) Management Frameworks", STD 62, RFC
+                3411, December 2002.
+
+   [FC-FS]      "Fibre Channel - Framing and Signaling (FC-FS)" ANSI
+                INCITS 373-2003, April 2003.
+
+   [FC-GS-3]    "Fibre Channel - Generic Services - 3 (FC-GS-3)", ANSI
+                INCITS 348-2000, November 2000.
+
+   [FC-GS-4]    "Fibre Channel - Generic Services - 4 (FC-GS-4)", ANSI
+                INCITS 387-2004, February 2004.
+
+   [FC-SW-3]    "Fibre Channel - Switch Fabric - 3 (FC-SW-3)", ANSI
+                INCITS 384-2004, June 2004.
+
+   [FC-SW-4]    "Fibre Channel - Switch Fabric - 4 (FC-SW-4)", ANSI
+                INCITS 418-2006, 2006.
+
+   [FC-MGMT]    McCloghrie, K., "Fibre Channel Management MIB", RFC
+                4044, May 2005.
+
+   [FC-FAM-MIB] DeSanti, C., Gaonkar, V., McCloghrie, K., and S. Gai,
+                "Fibre Channel Fabric Address Manager MIB", RFC 4439,
+                April 2006.
+
+
+
+
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 32]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+9.  Informative References
+
+   [RFC2741]    Daniele, M., Wijnen, B., Ellison, M., and D. Francisco,
+                "Agent Extensibility (AgentX) Protocol Version 1", RFC
+                2741, January 2000.
+
+   [RFC2837]    Teow, K., "Definitions of Managed Objects for the Fabric
+                Element in Fibre Channel Standard", RFC 2837, May 2000.
+
+   [RFC3410]    Case, J., Mundy, R., Partain, D., and B. Stewart,
+                "Introduction and Applicability Statements for
+                Internet-Standard Management Framework", RFC 3410,
+                December 2002.
+
+   [IF-MIB]     McCloghrie, K. and F. Kastenholz, "The Interfaces Group
+                MIB", RFC 2863, June 2000.
+
+10.  IANA Considerations
+
+   IANA has assigned a MIB OID to the T11-FC-NAME-SERVER-MIB module
+   under the appropriate subtree.
+
+11.  Security Considerations
+
+   There is one management object defined in this MIB module with a
+   MAX-ACCESS clause of read-write and/or read-create.  Such objects may
+   be considered sensitive or vulnerable in some network environments.
+   The support for SET operations in a non-secure environment without
+   proper protection can have a negative effect on network operations.
+   This object and its sensitivity/vulnerability is:
+
+      t11NsInfoSubsetRejReqNotfyEnable -- the ability to enable/disable
+                                          notifications.
+
+   Such objects may be considered sensitive or vulnerable in some
+   network environments.  For example, the ability to change network
+   topology or network speed may afford an attacker the ability to
+   obtain better performance at the expense of other network users.  The
+   support for SET operations in a non-secure environment without proper
+   protection can have a negative effect on network operations.
+
+   Some of the readable objects in this MIB module (i.e., objects with a
+   MAX-ACCESS other than not-accessible) may be considered sensitive or
+   vulnerable in some network environments.  It is thus important to
+   control even GET and/or NOTIFY access to these objects and possibly
+   to even encrypt the values of these objects when sending them over
+   the network via SNMP.  These are the tables and objects and their
+   sensitivity/vulnerability:
+
+
+
+DeSanti, et al.             Standards Track                    [Page 33]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+      t11NsRegTable -- contains information about registered Nx_Ports.
+
+      t11NsStatsTable -- contains statistics and state information about
+                         the Name Server.
+
+   SNMP versions prior to SNMPv3 did not include adequate security.
+   Even if the network itself is secure (for example by using IPsec),
+   even then, there is no control as to who on the secure network is
+   allowed to access and GET/SET (read/change/create/delete) the objects
+   in this MIB module.
+
+   It is RECOMMENDED that implementors consider the security features as
+   provided by the SNMPv3 framework (see [RFC3410], section 8),
+   including full support for the SNMPv3 cryptographic mechanisms (for
+   authentication and privacy).
+
+   Further, deployment of SNMP versions prior to SNMPv3 is NOT
+   RECOMMENDED.  Instead, it is RECOMMENDED to deploy SNMPv3 and to
+   enable cryptographic security.  It is then a customer/operator
+   responsibility to ensure that the SNMP entity giving access to an
+   instance of this MIB module is properly configured to give access to
+   the objects only to those principals (users) that have legitimate
+   rights to indeed GET or SET (change/create/delete) them.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 34]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+Authors' Addresses
+
+   Claudio DeSanti
+   Cisco Systems, Inc.
+   170 West Tasman Drive
+   San Jose, CA 95134 USA
+
+   Phone: +1 408 853-9172
+   EMail: cds@cisco.com
+
+
+   Vinay Gaonkar
+   Cisco Systems, Inc.
+   170 West Tasman Drive
+   San Jose, CA 95134 USA
+
+   Phone: +1 408 527-8576
+   EMail: vgaonkar@cisco.com
+
+
+   H.K. Vivek
+   Cisco Systems, Inc.
+   71 Millers Rd
+   Bangalore, India
+
+   Phone: +91 80 2289933x5117
+   EMail: hvivek@cisco.com
+
+
+   Keith McCloghrie
+   Cisco Systems, Inc.
+   170 West Tasman Drive
+   San Jose, CA USA 95134
+
+   Phone: +1 408-526-5260
+   EMail: kzm@cisco.com
+
+
+   Silvano Gai
+   Retired
+
+
+
+
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 35]
+
+RFC 4438             Fibre Channel Name Server MIB            April 2006
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2006).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is provided by the IETF
+   Administrative Support Activity (IASA).
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 36]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4438.txt](<www.ietf.org/rfc/rfc4438.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
