### PR TITLE
Archive rfc537.txt

### DIFF
--- a/www.ietf.org/rfc/rfc537.txt
+++ b/www.ietf.org/rfc/rfc537.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                           S. Bunch
+Request for Comments: 537                                       ILL-ANTS
+NIC: 17498                                                  27 June 1973
+
+
+                 Announcement of NGG meeting-JULY 16-17
+
+   The proposed NGG meeting date of 16-JULY-73 has been confirmed.  The
+   meeting will be held at the University of Illinois on July 16 and 17.
+   An informal meeting will be held Sunday evening, July 15, to arrange
+   the agenda.
+
+      The initial meeting place will be:
+
+         Room 201, Advanced Computation Building
+
+         1101 W. Springfield
+
+         Urbana, Ill.
+
+   In the event that more space is needed, subsequent meetings may take
+   place elsewhere.
+
+   James Michener suggests that those attending be sure to have read his
+   RFC 493 on graphics protocols.
+
+   Local accommodations at Ramada Inn can be reserved by calling
+   (800)648-5970(their tool-free number) or the local Inn, (217)352-
+   7891.  If you wish to make other arrangements, contact me and I will
+   try to help.
+
+   Airline reservations can best be handled by your local airline
+   office.  Jim suggested that I warn Ozark (the local service) of the
+   upcoming surge of non-student, non-standby passengers in the hopes of
+   getting better service. As Ozark is currently enjoying a pilot
+   strike, I have been unable to do this.  Hopefully, it will be over in
+   a few days, but if it isn't, I recommend that you get the closest
+   flight you can and reserve a car for the rest of the way. This
+   probably will be resolved in time to avoid any hassle, but I thought
+   you would like to know about it just in case.
+
+   So that I will have a rough idea how much space we will need, let me
+   know, if possible, if you plan to attend.
+
+
+
+
+
+
+
+
+Bunch                                                           [Page 1]
+
+RFC 537          Announcement of NGG meeting-JULY 16-17     27 June 1973
+
+
+   I can usually be reached by calling (217)333-9354, preferably in the
+   afternoon.  I will be gone July 2-6, so during that period, Nancy
+   Freece at (217)333-7161 will take your messages.  Network mail will
+   be read earliest (also during JULY 2-6) if sent to user BUNCH at site
+   USC-ISI.  My mailing address is:
+
+         Steve Bunch
+         Center for Advanced Computation, Room 208
+         University of Illinois at Urbana-Champaign
+         Urbana, Ill. 61801
+
+
+            [ This RFC was put into machine readable form for entry ]
+            [ into the online RFC archives by Robbie Bennett  11/98 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Bunch                                                           [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc537.txt](<www.ietf.org/rfc/rfc537.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
