### PR TITLE
Archive rfc5131.txt

### DIFF
--- a/www.ietf.org/rfc/rfc5131.txt
+++ b/www.ietf.org/rfc/rfc5131.txt
@@ -1,0 +1,339 @@
+
+
+
+
+
+
+Network Working Group                                   D. McWalter, Ed.
+Request for Comments: 5131                           Data Connection Ltd
+Category: Standards Track                                  December 2007
+
+
+               A MIB Textual Convention for Language Tags
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Abstract
+
+   This MIB module defines a textual convention to represent BCP 47
+   language tags.  The intent is that this textual convention will be
+   imported and used in MIB modules that would otherwise define their
+   own representation.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . . . 2
+   2.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . . . 2
+   3.  The Internet-Standard Management Framework  . . . . . . . . . . 2
+   4.  Definitions . . . . . . . . . . . . . . . . . . . . . . . . . . 3
+   5.  Security Considerations . . . . . . . . . . . . . . . . . . . . 4
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . . . 4
+   7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . 4
+   8.  References  . . . . . . . . . . . . . . . . . . . . . . . . . . 4
+     8.1.  Normative References  . . . . . . . . . . . . . . . . . . . 4
+     8.2.  Informative References  . . . . . . . . . . . . . . . . . . 5
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McWalter                    Standards Track                     [Page 1]
+
+RFC 5131                     LANGTAG TC MIB                December 2007
+
+
+1.  Introduction
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the Internet community.
+   It defines a textual convention to represent BCP 47 [RFC4646]
+   language tags.
+
+   The LangTag TEXTUAL-CONVENTION defined by this RFC replaces the
+   similar LanguageTag TEXTUAL-CONVENTION defined by RFC 2932 [RFC2932].
+
+   The old LanguageTag TEXTUAL-CONVENTION is used by some existing MIB
+   modules.  New MIB modules should use the LangTag TEXTUAL-CONVENTION,
+   which has been created (and is to be preferred) for the following
+   reasons:
+
+   o  Its syntax description is current, and is more comprehensive.
+
+   o  It is short enough to use as an index object without subtyping,
+      yet is of adequate length to represent any language tag in
+      practice.
+
+   o  It is provided in a dedicated MIB module to simplify module
+      dependencies.
+
+   It is not possible to apply changes in syntax and length to an
+   existing textual convention.  This is why the creation of a new
+   textual convention with a new name was necessary.
+
+2.  Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+3.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This memo specifies a MIB
+   module that is compliant to the SMIv2, which is described in STD 58,
+   RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579] and STD 58, RFC 2580
+   [RFC2580].
+
+
+
+McWalter                    Standards Track                     [Page 2]
+
+RFC 5131                     LANGTAG TC MIB                December 2007
+
+
+4.  Definitions
+
+LANGTAG-TC-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, mib-2             FROM SNMPv2-SMI      -- [RFC2578]
+    TEXTUAL-CONVENTION                 FROM SNMPv2-TC;      -- [RFC2579]
+
+langTagTcMIB MODULE-IDENTITY
+    LAST-UPDATED "200711090000Z" -- 9 November 2007
+    ORGANIZATION "IETF Operations and Management (OPS) Area"
+    CONTACT-INFO "EMail: ops-area@ietf.org
+                  Home page: http://www.ops.ietf.org/"
+    DESCRIPTION
+            "This MIB module defines a textual convention for
+            representing BCP 47 language tags."
+    REVISION     "200711090000Z" -- 9 November 2007
+    DESCRIPTION
+           "Initial revision, published as RFC 5131.
+
+            Copyright (C) The IETF Trust (2007).  This version of this
+            MIB module is part of RFC 5131; see the RFC itself for full
+            legal notices."
+    ::= { mib-2 165 }
+
+LangTag ::= TEXTUAL-CONVENTION
+   DISPLAY-HINT "1a"
+   STATUS      current
+   DESCRIPTION
+            "A language tag, constructed in accordance with BCP 47.
+
+            Only lowercase characters are allowed.  The purpose of this
+            restriction is to provide unique language tags for use as
+            indexes.  BCP 47 recommends case conventions for user
+            interfaces, but objects using this TEXTUAL-CONVENTION MUST
+            use only lowercase.
+
+            Values MUST be well-formed language tags, in conformance
+            with the definition of well-formed tags in BCP 47.  An
+            implementation MAY further limit the values it accepts to
+            those permitted by a 'validating' processor, as defined in
+            BCP 47.
+
+            In theory, BCP 47 language tags are of unlimited length.
+            The language tag described in this TEXTUAL-CONVENTION is of
+            limited length.  The analysis of language tag lengths in BCP
+            47 confirms that this limit will not pose a problem in
+            practice.  In particular, this length is greater than the
+
+
+
+McWalter                    Standards Track                     [Page 3]
+
+RFC 5131                     LANGTAG TC MIB                December 2007
+
+
+            minimum requirements set out in Section 4.3.1.
+
+            A zero-length language tag is not a valid language tag.
+            This can be used to express 'language tag absent' where
+            required, for example, when used as an index field."
+   REFERENCE "RFC 4646 BCP 47"
+   SYNTAX      OCTET STRING (SIZE (0 | 2..63))
+
+END
+
+5.  Security Considerations
+
+   This MIB module does not define any management objects.  Instead, it
+   defines a textual convention that may be imported by other MIB
+   modules and used for object definitions.
+
+   Meaningful security considerations can only be written in the MIB
+   modules that define management objects.  This document therefore has
+   no impact on the security of the Internet.
+
+6.  IANA Considerations
+
+   LANGTAG-TC-MIB is rooted under the mib-2 subtree.  IANA has assigned
+   { mib-2 165 } to the LANGTAG-TC-MIB module specified in this
+   document.
+
+7.  Acknowledgements
+
+   This MIB module is a reworking of existing material from RFC 2932.
+
+   This module was generated by editing together contributions from
+   Randy Presuhn, Dan Romascanu, Bill Fenner, Juergen Schoenwaelder,
+   Bert Wijnen, Doug Ewell, and Ira McDonald.
+
+8.  References
+
+8.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2578]  McCloghrie, K., Ed., Perkins, D., Ed., and J.
+              Schoenwaelder, Ed., "Structure of Management Information
+              Version 2 (SMIv2)", STD 58, RFC 2578, April 1999.
+
+   [RFC2579]  McCloghrie, K., Ed., Perkins, D., Ed., and J.
+              Schoenwaelder, Ed., "Textual Conventions for SMIv2",
+              STD 58, RFC 2579, April 1999.
+
+
+
+McWalter                    Standards Track                     [Page 4]
+
+RFC 5131                     LANGTAG TC MIB                December 2007
+
+
+   [RFC2580]  McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+              "Conformance Statements for SMIv2", STD 58, RFC 2580,
+              April 1999.
+
+   [RFC4646]  Phillips, A. and M. Davis, "Tags for Identifying
+              Languages", BCP 47, RFC 4646, September 2006.
+
+8.2.  Informative References
+
+   [RFC2932]  McCloghrie, K., Farinacci, D., and D. Thaler, "IPv4
+              Multicast Routing MIB", RFC 2932, October 2000.
+
+   [RFC3410]  Case, J., Mundy, R., Partain, D., and B. Stewart,
+              "Introduction and Applicability Statements for Internet-
+              Standard Management Framework", RFC 3410, December 2002.
+
+Author's Address
+
+   David McWalter (editor)
+   Data Connection Ltd
+   100 Church Street
+   Enfield  EN2 6BQ
+   United Kingdom
+
+   EMail: dmcw@dataconnection.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McWalter                    Standards Track                     [Page 5]
+
+RFC 5131                     LANGTAG TC MIB                December 2007
+
+
+Full Copyright Statement
+
+   Copyright (C) The IETF Trust (2007).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY, THE IETF TRUST AND
+   THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF
+   THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+
+
+
+
+
+
+
+
+
+
+
+McWalter                    Standards Track                     [Page 6]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc5131.txt](<www.ietf.org/rfc/rfc5131.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
