### PR TITLE
Archive rfc5125.txt

### DIFF
--- a/www.ietf.org/rfc/rfc5125.txt
+++ b/www.ietf.org/rfc/rfc5125.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Network Working Group                                          T. Taylor
+Request for Comments: 5125                                        Nortel
+Obsoletes: 3525                                            February 2008
+Category: Informational
+
+
+                Reclassification of RFC 3525 to Historic
+
+Status of This Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard of any kind.  Distribution of this
+   memo is unlimited.
+
+Abstract
+
+   This document reclassifies RFC 3525, Gateway Control Protocol Version
+   1, to Historic Status.  This memo also obsoletes RFC 3525.
+
+1.  Introduction
+
+   The purpose of this document is to reclassify RFC 3525, Gateway
+   Control Protocol Version 1, to Historic Status.
+
+2.  Reclassification of RFC 3525 to Historic
+
+   The protocol defined by RFC 3525 [RFC3525] was developed jointly by
+   the IETF Megaco Working Group and ITU-T Study Group 16.  The ITU-T
+   published ITU-T Recommendation H.248.1 (originally H.248) with the
+   same contents as RFC 3525.  Since that initial development, the ITU-T
+   has taken ownership of the protocol and has continued to work on it.
+   The protocol as originally defined in RFC 3525 underwent a series of
+   corrections and clarifications.  H.248.1 version 1 [h248v1] was
+   republished in March, 2002, incorporating all changes agreed upon up
+   to that date.  Since then, further corrections have been agreed upon.
+   The accumulated set of corrections to H.248.1 (03/2002) is available
+   in the Implementors' Guide for Recommendation H.248.1 Version 1 (03/
+   2002) ("Media Gateway Control Protocol") [impgdv1], which is
+   available at no charge on the ITU-T web site.
+
+   RFC 3525 has been rendered even more obsolete as a specification of
+   the Megaco/H.248 protocol by the publication of further versions of
+   ITU-T Recommendation H.248.1.  Version 2 [h248v2] was published in
+   May, 2002, and is the version most widely deployed at present.  It is
+   also the version that other standards bodies such as 3GPP are
+   currently using as the basis for their own profile specifications.
+   Version 3 [h248v3] was published more recently, in September, 2005.
+
+
+
+
+Taylor                       Informational                      [Page 1]
+
+RFC 5125                  RFC 3525 to Historic             February 2008
+
+
+   In short, RFC 3525 may serve as an introduction to the Megaco/H.248
+   protocol, but it is misleading as a description of the protocol as
+   currently standardized or deployed.  It is appropriate to reclassify
+   RFC 3525 to Historic status, as described in RFC 2026 [RFC2026].
+
+3.  Security Considerations
+
+   Reclassifying RFC 3525 has no security implications.
+
+4.  IANA Considerations
+
+   This document does not require any new actions by the IANA.  The IANA
+   registries established by RFC 3525 and extended by successive
+   versions of ITU-T H.248.1 remain in force, along with the requirement
+   for expert review by an IESG-designated expert.
+
+5.  References
+
+5.1.  Normative References
+
+   [RFC2026]  Bradner, S., "The Internet Standards Process -- Revision
+              3", BCP 9, RFC 2026, October 1996.
+
+   [RFC3525]  Groves, C., Ed., Pantaleo, M., Ed., Anderson, T., Ed., and
+              T. Taylor, Ed., "Gateway Control Protocol Version 1", RFC
+              3525, June 2003.
+
+5.2.  Informative References
+
+   [h248v1]   International Telecommunication Union, "Gateway control
+              protocol: Version 1", ITU-T Recommendation H.248.1, March
+              2002.
+
+   [h248v2]   International Telecommunication Union, "Gateway control
+              protocol: Version 2", ITU-T Recommendation H.248.1, May
+              2002.
+
+   [h248v3]   International Telecommunication Union, "Gateway control
+              protocol: Version 3", ITU-T Recommendation H.248.1,
+              September 2005.
+
+   [impgdv1]  International Telecommunication Union, "Implementors'
+              Guide for Recommendation H.248.1 Version 1 (03/2002)
+              ("Media Gateway Control Protocol")", ITU-T Recommendation
+              H.248.1, April 2006.
+
+
+
+
+
+
+Taylor                       Informational                      [Page 2]
+
+RFC 5125                  RFC 3525 to Historic             February 2008
+
+
+Author's Address
+
+   Tom Taylor
+   Nortel
+   1852 Lorraine Ave
+   Ottawa, Ontario  K1H 6Z8
+   Canada
+
+   EMail: taylor@nortel.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Taylor                       Informational                      [Page 3]
+
+RFC 5125                  RFC 3525 to Historic             February 2008
+
+
+Full Copyright Statement
+
+   Copyright (C) The IETF Trust (2008).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY, THE IETF TRUST AND
+   THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF
+   THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+
+
+
+
+
+
+
+
+
+
+
+Taylor                       Informational                      [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc5125.txt](<www.ietf.org/rfc/rfc5125.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
