### PR TITLE
Archive rfc4723.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4723.txt
+++ b/www.ietf.org/rfc/rfc4723.txt
@@ -1,0 +1,451 @@
+
+
+
+
+
+
+Network Working Group                                         T. Kosonen
+Request for Comments: 4723                                         Nokia
+Category: Informational                                         T. White
+                                                                     MMA
+                                                           December 2006
+
+
+              Registration of Media Type audio/mobile-xmf
+
+Status of This Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard of any kind.  Distribution of this
+   memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The IETF Trust (2006).
+
+Abstract
+
+   The MIDI Manufacturers Association (MMA) and the Association of
+   Musical Electronics Industry (AMEI) have produced the Mobile XMF
+   standard, which was developed particularly for mobile MIDI
+   applications.  Mobile XMF is a very compact media type providing
+   high-quality synthetic audio content for music downloading and
+   messaging applications that require MIME registration.  This document
+   registers the media type audio/mobile-xmf.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kosonen & White              Informational                      [Page 1]
+
+RFC 4723                    Mobile XMF MIME                December 2006
+
+
+1.  Introduction
+
+   MIDI content is used commonly in the Internet.  Typically, MIDI data
+   is stored in the Standard MIDI File (SMF) format [8].  This MIME type
+   registration uses the Mobile XMF file format for the encapsulation of
+   SP-MIDI [3,4] and Mobile DLS (Downloadable Sounds) [2] data.
+
+   The MIDI Manufacturers Association (MMA) and the Association of
+   Musical Electronics Industry (AMEI) have produced the Mobile XMF
+   standard [1], which was developed particularly for mobile MIDI [7]
+   applications.
+
+2.  Registration of audio/mobile-xmf
+
+   Type name: audio
+
+   Subtype name: mobile-xmf
+
+   Required parameters: none
+
+   Optional parameters:
+
+      revision: Mobile XMF file type revision ID
+
+         revision is the Mobile XMF file type revision ID number from
+         the XmfFileTypeRevisionID field of the XMF Meta File format
+         2.00. revision is encoded in hex in US-ASCII.
+
+      prl: Playback resource list
+
+         prl contains the playback resources included in all Content
+         Description MetaDataItems of the Mobile XMF file.  prl contains
+         two-digit hexadecimal numbers representing data bytes from the
+         Content Description Meta Data.  Each resource is listed exactly
+         once.  A playback resource contains two parts: a prefix and
+         data.  prl is a sequence of two-digit hexadecimal numbers
+         encoded in US-ASCII.  Thus, prl has an even number of
+         hexadecimal digits.
+
+         Example: If the file includes Playback Resource Lists such as
+         [00h 01h 00h 02h] and [00h 01h 00h 03h], the corresponding prl
+         is 000100020003 containing playback resources 01, 02, and 03
+         each with the prefix 00.
+
+
+
+
+
+
+
+
+Kosonen & White              Informational                      [Page 2]
+
+RFC 4723                    Mobile XMF MIME                December 2006
+
+
+      minimum-pr: Minimum playback requirements
+
+         minimum-pr contains the Maximum Instantaneous Resource (MIR)
+         values from the first row of all MIR Count Tables corresponding
+         to the playback resources listed in prl.  Only the largest
+         value from the values of the same resource is chosen.
+         minimum-prl is a sequence of two-digit hexadecimal numbers
+         encoded in US-ASCII.  Thus, minimum-prl has an even number of
+         hexadecimal digits.
+
+         minimum-pr requires the use of prl, and the values in
+         minimum-pr must be in the same order as the resources in prl.
+         minimum-pr is the more important of minimum-pr and total-pr,
+         because it defines the minimum playback requirements.
+
+         Example: If the file includes the first rows of MIR Count
+         Tables such as [02h 00h] and [01h 01h] corresponding to the
+         above Playback Resource Lists, the corresponding minimum-pr is
+         020001.  (02 is the largest of 2 and 1, 00 is the largest of 0,
+         and 01 is the largest of 1.)
+
+      total-pr: Total playback requirements
+
+         total-pr contains the MIR values from the last row of all MIR
+         Count Tables corresponding to the playback resources listed in
+         prl.  Only the largest value from the values of the same
+         resource is chosen.  total-pr is a sequence of two-digit
+         hexadecimal numbers encoded in US-ASCII.  Thus, total-pr has an
+         even number of hexadecimal digits.
+
+         total-pr requires the use of prl, and the values in total-pr
+         must be in the same order as the resources in prl.
+
+         Example: If the file includes the last rows of MIR Count Tables
+         such as [05h 02h] and [06h 01h] corresponding to the above
+         Playback Resource Lists, the corresponding total-pr is 060201.
+         (06 is the largest of 5 and 6, 02 is the largest of 2, and 01
+         is the largest of 1.)
+
+   Encoding considerations:
+
+      mobile-xmf data is binary data and must be encoded for non-binary
+      transport; Base64 [9] is suitable for Email.
+
+
+
+
+
+
+
+
+Kosonen & White              Informational                      [Page 3]
+
+RFC 4723                    Mobile XMF MIME                December 2006
+
+
+   Security considerations:
+
+      Many synthetic audio compositions have associated intellectual
+      property rights.  It is conceivable that the rights owners of
+      mobile-xmf content will want to protect their rights by applying
+      security mechanisms that prohibit the rendering of the content
+      without a legally acquired license to do so.  These mechanisms
+      would be applied externally to the Content-Type defined here;
+      mobile-xmf content itself is not encrypted internally.  mobile-xmf
+      streams do not contain executable content.  Mobile XMF players are
+      robust against corrupted mobile-xmf content, because Mobile XMF
+      players ignore unidentified content.  prl, minimum-pr, and
+      total-pr parameters can be used to represent Mobile DLS playback
+      memory requirements for protecting against the excessive usage of
+      playback memory.
+
+   Interoperability considerations:
+
+      Mobile XMF is a Musical Instrument Digital Interface (MIDI)
+      specification developed by MMA and AMEI.  Mobile XMF is based on
+      the XMF Meta File Format Specification v2.00 [5,6], which
+      standardizes a meta file format for the electronic distribution of
+      music.  mobile-xmf data is stored in XMF file format [5,6].
+
+   Published specification:
+
+      Mobile XMF Content Format Specification, MMA specification v1.0.,
+        RP-42, Los Angeles, CA, USA.  2004.
+
+      Specification is available from:
+        http://www.midi.org/about-midi/specshome.shtml
+
+   Applications which use this media type:
+
+      mobile-xmf is a synthetic audio format for the flexible
+      presentation of SP-MIDI and Mobile DLS instrument data on a wide
+      range of playback devices, particularly portable appliances such
+      as mobile phones, PDAs, and palmtop computers.
+
+   Additional information:
+
+      Magic number(s):
+
+      First twelve bytes:
+      \130\115\106\137\062\056\060\060\000\000\000\002
+
+
+
+
+
+
+Kosonen & White              Informational                      [Page 4]
+
+RFC 4723                    Mobile XMF MIME                December 2006
+
+
+      File extension(s): mxmf
+
+      Macintosh File Type Code(s): mxmf
+
+   Person & email address to contact for further information:
+
+      Timo Kosonen
+      Email: timo.kosonen@nokia.com
+
+   Intended usage: COMMON
+
+   Restrictions on usage: none
+
+   Authors:
+
+      Timo Kosonen
+      Email: timo.Kosonen@nokia.com
+
+      Tom White
+      Email: twhite@midi.org
+
+   Change controller:
+
+      MIDI Manufacturers Association
+      P.O. Box 3173
+      La Habra, CA  90632-3173
+      Tel (714) 736-9774
+      Fax (714) 736-9775
+      Point of contact:
+      Tom White
+      Email: twhite@midi.org
+
+3.  Security Considerations
+
+   Security considerations are specified in the MIME subtype
+   registration contained in Section 2.
+
+4.  IANA Considerations
+
+   Section 2 of this document registers one MIME subtype.
+
+
+
+
+
+
+
+
+
+
+
+Kosonen & White              Informational                      [Page 5]
+
+RFC 4723                    Mobile XMF MIME                December 2006
+
+
+5.  Normative References
+
+   [1] Mobile XMF Content Format Specification, MMA specification v1.0.,
+       RP-42, Los Angeles, CA, USA.  2004.
+
+   [2] Mobile DLS, MMA specification v1.0., RP-41, Los Angeles, CA, USA.
+       2004.
+
+   [3] Scalable Polyphony MIDI Specification.  December 2001, RP-034,
+       The MIDI Manufacturers Association, Los Angeles, CA, USA.
+
+   [4] Scalable Polyphony MIDI Device 5-24 Note Profile for 3GPP,
+       December 2001, RP-035, The MIDI Manufacturers Association, Los
+       Angeles, CA, USA.
+
+   [5] Specification for XMF Meta File Format, Version 1.00b.  The MIDI
+       Manufacturers Association, Los Angeles, CA, USA, 2001.
+
+   [6] XMF Meta File Format 2.00, RP-043, MIDI Manufacturers
+       Association, Los Angeles, CA, USA, 2004
+
+   [7] MIDI 1.0 Detailed Specification, Document Version 4.2.  February
+       1996, In 'The Complete MIDI 1.0 Detailed Specification, Document
+       Version 96.1.'  The MIDI Manufacturers Association., Los Angeles,
+       CA, USA.
+
+   [8] Standard MIDI Files 1.0, In 'The Complete MIDI 1.0 Detailed
+       Specification, Document Version 96.1.'  The MIDI Manufacturers
+       Association., Los Angeles, CA, USA.
+
+   [9] Josefsson, S., "The Base16, Base32, and Base64 Data Encodings",
+       RFC 4648, October 2006.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kosonen & White              Informational                      [Page 6]
+
+RFC 4723                    Mobile XMF MIME                December 2006
+
+
+Authors' Addresses
+
+   Timo Kosonen
+   Nokia
+   P.O. Box 100
+   33721 Tampere
+   Finland
+
+   Tel: +358 5048 35206
+   Fax: +358 7180 35899
+   EMail: timo.kosonen@nokia.com
+
+
+   Tom White
+   MIDI Manufacturers Association
+   P.O. Box 3173
+   La Habra, CA  90632-3173
+   USA
+
+   Tel: (714) 736-9774
+   Fax: (714) 736-9775
+   EMail: twhite@midi.org
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kosonen & White              Informational                      [Page 7]
+
+RFC 4723                    Mobile XMF MIME                December 2006
+
+
+Full Copyright Statement
+
+   Copyright (C) The IETF Trust (2006).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY, THE IETF TRUST,
+   AND THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT
+   THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY
+   IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+   PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+Kosonen & White              Informational                      [Page 8]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4723.txt](<www.ietf.org/rfc/rfc4723.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
