### PR TITLE
Archive rfc453.txt

### DIFF
--- a/www.ietf.org/rfc/rfc453.txt
+++ b/www.ietf.org/rfc/rfc453.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                                 Michael D. Kudlick
+RFC # 453                                             SRI-ARC
+NIC # 14317                                           February 7, 1973
+
+
+         Meeting Announcement to Discuss a Network Mail System
+
+Purpose
+
+The purpose of this RFC is to announce a meeting at SRI-ARC on the
+Network Mail problem discussed at the January 1973 Principal
+Investigators' Meeting in San Diego.
+
+We have set the meeting for Thursday, February 22, 1973, at 8:30 AM in
+the SRI-ARC conference room.  If a second day is is needed, Friday would
+be used.
+
+The agenda will include a discussion of the problem, and a discussion of
+alternate solutions.
+
+The goal of the meeting is to produce a clear definition of what the
+solution ought to be, what steps have to be taken, and who should do
+what.
+
+The results of the meeting will be published as an RFC for further
+dialogue, as is done with other suggested protocols.
+
+Aspects of the Problem
+
+There are already several subsystems existing on the Network whose
+function is to send and receive mail.
+
+The principal problem is to coordinates and extend these subsystems so
+that
+
+    a.  uniform user and site identifications are used,
+
+    b.  the File Transfer Protocol is utilized to allow mail to be
+        originated and distributed anywhere on the Network without
+        having to go through a central system.
+
+    c.  there is an option for the sender to record the dialogue and
+        have it catalogued for others to read and reference, and
+
+    d.  There is a way to handle mail for TIP users.
+
+
+
+
+
+
+Kudlick                                                         [Page 1]
+
+RFC 453         Meeting to Discuss a Network Mail System   February 1973
+
+
+        A suggestion made in the past to have a typewriter type terminal
+        permanently attached to TIP's to record all hardcopy messages
+        directed to that TIP should be reviewed.
+
+We (SRI-ARC) have been looking into the problem of using the File
+Transfer Protocol to allow NIC Journal mail to be sent and delivered
+over the Network, without the user having to know and use NLS.  We
+intend to integrate this function with the Tenex SNDMSG capabilities.
+For some preliminary internal ARC discussion on this subject, you may be
+interested in reading two Journal items, one by Charles Irby (IJOURNAL,
+14308,1:w) and the other by Jim White (IJOURNAL, 14312,1:w).
+
+    We realize that there are many benefits to this approach, but would
+    like to have such a scheme fit into an agreed upon Network wide
+    message and document sending protocol.
+
+    Especially important to us is that questions concerning user and
+    site identification, recorded and unrecorded dialogue, and
+    coordination among other mail subsystems on the Network, be fully
+    understood and mutually resolved at the design level before
+    implementation work proceeds.
+
+    We therefore want to discuss these issues at the Network Mail
+    meeting February 22.
+
+Role of the NIC
+
+In conjunction with the above discussion, we will consider offering the
+services of the Network Information Center in three related areas:
+
+    to implement and maintain identification files for all network users
+    and sites;
+
+        (These files could be made available in sequential form through
+        a standard socket so that Network sites could either query them
+        or periodically obtain updated copy.)
+
+    to record in the NIC Journal that mail which the sender wishes to
+    have recorded, and to catalogue those items for later reference;
+
+    to distribute Journal or message mail through the Network via File
+    Transfer Protocols if requested;
+
+    to provide and use NIC dialogue group identifications, in order to
+    make it simpler to send items to several persons who had a common
+    interest.
+
+
+
+
+
+Kudlick                                                         [Page 2]
+
+RFC 453         Meeting to Discuss a Network Mail System   February 1973
+
+
+Network Mail Meeting Logistics
+
+If you or anyone at your site would like to attend the meeting, please
+notify Mil Jernigan (MEJ) at SRI-ARC:
+    phone (415) 326-6200 ext. 4775
+
+If you request it, we will make motel reservations for you.
+
+Signed ... MD Kudlick
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.             9/99 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kudlick                                                         [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc453.txt](<www.ietf.org/rfc/rfc453.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
