### PR TITLE
Archive rfc499.txt

### DIFF
--- a/www.ietf.org/rfc/rfc499.txt
+++ b/www.ietf.org/rfc/rfc499.txt
@@ -1,0 +1,339 @@
+
+
+
+
+
+
+Network Working Group                                         B. Reussow
+Request for Comments: 499    Center for Research in Computing Technology
+NIC: 15716                                            Harvard University
+                                                            April 1 1973
+
+                         HARVARD'S NETWORK RJE
+
+Section I
+
+   RJE was designed to provide network users with the facility of
+   submitting jobs to remote servers via the ARPA net and retrieving
+   results using Harvard's PDP-10.
+
+   In order to be an expert in the use of the RJE program from a remote
+   host, the user must be familiar with the FTP commands and usage.  At
+   present RJE is only implemented for UCLA.  Accordingly, all examples
+   will deal with the UCLA installation.  Arrangements for a password
+   and a job ID must be made at UCLA before usage is to begin.  If you
+   are interested, we will see to it that an account is made up for you.
+   People at other sites should deal directly with UCLA to get an
+   account.
+
+Section II
+
+                         HOW TO USE RJE AT HARVARD
+
+   Start the program by taping R RJE<CR> at monitor level.  RJE will
+   respond with a "!".
+
+   Then type "RJE UCL<CR> to make the TELNET connection.  The TELNET
+   connection is used for transfer of commands to UCLA and error
+   messages from UCLA to the user of RJE.  It is important to realize
+   that, in using RJE, one is talking to two systems; the local system
+   (HARV-10) and the remote host where the job will actually be run.
+   Therefore, there are two command processors, one local and one
+   foreign.
+
+                  COMMANDS TO THE LOCAL (HARVARD) PROCESS
+
+   All commands to the local process begin with a *.
+
+   *READ LDEV:FILENAME.EXTENSION<CR>
+
+   Reads the specified file, which contains all job cards, JCL, program
+   and data, formats it for RJS at UCLA and ships it over a data
+   connection.  When using the data connection, ASCII files are
+   translated into EBCDIC, the UCLA end of the connection.  After
+   transfer is completed the file is immediately spooled for processing.
+
+
+
+B. Reussow                                                      [Page 1]
+
+RFC 499                  HARVARD'S NETWORK RJE              April 1 1973
+
+
+   *PRINT LDEV:FILENAME.EXTENSION<CR>
+
+   Gets the next print file from UCLA's 91 and reformats the print file
+   for a PDP-10 line printer.  Write the file to the user's specified
+   logical device with the specified FILENAME.EXTENSION.  FILENAME is up
+   to 6 characters in length and EXTENSION is up to 3 characters in
+   length.
+
+   *QUIT<CR>
+
+   Tear down all connections used by RJE and return to monitor level.
+
+                      COMMANDS TO THE REMOTE PROCESS
+                            (UCLA RJS COMMANDS)
+
+   Commands to the remote process have no special character preceding a
+   command.  For a explanation of the command arguments, ask Terry Sack
+   for the document named, RJS OPERATOR COMMANDS FOR REMOTE TERMINALS.
+
+   Terminal Control and Information Command
+   -------- ------- --- ----------- -------
+
+   SIGNON              First command of a session identifies VRBT
+                       (virtual remote batch terminal) by giving its
+                       terminal ID.  For UCLA, Harvard's terminal ID is
+                       NETHARV.
+
+   SIGNOFF             Last command of a session; RJS waits for any data
+                       transfer in progress to complete and then closes
+                       all connections.
+
+   STATUS              Outputs on the local user's terminal a complete
+                       list, or a summary, of all jobs in the system for
+                       this VRBT, with an indication of their
+                       progressing status in the Model 91.
+
+   ALERT               Outputs on the user's terminal any special
+                       "Alert" message from the CCN computer operator.
+                       The Alert message is also automatically sent when
+                       the user does a SIGNON, or whenever the message
+                       changes.
+
+   MSG                 Sends a message to CCN computer operator or to
+                       any other RJS terminal (real or virtual).  A
+                       message from the computer operator or another RJS
+                       terminal will automatically appear on the user's
+                       terminal.
+
+
+
+
+B. Reussow                                                      [Page 2]
+
+RFC 499                  HARVARD'S NETWORK RJE              April 1 1973
+
+
+   Job Control and Routing Commands
+   --- ------- --- ------- --------
+
+   Under CCN's job management system, the default destination for output
+   is the input source.  Thus, a job submitted under a given VRET will
+   be returned to that VRBT (i.e., the same terminal ID), unless the
+   user's JCL overrides the default destination.
+
+   RJS places print and punch output destined for a particular remote
+   terminal into either an Active Queue or a Deferred Queue.  When the
+   user opens his print or punch output channel (via the *PRINT command
+   of RJE), RJS immediately starts sending job output from the Active
+   Queue, and continues until this queue is empty.  Job output in the
+   Deferred Queue, on the other hand, must be called for by job name
+   (via a RESET command from the remote operator) before RJS will send
+   it.  The Active/Deferred choice for output from a job is determined
+   by the deferral status of the VRBT when the job is entered; the
+   deferral status, which is set to the Active option when the user
+   signs on, may be changed by the SET command.
+
+   SET                 Allows the remote user to change certain
+                       properties of his VRBT for the duration of the
+                       current session
+
+                       (a) May change the default output destination to
+                       be another (real or virtual) RJS terminal or the
+                       central facility.
+
+                       (b) May change the deferral status of the VRBT.
+
+   DEFER               Moves the print and punch output for a specified
+                       job or set of jobs from the Active Queue to the
+                       Deferred Queue.  If the job's output is in
+                       process of being transmitted over a channel, RJS
+                       aborts the channel and saves the current output
+                       location before moving the job to the Deferred
+                       Queue.  A subsequent RESET command will return it
+                       to the Active Queue with an implied Backspace
+                       (BSP).
+
+   RESET               Moves specified job(s) from Deferred to Active
+                       Queue so they may be sent to user.  A specific
+                       list of job names or all jobs can be moved with
+                       one RESET command.
+
+
+
+
+
+
+
+B. Reussow                                                      [Page 3]
+
+RFC 499                  HARVARD'S NETWORK RJE              April 1 1973
+
+
+   ROUTE               Re-routes output of specified jobs (or all jobs)
+                       waiting in the Active and Deferred Queues for
+                       this VRBT.  The new destination may be any other
+                       RJS terminal or the central facility.
+
+   ABORT               Cancels a job which was successfully submitted
+                       and awaiting execution or is currently executing
+                       in the Model 91.  If the cancelled job was in
+                       execution, all output it produced will be
+                       returned.
+
+   Output Stream Control Commands
+   ------ ------ ------- --------
+
+   BSP (BACKSPACE)     Backspaces output stream within current SYSOUT
+                       data set.  Actual amount backspaced depends upon
+                       SYSOUT blocking but is typically equivalent to a
+                       page on the line printer.
+
+   CAN (CANCEL)        (a) On an output channel, CAN causes the rest of
+                       the output in the SYSOUT data set currently being
+                       transmitted to be omitted.  Alternatively, may
+                       omit the rest of the SYSOUT data sets for the job
+                       currently being transmitted; however, the
+                       remaining system and accounting messages will be
+                       sent.
+
+                       (b) On an input channel, CAN causes RJS to ignore
+                       the job currently being read.  However, the
+                       channel is not aborted as a result, and RJS will
+                       continue reading in jobs on the channel.
+
+                       (c) CAN can delete all SYSOUT data sets for
+                       specified job(s) waiting in Active or Deferred
+                       Queue.
+
+   RST (RESTART)       (a) Restarts a specified output stream at the
+                       beginning of the current SYSOUT data set or,
+                       optionally, at the beginning of the job.
+
+                       (b) Marks as restarted specified job(s) whose
+                       transmission was earlier interrupted by system
+                       failure or user action (e.g., DEFER command or
+                       aborting the channel).  When RJS transmits these
+                       jobs again, it will start at the beginning of the
+                       partially transmitted SYSOUT data set or,
+                       optionally, at the beginning of the job.  This
+                       function may be applied to jobs in either the
+
+
+
+B. Reussow                                                      [Page 4]
+
+RFC 499                  HARVARD'S NETWORK RJE              April 1 1973
+
+
+                       Active or the Deferred Queue; however, if the job
+                       was in the Deferred Queue then RST also moves it
+                       to the Active Queue.  If the job was never
+                       transmitted, RST has no effect other than this
+                       queue movement.
+
+   REPEAT              Sends additional copies of the output of
+                       specified jobs.
+
+   EAM                 Echoes the card reader stream back in the printer
+                       or punch stream, or both.
+
+Section III
+
+                       USE OF RJE FROM A REMOTE HOST
+
+   To use RJE from a remote Host, make a TELNET connection to Harvard's
+   10 via your TELNET program.  Login under one of Harvard's guest
+   accounts: type LOGIN <CR>.  LOGIN will prompt you with a #.  When it
+   does, type 62,# <CR>.  Answer all questions that are asked.
+
+                        USING FTP TO TRANSFER FILES
+
+   Prompts:
+
+   "*"     Prompt from FTP when no network connections are established.
+
+   "!"      Prompt when network connections are open.
+
+   Type R FTP<CR>, then type 'Host host # or abbreviation' <CR> to set
+   up a TELNET connection.  The local FTP process will then type the
+   foreign host's greeting message.
+
+   If transferring files to or from other than a PDP-10, type the
+   commands 'TYPE A' and 'BYTE 8', each followed by a carriage return.
+
+   !USER 'Your project, programmer number'<CR>
+         Tell the server who you are.  The USR command should be the
+         first command to FTP.
+
+   !RETRIEVE FILENAME.EXTENSION <CR>
+         Retrieve a file from the foreign host.  After the message
+         "transfer completed" has been typed, use the QUIT command.
+
+   !QUIT<CR>
+         Break connections return to monitor level.  After you have
+         transfered your files consult Section II for the usage of RJE.
+
+
+
+
+B. Reussow                                                      [Page 5]
+
+RFC 499                  HARVARD'S NETWORK RJE              April 1 1973
+
+
+   Warning!!!
+   ----------
+
+   The RJE program formats printer output for a PDP-10 line printer.  If
+   you plan to use another type of printer, special arrangements will
+   have to be made.
+
+   Also, never leave a file on Harvard's disk area when detached.  A
+   detached job is a job to which no terminal is assigned.  You may find
+   that your file is gone when you come back.  We have limited disk
+   resources and, if a crisis arises, files belonging to detached jobs
+   are subject to deletion.
+
+
+         [ This RFC was put into machine readable form for entry ]
+               [ into the online RFC archives by Via Genie]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+B. Reussow                                                      [Page 6]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc499.txt](<www.ietf.org/rfc/rfc499.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
