### PR TITLE
Archive rfc464.txt

### DIFF
--- a/www.ietf.org/rfc/rfc464.txt
+++ b/www.ietf.org/rfc/rfc464.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                 Michael D. Kudlick
+RFC # 464                                             SRI-ARC
+NIC # 14738                                           February 27, 1973
+
+
+                      Resource Notebook Framework
+
+
+Introduction
+
+The purpose of this RFC is to present a framework for coordinating all
+the surveys and data gathering efforts concerned with "resource
+notebook" type of information.
+
+We have obtained agreement from ARPA with the framework, which is
+described below.
+
+    The scheme is designed with two purposes:
+
+        a) to avoid a proliferation of data gathering efforts, which
+        would overwhelm the sites and persons supplying the much-needed
+        information;
+
+        b) to give the responsibility to the NIC for coordinating the
+        tasks associated with the resource notebook.
+
+Two companion documents, NIC 14514 and NIC 14515 provide supplementary
+information to this RFC.
+
+    NIC 14514 describes the history of the Resource Notebook from 1971
+    to the present.
+
+    NIC 14515 contains the questionnaire that the NIC is currently
+    sending to server sites for data on Network Resources.
+
+A recent RFC by John Iseli and Dave Crocker (NWG/RFC #462, NIC 14434)
+also addresses the same problem area.
+
+    The proposed framework for data collection suggested by John and
+    Dave is different from the framework outlined in this RFC.
+
+Framework
+
+The Network Information Center will coordinate the task of collecting,
+verifying, and disseminating information of a "resource notebook"
+nature.
+
+    a) Collecting and verifying the data.
+
+
+
+Kudlick                                                         [Page 1]
+
+RFC 464               Resource Notebook Framework          February 1973
+
+
+        Because of the magnitude of this task, regional data collectors
+        would provide assistance both to the NIC and to the sites
+        supplying the information.
+
+            We think that initially there should be five regions:
+            Boston, Washington DC, San Francisco, Los Angeles, and Mid-
+            Continent.
+
+        The regional agent would collect the information from the sites
+        in their region and forward it to NIC for inclusion in the
+        Resource Notebook data base.
+
+        The NIC would work closely with the regional agents to ensure
+        that the data is accurate and up-to-date.
+
+    b) Disseminating data.
+
+        There is presently a need to prepare different subsets or
+        "views" of the resource notebook information.
+
+        Regardless of which groups on the Network are given
+        responsibility for preparing different views of the complete
+        resource notebook data base, these views should be available for
+        use on-line as the NIC as well as off-line.
+
+A working group of persons interested in the needs and problems of a
+resource notebook would meet periodically to review the situation, and
+to make concrete proposals for improvements.
+
+Discussion
+
+We welcome discussion on this RFC.
+
+I you think it is desirable, a meeting could be held at SRI-ARC to
+discuss the whole problem area.
+
+    If a meeting is desirable, we suggest it be held soon, say on Monday
+    March 19, 1973, at 8:30 AM in the SRI-ARC Conference Room.
+
+Please let us have your comments by March 9.
+
+    You may contact us at (415) 326-6200, ext 3617, care of Mlke
+    Kudlick.
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.             9/99 ]
+
+
+
+
+Kudlick                                                         [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc464.txt](<www.ietf.org/rfc/rfc464.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
