### PR TITLE
Archive rfc470.txt

### DIFF
--- a/www.ietf.org/rfc/rfc470.txt
+++ b/www.ietf.org/rfc/rfc470.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                     Bob Thomas
+Request for Comments: #470                                BBN - TENEX
+NIC #14799                                                March 13, 1973
+Categories: Socket Numbers
+
+
+                 Change in Socket for TIP News Facility
+
+
+The Socket which supports the TIP News Facility has been changed to
+socket 367 (Octal) at BBN-TENEX.  TIP users should be uneffected by this
+change since the TIP program has already been changed to ICP to the new
+socket.  Because some user TELNET programs have been implemented a
+"news" command, the old socket will be maintained until April 15, 1973
+to give implementers time to change to the new socket.
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.             9/99 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Thomas                                                          [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc470.txt](<www.ietf.org/rfc/rfc470.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
