### PR TITLE
Archive rfc45.txt

### DIFF
--- a/www.ietf.org/rfc/rfc45.txt
+++ b/www.ietf.org/rfc/rfc45.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                   J. Postel
+Request for Comments #45                                S. Crocker
+                                                        UCLA
+                                                        14 April 70
+
+                         New Protocol is Coming
+
+We are currently preparing a clean version of the Network protocol,
+hopefully suitable for immediate implementation.  As advertised, we
+will send these specs out on April 28.
+
+Since the SJCC is one week later, we will host a discussion meeting in
+Atlantic City, Thursday, May 7, win the afternoon.  The purpose of the
+discussion meeting will be for us to explicate unclear details of our
+April 29 document, and for everyone to exchange gripes, suggestions
+and schedules.
+
+(Note that the network session, chaired by Larry Roberts with papers
+from BBN, et al is Thursday morning.)
+
+       [ This RFC was put into machine readable form for entry ]
+         [ into the online RFC archives by Josh Elliott 1/98 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc45.txt](<www.ietf.org/rfc/rfc45.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
