### PR TITLE
Archive rfc488.txt

### DIFF
--- a/www.ietf.org/rfc/rfc488.txt
+++ b/www.ietf.org/rfc/rfc488.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                   Marilyn Auerbach
+RFC # 488                                               SRI-ARC
+NIC # 15266                                             March 23, 1973
+
+
+                      NLS Classes at Network Sites
+
+
+Purpose of this RFC
+
+Network users have expressed interest in holding NLS classes at sites on
+the Network, instead of at SRI-ARC.  This RFC solicits comments from the
+Network community on the desirability of doing on-site classes.
+
+A brief outline of course contents is included at the end of this RFC,
+together with some logistic information which we feel is necessary to
+conducting a useful class.
+
+Please review this information, and let us know whether such a class
+would be useful if conducted at or near your site.  We are eager to
+participate in this way, because we know it will be useful to us to have
+the benefit of consultation with experienced Network users.
+
+As we have to schedule our people's time in advance, we are tentatively
+considering making trips to Washington D.C. during the first week of
+May, and to Boston during the first week of June, for the purpose of
+conducting classes.  We will consider other arrangements, however,
+if they would be more satisfactory.
+
+Please respond by April 15 to Marilyn Auerbach (MFA) at the NIC
+(415)326-6200 extension 3722.
+
+
+NLS Class Information
+
+The class is a comprehensive introduction to the use of NLS over the
+Network.  The class generally runs for two to three days, depending on
+the composition and interests of the participants.
+
+For purposes of planning, the following information will be useful:
+
+    1.  We have found the optimum class size to be six, with an upper
+    limit of ten.
+
+    2.  We need a room large enough to hold the number of students, with
+    a teletype-type terminal and appropriate connections for each
+    student, a flip-chart stand and a large blackboard.
+
+
+
+
+Auerbach                                                        [Page 1]
+
+RFC 488               NLS Classes at Network Sites            March 1973
+
+
+Class Outline - TNLS Course
+
+We have held NLS classes approximately a dozen times.  In all, nearly a
+hundred people have attended these classes.  While we feel that the
+training has been helpful, we also recognize that teaching the class at
+SRI-ARC tends to overlook special problems of working through the
+Network and special interests of other sites.
+
+The people who conduct the class are experienced in working out
+procedures for using NLS in work environments.  Therefore, please accept
+the outline below as a flexible one, one that can be tailored to fit
+particular applications or needs.
+
+Part I:  Elementary Concepts
+
+    1.  Introduction to NLS
+    2.  Sending a Journal Message
+    3.  TENEX/NLS Interfaces
+    4.  Basic File Manipulation
+    5.  Basic Text Handling
+    6.  Addressing Data Within a Statement
+    7.  Elementary Text-Editing
+
+Part II:  Entering and Using Information
+
+    1.  NLS Data Structures
+    2.  Structure Editing and Text Editing
+    3.  "Viewspecs":  Controlling the Appearance of On-Line Output
+    4.  Submission and Retrieval of Journal Items
+    5.  "Partial Copies":  File Updating
+    6.  Use of the NIC On-Line:  "LOCATOR" and "NIC/QUERY"
+    7.  "Strucrels":  Relative Data and Statement Addressing
+    8.  "Directives":  Controlling the Appearance of Off-Line Output
+    9.   Adjusting NLS Control Characters to Your Terminal
+
+Part III:  Sorting and Searching
+
+    1.  Sort and Merge
+    2.  Content analyses
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.             9/99 ]
+
+
+
+
+
+
+Auerbach                                                        [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc488.txt](<www.ietf.org/rfc/rfc488.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
