### PR TITLE
Archive rfc490.txt

### DIFF
--- a/www.ietf.org/rfc/rfc490.txt
+++ b/www.ietf.org/rfc/rfc490.txt
@@ -1,0 +1,339 @@
+
+
+
+
+
+
+Network Working Group                                    John R. Pickens
+RFC # 490                                                UCSB
+NIC # 15355                                              6 March, 1973
+references RFC # 436
+           RFC # 477
+
+
+                       SURROGATE RJS FOR UCLA-CCN
+
+
+    By using UCSB's Network Standard RJS* users can now gain access to
+UCLA-CCN's RJS without converting to the UCLA protocol.  In addition,
+the need to use and create files in an intermediate host is avoided.
+For example, TIP users may operate with hot card readers and printers
+through UCSB's Remote Job Server and have their jobs execute at UCLA-
+CCN.  The disadvantages of this scheme as compared to direct connections
+to UCLA are as follows:
+
+    1.  A small amount of additional JCL is required to route jobs from
+        UCSB to UCLA.
+
+    2.  A UCSB batch account must be opened.
+
+    3.  Turnaround time includes waits in UCSB batch queues.
+
+    4.  The current implementation requires separate submission and
+        retrieval steps.
+
+    5.  The RJS terminal used for submission/retrieval at UCLA-CCN
+        should not be accessed online until all transfers to/from UCSB
+        are complete.
+
+Hopefully, these disadvantages are outweighed by the convenient
+interface to standard RJS.
+
+    Attached is the document which describes this procedure to access
+UCLA-CCN.
+
+
+
+
+
+
+
+
+
+_________________________________
+*RFC #436 announces RJS at UCSB and RFC #477 describes its use.
+
+
+
+Pickens                                                         [Page 1]
+
+RFC 490                SURROGATE RJS FOR UCLA-CCN             March 1973
+
+
+                  UCLA REMOTE JOB SUBMISSION FROM UCSB
+
+
+Introduction
+------------
+
+    Users of the IBM 360/75 at UCSB may now route jobs to and from
+UCLA-CCN (IBM 360/91).  Only the reading, printing, and punching are
+handled at UCSB while the scheduling, allocation of resources, and
+execution are handled at UCLA. The program described below operates by
+establishing operator and data connections with UCLA's Remote Job
+Service through the ARPA Network and issuing operator commands to
+control the submission and retrieval of jobs.  Thus it is possible for a
+user to run jobs on UCLA's 360/91 almost as if he were at UCLA.
+
+Procedure
+---------
+
+    Submission and retrieval are two separate phases which the user must
+initiate for each of his UCLA destined jobs.  Usually, two UCSB jobs
+will be required for the two phases of one UCLA job.  Exceptions do
+occur using the BATCH options described below and jobs with a guaranteed
+fast UCLA turnaround (e.g. QUICKRUN jobs.)
+
+    Commands are issued through JCL to the local process and resultant
+actions and messages are recorded in the RJS system log on the user's
+listing.  The user must be aware of the timing of his commands, e.g. a
+request to retrieve print output for a specific job will result in an
+error condition if the job has not finished executing at UCLA.
+Available commands are READ, PRINT, PUNCH, STATUS, and TERMID.
+
+    Effort has been made to provide the user with fairly intelligible
+error diagnostics although this is not always possible.  Error
+conditions are described in the section "ERRORS".
+
+Job Submission
+--------------
+
+    The READ command is used to send jobs to UCLA.  It is the default
+command if none other is specified.  UCLA jobs may be batched together
+under a single read operation.  Great care should be taken to terminate
+the batch with the correct delimiter (see DD Cards below) so that any
+following non-UCLA jobs won't be sent to UCLA by mistake.  A suggested
+procedure, if submitting jobs from the campus computer center, would be
+to indicate on the job submission card the intended destination.  If the
+job is accepted by UCLA a message from UCLA will be recorded indicating
+the job name and number of cards received.
+
+
+
+
+Pickens                                                         [Page 2]
+
+RFC 490                SURROGATE RJS FOR UCLA-CCN             March 1973
+
+
+Single Job Retrieval
+--------------------
+
+    PRINT (JOBNAME) and PUNCH (JOBNAME) are used to explicitly fetch
+print and punch output, respectively.  The UCLA RESET command is used to
+set all job priorities the same, and then to set the named job's
+priority to the highest value.  An unknown command, HEREIAM, is used for
+synchronization purposes only.  If the named job is not ready for output
+the local process will terminate with a timeout error (the current timer
+is set at one minute).
+
+Multiple Job Retrieval
+----------------------
+
+    PRINT (*) and PUNCH (*) are used to fetch all waiting output.  These
+commands should always be preceded by the TERMID command.  Users who
+have their own RJS terminal assigned to them will use this mode.
+
+UCSB Job Control Cards
+----------------------
+
+    EXEC Card
+
+    The catalogued procedure to executed is named UCLARJS.  Parameters
+are used to specify which functions are to be performed.  The general
+form of the execute card is:
+
+        //anyname EXEC UCLARJS, PARM.RJS-'...functions...'
+
+
+PARM Field
+----------
+
+    The following list defines the allowable parameters and their
+indicated functions.  All parameters are executed in sequence and
+separated by commas.
+
+    READ - Open the reader channel and send 80 column records from the
+           SYSIN data set.
+
+    PRINT(JOBNAME) - Set indicated job's priority to highest value and
+           retrieve the print output to the SYSPRINT data set. Records
+           over 132 characters are folded to the next line.
+
+    PRINT (*) - Retrieve all print jobs.
+
+    PUNCH(JOBNAME) - Set indicated job's priority to highest value and
+           retrieve 80 column punch output to the SYSPUNCH data set.
+
+
+
+Pickens                                                         [Page 3]
+
+RFC 490                SURROGATE RJS FOR UCLA-CCN             March 1973
+
+
+    PUNCH (*) - Retrieve all punch jobs.
+
+    STATUS - Query UCLA about the status of all jobs assigned to this
+           RJS terminal.
+
+    TERMID(NAME-PASSWORD) - Sign on as named RJS terminal.  PASSWORD is
+           optional and should be declared only if the terminal has a
+           password.  The local process always signs on initially as
+           NETUCSB.
+
+DD Cards
+--------
+
+    1.  Reader - The SYSIN data set should have the following format to
+          be able to send JCL and /* cards:
+
+       // RJS.SYSIN DD DATA,DLM=$$,DCB=(RECFM=F,LRECL=80,BLKSIZE=80)
+                       .
+                       .
+                       .
+                    job(s)
+                       .
+                       .
+                       .
+       $$ (note, this special delimiter is required)
+
+    2.  Printer - The default RJS.SYSPRINT data set is specified as
+          SYSOUT=A
+
+    3.  Punch - The default RJS.SYSPUNCH data set is specified as
+          SYSOUT=B
+
+    4.  RJS log - The default RJS.MESSAGES data set is specified as
+          SYSYOUT=A
+
+Problems and Errors
+-------------------
+
+    Most problems encountered fall into one of the following categories:
+
+    1.  UCLA-CCN or ARPANET down.
+          This condition is usually noted when the local process
+          attempts connection with UCLA.  The error message is usually
+          "INITIAL CONNECTION OPEN ERROR."
+
+    2.  RJS terminal in use by a non-UCSB-jobshop process.
+          This can occur if a user submits a job but signs on to his
+          UCLA RJS terminal online prior to the local batch process
+
+
+
+Pickens                                                         [Page 4]
+
+RFC 490                SURROGATE RJS FOR UCLA-CCN             March 1973
+
+
+          coming into execution.  This condition is usually noted by the
+          appearance of "FAILURE OR TIMEOUT IN OPERATOR, PRINT OR PUNCH
+          CHANNEL" with completion code 252.
+
+    3.  Job not ready to be retrieved.
+          The local process attempts to set the priority of the
+          indicated job but receives no successful response.  This
+          condition is also noted by the appearance of "FAILURE OR
+          TIMEOUT IN OPERATOR, PRINT OR PUNCH CHANNEL" with completion
+          code 252.
+
+    4.  UCLA is unable to retrieve output because of an age-old bug.
+          Unfortunately this condition can occur for very small amounts
+          of output.  It is usually noted by the message "BEGINNING
+          RETRIEVAL OF" followed by "(PROBABLE UCLA BUG)..  PREVIOUSLY
+          GOOD CONNECTION NOW HAS STATUS = 8".  The output in this case
+          is usually lost.
+
+Cases 1 through 3 are corrected by waiting and then trying again.  Other
+error messages may require reference to the NETWORK USER GUIDE or
+consultation with Computer Center or Computer Systems Lab personnel.
+
+
+Examples
+--------
+1.  Submit a job to UCLA-CCN through RJS terminal NETUCSB.
+
+    //SUBMIT JOB (0000,ROBERTS),'PSYCH BOX'
+    //STEP1 EXEC UCLARJS
+    //RJS.SYSIN DD DATA,DLM=$$,DCB=(RECFM=F,LRECL=80,BLKSIZE=80
+    //AAA000IC JOB......
+                .
+                .
+                .
+                .
+                .
+
+    $$
+    //
+
+2.  Retrieve print job AAA000IC from terminal NETUCSB.
+
+    //RETR JOB (0000,ROBERTS),'PSYCH BOX'
+    //STEP1 EXEC UCLARJS,PARM.RJS='PRINT(AAA000IC)'
+    //
+
+
+
+
+
+
+Pickens                                                         [Page 5]
+
+RFC 490                SURROGATE RJS FOR UCLA-CCN             March 1973
+
+
+3.  Retrieve all prints jobs from terminal NETRAND0
+
+    //RETR JOB (0000, ROBERTS),'PSYCH BOX'
+    //STEP1 EXEC UCLARJS,'TERMID(NETRAND0),PRINT(*),STATUS'
+    //
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.             9/99 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Pickens                                                         [Page 6]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc490.txt](<www.ietf.org/rfc/rfc490.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
