### PR TITLE
Archive rfc4547.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4547.txt
+++ b/www.ietf.org/rfc/rfc4547.txt
@@ -1,0 +1,2243 @@
+
+
+
+
+
+
+Network Working Group                                           A. Ahmad
+Request for Comments: 4547                            Cisco Systems Inc.
+Category: Standards Track                                   G. Nakanishi
+                                                                Motorola
+                                                               June 2006
+
+
+           Event Notification Management Information Base for
+  Data over Cable Service Interface Specifications (DOCSIS)-Compliant
+            Cable Modems and Cable Modem Termination Systems
+
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2006).
+
+Abstract
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the Internet community.
+   In particular, it defines a basic set of managed objects for Simple
+   Network Management Protocol (SNMP) based event notification
+   management of Data Over Cable Service Interface Specification
+   (DOCSIS) compliant Cable Modems and Cable Modem Termination Systems.
+   This MIB is defined as an extension to the DOCSIS Cable Device MIB.
+
+   This memo specifies a MIB module in a manner that is compliant to the
+   Structure of Management Information Version 2 (SMIv2).  The set of
+   objects is consistent with the SNMP framework and existing SNMP
+   standards.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ahmad & Makanishi           Standards Track                     [Page 1]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+Table of Contents
+
+   1. The Internet-Standard Management Framework ......................2
+   2. Glossary ........................................................2
+      2.1. BPI - Baseline Privacy Interface ...........................3
+      2.2. BPI - Baseline Privacy Plus Interface ......................3
+      2.3. CATV .......................................................3
+      2.4. CM - Cable Modem ...........................................3
+      2.5. CMTS - Cable Modem Termination System ......................3
+      2.6. DOCSIS .....................................................3
+      2.7. Downstream .................................................4
+      2.8. Head-end ...................................................4
+      2.9. MAC Packet .................................................4
+      2.10. RF ........................................................4
+      2.11. SID .......................................................4
+      2.12. TLV .......................................................4
+      2.13. Upstream ..................................................4
+   3. Overview ........................................................4
+      3.1. Structure of the MIB .......................................5
+   4. Definitions .....................................................5
+   5. Contributors ...................................................35
+   6. Acknowledgements ...............................................36
+   7. Security Considerations ........................................36
+   8. IANA Considerations ............................................37
+   9. References .....................................................37
+      9.1. Normative References ......................................37
+      9.2. Informative References ....................................38
+
+1.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [16].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This memo specifies a MIB
+   module that is compliant to the SMIv2, which is described in STD 58,
+   RFC 2578 [2], STD 58, RFC 2579 [3] and STD 58, RFC 2580 [4].
+
+2.  Glossary
+
+   The terms in this document are derived either from normal cable
+   system usage, or from the documents associated with the Data Over
+   Cable Service Interface Specification (DOCSIS) process.
+
+
+
+
+Ahmad & Makanishi           Standards Track                     [Page 2]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+2.1.  BPI - Baseline Privacy Interface
+
+   A mechanism for providing data privacy over the HFC network in DOCSIS
+   1.0 systems [8].
+
+2.2.  BPI - Baseline Privacy Plus Interface
+
+   A mechanism that extends the Baseline Privacy Interface with the
+   addition of CM authentication over the HFC network in DOCSIS 1.1/2.0
+   systems and beyond [9].
+
+2.3.  CATV
+
+   Originally "Community Antenna Television", now used to refer to any
+   cable or hybrid fiber and cable system used to deliver video signals
+   to a community.
+
+2.4.  CM - Cable Modem
+
+   A CM acts as a "slave" station in a DOCSIS-compliant cable data
+   system.
+
+2.5.  CMTS - Cable Modem Termination System
+
+   A generic term covering a cable bridge or cable router in a head-end.
+   A CMTS acts as the master station in a DOCSIS-compliant cable data
+   system.  It is the only station that transmits downstream, and it
+   controls the scheduling of upstream transmissions by its associated
+   CMs.
+
+2.6.  DOCSIS
+
+   DOCSIS stands for "Data-over-Cable Service Interface Specifications"
+   and refers to the ITU-T J.112 Annex B standard for cable modem
+   systems [10], [13] commonly known as DOCSIS 1.0.  The DOCSIS 1.1
+   specification is an extension of DOCSIS 1.0, with new features to
+   support quality of service, fragmentation, and requirements for
+   European cable plants [14].
+
+   DOCSIS 2.0 [15] builds upon DOCSIS 1.1 and provides all of the
+   features and functionality that DOCSIS 1.1 provides.  In addition, it
+   provides some significant enhancements in upstream capacity over
+   DOCSIS 1.1, such as 30.72 Mbps maximum upstream channel capacity,
+   Synchronous-Code Division Multiple Access (CDMA) operation, increased
+   robustness to upstream noise and channel impairments, Enhanced Reed-
+   Solomon error correction, and Trellis Coded Modulation.
+
+
+
+
+
+Ahmad & Makanishi           Standards Track                     [Page 3]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+2.7.  Downstream
+
+   The direction from the CMTS to the CM.
+
+2.8.  Head-end
+
+   The origination point in most cable systems of the subscriber video
+   signals.  Generally also the location of the CMTS equipment.
+
+2.9.  MAC Packet
+
+   A term referring to DOCSIS Protocol Data Unit (PDU).
+
+2.10.  RF
+
+   A term referring to Radio Frequency.
+
+2.11.  SID
+
+   A term referring to DOCSIS Service ID.  The SID identifies a
+   particular upstream bandwidth allocation and class-of-service
+   management for DOCSIS, and identifies a particular bidirectional
+   security association for BPI.
+
+2.12.  TLV
+
+   TLV stands for Type/Length/Value.  TLV is an encoding method
+   consisting of three fields.  The first field indicates the type of
+   element, the second field indicates the length of the element, and
+   the third field contains the element's value.
+
+2.13.  Upstream
+
+   The direction from the CM to the CMTS.
+
+3.  Overview
+
+   Offering High Speed Internet Service in the cable industry has become
+   extremely successful.  DOCSIS devices are being deployed at a rate of
+   multiple thousands per day.  Although operators are enjoying
+   successful deployment, they are also facing the challenge of properly
+   managing deployed devices.  Operators are using Simple Network
+   Management Protocol, a set of Management Information Base (MIB)
+   required by DOCSIS, and SNMP Notifications to manage deployed DOCSIS
+   devices.  The usage of SNMP Notification for event reporting is
+   becoming more popular as an effective and efficient method for
+   network monitoring.
+
+
+
+
+Ahmad & Makanishi           Standards Track                     [Page 4]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+   Unfortunately, only a minimal set of SNMP Notifications is currently
+   available.  This notification MIB, in conjunction with [11] and [12],
+   provides a minimum set of standard DOCSIS Notifications that DOCSIS
+   devices SHOULD support to enable successful management of DOCSIS
+   devices and networks.
+
+   This document defines a set of objects required for the event
+   notification management of DOCSIS-compliant Cable Modems (CMs) and
+   Cable Modem Termination Systems (CMTSs).  The MIB module is derived
+   from the DOCSIS [11] and [12].
+
+   Appendix H of [11] defines all DOCSIS 1.1 required events, and
+   Appendix D of [12] does that for DOCSIS 2.0.  The notifications
+   specified in this document are used to notify these events via SNMP.
+
+   In this document, the key words "MUST", "MUST NOT", "REQUIRED",
+   "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY",
+   and "OPTIONAL" are to be interpreted as described in RFC 2119 [1].
+
+3.1.  Structure of the MIB
+
+   This DOCS-IETF-CABLE-DEVICE-NOTIFICATION-MIB was designed to extend
+   the RFC2669 [5] notification module.
+
+   Two groups of SNMP notification objects are defined in this document.
+   One group defines notifications for cable modem events, and the other
+   group defines notifications for cable modem termination system
+   events.
+
+   DOCSIS defines numerous events, and each event is assigned to a
+   functional category.  This MIB defines a notification object for each
+   functional category.  The varbinding list of each notification
+   includes information about the event that occurred on the device.
+
+4.  Definitions
+
+   The MIB module defined here IMPORTs from SNMPv2-SMI [2], SNMPv2-CONF
+   [3], DOCS-CABLE-DEVICE-MIB [5], DOCS-IF-MIB [6], and IF-MIB [7].
+
+   DOCS-IETF-CABLE-DEVICE-NOTIFICATION-MIB DEFINITIONS ::= BEGIN
+
+     IMPORTS
+           MODULE-IDENTITY,
+           OBJECT-TYPE,
+           NOTIFICATION-TYPE,
+           mib-2
+                 FROM SNMPv2-SMI -- RFC 2578
+           MODULE-COMPLIANCE,
+
+
+
+Ahmad & Makanishi           Standards Track                     [Page 5]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+           OBJECT-GROUP,
+           NOTIFICATION-GROUP
+                 FROM SNMPv2-CONF -- RFC 2580
+
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           docsDevSwFilename,
+           docsDevSwServer,
+           docsDevServerDhcp,
+           docsDevServerTime
+                 FROM DOCS-CABLE-DEVICE-MIB -- RFC 2669
+
+           docsIfCmCmtsAddress,
+           docsIfCmtsCmStatusMacAddress,
+           docsIfDocsisBaseCapability,
+           docsIfCmStatusDocsisOperMode,
+           docsIfCmStatusModulationType,
+           docsIfCmtsCmStatusDocsisRegMode,
+           docsIfCmtsCmStatusModulationType
+                 FROM DOCS-IF-MIB -- RFC 4546
+
+           ifPhysAddress
+                 FROM IF-MIB;  -- RFC 2863
+
+     docsDevNotifMIB MODULE-IDENTITY
+
+           LAST-UPDATED    "200605240000Z" -- May 24, 2006
+           ORGANIZATION    "IETF IP over Cable Data Network
+                            Working Group"
+
+           CONTACT-INFO
+               "        Azlina Ahmad
+                Postal: Cisco Systems, Inc.
+                        170 West Tasman Drive
+                        San Jose, CA 95134, U.S.A.
+                Phone:   408 853 7927
+                E-mail: azlina@cisco.com
+
+                        Greg Nakanishi
+                Postal: Motorola
+                        6450 Sequence Drive
+                        San Diego, CA 92121, U.S.A.
+                Phone:   858 404 2366
+                E-mail: gnakanishi@motorola.com
+
+                IETF IPCDN Working Group
+                General Discussion: ipcdn@ietf.org
+
+
+
+Ahmad & Makanishi           Standards Track                     [Page 6]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+                Subscribe: http://www.ietf.org/mailman/listinfo/ipcdn
+                Archive: ftp://ftp.ietf.org/ietf-mail-archive/ipcdn
+                Co-chairs: Richard Woundy,
+                             richard_woundy@cable.comcast.com
+                           Jean-Francois Mule, jf.mule@cablelabs.com"
+
+           DESCRIPTION
+               "The Event Notification MIB is an extension of the
+               CABLE DEVICE MIB.  It defines various notification
+               objects for both cable modem and cable modem termination
+               systems.  Two groups of SNMP notification objects are
+               defined.  One group is for notifying cable modem events,
+               and one group is for notifying cable modem termination
+               system events.
+
+               DOCSIS defines numerous events, and each event is
+               assigned to a functional category.  This MIB defines
+               a notification object for each functional category.
+               The varbinding list of each notification includes
+               information about the event that occurred on the
+               device.
+
+               Copyright (C) The Internet Society (2006).  This version
+               of this MIB module is part of RFC 4547; see the RFC
+               itself for full legal notices."
+
+           REVISION "200605240000Z" -- May 24, 2006
+           DESCRIPTION
+               "Initial version, published as RFC 4547."
+           ::= { mib-2 132 }
+
+   docsDevNotifControl OBJECT IDENTIFIER ::= { docsDevNotifMIB 1}
+   docsDevCmNotifs OBJECT IDENTIFIER ::= { docsDevNotifMIB 2 0 }
+   docsDevCmtsNotifs OBJECT IDENTIFIER ::= { docsDevNotifMIB 3 0 }
+
+   docsDevCmNotifControl OBJECT-TYPE
+       SYNTAX BITS {
+           cmInitTLVUnknownNotif( 0),
+           cmDynServReqFailNotif( 1),
+           cmDynServRspFailNotif( 2),
+           cmDynServAckFailNotif( 3),
+           cmBpiInitNotif( 4),
+           cmBPKMNotif( 5),
+           cmDynamicSANotif( 6),
+           cmDHCPFailNotif( 7),
+           cmSwUpgradeInitNotif( 8),
+           cmSwUpgradeFailNotif( 9),
+           cmSwUpgradeSuccessNotif( 10),
+
+
+
+Ahmad & Makanishi           Standards Track                     [Page 7]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+           cmSwUpgradeCVCNotif( 11),
+           cmTODFailNotif( 12),
+           cmDCCReqFailNotif( 13),
+           cmDCCRspFailNotif( 14),
+           cmDCCAckFailNotif( 15)
+       }
+      MAX-ACCESS read-write
+
+      STATUS current
+      DESCRIPTION
+          "The object is used to enable specific CM notifications.
+           For example, if the first bit is set, then
+           docsDevCmInitTLVUnknownNotif is enabled.  If it is not set,
+           the notification is disabled.  Note that notifications are
+           also under the control of the MIB modules defined in
+           RFC3413.
+
+           If the device is rebooted,the value of this object SHOULD
+           revert to the default value.
+          "
+      DEFVAL { {} }
+      ::= { docsDevNotifControl 1 }
+
+   docsDevCmtsNotifControl OBJECT-TYPE
+       SYNTAX BITS {
+           cmtsInitRegReqFailNotif( 0),
+           cmtsInitRegRspFailNotif( 1),
+           cmtsInitRegAckFailNotif( 2),
+           cmtsDynServReqFailNotif( 3),
+           cmtsDynServRspFailNotif( 4),
+           cmtsDynServAckFailNotif( 5),
+           cmtsBpiInitNotif( 6),
+           cmtsBPKMNotif( 7),
+           cmtsDynamicSANotif( 8),
+           cmtsDCCReqFailNotif( 9),
+           cmtsDCCRspFailNotif( 10),
+           cmtsDCCAckFailNotif( 11)
+       }
+       MAX-ACCESS read-write
+       STATUS current
+       DESCRIPTION
+          "The object is used to enable specific CMTS notifications.
+           For example, if the first bit is set, then
+           docsDevCmtsInitRegRspFailNotif is enabled.  If it is not set,
+           the notification is disabled.  Note that notifications are
+           also under the control of the MIB modules defined in
+           RFC3413.
+
+
+
+
+Ahmad & Makanishi           Standards Track                     [Page 8]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+           If the device is rebooted,the value of this object SHOULD
+           revert to the default value.
+          "
+       DEFVAL { {} }
+       ::= { docsDevNotifControl 2 }
+
+   docsDevCmInitTLVUnknownNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           ifPhysAddress,
+           docsIfCmCmtsAddress,
+           docsIfDocsisBaseCapability,
+           docsIfCmStatusDocsisOperMode,
+           docsIfCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           "Notification to indicate that an unknown TLV was
+             encountered during the TLV parsing process.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - ifPhysAddress: the MAC address of the cable
+              interface of this cable modem.
+            - docsIfCmCmtsAddress: the MAC address of the CMTS
+              to which the CM is connected (if there is a cable
+              card/interface in the CMTS, then it is actually the
+              MAC address of the cable interface to which it is
+              connected).
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmStatusDocsisOperMode: the QOS level (1.0, 1.1)
+              that the CM is operating in.
+            - docsIfCmStatusModulationType: the upstream modulation
+              methodology used by the CM.
+           "
+       ::= { docsDevCmNotifs 1 }
+
+
+
+
+
+Ahmad & Makanishi           Standards Track                     [Page 9]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+   docsDevCmDynServReqFailNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           ifPhysAddress,
+           docsIfCmCmtsAddress,
+           docsIfDocsisBaseCapability,
+           docsIfCmStatusDocsisOperMode,
+           docsIfCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+
+           "A notification to report the failure of a dynamic service
+            request during the dynamic services process.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - ifPhysAddress: the MAC address of the cable
+              interface of this cable modem.
+            - docsIfCmCmtsAddress: the MAC address of the CMTS
+              to which the CM is connected to (if there is a cable
+              card/interface in the CMTS, then it is actually the
+              MAC address of the cable interface to which it is
+              connected).
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmStatusDocsisOperMode: the QOS level (1.0, 1.1)
+              that the CM is operating in.
+            - docsIfCmStatusModulationType: the upstream modulation
+              methodology used by the CM.
+           "
+       ::= { docsDevCmNotifs 2 }
+
+   docsDevCmDynServRspFailNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           ifPhysAddress,
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 10]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+           docsIfCmCmtsAddress,
+           docsIfDocsisBaseCapability,
+           docsIfCmStatusDocsisOperMode,
+           docsIfCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           " A notification to report the failure of a dynamic service
+            response during the dynamic services process.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - ifPhysAddress: the MAC address of the cable
+              interface of this cable modem.
+            - docsIfCmCmtsAddress: the MAC address of the CMTS
+              to which the CM is connected (if there is a cable
+              card/interface in the CMTS, then it is actually the
+              MAC address of the cable interface to which it is
+              connected).
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmStatusDocsisOperMode: the QOS level (1.0, 1.1)
+              that the CM is operating in.
+            - docsIfCmStatusModulationType: the upstream modulation
+              methodology used by the CM.
+           "
+       ::= { docsDevCmNotifs 3}
+
+   docsDevCmDynServAckFailNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           ifPhysAddress,
+           docsIfCmCmtsAddress,
+           docsIfDocsisBaseCapability,
+           docsIfCmStatusDocsisOperMode,
+           docsIfCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 11]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+           "A notification to report the failure of a dynamic service
+            acknowledgement during the dynamic services process.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - ifPhysAddress: the MAC address of the cable
+              interface of this cable modem.
+            - docsIfCmCmtsAddress: the MAC address of the CMTS
+              to which the CM is connected (if there is a cable
+              card/interface in the CMTS, then it is actually the
+              MAC address of the cable interface to which it is
+              connected).
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmStatusDocsisOperMode: the QOS level (1.0, 1.1)
+              that the CM is operating in.
+            - docsIfCmStatusModulationType: the upstream modulation
+              methodology used by the CM.
+           "
+       ::= { docsDevCmNotifs 4}
+
+   docsDevCmBpiInitNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           ifPhysAddress,
+           docsIfCmCmtsAddress,
+           docsIfDocsisBaseCapability,
+           docsIfCmStatusDocsisOperMode,
+           docsIfCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           "A notification to report the failure of a BPI
+            initialization attempt during the registration process.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 12]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - ifPhysAddress: the MAC address of the cable
+              interface of this cable modem.
+            - docsIfCmCmtsAddress: the MAC address of the CMTS
+              to which the CM is connected (if there is a cable
+              card/interface in the CMTS, then it is actually the
+              MAC address of the cable interface to which it is
+              connected).
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmStatusDocsisOperMode: the QOS level (1.0, 1.1)
+              that the CM is operating in.
+            - docsIfCmStatusModulationType: the upstream modulation
+              methodology used by the CM.
+           "
+       ::= { docsDevCmNotifs 5 }
+
+   docsDevCmBPKMNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           ifPhysAddress,
+           docsIfCmCmtsAddress,
+           docsIfDocsisBaseCapability,
+           docsIfCmStatusDocsisOperMode,
+           docsIfCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           "A notification to report the failure of a Baseline
+            Privacy Key Management (BPKM) operation.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - ifPhysAddress: the MAC address of the cable
+              interface of this cable modem.
+            - docsIfCmCmtsAddress: the MAC address of the CMTS
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 13]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+              to which the CM is connected (if there is a cable
+              card/interface in the CMTS, then it is actually the
+              MAC address of the cable interface to which it is
+              connected).
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmStatusDocsisOperMode: the QOS level (1.0, 1.1)
+              that the CM is operating in.
+            - docsIfCmStatusModulationType: the upstream modulation
+              methodology used by the CM.
+           "
+       ::= { docsDevCmNotifs 6 }
+
+   docsDevCmDynamicSANotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           ifPhysAddress,
+           docsIfCmCmtsAddress,
+           docsIfDocsisBaseCapability,
+           docsIfCmStatusDocsisOperMode,
+           docsIfCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           "A notification to report the failure of a dynamic security
+            association operation.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - ifPhysAddress: the MAC address of the cable
+              interface of this cable modem.
+            - docsIfCmCmtsAddress: the MAC address of the CMTS
+              to which the CM is connected (if there is a cable
+              card/interface in the CMTS, then it is actually the
+              MAC address of the cable interface to which it is
+              connected).
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 14]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+            - docsIfCmStatusDocsisOperMode: the QOS level (1.0, 1.1)
+              that the CM is operating in.
+            - docsIfCmStatusModulationType: the upstream modulation
+              methodology used by the CM.
+           "
+       ::= { docsDevCmNotifs 7 }
+
+   docsDevCmDHCPFailNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           ifPhysAddress,
+           docsIfCmCmtsAddress,
+           docsDevServerDhcp,
+           docsIfDocsisBaseCapability,
+           docsIfCmStatusDocsisOperMode,
+           docsIfCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           "A notification to report the failure of a DHCP operation.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - ifPhysAddress: the MAC address of the cable
+              interface of this cable modem.
+            - docsIfCmCmtsAddress: the MAC address of the CMTS
+              to which the CM is connected (if there is a cable
+              card/interface in the CMTS, then it is actually the
+              MAC address of the cable interface to which it is
+              connected).
+            - docsDevServerDhcp: the IP address of the DHCP server.
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmStatusDocsisOperMode: the QOS level (1.0, 1.1)
+              that the CM is operating in.
+            - docsIfCmStatusModulationType: the upstream modulation
+              methodology used by the CM.
+           "
+       ::= { docsDevCmNotifs 8 }
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 15]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+   docsDevCmSwUpgradeInitNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           ifPhysAddress,
+           docsIfCmCmtsAddress,
+           docsDevSwFilename,
+           docsDevSwServer,
+           docsIfDocsisBaseCapability,
+           docsIfCmStatusDocsisOperMode,
+           docsIfCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           "A notification to indicate that a software upgrade
+            has been initiated on the device.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - ifPhysAddress: the MAC address of the cable
+              interface of this cable modem.
+            - docsIfCmCmtsAddress: the MAC address of the CMTS
+              to which the CM is connected (if there is a cable
+              card/interface in the CMTS, then it is actually the
+              MAC address of the cable interface to which it is
+              connected).
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmStatusDocsisOperMode: the QOS level (1.0, 1.1)
+              that the CM is operating in.
+            - docsIfCmStatusModulationType: the upstream modulation
+              methodology used by the CM.
+           "
+       ::= { docsDevCmNotifs 9 }
+
+   docsDevCmSwUpgradeFailNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 16]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+           ifPhysAddress,
+           docsIfCmCmtsAddress,
+           docsDevSwFilename,
+           docsDevSwServer,
+           docsIfDocsisBaseCapability,
+           docsIfCmStatusDocsisOperMode,
+           docsIfCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           "A notification to report the failure of a software upgrade
+            attempt.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - ifPhysAddress: the MAC address of the cable
+              interface of this cable modem.
+            - docsIfCmCmtsAddress: the MAC address of the CMTS
+              to which the CM is connected (if there is a cable
+              card/interface in the CMTS, then it is actually the
+              MAC address of the cable interface to which it is
+              connected).
+            - docsDevSwFilename: the software image file name
+            - docsDevSwServer: the IP address of the server that
+              the image is retrieved from.
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmStatusDocsisOperMode: the QOS level (1.0, 1.1)
+              that the CM is operating in.
+            - docsIfCmStatusModulationType: the upstream modulation
+              methodology used by the CM.
+           "
+       ::= { docsDevCmNotifs 10 }
+
+   docsDevCmSwUpgradeSuccessNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           ifPhysAddress,
+           docsIfCmCmtsAddress,
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 17]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+           docsDevSwFilename,
+           docsDevSwServer,
+           docsIfDocsisBaseCapability,
+           docsIfCmStatusDocsisOperMode,
+           docsIfCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           "A notification to report the software upgrade success
+            status.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - ifPhysAddress: the MAC address of the cable
+              interface of this cable modem.
+            - docsIfCmCmtsAddress: the MAC address of the CMTS
+              to which the CM is connected (if there is a cable
+              card/interface in the CMTS, then it is actually the
+              MAC address of the cable interface to which it is
+              connected).
+            - docsDevSwFilename: the software image file name
+            - docsDevSwServer: the IP address of the server that
+              the image is retrieved from.
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmStatusDocsisOperMode: the QOS level (1.0, 1.1)
+              that the CM is operating in.
+            - docsIfCmStatusModulationType: the upstream modulation
+              methodology used by the CM.
+           "
+       ::= { docsDevCmNotifs 11 }
+
+   docsDevCmSwUpgradeCVCFailNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           ifPhysAddress,
+           docsIfCmCmtsAddress,
+           docsIfDocsisBaseCapability,
+           docsIfCmStatusDocsisOperMode,
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 18]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+           docsIfCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           "A notification to report that the verification of the
+            code file has failed during a secure software upgrade
+            attempt.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - ifPhysAddress: the MAC address of the cable
+              interface of this cable modem.
+            - docsIfCmCmtsAddress: the MAC address of the CMTS
+              to which the CM is connected (if there is a cable
+              card/interface in the CMTS, then it is actually the
+              MAC address of the cable interface to which it is
+              connected).
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmStatusDocsisOperMode: the QOS level (1.0, 1.1)
+              that the CM is operating in.
+            - docsIfCmStatusModulationType: the upstream modulation
+              methodology used by the CM.
+           "
+       ::= { docsDevCmNotifs 12 }
+
+   docsDevCmTODFailNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           ifPhysAddress,
+           docsIfCmCmtsAddress,
+           docsDevServerTime,
+           docsIfDocsisBaseCapability,
+           docsIfCmStatusDocsisOperMode,
+           docsIfCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           "A notification to report the failure of a time of day
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 19]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+            operation.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - ifPhysAddress: the MAC address of the cable
+              interface of this cable modem.
+            - docsIfCmCmtsAddress: the MAC address of the CMTS
+              to which the CM is connected (if there is a cable
+              card/interface in the CMTS, then it is actually the
+              MAC address of the cable interface to which it is
+              connected).
+            - docsDevServerTime: the IP address of the time server.
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmStatusDocsisOperMode: the QOS level (1.0, 1.1)
+              that the CM is operating in.
+            - docsIfCmStatusModulationType: the upstream modulation
+              methodology used by the CM.
+           "
+       ::= { docsDevCmNotifs 13 }
+
+   docsDevCmDCCReqFailNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           ifPhysAddress,
+           docsIfCmCmtsAddress,
+           docsIfDocsisBaseCapability,
+           docsIfCmStatusDocsisOperMode,
+           docsIfCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           " A notification to report the failure of a dynamic channel
+            change request during the dynamic channel change process
+            on the CM.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 20]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - ifPhysAddress: the MAC address of the cable
+              interface of this cable modem.
+            - docsIfCmCmtsAddress: the MAC address of the CMTS
+              to which the CM is connected (if there is a cable
+              card/interface in the CMTS, then it is actually the
+              MAC address of the cable interface to which it is
+              connected).
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmStatusDocsisOperMode: the QOS level (1.0, 1.1)
+              that the CM is operating in.
+            - docsIfCmStatusModulationType: the upstream modulation
+              methodology used by the CM.
+           "
+       ::= { docsDevCmNotifs 14 }
+
+   docsDevCmDCCRspFailNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           ifPhysAddress,
+           docsIfCmCmtsAddress,
+           docsIfDocsisBaseCapability,
+           docsIfCmStatusDocsisOperMode,
+           docsIfCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           "A notification to report the failure of a dynamic channel
+            change response during the dynamic channel
+            change process on the CM.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - ifPhysAddress: the MAC address of the cable
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 21]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+              interface of this cable modem.
+            - docsIfCmCmtsAddress: the MAC address of the CMTS
+              to which the CM is connected (if there is a cable
+              card/interface in the CMTS, then it is actually the
+              MAC address of the cable interface to which it is
+              connected).
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmStatusDocsisOperMode: the QOS level (1.0, 1.1)
+              that the CM is operating in.
+            - docsIfCmStatusModulationType: the upstream modulation
+              methodology used by the CM.
+           "
+       ::= { docsDevCmNotifs 15 }
+
+   docsDevCmDCCAckFailNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           ifPhysAddress,
+           docsIfCmCmtsAddress,
+           docsIfDocsisBaseCapability,
+           docsIfCmStatusDocsisOperMode,
+           docsIfCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           "A notification to report the failure of a dynamic channel
+            change acknowledgement during the dynamic channel
+            change process on the CM.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - ifPhysAddress: the MAC address of the cable
+              interface of this cable modem.
+            - docsIfCmCmtsAddress: the MAC address of the CMTS
+              to which the CM is connected (if there is a cable
+              card/interface in the CMTS, then it is actually the
+              MAC address of the cable interface to which it is
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 22]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+              connected).
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmStatusDocsisOperMode: the QOS level (1.0, 1.1)
+              that the CM is operating in.
+            - docsIfCmtsCmStatusModulationType the upstream modulation
+              methodology used by the CM.
+           "
+       ::= { docsDevCmNotifs 16}
+
+   docsDevCmtsInitRegReqFailNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           docsIfCmtsCmStatusMacAddress,
+           ifPhysAddress,
+           docsIfCmtsCmStatusDocsisRegMode,
+           docsIfDocsisBaseCapability,
+           docsIfCmtsCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           "A notification to report the failure of a registration
+            request from a CM during the CM initialization
+            process that was detected on the CMTS.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - docsIfCmtsCmStatusMacAddress: the MAC address of the CM
+              with which this notification is associated.
+            - ifPhysAddress: the MAC address of the CMTS
+              (if there is a cable card/interface in the CMTS,
+              then it is actually the MAC address of the cable
+              interface that connected to the CM) cable interface
+              connected to the CM.
+            - docsIfCmtsCmStatusDocsisRegMode: the QOS level (1.0, 1.1)
+              that the reporting CM is operating in.
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 23]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+            - docsIfCmtsCmStatusModulationType: the upstream
+              modulation methodology used by the CM.
+           "
+       ::= { docsDevCmtsNotifs 1 }
+
+   docsDevCmtsInitRegRspFailNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           docsIfCmtsCmStatusMacAddress,
+           ifPhysAddress,
+           docsIfCmtsCmStatusDocsisRegMode,
+           docsIfDocsisBaseCapability,
+           docsIfCmtsCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           "A notification to report the failure of a registration
+            response during the CM initialization
+            process that was detected by the CMTS.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - docsIfCmtsCmStatusMacAddress: the MAC address of the CM
+              with which this notification is associated.
+            - ifPhysAddress: the MAC address of the CMTS
+              (if there is a cable card/interface in the CMTS,
+              then it is actually the MAC address of the cable
+              interface that connected to the CM) cable interface
+              connected to the CM.
+            - docsIfCmtsCmStatusDocsisRegMode: the QOS level (1.0, 1.1)
+              that the reporting CM is operating in.
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmtsCmStatusModulationType: the upstream
+              modulation methodology used by the CM.
+           "
+       ::= { docsDevCmtsNotifs 2 }
+
+   docsDevCmtsInitRegAckFailNotif NOTIFICATION-TYPE
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 24]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           docsIfCmtsCmStatusMacAddress,
+           ifPhysAddress,
+           docsIfCmtsCmStatusDocsisRegMode,
+           docsIfDocsisBaseCapability,
+           docsIfCmtsCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           "A notification to report the failure of a registration
+            acknowledgement from the CM during the CM
+            initialization process that was detected by the CMTS.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - docsIfCmtsCmStatusMacAddress: the MAC address of the CM
+              with which this notification is associated.
+            - ifPhysAddress: the MAC address of the CMTS
+              (if there is a cable card/interface in the CMTS,
+              then it is actually the MAC address of the cable
+              interface that connected to the CM) cable interface
+              connected to the CM.
+            - docsIfCmtsCmStatusDocsisRegMode: the QOS level (1.0, 1.1)
+              that the reporting CM is operating in.
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmtsCmStatusModulationType: the upstream
+              modulation methodology used by the CM.
+           "
+       ::= { docsDevCmtsNotifs 3 }
+
+   docsDevCmtsDynServReqFailNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           docsIfCmtsCmStatusMacAddress,
+           ifPhysAddress,
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 25]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+           docsIfCmtsCmStatusDocsisRegMode,
+           docsIfDocsisBaseCapability,
+           docsIfCmtsCmStatusModulationType
+        }
+       STATUS current
+       DESCRIPTION
+           "A notification to report the failure of a dynamic service
+            request during the dynamic services process
+            that was detected by the CMTS.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - docsIfCmtsCmStatusMacAddress: the MAC address of the CM
+              with which this notification is associated.
+            - ifPhysAddress: the MAC address of the CMTS
+              (if there is a cable card/interface in the CMTS,
+              then it is actually the MAC address of the cable
+              interface that connected to the CM) cable interface
+              connected to the CM.
+            - docsIfCmtsCmStatusDocsisRegMode: the QOS level (1.0, 1.1)
+              that the reporting CM is operating in.
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmtsCmStatusModulationType: the upstream
+              modulation methodology used by the CM.
+           "
+       ::= { docsDevCmtsNotifs 4 }
+
+   docsDevCmtsDynServRspFailNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           docsIfCmtsCmStatusMacAddress,
+           ifPhysAddress,
+           docsIfCmtsCmStatusDocsisRegMode,
+           docsIfDocsisBaseCapability,
+           docsIfCmtsCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 26]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+           "A notification to report the failure of a dynamic service
+            response during the dynamic services process
+            that was detected by the CMTS.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - docsIfCmtsCmStatusMacAddress: the MAC address of the CM
+              with which this notification is associated.
+            - ifPhysAddress: the MAC address of the CMTS
+              (if there is a cable card/interface in the CMTS,
+              then it is actually the MAC address of the cable
+              interface that connected to the CM) cable interface
+              connected to the CM.
+            - docsIfCmtsCmStatusDocsisRegMode: the QOS level (1.0, 1.1)
+              that the reporting CM is operating in.
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmtsCmStatusModulationType: the upstream
+              modulation methodology used by the CM.
+           "
+       ::= { docsDevCmtsNotifs 5 }
+
+   docsDevCmtsDynServAckFailNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           docsIfCmtsCmStatusMacAddress,
+           ifPhysAddress,
+           docsIfCmtsCmStatusDocsisRegMode,
+           docsIfDocsisBaseCapability,
+           docsIfCmtsCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           "A notification to report the failure of a dynamic service
+            acknowledgement during the dynamic services
+            process that was detected by the CMTS.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 27]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - docsIfCmtsCmStatusMacAddress: the MAC address of the CM
+              with which this notification is associated.
+            - ifPhysAddress: the MAC address of the CMTS
+              (if there is a cable card/interface in the CMTS,
+              then it is actually the MAC address of the cable
+              interface that connected to the CM) cable interface
+              connected to the CM.
+            - docsIfCmtsCmStatusDocsisRegMode: the QOS level (1.0, 1.1)
+              that the reporting CM is operating in.
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmtsCmStatusModulationType: the upstream
+              modulation methodology used by the CM.
+           "
+       ::= { docsDevCmtsNotifs 6 }
+
+
+   docsDevCmtsBpiInitNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           docsIfCmtsCmStatusMacAddress,
+           ifPhysAddress,
+           docsIfCmtsCmStatusDocsisRegMode,
+           docsIfDocsisBaseCapability,
+           docsIfCmtsCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           "A notification to report the failure of a BPI
+            initialization attempt during the CM registration process
+            that was detected by the CMTS.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 28]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+            - docsDevEvText: a textual description of the event.
+            - docsIfCmtsCmStatusMacAddress: the MAC address of the CM
+              with which this notification is associated.
+            - ifPhysAddress: the MAC address of the CMTS
+              (if there is a cable card/interface in the CMTS,
+              then it is actually the MAC address of the cable
+              interface that connected to the CM) cable interface
+              connected to the CM.
+            - docsIfCmtsCmStatusDocsisRegMode: the QOS level (1.0, 1.1)
+              that the reporting CM is operating in.
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmtsCmStatusModulationType: the upstream
+              modulation methodology used by the CM.
+           "
+       ::= { docsDevCmtsNotifs 7 }
+
+   docsDevCmtsBPKMNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           docsIfCmtsCmStatusMacAddress,
+           ifPhysAddress,
+           docsIfCmtsCmStatusDocsisRegMode,
+           docsIfDocsisBaseCapability,
+           docsIfCmtsCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           "A notification to report the failure of a BPKM operation
+            that is detected by the CMTS.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - docsIfCmtsCmStatusMacAddress: the MAC address of the CM
+              with which this notification is associated.
+            - ifPhysAddress: the MAC address of the CMTS
+              (if there is a cable card/interface in the CMTS,
+              then it is actually the MAC address of the cable
+              interface that connected to the CM) cable interface
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 29]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+              connected to the CM.
+            - docsIfCmtsCmStatusDocsisRegMode: the QOS level (1.0, 1.1)
+              that the reporting CM is operating in.
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmtsCmStatusModulationType: the upstream
+              modulation methodology used by the CM.
+           "
+       ::= { docsDevCmtsNotifs 8 }
+
+   docsDevCmtsDynamicSANotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           docsIfCmtsCmStatusMacAddress,
+           ifPhysAddress,
+           docsIfCmtsCmStatusDocsisRegMode,
+           docsIfDocsisBaseCapability,
+           docsIfCmtsCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           "A notification to report the failure of a dynamic security
+            association operation that is detected by the CMTS.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - docsIfCmtsCmStatusMacAddress: the MAC address of the CM
+              with which this notification is associated.
+            - ifPhysAddress: the MAC address of the CMTS
+              (if there is a cable card/interface in the CMTS,
+              then it is actually the MAC address of the cable
+              interface that connected to the CM) cable interface
+              connected to the CM.
+            - docsIfCmtsCmStatusDocsisRegMode: the QOS level (1.0, 1.1)
+              that the reporting CM is operating in.
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 30]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+            - docsIfCmtsCmStatusModulationType: the upstream
+              modulation methodology used by the CM.
+           "
+       ::= { docsDevCmtsNotifs 9 }
+
+   docsDevCmtsDCCReqFailNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           docsIfCmtsCmStatusMacAddress,
+           ifPhysAddress,
+           docsIfCmtsCmStatusDocsisRegMode,
+           docsIfDocsisBaseCapability,
+           docsIfCmtsCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           "A notification to report the failure of a dynamic channel
+            change request during the dynamic channel
+            change process and is detected by the CMTS.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - docsIfCmtsCmStatusMacAddress: the MAC address of the CM
+              with which this notification is associated.
+            - ifPhysAddress: the MAC address of the CMTS
+              (if there is a cable card/interface in the CMTS,
+              then it is actually the MAC address of the cable
+              interface that connected to the CM) cable interface
+              connected to the CM.
+            - docsIfCmtsCmStatusDocsisRegMode: the QOS level (1.0, 1.1)
+              that the reporting CM is operating in.
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmtsCmStatusModulationType: the upstream
+              modulation methodology used by the CM.
+           "
+       ::= { docsDevCmtsNotifs 10 }
+
+   docsDevCmtsDCCRspFailNotif NOTIFICATION-TYPE
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 31]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           docsIfCmtsCmStatusMacAddress,
+           ifPhysAddress,
+           docsIfCmtsCmStatusDocsisRegMode,
+           docsIfDocsisBaseCapability,
+           docsIfCmtsCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           "A notification to report the failure of a dynamic channel
+            change response during the dynamic channel
+            change process and is detected by the CMTS.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+
+            - docsIfCmtsCmStatusMacAddress: the MAC address of the CM
+              with which this notification is associated.
+            - ifPhysAddress: the MAC address of the CMTS
+              (if there is a cable card/interface in the CMTS,
+              then it is actually the MAC address of the cable
+              interface that connected to the CM) cable interface
+              connected to the CM.
+            - docsIfCmtsCmStatusDocsisRegMode: the QOS level (1.0, 1.1)
+              that the reporting CM is operating in.
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmtsCmStatusModulationType: the upstream
+              modulation methodology used by the CM.
+           "
+       ::= { docsDevCmtsNotifs 11 }
+
+   docsDevCmtsDCCAckFailNotif NOTIFICATION-TYPE
+       OBJECTS {
+           docsDevEvLevel,
+           docsDevEvId,
+           docsDevEvText,
+           docsIfCmtsCmStatusMacAddress,
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 32]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+           ifPhysAddress,
+           docsIfCmtsCmStatusDocsisRegMode,
+           docsIfDocsisBaseCapability,
+           docsIfCmtsCmStatusModulationType
+       }
+       STATUS current
+       DESCRIPTION
+           "A notification to report the failure of a dynamic channel
+            change acknowledgement during the dynamic channel
+            change process and is detected by the CMTS.
+
+            This notification sends additional information about
+            the event by including the following objects in its
+            varbinding list.
+            - docsDevEvLevel: the priority level associated with the
+              event.
+            - docsDevEvId: the unique identifier of the event that
+              occurred.
+            - docsDevEvText: a textual description of the event.
+            - docsIfCmtsCmStatusMacAddress: the MAC address of the CM
+              with which this notification is associated.
+            - ifPhysAddress: the MAC address of the CMTS
+              (if there is a cable card/interface in the CMTS,
+              then it is actually the MAC address of the cable
+              interface that connected to the CM) cable interface
+              connected to the CM.
+            - docsIfCmtsCmStatusDocsisRegMode: the QOS level (1.0, 1.1)
+              that the reporting CM is operating in.
+            - docsIfDocsisBaseCapability: the highest
+              version of the DOCSIS specification (1.0, 1.1, 2.0)
+              that the device is capable of supporting.
+            - docsIfCmtsCmStatusModulationType: the upstream
+              modulation methodology used by the CM.
+           "
+       ::= { docsDevCmtsNotifs 12}
+
+   --
+   --Conformance definitions
+   --
+
+   docsDevNotifConformance OBJECT IDENTIFIER
+      ::= { docsDevNotifMIB 4 }
+   docsDevNotifGroups OBJECT IDENTIFIER
+      ::= { docsDevNotifConformance 1 }
+   docsDevNotifCompliances OBJECT IDENTIFIER
+      ::= { docsDevNotifConformance 2 }
+   docsDevCmNotifCompliance MODULE-COMPLIANCE
+       STATUS current
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 33]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+       DESCRIPTION
+       "The compliance statement for CM Notifications and Control."
+
+       MODULE --docsDevNotif
+         MANDATORY-GROUPS {
+                  docsDevCmNotifControlGroup,
+                  docsDevCmNotificationGroup
+              }
+       ::= { docsDevNotifCompliances 1 }
+
+   docsDevCmNotifControlGroup OBJECT-GROUP
+       OBJECTS {
+           docsDevCmNotifControl
+       }
+       STATUS current
+       DESCRIPTION
+           "This group represents objects that allow control
+            over CM Notifications."
+       ::= { docsDevNotifGroups 1 }
+
+   docsDevCmNotificationGroup NOTIFICATION-GROUP
+       NOTIFICATIONS {
+           docsDevCmInitTLVUnknownNotif,
+           docsDevCmDynServReqFailNotif,
+           docsDevCmDynServRspFailNotif,
+           docsDevCmDynServAckFailNotif,
+           docsDevCmBpiInitNotif,
+           docsDevCmBPKMNotif,
+           docsDevCmDynamicSANotif,
+           docsDevCmDHCPFailNotif,
+           docsDevCmSwUpgradeInitNotif,
+           docsDevCmSwUpgradeFailNotif,
+           docsDevCmSwUpgradeSuccessNotif,
+           docsDevCmSwUpgradeCVCFailNotif,
+           docsDevCmTODFailNotif,
+           docsDevCmDCCReqFailNotif,
+           docsDevCmDCCRspFailNotif,
+           docsDevCmDCCAckFailNotif
+       }
+       STATUS current
+       DESCRIPTION
+           "A collection of CM notifications providing device status
+      and control."
+       ::= { docsDevNotifGroups 2 }
+
+   docsDevCmtsNotifCompliance MODULE-COMPLIANCE
+       STATUS current
+       DESCRIPTION
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 34]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+           "The compliance statement for DOCSIS CMTS Notification
+            and Control."
+       MODULE --docsDevNotif
+          MANDATORY-GROUPS {
+             docsDevCmtsNotifControlGroup,
+             docsDevCmtsNotificationGroup
+          }
+       ::= { docsDevNotifCompliances 2 }
+
+   docsDevCmtsNotifControlGroup OBJECT-GROUP
+       OBJECTS {
+           docsDevCmtsNotifControl
+       }
+       STATUS current
+       DESCRIPTION
+           "This group represents objects that allow control
+            over CMTS Notifications."
+       ::= { docsDevNotifGroups 3 }
+
+   docsDevCmtsNotificationGroup NOTIFICATION-GROUP
+       NOTIFICATIONS {
+           docsDevCmtsInitRegReqFailNotif,
+           docsDevCmtsInitRegRspFailNotif,
+           docsDevCmtsInitRegAckFailNotif ,
+           docsDevCmtsDynServReqFailNotif,
+           docsDevCmtsDynServRspFailNotif,
+           docsDevCmtsDynServAckFailNotif,
+           docsDevCmtsBpiInitNotif,
+           docsDevCmtsBPKMNotif,
+           docsDevCmtsDynamicSANotif,
+           docsDevCmtsDCCReqFailNotif,
+           docsDevCmtsDCCRspFailNotif,
+           docsDevCmtsDCCAckFailNotif
+       }
+       STATUS current
+       DESCRIPTION
+           "A collection of CMTS notifications providing device
+            status and control."
+       ::= { docsDevNotifGroups 4 }
+
+   END
+
+5.  Contributors
+
+   Thanks go to the following people, who have made significant
+   contributions to this document: Junming Gao, Jean-Francois Mule, Dave
+   Raftus, Pak Siripunkaw, and Rich Woundy.
+
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 35]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+6.  Acknowledgements
+
+   This document was produced by the IPCDN Working Group.  Thanks to
+   Harrie Hazewinkel and Bert Wijnen for their thorough review and
+   insightful comments on this document.  Special thanks to Rich Woundy,
+   who made several valuable suggestions to improve the notifications.
+
+7.  Security Considerations
+
+   There are two management objects defined in this MIB module with a
+   MAX-ACCESS clause of read-write and/or read-create
+   (docsDevCmNotifControl and docsDevCmtsNotifControl).  Such objects
+   may be considered sensitive or vulnerable in some network
+   environments.  The support for SET operations in a non-secure
+   environment without proper protection can have a negative effect on
+   network operations.
+
+   Setting docsDevCmNotifControl or docsDevCmtsNotifControl may cause
+   flooding of notifications, which can disrupt network service.
+   Besides causing "flooding", changing the objects can also mean that
+   notifications will not be emitted when one intends that to happen.
+
+   This MIB defines a number of notification objects that send detailed
+   information about the event that caused the generation of the
+   notification.  Information in the notification message includes:
+   event priority, the event Id, the event message body, the CM DOCSIS
+   capability, the CM DOCSIS QOS level, the CM DOCSIS upstream
+   modulation type, the cable interface MAC address of the cable modem,
+   and the cable card MAC address of the CMTS to which the modem is
+   connected.  The monitoring of these notification messages could be
+   used to gather information about the state of the network and devices
+   (CM and CMTS) attached to the network.
+
+   SNMP versions prior to SNMPv3 did not include adequate security.
+   Even if the network itself is secure (for example by using IPSec),
+   even then there is no control as to who on the secure network is
+   allowed to access and GET/SET (read/change/create/delete) the objects
+   in this MIB module.
+
+   It is RECOMMENDED that implementers consider the security features as
+   provided by the SNMPv3 framework (see [16], section 8), including
+   full support for the SNMPv3 cryptographic mechanisms (for
+   authentication and privacy).
+
+   Further, deployment of SNMP versions prior to SNMPv3 is NOT
+   RECOMMENDED.  Instead, it is RECOMMENDED to deploy SNMPv3 and to
+   enable cryptographic security.  It is then a customer/operator
+   responsibility to ensure that the SNMP entity giving access to an
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 36]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+   instance of this MIB module is properly configured to give access to
+   the objects only to those principals (users) that have legitimate
+   rights to indeed GET or SET (change/create/delete) them.
+
+8.  IANA Considerations
+
+   The MIB module defined in this document uses the following IANA-
+   assigned OBJECT IDENTIFIER values recorded in the SMI Numbers
+   registry:
+
+   Descriptor        OBJECT IDENTIFIER value
+   ----------        -----------------------
+   docsDevNotifMIB   { mib-2 132 }
+
+9.  References
+
+9.1.  Normative References
+
+   [1]   Bradner, S., "Key words for use in RFCs to Indicate Requirement
+         Levels", BCP 14, RFC 2119, March 1997.
+
+   [2]   McCloghrie, K., Perkins, D., and J. Schoenwaelder, "Structure
+         of Management Information Version 2 (SMIv2)", STD 58, RFC 2578,
+         April 1999.
+
+   [3]   McCloghrie, K., Perkins, D., and J. Schoenwaelder, "Textual
+         Conventions for SMIv2", STD 58, RFC 2579, April 1999.
+
+   [4]   McCloghrie, K., Perkins, D., and J. Schoenwaelder, "Conformance
+         Statements for SMIv2", STD 58, RFC 2580, April 1999.
+
+   [5]   St. Johns, M., "DOCSIS Cable Device MIB Cable Device Management
+         Information Base for DOCSIS compliant Cable Modems and Cable
+         Modem Termination Systems", RFC 2669, August 1999.
+
+   [6]   Raftus, D. and E. Cardona, "Radio Frequency (RF) Interface
+         Management Information Base for Data over Cable Service
+         Interface Specifications (DOCSIS) 2.0 Compliant RF Interfaces",
+         RFC 4546, June 2006.
+
+   [7]   McCloghrie, K. and F. Kastenholz, "The Interfaces Group MIB",
+         RFC 2863, June 2000.
+
+   [8]   SCTE Data Standards Subcommittee, "Data-Over-Cable Service
+         Interface Specifications: DOCSIS 1.0 Baseline Privacy Interface
+         Specification SCTE 22-2", 2002,
+         <http://www.scte.org/standards/>.
+
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 37]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+   [9]   CableLabs, "Baseline Privacy Plus Interface Specification SP-
+         BPI+040407", April 2004,
+         <http://www.cablemodem.com/specifications/>.
+
+   [10]  SCTE Data Standards Subcommittee, "Data-Over-Cable Service
+         Interface Specifications: DOCSIS 1.0 Operations Support System
+         Interface Specification Radio Frequency Interface SCTE 22-3",
+         2002, <http://www.scte.org/standards/>.
+
+   [11]  CableLabs, "Data-Over-Cable Service Interface Specifications:
+         Operations Support System Interface Specification CM-SP-
+         OSSIv1.1-C01-050907", September 2005,
+         <http://www.cablemodem.com/specifications/>.
+
+   [12]  CableLabs, "Data-Over-Cable Service Interface Specifications:
+         Operations Support System Interface Specification CM-SP-
+         OSSIv2.0-I09-050812", August 2005,
+         <http://www.cablemodem.com/specifications/>.
+
+   [13]  SCTE Data Standards Subcommittee, "Data-Over-Cable Service
+         Interface Specifications: DOCSIS 1.0 Radio Frequency Interface
+         Specification SCTE 22-1", 2002,
+         <http://www.scte.org/standards/>.
+
+   [14]  CableLabs, "Data-Over-Cable Service Interface Specifications:
+         Radio Frequency Interface Specification CM-SP-RFIv1.1-C01-
+         050907", September 2005,
+         <http://www.cablemodem.com/specifications/>.
+
+   [15]  CableLabs, "Data-Over-Cable Service Interface Specifications:
+         Radio Frequency Interface Specification CM-SP-RFIv2.0-I10-
+         051209", December 2005,
+         <http://www.cablemodem.com/specifications/>.
+
+9.2.  Informative References
+
+   [16]  Case, J., Mundy, R., Partain, D., and B. Stewart, "Introduction
+         and Applicability Statements for Internet-Standard Management
+         Framework", RFC 3410, December 2002.
+
+
+
+
+
+
+
+
+
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 38]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+Authors' Addresses
+
+   Azlina Ahmad
+   Cisco Systems, Inc.
+   170 West Tasman Drive
+   San Jose, CA 95134
+   US
+
+   Phone: 408 853 7927
+   EMail: azlina@cisco.com
+
+
+   Greg Nakanishi
+   Motorola
+   6450 Sequence Dr.
+   San Diego, CA  92126
+   US
+
+   Phone: 858 404-2366
+   EMail: gnakanishi@motorola.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 39]
+
+RFC 4547                 Event Notification MIB                June 2006
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2006).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is provided by the IETF
+   Administrative Support Activity (IASA).
+
+
+
+
+
+
+
+Ahmad & Makanishi           Standards Track                    [Page 40]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4547.txt](<www.ietf.org/rfc/rfc4547.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
