### PR TITLE
Archive rfc526.txt

### DIFF
--- a/www.ietf.org/rfc/rfc526.txt
+++ b/www.ietf.org/rfc/rfc526.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                               Dr. William K. Pratt
+RFC # 526                                                            USC
+NIC # 17162                                                June 25, 1973
+
+
+                           Technical Meeting
+               Digital Image Processing Software Systems
+                            July 17-18, 1973
+                   University of Southern California
+
+
+The University of Southern California Image Processing Institute in
+conjunction with the Advanced Research Projects Agency, Information
+Processing Techniques Office is sponsoring a technical meeting on
+digital image processing software systems.  The meeting will be held at
+USC on July 17-18, 1973.  The purpose of the meeting is to consider the
+existing hardware facilities and software systems suitable for large
+scale image processing operations over the ARPANET.  Additionally,
+preliminary consideration will be given to the potential development of
+universal image processing software that will be of utility to the
+entire image processing R & D community.
+
+Representatives of interested organizations are invited to attend the
+technical meeting.  Attendees should contact:
+
+         Professor William K. Pratt
+         Olin Hall, Room 330H
+         University of Southern California
+         University Park
+         Los Angeles, California 90007
+         (213) 746-2694
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Pratt                                                           [Page 1]
+
+RFC 526    Digital Image Processing Software Systems Meeting   June 1973
+
+
+                           Technical Meeting
+               DIGITAL IMAGE PROCESSING SOFTWARE SYSTEMS
+                            July 17-18, 1973
+                   University of Southern California
+                        Los Angeles, California
+
+                                 AGENDA
+                                 ------
+
+17 July 1973
+------------
+
+         Powell Hall - Room 101
+         ----------------------
+
+1:00     Introduction; informal tour of USC image processing facilities
+
+         Seaver Science Center Conference Room
+         -------------------------------------
+
+         Image Processing Hardware and Software
+         Moderator: Bill Pratt - USC
+
+2:00     ARPA Image Processing Programs
+         John Perry - ARPA/IPT
+
+2:30     UCLA Campus Computer Network Computational Facilities
+         Bob Braden - UCLA
+
+3:00     Lawrence Berkeley Laboratories Computational Facilities
+
+3:30     ILLIAC IV Computational Facilities
+         Clark Oliphant - Computer Center Corp.
+
+4:00     Coffee Break
+
+4:30     VICAR Image Processing Software
+         John Krasner - JPL
+
+5:00     LARSYS Image Processing Software
+
+5:30     PAZ II Image Processing Software
+         Azriel Rosenfeld - University of Maryland (tentative)
+
+
+
+
+
+
+
+
+Pratt                                                           [Page 2]
+
+RFC 526    Digital Image Processing Software Systems Meeting   June 1973
+
+
+         Faculty Center
+         --------------
+
+6:30     Cocktail Hour
+
+7:30     Dinner
+
+8:30     Discussions of Other Image Processing Software
+         PECOS      -               -  ESL, Inc.
+         LADIES     -  Bob Hunt     -  Los Alamos
+         KANDIDATS  -  R. Haralick  -  Kansas
+
+
+18 July 1973
+------------
+
+         Seaver Science Center Conference Room
+         -------------------------------------
+
+9:00     Group discussion
+
+         Moderator: John Perry
+         - requirements of user community
+         - advantages and disadvantages of existing software systems
+         - desired properties of a software system
+
+10:30    Coffee Break
+
+11: 00   Group discussion continuation
+         - proposals for adoption of a universal image processing
+           software
+
+12:00 Meeting ends
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.            10/99 ]
+
+
+
+
+
+Pratt                                                           [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc526.txt](<www.ietf.org/rfc/rfc526.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
