### PR TITLE
Archive rfc466.txt

### DIFF
--- a/www.ietf.org/rfc/rfc466.txt
+++ b/www.ietf.org/rfc/rfc466.txt
@@ -1,0 +1,507 @@
+
+
+
+
+
+
+Network Working Group                                          J. Winett
+Request for Comments: 466                                          LL-67
+NIC: 14740                                              27 February 1973
+Category: TELNET
+
+
+                  TELNET LOGGER/SERVER For Host LL-67
+
+   The attached writeup documents the TELNET LOGGER/SERVER for the
+   CP/CMS system on the Lincoln Laboratory 360>67 (host 10).  The
+   facility serves both half duplex and full duplex TELNET users with
+   data in either ASCII or EBCDIC codes.
+
+   Use of the hide-your-input and noecho TELNET controls are used for
+   the EBCDIC print suppress (bypass) and print restore features during
+   the login procedure.  To support half duplex terminals, the TELNET
+   control break (reverse break) is sent as an input prompt when input
+   is desired.  This code can also be used to indicate that a previous
+   line sent without an end of line sequence (CR-LF) should be printed.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+   This material has not been reviewed for public release and is
+   intended only for use with the ARPA network.  It should not be quoted
+   or cited in any publication not related to the ARPA network.
+
+
+
+
+
+Winett                                                          [Page 1]
+
+RFC 466           TELNET LOGGER/SERVER For Host LL-67      February 1973
+
+
+                    Operation of the Lincoln Laboratory
+                        CP/CMS TELNET LOGGER/SERVER
+
+ICP Connection
+
+   The TELNET LOGGER/SERVER follows the ICP protocol for making a pair
+   of connections.  The LOGGER is initially enabled for a connection on
+   socket X'00000001'.  When an RFC is received for this socket a pair
+   of sockets will be chosen for the TELNET connections.  If the maximum
+   number of TELNET users which can be served are active, the initial
+   connection is refused.  Currently, three TELNET users can be served.
+
+TELNET LOGGER
+
+   After the ICP connections have been setup, the LOGGER expects a
+   TELNET data type code, a string of network ASCII characters, or a
+   null line (just CR-LF) to indicate whether its operation should be in
+   ASCII or in EBCDIC character codes.  ASCII is assumed unless the
+   first byte received is the TELNET EBCDIC data type code (X'A2).  When
+   something has been received, the message:
+
+                     Lincoln Laboratory CP/CMS Online
+
+   will be transmitted by the LOGGER.  For example, if ASCII operation
+   is desired a null line (just CR-LF) transmitted on the send socket
+   will cause the welcoming message to be sent in ASCII.  The CP login
+   procedure can then begin.  If communications is desired to be carried
+   on with EBCDIC character codes, the first byte transmitted should be
+   the TELNET data type code for EBCDIC (X'A2').  Thereafter all
+   communications will be in the code originally used.
+
+   The CP login procedure expects the user to enter:
+
+                               LOGIN userid
+
+   where the userid specifies the desired virtual machine.  CP then
+   replies with:
+
+                              ENTER PASSWORD:
+
+   followed by the EBCDIC code for bypass (x'24') which is mapped into
+   the TELNET code hide-your-input.
+
+   The user should then enter a password.  Passwords entered from the
+   network may be different from those entered from a local terminal.
+   The LOGGER maps network passwords into a corresponding CP password.
+   Thus, access to an account can only be made from the network if a
+   network password, together with a CP password and userid, is entered
+
+
+
+Winett                                                          [Page 2]
+
+RFC 466           TELNET LOGGER/SERVER For Host LL-67      February 1973
+
+
+   into a file which is read by the LOGGER.  If a userid entered from
+   the network is not in the LOGGER FILE (or if the network password
+   does not match the one included in the file for the specified userid)
+   the LOGGER passes an invalid userid (or password) to CP.  The CP
+   response for an invalid userid or password is then sent to the
+   network user.
+
+   After a password is received by CP, CP transmits the EBCDIC code for
+   restore (X'14') which is mapped into the TELNET control noecho.
+
+TELNET SERVER
+
+   Since the CP/CMS system operates with EBCDIC codes, ASCII codes must
+   be translated into EBCDIC before being sent to a virtual machine.
+   Figure 1 gives the ASCII codes and their EBCDIC mapping.  When the
+   ASCII sequence CR-LF is received, it is mapped into the EBCDIC code
+   NL.  Whenever the TELNET control NOP is included in an input string,
+   it is mapped into an EBCDIC idle (X'17') and then removed from the
+   string.  Thus, if TELNET NOP codes are included between a CR and LF,
+   they are removed before the CR-LF is mapped into the EBCDIC NL.
+
+   The TELNET control hide-your-input is mapped into the EBCDIC code for
+   bypass (X'24') and the TELNET control echo is mapped into the EBCDIC
+   control for restore (X'14').  If the TELNET control echo is received,
+   the SERVER should send the control noecho but this feature has not
+   yet been implemented.  Instead, the TELNET control echo is mapped
+   into the EBCDIC code X'23'.  If the TELNET break is received, it is
+   interpreted as an attention signal and the appropriate action is
+   taken by CP or CMS.
+
+   CP/CMS is a line at a time system and expects all input to consist of
+   lines ending with a NL code.  Characters received are buffered until
+   the newline code is received.
+
+   Since CP/CMS is also a half duplex system, characters are only
+   examined when the system is expecting input.  If the system is not
+   expecting input, a network interrupt is required to cause the SERVER
+   to process received characters.  On receipt of a network interrupt,
+   characters received before the TELNET data mark is received are
+   examined and discarded, except that if a TELNET break code is found,
+   the appropriate CP/CMS interrupt action is stimulated.
+
+   On output, EBCDIC codes are mapped into network ASCII if a mapping
+   exists; otherwise, the codes are mapped into the TELNET control NOP.
+   A NL code is mapped into CR-LF.  The EBCDIC code for bypass maps into
+   the TELNET control hide-your-input and the EBCDIC code for restore
+   maps into the TELNET control noecho.  Also, the code X'23' maps into
+   the TELNET control echo and the code X'38' maps into the TELNET
+
+
+
+Winett                                                          [Page 3]
+
+RFC 466           TELNET LOGGER/SERVER For Host LL-67      February 1973
+
+
+   control break.
+
+   Since CP/CMS is a line at a time, half duplex system the TELNET
+   control break is transmitted as an end of message signal and also as
+   an input prompt code.  If characters were output without a NL, the
+   break, as an end of message code, indicates to the user TELNET
+   operating on a line at a time mode that the characters previously
+   transmitted should be printed without waiting for the end of line
+   sequence.  If the user TELNET is also operating in a half duplex
+   mode, the break as an input prompt indicates that the system is ready
+   for input.
+
+   If input had been anticipated and sent by a full duplex user TELNET,
+   the TELNET SERVER will have that input available for immediate
+   processing.  Thus, in the case of a full duplex user TELNET the break
+   as a prompt should be ignored.
+
+   Though CP/CMS operates in a half duplex mode, it supports half duplex
+   terminals with the reverse break feature allowing the system to abort
+   an input mode in order to transmit a priority output message.  In
+   this situation, the TELNET SERVER transmits a TELNET SYNC.  A half
+   duplex user TELNET should interpret this by aborting the input mode,
+   i.e., revoking a previous TELNET break which was interpreted as an
+   input prompt.
+
+   No codes in the output character stream can cause the TELNET data
+   mark to be transmitted.
+
+LOGOUT
+
+   When a user logs out from his virtual machine, CP passes the
+   equivalent of a line disconnect to the LOGGER.  The LOGGER then
+   closes the TELNET send and receive sockets.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Winett                                                          [Page 4]
+
+RFC 466           TELNET LOGGER/SERVER For Host LL-67      February 1973
+
+
+   ASCII    ASCII    ASCII    SYMBOLS    EBCDIC    EBCDIC
+   DEC      OCT      HEX                 HEX       DEC
+
+     0        0      (00)      NUL       (00)       00
+     1        1      (01)      SOH       (01)       01
+     2        2      (02)      STX       (02)       02
+     3        3      (03)      ETX       (03)       03
+     4        4      (04)      EOT       (37)       55
+     5        5      (05)      ENQ       (2D)       45
+     6        6      (06)      ACK       (2E)       46
+     7        7      (07)      BEL       (2F)       47
+     8       10      (08)      BS        (16)       22
+     9       11      (09)      HT        (05)       05
+    10       12      (0A)      LF        (25)       37
+    11       13      (0B)      VT        (0B)       11
+    12       14      (0C)      FF        (0C)       12
+    13       15      (0D)      CR        (0D)       13
+    14       16      (0E)      SO        (0E)       14
+    15       17      (0F)      SI        (0F)       15
+    16       20      (10)      DLE       (10)       16
+    17       21      (11)      DC1       (11)       17
+    18       22      (12)      DC2       (12)       18
+    19       23      (13)      DC3       (13)       19
+    20       24      (14)      DC4       (3C)       60
+    21       25      (15)      NAK       (3D)       61
+    22       26      (16)      SYN       (32)       50
+    23       27      (17)      ETB       (26)       38
+    24       30      (18)      CAN       (18)       24
+    25       31      (19)      EM        (19)       25
+    26       32      (1A)      SUB       (3F)       63
+    27       33      (1B)      CTL       (27)       39
+    28       34      (1C)      FS        (1C)       28
+    29       35      (1D)      GS        (1D)       29
+    30       36      (1E)      RS        (1E)       30
+    31       37      (1F)      US        (1F)       31
+
+                       ASCII/EBCDIC Code Mappings
+                                FIGURE 1
+
+
+
+
+
+
+
+
+
+
+
+
+
+Winett                                                          [Page 5]
+
+RFC 466           TELNET LOGGER/SERVER For Host LL-67      February 1973
+
+
+   ASCII    ASCII    ASCII    SYMBOLS    EBCDIC    EBCDIC
+   DEC      OCT      HEX                 HEX       DEC
+
+    32       40      (20)      SP        (40)       64
+    33       41      (21)      !         (5A)       90
+    34       42      (22)      "         (7F)      127
+    35       43      (23)      #         (7B)      123
+    36       44      (24)      $         (5B)       91
+    37       45      (25)      %         (6C)      108
+    38       46      (26)      &         (50)       80
+    39       47      (27)      '         (7D)      124
+    40       50      (28)      (         (4D)       77
+    41       51      (29)      )         (5D)       93
+    42       52      (2A)      *         (5C)       92
+    43       53      (2B)      +         (4E)       78
+    44       54      (2C)      ,         (6D)      109
+    45       55      (2D)      -         (60)       96
+    46       56      (2E)      .         (4B)       75
+    47       57      (2F)      /         (61)       97
+    48       60      (30)      0         (F0)      240
+    49       61      (31)      1         (F1)      241
+    50       62      (32)      2         (F2)      242
+    51       63      (33)      3         (F3)      243
+    52       64      (34)      4         (F4)      244
+    53       65      (35)      5         (F5)      245
+    54       66      (36)      6         (F6)      246
+    55       67      (37)      7         (F7)      247
+    56       70      (38)      8         (F8)      248
+    57       71      (39)      9         (F9)      249
+    58       72      (3A)      :         (7A)      122
+    59       73      (3B)      ;         (5E)       94
+    60       74      (3C)      <         (4C)       76
+    61       75      (3D)      =         (7E)      126
+    62       76      (3E)      >         (6E)      110
+    63       77      (3F)      ?         (6F)      111
+
+                        ASCII/EBCDIC Code Mappings
+                           FIGURE 1 (CONTINUED)
+
+
+
+
+
+
+
+
+
+
+
+
+
+Winett                                                          [Page 6]
+
+RFC 466           TELNET LOGGER/SERVER For Host LL-67      February 1973
+
+
+   ASCII    ASCII    ASCII    SYMBOLS    EBCDIC    EBCDIC
+   DEC      OCT      HEX                 HEX       DEC
+
+    64      100      (40)      @         (7C)      124
+    65      101      (41)      A         (C1)      193
+    66      102      (42)      B         (C2)      194
+    67      103      (43)      C         (C3)      195
+    68      104      (44)      D         (C4)      196
+    69      105      (45)      E         (C5)      197
+    70      106      (46)      F         (C6)      198
+    71      107      (47)      G         (C7)      199
+    72      110      (48)      H         (C8)      200
+    73      111      (49)      I         (C9)      201
+    74      112      (4A)      J         (D1)      209
+    75      113      (4B)      K         (D2)      210
+    76      114      (4C)      L         (D3)      211
+    77      115      (4D)      M         (D4)      212
+    78      116      (4E)      N         (D5)      213
+    79      117      (4F)      O         (D6)      214
+    80      120      (50)      P         (D7)      215
+    81      121      (51)      Q         (D8)      216
+    82      122      (52)      R         (D9)      217
+    83      123      (53)      S         (E2)      226
+    84      124      (54)      T         (E3)      227
+    85      125      (55)      U         (E4)      228
+    86      126      (56)      V         (E5)      229
+    87      127      (57)      W         (E6)      230
+    88      130      (58)      X         (E7)      231
+    89      131      (59)      Y         (E8)      232
+    90      132      (5A)      Z         (E9)      233
+    91      133      (5B)      [         (AD)      173
+    92      134      (5C)     <cent>     (4A)       74  (BACK-SLASH)
+    93      135      (5D)      ]         (BD)      189
+    94      136      (5E)      ^         (71)      113  (CARAT)
+    95      137      (5F)      _         (6D)      109
+
+                        ASCII/EBCDIC Code Mappings
+                           FIGURE 1 (CONTINUED)
+
+
+
+
+
+
+
+
+
+
+
+
+
+Winett                                                          [Page 7]
+
+RFC 466           TELNET LOGGER/SERVER For Host LL-67      February 1973
+
+
+   ASCII    ASCII    ASCII    SYMBOLS    EBCDIC    EBCDIC
+   DEC      OCT      HEX                 HEX       DEC
+
+    96      140      (60)      `         (79)      121  (GRAVE)
+    97      141      (61)      a         (81)      129
+    98      142      (62)      b         (82)      130
+    99      143      (63)      c         (83)      131
+   100      144      (64)      d         (84)      132
+   101      145      (65)      e         (85)      133
+   102      146      (66)      f         (86)      134
+   103      147      (67)      g         (87)      135
+   104      150      (68)      h         (88)      136
+   105      151      (69)      i         (89)      137
+   106      152      (6A)      j         (91)      145
+   107      153      (6B)      k         (92)      146
+   108      154      (6C)      l         (93)      147
+   109      155      (6D)      m         (94)      148
+   110      156      (6E)      n         (95)      149
+   111      157      (6F)      o         (96)      150
+   112      160      (70)      p         (97)      151
+   113      161      (71)      q         (98)      152
+   114      162      (72)      r         (99)      153
+   115      163      (73)      s         (A2)      162
+   116      164      (74)      t         (A3)      163
+   117      165      (75)      u         (A4)      164
+   118      166      (76)      v         (A5)      165
+   119      167      (77)      w         (A6)      166
+   120      170      (78)      x         (A7)      167
+   121      171      (79)      y         (A8)      168
+   122      172      (7A)      z         (A9)      169
+   123      173      (7B)      {         (8B)      139
+   124      174      (7C)      |         (4F)       79  (BAR/OR)
+   125      175      (7D)      }         (9B)      155
+   126      176      (7E)    <bent bar>  (5F)       95  (TILDE/NOT)
+   127      177      (7F)      DEL       (07)        7
+
+   ASCII   ASCII   ASCII    TELNET         EBCDIC     EBCDIC
+   DEC     OCT     HEX     CONTROLS        HEX        DEC
+
+   128     100     (80)   DATA-MARK        (80)       128
+   129     101     (81)   BREAK            (38)        56
+   130     102     (82)   NOP              (17)        23  IDLE
+   131     103     (83)   NOECHO           (14)        20  RESTORE
+   132     104     (84)   ECHO             (23)        35
+   133     105     (85)   HIDE-YOUR INPUT  (24)        36  BYPASS
+
+                        ASCII/EBCDIC Code Mappings
+                           FIGURE 1 (CONTINUED)
+
+
+
+Winett                                                          [Page 8]
+
+RFC 466           TELNET LOGGER/SERVER For Host LL-67      February 1973
+
+
+        [This RFC was put into machine readable form for entry]
+    [into the online RFC archives by Helene Morin, Via Genie, 12/99]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Winett                                                          [Page 9]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc466.txt](<www.ietf.org/rfc/rfc466.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
