### PR TITLE
Archive rfc5000.txt

### DIFF
--- a/www.ietf.org/rfc/rfc5000.txt
+++ b/www.ietf.org/rfc/rfc5000.txt
@@ -1,0 +1,4203 @@
+
+
+
+
+
+
+Network Working Group                                         RFC Editor
+Request for Comments: 5000                                       USC/ISI
+STD: 1                                                          May 2008
+Obsoletes: 3700
+Category: Informational
+
+
+                  Internet Official Protocol Standards
+
+Status of This Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard of any kind.  Distribution of this
+   memo is unlimited.
+
+IESG Note
+
+   This document obsoletes RFC 3700.  It also reclassifies RFCs that
+   were previously published as STD 1 as Historic.  More specifically,
+   this RFC moves RFCs 3000, 3300, 3600, and 3700 to Historic status.
+
+Abstract
+
+   This document is published by the RFC Editor to provide a summary of
+   the current standards protocols (as of 18 February 2008).  It lists
+   those official protocol standards, Best Current Practice, and
+   Experimental RFCs that have not been obsoleted; it is not a complete
+   index to the RFC series.  Newly published RFCs and RFCs whose status
+   has changed are starred.
+
+   For an up-to-date list, see http://www.rfc-editor.org/rfcxx00.html,
+   which is updated daily.
+
+Table of Contents
+
+   1. Overview ........................................................2
+   2. RFC Resources and Retrieval .....................................2
+   3. Current Technical Specifications ................................3
+      3.1. Standard Protocols Ordered by STD ..........................3
+      3.2. Standard Protocols Ordered by RFC ..........................6
+      3.3. Draft Standard Protocols ...................................8
+      3.4. Proposed Standard Protocols ...............................11
+      3.5. Best Current Practice Ordered by BCP ......................57
+      3.6. Best Current Practice Ordered by RFC ......................62
+      3.7. Experimental Protocols ....................................67
+   4. Security Considerations ........................................74
+
+
+
+
+
+RFC Editor                   Informational                      [Page 1]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+1.  Overview
+
+   This memo contains a snapshot of the state of standardization of
+   protocols used in the Internet, as determined by the Internet
+   Engineering Task Force (IETF).  It is a 18 February 2008 snapshot of
+   the current official protocol standards list and the Best Current
+   Practice list, which is updated daily and is available from the RFC
+   Editor Web site.
+
+   The RFC Editor publishes Request for Comments (RFC) documents that
+   are the output of 4 streams: IAB, IETF, IRTF, and Independent
+   Submission via the RFC Editor.
+
+   This memo is published by the RFC Editor for the IESG and IAB, in
+   which the categorizations are in accordance with Section 2.1 of "The
+   Internet Standards Process -- Revision 3", RFC 2026, which specifies
+   the rules and procedures by which all Internet standards are set.
+   Sections 3.1 - 3.7 of this memo contain the lists of protocols in
+   each stage of standardization - Standard, Draft Standard, Proposed
+   Standard, Experimental, as well as Best Current Practice documents.
+   Protocols that are new to this document or have been moved from one
+   protocol level to another, or that differ from the previous edition
+   of this document are marked with an asterisk.  Informational and
+   Historic RFCs are not included.  This list is not a complete index to
+   RFCs.
+
+2.  RFC Resources and Retrieval
+
+   This list is a live document that is updated daily on the RFC Editor
+   site at:
+
+      http://www.rfc-editor.org/rfcxx00.html
+
+   RFCs are available online via http and ftp as:
+
+      http://www.rfc-editor.org/rfc/rfcXXXX.txt
+      ftp://ftp.rfc-editor.org/in-notes/rfcXXXX.txt
+
+   where XXXX represents the corresponding RFC number.
+
+   The RFC Editor maintains the official repository of all RFCs and
+   indexes to them.  The site also provides additional information about
+   the history of the RFC Editor, current submission and review
+   procedures, and editorial and publication procedures.  Please see the
+   RFC Editor site for all other RFC related information:
+
+      http://www.rfc-editor.org
+
+
+
+
+RFC Editor                   Informational                      [Page 2]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+3.  Current Technical Specifications
+
+3.1.  Standard Protocols Ordered by STD
+
+   [Note: an asterisk at the end of a line indicates a change from the
+   previous edition of this document.]
+
+Mnemonic   Title                                               RFC# STD#
+------------------------------------------------------------------------
+--------   Internet Official Protocol Standards                5000*   1
+--------   [Reserved for Assigned Numbers. See RFC 1700 and     xxx    2
+             RFC 3232.]
+--------   Requirements for Internet Hosts - Communication     1122    3
+             Layers
+--------   Requirements for Internet Hosts - Application and   1123    3
+             Support
+--------   [Reserved for Router Requirements. See RFC 1812.]    xxx    4
+IP         Internet Protocol                                    791    5
+ICMP       Internet Control Message Protocol                    792    5
+--------   Broadcasting Internet Datagrams                      919    5
+--------   Broadcasting Internet datagrams in the presence of   922    5
+             subnets
+--------   Internet Standard Subnetting Procedure               950    5
+IGMP       Host extensions for IP multicasting                 1112    5
+UDP        User Datagram Protocol                               768    6
+TCP        Transmission Control Protocol                        793    7
+TELNET     Telnet Protocol Specification                        854    8
+FTP        File Transfer Protocol                               959    9
+--------   ["Mail routing and the domain system". Was RFC 974   xxx   10
+             (STANDARD), Now HISTORIC.]
+SMTP       ["Simple Mail Transfer Protocol". Was RFC 821        xxx   10
+             (STANDARD), Obsoleted by RFC 2821 (PROPOSED
+             STANDARD)]
+--------   ["SMTP Service Extensions". Was RFC 1869             xxx   10
+             (STANDARD), Obsoleted by RFC 2821 (PROPOSED
+             STANDARD)]
+SMTP-SIZE  SMTP Service Extension for Message Size Declaration 1870   10
+MAIL       ["STANDARD FOR THE FORMAT OF ARPA INTERNET TEXT      xxx   11
+             MESSAGES". Was RFC 822 (STANDARD), Obsoleted by
+             RFC 2822 (PROPOSED STANDARD)]
+--------   [Reserved for Network Time Protocol (NTP). See RFC   xxx   12
+             1305.]
+DOMAIN     Domain names - concepts and facilities              1034   13
+DOMAIN     Domain names - implementation and specification     1035   13
+--------   [Was Mail Routing and the Domain System. Now         xxx   14
+             Historic.]
+--------   [Was Simple Network Management Protocol. Now         xxx   15
+             Historic.]
+
+
+
+RFC Editor                   Informational                      [Page 3]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+SMI        Structure and identification of management          1155   16
+             information for TCP/IP-based internets
+Concise-MI Concise MIB definitions                             1212   16
+MIB-II     Management Information Base for Network Management  1213   17
+             of TCP/IP-based internets:MIB-II
+--------   [Was Exterior Gateway Protocol (RFC 904). Now        xxx   18
+             Historic.]
+NETBIOS    Protocol standard for a NetBIOS service on a        1001   19
+             TCP/UDP transport: Concepts and methods
+NETBIOS    Protocol standard for a NetBIOS service on a        1002   19
+             TCP/UDP transport: Detailed specifications
+ECHO       Echo Protocol                                        862   20
+DISCARD    Discard Protocol                                     863   21
+CHARGEN    Character Generator Protocol                         864   22
+QUOTE      Quote of the Day Protocol                            865   23
+USERS      Active users                                         866   24
+DAYTIME    Daytime Protocol                                     867   25
+TIME       Time Protocol                                        868   26
+TOPT-BIN   Telnet Binary Transmission                             0   27
+TOPT-ECHO  Telnet Echo Option                                     0   28
+TOPT-SUPP  Telnet Suppress Go Ahead Option                        0   29
+--------   Telnet Status Option                                 859   30
+TOPT-TIM   Telnet Timing Mark Option                              0   31
+TOPT-EXTOP Telnet Extended Options: List Option                   0   32
+TFTP       The TFTP Protocol (Revision 2)                      1350   33
+--------   [Was Routing Information Protocol (RIP). Replaced    xxx   34
+             by STD 56.]
+TP-TCP     ISO Transport Service on top of the TCP Version: 3  1006   35
+IP-FDDI    Transmission of IP and ARP over FDDI Networks       1390   36
+ARP        Ethernet Address Resolution Protocol: Or             826   37
+             Converting Network Protocol Addresses to 48.bit
+             Ethernet Address for Transmission on Ethernet
+             Hardware
+RARP       A Reverse Address Resolution Protocol                903   38
+IP-ARPA    [Was BBN Report 1822 (IMP/Host Interface).  Now      xxx   39
+             Historic.]
+IP-WB      Host Access Protocol specification                   907   40
+IP-E       A Standard for the Transmission of IP Datagrams      894   41
+             over Ethernet Networks
+IP-EE      Standard for the transmission of IP datagrams over   895   42
+             experimental Ethernet networks
+IP-IEEE    Standard for the transmission of IP datagrams over  1042   43
+             IEEE 802 networks
+IP-DC      DCN Local-Network Protocols                          891   44
+IP-HC      Internet Protocol on Network System's               1044   45
+             HYPERchannel: Protocol Specification
+IP-ARC     Transmitting IP traffic over ARCNET networks        1201   46
+
+
+
+
+RFC Editor                   Informational                      [Page 4]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+IP-SLIP    Nonstandard for transmission of IP datagrams over   1055   47
+             serial lines: SLIP
+IP-NETBIOS Standard for the transmission of IP datagrams over  1088   48
+             NetBIOS networks
+IP-IPX     Standard for the transmission of 802.2 packets      1132   49
+             over IPX networks
+--------   [Reserved for Definitions of Managed Objects for     xxx   50
+             the Ethernet-like Interface Types. See RFC 3638.]
+PPP        The Point-to-Point Protocol (PPP)                   1661   51
+PPP-HDLC   PPP in HDLC-like Framing                            1662   51
+IP-SMDS    The Transmission of IP Datagrams over the SMDS      1209   52
+             Service
+POP3       Post Office Protocol - Version 3                    1939   53
+OSPF2      OSPF Version 2                                      2328   54
+IP-FR      Multiprotocol Interconnect over Frame Relay         2427   55
+RIP2       RIP Version 2                                       2453   56
+RIP2-APP   RIP Version 2 Protocol Applicability Statement      1722   57
+SMIv2      Structure of Management Information Version 2       2578   58
+             (SMIv2)
+CONV-MIB   Textual Conventions for SMIv2                       2579   58
+CONF-MIB   Conformance Statements for SMIv2                    2580   58
+RMON-MIB   Remote Network Monitoring Management Information    2819   59
+             Base
+SMTP-Pipe  SMTP Service Extension for Command Pipelining       2920   60
+ONE-PASS   A One-Time Password System                          2289   61
+ARCH-SNMP  An Architecture for Describing Simple Network       3411   62
+             Management Protocol (SNMP) Management Frameworks
+MPD-SNMP   Message Processing and Dispatching for the Simple   3412   62
+             Network Management Protocol (SNMP)
+SNMP-APP   Simple Network Management Protocol (SNMP)           3413   62
+             Applications
+USM-SNMPV3 User-based Security Model (USM) for version 3 of    3414   62
+             the Simple Network Management Protocol (SNMPv3)
+VACM-SNMP  View-based Access Control Model (VACM) for the      3415   62
+             Simple Network Management Protocol (SNMP)
+OPS-MIB    Version 2 of the Protocol Operations for the        3416   62
+             Simple Network Management Protocol (SNMP)
+TRANS-MIB  Transport Mappings for the Simple Network           3417   62
+             Management Protocol (SNMP)
+SNMPv2-MIB Management Information Base (MIB) for the Simple    3418   62
+             Network Management Protocol (SNMP)
+UTF-8      UTF-8, a transformation format of ISO 10646         3629   63
+RTP        RTP: A Transport Protocol for Real-Time             3550   64
+             Applications
+RTP-AV     RTP Profile for Audio and Video Conferences with    3551   65
+             Minimal Control
+--------   Uniform Resource Identifier (URI): Generic Syntax   3986*  66
+
+
+
+
+RFC Editor                   Informational                      [Page 5]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+XDR        XDR: External Data Representation Standard          4506*  67
+ABNF       Augmented BNF for Syntax Specifications: ABNF       5234*  68
+
+3.2.  Standard Protocols Ordered by RFC
+
+   [Note: an asterisk at the end of a line indicates a change from the
+   previous edition of this document.]
+
+Mnemonic   Title                                               STD# RFC#
+------------------------------------------------------------------------
+ABNF       Augmented BNF for Syntax Specifications: ABNF        68 5234*
+--------   Internet Official Protocol Standards                  1 5000*
+XDR        XDR: External Data Representation Standard           67 4506*
+--------   Uniform Resource Identifier (URI): Generic Syntax    66 3986*
+UTF-8      UTF-8, a transformation format of ISO 10646          63 3629
+RTP-AV     RTP Profile for Audio and Video Conferences with     65 3551
+             Minimal Control
+RTP        RTP: A Transport Protocol for Real-Time              64 3550
+             Applications
+SNMPv2-MIB Management Information Base (MIB) for the Simple     62 3418
+             Network Management Protocol (SNMP)
+TRANS-MIB  Transport Mappings for the Simple Network            62 3417
+             Management Protocol (SNMP)
+OPS-MIB    Version 2 of the Protocol Operations for the         62 3416
+             Simple Network Management Protocol (SNMP)
+VACM-SNMP  View-based Access Control Model (VACM) for the       62 3415
+             Simple Network Management Protocol (SNMP)
+USM-SNMPV3 User-based Security Model (USM) for version 3 of     62 3414
+             the Simple Network Management Protocol (SNMPv3)
+SNMP-APP   Simple Network Management Protocol (SNMP)            62 3413
+             Applications
+MPD-SNMP   Message Processing and Dispatching for the           62 3412
+             Simple Network Management Protocol (SNMP)
+ARCH-SNMP  An Architecture for Describing Simple Network        62 3411
+             Management Protocol (SNMP) Management Frameworks
+SMTP-Pipe  SMTP Service Extension for Command Pipelining        60 2920
+RMON-MIB   Remote Network Monitoring Management Information     59 2819
+             Base
+CONF-MIB   Conformance Statements for SMIv2                     58 2580
+CONV-MIB   Textual Conventions for SMIv2                        58 2579
+SMIv2      Structure of Management Information Version 2        58 2578
+             (SMIv2)
+RIP2       RIP Version 2                                        56 2453
+IP-FR      Multiprotocol Interconnect over Frame Relay          55 2427
+OSPF2      OSPF Version 2                                       54 2328
+ONE-PASS   A One-Time Password System                           61 2289
+POP3       Post Office Protocol - Version 3                     53 1939
+
+
+
+
+RFC Editor                   Informational                      [Page 6]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+SMTP-SIZE  SMTP Service Extension for Message Size              10 1870
+             Declaration
+RIP2-APP   RIP Version 2 Protocol Applicability Statement       57 1722
+PPP-HDLC   PPP in HDLC-like Framing                             51 1662
+PPP        The Point-to-Point Protocol (PPP)                    51 1661
+IP-FDDI    Transmission of IP and ARP over FDDI Networks        36 1390
+TFTP       The TFTP Protocol (Revision 2)                       33 1350
+MIB-II     Management Information Base for Network              17 1213
+             Management of TCP/IP-based internets:MIB-II
+Concise-MI Concise MIB definitions                              16 1212
+IP-SMDS    The Transmission of IP Datagrams over the SMDS       52 1209
+             Service
+IP-ARC     Transmitting IP traffic over ARCNET networks         46 1201
+SMI        Structure and identification of management           16 1155
+             information for TCP/IP-based internets
+IP-IPX     Standard for the transmission of 802.2 packets       49 1132
+             over IPX networks
+--------   Requirements for Internet Hosts - Application         3 1123
+             and Support
+--------   Requirements for Internet Hosts - Communication       3 1122
+             Layers
+IGMP       Host extensions for IP multicasting                   5 1112
+IP-NETBIOS Standard for the transmission of IP datagrams        48 1088
+             over NetBIOS networks
+IP-SLIP    Nonstandard for transmission of IP datagrams         47 1055
+             over serial lines: SLIP
+IP-HC      Internet Protocol on Network System's                45 1044
+             HYPERchannel: Protocol Specification
+IP-IEEE    Standard for the transmission of IP datagrams        43 1042
+             over IEEE 802 networks
+DOMAIN     Domain names - implementation and specification      13 1035
+DOMAIN     Domain names - concepts and facilities               13 1034
+TP-TCP     ISO Transport Service on top of the TCP Version:     35 1006
+             3
+NETBIOS    Protocol standard for a NetBIOS service on a         19 1002
+             TCP/UDP transport: Detailed specifications
+NETBIOS    Protocol standard for a NetBIOS service on a         19 1001
+             TCP/UDP transport: Concepts and methods
+FTP        File Transfer Protocol                                9  959
+--------   Internet Standard Subnetting Procedure                5  950
+--------   Broadcasting Internet datagrams in the presence       5  922
+             of subnets
+--------   Broadcasting Internet Datagrams                       5  919
+IP-WB      Host Access Protocol specification                   40  907
+RARP       A Reverse Address Resolution Protocol                38  903
+IP-EE      Standard for the transmission of IP datagrams        42  895
+             over experimental Ethernet networks
+
+
+
+
+RFC Editor                   Informational                      [Page 7]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+IP-E       A Standard for the Transmission of IP Datagrams      41  894
+             over Ethernet Networks
+IP-DC      DCN Local-Network Protocols                          44  891
+TIME       Time Protocol                                        26  868
+DAYTIME    Daytime Protocol                                     25  867
+USERS      Active users                                         24  866
+QUOTE      Quote of the Day Protocol                            23  865
+CHARGEN    Character Generator Protocol                         22  864
+DISCARD    Discard Protocol                                     21  863
+ECHO       Echo Protocol                                        20  862
+--------   Telnet Status Option                                 30  859
+TELNET     Telnet Protocol Specification                         8  854
+ARP        Ethernet Address Resolution Protocol: Or             37  826
+             Converting Network Protocol Addresses to 48.bit
+             Ethernet Address for Transmission on Ethernet
+             Hardware
+TCP        Transmission Control Protocol                         7  793
+ICMP       Internet Control Message Protocol                     5  792
+IP         Internet Protocol                                     5  791
+UDP        User Datagram Protocol                                6  768
+
+3.3.  Draft Standard Protocols
+
+   [Note: an asterisk at the end of a line indicates a change from the
+   previous edition of this document.]
+
+Mnemonic   Title                                                    RFC#
+------------------------------------------------------------------------
+IPv6-PPP   IP Version 6 over PPP                                   5072*
+--------   Autonomous System Confederations for BGP                5065*
+--------   LDP Specification                                       5036*
+--------   Privacy Extensions for Stateless Address                4941*
+             Autoconfiguration in IPv6
+--------   Extensible Provisioning Protocol (EPP) Transport        4934*
+             Over TCP
+--------   Extensible Provisioning Protocol (EPP) Contact          4933*
+             Mapping
+--------   Extensible Provisioning Protocol (EPP) Host Mapping     4932*
+--------   Extensible Provisioning Protocol (EPP) Domain Name      4931*
+             Mapping
+--------   Extensible Provisioning Protocol (EPP)                  4930*
+IPV6-AUTO  IPv6 Stateless Address Autoconfiguration                4862*
+IPV6-ND    Neighbor Discovery for IP version 6 (IPv6)              4861*
+MEXT-BGP4  Multiprotocol Extensions for BGP-4                      4760*
+RMON-MIB   Remote Network Monitoring Management Information        4502*
+             Base Version 2
+BGP-RR     BGP Route Reflection: An Alternative to Full Mesh       4456*
+             Internal BGP (IBGP)
+
+
+
+RFC Editor                   Informational                      [Page 8]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Internet Control Message Protocol (ICMPv6) for the      4443*
+             Internet Protocol Version 6 (IPv6) Specification
+--------   Message Submission for Mail                             4409*
+--------   IP Version 6 Addressing Architecture                    4291*
+BGP-4      A Border Gateway Protocol 4 (BGP-4)                     4271*
+SMFAX-IM   A Simple Mode of Facsimile Using Internet Mail          3965*
+FFIF       Tag Image File Format Fax eXtended (TIFF-FX) -          3950*
+             image/tiff-fx MIME Sub-type Registration
+FFIF       File Format for Internet Fax                            3949*
+NICNAME    WHOIS Protocol Specification                            3912*
+CONT-DUR   Content Duration MIME Header Definition                 3803
+MIME-ADPCM Toll Quality Voice - 32 kbit/s Adaptive Differential    3802
+             Pulse Code Modulation (ADPCM) MIME Sub-type
+             Registration
+MIME-VP2   Voice Profile for Internet Mail - version 2 (VPIMv2)    3801
+EMF-MDN    Message Disposition Notification                        3798
+VRRP       Virtual Router Redundancy Protocol (VRRP)               3768
+--------   DNS Extensions to Support IP Version 6                  3596
+--------   Textual Conventions for MIB Modules Using               3593
+             Performance History Based on 15 Minute Intervals
+--------   Definitions of Managed Objects for the Synchronous      3592
+             Optical Network/Synchronous Digital Hierarchy
+             (SONET/SDH) Interface Type
+DSN        An Extensible Message Format for Delivery Status        3464
+             Notifications
+EMS-CODE   Enhanced Mail System Status Codes                       3463
+MIME-RPT   The Multipart/Report Content Type for the Reporting     3462
+             of Mail System Administrative Messages
+SMTP-DSN   Simple Mail Transfer Protocol (SMTP) Service            3461
+             Extension for Delivery Status Notifications (DSNs)
+--------   Capabilities Advertisement with BGP-4                   3392
+TIFF       Tag Image File Format (TIFF) - image/tiff MIME          3302
+             Sub-type Registration
+--------   Content Language Headers                                3282
+--------   (Extensible Markup Language) XML-Signature Syntax       3275
+             and Processing
+MINFAX-IM  Minimal FAX address format in Internet Mail             3192
+MIN-PSTN   Minimal GSTN address format in Internet Mail            3191
+RMON-MIB   Remote Network Monitoring MIB Protocol Identifier       2895
+             Reference
+RADIUS     Remote Authentication Dial In User Service (RADIUS)     2865
+INTERGRMIB The Interfaces Group MIB                                2863
+--------   Host Resources MIB                                      2790
+SNMP       Definitions of Managed Objects for Extensible SNMP      2742
+             Agents
+--------   Agent Extensibility (AgentX) Protocol Version 1         2741
+--------   HTTP Authentication: Basic and Digest Access            2617
+             Authentication
+
+
+
+RFC Editor                   Informational                      [Page 9]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+HTTP       Hypertext Transfer Protocol -- HTTP/1.1                 2616
+--------   Remote Network Monitoring MIB Extensions for            2613
+             Switched Networks Version 1.0
+IPV6       Internet Protocol, Version 6 (IPv6) Specification       2460
+IARP       Inverse Address Resolution Protocol                     2390
+TN3270E    TN3270 Enhancements                                     2355
+TFTP-Opt   TFTP Timeout Interval and Transfer Size Options         2349
+TFTP-Blk   TFTP Blocksize Option                                   2348
+TFTP-Ext   TFTP Option Extension                                   2347
+DHCP-BOOTP DHCP Options and BOOTP Vendor Extensions                2132
+DHCP       Dynamic Host Configuration Protocol                     2131
+FRAME-MIB  Management Information Base for Frame Relay DTEs        2115
+             Using SMIv2
+IP-HIPPI   IP over HIPPI                                           2067
+MIME-CONF  Multipurpose Internet Mail Extensions (MIME) Part       2049
+             Five: Conformance Criteria and Examples
+MIME-MSG   MIME (Multipurpose Internet Mail Extensions) Part       2047
+             Three: Message Header Extensions for Non-ASCII Text
+MIME-MEDIA Multipurpose Internet Mail Extensions (MIME) Part       2046
+             Two: Media Types
+MIME       Multipurpose Internet Mail Extensions (MIME) Part       2045
+             One: Format of Internet Message Bodies
+PPP-CHAP   PPP Challenge Handshake Authentication Protocol         1994
+             (CHAP)
+PPP-MP     The PPP Multilink Protocol (MP)                         1990
+PPP-LINK   PPP Link Quality Monitoring                             1989
+MTU-IPV6   Path MTU Discovery for IP version 6                     1981
+CON-MD5    The Content-MD5 Header Field                            1864
+BGP-4-APP  Application of the Border Gateway Protocol in the       1772
+             Internet
+PPP-DNCP   The PPP DECnet Phase IV Control Protocol (DNCP)         1762
+802.5-MIB  IEEE 802.5 MIB using SMIv2                              1748
+RIP2-MIB   RIP Version 2 MIB Extension                             1724
+SIP-MIB    Definitions of Managed Objects for SMDS Interfaces      1694
+             using SMIv2
+--------   Definitions of Managed Objects for                      1660
+             Parallel-printer-like Hardware Devices using SMIv2
+--------   Definitions of Managed Objects for RS-232-like          1659
+             Hardware Devices using SMIv2
+--------   Definitions of Managed Objects for Character Stream     1658
+             Devices using SMIv2
+--------   SMTP Service Extension for 8bit-MIMEtransport           1652
+OSI-NSAP   Guidelines for OSI NSAP Allocation in the Internet      1629
+ISO-TS-ECH An Echo Function for CLNP (ISO 8473)                    1575
+DECNET-MIB DECnet Phase IV MIB Extensions                          1559
+--------   Clarifications and Extensions for the Bootstrap         1542
+             Protocol
+DHCP-BOOTP Interoperation Between DHCP and BOOTP                   1534
+
+
+
+RFC Editor                   Informational                     [Page 10]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+IP-X.25    Multiprotocol Interconnect on X.25 and ISDN in the      1356
+             Packet Mode
+NTPV3      Network Time Protocol (Version 3) Specification,        1305
+             Implementation and Analysis
+FINGER     The Finger User Information Protocol                    1288
+IP-MTU     Path MTU discovery                                      1191
+--------   Proposed Standard for the Transmission of IP            1188
+             Datagrams over FDDI Networks
+TOPT-LINE  Telnet Linemode Option                                  1184
+BOOTP      Bootstrap Protocol                                       951
+
+3.4.  Proposed Standard Protocols
+
+   [Note: an asterisk at the end of a line indicates a change from the
+   previous edition of this document.]
+
+Mnemonic   Title                                                    RFC#
+------------------------------------------------------------------------
+--------   Sieve Email Filtering: Spamtest and Virustest           5235*
+             Extensions
+--------   Sieve Email Filtering: Subaddress Extension             5233*
+--------   Sieve Email Filtering: Imap4flags Extension             5232*
+--------   Sieve Email Filtering: Relational Extension             5231*
+--------   Sieve Email Filtering: Vacation Extension               5230*
+--------   Sieve Email Filtering: Variables Extension              5229*
+--------   Sieve: An Email Filtering Language                      5228*
+--------   A More Loss-Tolerant RTP Payload Format for MP3 Audio   5219*
+--------   Mobility Header Home Agent Switch Message               5142*
+--------   Terminal Endpoint Identifier (TEI) Query Request        5133*
+             Number Change
+--------   IP Multicast MIB                                        5132*
+--------   A MIB Textual Convention for Language Tags              5131*
+--------   A Policy Control Mechanism in IS-IS Using               5130*
+             Administrative Tags
+--------   Explicit Congestion Marking in MPLS                     5129*
+--------   Transmission of IPv6 via the IPv6 Convergence           5121*
+             Sublayer over IEEE 802.16 Networks
+--------   M-ISIS: Multi Topology (MT) Routing in Intermediate     5120*
+             System to Intermediate Systems (IS-ISs)
+--------   An Interface and Algorithms for Authenticated           5116*
+             Encryption
+--------   Telephony Routing over IP (TRIP) Attribute for          5115*
+             Resource Priority
+--------   The Presence-Specific Static Dictionary for             5112*
+             Signaling Compression (Sigcomp)
+--------   RTP Payload Format for Generic Forward Error            5109*
+             Correction
+--------   DHCP Server Identifier Override Suboption               5107*
+
+
+
+RFC Editor                   Informational                     [Page 11]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   ENUM Validation Token Format Definition                 5105*
+--------   Bidirectional Flow Export Using IP Flow Information     5103*
+             Export (IPFIX)
+--------   Information Model for IP Flow Information Export        5102*
+--------   Specification of the IP Flow Information Export         5101*
+             (IPFIX) Protocol for the Exchange of IP Traffic Flow
+             Information
+--------   MIB for the UDP-Lite protocol                           5097*
+--------   Mobile IPv6 Experimental Messages                       5096*
+--------   Deprecation of Type 0 Routing Headers in IPv6           5095*
+--------   Mobile IPv6 Vendor Specific Option                      5094*
+IMAP-URL   IMAP URL Scheme                                         5092*
+--------   RADIUS Extension for Digest Authentication              5090*
+--------   IS-IS Protocol Extensions for Path Computation          5089*
+             Element (PCE) Discovery
+--------   OSPF Protocol Extensions for Path Computation           5088*
+             Element (PCE) Discovery
+--------   Pseudowire Virtual Circuit Connectivity Verification    5085*
+             (VCCV): A Control Channel for Pseudowires
+--------   Using AES-CCM and AES-GCM Authenticated Encryption      5084*
+             in the Cryptographic Message Syntax (CMS)
+--------   Cryptographic Message Syntax (CMS)                      5083*
+             Authenticated-Enveloped-Data Content Type
+--------   The Generalized TTL Security Mechanism (GTSM)           5082*
+--------   Common Remote Authentication Dial In User Service       5080*
+             (RADIUS) Implementation Issues and Suggested Fixes
+--------   Rejecting Anonymous Requests in the Session             5079*
+             Initiation Protocol (SIP)
+--------   Transport Layer Security (TLS) Session Resumption       5077*
+             without Server-Side State
+--------   ENUM Validation Information Mapping for the             5076*
+             Extensible Provisioning Protocol
+--------   IPv6 Router Advertisement Flags Option                  5075*
+--------   IGP Routing Protocol Extensions for Discovery of        5073*
+             Traffic Engineering Node Capabilities
+--------   The Incident Object Description Exchange Format         5070*
+--------   Ethernet in the First Mile Copper (EFMCu) Interfaces    5066*
+             MIB
+--------   The Archived-At Message Header Field                    5064*
+--------   Extensions to GMPLS Resource Reservation Protocol       5063*
+             (RSVP) Graceful Restart
+--------   Stream Control Transmission Protocol (SCTP) Dynamic     5061*
+             Address Reconfiguration
+--------   Protocol Independent Multicast MIB                      5060*
+--------   Bootstrap Router (BSR) Mechanism for Protocol           5059*
+             Independent Multicast (PIM)
+--------   On the Use of Channel Bindings to Secure Channels       5056*
+--------   Server-Based Certificate Validation Protocol (SCVP)     5055*
+
+
+
+RFC Editor                   Informational                     [Page 12]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Raptor Forward Error Correction Scheme for Object       5053*
+             Delivery
+--------   Forward Error Correction (FEC) Building Block           5052*
+--------   i;unicode-casemap - Simple Unicode Collation            5051*
+             Algorithm
+--------   Applying Signaling Compression (SigComp) to the         5049*
+             Session Initiation Protocol (SIP)
+--------   Internet Small Computer System Interface (iSCSI)        5048*
+             Corrections and Clarifications
+--------   Internet Small Computer System Interface (iSCSI)        5046*
+             Extensions for Remote Direct Memory Access (RDMA)
+--------   Marker PDU Aligned Framing for TCP Specification        5044*
+--------   Stream Control Transmission Protocol (SCTP) Direct      5043*
+             Data Placement (DDP) Adaptation
+--------   Direct Data Placement Protocol (DDP) / Remote Direct    5042*
+             Memory Access Protocol (RDMAP) Security
+--------   Direct Data Placement over Reliable Transports          5041*
+--------   A Remote Direct Memory Access Protocol Specification    5040*
+--------   Enhanced Security Services (ESS) Update: Adding         5035*
+             CertID Algorithm Agility
+POP3-AUTH  The Post Office Protocol (POP3) Simple                  5034*
+             Authentication and Security Layer (SASL)
+             Authentication Mechanism
+--------   WITHIN Search Extension to the IMAP Protocol            5032*
+--------   A Uniform Resource Name (URN) for Emergency and         5031*
+             Other Well-Known Services
+--------   Definition of an IS-IS Link Attribute Sub-TLV           5029*
+--------   A Telephone Number Mapping (ENUM) Service               5028*
+             Registration for Instant Messaging (IM) Services
+--------   Security Preconditions for Session Description          5027*
+             Protocol (SDP) Media Streams
+--------   Mobile IPv6 Bootstrapping in Split Scenario             5026*
+--------   Presence Authorization Rules                            5025*
+--------   The Atom Publishing Protocol                            5023*
+--------   Extended Kerberos Version 5 Key Distribution Center     5021*
+             (KDC) Exchanges over TCP
+--------   The Lightweight Directory Access Protocol (LDAP)        5020*
+             entryDN Operational Attribute
+--------   The Lightweight Online Certificate Status Protocol      5019*
+             (OCSP) Profile for High-Volume Environments
+--------   Connection Establishment in the Binary Floor Control    5018*
+             Protocol (BFCP)
+--------   MIB Textual Conventions for Uniform Resource            5017*
+             Identifiers (URIs)
+--------   Bidirectional Protocol Independent Multicast            5015*
+             (BIDIR-PIM)
+--------   Automated Updates of DNS Security (DNSSEC) Trust        5011*
+             Anchors
+
+
+
+RFC Editor                   Informational                     [Page 13]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   The Dynamic Host Configuration Protocol Version 4       5010*
+             (DHCPv4) Relay Agent Flags Suboption
+--------   DHCPv6 Leasequery                                       5007*
+--------   Feed Paging and Archiving                               5005*
+--------   Avoid BGP Best Path Transitions from One External to    5004*
+             Another
+--------   Attachment Individual Identifier (AII) Types for        5003*
+             Aggregation
+--------   DNS Name Server Identifier (NSID) Option                5001*
+--------   Evidence Record Syntax (ERS)                            4998*
+--------   Formal Notation for RObust Header Compression           4997*
+             (ROHC-FN)
+--------   RObust Header Compression (ROHC): A Profile for         4996*
+             TCP/IP (ROHC-TCP)
+--------   The RObust Header Compression (ROHC) Framework          4995*
+--------   DHCPv6 Relay Agent Echo Request Option                  4994*
+--------   A Lightweight UDP Transfer Protocol for the Internet    4993*
+             Registry Information Service
+--------   XML Pipelining with Chunks for the Internet Registry    4992*
+             Information Service
+--------   A Common Schema for Internet Registry Information       4991*
+             Service Transfer Protocols
+--------   Internet X.509 Public Key Infrastructure Subject        4985*
+             Alternative Name for Expression of Service Name
+--------   Fibre Channel Registered State Change Notification      4983*
+             (RSCN) MIB
+--------   Support for Multiple Hash Algorithms in                 4982*
+             Cryptographically Generated Addresses (CGAs)
+--------   IANA Registration for Enumservice 'XMPP'                4979*
+--------   The IMAP COMPRESS Extension                             4978*
+--------   Relay Extensions for the Message Sessions Relay         4976*
+             Protocol (MSRP)
+--------   The Message Session Relay Protocol (MSRP)               4975*
+--------   Generalized MPLS (GMPLS) RSVP-TE Signaling              4974*
+             Extensions in Support of Calls
+--------   Routing Extensions for Discovery of Multiprotocol       4972*
+             (MPLS) Label Switch Router (LSR) Traffic Engineering
+             (TE) Mesh Membership
+--------   Intermediate System to Intermediate System (IS-IS)      4971*
+             Extensions for Advertising Router Information
+--------   Extensions to OSPF for Advertising Optional Router      4970*
+             Capabilities
+--------   IANA Registration for vCard Enumservice                 4969*
+--------   Dial String Parameter for the Session Initiation        4967*
+             Protocol Uniform Resource Identifier
+--------   Stream Control Transmission Protocol                    4960*
+--------   IMAP Extension for Simple Authentication and            4959*
+             Security Layer (SASL) Initial Client Response
+
+
+
+RFC Editor                   Informational                     [Page 14]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   DNS Security (DNSSEC) Experiments                       4955*
+--------   SMTP Service Extension for Authentication               4954*
+--------   Fail Over Extensions for Layer 2 Tunneling Protocol     4951*
+             (L2TP) "failover"
+--------   ICMP Extensions for Multiprotocol Label Switching       4950*
+--------   The Internet IP Security PKI Profile of                 4945*
+             IKEv1/ISAKMP, IKEv2, and PKIX
+--------   Transmission of IPv6 Packets over IEEE 802.15.4         4944*
+             Networks
+--------   Definitions of Managed Objects for iSNS (Internet       4939*
+             Storage Name Service)
+--------   Fibre Channel Zone Server MIB                           4936*
+--------   Fibre Channel Fabric Configuration Server MIB           4935*
+--------   Crankback Signaling Extensions for MPLS and GMPLS       4920*
+             RSVP-TE
+WEBDAV     HTTP Extensions for Web Distributed Authoring and       4918*
+             Versioning (WebDAV)
+--------   Mobile IPv4 Message String Extension                    4917*
+--------   Connected Identity in the Session Initiation            4916*
+             Protocol (SIP)
+--------   Multi-Topology (MT) Routing in OSPF                     4915*
+--------   Representing Trunk Groups in tel/sip Uniform            4904*
+             Resource Identifiers (URIs)
+--------   Protocol Extensions for Header Compression over MPLS    4901*
+--------   TCP Extended Statistics MIB                             4898*
+--------   Signaling Compression (SigComp) Corrections and         4896*
+             Clarifications
+--------   Authenticated Chunks for the Stream Control             4895*
+             Transmission Protocol (SCTP)
+--------   BGP Support for Four-octet AS Number Space              4893*
+--------   Extended ICMP to Support Multi-Part Messages            4884*
+--------   OpenPGP Message Format                                  4880*
+--------   Definitions and Managed Objects for Operations,         4878*
+             Administration, and Maintenance (OAM) Functions on
+             Ethernet-Like Interfaces
+--------   Mobile IPv6 Operation with IKEv2 and the Revised        4877*
+             IPsec Architecture
+--------   Extensions to Resource Reservation Protocol -           4875*
+             Traffic Engineering (RSVP-TE) for
+             Point-to-Multipoint TE Label Switched Paths (LSPs)
+--------   Exclude Routes - Extension to Resource ReserVation      4874*
+             Protocol-Traffic Engineering (RSVP-TE)
+--------   GMPLS Segment Recovery                                  4873*
+--------   RSVP-TE Extensions in Support of End-to-End             4872*
+             Generalized Multi-Protocol Label Switching (GMPLS)
+             Recovery
+--------   DomainKeys Identified Mail (DKIM) Signatures            4871*
+
+
+
+
+RFC Editor                   Informational                     [Page 15]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Using HMAC-SHA-256, HMAC-SHA-384, and HMAC-SHA-512      4868*
+             with IPsec
+--------   RTP Payload Format and File Storage Format for the      4867*
+             Adaptive Multi-Rate (AMR) and Adaptive Multi-Rate
+             Wideband (AMR-WB) Audio Codecs
+--------   Enhanced Route Optimization for Mobile IPv6             4866*
+--------   SMTP Submission Service Extension for Future Message    4865*
+             Release
+--------   Wildcard Pseudowire Type                                4863*
+--------   Generic Aggregate Resource ReSerVation Protocol         4860*
+             (RSVP) Reservations
+--------   Media Type Registration of Payload Formats in the       4856*
+             RTP Profile for Audio and Video Conferences
+--------   Media Type Registration of RTP Payload Formats          4855*
+--------   Cryptographic Message Syntax (CMS) Multiple Signer      4853*
+             Clarification
+--------   Declarative Public Extension Key for Internet Small     4850*
+             Computer Systems Interface (iSCSI) Node Architecture
+--------   RADIUS Filter Rule Attribute                            4849*
+--------   Domain-Based Application Service Location Using URIs    4848*
+             and the Dynamic Delegation Discovery Service (DDDS)
+--------   Synchronous Optical Network/Synchronous Digital         4842*
+             Hierarchy (SONET/SDH) Circuit Emulation over Packet
+             (CEP)
+--------   Managed Objects of Ethernet Passive Optical Networks    4837*
+             (EPON)
+MAU-MIB    Definitions of Managed Objects for IEEE 802.3 Medium    4836*
+             Attachment Units (MAUs)
+ESP        Cryptographic Algorithm Implementation Requirements     4835*
+             for Encapsulating Security Payload (ESP) and
+             Authentication Header (AH)
+--------   Timezone Options for DHCP                               4833*
+--------   An Extensible Markup Language (XML) Configuration       4827*
+             Access Protocol (XCAP) Usage for Manipulating
+             Presence Document Contents
+--------   Extensible Markup Language (XML) Formats for            4826*
+             Representing Resource Lists
+--------   The Extensible Markup Language (XML) Configuration      4825*
+             Access Protocol (XCAP)
+RIP2-MD5   RIPv2 Cryptographic Authentication                      4822*
+--------   Packetization Layer Path MTU Discovery                  4821*
+--------   Padding Chunk and Parameter for the Stream Control      4820*
+             Transmission Protocol (SCTP)
+--------   Secure Shell Public Key Subsystem                       4819*
+--------   RADIUS Delegated-IPv6-Prefix Attribute                  4818*
+--------   Encapsulation of MPLS over Layer 2 Tunneling            4817*
+             Protocol Version 3
+
+
+
+
+RFC Editor                   Informational                     [Page 16]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Pseudowire Emulation Edge-to-Edge (PWE3)                4816*
+             Asynchronous Transfer Mode (ATM) Transparent Cell
+             Transport Service
+--------   RObust Header Compression (ROHC): Corrections and       4815*
+             Clarifications to RFC 3095
+--------   IPsec Security Policy Database Configuration MIB        4807*
+--------   Online Certificate Status Protocol (OCSP) Extensions    4806*
+             to IKEv2
+--------   Definitions of Managed Objects for the DS1, J1, E1,     4805*
+             DS2, and E2 Interface Types
+--------   Aggregation of Resource ReSerVation Protocol (RSVP)     4804*
+             Reservations over MPLS TE/DS-TE Tunnels
+--------   Generalized Multiprotocol Label Switching (GMPLS)       4803*
+             Label Switching Router (LSR) Management Information
+             Base
+--------   Generalized Multiprotocol Label Switching (GMPLS)       4802*
+             Traffic Engineering Management Information Base
+--------   Definitions of Textual Conventions for Generalized      4801*
+             Multiprotocol Label Switching (GMPLS) Management
+--------   Connecting IPv6 Islands over IPv4 MPLS Using IPv6       4798*
+             Provider Edge Routers (6PE)
+--------   The Session Description Protocol (SDP) Content          4796*
+             Attribute
+--------   Encoding Instructions for the Generic String            4792*
+             Encoding Rules (GSER)
+--------   Calendaring Extensions to WebDAV (CalDAV)               4791*
+--------   Internet Application Protocol Collation Registry        4790*
+--------   Simple Network Management Protocol (SNMP) over IEEE     4789*
+             802 Networks
+--------   Enhancements to RTP Payload Formats for EVRC Family     4788*
+             Codecs
+--------   Pre-Shared Key (PSK) Ciphersuites with NULL             4785*
+             Encryption for Transport Layer Security (TLS)
+--------   GMPLS - Communication of Alarm Information              4783*
+--------   Graceful Restart Mechanism for BGP with MPLS            4781*
+--------   Management Information Base for the Session             4780*
+             Initiation Protocol (SIP)
+--------   Dynamic Host Configuration Protocol (DHCPv4 and         4776*
+             DHCPv6) Option for Civic Addresses Configuration
+             Information
+--------   Integrity Transform Carrying Roll-Over Counter for      4771*
+             the Secure Real-time Transport Protocol (SRTP)
+--------   vCard Extensions for Instant Messaging (IM)             4770*
+--------   IANA Registration for an Enumservice Containing         4769*
+             Public Switched Telephone Network (PSTN) Signaling
+             Information
+--------   Virtual Private LAN Service (VPLS) Using Label          4762*
+             Distribution Protocol (LDP) Signaling
+
+
+
+RFC Editor                   Informational                     [Page 17]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Virtual Private LAN Service (VPLS) Using BGP for        4761*
+             Auto-Discovery and Signaling
+--------   The ENUM Dip Indicator Parameter for the "tel" URI      4759*
+--------   Forward Error Correction Grouping Semantics in          4756*
+             Session Description Protocol
+--------   IP over InfiniBand: Connected Mode                      4755*
+--------   IKE and IKEv2 Authentication Using the Elliptic         4754*
+             Curve Digital Signature Algorithm (ECDSA)
+SASL       The Kerberos V5 ("GSSAPI") Simple Authentication and    4752*
+             Security Layer (SASL) Mechanism
+OSPF-MIB   OSPF Version 2 Management Information Base              4750*
+--------   RTP Payload Format for the G.729.1 Audio Codec          4749*
+--------   The Virtual Fabrics MIB                                 4747*
+--------   Common Policy: A Document Format for Expressing         4745*
+             Privacy Preferences
+--------   Using the NETCONF Protocol over the Blocks              4744*
+             Extensible Exchange Protocol (BEEP)
+--------   Using NETCONF over the Simple Object Access Protocol    4743*
+             (SOAP)
+--------   Using the NETCONF Configuration Protocol over Secure    4742*
+             SHell (SSH)
+--------   NETCONF Configuration Protocol                          4741*
+--------   Diameter Session Initiation Protocol (SIP)              4740*
+             Application
+--------   MIKEY-RSA-R: An Additional Mode of Key Distribution     4738*
+             in Multimedia Internet KEYing (MIKEY)
+--------   Packet Reordering Metrics                               4737*
+--------   Example Media Types for Use in Documentation            4735*
+--------   Definition of Events for Modem, Fax, and Text           4734*
+             Telephony Signals
+--------   RTP Payload for DTMF Digits, Telephony Tones, and       4733*
+             Telephony Signals
+--------   IMAP4 Extension to SEARCH Command for Controlling       4731*
+             What Kind of Information Is Returned
+--------   A Session Initiation Protocol (SIP) Event Package       4730*
+             for Key Press Stimulus (KPML)
+--------   Experimental Values In IPv4, IPv6, ICMPv4, ICMPv6,      4727*
+             UDP, and TCP Headers
+--------   Graceful Restart Mechanism for BGP                      4724*
+--------   Mobile IPv4 Challenge/Response Extensions (Revised)     4721*
+--------   Pseudowire Emulation Edge-to-Edge (PWE3) Frame Check    4720*
+             Sequence Retention
+--------   Transport of Ethernet Frames over Layer 2 Tunneling     4719*
+             Protocol Version 3 (L2TPv3)
+--------   Encapsulation Methods for Transport of Asynchronous     4717*
+             Transfer Mode (ATM) over MPLS Networks
+
+
+
+
+
+RFC Editor                   Informational                     [Page 18]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Transport Mappings for Real-time Application            4712*
+             Quality-of-Service Monitoring (RAQMON) Protocol Data
+             Unit (PDU)
+--------   Real-time Application Quality-of-Service Monitoring     4711*
+             (RAQMON) MIB
+--------   Real-time Application Quality-of-Service Monitoring     4710*
+             (RAQMON) Framework
+--------   Definitions of Managed Objects for Asymmetric           4706*
+             Digital Subscriber Line 2 (ADSL2)
+--------   The Dynamic Host Configuration Protocol for IPv6        4704*
+             (DHCPv6) Client Fully Qualified Domain Name (FQDN)
+             Option
+--------   Resolution of Fully Qualified Domain Name (FQDN)        4703*
+             Conflicts among Dynamic Host Configuration Protocol
+             (DHCP) Clients
+--------   The Dynamic Host Configuration Protocol (DHCP)          4702*
+             Client Fully Qualified Domain Name (FQDN) Option
+--------   A DNS Resource Record (RR) for Encoding Dynamic Host    4701*
+             Configuration Protocol (DHCP) Information (DHCID RR)
+--------   IRIS: An Address Registry (areg) Type for the           4698*
+             Internet Registry Information Service
+--------   RTP Payload Format for MIDI                             4695*
+--------   Number Portability Parameters for the "tel" URI         4694*
+--------   Atom Threading Extensions                               4685*
+--------   Constrained Route Distribution for Border Gateway       4684*
+             Protocol/MultiProtocol Label Switching (BGP/MPLS)
+             Internet Protocol (IP) Virtual Private Networks
+             (VPNs)
+--------   Internet X.509 Public Key Infrastructure Subject        4683*
+             Identification Method (SIM)
+--------   Multimedia Terminal Adapter (MTA) Management            4682*
+             Information Base for PacketCable- and
+             IPCablecom-Compliant Devices
+--------   TLS User Mapping Extension                              4681*
+--------   TLS Handshake Message for Supplemental Data             4680*
+--------   RADIUS Attributes for Virtual LAN and Priority          4675*
+             Support
+--------   RADIUS Authentication Server MIB for IPv6               4669*
+--------   RADIUS Authentication Client MIB for IPv6               4668*
+--------   Layer 2 Virtual Private Network (L2VPN) Extensions      4667*
+             for Layer 2 Tunneling Protocol (L2TP)
+--------   Signaling System 7 (SS7) Message Transfer Part 3        4666*
+             (MTP3) - User Adaptation Layer (M3UA)
+--------   A Session Initiation Protocol (SIP) Event               4662*
+             Notification Extension for Resource Lists
+--------   An Extensible Markup Language (XML)-Based Format for    4661*
+             Event Notification Filtering
+
+
+
+
+RFC Editor                   Informational                     [Page 19]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Functional Description of Event Notification            4660*
+             Filtering
+--------   BGP-MPLS IP Virtual Private Network (VPN) Extension     4659*
+             for IPv6 VPN
+--------   A One-way Active Measurement Protocol (OWAMP)           4656*
+--------   HMAC-Authenticated Diffie-Hellman for Multimedia        4650*
+             Internet KEYing (MIKEY)
+--------   Dynamic Host Configuration Protocol for IPv6            4649*
+             (DHCPv6) Relay Agent Remote-ID Option
+--------   The Base16, Base32, and Base64 Data Encodings           4648*
+--------   Network News Transfer Protocol (NNTP) Extension for     4644*
+             Streaming Feeds
+--------   Network News Transfer Protocol (NNTP) Extension for     4643*
+             Authentication
+--------   Using Transport Layer Security (TLS) with Network       4642*
+             News Transfer Protocol (NNTP)
+--------   Cable Device Management Information Base for            4639*
+             Data-Over-Cable Service Interface Specification
+             (DOCSIS) Compliant Cable Modems and Cable Modem
+             Termination Systems
+--------   Foreign Agent Error Extension for Mobile IPv4           4636*
+--------   HMAC SHA (Hashed Message Authentication Code, Secure    4635*
+             Hash Algorithm) TSIG Algorithm Identifiers
+--------   Link Management Protocol (LMP) Management               4631*
+             Information Base (MIB)
+--------   Update to DirectoryString Processing in the Internet    4630*
+             X.509 Public Key Infrastructure Certificate and
+             Certificate Revocation List (CRL) Profile
+--------   RTP Payload Format for ITU-T Rec. H.263 Video           4629*
+--------   MIB for Fibre Channel's Fabric Shortest Path First      4626*
+             (FSPF) Protocol
+--------   Fibre Channel Routing Information MIB                   4625*
+--------   Pseudowire Emulation Edge-to-Edge (PWE3)                4623*
+             Fragmentation and Reassembly
+--------   Internationalized Resource Identifiers (IRIs) and       4622*
+             Uniform Resource Identifiers (URIs) for the
+             Extensible Messaging and Presence Protocol (XMPP)
+--------   Encapsulation Methods for Transport of Frame Relay      4619*
+             over Multiprotocol Label Switching (MPLS) Networks
+--------   Encapsulation Methods for Transport of                  4618*
+             PPP/High-Level Data Link Control (HDLC) over MPLS
+             Networks
+--------   The PLAIN Simple Authentication and Security Layer      4616*
+             (SASL) Mechanism
+--------   The Advanced Encryption Standard-Cipher-based           4615*
+             Message Authentication Code-Pseudo-Random
+             Function-128 (AES-CMAC-PRF-128) Algorithm for the
+             Internet Key Exchange Protocol (IKE)
+
+
+
+RFC Editor                   Informational                     [Page 20]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Anycast-RP Using Protocol Independent Multicast (PIM)   4610*
+--------   Source-Specific Multicast for IP                        4607*
+--------   Generalized Multi-Protocol Label Switching (GMPLS)      4606*
+             Extensions for Synchronous Optical Network (SONET)
+             and Synchronous Digital Hierarchy (SDH) Control
+--------   Internet Group Management Protocol (IGMP) /             4605*
+             Multicast Listener Discovery (MLD)-Based Multicast
+             Forwarding ("IGMP/MLD Proxying")
+--------   Using Internet Group Management Protocol Version 3      4604*
+             (IGMPv3) and Multicast Listener Discovery Protocol
+             Version 2 (MLDv2) for Source-Specific Multicast
+PIM-SM     Protocol Independent Multicast - Sparse Mode            4601*
+             (PIM-SM): Protocol Specification (Revised)
+--------   Real-time Transport Protocol (RTP) Payload Format       4598*
+             for Enhanced AC-3 (E-AC-3) Audio
+--------   The Role of Wildcards in the Domain Name System         4592*
+--------   Frame Relay over Layer 2 Tunneling Protocol Version     4591*
+             3 (L2TPv3)
+--------   Location Types Registry                                 4589*
+--------   RTP Retransmission Payload Format                       4588*
+RTP-H.261  RTP Payload Format for H.261 Video Streams              4587*
+--------   Extended RTP Profile for Real-time Transport Control    4585*
+             Protocol (RTCP)-Based Feedback (RTP/AVPF)
+--------   Session Description Protocol (SDP) Format for Binary    4583*
+             Floor Control Protocol (BFCP) Streams
+--------   The Binary Floor Control Protocol (BFCP)                4582*
+--------   Cryptographically Generated Addresses (CGA)             4581*
+             Extension Field Format
+--------   Dynamic Host Configuration Protocol for IPv6            4580*
+             (DHCPv6) Relay Agent Subscriber-ID Option
+--------   OSPF as the Provider/Customer Edge Protocol for         4577*
+             BGP/MPLS IP Virtual Private Networks (VPNs)
+--------   Using a Link State Advertisement (LSA) Options Bit      4576*
+             to Prevent Looping in BGP/MPLS IP Virtual Private
+             Networks (VPNs)
+--------   A Session Initiation Protocol (SIP) Event Package       4575*
+             for Conference State
+--------   The Session Description Protocol (SDP) Label            4574*
+             Attribute
+--------   MIME Type Registration for RTP Payload Format for       4573*
+             H.224
+--------   Connection-Oriented Media Transport over the            4572*
+             Transport Layer Security (TLS) Protocol in the
+             Session Description Protocol (SDP)
+--------   Framing Real-time Transport Protocol (RTP) and RTP      4571*
+             Control Protocol (RTCP) Packets over
+             Connection-Oriented Transport
+--------   Session Description Protocol (SDP) Source Filters       4570*
+
+
+
+RFC Editor                   Informational                     [Page 21]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Session Description Protocol (SDP) Security             4568*
+             Descriptions for Media Streams
+--------   Key Management Extensions for Session Description       4567*
+             Protocol (SDP) and Real Time Streaming Protocol
+             (RTSP)
+SDP        SDP: Session Description Protocol                       4566*
+--------   The Key ID Information Type for the General             4563*
+             Extension Payload in Multimedia Internet KEYing
+             (MIKEY)
+--------   Definition of a Record Route Object (RRO) Node-Id       4561*
+             Sub-Object
+--------   Definitions of Managed Objects for Remote Ping,         4560*
+             Traceroute, and Lookup Operations
+--------   Node-ID Based Resource Reservation Protocol (RSVP)      4558*
+             Hello: A Clarification Statement
+--------   Online Certificate Status Protocol (OCSP) Support       4557*
+             for Public Key Cryptography for Initial
+             Authentication in Kerberos (PKINIT)
+--------   Public Key Cryptography for Initial Authentication      4556*
+             in Kerberos (PKINIT)
+--------   IKEv2 Mobility and Multihoming Protocol (MOBIKE)        4555*
+SAToP      Structure-Agnostic Time Division Multiplexing (TDM)     4553*
+             over Packet (SAToP)
+--------   Authentication/Confidentiality for OSPFv3               4552*
+--------   IMAP Extension for Conditional STORE Operation or       4551*
+             Quick Flag Changes Resynchronization
+--------   Internet Email to Support Diverse Service               4550*
+             Environments (Lemonade) Profile
+--------   Internet Code Point (ICP) Assignments for NSAP          4548*
+             Addresses
+--------   Event Notification Management Information Base for      4547*
+             Data over Cable Service Interface Specifications
+             (DOCSIS)-Compliant Cable Modems and Cable Modem
+             Termination Systems
+--------   Radio Frequency (RF) Interface Management               4546*
+             Information Base for Data over Cable Service
+             Interface Specifications (DOCSIS) 2.0 Compliant RF
+             Interfaces
+--------   Definitions of Managed Objects for IP Storage User      4545*
+             Identity Authorization
+--------   Definitions of Managed Objects for Internet Small       4544*
+             Computer System Interface (iSCSI)
+--------   The Use of Galois Message Authentication Code (GMAC)    4543*
+             in IPsec ESP and AH
+--------   Request Authorization through Dialog Identification     4538*
+             in the Session Initiation Protocol (SIP)
+--------   Kerberos Cryptosystem Negotiation Extension             4537*
+
+
+
+
+RFC Editor                   Informational                     [Page 22]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   GSAKMP: Group Secure Association Key Management         4535*
+             Protocol
+--------   Group Security Policy Token v1                          4534*
+--------   Lightweight Directory Access Protocol (LDAP) "Who am    4532*
+             I?" Operation
+--------   Lightweight Directory Access Protocol (LDAP)            4530*
+             entryUUID Operational Attribute
+--------   Lightweight Directory Access Protocol (LDAP)            4528*
+             Assertion Control
+--------   Lightweight Directory Access Protocol (LDAP) Read       4527*
+             Entry Controls
+--------   Lightweight Directory Access Protocol (LDAP)            4526*
+             Absolute True and False Filters
+--------   COSINE LDAP/X.500 Schema                                4524*
+--------   Lightweight Directory Access Protocol (LDAP) Schema     4523*
+             Definitions for X.509 Certificates
+--------   Lightweight Directory Access Protocol (LDAP): The       4522*
+             Binary Encoding Option
+--------   Lightweight Directory Access Protocol (LDAP): Schema    4519*
+             for User Applications
+--------   Lightweight Directory Access Protocol (LDAP):           4518*
+             Internationalized String Preparation
+LDAP3-ATD  Lightweight Directory Access Protocol (LDAP):           4517*
+             Syntaxes and Matching Rules
+LDAP-URL   Lightweight Directory Access Protocol (LDAP):           4516*
+             Uniform Resource Locator
+STR-LDAP   Lightweight Directory Access Protocol (LDAP): String    4515*
+             Representation of Search Filters
+LDAP3-UTF8 Lightweight Directory Access Protocol (LDAP): String    4514*
+             Representation of Distinguished Names
+LDAP       Lightweight Directory Access Protocol (LDAP):           4513*
+             Authentication Methods and Security Mechanisms
+--------   Lightweight Directory Access Protocol (LDAP):           4512*
+             Directory Information Models
+LDAP       Lightweight Directory Access Protocol (LDAP): The       4511*
+             Protocol
+LDAPV3     Lightweight Directory Access Protocol (LDAP):           4510*
+             Technical Specification Road Map
+--------   Use of SHA-256 in DNSSEC Delegation Signer (DS)         4509*
+             Resource Records (RRs)
+--------   Conveying Feature Tags with the Session Initiation      4508*
+             Protocol (SIP) REFER Method
+SASL-ANON  Anonymous Simple Authentication and Security Layer      4505*
+             (SASL) Mechanism
+--------   Domain Name System Uniform Resource Identifiers         4501*
+--------   A Resource Reservation Protocol (RSVP) Extension for    4495*
+             the Reduction of Bandwidth of a Reservation Flow
+--------   The AES-CMAC-96 Algorithm and Its Use with IPsec        4494*
+
+
+
+RFC Editor                   Informational                     [Page 23]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Using the GOST R 34.10-94, GOST R 34.10-2001, and       4491*
+             GOST R 34.11-94 Algorithms with the Internet X.509
+             Public Key Infrastructure Certificate and CRL Profile
+--------   Using the GOST 28147-89, GOST R 34.11-94, GOST R        4490*
+             34.10-94, and GOST R 34.10-2001 Algorithms with
+             Cryptographic Message Syntax (CMS)
+--------   A Method for Generating Link-Scoped IPv6 Multicast      4489*
+             Addresses
+--------   Suppression of Session Initiation Protocol (SIP)        4488*
+             REFER Method Implicit Subscription
+--------   Subcodes for BGP Cease Notification Message             4486*
+--------   A Mechanism for Content Indirection in Session          4483*
+             Initiation Protocol (SIP) Messages
+--------   CIPID: Contact Information for the Presence             4482*
+             Information Data Format
+--------   Timed Presence Extensions to the Presence               4481*
+             Information Data Format (PIDF) to Indicate Status
+             Information for Past and Future Time Intervals
+--------   RPID: Rich Presence Extensions to the Presence          4480*
+             Information Data Format (PIDF)
+--------   A Data Model for Presence                               4479*
+--------   Attribute Certificate (AC) Policies Extension           4476*
+--------   Enhancements for Authenticated Identity Management      4474*
+             in the Session Initiation Protocol (SIP)
+--------   Minimally Covering NSEC Records and DNSSEC On-line      4470*
+             Signing
+--------   Internet Message Access Protocol (IMAP) CATENATE        4469*
+             Extension
+URLAUTH    Message Submission BURL Extension                       4468*
+--------   Internet Message Access Protocol (IMAP) - URLAUTH       4467*
+             Extension
+--------   Collected Extensions to IMAP4 ABNF                      4466*
+--------   Generic Security Service Application Program            4462*
+             Interface (GSS-API) Authentication and Key Exchange
+             for the Secure Shell (SSH) Protocol
+--------   Definition of Managed Objects for Small Computer        4455*
+             System Interface (SCSI) Entities
+--------   Asynchronous Transfer Mode (ATM) over Layer 2           4454*
+             Tunneling Protocol Version 3 (L2TPv3)
+--------   Securing Mobile IPv6 Route Optimization Using a         4449*
+             Static Shared Key
+--------   Encapsulation Methods for Transport of Ethernet over    4448*
+             MPLS Networks
+--------   Pseudowire Setup and Maintenance Using the Label        4447*
+             Distribution Protocol (LDP)
+--------   Management Information Base for Intermediate System     4444*
+             to Intermediate System (IS-IS)
+
+
+
+
+RFC Editor                   Informational                     [Page 24]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Bootstrapping Timed Efficient Stream Loss-Tolerant      4442*
+             Authentication (TESLA)
+--------   Fibre Channel Fabric Address Manager MIB                4439*
+--------   Fibre-Channel Name Server MIB                           4438*
+--------   Detecting Network Attachment in IPv4 (DNAv4)            4436*
+--------   The AES-XCBC-PRF-128 Algorithm for the Internet Key     4434*
+             Exchange Protocol (IKE)
+--------   Mobile IPv4 Dynamic Home Agent (HA) Assignment          4433*
+--------   RSA Key Exchange for the Secure Shell (SSH)             4432*
+             Transport Layer Protocol
+--------   Kerberized Internet Negotiation of Keys (KINK)          4430*
+--------   Optimistic Duplicate Address Detection (DAD) for IPv6   4429*
+--------   Generalized Multi-Protocol Label Switching (GMPLS)      4426*
+             Recovery Functional Specification
+--------   RTP Payload Format for Video Codec 1 (VC-1)             4425*
+--------   Real-Time Transport Protocol (RTP) Payload Format       4424*
+             for the Variable-Rate Multimode Wideband (VMR-WB)
+             Extension Audio Codec
+SASL       Simple Authentication and Security Layer (SASL)         4422*
+--------   RTP Payload Format for Uncompressed Video:              4421*
+             Additional Colour Sampling Modes
+--------   Encoding of Attributes for Multiprotocol Label          4420*
+             Switching (MPLS) Label Switched Path (LSP)
+             Establishment Using Resource ReserVation
+             Protocol-Traffic Engineering (RSVP-TE)
+--------   Diffie-Hellman Group Exchange for the Secure Shell      4419*
+             (SSH) Transport Layer Protocol
+--------   IANA Registration for Enumservice Voice                 4415*
+--------   An ENUM Registry Type for the Internet Registry         4414*
+             Information Service (IRIS)
+--------   Communications Resource Priority for the Session        4412*
+             Initiation Protocol (SIP)
+--------   Extending the Session Initiation Protocol (SIP)         4411*
+             Reason Header for Preemption Events
+--------   Definitions of Managed Objects for Fibre Channel        4404*
+             Over TCP/IP (FCIP)
+--------   A Pseudo-Random Function (PRF) for the Kerberos V       4402*
+             Generic Security Service Application Program
+             Interface (GSS-API) Mechanism
+--------   A Pseudo-Random Function (PRF) API Extension for the    4401*
+             Generic Security Service Application Program
+             Interface (GSS-API)
+SC-DNS     Storing Certificates in the Domain Name System (DNS)    4398*
+--------   RTP Payload Format for 3rd Generation Partnership       4396*
+             Project (3GPP) Timed Text
+--------   MIME Type Registrations for 3GPP2 Multimedia Files      4393*
+--------   Transmission of IP over InfiniBand (IPoIB)              4391*
+
+
+
+
+RFC Editor                   Informational                     [Page 25]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Dynamic Host Configuration Protocol (DHCP) over         4390*
+             InfiniBand
+--------   Dynamic Host Configuration Protocol (DHCP) Leasequery   4388*
+--------   Internet X.509 Public Key Infrastructure Operational    4387*
+             Protocols: Certificate Store Access via HTTP
+--------   Pseudowire Emulation Edge-to-Edge (PWE3) Control        4385*
+             Word for Use over an MPLS PSN
+--------   The Use of Timed Efficient Stream Loss-Tolerant         4383*
+             Authentication (TESLA) in the Secure Real-time
+             Transport Protocol (SRTP)
+--------   MPLS/BGP Layer 3 Virtual Private Network (VPN)          4382*
+             Management Information Base
+--------   Teredo: Tunneling IPv6 over UDP through Network         4380*
+             Address Translations (NATs)
+--------   Detecting Multi-Protocol Label Switched (MPLS) Data     4379*
+             Plane Failures
+--------   Chargeable User Identity                                4372*
+--------   Lightweight Directory Access Protocol (LDAP) Proxied    4370*
+             Authorization Control
+--------   Definitions of Managed Objects for Internet Fibre       4369*
+             Channel Protocol (iFCP)
+--------   Multiprotocol Label Switching (MPLS)                    4368*
+             Label-Controlled Asynchronous Transfer Mode (ATM)
+             and Frame-Relay Management Interface Definition
+--------   Transport Layer Security (TLS) Extensions               4366*
+--------   BGP/MPLS IP Virtual Private Networks (VPNs)             4364*
+--------   Definitions of Managed Objects for Bridges with         4363*
+             Traffic Classes, Multicast Filtering, and Virtual
+             LAN Extensions
+--------   RObust Header Compression (ROHC): A Link-Layer          4362*
+             Assisted Profile for IP/UDP/RTP
+--------   Node-specific Client Identifiers for Dynamic Host       4361*
+             Configuration Protocol Version Four (DHCPv4)
+--------   BGP Extended Communities Attribute                      4360*
+--------   The Use of RSA/SHA-1 Signatures within Encapsulating    4359*
+             Security Payload (ESP) and Authentication Header (AH)
+--------   Mapping Between the Multimedia Messaging Service        4356*
+             (MMS) and Internet Mail
+--------   IANA Registration for Enumservices email, fax, mms,     4355*
+             ems, and sms
+--------   RTP Payload Format for the Extended Adaptive            4352*
+             Multi-Rate Wideband (AMR-WB+) Audio Codec
+--------   High-Level Data Link Control (HDLC) Frames over         4349*
+             Layer 2 Tunneling Protocol, Version 3 (L2TPv3)
+--------   Real-Time Transport Protocol (RTP) Payload Format       4348*
+             for the Variable-Rate Multimode Wideband (VMR-WB)
+             Audio Codec
+--------   Datagram Transport Layer Security                       4347*
+
+
+
+RFC Editor                   Informational                     [Page 26]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   The Transport Layer Security (TLS) Protocol Version     4346*
+             1.1
+--------   Improved Arcfour Modes for the Secure Shell (SSH)       4345*
+             Transport Layer Protocol
+--------   The Secure Shell (SSH) Transport Layer Encryption       4344*
+             Modes
+--------   Domain Name System (DNS) Case Insensitivity             4343*
+             Clarification
+--------   Profile for Datagram Congestion Control Protocol        4342*
+             (DCCP) Congestion Control ID 3: TCP-Friendly Rate
+             Control (TFRC)
+--------   Profile for Datagram Congestion Control Protocol        4341*
+             (DCCP) Congestion Control ID 2: TCP-like Congestion
+             Control
+--------   Datagram Congestion Control Protocol (DCCP)             4340*
+--------   Transmission of IPv6, IPv4, and Address Resolution      4338*
+             Protocol (ARP) Packets over Fibre Channel
+--------   MIME Type Registration for MPEG-4                       4337*
+--------   The Secure Shell (SSH) Session Channel Break            4335*
+             Extension
+--------   Certificate Extensions and Attributes Supporting        4334*
+             Authentication in Point-to-Point Protocol (PPP) and
+             Wireless Local Area Networks (WLAN)
+--------   Quota and Size Properties for Distributed Authoring     4331*
+             and Versioning (DAV) Collections
+--------   Generalized Multi-Protocol Label Switching (GMPLS)      4328*
+             Signaling Extensions for G.709 Optical Transport
+             Networks Control
+--------   Unidirectional Lightweight Encapsulation (ULE) for      4326*
+             Transmission of IP Datagrams over an MPEG-2
+             Transport Stream (TS)
+--------   Internet X.509 Public Key Infrastructure Authority      4325*
+             Information Access Certificate Revocation List (CRL)
+             Extension
+--------   Data Over Cable System Interface Specification          4323*
+             Quality of Service Management Information Base
+             (DOCSIS-QoS MIB)
+--------   Actions Addressing Identified Issues with the           4320*
+             Session Initiation Protocol's (SIP) Non-INVITE
+             Transaction
+--------   Definitions of Managed Objects for High Bit-Rate DSL    4319*
+             - 2nd generation (HDSL2) and Single-Pair High-Speed
+             Digital Subscriber Line (SHDSL) Lines
+--------   Definitions of Managed Objects for Bridges with         4318*
+             Rapid Spanning Tree Protocol
+IMAP4UIDPL Internet Message Access Protocol (IMAP) - UIDPLUS       4315*
+             extension
+IMAP4-ACL  IMAP4 Access Control List (ACL) Extension               4314*
+
+
+
+RFC Editor                   Informational                     [Page 27]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   The Camellia Cipher Algorithm and Its Use With IPsec    4312*
+--------   IPv6 Host-to-Router Load Sharing                        4311*
+--------   Domain Name System (DNS) Security Extensions Mapping    4310*
+             for the Extensible Provisioning Protocol (EPP)
+--------   Using Advanced Encryption Standard (AES) CCM Mode       4309*
+             with IPsec Encapsulating Security Payload (ESP)
+--------   Cryptographic Suites for IPsec                          4308*
+--------   Cryptographic Algorithms for Use in the Internet Key    4307*
+             Exchange Version 2 (IKEv2)
+ISAKMPSEC  Internet Key Exchange (IKEv2) Protocol                  4306*
+--------   Extended Sequence Number (ESN) Addendum to IPsec        4304*
+             Domain of Interpretation (DOI) for Internet Security
+             Association and Key Management Protocol (ISAKMP)
+ESP        IP Encapsulating Security Payload (ESP)                 4303*
+IP-AUTH    IP Authentication Header                                4302*
+IPSEC      Security Architecture for the Internet Protocol         4301*
+--------   RTP Payload Format for BroadVoice Speech Codecs         4298*
+--------   Mobile IPv6 Management Information Base                 4295*
+--------   Management Information Base for the Internet            4293*
+             Protocol (IP)
+TABLE-MIB  IP Forwarding Table MIB                                 4292*
+--------   The Atom Syndication Format                             4287*
+--------   Multicast Router Discovery                              4286*
+--------   Mobile Node Identifier Option for Mobile IPv6 (MIPv6)   4283*
+NAI        The Network Access Identifier                           4282*
+--------   The Codecs Parameter for "Bucket" Media Types           4281*
+--------   Dynamic Host Configuration Protocol (DHCP) Options      4280*
+             for Broadcast and Multicast Control Servers
+--------   Pre-Shared Key Ciphersuites for Transport Layer         4279*
+             Security (TLS)
+BGP-4-MIB  Definitions of Managed Objects for BGP-4                4273*
+--------   Entity State MIB                                        4268*
+--------   The gopher URI Scheme                                   4266*
+--------   Definition of Textual Conventions for Virtual           4265*
+             Private Network (VPN) Management
+--------   X.509 Certificate Extension for Secure/Multipurpose     4262*
+             Internet Mail Extensions (S/MIME) Capabilities
+--------   Common Open Policy Service (COPS) Over Transport        4261*
+             Layer Security (TLS)
+--------   Generic Message Exchange Authentication for the         4256*
+             Secure Shell Protocol (SSH)
+--------   Using DNS to Securely Publish Secure Shell (SSH) Key    4255*
+             Fingerprints
+--------   The Secure Shell (SSH) Connection Protocol              4254*
+--------   The Secure Shell (SSH) Transport Layer Protocol         4253*
+--------   The Secure Shell (SSH) Authentication Protocol          4252*
+--------   The Secure Shell (SSH) Protocol Architecture            4251*
+--------   The Secure Shell (SSH) Protocol Assigned Numbers        4250*
+
+
+
+RFC Editor                   Informational                     [Page 28]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   The telnet URI Scheme                                   4248*
+--------   An Extension to the Session Initiation Protocol         4244*
+             (SIP) for Request History Information
+--------   Vendor-Specific Information Suboption for the           4243*
+             Dynamic Host Configuration Protocol (DHCP) Relay
+             Agent Option
+--------   Information Refresh Time Option for Dynamic Host        4242*
+             Configuration Protocol for IPv6 (DHCPv6)
+--------   Internet Voice Messaging (IVM)                          4239*
+--------   Voice Message Routing Service                           4238*
+--------   Voice Messaging Directory Service                       4237*
+--------   HTTP Adaptation with Open Pluggable Edge Services       4236*
+             (OPES)
+--------   An INVITE-Initiated Dialog Event Package for the        4235*
+             Session Initiation Protocol (SIP)
+--------   Integrated Services Digital Network (ISDN)              4233*
+             Q.921-User Adaptation Layer
+--------   Identifiers and Test Vectors for HMAC-SHA-224,          4231*
+             HMAC-SHA-256, HMAC-SHA-384, and HMAC-SHA-512
+--------   Using the Simple Object Access Protocol (SOAP) in       4227*
+             Blocks Extensible Exchange Protocol (BEEP)
+--------   Traffic Engineering Link Management Information Base    4220*
+--------   Securing FTP with TLS                                   4217*
+TRANS-IPV6 Basic Transition Mechanisms for IPv6 Hosts and          4213*
+             Routers
+X.509-CRMF Internet X.509 Public Key Infrastructure Certificate    4211*
+             Request Message Format (CRMF)
+PKICMP     Internet X.509 Public Key Infrastructure Certificate    4210*
+             Management Protocol (CMP)
+--------   Link Management Protocol (LMP) for Dense Wavelength     4209*
+             Division Multiplexing (DWDM) Optical Line Systems
+--------   Generalized Multiprotocol Label Switching (GMPLS)       4208*
+             User-Network Interface (UNI): Resource ReserVation
+             Protocol-Traffic Engineering (RSVP-TE) Support for
+             the Overlay Model
+--------   Synchronous Optical Network (SONET)/Synchronous         4207*
+             Digital Hierarchy (SDH) Encoding for Link Management
+             Protocol (LMP) Test Messages
+--------   Label Switched Paths (LSP) Hierarchy with               4206*
+             Generalized Multi-Protocol Label Switching (GMPLS)
+             Traffic Engineering (TE)
+--------   Link Management Protocol (LMP)                          4204*
+--------   OSPF Extensions in Support of Generalized               4203*
+             Multi-Protocol Label Switching (GMPLS)
+--------   Routing Extensions in Support of Generalized            4202*
+             Multi-Protocol Label Switching (GMPLS)
+--------   Link Bundling in MPLS Traffic Engineering (TE)          4201*
+--------   The SEED Cipher Algorithm and Its Use with IPsec        4196*
+
+
+
+RFC Editor                   Informational                     [Page 29]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   The S Hexdump Format                                    4194*
+--------   Unique Local IPv6 Unicast Addresses                     4193*
+--------   Default Router Preferences and More-Specific Routes     4191*
+BRIDGE-MIB Definitions of Managed Objects for Bridges              4188*
+--------   RTP Payload Format for AC-3 Audio                       4184*
+--------   Removing a Restriction on the use of MPLS Explicit      4182*
+             NULL
+--------   The Simple and Protected Generic Security Service       4178*
+             Application Program Interface (GSS-API) Negotiation
+             Mechanism
+--------   RTP Payload Format for Uncompressed Video               4175*
+--------   The IPv4 Dynamic Host Configuration Protocol (DHCP)     4174*
+             Option for the Internet Storage Name Service
+--------   Bootstrapping Clients using the Internet Small          4173*
+             Computer System Interface (iSCSI) Protocol
+--------   iFCP - A Protocol for Internet Fibre Channel Storage    4172*
+             Networking
+--------   Internet Storage Name Service (iSNS)                    4171*
+--------   The Stream Control Transmission Protocol (SCTP) as a    4168*
+             Transport for the Session Initiation Protocol (SIP)
+--------   Signaling System 7 (SS7) Message Transfer Part 2        4165*
+             (MTP2) - User Peer-to-Peer Adaptation Layer (M2PA)
+--------   RObust Header Compression (ROHC): Context               4164*
+             Replication for ROHC Profiles
+--------   Addition of SEED Cipher Suites to Transport Layer       4162*
+             Security (TLS)
+--------   Transport Performance Metrics MIB                       4150*
+--------   Definition of Managed Objects for Synthetic Sources     4149*
+             for Performance Monitoring Algorithms
+--------   TCP-Based Media Transport in the Session Description    4145*
+             Protocol (SDP)
+--------   Facsimile Using Internet Mail (IFAX) Service of ENUM    4143*
+--------   Full-mode Fax Profile for Internet Mail (FFPIM)         4142*
+--------   SMTP and MIME Extensions for Content Conversion         4141*
+--------   Entity MIB (Version 3)                                  4133*
+--------   Addition of Camellia Cipher Suites to Transport         4132*
+             Layer Security (TLS)
+--------   Management Information Base for Data Over Cable         4131*
+             Service Interface Specification (DOCSIS) Cable
+             Modems and Cable Modem Termination Systems for
+             Baseline Privacy Plus
+--------   MIME-Based Secure Peer-to-Peer Business Data            4130*
+             Interchange Using HTTP, Applicability Statement 2
+             (AS2)
+--------   Digital Private Network Signaling System                4129*
+             (DPNSS)/Digital Access Signaling System 2 (DASS 2)
+             Extensions to the IUA Protocol
+
+
+
+
+RFC Editor                   Informational                     [Page 30]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Protocol Extensions for Support of Diffserv-aware       4124*
+             MPLS Traffic Engineering
+--------   A Universally Unique IDentifier (UUID) URN Namespace    4122*
+--------   The Kerberos Version 5 Generic Security Service         4121*
+             Application Program Interface (GSS-API) Mechanism:
+             Version 2
+KERBEROS   The Kerberos Network Authentication Service (V5)        4120*
+--------   A Presence-based GEOPRIV Location Object Format         4119*
+--------   E.164 Number Mapping for the Extensible Provisioning    4114*
+             Protocol (EPP)
+MIB-UDP    Management Information Base for the User Datagram       4113*
+             Protocol (UDP)
+--------   Electronic Commerce Modeling Language (ECML) Version    4112*
+             2 Specification
+--------   Algorithms for Internet Key Exchange version 1          4109*
+             (IKEv1)
+--------   Using Cryptographic Message Syntax (CMS) to Protect     4108*
+             Firmware Packages
+--------   The Use of Galois/Counter Mode (GCM) in IPsec           4106*
+             Encapsulating Security Payload (ESP)
+--------   Policy Core Extension Lightweight Directory Access      4104*
+             Protocol Schema (PCELS)
+--------   RTP Payload for Text Conversation                       4103*
+--------   Registration of the text/red MIME Sub-Type              4102*
+--------   Attaching Meaning to Solicitation Class Keywords        4095*
+--------   Usage of the Session Description Protocol (SDP)         4092*
+             Alternative Network Address Types (ANAT) Semantics
+             in the Session Initiation Protocol (SIP)
+--------   The Alternative Network Address Types (ANAT)            4091*
+             Semantics for the Session Description Protocol (SDP)
+             Grouping Framework
+--------   Fast Reroute Extensions to RSVP-TE for LSP Tunnels      4090*
+--------   Uniform Resource Identifier (URI) Scheme for the        4088*
+             Simple Network Management Protocol (SNMP)
+--------   IP Tunnel MIB                                           4087*
+--------   A Negative Acknowledgement Mechanism for Signaling      4077*
+             Compression
+--------   Simple Network Time Protocol (SNTP) Configuration       4075*
+             Option for DHCPv6
+--------   Protecting Multiple Contents with the Cryptographic     4073*
+             Message Syntax (CMS)
+--------   Diameter Extensible Authentication Protocol (EAP)       4072*
+             Application
+--------   Definitions of Managed Object Extensions for Very       4070*
+             High Speed Digital Subscriber Lines (VDSL) Using
+             Multiple Carrier Modulation (MCM) Line Coding
+
+
+
+
+
+RFC Editor                   Informational                     [Page 31]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Definitions of Managed Object Extensions for Very       4069*
+             High Speed Digital Subscriber Lines (VDSL) Using
+             Single Carrier Modulation (SCM) Line Coding
+--------   Experimental Message, Extensions, and Error Codes       4064*
+             for Mobile IPv4
+--------   RTP Payload Formats for European Telecommunications     4060*
+             Standards Institute (ETSI) European Standard ES 202
+             050, ES 202 211, and ES 202 212 Distributed Speech
+             Recognition Encoding
+--------   Use of the RSASSA-PSS Signature Algorithm in            4056*
+             Cryptographic Message Syntax (CMS)
+--------   Additional Algorithms and Identifiers for RSA           4055*
+             Cryptography for use in the Internet X.509 Public
+             Key Infrastructure Certificate and Certificate
+             Revocation List (CRL) Profile
+--------   Additional XML Security Uniform Resource Identifiers    4051*
+             (URIs)
+--------   Fibre Channel Management MIB                            4044*
+--------   Internet X.509 Public Key Infrastructure Permanent      4043*
+             Identifier
+--------   RTP Payload Format for a 64 kbit/s Transparent Call     4040*
+--------   Rapid Commit Option for the Dynamic Host                4039*
+             Configuration Protocol version 4 (DHCPv4)
+--------   Open Pluggable Edge Services (OPES) Callout Protocol    4037*
+             (OCP) Core
+--------   Management Information Base for Data Over Cable         4036*
+             Service Interface Specification (DOCSIS) Cable Modem
+             Termination Systems for Subscriber Management
+--------   Protocol Modifications for the DNS Security             4035*
+             Extensions
+--------   Resource Records for the DNS Security Extensions        4034*
+--------   DNS Security Introduction and Requirements              4033*
+--------   Update to the Session Initiation Protocol (SIP)         4032*
+             Preconditions Framework
+--------   The Authentication Suboption for the Dynamic Host       4030*
+             Configuration Protocol (DHCP) Relay Agent Option
+--------   Session Timers in the Session Initiation Protocol       4028*
+             (SIP)
+--------   A Method for Storing IPsec Keying Material in DNS       4025*
+--------   Encapsulating MPLS in IP or Generic Routing             4023*
+             Encapsulation (GRE)
+MIB-TCP    Management Information Base for the Transmission        4022*
+             Control Protocol (TCP)
+--------   Registration of Mail and MIME Header Fields             4021*
+--------   RObust Header Compression (ROHC): Profiles for User     4019*
+             Datagram Protocol (UDP) Lite
+
+
+
+
+
+RFC Editor                   Informational                     [Page 32]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Finding Internet Small Computer Systems Interface       4018*
+             (iSCSI) Targets and Name Servers by Using Service
+             Location Protocol version 2 (SLPv2)
+--------   The Eifel Response Algorithm for TCP                    4015*
+--------   Remote Authentication Dial-In User Service (RADIUS)     4014*
+             Attributes Suboption for the Dynamic Host
+             Configuration Protocol (DHCP) Relay Agent
+             Information Option
+--------   SASLprep: Stringprep Profile for User Names and         4013*
+             Passwords
+--------   Routing Policy Specification Language next              4012*
+             generation (RPSLng)
+--------   Policy Based Management MIB                             4011*
+--------   Use of the SEED Encryption Algorithm in                 4010*
+             Cryptographic Message Syntax (CMS)
+--------   Definitions of Managed Objects for Network Address      4008*
+             Translators (NAT)
+--------   IPv6 Scoped Address Architecture                        4007*
+--------   Diameter Credit-Control Application                     4006*
+--------   Diameter Network Access Server Application              4005*
+--------   Diameter Mobile IPv4 Application                        4004*
+--------   GMPLS Signaling Procedure for Egress Control            4003*
+--------   IANA Registration for Enumservice 'web' and 'ft'        4002*
+--------   Textual Conventions for Internet Network Addresses      4001*
+--------   Internet Printing Protocol (IPP): Job and Printer       3998*
+             Administrative Operations
+--------   Internet Printing Protocol (IPP): The 'ippget'          3996*
+             Delivery Method for Event Notifications
+--------   Internet Printing Protocol (IPP): Event                 3995*
+             Notifications and Subscriptions
+--------   Indication of Message Composition for Instant           3994*
+             Messaging
+--------   Subscriber-ID Suboption for the Dynamic Host            3993*
+             Configuration Protocol (DHCP) Relay Agent Option
+--------   Internationalized Resource Identifiers (IRIs)           3987*
+--------   RTP Payload Format for H.264 Video                      3984*
+--------   Using the Internet Registry Information Service         3983*
+             (IRIS) over the Blocks Extensible Exchange Protocol
+             (BEEP)
+--------   IRIS:  A Domain Registry (dreg) Type for the            3982*
+             Internet Registry Information Service (IRIS)
+--------   IRIS: The Internet Registry Information Service         3981*
+             (IRIS) Core Protocol
+--------   T11 Network Address Authority (NAA) Naming Format       3980*
+             for iSCSI Node Names
+--------   Network News Transfer Protocol (NNTP)                   3977*
+--------   Cryptographically Generated Addresses (CGA)             3972*
+--------   SEcure Neighbor Discovery (SEND)                        3971*
+
+
+
+RFC Editor                   Informational                     [Page 33]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   A Traffic Engineering (TE) MIB                          3970*
+--------   The tel URI for Telephone Numbers                       3966*
+--------   Network Mobility (NEMO) Basic Support Protocol          3963*
+--------   Advanced Encryption Standard (AES) Encryption for       3962*
+             Kerberos 5
+--------   Encryption and Checksum Specifications for Kerberos 5   3961*
+--------   The Early Session Disposition Type for the Session      3959*
+             Initiation Protocol (SIP)
+--------   Domain-Based Application Service Location Using SRV     3958*
+             RRs and the Dynamic Delegation Discovery Service
+             (DDDS)
+--------   Authentication, Authorization, and Accounting (AAA)     3957*
+             Registration Keys for Mobile IPv4
+--------   Embedding the Rendezvous Point (RP) Address in an       3956*
+             IPv6 Multicast Address
+--------   Telephone Number Mapping (ENUM) Service Registration    3953*
+             for Presence Services
+--------   UDP Encapsulation of IPsec ESP Packets                  3948*
+--------   Negotiation of NAT-Traversal in the IKE                 3947*
+--------   Generalized Multi-Protocol Label Switching (GMPLS)      3945*
+             Architecture
+--------   Reclassifying Dynamic Host Configuration Protocol       3942*
+             version 4 (DHCPv4) Options
+--------   Calling Line Identification for Voice Mail Messages     3939*
+--------   Video-Message Message-Context                           3938*
+--------   Layer Two Tunneling Protocol - Version 3 (L2TPv3)       3931*
+--------   Lightweight Directory Access Protocol (LDAP) Client     3928*
+             Update Protocol (LCUP)
+--------   Dynamic Configuration of IPv4 Link-Local Addresses      3927*
+--------   Vendor-Identifying Vendor Options for Dynamic Host      3925*
+             Configuration Protocol version 4 (DHCPv4)
+--------   End-to-End Signing and Object Encryption for the        3923*
+             Extensible Messaging and Presence Protocol (XMPP)
+--------   Mapping the Extensible Messaging and Presence           3922*
+             Protocol (XMPP) to Common Presence and Instant
+             Messaging (CPIM)
+--------   Extensible Messaging and Presence Protocol (XMPP):      3921*
+             Instant Messaging and Presence
+--------   Extensible Messaging and Presence Protocol (XMPP):      3920*
+             Core
+--------   Domain Registry Grace Period Mapping for the            3915*
+             Extensible Provisioning Protocol (EPP)
+--------   The Session Initiation Protocol (SIP) "Join" Header     3911*
+--------   The SPIRITS (Services in PSTN requesting Internet       3910*
+             Services) Protocol
+--------   Lightweight Directory Access Protocol (LDAP) Cancel     3909*
+             Operation
+
+
+
+
+RFC Editor                   Informational                     [Page 34]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Session Initiation Protocol (SIP) Extension for         3903*
+             Event State Publication
+--------   Network Information Service (NIS) Configuration         3898*
+             Options for Dynamic Host Configuration Protocol for
+             IPv6 (DHCPv6)
+DS3-E3-MIB Definitions of Managed Objects for the DS3/E3           3896*
+             Interface Type
+--------   Sieve Extension: Copying Without Side Effects           3894*
+--------   Session Initiation Protocol (SIP) Authenticated         3893*
+             Identity Body (AIB) Format
+--------   The Session Initiation Protocol (SIP) Referred-By       3892*
+             Mechanism
+--------   The Session Initiation Protocol (SIP) "Replaces"        3891*
+             Header
+--------   A Transport Independent Bandwidth Modifier for the      3890*
+             Session Description Protocol (SDP)
+--------   Message Tracking Query Protocol                         3887*
+--------   An Extensible Message Format for Message Tracking       3886*
+             Responses
+--------   SMTP Service Extension for Message Tracking             3885*
+--------   Detecting Inactive Neighbors over OSPF Demand           3883*
+             Circuits (DC)
+--------   Call Processing Language (CPL): A Language for User     3880*
+             Control of Internet Telephony Services
+--------   Deprecating Site Local Addresses                        3879*
+--------   Alarm Reporting Control Management Information Base     3878*
+             (MIB)
+--------   Alarm Management Information Base (MIB)                 3877*
+--------   Returning Matched Values with the Lightweight           3876*
+             Directory Access Protocol version 3 (LDAPv3)
+--------   Stream Control Transmission Protocol (SCTP)             3873*
+             Management Information Base (MIB)
+--------   Management Information Base for Telephony Routing       3872*
+             over IP (TRIP)
+--------   Signalling Connection Control Part User Adaptation      3868*
+             Layer (SUA)
+--------   Language Tags and Ranges in the Lightweight             3866
+             Directory Access Protocol (LDAP)
+--------   A No Soliciting Simple Mail Transfer Protocol (SMTP)    3865*
+             Service Extension
+--------   Presence Information Data Format (PIDF)                 3863*
+--------   Common Presence and Instant Messaging (CPIM):           3862*
+             Message Format
+--------   Address Resolution for Instant Messaging and Presence   3861*
+--------   Common Profile for Instant Messaging (CPIM)             3860*
+--------   Common Profile for Presence (CPP)                       3859*
+--------   An Extensible Markup Language (XML) Based Format for    3858*
+             Watcher Information
+
+
+
+RFC Editor                   Informational                     [Page 35]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   A Watcher Information Event Template-Package for the    3857*
+             Session Initiation Protocol (SIP)
+--------   A Presence Event Package for the Session Initiation     3856*
+             Protocol (SIP)
+--------   Transporting Secure/Multipurpose Internet Mail          3855
+             Extensions (S/MIME) Objects in X.400
+--------   Securing X.400 Content with Secure/Multipurpose         3854
+             Internet Mail Extensions (S/MIME)
+SIP        S/MIME Advanced Encryption Standard (AES)               3853
+             Requirement for the Session Initiation Protocol (SIP)
+--------   Cryptographic Message Syntax (CMS)                      3852
+--------   Secure/Multipurpose Internet Mail Extensions            3851
+             (S/MIME) Version 3.1 Message Specification
+--------   Secure/Multipurpose Internet Mail Extensions            3850
+             (S/MIME) Version 3.1 Certificate Handling
+--------   ESMTP and LMTP Transmission Types Registration          3848
+--------   Mobile IPv4 Extension for Carrying Network Access       3846
+             Identifiers
+--------   RObust Header Compression (ROHC): A Compression         3843
+             Profile for IP
+--------   A Message Summary and Message Waiting Indication        3842*
+             Event Package for the Session Initiation Protocol
+             (SIP)
+--------   Caller Preferences for the Session Initiation           3841*
+             Protocol (SIP)
+--------   Indicating User Agent Capabilities in the Session       3840*
+             Initiation Protocol (SIP)
+--------   MIME Type Registrations for 3rd Generation              3839
+             Partnership Project (3GPP) Multimedia files
+--------   Recommendations for Automatic Responses to              3834*
+             Electronic Mail
+--------   MIKEY: Multimedia Internet KEYing                       3830*
+--------   The Lightweight User Datagram Protocol (UDP-Lite)       3828
+--------   The Advanced Encryption Standard (AES) Cipher           3826
+             Algorithm in the SNMP User-based Security Model
+--------   Dynamic Host Configuration Protocol Option for          3825
+             Coordinate-based Location Configuration Information
+--------   Finding Fibre Channel over TCP/IP (FCIP) Entities       3822
+             Using Service Location Protocol version 2 (SLPv2)
+--------   Fibre Channel Over TCP/IP (FCIP)                        3821
+--------   Internet X.509 Public Key Infrastructure (PKI) Proxy    3820
+             Certificate Profile
+--------   Definitions of Managed Objects for RObust Header        3816
+             Compression (ROHC)
+--------   Definitions of Managed Objects for the Multiprotocol    3815
+             Label Switching (MPLS), Label Distribution Protocol
+             (LDP)
+
+
+
+
+RFC Editor                   Informational                     [Page 36]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Multiprotocol Label Switching (MPLS) Forwarding         3814
+             Equivalence Class To Next Hop Label Forwarding Entry
+             (FEC-To-NHLFE) Management Information Base (MIB)
+--------   Multiprotocol Label Switching (MPLS) Label Switching    3813
+             Router (LSR) Management Information Base (MIB)
+--------   Multiprotocol Label Switching (MPLS) Traffic            3812
+             Engineering (TE) Management Information Base (MIB)
+--------   Definitions of Textual Conventions (TCs) for            3811
+             Multiprotocol Label Switching (MPLS) Management
+--------   Multicast Listener Discovery Version 2 (MLDv2) for      3810
+             IPv6
+--------   V5.2-User Adaptation Layer (V5UA)                       3807
+Print-MIB  Printer MIB v2                                          3805
+--------   Voice Profile for Internet Mail (VPIM) Addressing       3804
+--------   Security Considerations for Signaling Transport         3788
+             (SIGTRAN) Protocols
+--------   The NewReno Modification to TCP's Fast Recovery         3782
+             Algorithm
+--------   X.509 Extensions for IP Addresses and AS Identifiers    3779
+--------   Using IPsec to Protect Mobile IPv6 Signaling Between    3776
+             Mobile Nodes and Home Agents
+--------   Mobility Support in IPv6                                3775
+--------   Point-to-Point Protocol (PPP) Vendor Protocol           3772
+--------   Securely Available Credentials Protocol                 3767
+--------   enumservice registration for Session Initiation         3764
+             Protocol (SIP) Addresses-of-Record
+--------   Telephone Number Mapping (ENUM) Service Registration    3762
+             for H.323
+--------   The E.164 to Uniform Resource Identifiers (URI)         3761
+             Dynamic Delegation Discovery System (DDDS)
+             Application (ENUM)
+--------   Stream Control Transmission Protocol (SCTP) Partial     3758
+             Reliability Extension
+--------   Transport Layer Security Protocol Compression Methods   3749
+PPP-EAP    Extensible Authentication Protocol (EAP)                3748
+--------   The Differentiated Services Configuration MIB           3747
+--------   MIME Type Registrations for JPEG 2000 (ISO/IEC 15444)   3745
+--------   Web Distributed Authoring and Versioning (WebDAV)       3744
+             Access Control Protocol
+--------   Internet X.509 Public Key Infrastructure: Qualified     3739
+             Certificates Profile
+--------   IANA Guidelines for the Registry of Remote              3737
+             Monitoring (RMON) MIB modules
+--------   Stateless Dynamic Host Configuration Protocol (DHCP)    3736
+             Service for IPv6
+--------   Application Performance Measurement MIB                 3729
+--------   Definitions of Managed Objects for Very High Speed      3728
+             Digital Subscriber Lines (VDSL)
+
+
+
+RFC Editor                   Informational                     [Page 37]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   ASN.1 Module Definition for the LDAP and X.500          3727
+             Component Matching Rules
+--------   Securing Block Storage Protocols over IP                3723
+--------   String Profile for Internet Small Computer Systems      3722
+             Interface (iSCSI) Names
+--------   Internet Small Computer Systems Interface (iSCSI)       3720
+--------   The Secure Real-time Transport Protocol (SRTP)          3711
+--------   Internet X.509 Public Key Infrastructure: Logotypes     3709
+             in X.509 Certificates
+--------   High Capacity Textual Conventions for MIB Modules       3705
+             Using Performance History Based on 15 Minute
+             Intervals
+--------   Policy Core Lightweight Directory Access Protocol       3703
+             (LDAP) Schema
+--------   Lightweight Directory Access Protocol (LDAP):           3698
+             Additional Matching Rules
+--------   IPv6 Flow Label Specification                           3697
+--------   Internet Message Access Protocol (IMAP) UNSELECT        3691
+             command
+--------   Lightweight Directory Access Protocol (LDAP) and        3687
+             X.500 Component Matching Rules
+--------   Using Advanced Encryption Standard (AES) Counter        3686
+             Mode With IPsec Encapsulating Security Payload (ESP)
+--------   A Session Initiation Protocol (SIP) Event Package       3680
+             for Registrations
+--------   The Text/Plain Format and DelSp Parameters              3676
+--------   Lightweight Directory Access Protocol version 3         3673
+             (LDAPv3): All Operational Attributes
+--------   Subentries in the Lightweight Directory Access          3672
+             Protocol (LDAP)
+--------   Collective Attributes in the Lightweight Directory      3671
+             Access Protocol (LDAP)
+--------   Information Model for Describing Network Device QoS     3670
+             Datapath Mechanisms
+FTP        Extensions to FTP                                       3659*
+--------   Use of the Camellia Encryption Algorithm in             3657
+             Cryptographic Message Syntax (CMS)
+--------   Web Distributed Authoring and Versioning (WebDAV)       3648
+             Ordered Collections Protocol
+--------   DNS Configuration options for Dynamic Host              3646
+             Configuration Protocol for IPv6 (DHCPv6)
+--------   Generic Security Service Algorithm for Secret Key       3645
+             Transaction Authentication for DNS (GSS-TSIG)
+--------   Policy Quality of Service (QoS) Information Model       3644
+--------   Fibre Channel (FC) Frame Encapsulation                  3643
+--------   Common Elements of Generic String Encoding Rules        3642
+             (GSER) Encodings
+--------   Generic String Encoding Rules (GSER) for ASN.1 Types    3641
+
+
+
+RFC Editor                   Informational                     [Page 38]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   RTP Payload Format for Transport of MPEG-4              3640
+             Elementary Streams
+--------   Definitions of Managed Objects for the Ethernet WAN     3637
+             Interface Sublayer
+--------   Definitions of Managed Objects for the Ethernet-like    3635
+             Interface Types
+--------   Key Distribution Center (KDC) Server Address            3634
+             Sub-option for the Dynamic Host Configuration
+             Protocol (DHCP) CableLabs Client Configuration (CCC)
+             Option
+--------   IPv6 Prefix Options for Dynamic Host Configuration      3633
+             Protocol (DHCP) version 6
+--------   Traffic Engineering (TE) Extensions to OSPF Version 2   3630
+--------   Graceful OSPF Restart                                   3623
+--------   Power Ethernet MIB                                      3621
+--------   The TUNNEL Profile                                      3620
+--------   RTP Control Protocol Extended Reports (RTCP XR)         3611
+--------   Session Initiation Protocol (SIP) Extension Header      3608
+             Field for Service Route Discovery During Registration
+--------   Definitions of Supplemental Managed Objects for ATM     3606
+             Interface
+--------   Real Time Control Protocol (RTCP) attribute in          3605
+             Session Description Protocol (SDP)
+--------   The AES-CBC Cipher Algorithm and Its Use with IPsec     3602
+--------   Text String Notation for Dial Sequences and Global      3601
+             Switched Telephone Network (GSTN) / E.164 Addresses
+--------   Handling of Unknown DNS Resource Record (RR) Types      3597
+--------   Textual Conventions for IPv6 Flow Label                 3595
+--------   PacketCable Security Ticket Control Sub-Option for      3594
+             the DHCP CableLabs Client Configuration (CCC) Option
+--------   Definitions of Managed Objects for the Optical          3591
+             Interface Type
+--------   Source Address Selection for the Multicast Listener     3590
+             Discovery (MLD) Protocol
+--------   Diameter Base Protocol                                  3588
+--------   IP Security Policy (IPSP) Requirements                  3586
+--------   IPsec Configuration Policy Information Model            3585
+--------   An Extension to the Session Initiation Protocol         3581
+             (SIP) for Symmetric Response Routing
+--------   Mapping of Integrated Services Digital Network          3578
+             (ISDN) User Part (ISUP) Overlap Signalling to the
+             Session Initiation Protocol (SIP)
+--------   IANA Considerations for RADIUS (Remote                  3575
+             Authentication Dial In User Service)
+--------   Signalling of Modem-On-Hold status in Layer 2           3573
+             Tunneling Protocol (L2TP)
+--------   The AES-XCBC-MAC-96 Algorithm and Its Use With IPsec    3566
+
+
+
+
+RFC Editor                   Informational                     [Page 39]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Use of the Advanced Encryption Standard (AES)           3565
+             Encryption Algorithm in Cryptographic Message Syntax
+             (CMS)
+--------   Use of the RSAES-OAEP Key Transport Algorithm in        3560
+             Cryptographic Message Syntax (CMS)
+--------   Multicast Address Allocation MIB                        3559
+--------   RTP Payload Format for Enhanced Variable Rate Codecs    3558
+             (EVRC) and Selectable Mode Vocoders (SMV)
+--------   RTP Payload Format for European Telecommunications      3557
+             Standards Institute (ETSI) European Standard ES 201
+             108 Distributed Speech Recognition Encoding
+--------   Session Description Protocol (SDP) Bandwidth            3556
+             Modifiers for RTP Control Protocol (RTCP) Bandwidth
+--------   On the Use of Stream Control Transmission Protocol      3554
+             (SCTP) with IPsec
+--------   The Group Domain of Interpretation                      3547
+--------   Enhanced Compressed RTP (CRTP) for Links with High      3545
+             Delay, Packet Loss and Reordering
+IPCOM-PPP  IP Header Compression over PPP                          3544
+--------   Registration Revocation in Mobile IPv4                  3543
+--------   Authentication, Authorization and Accounting (AAA)      3539
+             Transport Profile
+--------   Wrapping a Hashed Message Authentication Code (HMAC)    3537
+             key with a Triple-Data Encryption Standard (DES) Key
+             or an Advanced Encryption Standard (AES) Key
+--------   The application/ogg Media Type                          3534
+NFSv4      Network File System (NFS) version 4 Protocol            3530
+--------   Link Selection sub-option for the Relay Agent           3527
+             Information Option for DHCPv4
+--------   More Modular Exponential (MODP) Diffie-Hellman          3526
+             groups for Internet Key Exchange (IKE)
+--------   Mapping of Media Streams to Resource Reservation        3524
+             Flows
+--------   Session Authorization Policy Element                    3520
+--------   Mobile IP Traversal of Network Address Translation      3519
+             (NAT) Devices
+PPP-BCP    Point-to-Point Protocol (PPP) Bridging Control          3518
+             Protocol (BCP)
+--------   A Conservative Selective Acknowledgment (SACK)-based    3517
+             Loss Recovery Algorithm for TCP
+--------   IMAP4 Binary Content Extension                          3516
+--------   The Session Initiation Protocol (SIP) Refer Method      3515
+IPP-E-T    Internet Printing Protocol/1.1: IPP URL Scheme          3510
+--------   Message Disposition Notification (MDN) profile for      3503
+             Internet Message Access Protocol (IMAP)
+--------   Internet Message Access Protocol (IMAP) -               3502
+             MULTIAPPEND Extension
+IMAPv4     INTERNET MESSAGE ACCESS PROTOCOL - VERSION 4rev1        3501
+
+
+
+RFC Editor                   Informational                     [Page 40]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Definitions of Managed Objects for Synchronous          3498
+             Optical Network (SONET) Linear Automatic Protection
+             Switching (APS) Architectures
+--------   RTP Payload Format for Society of Motion Picture and    3497
+             Television Engineers (SMPTE) 292M Video
+--------   Dynamic Host Configuration Protocol (DHCP) Option       3495
+             for CableLabs Client Configuration
+--------   Punycode: A Bootstring encoding of Unicode for          3492
+             Internationalized Domain Names in Applications (IDNA)
+--------   Nameprep: A Stringprep Profile for Internationalized    3491
+             Domain Names (IDN)
+--------   Internationalizing Domain Names in Applications         3490
+             (IDNA)
+--------   STUN - Simple Traversal of User Datagram Protocol       3489
+             (UDP) Through Network Address Translators (NATs)
+--------   Compressing the Session Initiation Protocol (SIP)       3486
+--------   The Session Initiation Protocol (SIP) and Session       3485
+             Description Protocol (SDP) Static Dictionary for
+             Signaling Compression (SigComp)
+--------   Default Address Selection for Internet Protocol         3484
+             version 6 (IPv6)
+--------   Signalling Unnumbered Links in CR-LDP                   3480
+             (Constraint-Routing Label Distribution Protocol)
+--------   Fault Tolerance for the Label Distribution Protocol     3479
+             (LDP)
+--------   Graceful Restart Mechanism for Label Distribution       3478
+             Protocol
+--------   Signalling Unnumbered Links in Resource ReSerVation     3477
+             Protocol - Traffic Engineering (RSVP-TE)
+--------   Generalized Multi-Protocol Label Switching (GMPLS)      3473
+             Signaling Resource ReserVation Protocol-Traffic
+             Engineering (RSVP-TE) Extensions
+--------   Generalized Multi-Protocol Label Switching (GMPLS)      3472
+             Signaling Constraint-based Routed Label Distribution
+             Protocol (CR-LDP) Extensions
+--------   Generalized Multi-Protocol Label Switching (GMPLS)      3471
+             Signaling Functional Description
+CIM        Policy Core Information Model (PCIM) Extensions         3460
+--------   Critical Content Multi-purpose Internet Mail            3459
+             Extensions (MIME) Parameter
+--------   Message Context for Internet Mail                       3458
+--------   Dynamic Host Configuration Protocol (DHCPv4)            3456
+             Configuration of IPsec Tunnel Mode
+--------   Preparation of Internationalized Strings                3454
+             ("stringprep")
+--------   TCP Friendly Rate Control (TFRC): Protocol              3448
+             Specification
+
+
+
+
+RFC Editor                   Informational                     [Page 41]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Time To Live (TTL) Processing in Multi-Protocol         3443
+             Label Switching (MPLS) Networks
+--------   The Classless Static Route Option for Dynamic Host      3442
+             Configuration Protocol (DHCP) version 4
+--------   Definitions of Extension Managed Objects for            3440
+             Asymmetric Digital Subscriber Lines
+--------   Layer-Two Tunneling Protocol Extensions for PPP Link    3437
+             Control Protocol Negotiation
+--------   Transport Layer Security over Stream Control            3436
+             Transmission Protocol
+--------   Remote Monitoring MIB Extensions for High Capacity      3434
+             Alarms
+--------   Entity Sensor Management Information Base               3433
+--------   Network performance measurement with periodic streams   3432
+--------   Session Initiation Protocol (SIP) Extension for         3428
+             Instant Messaging
+--------   Obsoleting IQUERY                                       3425
+--------   Internet Media Type message/sipfrag                     3420
+--------   Textual Conventions for Transport Addresses             3419
+--------   Zero-byte Support for Bidirectional Reliable Mode       3408
+             (R-mode) in Extended Link-Layer Assisted RObust
+             Header Compression (ROHC) Profile
+--------   Session Description Protocol (SDP) Simple Capability    3407
+             Declaration
+NAPTR      Dynamic Delegation Discovery System (DDDS) Part         3404
+             Four: The Uniform Resource Identifiers (URI)
+NAPTR      Dynamic Delegation Discovery System (DDDS) Part         3403
+             Three: The Domain Name System (DNS) Database
+NAPTR      Dynamic Delegation Discovery System (DDDS) Part Two:    3402
+             The Algorithm
+--------   Integrated Services Digital Network (ISDN) User Part    3398
+             (ISUP) to Session Initiation Protocol (SIP) Mapping
+--------   Dynamic Host Configuration Protocol (DHCP) Domain       3397
+             Search Option
+--------   Encoding Long Options in the Dynamic Host               3396
+             Configuration Protocol (DHCPv4)
+RMON-MIB   Remote Network Monitoring MIB Protocol Identifier       3395
+             Reference Extensions
+--------   IP Packet Delay Variation Metric for IP Performance     3393
+             Metrics (IPPM)
+--------   Increasing TCP's Initial Window                         3390
+--------   Real-time Transport Protocol (RTP) Payload for          3389
+             Comfort Noise (CN)
+--------   Grouping of Media Lines in the Session Description      3388
+             Protocol (SDP)
+IPP-E-T    Internet Printing Protocol (IPP): The 'collection'      3382
+             attribute syntax
+
+
+
+
+RFC Editor                   Informational                     [Page 42]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+IPP-E-T    Internet Printing Protocol (IPP): Job Progress          3381
+             Attributes
+IPP-E-T    Internet Printing Protocol (IPP): Job and Printer       3380
+             Set Operations
+IGMP       Internet Group Management Protocol, Version 3           3376
+--------   Layer Two Tunneling Protocol "L2TP" Management          3371
+             Information Base
+--------   Cryptographic Message Syntax (CMS) Algorithms           3370
+--------   The 'go' URI Scheme for the Common Name Resolution      3368
+             Protocol
+--------   Common Name Resolution Protocol (CNRP)                  3367
+--------   Real-time Facsimile (T.38) - image/t38 MIME Sub-type    3362
+             Registration
+--------   Dynamic Host Configuration Protocol (DHCP-for-IPv4)     3361
+             Option for Session Initiation Protocol (SIP) Servers
+--------   Layer Two Tunnelling Protocol (L2TP) Over ATM           3355
+             Adaptation Layer 5 (AAL5)
+--------   Small Computer Systems Interface protocol over the      3347
+             Internet (iSCSI) Requirements and Design
+             Considerations
+MOBILEIPSU IP Mobility Support for IPv4                            3344
+--------   The Application Exchange (APEX) Option Party Pack,      3342
+             Part Deux!
+--------   The Application Exchange (APEX) Access Service          3341
+--------   The Application Exchange Core                           3340
+--------   Date and Time on the Internet: Timestamps               3339
+--------   Class Extensions for PPP over Asynchronous Transfer     3337
+             Mode Adaptation Layer 2
+--------   PPP Over Asynchronous Transfer Mode Adaptation Layer    3336
+             2 (AAL2)
+--------   MIME-based Secure Peer-to-Peer Business Data            3335
+             Interchange over the Internet
+--------   Signaling System 7 (SS7) Message Transfer Part 2        3331
+             (MTP2) - User Adaptation Layer
+--------   Security Mechanism Agreement for the Session            3329
+             Initiation Protocol (SIP)
+--------   Session Initiation Protocol (SIP) Extension Header      3327
+             Field for Registering Non-Adjacent Contacts
+--------   The Reason Header Field for the Session Initiation      3326
+             Protocol (SIP)
+--------   A Privacy Mechanism for the Session Initiation          3323
+             Protocol (SIP)
+--------   Signaling Compression (SigComp) - Extended Operations   3321
+--------   Signaling Compression (SigComp)                         3320
+--------   Dynamic Host Configuration Protocol (DHCPv6) Options    3319
+             for Session Initiation Protocol (SIP) Servers
+--------   Dynamic Host Configuration Protocol for IPv6 (DHCPv6)   3315
+
+
+
+
+RFC Editor                   Informational                     [Page 43]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Integration of Resource Management and Session          3312
+             Initiation Protocol (SIP)
+--------   The Session Initiation Protocol (SIP) UPDATE Method     3311
+--------   Layer Two Tunneling Protocol (L2TP) Differentiated      3308
+             Services Extension
+--------   Allocation Guidelines for IPv6 Multicast Addresses      3307
+--------   Unicast-Prefix-based IPv6 Multicast Addresses           3306
+--------   Layer Two Tunnelling Protocol (L2TP): ATM access        3301
+             network extensions
+--------   Content Negotiation for Messaging Services based on     3297
+             Email
+--------   Named Subordinate References in Lightweight             3296
+             Directory Access Protocol (LDAP) Directories
+--------   Definitions of Managed Objects for the General          3295
+             Switch Management Protocol (GSMP)
+--------   General Switch Management Protocol (GSMP) Packet        3293
+             Encapsulations for Asynchronous Transfer Mode (ATM),
+             Ethernet and Transmission Control Protocol (TCP)
+--------   General Switch Management Protocol (GSMP) V3            3292
+--------   Management Information Base for the Differentiated      3289
+             Services Architecture
+--------   Remote Monitoring MIB Extensions for Differentiated     3287
+             Services
+--------   The VCDIFF Generic Differencing and Compression Data    3284
+             Format
+--------   An Internet Attribute Certificate Profile for           3281
+             Authorization
+--------   Internet X.509 Public Key Infrastructure Certificate    3280
+             and Certificate Revocation List (CRL) Profile
+--------   Algorithms and Identifiers for the Internet X.509       3279
+             Public Key Infrastructure Certificate and
+             Certificate Revocation List (CRL) Profile
+--------   Compressed Data Content Type for Cryptographic          3274
+             Message Syntax (CMS)
+--------   Remote Network Monitoring Management Information        3273
+             Base for High Capacity Networks
+--------   Multi-Protocol Label Switching (MPLS) Support of        3270
+             Differentiated Services
+--------   Advanced Encryption Standard (AES) Ciphersuites for     3268
+             Transport Layer Security (TLS)
+SIP        Session Initiation Protocol (SIP)-Specific Event        3265
+             Notification
+SIP        An Offer/Answer Model with Session Description          3264
+             Protocol (SDP)
+SIP        Session Initiation Protocol (SIP): Locating SIP         3263
+             Servers
+SIP        Reliability of Provisional Responses in Session         3262
+             Initiation Protocol (SIP)
+
+
+
+RFC Editor                   Informational                     [Page 44]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+SIP        SIP: Session Initiation Protocol                        3261
+--------   The DOCSIS (Data-Over-Cable Service Interface           3256
+             Specifications) Device Class DHCP (Dynamic Host
+             Configuration Protocol) Relay Agent Information
+             Sub-option
+--------   Extending Point-to-Point Protocol (PPP) over            3255
+             Synchronous Optical NETwork/Synchronous Digital
+             Hierarchy (SONET/SDH) with virtual concatenation,
+             high order and low order payloads
+--------   Versioning Extensions to WebDAV (Web Distributed        3253
+             Authoring and Versioning)
+--------   An Expedited Forwarding PHB (Per-Hop Behavior)          3246
+--------   Robust Header Compression (ROHC) over PPP               3241
+--------   Definitions of Managed Objects for Scheduling           3231
+             Management Operations
+--------   Instance Digests in HTTP                                3230
+--------   Delta encoding in HTTP                                  3229
+--------   DNSSEC and IPv6 A6 aware server/resolver message        3226
+             size requirements
+--------   Indicating Resolver Support of DNSSEC                   3225
+SLP        Vendor Extensions for Service Location Protocol,        3224
+             Version 2
+--------   Telephony Routing over IP (TRIP)                        3219
+--------   LSP Modification Using CR-LDP                           3214
+--------   Constraint-Based LSP Setup using LDP                    3212
+--------   RSVP-TE: Extensions to RSVP for LSP Tunnels             3209
+--------   SMTP Service Extension for Secure SMTP over             3207
+             Transport Layer Security
+--------   The SYS and AUTH POP Response Codes                     3206
+--------   MIME media types for ISUP and QSIG Objects              3204
+--------   DHCP reconfigure extension                              3203
+--------   Definitions of Managed Objects for Frame Relay          3202
+             Service Level Definitions
+--------   Definitions of Managed Objects for Circuit to           3201
+             Interface Translation
+--------   Reliable Delivery for syslog                            3195
+--------   Securing L2TP using IPsec                               3193
+--------   RTP Payload Format for 12-bit DAT Audio and 20- and     3190
+             24-bit Linear Sampled Audio
+--------   RTP Payload Format for DV (IEC 61834) Video             3189
+--------   Reuse of CMS Content Encryption Keys                    3185
+--------   Identity Representation for RSVP                        3182
+--------   Signaled Preemption Priority Policy Element             3181
+--------   Aggregation of RSVP for IPv4 and IPv6 Reservations      3175
+IPCOMP     IP Payload Compression Protocol (IPComp)                3173
+--------   The Addition of Explicit Congestion Notification        3168
+             (ECN) to IP
+
+
+
+
+RFC Editor                   Informational                     [Page 45]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Definitions of Managed Objects for the Delegation of    3165
+             Management Scripts
+--------   RADIUS and IPv6                                         3162
+TSA        Internet X.509 Public Key Infrastructure Time-Stamp     3161
+             Protocol (TSP)
+PIB        Structure of Policy Provisioning Information (SPPI)     3159
+MIME-PGP   MIME Security with OpenPGP                              3156
+--------   PPP Multiplexing                                        3153
+--------   Transmission of IPv6 Packets over IEEE 1394 Networks    3146
+--------   L2TP Disconnect Cause Information                       3145
+--------   Remote Monitoring MIB Extensions for Interface          3144
+             Parameters Monitoring
+--------   Per Hop Behavior Identification Codes                   3140
+--------   The Congestion Manager                                  3124
+--------   Extensions to IPv6 Neighbor Discovery for Inverse       3122
+             Discovery Specification
+--------   Authentication for DHCP Messages                        3118
+--------   Mobile IP Vendor/Organization-Specific Extensions       3115
+--------   Service Location Protocol Modifications for IPv6        3111
+--------   RSA/SHA-1 SIGs and RSA KEYs in the Domain Name          3110
+             System (DNS)
+--------   Conventions for the use of the Session Description      3108
+             Protocol (SDP) for ATM Bearer Connections
+SDP        Carrying Label Information in BGP-4                     3107
+OSPF-NSSA  The OSPF Not-So-Stubby Area (NSSA) Option               3101
+RSVP       RSVP Cryptographic Authentication -- Updated Message    3097
+             Type Value
+--------   RObust Header Compression (ROHC): Framework and four    3095
+             profiles
+COPS-PR    COPS Usage for Policy Provisioning (COPS-PR)            3084
+--------   Mapping the BEEP Core onto TCP                          3081
+BEEP       The Blocks Extensible Exchange Protocol Core            3080
+--------   A Link-Layer Tunneling Mechanism for Unidirectional     3077
+             Links
+--------   DHC Load Balancing Algorithm                            3074
+L2TP-FR    Layer Two Tunneling Protocol (L2TP) over Frame Relay    3070
+--------   An Anycast Prefix for 6to4 Relay Routers                3068
+--------   LDAP Password Modify Extended Operation                 3062
+CIM        Policy Core Information Model -- Version 1              3060
+             Specification
+SLPv2      Attribute List Extension for the Service Location       3059
+             Protocol
+--------   Connection of IPv6 Domains via IPv4 Clouds              3056
+--------   Management Information Base for the PINT Services       3055
+             Architecture
+--------   TN3270E Service Location and Session Balancing          3049
+--------   RTP Payload Format for ITU-T Recommendation G.722.1     3047
+--------   DHCP Relay Agent Information Option                     3046
+
+
+
+RFC Editor                   Informational                     [Page 46]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Enhancing TCP's Loss Recovery Using Limited Transmit    3042
+--------   VCID Notification over ATM link for LDP                 3038
+--------   MPLS using LDP and ATM VC Switching                     3035
+--------   Use of Label Switching on Frame Relay Networks          3034
+             Specification
+--------   The Assignment of the Information Field and Protocol    3033
+             Identifier in the Q.2941 Generic Identifier and
+             Q.2957 User-to-user Signaling for the Internet
+             Protocol
+--------   MPLS Label Stack Encoding                               3032
+MPLS       Multiprotocol Label Switching Architecture              3031
+--------   SMTP Service Extensions for Transmission of Large       3030
+             and Binary MIME Messages
+--------   Reverse Tunneling for Mobile IP, revised                3024
+--------   XML Media Types                                         3023
+--------   Using 31-Bit Prefixes on IPv4 Point-to-Point Links      3021
+--------   Definitions of Managed Objects for Monitoring and       3020
+             Controlling the UNI/NNI Multilink Frame Relay
+             Function
+--------   IP Version 6 Management Information Base for The        3019
+             Multicast Listener Discovery Protocol
+--------   XML DTD for Roaming Access Phone Book                   3017
+--------   RTP Payload Format for MPEG-4 Audio/Visual Streams      3016
+--------   Notification Log MIB                                    3014
+--------   The IPv4 Subnet Selection Option for DHCP               3011
+--------   Secure Domain Name System (DNS) Dynamic Update          3007
+--------   Integrated Services in the Presence of Compressible     3006
+             Flows
+--------   The User Class Option for DHCP                          3004
+--------   The audio/mpeg Media Type                               3003
+--------   Specification of the Null Service Type                  2997
+--------   Format of the RSVP DCLASS Object                        2996
+--------   Computing TCP's Retransmission Timer                    2988
+--------   Registration of Charset and Languages Media Features    2987
+             Tags
+--------   Use of the CAST-128 Encryption Algorithm in CMS         2984
+--------   Distributed Management Expression MIB                   2982
+--------   Event MIB                                               2981
+--------   The SIP INFO Method                                     2976
+--------   IMAP4 ID extension                                      2971
+--------   HTTP State Management Mechanism                         2965
+--------   RSVP Refresh Overhead Reduction Extensions              2961
+--------   Real-Time Transport Protocol Management Information     2959
+             Base
+--------   Definitions of Managed Objects for Monitoring and       2955
+             Controlling the Frame Relay/ATM PVC Service
+             Interworking Function
+
+
+
+
+RFC Editor                   Informational                     [Page 47]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+FR-MIB     Definitions of Managed Objects for Frame Relay          2954
+             Service
+--------   Telnet Encryption: CAST-128 64 bit Cipher Feedback      2950
+--------   Telnet Encryption: CAST-128 64 bit Output Feedback      2949
+--------   Telnet Encryption: DES3 64 bit Output Feedback          2948
+--------   Telnet Encryption: DES3 64 bit Cipher Feedback          2947
+--------   Telnet Data Encryption Option                           2946
+--------   The SRP Authentication and Key Exchange System          2945
+--------   Telnet Authentication: SRP                              2944
+--------   TELNET Authentication Using DSA                         2943
+--------   Telnet Authentication: Kerberos Version 5               2942
+TOPT-AUTH  Telnet Authentication Option                            2941
+--------   Definitions of Managed Objects for Common Open          2940
+             Policy Service (COPS) Protocol Clients
+--------   Identifying Composite Media Features                    2938
+--------   The Name Service Search Option for DHCP                 2937
+IOTP-HTTP  Internet Open Trading Protocol (IOTP) HTTP Supplement   2935
+--------   Internet Group Management Protocol MIB                  2933
+--------   DNS Request and Transaction Signatures ( SIG(0)s )      2931
+TKEY-RR    Secret Key Establishment for DNS (TKEY RR)              2930
+--------   List-Id: A Structured Field and Namespace for the       2919
+             Identification of Mailing Lists
+--------   Route Refresh Capability for BGP-4                      2918
+--------   MIME Content Types in Media Feature Expressions         2913
+--------   Indicating Media Features for MIME Content              2912
+IPP-M-S    Internet Printing Protocol/1.1: Model and Semantics     2911
+IPP-E-T    Internet Printing Protocol/1.1: Encoding and            2910
+             Transport
+--------   MADCAP Multicast Scope Nesting State Option             2907
+--------   Router Renumbering for IPv6                             2894
+--------   LDAP Control Extension for Server Side Sorting of       2891
+             Search Results
+--------   Key and Sequence Number Extensions to GRE               2890
+SACK       An Extension to the Selective Acknowledgement (SACK)    2883
+             Option for TCP
+--------   Content Feature Schema for Internet Fax (V2)            2879
+--------   Diffie-Hellman Proof-of-Possession Algorithms           2875
+--------   TCP Processing of the IPv4 Precedence Field             2873
+--------   Application and Sub Application Identity Policy         2872
+             Element for Use with RSVP
+--------   The Inverted Stack Table Extension to the Interfaces    2864
+             Group MIB
+--------   RTP Payload Format for Real-Time Pointers               2862
+--------   The Use of HMAC-RIPEMD-160-96 within ESP and AH         2857
+--------   Textual Conventions for Additional High Capacity        2856
+             Data Types
+--------   DHCP for IEEE 1394                                      2855
+
+
+
+
+RFC Editor                   Informational                     [Page 48]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Generic Security Service API Version 2 : Java           2853
+             Bindings
+--------   Deliver By SMTP Service Extension                       2852
+LDIF       The LDAP Data Interchange Format (LDIF) - Technical     2849
+             Specification
+--------   The PINT Service Protocol: Extensions to SIP and SDP    2848
+             for IP Access to Telephone Call Services
+LIPKEY     LIPKEY - A Low Infrastructure Public Key Mechanism      2847
+             Using SPKM
+--------   GSTN Address Element Extensions in E-mail Services      2846
+TSIG       Secret Key Transaction Authentication for DNS (TSIG)    2845
+GSN        IP and ARP over HIPPI-6400 (GSN)                        2835
+--------   ARP and IP Broadcast over HIPPI-800                     2834
+--------   Using Digest Authentication as a SASL Mechanism         2831
+MAIL       Internet Message Format                                 2822
+--------   Upgrading to TLS Within HTTP/1.1                        2817
+--------   Integrated Service Mappings on IEEE 802 Networks        2815
+--------   SBM (Subnet Bandwidth Manager): A Protocol for          2814
+             RSVP-based Admission Control over IEEE 802-style
+             networks
+--------   Certificate Management Messages over CMS                2797
+--------   Mobile IP Network Access Identifier Extension for       2794
+             IPv4
+--------   Mail Monitoring MIB                                     2789
+--------   Network Services Monitoring MIB                         2788
+--------   Definitions of Managed Objects for the Virtual          2787
+             Router Redundancy Protocol
+GRE        Generic Routing Encapsulation (GRE)                     2784
+DNS-SRV    A DNS RR for specifying the location of services        2782
+             (DNS SRV)
+MZAP       Multicast-Scope Zone Announcement Protocol (MZAP)       2776
+RPSL       Routing Policy System Replication                       2769
+SIIT       Stateless IP/ICMP Translation Algorithm (SIIT)          2765
+--------   RSVP Extensions for Policy Control                      2750
+--------   COPS usage for RSVP                                     2749
+COPS       The COPS (Common Open Policy Service) Protocol          2748
+--------   RSVP Cryptographic Authentication                       2747
+--------   RSVP Operation Over IP Tunnels                          2746
+--------   RSVP Diagnostic Messages                                2745
+--------   Generic Security Service API Version 2 : C-bindings     2744
+--------   Generic Security Service Application Program            2743
+             Interface Version 2, Update 1
+--------   OSPF for IPv6                                           2740
+--------   Calendar Attributes for vCard and LDAP                  2739
+--------   Corrections to "A Syntax for Describing Media           2738
+             Feature Sets"
+--------   NHRP Support for Virtual Private Networks               2735
+--------   IPv4 over IEEE 1394                                     2734
+
+
+
+RFC Editor                   Informational                     [Page 49]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+MADCAP     Multicast Address Dynamic Client Allocation Protocol    2730
+             (MADCAP)
+--------   The Transmission of IP Over the Vertical Blanking       2728
+             Interval of a Television Signal
+--------   PGP Authentication for RIPE Database Updates            2726
+--------   Routing Policy System Security                          2725
+--------   Traffic Flow Measurement: Meter MIB                     2720
+TLS        Addition of Kerberos Cipher Suites to Transport         2712
+             Layer Security (TLS)
+--------   IPv6 Router Alert Option                                2711
+MLD-IPv6   Multicast Listener Discovery (MLD) for IPv6             2710
+--------   Integrated Services Mappings for Low Speed Networks     2688
+--------   PPP in a Real-time Oriented HDLC-like Framing           2687
+--------   The Multi-Class Extension to Multi-Link PPP             2686
+VPNI       Virtual Private Networks Identifier                     2685
+--------   Multiprotocol Encapsulation over ATM Adaptation         2684
+             Layer 5
+--------   A Round-trip Delay Metric for IPPM                      2681
+--------   A One-way Packet Loss Metric for IPPM                   2680
+--------   A One-way Delay Metric for IPPM                         2679
+IPPM-MET   IPPM Metrics for Measuring Connectivity                 2678
+NHRP-MIB   Definitions of Managed Objects for the NBMA Next Hop    2677
+             Resolution Protocol (NHRP)
+--------   IPv6 Jumbograms                                         2675
+--------   Non-Terminal DNS Name Redirection                       2672
+EDNS0      Extension Mechanisms for DNS (EDNS0)                    2671
+--------   Definitions of Managed Objects for the ADSL Lines       2662
+L2TP       Layer Two Tunneling Protocol "L2TP"                     2661
+--------   RTP Payload Format for PureVoice(tm) Audio              2658
+--------   CIP Transport Protocols                                 2653
+--------   MIME Object Definitions for the Common Indexing         2652
+             Protocol (CIP)
+CIP        The Architecture of the Common Indexing Protocol        2651
+             (CIP)
+ODMR-SMTP  ON-DEMAND MAIL RELAY (ODMR) SMTP with Dynamic IP        2645
+             Addresses
+--------   Internationalization of the File Transfer Protocol      2640
+--------   Enhanced Security Services for S/MIME                   2634
+--------   Diffie-Hellman Key Agreement Method                     2631
+--------   NFS Version 2 and Version 3 Security Issues and the     2623
+             NFS Protocol's Use of RPCSEC_GSS and Kerberos V5
+RPSL       Routing Policy Specification Language (RPSL)            2622
+--------   PPP over SONET/SDH                                      2615
+--------   DHCP Options for Service Location Protocol              2610
+--------   Service Templates and Service: Schemes                  2609
+--------   Service Location Protocol, Version 2                    2608
+--------   Directory Server Monitoring MIB                         2605
+--------   ILMI-Based Server Discovery for NHRP                    2603
+
+
+
+RFC Editor                   Informational                     [Page 50]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   ILMI-Based Server Discovery for MARS                    2602
+--------   ILMI-Based Server Discovery for ATMARP                  2601
+--------   Assured Forwarding PHB Group                            2597
+--------   Using TLS with IMAP, POP3 and ACAP                      2595
+--------   Definitions of Managed Objects for WWW Services         2594
+--------   Transmission of IPv6 Packets over Frame Relay           2590
+             Networks Specification
+LDAPv3     Lightweight Directory Access Protocol (v3):             2589
+             Extensions for Dynamic Directory Services
+--------   Internet X.509 Public Key Infrastructure Operational    2585
+             Protocols: FTP and HTTP
+--------   Definitions of Managed Objects for APPN/HPR in IP       2584
+             Networks
+TCP-CC     TCP Congestion Control                                  2581
+APP-MIB    Application Management MIB                              2564
+--------   DHCP Option to Disable Stateless Auto-Configuration     2563
+             in IPv4 Clients
+TN2370E-RT Definitions of Protocol and Managed Objects for         2562
+             TN3270E Response Time Collection Using SMIv2
+             (TN3270E-RT-MIB)
+--------   Base Definitions of Managed Objects for TN3270E         2561
+             Using SMIv2
+PKIX       X.509 Internet Public Key Infrastructure Online         2560
+             Certificate Status Protocol - OCSP
+MHTML      MIME Encapsulation of Aggregate Documents, such as      2557
+             HTML (MHTML)
+--------   Use of BGP-4 Multiprotocol Extensions for IPv6          2545
+             Inter-Domain Routing
+DHK-DNS    Storage of Diffie-Hellman Keys in the Domain Name       2539
+             System (DNS)
+--------   DSA KEYs and SIGs in the Domain Name System (DNS)       2536
+--------   Media Features for Display, Print, and Fax              2534
+--------   A Syntax for Describing Media Feature Sets              2533
+--------   Extended Facsimile Using Internet Mail                  2532
+--------   Indicating Supported Media Features Using Extensions    2530
+             to DSN and MDN
+--------   Transmission of IPv6 over IPv4 Domains without          2529
+             Explicit Tunnels
+--------   Reserved IPv6 Subnet Anycast Addresses                  2526
+ATM-MIBMAN Definitions of Managed Objects for ATM Management       2515
+ATM-TC-OID Definitions of Textual Conventions and                  2514
+             OBJECT-IDENTITIES for ATM Management
+--------   Managed Objects for Controlling the Collection and      2513
+             Storage of Accounting Information for
+             Connection-Oriented Networks
+--------   Accounting Information for ATM Networks                 2512
+--------   Compressing IP/UDP/RTP Headers for Low-Speed Serial     2508
+             Links
+
+
+
+RFC Editor                   Informational                     [Page 51]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   IP Header Compression                                   2507
+--------   Transmission of IPv6 Packets over ARCnet Networks       2497
+--------   Definitions of Managed Objects for the DS0 and DS0      2494
+             Bundle Interface Type
+IPv6ATMNET IPv6 over ATM Networks                                  2492
+IPv6-NBMA  IPv6 over Non-Broadcast Multiple Access (NBMA)          2491
+             networks
+--------   DHCP Option for The Open Group's User Authentication    2485
+             Protocol
+--------   PPP LCP Internationalization Configuration Option       2484
+--------   Gateways and MIME Security Multiparts                   2480
+--------   Definition of the Differentiated Services Field (DS     2474
+             Field) in the IPv4 and IPv6 Headers
+--------   Generic Packet Tunneling in IPv6 Specification          2473
+--------   Transmission of IPv6 Packets over Token Ring Networks   2470
+--------   Transmission of IPv6 Packets over FDDI Networks         2467
+--------   Transmission of IPv6 Packets over Ethernet Networks     2464
+EBN-MIB    Definitions of Managed Objects for Extended Border      2457
+             Node
+--------   Definitions of Managed Objects for APPN TRAPS           2456
+APPN-MIB   Definitions of Managed Objects for APPN                 2455
+--------   The ESP CBC-Mode Cipher Algorithms                      2451
+POP3-EXT   POP3 Extension Mechanism                                2449
+IMIP       iCalendar Message-Based Interoperability Protocol       2447
+             (iMIP)
+ITIP       iCalendar Transport-Independent Interoperability        2446
+             Protocol (iTIP) Scheduling Events, BusyTime, To-dos
+             and Journal Entries
+ICALENDAR  Internet Calendaring and Scheduling Core Object         2445
+             Specification (iCalendar)
+OTP-SASL   The One-Time-Password SASL Mechanism                    2444
+--------   BGP Route Flap Damping                                  2439
+--------   RTP Payload Format for JPEG-compressed Video            2435
+--------   RTP Payload Format for BT.656 Video Encoding            2431
+--------   FTP Extensions for IPv6 and NATs                        2428
+MIME-VCARD vCard MIME Directory Profile                            2426
+TXT-DIR    A MIME Content-Type for Directory Information           2425
+3DESE      The PPP Triple-DES Encryption Protocol (3DESE)          2420
+DESE-bis   The PPP DES Encryption Protocol, Version 2 (DESE-bis)   2419
+--------   Definitions of Managed Objects for Multicast over       2417
+             UNI 3.0/3.1 based ATM Networks
+--------   The NULL Encryption Algorithm and Its Use With IPsec    2410
+ESPDES-CBC The ESP DES-CBC Cipher Algorithm With Explicit IV       2405
+--------   The Use of HMAC-SHA-1-96 within ESP and AH              2404
+--------   The Use of HMAC-MD5-96 within ESP and AH                2403
+DATA-URL   The "data" URL scheme                                   2397
+CIDMID-URL Content-ID and Message-ID Uniform Resource Locators     2392
+
+
+
+
+RFC Editor                   Informational                     [Page 52]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Feature negotiation mechanism for the File Transfer     2389
+             Protocol
+--------   Returning Values from Forms: multipart/form-data        2388
+MIME-RELAT The MIME Multipart/Related Content-type                 2387
+--------   Protection of BGP Sessions via the TCP MD5 Signature    2385
+             Option
+POP-URL    POP URL Scheme                                          2384
+--------   Interoperation of Controlled-Load Service and           2381
+             Guaranteed Service with ATM
+--------   RSVP over ATM Implementation Requirements               2380
+TIPV3      Transaction Internet Protocol Version 3.0               2371
+OSPF-LSA   The OSPF Opaque LSA Option                              2370
+--------   The Use of URLs as Meta-Syntax for Core Mail List       2369
+             Commands and their Transport through Message Header
+             Fields
+URLMAILTO  The mailto URL scheme                                   2368
+PPP-AAL    PPP Over AAL5                                           2364
+PPP-FUNI   PPP Over FUNI                                           2363
+IMAP4NAME  IMAP4 Namespace                                         2342
+NHRP-SCSP  A Distributed NHRP Service Using SCSP                   2335
+SCSP       Server Cache Synchronization Protocol (SCSP)            2334
+--------   NHRP Protocol Applicability Statement                   2333
+NHRP       NBMA Next Hop Resolution Protocol (NHRP)                2332
+UNI-SIG    ATM Signalling Support for IP over ATM - UNI            2331
+             Signalling 4.0 Update
+RTSP       Real Time Streaming Protocol (RTSP)                     2326
+IPOA-MIB   Definitions of Managed Objects for Classical IP and     2320
+             ARP Over ATM Using SMIv2 (IPOA-MIB)
+DNS-NCACHE Negative Caching of DNS Queries (DNS NCACHE)            2308
+OR-ADD     Representing the O/R Address hierarchy in the X.500     2294
+             Directory Information Tree
+SUBTABLE   Representing Tables and Subtrees in the X.500           2293
+             Directory
+--------   Mobile-IPv4 Configuration Option for PPP IPCP           2290
+SLM-APP    Definitions of System-Level Managed Objects for         2287
+             Applications
+--------   Definitions of Managed Objects for IEEE 802.12          2266
+             Repeater Devices
+RTP-MPEG   RTP Payload Format for MPEG1/MPEG2 Video                2250
+--------   Using Domains in LDAP/X.500 Distinguished Names         2247
+ACAP       ACAP -- Application Configuration Access Protocol       2244
+OTP-ER     OTP Extended Responses                                  2243
+NETWAREIP  NetWare/IP Domain Name and Information                  2242
+DHCP-NDS   DHCP Options for Novell Directory Services              2241
+HPR-MIB    Definitions of Managed Objects for HPR using SMIv2      2238
+DLUR-MIB   Definitions of Managed Objects for DLUR using SMIv2     2232
+MIME-EXT   MIME Parameter Value and Encoded Word Extensions:       2231
+             Character Sets, Languages, and Continuations
+
+
+
+RFC Editor                   Informational                     [Page 53]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+FTPSECEXT  FTP Security Extensions                                 2228
+--------   Simple Hit-Metering and Usage-Limiting for HTTP         2227
+--------   IP Broadcast over ATM Networks                          2226
+IP-ATM     Classical IP and ARP over ATM                           2225
+IMAP4LOGIN IMAP4 Login Referrals                                   2221
+--------   A Common Schema for the Internet White Pages Service    2218
+--------   General Characterization Parameters for Integrated      2215
+             Service Network Elements
+--------   Integrated Services Management Information Base         2214
+             Guaranteed Service Extensions using SMIv2
+--------   Integrated Services Management Information Base         2213
+             using SMIv2
+GQOS       Specification of Guaranteed Quality of Service          2212
+--------   Specification of the Controlled-Load Network Element    2211
+             Service
+RSVP-IS    The Use of RSVP with IETF Integrated Services           2210
+RSVP-IPSEC RSVP Extensions for IPSEC Data Flows                    2207
+RSVP-MIB   RSVP Management Information Base using SMIv2            2206
+RSVP       Resource ReSerVation Protocol (RSVP) -- Version 1       2205
+             Functional Specification
+RPCSEC-GSS RPCSEC_GSS Protocol Specification                       2203
+RTP-RAD    RTP Payload for Redundant Audio Data                    2198
+IMAPPOPAU  IMAP/POP AUTHorize Extension for Simple                 2195
+             Challenge/Response
+IMAP4MAIL  IMAP4 Mailbox Referrals                                 2193
+--------   Communicating Presentation Information in Internet      2183
+             Messages: The Content-Disposition Header Field
+DNS-CLAR   Clarifications to the DNS Specification                 2181
+IMAP4-IDLE IMAP4 IDLE command                                      2177
+SLP        Service Location Protocol                               2165
+--------   Use of an X.500/LDAP directory to support MIXER         2164
+             address mapping
+DNS-MCGAM  Using the Internet DNS to Distribute MIXER              2163
+             Conformant Global Address Mapping (MCGAM)
+--------   Carrying PostScript in X.400 and MIME                   2160
+--------   A MIME Body Part for FAX                                2159
+--------   X.400 Image Body Parts                                  2158
+--------   Mapping between X.400 and RFC-822/MIME Message Bodies   2157
+MIXER      MIXER (Mime Internet X.400 Enhanced Relay): Mapping     2156
+             between X.400 and RFC 822/MIME
+MAIL-SERV  Mailbox Names for Common Services, Roles and            2142
+             Functions
+URN-SYNTAX URN Syntax                                              2141
+DNS-UPDATE Dynamic Updates in the Domain Name System (DNS          2136
+             UPDATE)
+DC-MIB     Dial Control Management Information Base using SMIv2    2128
+ISDN-MIB   ISDN Management Information Base using SMIv2            2127
+ITOT       ISO Transport Service on top of TCP (ITOT)              2126
+
+
+
+RFC Editor                   Informational                     [Page 54]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+BAP-BACP   The PPP Bandwidth Allocation Protocol (BAP) / The       2125
+             PPP Bandwidth Allocation Control Protocol (BACP)
+VEMMI-URL  VEMMI URL Specification                                 2122
+ROUT-ALERT IP Router Alert Option                                  2113
+802.3-MIB  Definitions of Managed Objects for IEEE 802.3           2108
+             Repeater Devices using SMIv2
+PPP-NBFCP  The PPP NetBIOS Frames Control Protocol (NBFCP)         2097
+RIP-TRIG   Triggered Extensions to RIP to Support Demand           2091
+             Circuits
+IMAP4-LIT  IMAP4 non-synchronizing literals                        2088
+IMAP4-QUO  IMAP4 QUOTA extension                                   2087
+HMAC-MD5   HMAC-MD5 IP Authentication with Replay Prevention       2085
+RIPNG-IPV6 RIPng for IPv6                                          2080
+URI-ATT    Definition of an X.500 Attribute Type and an Object     2079
+             Class to Hold Uniform Resource Identifiers (URIs)
+MIME-MODEL The Model Primary Content Type for Multipurpose         2077
+             Internet Mail Extensions
+URLZ39.50  Uniform Resource Locators for Z39.50                    2056
+SNANAU-APP Definitions of Managed Objects for APPC using SMIv2     2051
+PPP-SNACP  The PPP SNA Control Protocol (SNACP)                    2043
+SMTP-ENH   SMTP Service Extension for Returning Enhanced Error     2034
+             Codes
+RTP-CELLB  RTP Payload Format of Sun's CellB Video Encoding        2029
+SPKM       The Simple Public-Key GSS-API Mechanism (SPKM)          2025
+DLSW-MIB   Definitions of Managed Objects for Data Link            2024
+             Switching using SMIv2
+MULTI-UNI  Support for Multicast over UNI 3.0/3.1 based ATM        2022
+             Networks
+802.12-MIB IEEE 802.12 Interface MIB                               2020
+TCP-ACK    TCP Selective Acknowledgment Options                    2018
+URL-ACC    Definition of the URL MIME External-Body Access-Type    2017
+MIME-PGP   MIME Security with Pretty Good Privacy (PGP)            2015
+MOBILEIPMI The Definitions of Managed Objects for IP Mobility      2006
+             Support using SMIv2
+--------   Applicability Statement for IP Mobility Support         2005
+MINI-IP    Minimal Encapsulation within IP                         2004
+IPENCAPIP  IP Encapsulation within IP                              2003
+BGP-COMM   BGP Communities Attribute                               1997
+DNS-NOTIFY A Mechanism for Prompt Notification of Zone Changes     1996
+             (DNS NOTIFY)
+DNS-IZT    Incremental Zone Transfer in DNS                        1995
+SMTP-ETRN  SMTP Service Extension for Remote Message Queue         1985
+             Starting
+SNA        Serial Number Arithmetic                                1982
+PPP-FRAME  PPP in Frame Relay                                      1973
+PPP-ECP    The PPP Encryption Control Protocol (ECP)               1968
+GSSAPI-KER The Kerberos Version 5 GSS-API Mechanism                1964
+PPP-CCP    The PPP Compression Control Protocol (CCP)              1962
+
+
+
+RFC Editor                   Informational                     [Page 55]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+GSSAPI-SOC GSS-API Authentication Method for SOCKS Version 5       1961
+AUTH-SOCKS Username/Password Authentication for SOCKS V5           1929
+SOCKSV5    SOCKS Protocol Version 5                                1928
+MIME-Encyp Security Multiparts for MIME: Multipart/Signed and      1847
+             Multipart/Encrypted
+--------   Binding Protocols for ONC RPC Version 2                 1833
+RPC        RPC: Remote Procedure Call Protocol Specification       1831
+             Version 2
+--------   The ESP DES-CBC Transform                               1829
+--------   Requirements for IP Version 4 Routers                   1812
+OSPF-DC    Extending OSPF to Support Demand Circuits               1793
+MIME-EDI   MIME Encapsulation of EDI Objects                       1767
+ATM        ATM Signaling Support for IP over ATM                   1755
+IPNG       The Recommendation for the IP Next Generation           1752
+             Protocol
+MacMIME    MIME Encapsulation of Macintosh Files - MacMIME         1740
+IMAP4-AUTH IMAP4 Authentication Mechanisms                         1731
+RDBMS-MIB  Relational Database Management System (RDBMS)           1697
+             Management Information Base (MIB) using SMIv2
+PPP-TRANS  PPP Reliable Transmission                               1663
+PPP-ISDN   PPP over ISDN                                           1618
+PPP-X25    PPP in X.25                                             1598
+RIP-DC     Extensions to RIP to Support Demand Circuits            1582
+TOPT-ENVIR Telnet Environment Option                               1572
+PPP-LCP    PPP LCP Extensions                                      1570
+PPP/IPMIB  The Definitions of Managed Objects for the IP           1473
+             Network Control Protocol of the Point-to-Point
+             Protocol
+PPP/SECMIB The Definitions of Managed Objects for the Security     1472
+             Protocols of the Point-to-Point Protocol
+PPP/LCPMIB The Definitions of Managed Objects for the Link         1471
+             Control Protocol of the Point-to-Point Protocol
+SNMP-IPX   SNMP over IPX                                           1420
+IDENT      Identification Protocol                                 1413
+SNMP-X.25  SNMP MIB Extension for the X.25 Packet Layer            1382
+SNMP-LAPB  SNMP MIB Extension for X.25 LAPB                        1381
+PPP-OSINLC The PPP OSI Network Layer Control Protocol (OSINLCP)    1377
+TOPT-RFC   Telnet Remote Flow Control Option                       1372
+PPP-IPCP   The PPP Internet Protocol Control Protocol (IPCP)       1332
+TCP-EXT    TCP Extensions for High Performance                     1323
+--------   Encoding Network Addresses to Support Operation over    1277
+             Non-OSI Lower Layers
+ICMP-ROUT  ICMP Router Discovery Messages                          1256
+IS-IS      Use of OSI IS-IS for routing in TCP/IP and dual         1195
+             environments
+IP-CMPRS   Compressing TCP/IP Headers for Low-Speed Serial Links   1144
+TOPT-XDL   Telnet X display location option                        1096
+TOPT-TERM  Telnet terminal-type option                             1091
+
+
+
+RFC Editor                   Informational                     [Page 56]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+TOPT-TS    Telnet terminal speed option                            1079
+TOPT-NAWS  Telnet window size option                               1073
+TOPT-X.3   Telnet X.3 PAD option                                   1053
+TOPT-DATA  Telnet Data Entry Terminal option: DODIIS               1043
+             implementation
+TOPT-3270  Telnet 3270 regime option                               1041
+TOPT-TLN   Telnet terminal location number option                   946
+TOPT-OM    Output marking Telnet option                             933
+TOPT-TACAC TACACS user identification Telnet option                 927
+TOPT-EOR   Telnet end of record option                              885
+TOPT-SNDL  Telnet send-location option                              779
+TOPT-SUPO  Telnet SUPDUP-Output option                              749
+TOPT-SUP   Telnet SUPDUP option                                     736
+TOPT-BYTE  Revised Telnet byte macro option                         735
+TOPT-LOGO  Telnet logout option                                     727
+TOPT-REM   Remote Controlled Transmission and Echoing Telnet        726
+             option
+TOPT-EXT   Telnet extended ASCII option                             698
+
+3.5.  Best Current Practice Ordered by BCP
+
+   [Note: an asterisk at the end of a line indicates a change from the
+   previous edition of this document.]
+
+Mnemonic   Title                                               RFC# BCP#
+------------------------------------------------------------------------
+--------   Variance for The PPP Compression Control Protocol   1915    3
+             and The PPP Encryption Control Protocol
+--------   An Appeal to the Internet Community to Return       1917    4
+             Unused IP Networks (Prefixes) to the IANA
+--------   Address Allocation for Private Internets            1918    5
+--------   Guidelines for creation, selection, and             1930    6
+             registration of an Autonomous System (AS)
+--------   Implications of Various Address Allocation          2008    7
+             Policies for Internet Routing
+--------   IRTF Research Group Guidelines and Procedures       2014    8
+--------   The Internet Standards Process -- Revision 3        2026    9
+--------   IAB and IESG Selection, Confirmation, and Recall    3777   10
+             Process: Operation of the Nominating and Recall
+             Committees
+--------   The Organizations Involved in the IETF Standards    2028   11
+             Process
+--------   Internet Registry IP Allocation Guidelines          2050   12
+--------   Media Type Specifications and Registration          4288*  13
+             Procedures
+--------   Multipurpose Internet Mail Extensions (MIME) Part   4289*  13
+             Four: Registration Procedures
+
+
+
+
+RFC Editor                   Informational                     [Page 57]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Key words for use in RFCs to Indicate Requirement   2119   14
+             Levels
+--------   Deployment of the Internet White Pages Service      2148   15
+--------   Selection and Operation of Secondary DNS Servers    2182   16
+--------   Use of DNS Aliases for Network Services             2219   17
+--------   IETF Policy on Character Sets and Languages         2277   18
+--------   IANA Charset Registration Procedures                2978   19
+--------   Classless IN-ADDR.ARPA delegation                   2317   20
+--------   Expectations for Computer Security Incident         2350   21
+             Response
+--------   Guide for Internet Standards Writers                2360   22
+--------   Administratively Scoped IP Multicast                2365   23
+--------   RSVP over ATM Implementation Guidelines             2379   24
+--------   IETF Working Group Guidelines and Procedures        2418   25
+--------   Guidelines for Writing an IANA Considerations       2434   26
+             Section in RFCs
+--------   Advancement of MIB specifications on the IETF       2438   27
+             Standards Track
+--------   Enhancing TCP Over Satellite Channels using         2488   28
+             Standard Mechanisms
+--------   Anti-Spam Recommendations for SMTP MTAs             2505   30
+--------   Media Feature Tag Registration Procedure            2506   31
+--------   Reserved Top Level DNS Names                        2606   32
+--------   Changing the Default for Directed Broadcasts in     2644   34
+             Routers
+--------   Guidelines for Writers of RTP Payload Format        2736   36
+             Specifications
+--------   IANA Allocation Guidelines For Values In the        2780   37
+             Internet Protocol and Related Headers
+--------   Network Ingress Filtering: Defeating Denial of      2827   38
+             Service Attacks which employ IP Source Address
+             Spoofing
+--------   Charter of the Internet Architecture Board (IAB)    2850   39
+--------   Root Name Server Operational Requirements           2870   40
+--------   Congestion Control Principles                       2914   41
+--------   Domain Name System (DNS) IANA Considerations        2929   42
+--------   Procedures and IANA Guidelines for Definition of    2939   43
+             New DHCP Options and Message Types
+--------   Use of HTTP State Management                        2964   44
+--------   IETF Discussion List Charter                        3005   45
+--------   Recommended Internet Service Provider Security      3013   46
+             Services and Procedures
+--------   Tags for Identifying Languages                      4646*  47
+--------   Matching of Language Tags                           4647*  47
+--------   End-to-end Performance Implications of Slow Links   3150   48
+--------   End-to-end Performance Implications of Links with   3155   50
+             Errors
+
+
+
+
+RFC Editor                   Informational                     [Page 58]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   IANA Guidelines for IPv4 Multicast Address          3171   51
+             Assignments
+--------   Management Guidelines & Operational Requirements    3172   52
+             for the Address and Routing Parameter Area Domain
+             ("arpa")
+--------   GLOP Addressing in 233/8                            3180   53
+--------   IETF Guidelines for Conduct                         3184   54
+--------   Guidelines for Evidence Collection and Archiving    3227   55
+--------   On the use of HTTP as a Substrate                   3205   56
+--------   IANA Considerations for IPv4 Internet Group         3228   57
+             Management Protocol (IGMP)
+--------   Defining the IETF                                   3233   58
+--------   A Transient Prefix for Identifying Profiles under   3349   59
+             Development by the Working Groups of the Internet
+             Engineering Task Force
+--------   Inappropriate TCP Resets Considered Harmful         3360   60
+--------   Strong Security Requirements for Internet           3365   61
+             Engineering Task Force Standard Protocols
+--------   Advice to link designers on link Automatic Repeat   3366   62
+             reQuest (ARQ)
+--------   Session Initiation Protocol for Telephones          3372   63
+             (SIP-T): Context and Architectures
+--------   Internet Assigned Numbers Authority (IANA)          4520*  64
+             Considerations for the Lightweight Directory
+             Access Protocol (LDAP)
+--------   Dynamic Delegation Discovery System (DDDS) Part     3405   65
+             Five: URI.ARPA Assignment Procedures
+--------   Uniform Resource Names (URN) Namespace Definition   3406   66
+             Mechanisms
+--------   Change Process for the Session Initiation Protocol  3427   67
+             (SIP)
+--------   Layer Two Tunneling Protocol (L2TP) Internet        3438   68
+             Assigned Numbers Authority (IANA) Considerations
+             Update
+--------   TCP Performance Implications of Network Path        3449   69
+             Asymmetry
+--------   Guidelines for the Use of Extensible Markup         3470   70
+             Language (XML) within IETF Protocols
+--------   TCP over Second (2.5G) and Third (3G) Generation    3481   71
+             Wireless Networks
+--------   Guidelines for Writing RFC Text on Security         3552   72
+             Considerations
+--------   An IETF URN Sub-namespace for Registered Protocol   3553   73
+             Parameters
+--------   Coexistence between Version 1, Version 2, and       3584   74
+             Version 3 of the Internet-standard Network
+             Management Framework
+
+
+
+
+RFC Editor                   Informational                     [Page 59]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Session Initiation Protocol (SIP) Basic Call Flow   3665   75
+             Examples
+--------   Session Initiation Protocol (SIP) Public Switched   3666   76
+             Telephone Network (PSTN) Call Flows
+--------   IETF ISOC Board of Trustee Appointment Procedures   3677   77
+--------   IETF Rights in Contributions                        3978*  78
+--------   RFC 3978 Update to Recognize the IETF Trust         4748*  78
+--------   Intellectual Property Rights in IETF Technology     3979*  79
+--------   Clarification of the Third Party Disclosure         4879*  79
+             Procedure in RFC 3979
+--------   Delegation of E.F.F.3.IP6.ARPA                      3681   80
+--------   The IETF XML Registry                               3688   81
+--------   Assigning Experimental and Testing Numbers          3692   82
+             Considered Useful
+--------   A Practice for Revoking Posting Rights to IETF      3683   83
+             Mailing Lists
+--------   Ingress Filtering for Multihomed Networks           3704   84
+--------   Best Current Practices for Third Party Call         3725   85
+             Control (3pcc) in the Session Initiation Protocol
+             (SIP)
+--------   Determining Strengths For Public Keys Used For      3766   86
+             Exchanging Symmetric Keys
+--------   Use of Interior Gateway Protocol (IGP) Metric as a  3785   87
+             second MPLS Traffic Engineering (TE) Metric
+--------   IANA Considerations for the Point-to-Point          3818   88
+             Protocol (PPP)
+--------   Advice for Internet Subnetwork Designers            3819   89
+--------   Registration Procedures for Message Header Fields   3864*  90
+--------   DNS IPv6 Transport Operational Guidelines           3901*  91
+--------   The IESG and RFC Editor Documents: Procedures       3932*  92
+--------   A Model for IETF Process Experiments                3933*  93
+--------   Updates to RFC 2418 Regarding the Management of     3934*  94
+             IETF Mailing Lists
+--------   A Mission Statement for the IETF                    3935*  95
+--------   Procedures for Modifying the Resource reSerVation   3936*  96
+             Protocol (RSVP)
+--------   Clarifying when Standards Track Documents may       3967*  97
+             Refer Normatively to Documents at a Lower Level
+--------   Handling Normative References to Standards-Track    4897*  97
+             Documents
+--------   The Internet Assigned Number Authority (IANA)       3968*  98
+             Header Field Parameter Registry for the Session
+             Initiation Protocol (SIP)
+--------   The Internet Assigned Number Authority (IANA)       3969*  99
+             Uniform Resource Identifier (URI) Parameter
+             Registry for the Session Initiation Protocol (SIP
+--------   Early IANA Allocation of Standards Track Code       4020* 100
+             Points
+
+
+
+RFC Editor                   Informational                     [Page 60]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Structure of the IETF Administrative Support        4071* 101
+             Activity (IASA)
+--------   BCP 101 Update for IPR Trust                        4371* 101
+--------   IAB Processes for Management of IETF Liaison        4052* 102
+             Relationships
+--------   Procedures for Handling Liaison Statements to and   4053* 103
+             from the IETF
+--------   Terminology for Describing Internet Connectivity    4084* 104
+--------   Embedding Globally-Routable Internet Addresses      4085* 105
+             Considered Harmful
+--------   Randomness Requirements for Security                4086* 106
+--------   Guidelines for Cryptographic Key Management         4107* 107
+--------   IP Performance Metrics (IPPM) Metrics Registry      4148* 108
+--------   Deprecation of "ip6.int"                            4159* 109
+--------   Tunneling Multiplexed Compressed RTP (TCRTP)        4170* 110
+--------   Guidelines for Authors and Reviewers of MIB         4181* 111
+             Documents
+--------   RFC 4181 Update to Recognize the IETF Trust         4841* 111
+--------   Prioritized Treatment of Specific OSPF Version 2    4222* 112
+             Packets and Congestion Avoidance
+--------   The IETF Administrative Oversight Committee (IAOC)  4333* 113
+             Member Selection Guidelines and Process
+--------   BGP Communities for Data Collection                 4384* 114
+--------   Guidelines and Registration Procedures for New URI  4395* 115
+             Schemes
+--------   IANA Allocations for Pseudowire Edge to Edge        4446* 116
+             Emulation (PWE3)
+--------   Interworking between the Session Initiation         4497* 117
+             Protocol (SIP) and QSIG
+--------   Considerations for Lightweight Directory Access     4521* 118
+             Protocol (LDAP) Extensions
+--------   Session Initiation Protocol (SIP) Call Control -    4579* 119
+             Conferencing for User Agents
+--------   Source-Specific Protocol Independent Multicast in   4608* 120
+             232/8
+--------   Multicast Source Discovery Protocol (MSDP)          4611* 121
+             Deployment Scenarios
+CIDR-STRA  Classless Inter-domain Routing (CIDR): The          4632* 122
+             Internet Address Assignment and Aggregation Plan
+--------   Observed DNS Resolution Misbehavior                 4697* 123
+--------   Specifying Alternate Semantics for the Explicit     4774* 124
+             Congestion Notification (ECN) Field
+--------   Procedures for Protocol Extensions and Variations   4775* 125
+--------   Operation of Anycast Services                       4786* 126
+--------   Network Address Translation (NAT) Behavioral        4787* 127
+             Requirements for Unicast UDP
+--------   Avoiding Equal Cost Multipath Treatment in MPLS     4928* 128
+             Networks
+
+
+
+RFC Editor                   Informational                     [Page 61]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Change Process for Multiprotocol Label Switching    4929* 129
+             (MPLS) and Generalized MPLS (GMPLS) Protocols and
+             Procedures
+--------   IANA Considerations for OSPF                        4940* 130
+--------   Symmetric RTP / RTP Control Protocol (RTCP)         4961* 131
+--------   Guidance for Authentication, Authorization, and     4962* 132
+             Accounting (AAA) Key Management
+--------   Specifying New Congestion Control Algorithms        5033* 133
+--------   Email Submission Operations: Access and             5068* 134
+             Accountability Requirements
+--------   IP Multicast Requirements for a Network Address     5135* 135
+             Translator (NAT) and a Network Address Port
+             Translator (NAPT)
+
+3.6.  Best Current Practice Ordered by RFC
+
+   [Note: an asterisk at the end of a line indicates a change from the
+   previous edition of this document.]
+
+Mnemonic   Title                                               BCP# RFC#
+------------------------------------------------------------------------
+--------   IP Multicast Requirements for a Network Address     135 5135*
+             Translator (NAT) and a Network Address Port
+             Translator (NAPT)
+--------   Email Submission Operations: Access and             134 5068*
+             Accountability Requirements
+--------   Specifying New Congestion Control Algorithms        133 5033*
+--------   Guidance for Authentication, Authorization, and     132 4962*
+             Accounting (AAA) Key Management
+--------   Symmetric RTP / RTP Control Protocol (RTCP)         131 4961*
+--------   IANA Considerations for OSPF                        130 4940*
+--------   Change Process for Multiprotocol Label Switching    129 4929*
+             (MPLS) and Generalized MPLS (GMPLS) Protocols
+             and Procedures
+--------   Avoiding Equal Cost Multipath Treatment in MPLS     128 4928*
+             Networks
+--------   Handling Normative References to Standards-Track     97 4897*
+             Documents
+--------   Clarification of the Third Party Disclosure          79 4879*
+             Procedure in RFC 3979
+--------   RFC 4181 Update to Recognize the IETF Trust         111 4841*
+--------   Network Address Translation (NAT) Behavioral        127 4787*
+             Requirements for Unicast UDP
+--------   Operation of Anycast Services                       126 4786*
+--------   Procedures for Protocol Extensions and Variations   125 4775*
+--------   Specifying Alternate Semantics for the Explicit     124 4774*
+             Congestion Notification (ECN) Field
+--------   RFC 3978 Update to Recognize the IETF Trust          78 4748*
+
+
+
+RFC Editor                   Informational                     [Page 62]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Observed DNS Resolution Misbehavior                 123 4697*
+--------   Matching of Language Tags                            47 4647*
+--------   Tags for Identifying Languages                       47 4646*
+CIDR-STRA  Classless Inter-domain Routing (CIDR): The          122 4632*
+             Internet Address Assignment and Aggregation Plan
+--------   Multicast Source Discovery Protocol (MSDP)          121 4611*
+             Deployment Scenarios
+--------   Source-Specific Protocol Independent Multicast      120 4608*
+             in 232/8
+--------   Session Initiation Protocol (SIP) Call Control -    119 4579*
+             Conferencing for User Agents
+--------   Considerations for Lightweight Directory Access     118 4521*
+             Protocol (LDAP) Extensions
+--------   Internet Assigned Numbers Authority (IANA)           64 4520*
+             Considerations for the Lightweight Directory
+             Access Protocol (LDAP)
+--------   Interworking between the Session Initiation         117 4497*
+             Protocol (SIP) and QSIG
+--------   IANA Allocations for Pseudowire Edge to Edge        116 4446*
+             Emulation (PWE3)
+--------   Guidelines and Registration Procedures for New      115 4395*
+             URI Schemes
+--------   BGP Communities for Data Collection                 114 4384*
+--------   BCP 101 Update for IPR Trust                        101 4371*
+--------   The IETF Administrative Oversight Committee         113 4333*
+             (IAOC) Member Selection Guidelines and Process
+--------   Multipurpose Internet Mail Extensions (MIME)         13 4289*
+             Part Four: Registration Procedures
+--------   Media Type Specifications and Registration           13 4288*
+             Procedures
+--------   Prioritized Treatment of Specific OSPF Version 2    112 4222*
+             Packets and Congestion Avoidance
+--------   Guidelines for Authors and Reviewers of MIB         111 4181*
+             Documents
+--------   Tunneling Multiplexed Compressed RTP (TCRTP)        110 4170*
+--------   Deprecation of "ip6.int"                            109 4159*
+--------   IP Performance Metrics (IPPM) Metrics Registry      108 4148*
+--------   Guidelines for Cryptographic Key Management         107 4107*
+--------   Randomness Requirements for Security                106 4086*
+--------   Embedding Globally-Routable Internet Addresses      105 4085*
+             Considered Harmful
+--------   Terminology for Describing Internet Connectivity    104 4084*
+--------   Structure of the IETF Administrative Support        101 4071*
+             Activity (IASA)
+--------   Procedures for Handling Liaison Statements to       103 4053*
+             and from the IETF
+--------   IAB Processes for Management of IETF Liaison        102 4052*
+             Relationships
+
+
+
+RFC Editor                   Informational                     [Page 63]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Early IANA Allocation of Standards Track Code       100 4020*
+             Points
+--------   Intellectual Property Rights in IETF Technology      79 3979*
+--------   IETF Rights in Contributions                         78 3978*
+--------   The Internet Assigned Number Authority (IANA)        99 3969*
+             Uniform Resource Identifier (URI) Parameter
+             Registry for the Session Initiation Protocol
+             (SIP)
+--------   The Internet Assigned Number Authority (IANA)        98 3968*
+             Header Field Parameter Registry for the Session
+             Initiation Protocol (SIP)
+--------   Clarifying when Standards Track Documents may        97 3967*
+             Refer Normatively to Documents at a Lower Level
+--------   Procedures for Modifying the Resource                96 3936*
+             reSerVation Protocol (RSVP)
+--------   A Mission Statement for the IETF                     95 3935*
+--------   Updates to RFC 2418 Regarding the Management of      94 3934*
+             IETF Mailing Lists
+--------   A Model for IETF Process Experiments                 93 3933*
+--------   The IESG and RFC Editor Documents: Procedures        92 3932*
+--------   DNS IPv6 Transport Operational Guidelines            91 3901*
+--------   Registration Procedures for Message Header Fields    90 3864*
+--------   Advice for Internet Subnetwork Designers             89 3819
+--------   IANA Considerations for the Point-to-Point           88 3818
+             Protocol (PPP)
+--------   Use of Interior Gateway Protocol (IGP) Metric as     87 3785
+             a second MPLS Traffic Engineering (TE) Metric
+--------   IAB and IESG Selection, Confirmation, and Recall     10 3777
+             Process: Operation of the Nominating and Recall
+             Committees
+--------   Determining Strengths For Public Keys Used For       86 3766
+             Exchanging Symmetric Keys
+--------   Best Current Practices for Third Party Call          85 3725
+             Control (3pcc) in the Session Initiation
+             Protocol (SIP)
+--------   Ingress Filtering for Multihomed Networks            84 3704
+--------   Assigning Experimental and Testing Numbers           82 3692
+             Considered Useful
+--------   The IETF XML Registry                                81 3688
+--------   A Practice for Revoking Posting Rights to IETF       83 3683
+             Mailing Lists
+--------   Delegation of E.F.F.3.IP6.ARPA                       80 3681
+--------   IETF ISOC Board of Trustee Appointment Procedures    77 3677
+--------   Session Initiation Protocol (SIP) Public             76 3666
+             Switched Telephone Network (PSTN) Call Flows
+--------   Session Initiation Protocol (SIP) Basic Call         75 3665
+             Flow Examples
+
+
+
+
+RFC Editor                   Informational                     [Page 64]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Coexistence between Version 1, Version 2, and        74 3584
+             Version 3 of the Internet-standard Network
+             Management Framework
+--------   An IETF URN Sub-namespace for Registered             73 3553
+             Protocol Parameters
+--------   Guidelines for Writing RFC Text on Security          72 3552
+             Considerations
+--------   TCP over Second (2.5G) and Third (3G) Generation     71 3481
+             Wireless Networks
+--------   Guidelines for the Use of Extensible Markup          70 3470
+             Language (XML) within IETF Protocols
+--------   TCP Performance Implications of Network Path         69 3449
+             Asymmetry
+--------   Layer Two Tunneling Protocol (L2TP) Internet         68 3438
+             Assigned Numbers Authority (IANA) Considerations
+             Update
+--------   Change Process for the Session Initiation            67 3427
+             Protocol (SIP)
+--------   Uniform Resource Names (URN) Namespace               66 3406
+             Definition Mechanisms
+--------   Dynamic Delegation Discovery System (DDDS) Part      65 3405
+             Five: URI.ARPA Assignment Procedures
+--------   Session Initiation Protocol for Telephones           63 3372
+             (SIP-T): Context and Architectures
+--------   Advice to link designers on link Automatic           62 3366
+             Repeat reQuest (ARQ)
+--------   Strong Security Requirements for Internet            61 3365
+             Engineering Task Force Standard Protocols
+--------   Inappropriate TCP Resets Considered Harmful          60 3360
+--------   A Transient Prefix for Identifying Profiles          59 3349
+             under Development by the Working Groups of the
+             Internet Engineering Task Force
+--------   Defining the IETF                                    58 3233
+--------   IANA Considerations for IPv4 Internet Group          57 3228
+             Management Protocol (IGMP)
+--------   Guidelines for Evidence Collection and Archiving     55 3227
+--------   On the use of HTTP as a Substrate                    56 3205
+--------   IETF Guidelines for Conduct                          54 3184
+--------   GLOP Addressing in 233/8                             53 3180
+--------   Management Guidelines & Operational Requirements     52 3172
+             for the Address and Routing Parameter Area
+             Domain ("arpa")
+--------   IANA Guidelines for IPv4 Multicast Address           51 3171
+             Assignments
+--------   End-to-end Performance Implications of Links         50 3155
+             with Errors
+--------   End-to-end Performance Implications of Slow Links    48 3150
+
+
+
+
+RFC Editor                   Informational                     [Page 65]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Recommended Internet Service Provider Security       46 3013
+             Services and Procedures
+--------   IETF Discussion List Charter                         45 3005
+--------   IANA Charset Registration Procedures                 19 2978
+--------   Use of HTTP State Management                         44 2964
+--------   Procedures and IANA Guidelines for Definition of     43 2939
+             New DHCP Options and Message Types
+--------   Domain Name System (DNS) IANA Considerations         42 2929
+--------   Congestion Control Principles                        41 2914
+--------   Root Name Server Operational Requirements            40 2870
+--------   Charter of the Internet Architecture Board (IAB)     39 2850
+--------   Network Ingress Filtering: Defeating Denial of       38 2827
+             Service Attacks which employ IP Source Address
+             Spoofing
+--------   IANA Allocation Guidelines For Values In the         37 2780
+             Internet Protocol and Related Headers
+--------   Guidelines for Writers of RTP Payload Format         36 2736
+             Specifications
+--------   Changing the Default for Directed Broadcasts in      34 2644
+             Routers
+--------   Reserved Top Level DNS Names                         32 2606
+--------   Media Feature Tag Registration Procedure             31 2506
+--------   Anti-Spam Recommendations for SMTP MTAs              30 2505
+--------   Enhancing TCP Over Satellite Channels using          28 2488
+             Standard Mechanisms
+--------   Advancement of MIB specifications on the IETF        27 2438
+             Standards Track
+--------   Guidelines for Writing an IANA Considerations        26 2434
+             Section in RFCs
+--------   IETF Working Group Guidelines and Procedures         25 2418
+--------   RSVP over ATM Implementation Guidelines              24 2379
+--------   Administratively Scoped IP Multicast                 23 2365
+--------   Guide for Internet Standards Writers                 22 2360
+--------   Expectations for Computer Security Incident          21 2350
+             Response
+--------   Classless IN-ADDR.ARPA delegation                    20 2317
+--------   IETF Policy on Character Sets and Languages          18 2277
+--------   Use of DNS Aliases for Network Services              17 2219
+--------   Selection and Operation of Secondary DNS Servers     16 2182
+--------   Deployment of the Internet White Pages Service       15 2148
+--------   Key words for use in RFCs to Indicate                14 2119
+             Requirement Levels
+--------   Internet Registry IP Allocation Guidelines           12 2050
+--------   The Organizations Involved in the IETF Standards     11 2028
+             Process
+--------   The Internet Standards Process -- Revision 3          9 2026
+--------   IRTF Research Group Guidelines and Procedures         8 2014
+
+
+
+
+RFC Editor                   Informational                     [Page 66]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Implications of Various Address Allocation            7 2008
+             Policies for Internet Routing
+--------   Guidelines for creation, selection, and               6 1930
+             registration of an Autonomous System (AS)
+--------   Address Allocation for Private Internets              5 1918
+--------   An Appeal to the Internet Community to Return         4 1917
+             Unused IP Networks (Prefixes) to the IANA
+--------   Variance for The PPP Compression Control              3 1915
+             Protocol and The PPP Encryption Control Protocol
+
+3.7.  Experimental Protocols
+
+   [Note: an asterisk at the end of a line indicates a change from the
+   previous edition of this document.]
+
+Mnemonic   Title                                                    RFC#
+------------------------------------------------------------------------
+--------   Experiment in Exploratory Group Formation within the    5111*
+             Internet Engineering Task Force (IETF)
+--------   The Extensible Authentication Protocol-Internet Key     5106*
+             Exchange Protocol version 2 (EAP-IKEv2) Method
+--------   Using OpenPGP Keys for Transport Layer Security         5081*
+             (TLS) Authentication
+--------   Explicit Multicast (Xcast) Concepts and Options         5058*
+--------   Bundle Protocol Specification                           5050*
+--------   IPv6 Router Advertisement Option for DNS                5006*
+             Configuration
+--------   Mobile IPv4 Fast Handovers                              4988*
+--------   OSPF-xTE: Experimental Extension to OSPF for Traffic    4973*
+             Engineering
+--------   DNS Security (DNSSEC) Opt-In                            4956*
+--------   Atom License Extension                                  4946*
+--------   Abstract Syntax Notation X (ASN.X) Representation of    4914*
+             Encoding Instructions for the XML Encoding Rules (XER
+--------   Abstract Syntax Notation X (ASN.X) Representation of    4913*
+             Encoding Instructions for the Generic String
+             Encoding Rules (GSER)
+--------   Abstract Syntax Notation X (ASN.X)                      4912*
+--------   Encoding Instructions for the Robust XML Encoding       4911*
+             Rules (RXER)
+--------   Robust XML Encoding Rules (RXER) for Abstract Syntax    4910*
+             Notation One (ASN.1)
+--------   Multi-homing for small scale fixed network Using        4908*
+             Mobile IP and NEMO
+--------   Low-Latency Handoffs in Mobile IPv4                     4881*
+--------   Mobile IPv4 Regional Registration                       4857*
+--------   An IPv6 Prefix for Overlay Routable Cryptographic       4843*
+             Hash Identifiers (ORCHID)
+
+
+
+RFC Editor                   Informational                     [Page 67]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   TCP Friendly Rate Control (TFRC): The Small-Packet      4828*
+             (SP) Variant
+--------   OSPF Link-Local Signaling                               4813*
+--------   Quick-Start for TCP and IP                              4782*
+--------   The Intrusion Detection Exchange Protocol (IDXP)        4767*
+--------   The Intrusion Detection Message Exchange Format         4765*
+             (IDMEF)
+--------   The EAP-PSK Protocol: A Pre-Shared Key Extensible       4764*
+             Authentication Protocol (EAP) Method
+--------   Multiple Authentication Exchanges in the Internet       4739*
+             Key Exchange (IKEv2) Protocol
+--------   The Dynamic Source Routing Protocol (DSR) for Mobile    4728*
+             Ad Hoc Networks for IPv4
+--------   Netnews Administration System (NAS)                     4707*
+--------   IETF Operational Notes                                  4693*
+--------   TCP-Friendly Multicast Congestion Control (TFMCC):      4654*
+             Protocol Specification
+--------   Improving the Robustness of TCP to Non-Congestion       4653*
+             Events
+--------   Experiment in Long-Term Suspensions From Internet       4633*
+             Engineering Task Force (IETF) Mailing Lists
+--------   Multicast Source Discovery Protocol (MSDP) MIB          4624*
+--------   IPv6 Node Information Queries                           4620*
+--------   NEC's Simple Middlebox Configuration (SIMCO)            4540*
+             Protocol Version 3.0
+--------   The Lightweight Directory Access Protocol (LDAP)        4533*
+             Content Synchronization Operation
+--------   Lightweight Directory Access Protocol (LDAP) Turn       4531*
+             Operation
+--------   The Managed Object Aggregation MIB                      4498*
+--------   Repeated Authentication in Internet Key Exchange        4478*
+             (IKEv2) Protocol
+--------   Derivation of DNS Name Predecessor and Successor        4471*
+--------   Web Distributed Authoring and Versioning (WebDAV)       4437*
+             Redirect Reference Resources
+--------   Selectively Reliable Multicast Protocol (SRMP)          4410*
+--------   Sender Policy Framework (SPF) for Authorizing Use of    4408*
+             Domains in E-Mail, Version 1
+--------   Purported Responsible Address in E-Mail Messages        4407*
+--------   Sender ID: Authenticating E-Mail                        4406*
+--------   SMTP Service Extension for Indicating the               4405*
+             Responsible Submitter of an E-Mail Message
+--------   Neighbor Discovery Proxies (ND Proxy)                   4389*
+--------   Internet X.509 Public Key Infrastructure Repository     4386*
+             Locator Service
+--------   Calendar Access Protocol (CAP)                          4324*
+--------   Datatypes for Web Distributed Authoring and             4316*
+             Versioning (WebDAV) Properties
+
+
+
+RFC Editor                   Informational                     [Page 68]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+ISATAP     Intra-Site Automatic Tunnel Addressing Protocol         4214*
+             (ISATAP)
+--------   Hierarchical Mobile IPv6 Mobility Management (HMIPv6)   4140*
+--------   Forward RTO-Recovery (F-RTO): An Algorithm for          4138*
+             Detecting Spurious Retransmission Timeouts with TCP
+             and the Stream Control Transmission Protocol (SCTP)
+--------   Russian Dolls Bandwidth Constraints Model for           4127*
+             Diffserv-aware MPLS Traffic Engineering
+--------   Max Allocation with Reservation Bandwidth               4126*
+             Constraints Model for Diffserv-aware MPLS Traffic
+             Engineering & Performance Comparisons
+--------   Maximum Allocation Bandwidth Constraints Model for      4125*
+             Diffserv-aware MPLS Traffic Engineering
+--------   Fast Handovers for Mobile IPv6                          4068*
+--------   Context Transfer Protocol (CXTP)                        4067*
+--------   Candidate Access Router Discovery (CARD)                4066*
+--------   Instructions for Seamoby and Experimental Mobility      4065*
+             Protocol IANA Allocations
+--------   BinaryTime: An Alternate Format for Representing        4049*
+             Date and Time in ASN.1
+--------   Extensions to Support Efficient Carrying of             4045*
+             Multicast Traffic in Layer-2 Tunneling Protocol
+             (L2TP)
+--------   Maximum Transmission Unit Signalling Extensions for     3988*
+             the Label Distribution Protocol
+--------   Protocol Independent Multicast - Dense Mode             3973*
+             (PIM-DM): Protocol Specification (Revised)
+--------   Real-time Transport Protocol (RTP) Payload Format       3952*
+             for internet Low Bit Rate Codec (iLBC) Speech
+--------   Internet Low Bit Rate Codec (iLBC)                      3951*
+--------   Negative-Acknowledgment (NACK)-Oriented Reliable        3941*
+             Multicast (NORM) Building Blocks
+--------   Negative-acknowledgment (NACK)-Oriented Reliable        3940*
+             Multicast (NORM) Protocol
+--------   Alternative Decision Making Processes for               3929*
+             Consensus-Blocked Decisions in the IETF
+--------   FLUTE - File Delivery over Unidirectional Transport     3926*
+DNS-SRV    Remote Service Discovery in the Service Location        3832
+             Protocol (SLP) via DNS SRV
+--------   Next Generation Structure of Management Information     3781
+             (SMIng) Mappings to the Simple Network Management
+             Protocol (SNMP)
+--------   SMIng - Next Generation Structure of Management         3780
+             Information
+--------   Limited Slow-Start for TCP with Large Congestion        3742
+             Windows
+--------   Wave and Equation Based Rate Control (WEBRC)            3738
+             Building Block
+
+
+
+RFC Editor                   Informational                     [Page 69]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Using TCP Duplicate Selective Acknowledgement           3708
+             (DSACKs) and Stream Control Transmission Protocol
+             (SCTP) Duplicate Transmission Sequence Numbers
+             (TSNs) to Detect Spurious Retransmissions
+--------   Compact Forward Error Correction (FEC) Schemes          3695
+--------   Topology Dissemination Based on Reverse-Path            3684
+             Forwarding (TBRPF)
+--------   Domain Administrative Data in Lightweight Directory     3663
+             Access Protocol (LDAP)
+--------   The Mailbox Update (MUPDATE) Distributed Mailbox        3656
+             Database Protocol
+--------   HighSpeed TCP for Large Congestion Windows              3649
+--------   Optimized Link State Routing Protocol (OLSR)            3626
+--------   Multicast Source Discovery Protocol (MSDP)              3618
+--------   Ad hoc On-Demand Distance Vector (AODV) Routing         3561
+--------   Robust Explicit Congestion Notification (ECN)           3540
+             Signaling with Nonces
+--------   Using Extensible Markup Language-Remote Procedure       3529
+             Calling (XML-RPC) in Blocks Extensible Exchange
+             Protocol (BEEP)
+--------   Mesh-enhanced Service Location Protocol (mSLP)          3528
+--------   The Eifel Detection Algorithm for TCP                   3522
+--------   TCP Congestion Control with Appropriate Byte            3465
+             Counting (ABC)
+--------   Layered Coding Transport (LCT) Building Block           3451
+--------   Asynchronous Layered Coding (ALC) Protocol              3450
+             Instantiation
+--------   Simple Network Management Protocol Over Transmission    3430
+             Control Protocol Transport Mapping
+--------   Select and Sort Extensions for the Service Location     3421
+             Protocol (SLP)
+--------   The Application Exchange (APEX) Presence Service        3343
+--------   Dual Stack Hosts Using "Bump-in-the-API" (BIA)          3338
+--------   Policy-Based Accounting                                 3334
+--------   PGM Reliable Transport Protocol Specification           3208
+--------   Domain Security Services using S/MIME                   3183
+SMX        Script MIB Extensibility Protocol Version 1.1           3179
+--------   ISO/IEC 9798-3 Authentication SASL Mechanism            3163
+--------   Electronic Signature Policies                           3125
+--------   A DNS RR Type for Lists of Address Prefixes (APL RR)    3123
+--------   Finding an RSIP Server with SLP                         3105
+--------   RSIP Support for End-to-end IPsec                       3104
+--------   Realm Specific IP: Protocol Specification               3103
+--------   Realm Specific IP: Framework                            3102
+--------   OpenLDAP Root Service An experimental LDAP referral     3088
+             service
+--------   Notification and Subscription for SLP                   3082
+--------   MPLS Loop Prevention Mechanism                          3063
+
+
+
+RFC Editor                   Informational                     [Page 70]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Internet X.509 Public Key Infrastructure Data           3029
+             Validation and Certification Server Protocols
+--------   Unified Memory Space Protocol Specification             3018
+SAP        Session Announcement Protocol                           2974
+--------   Protocol Independent Multicast MIB for IPv4             2934
+MASC       The Multicast Address-Set Claim (MASC) Protocol         2909
+--------   Generic AAA Architecture                                2903
+--------   DNS Extensions to Support IPv6 Address Aggregation      2874
+             and Renumbering
+--------   TCP Congestion Window Validation                        2861
+TSWTCM     A Time Sliding Window Three Colour Marker (TSWTCM)      2859
+--------   OSPF over ATM and Proxy-PAR                             2844
+PPP-SDL    PPP over Simple Data Link (SDL) using SONET/SDH with    2823
+             ATM-like framing
+--------   Diffie-Helman USM Key Management Information Base       2786
+             and Textual Convention
+--------   An HTTP Extension Framework                             2774
+--------   Encryption using KEA and SKIPJACK                       2773
+--------   Sampling of the Group Membership in RTP                 2762
+--------   Definitions of Managed Objects for Service Level        2758
+             Agreements Performance Monitoring
+HTCP       Hyper Text Caching Protocol (HTCP/0.0)                  2756
+--------   RTFM: New Attributes for Traffic Flow Measurement       2724
+--------   PPP EAP TLS Authentication Protocol                     2716
+--------   SPKI Certificate Theory                                 2693
+--------   SPKI Requirements                                       2692
+--------   QoS Routing Mechanisms and OSPF Extensions              2676
+DNS        Binary Labels in the Domain Name System                 2673
+--------   The Secure HyperText Transfer Protocol                  2660
+--------   Security Extensions For HTML                            2659
+--------   LDAPv2 Client vs. the Index Mesh                        2657
+--------   Registration Procedures for SOIF Template Types         2656
+--------   CIP Index Object Format for SOIF Objects                2655
+--------   A Tagged Index Object for use in the Common Indexing    2654
+             Protocol
+--------   An LDAP Control and Schema for Holding Operation        2649
+             Signatures
+--------   Mapping between LPD and IPP Protocols                   2569
+IPP-RAT    Rationale for the Structure of the Model and            2568
+             Protocol for the Internet Printing Protocol
+IPP-DG     Design Goals for an Internet Printing Protocol          2567
+DNS-INFO   Detached Domain Name System (DNS) Information           2540
+PHOTURIS-E Photuris: Extended Schemes and Attributes               2523
+PHOTURIS-S Photuris: Session-Key Management Protocol               2522
+ICMP-SEC   ICMP Security Failures Messages                         2521
+NHRP-MNHCS NHRP with Mobile NHCs                                   2520
+--------   URI Resolution Services Necessary for URN Resolution    2483
+MARS-SCSP  A Distributed MARS Service Using SCSP                   2443
+
+
+
+RFC Editor                   Informational                     [Page 71]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+--------   Domain Names and Company Name Retrieval                 2345
+RTP-MPEG   RTP Payload Format for Bundled MPEG                     2343
+--------   Intra-LIS IP multicast among routers over ATM using     2337
+             Sparse Mode PIM
+--------   The Safe Response Header Field                          2310
+LDAP-NIS   An Approach for Using LDAP as a Network Information     2307
+             Service
+HTTP-RVSA  HTTP Remote Variant Selection Algorithm -- RVSA/1.0     2296
+TCN-HTTP   Transparent Content Negotiation in HTTP                 2295
+TOPT-COMPO Telnet Com Port Control Option                          2217
+--------   A Trivial Convention for using HTTP in URN Resolution   2169
+MAP-MAIL   MaXIM-11 - Mapping between X.400 / Internet mail and    2162
+              Mail-11 mail
+MIME-ODA   A MIME Body Part for ODA                                2161
+OSPF-DIG   OSPF with Digital Signatures                            2154
+IP-SCSI    Encapsulating IP with the Small Computer System         2143
+             Interface
+X.500-NAME Managing the X.500 Root Naming Context                  2120
+GKMP-ARCH  Group Key Management Protocol (GKMP) Architecture       2094
+GKMP-SPEC  Group Key Management Protocol (GKMP) Specification      2093
+TFTP-MULTI TFTP Multicast Option                                   2090
+IP-Echo    IP Echo Host Service                                    2075
+TOPT-CHARS TELNET CHARSET Option                                   2066
+URAS       Uniform Resource Agents (URAs)                          2016
+GPS-AR     GPS-Based Addressing and Routing                        2009
+ETFTP      Experiments with a Simple File Transfer Protocol for    1986
+             Radio Links using Enhanced Trivial File Transfer
+             Protocol (ETFTP)
+SMKD       Scalable Multicast Key Distribution                     1949
+DNS-LOC    A Means for Expressing Location Information in the      1876
+             Domain Name System
+SGML-MT    SGML Media Types                                        1874
+CONT-MT    Message/External-Body Content-ID Access Type            1873
+UNARP      ARP Extension - UNARP                                   1868
+ESP3DES    The ESP Triple DES Transform                            1851
+--------   SMTP 521 Reply Code                                     1846
+--------   SMTP Service Extension for Checkpoint/Restart           1845
+--------   Communicating Presentation Information in Internet      1806
+             Messages: The Content-Disposition Header
+--------   Schema Publishing in X.500 Directory                    1804
+--------   MHS use of the X.500 Directory to support MHS Routing   1801
+--------   Class A Subnet Experiment                               1797
+TCP/IPXMIB TCP/IPX Connection Mib Specification                    1792
+--------   TCP And UDP Over IPX Networks With Fixed Path MTU       1791
+ICMP-DM    ICMP Domain Name Messages                               1788
+CLNP-MULT  Host Group Extensions for CLNP Multicasting             1768
+OSPF-OVFL  OSPF Database Overflow                                  1765
+RWP        Remote Write Protocol - Version 1.0                     1756
+
+
+
+RFC Editor                   Informational                     [Page 72]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+NARP       NBMA Address Resolution Protocol (NARP)                 1735
+DNS-ENCODE DNS Encoding of Geographical Location                   1712
+TCP-POS    An Extension to TCP : Partial Order Service             1693
+T/TCP      T/TCP -- TCP Extensions for Transactions Functional     1644
+             Specification
+MIME-UNI   Using Unicode with MIME                                 1641
+FOOBAR     FTP Operation Over Big Address Records (FOOBAR)         1639
+X500-CHART Charting Networks in the X.500 Directory                1609
+X500-DIR   Representing IP Information in the X.500 Directory      1608
+SNMP-DPI   Simple Network Management Protocol Distributed          1592
+             Protocol Interface Version 2.0
+CLNP-TUBA  Use of ISO CLNP in TUBA Environments                    1561
+REM-PRINT  Principles of Operation for the TPC.INT Subdomain:      1528
+             Remote Printing -- Technical Procedures
+DASS       DASS - Distributed Authentication Security Service      1507
+EHF-MAIL   Encoding Header Field for Internet Messages             1505
+RAP        RAP: Internet Route Access Protocol                     1476
+TP-IX      TP/IX: The Next Internet                                1475
+--------   Routing Coordination for X.400 MHS Services Within a    1465
+             Multi Protocol / Multi Network Environment Table
+             Format V3 for Static Routing
+--------   Using the Domain Name System To Store Arbitrary         1464
+             String Attributes
+IRCP       Internet Relay Chat Protocol                            1459
+SIFT       SIFT/UFT: Sender-Initiated/Unsolicited File Transfer    1440
+DIR-ARP    Directed ARP                                            1433
+TEL-SPX    Telnet Authentication: SPX                              1412
+TEL-KER    Telnet Authentication: Kerberos Version 4               1411
+TRACE-IP   Traceroute Using an IP Option                           1393
+DNS-IP     An Experiment in DNS Based IP Routing                   1383
+RMCP       Remote Mail Checking Protocol                           1339
+MSP2       Message Send Protocol 2                                 1312
+DSLCP      Dynamically Switched Link Control Protocol              1307
+--------   X.500 and Domains                                       1279
+IN-ENCAP   Scheme for an internet encapsulation protocol:          1241
+             Version 1
+CLNS-MIB   CLNS MIB for use with Connectionless Network            1238
+             Protocol (ISO 8473) and End System to Intermediate
+             System (ISO 9542)
+CFDP       Coherent File Distribution Protocol                     1235
+IP-AX.25   Internet protocol encapsulation of AX.25 frames         1226
+ALERTS     Techniques for managing asynchronously generated        1224
+             alerts
+MPP        Message Posting Protocol (MPP)                          1204
+SNMP-BULK  Bulk Table Retrieval with the SNMP                      1187
+DNS-RR     New DNS RR Definitions                                  1183
+IMAP2      Interactive Mail Access Protocol: Version 2             1176
+
+
+
+
+RFC Editor                   Informational                     [Page 73]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+NTP-OSI    Network Time Protocol (NTP) over the OSI Remote         1165
+             Operations Service
+DMF-MAIL   Digest message format                                   1153
+RDP        Version 2 of the Reliable Data Protocol (RDP)           1151
+--------   Standard for the transmission of IP datagrams on        1149
+             avian carriers
+TCP-ACO    TCP alternate checksum options                          1146
+--------   The Q Method of Implementing TELNET Option              1143
+             Negotiation
+IP-DVMRP   Distance Vector Multicast Routing Protocol              1075
+VMTP       VMTP: Versatile Message Transaction Protocol            1045
+COOKIE-JAR Distributed-protocol authentication scheme              1004
+NETBLT     NETBLT: A bulk data transfer protocol                    998
+IRTP       Internet Reliable Transaction Protocol functional        938
+             and interface specification
+LDP        Loader Debugger Protocol                                 909
+RDP        Reliable Data Protocol                                   908
+RLP        Resource Location Protocol                               887
+
+4.  Security Considerations
+
+   This memo does not affect the technical security of the Internet, but
+   it does cite a number of important security specifications.
+
+Editors' Addresses
+
+   RFC Editor
+   USC/Information Sciences Institute
+   4676 Admiralty Way
+   Marina del Rey, CA 90292
+
+   EMail: rfc-editor@rfc-editor.org
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+RFC Editor                   Informational                     [Page 74]
+
+RFC 5000          Internet Official Protocol Standards          May 2008
+
+
+Full Copyright Statement
+
+   Copyright (C) The IETF Trust (2008).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78 and at http://www.rfc-editor.org/copyright.html,
+   and except as set forth therein, the authors retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY, THE IETF TRUST AND
+   THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF
+   THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+
+
+
+
+
+
+
+
+
+
+
+RFC Editor                   Informational                     [Page 75]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc5000.txt](<www.ietf.org/rfc/rfc5000.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
