### PR TITLE
Archive rfc496.txt

### DIFF
--- a/www.ietf.org/rfc/rfc496.txt
+++ b/www.ietf.org/rfc/rfc496.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                      Auerbach
+RFC # 496                                                  SRI-ARC
+NIC # 15496                                                April 5, 1973
+
+
+                A TNLS QUICK REFERENCE CARD IS AVAILABLE
+
+
+This RFC announces a new TNLS Quick Reference Card.  It documents all of
+the basic commands required for everyday TNLS usage as well as some
+special purpose features.  It includes TIP settings for connecting to
+SRI-ARC, basic TENEX/EXECUTIVE commands, and a complete of set of
+VIEWSPECS codes for TNLS usage.
+
+    One copy of this card will be sent to your station agent.  If you
+    would like to obtain copies for users at your site, please contact
+    Marcia Keeney (MLK) at SRI-ARC indicating the number of copies you
+    require.
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.             9/99 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Auerbach                                                        [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc496.txt](<www.ietf.org/rfc/rfc496.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
