### PR TITLE
Archive rfc551.txt

### DIFF
--- a/www.ietf.org/rfc/rfc551.txt
+++ b/www.ietf.org/rfc/rfc551.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                        Y. Feinroth
+Request for Comments: 551                                            NYU
+                                                                 R. Fink
+                                                                     LBL
+                                                         August 27, 1973
+
+New York University
+Courant Institute of Mathematical Sciences
+AEC Computing and Applied Mathematics Center
+251 Mercer Street
+New York, N.Y. 10012
+
+ARPA Network Information Center
+Stanford Research Institute
+Menlo Park, California
+
+        Several Atomic Energy Commission installations are planning to
+   enter the network in the (hopefully) near future.  These sites
+   include Argonne National Laboratory (IBM 360/195), Lawrence Berkeley
+   Labs, (CDC 7600), and New York University (CDC 6600).  Our
+   applications make early implementation of an RJE facility imperative,
+   and although we are resigned to the necessity of implementing FTP, we
+   would like to avoid RJE protocol at least in the first go-around.  We
+   would like to be able to use FTP to transfer a file, have it queued
+   for execution, and return output and status information.
+
+        To this end we propose to implement local conventions within the
+   site dependent PATHNAME parameter of the FTP.  Specifically, the
+   following commands are specified:
+
+STOR           RJE.JOB<rest of pathname>  queue this file for execution
+(STOR/RETR)    RJE.PR <    >              transfer remote job print file
+(STOR/RETR)    RJE.PU <    >                 "        "    "  punch   "
+(STOR/RETR)    RJE.MT <    >                 "        "    "  magtape "
+
+RETR           RJE.STAT  <    >           retrieve  status of remote job
+
+        The job execution parameters are not part of the protocol, but
+   must be specified in the standard site dependent control cards which
+   are transmitted with the file.  These parameters also determine the
+   output disposition, and the output can be retrieved by the user via
+   RETR, or (optionally) automatically by server initiation via STOR.*
+   The RETR RJE.STAT causes the server to create a file with the status
+   information and transfer it to the user.  The FTP user/acct/pass
+   logon is used only to validate the data transfer, not the job's right
+   to execute, and to identify and distribute the output.
+
+
+
+
+
+Feinroth & Fink                                                 [Page 1]
+
+RFC 551                                                      August 1973
+
+
+        We are concerned that we may have overlooked some problems which
+   are obvious to more knowledgeable people and invite (and request)
+   comments.
+
+   *  note that in this case the RJE server is an FTP user.
+
+         [ This RFC was put into machine readable form for entry ]
+         [   into the online RFC archives by Tony Hansen 08/08   ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Feinroth & Fink                                                 [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc551.txt](<www.ietf.org/rfc/rfc551.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
