### PR TITLE
Archive rfc460.txt

### DIFF
--- a/www.ietf.org/rfc/rfc460.txt
+++ b/www.ietf.org/rfc/rfc460.txt
@@ -1,0 +1,395 @@
+
+
+
+
+
+
+Network Working Group                                 Chuck S. Kline CSK
+Request for Comments: 460                                           UCLA
+NIC 14415                                                 13 February 73
+
+
+                               NCP Survey
+
+   1 This RFC is the first in a series which will request information on
+   implementation of host to host protocol.  We would appreciate a reply
+   to this RFC from all sites within two weeks.  One convenient way to
+   reply is to make a copy of this RFC at the NIC and insert the replies
+   at the appropriate spots.  The results of this survey will be
+   published.  Please send replies to nic ident CSK or to
+
+   Charles Kline
+   Boelter Hall 3804
+   UCLA
+   405 Hilgard Ave.
+   Los Angeles, Cal. 90034
+
+   2 This particular RFC will deal with implementations of Network
+   Control Programs (NCPs).  Future RFCs will deal with .
+   implementations of Telnet, RJE, etc.
+
+   3 In order to ask questions about NCPs and get meaningful replies, I
+   will here describe what I consider to be my concept of an NCP.
+
+      3a An NCP is that part of the system which performs the tasks
+      necessary for host to host protocol as specified by document NIC
+      7104 (protocols notebook).
+
+      3b NCPs contain the following parts (though not necessarily as
+      separate pieces):
+
+         3b1 Code which handles connection establishment including
+         maintenance of the rendezvous table (table of open and pending
+         connections).
+
+         3b2 Code which handles transmission over open connections
+         including buffer management and the sending of allocate and
+         giveback commands.
+
+         3b3 Code which handles the actual movement of messages in and
+         out of the Imp (sometimes called the Imp handler and sometimes
+         in a separate cpu).
+
+         3b4 Other code including measurements, initialization, etc.
+
+
+
+
+Kline                                                           [Page 1]
+
+RFC 460                        NCP Survey                  February 1973
+
+
+   4. Please answer the following questions.  It is probably appropriate
+   to give this survey to the coder of the NCP or other knowledgeable
+   person.  Write na (not applicable) where it is appropriate.  Circle
+   the number of the appropriate choice when a choice is required.
+   Thank you.
+
+   5 General Information
+
+      5a Host Name: ----
+
+      5b Site Number: ----
+
+      5c Your name ----
+
+      5d Main cpu is a ---- (360/75, PDP-10, B6700, etc.)
+
+      5e Operating system in main cpu is ---- (tenex, os/360, etc.)
+
+      5f Is documentation available on your NCP?
+
+         5f1 user level (how to use NCP)
+
+         5f2 system level (implementation)
+
+         5f3 Is the documentation available at the NIC?
+
+   6 Imp interface
+
+      6a built:
+
+         6a1 in house
+
+         6a2 contracted to ----
+
+      6b full or half duplex?
+
+      6c maximum bandwidth is ---- baud in each direction
+
+   7 Coding of NCP
+
+      7a ncp was written:
+
+         7a1 in house
+
+            7a1a written in ---- man-months
+
+            7a1b Name of person who wrote NCP ----
+
+
+
+
+Kline                                                           [Page 2]
+
+RFC 460                        NCP Survey                  February 1973
+
+
+            7a1c debugged in ---- man-weeks
+
+            7a1d machine hours used in development and debugging of NCP
+            ----
+
+         7a2 contracted to ----
+
+            7a2a contractor took ---- man-months
+
+         7a3 supplied another site without modification by this site
+         (specify site where NCP obtained from ------).
+
+         7a4 supplied from another site but modified by this site for
+         different system or for other reasons (specify site where NCP
+         obtained from ------)
+
+            7a4a modifications took ---- man-weeks
+
+      7b NCP is maintained:
+
+         7b1 in house (person's name ----)
+
+         7b2 by another site (specify site ----)
+
+      7c Size of NCP code:
+
+         7c1 Total size of all NCP code (not tables or buffers) as
+         described above
+
+            7c1a ---- words of ---- bits per word
+
+         7c2 size of code which initializes NCP (on system up or after
+         NCP or NET crash)
+
+            7c2a ---- words of ---- bits per word
+
+         7c3 size of code which handles opening and closing of
+         connections
+
+            7c3a ---- words of ---- bits per word
+
+         7c4 size of code which moves data from user process to Imp
+         handler or from Imp handler to user process
+
+            7c4a ---- words of ---- bits per word
+
+
+
+
+
+
+Kline                                                           [Page 3]
+
+RFC 460                        NCP Survey                  February 1973
+
+
+         7c5 size of Imp handler code
+
+            7c5a ---- words of ---- bits per word
+
+         7c6 size of other code (explain what it is)
+
+            7c6a ---- words of ---- bits per word
+
+      7d Size of NCP tables:
+
+         7d1 size of tables indexed by open connection (i.e. tables for
+         control of open connections)
+
+            7d1a ---- entries or ---- words per entry of ---- bits per
+            word
+
+         7d2 size of tables indexed by link (i.e. tables for link
+         management and for quick association of an input message with a
+         process)
+
+            7d2a ---- entries of ---- words per entry of ---- bits per
+            word
+
+         7d3 size of other tables (explain)
+
+            7d3a ---- entries of ---- words per entry of ---- bits per
+            word
+
+   8 Host-Imp communications
+
+      8a Imp handling is performed in
+
+         8a1 main cpu
+
+         8a2 additional processor (specify machine ----)
+
+      8b Imp handling is performed at:
+
+         8b1 interrupt level by resident code
+
+         8b2 scheduled process with resident code
+
+         8b3 scheduled process with swappable code
+
+      8c Number and size of buffers for the Imp handler (on input,
+      number of buffers for messages before cpu will stop taking bits
+      from imp.  On output, number of buffers which may be queued before
+      user processes will be blocked waiting for a free buffer)
+
+
+
+Kline                                                           [Page 4]
+
+RFC 460                        NCP Survey                  February 1973
+
+
+         8c1 ---- output buffers for sending to net of ---- words of
+         ---- bits per word
+
+         8c2 ---- input buffers for receiving from net of ---- words of
+         ---- bits per word
+
+   9 NCP-Imp handler communications
+
+      9a NCP communicates with Imp handler by
+
+         9a1 putting message on queue for handler and waking
+         (unblocking) handler (i.e. shared memory approach)
+
+         9a2 some other mechanism (explain)
+
+   10 NCP-User communication
+
+      10a Mechanism:
+
+         10a1 special mechanism for network (i.e. different than files)
+         using:
+
+            10a1a shared resident memory
+
+            10a1b shared non-resident (swappable memory or file)
+
+            10a1c other (explain)
+
+         10a2 similar to file io but network assigned rather than file
+         (i.e. transparent to user process coding)
+
+      10b Bytes sizes allowed (circle all)
+
+         10b1 1 bit
+
+         10b2 7 bit
+
+         10b3 8 bit
+
+         10b4 9 bit
+
+         10b5 16 bit
+
+         10b6 18 bit
+
+         10b7 24 bit
+
+         10b8 32 bit
+
+
+
+Kline                                                           [Page 5]
+
+RFC 460                        NCP Survey                  February 1973
+
+
+         10b9 36 bit
+
+         10b10 other (explain)
+
+   11 Buffer space allocations
+
+      11a initial allocation when connection (receive) is opened
+
+         11a1 ---- messages and ---- bits
+
+      11b factors which will change this allocation
+
+         11b1 up
+
+         11b2 down
+
+      11c conditions which would cause a giveback command to be sent
+
+   12 Protocol facilities
+
+      12a Errors
+
+         12a1 Do you send error commands when you detect protocol
+         errors?
+
+         12a2 Do you log it (or take some other action) when you recieve
+         error commands?
+
+      12b Queuing
+
+         12b1 do you allow queuing of connections (i.e. when an rts or
+         str is received for which no request is pending, do you refuse
+         it (send back a cls) or queue it? also do you queue when two or
+         more requests match the same socket?)
+
+            12b1a yes always
+
+            12b1b no always
+
+            12b1c yes for listens
+
+            12b1d other (explain)
+
+         12c Are there hooks (code) in the NCP for:
+
+            12c1 NCP measurement
+
+            12c2 Network measurement
+
+
+
+Kline                                                           [Page 6]
+
+RFC 460                        NCP Survey                  February 1973
+
+
+            12c3 MSP and other protocol experiments
+
+            12c4 Do any of these hooks allow a user process to send a
+            message with a given leader or look at all messages which
+            arrive with a given leader?
+
+   13 Time outs
+
+      13a How long will the NCP hold a request for connection (INIT or
+      LISTEN) from a user process before timing out if not matched by an
+      RTS or STR from the net ----
+
+      13b How long will the NCP hold an STR or RTS recieved from the net
+      before timing out and sending a CLS ----
+
+      13c How long will the NCP wait after sending a reset or echo
+      command before declaring the host dead (assuming you got a RFNM at
+      least) ----
+
+      13d Any other timeouts? (explain)
+
+   14 Have you made any measurements on the effect of network use on
+   your system?
+
+      14a effect of local users using telnet to go out to net
+
+      14b effect of foreign users using your system via net
+
+      14c bandwidth you have been able to achieve
+
+   15 Are any changes planned or in progress in the design or coding of
+   your NCP? (explain)
+
+   16 Other Comments
+
+      16a Please feel free to add other comments on your NCP which you
+      feel would be of interest to the network community.
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+         [ into the online RFC archives by Grant Bowman 11/97 ]
+
+
+
+
+
+
+
+
+
+Kline                                                           [Page 7]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc460.txt](<www.ietf.org/rfc/rfc460.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
