### PR TITLE
Archive rfc4926.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4926.txt
+++ b/www.ietf.org/rfc/rfc4926.txt
@@ -1,0 +1,507 @@
+
+
+
+
+
+
+Network Working Group                                           T. Kalin
+Request for Comments: 4926                                     M. Molina
+Category: Informational                                            DANTE
+                                                               July 2007
+
+
+                       A URN Namespace for GEANT
+
+Status of This Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard of any kind.  Distribution of this
+   memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The IETF Trust (2007).
+
+Abstract
+
+   This document describes a proposed URN (Uniform Resource Name)
+   namespace that would be managed by DANTE, representing European
+   Research and academic networks, for naming persistent resources
+   defined by GEANT, the Consortium of European Academic and Research
+   Networks, its projects, activities, working groups, and other
+   designated subordinates.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kalin & Molina               Informational                      [Page 1]
+
+RFC 4926               A URN Namespace for GEANT               July 2007
+
+
+1.  Introduction
+
+   The Consortium of European Academic and Research Networks (GEANT)
+   provides high-speed, high-quality network connectivity for education
+   institutions, universities, and research centres in Europe.  The
+   network infrastructure is composed of several National Research and
+   Education Networks (NRENs) and their European-wide interconnection,
+   GEANT.  The current network is GEANT2 [6], and is the seventh
+   generation of pan-European research and education network, successor
+   to the pan-European multi-gigabit research network GEANT.  DANTE [7]
+   is a UK-based organization representing the members of the Consortium
+   and operating the GEANT2 Network.  This cooperative work is mainly
+   done in the framework of EU-funded projects.  The biggest of such
+   activities is currently the GN2 project [6], started in September
+   2004, that follows other successful ones that have evolved the
+   European Networks for Research and Education for almost two decades.
+   It is expected that these activities and the network evolution will
+   continue to be supported by the European Union and all European
+   governments in the years to come, as they view the existence of a
+   state-of-the-art network for research in Europe as being of top
+   strategic importance.  We will refer to the organization involved in
+   these projects and those that benefit from their outcome as the
+   "GEANT community".
+
+   The GEANT community produces many kinds of documents: specifications,
+   working drafts, project reports, schemas, stylesheets, etc.  The
+   community wishes to provide global, distributed, persistent,
+   location-independent names for these resources.  The Uniform Resource
+   Name (URN) variant of URIs meets these requirements.
+
+   The GEANT community and other GEANT-affiliated groups would benefit
+   from the GEANT URN proposal by having an easy, efficient way to
+   assign globally unique, persistent identifiers to resources that they
+   create.  The nature of GEANT work is that it serves the needs of many
+   communities of interest.  A namespace managed so as to facilitate the
+   creation, registration, and resolution of unique, persistent
+   identifiers would be of great value for GEANT, its affiliates, and
+   the higher education community generally.  The possibility of fitting
+   the naming needs under existing namespaces has been considered, but
+   the conclusion was that the number of activities and the size of the
+   developers community is such that creating a lot of (possibly
+   uncoordinated) dependencies from other namespaces is undesirable.
+
+   The proposed URN namespace specification is for a formal namespace.
+
+
+
+
+
+
+
+Kalin & Molina               Informational                      [Page 2]
+
+RFC 4926               A URN Namespace for GEANT               July 2007
+
+
+2.  Specification Template
+
+   Namespace ID:
+
+         geant
+
+   Registration Information:
+
+         Registration Version Number 1
+
+         Registration Date: 2006-03-21
+
+   Registrant of the namespace:
+
+         DANTE
+         ATTN: Maurizio Molina
+         City House
+         126 - 130 Hills Road
+         Cambridge CB2 1PQ
+         United Kingdom
+         Phone: +44 1223 371340
+
+         Contact: Tomaz Kalin
+         Affiliation: DANTE
+         City House
+         126 - 130 Hills Road
+         Cambridge CB2 1PQ
+
+         Email: tomaz.kalin@dante.org.uk
+         Phone: +386 1 430 3055
+
+   Syntactic structure:
+
+         The Namespace Specific Strings (NSS) of all URNs assigned by
+         GEANT will conform to the syntax defined in section 2.2 of RFC
+         2141, "URN Syntax" [2].  In addition, all GEANT URN NSSs will
+         consist of a left-to-right series of tokens delimited by
+         colons.  The left-to-right sequence of colon-delimited tokens
+         corresponds to descending nodes in a tree.  To the right of the
+         lowest naming authority node, there may be zero, one, or more
+         levels of hierarchical naming nodes terminating in a rightmost
+         leaf node.  See the section below entitled "Identifier
+         assignment" for more on the semantics of NSSs.  This syntax
+         convention is captured in the following normative ABNF rules
+         for GEANT NSSs (see RFC 4234 [1]):
+
+
+
+
+
+
+Kalin & Molina               Informational                      [Page 3]
+
+RFC 4926               A URN Namespace for GEANT               July 2007
+
+
+         GEANT-NSS        =   1*(subStChar) 0*(":" 1*(subStChar))
+
+         subStChar       =   trans / "%" HEXDIG HEXDIG
+
+         trans           =   ALPHA / DIGIT / other / reserved
+
+         other           =   "(" / ")" / "+" / "," / "-" / "." /
+                             "=" / "@" / ";" / "$" /
+                             "_" / "!" / "*" / "'"
+
+         reserved        =   "%" / "/" / "?" / "#"
+
+         The exclusion of the colon from the list of "other" characters
+         means that the colon can only occur as a delimiter between
+         string tokens.  Note that this ABNF rule set guarantees that
+         any valid GEANT NSS is also a valid RFC 2141 NSS.
+
+   Relevant ancillary documentation:
+
+         None.
+
+   Identifier uniqueness:
+
+         It is the responsibility of DANTE to guarantee uniqueness of
+         the names of immediately subordinate naming authorities.  Each
+         lower-level naming authority in turn inherits the
+         responsibility of guaranteeing uniqueness of names in their
+         branch of the naming tree.
+
+   Identifier persistence:
+
+         DANTE bears ultimate responsibility for maintaining the
+         usability of GEANT URNs over time.  This responsibility may be
+         delegated to subordinate naming authorities per the discussion
+         in the section below on identifier assignment.  That section
+         provides a mechanism for the delegation to be revoked in the
+         case a subordinate naming authority ceases to function.
+
+   Identifier assignment:
+
+         DANTE will create an initial series of immediately subordinate
+         naming authorities, and will define a process for adding to
+         that list of authorities.  Each top-level working group of
+         GEANT will be invited to designate a naming authority and to
+         suggest one or more candidate names.
+
+
+
+
+
+
+Kalin & Molina               Informational                      [Page 4]
+
+RFC 4926               A URN Namespace for GEANT               July 2007
+
+
+         Institutions and communities affiliated with GEANT may request,
+         through their designated GEANT liaison, that they be granted
+         GEANT-subordinate naming authority status.  They may propose
+         candidate names for that authority.  One way for such entities
+         to guarantee uniqueness of their proposed name is to base it on
+         a DNS name.  That is, if, e.g., the German National Research
+         and Education Network wished to be designated a subordinate
+         naming authority under GEANT, the institutional GEANT liaison
+         could propose to DANTE to be delegated control over names
+         beginning with "urn:geant:dfn.de".  Institutions seeking
+         affiliation with GEANT should send email to
+         geant-submit@dante.org.uk, nominating an institutional liaison
+         and providing contact information for that person.
+
+         On at least an annual basis, DANTE will contact the liaisons or
+         directors of each immediately subordinate naming authority.  If
+         there is no response, or if the respondent indicates that they
+         wish to relinquish naming authority, the authority over that
+         branch of the tree reverts to GEANT.  This process will be
+         enforced recursively by each naming authority on its
+         subordinates.  This process guarantees that responsibility for
+         each branch of the tree will lapse for less than one year, at
+         worst, before being reclaimed by a superior authority.
+
+         Lexical equivalence of two GEANT namespace specific strings
+         (NSSs) is defined below as an exact, case-sensitive string
+         match.  DANTE will assign names of immediately subordinate
+         naming authorities in lowercase only.  This forestalls the
+         registration of two GEANT-subordinate naming authorities whose
+         names differ only in case.
+
+   Identifier resolution:
+
+         DANTE will maintain an index of all GEANT and GEANT workgroup
+         assigned URNs on its Web site,
+         http://www.dante.net/urn-geant/urn-geant.html.  That index will
+         map URNs to resource identifiers, usually URLs.  GEANT-
+         affiliated naming authorities will specify how to resolve the
+         URNs they assign if they are resolvable.
+
+   Lexical equivalence:
+
+         Lexical equivalence of two GEANT Namespace Specific Strings
+         (NSSs) is defined as an exact, case-sensitive string match.
+
+   Conformance with URN syntax:
+
+         All GEANT NSSs fully conform to RFC 2141 syntax rules for NSSs.
+
+
+
+Kalin & Molina               Informational                      [Page 5]
+
+RFC 4926               A URN Namespace for GEANT               July 2007
+
+
+   Validation mechanism:
+
+         As specified in the "Identifier resolution" section above,
+         DANTE will maintain an index of all GEANT and GEANT workgroup
+         assigned URNs on its Web site,
+         http://www.dante.net/urn-geant/urn-geant.html Presence in that
+         index implies that a given URN is valid.  GEANT-affiliated
+         naming authorities will specify how to validate the URNs they
+         assign.
+
+   Scope:
+
+         Global.
+
+3.  Security Considerations
+
+   There are no additional security considerations beyond those normally
+   associated with the use and resolution of URNs in general.
+
+4.  Namespace Considerations
+
+   Registration of an Namespace Identifier (NID) specific to GEANT is
+   reasonable given the following considerations:
+
+   1.  GEANT would like to assign URNs to some very fine-grained
+       objects.  This does not seem to be the primary intended use of
+       the XMLORG namespace (RFC 3120) [3], or the more tightly
+       controlled OASIS namespace (RFC 3121) [4].
+
+   2.  GEANT seeks naming autonomy.  GEANT is not a member of OASIS, so
+       becoming a subordinate naming authority under the OASIS URN space
+       is not an option.
+
+   3.  GEANT will want to assign URNs to non-XML objects as well.  That
+       is another reason that XMLORG may not be an appropriate higher-
+       level naming authority for GEANT.
+
+   Some GEANT-developed schema and namespaces may be good candidates for
+   inclusion in the XMLORG or possible future "EU" registry.  The fact
+   that such an object might already have a GEANT-assigned URN shouldn't
+   be a hindrance.  RFC 3406 [5] (which replaced RFC 2611) includes an
+   explicit statement that two or more URNs may point to the same
+   resource.  A resource with a GEANT-assigned Namespace Specific String
+   would, of course, be given an XMLORG or EU Namespace Specific String
+   as it enters the XMLORG or "EU" registry.
+
+
+
+
+
+
+Kalin & Molina               Informational                      [Page 6]
+
+RFC 4926               A URN Namespace for GEANT               July 2007
+
+
+5.  Community Considerations
+
+   The assignment and use of identifiers within the namespace are open,
+   and the related rule is established by DANTE.  Registration agencies
+   (the next level naming authorities) will be the European National
+   Research and Education Networks and the established organizational
+   cross-border formations.
+
+   It is expected that the majority of the NRENs and all GEANT base
+   activities make use of the GEANT namespace.
+
+   After the establishment of the GEANT namespace, the consortium will,
+   as soon as practical, establish a resolution service (analogously to
+   other distributed pan-European services, like EduROAM, PerfSONAR,
+   etc.) for the namespace clients.
+
+6.  IANA Considerations
+
+   IANA has registered the "geant" NID within the IANA registry of URN
+   NIDs.
+
+7.  Normative References
+
+   [1]  Crocker, D. and P. Overell, "Augmented BNF for Syntax
+        Specifications: ABNF", RFC 4234, October 2005.
+
+8.  Informative References
+
+   [2]  Moats, R., "URN Syntax", RFC 2141, May 1997.
+
+   [3]  Best, K. and N. Walsh, "A URN Namespace for XML.org", RFC 3120,
+        June 2001.
+
+   [4]  Best, K. and N. Walsh, "A URN Namespace for OASIS", RFC 3121,
+        June 2001.
+
+   [5]  Daigle, L., van Gulik, D., Iannella, R., and P. Faltstrom, "URN
+        Namespace Definition Mechanisms", BCP 66, RFC 3406, October
+        2002.
+
+   [6]  GEANT2 project's Web site, <http://www.geant2.net/>.
+
+   [7]  DANTE's company Web site, <http://www.dante.net/>.
+
+
+
+
+
+
+
+
+Kalin & Molina               Informational                      [Page 7]
+
+RFC 4926               A URN Namespace for GEANT               July 2007
+
+
+Authors' Addresses
+
+   T. Kalin
+   DANTE
+   City House
+   126 - 130 Hills Road
+   Cambridge
+   CB2 1PQ
+   United Kingdom
+
+   EMail: tomaz.kalin@dante.org.uk
+
+
+   Maurizio Molina
+   DANTE
+   City House
+   126 - 130 Hills Road
+   Cambridge
+   CB2 1PQ
+   United Kingdom
+
+   EMail: maurizio.molina@dante.org.uk
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Kalin & Molina               Informational                      [Page 8]
+
+RFC 4926               A URN Namespace for GEANT               July 2007
+
+
+Full Copyright Statement
+
+   Copyright (C) The IETF Trust (2007).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY, THE IETF TRUST AND
+   THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF
+   THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+Kalin & Molina               Informational                      [Page 9]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4926.txt](<www.ietf.org/rfc/rfc4926.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
