### PR TITLE
Archive rfc449.txt

### DIFF
--- a/www.ietf.org/rfc/rfc449.txt
+++ b/www.ietf.org/rfc/rfc449.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                       Dave Walden
+RFC # 449                                                   BBN-NET
+NIC # 14133                                                 Jan. 6, 1973
+Updates RFC 442
+
+
+              The Current Flow-control Scheme for IMPSYS.
+
+
+    While Vint's notes on IMPSYS flow-control from the March 16, 1972,
+meeting (RFC 442) seem reasonably accurate and while he does cite our
+Quarterly Technical Report #13, he might have done better to cite BBN's
+two formal publications relevant to the IMPSYS flow-control scheme:
+
+    1.  McQuillan et al, Improvements in the Design and Performance of
+        the ARPA Network, Proceedings AFIPS 1972 FJCC, pp. 741-754.
+
+    2.  BBN Report 1822, Specifications for the Interconnection of a
+        Host and an IMP, December 1972 Revision, section 3, pp. 17-35.
+
+Reference 2 is particularly important reading for NCP programmers -
+things have recently changed somewhat.
+
+    The inter-IMP acknowledgement mechanism, described in the last
+section of Vint's RFC 442, is also described in reference 1 and an
+almost identical mechanism is described in Appendix F of reference 2.
+The acknowledgement is of only intellectual interest to most Hosts as it
+is transparent to network users.  However, the description in reference
+2 is of vital interest to so-called Very Distant Hosts.
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.             9/99 ]
+
+
+
+
+
+
+
+
+
+Walden                                                          [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc449.txt](<www.ietf.org/rfc/rfc449.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
