### PR TITLE
Archive rfc476.txt

### DIFF
--- a/www.ietf.org/rfc/rfc476.txt
+++ b/www.ietf.org/rfc/rfc476.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                 Alexander McKenzie
+RFC # 476                                             BBN-NET
+NIC # 14920                                           March 7, 1973
+
+
+             IMP/TIP Memory Retrofit Schedule (Revision 2)
+
+
+This revision contains two types of changes to RFC #447.  First, the
+retrofits to Utah, Belvoir, NOAA, USC, Stanford, ISI, Case, and CCA have
+been completed and are therefore removed from the schedule.  Second, the
+retrofits to UCSB, ETAC, Aberdeen, and Rome have been rescheduled.
+
+The revised text of RFC #447 follows:
+
+During the first several months of 1973 we will be retrofitting each IMP
+and TIP with additional core memory.  At the end of the retrofit
+program, the memory sizes of the various machines will be as follows:
+
+    IMP (516 or 316) - 16K words
+
+    TIP - 28K words
+
+    TIP with Magnetic Tape Option - 32K words
+
+In addition, the expansion of the TIP core memory will necessitate
+enlarging the TIP to two cabinets.
+
+Listed below is the schedule for the remaining retrofits.  We have
+arranged this schedule to coincide with the usual monthly Preventive
+Maintenance at each site so as to minimize user inconvenience, but the
+work required will frequently require the machines to be down longer
+than normal.  I will issue additional RFC's updating this schedule as
+necessary.
+
+Any site which anticipates difficulty with the expansion of TIP size,
+and thus the floor space requirement, should contact Hawley Rising (BBN)
+at
+    (617)491-1850 ext. 473
+All dates given below are below in the form (month/day)
+
+    SRI (3/7)
+    ETAC (3/15)
+    FNWC (3/15
+    Rome (3/16)
+    UCLA (3/19)
+    AMES IMP (3/21)
+    GWC (3/22)
+
+
+
+McKenzie                                                        [Page 1]
+
+RFC 476         IMP/TIP Memory Retrofit Schedule (Rev 2)      March 1973
+
+
+    Carnegie (4/4)
+    SDC (4/17)
+    Illinois (4/18)
+    UCSB (5/1)
+    Aberdeen (postponed indefinitely)
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.             9/99 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McKenzie                                                        [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc476.txt](<www.ietf.org/rfc/rfc476.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
