### PR TITLE
Archive rfc474.txt

### DIFF
--- a/www.ietf.org/rfc/rfc474.txt
+++ b/www.ietf.org/rfc/rfc474.txt
@@ -1,0 +1,60 @@
+
+
+
+
+
+
+NIC #14905
+
+RFC#: 474
+
+Title:  Announcement of forthcoming meeting of the Network Graphics
+        Working Group and call for RFC's
+
+Author: Steve Bunch, ILL-ANTS
+
+Distribution:   Network Graphics Group
+
+
+
+
+Ira Cotton (NBS) has proposed that Illinois host the next NGWG meeting
+and that it be held in early May.  Please let me know if there are
+pressing reasons for not scheduling the meeting for Friday, May 11,
+1973.  A formal announcement of the final meting date will be announced
+in a week or two, along with details for making local arrangements.  I
+can be reached best via mail at:
+
+          Center for Advanced Computation
+          University of Illinois
+          Urbana, Illinois 61801
+
+My phone is (217) 333-9354.  If no answer, try 333-8150.  I can also be
+reached via BUNCH@USC-ISI.
+
+If you have ideas, comments, suggestions, or even derision for higher-
+level graphics protocols, please air your opinions via RFC sometime
+before the meeting to give everyone time to think about it.
+
+
+
+Steve Bunch
+
+
+         [ This RFC was put into machine readable form for entry ]
+         [   into the online RFC archives by Tony Hansen 11/99   ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc474.txt](<www.ietf.org/rfc/rfc474.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
