### PR TITLE
Archive rfc4913.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4913.txt
+++ b/www.ietf.org/rfc/rfc4913.txt
@@ -1,0 +1,507 @@
+
+
+
+
+
+
+Network Working Group                                            S. Legg
+Request for Comments: 4913                                       eB2Bcom
+Category: Experimental                                         July 2007
+
+
+           Abstract Syntax Notation X (ASN.X) Representation
+                      of Encoding Instructions for
+                the Generic String Encoding Rules (GSER)
+
+Status of This Memo
+
+   This memo defines an Experimental Protocol for the Internet
+   community.  It does not specify an Internet standard of any kind.
+   Discussion and suggestions for improvement are requested.
+   Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The IETF Trust (2007).
+
+Abstract
+
+   Abstract Syntax Notation X (ASN.X) is an Extensible Markup Language
+   (XML) representation for Abstract Syntax Notation One (ASN.1)
+   specifications.  This document specifies the ASN.X representation of
+   encoding instructions for the Generic String Encoding Rules (GSER).
+
+Table of Contents
+
+   1. Introduction ....................................................2
+   2. Conventions .....................................................2
+   3. EncodingInstructionAssignmentList Translation ...................3
+   4. EncodingInstruction Translation .................................3
+      4.1. ChoiceOfStringsInstruction Translation .....................3
+   5. Security Considerations .........................................4
+   6. Normative References ............................................4
+   Appendix A. ASN.1 for GSER Encoding Instruction Notation ...........6
+   Appendix B. ASN.X for GSER Encoding Instruction Notation ...........7
+
+
+
+
+
+
+
+
+
+
+
+
+
+Legg                          Experimental                      [Page 1]
+
+RFC 4913           ASN.X: GSER Encoding Instructions   July 2007
+
+
+1.  Introduction
+
+   Abstract Syntax Notation X (ASN.X) [ASN.X] is an Extensible Markup
+   Language (XML) [XML10][XML11] representation for Abstract Syntax
+   Notation One (ASN.1) [X.680] specifications.  The ASN.X
+   representation for the ASN.1 basic notation [X.680] [X.680-1] is
+   described elsewhere [ASN.X].
+
+   The grammar of ASN.1 permits the application of encoding instructions
+   [X.680-1], through type prefixes and encoding control sections, that
+   modify how abstract values are encoded by nominated encoding rules.
+
+   The generic notation for type prefixes and encoding control sections
+   is defined by the ASN.1 basic notation; however, the notation for
+   specific encoding instructions, i.e., the EncodingInstruction and
+   EncodingInstructionAssignmentList productions of the notation, are
+   defined separately for each set of encoding rules using encoding
+   instructions.  This document specifies the ASN.X representation for
+   EncodingInstructionAssignmentList and EncodingInstruction as they are
+   defined for the Generic String Encoding Rules (GSER) [GSER][GSEREI].
+
+   ASN.X is defined in terms of rules for translating from an ASN.1
+   specification.  This does not preclude an ASN.X module being written
+   directly without a pre-existing ASN.1 module; however, such an ASN.X
+   module is considered valid if and only if there exists, in principle,
+   an ASN.1 module that when translated would yield the ASN.X module.
+
+   By design, an ASN.X module is also the Robust XML Encoding Rules
+   (RXER) [RXER] encoding of an ASN.1 value.  The ASN.1 type definitions
+   for such values, insofar as they pertain to the ASN.1 basic notation,
+   are provided elsewhere [ASN.X]; however, this document provides the
+   ASN.1 type definitions for representing GSER encoding instructions as
+   abstract values.  These definitions appear in Appendix A.
+
+   The ASN.X translation of the ASN.1 module in Appendix A is presented
+   in Appendix B.
+
+   The General Considerations of the specification for ASN.X [ASN.X]
+   also apply here.
+
+2.  Conventions
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", and "MAY" in this document are
+   to be interpreted as described in BCP 14, RFC 2119 [BCP14].  The key
+   word "OPTIONAL" is exclusively used with its ASN.1 meaning.
+
+
+
+
+
+Legg                          Experimental                      [Page 2]
+
+RFC 4913           ASN.X: GSER Encoding Instructions   July 2007
+
+
+   A reference to an ASN.1 production [X.680] (e.g., Type, NamedType) is
+   a reference to the text in an ASN.1 specification corresponding to
+   that production.
+
+   The description of the translation of GSER encoding instructions into
+   ASN.X makes use of definitions from the XML Information Set (Infoset)
+   [INFOSET].  In particular, information item property names follow the
+   Infoset convention of being shown in square brackets, e.g.,
+   [local name].  Literal values of Infoset properties are enclosed in
+   double quotes; however, the double quotes are not part of the
+   property values.  In the sections that follow, "information item"
+   will be abbreviated to "item", e.g., "element information item" is
+   abbreviated to "element item".  Element items will be referred to by
+   their [local name] in angle brackets, e.g., "the <type> element item"
+   means the element item with the [local name] "type".
+
+3.  EncodingInstructionAssignmentList Translation
+
+   As described in the specification for ASN.X [ASN.X], the translation
+   of an EncodingControlSection for GSER is an element item with the
+   [local name] "GSER".  The translation of the
+   EncodingInstructionAssignmentList in such an EncodingControlSection
+   determines the content of the <GSER> element item.
+
+   The EncodingInstructionAssignmentList for GSER is currently defined
+   to be empty [GSEREI]; therefore, the [attributes] and [children] of
+   the <GSER> element item are both empty.
+
+4.  EncodingInstruction Translation
+
+   The translation of an EncodingInstruction for GSER can appear in the
+   translation of an EncodingPrefix.  The translation for an
+   EncodingPrefix is described by the specification for ASN.X.
+
+   The translation of an EncodingInstruction for GSER is the translation
+   of the ChoiceOfStringsInstruction in the EncodingInstruction
+   (currently the only defined encoding instruction for GSER).
+
+4.1.  ChoiceOfStringsInstruction Translation
+
+   The translation of a ChoiceOfStringsInstruction is an element item
+   with the [local name] "choiceOfStrings".
+
+   If the ChoiceOfStringsInstruction has an AlternativesPrecedence, then
+   an attribute item with the [local name] "precedence" SHALL be added
+   to the [attributes] of the <choiceOfStrings> element item.  The
+   [normalized value] of this attribute item is the white space
+   separated list of qualified names for the expanded names [XMLNS10] of
+
+
+
+Legg                          Experimental                      [Page 3]
+
+RFC 4913           ASN.X: GSER Encoding Instructions   July 2007
+
+
+   the NamedType instances (see [RXEREI]) corresponding to the
+   identifiers nested in the PrecedenceList in the
+   AlternativesPrecedence.
+
+   Example
+
+      [GSER:CHOICE-OF-STRINGS PRECEDENCE utf8 visible] CHOICE {
+          visible  [RXER:NAME "ascii"] VisibleString,
+          utf8     UTF8String
+      }
+
+      <type xmlns:asnx="urn:ietf:params:xml:ns:asnx">
+       <prefixed>
+        <GSER><choiceOfStrings precedence="utf8 ascii"/></GSER>
+        <type>
+         <choice>
+          <element name="ascii" identifier="visible"
+                   type="asnx:VisibleString"/>
+          <element name="utf8" type="asnx:UTF8String"/>
+         </choice>
+        </type>
+       </prefixed>
+      </type>
+
+5.  Security Considerations
+
+   The ASN.X translation of a GSER encoding instruction is semantically
+   equivalent to the original GSER encoding instruction.  The security
+   considerations that apply to an application built from an original
+   ASN.1 specification with GSER encoding instructions apply equally to
+   an application built from the ASN.X translation of the ASN.1
+   specification.
+
+   See the main specification for ASN.X [ASN.X] for security
+   considerations related to ASN.X modules.
+
+6.  Normative References
+
+   [BCP14]    Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [GSER]     Legg, S., "Generic String Encoding Rules (GSER) for ASN.1
+              Types", RFC 3641, October 2003.
+
+   [GSEREI]   Legg, S., "Encoding Instructions for the Generic String
+              Encoding Rules (GSER)", RFC 4792, January 2007.
+
+
+
+
+
+Legg                          Experimental                      [Page 4]
+
+RFC 4913           ASN.X: GSER Encoding Instructions   July 2007
+
+
+   [RXER]     Legg, S. and D. Prager, "Robust XML Encoding Rules (RXER)
+              for Abstract Syntax Notation One (ASN.1)", RFC 4910, July
+              2007.
+
+   [RXEREI]   Legg, S., "Encoding Instructions for the Robust XML
+              Encoding Rules (RXER)", RFC 4911, July 2007.
+
+   [ASN.X]    Legg, S., "Abstract Syntax Notation X (ASN.X)", RFC 4912,
+              July 2007.
+
+   [X.680]    ITU-T Recommendation X.680 (07/02) | ISO/IEC 8824-1,
+              Information technology - Abstract Syntax Notation One
+              (ASN.1):  Specification of basic notation.
+
+   [X.680-1]  ITU-T Recommendation X.680 (2002) Amendment 1 (10/03) |
+              ISO/IEC 8824-1:2002/Amd 1:2004, Support for EXTENDED-XER.
+
+   [XML10]    Bray, T., Paoli, J., Sperberg-McQueen, C., Maler, E. and
+              F. Yergeau, "Extensible Markup Language (XML) 1.0 (Fourth
+              Edition)", W3C Recommendation,
+              http://www.w3.org/TR/2006/REC-xml-20060816, August 2006.
+
+   [XML11]    Bray, T., Paoli, J., Sperberg-McQueen, C., Maler, E.,
+              Yergeau, F., and J. Cowan, "Extensible Markup Language
+              (XML) 1.1 (Second Edition)", W3C Recommendation,
+              http://www.w3.org/TR/2006/REC-xml11-20060816, August 2006.
+
+   [XMLNS10]  Bray, T., Hollander, D., Layman, A., and R. Tobin,
+              "Namespaces in XML 1.0 (Second Edition)", W3C
+              Recommendation,
+              http://www.w3.org/TR/2006/REC-xml-names-20060816, August
+              2006.
+
+   [INFOSET]  Cowan, J. and R. Tobin, "XML Information Set (Second
+              Edition)", W3C Recommendation,
+              http://www.w3.org/TR/2004/REC-xml-infoset-20040204,
+              February 2004.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Legg                          Experimental                      [Page 5]
+
+RFC 4913           ASN.X: GSER Encoding Instructions   July 2007
+
+
+Appendix A.  ASN.1 for GSER Encoding Instruction Notation
+
+   This appendix is normative.
+
+   GSER-EncodingInstructionNotation
+       { iso(1) identified-organization(3) dod(6)
+         internet(1) private(4) enterprise(1)
+         xmled(21472) asnx(1) module(0) gser-ei-notation(2) }
+
+   -- Copyright (C) The IETF Trust (2007).  This version of
+   -- this ASN.1 module is part of RFC 4913; see the RFC itself
+   -- for full legal notices.
+   --
+   -- Regarding this ASN.1 module or any portion of it, the author
+   -- makes no guarantees and is not responsible for any damage
+   -- resulting from its use.  The author grants irrevocable permission
+   -- to anyone to use, modify, and distribute it in any way that does
+   -- not diminish the rights of anyone else to use, modify, and
+   -- distribute it, provided that redistributed derivative works do
+   -- not contain misleading author or version information.
+   -- Derivative works need not be licensed under similar terms.
+
+   DEFINITIONS
+   RXER INSTRUCTIONS
+   AUTOMATIC TAGS
+   EXTENSIBILITY IMPLIED ::= BEGIN
+
+   IMPORTS
+       PrecedenceList
+           FROM AbstractSyntaxNotation-X
+               { iso(1) identified-organization(3) dod(6)
+                 internet(1) private(4) enterprise(1)
+                 xmled(21472) asnx(1) module(0) notation(1) }
+       ;
+
+   GSER-EncodingInstruction ::= [SINGULAR-INSERTIONS] CHOICE {
+       choiceOfStrings  GSER-ChoiceOfStringsInstruction
+   }
+
+   GSER-EncodingInstructionAssignmentList ::= SEQUENCE { }
+
+   GSER-ChoiceOfStringsInstruction ::= SEQUENCE {
+       precedence  [ATTRIBUTE] PrecedenceList OPTIONAL
+   }
+
+   ENCODING-CONTROL RXER
+
+       SCHEMA-IDENTITY  "urn:oid:1.3.6.1.4.1.21472.1.0.2"
+
+
+
+Legg                          Experimental                      [Page 6]
+
+RFC 4913           ASN.X: GSER Encoding Instructions   July 2007
+
+
+       TARGET-NAMESPACE "urn:ietf:params:xml:ns:asnx" PREFIX "asnx"
+
+   END
+
+Appendix B.  ASN.X for GSER Encoding Instruction Notation
+
+   This appendix is non-normative.
+
+   <?xml version="1.0"?>
+   <asnx:module xmlns:asnx="urn:ietf:params:xml:ns:asnx"
+                name="GSER-EncodingInstructionNotation"
+                identifier="1.3.6.1.4.1.21472.1.0.2"
+                schemaIdentity="urn:oid:1.3.6.1.4.1.21472.1.0.2"
+                targetNamespace="urn:ietf:params:xml:ns:asnx"
+                targetPrefix="asnx"
+                extensibilityImplied="true">
+
+    <annotation>
+     Copyright (C) The IETF Trust (2007).  This version of
+     this ASN.X module is part of RFC 4913; see the RFC itself
+     for full legal notices.
+
+     Regarding this ASN.X module or any portion of it, the author
+     makes no guarantees and is not responsible for any damage
+     resulting from its use.  The author grants irrevocable permission
+     to anyone to use, modify, and distribute it in any way that does
+     not diminish the rights of anyone else to use, modify, and
+     distribute it, provided that redistributed derivative works do
+     not contain misleading author or version information.
+     Derivative works need not be licensed under similar terms.
+    </annotation>
+
+    <import name="AbstractSyntaxNotation-X"
+            identifier="1.3.6.1.4.1.21472.1.0.1"
+            schemaIdentity="urn:oid:1.3.6.1.4.1.21472.1.0.1"
+            namespace="urn:ietf:params:xml:ns:asnx"/>
+
+    <namedType name="GSER-EncodingInstruction">
+     <type>
+      <choice insertions="singular">
+       <element name="choiceOfStrings"
+                type="asnx:GSER-ChoiceOfStringsInstruction"/>
+      </choice>
+     </type>
+    </namedType>
+
+    <namedType name="GSER-EncodingInstructionAssignmentList">
+     <type>
+
+
+
+Legg                          Experimental                      [Page 7]
+
+RFC 4913           ASN.X: GSER Encoding Instructions   July 2007
+
+
+      <sequence/>
+     </type>
+    </namedType>
+
+    <namedType name="GSER-ChoiceOfStringsInstruction">
+     <type>
+      <sequence>
+       <optional>
+        <attribute name="precedence" type="asnx:PrecedenceList"/>
+       </optional>
+      </sequence>
+     </type>
+    </namedType>
+
+   </asnx:module>
+
+Author's Address
+
+   Dr. Steven Legg
+   eB2Bcom
+   Suite 3, Woodhouse Corporate Centre
+   935 Station Street
+   Box Hill North, Victoria 3129
+   AUSTRALIA
+
+   Phone: +61 3 9896 7830
+   Fax:   +61 3 9896 7801
+   EMail: steven.legg@eb2bcom.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Legg                          Experimental                      [Page 8]
+
+RFC 4913           ASN.X: GSER Encoding Instructions   July 2007
+
+
+Full Copyright Statement
+
+   Copyright (C) The IETF Trust (2007).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY, THE IETF TRUST AND
+   THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF
+   THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+Legg                          Experimental                      [Page 9]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4913.txt](<www.ietf.org/rfc/rfc4913.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
