### PR TITLE
Archive rfc4983.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4983.txt
+++ b/www.ietf.org/rfc/rfc4983.txt
@@ -1,0 +1,1571 @@
+
+
+
+
+
+
+Network Working Group                                         C. DeSanti
+Request for Comments: 4983                                    H.K. Vivek
+Category: Standards Track                                  K. McCloghrie
+                                                           Cisco Systems
+                                                                  S. Gai
+                                                           Nuova Systems
+                                                             August 2007
+
+
+     Fibre Channel Registered State Change Notification (RSCN) MIB
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Abstract
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the Internet community.
+   In particular, it describes managed objects for information related
+   to the management of Fibre Channel's Registered State Change
+   Notifications (RSCNs).
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                     [Page 1]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+Table of Contents
+
+   1. Introduction ....................................................3
+   2. The Internet-Standard Management Framework ......................3
+   3. Short Overview of Fibre Channel .................................3
+   4. Relationship to Other MIBs ......................................5
+   5. MIB Overview ....................................................5
+      5.1. Fibre Channel Management Instance ..........................5
+      5.2. Switch Index ...............................................6
+      5.3. Fabric Index ...............................................6
+      5.4. The t11FcRscnRegistrationGroup Group .......................6
+      5.5. The t11FcRscnNotifyGroup Group .............................6
+      5.6. The t11FcRscnNotifyControlGroup Group ......................7
+      5.7. The t11FcRscnStatsGroup Group ..............................7
+   6. Definitions .....................................................8
+      6.1. The T11-FC-RSCN-MIB Module .................................8
+   7. IANA Considerations ............................................23
+   8. Security Considerations ........................................24
+   9. Acknowledgements ...............................................25
+   10. Normative References ..........................................25
+   11. Informative References ........................................26
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                     [Page 2]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+1.  Introduction
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the Internet community.
+   In particular, it describes managed objects for information related
+   to Registered State Change Notifications (RSCNs) [FC-LS] in a Fibre
+   Channel network, including which Nx_Ports are registered to receive
+   which types of RSCNs, the control and generation of Simple Network
+   Management Protocol (SNMP) notifications on registration failures,
+   and RSCN-related statistics.
+
+   This memo was previously approved by INternational Committee for
+   Information Technology Standards (INCITS) Task Group T11.5
+   (http://www.t11.org); this document is a product of the IETF's IMSS
+   working group.
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in BCP 14, RFC 2119
+   [RFC2119].
+
+2.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This memo specifies a MIB
+   module that is compliant to the SMIv2, which is described in STD 58,
+   RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579] and STD 58, RFC 2580
+   [RFC2580].
+
+3.  Short Overview of Fibre Channel
+
+   The Fibre Channel (FC) is logically a bidirectional point-to-point
+   serial data channel, structured for high performance.  Fibre Channel
+   provides a general transport vehicle for higher level protocols such
+   as Small Computer System Interface (SCSI) command sets, the High-
+   Performance Parallel Interface (HIPPI) data framing, IP (Internet
+   Protocol), IEEE 802.2, and others.
+
+   Physically, Fibre Channel is an interconnection of multiple
+   communication points, called N_Ports, interconnected either by a
+   switching network, called a Fabric, or by a point-to-point link.  A
+
+
+
+DeSanti, et al.             Standards Track                     [Page 3]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+   Fibre Channel "node" consists of one or more N_Ports.  A Fabric may
+   consist of multiple Interconnect Elements, some of which are
+   switches.  An N_Port connects to the Fabric via a port on a switch
+   called an F_Port.  When multiple FC nodes are connected to a single
+   port on a switch via an "Arbitrated Loop" topology, the switch port
+   is called an FL_Port, and the nodes' ports are called NL_Ports.  The
+   term Nx_Port is used to refer to either an N_Port or an NL_Port.  The
+   term Fx_Port is used to refer to either an F_Port or an FL_Port.  A
+   switch port, which is interconnected to another switch port via an
+   Inter-Switch Link (ISL), is called an E_Port.  A B_Port connects a
+   bridge device with an E_Port on a switch; a B_Port provides a subset
+   of E_Port functionality.
+
+   Many Fibre Channel components, including the fabric, each node, and
+   most ports, have globally unique names.  These globally unique names
+   are typically formatted as World Wide Names (WWNs).  More information
+   on WWNs can be found in [FC-FS].  WWNs are expected to be persistent
+   across agent and unit resets.
+
+   Fibre Channel frames contain 24-bit address identifiers that identify
+   the frame's source and destination ports.  Each FC port has both an
+   address identifier and a WWN.  When a fabric is in use, the FC
+   address identifiers are dynamically assigned by a switch.  Each octet
+   of a 24-bit address represents a level in an address hierarchy, with
+   a Domain_ID being the highest level of the hierarchy.
+
+   Registered State Change Notifications (RSCNs) are defined in [FC-LS]
+   as a means to provide Nx_Ports that have registered to receive such
+   notifications with a timely indication of changes in the state of
+   nodes attached to the fabric.  Specifically, an Nx_Port may choose to
+   register, using a State Change Registration (SCR) request [FC-LS] to
+   receive RSCNs.  When an event occurs that may affect a registered
+   Nx_Port's port's state, the registered Nx_Port will receive an RSCN.
+   For example, an Nx_Port can use RSCNs as the means by which it is
+   informed of the failures of other nodes, of new devices coming
+   online, or even of more network-accessible storage becoming
+   available.  The payload of the RSCN indicates the type of change and
+   includes the address of the changed port.  RSCNs are often generated
+   by the fabric, but an Nx_Port can also generate (and send to the
+   fabric) an RSCN if and when it detects an event not visible to the
+   fabric.  The sender of an RSCN may coalesce several events into a
+   single RSCN message.  Each RSCN is a "request" that is acknowledged
+   by the receiver with an accept or reject.
+
+   An RSCN is received by an Nx_Port from the Fabric as an Extended Link
+   Service (ELS) request [FC-LS].  The Fabric distributes RSCNs between
+   Switches using an SW_ILS frame with an Inter-Switch RSCN payload,
+   also known as an SW_RSCN [FC-SW-4].  So, when a Switch has directly
+
+
+
+DeSanti, et al.             Standards Track                     [Page 4]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+   attached Nx_Ports that have registered to receive RSCNs, it converts
+   received SW_RSCNs (i.e., SW_ILS frames containing SW_RSCN payloads)
+   into ELS requests containing the corresponding RSCN which it sends to
+   each such Nx_Port.
+
+   The latest standard for an interconnecting Fabric containing multiple
+   Fabric Switch elements is [FC-SW-4].  [FC-SW-4] carries forward the
+   earlier specification for the operation of a single Fabric in a
+   physical infrastructure, and augments it with the definition of
+   Virtual Fabrics and with the specification of how multiple Virtual
+   Fabrics can operate within one (or more) physical infrastructures.
+   The use of Virtual Fabrics provides for each frame to be tagged in
+   its header to indicate which one of several Virtual Fabrics that
+   frame is being transmitted on.  All frames entering a particular
+   "Core Switch" [FC-SW-4] (i.e., a physical switch) on the same Virtual
+   Fabric are processed by the same "Virtual Switch" within that Core
+   Switch.
+
+4.  Relationship to Other MIBs
+
+   The first standardized MIB for Fibre Channel [RFC2837] was focused on
+   Fibre Channel switches.  It was replaced by the more generic Fibre
+   Channel Management MIB [RFC4044] which defines basic information for
+   Fibre Channel hosts and switches, including extensions to the
+   standard [IF-MIB] for Fibre Channel interfaces.  [RFC4044] includes
+   the specification of how the generic objects defined in [IF-MIB]
+   apply to Fibre Channel interfaces.
+
+   This MIB imports some common Textual Conventions defined in the
+   T11-TC-MIB [RFC4439] and in the T11-FC-NAME-SERVER-MIB [RFC4438].
+
+5.  MIB Overview
+
+   This section explains the use of a Fibre Channel management instance,
+   a Switch Index, and a Fabric Index.  It also describes the four MIB
+   groups contained in the MIB.
+
+5.1.  Fibre Channel Management Instance
+
+   A Fibre Channel management instance is defined in [RFC4044] as a
+   separable managed instance of Fibre Channel functionality.  Fibre
+   Channel functionality may be grouped into Fibre Channel management
+   instances in whatever way is most convenient for the
+   implementation(s).  For example, one such grouping accommodates a
+   single SNMP agent having multiple AgentX [RFC2741] sub-agents, with
+   each sub-agent implementing a different Fibre Channel management
+   instance.
+
+
+
+
+DeSanti, et al.             Standards Track                     [Page 5]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+   The object, fcmInstanceIndex, is IMPORTed from the FC-MGMT-MIB
+   [RFC4044] as the index value to uniquely identify each Fibre Channel
+   management instance, for example, within the same SNMP context
+   ([RFC3411], section 3.3.1).
+
+5.2.  Switch Index
+
+   The FC-MGMT-MIB [RFC4044] defines the fcmSwitchTable as a table of
+   information about Fibre Channel switches which are managed by Fibre
+   Channel management instances.  Each Fibre Channel management instance
+   can manage one or more Fibre Channel switches.  The Switch Index,
+   fcmSwitchIndex, is IMPORTed from the FC-MGMT-MIB as the index value
+   to uniquely identify a Fibre Channel switch amongst those (one or
+   more) managed by the same Fibre Channel management instance.
+
+5.3.  Fabric Index
+
+   Whether operating on a Physical Fabric (i.e., without Virtual
+   Fabrics) or within a Virtual Fabric, the manner of operation of RSCNs
+   within a/each Fabric is identical.  Therefore, this MIB defines all
+   Fabric-related information in tables that are INDEXed by an arbitrary
+   integer, named a "Fabric Index", the syntax of which is IMPORTed from
+   the T11-TC-MIB [RFC4439].  When a device is connected to a single
+   Physical Fabric, without use of any Virtual Fabrics, the value of
+   this Fabric Index will always be 1.  In an environment of multiple
+   Virtual and/or Physical Fabrics, this index provides a means to
+   distinguish one Fabric from another.
+
+   It is quite possible, and may even be likely, that a Fibre Channel
+   switch will have ports connected to multiple Virtual and/or Physical
+   Fabrics.  Thus, in order to simplify a management protocol query
+   concerning all the Fabrics to which a single switch is connected,
+   fcmSwitchIndex will be listed before t11FcRscnFabricIndex when they
+   both appear in the same INDEX clause.
+
+5.4.  The t11FcRscnRegistrationGroup Group
+
+   This group contains information about the Nx_Ports which have
+   registered to receive RSCNs.
+
+5.5.  The t11FcRscnNotifyGroup Group
+
+   This group contains two notifications: one generated when a switch
+   rejects an SCR or RSCN; the other when a switch rejects an SW_RSCN.
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                     [Page 6]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+5.5.1.  Flow-Control for Notifications
+
+   When defining SNMP notifications for events that occur in the data-
+   plane, the maximum frequency of their generation needs to be
+   considered.  Unless there is some limiting factor, such notifications
+   need to be flow-controlled in some way, e.g., defined such that after
+   some maximum number within a specified time interval have occurred,
+   further notifications are suppressed for some subsequent time
+   interval.  However, when such a suppression occurs, the Network
+   Management System (NMS) that didn't receive the notifications
+   (because they were suppressed) needs to be able to obtain an
+   indication of how many were suppressed.  Therefore, an additional
+   Counter32 object needs to be defined, and/or a new type of
+   notification needs to be defined for use at the end of the interval.
+   While this is extra complexity, it is necessary for notifications
+   that need to be flow-controlled.
+
+   In contrast, for notifications such as both the ones defined in this
+   MIB module, which are generated due to control-plane events (and are
+   not able to start a chain reaction), the extra complexity of flow-
+   controlling these types of notifications is not warranted.
+
+5.6.  The t11FcRscnNotifyControlGroup Group
+
+   This group contains one object for each notification in the
+   t11FcRscnNotifyGroup group to enable/disable that notification, as
+   well as three objects that record information about the latest
+   rejection of an SCR, RSCN or SW_RSCN.  Specifically, they record the
+   content (if available) of the rejected request, the source of the
+   rejected request, and the reason for the rejection.
+
+5.7.  The t11FcRscnStatsGroup Group
+
+   This group contains RSCN-related statistics.  Two levels of
+   statistics are included:
+
+      1) counters at the message-type level, for:
+         - the number of SCRs received/rejected,
+         - the number of RSCNs sent/received/rejected,
+         - the number of SW_RSCNs sent/received/rejected.
+
+      2) counters for each different category of sent/received RSCNs,
+         where different categories are indicated by different values of
+         the 'Event Qualifier' contained in an RSCN message.  Note that
+         if and when several RSCN events are coalesced into a single
+         RSCN message, then that message may be counted in more than one
+         of these counters.  No counters are defined in this MIB for the
+         'Event Qualifier' value of '0001'b (meaning "Changed Name
+
+
+
+DeSanti, et al.             Standards Track                     [Page 7]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+         Server Object") because these types of RSCNs are counted by the
+         t11NsInRscns and t11NsOutRscns objects already defined in
+         [RFC4438].
+
+6.  Definitions
+
+6.1.  The T11-FC-RSCN-MIB Module
+
+T11-FC-RSCN-MIB DEFINITIONS ::= BEGIN
+
+-- The Fibre Channel RSCN MIB
+--
+-- for the monitoring of registrations by Nx_Ports to receive
+-- Registered State Change Notifications (RSCNs), and the
+-- monitoring of RSCN usage.
+--
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE,
+    NOTIFICATION-TYPE,
+    Counter32, mib-2                     FROM SNMPv2-SMI   -- [RFC2578]
+    MODULE-COMPLIANCE, OBJECT-GROUP,
+    NOTIFICATION-GROUP                   FROM SNMPv2-CONF  -- [RFC2580]
+    TruthValue                           FROM SNMPv2-TC    -- [RFC2579]
+    fcmInstanceIndex, fcmSwitchIndex,
+    FcNameIdOrZero, FcAddressIdOrZero    FROM FC-MGMT-MIB  -- [RFC4044]
+    T11NsGs4RejectReasonCode   FROM T11-FC-NAME-SERVER-MIB -- [RFC4438]
+    T11FabricIndex                       FROM T11-TC-MIB;  -- [RFC4439]
+
+t11FcRscnMIB  MODULE-IDENTITY
+    LAST-UPDATED "200701080000Z"
+    ORGANIZATION "For the initial versions, T11.
+                  For later versions, the IETF's IMSS Working Group."
+    CONTACT-INFO
+            "     Claudio DeSanti
+                  Cisco Systems, Inc.
+                  170 West Tasman Drive
+                  San Jose, CA 95134 USA
+                  EMail: cds@cisco.com
+
+                  Keith McCloghrie
+                  Cisco Systems, Inc.
+                  170 West Tasman Drive
+                  San Jose, CA 95134 USA
+                  EMail: kzm@cisco.com"
+
+    DESCRIPTION
+           "The MIB module for the management of registrations
+
+
+
+DeSanti, et al.             Standards Track                     [Page 8]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+           by Nx_Ports to receive RSCNs (Registered State Change
+           Notifications) on a Fibre Channel Fabric, as defined
+           in FC-LS, and for the monitoring of RSCNs sent/received
+           or rejected in a Fibre Channel Fabric.
+
+           Copyright (C) The Internet Society (2007).  This version of
+           this MIB module is part of RFC 4983;  see the RFC itself for
+           full legal notices."
+    REVISION    "200701080000Z"
+    DESCRIPTION
+           "Initial version of this MIB module, published as RFC 4983."
+    ::= { mib-2 161 }
+
+t11FcRscnNotifications  OBJECT IDENTIFIER ::= { t11FcRscnMIB 0 }
+t11FcRscnObjects        OBJECT IDENTIFIER ::= { t11FcRscnMIB 1 }
+t11FcRscnConformance    OBJECT IDENTIFIER ::= { t11FcRscnMIB 2 }
+t11FcRscnRegistrations  OBJECT IDENTIFIER ::= { t11FcRscnObjects 1 }
+t11FcRscnStats          OBJECT IDENTIFIER ::= { t11FcRscnObjects 2 }
+t11FcRscnInformation    OBJECT IDENTIFIER ::= { t11FcRscnObjects 3 }
+
+
+-- State Change Registration Table
+
+t11FcRscnRegTable  OBJECT-TYPE
+    SYNTAX         SEQUENCE OF T11FcRscnRegEntry
+    MAX-ACCESS     not-accessible
+    STATUS         current
+    DESCRIPTION
+           "A table of Nx_Ports that have registered to receive
+           RSCNs on all Fabrics configured on one or more Fibre
+           Channel switches."
+    ::= { t11FcRscnRegistrations 1 }
+
+t11FcRscnRegEntry  OBJECT-TYPE
+    SYNTAX        T11FcRscnRegEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+           "An entry containing information about one Nx_Port that
+           has registered with a particular switch (identified by
+           values of fcmInstanceIndex and fcmSwitchIndex) for a
+           particular Fabric (identified by a t11FcRscnFabricIndex
+           value)."
+    INDEX   { fcmInstanceIndex, fcmSwitchIndex, t11FcRscnFabricIndex,
+              t11FcRscnRegFcId }
+    ::= { t11FcRscnRegTable 1 }
+
+T11FcRscnRegEntry ::= SEQUENCE {
+
+
+
+DeSanti, et al.             Standards Track                     [Page 9]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+    t11FcRscnFabricIndex         T11FabricIndex,
+    t11FcRscnRegFcId             FcAddressIdOrZero,
+    t11FcRscnRegType             BITS
+}
+
+t11FcRscnFabricIndex OBJECT-TYPE
+    SYNTAX      T11FabricIndex
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+           "An index value that uniquely identifies a particular
+           Fabric.
+
+           In a Fabric conformant to FC-SW-4, multiple Virtual Fabrics
+           can operate within one (or more) physical infrastructures.
+           In such a case, this index value is used to uniquely
+           identify a particular Fabric within a physical
+           infrastructure.
+
+           In a Fabric that has (or can have) only a single Fabric
+           operating within the physical infrastructure, the
+           value of this Fabric Index will always be 1."
+    REFERENCE
+          "ANSI INCITS 418-2006, Fibre Channel - Switch Fabric - 4
+          (FC-SW-4), December 2006."
+    ::= { t11FcRscnRegEntry 1 }
+
+t11FcRscnRegFcId  OBJECT-TYPE
+    SYNTAX        FcAddressIdOrZero (SIZE (3))
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+           "The Fibre Channel Address Identifier of the
+           registering Nx_Port."
+    ::= { t11FcRscnRegEntry 2 }
+
+t11FcRscnRegType  OBJECT-TYPE
+    SYNTAX        BITS {
+                      fromFabricController(0),
+                      fromNxPort(1)
+                  }
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "This object indicates the type of registration
+           desired by the registering Nx_Port, one bit per type:
+
+           'fromFabricController' -- RSCNs generated for events
+
+
+
+DeSanti, et al.             Standards Track                    [Page 10]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+                                  detected by the Fabric Controller.
+
+           'fromNxPorts'          -- RSCNs generated for events
+                                  detected by the affected Nx_Port."
+    REFERENCE
+          "ANSI INCITS 433-2007, Fibre Channel - Link Services
+          (FC-LS), July 2007, Table 40."
+    ::= { t11FcRscnRegEntry 3 }
+
+
+-- Statistics
+
+t11FcRscnStatsTable  OBJECT-TYPE
+    SYNTAX         SEQUENCE OF T11FcRscnStatsEntry
+    MAX-ACCESS     not-accessible
+    STATUS         current
+    DESCRIPTION
+           "The RSCN-related statistics on all Fabrics configured
+           on one or more Fibre Channel switches.
+
+           Two levels of statistics are included:
+
+              1) counters at the message-type level, for:
+                 - the number of SCRs received/rejected,
+                 - the number of RSCNs sent/received/rejected,
+                 - the number of SW_RSCNs sent/received/rejected.
+
+              2) counters of sent/received RSCNs per 'Event
+                 Qualifier' value.  Note that if and when several
+                 RSCN events are coalesced into a single RSCN
+                 message, then that message may be counted in
+                 more than one of these counters."
+    ::= { t11FcRscnStats 1 }
+
+t11FcRscnStatsEntry  OBJECT-TYPE
+    SYNTAX        T11FcRscnStatsEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+           "An entry containing statistics for a particular Fabric
+           (identified by a t11FcRscnFabricIndex value) on a particular
+           switch (identified by values of fcmInstanceIndex and
+           fcmSwitchIndex)."
+    INDEX  { fcmInstanceIndex, fcmSwitchIndex, t11FcRscnFabricIndex }
+    ::= { t11FcRscnStatsTable 1 }
+
+T11FcRscnStatsEntry ::= SEQUENCE {
+    t11FcRscnInScrs                    Counter32,
+
+
+
+DeSanti, et al.             Standards Track                    [Page 11]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+    t11FcRscnInRscns                   Counter32,
+    t11FcRscnOutRscns                  Counter32,
+    t11FcRscnInSwRscns                 Counter32,
+    t11FcRscnOutSwRscns                Counter32,
+    t11FcRscnScrRejects                Counter32,
+    t11FcRscnRscnRejects               Counter32,
+    t11FcRscnSwRscnRejects             Counter32,
+    t11FcRscnInUnspecifiedRscns        Counter32,
+    t11FcRscnOutUnspecifiedRscns       Counter32,
+    t11FcRscnInChangedAttribRscns      Counter32,
+    t11FcRscnOutChangedAttribRscns     Counter32,
+    t11FcRscnInChangedServiceRscns     Counter32,
+    t11FcRscnOutChangedServiceRscns    Counter32,
+    t11FcRscnInChangedSwitchRscns      Counter32,
+    t11FcRscnOutChangedSwitchRscns     Counter32,
+    t11FcRscnInRemovedRscns            Counter32,
+    t11FcRscnOutRemovedRscns           Counter32
+}
+
+t11FcRscnInScrs  OBJECT-TYPE
+    SYNTAX         Counter32
+    MAX-ACCESS     read-only
+    STATUS         current
+    DESCRIPTION
+           "The number of SCRs received from Nx_Ports
+           by this switch on this Fabric.
+
+           This counter has no discontinuities other than
+           those that all Counter32s have when sysUpTime=0."
+    ::= { t11FcRscnStatsEntry 1 }
+
+
+t11FcRscnInRscns  OBJECT-TYPE
+    SYNTAX         Counter32
+    MAX-ACCESS     read-only
+    STATUS         current
+    DESCRIPTION
+           "The number of RSCNs received from Nx_Ports
+           by this switch on this Fabric.
+
+           This counter has no discontinuities other than
+           those that all Counter32s have when sysUpTime=0."
+    ::= { t11FcRscnStatsEntry 2 }
+
+t11FcRscnOutRscns  OBJECT-TYPE
+    SYNTAX         Counter32
+    MAX-ACCESS     read-only
+    STATUS         current
+
+
+
+DeSanti, et al.             Standards Track                    [Page 12]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+    DESCRIPTION
+           "The number of RSCNs transmitted to Nx_Ports
+           by this switch on this Fabric.
+
+           This counter has no discontinuities other than
+           those that all Counter32s have when sysUpTime=0."
+    ::= { t11FcRscnStatsEntry 3 }
+
+
+t11FcRscnInSwRscns  OBJECT-TYPE
+    SYNTAX         Counter32
+    MAX-ACCESS     read-only
+    STATUS         current
+    DESCRIPTION
+           "The number of SW_RSCNs received by this switch from
+           other switches on this Fabric.
+
+           This counter has no discontinuities other than
+           those that all Counter32s have when sysUpTime=0."
+    ::= { t11FcRscnStatsEntry 4 }
+
+t11FcRscnOutSwRscns  OBJECT-TYPE
+    SYNTAX         Counter32
+    MAX-ACCESS     read-only
+    STATUS         current
+    DESCRIPTION
+           "The number of SW_RSCNs transmitted by this switch
+           from other switches on this Fabric.
+
+           This counter has no discontinuities other than
+           those that all Counter32s have when sysUpTime=0."
+    ::= { t11FcRscnStatsEntry 5 }
+
+t11FcRscnScrRejects  OBJECT-TYPE
+    SYNTAX         Counter32
+    MAX-ACCESS     read-only
+    STATUS         current
+    DESCRIPTION
+           "The number of SCRs rejected by this switch on
+           this Fabric.
+
+           This counter has no discontinuities other than
+           those that all Counter32s have when sysUpTime=0."
+    ::= { t11FcRscnStatsEntry 6 }
+
+t11FcRscnRscnRejects OBJECT-TYPE
+    SYNTAX         Counter32
+    MAX-ACCESS     read-only
+
+
+
+DeSanti, et al.             Standards Track                    [Page 13]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+    STATUS         current
+    DESCRIPTION
+           "The number of RSCNs rejected by this switch on this
+           Fabric.
+
+           This counter has no discontinuities other than
+           those that all Counter32s have when sysUpTime=0."
+    ::= { t11FcRscnStatsEntry 7 }
+
+t11FcRscnSwRscnRejects  OBJECT-TYPE
+    SYNTAX         Counter32
+    MAX-ACCESS     read-only
+    STATUS         current
+    DESCRIPTION
+           "The number of SW_RSCN rejected by this switch on this
+           Fabric.
+
+           This counter has no discontinuities other than
+           those that all Counter32s have when sysUpTime=0."
+    ::= { t11FcRscnStatsEntry 8 }
+
+t11FcRscnInUnspecifiedRscns  OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The number of Registered State Change Notifications
+           (RSCNs) received by this switch on this Fabric which
+           contained an RSCN Event Qualifier value of '0000'b
+           meaning 'Event is not specified'.
+
+           This counter has no discontinuities other than
+           those that all Counter32s have when sysUpTime=0."
+    REFERENCE
+           "ANSI INCITS 433-2007, Fibre Channel - Link Services
+          (FC-LS), July 2007, Table 36."
+    ::= { t11FcRscnStatsEntry 9 }
+
+t11FcRscnOutUnspecifiedRscns  OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The number of Registered State Change Notifications
+           (RSCNs) sent by this switch on this Fabric which
+           contained an RSCN Event Qualifier value of '0000'b
+           meaning 'Event is not specified'.
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 14]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+           This counter has no discontinuities other than
+           those that all Counter32s have when sysUpTime=0."
+    REFERENCE
+           "ANSI INCITS 433-2007, Fibre Channel - Link Services
+          (FC-LS), July 2007, Table 36."
+    ::= { t11FcRscnStatsEntry 10 }
+
+t11FcRscnInChangedAttribRscns  OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The number of Registered State Change Notifications
+           (RSCNs) received by this switch on this Fabric which
+           contained an RSCN Event Qualifier value of '0002'b
+           meaning 'Changed Port Attribute'.
+
+           This counter has no discontinuities other than
+           those that all Counter32s have when sysUpTime=0."
+    REFERENCE
+           "ANSI INCITS 433-2007, Fibre Channel - Link Services
+          (FC-LS), July 2007, Table 36."
+    ::= { t11FcRscnStatsEntry 11 }
+
+t11FcRscnOutChangedAttribRscns  OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The number of Registered State Change Notifications
+           (RSCNs) sent by this switch on this Fabric which
+           contained an RSCN Event Qualifier value of '0002'b
+           meaning 'Changed Port Attribute'.
+
+           This counter has no discontinuities other than
+           those that all Counter32s have when sysUpTime=0."
+    REFERENCE
+           "ANSI INCITS 433-2007, Fibre Channel - Link Services
+          (FC-LS), July 2007, Table 36."
+    ::= { t11FcRscnStatsEntry 12 }
+
+t11FcRscnInChangedServiceRscns  OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The number of Registered State Change Notifications
+           (RSCNs) received by this switch on this Fabric which
+
+
+
+DeSanti, et al.             Standards Track                    [Page 15]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+           contained an RSCN Event Qualifier value of '0003'b
+           meaning 'Changed Service Object'.
+
+           This counter has no discontinuities other than
+           those that all Counter32s have when sysUpTime=0."
+    REFERENCE
+           "ANSI INCITS 433-2007, Fibre Channel - Link Services
+          (FC-LS), July 2007, Table 36."
+    ::= { t11FcRscnStatsEntry 13 }
+
+t11FcRscnOutChangedServiceRscns  OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The number of Registered State Change Notifications
+           (RSCNs) sent by this switch on this Fabric which
+           contained an RSCN Event Qualifier value of '0003'b
+           meaning 'Changed Service Object'.
+
+           This counter has no discontinuities other than
+           those that all Counter32s have when sysUpTime=0."
+    REFERENCE
+           "ANSI INCITS 433-2007, Fibre Channel - Link Services
+          (FC-LS), July 2007, Table 36."
+    ::= { t11FcRscnStatsEntry 14 }
+
+t11FcRscnInChangedSwitchRscns  OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The number of Registered State Change Notifications
+           (RSCNs) received by this switch on this Fabric which
+           contained an RSCN Event Qualifier value of '0004'b
+           meaning 'Changed Switch Configuration'.
+
+           This counter has no discontinuities other than
+           those that all Counter32s have when sysUpTime=0."
+    REFERENCE
+           "ANSI INCITS 433-2007, Fibre Channel - Link Services
+          (FC-LS), July 2007, Table 36."
+    ::= { t11FcRscnStatsEntry 15 }
+
+t11FcRscnOutChangedSwitchRscns  OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+
+
+
+DeSanti, et al.             Standards Track                    [Page 16]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+    DESCRIPTION
+            "The number of Registered State Change Notifications
+           (RSCNs) sent by this switch on this Fabric which
+           contained an RSCN Event Qualifier value of '0004'b
+           meaning 'Changed Switch Configuration'.
+
+           This counter has no discontinuities other than
+           those that all Counter32s have when sysUpTime=0."
+    REFERENCE
+           "ANSI INCITS 433-2007, Fibre Channel - Link Services
+          (FC-LS), July 2007, Table 36."
+    ::= { t11FcRscnStatsEntry 16 }
+
+t11FcRscnInRemovedRscns  OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The number of Registered State Change Notifications
+           (RSCNs) received by this switch on this Fabric which
+           contained an RSCN Event Qualifier value of '0005'b
+           meaning 'Removed Object'.
+
+           This counter has no discontinuities other than
+           those that all Counter32s have when sysUpTime=0."
+    REFERENCE
+           "ANSI INCITS 433-2007, Fibre Channel - Link Services
+          (FC-LS), July 2007, Table 36."
+    ::= { t11FcRscnStatsEntry 17 }
+
+t11FcRscnOutRemovedRscns  OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+            "The number of Registered State Change Notifications
+           (RSCNs) sent by this switch on this Fabric which
+           contained an RSCN Event Qualifier value of '0005'b
+           meaning 'Removed Object'.
+
+           This counter has no discontinuities other than
+           those that all Counter32s have when sysUpTime=0."
+    REFERENCE
+           "ANSI INCITS 433-2007, Fibre Channel - Link Services
+          (FC-LS), July 2007, Table 36."
+    ::= { t11FcRscnStatsEntry 18 }
+
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 17]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+--
+-- Notification Control Table
+--
+t11FcRscnNotifyControlTable OBJECT-TYPE
+    SYNTAX       SEQUENCE OF T11FcRscnNotifyControlEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+           "A table of control information for notifications
+           generated due to the rejection of an SCR or RSCN."
+    ::= { t11FcRscnInformation 1 }
+
+t11FcRscnNotifyControlEntry OBJECT-TYPE
+    SYNTAX       T11FcRscnNotifyControlEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+           "Each entry contains notification control information
+           concerning the rejection of RSCN/SCRs for a particular
+           Fabric (identified by the value of t11FcRscnFabricIndex)
+           by a particular switch (identified by values of
+           fcmInstanceIndex and fcmSwitchIndex)."
+    INDEX  { fcmInstanceIndex, fcmSwitchIndex, t11FcRscnFabricIndex }
+    ::= { t11FcRscnNotifyControlTable 1 }
+
+T11FcRscnNotifyControlEntry ::= SEQUENCE {
+     t11FcRscnIlsRejectNotifyEnable     TruthValue,
+     t11FcRscnElsRejectNotifyEnable     TruthValue,
+     t11FcRscnRejectedRequestString     OCTET STRING,
+     t11FcRscnRejectedRequestSource     FcNameIdOrZero,
+     t11FcRscnRejectReasonCode          T11NsGs4RejectReasonCode,
+     t11FcRscnRejectReasonCodeExp       OCTET STRING,
+     t11FcRscnRejectReasonVendorCode    OCTET STRING
+}
+
+t11FcRscnIlsRejectNotifyEnable OBJECT-TYPE
+    SYNTAX       TruthValue
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+           "This object specifies if a t11FcRscnIlsRejectReqNotify
+           notification should be generated when this switch
+           rejects an SW_RSCN on this Fabric.
+
+           Values written to this object should be retained
+           over agent reboots."
+    DEFVAL { false }
+    ::= { t11FcRscnNotifyControlEntry 1 }
+
+
+
+DeSanti, et al.             Standards Track                    [Page 18]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+t11FcRscnElsRejectNotifyEnable OBJECT-TYPE
+    SYNTAX        TruthValue
+    MAX-ACCESS    read-write
+    STATUS        current
+    DESCRIPTION
+           "This object specifies if a t11FcRscnElsRejectReqNotify
+           notification should be generated when this switch
+           rejects an RSCN or SCR on this Fabric.
+
+           Values written to this object should be retained
+           over agent reboots."
+    DEFVAL { false }
+    ::= { t11FcRscnNotifyControlEntry 2 }
+
+t11FcRscnRejectedRequestString OBJECT-TYPE
+    SYNTAX        OCTET STRING (SIZE (0..255))
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "The binary content of the RSCN, SCR, or SW_RSCN that
+           was most recently rejected by this switch on this Fabric.
+           The value is formatted as an octet string (in network
+           byte order) as described in the relevant Fibre Channel
+           standard, containing the payload (which is typically a
+           list of affected ports and error codes) of the rejected
+           RSCN or SCR as described in FC-LS, or the rejected
+           SW_RSCN as described in FC-SW-4.
+
+           This object contains the zero-length string if and when
+           the RSCN/SCR/SW_RSCN payload is unavailable.  When the
+           length of this object is 255 octets, it contains the
+           first 255 octets of the payload (in network byte order)."
+    REFERENCE
+           "ANSI INCITS 433-2007, Fibre Channel - Link Services
+           (FC-LS), July 2007, Tables 34 & 39.
+
+           ANSI INCITS 418-2006, Fibre Channel - Switch Fabric - 4
+           (FC-SW-4), December 2006, Table 45."
+    ::= { t11FcRscnNotifyControlEntry 3 }
+
+t11FcRscnRejectedRequestSource OBJECT-TYPE
+    SYNTAX       FcNameIdOrZero
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+           "The WWN that was the source of the RSCN, SCR, or
+           SW_RSCN that was most recently rejected by this switch
+           on this Fabric."
+
+
+
+DeSanti, et al.             Standards Track                    [Page 19]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+    ::= { t11FcRscnNotifyControlEntry 4 }
+
+t11FcRscnRejectReasonCode OBJECT-TYPE
+    SYNTAX        T11NsGs4RejectReasonCode
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "This object contains the Reason Code of the most recent
+           rejection by this switch of an RSCN, SCR or SW_RSCN on
+           this Fabric."
+    REFERENCE
+           "ANSI INCITS 433-2007, Fibre Channel - Link Services
+           (FC-LS), July 2007, Table 146.
+
+           ANSI INCITS 418-2006, Fibre Channel - Switch Fabric - 4
+           (FC-SW-4), December 2006, Table 5."
+    ::= { t11FcRscnNotifyControlEntry 5 }
+
+t11FcRscnRejectReasonCodeExp OBJECT-TYPE
+    SYNTAX        OCTET STRING (SIZE(1))
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "This object contains the Reason Code Explanation
+           of the most recent rejection by this switch of an
+           RSCN, SCR or SW_RSCN on this Fabric."
+    REFERENCE
+           "ANSI INCITS 433-2007, Fibre Channel - Link Services
+           (FC-LS), July 2007, Table 147.
+
+           ANSI INCITS 418-2006, Fibre Channel - Switch Fabric - 4
+           (FC-SW-4), December 2006, Table 6."
+    ::= { t11FcRscnNotifyControlEntry 6 }
+
+t11FcRscnRejectReasonVendorCode OBJECT-TYPE
+    SYNTAX        OCTET STRING (SIZE(1))
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+           "This object contains the Reason Vendor Specific
+           Code of the most recent rejection by this switch
+           of an RSCN, SCR or SW_RSCN on this Fabric."
+    REFERENCE
+           "ANSI INCITS 433-2007, Fibre Channel - Link Services
+           (FC-LS), July 2007, Table 148.
+
+           ANSI INCITS 418-2006, Fibre Channel - Switch Fabric - 4
+           (FC-SW-4), December 2006, Section 6.1.3."
+
+
+
+DeSanti, et al.             Standards Track                    [Page 20]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+    ::= { t11FcRscnNotifyControlEntry 7 }
+
+
+-- Notifications
+
+t11FcRscnElsRejectReqNotify NOTIFICATION-TYPE
+    OBJECTS { t11FcRscnRejectedRequestString,
+              t11FcRscnRejectedRequestSource,
+              t11FcRscnRejectReasonCode,
+              t11FcRscnRejectReasonCodeExp,
+              t11FcRscnRejectReasonVendorCode }
+    STATUS  current
+    DESCRIPTION
+           "This notification is generated when a switch rejects
+           an SCR or RSCN.
+
+           The value of t11FcRscnRejectedRequestString indicates the
+           binary content of the rejected request if available, or
+           the zero-length string otherwise.  The source of the
+           rejected request is given by t11FcRscnRejectedRequestSource,
+           and the reason for rejection is given by the values of
+           t11FcRscnRejectReasonCode, t11FcRscnRejectReasonCodeExp
+           and t11FcRscnRejectReasonVendorCode."
+    ::= { t11FcRscnNotifications 1 }
+
+t11FcRscnIlsRejectReqNotify NOTIFICATION-TYPE
+    OBJECTS { t11FcRscnRejectedRequestString,
+              t11FcRscnRejectedRequestSource,
+              t11FcRscnRejectReasonCode,
+              t11FcRscnRejectReasonCodeExp,
+              t11FcRscnRejectReasonVendorCode }
+    STATUS  current
+    DESCRIPTION
+           "This notification is generated when a switch rejects
+           an SW_RSCN.
+
+           The value of t11FcRscnRejectedRequestString indicates the
+           binary content of the rejected request if available, or
+           the zero-length string otherwise.  The source of the
+           rejected request is given by t11FcRscnRejectedRequestSource,
+           and the reason for rejection is given by the values of
+           t11FcRscnRejectReasonCode, t11FcRscnRejectReasonCodeExp
+           and t11FcRscnRejectReasonVendorCode."
+    ::= { t11FcRscnNotifications 2 }
+
+-- Conformance
+t11FcRscnCompliances OBJECT IDENTIFIER ::= { t11FcRscnConformance 1 }
+t11FcRscnGroups      OBJECT IDENTIFIER ::= { t11FcRscnConformance 2 }
+
+
+
+DeSanti, et al.             Standards Track                    [Page 21]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+t11FcRscnCompliance MODULE-COMPLIANCE
+    STATUS    current
+    DESCRIPTION
+           "The compliance statement for entities that implement
+           this MIB."
+    MODULE
+        MANDATORY-GROUPS { t11FcRscnRegistrationGroup,
+                           t11FcRscnNotifyControlGroup,
+                           t11FcRscnNotifyGroup }
+
+    GROUP   t11FcRscnStatsGroup
+    DESCRIPTION
+            "These counters, containing RSCN-related statistics, are
+            mandatory only for those systems that count such events."
+
+    OBJECT       t11FcRscnIlsRejectNotifyEnable
+    MIN-ACCESS   read-only
+    DESCRIPTION
+            "Write access is not required."
+
+    OBJECT       t11FcRscnElsRejectNotifyEnable
+    MIN-ACCESS   read-only
+    DESCRIPTION
+            "Write access is not required."
+
+    ::= { t11FcRscnCompliances 1 }
+
+
+-- Units of conformance
+
+t11FcRscnRegistrationGroup  OBJECT-GROUP
+    OBJECTS { t11FcRscnRegType }
+    STATUS  current
+    DESCRIPTION
+           "A collection of objects for monitoring RSCN
+           registrations."
+    ::= { t11FcRscnGroups 1 }
+
+t11FcRscnStatsGroup   OBJECT-GROUP
+    OBJECTS { t11FcRscnInScrs,
+              t11FcRscnInRscns,
+              t11FcRscnOutRscns,
+              t11FcRscnInSwRscns,
+              t11FcRscnOutSwRscns,
+              t11FcRscnScrRejects,
+              t11FcRscnRscnRejects,
+              t11FcRscnSwRscnRejects,
+              t11FcRscnInUnspecifiedRscns,
+
+
+
+DeSanti, et al.             Standards Track                    [Page 22]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+              t11FcRscnOutUnspecifiedRscns,
+              t11FcRscnInChangedAttribRscns,
+              t11FcRscnOutChangedAttribRscns,
+              t11FcRscnInChangedServiceRscns,
+              t11FcRscnOutChangedServiceRscns,
+              t11FcRscnInChangedSwitchRscns,
+              t11FcRscnOutChangedSwitchRscns,
+              t11FcRscnInRemovedRscns,
+              t11FcRscnOutRemovedRscns
+            }
+    STATUS  current
+    DESCRIPTION
+           "A collection of objects for collecting RSCN-related
+           statistics."
+    ::= { t11FcRscnGroups 2 }
+
+t11FcRscnNotifyControlGroup  OBJECT-GROUP
+    OBJECTS { t11FcRscnIlsRejectNotifyEnable,
+              t11FcRscnElsRejectNotifyEnable,
+              t11FcRscnRejectedRequestString,
+              t11FcRscnRejectedRequestSource,
+              t11FcRscnRejectReasonCode,
+              t11FcRscnRejectReasonCodeExp,
+              t11FcRscnRejectReasonVendorCode
+            }
+    STATUS  current
+    DESCRIPTION
+           "A collection of notification control and
+           notification information objects."
+    ::= { t11FcRscnGroups 3 }
+
+t11FcRscnNotifyGroup   NOTIFICATION-GROUP
+    NOTIFICATIONS { t11FcRscnIlsRejectReqNotify,
+                    t11FcRscnElsRejectReqNotify
+                  }
+    STATUS        current
+    DESCRIPTION
+           "A collection of notifications for monitoring
+           ILS and ELS rejections by the RSCN module."
+    ::= { t11FcRscnGroups 4 }
+
+END
+
+7.  IANA Considerations
+
+   IANA has assigned a MIB OID for the T11-FC-RSCN-MIB module under the
+   appropriate subtree.
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 23]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+8.  Security Considerations
+
+   There are a number of management objects defined in this MIB module
+   with a MAX-ACCESS clause of read-write and/or read-create.  Such
+   objects may be considered sensitive or vulnerable in some network
+   environments.  The support for SET operations in a non-secure
+   environment without proper protection can have a negative effect on
+   network operations.  These objects and their
+   sensitivity/vulnerability are:
+
+        t11FcRscnIlsRejectNotifyEnable
+        t11FcRscnElsRejectNotifyEnable
+          -- ability to enable/disable a notification; these object, if
+             misconfigured, would either generate unwanted notifications
+             or suppress wanted notifications.
+
+
+   Some of the readable objects in this MIB module (i.e., objects with a
+   MAX-ACCESS other than not-accessible) may also be considered
+   sensitive or vulnerable in some network environments.  It is thus
+   important to control even GET and/or NOTIFY access to these objects
+   and possibly to even encrypt the values of these objects when sending
+   them over the network via SNMP.  These are the tables and objects and
+   their sensitivity/vulnerability:
+
+        t11FcRscnRegTable -- contains a list of Nx_Ports that are
+        currently registered to received RSCNs.
+
+        t11FcRscnStatsTable -- contains RSCN-related statistics.
+
+        t11FcRscnNotifyControlTable -- contains control and logging
+        information for notifications that are concerned with the
+        rejection of RSCN-related requests.
+
+   SNMP versions prior to SNMPv3 did not include adequate security.
+   Even if the network itself is secure (for example by using IPsec),
+   even then, there is no control as to who on the secure network is
+   allowed to access and GET/SET (read/change/create/delete) the objects
+   in this MIB module.
+
+   It is RECOMMENDED that implementors consider the security features as
+   provided by the SNMPv3 framework (see [RFC3410], section 8),
+   including full support for the SNMPv3 cryptographic mechanisms (for
+   authentication and privacy).
+
+   Further, deployment of SNMP versions prior to SNMPv3 is NOT
+   RECOMMENDED.  Instead, it is RECOMMENDED to deploy SNMPv3 and to
+   enable cryptographic security.  It is then a customer/operator
+
+
+
+DeSanti, et al.             Standards Track                    [Page 24]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+   responsibility to ensure that the SNMP entity giving access to an
+   instance of this MIB module is properly configured to give access to
+   the objects only to those principals (users) that have legitimate
+   rights to indeed GET or SET (change/create/delete) them.
+
+9.  Acknowledgements
+
+   This document was originally developed and approved by the INCITS
+   Task Group T11.5 (http://www.t11.org) as the SM-RSCNM project.  We
+   wish to acknowledge the many contributions and comments from the
+   INCITS Technical Committee T11, especially from the following:
+
+      T11 Chair: Robert Snively, Brocade
+      T11 Vice Chair: Claudio DeSanti, Cisco Systems
+      T11.5 Chair: Roger Cummings, Symantec
+      T11.5 Vice Chair: Scott Kipp, McData
+      and T11.5 members.
+
+   The document was subsequently a work item of the IETF's IMSS Working
+   Group, chaired by David Black (EMC Corporation).   We thank Bert
+   Wijnen (Lucent Technologies) for his thorough review of the document.
+   We also wish to acknowledge Dan Romascanu (Avaya), the IETF Area
+   Director, for his comments and assistance.
+
+10.  Normative References
+
+   [RFC2578]  McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J.,
+              Rose, M. and S. Waldbusser, "Structure of Management
+              Information Version 2 (SMIv2)", STD 58, RFC 2578, April
+              1999.
+
+   [RFC2579]  McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J.,
+              Rose, M. and S. Waldbusser, "Textual Conventions for
+              SMIv2", STD 58, RFC 2579, April 1999.
+
+   [RFC2580]  McCloghrie, K., Perkins, D., Schoenwaelder, J., Case, J.,
+              Rose, M. and S. Waldbusser, "Conformance Statements for
+              SMIv2", STD 58, RFC 2580, April 1999.
+
+   [RFC3411]  Harrington, D., Presuhn, R., and B. Wijnen, "An
+              Architecture for Describing Simple Network Management
+              Protocol (SNMP) Management Frameworks", STD 58, RFC 3411,
+              December 2002.
+
+   [IF-MIB]   McCloghrie, K. and F. Kastenholz, "The Interfaces Group
+              MIB", RFC 2863, June 2000.
+
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 25]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+   [RFC4044]  McCloghrie, K., "Fibre Channel Management MIB", RFC 4044,
+              May 2005.
+
+   [RFC4438]  DeSanti, C., Gaonkar, V., Vivek, H.K., McCloghrie, K., and
+              S. Gai, "Fibre Channel Name Server MIB", RFC 4438, March
+              2006.
+
+   [RFC4439]  DeSanti, C., Gaonkar, V., McCloghrie, K., and S. Gai,
+              "Fibre Channel Fabric Address Manager MIB", RFC 4439,
+              March 2006.
+
+   [FC-SW-4]  "Fibre Channel - Switch Fabric - 4 (FC-SW-4)", ANSI INCITS
+              418-2006, http://www.t11.org/t11/stat.nsf/upnum/1674-d,
+              December 2006.
+
+   [FC-FS]    "Fibre Channel - Framing and Signaling (FC-FS)", ANSI
+              INCITS 373-2003,
+              http://www.t11.org/t11/stat.nsf/upnum/1331-d, April 2003.
+
+   [FC-LS]    "Fibre Channel - Link Services (FC-LS)", ANSI INCITS
+              433-2007, http://www.t11.org/t11/stat.nsf/upnum/1620-d,
+              July 2007.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+11.  Informative References
+
+   [RFC2741]  Daniele, M., Wijnen, B., Ellison, M., and D. Francisco,
+              "Agent Extensibility (AgentX) Protocol Version 1", RFC
+              2741, January 2000.
+
+   [RFC2837]  Teow, K., "Definitions of Managed Objects for the Fabric
+              Element in Fibre Channel Standard", RFC 2837, May 2000.
+
+   [RFC3410]  Case, J., Mundy, R., Partain, D., and B. Stewart,
+              "Introduction and Applicability Statements for Internet-
+              Standard Management Framework", RFC 3410, December 2002.
+
+
+
+
+
+
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 26]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+Authors' Addresses
+
+   Claudio DeSanti
+   Cisco Systems, Inc.
+   170 West Tasman Drive
+   San Jose, CA 95134 USA
+   Phone: +1 408 853-9172
+   EMail: cds@cisco.com
+
+   H.K. Vivek
+   Cisco Systems, Inc.
+   71 Millers Rd
+   Bangalore, India
+   Phone: +91 80 2289933x5117
+   EMail: hvivek@cisco.com
+
+   Keith McCloghrie
+   Cisco Systems, Inc.
+   170 West Tasman Drive
+   San Jose, CA 95134 USA
+   Phone: +1 408 526-5260
+   EMail: kzm@cisco.com
+
+   Silvano Gai
+   Nuova Systems
+   3 West Plumeria Drive
+   San Jose, CA 95134
+   Phone: +1 408 387-6123
+   EMail: sgai@nuovasystems.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 27]
+
+RFC 4983                 Fibre Channel RSCN MIB              August 2007
+
+
+Full Copyright Statement
+
+   Copyright (C) The IETF Trust (2007).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY, THE IETF TRUST AND
+   THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF
+   THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+
+
+
+
+
+
+
+
+
+
+
+DeSanti, et al.             Standards Track                    [Page 28]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4983.txt](<www.ietf.org/rfc/rfc4983.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
