### PR TITLE
Archive rfc4841.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4841.txt
+++ b/www.ietf.org/rfc/rfc4841.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                                      C. Heard, Ed.
+Request for Comments: 4841                                    March 2007
+BCP: 111
+Updates: 4181
+Category: Best Current Practice
+
+
+              RFC 4181 Update to Recognize the IETF Trust
+
+Status of This Memo
+
+   This document specifies an Internet Best Current Practices for the
+   Internet Community, and requests discussion and suggestions for
+   improvements.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The IETF Trust (2007).
+
+Abstract
+
+   This document updates RFC 4181, "Guidelines for Authors and Reviewers
+   of MIB Documents", to recognize the creation of the IETF Trust.
+
+1.  Introduction
+
+   In order to reflect the creation of the IETF Trust, certain updates
+   to the copyright notices required in IETF documents by RFC 3978
+   [RFC3978] have been published in RFC 4748 [RFC4748].  This document
+   updates RFC 4181 [RFC4181] to bring it into alignment with those
+   changes.
+
+2.  Updates to RFC 4181
+
+   The text of RFC 4181 is hereby updated as set forth below to reflect
+   the creation of the IETF Trust.
+
+2.1.  Updates to Section 3.7
+
+   In the copyright notice templates in Section 3.7, replace all
+   occurrences of "The Internet Society" with "The IETF Trust".
+
+3.  Security Considerations
+
+   The updates in this document have no impact on the security of the
+   Internet.
+
+
+
+
+
+Heard                    Best Current Practice                  [Page 1]
+
+RFC 4841      RFC 4181 Update to Recognize the IETF Trust     March 2007
+
+
+4.  Normative References
+
+   [RFC3978] Bradner, S., "IETF Rights in Contributions", BCP 78, RFC
+             3978, March 2005.
+
+   [RFC4748] Bradner, S., "RFC 3978 Update to Recognize the IETF Trust",
+             BCP 78, RFC 4748, October 2006.
+
+   [RFC4181] Heard, C., "Guidelines for Authors and Reviewers of MIB
+             Documents", BCP 111, RFC 4181, September 2005.
+
+Editor's Address
+
+   C. M. Heard
+   158 South Madison Ave. #207
+   Pasadena, CA 91101-2569
+   USA
+
+   Phone: +1 626 795 5311
+   EMail: heard@pobox.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Heard                    Best Current Practice                  [Page 2]
+
+RFC 4841      RFC 4181 Update to Recognize the IETF Trust     March 2007
+
+
+Full Copyright Statement
+
+   Copyright (C) The IETF Trust (2007).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY, THE IETF TRUST AND
+   THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF
+   THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+Heard                    Best Current Practice                  [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4841.txt](<www.ietf.org/rfc/rfc4841.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
