### PR TITLE
Archive rfc4965.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4965.txt
+++ b/www.ietf.org/rfc/rfc4965.txt
@@ -1,0 +1,563 @@
+
+
+
+
+
+
+Network Working Group                                          J-F. Mule
+Request for Comments: 4965                                     CableLabs
+Category: Informational                                      W. Townsley
+                                                           Cisco Systems
+                                                          September 2007
+
+
+             CableLabs - IETF Standardization Collaboration
+
+Status of This Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard of any kind.  Distribution of this
+   memo is unlimited.
+
+Abstract
+
+   This document describes the collaboration and liaison relationship
+   between the Internet Engineering Task Force (IETF) and the Cable
+   Television Laboratories, Inc. (CableLabs).
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . . . 2
+   2.  Basis of Collaboration  . . . . . . . . . . . . . . . . . . . . 3
+   3.  Document Sharing  . . . . . . . . . . . . . . . . . . . . . . . 3
+   4.  Participation in the IETF Process . . . . . . . . . . . . . . . 4
+   5.  Designated Liaison Managers and Responsibilities  . . . . . . . 4
+   6.  Formal Liaison Statements . . . . . . . . . . . . . . . . . . . 6
+   7.  Contributions . . . . . . . . . . . . . . . . . . . . . . . . . 6
+   8.  Security Considerations . . . . . . . . . . . . . . . . . . . . 6
+   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . . . 7
+   10. Acknowledgments . . . . . . . . . . . . . . . . . . . . . . . . 7
+   11. Common Work Areas . . . . . . . . . . . . . . . . . . . . . . . 7
+   12. Informative References  . . . . . . . . . . . . . . . . . . . . 8
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Mule & Townsley              Informational                      [Page 1]
+
+RFC 4965              CableLabs-IETF Collaboration        September 2007
+
+
+1.  Introduction
+
+   This document contains a set of principles and guidelines that serves
+   as the basis for establishing a liaison relationship between the
+   Cable Television Laboratories, Inc. and the Internet Engineering Task
+   Force (IETF).  This cooperation framework is intended to secure
+   timely development of technical specifications that facilitate
+   maximum interoperability with existing Internet systems, devices, and
+   protocols.
+
+   CableLabs is a non-profit research and development consortium that is
+   dedicated to pursuing new cable telecommunications technologies and
+   to helping its cable operator members integrate those technical
+   advancements into their business objectives.  Within CableLabs,
+   specification activities are organized into projects such as
+   DOCSIS(r), PacketCable(tm), and OpenCable(tm), and technical work is
+   conducted in focus teams.  Product vendors, manufacturers, and cable
+   operator members are invited to join the focus teams that create
+   technical specifications.  From time to time, individuals involved
+   with CableLabs focus teams submit CableLabs technical requirements or
+   requirement specifications to IETF in order to seek expert reviews
+   and solicit comments to create solutions that foster product
+   interoperability beyond cable.  The submissions related to CableLabs
+   specifications may, for example, include use cases, protocol
+   requirements, draft MIB modules, and proposed solutions such as new
+   DHCP options.  CableLabs also references the work of IETF and Request
+   For Comments in its specifications.  The list of CableLabs projects
+   and specifications available publicly can be found at the CableLabs
+   Web site, http://www.cablelabs.com.
+
+   Within the IETF, activities are undertaken within a framework of
+   Areas, with specific activities being undertaken by working groups
+   that are chartered within each Area.  Working group output is
+   reviewed by the Internet Engineering Steering Group (IESG) and
+   published by the RFC Editor.  IETF activities are based on a
+   principle of open contribution and participation by any interested
+   party.  Details on the Internet Standards Process followed by the
+   IETF can be found in [RFC2026].  Information on IETF working groups,
+   current work item drafts, meeting schedules, and mailing lists are
+   published on the IETF Web site, http://www.ietf.org.
+
+   The IETF and CableLabs are forming a liaison relationship with a
+   mutual desire to support the integrity of specifications developed by
+   each body.  CableLabs does not develop standards other than through
+   its participation with Standards Defining Organizations (SDOs) like
+   the IETF.
+
+
+
+
+
+Mule & Townsley              Informational                      [Page 2]
+
+RFC 4965              CableLabs-IETF Collaboration        September 2007
+
+
+   The preferred approach is that CableLabs uses the IETF specifications
+   unchanged, if feasible, and communicates requirements for change to
+   the IETF, as needed.  The parties intend to work together in an
+   effort to avoid duplication of work.
+
+   Within the framework of this liaison relationship, each organization
+   will operate according to its own rules and procedures, including
+   rules governing Intellectual Property Rights (IPR), specification
+   elaboration, approval, and maintenance.
+
+2.  Basis of Collaboration
+
+   In the further development of CableLabs specifications, the benefit
+   of adopting IETF specifications has been identified.  Although this
+   document recognizes the importance of interoperability of the
+   CableLabs specifications with the existing Internet and hence the use
+   of IETF standards, CableLabs recognizes that additions or
+   modifications might be needed in order to make the IETF
+   specifications meet the needs of CableLabs.  In such cases, a
+   CableLabs individual or a vendor participant working on a CableLabs
+   specification may take its concerns directly to the appropriate IETF
+   working groups for resolution.  When no appropriate working group can
+   be found or it is not known where to direct the communication, or in
+   the case of resolution of consequent matters, the issue will be
+   raised through the CableLabs designated liaison manager to the IETF
+   liaison manager.
+
+   The IETF may also need to ask questions of CableLabs in order to
+   refine its understanding of CableLabs requirements or may wish to
+   offer guidance to CableLabs on the effective use of IETF
+   specifications.  Where possible, these communications will occur in
+   the context of a discussion between CableLabs and an IETF working
+   group.  In the event that a working-group-level discussion is deemed
+   inappropriate for the desired communication, the matter will be
+   raised through the IETF's designated liaison manager to CableLabs.
+
+3.  Document Sharing
+
+   Both CableLabs and the IETF encourage the sharing of specification
+   documents and draft requirements that are of mutual interest.
+
+   All IETF documents are publicly available from the IETF Web site, and
+   discussion of documents is hosted on open mailing lists.
+
+   CableLabs documents intended for public consumption include CableLabs
+   Technical Reports and CableLabs Specifications that are in an
+   approved and published status.  These documents have the CableLabs
+
+
+
+
+Mule & Townsley              Informational                      [Page 3]
+
+RFC 4965              CableLabs-IETF Collaboration        September 2007
+
+
+   ISSUED status and are published for open access on CableLabs' Web
+   site, http://www.cablelabs.com, or
+   http://www.cablelabs.com/specifications/archives/.
+
+   In order for the IETF to make any reference (informative or
+   normative), the document must be in an approved and published state,
+   and publicly available.  It is expected that CableLabs will share
+   relevant information with IETF participants via individual IETF
+   Contributions, as described in [RFC3978], and without requiring a
+   non-disclosure agreement.
+
+   CableLabs and the IETF will work to update and exchange, when
+   appropriate and on a regular basis, a list of dependencies between
+   each organization's specifications and work in progress.
+
+4.  Participation in the IETF Process
+
+   The Internet Standards Process is described in [RFC2026].
+   Participation in the IETF process is open to any individual willing
+   to contribute.  This naturally includes individuals who also
+   represent or otherwise contribute to the development of CableLabs
+   specifications.  Such individuals may freely participate in IETF
+   mailing list discussions, submit and review Internet Drafts, and
+   attend IETF meetings in order to assist the IETF in refining its
+   understanding of CableLabs requirements as well as offering CableLabs
+   an opportunity to receive informal guidance on CableLabs' use of IETF
+   specifications.  The vast majority of technical discussions and
+   decision making within the IETF is undertaken on open mailing lists.
+   Interested individuals should subscribe to and participate on these
+   lists.
+
+5.  Designated Liaison Managers and Responsibilities
+
+   When the informal working group level of interaction is insufficient,
+   matters can be raised through a liaison channel.  CableLabs and the
+   IETF shall each establish liaison functions for communication with
+   the other organization and each shall appoint one individual acting
+   as a liaison manager as described in [RFC4052] and [RFC4053].
+
+   Formal communications from CableLabs will be initiated by the
+   designated CableLabs liaison manager by sending a liaison statement
+   to the IETF liaison manager; these must follow the procedures
+   described in [RFC4053].  The role of the IETF liaison manager is
+   defined in [RFC4052] and [RFC4691].  The IETF liaison manager is not
+   responsible for notifying CableLabs of new work to be undertaken by
+   the IETF.  Instead, the designated CableLabs liaison manager or
+
+
+
+
+
+Mule & Townsley              Informational                      [Page 4]
+
+RFC 4965              CableLabs-IETF Collaboration        September 2007
+
+
+   delegates should subscribe to IETF lists announcing the creation or
+   rechartering of IETF working groups (ietf-announce) and the lists
+   announcing new work (new-work).
+
+5.1.  IETF Liaison Manager to CableLabs
+
+   The preferred way for organizations to work with IETF is through the
+   working groups.  However, IETF has a limited number of liaison
+   relationships and liaison managers with other organizations when
+   conditions warrant the appointment of a specific person.
+
+   The Internet Architecture Board (IAB) shall appoint a specific person
+   to serve as the IETF liaison manager to CableLabs.  The role and
+   responsibilities of the IETF liaison manager to CableLabs are
+   described below.  In particular, it is expected that the designated
+   liaison manager will act as an initial contact point in IETF for
+   administrative aspects of this collaboration that cannot easily be
+   handled in other ways (e.g., at a technical level by interactions
+   with IETF Working Groups or Area Directors).  It is agreed that the
+   role does not carry the expectation of attendance at CableLabs
+   meetings or participation in CableLabs specification development
+   processes, and it is anticipated that all liaison efforts assigned to
+   this individual will be carried out by electronic mail.  It is
+   understood that the IETF liaison manager does not have the ability to
+   make exceptions to, or special provisions for, IETF policies and
+   procedures.
+
+   It is expected that the individual appointed to the liaison manager
+   role would:
+
+   o  perform all tasks as defined in [RFC4052] and [RFC4691],
+
+   o  be informed by CableLabs, when appropriate, of CableLabs
+      activities within the IETF, including new work proposals, and be
+      able to report those using appropriate channels within the IETF,
+
+   o  convey liaison statements from the IETF to CableLabs as described
+      in [RFC4053], and be responsible for shepherding CableLabs
+      communication to the relevant parts of the IETF,
+
+   o  be able to raise issues with CableLabs technical leadership as
+      well as the IAB members and IETF Area Directors, as required.
+
+   CableLabs meetings are normally only open to delegates from CableLabs
+   members or those manufacturers who have signed the appropriate
+   agreements to participate in CableLabs projects or meetings.
+
+
+
+
+
+Mule & Townsley              Informational                      [Page 5]
+
+RFC 4965              CableLabs-IETF Collaboration        September 2007
+
+
+5.2.  CableLabs Liaison Manager to IETF
+
+   CableLabs shall establish an IETF liaison function and name an
+   individual to be the CableLabs liaison Manager to IETF for matters
+   pertaining to the CableLabs-IETF cooperation.  The CableLabs liaison
+   manager to IETF is expected to work with the concerned IETF and
+   CableLabs projects and focus teams and to support the interaction
+   between CableLabs and the IETF.
+
+6.  Formal Liaison Statements
+
+   Whenever possible, and as the preferred primary method of
+   communication and coordination of activity, communication at the
+   working group level is strongly encouraged.
+
+   When deemed necessary, formal communication between CableLabs and
+   IETF is also permitted.  These communications are to be recorded in
+   the form of Liaison Statements, and the IETF will use the CableLabs
+   liaison manager to convey these statements between the IETF and
+   CableLabs.  The procedure for proper handling of incoming liaison
+   statements defined in [RFC4053] must be followed by both the liaison
+   manager named by IETF and the liaison manager designated by
+   CableLabs.  It is important to note that all liaison statements made
+   by the IETF or directed to the IETF shall be published by the IETF as
+   public documents.  All liaison statements made by the IETF will
+   comply with the IETF IPR policy as documented in [RFC3978],
+   [RFC3979], [RFC4748], [RFC4371] and any updates.
+
+7.  Contributions
+
+   Individuals who are involved in CableLabs' projects and are willing
+   to contribute to IETF may make contributions to the IETF in their
+   capacity as IETF participants, under the IETF's IPR policy, as
+   documented in [RFC3978] and [RFC3979].
+
+   IETF participants whose companies are CableLabs members or have
+   signed the appropriate agreements with CableLabs may also make
+   contributions to CableLabs' projects and specifications.
+
+   CableLabs mailing lists are not open to the general public.  It is
+   recommended that work of mutual interest be discussed on the relevant
+   IETF mailing lists.
+
+   The IETF and CableLabs will not co-develop any documents or material.
+
+8.  Security Considerations
+
+   This document does not directly affect the security of the Internet.
+
+
+
+Mule & Townsley              Informational                      [Page 6]
+
+RFC 4965              CableLabs-IETF Collaboration        September 2007
+
+
+9.  IANA Considerations
+
+   This section provides some guidelines for IANA to consider when
+   adding references to a CableLabs specification in its registries.
+   CableLabs maintains a specification repository with a stable URL for
+   each published document under
+   http://www.cablelabs.com/specifications/.  A stable document URL is
+   one following the format:
+   http://www.cablelabs.com/specifications/CableLabs_docname.pdf, where
+   'CableLabs_docname' is the CableLabs document name.
+
+   IANA is requested to use the above document URL format when
+   referencing CableLabs specifications in its registries.
+
+10.  Acknowledgments
+
+   The authors wish to thank the following individuals for their
+   comments and contributions: Ralph Brown, Brian Carpenter, Leslie
+   Daigle, Ralph Droms, Alain Durand, Simon Krauss, Thomas Narten, Dan
+   Romascanu, and Dave Oran.
+
+   It is also acknowledged that this document is inspired from [RFC3113]
+   and [RFC3131].
+
+   This document was produced using the xml2rfc tool (RFC2629).
+
+11.  Common Work Areas
+
+   This section may be removed from future versions of this document.
+   It is provided here to give some background information on the areas
+   that may be common to both CableLabs and the IETF.
+
+   At the time of this writing, IETF working groups that are of
+   particular interest to CableLabs include:
+
+   DHCWG, KERBEROS, IPCDN, SIP, SIPPING, SIMPLE, SPEERMINT, IPTEL,
+   BEHAVE, AVT, MMUSIC, AAA, GEOPRIV, DISMAN, MSEC, ENUM, ECRIT, IPV6,
+   MIP6, NETCONF, ISMS, BRIDGE, ENTMIB, MAGMA, V6OPS, DNSEXT, IPSEC,
+   L2VPN, ZEROCONF, L2TPEXT, and TLS.
+
+
+
+
+
+
+
+
+
+
+
+
+Mule & Townsley              Informational                      [Page 7]
+
+RFC 4965              CableLabs-IETF Collaboration        September 2007
+
+
+12.  Informative References
+
+   [RFC2026]  Bradner, S., "The Internet Standards Process -- Revision
+              3", BCP 9, RFC 2026, October 1996.
+
+   [RFC3113]  Rosenbrock, K., Sanmugam, R., Bradner, S., and J. Klensin,
+              "3GPP-IETF Standardization Collaboration", RFC 3113,
+              June 2001.
+
+   [RFC3131]  Bradner, S., Calhoun, P., Cuschieri, H., Dennett, S.,
+              Flynn, G., Lipford, M., and M. McPheters, "3GPP2-IETF
+              Standardization Collaboration", RFC 3131, June 2001.
+
+   [RFC3978]  Bradner, S., "IETF Rights in Contributions", BCP 78,
+              RFC 3978, March 2005.
+
+   [RFC3979]  Bradner, S., "Intellectual Property Rights in IETF
+              Technology", BCP 79, RFC 3979, March 2005.
+
+   [RFC4052]  Daigle, L. and Internet Architecture Board, "IAB Processes
+              for Management of IETF Liaison Relationships", BCP 102,
+              RFC 4052, April 2005.
+
+   [RFC4053]  Trowbridge, S., Bradner, S., and F. Baker, "Procedures for
+              Handling Liaison Statements to and from the IETF",
+              BCP 103, RFC 4053, April 2005.
+
+   [RFC4371]  Carpenter, B. and L. Lynch, "BCP 101 Update for IPR
+              Trust", BCP 101, RFC 4371, January 2006.
+
+   [RFC4691]  Andersson, L., "Guidelines for Acting as an IETF Liaison
+              to Another Organization", RFC 4691, October 2006.
+
+   [RFC4748]  Bradner, S., "RFC 3978 Update to Recognize the IETF
+              Trust", BCP 78, RFC 4748, October 2006.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Mule & Townsley              Informational                      [Page 8]
+
+RFC 4965              CableLabs-IETF Collaboration        September 2007
+
+
+Authors' Addresses
+
+   Jean-Francois Mule
+   CableLabs
+   858 Coal Creek Circle
+   Louisville, CO  80027
+   USA
+
+   EMail: jf.mule@cablelabs.com
+
+
+   W. Mark Townsley
+   Cisco Systems
+   7025 Kit Creek Road
+   PO Box 14987
+   Research Triangle Park, NC  27709
+   USA
+
+   EMail: mark@townsley.net
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Mule & Townsley              Informational                      [Page 9]
+
+RFC 4965              CableLabs-IETF Collaboration        September 2007
+
+
+Full Copyright Statement
+
+   Copyright (C) The IETF Trust (2007).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY, THE IETF TRUST AND
+   THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF
+   THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+
+
+
+
+
+
+
+
+
+
+
+Mule & Townsley              Informational                     [Page 10]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4965.txt](<www.ietf.org/rfc/rfc4965.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
