### PR TITLE
Archive rfc4967.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4967.txt
+++ b/www.ietf.org/rfc/rfc4967.txt
@@ -1,0 +1,339 @@
+
+
+
+
+
+
+Network Working Group                                           B. Rosen
+Request for Comments: 4967                                       NeuStar
+Category: Standards Track                                      July 2007
+
+
+                     Dial String Parameter for the
+        Session Initiation Protocol Uniform Resource Identifier
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The IETF Trust (2007).
+
+Abstract
+
+   RFC 3966 explicitly states that 'tel' URIs may not represent a dial
+   string.  That leaves no way specify a dial string in a standardized
+   way.  Great confusion exists with the SIP URI parameter "user=phone",
+   and specifically, if it can represent a dial string.  This memo
+   creates a new value for the user parameter "dialstring", so that one
+   may specify "user=dialstring" to encode a dial string as a 'sip:' or
+   'sips:' URI.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . . . 2
+   2.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . . . 2
+   3.  Requirements  . . . . . . . . . . . . . . . . . . . . . . . . . 3
+   4.  Solution  . . . . . . . . . . . . . . . . . . . . . . . . . . . 3
+   5.  IANA Considerations . . . . . . . . . . . . . . . . . . . . . . 4
+   6.  Security Considerations . . . . . . . . . . . . . . . . . . . . 4
+   7.  Normative References  . . . . . . . . . . . . . . . . . . . . . 5
+
+
+
+
+
+
+
+
+
+
+
+
+Rosen                       Standards Track                     [Page 1]
+
+RFC 4967                 Dial String Parameter                 July 2007
+
+
+1.  Introduction
+
+   A user at a phone often has a limited User Interface, and in some
+   cases, is limited to a 10 key pad (and sometimes a "flash" function
+   with the switchhook).  The user enters a series of digits that invoke
+   some kind of function.  The entered sequence, called a "dial string",
+   may be translated to a telephone number, or it may invoke a special
+   service.  In many newer designs, the mapping between a dial string
+   and a phone number or service URI is contained within the phone
+   (digitmap).  However, there are many phones and terminal adapters
+   that do not have internal translation mechanisms.  Without a
+   translation mechanism in the phone, the phone must send the dial
+   string in a 'sip:' or 'sips:' URI [RFC3261] to an intermediary that
+   can transform the dial string to a phone number or a service
+   invocation.  The intermediary is able to perform this transform
+   provided that it knows the context (i.e., dialing plan) within which
+   the number was dialed.
+
+   There is a problem here.  The intermediary can apply its
+   transformation only if it recognizes that the user part of the SIP
+   URI is a dial string.  However, there is currently no way to
+   distinguish a user part consisting of a dial string from a user part
+   that happens to be composed of characters that would appear in a dial
+   string.
+
+   Use of DTMF (dual tone multi-frequency) detectors after the initial
+   number has been dialed is not uncommon.  A common function some
+   systems have is to express a string that incorporates fixed time
+   delays, or in some cases, an actual "wait for call completion" after
+   which additional DTMF signals are emitted.  For example, many
+   voicemail systems use a common phone number, after which the system
+   expects the desired mailbox number as a series of DTMF digits to
+   deposit a message for.  Many gateways have the ability to interpret
+   such strings, but there is no standardized way to express them,
+   leading to interoperability problems between endpoints.  This is
+   another case where the ability to indicate that a dial string is
+   being presented would be useful.
+
+2.  Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+   It is assumed that the reader is familiar with the terminology and
+   acronyms defined in [RFC3261].
+
+
+
+
+
+Rosen                       Standards Track                     [Page 2]
+
+RFC 4967                 Dial String Parameter                 July 2007
+
+
+3.  Requirements
+
+   A mechanism to express a dial string in a 'sip:' or 'sips:' URI is
+   required.  A dial string consists of a sequence of
+
+   *  the digits 0-9
+
+   *  the special characters # and *
+
+   *  the DTMF digits A-D
+
+   *  characters representing a short pause, and a "Wait for call
+      completion" in a dial string
+
+   Note: DTMF = dual tone multi-frequency.  Each "tone:" is actually two
+   frequencies superimposed.  DTMF is a 4 x 4 matrix with four row
+   frequencies (697, 770, 852, 941 Hz) and four column frequencies
+   (1209, 1336, 1477, 1633).  Most telephones only implement 3 of the 4
+   columns, which are used just as the telephone dial pad implies.
+   Thus, the digit 2 is the first row, second column, and consists of
+   770Hz and 1209Hz frequencies mixed together.  The fourth column is
+   not used in the PSTN (Public Switched Telephone Network).  The
+   "digits" for the fourth column are usually expressed using the
+   letters A through D.  Thus, "C" is 852/1633Hz.  Some systems do use
+   these digits, so we include them in the definition of the dial
+   string.
+
+   A dial string always exists within a context.  The context MUST be
+   specified when expressing a dial string.
+
+   It MUST be possible to distinguish between a dial string and a user
+   part that happens to consist of the same characters.
+
+4.  Solution
+
+   A new alternative value for the "userinfo" parameter of the 'sip:' or
+   'sips:' URI schemes is defined, "dialstring".  This value may be used
+   in a 'sip:' or 'sips:' URI when the user part is a dial string.  The
+   dial string is a sequence of the characters 0-9, A-F, P, X, '*' and
+   '#'.  E represents *, F represents #, P is a pause (short wait, like
+   a comma in a modem string) and X represents "wait for call
+   completion".
+
+   When the "user=dialstring" is used, a context parameter, as defined
+   in [RFC3966], MUST be specified.  The context parameter would
+   normally be a domain name.  The domain name does not have to resolve
+   to any actual host but MUST be under the administrative control of
+   the entity managing the local phone context.  The context parameter
+
+
+
+Rosen                       Standards Track                     [Page 3]
+
+RFC 4967                 Dial String Parameter                 July 2007
+
+
+   value is normally configured in the user agent.
+
+   The syntax of the context parameter follows the same conventions as
+   the same parameter in [RFC3966], that is, it appears between the
+   digits and the "@" in the userinfo [RFC3261] of the URI:
+
+       dialstring = dialstring-digits context; context from RFC 3966
+       dialstring-digits = *dialstring-element dialstring-digit
+                  *dialstring-element
+       dialstring-digit = HEXDIG / "*" / "#"; HEXDIG from RFC 3966
+       dialstring-element =  dialstring-digit  / "P" / "X" /
+                  visual-separator; visual-separator from RFC 3966
+
+   A dial string SHOULD NOT be used for an AoR (Address of Record) in a
+   REGISTER.  Parameters are ignored in registration.  Thus, two
+   registrations with different phone-contexts would be considered
+   equivalent, which is probably not desirable.
+
+   A proxy server or Back to Back User Agent (B2BUA) [RFC3261], which is
+   authoritative for the context, may translate the dial string to a
+   telephone number or service invocation URI.  The telephone number MAY
+   be expressed as a global or local tel: URI, or it MAY be left as a
+   sip: or sips: URI with the URI parameter value changed from "user= "
+   to "user=phone".
+
+   Examples of dial string use include:
+
+   ;what a SIP Phone might emit when a user dials extension 123
+sip:123;phone-context=atlanta.example.com@example.com;user=dialstring
+
+   ;existing voicemail systems have a local access extension,
+   ;then expect to see the extension number as DTMF for the mailbox
+sip:450X123;phone-context=biloxi.example.com@example.com;user=dialstring
+
+5.  IANA Considerations
+
+   [RFC3969] defines a 'sip:' or 'sips:' URI Parameter sub registry.
+   The "user" parameter is specified as having predefined values.
+
+   This RFC defines a new value for the "user" parameter, "dialstring".
+   This RFC has been added to the references listed for the "user"
+   parameter.
+
+6.  Security Considerations
+
+   Dial strings exposed to the Internet may reveal information about
+   internal network details or service invocations that could allow
+   attackers to use the PSTN or the Internet to attack such internal
+
+
+
+Rosen                       Standards Track                     [Page 4]
+
+RFC 4967                 Dial String Parameter                 July 2007
+
+
+   systems.  Dial strings normally SHOULD NOT be sent beyond the domain
+   of the UAC (User Agent Client).  If they are sent across the
+   Internet, they SHOULD be protected against eavesdropping with TLS
+   (Transport Layer Security) per the procedures in [RFC3261].
+
+7.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC3261]  Rosenberg, J., Schulzrinne, H., Camarillo, G., Johnston,
+              A., Peterson, J., Sparks, R., Handley, M., and E.
+              Schooler, "SIP: Session Initiation Protocol", RFC 3261,
+              June 2002.
+
+   [RFC3966]  Schulzrinne, H., "The tel URI for Telephone Numbers",
+              RFC 3966, December 2004.
+
+   [RFC3969]  Camarillo, G., "The Internet Assigned Number Authority
+              (IANA) Uniform Resource Identifier (URI) Parameter
+              Registry for the Session Initiation Protocol (SIP)",
+              BCP 99, RFC 3969, December 2004.
+
+Author's Address
+
+   Brian Rosen
+   NeuStar
+   470 Conrad Dr
+   Mars, PA  16046
+   USA
+
+   Phone: +1 724 382 1051
+   EMail: br@brianrosen.net
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rosen                       Standards Track                     [Page 5]
+
+RFC 4967                 Dial String Parameter                 July 2007
+
+
+Full Copyright Statement
+
+   Copyright (C) The IETF Trust (2007).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY, THE IETF TRUST AND
+   THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF
+   THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+Rosen                       Standards Track                     [Page 6]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4967.txt](<www.ietf.org/rfc/rfc4967.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
