### PR TITLE
Archive rfc456.txt

### DIFF
--- a/www.ietf.org/rfc/rfc456.txt
+++ b/www.ietf.org/rfc/rfc456.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                  M.D. Kudlick
+RFC # 456                                              SRI-ARC
+NIC # 14376                                            February 13, 1973
+Updates: RFC 453
+
+
+    Meeting Announcement to Discuss a Network Mail System (Revised)
+
+
+This RFC announces a slight change in the meeting time for the Network
+Mail meeting discussed in RFC #453.
+
+The new meeting time is:
+
+                       FRIDAY, FEBRUARY 23, 1973
+
+                                8:30 AM
+
+                        SRI-ARC Conference Room
+
+If a second day is needed, we will meet on Saturday, February 24th.
+
+
+M.D. Kudlick
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.             9/99 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kudlick                                                         [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc456.txt](<www.ietf.org/rfc/rfc456.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
