### PR TITLE
Archive rfc5498.txt

### DIFF
--- a/www.ietf.org/rfc/rfc5498.txt
+++ b/www.ietf.org/rfc/rfc5498.txt
@@ -1,0 +1,283 @@
+
+
+
+
+
+
+Network Working Group                                        I. Chakeres
+Request for Comments: 5498                                        CenGen
+Category: Standards Track                                     March 2009
+
+
+      IANA Allocations for Mobile Ad Hoc Network (MANET) Protocols
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (c) 2009 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents in effect on the date of
+   publication of this document (http://trustee.ietf.org/license-info).
+   Please review these documents carefully, as they describe your rights
+   and restrictions with respect to this document.
+
+   This document may contain material from IETF Documents or IETF
+   Contributions published or made publicly available before November
+   10, 2008.  The person(s) controlling the copyright in some of this
+   material may not have granted the IETF Trust the right to allow
+   modifications of such material outside the IETF Standards Process.
+   Without obtaining an adequate license from the person(s) controlling
+   the copyright in such materials, this document may not be modified
+   outside the IETF Standards Process, and derivative works of it may
+   not be created outside the IETF Standards Process, except to format
+   it for publication as an RFC or to translate it into languages other
+   than English.
+
+Abstract
+
+   This document enumerates several common IANA allocations for use by
+   Mobile Ad hoc NETwork (MANET) protocols.  The following well-known
+   numbers are required: a UDP port number, an IP protocol number, and a
+   link-local multicast group address.
+
+
+
+
+
+
+
+Chakeres                    Standards Track                     [Page 1]
+
+RFC 5498          IANA Allocations for MANET Protocols        March 2009
+
+
+Table of Contents
+
+   1. Introduction ....................................................2
+   2. Conventions Used in This Document ...............................2
+   3. UDP Port Number .................................................2
+   4. IP Protocol Number ..............................................2
+   5. Link-Local Multicast Group for MANET Routers ....................3
+   6. IANA Considerations .............................................3
+   7. Security Considerations .........................................4
+   8. Acknowledgements ................................................4
+   9. References ......................................................5
+      9.1. Normative References .......................................5
+      9.2. Informative References .....................................5
+
+1.  Introduction
+
+   This document enumerates several common IANA allocations for use by
+   one or more protocols that conform to [RFC5444].  The following
+   well-known numbers are required: a UDP port number, an IP protocol
+   number, and a link-local multicast group address.  All interoperable
+   protocols running on these well-known IANA allocations MUST conform
+   to [RFC5444].  [RFC5444] provides a common format that enables one or
+   more protocols to share the IANA allocations defined in this document
+   unambiguously.
+
+2.  Conventions Used in This Document
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+3.  UDP Port Number
+
+   MANET routers require a well-known UDP port number [IANA] to send and
+   receive MANET routing protocol packets.  The title of this UDP port
+   is "manet".  The value of this UDP port is 269.
+
+4.  IP Protocol Number
+
+   MANET routers require a well-known IP protocol number [IANA] to send
+   and receive MANET routing protocol packets.  The title of this IP
+   protocol number is "manet".  The value of this IP protocol number is
+   138.
+
+
+
+
+
+
+
+
+Chakeres                    Standards Track                     [Page 2]
+
+RFC 5498          IANA Allocations for MANET Protocols        March 2009
+
+
+5.  Link-Local Multicast Group for MANET Routers
+
+   MANET routers require a well-known, link-local multicast address
+   [RFC4291] to send and receive MANET routing protocol packets.  The
+   name of the multicast address to reach link-local (LL) MANET routers
+   is "LL-MANET-Routers".
+
+   For IPv4, a well-known, link-local scope multicast address is
+   required.  The address for LL-MANET-Routers is 224.0.0.109.
+
+   For IPv6, a well-known, link-local scope multicast address is
+   required.  The address for LL-MANET-Routers is FF02:0:0:0:0:0:0:6D.
+
+6.  IANA Considerations
+
+   This document enumerates several common IANA allocations for use by
+   one or more protocols that conform to [RFC5444].  Specifically, the
+   following well-known numbers have been assigned: a UDP port
+   (Section 3), an IP protocol number (Section 4), and a link-local
+   multicast group address (Section 5).
+
+   Action 1:
+
+      IANA has made the following assignments in the "PORT NUMBERS"
+      registry:
+
+      sub-registry "WELL KNOWN PORT NUMBERS"
+
+      Keyword Decimal Description     References
+      ------- ------- -----------     ----------
+      manet   269/udp MANET Protocols [RFC5498]
+
+   Action 2:
+
+      IANA has made the following assignments in the "PROTOCOL NUMBERS"
+      registry:
+
+      sub-registry "WELL KNOWN PORT NUMBERS"
+
+      Keyword Decimal Description     References
+      ------- ------- -----------     ----------
+      manet   138     MANET Protocols [RFC5498]
+
+
+
+
+
+
+
+
+
+Chakeres                    Standards Track                     [Page 3]
+
+RFC 5498          IANA Allocations for MANET Protocols        March 2009
+
+
+   Action 3:
+
+      IANA has made the following assignments in the "Internet Multicast
+      Addresses" registry:
+
+      sub-registry "224.0.0.0 - 224.0.0.255 (224.0.0/24) Local Network
+      Control Block"
+
+      224.0.0.109 LL-MANET-Routers   [RFC5498]
+
+   Action 4:
+
+      IANA has made the following assignments in the "INTERNET PROTOCOL
+      VERSION 6 MULTICAST ADDRESSES" registry:
+
+      sub-registry "Fixed Scope Multicast Addresses"
+
+      sub-sub-registry "Link-Local Scope"
+
+      FF02:0:0:0:0:0:0:6D LL-MANET-Routers [RFC5498]
+
+7.  Security Considerations
+
+   This document specifies only well-known numbers for protocols that
+   conform to [RFC5444], and it not does not specify the protocols that
+   carry the information across the network.  Each protocol using these
+   well-known numbers may have its own set of security issues, but those
+   issues are not affected by using the IANA allocations specified
+   herein.
+
+   The security issues associated with possibly operating multiple
+   cooperating protocols using the same IANA assignments (e.g., UDP
+   port) MUST be addressed in each protocol's specification.
+
+8.  Acknowledgements
+
+   Fred Templin, Bill Fenner, Alexandru Petrescu, Sam Weiler, Ross
+   Callon, and Lars Eggert provided valuable input to this document.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Chakeres                    Standards Track                     [Page 4]
+
+RFC 5498          IANA Allocations for MANET Protocols        March 2009
+
+
+9.  References
+
+9.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC4291]  Hinden, R. and S. Deering, "IP Version 6 Addressing
+              Architecture", RFC 4291, February 2006.
+
+   [RFC5444]  Clausen, T., Dearlove, C., Dean, J., and C. Adjih,
+              "Generalized Mobile Ad Hoc Network (MANET) Packet/Message
+              Format", RFC 5444, February 2009.
+
+9.2.  Informative References
+
+   [IANA]     http://www.iana.org/
+
+Author's Address
+
+   Ian D Chakeres
+   CenGen
+   9250 Bendix Road North
+   Columbia MD 21045  USA
+
+   EMail: ian.chakeres@gmail.com
+   URI:   http://www.ianchak.com/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Chakeres                    Standards Track                     [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc5498.txt](<www.ietf.org/rfc/rfc5498.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
