### PR TITLE
Archive rfc548.txt

### DIFF
--- a/www.ietf.org/rfc/rfc548.txt
+++ b/www.ietf.org/rfc/rfc548.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                    D. Walden
+RFC # 548                                                BBN-NET
+NIC # 17794                                              August 16, 1973
+
+
+                 Hosts Using the IMP Going Down Message
+
+
+    As given in BBN Report 1822 (Specifications for the Interconnection
+of a Host and an IMP), IMP to Host message type 2 specifies that the IMP
+local to the Host is going down; the message further says when the IMP
+is going down, for how long, and why.
+
+    When the IMP goes down after sending the IMP Going Down message to
+the Host, the Host's network users and local users of the network will
+not, in general, be forewarned unless the Host sends a message to these
+users.  We therefore urge all Hosts to warn their network users and
+users of the network of impending IMP downs; just logging the received
+IMP Going Down message on a logging teletype, as many Hosts currently
+do, seems insufficient.
+
+    Incidentally, please remember that Tuesday mornings from 7 a.m. to 9
+a.m.  (Eastern Time) are reserved for Network Software Maintenance, as
+announced in RFC #440.
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.            10/99 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Walden                                                          [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc548.txt](<www.ietf.org/rfc/rfc548.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
