### PR TITLE
Archive rfc4854.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4854.txt
+++ b/www.ietf.org/rfc/rfc4854.txt
@@ -1,0 +1,507 @@
+
+
+
+
+
+
+Network Working Group                                     P. Saint-Andre
+Request for Comments: 4854                                           XSF
+Category: Informational                                       April 2007
+
+
+              A Uniform Resource Name (URN) Namespace for
+  Extensions to the Extensible Messaging and Presence Protocol (XMPP)
+
+Status of This Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard of any kind.  Distribution of this
+   memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The IETF Trust (2007).
+
+Abstract
+
+   This document describes a Uniform Resource Name (URN) namespace for
+   uniquely identifying Extensible Markup Language (XML) formats and
+   protocols that provide extensions to the Extensible Messaging and
+   Presence Protocol (XMPP) and are defined in specifications published
+   by the XMPP Standards Foundation (XSF).
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Saint-Andre                  Informational                      [Page 1]
+
+RFC 4854           URN Namespace for XMPP Extensions          April 2007
+
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . . . 3
+   2.  Specification Template  . . . . . . . . . . . . . . . . . . . . 3
+   3.  Namespace Considerations  . . . . . . . . . . . . . . . . . . . 6
+   4.  Community Considerations  . . . . . . . . . . . . . . . . . . . 6
+   5.  Security Considerations . . . . . . . . . . . . . . . . . . . . 7
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . . . 7
+   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . . . 8
+     7.1.  Normative References  . . . . . . . . . . . . . . . . . . . 8
+     7.2.  Informative References  . . . . . . . . . . . . . . . . . . 8
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Saint-Andre                  Informational                      [Page 2]
+
+RFC 4854           URN Namespace for XMPP Extensions          April 2007
+
+
+1.  Introduction
+
+   While the Extensible Messaging and Presence Protocol (XMPP), as
+   specified in [XMPP-CORE] and [XMPP-IM], provides basic messaging and
+   presence functionality, the fact that XMPP is at root a technology
+   for streaming Extensible Markup Language [XML] data makes it possible
+   to include virtually any structured information within XMPP, as long
+   as such information is qualified by appropriate XML namespaces
+   [XML-NAMES].  When sent over XMPP, such structured data formats and
+   protocols are generally referred to as "XMPP extensions".
+
+   A large number of such XMPP extensions exist.  The main standards
+   development organization in which such extensions are defined is the
+   XMPP Standards Foundation (XSF) (formerly the Jabber Software
+   Foundation), which contributed XMPP to the Internet Standards
+   process.  Typically, such extensions are defined within the XSF's
+   XMPP Extension Protocol (XEP) specification series.  To date, the XML
+   namespaces defined within the Jabber/XMPP community have used names
+   of the form "jabber:*" (deprecated since early 2002) and
+   "http://jabber.org/protocol/*" (not including names of the form
+   "urn:ietf:params:xml:ns:xmpp-*" specified in the XMPP RFCs).
+   However, it is desirable that names associated with future XMPP
+   extensions be both unique and persistent, which is not necessarily
+   the case with names that are also HTTP URLs.  Therefore, in
+   accordance with the process defined in [MECHANISMS], this document
+   registers a formal namespace identifier (NID) for Uniform Resource
+   Names [URN] associated with XMPP extensions published in the XSF's
+   XEP series and for XML namespaces registered with the XSF's XMPP
+   Registrar function [REGISTRAR].
+
+2.  Specification Template
+
+   Namespace ID:
+
+      The Namespace ID "xmpp" is requested.
+
+   Registration Information:
+
+      Version 1
+      Date: 2007-04-27
+
+   Declared Registrant of the Namespace:
+
+      Registering organization
+         Organization: XMPP Standards Foundation
+         Address: P.O. Box 1641, Denver, CO 80201 USA
+
+
+
+
+
+Saint-Andre                  Informational                      [Page 3]
+
+RFC 4854           URN Namespace for XMPP Extensions          April 2007
+
+
+      Designated contact
+         Role: XMPP Registrar
+         Email: registrar@xmpp.org
+
+   Declaration of Syntactic Structure:
+
+      The Namespace Specific String (NSS) of all URNs that use the
+      "xmpp" NID shall have the following structure:
+
+         urn:xmpp:{ShortName}:{SubName}
+
+      The keywords have the following meaning:
+
+         (1) the "ShortName" is a required US-ASCII string that
+         conforms to the URN syntax requirements (see RFC 2141)
+         and defines a particular protocol or format that is used
+         as an XMPP extension.
+
+         (2) the "SubName" is an optional US-ASCII string that
+         conforms to the URN syntax requirements (see RFC 2141)
+         and defines a particular subset of the relevant protocol
+         or format.
+
+      The XSF's XMPP Registrar function shall be responsible for
+      managing the assignment of both "ShortName" and "SubName"
+      strings and maintaining a registry of resulting namespaces
+      at <http://www.xmpp.org/registrar/namespaces.html>.  The
+      XMPP Registrar may also assign URNs in sub-trees below the
+      level of the ShortName or SubName as needed for use in various
+      XMPP extensions.
+
+   Relevant Ancillary Documentation:
+
+      Information about the XSF's XMPP Registrar function can be
+      found at <http://www.xmpp.org/extensions/xep-0053.html>
+      and <http://www.xmpp.org/registrar/>.
+
+   Identifier Uniqueness Considerations:
+
+      The XMPP Registrar is already responsible for managing
+      the assignment of XML namespace names of the form
+      "http://jabber.org/protocol/{ShortName}" and
+      "http://jabber.org/protocol/{ShortName}#{SubName}"
+      (e.g., "http://jabber.org/protocol/pubsub" and
+      "http://jabber.org/protocol/disco#info").  In order to
+      assign namespace names in the context of the "xmpp"
+      NID, the XMPP Registrar shall simply modify the syntax
+      of the namespace names it assigns from
+
+
+
+Saint-Andre                  Informational                      [Page 4]
+
+RFC 4854           URN Namespace for XMPP Extensions          April 2007
+
+
+      "http://jabber.org/protocol/{ShortName}" and
+      "http://jabber.org/protocol/{ShortName}#{SubName}" to
+      "urn:xmpp:{ShortName}" and "urn:xmpp:{ShortName}:{SubName}".
+
+      The XMPP Registrar shall ensure the uniqueness of all
+      XMPP URNs by checking such names against the list of
+      existing namespace names, as documented in XEP-0053
+      (the controlling specification for the XMPP Registrar
+      function).  The XMPP Registrar shall, in all cases, directly
+      ensure the uniqueness of the assigned strings and shall
+      not assign secondary responsibility for management of any
+      sub-trees.  However, the XMPP Registrar may assign URNs
+      in sub-trees below the level of the ShortName or SubName
+      as needed for use in various XMPP extensions.  The
+      resulting URNs shall not be re-assigned.
+
+   Identifier Persistence Considerations:
+
+      The XMPP Registrar shall provide clear documentation of
+      the registered uses of the "xmpp" NID in the form of
+      XMPP Extension Protocol (XEP) specifications published
+      at <http://www.xmpp.org/extensions/>, as well as a
+      registry of the namespace names themselves at
+      <http://www.xmpp.org/registrar/namespaces.html>.
+
+   Process of Identifier Assignment:
+
+      The XMPP Registrar's processes and procedures for
+      identifier assignment are documented in XEP-0053,
+      which is the controlling specification for the XMPP
+      Registrar function.  In particular, identifiers shall
+      be issued only upon advancement of the relevant protocol
+      specification to a status of Draft within the standards
+      process, followed by the XMPP Standards Foundation (as
+      specified in XEP-0001).  The XMPP Registrar shall check
+      all identifiers against the list of existing namespace
+      names to ensure uniqueness and to encourage relevance
+      and memorability.  Assignment of URNs within the "xmpp"
+      tree is reserved to the XMPP Standards Foundation,
+      specifically to its XMPP Registrar function.
+
+   Process for Identifier Resolution:
+
+      The namespace is not currently listed with a Resolution
+      Discovery System (RDS), but nothing about the namespace
+      prohibits the future definition of appropriate resolution
+      methods or listing with an RDS.
+
+
+
+
+Saint-Andre                  Informational                      [Page 5]
+
+RFC 4854           URN Namespace for XMPP Extensions          April 2007
+
+
+   Rules for Lexical Equivalence:
+
+      No special considerations; the rules for lexical
+      equivalence specified in RFC 2141 apply.
+
+   Conformance with URN Syntax:
+
+      No special considerations.
+
+   Validation Mechanism:
+
+      None specified.
+
+   Scope:
+
+      Global.
+
+3.  Namespace Considerations
+
+   The XMPP Standards Foundation has been developing Internet protocols
+   since August 2001 and that work is expected to continue for the
+   foreseeable future.  The old-style "jabber:*" namespace names
+   originally used in the Jabber open-source community were not proper
+   URNs or URIs and thus were deprecated in early 2002.  Since then, the
+   namespace names assigned by the XMPP Registrar function of the XMPP
+   Standards Foundation have been (equivalent to) specialized HTTP URLs
+   whose authority component is "jabber.org".  While that domain is
+   currently under the control of the XMPP Standards Foundation, there
+   is no guarantee that it will always remain so, thus potentially
+   threatening the reliability and permanence of the assigned namespace
+   names.  The use of Uniform Resource Names with an appropriate
+   Namespace ID will enable the XMPP Standards Foundation to assign
+   cleaner, more general, more permanent, more reliable, and more
+   controllable namespace names related to the XMPP extensions it
+   defines, while keeping the tree of XMPP extensions produced by the
+   XMPP Standards Foundation properly separate from the IETF tree used
+   to define some of the core XMPP namespaces as well as namespaces
+   related to XMPP extensions that may be produced in the future by the
+   IETF.
+
+4.  Community Considerations
+
+   The XMPP standards development community will benefit from
+   publication of this namespace by having more permanent and reliable
+   names for the XML namespaces defined in XMPP Extension Protocol
+   specifications produced by the XMPP Standards Foundation.
+
+
+
+
+
+Saint-Andre                  Informational                      [Page 6]
+
+RFC 4854           URN Namespace for XMPP Extensions          April 2007
+
+
+   The standards process followed by the XSF is open to contributions
+   from any interested individual; such a contribution takes the form of
+   a proposal submitted to the XMPP Extensions Editor
+   <mailto:editor@xmpp.org>, accepted by the XMPP Council
+   <http://www.xmpp.org/council/>, and published in the XSF's XMPP
+   Extension Protocol (XEP) series at <http://www.xmpp.org/extensions/>.
+   Use of the proposed space for a particular XML format or protocol
+   extension will be contingent upon advancement of the appropriate
+   specification within the XSF's standards process (as documented in
+   [XEP]) and issuance of a namespace name within the "xmpp" tree by the
+   XMPP Registrar (as documented in [REGISTRAR]).
+
+5.  Security Considerations
+
+   This document introduces no additional security considerations beyond
+   those associated with the use and resolution of URNs in general.
+
+6.  IANA Considerations
+
+   This document defines a URN NID registration of "xmpp", which has
+   been entered into the IANA registry located at
+   <http://www.iana.org/assignments/urn-namespaces>.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Saint-Andre                  Informational                      [Page 7]
+
+RFC 4854           URN Namespace for XMPP Extensions          April 2007
+
+
+7.  References
+
+7.1.  Normative References
+
+   [MECHANISMS]  Daigle, L., van Gulik, D., Iannella, R., and P.
+                 Faltstrom, "Uniform Resource Names (URN) Namespace
+                 Definition Mechanisms", BCP 66, RFC 3406, October 2002.
+
+   [URN]         Moats, R., "URN Syntax", RFC 2141, May 1997.
+
+7.2.  Informative References
+
+   [REGISTRAR]   Saint-Andre, P., "XMPP Registrar Function", XSF
+                 XEP 0053, December 2006.
+
+   [XEP]         Saint-Andre, P., "XMPP Extension Protocols", XSF
+                 XEP 0001, December 2006.
+
+   [XML]         Bray, T., Paoli, J., Sperberg-McQueen, C., and E.
+                 Maler, "Extensible Markup Language (XML) 1.0 (2nd ed)",
+                 W3C REC-xml, October 2000,
+                 <http://www.w3.org/TR/REC-xml>.
+
+   [XML-NAMES]   Bray, T., Hollander, D., and A. Layman, "Namespaces in
+                 XML", W3C REC-xml-names, January 1999,
+                 <http://www.w3.org/TR/REC-xml-names>.
+
+   [XMPP-CORE]   Saint-Andre, P., "Extensible Messaging and Presence
+                 Protocol (XMPP): Core", RFC 3920, October 2004.
+
+   [XMPP-IM]     Saint-Andre, P., "Extensible Messaging and Presence
+                 Protocol (XMPP): Instant Messaging and Presence",
+                 RFC 3921, October 2004.
+
+Author's Address
+
+   Peter Saint-Andre
+   XMPP Standards Foundation
+   P.O. Box 1641
+   Denver, CO  80201
+   USA
+
+   EMail: stpeter@jabber.org
+   URI:   xmpp:stpeter@jabber.org
+
+
+
+
+
+
+
+Saint-Andre                  Informational                      [Page 8]
+
+RFC 4854           URN Namespace for XMPP Extensions          April 2007
+
+
+Full Copyright Statement
+
+   Copyright (C) The IETF Trust (2007).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY, THE IETF TRUST AND
+   THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF
+   THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+Saint-Andre                  Informational                      [Page 9]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4854.txt](<www.ietf.org/rfc/rfc4854.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
