### PR TITLE
Archive rfc52.txt

### DIFF
--- a/www.ietf.org/rfc/rfc52.txt
+++ b/www.ietf.org/rfc/rfc52.txt
@@ -1,0 +1,165 @@
+
+
+
+
+
+
+Network Working Group                                          J. Postel
+Request for Comments #52                                      S. Crocker
+                                                                 Revised
+                                                               1 July 70
+                       Updated Distribution List
+                       -------------------------
+
+One copy only will be sent from the author's site to:
+
+     1.  Abhai Bhushan, MIT
+     2.  Alfred Cocanower, MERIT
+     3.  Gerry Cole, SDC
+     4.  Bill English, SRI
+     5.  Bob Flegel, Utah
+     6.  James Forgie, LL
+     7.  Jim Fry, MITRE
+     8.  Nico Haberman, Carnegie-Mellon
+     9.  John Heafner, RAND
+     10.  Bob Kahn, BB&N
+     11.  Margie Lannon, Harvard
+     12.  James Madden, Univ. of Ill.
+     13.  Thomas O'Sullivan, Raytheon
+     14.  Larry Roberts, ARPA
+     15.  Robert Sproull, Stanford
+     16.  Ron Stoughton, UCSB
+     17.  Chuck Rose, Case University
+     18.  Benita Kirstel
+
+Below are the most current addresses I have.  Please correct as
+necessary:
+
+    Abhai Bhushan                           MIT
+    Room 807 - Project MAC                  (617) 864-6900
+    545 Technology Square                            x5857 5887
+    Cambridge, Mass.  02139
+
+    Alfred Cocanower                        (313) 764-9423
+    MERIT Computer Network Project
+    622 Church Street
+    Ann Arbour, Michigan 48104
+
+    Gerry Cole                              SDC
+    7842 Croyden                            2500 Colorado
+    Los Angeles, Calif. 90045               Santa Monica, Calif.  90406
+                                            (213) 393-9411 x6135 6186
+                                                           x7057 (Sec'y)
+                                                            6419
+
+
+
+
+                                                                [Page 1]
+
+    Bill English                            SRI
+    Stanford Research Institute             (415) 326-6200
+    333 Ravenswood                                x2375
+    Menlo Park, Calif.  94025
+
+    Bob Flegel                              Utah
+    Computer Science Dept.                  (801) 322-8224
+    University of Utah
+    Salt Lake City, Utah 84112
+
+    James Forgie                            LL
+    Mass. Institute of Technology           (617) 862-5500
+    Lincoln Laboratory B-115                       x7173
+    P.O. Box 73
+    Lexington, Mass. 02173
+
+    Jim Fry                                 MITRE
+    The MITRE Corporation                   (703) 893-3500, x355
+    Westgate Research Park                                  x318
+    McLean, Va. 22101
+
+    Nico Haberman                           Carnegie-Mellon
+    Computer Science Dept.                  (412) 683-7000, x226
+    Carnegie-Mellon University
+    Schenley Park
+    Pittsburgh, Pa. 15213
+
+    John Heafner                            RAND
+    The Rand Corporation                    (213) 393-0411
+    1700 Main Street
+    Santa Monica, Calif. 90406
+
+    Robert Kahn                             BB&N
+    Bolt, Beranek and Newman                (617) 491-1850
+    50 Mouton Street
+    Cambridge, Mass. 02138
+
+    Margie Lannon                           Harvard
+    Harvard Network Project                 (617) 868-7600 x 3989
+    Aiken Computation Lab.
+    Room 212
+    33 Oxford Street
+    Cambridge, Mass. 02138
+
+
+
+
+
+
+
+
+                                                                [Page 2]
+
+    James Madden                            Univ. of Ill.
+    University of Illinois                  (217) 333-1000
+    ILLIAC IV PROS.
+    168 Engineering Res. Lab.
+    Urbana, Illinois  61801
+
+    Thomas O'Sullivan                       Raytheon
+    Equipment Division Headquarters         (617) 899-8400
+    Raytheon Company                                  x228
+    40 Second Avenue
+    Waltham, Mass. 02154
+
+    Larry Roberts                           ARPA
+    ODS/ARPA                                (202) OX7-8663
+    3D167 Pentagon                                OX7-8654
+    Washington, D.C. 20301
+
+    Robert Sproull                          Stanford
+    Artificial Intelligence Project         (415) 321-2300
+    Stanford University                              x4971
+    Stanford, Calif. 94305
+
+    Ron Stoughton                           UCSB
+    Computer Research Lab.                  (805) 961-3221
+    University of California
+    Santa Barbara, Calif.  94025
+
+    Chuck Rose                              Case University
+    Jennings Computing Center               (216) 368-2000
+    Case Western Reserve University                x2808
+    10900 Euclid Avenue
+    Cleveland, Ohio  44106
+
+    Benita Kirstel                          UCLA
+    3732 Boelter Hall                       (213) 825-2368
+    University of California                      825-4864
+    Los Angeles, California
+
+
+
+         [ This RFC was put into machine readable form for entry ]
+          [ into the online RFC archives by Kathy de Graaf 3/98 ]
+
+
+
+
+
+
+
+
+
+                                                                [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc52.txt](<www.ietf.org/rfc/rfc52.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
