### PR TITLE
Archive rfc4935.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4935.txt
+++ b/www.ietf.org/rfc/rfc4935.txt
@@ -1,0 +1,2803 @@
+
+
+
+
+
+
+Network Working Group                                         C. DeSanti
+Request for Comments: 4935                                    H.K. Vivek
+Category: Standards Track                                  K. McCloghrie
+                                                           Cisco Systems
+                                                                  S. Gai
+                                                           Nuova Systems
+                                                             August 2007
+
+
+             Fibre Channel Fabric Configuration Server MIB
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The IETF Trust (2007).
+
+Abstract
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the Internet community.
+   In particular, it describes managed objects for information related
+   to the Fabric Configuration Server function of a Fibre Channel
+   network.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                     [Page 1]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+Table of Contents
+
+   1. Introduction ....................................................3
+   2. The Internet-Standard Management Framework ......................3
+   3. Short Overview of Fibre Channel .................................3
+   4. Relationship to Other MIBs ......................................5
+   5. MIB Overview ....................................................5
+      5.1. Fibre Channel Management Instance ..........................6
+      5.2. Switch Index ...............................................6
+      5.3. Fabric Index ...............................................6
+      5.4. The MIB Groups .............................................7
+      5.5. OS Logical Unit Number (LUN) Map Entries ...................8
+   6. The T11-FC-FABRIC-CONFIG-SERVER-MIB Module ......................9
+   7. IANA Considerations ............................................45
+   8. Security Considerations ........................................45
+   9. Acknowledgements ...............................................46
+   10. Normative References ..........................................47
+   11. Informative References ........................................48
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                     [Page 2]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+1.  Introduction
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the Internet community.
+   In particular, it describes managed objects for information related
+   to a Fibre Channel network's Fabric Configuration Server function,
+   which provides a means by which a management application can discover
+   Fibre Channel fabric topology and attributes.  Discovered topology
+   includes Interconnect Elements (i.e., switches, hubs, bridges, etc.)
+   and their ports, as well as "platforms" that consist of one or more
+   Fibre Channel nodes.
+
+   This memo was previously approved by INternational Committee for
+   Information Technology Standards (INCITS) Task Group T11.5
+   (http://www.t11.org); this document is a product of the IETF's IMSS
+   working group.
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in BCP 14, RFC 2119
+   [RFC2119].
+
+2.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This memo specifies a MIB
+   module that is compliant to the SMIv2, which is described in STD 58,
+   RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579] and STD 58, RFC 2580
+   [RFC2580].
+
+3.  Short Overview of Fibre Channel
+
+   The Fibre Channel (FC) is logically a bidirectional point-to-point
+   serial data channel, structured for high performance.  Fibre Channel
+   provides a general transport vehicle for higher-level protocols such
+   as Small Computer System Interface (SCSI) command sets, the High-
+   Performance Parallel Interface (HIPPI) data framing, IP (Internet
+   Protocol), IEEE 802.2, and others.
+
+   Physically, Fibre Channel is an interconnection of multiple
+   communication points, called N_Ports, interconnected either by a
+
+
+
+DeSanti, et al.             Standards Track                     [Page 3]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+   switching network, called a Fabric, or by a point-to-point link.  A
+   Fibre Channel "node" consists of one or more N_Ports.  A Fabric may
+   consist of multiple Interconnect Elements, some of which are
+   switches.  An N_Port connects to the Fabric via a port on a switch
+   called an F_Port.  When multiple FC nodes are connected to a single
+   port on a switch via an "Arbitrated Loop" topology, the switch port
+   is called an FL_Port, and the nodes' ports are called NL_Ports.  The
+   term Nx_Port is used to refer to either an N_Port or an NL_Port.  The
+   term Fx_Port is used to refer to either an F_Port or an FL_Port.  A
+   switch port, which is interconnected to another switch port via an
+   Inter-Switch Link (ISL), is called an E_Port.  A B_Port connects a
+   bridge device with an E_Port on a switch; a B_Port provides a subset
+   of E_Port functionality.
+
+   Many Fibre Channel components, including the Fabric, each node, and
+   most ports, have globally unique names.  These globally unique names
+   are typically formatted as World Wide Names (WWNs).  More information
+   on WWNs can be found in [FC-FS].  WWNs are expected to be persistent
+   across agent and unit resets.
+
+   Fibre Channel frames contain 24-bit address identifiers that identify
+   the frame's source and destination ports.  Each FC port has both an
+   address identifier and a WWN.  When a Fabric is in use, the FC
+   address identifiers are dynamic and are assigned by a switch.  Each
+   octet of a 24-bit address represents a level in an address hierarchy,
+   with a Domain_ID being the highest level of the hierarchy.
+
+   The Fibre Channel Fabric Configuration Server provides a way for a
+   management application to discover Fibre Channel fabric topology and
+   attributes.  The Fabric Configuration Server is designed so that it
+   can be distributed among switches and accessed from any Nx_Port.
+   However, the Fabric Configuration Server is not restricted or
+   required to be part of/within a Fabric.
+
+   The information registered with and available from each Fabric
+   Configuration Server is modeled as a Fabric consisting of one or more
+   Interconnect Elements that each have some number of physical Ports,
+   and one or more Fibre Channel nodes grouped together into Platforms
+   to facilitate discovery and management.  The Ports are connected
+   either to other Ports on other Interconnect Elements, or to Nx_Ports.
+   Each Interconnect Element may have attributes including its name,
+   type, Domain Identifier, Management Identifier, Logical Name,
+   Management Address(es), Information List, Zoning Enforcement Status,
+   etc.  Each Port may have attributes including its name, type, TX
+   type, Module type, physical port number, attached port name(s), port
+   state, speed, etc.  Each platform may have attributes including its
+   name, type, description, label, location, management address, etc.
+
+
+
+
+DeSanti, et al.             Standards Track                     [Page 4]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+   The Fibre Channel Fabric Configuration Server is defined in the FC-GS
+   specification.  The Fabric Configuration Server is one of a set of
+   functions that are collectively known as the Management Service.  The
+   latest version of the specification is [FC-GS-5].
+
+   The latest standard for an interconnecting Fabric containing multiple
+   Fabric Switch elements is [FC-SW-4].  [FC-SW-4] carries forward the
+   earlier specification for the operation of a single Fabric in a
+   physical infrastructure, and augments it with the definition of
+   Virtual Fabrics and with the specification of how multiple Virtual
+   Fabrics can operate within one (or more) physical infrastructures.
+   The use of Virtual Fabrics provides for each frame to be tagged in
+   its header to indicate which one of several Virtual Fabrics that
+   frame is being transmitted on.  All frames entering a particular
+   "Core Switch" [FC-SW-4] (i.e., a physical switch) on the same Virtual
+   Fabric are processed by the same "Virtual Switch" within that Core
+   Switch.
+
+4.  Relationship to Other MIBs
+
+   The first standardized MIB for Fibre Channel [RFC2837] was focused on
+   Fibre Channel switches.  It has been replaced by the more generic
+   Fibre Channel Management MIB [RFC4044], which defines basic
+   information for Fibre Channel hosts and switches, including
+   extensions to the standard IF-MIB for Fibre Channel interfaces.
+
+   This MIB extends beyond [RFC4044] to cover the functionality, in
+   Fibre Channel switches, of providing Fibre Channel's Fabric
+   Configuration Server function.
+
+   This MIB imports some common Textual Conventions from T11-TC-MIB
+   [RFC4439] and from T11-FC-NAME-SERVER-MIB [RFC4438].  It also imports
+   URLString from NETWORK-SERVICES-MIB [RFC2788].
+
+5.  MIB Overview
+
+   This MIB module provides the means for monitoring the operation of,
+   and configuring some parameters of, one or more Fabric Configuration
+   Servers (FCS) in a Fibre Channel (FC) network.  The capabilities
+   provided include triggering a discovery of the configuration of one
+   or more Fabrics, retrieving the results of such a discovery, as well
+   as controlling and monitoring the operation of an FCS.  The
+   discovered configuration contains information about:
+
+   - Interconnect Elements (IEs), i.e., switches, hubs, bridges, etc.,
+   - Ports on IEs, and
+   - Platforms that consist of one or more FC nodes.
+
+
+
+
+DeSanti, et al.             Standards Track                     [Page 5]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+5.1.  Fibre Channel Management Instance
+
+   A Fibre Channel management instance is defined in [RFC4044] as a
+   separable managed instance of Fibre Channel functionality.  Fibre
+   Channel functionality may be grouped into Fibre Channel management
+   instances in whatever way is most convenient for the
+   implementation(s).  For example, one such grouping accommodates a
+   single SNMP agent having multiple AgentX [RFC2741] sub-agents, with
+   each sub-agent implementing a different Fibre Channel management
+   instance.
+
+   The object, fcmInstanceIndex, is IMPORTed from the FC-MGMT-MIB
+   [RFC4044] as the index value to uniquely identify each Fibre Channel
+   management instance, for example, within the same SNMP context
+   ([RFC3411], section 3.3.1).
+
+5.2.  Switch Index
+
+   The FC-MGMT-MIB [RFC4044] defines the fcmSwitchTable as a table of
+   information about Fibre Channel switches that are managed by Fibre
+   Channel management instances.  Each Fibre Channel management instance
+   can manage one or more Fibre Channel switches.  The Switch Index,
+   fcmSwitchIndex, is IMPORTed from the FC-MGMT-MIB as the index value
+   to uniquely identify a Fibre Channel switch amongst those (one or
+   more) managed by the same Fibre Channel management instance.
+
+5.3.  Fabric Index
+
+   With multiple Fabrics, each Fabric has its own instances of the
+   Fabric-related management instrumentation.  Thus, this MIB defines
+   all Fabric-related information in tables that are INDEXed by an
+   arbitrary integer, named a "Fabric Index".  The syntax of a Fabric
+   Index is T11FabricIndex, imported from T11-TC-MIB [RFC4439].  When a
+   device is connected to a single physical Fabric, without use of any
+   virtual Fabrics, the value of this Fabric Index will always be 1.  In
+   an environment of multiple virtual and/or physical Fabrics, this
+   index provides a means to distinguish one Fabric from another.
+
+   It is quite possible, and may even be likely, that a Fibre Channel
+   switch will have ports connected to multiple virtual and/or physical
+   Fabrics.  Thus, in order to simplify a management protocol query
+   concerning all the Fabrics to which a single switch is connected,
+   fcmSwitchIndex will be listed before t11FcsFabricIndex when they both
+   appear in the same INDEX clause.
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                     [Page 6]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+5.4.  The MIB Groups
+
+   This section describes the six MIB groups contained in the MIB
+   module.
+
+5.4.1.  The t11FcsDiscoveredConfigGroup Group
+
+   This group contains the Fabric configuration information discovered
+   by Fabric Configuration Servers.
+
+5.4.2.  The t11FcsDiscoveryStatusGroup Group
+
+   This group contains objects by which to monitor the status of
+   discovery of Fabric configurations by Fabric Configuration Servers.
+
+5.4.3.  The t11FcsDiscoveryControlGroup Group
+
+   This group contains objects for requesting a Fabric Configuration
+   Server to discover the configuration of one or more Fabrics.
+
+5.4.4.  The t11FcsStatisticsGroup Group
+
+   This group contains objects for Fabric Configuration Server
+   statistics information.
+
+5.4.5.  The t11FcsNotificationGroup Group
+
+   This group contains three notifications, generated when an FCS:
+
+   - rejects a registration, deregistration, or query request;
+   - completes discovery on a range of Fabrics;
+   - learns that a management address of an Interconnect Element has
+     changed.
+
+5.4.5.1. Flow Control for Notifications
+
+   When defining SNMP notifications for events that occur in the data-
+   plane, the maximum frequency of their generation needs to be
+   considered.  Unless there is some limiting factor, such notifications
+   need to be flow-controlled in some way, e.g., defined such that after
+   some maximum number within a specified time interval have occurred,
+   further notifications are suppressed for some subsequent time
+   interval.  However, as and when such a suppression occurs, the
+   Network Management System (NMS) that didn't receive the notifications
+   (because they were suppressed) needs to be able to obtain an
+   indication of how many were suppressed.  Therefore, an additional
+   Counter32 object needs to be defined, and/or a new type of
+   notification needs to be defined for use at the end of the interval.
+
+
+
+DeSanti, et al.             Standards Track                     [Page 7]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+   While this is extra complexity, it is necessary for notifications
+   that need to be flow-controlled.
+
+   In contrast, for notifications such as all the ones defined in this
+   MIB module, which are generated due to control-plane events (and are
+   not able to start a chain reaction):
+
+   - estimating the maximum number that could possibly be generated per
+     unit time for each type of notification is too simplistic.  For
+     example, it's unreasonable to ask how many of the
+     t11FcsDiscoveryCompleteNotify notifications can be generated in a
+     time interval, because it depends on several factors: how big is
+     the network? how many Virtual Fabrics need to be discovered? how
+     quickly can the operator ask for another discovery after the last
+     one completes?
+
+   - the extra complexity of flow-controlling these types of
+     notifications is not warranted.
+
+5.4.6.  The t11FcsNotificationInfoGroup Group
+
+   This group contains notification control and notification information
+   objects for monitoring Fabric Configuration Server request rejection
+   and discovery of topology information.
+
+5.5.  OS Logical Unit Number (LUN) Map Entries
+
+   A "Platform" is defined in FC-GS-5 to be not only a set of zero or
+   more FC nodes, but also a set of zero or more "OS LUN Map Entries"
+   (see Figure 8 in [FC-GS-5]).  Information on "OS LUN Map Entries" is
+   not included in this T11-FC-FABRIC-CONFIG-SERVER-MIB.  Instead,
+   information on LUN Maps can be obtained via the scsiLunMapGroup
+   object group defined in the SCSI-MIB [RFC4455].
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                     [Page 8]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+6.  The T11-FC-FABRIC-CONFIG-SERVER-MIB Module
+
+T11-FC-FABRIC-CONFIG-SERVER-MIB  DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE,
+    NOTIFICATION-TYPE, mib-2, Counter32, Unsigned32
+                  FROM SNMPv2-SMI                  -- [RFC2578]
+    MODULE-COMPLIANCE, OBJECT-GROUP, NOTIFICATION-GROUP
+                  FROM SNMPv2-CONF                 -- [RFC2580]
+    TEXTUAL-CONVENTION, TruthValue, TimeStamp
+                  FROM SNMPv2-TC                   -- [RFC2579]
+    SnmpAdminString
+                  FROM SNMP-FRAMEWORK-MIB          -- [RFC3411]
+    URLString
+                  FROM NETWORK-SERVICES-MIB        -- [RFC2788]
+
+    FcPortType, FcNameIdOrZero, FcDomainIdOrZero,
+    fcmInstanceIndex, fcmSwitchIndex, FcAddressIdOrZero
+                  FROM FC-MGMT-MIB                 -- [RFC4044]
+    T11NsGs4RejectReasonCode
+                  FROM T11-FC-NAME-SERVER-MIB      -- [RFC4438]
+    T11FabricIndex
+                  FROM T11-TC-MIB                  -- [RFC4439]
+    t11FamLocalSwitchWwn
+                  FROM T11-FC-FABRIC-ADDR-MGR-MIB; -- [RFC4439]
+
+
+t11FcFabricConfigServerMIB   MODULE-IDENTITY
+    LAST-UPDATED  "200706270000Z"
+    ORGANIZATION  "For the initial versions, T11.
+                   For later versions, the IETF's IMSS Working Group."
+    CONTACT-INFO
+             "     Claudio DeSanti
+                   Cisco Systems, Inc.
+                   170 West Tasman Drive
+                   San Jose, CA 95134 USA
+                   EMail: cds@cisco.com
+
+                   Keith McCloghrie
+                   Cisco Systems, Inc.
+                   170 West Tasman Drive
+                   San Jose, CA 95134 USA
+                   EMail: kzm@cisco.com"
+    DESCRIPTION
+            "The MIB module for the management of a Fabric
+            Configuration Server (FCS) in a Fibre Channel (FC)
+            network.  An FCS is defined by the FC-GS-5 standard.  This
+
+
+
+DeSanti, et al.             Standards Track                     [Page 9]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+            MIB provides the capabilities to trigger a discovery of
+            the configuration of one or more Fabrics, to retrieve the
+            results of such a discovery, as well as to control and
+            monitor the operation of an FCS.  The discovered
+            configuration contains information about:
+
+               - Interconnect Elements (IEs), i.e., switches, hubs,
+                 bridges, etc.,
+               - Ports on IEs, and
+               - Platforms that consist of one or more FC nodes.
+
+           Copyright (C) The IETF Trust (2007).  This version of
+           this MIB module is part of RFC 4935;  see the RFC itself for
+           full legal notices."
+    REVISION    "200706270000Z"
+    DESCRIPTION
+           "Initial version of this MIB module, published as RFC 4935."
+    ::= { mib-2 162 }
+
+t11FcsMIBObjects       OBJECT IDENTIFIER
+                                    ::= { t11FcFabricConfigServerMIB 1 }
+t11FcsMIBConformance   OBJECT IDENTIFIER
+                                    ::= { t11FcFabricConfigServerMIB 2 }
+t11FcsNotifications    OBJECT IDENTIFIER
+                                    ::= { t11FcFabricConfigServerMIB 0 }
+
+t11FcsDiscovery        OBJECT IDENTIFIER ::= { t11FcsMIBObjects 1 }
+t11FcsDiscoveredConfig OBJECT IDENTIFIER ::= { t11FcsMIBObjects 2 }
+t11FcsStats            OBJECT IDENTIFIER ::= { t11FcsMIBObjects 3 }
+t11FcsNotificationInfo OBJECT IDENTIFIER ::= { t11FcsMIBObjects 4 }
+
+--
+-- Textual Conventions
+--
+
+T11FcListIndex ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT  "d"
+    STATUS  current
+    DESCRIPTION
+            "An index that identifies a list of elements.
+            All elements that belong to the same list have the
+            same index value.  This syntax is used for objects
+            which identify a list in the INDEX clause of a table
+            of elements of that type of list."
+    SYNTAX  Unsigned32 (1..4294967295)
+
+T11FcListIndexPointerOrZero ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT  "d"
+
+
+
+DeSanti, et al.             Standards Track                    [Page 10]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+    STATUS  current
+    DESCRIPTION
+            "Objects with this syntax point to a list of elements
+            contained in a table, by holding the same value as the
+            object with syntax T11FcListIndex defined in the table's
+            INDEX clause, or, zero to indicate an empty list.
+            Note that such a table could have one row per list, or
+            it could have one row per element of a list.
+
+            The definition of an object with this syntax must
+            identify the table(s) into which it points."
+    SYNTAX  Unsigned32 -- the default range of (0..4294967295)
+
+T11FcIeType ::= TEXTUAL-CONVENTION
+    STATUS  current
+    DESCRIPTION
+            "The type of Interconnect Element (IE):
+
+                     unknown(1)  - an unknown IE.
+                     other(2)    - some other type of IE.
+                     switch(3)   - the IE is a switch.
+                     hub(4)      - the IE is a hub.
+                     bridge(5)   - the IE is a bridge."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, Table 96."
+    SYNTAX  INTEGER {
+                unknown(1),
+                other(2),
+                switch(3),
+                hub(4),
+                bridge(5)
+            }
+
+T11FcPortState  ::= TEXTUAL-CONVENTION
+    STATUS  current
+    DESCRIPTION
+            "The state of a port:
+
+                     unknown(1)  - unknown state.
+                     other(2)    - some other state.
+                     online(3)   - port is in online state.
+                     offline(4)  - port is in offline state.
+                     testing(5)  - port is in testing state.
+                     fault(6)    - port is faulty."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, Table 106."
+
+
+
+DeSanti, et al.             Standards Track                    [Page 11]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+    SYNTAX  INTEGER {
+                unknown(1),
+                other(2),
+                online(3),
+                offline(4),
+                testing(5),
+                fault(6)
+            }
+
+T11FcPortTxType ::= TEXTUAL-CONVENTION
+    STATUS  current
+    DESCRIPTION
+            "The technology of the port transceiver:
+
+               unknown(1)         - unknown (includes the 'null' type)
+               other(2)           - some other technology
+               shortwave850nm(3)  - Short wave laser - SN (850 nm)
+               longwave1550nm(4)  - Long wave laser - LL (1550 nm)
+               longwave1310nm(5)  - Long wave laser cost
+                                    reduced - LC (1310 nm)
+               electrical(6)      - Electrical - EL.
+               tenGbaseSr850(7)   - 10GBASE-SR 850nm laser
+               tenGbaseLr1310(8)  - 10GBASE-LR 1310nm laser
+               tenGbaseEr1550(9)  - 10GBASE-ER 1550nm laser
+               tenGbaseLx1300(10) - 10GBASE-LX4 WWDM 1300nm laser
+               tenGbaseSw850(11)  - 10GBASE-SW 850nm laser
+               tenGbaseLw1310(12) - 10GBASE-LW 1310nm laser
+               tenGbaseEw1550(13) - 10GBASE-EW 1550nm laser
+            "
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, Table 101."
+    SYNTAX  INTEGER {
+                unknown(1),
+                other(2),
+                shortwave850nm(3),
+                longwave1550nm(4),
+                longwave1310nm(5),
+                electrical(6),
+                tenGbaseSr850(7),
+                tenGbaseLr1310(8),
+                tenGbaseEr1550(9),
+                tenGbaseLx1300(10),
+                tenGbaseSw850(11),
+                tenGbaseLw1310(12),
+                tenGbaseEw1550(13)
+            }
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 12]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+T11FcsRejectReasonExplanation ::= TEXTUAL-CONVENTION
+    STATUS  current
+    DESCRIPTION
+            "The reject reason code explanation:
+
+                  noAdditionalExplanation(1)
+                       - no additional explanation.
+                  invNameIdForIEOrPort(2)
+                       - the format of IE or port name is invalid.
+                  ieListNotAvailable(3)
+                       - IE list is not available.
+                  ieTypeNotAvailable(4)
+                       - IE type is not available.
+                  domainIdNotAvailable(5)
+                       - Domain ID is not available.
+                  mgmtIdNotAvailable(6)
+                       - mgmt ID is not available.
+                  fabNameNotAvailable(7)
+                       - Fabric_Name is not available.
+                  ielogNameNotAvailable(8)
+                       - IE logical name is not available.
+                  mgmtAddrListNotAvailable(9)
+                       - mgmt address list is not available.
+                  ieInfoListNotAvailable(10)
+                       - IE info list is not available.
+                  portListNotAvailable(11)
+                       - port list is not available.
+                  portTypeNotAvailable(12)
+                       - port type is not available.
+                  phyPortNumNotAvailable(13)
+                       - physical port number is not available.
+                  attPortNameListNotAvailable(14)
+                       - attached port name list is not available.
+                  portStateNotAvailable(15)
+                       - port state is not available.
+                  unableToRegIELogName(16)
+                       - not able to register IE logical name.
+                  platformNameNoExist(17)
+                       - platform name does not exist.
+                  platformNameAlreadyExists(18)
+                       - platform name already exists.
+                  platformNodeNameNoExists(19)
+                       - platform node name does not exist.
+                  platformNodeNameAlreadyExists(20)
+                       - platform node name already exists.
+                  resourceUnavailable(21)
+                       - resource unavailable.
+                  noEntriesInLunMap(22)
+
+
+
+DeSanti, et al.             Standards Track                    [Page 13]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+                       - zero entries in OS LUN Map.
+                  invalidDeviceNameLength(23)
+                       - invalid OS device name length.
+                  multipleAttributes(24)
+                       - multiple attributes of same type in
+                         platform attribute block.
+                  invalidAttribBlockLength(25)
+                       - invalid platform attribute block length.
+                  attributesMissing(26)
+                       - required platform attributes not present."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, Table 124."
+    SYNTAX  INTEGER {
+                noAdditionalExplanation(1),
+                invNameIdForIEOrPort(2),
+                ieListNotAvailable(3),
+                ieTypeNotAvailable(4),
+                domainIdNotAvailable(5),
+                mgmtIdNotAvailable(6),
+                fabNameNotAvailable(7),
+                ielogNameNotAvailable(8),
+                mgmtAddrListNotAvailable(9),
+                ieInfoListNotAvailable(10),
+                portListNotAvailable(11),
+                portTypeNotAvailable(12),
+                phyPortNumNotAvailable(13),
+                attPortNameListNotAvailable(14),
+                portStateNotAvailable(15),
+                unableToRegIELogName(16),
+                platformNameNoExist(17),
+                platformNameAlreadyExists(18),
+                platformNodeNameNoExists(19),
+                platformNodeNameAlreadyExists(20),
+                resourceUnavailable(21),
+                noEntriesInLunMap(22),
+                invalidDeviceNameLength(23),
+                multipleAttributes(24),
+                invalidAttribBlockLength(25),
+                attributesMissing(26)
+            }
+
+--
+-- Objects for Fabric Discovery
+--
+
+t11FcsFabricDiscoveryTable OBJECT-TYPE
+    SYNTAX       SEQUENCE OF T11FcsFabricDiscoveryEntry
+
+
+
+DeSanti, et al.             Standards Track                    [Page 14]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "This table contains control information for discovery
+            of Fabric configuration by switches.
+
+            Values written to objects in this table are not
+            retained over agent reboots."
+    ::= { t11FcsDiscovery 1 }
+
+t11FcsFabricDiscoveryEntry OBJECT-TYPE
+    SYNTAX       T11FcsFabricDiscoveryEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "Control information for discovery by the switch
+            identified by fcmInstanceIndex and fcmSwitchIndex."
+    INDEX   { fcmInstanceIndex, fcmSwitchIndex }
+    ::= { t11FcsFabricDiscoveryTable 1 }
+
+T11FcsFabricDiscoveryEntry ::= SEQUENCE {
+    t11FcsFabricDiscoveryRangeLow   T11FabricIndex,
+    t11FcsFabricDiscoveryRangeHigh  T11FabricIndex,
+    t11FcsFabricDiscoveryStart      INTEGER,
+    t11FcsFabricDiscoveryTimeOut    Unsigned32
+}
+
+t11FcsFabricDiscoveryRangeLow  OBJECT-TYPE
+    SYNTAX       T11FabricIndex
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+            "The discovery by a particular switch operates
+            within all existing Fabrics that have a Fabric
+            Index within a specific inclusive range.  This
+            object specifies the minimum Fabric Index value
+            within that range.  This value just represents
+            the lower end of the range and does not necessarily
+            represent any existing Fabric."
+    ::= { t11FcsFabricDiscoveryEntry 1 }
+
+t11FcsFabricDiscoveryRangeHigh  OBJECT-TYPE
+    SYNTAX       T11FabricIndex
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+            "The discovery by a particular switch operates
+            within all existing Fabrics that have a Fabric
+
+
+
+DeSanti, et al.             Standards Track                    [Page 15]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+            Index within a specific inclusive range.  This
+            object specifies the maximum Fabric Index value
+            within that range.  This value just represents the
+            higher end of the range and does not necessarily
+            represent any existing Fabric."
+    ::= { t11FcsFabricDiscoveryEntry 2 }
+
+t11FcsFabricDiscoveryStart  OBJECT-TYPE
+    SYNTAX       INTEGER {
+                     start(1),
+                     noOp(2)
+                 }
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+            "This object provides the capability to trigger the start
+            of a discovery by a Fabric Configuration Server.  If this
+            object is set to 'start', then the discovery is started on
+            those Fabrics that have their Fabric Index value in the
+            range specified by t11FcsFabricDiscoveryRangeLow and
+            t11FcsFabricDiscoveryRangeHigh.  It is recommended that
+            whenever an instance of this object is set to 'start',
+            that the desired range be specified at the same time by
+            setting the corresponding instances of
+            t11FcsFabricDiscoveryRangeLow and
+            t11FcsFabricDiscoveryRangeHigh.
+
+            Setting this object to 'start' will be rejected if a
+            discovery is already/still in progress on any Fabrics in
+            the specified range.
+
+            No action is taken if this object is set to 'noOp'.
+            The value of this object when read is always 'noOp'."
+    ::= { t11FcsFabricDiscoveryEntry 3 }
+
+t11FcsFabricDiscoveryTimeOut OBJECT-TYPE
+    SYNTAX       Unsigned32 (300..86400)
+    UNITS        "Seconds"
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+            "The minimum interval of time for which the discovered
+            Fabric information is cached by a Fabric Configuration
+            Server."
+    DEFVAL { 900 }
+    ::= { t11FcsFabricDiscoveryEntry 4 }
+
+--
+
+
+
+DeSanti, et al.             Standards Track                    [Page 16]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+-- Discovery State table
+--
+
+t11FcsDiscoveryStateTable OBJECT-TYPE
+    SYNTAX       SEQUENCE OF T11FcsDiscoveryStateEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "This table contains the status of discovery of
+            locally known Fabrics."
+    ::= { t11FcsDiscovery 2 }
+
+t11FcsDiscoveryStateEntry OBJECT-TYPE
+    SYNTAX       T11FcsDiscoveryStateEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "The discovery status for a particular Fabric on the
+            switch identified by fcmInstanceIndex and fcmSwitchIndex."
+    INDEX   { fcmInstanceIndex, fcmSwitchIndex, t11FcsFabricIndex }
+    ::= { t11FcsDiscoveryStateTable 1 }
+
+T11FcsDiscoveryStateEntry ::= SEQUENCE {
+    t11FcsFabricIndex              T11FabricIndex,
+    t11FcsDiscoveryStatus          INTEGER,
+    t11FcsDiscoveryCompleteTime    TimeStamp
+}
+
+t11FcsFabricIndex OBJECT-TYPE
+    SYNTAX       T11FabricIndex
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "A unique index value that uniquely identifies a
+            particular Fabric.
+
+            In a Fabric conformant to FC-SW-4, multiple Virtual Fabrics
+            can operate within one (or more) physical infrastructures,
+            and this index value is used to uniquely identify a
+            particular (physical or virtual) Fabric within a physical
+            infrastructure.
+
+            In a Fabric conformant to versions earlier than FC-SW-4,
+            only a single Fabric could operate within a physical
+            infrastructure, and thus, the value of this Fabric Index
+            was defined to always be 1."
+    ::= { t11FcsDiscoveryStateEntry 1 }
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 17]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+t11FcsDiscoveryStatus  OBJECT-TYPE
+    SYNTAX       INTEGER {
+                     inProgress(1),
+                     completed(2),
+                     localOnly(3)
+                 }
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+            "The status of the discovery for the particular Fabric.
+
+            Initially when the switch comes up, all instances of this
+            object have the value: 'localOnly', and the database
+            contains only local information, i.e., no information
+            discovered via the Fabric Configuration Server protocol
+            specified in FC-GS-5.
+
+            If t11FcsFabricDiscoveryStart is set to 'start' for a
+            range of Fabrics that includes this Fabric, then the
+            value of this object transitions to 'inProgress'.  When
+            the discovery completes, this object transitions to
+            'completed', and the data is cached for the minimum
+            interval of time specified by
+            t11FcsFabricDiscoveryTimeOut.  After this interval has
+            been exceeded, the data may be lost, in which case, the
+            value of this object changes to 'localOnly'.
+
+            This object cannot be set via SNMP to any value other
+            than 'localOnly'.  If this object is set (via SNMP) to
+            'localOnly', the cached data for the Fabric is discarded
+            immediately, and if a discovery initiated from this
+            switch was in progress for this Fabric, then that
+            discovery is aborted."
+    ::= { t11FcsDiscoveryStateEntry 2 }
+
+t11FcsDiscoveryCompleteTime  OBJECT-TYPE
+    SYNTAX       TimeStamp
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "This object contains the value of sysUpTime at which
+            discovery was most recently completed or aborted on this
+            Fabric.  This object contains the value of zero before
+            the first discovery on this Fabric."
+    ::= { t11FcsDiscoveryStateEntry 3 }
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 18]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+--
+--      The Database of Fabric Configuration Information
+
+--
+-- Interconnect Element table
+--
+
+t11FcsIeTable OBJECT-TYPE
+    SYNTAX       SEQUENCE OF T11FcsIeEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "A table of Interconnect Elements.  Interconnect
+            Elements (IEs) are switches, hubs, bridges etc.
+
+            By default, the Fabric Configuration Server will
+            maintain detailed information pertaining only to
+            local resources.  As far as discovered topology is
+            concerned, only the IE name, type, and Domain ID
+            information will be maintained.  If a discovery
+            cycle is triggered on a set of Fabrics, this table
+            along with the Port and Platform tables will be
+            populated with the discovered information.  The
+            discovered data will be retained in this table for
+            at least t11FcsFabricDiscoveryTimeOut seconds after
+            the completion of its discovery or until the
+            discovered data is invalidated."
+    ::= { t11FcsDiscoveredConfig 1 }
+
+t11FcsIeEntry OBJECT-TYPE
+    SYNTAX       T11FcsIeEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "Information about an Interconnect Element that was
+            discovered on a Fabric (identified by t11FcsFabricIndex),
+            by a switch (identified by fcmInstanceIndex and
+            fcmSwitchIndex)."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.2."
+    INDEX   { fcmInstanceIndex, fcmSwitchIndex, t11FcsFabricIndex,
+              t11FcsIeName }
+    ::= { t11FcsIeTable 1 }
+
+T11FcsIeEntry ::= SEQUENCE {
+    t11FcsIeName                FcNameIdOrZero,
+    t11FcsIeType                T11FcIeType,
+
+
+
+DeSanti, et al.             Standards Track                    [Page 19]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+    t11FcsIeDomainId            FcDomainIdOrZero,
+    t11FcsIeMgmtId              FcAddressIdOrZero,
+    t11FcsIeFabricName          FcNameIdOrZero,
+    t11FcsIeLogicalName         OCTET STRING,
+    t11FcsIeMgmtAddrListIndex   T11FcListIndexPointerOrZero,
+    t11FcsIeInfoList            OCTET STRING
+}
+
+t11FcsIeName  OBJECT-TYPE
+    SYNTAX       FcNameIdOrZero (SIZE(8 | 16))
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "The WWN of an Interconnect Element.  This object
+            uniquely identifies an Interconnect Element on a
+            Fabric.  If the IE is a switch, then this object
+            is the Switch_Name (WWN) of the switch."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.2.1."
+    ::= { t11FcsIeEntry 1 }
+
+t11FcsIeType  OBJECT-TYPE
+    SYNTAX       T11FcIeType
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The type of this Interconnect Element."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.2.2"
+    ::= { t11FcsIeEntry 2 }
+
+t11FcsIeDomainId  OBJECT-TYPE
+    SYNTAX       FcDomainIdOrZero
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The Domain ID of this Interconnect Element."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.2.3."
+    ::= { t11FcsIeEntry 3 }
+
+t11FcsIeMgmtId  OBJECT-TYPE
+    SYNTAX       FcAddressIdOrZero
+    MAX-ACCESS   read-only
+    STATUS       current
+
+
+
+DeSanti, et al.             Standards Track                    [Page 20]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+    DESCRIPTION
+            "The management identifier of this Interconnect Element.
+            If the Interconnect Element is a switch, this object will
+            be the Domain Controller identifier of the switch.  When
+            the value of the identifier is unknown, this object
+            contains the all-zeros value: x'00 00 00'."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.2.4."
+    DEFVAL { '000000'h }
+    ::= { t11FcsIeEntry 4 }
+
+t11FcsIeFabricName  OBJECT-TYPE
+    SYNTAX       FcNameIdOrZero (SIZE(8 | 16))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The Fabric_Name (WWN) of this Interconnect Element.
+            When the Fabric_Name is unknown, this object contains
+            the all-zeros value: x'00 00 00 00 00 00 00 00'."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.2.5."
+    DEFVAL { '0000000000000000'h }
+    ::= { t11FcsIeEntry 5 }
+
+t11FcsIeLogicalName  OBJECT-TYPE
+    SYNTAX       OCTET STRING (SIZE (0..255))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The logical name of this Interconnect Element.
+            When the logical name is unknown, this object contains
+            the zero-length string."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.2.6."
+    ::= { t11FcsIeEntry 6 }
+
+t11FcsIeMgmtAddrListIndex  OBJECT-TYPE
+    SYNTAX       T11FcListIndexPointerOrZero
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The management address list for this Interconnect Element.
+            This object points to an entry in the
+            t11FcsMgmtAddrListTable."
+    REFERENCE
+
+
+
+DeSanti, et al.             Standards Track                    [Page 21]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.2.7."
+    ::= { t11FcsIeEntry 7 }
+
+t11FcsIeInfoList  OBJECT-TYPE
+    SYNTAX       OCTET STRING (SIZE (0..252))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The information list for this Interconnect Element.
+
+            The value of this object is formatted as specified in
+            FC-GS-5, i.e., it has the following substrings in order:
+            vendor name, model name/number, and release code/level,
+            followed by zero or more substrings of vendor-specific
+            information.  Each substring is terminated with a byte
+            containing a null value (x'00')."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.2.8"
+    ::= { t11FcsIeEntry 8 }
+
+--
+-- Management Address List table
+--
+
+t11FcsMgmtAddrListTable  OBJECT-TYPE
+    SYNTAX       SEQUENCE OF T11FcsMgmtAddrListEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "This table contains the set of management address lists
+            that are currently referenced by any instance of the
+            t11FcsIeMgmtAddrListIndex or
+            t11FcsPlatformMgmtAddrListIndex objects."
+    ::= { t11FcsDiscoveredConfig 2 }
+
+t11FcsMgmtAddrListEntry  OBJECT-TYPE
+    SYNTAX       T11FcsMgmtAddrListEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "Information about one management address in a
+            management address list, which is known to a
+            switch (identified by fcmInstanceIndex and
+            fcmSwitchIndex)."
+    INDEX   { fcmInstanceIndex, fcmSwitchIndex,
+              t11FcsMgmtAddrListIndex, t11FcsMgmtAddrIndex }
+
+
+
+DeSanti, et al.             Standards Track                    [Page 22]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+    ::= { t11FcsMgmtAddrListTable 1 }
+
+T11FcsMgmtAddrListEntry ::= SEQUENCE {
+    t11FcsMgmtAddrListIndex        T11FcListIndex,
+    t11FcsMgmtAddrIndex            Unsigned32,
+    t11FcsMgmtAddr                 URLString
+}
+
+t11FcsMgmtAddrListIndex  OBJECT-TYPE
+    SYNTAX       T11FcListIndex
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "The index value of the management address list."
+    ::= { t11FcsMgmtAddrListEntry 1 }
+
+t11FcsMgmtAddrIndex OBJECT-TYPE
+    SYNTAX       Unsigned32 (1..4294967295)
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "An integer value to distinguish different
+            management addresses in the same list."
+    ::= { t11FcsMgmtAddrListEntry 2 }
+
+t11FcsMgmtAddr  OBJECT-TYPE
+    SYNTAX       URLString
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The management address of this entry.
+
+            The format of this object is a Uniform Resource
+            Locator (URL), e.g., for SNMP, see RFC 4088."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.2.7"
+    ::= { t11FcsMgmtAddrListEntry 3 }
+
+--
+-- Ports
+--
+
+t11FcsPortTable  OBJECT-TYPE
+    SYNTAX       SEQUENCE OF T11FcsPortEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+
+
+
+DeSanti, et al.             Standards Track                    [Page 23]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+            "This table contains information about the ports of IEs."
+    ::= { t11FcsDiscoveredConfig 4 }
+
+t11FcsPortEntry  OBJECT-TYPE
+    SYNTAX       T11FcsPortEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "Information about a particular port of an Interconnect
+            Element (identified by t11FcsIeName).  The port is
+            connected to a Fabric (identified by t11FcsFabricIndex)
+            and known to a switch (identified by fcmInstanceIndex
+            and fcmSwitchIndex)."
+    INDEX   { fcmInstanceIndex, fcmSwitchIndex, t11FcsFabricIndex,
+              t11FcsIeName, t11FcsPortName }
+    ::= { t11FcsPortTable 1 }
+
+T11FcsPortEntry ::= SEQUENCE {
+    t11FcsPortName                    FcNameIdOrZero,
+    t11FcsPortType                    FcPortType,
+    t11FcsPortTxType                  T11FcPortTxType,
+    t11FcsPortModuleType              Unsigned32,
+    t11FcsPortPhyPortNum              Unsigned32,
+    t11FcsPortAttachPortNameIndex     T11FcListIndexPointerOrZero,
+    t11FcsPortState                   T11FcPortState,
+    t11FcsPortSpeedCapab              OCTET STRING,
+    t11FcsPortOperSpeed               OCTET STRING,
+    t11FcsPortZoningEnfStatus         OCTET STRING
+}
+
+t11FcsPortName  OBJECT-TYPE
+    SYNTAX       FcNameIdOrZero (SIZE(8 | 16))
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "The Port_Name (WWN) of the port for which this row
+            contains information."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.3.1."
+    ::= { t11FcsPortEntry 1 }
+
+t11FcsPortType  OBJECT-TYPE
+    SYNTAX       FcPortType
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The Port Type of this port."
+
+
+
+DeSanti, et al.             Standards Track                    [Page 24]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.3.2."
+    ::= { t11FcsPortEntry 2 }
+
+t11FcsPortTxType  OBJECT-TYPE
+    SYNTAX       T11FcPortTxType
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The Port TX Type of this port."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.3.3."
+    ::= { t11FcsPortEntry 3 }
+
+t11FcsPortModuleType  OBJECT-TYPE
+    SYNTAX       Unsigned32 (0..255)
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The port module type of this port."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.3.4."
+    ::= { t11FcsPortEntry 4 }
+
+t11FcsPortPhyPortNum  OBJECT-TYPE
+    SYNTAX       Unsigned32 -- the default range of (0..4294967295)
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The physical number for this port.  FC-GS-5 says that
+            the contents of this field, which are carried in a field
+            with a size of 4 bytes, are not to be restricted due to
+            vendor-specific methods for numbering physical ports."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.3.5."
+    ::= { t11FcsPortEntry 5 }
+
+t11FcsPortAttachPortNameIndex  OBJECT-TYPE
+    SYNTAX       T11FcListIndexPointerOrZero
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The attached port name list for this port.  This object
+            points to an entry in the t11FcsAttachPortNameListTable."
+
+
+
+DeSanti, et al.             Standards Track                    [Page 25]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.3.6."
+    ::= { t11FcsPortEntry 6 }
+
+t11FcsPortState  OBJECT-TYPE
+    SYNTAX       T11FcPortState
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The state of this port."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.3.7."
+    ::= { t11FcsPortEntry 7 }
+
+t11FcsPortSpeedCapab  OBJECT-TYPE
+    SYNTAX       OCTET STRING (SIZE (2))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The port speed capabilities of this port.  The two octets
+            of the value are formatted as described in FC-GS-5."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.3.8."
+    ::= { t11FcsPortEntry 8 }
+
+t11FcsPortOperSpeed  OBJECT-TYPE
+    SYNTAX       OCTET STRING (SIZE (2))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The operating speed of this port.  The two octets
+            of the value are formatted as described in FC-GS-5."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.3.9."
+    ::= { t11FcsPortEntry 9 }
+
+t11FcsPortZoningEnfStatus  OBJECT-TYPE
+    SYNTAX       OCTET STRING (SIZE (12))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The zoning enforcement status of this port.  The 12
+            octets of the value are formatted as described in FC-GS-5."
+    REFERENCE
+
+
+
+DeSanti, et al.             Standards Track                    [Page 26]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.3.10."
+    ::= { t11FcsPortEntry 10 }
+
+--
+-- Attached Port List table
+--
+
+t11FcsAttachPortNameListTable  OBJECT-TYPE
+    SYNTAX       SEQUENCE OF T11FcsAttachPortNameListEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "This table contains all the lists of attach port
+            names."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.3.6"
+    ::= { t11FcsDiscoveredConfig 5 }
+
+t11FcsAttachPortNameListEntry  OBJECT-TYPE
+    SYNTAX       T11FcsAttachPortNameListEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "Information about the name of a particular attached port,
+            which is known to a switch (identified by fcmInstanceIndex
+            and fcmSwitchIndex)."
+    INDEX   { fcmInstanceIndex,  fcmSwitchIndex,
+              t11FcsAttachPortNameListIndex, t11FcsAttachPortName }
+    ::= { t11FcsAttachPortNameListTable 1 }
+
+T11FcsAttachPortNameListEntry ::= SEQUENCE {
+    t11FcsAttachPortNameListIndex        T11FcListIndex,
+    t11FcsAttachPortName                 OCTET STRING
+}
+
+t11FcsAttachPortNameListIndex  OBJECT-TYPE
+    SYNTAX       T11FcListIndex
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "The index value of the attach port name list."
+    ::= { t11FcsAttachPortNameListEntry 1 }
+
+t11FcsAttachPortName  OBJECT-TYPE
+    SYNTAX       OCTET STRING (SIZE (12))
+    MAX-ACCESS   read-only
+
+
+
+DeSanti, et al.             Standards Track                    [Page 27]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+    STATUS       current
+    DESCRIPTION
+            "The attached port name.  Zero or more of these names
+            may be associated with a port object.
+            The first 8 bytes of this object contain the WWN of
+            the port followed by 2 reserved bytes.  Following
+            this is one byte of Port flags and one byte of
+            Port type, as described in FC-GS-5."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.3.6"
+    ::= { t11FcsAttachPortNameListEntry 2 }
+
+--
+-- Platforms
+--
+
+t11FcsPlatformTable  OBJECT-TYPE
+    SYNTAX       SEQUENCE OF T11FcsPlatformEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "This table contains information on platforms.
+
+            By default, this table only contains local (e.g., for a
+            local switch) information.  If a discovery is triggered,
+            this table will also contain information gathered by the
+            discovery process.  The discovered information is retained
+            in this table for at least t11FcsFabricDiscoveryTimeOut
+            seconds after the completion of its discovery or until
+            the discovered cache is invalidated."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.4"
+    ::= { t11FcsDiscoveredConfig 6 }
+
+t11FcsPlatformEntry  OBJECT-TYPE
+    SYNTAX       T11FcsPlatformEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "Information about a particular platform, which is
+            known to a switch (identified by fcmInstanceIndex and
+            fcmSwitchIndex).
+
+            A platform can contain multiple nodes.  Information on
+            nodes is contained in the t11FcsNodeNameListTable.  The
+            t11FcsPlatformNodeNameListIndex object in this table
+
+
+
+DeSanti, et al.             Standards Track                    [Page 28]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+            points to the list of nodes contained in this platform.
+            Similarly, the t11FcsPlatformMgmtAddrListIndex object in
+            this table points to the list of management addresses
+            associated with this platform."
+    INDEX   { fcmInstanceIndex, fcmSwitchIndex,
+              t11FcsFabricIndex, t11FcsPlatformIndex }
+    ::= { t11FcsPlatformTable 1 }
+
+T11FcsPlatformEntry ::= SEQUENCE {
+    t11FcsPlatformIndex              Unsigned32,
+    t11FcsPlatformName               OCTET STRING,
+    t11FcsPlatformType               OCTET STRING,
+    t11FcsPlatformNodeNameListIndex  T11FcListIndexPointerOrZero,
+    t11FcsPlatformMgmtAddrListIndex  T11FcListIndexPointerOrZero,
+    t11FcsPlatformVendorId           SnmpAdminString,
+    t11FcsPlatformProductId          SnmpAdminString,
+    t11FcsPlatformProductRevLevel    SnmpAdminString,
+    t11FcsPlatformDescription        SnmpAdminString,
+    t11FcsPlatformLabel              SnmpAdminString,
+    t11FcsPlatformLocation           SnmpAdminString,
+    t11FcsPlatformSystemID           SnmpAdminString,
+    t11FcsPlatformSysMgmtAddr        T11FcListIndexPointerOrZero,
+    t11FcsPlatformClusterId          SnmpAdminString,
+    t11FcsPlatformClusterMgmtAddr    T11FcListIndexPointerOrZero,
+    t11FcsPlatformFC4Types           OCTET STRING
+}
+
+t11FcsPlatformIndex OBJECT-TYPE
+    SYNTAX       Unsigned32 (1..4294967295)
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "An integer value to distinguish one platform from
+            other platforms in the same Fabric."
+    ::= { t11FcsPlatformEntry 1 }
+
+t11FcsPlatformName  OBJECT-TYPE
+    SYNTAX       OCTET STRING (SIZE (1..255))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The name of this platform.  The last byte of the value
+            indicates the format of the name (even if the name itself
+            is the zero-length string) as specified in FC-GS-5."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.4.2"
+    ::= { t11FcsPlatformEntry 2 }
+
+
+
+DeSanti, et al.             Standards Track                    [Page 29]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+t11FcsPlatformType  OBJECT-TYPE
+    SYNTAX       OCTET STRING (SIZE (4))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The type(s) of this platform, encoded in 4 bytes as
+            specified in FC-GS-5."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.4.3"
+    ::= { t11FcsPlatformEntry 3 }
+
+t11FcsPlatformNodeNameListIndex  OBJECT-TYPE
+    SYNTAX       T11FcListIndexPointerOrZero
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The list of nodes for this platform.  This object points
+            to an entry in the t11FcsNodeNameListTable."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.4.6"
+    ::= { t11FcsPlatformEntry 4 }
+
+t11FcsPlatformMgmtAddrListIndex  OBJECT-TYPE
+    SYNTAX       T11FcListIndexPointerOrZero
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The list of management addresses for this platform.  This
+            object points to an entry in the t11FcsMgmtAddrListTable."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.4.7"
+    ::= { t11FcsPlatformEntry 5 }
+
+t11FcsPlatformVendorId  OBJECT-TYPE
+    SYNTAX       SnmpAdminString (SIZE (0 | 12))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The identifier of the vendor of this platform, in the
+            format specified in FC-GS-5."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.4.5"
+    ::= { t11FcsPlatformEntry 6 }
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 30]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+t11FcsPlatformProductId  OBJECT-TYPE
+    SYNTAX       SnmpAdminString (SIZE (0 | 20))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The vendor's product and/or model identifier for this
+            platform, in the format specified in FC-GS-5."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.4.5"
+    ::= { t11FcsPlatformEntry 7 }
+
+t11FcsPlatformProductRevLevel  OBJECT-TYPE
+    SYNTAX       SnmpAdminString (SIZE (0 | 4..32))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The product revision level for this platform, in the
+            format specified in FC-GS-5."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.4.5"
+    ::= { t11FcsPlatformEntry 8 }
+
+t11FcsPlatformDescription  OBJECT-TYPE
+    SYNTAX       SnmpAdminString (SIZE (0 | 4..128))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The description of this platform, in the
+            format specified in FC-GS-5.  This value should
+            include the full name and version identification of the
+            platform's hardware type and software operating system."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.4.10"
+    ::= { t11FcsPlatformEntry 9 }
+
+t11FcsPlatformLabel  OBJECT-TYPE
+    SYNTAX       SnmpAdminString (SIZE (0 | 4..64))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "An administratively assigned symbolic name for the
+            platform, in the format specified in FC-GS-5."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.4.11"
+
+
+
+DeSanti, et al.             Standards Track                    [Page 31]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+    ::= { t11FcsPlatformEntry 10 }
+
+t11FcsPlatformLocation  OBJECT-TYPE
+    SYNTAX       SnmpAdminString (SIZE (0 | 4..128))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The physical location of the platform, in the format
+            specified in FC-GS-5 (e.g., 'telephone closet, 3rd floor')."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.4.12"
+    ::= { t11FcsPlatformEntry 11 }
+
+t11FcsPlatformSystemID  OBJECT-TYPE
+    SYNTAX       SnmpAdminString (SIZE (0 | 4..64))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "An identifier for a hosting system that this platform is
+            associated with.  This identifier is used to associate
+            platforms of logical types (e.g., logical partitions) with
+            a physical system."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.4.5"
+    ::= { t11FcsPlatformEntry 12 }
+
+t11FcsPlatformSysMgmtAddr  OBJECT-TYPE
+    SYNTAX       T11FcListIndexPointerOrZero
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "A list of management addresses for the platform."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, sections 6.2.3.4.5 and 6.2.3.2.7."
+    ::= { t11FcsPlatformEntry 13 }
+
+t11FcsPlatformClusterId  OBJECT-TYPE
+    SYNTAX       SnmpAdminString (SIZE (0 | 4..64))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "An identifier for a cluster that this platform is
+             associated with, where a cluster is a set of independent
+             platforms that are managed together to provide increased
+             performance capabilities, failover, etc."
+
+
+
+DeSanti, et al.             Standards Track                    [Page 32]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.4.5"
+    ::= { t11FcsPlatformEntry 14 }
+
+t11FcsPlatformClusterMgmtAddr  OBJECT-TYPE
+    SYNTAX       T11FcListIndexPointerOrZero
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "A list of management addresses for the cluster identified
+            in the corresponding instance of t11FcsPlatformClusterId."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, sections 6.2.3.4.5 and 6.2.3.2.7."
+    ::= { t11FcsPlatformEntry 15 }
+
+t11FcsPlatformFC4Types  OBJECT-TYPE
+    SYNTAX       OCTET STRING (SIZE (0 | 32))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The FC-4 types supported by this platform, formatted as
+            a bit mask as specified in FC-GS-5.  If this object
+            contains the zero-length string, the types are unknown."
+    REFERENCE
+            "ANSI INCITS 427-2007, Fibre Channel - Generic Services 5,
+            FC-GS-5, section 6.2.3.4.5"
+    ::= { t11FcsPlatformEntry 16 }
+
+--
+-- Node Name List table
+--
+
+t11FcsNodeNameListTable  OBJECT-TYPE
+    SYNTAX       SEQUENCE OF T11FcsNodeNameListEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "This table contains all the lists of nodes."
+    ::= { t11FcsDiscoveredConfig 7 }
+
+t11FcsNodeNameListEntry  OBJECT-TYPE
+    SYNTAX       T11FcsNodeNameListEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "Information about a node, which is known to a
+
+
+
+DeSanti, et al.             Standards Track                    [Page 33]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+            switch (identified by fcmInstanceIndex and
+            fcmSwitchIndex)."
+    INDEX   { fcmInstanceIndex,  fcmSwitchIndex,
+              t11FcsNodeNameListIndex, t11FcsNodeName }
+    ::= { t11FcsNodeNameListTable 1 }
+
+T11FcsNodeNameListEntry ::= SEQUENCE {
+    t11FcsNodeNameListIndex       T11FcListIndex,
+    t11FcsNodeName                FcNameIdOrZero
+}
+
+t11FcsNodeNameListIndex  OBJECT-TYPE
+    SYNTAX       T11FcListIndex
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "The index value of the node name list."
+    ::= { t11FcsNodeNameListEntry 1 }
+
+t11FcsNodeName  OBJECT-TYPE
+    SYNTAX       FcNameIdOrZero (SIZE(8 | 16))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The name of this node."
+    ::= { t11FcsNodeNameListEntry 2 }
+
+--
+-- Statistics
+--
+
+t11FcsStatsTable  OBJECT-TYPE
+    SYNTAX       SEQUENCE OF T11FcsStatsEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "This table contains all the statistics related
+            to the Fabric Configuration Server."
+    ::= { t11FcsStats 1 }
+
+t11FcsStatsEntry  OBJECT-TYPE
+    SYNTAX       T11FcsStatsEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "A set of statistics for a particular Fabric (identified
+            by t11FcsFabricIndex) on a switch (identified by
+            fcmInstanceIndex and fcmSwitchIndex)."
+
+
+
+DeSanti, et al.             Standards Track                    [Page 34]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+    INDEX   { fcmInstanceIndex, fcmSwitchIndex, t11FcsFabricIndex }
+    ::= { t11FcsStatsTable 1 }
+
+T11FcsStatsEntry ::= SEQUENCE {
+    t11FcsInGetReqs                Counter32,
+    t11FcsOutGetReqs               Counter32,
+    t11FcsInRegReqs                Counter32,
+    t11FcsOutRegReqs               Counter32,
+    t11FcsInDeregReqs              Counter32,
+    t11FcsOutDeregReqs             Counter32,
+    t11FcsRejects                  Counter32
+}
+
+t11FcsInGetReqs  OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The number of Get Requests received by the Fabric
+            Configuration Server on this Fabric.
+
+            This counter has no discontinuities other than
+            those that all Counter32s have when sysUpTime=0."
+    ::= { t11FcsStatsEntry 1 }
+
+
+t11FcsOutGetReqs  OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The number of Get Requests sent by the Fabric
+            Configuration Server on this Fabric to other
+            servers in the Fabric.
+
+            This counter has no discontinuities other than
+            those that all Counter32s have when sysUpTime=0."
+    ::= { t11FcsStatsEntry 2 }
+
+
+t11FcsInRegReqs  OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The number of Registration Requests received by the
+            Fabric Configuration Server on this Fabric.
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 35]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+            This counter has no discontinuities other than
+            those that all Counter32s have when sysUpTime=0."
+    ::= { t11FcsStatsEntry 3 }
+
+t11FcsOutRegReqs  OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The number of Registration Requests sent by the
+            Fabric Configuration Server on this Fabric.
+
+            This counter has no discontinuities other than
+            those that all Counter32s have when sysUpTime=0."
+    ::= { t11FcsStatsEntry 4 }
+
+
+t11FcsInDeregReqs  OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The number of Deregistration Requests received by
+            the Fabric Configuration Server on this Fabric.
+
+            This counter has no discontinuities other than
+            those that all Counter32s have when sysUpTime=0."
+    ::= { t11FcsStatsEntry 5 }
+
+t11FcsOutDeregReqs  OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The number of Deregistration Requests sent by
+            the Fabric Configuration Server on this Fabric.
+
+            This counter has no discontinuities other than
+            those that all Counter32s have when sysUpTime=0."
+    ::= { t11FcsStatsEntry 6 }
+
+t11FcsRejects  OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The total number of requests rejected by the Fabric
+            Configuration Server on this Fabric.
+
+
+
+DeSanti, et al.             Standards Track                    [Page 36]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+            This counter has no discontinuities other than
+            those that all Counter32s have when sysUpTime=0."
+    ::= { t11FcsStatsEntry 7 }
+
+--
+-- Notification Control Table
+--
+
+t11FcsNotifyControlTable OBJECT-TYPE
+    SYNTAX       SEQUENCE OF T11FcsNotifyControlEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "A table of control information for notifications
+            generated due to Fabric Configuration Server events.
+
+            Values written to objects in this table should be
+            persistent/retained over agent reboots."
+    ::= { t11FcsNotificationInfo 1 }
+
+t11FcsNotifyControlEntry OBJECT-TYPE
+    SYNTAX       T11FcsNotifyControlEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+            "Each entry contains notification control information
+            for a Fabric Configuration Server on a particular Fabric
+            (identified by t11FcsFabricIndex) on a particular
+            switch (identified by fcmInstanceIndex and
+            fcmSwitchIndex)."
+    INDEX   { fcmInstanceIndex, fcmSwitchIndex,
+              t11FcsFabricIndex }
+    ::= { t11FcsNotifyControlTable 1 }
+
+T11FcsNotifyControlEntry ::= SEQUENCE {
+     t11FcsReqRejectNotifyEnable        TruthValue,
+     t11FcsDiscoveryCompNotifyEnable    TruthValue,
+     t11FcsMgmtAddrChangeNotifyEnable   TruthValue,
+     t11FcsRejectCtCommandString        OCTET STRING,
+     t11FcsRejectRequestSource          FcNameIdOrZero,
+     t11FcsRejectReasonCode             T11NsGs4RejectReasonCode,
+     t11FcsRejectReasonCodeExp          T11FcsRejectReasonExplanation,
+     t11FcsRejectReasonVendorCode       OCTET STRING
+}
+
+t11FcsReqRejectNotifyEnable OBJECT-TYPE
+    SYNTAX        TruthValue
+    MAX-ACCESS    read-write
+
+
+
+DeSanti, et al.             Standards Track                    [Page 37]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+    STATUS        current
+    DESCRIPTION
+            "This object specifies if the Fabric Configuration
+            Server should generate 't11FcsRqRejectNotification'
+            notifications.
+
+            If the value of this object is 'true', then the
+            notification is issued.  If the value of this object
+            is 'false', then the notification is not issued."
+    DEFVAL { false }
+    ::= { t11FcsNotifyControlEntry 1 }
+
+t11FcsDiscoveryCompNotifyEnable OBJECT-TYPE
+    SYNTAX        TruthValue
+    MAX-ACCESS    read-write
+    STATUS        current
+    DESCRIPTION
+            "This object specifies if the Fabric Configuration
+            Server should generate 't11FcsDiscoveryCompleteNotify'
+            notifications.
+
+            If the value of this object is 'true', then the
+            notification is issued.  If the value of this object
+            is 'false', then the notification is not issued."
+    DEFVAL { false }
+    ::= { t11FcsNotifyControlEntry 2 }
+
+t11FcsMgmtAddrChangeNotifyEnable OBJECT-TYPE
+    SYNTAX        TruthValue
+    MAX-ACCESS    read-write
+    STATUS        current
+    DESCRIPTION
+            "This object specifies if the Fabric Configuration
+            Server should generate 't11FcsMgmtAddrChangeNotify'
+            notifications.
+
+            If the value of this object is 'true', then the
+            notification is issued.  If the value of this object
+            is 'false', then the notification is not issued."
+    DEFVAL { false }
+    ::= { t11FcsNotifyControlEntry 3 }
+
+t11FcsRejectCtCommandString OBJECT-TYPE
+    SYNTAX        OCTET STRING (SIZE (0..255))
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+            "The binary content of the Fabric Configuration Server
+
+
+
+DeSanti, et al.             Standards Track                    [Page 38]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+            request, formatted as an octet string (in network byte
+            order) containing the Common Transport Information Unit
+            (CT_IU), as described in Table 2 of FC-GS-5 (including
+            the preamble), which was most recently rejected by the
+            Fabric Configuration Server for this Fabric.
+
+            This object contains the zero-length string if and when the
+            CT-IU's content is unavailable.
+
+            When the length of this object is 255 octets, it contains
+            the first 255 octets of the CT-IU (in network byte order)."
+    ::= { t11FcsNotifyControlEntry 4 }
+
+t11FcsRejectRequestSource OBJECT-TYPE
+    SYNTAX       FcNameIdOrZero
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The WWN that was the source of the CT_IU contained in
+            the corresponding instance of t11FcsRejectCtCommandString."
+    ::= { t11FcsNotifyControlEntry 5 }
+
+t11FcsRejectReasonCode OBJECT-TYPE
+    SYNTAX        T11NsGs4RejectReasonCode
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+            "This object contains the reason code corresponding
+            to the latest Fabric Configuration Server request
+            rejected by the local system."
+    ::= { t11FcsNotifyControlEntry 6 }
+
+t11FcsRejectReasonCodeExp OBJECT-TYPE
+    SYNTAX        T11FcsRejectReasonExplanation
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+            "When the corresponding instance of
+            t11FcsRejectReasonCode has the value: 'unable to
+            perform command request', this object contains the
+            corresponding reason code explanation."
+    ::= { t11FcsNotifyControlEntry 7 }
+
+t11FcsRejectReasonVendorCode OBJECT-TYPE
+    SYNTAX        OCTET STRING (SIZE(1))
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+
+
+
+DeSanti, et al.             Standards Track                    [Page 39]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+            "A registration reject vendor-specific code.  This
+            object contains the vendor-specific code of the most
+            recently rejected Fabric Configuration Server
+            Registration request for the particular port on
+            the particular Fabric."
+    ::= { t11FcsNotifyControlEntry 8 }
+--
+-- Notifications
+--
+
+t11FcsRqRejectNotification NOTIFICATION-TYPE
+    OBJECTS { t11FamLocalSwitchWwn,
+              t11FcsRejectReasonCode,
+              t11FcsRejectReasonCodeExp,
+              t11FcsRejectReasonVendorCode }
+    STATUS  current
+    DESCRIPTION
+            "This notification is generated whenever the Fabric
+            Configuration Server on a switch (indicated by the
+            value of t11FamLocalSwitchWwn) rejects a Fabric
+            Configuration Server request.
+
+            The Fabric Configuration Server should update the
+            t11FcsRejectReasonCode, t11FcsRejectReasonCodeExp
+            and t11FcsRejectReasonVendorCode objects with the
+            corresponding reason code, explanation and vendor
+            specific code before sending the notification."
+    ::= { t11FcsNotifications 1 }
+
+t11FcsDiscoveryCompleteNotify NOTIFICATION-TYPE
+    OBJECTS {t11FcsFabricDiscoveryRangeLow}
+    STATUS  current
+    DESCRIPTION
+            "This notification is generated by the Fabric
+            Configuration Server on the completion of the
+            discovery of Fabrics in the range that has
+            t11FcsFabricDiscoveryRangeLow at its low end."
+    ::= { t11FcsNotifications 2 }
+
+t11FcsMgmtAddrChangeNotify NOTIFICATION-TYPE
+    OBJECTS { t11FcsMgmtAddrChangeFabricIndex,
+              t11FcsMgmtAddrChangeIeName }
+    STATUS  current
+    DESCRIPTION
+            "This notification is generated by the Fabric
+            Configuration Server whenever the management
+            address of an IE changes, i.e., whenever an
+            entry in the t11FcsMgmtAddrListTable changes."
+
+
+
+DeSanti, et al.             Standards Track                    [Page 40]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+    ::= { t11FcsNotifications 3 }
+
+t11FcsMgmtAddrChangeFabricIndex OBJECT-TYPE
+    SYNTAX        T11FabricIndex
+    MAX-ACCESS    accessible-for-notify
+    STATUS        current
+    DESCRIPTION
+            "The index value that identifies the Fabric on which
+            a management address change has been detected."
+    ::= { t11FcsNotificationInfo 2 }
+
+t11FcsMgmtAddrChangeIeName OBJECT-TYPE
+    SYNTAX        FcNameIdOrZero
+    MAX-ACCESS    accessible-for-notify
+    STATUS        current
+    DESCRIPTION
+            "The IE for which a management address change has been
+            detected."
+    ::= { t11FcsNotificationInfo 3 }
+
+
+-- Conformance
+
+t11FcsMIBCompliances OBJECT IDENTIFIER ::= { t11FcsMIBConformance 1 }
+t11FcsMIBGroups      OBJECT IDENTIFIER ::= { t11FcsMIBConformance 2 }
+
+t11FcsMIBCompliance MODULE-COMPLIANCE
+    STATUS        current
+    DESCRIPTION
+            "The compliance statement for entities that
+            implement the Fabric Configuration Server."
+    MODULE MANDATORY-GROUPS { t11FcsDiscoveredConfigGroup,
+                              t11FcsDiscoveryStatusGroup,
+                              t11FcsNotificationInfoGroup,
+                              t11FcsNotificationGroup }
+
+    GROUP   t11FcsDiscoveryControlGroup
+    DESCRIPTION
+            "This group is mandatory only for those systems that
+            allow discovery of configuration by Fabric Configuration
+            Servers to be controlled via a MIB."
+
+    GROUP   t11FcsStatisticsGroup
+    DESCRIPTION
+            "These counters, containing Fabric Configuration
+            Server statistics, are mandatory only for those systems
+            that count such events."
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 41]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+    OBJECT   t11FcsDiscoveryStatus
+    WRITE-SYNTAX INTEGER { localOnly(3) }
+    MIN-ACCESS   read-only
+    DESCRIPTION
+            "Write access is not required.
+             However, if write access is supported, then the only
+             writable value is 'localOnly'."
+
+    OBJECT   t11FcsReqRejectNotifyEnable
+    MIN-ACCESS   read-only
+    DESCRIPTION
+            "Write access is not required."
+
+    OBJECT   t11FcsDiscoveryCompNotifyEnable
+    MIN-ACCESS   read-only
+    DESCRIPTION
+            "Write access is not required."
+
+    OBJECT   t11FcsMgmtAddrChangeNotifyEnable
+    MIN-ACCESS   read-only
+    DESCRIPTION
+            "Write access is not required."
+
+    ::= { t11FcsMIBCompliances 1 }
+
+
+-- Units of Conformance
+
+t11FcsDiscoveryControlGroup OBJECT-GROUP
+    OBJECTS { t11FcsFabricDiscoveryRangeLow,
+              t11FcsFabricDiscoveryRangeHigh,
+              t11FcsFabricDiscoveryStart,
+              t11FcsFabricDiscoveryTimeOut }
+    STATUS   current
+    DESCRIPTION
+            "A collection of objects for requesting a Fabric
+            Configuration Server to discover the configuration
+            of one or more Fabrics."
+    ::= { t11FcsMIBGroups 1 }
+
+t11FcsDiscoveryStatusGroup OBJECT-GROUP
+    OBJECTS { t11FcsDiscoveryStatus,
+              t11FcsDiscoveryCompleteTime }
+    STATUS   current
+    DESCRIPTION
+            "A collection of objects with which to monitor the
+            status of discovery (of Fabric configurations) by
+            Fabric Configuration Servers."
+
+
+
+DeSanti, et al.             Standards Track                    [Page 42]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+    ::= { t11FcsMIBGroups 2 }
+
+t11FcsDiscoveredConfigGroup OBJECT-GROUP
+    OBJECTS {
+              t11FcsIeType,
+              t11FcsIeDomainId,
+              t11FcsIeMgmtId,
+              t11FcsIeFabricName,
+              t11FcsIeLogicalName,
+              t11FcsIeMgmtAddrListIndex,
+              t11FcsIeInfoList,
+              t11FcsMgmtAddr,
+              t11FcsPortType,
+              t11FcsPortTxType,
+              t11FcsPortModuleType,
+              t11FcsPortPhyPortNum,
+              t11FcsPortAttachPortNameIndex,
+              t11FcsPortState,
+              t11FcsPortSpeedCapab,
+              t11FcsPortOperSpeed,
+              t11FcsPortZoningEnfStatus,
+              t11FcsAttachPortName,
+              t11FcsPlatformName,
+              t11FcsPlatformType,
+              t11FcsPlatformNodeNameListIndex,
+              t11FcsPlatformMgmtAddrListIndex,
+              t11FcsPlatformVendorId,
+              t11FcsPlatformProductId,
+              t11FcsPlatformProductRevLevel,
+              t11FcsPlatformDescription,
+              t11FcsPlatformLabel,
+              t11FcsPlatformLocation,
+              t11FcsPlatformSystemID,
+              t11FcsPlatformSysMgmtAddr,
+              t11FcsPlatformClusterId,
+              t11FcsPlatformClusterMgmtAddr,
+              t11FcsPlatformFC4Types,
+              t11FcsNodeName }
+    STATUS   current
+    DESCRIPTION
+            "A collection of objects to contain the Fabric configuration
+            information discovered by Fabric Configuration Servers."
+    ::= { t11FcsMIBGroups 3 }
+
+t11FcsStatisticsGroup OBJECT-GROUP
+    OBJECTS { t11FcsInGetReqs,
+              t11FcsOutGetReqs,
+              t11FcsInRegReqs,
+
+
+
+DeSanti, et al.             Standards Track                    [Page 43]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+              t11FcsOutRegReqs,
+              t11FcsInDeregReqs,
+              t11FcsOutDeregReqs,
+              t11FcsRejects }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects for Fabric Configuration Server
+            statistics information."
+    ::= { t11FcsMIBGroups 4 }
+
+t11FcsNotificationInfoGroup OBJECT-GROUP
+    OBJECTS { t11FcsReqRejectNotifyEnable,
+              t11FcsDiscoveryCompNotifyEnable,
+              t11FcsMgmtAddrChangeNotifyEnable,
+              t11FcsRejectCtCommandString,
+              t11FcsRejectRequestSource,
+              t11FcsRejectReasonCode,
+              t11FcsRejectReasonCodeExp,
+              t11FcsRejectReasonVendorCode,
+              t11FcsMgmtAddrChangeFabricIndex,
+              t11FcsMgmtAddrChangeIeName }
+    STATUS  current
+    DESCRIPTION
+            "A collection of notification control and notification
+            information objects for monitoring Fabric
+            Configuration Servers."
+    ::= { t11FcsMIBGroups 5 }
+
+t11FcsNotificationGroup NOTIFICATION-GROUP
+    NOTIFICATIONS { t11FcsRqRejectNotification,
+                    t11FcsDiscoveryCompleteNotify,
+                    t11FcsMgmtAddrChangeNotify }
+    STATUS  current
+    DESCRIPTION
+            "A collection of notifications for monitoring Fabric
+            Configuration Servers."
+    ::= { t11FcsMIBGroups 6 }
+
+END
+
+
+
+
+
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 44]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+7.  IANA Considerations
+
+   IANA has assigned a MIB OID (162) under the mib-2 subtree.
+
+8.  Security Considerations
+
+   There are several management objects defined in this MIB module with
+   a MAX-ACCESS clause of read-write and/or read-create.  Such objects
+   may be considered sensitive or vulnerable in some network
+   environments.  The support for SET operations in a non-secure
+   environment without proper protection can have a negative effect on
+   network operations.  These objects and their
+   sensitivity/vulnerability is:
+
+      t11FcsFabricDiscoveryRangeLow
+      t11FcsFabricDiscoveryRangeHigh
+      t11FcsFabricDiscoveryTimeOut
+      t11FcsFabricDiscoveryStart -- the ability to specify parameters
+                                    for, and trigger the start of,
+                                    a topology discovery.
+      t11FcsDiscoveryStatus      -- the ability to abort a discovery, or
+                                    invalidate discovered information.
+      t11FcsReqRejectNotifyEnable
+      t11FcsDiscoveryCompNotifyEnable
+      t11FcsMgmtAddrChangeNotifyEnable -- the ability to enable/disable
+                                          notifications.
+
+   Such objects may be considered sensitive or vulnerable in some
+   network environments.  For example, the ability to invalidate
+   discovered topology may afford an attacker the ability to hide the
+   presence of unauthorized equipment on the network.  The support for
+   SET operations in a non-secure environment without proper protection
+   can have a negative effect on network operations.
+
+   Some of the readable objects in this MIB module (i.e., objects with a
+   MAX-ACCESS other than not-accessible) may be considered sensitive or
+   vulnerable in some network environments.  It is thus important to
+   control even GET and/or NOTIFY access to these objects and possibly
+   to even encrypt the values of these objects when sending them over
+   the network via SNMP.  These are the tables and objects and their
+   sensitivity/vulnerability:
+
+      t11FcsIeTable
+      t11FcsMgmtAddrListTable
+      t11FcsPortTable
+      t11FcsAttachPortNameListTable
+      t11FcsPlatformTable
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 45]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+      t11FcsNodeNameListTable -- contains information about the topology
+                                 of the Fibre Channel network.
+
+      t11FcsStatsTable -- contains statistics information about the
+                          operation of the Fabric Configuration Server.
+
+   SNMP versions prior to SNMPv3 did not include adequate security.
+   Even if the network itself is secure (for example by using IPsec),
+   even then, there is no control as to who on the secure network is
+   allowed to access and GET/SET (read/change/create/delete) the objects
+   in this MIB module.
+
+   It is RECOMMENDED that implementors consider the security features as
+   provided by the SNMPv3 framework (see [RFC3410], section 8),
+   including full support for the SNMPv3 cryptographic mechanisms (for
+   authentication and privacy).
+
+   Further, deployment of SNMP versions prior to SNMPv3 is NOT
+   RECOMMENDED.  Instead, it is RECOMMENDED to deploy SNMPv3 and to
+   enable cryptographic security.  It is then a customer/operator
+   responsibility to ensure that the SNMP entity giving access to an
+   instance of this MIB module is properly configured to give access to
+   the objects only to those principals (users) that have legitimate
+   rights to indeed GET or SET (change/create/delete) them.
+
+9.  Acknowledgements
+
+   This document was originally developed and approved by the INCITS
+   Task Group T11.5 (http://www.t11.org) as the SM-FCFGM project.  We
+   wish to acknowledge the many contributions and comments from the
+   INCITS Technical Committee T11, especially from the following:
+
+      T11 Chair: Robert Snively, Brocade
+      T11 Vice Chair: Claudio DeSanti, Cisco Systems
+      T11.5 Chair: Roger Cummings, Symantec
+      T11.5 Vice Chair: Scott Kipp, McData
+      and T11.5 members.
+
+   The document was subsequently a work item of the IETF's IMSS Working
+   Group, chaired by David Black (EMC Corporation).  We thank Bert
+   Wijnen (Lucent Technologies) for his thorough review of the document.
+   We also wish to acknowledge Dan Romascanu (Avaya), the IETF Area
+   Director, for his comments and assistance.
+
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 46]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+10.  Normative References
+
+   [RFC2578]  McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J.,
+              Rose, M. and S. Waldbusser, "Structure of Management
+              Information Version 2 (SMIv2)", STD 58, RFC 2578, April
+              1999.
+
+   [RFC2579]  McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J.,
+              Rose, M. and S. Waldbusser, "Textual Conventions for
+              SMIv2", STD 58, RFC 2579, April 1999.
+
+   [RFC2580]  McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J.,
+              Rose, M. and S. Waldbusser, "Conformance Statements for
+              SMIv2", STD 58, RFC 2580, April 1999.
+
+   [RFC2788]  Freed, N. and S. Kille, "Network Services Monitoring MIB",
+              RFC 2788, March 2000.
+
+   [RFC3411]  Harrington, D., Presuhn, R., and B. Wijnen, "An
+              Architecture for Describing Simple Network Management
+              Protocol (SNMP) Management Frameworks", STD 58, RFC 3411,
+              December 2002.
+
+   [FC-FS]    "Fibre Channel - Framing and Signaling (FC-FS)" ANSI
+              INCITS 373-2003,
+              http://www.t11.org/t11/stat.nsf/upnum/1331-d, April 2003.
+
+   [FC-GS-5]  "Fibre Channel - Generic Services - 5 (FC-GS-5)", ANSI
+              INCITS 427-2007,
+              http://www.t11.org/t11/stat.nsf/upnum/1677-d, 2007.
+
+   [FC-SW-4]  "Fibre Channel - Switch Fabric - 4 (FC-SW-4)", ANSI INCITS
+              418-2006, http://www.t11.org/t11/stat.nsf/upnum/1674-d,
+              December 2006.
+
+   [RFC4044]  McCloghrie, K., "Fibre Channel Management MIB", RFC 4044,
+              May 2005.
+
+   [RFC4438]  DeSanti, C., Gaonkar, V., Vivek, H.K., McCloghrie, K., and
+              S. Gai, "Fibre Channel Name Server MIB", RFC 4438, March
+              2006.
+
+   [RFC4439]  DeSanti, C., Gaonkar, V., McCloghrie, K., and S. Gai,
+              "Fibre Channel Fabric Address Manager MIB", RFC 4439,
+              March 2006.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+
+
+DeSanti, et al.             Standards Track                    [Page 47]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+11.  Informative References
+
+   [RFC2741]  Daniele, M., Wijnen, B., Ellison, M., and D. Francisco,
+              "Agent Extensibility (AgentX) Protocol Version 1", RFC
+              2741, January 2000.
+
+   [RFC2837]  Teow, K., "Definitions of Managed Objects for the Fabric
+              Element in Fibre Channel Standard", RFC 2837, May 2000.
+
+   [RFC3410]  Case, J., Mundy, R., Partain, D., and B. Stewart,
+              "Introduction and Applicability Statements for Internet-
+              Standard Management Framework", RFC 3410, December 2002.
+
+   [RFC4455]  Hallak-Stamler, M., Bakke, M., Lederman, Y., Krueger, M.,
+              and K. McCloghrie, "Definition of Managed Objects for
+              Small Computer System Interface (SCSI) Entities", RFC
+              4455, April 2006.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 48]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+Authors' Addresses
+
+   Claudio DeSanti
+   Cisco Systems, Inc.
+   170 West Tasman Drive
+   San Jose, CA 95134 USA
+   Phone: +1 408 853-9172
+   EMail: cds@cisco.com
+
+   H.K. Vivek
+   Cisco Systems, Inc.
+   71 Millers Rd
+   Bangalore, India
+   Phone: +91 80 2289933x5117
+   EMail: hvivek@cisco.com
+
+   Keith McCloghrie
+   Cisco Systems, Inc.
+   170 West Tasman Drive
+   San Jose, CA 95134 USA
+   Phone: +1 408 526-5260
+   EMail: kzm@cisco.com
+
+   Silvano Gai
+   Nuova Systems
+   3 West Plumeria Drive
+   San Jose, CA 95134
+   Phone: +1 408 387-6123
+   EMail: sgai@nuovasystems.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 49]
+
+RFC 4935            Fabric Configuration Server MIB          August 2007
+
+
+Full Copyright Statement
+
+   Copyright (C) The IETF Trust (2007).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY, THE IETF TRUST AND
+   THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF
+   THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 50]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4935.txt](<www.ietf.org/rfc/rfc4935.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
