### PR TITLE
Archive rfc5038.txt

### DIFF
--- a/www.ietf.org/rfc/rfc5038.txt
+++ b/www.ietf.org/rfc/rfc5038.txt
@@ -1,0 +1,1291 @@
+
+
+
+
+
+
+Network Working Group                                          B. Thomas
+Request for Comments: 5038                           Cisco Systems, Inc.
+Category: Informational                                     L. Andersson
+                                                                Acreo AB
+                                                            October 2007
+
+
+  The Label Distribution Protocol (LDP) Implementation Survey Results
+
+Status of This Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard of any kind.  Distribution of this
+   memo is unlimited.
+
+Abstract
+
+   Multiprotocol Label Switching (MPLS), described in RFC 3031, is a
+   method for forwarding packets that uses short, fixed-length values
+   carried by packets, called labels, to determine packet next hops.  A
+   fundamental concept in MPLS is that two Label Switching Routers
+   (LSRs) must agree on the meaning of the labels used to forward
+   traffic between and through them.  This common understanding is
+   achieved by using a set of procedures, called a Label Distribution
+   Protocol (as described in RFC 3036) , by which one LSR informs
+   another of label bindings it has made.  One such protocol, called
+   LDP, is used by LSRs to distribute labels to support MPLS forwarding
+   along normally routed paths.  This document reports on a survey of
+   LDP implementations conducted in August 2002 as part of the process
+   of advancing LDP from Proposed to Draft Standard.
+
+Table of Contents
+
+   1. Introduction ....................................................2
+      1.1. The LDP Survey Form ........................................2
+      1.2. LDP Survey Highlights ......................................3
+   2. Survey Results for LDP Features .................................4
+   3. Security Considerations .........................................7
+   4. References ......................................................7
+   Appendix A. Full LDP Survey Results ................................8
+   Appendix B. LDP Implementation Survey Form ........................13
+
+
+
+
+
+
+
+
+
+
+Thomas & Andersson           Informational                      [Page 1]
+
+RFC 5038           LDP Implementation Survey Results        October 2007
+
+
+1.  Introduction
+
+   Multiprotocol Label Switching (MPLS) is a method for forwarding
+   packets that uses short fixed-length values carried by packets,
+   called labels, to determine packet next hops [RFC3031].  A
+   fundamental MPLS concept is that two Label Switching Routers (LSRs)
+   must agree on the meaning of the labels used to forward traffic
+   between and through them.  This common understanding is achieved by
+   using a set of procedures by which one LSR informs another of label
+   bindings it has made.
+
+   Label Distribution Protocol (LDP) specifies a set of procedures LSRs
+   use to distribute labels to support MPLS forwarding along normally
+   routed paths.  LDP was specified originally by [RFC3036].  The
+   current LDP specification is [RFC5036], which obsoletes [RFC3036].
+   [RFC3037] describes the applicability of LDP.
+
+   This document reports on a survey of LDP implementations conducted in
+   August 2002 as part of the process of advancing LDP from Proposed to
+   Draft standard.
+
+   This section highlights some of the survey results.  Section 2
+   presents the survey results for LDP features, and Appendix A presents
+   the survey results in full.  Appendix B contains a copy of the survey
+   form.
+
+1.1.  The LDP Survey Form
+
+   The LDP implementation survey requested the following information
+   about LDP implementation:
+
+   -  Responding organization.  Provisions were made to accommodate
+      organizations that wished to respond anonymously.
+
+   -  The status, availability, and origin of the LDP implementation.
+
+   -  The LDP features implemented and for each whether it was tested
+      against an independent implementation.  The survey form listed
+      each LDP feature defined by [RFC3036] and requested one of the
+      following as the status of the feature:
+
+         t: Tested against another independent implementation
+         y: Implemented but not tested against independent
+            implementation
+         n: Not implemented
+         x: Not applicable to this type of implementation
+
+
+
+
+
+Thomas & Andersson           Informational                      [Page 2]
+
+RFC 5038           LDP Implementation Survey Results        October 2007
+
+
+      In addition, for the 'n' status, the responder could optionally
+      provide the following additional information:
+
+         s: RFC specification inadequate, unclear, or confusing
+         u: Utility of feature unclear
+         r: Feature not required for feature set implemented
+
+   This document uses the following conventions for reporting survey
+   results for a feature:
+
+      At By Cn indicates:
+
+      -  A responders implemented the feature and tested it against
+         another independent implementation (t)
+      -  B responders implemented the feature but have not tested it
+         against an independent implemented (y)
+      -  C responders did not implement the feature (n)
+
+      (Ds Eu Fr) indicates optional responses:
+
+      -  D responders thought the RFC 3036 specification of the feature
+         inadequate, unclear, or confusing (s).
+      -  E responders thought the utility of the feature unclear (u).
+      -  F responders considered the feature not required for the
+         feature set implemented (combines x and r).
+
+1.2.  LDP Survey Highlights
+
+   This section presents some highlights from the implementation survey.
+
+      -  There were 12 responses to the survey, 2 of which were
+         anonymous.  At the time of the survey, 10 of the implementation
+         were available as products and 2 were in beta test.  Eleven of
+         the implementations were available for sale; the remaining
+         implementation had been done by a company no longer in
+         business.
+
+      -  Seven implementations were independently written from the RFC
+         3036 specification.  Four implementations combined purchased or
+         free code with code written by the responder.
+
+         One of the implementations was fully purchased code ported to
+         the vendor's platform.
+
+      -  Every LDP feature in the survey questionnaire was implemented
+         by at least 2 respondents.
+
+
+
+
+
+Thomas & Andersson           Informational                      [Page 3]
+
+RFC 5038           LDP Implementation Survey Results        October 2007
+
+
+      -  Each of the 8 LDP Label Distribution Modes implemented and
+         tested:
+
+            8t 2y 2n   DU,  Ord Cntl, Lib reten
+            7t 1y 4n   DU,  Ind Cntl, Lib reten
+            7t 1y 4n   DoD  Ord Cntl, Cons reten
+            6t 1y 5n   DoD, Ind Cntl, Cons reten
+            6t 1y 5n   DU,  Ord Cntl, Cons reten
+            6t 0y 6n   DU,  Ind Cntl, Cons reten
+            4t 3y 5n   DoD, Ord Cntl, Lib reten
+            4t 2y 6n   DoD, Ind Cntl, Lib reten
+
+      -  Platform and Interface Label Spaces were both widely supported.
+
+            12t 0y 0n  Per platform
+             7t 1y 4n  Per interface
+
+      -  LDP Basic and Targeted Sessions were both widely supported.
+
+            12t 0y 0n  Basic/Directly Connected
+            11t 1y 0n  Targeted
+
+      -  The TCP MD5 Option for LDP session TCP connections was not
+         widely implemented.
+
+            3t 1y 8n
+
+2.  Survey Results for LDP Features
+
+   This section presents the survey results for LDP features using the
+   notational convention described in Section 1.2.  It omits the
+   optional status responses (s, u, r); complete results may be found in
+   Appendix A.
+
+      Feature
+         Survey Result
+
+      Interface types
+         12t 0y 0n      Packet
+         2t 3y 7n       Frame Relay
+         6t 2y 4n       ATM
+      Label Spaces
+         12t 0y 0n      Per platform
+         7t 1y 4n       Per interface
+      LDP Discovery
+         12t 0y 0n      Basic
+         11t 1y 0n      Targeted
+
+
+
+
+Thomas & Andersson           Informational                      [Page 4]
+
+RFC 5038           LDP Implementation Survey Results        October 2007
+
+
+      LDP Sessions
+         12t 0y 0n      Directly Connected
+         11t 1y 0n      Targeted
+      LDP Modes
+         7t 1y 4n       DU, Ind Cntl, Lib reten
+         8t 2y 2n       DU, Ord Cntl, Lib reten
+         6t 0y 6n       DU, Ind Cntl, Cons reten
+         6t 1y 5n       DU, Ord Cntl Cons reten
+         4t 2y 6n       DoD, Ind Cntl, Lib reten
+         4t 3y 5n       DoD, Ord Cntl, Lib reten
+         6t 1y 5n       DoD, Ind Cntl, Cons reten
+         7t 1y 4n       DoD, Ord Cntl, Cons reten
+      Loop Detection
+         9t 2y 1n
+      TCP MD5 Option
+         3t 1y 8n
+      LDP TLVs
+         7t 4y 0n       U-bit
+         7t 4y 0n       F-bit
+         12t 0y 0n      FEC TLV
+         6t 5y 1n         Wildcard
+         12t 0y 0n        Prefix
+         10t 0y 2n        Host
+         12t 0y 0n      Address List TLV
+         10t 1y 1n      Hop Count TLV
+         9t 2y 1n       Path Vector TLV
+         12t 0y 0n      Generic Label TLV
+         6t 2y 4n       ATM Label TLV
+         2t 3y 7n       Frame Relay Label TLV
+         12t 0y 0n      Status TLV
+         9t 3y 0n       Extended Status TLV
+         6t 4y 2n       Returned PDU TLV
+         6t 4y 2n       Returned Message TLV
+         12t 0y 0n      Common Hello Param TLV
+         12t 0y 0n        T-bit
+         11t 0y 1n        R-bit
+         11t 1y 0n        Hold Time
+         12t 0y 0n      IPv4 Transport Addr TLV
+         7t 2y 3n       Config Sequence Num TLV
+         1t 1y 1n       IPv6 Transport Addr TLV
+         12t 0y 0n      Common Session Param TLV
+         12t 0y 0n        KeepAlive Time
+         11t 0y 1n        PVLim
+         11t 1y 0n        PDU Max Length
+         6t 2y 2n       ATM Session Param TLV
+                          M values
+         5t 3y 4n           0 No Merge
+         3t 3y 6n           1 VP Merge
+
+
+
+Thomas & Andersson           Informational                      [Page 5]
+
+RFC 5038           LDP Implementation Survey Results        October 2007
+
+
+         5t 3y 4n           2 VC Merge
+         3t 3y 6n           3 VP & VC Merge
+         6t 2y 4n         D-bit
+         6t 2y 4n         ATM Label Range Component
+         2t 3y 7n       FR Session Param TLV
+                          M values
+         2t 3y 7n           0 No Merge
+         2t 3y 7n           1 Merge
+         2t 3y 7n         D-bit
+         2t 3y 7n         FR Label Range Component
+         10t 0y 2n      Label Request Msg ID TLV
+         2t 5y 5n       Vendor-Private TLV
+         1t 5y 6n       Experimental TLV
+      LDP Messages
+         12t 0y 0n      Notification Msg
+         12t 0y 0n      Hello Msg
+         12t 0y 0n      Initialization Msg
+         12t 0y 0n      KeepAlive Msg
+         12t 0y 0n      Address Msg
+         12t 0y 0n      Address Withdraw Msg
+         12t 0y 0n      Label Mapping Msg
+         10t 0y 2n        Label Request Msg Id TLV
+         10t 1y 1n        Hop Count TLV
+         10t 1y 1n        Path Vect TLV
+         9t 0y 3n       Label Request Msg
+         9t 0y 3n         Hop Count TLV
+         9t 0y 3n         Path Vect TLV
+         12t 0y 0n      Label Withdraw Msg
+         12t 0y 0n        Label TLV
+         11t 0y 1n      Label Release Msg
+         10t 1y 1n        Label TLV
+         9t 2y 1n       Label Abort Req Msg
+         2t 5y 5n       Vendor-Private Msg
+         1t 5y 6n       Experimental Msg
+      LDP Status Codes
+         9t 3y 0n       Success
+         8t 4y 0n       Bad LDP Id
+         7t 5y 0n       Bad Ptcl Version
+         7t 5y 0n       Bad PDU Length
+         7t 5y 0n       Unknown Message Type
+         7t 5y 0n       Bad Message Length
+         7t 4y 0n       Unknown TLV
+         7t 5y 0n       Bad TLV length
+         7t 5y 0n       Malformed TLV Value
+         11t 1y 0n      Hold Timer Expired
+         11t 1y 0n      Shutdown
+         10t 1y 1n      Loop Detected
+         7t 5y 0n       Unknown FEC
+
+
+
+Thomas & Andersson           Informational                      [Page 6]
+
+RFC 5038           LDP Implementation Survey Results        October 2007
+
+
+         11t 1y 0n      No Route
+         9t 3y 0n       No Label Resources
+         8t 3y 1n       Label Resources Available
+                        Session Rejected
+         7t 5y 0n         No Hello
+         9t 2y 1n         Param Advert Mode
+         9t 2y 1n         Param PDUMax Len
+         8t 3y 1n         Param Label Range
+         7t 5y 0n         Bad KA Time
+         11t 1y 0n      KeepAlive Timer Expired
+         9t 1y 2n       Label Request Aborted
+         6t 5y 1n       Missing Message Params
+         7t 5y 0n       Unsupported Addr Family
+         7t 5y 0n       Internal Error
+
+3.  Security Considerations
+
+   This document is a survey of existing LDP implementations; it does
+   not specify any protocol behavior.  Thus, security issues introduced
+   by the document are not discussed.
+
+4.  Informative References
+
+   [RFC3031] Rosen, E., Viswanathan, A., and R. Callon, "Multiprotocol
+             Label Switching Architecture", RFC 3031, January 2001.
+
+   [RFC3036] Andersson, L., Doolan, P., Feldman, N., Fredette, A., and
+             B. Thomas, "LDP Specification", RFC 3036, January 2001.
+
+   [RFC3037] Thomas, B. and E. Gray, "LDP Applicability", RFC 3037,
+             January 2001.
+
+   [RFC5036] Andersson, L., Ed., Minei, I., Ed., and B. Thomas, Ed.,
+             "LDP Specification", RFC 5036, October 2007.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Thomas & Andersson           Informational                      [Page 7]
+
+RFC 5038           LDP Implementation Survey Results        October 2007
+
+
+Appendix A.  Full LDP Survey Results
+
+LDP Implementation Survey Form (V 1.0)
+
+=======================================================================
+A. General Information
+
+Responders:
+
+  Anonymous:   2
+  Public:      10
+
+    Agilent Technologies
+    Celox Networks, Inc.
+    Cisco Systems, Inc.
+    Data Connection Ltd.
+    NetPlane Systems, Inc
+    Redback Networks
+    Riverstone Networks
+    Trillium, An Intel Company
+    Vivace Networks, Inc.
+    Wipro Technologies
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Thomas & Andersson           Informational                      [Page 8]
+
+RFC 5038           LDP Implementation Survey Results        October 2007
+
+
+=======================================================================
+B. LDP Implementation Status, Availability, Origin
+
+Status:
+     [  ]  Development
+     [  ]  Alpha
+     [ 2]  Beta
+     [10]  Product
+     [  ]  Other (describe):
+
+Availability:
+     [  ]  Public and free
+     [  ]  Only to selected organizations/companies but free
+     [11]  On sale
+     [  ]  For internal company use only
+     [ 1]  Other:
+
+Implementation based on:  (check all that apply)
+     [ 1]  Purchased code
+          (please list source if possible)
+     [  ]  Free code
+          (please list source if possible)
+     [ 7]  Internal implementation
+          (no outside code, just from specs)
+     [ 4]  Internal implementation on top of purchased
+          or free code
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Thomas & Andersson           Informational                      [Page 9]
+
+RFC 5038           LDP Implementation Survey Results        October 2007
+
+
+=======================================================================
+C. LDP Feature Survey
+
+For each feature listed, please indicate the status of the
+implementation using one of the following:
+
+    't'   tested against another independent implementation
+    'y'   implemented but not tested against independent
+          implementation
+    'n'   not implemented
+    'x'   not applicable to this type of implementation
+
+  Optional: For 'n' status, indicate reason for not implementing
+            using one of the following:
+
+            's'  RFC specification inadequate, unclear, or confusing
+            'u'  utility of feature unclear
+            'r'  feature not required for feature set implemented
+
+  Feature                                           RFC 3036 Section(s)
+    Survey Result
+
+  Interface types                                   2.2.1, 2.5.3,
+                                                    2.8.2, 3.4.2
+    12t 0y 0n            Packet
+    2t 3y 7n(3r 1x)      Frame Relay
+    6t 2y 4n(3r)         ATM
+  Label Spaces                                      2.2.1, 2.2.2
+    12t 0y 0n            Per platform
+    7t 1y 4n(4r)         Per interface
+  LDP Discovery                                     2.4
+    12t 0y 0n            Basic                      2.4.1
+    11t 1y 0n            Targeted                   2.4.2
+  LDP Sessions                                      2.2.3
+    12t 0y 0n            Directly Connected         --
+    11t 1y 0n            Targeted                   2.3
+  LDP Modes                                         2.6
+    7t 1y 4n(2u 1r)      DU, Ind cntl, Lib reten    2.6
+    8t 2y 2n(1r)         DU, Ord cntl, Lib reten    2.6
+    6t 0y 6n(2u 2r)      DU, Ind cntl, Cons reten   2.6
+    6t 1y 5n(1u 2r)      DU, Ord cntl, Cons reten   2.6
+    4t 2y 6n(2u 2r)      DoD, Ind cntl, Lib reten   2.6
+    4t 3y 5n(2r)         DoD, Ord cntl, Lib reten   2.6
+    6t 1y 5n(2u 2r)      DoD, Ind cntl, Cons reten  2.6
+    7t  1y 4n(1u 2r)     DoD, Ord cntl, Cons reten  2.6
+  Loop Detection                                    2.8
+    9t 2y 1n
+
+
+
+
+Thomas & Andersson           Informational                     [Page 10]
+
+RFC 5038           LDP Implementation Survey Results        October 2007
+
+
+  TCP MD5 Option                                    2.9
+    3t 1y 8n(1u 1r 1x)
+  LDP TLVs                                          3.3, 3.4, throughout
+    7t 4y 0n(1 noreply)  U-bit                      3.3
+    7t 4y 0n(1 noreply)  F-bit                      3.3
+                         FEC TLV                    1, 2.1, 3.4.1
+    6t 5y 1n(1r)           Wildcard                 3.4.1
+    12t 0y 0n              Prefix                   3.4.1
+    10t 0y 2n(s1 1u 1r)    Host                     2.1, 3.4.1
+    12t 0y 0n            Address List TLV           3.4.3
+    10t 1y 1n            Hop Count TLV              3.4.4
+    9t 2y 1n             Path Vector TLV            3.4.5
+    12t 0y 0n            Generic Label TLV          3.4.2.1
+    6t 2y 4n(2r)         ATM Label TLV              3.4.2.2
+    2t 3y 7n(1u 2r 1x)   Frame Relay Label TLV      3.4.2.3
+    12t 0y 0n            Status TLV                 3.4.6
+    9t 3y 0n             Extended Status TLV        3.5.1
+    6t 4y 2n             Returned PDU TLV           3.5.1
+    6t 4y 2n             Returned Message TLV       3.5.1
+    12t 0y 0n            Common Hello Param TLV     3.5.2
+    12t 0y 0n                T-bit                  3.5.2
+    11t 0y 1n                R-bit                  3.5.2
+    11t 1y 0n                Hold Time              3.5.2
+    12t 0y 0n            IPv4 Transport Addr TLV    3.5.2
+    7t 2y 3n             Config Sequence Num TLV    3.5.2
+    1t 1y 1n(1u 4r 1x)   IPv6 Transport Addr TLV    3.5.2
+    12t 0y 0n            Common Session Param TLV   3.5.3
+    12t 0y 0n              KeepAlive Time           3.5.3
+    11t 0y 1n              PVLim                    3.5.3
+    11t 1y 0n              PDU Max Length           3.5.3
+    6t 2y 2n(1r 1x)      ATM Session Param TLV      3.5.3
+                           M values
+    5t 3y 4n(1r 1x)          0 No Merge             3.5.3
+    3t 3y 6n(s 1 1r 1x)      1 VP Merge             3.5.3
+    5t 3y 4n(1r 1x)          2 VC Merge             3.5.3
+    3t 3y 6n(s1 1r 1x)       3 VP & VC Merge        3.5.3
+    6t 2y 4n(1r 1x)        D-bit                    3.5.3
+    6t 2y 4n(1r 1x)        ATM Label Range          3.5.3
+                             Component
+    2t 3y 7n(1u 1r 2x)   FR Session Param TLV       3.5.3
+                           M values
+    2t 3y 7n(1u 1r 2x)       0 No Merge             3.5.3
+    2t 3y 7n                 1 Merge                3.5.3
+    2t 3y 7n(1u 1r 2x)     D-bit                    3.5.3
+    2t 3y 7n(1u 1r 2x)     FR Label Range           3.5.3
+                             Component
+    10t 0y 2n            Label Request Msg Id TLV   3.5.7
+    2t 5y 5n(1u 1r)      Vendor-Private TLV         3.6.1.1
+
+
+
+Thomas & Andersson           Informational                     [Page 11]
+
+RFC 5038           LDP Implementation Survey Results        October 2007
+
+
+    1t 5y 6n(2r)         Experimental TLV           3.6.2
+  LDP Messages                                      3.5, throughout
+    12t 0y 0n            Notification Msg           3.5.1
+    12t 0y 0n            Hello Msg                  3.5.2
+    12t 0y 0n            Initialization Msg         3.5.3
+    12t 0y 0n            KeepAlive Msg              3.5.4
+    12t 0y 0n            Address Msg                3.5.5
+    12t 0y 0n            Address Withdraw Msg       3.5.6
+    12t 0y 0n            Label Mapping Msg          3.5.7
+    10t 0y 2n(1r)          Label Request Msg Id TLV 3.5.7
+    10t 1y 1n              Hop Count TLV            3.5.7
+    10t 1y 1n              Path Vect TLV             3.5.7
+    9t 0y 3n(1x)         Label Request Msg          3.5.8
+    9t 0y 3n(1x)           Hop Count TLV            3.5.8
+    9t 0y 3n(1x)           Path Vect TLV            3.5.8
+    12t 0y 0n            Label Withdraw Msg         3.5.10
+    12t 0y 0n              Label TLV                3.5.10
+    11t 0y 1n            Label Release Msg          3.5.11
+    10t 1y 1n              Label TLV                3.5.11
+    9t 2y 1n             Label Abort Req Msg        3.5.9
+    2t 5y 5n(1u 1r)      Vendor-Private Msg         3.6.1.2
+    1t 5y 6n(2r)         Experimental Msg           3.6.2
+  LDP Status Codes                                  3.4.6
+    9t 3y 0n             Success                    3.4.6, 3.9
+    8t 4y 0n             Bad LDP Id                 3.5.1.2.1
+    7t 5y 0n             Bad Ptcl Version           3.5.1.2.1
+    7t 5y 0n             Bad PDU Length             3.5.1.2.1
+    7t 5y 0n             Unknown Message Type       3.5.1.2.1
+    7t 5y 0n             Bad Message Length         3.5.1.2.1
+    7t 4y 0n(1 noreply)  Unknown TLV                3.5.1.2.2
+    7t 5y 0n             Bad TLV Length             3.5.1.2.2
+    7t 5y 0n             Malformed TLV Value        3.5.1.2.2
+    11t 1y 0n            Hold Timer Expired         3.5.1.2.3
+    11t 1y 0n            Shutdown                   3.5.1.2.4
+    10t 1y 1n            Loop Detected              3.4.5.1.2, 3.5.8.1
+    7t 5y 0n             Unknown FEC                3.4.1.1
+    11t 1y 0n            No Route                   3.5.8.1
+    9t 3y 0n             No Label Resources         3.5.8.1
+    8t 3y 1n             Label Resources Available  3.5.8.1
+                         Session Rejected           2.5.3, 3.5.3
+    7t 5y 0n               No Hello                 2.5.3, 3.5.3
+    9t 2y 1n               Param Advert Mode        2.5.3, 3.5.3
+    9t 2y 1n               Param PDU Max Len        2.5.3, 3.5.3
+    8t 3y 1n               Param Label Range        2.5.3, 3.5.3
+    7t 5y 0n               Bad KA Time              3.5.1.2.5, 3.5.3
+    11t 1y 0n            KeepAlive Timer Expired    2.5.6, 3.5.1.2.3
+    9t 1y 2n             Label Request Aborted      3.5.9.1
+    6t 5y 1n             Missing Message Params     3.5.1.2.1
+
+
+
+Thomas & Andersson           Informational                     [Page 12]
+
+RFC 5038           LDP Implementation Survey Results        October 2007
+
+
+    7t 5y 0n             Unsupported Addr Family    3.4.1.1, 3.5.5.1
+    7t 5y 0n             Internal Error             3.5.1.2.7
+
+Appendix B.  LDP Implementation Survey Form
+
+LDP Implementation Survey Form (V 1.0)
+
+The purpose of this form is to gather information about implementations
+of LDP as defined by RFC 3036.  The information is being requested as
+part of the process of advancing LDP from Proposed to Draft Standard.
+
+The form is patterned after the implementation report form used for
+HTTP/1.1; see:
+
+http://www.ietf.org/IESG/Implementations/http1.1-implementations.txt
+
+=======================================================================
+A. General Information
+
+Please provide the following information.
+----------------------------------------------------------------
+
+Organization:
+
+Organization url(s):
+
+----------------------------------------------------------------
+
+Product title(s):
+
+Brief description(s):
+
+----------------------------------------------------------------
+
+Contact for LDP information
+   Name:
+   Title:
+   E-mail:
+   Organization/department:
+   Postal address:
+   Phone:
+   Fax:
+
+
+
+
+
+
+
+
+
+Thomas & Andersson           Informational                     [Page 13]
+
+RFC 5038           LDP Implementation Survey Results        October 2007
+
+
+=======================================================================
+B. LDP Implementation Status, Availability, Origin
+
+Please check [x] the boxes that apply.
+----------------------------------------------------------------
+
+Status:
+     [ ]  Development
+     [ ]  Alpha
+     [ ]  Beta
+     [ ]  Product
+     [ ]  Other (describe):
+
+Availability
+     [ ]  Public and free
+     [ ]  Only to selected organizations/companies but free
+     [ ]  On sale.
+     [ ]  For internal company use only
+     [ ]  Other:
+
+Implementation based on:  (check all that apply)
+     [ ]  Purchased code
+          (please list source if possible)
+     [ ]  Free code
+          (please list source if possible)
+     [ ]  Internal implementation
+          (no outside code, just from specs)
+     [ ]  Internal implementation on top of purchased
+          or free code
+          List portions from external source:
+          List portions developed internally:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Thomas & Andersson           Informational                     [Page 14]
+
+RFC 5038           LDP Implementation Survey Results        October 2007
+
+
+=======================================================================
+C. LDP Feature Survey
+
+For each feature listed, please indicate the status of the
+implementation using one of the following:
+
+    't'   tested against another independent implementation
+    'y'   implemented but not tested against independent implementation
+    'n'   not implemented
+    '-'   not applicable to this type of implementation
+
+  Optional: For 'n' status, indicate reason for not implementing using
+            one of the following:
+
+            's'  RFC specification inadequate, unclear, or confusing
+            'u'  utility of feature unclear
+            'r'  feature not required for feature set implemented
+
+------------------+-----------------------------+-----------------------
+                  |                             | Status
+                  |                             | (one of t, y, n, -;
+                  |                             | if n, optionally
+Feature           | RFC 3036 Section(s)         | one of s, u, r)
+==================+=============================+=======================
+Interface types   | 2.2.1, 2.5.3, 2.8.2, 3.4.2
+  ----------------+-----------------------------+-----------------------
+  Packet          |                             |
+  ----------------+-----------------------------+-----------------------
+  Frame Relay     |                             |
+  ----------------+-----------------------------+-----------------------
+  ATM             |                             |
+==================+=============================+=======================
+Label Spaces      | 2.2.1, 2.2.2
+  ----------------+-----------------------------+-----------------------
+  Per platform    |                             |
+  ----------------+-----------------------------+-----------------------
+  Per interface   |                             |
+==================+=============================+=======================
+LDP Discovery     | 2.4
+  ----------------+-----------------------------+-----------------------
+  Basic           | 2.4.1                       |
+  ----------------+-----------------------------+-----------------------
+  Targeted        | 2.4.2                       |
+
+
+
+
+
+
+
+
+Thomas & Andersson           Informational                     [Page 15]
+
+RFC 5038           LDP Implementation Survey Results        October 2007
+
+
+------------------+-----------------------------+-----------------------
+LDP Sessions      | 2.2.3
+  ----------------+-----------------------------+-----------------------
+  Directly        | --                          |
+  Connected       |                             |
+  ----------------+-----------------------------+-----------------------
+  Targeted        | 2.3                         |
+==================+=============================+=======================
+LDP Modes         | 2.6
+  ----------------+-----------------------------+-----------------------
+  DU, Ind cntl,   | 2.6                         |
+  Lib retention   |                             |
+  ----------------+-----------------------------+-----------------------
+  DU, Ord cntl,   | 2.6                         |
+  Lib retention   |                             |
+  ----------------+-----------------------------+-----------------------
+  DU, Ind cntl,   | 2.6                         |
+  Cons retention  |                             |
+  ----------------+-----------------------------+-----------------------
+  DU, Ord cntl,   | 2.6                         |
+  Cons retention  |                             |
+  ----------------+-----------------------------+-----------------------
+  DoD, Ind cntl,  | 2.6                         |
+  Lib retention   |                             |
+  ----------------+-----------------------------+-----------------------
+  DoD, Ord cntl,  | 2.6                         |
+  Lib retention   |                             |
+  ----------------+-----------------------------+-----------------------
+  DoD, Ind cntl,  | 2.6                         |
+  Cons retention  |                             |
+  ----------------+-----------------------------+-----------------------
+  DoD, Ord cntl,  | 2.6                         |
+  Cons retention  |                             |
+==================+=============================+=======================
+Loop Detection    | 2.8                         |
+==================+=============================+=======================
+TCP MD5 Option    | 2.9                         |
+==================+=============================+=======================
+LDP TLVs          | 3.3, 3.4, throughout
+  ----------------+-----------------------------+-----------------------
+  U-bit           | 3.3                         |
+  ----------------+-----------------------------+-----------------------
+  F-bit           | 3.3                         |
+------------------+-----------------------------+-----------------------
+  FEC             | 1., 2.1, 3.4.1              |
+
+
+
+
+
+
+Thomas & Andersson           Informational                     [Page 16]
+
+RFC 5038           LDP Implementation Survey Results        October 2007
+
+
+  ----------------+-----------------------------+-----------------------
+    Wildcard      | 3.4.1                       |
+  ----------------+-----------------------------+-----------------------
+    Prefix        | 2.1, 3.4.1                  |
+  ----------------+-----------------------------+-----------------------
+    Host          | 2.1, 3.4.1                  |
+------------------+-----------------------------+-----------------------
+  Address List    | 3.4.3                       |
+------------------+-----------------------------+-----------------------
+  Hop Count       | 3.4.4                       |
+------------------+-----------------------------+-----------------------
+  Path Vector     | 3.4.5                       |
+------------------+-----------------------------+-----------------------
+  Generic Label   | 3.4.2.1                     |
+------------------+-----------------------------+-----------------------
+  ATM Label       | 3.4.2.2                     |
+------------------+-----------------------------+-----------------------
+  Frame Relay     | 3.4.2.3                     |
+  Label           |                             |
+------------------+-----------------------------+-----------------------
+  Status          | 3.4.6                       |
+------------------+-----------------------------+-----------------------
+  Extended Status | 3.5.1                       |
+------------------+-----------------------------+-----------------------
+  Returned PDU    | 3.5.1                       |
+------------------+-----------------------------+-----------------------
+  Returned Message| 3.5.1                       |
+------------------+-----------------------------+-----------------------
+  Common Hello    | 3.5.2                       |
+  Parameters      |                             |
+  ----------------+-----------------------------+-----------------------
+    T-bit         | 3.5.2                       |
+  ----------------+-----------------------------+-----------------------
+    R-bit         | 3.5.2                       |
+  ----------------+-----------------------------+-----------------------
+    Hold Time     | 3.5.2                       |
+------------------+-----------------------------+-----------------------
+  IPv4 Transport  | 3.5.2                       |
+  Address         |                             |
+------------------+-----------------------------+-----------------------
+  Configuration   | 3.5.2                       |
+  Sequence Number |                             |
+------------------+-----------------------------+-----------------------
+  IPv6 Transport  | 3.5.2                       |
+  Address         |                             |
+------------------+-----------------------------+-----------------------
+  Common Session  | 3.5.3                       |
+  Parameters      |                             |
+
+
+
+Thomas & Andersson           Informational                     [Page 17]
+
+RFC 5038           LDP Implementation Survey Results        October 2007
+
+
+  ----------------+-----------------------------+-----------------------
+    KeepAlive Time| 3.5.3                       |
+  ----------------+-----------------------------+-----------------------
+    PVLim         | 3.5.3                       |
+  ----------------+-----------------------------+-----------------------
+    Max PDU Length| 3.5.3                       |
+------------------+-----------------------------+-----------------------
+  ATM Session     | 3.5.3                       |
+  Parameters      |                             |
+  ----------------+-----------------------------+-----------------------
+    M values      |                             |
+      0 No Merge  | 3.5.3                       |
+      ------------+-----------------------------+-----------------------
+      1 VP Merge  | 3.5.3                       |
+      ------------+-----------------------------+-----------------------
+      2 VC Merge  | 3.5.3                       |
+      ------------+-----------------------------+-----------------------
+      3 VP &      | 3.5.3                       |
+        VC Merge  |                             |
+  ----------------+-----------------------------+-----------------------
+    D-bit         | 3.5.3                       |
+  ----------------+-----------------------------+-----------------------
+    ATM Label     | 3.5.3                       |
+    Range         |                             |
+    Component     |                             |
+------------------+-----------------------------+-----------------------
+  Frame Relay     | 3.5.3                       |
+  Session         |                             |
+  Parameters      |                             |
+------------------+-----------------------------+-----------------------
+    M values      |                             |
+      0 No Merge  | 3.5.3                       |
+      ------------+-----------------------------+-----------------------
+      1 Merge     | 3.5.3                       |
+  ----------------+-----------------------------+-----------------------
+    D-bit         | 3.5.3                       |
+  ----------------+-----------------------------+-----------------------
+    Frame Relay   | 3.5.3                       |
+    Label Range   |                             |
+    Component     |                             |
+  ----------------+-----------------------------+-----------------------
+  Label Request   | 3.5.7                       |
+  Message Id      |                             |
+------------------+-----------------------------+-----------------------
+  Vendor-Private  | 3.6.1.1                     |
+------------------+-----------------------------+-----------------------
+  Experimental    | 3.6.2                       |
+
+
+
+
+Thomas & Andersson           Informational                     [Page 18]
+
+RFC 5038           LDP Implementation Survey Results        October 2007
+
+
+==================+=============================+=======================
+LDP Messages      | 3.5, throughout
+------------------+-----------------------------+-----------------------
+  Notification    | 3.5.1                       |
+------------------+-----------------------------+-----------------------
+  Hello           | 3.5.2                       |
+------------------+-----------------------------+-----------------------
+  Initialization  | 3.5.3                       |
+------------------+-----------------------------+-----------------------
+  KeepAlive       | 3.5.4                       |
+------------------+-----------------------------+-----------------------
+  Address         | 3.5.5                       |
+------------------+-----------------------------+-----------------------
+  Address Withdraw| 3.5.6                       |
+------------------+-----------------------------+-----------------------
+  Label Mapping   | 3.5.7                       |
+  ----------------+-----------------------------+-----------------------
+    Label Request | 3.5.7                       |
+    Message Id TLV|                             |
+  ----------------+-----------------------------+-----------------------
+    Hop Count TLV | 3.5.7                       |
+  ----------------+-----------------------------+-----------------------
+    Path Vect TLV | 3.5.7                       |
+------------------+-----------------------------+-----------------------
+  Label Request   | 3.5.8                       |
+  ----------------+-----------------------------+-----------------------
+    Hop Count TLV | 3.5.8                       |
+  ----------------+-----------------------------+-----------------------
+    Path Vect TLV | 3.5.8                       |
+------------------+-----------------------------+-----------------------
+  Label Withdraw  | 3.5.10                      |
+  ----------------+-----------------------------+-----------------------
+    Label TLV     | 3.5.10                      |
+------------------+-----------------------------+-----------------------
+  Label Release   | 3.5.11                      |
+  ----------------+-----------------------------+-----------------------
+    Label TLV     | 3.5.11                      |
+------------------+-----------------------------+-----------------------
+  Label Abort Req | 3.5.9                       |
+------------------+-----------------------------+-----------------------
+  Vendor-Private  | 3.6.1.2                     |
+------------------+-----------------------------+-----------------------
+  Experimental    | 3.6.2                       |
+
+
+
+
+
+
+
+
+Thomas & Andersson           Informational                     [Page 19]
+
+RFC 5038           LDP Implementation Survey Results        October 2007
+
+
+==================+=============================+=======================
+LDP Status Codes  | 3.4.6
+------------------+-----------------------------+-----------------------
+  Success         | 3.4.6, 3.9                  |
+------------------+-----------------------------+-----------------------
+  Bad LDP Id      | 3.5.1.2.1                   |
+------------------+-----------------------------+-----------------------
+  Bad Ptcl Version| 3.5.1.2.1                   |
+------------------+-----------------------------+-----------------------
+  Bad PDU Length  | 3.5.1.2.1                   |
+------------------+-----------------------------+-----------------------
+  Unknown Message | 3.5.1.2.1                   |
+  Type            |                             |
+------------------+-----------------------------+-----------------------
+  Bad Message     | 3.5.1.2.1                   |
+  Length          |                             |
+------------------+-----------------------------+-----------------------
+  Unknown TLV     | 3.5.1.2.2                   |
+------------------+-----------------------------+-----------------------
+  Bad TLV length  | 3.5.1.2.2                   |
+------------------+-----------------------------+-----------------------
+  Malformed TLV   | 3.5.1.2.2                   |
+  Value           |                             |
+------------------+-----------------------------+-----------------------
+  Hold Timer      | 3.5.1.2.3                   |
+  Expired         |                             |
+------------------+-----------------------------+-----------------------
+  Shutdown        | 3.5.1.2.4                   |
+------------------+-----------------------------+-----------------------
+  Loop Detected   | 3.4.5.1.2, 3.5.8.1          |
+------------------+-----------------------------+-----------------------
+  Unknown FEC     | 3.4.1.1                     |
+------------------+-----------------------------+-----------------------
+  No Route        | 3.5.8.1                     |
+------------------+-----------------------------+-----------------------
+  No Label        | 3.5.8.1                     |
+  Resources       |                             |
+------------------+-----------------------------+-----------------------
+  Label Resources | 3.5.8.1                     |
+  Available       |                             |
+------------------+-----------------------------+-----------------------
+  Session Rejected| 2.5.3, 3.5.3                |
+  No Hello        |                             |
+
+
+
+
+
+
+
+
+Thomas & Andersson           Informational                     [Page 20]
+
+RFC 5038           LDP Implementation Survey Results        October 2007
+
+
+------------------+-----------------------------+-----------------------
+  Session Rejected| 2.5.3, 3.5.3                |
+  Parameters      |                             |
+  Advert Mode     |                             |
+------------------+-----------------------------+-----------------------
+  Session Rejected| 2.5.3, 3.5.3                |
+  Parameters      |                             |
+  Max PDU Length  |                             |
+------------------+-----------------------------+-----------------------
+  Session Rejected| 2.5.3, 3.5.3                |
+  Parameters      |                             |
+  Label Range     |                             |
+------------------+-----------------------------+-----------------------
+  KeepAlive Timer | 2.5.6, 3.5.1.2.3            |
+  Expired         |                             |
+------------------+-----------------------------+-----------------------
+  Label Request   | 3.5.9.1                     |
+  Aborted         |                             |
+------------------+-----------------------------+-----------------------
+  Missing Message | 3.5.1.2.1                   |
+  Parameters      |                             |
+------------------+-----------------------------+-----------------------
+  Unsupported     | 3.4.1.1, 3.5.5.1            |
+  Address Family  |                             |
+------------------+-----------------------------+-----------------------
+  Session Rejected| 3.5.1.2.5, 3.5.3            |
+  Bad KeepAlive   |                             |
+  Time            |                             |
+------------------+-----------------------------+-----------------------
+  Internal Error  | 3.5.1.2.7                   |
+==================+=============================+=======================
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Thomas & Andersson           Informational                     [Page 21]
+
+RFC 5038           LDP Implementation Survey Results        October 2007
+
+
+Author's Addresses
+
+   Bob Thomas
+   Cisco Systems, Inc.
+   1414 Massachusetts Ave.
+   Boxborough MA 01719
+
+   EMail: rhthomas@cisco.com
+
+
+   Loa Andersson
+   Acreo AB
+   Isafjordsgatan 22
+   Kista, Sweden
+
+   EMail: loa.andersson@acreo.se
+          loa@pi.se
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Thomas & Andersson           Informational                     [Page 22]
+
+RFC 5038           LDP Implementation Survey Results        October 2007
+
+
+Full Copyright Statement
+
+   Copyright (C) The IETF Trust (2007).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY, THE IETF TRUST AND
+   THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF
+   THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+
+
+
+
+
+
+
+
+
+
+
+Thomas & Andersson           Informational                     [Page 23]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc5038.txt](<www.ietf.org/rfc/rfc5038.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
