### PR TITLE
Archive rfc544.txt

### DIFF
--- a/www.ietf.org/rfc/rfc544.txt
+++ b/www.ietf.org/rfc/rfc544.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                               Dean Meyer (SRI-ARC)
+RFC # 544                                          Kirk Kelley (SRI-ARC)
+NIC # 17782                                                July 13, 1973
+
+
+               Locating On-Line Documentation at SRI-ARC
+
+Where there used to be one, there are now two files to help users locate
+user documentation and other files available in NLS:
+
+    <NIC>LOCATOR will lead the user to NIC functional documents by means
+    of links.  Its branch labeled "ARC SYSTEM DOCUMENTATION" will direct
+    the user to <USERGUIDES>ARCLOCATOR.
+
+        (nic, locator, l:w)
+
+    <USERGUIDES>ARCLOCATOR includes documentation of the SRI-ARC system.
+    Many ARC features are available for Network use, and the documents
+    in <USERGUIDES>ARCLOCATOR should serve to introduce users to these
+    capabilities.
+
+        (userguides, arclocator, l:w)
+
+These files are formatted in a way that allows the documents to be
+easily accessed by inexperienced NLS users.  Both files contain
+instructions for their use as branch one.  To see these instructions:
+
+    L[oad] F[ile] <nic>locator CR
+
+    P[rint] B[ranch] .1 CA wn  CA
+
+Please send ideas and suggestions for the LOCATOR files to KIRK or NDM
+at SRI-ARC.
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.            10/99 ]
+
+
+
+
+
+Meyer & Kelley                                                  [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc544.txt](<www.ietf.org/rfc/rfc544.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
