### PR TITLE
Archive rfc4628.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4628.txt
+++ b/www.ietf.org/rfc/rfc4628.txt
@@ -1,0 +1,283 @@
+
+
+
+
+
+
+Network Working Group                                            R. Even
+Request for Comments: 4628                                       Polycom
+Category: Informational                                     January 2007
+
+
+    RTP Payload Format for H.263 Moving RFC 2190 to Historic Status
+
+Status of This Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard of any kind.  Distribution of this
+   memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The IETF Trust (2007).
+
+Abstract
+
+   The first RFC that describes an RTP payload format for ITU
+   Telecommunication Standardization Sector (ITU-T) recommendation H.263
+   is RFC 2190.  This specification discusses why to move RFC 2190 to
+   historic status.
+
+Table of Contents
+
+   1. Introduction ....................................................2
+   2. Terminology .....................................................2
+   3. Recommendation ..................................................2
+   4. Security Considerations .........................................3
+   5. Normative References ............................................3
+   6. Informative References ..........................................3
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Even                         Informational                      [Page 1]
+
+RFC 4628                  RFC 2190 to Historic              January 2007
+
+
+1.  Introduction
+
+   The ITU-T recommendation H.263 [H263] specifies the encoding used by
+   ITU-T-compliant video-conference codecs.  The first version (version
+   1) was approved in 1996 by the ITU, and a payload format for
+   encapsulating this H.263 bitstream in the Real-time Transport
+   Protocol (RTP) is in RFC 2190 [RFC2190].  In 1998 the ITU approved a
+   new version of H.263 [H263P] that is also known as H.263 plus.  This
+   version added optional features, and a new payload format is now in
+   RFC 2429 [RFC2429].  RFC 2429 is capable of carrying encoded video
+   bit streams that are using only the basic H.263 version 1 options.
+
+   RFC 2429 [RFC2429] states that it does not replace RFC 2190, which
+   continues to be used by existing implementations and may be required
+   for backward compatibility in new implementations.  Implementations
+   using the new features of the 1998 version of H.263 and later
+   versions shall use the format described in RFC 2429.
+
+   RFC 2429 is now being revised and will include language that will
+   make it clear that all new implementations MUST use RFC 4629
+   [RFC4629] for encoding of any version of H.263.
+
+2.  Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119] and
+   indicate requirement levels for compliant RTP implementations.
+
+3.  Recommendation
+
+   RFC 2429 and RFC 4629 [RFC4629] can be used to carry new H.263
+   payloads even if they are using only the features defined in the 1996
+   version.  All the H.263 features that are part of the 1996 version
+   are also part of the 1998 version and later versions.
+
+   It is recommended that RFC 2190 be moved to historic status and that,
+   as stated in RFC 4629 [RFC4629], new implementations use the RFC 4629
+   and the H263-1998 and H263-2000 Media Types.
+
+   This recommendation will come into effect at the publication or as
+   soon as possible after the publication of RFC 4629 [RFC4629].
+
+
+
+
+
+
+
+
+
+Even                         Informational                      [Page 2]
+
+RFC 4628                  RFC 2190 to Historic              January 2007
+
+
+4.  Security Considerations
+
+   Security considerations for the H263 video RTP payload can be found
+   in the RFC 4629 [RFC4629].  Using the payload specification in RFC
+   4629 instead of that in RFC 2190 does not affect the security
+   consideration since both of them refer to RFC 3550 [RFC3550] and RFC
+   3551 [RFC3551] for security considerations.
+
+5.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+6.  Informative References
+
+   [H263]     International Telecommunication Union, "Video coding for
+              low bit rate communication", ITU Recommendation H.263,
+              March 1996.
+
+   [H263P]    International Telecommunication Union, "Video coding for
+              low bit rate communication", ITU Recommendation H.263,
+              January 2005.
+
+   [RFC2190]  Zhu, C., "RTP Payload Format for H.263 Video Streams", RFC
+              2190, September 1997.
+
+   [RFC2429]  Bormann, C., Cline, L., Deisher, G., Gardos, T., Maciocco,
+              C., Newell, D., Ott, J., Sullivan, G., Wenger, S., and C.
+              Zhu, "RTP Payload Format for the 1998 Version of ITU-T
+              Rec. H.263 Video (H.263+)", RFC 2429, October 1998.
+
+   [RFC3550]  Schulzrinne, H., Casner, S., Frederick, R., and V.
+              Jacobson, "RTP: A Transport Protocol for Real-Time
+              Applications", STD 64, RFC 3550, July 2003.
+
+   [RFC3551]  Schulzrinne, H. and S. Casner, "RTP Profile for Audio and
+              Video Conferences with Minimal Control", STD 65, RFC 3551,
+              July 2003.
+
+   [RFC4629]  Ott, J., Borman, C., Sullivan, G., Wenger, S., and R.
+              Even, Ed., "RTP Payload Format for ITU-T Rec. H.263
+              Video", RFC 4629, January 2007.
+
+
+
+
+
+
+
+
+
+Even                         Informational                      [Page 3]
+
+RFC 4628                  RFC 2190 to Historic              January 2007
+
+
+Author's Address
+
+   Roni Even
+   Polycom
+   94 Derech Em Hamoshavot
+   Petach Tikva  49130
+   Israel
+
+   EMail: roni.even@polycom.co.il
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Even                         Informational                      [Page 4]
+
+RFC 4628                  RFC 2190 to Historic              January 2007
+
+
+Full Copyright Statement
+
+   Copyright (C) The IETF Trust (2007).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY, THE IETF TRUST AND
+   THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF
+   THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+Even                         Informational                      [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4628.txt](<www.ietf.org/rfc/rfc4628.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
