### PR TITLE
Archive rfc5457.txt

### DIFF
--- a/www.ietf.org/rfc/rfc5457.txt
+++ b/www.ietf.org/rfc/rfc5457.txt
@@ -1,0 +1,1179 @@
+
+
+
+
+
+
+Independent Submission                                       E. Guy, Ed.
+Request for Comments: 5457                                      Truphone
+Category: Informational                                    February 2010
+ISSN: 2070-1721
+
+
+     IANA Considerations for IAX: Inter-Asterisk eXchange Version 2
+
+Abstract
+
+   This document establishes the IANA registries for IAX, the Inter-
+   Asterisk eXchange protocol, an application-layer control and media
+   protocol for creating, modifying, and terminating multimedia sessions
+   over Internet Protocol (IP) networks.  IAX was developed by the open
+   source community for the Asterisk PBX and is targeted primarily at
+   Voice over Internet Protocol (VoIP) call control, but it can be used
+   with streaming video or any other type of multimedia.
+
+Status of This Memo
+
+   This document is not an Internet Standards Track specification; it is
+   published for informational purposes.
+
+   This is a contribution to the RFC Series, independently of any other
+   RFC stream.  The RFC Editor has chosen to publish this document at
+   its discretion and makes no statement about its value for
+   implementation or deployment.  Documents approved for publication by
+   the RFC Editor are not a candidate for any level of Internet
+   Standard; see Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc5457.
+
+IESG Note
+
+   The IESG thinks that this work is related to IETF work done in SIP,
+   MMUSIC, and AVT WGs, but this does not prevent publishing.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Guy                           Informational                     [Page 1]
+
+RFC 5457                 IANA IAX Considerations           February 2010
+
+
+Copyright Notice
+
+   Copyright (c) 2010 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.
+
+Table of Contents
+
+   1. Introduction ....................................................2
+   2. IANA Considerations .............................................3
+      2.1. Meta Command ...............................................3
+      2.2. Frame Types ................................................3
+      2.3. Control Frame Subclass .....................................4
+      2.4. IAX Control Frames .........................................6
+      2.5. HTML Command Subclasses ....................................8
+      2.6. Information Elements .......................................8
+      2.7. Authentication Methods ....................................11
+      2.8. Dialplan Status Flags .....................................12
+      2.9. Calling Presentation ......................................12
+      2.10. Calling Type of Number (CALLINGTON) ......................13
+      2.11. IAX Transit Network Identification .......................14
+      2.12. IAX Type of Network ......................................15
+      2.13. Cause Codes ..............................................16
+      2.14. Encryption Methods .......................................18
+      2.15. Media Formats ............................................19
+   3. Security Considerations ........................................20
+   4. Acknowledgments ................................................20
+   5. Normative References ...........................................20
+
+1.  Introduction
+
+   IAX (Inter-Asterisk eXchange) is an "all-in-one" protocol for
+   handling multimedia in IP networks.  It combines both control and
+   media services in the same protocol.  In addition, IAX uses a single
+   UDP data stream on a static port greatly simplifying Network Address
+   Translation (NAT) gateway traversal, eliminating the need for other
+   protocols to work around NAT, and simplifying network and firewall
+   management.  IAX employs a compact encoding that decreases bandwidth
+   usage and is well suited for Internet telephony service.  In
+   addition, its open nature permits new payload type additions needed
+   to support additional services.
+
+
+
+
+Guy                           Informational                     [Page 2]
+
+RFC 5457                 IANA IAX Considerations           February 2010
+
+
+   This document specifies and provides the initial values for the
+   creation of the IAX-related IANA registries as per [RFC5226].
+
+2.  IANA Considerations
+
+   The IAX protocol, as defined in [RFC5456], defines 15 namespaces that
+   have been registered.  These namespaces are described below.
+
+   Each of these namespaces utilizes an 'Expert Review' for extension.
+   Documentation of new values is not mandated as RFCs.  The Expert
+   Review should be guided by a few common sense considerations.  For
+   example, new values should not be specific to a country, region,
+   organization, or company; they should be well-defined and widely
+   recognized.
+
+2.1.  Meta Command
+
+   Registry Name: IAX Meta Commands
+
+   Required Information for New Values: Name, description, and relevant
+   security considerations, if any.
+
+   Description: See Section 8.1.3.2 of [RFC5456].
+
+   Valid Range: 0x01-x7F.
+
+   Display format: hex.
+
+   The following table specifies the initial assignments of Meta Command
+   values:
+
+   +------+-----------------+------------------------------------------+
+   | TYPE | Name            | Description                              |
+   +------+-----------------+------------------------------------------+
+   | 0x01 | Trunk Meta      | Indicates that frame is a trunk meta     |
+   |      | Frame           | frame.                                   |
+   +------+-----------------+------------------------------------------+
+
+2.2.  Frame Types
+
+   Registry Name: IAX Frame Types
+
+   Required Information for New Values: Name, description, and relevant
+   security considerations, if any.  In addition, the definition and
+   description of subclasses.
+
+   Description: See Section 8.2 of [RFC5456].
+
+
+
+
+Guy                           Informational                     [Page 3]
+
+RFC 5457                 IANA IAX Considerations           February 2010
+
+
+   Valid Range: 0x01-xFF.
+
+   Display format: hex.
+
+   The following table specifies the initial assignments of Frame Type
+   Values:
+
+   +------+-------------+--------------------------+-------------------+
+   | TYPE | Description | Subclass Description     | Data Description  |
+   +------+-------------+--------------------------+-------------------+
+   | 0x01 | DTMF        | 0-9, A-D, *, #           | Undefined         |
+   |      |             |                          |                   |
+   | 0x02 | Voice       | Audio Compression Format | Data              |
+   |      |             |                          |                   |
+   | 0x03 | Video       | Video Compression Format | Data              |
+   |      |             |                          |                   |
+   | 0x04 | Control     | See Control Frame        | Varies with       |
+   |      |             | Subclass                 | subclass          |
+   |      |             |                          |                   |
+   | 0x05 | Null        | Undefined                | Undefined         |
+   |      |             |                          |                   |
+   | 0x06 | IAX Control | See IAX Protocol         | Information       |
+   |      |             | Messages                 | Elements          |
+   |      |             |                          |                   |
+   | 0x07 | Text        | Always 0                 | Raw Text          |
+   |      |             |                          |                   |
+   | 0x08 | Image       | Image Compression Format | Raw image         |
+   |      |             |                          |                   |
+   | 0x09 | HTML        | See HTML Frame Types     | Message Specific  |
+   |      |             |                          |                   |
+   | 0x0A | Comfort     | Level in -dBov of        | None              |
+   |      | Noise       | comfort noise            |                   |
+   +------+-------------+--------------------------+-------------------+
+
+2.3.  Control Frame Subclass
+
+   Registry Name: IAX Control Frame Subclass
+
+   Required Information for New Values: Name, description, and relevant
+   security considerations, if any.
+
+   Description: See Section 8.3 of [RFC5456].
+
+   Valid Range: 0x00-x7F.
+
+   Display format: hex.
+
+
+
+
+
+Guy                           Informational                     [Page 4]
+
+RFC 5457                 IANA IAX Considerations           February 2010
+
+
+   The following table specifies the initial assignments of Control
+   Frame Subclasses:
+
+   +-------------+---------------+-------------------------------------+
+   | VALUE       | Name          | Description                         |
+   +-------------+---------------+-------------------------------------+
+   | 0x01        | Hangup        | The call has been hungup at the     |
+   |             |               | remote end                          |
+   |             |               |                                     |
+   | 0x02        | Reserved      | Reserved for future use             |
+   |             |               |                                     |
+   | 0x03        | Ringing       | Remote end is ringing (ring-back)   |
+   |             |               |                                     |
+   | 0x04        | Answer        | Remote end has answered             |
+   |             |               |                                     |
+   | 0x05        | Busy          | Remote end is busy                  |
+   |             |               |                                     |
+   | 0x06        | Reserved      | Reserved for future use             |
+   |             |               |                                     |
+   | 0x07        | Reserved      | Reserved for future use             |
+   |             |               |                                     |
+   | 0x08        | Congestion    | The call is congested               |
+   |             |               |                                     |
+   | 0x09        | Flash Hook    | Flash hook                          |
+   |             |               |                                     |
+   | 0x0a        | Reserved      | Reserved for future use             |
+   |             |               |                                     |
+   | 0x0b        | Option        | Device-specific options are being   |
+   |             |               | transmitted                         |
+   |             |               |                                     |
+   | 0x0c        | Key Radio     | Key Radio                           |
+   |             |               |                                     |
+   | 0x0d        | Unkey Radio   | Unkey Radio                         |
+   |             |               |                                     |
+   | 0x0e        | Call Progress | Call is in progress                 |
+   |             |               |                                     |
+   | 0x0f        | Call          | Call is proceeding                  |
+   |             | Proceeding    |                                     |
+   |             |               |                                     |
+   | 0x10        | Hold          | Call is placed on hold              |
+   |             |               |                                     |
+   | 0x11        | Unhold        | Call is taken off hold              |
+   +-------------+---------------+-------------------------------------+
+
+
+
+
+
+
+
+
+Guy                           Informational                     [Page 5]
+
+RFC 5457                 IANA IAX Considerations           February 2010
+
+
+2.4.  IAX Control Frames
+
+   Registry Name: IAX Control Frames
+
+   Required Information for New Values: Name, description, and relevant
+   security considerations, if any.
+
+   Description: See Section 8.4 of [RFC5456].
+
+   Valid Range: 0x01-x7F.
+
+   Display format: hex.
+
+   The following table specifies the initial assignments of IAX Control
+   Frame values:
+
+      +------+-----------+-----------------------------------------+
+      | Hex  | Name      | Description                             |
+      +------+-----------+-----------------------------------------+
+      | 0x01 | NEW       | Initiate a new call                     |
+      |      |           |                                         |
+      | 0x02 | PING      | Ping request                            |
+      |      |           |                                         |
+      | 0x03 | PONG      | Ping or poke reply                      |
+      |      |           |                                         |
+      | 0x04 | ACK       | Explicit acknowledgment                 |
+      |      |           |                                         |
+      | 0x05 | HANGUP    | Initiate call tear-down                 |
+      |      |           |                                         |
+      | 0x06 | REJECT    | Reject a call                           |
+      |      |           |                                         |
+      | 0x07 | ACCEPT    | Accept a call                           |
+      |      |           |                                         |
+      | 0x08 | AUTHREQ   | Authentication request                  |
+      |      |           |                                         |
+      | 0x09 | AUTHREP   | Authentication reply                    |
+      |      |           |                                         |
+      | 0x0a | INVAL     | Invalid message                         |
+      |      |           |                                         |
+      | 0x0b | LAGRQ     | Lag request                             |
+      |      |           |                                         |
+      | 0x0c | LAGRP     | Lag reply                               |
+      |      |           |                                         |
+      | 0x0d | REGREQ    | Registration request                    |
+      |      |           |                                         |
+      | 0x0e | REGAUTH   | Registration authentication             |
+      |      |           |                                         |
+      | 0x0f | REGACK    | Registration acknowledgement            |
+
+
+
+Guy                           Informational                     [Page 6]
+
+RFC 5457                 IANA IAX Considerations           February 2010
+
+
+      |      |           |                                         |
+      | 0x10 | REGREJ    | Registration reject                     |
+      |      |           |                                         |
+      | 0x11 | REGREL    | Registration release                    |
+      |      |           |                                         |
+      | 0x12 | VNAK      | Video/Voice retransmit request          |
+      |      |           |                                         |
+      | 0x13 | DPREQ     | Dialplan request                        |
+      |      |           |                                         |
+      | 0x14 | DPREP     | Dialplan reply                          |
+      |      |           |                                         |
+      | 0x15 | DIAL      | Dial                                    |
+      |      |           |                                         |
+      | 0x16 | TXREQ     | Transfer request                        |
+      |      |           |                                         |
+      | 0x17 | TXCNT     | Transfer connect                        |
+      |      |           |                                         |
+      | 0x18 | TXACC     | Transfer accept                         |
+      |      |           |                                         |
+      | 0x19 | TXREADY   | Transfer ready                          |
+      |      |           |                                         |
+      | 0x1a | TXREL     | Transfer release                        |
+      |      |           |                                         |
+      | 0x1b | TXREJ     | Transfer reject                         |
+      |      |           |                                         |
+      | 0x1c | QUELCH    | Halt audio/video [media] transmission   |
+      |      |           |                                         |
+      | 0x1d | UNQUELCH  | Resume audio/video [media] transmission |
+      |      |           |                                         |
+      | 0x1e | POKE      | Poke request                            |
+      |      |           |                                         |
+      | 0x1f | Reserved  | Reserved for future use                 |
+      |      |           |                                         |
+      | 0x20 | MWI       | Message waiting indication              |
+      |      |           |                                         |
+      | 0x21 | UNSUPPORT | Unsupported message                     |
+      |      |           |                                         |
+      | 0x22 | TRANSFER  | Remote transfer request                 |
+      |      |           |                                         |
+      | 0x23 | Reserved  | Reserved for future use                 |
+      |      |           |                                         |
+      | 0x24 | Reserved  | Reserved for future use                 |
+      |      |           |                                         |
+      | 0x25 | Reserved  | Reserved for future use                 |
+      +------+-----------+-----------------------------------------+
+
+
+
+
+
+
+Guy                           Informational                     [Page 7]
+
+RFC 5457                 IANA IAX Considerations           February 2010
+
+
+2.5.  HTML Command Subclasses
+
+   Registry Name: IAX HTML Command Subclasses
+
+   Required Information for New Values: Name, description, and relevant
+   security considerations, if any.
+
+   Description: See Section 8.2 of [RFC5456].
+
+   Valid Range: 0x01-x7F.
+
+   Display format: hex.
+
+   The following table specifies the initial assignments of IAX HTML
+   Command Subclasses:
+
+                  +--------+----------------------------+
+                  | NUMBER | DESCRIPTION                |
+                  +--------+----------------------------+
+                  | 0x01   | Sending a URL              |
+                  |        |                            |
+                  | 0x02   | Data frame                 |
+                  |        |                            |
+                  | 0x04   | Beginning frame            |
+                  |        |                            |
+                  | 0x08   | End frame                  |
+                  |        |                            |
+                  | 0x10   | Load is complete           |
+                  |        |                            |
+                  | 0x11   | Peer does not support HTML |
+                  |        |                            |
+                  | 0x12   | Link URL                   |
+                  |        |                            |
+                  | 0x13   | Unlink URL                 |
+                  |        |                            |
+                  | 0x14   | Reject Link URL            |
+                  +--------+----------------------------+
+
+2.6.  Information Elements
+
+   Registry Name: IAX Information Elements
+
+   Required Information for New Values: Name, description, and relevant
+   security considerations, if any.
+
+   Description: See Section 8.6 of [RFC5456].
+
+   Valid Range: 0x01-xFF.
+
+
+
+Guy                           Informational                     [Page 8]
+
+RFC 5457                 IANA IAX Considerations           February 2010
+
+
+   Display format: hex.
+
+   The following table specifies the Initial Assignments of Information
+   Element Definitions:
+
+   +------+----------------+-------------------------------------------+
+   | HEX  | NAME           | DESCRIPTION                               |
+   +------+----------------+-------------------------------------------+
+   | 0x01 | CALLED NUMBER  | Number/extension being called             |
+   |      |                |                                           |
+   | 0x02 | CALLING NUMBER | Calling number                            |
+   |      |                |                                           |
+   | 0x03 | CALLING ANI    | Calling number ANI for billing            |
+   |      |                |                                           |
+   | 0x04 | CALLING NAME   | Name of caller                            |
+   |      |                |                                           |
+   | 0x05 | CALLED CONTEXT | Context for number                        |
+   |      |                |                                           |
+   | 0x06 | USERNAME       | Username (peer or user) for               |
+   |      |                | authentication                            |
+   |      |                |                                           |
+   | 0x07 | PASSWORD       | Password for authentication               |
+   |      |                |                                           |
+   | 0x08 | CAPABILITY     | Actual CODEC capability                   |
+   |      |                |                                           |
+   | 0x09 | FORMAT         | Desired CODEC format                      |
+   |      |                |                                           |
+   | 0x0a | LANGUAGE       | Desired language                          |
+   |      |                |                                           |
+   | 0x0b | VERSION        | Protocol version                          |
+   |      |                |                                           |
+   | 0x0c | ADSICPE        | CPE ADSI capability                       |
+   |      |                |                                           |
+   | 0x0d | DNID           | Originally dialed DNID                    |
+   |      |                |                                           |
+   | 0x0e | AUTHMETHODS    | Authentication method(s)                  |
+   |      |                |                                           |
+   | 0x0f | CHALLENGE      | Challenge data for MD5/RSA                |
+   |      |                |                                           |
+   | 0x10 | MD5 RESULT     | MD5 challenge result                      |
+   |      |                |                                           |
+   | 0x11 | RSA RESULT     | RSA challenge result                      |
+   |      |                |                                           |
+   | 0x12 | APPARENT ADDR  | Apparent address of peer                  |
+   |      |                |                                           |
+   | 0x13 | REFRESH        | When to refresh registration              |
+   |      |                |                                           |
+   | 0x14 | DPSTATUS       | Dialplan status                           |
+
+
+
+Guy                           Informational                     [Page 9]
+
+RFC 5457                 IANA IAX Considerations           February 2010
+
+
+   |      |                |                                           |
+   | 0x15 | CALLNO         | Call number of peer                       |
+   |      |                |                                           |
+   | 0x16 | CAUSE          | Cause                                     |
+   |      |                |                                           |
+   | 0x17 | IAX UNKNOWN    | Unknown IAX command                       |
+   |      |                |                                           |
+   | 0x18 | MSGCOUNT       | How many messages waiting                 |
+   |      |                |                                           |
+   | 0x19 | AUTOANSWER     | Request auto-answering                    |
+   |      |                |                                           |
+   | 0x1a | MUSICONHOLD    | Request musiconhold with QUELCH           |
+   |      |                |                                           |
+   | 0x1b | TRANSFERID     | Transfer Request Identifier               |
+   |      |                |                                           |
+   | 0x1c | RDNIS          | Referring DNIS                            |
+   |      |                |                                           |
+   | 0x1d | Reserved       | Reserved for future use                   |
+   |      |                |                                           |
+   | 0x1e | Reserved       | Reserved for future use                   |
+   |      |                |                                           |
+   | 0x1f | DATETIME       | Date/Time                                 |
+   |      |                |                                           |
+   | 0x20 | Reserved       | Reserved for future use                   |
+   |      |                |                                           |
+   | 0x21 | Reserved       | Reserved for future use                   |
+   |      |                |                                           |
+   | 0x22 | Reserved       | Reserved for future use                   |
+   |      |                |                                           |
+   | 0x23 | Reserved       | Reserved for future use                   |
+   |      |                |                                           |
+   | 0x24 | Reserved       | Reserved for future use                   |
+   |      |                |                                           |
+   | 0x25 | Reserved       | Reserved for future use                   |
+   |      |                |                                           |
+   | 0x26 | CALLINGPRES    | Calling presentation                      |
+   |      |                |                                           |
+   | 0x27 | CALLINGTON     | Calling type of number                    |
+   |      |                |                                           |
+   | 0x28 | CALLINGTNS     | Calling transit network select            |
+   |      |                |                                           |
+   | 0x29 | SAMPLINGRATE   | Supported sampling rates                  |
+   |      |                |                                           |
+   | 0x2a | CAUSECODE      | Hangup cause                              |
+   |      |                |                                           |
+   | 0x2b | ENCRYPTION     | Encryption format                         |
+   |      |                |                                           |
+   | 0x2c | ENCKEY         | Reserved for future use                   |
+
+
+
+Guy                           Informational                    [Page 10]
+
+RFC 5457                 IANA IAX Considerations           February 2010
+
+
+   |      |                |                                           |
+   | 0x2d | CODEC PREFS    | CODEC Negotiation                         |
+   |      |                |                                           |
+   | 0x2e | RR JITTER      | Received jitter, as in RFC 3550           |
+   |      |                |                                           |
+   | 0x2f | RR LOSS        | Received loss, as in RFC 3550             |
+   |      |                |                                           |
+   | 0x30 | RR PKTS        | Received frames                           |
+   |      |                |                                           |
+   | 0x31 | RR DELAY       | Max playout delay for received frames in  |
+   |      |                | ms                                        |
+   |      |                |                                           |
+   | 0x32 | RR DROPPED     | Dropped frames (presumably by jitter      |
+   |      |                | buffer)                                   |
+   |      |                |                                           |
+   | 0x33 | RR OOO         | Frames received Out of Order              |
+   |      |                |                                           |
+   | 0x34 | OSPTOKEN       | OSP Token Block                           |
+   +------+----------------+-------------------------------------------+
+
+                 Table 1: Information Element Definitions
+
+2.7.  Authentication Methods
+
+   Registry Name: IAX Authentication Methods
+
+   Required Information for New Values: Name, description, and relevant
+   security considerations, if any.
+
+   Description: See Section 8.6.13 of [RFC5456].
+
+   Valid Range: 0x0001-xFFFF bitmask, values must be a power of two.
+
+   Display format: hex.
+
+   The following table specifies the initial assignments of IAX
+   Authentication Methods:
+
+                   +--------+--------------------------+
+                   | METHOD | DESCRIPTION              |
+                   +--------+--------------------------+
+                   | 0x0001 | Reserved (was Plaintext) |
+                   |        |                          |
+                   | 0x0002 | MD5                      |
+                   |        |                          |
+                   | 0x0004 | RSA                      |
+                   +--------+--------------------------+
+
+
+
+
+Guy                           Informational                    [Page 11]
+
+RFC 5457                 IANA IAX Considerations           February 2010
+
+
+2.8.  Dialplan Status Flags
+
+   Registry Name: IAX Dialplan Status Flags
+
+   Required Information for New Values: Name, description, and relevant
+   security considerations, if any.
+
+   Description: See Section 8.6.19 of [RFC5456].
+
+   Valid Range: 0x0001-xFFFF bitmask, values must be a power of two.
+
+   Display format: hex.
+
+   The following table specifies the initial assignments of IAX dialplan
+   status flags:
+
+                 +--------+------------------------------+
+                 | FLAG   | DESCRIPTION                  |
+                 +--------+------------------------------+
+                 | 0x0001 | Exists                       |
+                 |        |                              |
+                 | 0x0002 | Can exist                    |
+                 |        |                              |
+                 | 0x0004 | Non-existent                 |
+                 |        |                              |
+                 | 0x4000 | Retain dialtone (ignorepat)  |
+                 |        |                              |
+                 | 0x8000 | More digits may match number |
+                 +--------+------------------------------+
+
+2.9.  Calling Presentation
+
+   Registry Name: IAX Calling Presentation
+
+   Required Information for New Values: Name, description, and relevant
+   security considerations, if any.
+
+   Description: See Section 8.6.29 of [RFC5456].
+
+   Valid Range: 0x00-xFF.
+
+   Display format: hex.
+
+
+
+
+
+
+
+
+
+Guy                           Informational                    [Page 12]
+
+RFC 5457                 IANA IAX Considerations           February 2010
+
+
+   The following table specifies the initial assignments of calling
+   presentation values:
+
+              +------+--------------------------------------+
+              | FLAG | PRESENTATION                         |
+              +------+--------------------------------------+
+              | 0x00 | Allowed user/number not screened     |
+              |      |                                      |
+              | 0x01 | Allowed user/number passed screen    |
+              |      |                                      |
+              | 0x02 | Allowed user/number failed screen    |
+              |      |                                      |
+              | 0x03 | Allowed network number               |
+              |      |                                      |
+              | 0x20 | Prohibited user/number not screened  |
+              |      |                                      |
+              | 0x21 | Prohibited user/number passed screen |
+              |      |                                      |
+              | 0x22 | Prohibited user/number failed screen |
+              |      |                                      |
+              | 0x23 | Prohibited network number            |
+              |      |                                      |
+              | 0x43 | Number not available                 |
+              +------+--------------------------------------+
+
+   NOTE: The values in this table are derived from Q.931; however,
+   future values may be from other sources.
+
+2.10.  Calling Type of Number (CALLINGTON)
+
+   Registry Name: IAX Calling Type of Number
+
+   Required Information for New Values: Name, description, and relevant
+   security considerations, if any.
+
+   Description: See Section 8.6.30 of [RFC5456].
+
+   Valid Range: 0x00-xFF.
+
+   Display format: hex.
+
+
+
+
+
+
+
+
+
+
+
+Guy                           Informational                    [Page 13]
+
+RFC 5457                 IANA IAX Considerations           February 2010
+
+
+   The following table specifies the initial assignments of valid
+   calling type of number values:
+
+                    +-------+-------------------------+
+                    | VALUE | DESCRIPTION             |
+                    +-------+-------------------------+
+                    | 0x00  | Unknown                 |
+                    |       |                         |
+                    | 0x10  | International Number    |
+                    |       |                         |
+                    | 0x20  | National Number         |
+                    |       |                         |
+                    | 0x30  | Network Specific Number |
+                    |       |                         |
+                    | 0x40  | Subscriber Number       |
+                    |       |                         |
+                    | 0x60  | Abbreviated Number      |
+                    |       |                         |
+                    | 0x70  | Reserved for extension  |
+                    +-------+-------------------------+
+
+   NOTE: The values in this table are derived from Q.931; however,
+   future values may be from other sources.
+
+2.11.  IAX Transit Network Identification
+
+   Registry Name: IAX Transit Network Identification Plan
+
+   Required Information for New Values: Name, description, and relevant
+   security considerations, if any.
+
+   Description: See Section 8.6.31 of [RFC5456].
+
+   Valid Range: 0000-1111 (four bits).
+
+   Display format: binary.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Guy                           Informational                    [Page 14]
+
+RFC 5457                 IANA IAX Considerations           February 2010
+
+
+   The following table specifies the initial assignments of IAX Calling
+   Type of Number values:
+
+                +------+----------------------------------+
+                | BITS | DESCRIPTION                      |
+                +------+----------------------------------+
+                | 0000 | Unknown                          |
+                |      |                                  |
+                | 0001 | Caller Identification Code       |
+                |      |                                  |
+                | 0011 | Data Network Identification Code |
+                +------+----------------------------------+
+
+   NOTE: The values in this table are derived from Q.931; however,
+   future values may be from other sources.
+
+2.12.  IAX Type of Network
+
+   Registry Name: IAX Type of Network
+
+   Required Information for New Values: Name, description, and relevant
+   security considerations, if any.
+
+   Description: See Section 8.6.30 of [RFC5456].
+
+   Valid Range: 000-111 (three bits).
+
+   Display format: binary.
+
+   The following table specifies the initial assignments of IAX Calling
+   Type of Network values:
+
+              +------+--------------------------------------+
+              | BITS | DESCRIPTION                          |
+              +------+--------------------------------------+
+              | 000  | User Specified                       |
+              |      |                                      |
+              | 010  | National Network Identification      |
+              |      |                                      |
+              | 011  | International Network Identification |
+              +------+--------------------------------------+
+
+   NOTE: The values in this table are derived from Q.931, however,
+   future values may be from other sources.
+
+
+
+
+
+
+
+Guy                           Informational                    [Page 15]
+
+RFC 5457                 IANA IAX Considerations           February 2010
+
+
+2.13.  Cause Codes
+
+   Registry Name: IAX Cause Codes
+
+   Required Information for New Values: Name, description, and relevant
+   security considerations, if any.
+
+   Description: See Section 8.6.30 of [RFC5456].
+
+   Valid Range: 1-255.
+
+   Display format: decimal.
+
+   The following table specifies the initial assignments of IAX Cause
+   Code values:
+
+   +--------+----------------------------------------------------------+
+   | NUMBER | CAUSE                                                    |
+   +--------+----------------------------------------------------------+
+   | 1      | Unassigned/unallocated number                            |
+   |        |                                                          |
+   | 2      | No route to specified transit network                    |
+   |        |                                                          |
+   | 3      | No route to destination                                  |
+   |        |                                                          |
+   | 6      | Channel unacceptable                                     |
+   |        |                                                          |
+   | 7      | Call awarded and delivered                               |
+   |        |                                                          |
+   | 16     | Normal call clearing                                     |
+   |        |                                                          |
+   | 17     | User busy                                                |
+   |        |                                                          |
+   | 18     | No user response                                         |
+   |        |                                                          |
+   | 19     | No answer                                                |
+   |        |                                                          |
+   | 21     | Call rejected                                            |
+   |        |                                                          |
+   | 22     | Number changed                                           |
+   |        |                                                          |
+   | 27     | Destination out of order                                 |
+   |        |                                                          |
+   | 28     | Invalid number format/incomplete number                  |
+   |        |                                                          |
+   | 29     | Facility rejected                                        |
+   |        |                                                          |
+   | 30     | Response to status enquiry                               |
+
+
+
+Guy                           Informational                    [Page 16]
+
+RFC 5457                 IANA IAX Considerations           February 2010
+
+
+   |        |                                                          |
+   | 31     | Normal, unspecified                                      |
+   |        |                                                          |
+   | 34     | No circuit/channel available                             |
+   |        |                                                          |
+   | 38     | Network out of order                                     |
+   |        |                                                          |
+   | 41     | Temporary failure                                        |
+   |        |                                                          |
+   | 42     | Switch congestion                                        |
+   |        |                                                          |
+   | 43     | Access information discarded                             |
+   |        |                                                          |
+   | 44     | Requested channel not available                          |
+   |        |                                                          |
+   | 45     | Preempted (causes.h only)                                |
+   |        |                                                          |
+   | 47     | Resource unavailable, unspecified (Q.931 only)           |
+   |        |                                                          |
+   | 50     | Facility not subscribed (causes.h only)                  |
+   |        |                                                          |
+   | 52     | Outgoing call barred (causes.h only)                     |
+   |        |                                                          |
+   | 54     | Incoming call barred (causes.h only)                     |
+   |        |                                                          |
+   | 57     | Bearer capability not authorized                         |
+   |        |                                                          |
+   | 58     | Bearer capability not available                          |
+   |        |                                                          |
+   | 63     | Service or option not available (Q.931 only)             |
+   |        |                                                          |
+   | 65     | Bearer capability not implemented                        |
+   |        |                                                          |
+   | 66     | Channel type not implemented                             |
+   |        |                                                          |
+   | 69     | Facility not implemented                                 |
+   |        |                                                          |
+   | 70     | Only restricted digital information bearer capability is |
+   |        | available (Q.931 only)                                   |
+   |        |                                                          |
+   | 79     | Service or option not available (Q.931 only)             |
+   |        |                                                          |
+   | 81     | Invalid call reference                                   |
+   |        |                                                          |
+   | 82     | Identified channel does not exist (Q.931 only)           |
+   |        |                                                          |
+   | 83     | A suspended call exists, but this call identity does not |
+   |        | (Q.931 only)                                             |
+
+
+
+Guy                           Informational                    [Page 17]
+
+RFC 5457                 IANA IAX Considerations           February 2010
+
+
+   |        |                                                          |
+   | 84     | Call identity in use (Q.931 only)                        |
+   |        |                                                          |
+   | 85     | No call suspended (Q.931 only)                           |
+   |        |                                                          |
+   | 86     | Call has been cleared (Q.931 only)                       |
+   |        |                                                          |
+   | 88     | Incompatible destination                                 |
+   |        |                                                          |
+   | 91     | Invalid transit network selection (Q.931 only)           |
+   |        |                                                          |
+   | 95     | Invalid message, unspecified                             |
+   |        |                                                          |
+   | 96     | Mandatory information element missing (Q.931 only)       |
+   |        |                                                          |
+   | 97     | Message type nonexistent/not implemented                 |
+   |        |                                                          |
+   | 98     | Message not compatible with call state                   |
+   |        |                                                          |
+   | 99     | Information element nonexistent                          |
+   |        |                                                          |
+   | 100    | Invalid information element contents                     |
+   |        |                                                          |
+   | 101    | Message not compatible with call state                   |
+   |        |                                                          |
+   | 102    | Recovery on timer expiration                             |
+   |        |                                                          |
+   | 103    | Mandatory information element length error (causes.h     |
+   |        | only)                                                    |
+   |        |                                                          |
+   | 111    | Protocol error, unspecified                              |
+   |        |                                                          |
+   | 127    | Internetworking, unspecified                             |
+   +--------+----------------------------------------------------------+
+
+2.14.  Encryption Methods
+
+   Registry Name: IAX Encryption Methods
+
+   Required Information for New Values: Name, description, and relevant
+   security considerations, if any.
+
+   Description: See Section 8.6.34 of [RFC5456].
+
+   Valid Range: 0x0001-x8000 bitmask, values must be a power of two.
+
+   Display format: hex.
+
+
+
+
+Guy                           Informational                    [Page 18]
+
+RFC 5457                 IANA IAX Considerations           February 2010
+
+
+   The following table specifies the initial assignments of IAX
+   encryption methods:
+
+                         +--------+-------------+
+                         | METHOD | DESCRIPTION |
+                         +--------+-------------+
+                         | 0x0001 | AES-128     |
+                         +--------+-------------+
+
+2.15.  Media Formats
+
+   Registry Name: IAX Media Formats
+
+   Required Information for New Values: Name, description, and relevant
+   security considerations, if any.
+
+   Description: See Section 8.7 of [RFC5456].
+
+   Valid Range: 0x0001-x8000 bitmask, values must be a power of two.
+
+   Display format: hex.
+
+   The following table specifies the initial assignments of IAX Media
+   Format Values
+
+               +------------+-----------------------------+
+               | SUBCLASS   | DESCRIPTION                 |
+               +------------+-----------------------------+
+               | 0x00000001 | G.723.1                     |
+               |            |                             |
+               | 0x00000002 | GSM Full Rate               |
+               |            |                             |
+               | 0x00000004 | G.711 mu-law                |
+               |            |                             |
+               | 0x00000008 | G.711 a-law                 |
+               |            |                             |
+               | 0x00000010 | G.726                       |
+               |            |                             |
+               | 0x00000020 | IMA ADPCM                   |
+               |            |                             |
+               | 0x00000040 | 16-bit linear little-endian |
+               |            |                             |
+               | 0x00000080 | LPC10                       |
+               |            |                             |
+               | 0x00000100 | G.729                       |
+               |            |                             |
+               | 0x00000200 | Speex                       |
+               |            |                             |
+
+
+
+Guy                           Informational                    [Page 19]
+
+RFC 5457                 IANA IAX Considerations           February 2010
+
+
+               | 0x00000400 | ILBC                        |
+               |            |                             |
+               | 0x00000800 | G.726 AAL2                  |
+               |            |                             |
+               | 0x00001000 | G.722                       |
+               |            |                             |
+               | 0x00002000 | AMR                         |
+               |            |                             |
+               | 0x00010000 | JPEG                        |
+               |            |                             |
+               | 0x00020000 | PNG                         |
+               |            |                             |
+               | 0x00040000 | H.261                       |
+               |            |                             |
+               | 0x00080000 | H.263                       |
+               |            |                             |
+               | 0x00100000 | H.263p                      |
+               |            |                             |
+               | 0x00200000 | H.264                       |
+               +------------+-----------------------------+
+
+3.  Security Considerations
+
+   This document defines IAX registries and as such does not raise
+   security issues beyond those discussed in [RFC5456].
+
+4.  Acknowledgments
+
+   The author would like to thank Marc Blanchet and Michelle Cotton for
+   their support and suggestions.
+
+5.  Normative References
+
+   [RFC5226]  Narten, T. and H. Alvestrand, "Guidelines for Writing an
+              IANA Considerations Section in RFCs", BCP 26, RFC 5226,
+              May 2008.
+
+   [RFC5456]  Spencer, M., Capouch, B., Guy, E., Ed., Miller, F., and K.
+              Shumard, "IAX: Inter-Asterisk eXchange Version 2", RFC
+              5456, February 2010.
+
+
+
+
+
+
+
+
+
+
+
+Guy                           Informational                    [Page 20]
+
+RFC 5457                 IANA IAX Considerations           February 2010
+
+
+Author's Address
+
+   Ed Guy (editor)
+   Truphone
+   12 Williams Rd
+   Chatham, NJ  07928
+   US
+
+   Phone: +1 973 437 4519
+   EMail: edguy@emcsw.com
+   URI:   http://www.truphone.com/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Guy                           Informational                    [Page 21]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc5457.txt](<www.ietf.org/rfc/rfc5457.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
