### PR TITLE
Archive rfc4839.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4839.txt
+++ b/www.ietf.org/rfc/rfc4839.txt
@@ -1,0 +1,283 @@
+
+
+
+
+
+
+Network Working Group                                          G. Conboy
+Request for Comments: 4839                                     J. Rivlin
+Category: Informational                         eBook Technologies, Inc.
+                                                            J. Ferraiolo
+                                                                     IBM
+                                                              April 2007
+
+
+                     Media Type Registrations for
+    the Open eBook Publication Structure (OEBPS) Package File (OPF)
+
+Status of This Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard of any kind.  Distribution of this
+   memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The IETF Trust (2007).
+
+Abstract
+
+   This document serves to register a media type for the Open eBook
+   Publication Structure (OEBPS) Package Files.
+
+1.  Introduction
+
+   The present document registers a media type for the Open eBook
+   Publication Structure (OEBPS) Package File (OPF).  The OPF file is an
+   XML file that describes an OEBPS Publication [OEBPS].  It identifies
+   all other files in the publication and provides descriptive
+   information about them.  OPF and its related standards are maintained
+   and defined by the International Digital Publishing Forum (IDPF).
+
+   The media type defined here is needed to correctly identify OPF files
+   when they are edited on disk, referenced in OEBPS Container files, or
+   used in other places where media types are used.
+
+2.  Security Considerations
+
+   The OPF files contain well-formed XML conforming to the XML 1.0
+   specification.
+
+   Clearly, it is possible to author malicious files which, for example,
+   contain malformed data.  Most XML parsers protect themselves from
+   such attacks by rigorously enforcing conformance.
+
+
+
+
+Conboy, et al.               Informational                      [Page 1]
+
+RFC 4839            Media Type Registrations for OPF          April 2007
+
+
+   All processors that read OPF files should rigorously check the size
+   and validity of data retrieved.
+
+   There is no current provision in the OEBPS Package File standard for
+   encryption, signing, or authentication within the file format.
+
+3.  IANA Considerations
+
+   IANA has registered the media type application/oebps-package+xml as
+   specified in Section 3.1.  The registration uses the template present
+   in [RFC4288].
+
+3.1.  Media Type for Downloadable Sounds
+
+   Type name:                         application
+
+   Subtype name:                      oebps-package+xml
+
+   Required parameters:               none
+
+   Optional parameters:               none
+
+   Encoding considerations:           OPF files are UTF-8 or UTF-16
+                                      encoded XML
+
+   Security considerations:           none
+
+
+   Interoperability considerations:   none
+
+   Published specification:           Specification is published by the
+                                      International Digital Publishing
+                                      Forum and can be found at
+                                      http://www.idpf.org/oebps/
+                                      oebps1.2/download/oeb12-xhtml.htm
+
+   Applications which use this media type:
+                                      1) eBook Technologies, Inc.
+                                         eBook reading system.
+                                      2) Microsoft Reader
+                                      3) OSoft reader
+                                      4) Content Reserve Publishing
+                                         System
+                                      5) IDPF Container WG
+                                      6) PC Reader.com
+                                      7) MobiPocket reader
+
+
+
+
+
+Conboy, et al.               Informational                      [Page 2]
+
+RFC 4839            Media Type Registrations for OPF          April 2007
+
+
+   Additional information:
+
+      Magic number(s):                none
+
+      File extension(s):              .opf
+
+      Macintosh file type code(s):    TEXT
+
+   Person & email address to contact for further information:
+                                      Nick Bogaty (nbogaty@idpf.org)
+
+   Intended usage:                    COMMON
+
+   Restrictions on usage:             None
+
+   Author:                            International Digital Publishing
+                                      Forum (www.idpf.org)
+
+   Change controller:                 International Digital Publishing
+                                      Forum (www.idpf.org)
+
+4.  Normative References
+
+   [OEBPS]   "Open eBook Publication Structure 1.2", International
+             Digital Publishing Forum (IDPF), New York, NY USA, 2002.
+
+   [RFC4288] Freed, N. and J. Klensin, "Media Type Specifications and
+             Registration Procedures", BCP 13, RFC 4288, December 2005.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Conboy, et al.               Informational                      [Page 3]
+
+RFC 4839            Media Type Registrations for OPF          April 2007
+
+
+Authors' Addresses
+
+   Garth Conboy
+   eBook Technologies, Inc.
+   7745 Herschel Avenue
+   La Jolla, CA 92037
+
+   Phone: (858) 551-4950
+   EMail: gc@ebooktechnologies.com
+
+
+   John Rivlin
+   eBook Technologies, Inc.
+   7745 Herschel Avenue
+   La Jolla, CA 92037
+
+   Phone: (650) 255-3389
+   EMail: john@ebooktechnologies.com
+
+
+   Jon Ferraiolo
+   IBM
+   Menlo Park, CA
+
+   Phone: (650) 926-5865
+   EMail: jferrai@us.ibm.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Conboy, et al.               Informational                      [Page 4]
+
+RFC 4839            Media Type Registrations for OPF          April 2007
+
+
+Full Copyright Statement
+
+   Copyright (C) The IETF Trust (2007).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY, THE IETF TRUST AND
+   THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF
+   THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+Conboy, et al.               Informational                      [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4839.txt](<www.ietf.org/rfc/rfc4839.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
