### PR TITLE
Archive rfc510.txt

### DIFF
--- a/www.ietf.org/rfc/rfc510.txt
+++ b/www.ietf.org/rfc/rfc510.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                           J. White
+Request for Comments: 510                                        SRI-ARC
+NIC: 16400                                                   30 May 1973
+
+
+                 Request for Network Mailbox Addresses
+
+   To Liaisons:
+
+   Within the next few weeks, the NIC will begin providing Network
+   Journal delivery to those users in the Net who desire it.
+
+      Submission of Journal articles will also be possible through FTP.
+
+   Each user will then have his choice of three Journal delivery modes:
+   ONLINE delivery to the AUTHOR branch of his initial file at the NIC,
+   HARDCOPY delivery to his place of business via the Postal Service,
+   and NETWORK delivery to his on-line mailbox at his home host.  Each
+   user may select any or all forms of delivery.
+
+   Initially, Network Journal delivery will consist of the following:
+
+      Each piece of mail addressed to the user will be delivered to a
+      host and mailbox of his choosing, using the mail command(s)
+      defined by the File Transfer Protocol.  The mail will contain in
+      its text, a header containing the author's NIC Ident, the date of
+      submission, a title, etc., and either the text of the message or,
+      if it's long, a pointer to it (according to the 'Submit Message'
+      and 'Submit File' distinction in NLS Journal submission).  More
+      than one piece of Journal mail may, in general, be delivered as a
+      single piece of FTP mail.
+
+      The user's delivery host and mailbox will be stored in the NIC's
+      Ident file, and the user can change or view them (along with his
+      delivery mode(s)) from the Identification System in NLS.
+
+      The pointer sent to the user for bulk mail will be a pathname by
+      which an FTP user process, acting on the user's behalf, can
+      retrieve the text of the mail from SRI-ARC.  The pathname will
+      contain the necessary parameters to cause SRI-ARC's FTP server
+      process to convert the file from NLS (tree-structured) to
+      sequential form before transmission.
+
+   The purpose of this memo is not to document the service (we'll do
+   that as soon as it's available), but to solicit help from Liaisons,
+   each of whom is asked to provide the NIC with the following
+   information for EACH user affiliated with his host organization who
+   desires Network Journal delivery:
+
+
+
+White                                                           [Page 1]
+
+RFC 510          Request for Network Mailbox Addresses       30 May 1973
+
+
+      (1) His NIC Ident.
+
+      (2) The type(s) of delivery he desires, if any, IN ADDITION TO
+          Network delivery.
+
+          It's fair, for example, to retain one's current delivery mode
+          initially until convinced that Network delivery really works.
+
+      (3) The standard host name or decimal host address of the host at
+          which he desires delivery.
+
+          TIP users, for example, may choose to receive delivery at
+          their favorite TENEX host.
+
+      (4) The 'user name' his host's FTP server process requires to
+          identify him in the context of an FTP mail command.
+
+            For a TENEX user, for example, that's his directory.
+
+   Please communicate answers to these questions in writing to Jim White
+   -- to JEW through the Journal, to WHITE@SRI-ARC via FTP mail, or to
+   Jim White at the NIC via the Postal Service.  All information
+   obtained in response to this memo will be made accessible form NLS
+   (as already mentioned) and from a yet-to-be-written Ident server
+   process, and will be maintained by the NIC as a functional document
+   in on-line and hardcopy forms.
+
+   We ask Liaisons to assume responsibility for providing delivery
+   parameters for all interested users at their host, although
+   information will be gladly accepted from anyone who chooses to
+   provide it.
+
+   Thanks.
+
+   Jim White
+
+
+         [ This RFC was put into machine readable form for entry ]
+            [ into the online RFC archives by Tim Mains 12/97 ]
+
+
+
+
+
+
+
+
+
+
+
+
+White                                                           [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc510.txt](<www.ietf.org/rfc/rfc510.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
