### PR TITLE
Archive rfc480.txt

### DIFF
--- a/www.ietf.org/rfc/rfc480.txt
+++ b/www.ietf.org/rfc/rfc480.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                     James E. White
+RFC #480                                                  SRI-ARC
+NIC #14949                                                8 March 73
+
+
+                     Host-Dependent FTP Parameters
+
+This memo is in response to (and support of) one of the points raised by
+Bob Braden (RTB) of UCLA-CCN in RFC #430, "COMMENTS ON FILE TRANSFER
+PROTOCOL" (see -- 13299,), namely that raised in Section D., "Site-
+Dependent FTP Parameters".
+
+The NIC has been confronted with similar problems (and tentatively
+decided upon similar solutions) in designing mechanisms which would
+enable a user to use FTP to retrieve from the NIC, in sequential form, a
+VIEW of some portion for an NLS tree-structured file.
+
+To be done without modification to FTP, this task requires the user to
+communicate information -- a filename, a statement address, viewspecs,
+and the name of a conversion algorithm -- to SRI-ARC's server FTP
+process in a manner that is transparent to the user's user FTP process.
+
+We currently intend to require the user to embed this information in the
+pathname of FTP's STOR and RETR commands by appending to a standard
+TENEX filename, a field of the form:
+
+    ;x <program> [ / <parameters> ]
+
+where <program> identifies an arbitrary program to be dispatched by
+SRI-ARC's server FTP process, with a pointer to the file being stored or
+retrieved as an argument.  <parameters> is optional and, if present, is
+also passed to the program.
+
+To store and retrieve NLS files in sequential form, we will require that
+<program> be 'NLS' and <parameters> be of the form.
+
+    [ T: <conversion-algorithm> ] [ S: <statement address> ] [ V:
+    <viewspecs> ]
+
+where each of the three items is optional, and any that appear are
+separated by commas.
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.             9/99 ]
+
+
+
+
+
+White                                                           [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc480.txt](<www.ietf.org/rfc/rfc480.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
