### PR TITLE
Archive rfc4994.txt

### DIFF
--- a/www.ietf.org/rfc/rfc4994.txt
+++ b/www.ietf.org/rfc/rfc4994.txt
@@ -1,0 +1,339 @@
+
+
+
+
+
+
+Network Working Group                                            S. Zeng
+Request for Comments: 4994                                       B. Volz
+Category: Standards Track                                     K. Kinnear
+                                                     Cisco Systems, Inc.
+                                                           J. Brzozowski
+                                                           Comcast Cable
+                                                          September 2007
+
+
+                 DHCPv6 Relay Agent Echo Request Option
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Abstract
+
+   This memo defines a Relay Agent Echo Request option for the Dynamic
+   Host Configuration Protocol for IPv6 (DHCPv6).  The option allows a
+   DHCPv6 relay agent to request a list of relay agent options that the
+   server echoes back to the relay agent.
+
+Table of Contents
+
+   1. Introduction ....................................................2
+   2. Requirements Terminology ........................................2
+   3. The Relay Agent Echo Request Option .............................2
+   4. DHCPv6 Relay Agent Behavior .....................................3
+   5. DHCPv6 Server Behavior ..........................................3
+   6. Security Considerations .........................................4
+   7. IANA Considerations .............................................4
+   8. Acknowledgements ................................................4
+   9. References ......................................................4
+      9.1. Normative References .......................................4
+      9.2. Informative References .....................................4
+
+
+
+
+
+
+
+
+
+
+
+
+Zeng, et al.                Standards Track                     [Page 1]
+
+RFC 4994                    Relay Agent ERO               September 2007
+
+
+1.  Introduction
+
+   DHCPv6 [2] provides a framework for configuring IPv6 clients with
+   addresses and other network parameters.  It includes a relay agent
+   capability.  A relay agent is an intermediary node that delivers DHCP
+   messages between clients and servers.  The relay agent and the server
+   exchange information using options in relay agent messages.  The
+   relay agent may add relay agent options to the client DHCP message
+   before forwarding it.
+
+   The information that relay agents supply can be used in the server's
+   decision making about the addresses, delegated prefixes, and
+   configuration parameters that the client is to receive.  Likewise,
+   the relay may need some of the information to efficiently return
+   replies to clients.
+
+   In DHCPv4, the server generally echoes the relay agent option back
+   verbatim to the relay agent in server-to-client replies [3].
+   However, DHCPv6 [2] does not require the server to do so.  This could
+   be problematic, as the relay agent may need to use some relay options
+   even if the server does not recognize them.
+
+   This memo defines a relay agent echo request option that the relay
+   agent uses to explicitly request a list of options that the server
+   echoes back to the relay agent.
+
+2.  Requirements Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [1].
+
+3.  The Relay Agent Echo Request Option
+
+   The relay agent adds options in the Relay Forward message that the
+   server uses to guide its decision making with regard to address
+   assignment, prefix delegation, and configuration parameters.  The
+   relay agent also knows which of these options that it will need to
+   efficiently return replies to the client.  It uses the relay agent
+   Echo Request option to inform the server of the list of relay agent
+   options that the server must echo back.
+
+
+
+
+
+
+
+
+
+
+Zeng, et al.                Standards Track                     [Page 2]
+
+RFC 4994                    Relay Agent ERO               September 2007
+
+
+   The format of the DHCPv6 Relay Agent Echo Request option is shown
+   below:
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |           OPTION_ERO          |           option-len          |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |    requested-option-code-1    |    requested-option-code-2    |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                              ...                              |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   option-code              OPTION_ERO (43).
+   option-len               2 * number of requested options.
+   requested-option-code-n  The option code for an option requested by
+                            the relay agent.
+
+4.  DHCPv6 Relay Agent Behavior
+
+   A relay agent MAY include an Echo Request option in a Relay Forward
+   message to inform the server about options the relay agent wants the
+   server to echo back to the relay agent.  If the relay agent takes
+   different actions based on whether an option is echoed back or not,
+   then the relay agent SHOULD NOT include such an option in the Echo
+   Request option.  Note that the relay uses the OPTION_ORO [2] to
+   request the server to return options (e.g., [4]) other than relay
+   agent options in the Relay Forward message.
+
+5.  DHCPv6 Server Behavior
+
+   When a server creates a Relay-Reply, it SHOULD perform ERO processing
+   after processing the ORO and other options processing.  For each
+   option in the ERO:
+
+   a.  If the option is already in the Relay-Reply, the server MUST
+       ignore that option and continue to process any remaining options
+       in the ERO.
+
+   b.  If the option was not in the received Relay-Forward, the server
+       MUST ignore that option and continue to process any remaining
+       options in the ERO.
+
+   c.  Otherwise, the server MUST copy the option, verbatim, from the
+       received Relay-Forward to the Relay-Reply, even if the server
+       does not otherwise recognize that option.
+
+
+
+
+
+Zeng, et al.                Standards Track                     [Page 3]
+
+RFC 4994                    Relay Agent ERO               September 2007
+
+
+6.  Security Considerations
+
+   As the Echo Request option is only exchanged between relay agents and
+   DHCPv6 servers, section 21.1 of [2] provides details on securing
+   DHCPv6 messages sent between servers and relay agents.  And, section
+   23 of [2] provides general DHCPv6 security considerations.
+
+7.  IANA Considerations
+
+   IANA has assigned a DHCPv6 option code for the OPTION_ERO (Relay
+   Agent Echo Request) Option (43).
+
+8.  Acknowledgements
+
+   Thanks to Ralph Droms, Josh Littlefield, Richard Johnson, and Hemant
+   Singh for their consistent input, ideas, and review during the
+   production of this document.
+
+9.  References
+
+9.1.  Normative References
+
+   [1]  Bradner, S., "Key words for use in RFCs to Indicate Requirement
+        Levels", BCP 14, RFC 2119, March 1997.
+
+   [2]  Droms, R., Bound, J., Volz, B., Lemon, T., Perkins, C., and M.
+        Carney, "Dynamic Host Configuration Protocol for IPv6 (DHCPv6)",
+        RFC 3315, July 2003.
+
+   [3]  Patrick, M., "DHCP Relay Agent Information Option", RFC 3046,
+        January 2001.
+
+9.2.  Informative References
+
+   [4]  Droms, R., Volz, B., and O. Troan, "DHCPv6 Relay Agent
+        Assignment Notification (RAAN) Option", Work in Progress,
+        November 2006.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Zeng, et al.                Standards Track                     [Page 4]
+
+RFC 4994                    Relay Agent ERO               September 2007
+
+
+Authors' Addresses
+
+   Shengyou Zeng
+   Cisco Systems, Inc.
+   1414 Massachusetts Ave.
+   Boxborough, MA  01719
+   USA
+
+   Phone: +1 978 936 0000
+   EMail: szeng@cisco.com
+
+
+   Bernard Volz
+   Cisco Systems, Inc.
+   1414 Massachusetts Ave.
+   Boxborough, MA  01719
+   USA
+
+   Phone: +1 978 936 0000
+   EMail: volz@cisco.com
+
+
+   Kim Kinnear
+   Cisco Systems, Inc.
+   1414 Massachusetts Ave.
+   Boxborough, MA  01719
+   USA
+
+   Phone: +1 978 936 0000
+   EMail: kkinnear@cisco.com
+
+
+   John Jason Brzozowski
+   Comcast Cable
+   1800 Bishops Gate Boulevard
+   Mt. Laurel, NJ  08054
+   USA
+
+   Phone: +1 856 324 2671
+   EMail: john_brzozowski@cable.comcast.com
+
+
+
+
+
+
+
+
+
+
+
+Zeng, et al.                Standards Track                     [Page 5]
+
+RFC 4994                    Relay Agent ERO               September 2007
+
+
+Full Copyright Statement
+
+   Copyright (C) The IETF Trust (2007).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY, THE IETF TRUST AND
+   THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF
+   THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+
+
+
+
+
+
+
+
+
+
+
+Zeng, et al.                Standards Track                     [Page 6]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc4994.txt](<www.ietf.org/rfc/rfc4994.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
