### PR TITLE
Archive rfc471.txt

### DIFF
--- a/www.ietf.org/rfc/rfc471.txt
+++ b/www.ietf.org/rfc/rfc471.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                     Bob Thomas
+Request for Comments: #471                                BBN-TENEX
+NIC #14800                                                March 13, 1973
+
+
+                 Announcement Of A (Tentative) Workshop
+                    On Multi Site Executive Programs
+
+
+An executive program is one which accepts and interprets commands from a
+user, calling upon other programs to provide the resources required to
+satisfy each command. There is currently interest in making resources on
+the ARPANET available to the user via a standard, conversational
+facility which one might call an ARPANET Executive. With such a facility
+a user at a Host site or a TIP could conveniently access a wide range of
+resources at other sites without mastering the idiosyncrasies of each
+Host operating system which is contributing resources.
+
+For example, the ARPANET executive could make it possible to locate (by
+name) a user logged in anywhere on the network and to establish a
+teletype link to that user in order to engage in an on-line dialogue. It
+could also provide status information on the subnet and on all Hosts,
+on-line ARPANET news service, on-line collections of trouble reports,
+etc.  The range of possible services is practically unlimited once a
+basic structure is devised for calling upon these services.
+
+Major areas of interest here are:
+1.  How can the interfaces to resources of interest be standardized so
+    as to be accessible by "server" processes;
+
+2.  How can communications with such server processes be standardized?
+    (an ARPANET Executive protocol?)
+
+3.  To what extent can the conversational user interface be standardized
+    in the user processes? (an ARPANET Executive language?)
+
+4.  How can access authentication and accounting procedures be modified
+    to permit a user to "login" only once, yet use resources at many
+    Host sites?
+
+If you are interested in discussing these and related issues forward
+your name to Bob Thomas (BTHOMAS @BBN-TENEX), Bolt Beranek and Newman,
+Inc., 50 Moulton Street, Cambridge, Massachusetts 02139, (617) 491-1850,
+extension 483.  If there is sufficient response, a Workshop (tentatively
+planned for April) will be hosted by the BBN TENEX and BBN TIP groups.
+The Workshop will permit participants to present relevant work and to
+discuss the issues raised above.
+
+
+
+
+Thomas                                                          [Page 1]
+
+RFC 471        Workshop On Multi Site Executive Programs      March 1973
+
+
+In the meantime, an example of an executive program which interprets a
+limited set of commands in a multi-site context is available for
+experimental use by TIP and TENEX users. The "N" command of the TIP and
+the RSEXEC (Resource Sharing Executive) subsystem on TENEX, provide
+command interpretation in the context of TENEX and ITS sites. Users
+whose access to the network is neither via a TIP or a TENEX may use the
+RSEXEC by directing their user TELNET to ICP to socket 367 (Octal) at
+BBN-TENEX.
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.             9/99 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Thomas                                                          [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc471.txt](<www.ietf.org/rfc/rfc471.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
