### PR TITLE
Archive rfc5138.txt

### DIFF
--- a/www.ietf.org/rfc/rfc5138.txt
+++ b/www.ietf.org/rfc/rfc5138.txt
@@ -1,0 +1,451 @@
+
+
+
+
+
+
+Network Working Group                                             S. Cox
+Request for Comments: 5138                                         CSIRO
+Category: Informational                                    February 2008
+
+
+      A Uniform Resource Name (URN) Namespace for the Commission
+   for the Management and Application of Geoscience Information (CGI)
+
+Status of This Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard of any kind.  Distribution of this
+   memo is unlimited.
+
+Abstract
+
+   This document describes a URN (Uniform Resource Name) namespace that
+   is engineered by the Commission for the Management and Application of
+   Geoscience Information (CGI) for naming (i) persistent resources
+   published by the CGI and (ii) resources published by organizations
+   that wish them to be used in the context of services conforming to
+   protocols and agreements issued by CGI.  The formal Namespace
+   Identifier (NID) is "cgi".
+
+1.  Introduction
+
+   CGI is a Commission of the International Union of Geological Sciences
+   (IUGS) concerned with developing best practices in the management and
+   application of geoscience information.  The active membership is
+   primarily drawn from organizations with statutory responsibility for
+   providing geoscience information to external users (e.g., Geologic
+   Surveys).  An important focus of activity is the development of
+   standards for networked data interchange to complement or supersede
+   the traditional map product.
+
+   A number of documents, definitions, and other artifacts, are required
+   to support this.  CGI wishes to provide persistent,
+   location-independent identifiers for these resources.  In addition,
+   organizations that subscribe to the interchange standards proposed by
+   CGI require external identifiers for data objects that are
+   transferred.  CGI wishes to provide a scheme to enable data providers
+   to uniquely identify data, which is consistent with the requirements
+   of the interchange framework.
+
+   Products and services that conform to CGI endorsed interchange
+   specifications enable users to exchange and process geoscience
+   information across networks, computing platforms, and products.
+   Interoperability in such an environment is facilitated by the use of
+
+
+
+Cox                          Informational                      [Page 1]
+
+RFC 5138              A URN Namespace for the CGI          February 2008
+
+
+   a system of identifiers that is global in scope.  CGI is the lead
+   forum for statutory organizations that act as primary providers of
+   technical data in this application domain.
+
+   Motivated by these concerns, CGI would like to assign formal URNs to
+   published resources in order to provide persistent,
+   location-independent identifiers for them.  The process for
+   registering a namespace identifier is documented in [RFC3406].
+
+   The official IANA registry of URN namespaces is available online at:
+
+   <http://www.iana.org/assignments/urn-namespaces>
+
+2.  URN Specification for the "cgi" NID
+
+   Namespace ID:
+
+      cgi
+
+   Registration Information:
+
+      Registration Version Number: 1
+      Registration Date: 2007-10-04
+
+   Declared registrant of the namespace:
+
+      Commission for Geoscience Information (Secretariat)
+      c/o British Geological Survey
+      Kingsley Dunham Centre
+      Keyworth
+      Nottingham
+      Nottinghamshire
+      NG12 5GG
+      U K
+      Attn. Ian Jackson (ij@bgs.ac.uk)
+
+   Declaration of syntactic structure:
+
+      The Namespace Specific String (NSS) of all URNs that use the "cgi"
+      NID has the following structure:
+
+      urn:cgi:{CGIResource}:{ResourceSpecificString}
+
+      where the "CGIResource" is a US-ASCII string that conforms to the
+      URN syntax requirements [RFC2141] and defines a specific class of
+      resource type.  Each resource type has a specific labeling scheme
+      that is covered by "ResourceSpecificString", which also conforms
+      to the naming requirements of [RFC2141].
+
+
+
+Cox                          Informational                      [Page 2]
+
+RFC 5138              A URN Namespace for the CGI          February 2008
+
+
+      The CGI maintains a naming authority, the CGI Naming Authority
+      (CGINA), that manages the assignment of CGIResource classes and
+      the specific registration values assigned for each resource class.
+
+   Relevant ancillary documentation:
+
+      The CGI Naming Authority (CGINA) provides information on the
+      registered resources and the registrations for each.  More
+      information about CGINA and the registration activities and
+      procedures to be followed are available at:
+
+      <http://www.cgi-iugs.org/CGIIdentifierScheme>
+
+      A URN resolver is available at:
+
+      <http://www.cgi-iugs.org/uri>
+
+      The resolver provides a registry of CGI URNs used in CGI services.
+
+   Identifier uniqueness considerations:
+
+      The CGINA manages resources using the "cgi" NID and is the
+      authority for managing the resources and subsequent strings
+      associated.  In the associated procedures, CGINA ensures the
+      uniqueness of the strings themselves or permits secondary
+      responsibility for management of well-defined sub-trees.
+
+      CGI may permit use of experimental-type values that will not be
+      registered.  As a consequence, multiple users may end up using the
+      same value for separate uses.  As experimental usage is only
+      intended for testing purposes, this should not interfere with
+      operational services.
+
+   Identifier persistence considerations:
+
+      CGINA provides clear documentation of the registered uses of the
+      "cgi" NID.  This is structured such that each CGIResource has a
+      separate description and associated ResourceSpecificString with
+      separate registration tables for elements of the strings that are
+      separately maintained.
+
+      The registration tables and information are published and
+      maintained by CGINA on the CGI web site, indicated above.
+
+
+
+
+
+
+
+
+Cox                          Informational                      [Page 3]
+
+RFC 5138              A URN Namespace for the CGI          February 2008
+
+
+   Process of identifier assignment:
+
+      CGINA defines CGIResource classes used with the "cgi" NID, and
+      specifies the process for identifier assignment for each class.
+      These are described at:
+
+      <http://www.cgi-iugs.org/CGIIdentifierScheme>
+
+      and a set of registers is linked from there.  Each such resource
+      may have three types of registration activities:
+
+         1) Registered values associated with CGI resources
+         2) Registration of values or sub-trees to other entities
+         3) Name models for use in experimental purposes
+
+   Process for Identifier Resolution:
+
+      The namespace is not listed with a Resolution Discovery System
+      (RDS); this is not relevant.
+
+   Rules for Lexical Equivalence:
+
+      No special considerations; the rules for lexical equivalence of
+      [RFC2141] apply.
+
+   Conformance with URN Syntax:
+
+      No special considerations.
+
+   Validation mechanism:
+
+      None specified.  URN assignment will be handled by procedures
+      implemented in support of CGINA activities.
+
+   Scope:
+
+      Global
+
+3.  Examples
+
+   The following examples are representative URNs that have been
+   assigned by CGINA:
+
+   urn:cgi:document:CGI:CGIIdentifierScheme
+
+      - identifies the document that describes the CGI Identifier
+        Scheme.
+
+
+
+
+Cox                          Informational                      [Page 4]
+
+RFC 5138              A URN Namespace for the CGI          February 2008
+
+
+   urn:cgi:register:CGI:CGIResourceClasses
+
+      - identifies the register of resource classes for which
+        identifiers from the CGI scheme may be provided.
+
+   urn:cgi:xmlns:CGI:GeoSciML:2.0
+
+      - is the XML namespace for version 2.0 of GeoSciML, which is owned
+        by CGI.
+
+   urn:cgi:schema:GGIC:MineralOccurences:1.0:XMI
+
+      - identifies the XML Metadata Interchange (XMI) representation of
+        version 1.0 of the Mineral Occurrences information model owned
+        by the (Australasian) Government Geoscience Information
+        Committee.
+
+   urn:cgi:featureType:CGI:GeoSciML:2.0:Fault
+
+      - identifies the Fault feature-type from version 2.0 of the
+        GeoSciML schema that is owned by CGI.
+
+   urn:ogc:serviceType:CGI:GSML-FS:1.0
+
+      - identifies version 1.0 of the "GSML-FS" service-type owned by
+        CGI.
+
+   urn:cgi:classifierScheme:ICS:StratChart:2004
+
+      - identifies the 2004 edition of the Stratigraphic Chart published
+        by the International Commission for Stratigraphy.
+
+   urn:cgi:classifier:ICS:StratChart:2004:Silurian
+
+      - identifies the geologic period designated Silurian from the 2004
+        edition of the Stratigraphic Chart published by the
+        International Commission for Stratigraphy.
+
+   urn:cgi:classifier:GSV:Lithology:UIUYG1245NN07
+
+      - identifies the concept given the designation UIUYG1245NN07 from
+        the lithology scheme published by Geoscience Victoria
+        (Australia).
+
+
+
+
+
+
+
+
+Cox                          Informational                      [Page 5]
+
+RFC 5138              A URN Namespace for the CGI          February 2008
+
+
+   urn:cgi:feature:USGS:2feb49bc-6755-11dc-8314-0800200c9a66
+
+      - identifies a feature instance given the designation
+        2feb49bc-6755-11dc-8314-0800200c9a66 by the US Geological
+        Survey.
+
+   urn:cgi:object:SGU:552cb080-6755-11dc-8314-0800200c9a66
+
+      - identifies an object given the designation
+        552cb080-6755-11dc-8314-0800200c9a66 by the Geological Survey of
+        Sweden.
+
+4.  Namespace Considerations
+
+   There is currently no available namespace that will allow the CGI to
+   uniquely specify and access resources, such as schemas and
+   registries, that are required by organizations implementing CGI
+   standards.  There is also a need for other standards organizations,
+   such as the Open Geospatial Consortium (OGC) to be able to access
+   CGI-specific resources.
+
+   The CGI members considered use of other existing NIDs, such as those
+   for OGC.  However, these do not support the semantics required and in
+   particular do not allow for the delegation of identifier assignment
+   within the CGI community that is demonstrated here.
+
+5.  Community Considerations
+
+   CGI standards require access to resources, such as schemas,
+   registries, catalogues, documents, and services.  In order for the
+   larger IT community to be able to implement applications that access
+   CGI resources effectively, a unique namespace is required.  We desire
+   these resources to be freely and openly available as a set of
+   community resources.
+
+   The design of the CGI namespace builds on the experience of the Open
+   Geospatial Consortium (OGC) which has defined the framework of
+   geospatial services within which CGI standards have been developed.
+   The OGC membership has expertise in using the OGC URN [OGC-URN]
+   [OGC-DEF], gained through implementation experiments and a variety of
+   operational testbeds.  The CGI namespace is compatible with this
+   experience.
+
+6.  Security Considerations
+
+   There are no additional security considerations other than those
+   normally associated with the use and resolution of URNs in general.
+
+
+
+
+Cox                          Informational                      [Page 6]
+
+RFC 5138              A URN Namespace for the CGI          February 2008
+
+
+7.  IANA Considerations
+
+   This document defines a URN NID registration of "cgi", which has been
+   entered into the IANA registry located at:
+
+   <http://www.iana.org/assignments/urn-namespaces>
+
+8.  References
+
+8.1 Normative References
+
+   [RFC2141] Moats, R., "URN Syntax", RFC 2141, May 1997.
+
+   [RFC3406] Daigle, L., van Gulik, D., Iannella, R., and P. Faltstrom,
+             "Uniform Resource Names (URN) Namespace Definition
+             Mechanisms", BCP 66, RFC 3406, October 2002.
+
+8.2 Informative References
+
+   [OGC-URN] Reed, C., "A URN namespace for the Open Geospatial
+             Consortium (OGC)", Work in Progress, October 2007.
+
+   [OGC-DEF] Whiteside, A., "Definition identifier URNs in OGC
+             namespace", OpenGIS Best Practice document, OGC 06-023r1,
+             August 2006.  Available [online]:
+             <http://portal.opengeospatial.org/files/?artifact_id=16339>
+
+9.  Acknowledgement
+
+   Thanks to Carl Reed for preparing the document, "A URN Namespace for
+   the Open Geospatial Consortium", upon which this submission is based.
+
+Author's Address
+
+   S.J.D. Cox
+   Commonwealth Scientific and Industrial Research Organisation
+   PO Box 1130
+   Bentley, WA, 6102, Australia
+   EMail: Simon.Cox@csiro.au
+
+
+
+
+
+
+
+
+
+
+
+
+Cox                          Informational                      [Page 7]
+
+RFC 5138              A URN Namespace for the CGI          February 2008
+
+
+Full Copyright Statement
+
+   Copyright (C) The IETF Trust (2008).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY, THE IETF TRUST AND
+   THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF
+   THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+
+
+
+
+
+
+
+
+
+
+
+Cox                          Informational                      [Page 8]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc5138.txt](<www.ietf.org/rfc/rfc5138.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
