### PR TITLE
Archive rfc4879.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4879.txt
+++ b/www.ietf.org/rfc/rfc4879.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Network Working Group                                          T. Narten
+Request for Comments: 4879                                           IBM
+BCP: 79                                                       April 2007
+Updates: 3979
+Category: Best Current Practice
+
+
+   Clarification of the Third Party Disclosure Procedure in RFC 3979
+
+Status of This Memo
+
+   This document specifies an Internet Best Current Practices for the
+   Internet Community, and requests discussion and suggestions for
+   improvements.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The IETF Trust (2007).
+
+Abstract
+
+   This document clarifies and updates a single sentence in RFC 3979.
+   Specifically, when third party Intellectual Property Rights (IPR)
+   disclosures are made, the intention is that the IETF Executive
+   Director notify the IPR holder that a third party disclosure has been
+   filed, and to ask the IPR holder whether they have any disclosure
+   that needs to be made, per applicable RFC 3979 rules.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Narten                   Best Current Practice                  [Page 1]
+
+RFC 4879              Third Party Fix for RFC 3979            April 2007
+
+
+1.  Introduction
+
+   This document clarifies and updates a single sentence in RFC 3979
+   [RFC3979].  Specifically, when third party IPR disclosures are made,
+   the intention is that the IETF Executive Director notify the IPR
+   holder that a third party disclosure has been filed, and to ask the
+   IPR holder whether they have any disclosure that needs to be made,
+   per applicable RFC 3979 rules.
+
+   This document updates RFC 3979.
+
+2.  The Fix
+
+   RFC 3979, Section 4 (C), states:
+
+    (C) Where Intellectual Property Rights have been disclosed for IETF
+        Documents as provided in Section 6 of this document, the IETF
+        Executive Director shall request from the discloser of such IPR,
+        a written assurance that upon approval by the IESG for
+        publication as RFCs of the relevant IETF specification(s), all
+        persons will be able to obtain the right to implement, use,
+        distribute and exercise other rights with respect to
+        Implementing Technology under one of the licensing options
+        specified in Section 6.5 below unless such a statement has
+        already been submitted.
+
+   In the case of third party disclosures, it makes no sense to ask the
+   discloser about potential licensing terms, since they do not own the
+   IPR.  Instead, it only makes sense to ask the IPR holder.
+
+   This document updates RFC 3979 by changing the word "discloser" to
+   "holder" in the above text.
+
+3.  Security Considerations
+
+   This document has no known security implications.
+
+4.  Normative Reference
+
+   [RFC3979]  Bradner, S., "Intellectual Property Rights in IETF
+              Technology", BCP 79, RFC 3979, March 2005.
+
+
+
+
+
+
+
+
+
+
+Narten                   Best Current Practice                  [Page 2]
+
+RFC 4879              Third Party Fix for RFC 3979            April 2007
+
+
+Author's Address
+
+   Thomas Narten
+   IBM Corporation
+   3039 Cornwallis Ave.
+   PO Box 12195 - BRQA/502
+   Research Triangle Park, NC 27709-2195
+
+   Phone: 919-254-7798
+   EMail: narten@us.ibm.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Narten                   Best Current Practice                  [Page 3]
+
+RFC 4879              Third Party Fix for RFC 3979            April 2007
+
+
+Full Copyright Statement
+
+   Copyright (C) The IETF Trust (2007).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY, THE IETF TRUST AND
+   THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF
+   THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+Narten                   Best Current Practice                  [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4879.txt](<www.ietf.org/rfc/rfc4879.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
