### PR TITLE
Archive rfc495.txt

### DIFF
--- a/www.ietf.org/rfc/rfc495.txt
+++ b/www.ietf.org/rfc/rfc495.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                        A. McKenzie
+Request for Comments: 495                                        BBN-NET
+NIC #15371                                                    1 May 1973
+Categories: TELNET, Protocols
+References: RFCs 318, 435; NIC 7104
+
+
+                     TELNET Protocol Specification
+
+Following much discussion of TELNET via the RFC series, an open meeting
+was held at UCLA on 5 March to formulate a new specification for the
+TELNET Protocol.  Two attached documents (TELNET Protocol Specification,
+NIC #15372, and TELNET Option Specifications, NIC #15373) report the
+results of that meeting, which was attended by: Alex McKenzie, BBN-NET,
+co-chairman; Jon Postel, UCLA-NMC, co-chairman; Bob Braden, UCLA-CCN;
+Vint Cerf, Stanford University; Bernie Cosell, BBN-NET; Dave Crocker,
+UCLA-NMC; Steve Crocker, ARPA; John Davidson, Univ. of Hawaii; Gary
+Grossman, Univ. of Illinois; Bob Merryman, UCSD; Lou Nelson, UCLA-NMC;
+Mike Padlipsky, MIT-MULTICS: Milt Reese, FNW; Bob Thomas, BBN-TENEX;
+Steve Wolfe, UCLA-CCN.
+
+
+The two attached specifications referenced above have been reviewed by
+the meeting attendees, and should be viewed as the "official" TELNET
+Protocol (subject to the implementation schedule given below).
+Nevertheless, these documents are still subject to minor revisions and
+any pertinent comments should be addressed to me at the NIC as AAM, or
+by mail at:
+
+                           Alex McKenzie
+                           Bolt Beranek and Newman Inc.
+                           50 Moulton Street
+                           Cambridge, Ma. 02138
+
+   There are two key dates for a phasing in of the new protocol:  the
+   date when sites should feel free to send the "new" form of TELNET
+   commands and special codes without expecting to receive "error"
+   responses, and the date when sites may remove the code which
+   processes the "old" form of TELNET commands.  Between these two
+   dates, sites may gradually implement and test the "interpreter" for
+   the new commands.  It was the sense of the meeting that appropriate
+   lead times to these two dates were about 60 and 260 days.
+   Accordingly, these two dates are hereby established as 1 July 1973
+   and 1 January 1974.
+
+
+
+
+
+
+
+McKenzie                                                        [Page 1]
+
+RFC 495              TELNET Protocol Specification            1 May 1973
+
+
+   I have also attached specifications for TELNET options which allow
+   negotiation of:
+
+            o binary transmission
+            o echoing
+            o reconnection
+            o suppression of "Go Ahead"
+            o approximate message size
+            o use of a "timing mark"
+            o discussion of status
+            o extension of option code set
+
+   These specifications have been prepared by Dave Walden (BBN-NET) with
+   the help of Bernie Cosell, Ray Tomlinson (BBN-TENEX) and Bob Thomas;
+   by Jerry Burchfiel (BBN-TENEX); and by David Crocker (ULCA-NMC).  It
+   appears that these options cover most of the capabilities of the
+   current version of TELNET, with the exception of "Hide Your Input."
+   Dave Walden has also promised to specify the following options in the
+   near future:
+
+            o NVT printer line width negotiation
+            o NVT printer page size negotiation
+            o negotiation of the mapping between the line terminator
+              character available on a physical terminal (e.g., LF,
+              CR, NL) and the NVT characters to be transmitted
+              (e.g., CR NUL, LF, CR LF).
+
+   Dave has also announced his intent to seek collaboration with
+   Gary Grossman, Bob Braden, and perhaps others in defining an
+   EBCDIC option.  The announcement of intent to specify these
+   options should, of course, be seen as useful information rather
+   than as the granting of an "exclusive right" to Dave, or any
+   other author.
+
+   I gratefully acknowledge the assistance of Bernie Cosell
+   in the preparation of the protocol specification.
+
+   AAM/jm
+   Attachments
+
+
+       [ This RFC was put into machine readable form for entry ]
+        [ into the online RFC archives by Gottfried Janik 4/98 ]
+
+
+
+
+
+
+
+
+McKenzie                                                        [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc495.txt](<www.ietf.org/rfc/rfc495.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
