### PR TITLE
Archive rfc450.txt

### DIFF
--- a/www.ietf.org/rfc/rfc450.txt
+++ b/www.ietf.org/rfc/rfc450.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                   M. Padlipsky
+Request for Comments # 450                              MIT-MULTICS
+NIC # 14134                                             February 8, 1973
+
+
+
+                    MULTICS SAMPLING TIMEOUT CHANGE
+
+
+In response to popular demand, and in view of the fact that we've found
+an extra bit of budget, the timeout on sampling ("anonymous") use of
+Multics via the Net has been increased to 5 cpu minutes (from 1 cpu
+minute); coupled with various internal speedups, this change should
+allow the performance of substantive experiments in a single session.
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.             9/99 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Padlipsky                                                       [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc450.txt](<www.ietf.org/rfc/rfc450.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
