### PR TITLE
Archive rfc457.txt

### DIFF
--- a/www.ietf.org/rfc/rfc457.txt
+++ b/www.ietf.org/rfc/rfc457.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                  Dave Walden
+RFC #457                                               BBN-NET
+NIC #14377                                             February 15, 1973
+
+
+
+                                 TIPUG
+
+
+To any TIP users who have not been receiving updates to their TIP User's
+Guide or who have not been receiving copies of TIP User's Group Notes:
+please send me your name (along with the TIP and Host you normally use)
+and I'll make sure you get on a distribution list for these materials.
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.             9/99 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Walden                                                          [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc457.txt](<www.ietf.org/rfc/rfc457.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
