### PR TITLE
Archive rfc5516.txt

### DIFF
--- a/www.ietf.org/rfc/rfc5516.txt
+++ b/www.ietf.org/rfc/rfc5516.txt
@@ -1,0 +1,283 @@
+
+
+
+
+
+
+Network Working Group                                           M. Jones
+Request for Comments: 5516                           Bridgewater Systems
+Category: Informational                                        L. Morand
+                                                             Orange Labs
+                                                              April 2009
+
+
+               Diameter Command Code Registration for the
+Third Generation Partnership Project (3GPP) Evolved Packet System (EPS)
+
+Status of This Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard of any kind.  Distribution of this
+   memo is unlimited.
+
+Copyright Notice
+
+   Copyright (c) 2009 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents in effect on the date of
+   publication of this document (http://trustee.ietf.org/license-info).
+   Please review these documents carefully, as they describe your rights
+   and restrictions with respect to this document.
+
+Abstract
+
+   This document registers a set of IANA Diameter Command Codes to be
+   used in new vendor-specific Diameter applications defined for the
+   Third Generation Partnership Project (3GPP) Evolved Packet System
+   (EPS).  These new Diameter applications are defined for Mobile
+   Management Entity (MME)- and Serving GPRS (General Packet Radio
+   Service) Support Node (SGSN)-related interfaces in in the
+   architecture for the Evolved 3GPP Packet Switched Domain, which is
+   also known as the Evolved Packet System (EPS).
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Jones & Morand               Informational                      [Page 1]
+
+RFC 5516                 3GPP EPS Command Codes               April 2009
+
+
+Table of Contents
+
+   1. Introduction ....................................................2
+   2. Terminology .....................................................2
+   3. Command Codes ...................................................3
+   4. IANA Considerations .............................................3
+   5. Security Considerations .........................................4
+   6. Acknowledgements ................................................4
+   7. References ......................................................5
+      7.1. Normative References .......................................5
+      7.2. Informative References .....................................5
+
+1.  Introduction
+
+   The Third Generation Partnership Project (3GPP) is defining the
+   Evolved 3GPP Packet Switched Domain - also known as the Evolved
+   Packet System (EPS).  As part of this architecture, the interfaces
+   based on the Diameter protocol [RFC3588] require the definition of
+   two new Diameter applications.
+
+   As defined in [TS29.272], the 3GPP S6a/S6d application (vendor-
+   specific application id: 16777251) enables the transfer of
+   subscriber-related data between the Mobile Management Entity (MME)
+   and the Home Subscriber Server (HSS) on the S6a interface and between
+   the Serving GPRS Support Node (SGSN) and the Home Subscriber Server
+   (HSS) on the S6d interface.
+
+   Also defined in [TS29.272], the 3GPP S13/S13' application (vendor-
+   specific application id: 16777252) enables the Mobile Equipment
+   Identity check procedure between the Mobile Management Entity (MME)
+   and the Equipment Identity Register (EIR) on the S13 interface and
+   between the Serving GPRS Support Node (SGSN) and the Equipment
+   Identity Register (EIR) on the S13' interface.
+
+   Both Diameter applications are defined under the 3GPP vendor-id
+   "10415".  This document defines the assigned values of the command
+   codes used in these applications.
+
+2.  Terminology
+
+   The base Diameter specification (Section 1.3 of [RFC3588]) defines
+   most of the terminology used in this document.  Additionally, the
+   terms and acronyms defined in [TS29.272] are used in this document.
+
+
+
+
+
+
+
+
+Jones & Morand               Informational                      [Page 2]
+
+RFC 5516                 3GPP EPS Command Codes               April 2009
+
+
+3.  Command Codes
+
+   The 3GPP S6a/S6d application described in Section 5 of [TS29.272]
+   requires the allocation of command code values for the following
+   command pairs:
+
+   o  3GPP-Update-Location-Request/Answer (ULR/ULA)
+
+   o  3GPP-Cancel-Location-Request/Answer (CLR/CLA)
+
+   o  3GPP-Authentication-Information-Request/ Answer (AIR/AIA)
+
+   o  3GPP-Insert-Subscriber-Data-Request/Answer (IDR/IDA)
+
+   o  3GPP-Delete-Subscriber-Data-Request/Answer (DSR/DSA)
+
+   o  3GPP-Purge-UE-Request/Answer (PUR/PUA)
+
+   o  3GPP-Reset-Request/Answer (RSR/RSA)
+
+   o  3GPP-Notify-Request/Answer (NOR/NOA)
+
+   The 3GPP S13/S13 application described in Section 6 of [TS29.272]
+   requires the allocation of a command code value for the following
+   command pair:
+
+   o  3GPP-ME-Identity-Check-Request/Answer (ECR/ECA)
+
+4.  IANA Considerations
+
+   This section provides guidance to the Internet Assigned Numbers
+   Authority (IANA) regarding registration of values related to the
+   Diameter protocol, in accordance with BCP 26 [RFC5226].
+
+   This document defines values in the namespace that has been defined
+   in the Diameter base specification [RFC3588].  Section 11 of
+   [RFC3588] (that document's IANA Considerations) details the
+   assignment criteria.  IANA allocated the following command code
+   values:
+
+
+
+
+
+
+
+
+
+
+
+
+Jones & Morand               Informational                      [Page 3]
+
+RFC 5516                 3GPP EPS Command Codes               April 2009
+
+
++----------------------------------------------------------------------+
+| Code Command Name                            Abbrev.  Defined in     |
++----------------------------------------------------------------------+
+| 316  3GPP-Update-Location-Request            ULR      3GPP TS 29.272 |
+| 316  3GPP-Update-Location-Answer             ULA      3GPP TS 29.272 |
+| 317  3GPP-Cancel-Location-Request            CLR      3GPP TS 29.272 |
+| 317  3GPP-Cancel-Location-Answer             CLA      3GPP TS 29.272 |
+| 318  3GPP-Authentication-Information-Request AIR      3GPP TS 29.272 |
+| 318  3GPP-Authentication-Information-Answer  AIA      3GPP TS 29.272 |
+| 319  3GPP-Insert-Subscriber-Data-Request     IDR      3GPP TS 29.272 |
+| 319  3GPP-Insert-Subscriber-Data-Answer      IDA      3GPP TS 29.272 |
+| 320  3GPP-Delete-Subscriber-Data-Request     DSR      3GPP TS 29.272 |
+| 320  3GPP-Delete-Subscriber-Data-Answer      DSA      3GPP TS 29.272 |
+| 321  3GPP-Purge-UE-Request                   PUR      3GPP TS 29.272 |
+| 321  3GPP-Purge-UE-Answer                    PUA      3GPP TS 29.272 |
+| 322  3GPP-Reset-Request                      RSR      3GPP TS 29.272 |
+| 322  3GPP-Reset-Answer                       RSA      3GPP TS 29.272 |
+| 323  3GPP-Notify-Request                     NOR      3GPP TS 29.272 |
+| 323  3GPP-Notify-Answer                      NOA      3GPP TS 29.272 |
+| 324  3GPP-ME-Identity-Check-Request          ECR      3GPP TS 29.272 |
+| 324  3GPP-ME-Identity-Check-Answer           ECA      3GPP TS 29.272 |
++----------------------------------------------------------------------+
+
+5.  Security Considerations
+
+   This document describes command codes used in applications that build
+   on top of the Diameter base protocol and the same security
+   considerations described in [RFC3588] are applicable to this
+   document.  No further extensions are required beyond the security
+   mechanisms offered by [RFC3588].
+
+6.  Acknowledgements
+
+   We would like to thank the 3GPP CT4 delegates, Victor Fajardo, and
+   Glen Zorn for their review and comments.  We would also like to thank
+   Dan Romascanu for volunteering to be AD sponsor and Hannes Tschofenig
+   for volunteering to be Document Shepherd.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Jones & Morand               Informational                      [Page 4]
+
+RFC 5516                 3GPP EPS Command Codes               April 2009
+
+
+7.  References
+
+7.1.  Normative References
+
+   [RFC3588]   Calhoun, P., Loughney, J., Guttman, E., Zorn, G., and J.
+               Arkko, "Diameter Base Protocol", RFC 3588,
+               September 2003.
+
+   [TS29.272]  3rd Generation Partnership Project, "3GPP TS 29.272;
+               Technical Specification Group Core Network and Terminals;
+               Evolved Packet System; Mobility Management Entity (MME)
+               and Serving GPRS Support Node (SGSN) Related Interfaces
+               Based on Diameter Protocol",
+               http://www.3gpp.org/ftp/Specs/html-info/29272.htm.
+
+7.2.  Informative References
+
+   [RFC5226]   Narten, T. and H. Alvestrand, "Guidelines for Writing an
+               IANA Considerations Section in RFCs", BCP 26, RFC 5226,
+               May 2008.
+
+Authors' Addresses
+
+   Mark Jones
+   Bridgewater Systems
+
+   EMail: mark.jones@bridgewatersystems.com
+
+
+   Lionel Morand
+   Orange Labs
+
+   EMail: lionel.morand@orange-ftgroup.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Jones & Morand               Informational                      [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc5516.txt](<www.ietf.org/rfc/rfc5516.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
