### PR TITLE
Archive rfc478.txt

### DIFF
--- a/www.ietf.org/rfc/rfc478.txt
+++ b/www.ietf.org/rfc/rfc478.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                        B. Bressler
+Request for Comments: 478                                      B. Thomas
+NIC: 14947                                                           BBN
+                                                           26 March 1973
+
+                    FTP Server-Server Interaction-II
+
+   At the recent FTP meeting at BBN in Cambridge, one of the topics
+   discussed was that of server-server interaction.  In a typical
+   situation a user (A) conversing with two servers (B,C) is interested
+   in retrieving a file from one site (B) and sending it to the other
+   (C).
+
+
+                          +------+
+                          | USER |
+                          |   A  |
+                         /+------+\
+                   control        control
+                      /              \
+                +------+            +------+
+                |SERVER|    DATA    |SERVER|
+                |   B  |----------->|  C   |
+                +------+            +------+
+
+   The consensus of the meeting was that mechanisms were necessary to
+   make B and C aware of each other and to allow a data connection to be
+   established without forcing each other to queue RFCs for local
+   sockets before they exist.
+
+   The proposed solution to this problem was a command called PASSIVE
+   (PASV?).  The following is our conclusion as to the meaning of the
+   command and how it would be used.
+
+   Third party connections would be established using the SOCK command,
+   which says "Be prepared to use socket S at Host H to establish your
+   data connection", and the PASV command which says "open your data
+   socket for listening, and upon receipt of a transfer command wait for
+   an RFC rather than initiating one."
+
+   A positive acknowledgement to the PASV command indicates that the
+   data socket has been opened for listening.  When an RFC for its data
+   socket arrives after it has positively acknowledged a PASV command,
+   the server should respond with a matching RFC to open the data
+   connection (assuming, of course, that the incoming RFC is consistent
+   with the previous SOCK commands, if any).
+
+
+
+
+
+Bressler                                                        [Page 1]
+
+RFC 478             FTP Server-Server Interaction-II       26 March 1973
+
+
+                            +---------------+
+                            |               |
+                 +----------| USER PROCESS  |----------+
+                 |          |       A       |          |
+               telnet       +---------------+        telnet
+                 |                                     |
+                 |                                     |
+          +-----------+                         +-------------+
+          |           |-------->      --------->|             |
+          |  SERVER   |data sockets  data socket|   SERVER    |
+          |     B     |    Sb           Sc      |     C       |
+          |           |<--------      <---------|             |
+          +-----------+                         +-------------+
+
+
+   USER A TO SERVER B                     USER A TO SERVER C
+   __________________                     __________________
+
+   A->B   SOCK  HOST-C  SKT- Sc           A->C   SOCK  HOST-B  SKT-  Sb
+
+   B->A       ACK                         C->A      ACK
+
+   A->B   PASV
+
+   B->A       ACK
+
+   A->B   STOR                            A->C   RTRV
+
+      1. After the PASV command has been acknowledged, the two data
+         transfer commands can be sent in either order, since the
+         LISTENING action takes place with the PASV command
+
+      2. The user knows the socket numbers Sc and Sb to be the data
+         sockets as specified by the protocol.
+
+      3. Note that it is not essential for a SOCK command to be sent to
+         the same Host to whom a PASV will be sent.  Sending one to him
+         provides security in that the incoming RFC can be checked.
+
+   RB/nlg
+
+
+
+
+          [This RFC was put into machine readable form for entry]
+     [into the online RFC archives by Helene Morin, Via Genie 12/1999]
+
+
+
+
+
+Bressler                                                        [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc478.txt](<www.ietf.org/rfc/rfc478.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
