### PR TITLE
Archive rfc483.txt

### DIFF
--- a/www.ietf.org/rfc/rfc483.txt
+++ b/www.ietf.org/rfc/rfc483.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                     Mike Kudlick
+RFC # 483                                                 SRI-ARC
+NIC # 15061                                               March 14, 1973
+
+
+                          Meeting Cancellation
+
+
+The purpose of this RFC is to announce a cancellation of the Resource
+Notebook Framework meeting that had tentatively been scheduled for March
+19, 1973.  (Please refer to NWG/RFC #464 (NIC #14738) for background
+information).
+
+Further information concerning the Resource Notebook Framework that was
+discussed in RFC #464 will be distributed soon.
+
+If there are any questions please contact either Jake Feinler or Mike
+Kudlick at the NIC, (415) 326-6200.
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.             9/99 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kudlick                                                         [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc483.txt](<www.ietf.org/rfc/rfc483.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
