### PR TITLE
Archive rfc462.txt

### DIFF
--- a/www.ietf.org/rfc/rfc462.txt
+++ b/www.ietf.org/rfc/rfc462.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                 Jean Iseli (MITRE)
+RFC # 462                                        Dave Crocker (UCLA-NMC)
+NIC # 14434                                            February 22, 1973
+
+
+                        Responding to User Needs
+
+
+INTRODUCTION
+
+The ARPANET is currently undergoing a transition to an environment in
+which network resources will be made available to a larger user base.
+This emergent user base already contains a significant number of
+terminal users not associated with a server site.  Information relative
+to network host services and access characteristics is needed to
+encourage and assist new users.
+
+To date, the Resources Notebook has been the primary outlet for efforts
+to provide users with Network-wide information. A separate RFC, from the
+NIC, discusses the past and current history more completely. In this
+RFC, we would like to second the NIC's suggestion for the formation of a
+Working Group concerned with User Information and Services, and we would
+like to offer a specific suggestion for consideration at the NIC's
+proposed meeting.
+
+
+PROPOSAL
+
+Many of the problems associated with the lack of adequate Network
+information are caused by the many compilation steps. Too many resources
+(most of them human) are required. In addition to delay, errors are
+introduced. Part of the solution is to place the acquisition of basic
+information closer to the source and make the source responsible for the
+acquisition and maintenance.
+
+    The "source" is distributed around the Network and, therefore, the
+    proposal is to develop and implement a distributed and extensible
+    network data-base which contains the desired information.  This
+    would require each server site to create and maintain an information
+    file locally and/or at the NIC. As a further (more down stream)
+    step, a mechanism to access these files could be specified and
+    implemented.
+
+        People at different sites would thereby be able to use the tools
+        most comfortable and accessible to them.
+
+
+
+
+
+
+Iseli & D. Crocker                                              [Page 1]
+
+RFC 462                 Responding to User Needs           February 1973
+
+
+        An interesting technical issue involves making the disparate
+        files accessible by an automaton.  The NIC is currently
+        attempting to smooth out the interface between NLS and non-NLS
+        files, and this seems like a reasonable object for such efforts.
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.             9/99 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Iseli & D. Crocker                                              [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc462.txt](<www.ietf.org/rfc/rfc462.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
