### PR TITLE
Archive rfc485.txt

### DIFF
--- a/www.ietf.org/rfc/rfc485.txt
+++ b/www.ietf.org/rfc/rfc485.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                    John R. Pickens
+RFC # 485                                                UCSB
+NIC # 15063                                              19 March 1973
+References NWG/RFC #473
+
+
+                         MIX and MIXAL at UCSB
+
+The following, in response to David Walden's MIX query (RFC#473) was
+written by a graduate student at UCSB.  Questions regarding "cheap"
+usage should be directed to Roland F. Bryan (RFB) at UCSB.
+-----------------------------------------------------------------------
+
+Mark Scott Johnson
+18 March 1973
+
+    I wrote a MIXAL assembler and a MIX simulator last summer.  The
+assembler is written in SNOBOL4 and, unfortunately, is fairly expensive
+to run.  The assembler has been fairly well debugged and is documented.
+However, although the MIX simulator is written (in 360 Assembler), it
+has only been partially debugged.  Due to the resumption of school and
+other commitments, I was unable to give the simulator a thorough
+debugging.  All the simulated instructions except I/O instructions have
+been tested somewhat and appear to be operating well.  Also, card reader
+input and printer output are operational, but my simulation of disk
+files and magnetic tape has not been completed.  There is presently no
+documentation for the simulator.  Very little documentation is needed,
+however, since the simulator follows almost to the letter the
+specifications detailed in _Fundamental_Algorithms_.
+
+    If anyone is interested in using the assembler and/or the simulator,
+I will be happy to supply what documentation exists plus some
+information on how the programs can be accessed.  Also, if anyone is
+interested in the source code for the programs, I will be happy to send
+it.  I hope to be able to finish the simulator this next quarter.  If
+anyone wants to use the system and if they should find any bugs, I will
+do my best to maintain and correct the programs.
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.             9/99 ]
+
+
+
+
+
+
+Pickens                                                         [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc485.txt](<www.ietf.org/rfc/rfc485.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
