### PR TITLE
Archive rfc5029.txt

### DIFF
--- a/www.ietf.org/rfc/rfc5029.txt
+++ b/www.ietf.org/rfc/rfc5029.txt
@@ -1,0 +1,339 @@
+
+
+
+
+
+
+Network Working Group                                        JP. Vasseur
+Request for Comments: 5029                                    S. Previdi
+Category: Standards Track                             Cisco Systems, Inc
+                                                          September 2007
+
+
+             Definition of an IS-IS Link Attribute Sub-TLV
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Abstract
+
+   This document defines a sub-TLV called "Link-attributes" carried
+   within the TLV 22 and used to flood some link characteristics.
+
+Table of Contents
+
+   1. Introduction ....................................................2
+      1.1. Terminology ................................................2
+   2. Link-Attributes Sub-TLV Format ..................................2
+   3. Interoperability with Routers Not Supporting This Capability ....3
+   4. IANA Considerations .............................................3
+   5. Security Considerations .........................................3
+   6. Acknowledgements ................................................3
+   7. References ......................................................4
+      7.1. Normative References .......................................4
+      7.2. Informative References .....................................4
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vasseur & Previdi           Standards Track                     [Page 1]
+
+RFC 5029                  IS-IS Link Attribute            September 2007
+
+
+1.  Introduction
+
+   [IS-IS] specifies the IS-IS protocol (ISO 10589) with extensions to
+   support IPv4 in [RFC1195].  A router advertises one or several Link
+   State Protocol data units that are composed of variable length tuples
+   called TLVs (Type-Length-Value).
+
+   [RFC3784] defines a set of new TLVs whose aims are to add more
+   information about links characteristics, increase the range of IS-IS
+   metrics, and optimize the encoding of IS-IS prefixes.
+
+   This document defines a new sub-TLV named "Link-attributes" carried
+   within the extended IS reachability TLV (type 22) specified in
+   [RFC3784].
+
+1.1  Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+2.  Link-Attributes Sub-TLV Format
+
+   The link-attribute sub-TLV is carried within the TLV 22 and has a
+   format identical to the sub-TLV format used by the Traffic
+   Engineering Extensions for IS-IS ([RFC3784]): 1 octet of sub-type, 1
+   octet of length of the value field of the sub-TLV followed by the
+   value field -- in this case, a 16 bit flags field.
+
+   The Link-attribute sub-type is 19 and the link-attribute has a length
+   of 2 octets.
+
+   This sub-TLV is OPTIONAL and MUST appear at most once for a single IS
+   neighbor.  If a received Link State Packet (LSP) contains more than
+   one Link-Attribute Sub-TLV, an implementation SHOULD decide to
+   consider only the first encountered instance.
+
+   The following bits are defined:
+
+   Local Protection Available (0x01).  When set, this indicates that the
+   link is protected by means of some local protection mechanism (e.g.,
+   [RFC4090]).
+
+   Link excluded from local protection path (0x02).  When set, this link
+   SHOULD not be included in any computation of a repair path by any
+   other router in the routing area.  The triggers for setting up this
+   bit are out of the scope of this document.
+
+
+
+
+Vasseur & Previdi           Standards Track                     [Page 2]
+
+RFC 5029                  IS-IS Link Attribute            September 2007
+
+
+3.  Interoperability with Routers Not Supporting This Capability
+
+   A router not supporting the link-attribute sub-TLV will just silently
+   ignore this sub-TLV.
+
+4.  IANA Considerations
+
+   IANA has assigned codepoint 19 for the link-attribute sub-TLV defined
+   in this document and carried within TLV 22.
+
+   IANA has created a registry for bit values inside the link-attributes
+   sub-TLV.  The initial contents of this registry are as follows
+
+     Value   Name                                 Reference
+     -----   ----                                 ---------
+     0x1     Local Protection Available           [RFC5029]
+     0x2     Link Excluded from Local Protection  [RFC5029]
+
+   Further values are to be allocated by the Standards Action process
+   defined in [RFC2434], with Early Allocation (defined in [RFC4020])
+   permitted.
+
+5.  Security Considerations
+
+   Any new security issues raised by the procedures in this document
+   depend upon the opportunity for LSPs to be snooped and modified, the
+   ease/difficulty of which has not been altered.  As the LSPs may now
+   contain additional information regarding router capabilities, this
+   new information would also become available to an attacker.
+   Specifications based on this mechanism need to describe the security
+   considerations around the disclosure and modification of their
+   information.  Note that an integrity mechanism, such as one defined
+   in [RFC3567], should be applied if there is high risk resulting from
+   the modification of capability information.
+
+6.  Acknowledgements
+
+   The authors would like to thank Mike Shand, Les Ginsberg, and Bill
+   Fenner for their useful comments.
+
+
+
+
+
+
+
+
+
+
+
+
+Vasseur & Previdi           Standards Track                     [Page 3]
+
+RFC 5029                  IS-IS Link Attribute            September 2007
+
+
+7.  References
+
+7.1.  Normative References
+
+   [IS-IS]    "Intermediate System to Intermediate System Intra-Domain
+              Routing Exchange Protocol for use in Conjunction with the
+              Protocol for Providing the Connectionless-mode Network
+              Service (ISO 8473)", ISO 10589.
+
+   [RFC1195]  Callon, R., "Use of OSI IS-IS for routing in TCP/IP and
+              dual environments", RFC 1195, December 1990.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2434]  Narten, T. and H. Alvestrand, "Guidelines for Writing an
+              IANA Considerations Section in RFCs", BCP 26, RFC 2434,
+              October 1998.
+
+   [RFC3784]  Smit, H. and T. Li, "Intermediate System to Intermediate
+              System (IS-IS) Extensions for Traffic Engineering (TE)",
+              RFC 3784, June 2004.
+
+   [RFC4020]  Kompella, K. and A. Zinin, "Early IANA Allocation of
+              Standards Track Code Points", BCP 100, RFC 4020, February
+              2005.
+
+7.2.  Informative References
+
+   [RFC3567]  Li, T. and R. Atkinson, "Intermediate System to
+              Intermediate System (IS-IS) Cryptographic Authentication",
+              RFC 3567, July 2003.
+
+   [RFC4090]  Pan, P., Swallow, G., and A. Atlas, "Fast Reroute
+              Extensions to RSVP-TE for LSP Tunnels", RFC 4090, May
+              2005.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vasseur & Previdi           Standards Track                     [Page 4]
+
+RFC 5029                  IS-IS Link Attribute            September 2007
+
+
+Authors' Addresses
+
+   JP Vasseur
+   Cisco Systems, Inc
+   1414 Massachusetts Avenue
+   Boxborough, MA  01719
+   USA
+
+   EMail: jpv@cisco.com
+
+
+   Stefano Previdi
+   Cisco Systems, Inc
+   Via Del Serafico 200
+   Roma  00142
+   Italy
+
+   EMail: sprevidi@cisco.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vasseur & Previdi           Standards Track                     [Page 5]
+
+RFC 5029                  IS-IS Link Attribute            September 2007
+
+
+Full Copyright Statement
+
+   Copyright (C) The IETF Trust (2007).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY, THE IETF TRUST AND
+   THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF
+   THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+
+
+
+
+
+
+
+
+
+
+
+Vasseur & Previdi           Standards Track                     [Page 6]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc5029.txt](<www.ietf.org/rfc/rfc5029.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
