### PR TITLE
Archive rfc543.txt

### DIFF
--- a/www.ietf.org/rfc/rfc543.txt
+++ b/www.ietf.org/rfc/rfc543.txt
@@ -1,0 +1,451 @@
+
+
+
+
+
+
+Network Working Group                                           D. Meyer
+Request for Comments: 543                                        SRI-ARC
+NIC: 17777                                                  31 July 1973
+
+
+                Network Journal Submission and Delivery
+
+
+Augmentation Research Center
+
+Stanford Research Center
+Menlo Park, California 94025
+
+   The on-line documentation will be maintained as (userguides.
+   journal-netsub,).  Hard copies are available from Marcia Keeney.
+
+   The first implementation of a Network Journal Submission and Delivery
+   system is now experimentally up.  This system allows use of the NIC's
+   NLS Journal System without entering NLS.  Network users may submit
+   text files written on their host systems using their mail subsystems
+   (e.g. SNDMSG, FTP, TELNET).  The mail will then be converted at SRI-
+   ARC into NLS files, journalized, and sent to the specified recipients
+   according to their preset Journal delivery options.  A newly added
+   option permits the user to receive automatic Journal delivery (of
+   citations to journalized documents) at his host via the Network mail
+   protocol.
+
+Overview
+
+   Network mail sent to SRI-ARC (NIC) will be entered into the NIC
+   Journal system if a slash appears in the user-name.  To get the mail
+   to the NIC, you may use either the FTP, TELNET, or mail subsystem
+   provided by your local system.
+
+   The author's NIC Ident(s) are assumed to appear before the slash; the
+   recipients' NIC Ident(s) after it.  Idents should be separated by
+   spaces.  (See scenarios in branch 3)
+   (e.g. jew / mdk dhc)
+
+
+
+
+
+
+
+
+
+
+
+
+
+Meyer                                                           [Page 1]
+
+RFC 543         Network Journal Submission and Delivery     13 July 1973
+
+
+   When this format is detected by the NIC, the Network Journal system
+   will be invoked.  At SRI-ARC the mail will be transformed into an NLS
+   file, assigned a unique catalog number, stored permanently under that
+   number, and a notice of it will be sent to all the listed recipients.
+   If the slash is not found, the mail will be handled in the normal
+   way.
+
+   Delivery of Journal citations may now be obtained via the Network (as
+   well as to an NLS file at SRI-ARC and in hard copy).  If you wish to
+   receive your Journal mail at you host computer, contact the NIC (see
+   RFC510 -- 16400,).
+
+   A more detailed description follows.
+
+NETWORK JOURNAL SUBMISSION
+
+   The remote user prepares the text of his Journal article in his host
+   using whatever tools he has available to him.  He may wish to prepare
+   long articles beforehand using his text editor (e.g. TECO if he's a
+   TENEX user).  For short messages, he may be content with the basic
+   editing features (such as backspace character and line delete)
+   provided by his submission subsystem.
+
+Connecting to the NIC
+
+   To get the mail to the SRI-ARC FTP server, you must either:
+
+      1) via FTP and TELNET mail subsystems, connect to SRI-ARC's FTP
+         server process, then issue the FTP mail command, or
+
+      2) use the mail subsystem provided by your local system.
+
+         For TENEX SNDMSG mail: put "@nic" at the end of the "User:"
+         field.
+            (e.g. jew / mdk dhc@nic)
+
+         If you wish to send the mail as a SNDMSG message to  some
+         people as well as submit it to the Journal, you may treat the
+         Journal form as one name, follow it with a comma, and then list
+         other names of which SNDMSG is aware, separated by commas.
+            (e.g. jew/mdk dhc@nic, meyer, white)
+
+Specifying Authors and Recipients
+
+   The user invokes Network Journal submission via his mail subsystem.
+   Network Journal Submission is invoked by a user-name field of the
+   following format:
+
+
+
+
+Meyer                                                           [Page 2]
+
+RFC 543         Network Journal Submission and Delivery     13 July 1973
+
+
+      author $(SP author) [SP] / [SP] recipient $ (SP recipient) [SP]
+      [ ; conversion algorithm]
+
+         "$(..)" means "any number of occurrences, possibly
+                 zero, of what's inside the parentheses"
+         "SP" means "space"
+         "[..]" mean "the contents of the brackets are optional"
+
+   i.e., author(s), slash, recipient(s), optional semicolon and
+   conversion-algorithm
+
+      e.g., jew/mdk rww   cr    dcs rww jcn / sri-arc ;h
+
+   'Author' is the NIC Ident of (one of) the user(s) submitting the
+   article, and 'recipient' the Ident of (one of) its intended
+   recipient(s).  An Ident, as usual, may designate either a "group" or
+   an "individual".  SRI-ARC will verify the idents.  If it finds them
+   correct, it will accept the mail.  An invalid Ident will cause the
+   mail to be rejected; the user will get an error message and have to
+   start over.  The first author Ident will be taken to be the clerk.
+
+   If the SRI-ARC mail subsystem finds the slash in the user-name field,
+   the Network Journal Submission system will be invoked; otherwise, the
+   mail will be treated as normal Network mail (delivered to the
+   directory specified by the user-name).
+
+Specifying an NLS Conversion Algorithm
+
+   Optionally, the sender may specify the algorithm by which his
+   sequential message file is to be converted to NLS format.  This
+   choice is made by inserting:
+
+      ; conversion algorithm
+
+   anywhere in the 'user-name' field (e.g. jew/mdk rww;s).  (This should
+   be before the "@nic" for SNDMSG.)  Legal values for conversion-
+   algorithm are:
+
+      s -- Insert Sequential, each line an NLS statement (default
+      conversion-algorithm)
+
+      a -- Insert Assembler with structure
+
+      m -- Insert Assembler without structure
+
+      h -- Heuristic Insert Sequential, double <CR>s indicating end of
+      statements, assuming no right justification in the source file.
+
+
+
+
+Meyer                                                           [Page 3]
+
+RFC 543         Network Journal Submission and Delivery     13 July 1973
+
+
+      j -- Heuristic Insert Sequential, double <CR>s indicating end of
+      statements, assuming right justification in the source file (for
+      those who put multiple spaces between words to line up the right
+      margin, multiple spaces will be removed)
+
+         By "Heuristic Insert Sequential", we mean that the Insert
+         Sequential algorithm attempts to be smarter about handling
+         statements and levels.  Statements are delimited by two
+         successive carriage returns.  Statement level will be
+         determined by the amount the statement is indented.  If it is
+         indented more than the previous statement, it will be taken to
+         be a substatement and put down a level; if it is the same as
+         the previous statement, it will be on the same level.  If the
+         statement is indented less than the previous statement, the
+         program will look for a past statement with the same
+         indentation and put it at that level, The indentation of a
+         statement is taken to be that of either the first or second
+         line of the statement, whichever is less (to ignore paragraph
+         indentation, for example).  This is good from 1 to 12 levels.
+         Carriage returns at the end of full (within 10 characters of
+         the right margin, i.e. 62nd column) lines are replaced by
+         spaces.
+
+         This algorithm is an attempt to answer a very difficult need.
+         It won't always do just the right thing, but it should often
+         provide the intended result.  The user is encouraged to
+         experiment with it; suggestions will be welcomed.
+
+Titling the Message
+
+      Once the conversion has been performed, an optional title,
+      signaled by the label 're:'. 'title:', or 'subject:' is searched
+      for in the first statement of the message text.  (The label may
+      either be all upper or all lower case, or the first character
+      upper and the rest lower case.)  If a label is found anywhere in
+      the statement, the line of that statement beginning with the first
+      non-blank character following the label and going up to the first
+      carriage return (and line feed) or else to the end of the
+      statement is taken as the Journal title, and the statement
+      containing the title is deleted from the file,  Any substructure
+      will be moved up a level.
+
+   The submission is equivalent to the NLS 'Submit Message' command if
+   th NLS file (after the title statement (if any) has been deleted) has
+   only one statement in it besides the origin statement; in such a
+   case, the message in its entirety will be delivered as part of the
+   Journal citation.  Otherwise the Network submission is equivalent to
+   'Submit File'; only a reference to the Journal document will be
+
+
+
+Meyer                                                           [Page 4]
+
+RFC 543         Network Journal Submission and Delivery     13 July 1973
+
+
+   delivered to each of the recipients.
+
+TENEX SCENARIOS
+
+   If you're a TENEX user, you can do Network Journal Submission with
+   any of the following subsystems (system responses are in square
+   brackets):
+
+      (1)   SNDMSG  (The header and trailer supplied by SNDMSG aren't
+                     stripped off, and one can only title the document
+                     by using the h or j conversion algorithms and
+                     beginning the message with a carriage return (and
+                     line feed).)
+
+            [@] SNDMSG <CR>
+            [Type ? for help]
+            [Users:] JEW/DHC@NIC <CR>
+            [Subject:] Title of message <CR>
+            [Message: (? for help):] Text of message ... <^Z>
+              (Note: ^B allows the insertion of a sequential
+              file at any point in the text of the message.)
+            [jew/dhc at NIC -- ok]
+
+      (2) FTP
+
+         For short messages:
+
+            [@] FTP <CR>
+            [HOST FTP User process x.xx.x]
+            [*] CONN <SP> NIC <CR>
+            [   Connection opened]
+            [   Assuming 36-bit connections.]
+            [*< SRI-ARC FTP Server x.xx.x - at DAY DATE TIME]
+            [*] QUO <ALT> MAIL JEW/MDK RWW <CR>
+            (pause)
+            [*< Type mail, ended by a line with only a "."]
+            [*] QUO <ALT> Re: Title of Message <CR>
+            [*] QUO <ALT> line one of the message <CR>
+            [*] QUO <ALT> line two of the message <CR>
+            [*] ...etc...
+            [*] QUO <ALT>.<CR>
+            (pause)
+            [*< Mail completed successfully]
+            [*] DISC <CR>
+            [*] QUIT <CR>
+
+
+
+
+
+
+Meyer                                                           [Page 5]
+
+RFC 543         Network Journal Submission and Delivery     13 July 1973
+
+
+         For longer ones:
+
+            [@] FTP <CR>
+            [HOST FTP User process x.xx.x]
+            [*] CONN <SP> NIC <CR>
+            [   Connection opened]
+            [   Assuming 36-bit connections.]
+            [*< SRI-ARC FTP Server x.xx.x - at DAY DATE TIME]
+            [*] MAIL <ALT> sequentialfilename <CR> [Confirm] <CR>
+            [   to remote-user] JEW/MDK RWW <CR>
+            (pause)
+            [<Begin mail file transfer.]
+            [   xx. bytes transfered, run time = xxx. MS,]
+            [   Elapsed time = xxxxx. MS, Rate = xxxx Baud]
+            [*< Mail completed successfully]
+            [*] DISC <CR>
+            [*] QUIT <CR>
+
+      TELNET (for short messages only)
+
+            [@] TELNET <CR>
+            [User Telnet x.x DATE Type HELP<cr> for help.]
+            [*] NIC <SP> FTP Server [is complete.#]
+            [300 SRI-ARC FTP Server x.xx.x.x - at DAY DATE TIME]
+            MAIL JEW/MDK RWW <CR>
+            (pause)
+            [350 Type mail, ended by a line with only a "."]
+            re: Title of Message
+            line one of message <CR>
+            line two of message <CR>
+             ...etc...
+             .<CR>
+            (pause)
+            [256 Mail completed successfully]
+            <^Z>
+            [*] DISC <CR>
+            [*] QUIT <CR>
+
+NETWORK JOURNAL DELIVERY
+
+   Three modes of Journal delivery are currently available to NLS users;
+   each user can select any one or a combination of ways of receiving
+   journal mail:
+
+      (1)   ONLINE -- an entry containing the text of the mail or, for
+            longer items, a citation to it, made in the user's initial
+            file, which resides in his directory at SRI-ARC.
+
+
+
+
+Meyer                                                           [Page 6]
+
+RFC 543         Network Journal Submission and Delivery     13 July 1973
+
+
+      (2)   HARDCOPY -- the text of the mail is sent to the user (i.e.,
+            to an address of his choosing) via the U.S. Postal Service.
+
+      (3)   NETWORK -- Journal mail will be delivered to a user via the
+            Net, to a host and mailbox of his choosing.  If you wish
+            this option, let the NIC know and give them the name of your
+            host and mailbox.
+
+               Short messages ('Submit Message') will be delivered in
+               their entirety to the remote user, preceded by the usual
+               sort of header giving author, date and time, citation
+               number, and title:
+
+                  JEW 4-APR-73 11:21  15490
+                  SMFS Runs on TENEX 1.31 at the NIC
+                  Message: Dave-- The NIC came up on TENEX 1.31 on
+                  1-APR...
+
+               A citation to larger Journal articles ('Submit File')
+               will sent:
+
+                  JEW 4-APR-73 17:51  15491
+                  Farming Batch Work out to UCSB -- A Scenario
+                  Location: SRI-ARC <MJOURNAL> 15491.NLSXNLS
+
+                  In place of the usual link (which appears in ONLINE
+                  delivery) is a host name (SRI-ARC) and a pathname to
+                  the file at the host.  Using it, the remote user or a
+                  process running on his behalf can fetch a copy of the
+                  file from SRI-ARC FTP.  The parameter ';XNLS' signals
+                  SRI-ARC's FTP server process to convert the NLS file
+                  to sequential form (using a default conversion
+                  algorithm) before transmission to the user through the
+                  Net.
+
+   By Network Journal delivery, mail will be delivered via FTP mail
+   command to a host (i.e., to it's FTP server process) and mailbox
+   address of the user's choosing.
+
+         These two parameters will be maintained in the NIC Ident file
+         for each user who selects NETWORK delivery, and can, like his
+         delivery mode, be viewed or changed from the Ident System in
+         NLS.  Initial values for host and mailbox address have been
+         solicited from the Network community (see RFC 510 -- 16400,).
+
+
+
+
+
+
+
+Meyer                                                           [Page 7]
+
+RFC 543         Network Journal Submission and Delivery     13 July 1973
+
+
+   The implementation of Network Journal submission and delivery
+   described here is a first-cut.  A more flexible and slightly cleaner
+   user interface will be fashioned when the File Transfer Protocol
+   (FTP), upon which both implementations will rely, is revised to deal
+   more comprehensibly with the issue of mail delivery, forwarding, and
+   recording (see RFC 524 -- 15146,1).
+
+
+          [This RFC was put into machine readable form for entry]
+             [into the online RFC archives by Via Genie 12/99]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Meyer                                                           [Page 8]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc543.txt](<www.ietf.org/rfc/rfc543.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
