### PR TITLE
Archive rfc458.txt

### DIFF
--- a/www.ietf.org/rfc/rfc458.txt
+++ b/www.ietf.org/rfc/rfc458.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                        B. Bressler
+Request for Comments: 458                                        BBN-NET
+NIC: 14378                                                     B. Thomas
+                                                               BBN-TENEX
+                                                        20 February 1973
+
+
+                         Mail Retrieval via FTP
+
+   We propose two new FTP commands called ReaDMailFile and ReaDMail.
+   These commands are intended to be symmetric with respect to the
+   current MLFL and MAIL commands.  They would allow a user to read his
+   mail at one or more sites without incurring the overhead of logging
+   in and without having to use several different retrieval methods.
+   The user might go further and create a program to go around to all
+   the server sites and retrieve his mail for him.  The current FTP
+   mechanisms provide for password protection, should security be
+   required.
+
+   This proposal brings into focus, once again, the problems of
+   different users with the same ID, and to a lesser extent, one user
+   with multiple IDs.  This RFC does not attempt to address these issues
+   at this time, as much effort is currently being devoted to them.
+   However, we believe that a satisfactory system for network mail
+   should include a mechanism to enable each user to have mail for him
+   sent to a single repository (ideally, the site of his choice).  We
+   further believe that the two commands proposed here would be useful
+   in such an environment as well as within the current network
+   environment.
+
+   The format of the commands is
+
+   COMMAND    REPLY
+              success        fail
+
+   RDMF       200,250,330    433,450,451,454,455,457,500,507
+              secondary replies:
+              252            452
+
+   RDML       152,330        433,450,451,455,500,507
+
+   The success reply 200 would take the text "NO MAIL NOW".  For the
+   RDMF command the mail itself is transferred over the data connection,
+   and the FTP replies come over the TELNET connection.
+
+
+
+
+
+
+
+Bressler, et. al.                                               [Page 1]
+
+RFC 458                  Mail Retrieval via FTP         20 February 1973
+
+
+   For the RDML command both the mail and the FTP replies come over the
+   TELNET connection.  The reply 152 is a new code meaning "mail text
+   follows" the text that follows may be "NO MAIL NOW".
+
+
+          [This RFC was put into machine readable form for entry]
+     [into the online RFC archives by Helene Morin, Via Genie 12/1999]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Bressler, et. al.                                               [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc458.txt](<www.ietf.org/rfc/rfc458.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
