### PR TITLE
Archive rfc53.txt

### DIFF
--- a/www.ietf.org/rfc/rfc53.txt
+++ b/www.ietf.org/rfc/rfc53.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                         S. Crocker
+Request for Comments #53                                      UCLA
+                                                              9 June 70
+
+
+                     An Official Protocol Mechanism
+
+
+During the Spring Joint Computer Conference in Atlantic City, Larry
+Roberts, Barry Wessler, Cordell Green, Jon Postel and I discussed rules
+for establishing and modifying an official Host-Host protocol.
+
+The following decisions were made:
+
+      1.  A new set of documents will be created.  This set of
+          documents will specify the official Host-Host protocol.  When
+          it becomes appropriate, these documents will be maintained at
+          the Network Information Center on SRI's computer.
+
+      2.  I will distribute proposals for the initial version of the
+          official protocol and all subsequent changes as NWG/RFC's.
+          These proposals will be formulated from suggestions made by
+          any interested parties.
+
+      3.  After a proposal for a change in the official protocol
+          has been issued as an NWG/RFC, networkers are requested to
+          respond with approval, criticism, etc.  A cutoff date will be
+          included with each protocol.
+
+      4.  After the cutoff date, one of two situations will prevail.
+          Either the proposal will have been substantially accepted by
+          the network community, or substantial criticism will have been
+          generated.  In the latter case, the process stops and no
+          change occurs to the official protocol.
+
+      5.  If the proposal has been substantially accepted, the
+          proposal, together with its minor revisions will be forwarded
+          to the ARPA office.  Barry Wessler or his successor will then
+          either approve or disapprove the whole proposal.  His decision
+          will be returned to me by letter.
+
+      6.  After the ARPA office approves the proposal, I will send
+          out the new protocol (as mentioned in item 1 above).
+
+The first version of an official protocol will be proferred this month.
+
+       [ This RFC was put into machine readable form for entry ]
+[ into the online RFC archives by Kathy de Graaf 2/98 ]
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc53.txt](<www.ietf.org/rfc/rfc53.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
