### PR TITLE
Archive rfc527.txt

### DIFF
--- a/www.ietf.org/rfc/rfc527.txt
+++ b/www.ietf.org/rfc/rfc527.txt
@@ -1,0 +1,44 @@
+Network Working Group                                    R. Merryman  (UCSD-CC)
+Request for Comments:  527                                              6/22/73
+
+
+                              ARPAWOCKY
+
+
+                    Twas brillig, and the Protocols
+                         Did USER-SERVER in the wabe.
+                    All mimsey was the FTP,
+                         And the RJE outgrabe,
+
+                    Beware the ARPANET, my son;
+                         The bits that byte, the heads that scratch;
+                    Beware the NCP, and shun
+                         the frumious system patch,
+
+                    He took his coding pad in hand;
+                         Long time the Echo-plex he sought.
+                    When his HOST-to-IMP began to limp
+                         he stood a while in thought,
+
+                    And while he stood, in uffish thought,
+                         The ARPANET, with IMPish bent,
+                    Sent packets through conditioned lines,
+                         And checked them as they went,
+
+                    One-two, one-two, and through and through
+                         The IMP-to-IMP went ACK and NACK,
+                    When the RFNM came, he said "I'm game",
+                         And sent the answer back,
+
+                    Then hast thou joined the ARPANET?
+                         Oh come to me, my bankrupt boy!
+                    Quick, call the NIC! Send RFCs!
+                         He chortled in his joy.
+
+                    Twas brillig, and the Protocols
+                         Did USER-SERVER in the wabe.
+                    All mimsey was the FTP,
+                         And the RJE outgrabe.
+
+                                                            D.L. COVILL
+                                                            May 1973


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc527.txt](<www.ietf.org/rfc/rfc527.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
