### PR TITLE
Archive rfc5478.txt

### DIFF
--- a/www.ietf.org/rfc/rfc5478.txt
+++ b/www.ietf.org/rfc/rfc5478.txt
@@ -1,0 +1,339 @@
+
+
+
+
+
+
+Network Working Group                                            J. Polk
+Request for Comments: 5478                                 Cisco Systems
+Category: Standards Track                                     March 2009
+
+
+       IANA Registration of New Session Initiation Protocol (SIP)
+                      Resource-Priority Namespaces
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (c) 2009 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents in effect on the date of
+   publication of this document (http://trustee.ietf.org/license-info).
+   Please review these documents carefully, as they describe your rights
+   and restrictions with respect to this document.
+
+   This document may contain material from IETF Documents or IETF
+   Contributions published or made publicly available before November
+   10, 2008.  The person(s) controlling the copyright in some of this
+   material may not have granted the IETF Trust the right to allow
+   modifications of such material outside the IETF Standards Process.
+   Without obtaining an adequate license from the person(s) controlling
+   the copyright in such materials, this document may not be modified
+   outside the IETF Standards Process, and derivative works of it may
+   not be created outside the IETF Standards Process, except to format
+   it for publication as an RFC or to translate it into languages other
+   than English.
+
+Abstract
+
+   This document creates additional Session Initiation Protocol (SIP)
+   Resource-Priority namespaces to meet the requirements of the US
+   Defense Information Systems Agency, and places these namespaces in
+   the IANA registry.
+
+
+
+
+
+
+Polk                        Standards Track                     [Page 1]
+
+RFC 5478            New SIP RPH Namespaces for DISA           March 2009
+
+
+Table of Contents
+
+   1. Introduction ....................................................2
+      1.1. Conventions Used in This Document ..........................3
+   2. New SIP Resource-Priority Namespaces Created ....................3
+   3. IANA Considerations .............................................4
+      3.1. IANA Resource-Priority Namespace Registration ..............4
+      3.2. IANA Priority-Value Registrations ..........................6
+   4. Security Considerations .........................................6
+   5. Acknowledgments .................................................6
+   6. Normative References ............................................6
+
+1.  Introduction
+
+   The US Defense Information Systems Agency (DISA) is rolling out their
+   Session Initiation Protocol (SIP) based architecture at this time.
+   This network will require more Resource-Priority namespaces than were
+   defined, and IANA registered, in RFC 4412 [RFC4412].  The purpose of
+   this document is to define these additional namespaces.  Each will be
+   preemptive in nature, as defined in RFC 4412, and will have the same
+   10 priority-values.
+
+   DISA has a requirement to be able to assign different Resource-
+   Priority namespaces to differing groups of differing sizes throughout
+   their networks.  Examples of this may be
+
+   - namespaces as large as each branch of service (Army, Navy, Air
+     Force, Marines, Coast Guard)
+
+   - namespaces for some departments within the government (for example,
+     Homeland Security)
+
+   - namespaces that are temporary assignments to individual units of
+     varying sizes (from battle groups to patrol groups or platoons)
+
+   These temporary assignments might be combinations of smaller units
+   involving several branches of service operating as one unit (say, one
+   task force, which is separate than the branch of service), or a
+   single commando unit requiring special treatment for a short period
+   of time, making it appear separate from the branch of service they
+   are from.
+
+   Providing DISA with a pool of namespaces for fine-grained
+   assignment(s) allows them the flexibility they need for their mission
+   requirements.  One can imagine due to their sheer size and separation
+   of purpose, they can easily utilize a significant number of
+   namespaces within their networks.  This is the reason for the
+
+
+
+
+Polk                        Standards Track                     [Page 2]
+
+RFC 5478            New SIP RPH Namespaces for DISA           March 2009
+
+
+   assignment of so many new namespaces, which seems to deviate from
+   guidance in RFC 4412 to have as few namespaces as possible.
+
+   This document makes no changes to SIP, it just adds IANA-registered
+   namespaces for SIP's use within the Resource-Priority header
+   framework.
+
+1.1.  Conventions Used in This Document
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+2.  New SIP Resource-Priority Namespaces Created
+
+   The following 40 SIP namespaces are created by this document:
+
+   dsn-000000      drsn-000000      rts-000000      crts-000000
+   dsn-000001      drsn-000001      rts-000001      crts-000001
+   dsn-000002      drsn-000002      rts-000002      crts-000002
+   dsn-000003      drsn-000003      rts-000003      crts-000003
+   dsn-000004      drsn-000004      rts-000004      crts-000004
+   dsn-000005      drsn-000005      rts-000005      crts-000005
+   dsn-000006      drsn-000006      rts-000006      crts-000006
+   dsn-000007      drsn-000007      rts-000007      crts-000007
+   dsn-000008      drsn-000008      rts-000008      crts-000008
+   dsn-000009      drsn-000009      rts-000009      crts-000009
+
+   Each namespace listed above is wholly different.  However, according
+   to the rules within Section 8 of RFC 4412, one or more sets can be
+   treated as if they are the same when they are configured as an
+   aggregated grouping of namespaces.
+
+   These aggregates of two or more namespaces, that are to be considered
+   equivalent during treatment, can be a set of any IANA registered
+   namespaces, not just adjacent (i.e., consecutive) namespaces.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Polk                        Standards Track                     [Page 3]
+
+RFC 5478            New SIP RPH Namespaces for DISA           March 2009
+
+
+   Each namespace listed above will have the same 10 priority levels:
+
+      .0 (lowest priority)
+      .1
+      .2
+      .3
+      .4
+      .5
+      .6
+      .7
+      .8
+      .9 (highest priority)
+
+   According to the rules established in RFC 4412 [RFC4412], priority-
+   values have a relative order for preferential treatment, unless one
+   or more consecutive groups of priority-values are to be considered
+   equivalent (i.e., first-received, first treated).
+
+   The dash character ('-') is just like any other ASCII character
+   within a namespace, and is not to be considered a delimiter in any
+   official way within any namespace here.  Other namespace definitions
+   in the future could change this.
+
+   As stated in Section 9 of RFC 4412 [RFC4412] an IANA-registered
+   namespace SHOULD NOT change the number, and MUST NOT change the
+   relative priority order, of its assigned priority-values.
+
+3.  IANA Considerations
+
+   Abiding by the rules established within RFC 4412 [RFC4412], this is a
+   Standards-Track document registering new namespaces, their associated
+   priority-values, and intended algorithms.
+
+3.1.  IANA Resource-Priority Namespace Registration
+
+   Within the "Resource-Priority Namespaces" registry in the sip-
+   parameters section of IANA, the following table lists the new
+   namespaces registered by this document.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Polk                        Standards Track                     [Page 4]
+
+RFC 5478            New SIP RPH Namespaces for DISA           March 2009
+
+
+                        Intended     New warn-   New resp.
+   Namespace   Levels   Algorithm      code        code     Reference
+   ----------  ------  ------------  ---------   ---------  ---------
+   dsn-000000    10     preemption      no          no      [RFC5478]
+   dsn-000001    10     preemption      no          no      [RFC5478]
+   dsn-000002    10     preemption      no          no      [RFC5478]
+   dsn-000003    10     preemption      no          no      [RFC5478]
+   dsn-000004    10     preemption      no          no      [RFC5478]
+   dsn-000005    10     preemption      no          no      [RFC5478]
+   dsn-000006    10     preemption      no          no      [RFC5478]
+   dsn-000007    10     preemption      no          no      [RFC5478]
+   dsn-000008    10     preemption      no          no      [RFC5478]
+   dsn-000009    10     preemption      no          no      [RFC5478]
+
+   drsn-000000   10     preemption      no          no      [RFC5478]
+   drsn-000001   10     preemption      no          no      [RFC5478]
+   drsn-000002   10     preemption      no          no      [RFC5478]
+   drsn-000003   10     preemption      no          no      [RFC5478]
+   drsn-000004   10     preemption      no          no      [RFC5478]
+   drsn-000005   10     preemption      no          no      [RFC5478]
+   drsn-000006   10     preemption      no          no      [RFC5478]
+   drsn-000007   10     preemption      no          no      [RFC5478]
+   drsn-000008   10     preemption      no          no      [RFC5478]
+   drsn-000009   10     preemption      no          no      [RFC5478]
+
+   rts-000000    10     preemption      no          no      [RFC5478]
+   rts-000001    10     preemption      no          no      [RFC5478]
+   rts-000002    10     preemption      no          no      [RFC5478]
+   rts-000003    10     preemption      no          no      [RFC5478]
+   rts-000004    10     preemption      no          no      [RFC5478]
+   rts-000005    10     preemption      no          no      [RFC5478]
+   rts-000006    10     preemption      no          no      [RFC5478]
+   rts-000007    10     preemption      no          no      [RFC5478]
+   rts-000008    10     preemption      no          no      [RFC5478]
+   rts-000009    10     preemption      no          no      [RFC5478]
+
+   crts-000000   10     preemption      no          no      [RFC5478]
+   crts-000001   10     preemption      no          no      [RFC5478]
+   crts-000002   10     preemption      no          no      [RFC5478]
+   crts-000003   10     preemption      no          no      [RFC5478]
+   crts-000004   10     preemption      no          no      [RFC5478]
+   crts-000005   10     preemption      no          no      [RFC5478]
+   crts-000006   10     preemption      no          no      [RFC5478]
+   crts-000007   10     preemption      no          no      [RFC5478]
+   crts-000008   10     preemption      no          no      [RFC5478]
+   crts-000009   10     preemption      no          no      [RFC5478]
+
+
+
+
+
+Polk                        Standards Track                     [Page 5]
+
+RFC 5478            New SIP RPH Namespaces for DISA           March 2009
+
+
+3.2.  IANA Priority-Value Registrations
+
+   Within the "Resource-Priority Priority-values" registry in the
+   sip-parameters section of IANA, the list of priority-values for each
+   of the 40 newly created namespaces from Section 3.1 of this
+   document, prioritized least to greatest, is registered by the
+   following (replicated similar to the following format):
+
+   Namespace: dsn-000000
+   Reference: RFC5478 (this document)
+   Priority-Values (least to greatest): "0", "1", "2", "3", "4", "5",
+   "6", "7", "8", "9"
+
+4.  Security Considerations
+
+   This document has the same Security Considerations as RFC 4412.
+
+5.  Acknowledgments
+
+   To Jeff Hewett for his helpful guidance in this effort.  Thanks to
+   Janet Gunn, John Rosenberg, Joel Halpern, Michael Giniger, Henning
+   Schulzrinne, Keith Drage, and Suresh Krishnan for their comments.
+
+6.  Normative References
+
+   [RFC4412]  Schulzrinne, H. and J. Polk, "Communications Resource
+              Priority for the Session Initiation Protocol (SIP)", RFC
+              4412, February 2006.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+Author's Address
+
+   James Polk
+   3913 Treemont Circle
+   Colleyville, Texas  76034
+   USA
+
+   Phone: +1-817-271-3552
+   EMail: jmpolk@cisco.com
+
+
+
+
+
+
+
+
+
+
+Polk                        Standards Track                     [Page 6]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc5478.txt](<www.ietf.org/rfc/rfc5478.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
