### PR TITLE
Archive rfc446.txt

### DIFF
--- a/www.ietf.org/rfc/rfc446.txt
+++ b/www.ietf.org/rfc/rfc446.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                   L. Peter Deutsch
+RFC # 446                                               SRI
+NIC # 14068                                             January 25, 1973
+
+
+        Proposal to consider a Network Program Resource Notebook
+
+
+The recent requests by Jean Iseli of MITRE for information about all
+resources of type X available on the network (where X=macro processors,
+data management systems, and electromagnetic wave analysis programs)
+lead me to suggest that the NIC be a repository for the replies.
+
+    Since the exchange of knowledge and techniques (not to mention
+    programs) is a central motivating factor in the development of the
+    ARPANET, it seems only reasonable that we begin to systematize the
+    process now that someone (MITRE and the government agencies on whose
+    behalf it is acting) feels there is enough information to be worth
+    collecting.
+
+    Obviously, the network community should be in a position to profit
+    from such compilation at least as much as outside agencies.
+
+The NIC already has catalog and keyword capabilities for the Journal and
+a large index of computer-related documents which are not on-line.  I
+would presume that extending this system to include programs and
+documentation would not be a major task and would probably bring
+immediate payoffs in terms of increased effectiveness of research sites.
+
+This suggestion does not touch on the important larger issue, namely,
+what obligations does the network community have to act as a service and
+information resource to the outside world (government agencies in
+particular) as opposed to its presumed major function of learning about
+how to build and use computer networks and its actual major function of
+research in many areas of computing which have nothing to do with
+networks at all.
+
+    I feel that the confusion between the ARPANET as a service network
+    and the ARPANET as an experiment in the line of network research,
+    and the frustrations and communication failures resulting from
+    superimposing network responsibilities on top of existing research
+    projects, have not received adequate contemplation by the network
+    community.
+
+
+
+
+
+
+
+
+Deutsch                                                         [Page 1]
+
+RFC 446            Network Program Resource Notebook        January 1973
+
+
+    I also feel that the ambiguous status of the network has lead to a
+    sharp division between research/maintenance sites and government
+    agency user sites, a situation which only can exacerbate my own
+    feeling that to some extent the former are being exploited for non-
+    research purposes in a manner that has been fairly rare in the
+    history or ARPA/IPT.
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.             9/99 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Deutsch                                                         [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc446.txt](<www.ietf.org/rfc/rfc446.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
