### PR TITLE
Archive rfc538.txt

### DIFF
--- a/www.ietf.org/rfc/rfc538.txt
+++ b/www.ietf.org/rfc/rfc538.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Network Working Group                                        A. McKenzie
+Request for Comments: 538                                        BBN-NET
+NIC: 17642                                                   5 July 1973
+Updates: RFC 522
+
+
+                     Traffic Statistics (June 1973)
+
+ABSTRACT
+
+   Attached are the Host traffic statistics for the month of June 1973.
+
+   AAM/jm
+
+
+   Attach
+
+HOST THROUGHPUT SUMMARY (PACKETS OUTPUT)
+
+JUNE 1973
+
+                     INTER-       INTRA-               AVG.DAILY
+                      NODE         NODE        TOTAL   INTERNODE  DAYS
+
+   UCLA    HOST 0    233219       23987       257205
+   UCLA    HOST 1   1622927       86513     17094400
+   UCLA    HOST 2         0      634752       634752
+                    -------     -------     --------
+                    1856146      745252      2601398     61872     30
+
+   SRI     HOST 0   3437898     1923744      5361642
+   SRI     HOST 1    140401        5809       146210
+                    -------     -------      -------
+                    3578299     1929553      5507852    119277     30
+
+   UCSB    HOST 0    927927     1374995      2302922
+   UCSB    HOST 1    101548        4678       106226
+                    -------     -------      -------
+                    1029475     1379673      2409148     34316     30
+
+   UTAH    HOST 0    332271       86501       418772     11076     30
+
+   BBN     HOST 0        15       36219        36234
+   BBN     HOST 1   3408020     1030589      4438609
+   BBN     HOST 2     24615     1298310      1322925
+   BBN     HOST 3    147715       32258       179973
+                    -------     -------      -------
+                    3580365     2397376      5977741    119345     30
+
+
+
+McKenzie                                                        [Page 1]
+
+RFC 538              Traffic Statistics (June 1973)          5 July 1973
+
+
+
+   MIT     HOST 0    308724       36296       345020
+   MIT     HOST 1    432893      152824       585717
+   MIT     HOST 2    930496      827731      1758227
+   MIT     HOST 3    513995      758319      1272314
+                    -------     -------      -------
+                    2186108     1775170      3961278     72870     30
+
+   RAND    HOST 0    958910       29842       988752     31964     30
+
+   SDC     HOST 0      4458         147         4605       149     30
+
+   HARV    HOST 0   1052027     4450914      5502941
+   HARV    HOST 1     87089     3967307      4054396
+                    -------     -------      -------
+                    1139116     8418221      9557337     37971     30
+
+   LINC    HOST 0     11599       56055        67654
+   LINC    HOST 1     32908       57651        90559
+   LINC    HOST 2      5333       96016       101349
+                      -----      ------       ------
+                      49840      209722       259662      1661     30
+
+   STAN    HOST 0   1759136       11587      1770723     58638     30
+
+   ILL     HOST 0    715870         304       716174     23862     30
+
+   CASE    HOST 0   1187526       11632      1199158     39584     30
+
+   CARN    HOST 0    821846      699582      1521428
+   CARN    HOST 1    626844      643001      1269845
+                    -------     -------     --------
+                    1448690     1342583      2791273     48290     30
+
+   AMES    HOST 0   9143319      352313      9495632    304777     30
+
+   AMEST   HOST 0     70594       21028        91622
+   AMEST   HOST 1   9712840       21772      9734612
+                    -------      ------     --------
+                    9783434       42800      9826234
+
+   MITRE   HOST 2   2144923          25      2144948     71497     30
+
+   ROME    HOST 2   8382240          70       838310     27941     30
+
+   NBS     HOST 2   1840391       72205      1912596     61346     30
+
+   ETAC    HOST 2   1274869          90      1274959     42496     30
+
+
+
+McKenzie                                                        [Page 2]
+
+RFC 538              Traffic Statistics (June 1973)          5 July 1973
+
+
+
+   ISI     HOST 1  10795800      161320     10967120    359860     30
+
+   USC     HOST 0     38573     2888042      2926615
+   USC     HOST 2   3410926     2704032      6114958
+                   --------    --------     --------
+                    3449499     5592074      9041573    114983     30
+
+   GWC     HOST 2   2541199          20      2542319     84743     30
+
+   DOCB    HOST 2    104182        2785       106967      3473     30
+
+   SDAC    HOST 0     30926           7        30933
+   SDAC    HOST 2    558085          90       558175
+                    -------     -------      -------
+                     589011          97       589108     19634     30
+
+   BELV HAD NO TRAFFIC
+
+   ARPA    HOST 0      6806      245351       252157
+   ARPA    HOST 2   1040441      244311      1284752
+                    -------     -------      -------
+                    1047247      489662      1536909     34908     30
+
+   ABER HAD NO TRAFFIC
+
+   BBN T   HOST 2   1138466        1935      1140401     37949     30
+
+   CCA     HOST 0   1149742     3366173      4515915
+   CCA     HOST 2   1757435      113609       187044
+                   --------    --------      -------
+                    2907177     3479782      6386959     96906     30
+
+   XEROX   HOST 0   1060104       44317      1104421     35337     30
+
+   FNWC    HOST 2     36672          52        36724      1222     30
+
+   LBL HAD NO TRAFFIC
+
+   UCSB    HOST 0    322222       20697       342919     10741     30
+
+   HAW T   HOST 2    465142        4226       439368     15505     30
+
+   RML     HOST 2    934680        7737       942417     31156     30
+
+   NORSR   HOST 2      1604          10         1614       401      4
+
+   -----------------------------------------------------
+
+
+
+McKenzie                                                        [Page 3]
+
+RFC 538              Traffic Statistics (June 1973)          5 July 1973
+
+
+   TOTAL           70245490    28609780
+   DAILY AVERAGE    2341516      953659
+   AVERAGE PER        64802       26393
+   NODE-DAY
+   PACKETS/MESSAGES (INTERNODE)    1.07
+
+
+
+          [This RFC was put into machine readable form for entry]
+      [into the online RFC archives by Helene Morin, Via Genie 12/99]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McKenzie                                                        [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc538.txt](<www.ietf.org/rfc/rfc538.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
