### PR TITLE
Archive rfc5519.txt

### DIFF
--- a/www.ietf.org/rfc/rfc5519.txt
+++ b/www.ietf.org/rfc/rfc5519.txt
@@ -1,0 +1,2299 @@
+
+
+
+
+
+
+Network Working Group                                    J. Chesterfield
+Request for Comments: 5519                       University of Cambridge
+Obsoletes: 2933, 3019                                   B. Haberman, Ed.
+Category: Standards Track                                        JHU/APL
+                                                              April 2009
+
+
+                Multicast Group Membership Discovery MIB
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (c) 2009 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents in effect on the date of
+   publication of this document (http://trustee.ietf.org/license-info).
+   Please review these documents carefully, as they describe your rights
+   and restrictions with respect to this document.
+
+Abstract
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the Internet community.
+   In particular, it describes objects used for managing the Internet
+   Group Management Protocol (IGMP) and the Multicast Listener Discovery
+   (MLD) protocol.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Chesterfield & Haberman     Standards Track                     [Page 1]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+Table of Contents
+
+   1.  Introduction . . . . . . . . . . . . . . . . . . . . . . . . .  2
+   2.  The Internet-Standard Management Framework . . . . . . . . . .  2
+   3.  Conventions  . . . . . . . . . . . . . . . . . . . . . . . . .  3
+   4.  Overview . . . . . . . . . . . . . . . . . . . . . . . . . . .  3
+   5.  Definitions  . . . . . . . . . . . . . . . . . . . . . . . . .  4
+   6.  Security Considerations  . . . . . . . . . . . . . . . . . . . 38
+   7.  IANA Considerations  . . . . . . . . . . . . . . . . . . . . . 39
+   8.  Contributors . . . . . . . . . . . . . . . . . . . . . . . . . 39
+   9.  Acknowledgements . . . . . . . . . . . . . . . . . . . . . . . 40
+   10. References . . . . . . . . . . . . . . . . . . . . . . . . . . 40
+     10.1.  Normative References  . . . . . . . . . . . . . . . . . . 40
+     10.2.  Informative References  . . . . . . . . . . . . . . . . . 41
+
+1.  Introduction
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols in the Internet community.
+   In particular, it describes objects used for managing the Internet
+   Group Management Protocol (IGMP) version 1 [RFC1112], version 2
+   [RFC2236], or version 3 [RFC3376] and the Multicast Listener
+   Discovery (MLD) protocol version 1 [RFC2710] or version 2 [RFC3810].
+   Both protocols provide multicast membership discovery capability.
+   IGMP pertains to IP version 4 clients, and MLD to IP version 6
+   clients.  This version of the MIB obsoletes both RFC 2933 [RFC2933]
+   and RFC 3019 [RFC3019], incorporating a generic interface for both
+   IGMP and MLD implementations and incorporating changes to enable
+   "source filtering" in multicast clients.  The MIB encompasses both
+   router and host nodes with relevant management objects defined for
+   each.
+
+2.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This memo specifies a MIB
+   module that is compliant to the SMIv2, which is described in STD 58,
+   RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579] and STD 58, RFC 2580
+   [RFC2580].
+
+
+
+
+
+Chesterfield & Haberman     Standards Track                     [Page 2]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+3.  Conventions
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+4.  Overview
+
+   This Multicast Group Membership Discovery (MGMD) MIB module contains
+   eight tables:
+
+   1.  the MGMD Host Interface Table, which contains one row for each
+       interface on which IGMP or MLD is enabled on a host,
+
+   2.  the MGMD Router Interface Table, which contains one row for each
+       interface on which MGMD is enabled on a router,
+
+   3.  the MGMD Host Cache Table, which contains one row for each IP
+       multicast group for which there are members on a particular
+       interface on a host,
+
+   4.  the MGMD Router Cache Table, which contains one row for each IP
+       multicast group for which there are members on a particular
+       interface on a router,
+
+   5.  the reverse MGMD Host Table, which contains one row for each
+       interface for which there are active multicast groups on a host,
+
+   6.  the reverse MGMD Router Table, which contains one row for each
+       interface for which there are active multicast groups on a
+       router,
+
+   7.  the MGMD HostSrcList Table, which contains one row for each entry
+       in the source filter record for an interface and multicast group
+       pair on a host, and
+
+   8.  the MGMD RouterSrcList Table, which contains one row for each
+       entry in the source filter record for an interface and multicast
+       group pair on a router.
+
+   All tables are intended for EITHER router OR host functionality as
+   indicated by the name and corresponding description, although it is
+   anticipated that there will be scenarios where both terms might apply
+   to a device, e.g., a router that joins a multicast group also as a
+   host for measurement purposes.  The source list tables provide an
+   extension to the cache tables to indicate the source-specific
+
+
+
+
+
+Chesterfield & Haberman     Standards Track                     [Page 3]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+   includes or excludes associated with each IP multicast group on each
+   specific interface.  This functionality is only supported in IGMPv3-
+   and MLDv2-capable nodes.
+
+   Incorporated within the MGMD MIB tables are objects for the
+   management of IGMP and MLD proxy devices as described in RFC 4605
+   [RFC4605].  Proxy devices can be used in simple topologies where it
+   is not necessary to run a full multicast routing protocol.  A proxy
+   device can make forwarding decisions based on IGMP or MLD group
+   membership activity.
+
+   The MIB references InterfaceIndex and InterfaceIndexOrZero objects as
+   defined in RFC 2863 [RFC2863], the MIB that describes generic objects
+   for network interface sub-layers.
+
+   Extensive references to the InetAddress and InetAddressType objects
+   are made as defined in RFC 4001 [RFC4001].
+
+5.  Definitions
+
+MGMD-STD-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, mib-2, Counter32, Gauge32,
+    Unsigned32, TimeTicks            FROM SNMPv2-SMI
+    InetAddress, InetAddressType     FROM INET-ADDRESS-MIB
+    RowStatus                        FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP  FROM SNMPv2-CONF
+    InterfaceIndexOrZero,
+    InterfaceIndex                   FROM IF-MIB;
+
+mgmdStdMIB MODULE-IDENTITY
+    LAST-UPDATED "200903300000Z" -- March 30, 2009
+    ORGANIZATION "INTERNET ENGINEERING TASK FORCE MULTICAST and
+    ANYCAST GROUP MEMBERSHIP Working
+        Group.
+        www:   http://www.ietf.org/html.charters/magma-charter.html
+        EMail: magma@ietf.org"
+    CONTACT-INFO
+        "Julian Chesterfield
+        University of Cambridge,
+        Computer Laboratory,
+        15 JJ Thompson Avenue,
+        Cambridge,
+        CB3 0FD
+        UK
+
+        EMail: julian.chesterfield@cl.cam.ac.uk"
+
+
+
+Chesterfield & Haberman     Standards Track                     [Page 4]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    DESCRIPTION
+        "The MIB module for MGMD management.
+        A new version of MGMD combining RFC 2933 and RFC 3019.
+        Includes IGMPv3 and MLDv2 source filtering changes.
+
+        Copyright (c) 2009 IETF Trust and the persons
+        identified as authors of the code.  All rights reserved.
+
+        Redistribution and use in source and binary forms, with or
+        without modification, are permitted provided that the
+        following conditions are met:
+
+        - Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+
+        - Redistributions in binary form must reproduce the above
+          copyright notice, this list of conditions and the following
+          disclaimer in the documentation and/or other materials
+          provided with the distribution.
+
+        - Neither the name of Internet Society, IETF or IETF Trust,
+          nor the names of specific contributors, may be used to endorse
+          or promote products derived from this software without
+          specific prior written permission.
+
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+        CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+        MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+        DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+        CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+        SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+        NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+        LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+        HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+        OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+        EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+        This version of this MIB module is part of RFC 5519;
+        see the RFC itself for full legal notices."
+
+    REVISION "200903300000Z" -- March 30, 2009
+    DESCRIPTION
+        "This MIB obsoletes both RFC 2933 and RFC 3019."
+
+    ::= { mib-2 185 }
+
+
+
+
+Chesterfield & Haberman     Standards Track                     [Page 5]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+mgmdMIBObjects     OBJECT IDENTIFIER ::= { mgmdStdMIB 1 }
+
+--
+--  The MGMD Host Interface Table
+--
+
+mgmdHostInterfaceTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF MgmdHostInterfaceEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The (conceptual) table listing the interfaces on which
+             IGMP or MLD is enabled."
+
+    ::= { mgmdMIBObjects 1 }
+
+mgmdHostInterfaceEntry OBJECT-TYPE
+    SYNTAX     MgmdHostInterfaceEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "An entry (conceptual row) representing an interface on
+            which IGMP or MLD is enabled."
+    INDEX      { mgmdHostInterfaceIfIndex,
+                 mgmdHostInterfaceQuerierType }
+
+    ::= { mgmdHostInterfaceTable 1 }
+
+MgmdHostInterfaceEntry ::= SEQUENCE {
+    mgmdHostInterfaceIfIndex               InterfaceIndex,
+    mgmdHostInterfaceQuerierType           InetAddressType,
+    mgmdHostInterfaceQuerier               InetAddress,
+    mgmdHostInterfaceStatus                RowStatus,
+    mgmdHostInterfaceVersion               Unsigned32,
+    mgmdHostInterfaceVersion1QuerierTimer  TimeTicks,
+    mgmdHostInterfaceVersion2QuerierTimer  TimeTicks,
+    mgmdHostInterfaceVersion3Robustness    Unsigned32
+}
+
+mgmdHostInterfaceIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The ifIndex value of the interface for which IGMP or MLD is
+             enabled.  The table is indexed by the ifIndex value and the
+             InetAddressType to allow for interfaces that may be
+             configured in both IPv4 and IPv6 modes."
+
+
+
+Chesterfield & Haberman     Standards Track                     [Page 6]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    ::= { mgmdHostInterfaceEntry 1 }
+
+mgmdHostInterfaceQuerierType OBJECT-TYPE
+    SYNTAX     InetAddressType { ipv4(1), ipv6(2) }
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The address type of this interface.  This entry along with
+             the ifIndex value acts as an index to the mgmdHostInterface
+             table.  A physical interface may be configured in multiple
+             modes concurrently, e.g., in IPv4 and IPv6 modes connected
+             to the same interface; however, the traffic is considered
+             to be logically separate."
+
+    ::= { mgmdHostInterfaceEntry 2 }
+
+mgmdHostInterfaceQuerier OBJECT-TYPE
+    SYNTAX     InetAddress (SIZE(4|16))
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The address of the IGMP or MLD Querier on the IP subnet to
+             which this interface is attached.  The InetAddressType,
+             e.g., IPv4 or IPv6, is identified by the
+             mgmdHostInterfaceQuerierType variable in the
+             mgmdHostInterface table."
+
+    ::= { mgmdHostInterfaceEntry 3 }
+
+mgmdHostInterfaceStatus OBJECT-TYPE
+    SYNTAX     RowStatus
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+            "The activation of a row enables the host side of IGMP or
+            MLD on the interface.  The destruction of a row disables
+            the host side of IGMP or MLD on the interface."
+
+    ::= { mgmdHostInterfaceEntry 4 }
+
+mgmdHostInterfaceVersion OBJECT-TYPE
+    SYNTAX     Unsigned32 (1..3)
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+            "The maximum version of MGMD that the host can run on
+            this interface.  A value of 1 is only applicable for IPv4,
+            and indicates that the host only supports IGMPv1 on the
+
+
+
+Chesterfield & Haberman     Standards Track                     [Page 7]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+            interface.  A value of 2 indicates that the host also
+            supports IGMPv2 (for IPv4) or MLDv1 (for IPv6).  A value of
+            3 indicates that the host also supports IGMPv3 (for IPv4)
+            or MLDv2 (for IPv6)."
+    DEFVAL     { 3 }
+
+    ::= { mgmdHostInterfaceEntry 5 }
+
+mgmdHostInterfaceVersion1QuerierTimer OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The time remaining until the host assumes that there are
+            no IGMPv1 routers present on the interface.  While this is
+            non-zero, the host will reply to all queries with version 1
+            membership reports.  This variable applies to IGMPv2 or 3
+            hosts that are forced to run in v1 for compatibility with
+            v1 routers present on the interface.  This object may only
+            be present when the corresponding value of
+            mgmdHostInterfaceQuerierType is ipv4."
+    REFERENCE "RFC 2236, Section 4 and RFC 3376, Section 7.2.1"
+    DEFVAL     { 0 }
+
+    ::= { mgmdHostInterfaceEntry 6 }
+
+mgmdHostInterfaceVersion2QuerierTimer OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The time remaining until the host assumes that there are
+            no MGMDv2 routers present on the interface.  While this is
+            non-zero, the host will reply to all queries with version 1
+            or 2 membership reports.  This variable applies to MGMDv3
+            hosts that are forced to run in v2 for compatibility with
+            v2 hosts or routers present on the interface."
+    REFERENCE "RFC 3376, Section 7.2.1 and RFC 3810, Section 8.2.1"
+    DEFVAL     { 0 }
+
+    ::= { mgmdHostInterfaceEntry 7 }
+
+mgmdHostInterfaceVersion3Robustness OBJECT-TYPE
+    SYNTAX     Unsigned32
+    MAX-ACCESS read-create
+    STATUS     current
+
+
+
+
+
+Chesterfield & Haberman     Standards Track                     [Page 8]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    DESCRIPTION
+            "The robustness variable utilised by an MGMDv3 host in
+            sending state-change reports for multicast routers.  To
+            ensure the state-change report is not missed, the host
+            retransmits the state-change report
+            [mgmdHostInterfaceVersion3Robustness - 1] times.  The
+            variable must be a non-zero value."
+    REFERENCE "RFC 3376, Section 8.1 and RFC 3810, Section 9.14.1"
+    DEFVAL     { 2 }
+
+    ::= { mgmdHostInterfaceEntry 8 }
+
+--
+--  The MGMD Router Interface Table
+--
+
+mgmdRouterInterfaceTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF MgmdRouterInterfaceEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The (conceptual) table listing the interfaces on which
+            IGMP or MLD is enabled."
+
+    ::= { mgmdMIBObjects 2 }
+
+mgmdRouterInterfaceEntry OBJECT-TYPE
+    SYNTAX     MgmdRouterInterfaceEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "An entry (conceptual row) representing an interface on
+            which IGMP or MLD is enabled."
+    INDEX      { mgmdRouterInterfaceIfIndex,
+                 mgmdRouterInterfaceQuerierType }
+
+    ::= { mgmdRouterInterfaceTable 1 }
+
+MgmdRouterInterfaceEntry ::= SEQUENCE {
+    mgmdRouterInterfaceIfIndex                 InterfaceIndex,
+    mgmdRouterInterfaceQuerierType             InetAddressType,
+    mgmdRouterInterfaceQuerier                 InetAddress,
+    mgmdRouterInterfaceQueryInterval           Unsigned32,
+    mgmdRouterInterfaceStatus                  RowStatus,
+    mgmdRouterInterfaceVersion                 Unsigned32,
+    mgmdRouterInterfaceQueryMaxResponseTime    Unsigned32,
+    mgmdRouterInterfaceQuerierUpTime           TimeTicks,
+    mgmdRouterInterfaceQuerierExpiryTime       TimeTicks,
+
+
+
+Chesterfield & Haberman     Standards Track                     [Page 9]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    mgmdRouterInterfaceWrongVersionQueries     Counter32,
+    mgmdRouterInterfaceJoins                   Counter32,
+    mgmdRouterInterfaceProxyIfIndex            InterfaceIndexOrZero,
+    mgmdRouterInterfaceGroups                  Gauge32,
+    mgmdRouterInterfaceRobustness              Unsigned32,
+    mgmdRouterInterfaceLastMemberQueryInterval Unsigned32,
+    mgmdRouterInterfaceLastMemberQueryCount    Unsigned32,
+    mgmdRouterInterfaceStartupQueryCount       Unsigned32,
+    mgmdRouterInterfaceStartupQueryInterval    Unsigned32
+}
+
+mgmdRouterInterfaceIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The ifIndex value of the interface for which IGMP or MLD
+            is enabled.  The table is indexed by the ifIndex value and
+            the InetAddressType to allow for interfaces that may be
+            configured in both IPv4 and IPv6 modes."
+
+    ::= { mgmdRouterInterfaceEntry 1 }
+
+mgmdRouterInterfaceQuerierType OBJECT-TYPE
+    SYNTAX     InetAddressType { ipv4(1), ipv6(2) }
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The address type of this interface.  This entry along with
+            the ifIndex value acts as the index to the
+            mgmdRouterInterface table.  A physical interface may be
+            configured in multiple modes concurrently, e.g., in IPv4
+            and IPv6 modes connected to the same interface; however,
+            the traffic is considered to be logically separate."
+
+    ::= { mgmdRouterInterfaceEntry 2 }
+
+mgmdRouterInterfaceQuerier OBJECT-TYPE
+    SYNTAX     InetAddress (SIZE(4|16))
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The address of the IGMP or MLD Querier on the IP subnet to
+            which this interface is attached.  The InetAddressType,
+            e.g., IPv4 or IPv6, is identified by the
+            mgmdRouterInterfaceQuerierType variable in the
+            mgmdRouterInterface table."
+
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 10]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    ::= { mgmdRouterInterfaceEntry 3 }
+
+mgmdRouterInterfaceQueryInterval OBJECT-TYPE
+    SYNTAX     Unsigned32 (1..31744)
+    UNITS      "seconds"
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+            "The frequency at which IGMP or MLD Host-Query packets are
+            transmitted on this interface."
+    DEFVAL     { 125 }
+
+    ::= { mgmdRouterInterfaceEntry 4 }
+
+mgmdRouterInterfaceStatus OBJECT-TYPE
+    SYNTAX     RowStatus
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+            "The activation of a row enables the router side of IGMP or
+            MLD on the interface.  The destruction of a row disables
+            the router side of IGMP or MLD on the interface."
+
+    ::= { mgmdRouterInterfaceEntry 5 }
+
+mgmdRouterInterfaceVersion OBJECT-TYPE
+    SYNTAX     Unsigned32 (1..3)
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+            "The version of MGMD that is running on this interface.
+            Value 1 applies to IGMPv1 routers only.  Value 2 applies
+            to IGMPv2 and MLDv1 routers, and value 3 applies to IGMPv3
+            and MLDv2 routers.
+
+            This object can be used to configure a router capable of
+            running either version.  For IGMP and MLD to function
+            correctly, all routers on a LAN must be configured to run
+            the same version on that LAN."
+    DEFVAL     { 3 }
+
+    ::= { mgmdRouterInterfaceEntry 6 }
+
+mgmdRouterInterfaceQueryMaxResponseTime OBJECT-TYPE
+    SYNTAX     Unsigned32  (0..31744)
+    UNITS      "tenths of seconds"
+    MAX-ACCESS read-create
+    STATUS     current
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 11]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    DESCRIPTION
+            "The maximum query response interval advertised in MGMDv2
+            or IGMPv3 queries on this interface."
+    REFERENCE "RFC 3810, Section 9.3"
+    DEFVAL     { 100 }
+
+    ::= { mgmdRouterInterfaceEntry 7 }
+
+mgmdRouterInterfaceQuerierUpTime OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The time since mgmdRouterInterfaceQuerier was last
+            changed."
+
+    ::= { mgmdRouterInterfaceEntry 8 }
+
+mgmdRouterInterfaceQuerierExpiryTime OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The amount of time remaining before the Other Querier
+            Present Timer expires.  If the local system is the querier,
+            the value of this object is zero."
+
+    ::= { mgmdRouterInterfaceEntry 9 }
+
+mgmdRouterInterfaceWrongVersionQueries OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The number of general queries received whose IGMP or MLD
+            version does not match the equivalent
+            mgmdRouterInterfaceVersion, over the lifetime of the row
+            entry.  Both IGMP and MLD require that all routers on a LAN
+            be configured to run the same version.  Thus, if any general
+            queries are received with the wrong version, this indicates
+            a configuration error."
+
+    ::= { mgmdRouterInterfaceEntry 10 }
+
+mgmdRouterInterfaceJoins OBJECT-TYPE
+    SYNTAX     Counter32
+
+    MAX-ACCESS read-only
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 12]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    STATUS     current
+    DESCRIPTION
+            "The number of times a group membership has been added on
+            this interface, that is, the number of times an entry for
+            this interface has been added to the Cache Table.  This
+            object can give an indication of the amount of activity
+            between samples over time."
+
+    ::= { mgmdRouterInterfaceEntry 11 }
+
+mgmdRouterInterfaceProxyIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndexOrZero
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+            "Some devices implement a form of IGMP or MLD proxying
+            whereby memberships learned on the interface represented by
+            this row cause Host Membership Reports to be sent on the
+            interface whose ifIndex value is given by this object.
+            Such a device would implement the mgmdV2RouterBaseMIBGroup
+            only on its router interfaces (those interfaces with
+            non-zero mgmdRouterInterfaceProxyIfIndex).  Typically, the
+            value of this object is 0, indicating that no proxying is
+            being done."
+    DEFVAL     { 0 }
+
+    ::= { mgmdRouterInterfaceEntry 12 }
+
+mgmdRouterInterfaceGroups OBJECT-TYPE
+    SYNTAX     Gauge32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The current number of entries for this interface in the
+            mgmdRouterCacheTable."
+
+    ::= { mgmdRouterInterfaceEntry 13 }
+
+mgmdRouterInterfaceRobustness OBJECT-TYPE
+    SYNTAX     Unsigned32 (1..255)
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+            "The Robustness Variable allows tuning for the expected
+            packet loss on a subnet.  If a subnet is expected to be
+            lossy, the Robustness Variable may be increased.  IGMP and
+            MLD are robust to (Robustness Variable-1) packet losses."
+    DEFVAL     { 2 }
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 13]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    ::= { mgmdRouterInterfaceEntry 14 }
+
+mgmdRouterInterfaceLastMemberQueryInterval OBJECT-TYPE
+    SYNTAX     Unsigned32  (0..31744)
+    UNITS      "tenths of seconds"
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+            "The Last Member Query Interval is the Max Query Response
+            Interval inserted into group-specific queries sent in
+            response to leave group messages, and is also the amount
+            of time between group-specific query messages.  This value
+            may be tuned to modify the leave latency of the network.  A
+            reduced value results in reduced time to detect the loss of
+            the last member of a group.  The value of this object is
+            irrelevant if mgmdRouterInterfaceVersion is 1."
+    DEFVAL     { 10 }
+
+    ::= { mgmdRouterInterfaceEntry 15 }
+
+mgmdRouterInterfaceLastMemberQueryCount OBJECT-TYPE
+    SYNTAX     Unsigned32 (1..255)
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "Represents the number of group-specific and group-and-
+            source-specific queries sent by the router before it assumes
+            there are no local members."
+
+    ::= { mgmdRouterInterfaceEntry 16 }
+
+mgmdRouterInterfaceStartupQueryCount OBJECT-TYPE
+    SYNTAX     Unsigned32 (1..255)
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "Represents the number of Queries sent out on startup,
+            separated by the Startup Query Interval."
+
+    ::= { mgmdRouterInterfaceEntry 17 }
+
+mgmdRouterInterfaceStartupQueryInterval OBJECT-TYPE
+    SYNTAX     Unsigned32 (0..31744)
+    UNITS      "seconds"
+    MAX-ACCESS read-only
+    STATUS     current
+
+
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 14]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    DESCRIPTION
+            "This variable represents the interval between General
+            Queries sent by a Querier on startup."
+
+    ::= { mgmdRouterInterfaceEntry 18 }
+
+--
+--  The MGMD Host Cache Table
+--
+
+mgmdHostCacheTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF MgmdHostCacheEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The (conceptual) table listing the IP multicast groups for
+             which the host is a member on a particular interface."
+
+    ::= { mgmdMIBObjects 3 }
+
+mgmdHostCacheEntry OBJECT-TYPE
+    SYNTAX     MgmdHostCacheEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "An entry (conceptual row) in the mgmdHostCacheTable."
+    INDEX      { mgmdHostCacheAddressType, mgmdHostCacheAddress,
+                 mgmdHostCacheIfIndex }
+
+    ::= { mgmdHostCacheTable 1 }
+
+MgmdHostCacheEntry ::= SEQUENCE {
+    mgmdHostCacheAddressType        InetAddressType,
+    mgmdHostCacheAddress            InetAddress ,
+    mgmdHostCacheIfIndex            InterfaceIndex,
+    mgmdHostCacheUpTime             TimeTicks,
+    mgmdHostCacheLastReporter       InetAddress,
+    mgmdHostCacheSourceFilterMode   INTEGER
+}
+
+mgmdHostCacheAddressType OBJECT-TYPE
+    SYNTAX     InetAddressType { ipv4(1), ipv6(2) }
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The address type of the mgmdHostCacheTable entry.  This
+            value applies to both the mgmdHostCacheAddress and the
+            mgmdHostCacheLastReporter entries."
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 15]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    ::= { mgmdHostCacheEntry 1 }
+
+mgmdHostCacheAddress OBJECT-TYPE
+    SYNTAX      InetAddress (SIZE(4|16))
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The IP multicast group address for which this entry
+            contains information.  The InetAddressType, e.g., IPv4 or
+            IPv6, is identified by the mgmdHostCacheAddressType variable
+            in the mgmdHostCache table."
+
+    ::= { mgmdHostCacheEntry 2 }
+
+mgmdHostCacheIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The interface for which this entry contains information
+            for an IP multicast group address."
+
+    ::= { mgmdHostCacheEntry 3 }
+
+mgmdHostCacheUpTime OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The time elapsed since this entry was created."
+
+    ::= { mgmdHostCacheEntry 4 }
+
+mgmdHostCacheLastReporter OBJECT-TYPE
+    SYNTAX     InetAddress (SIZE(4|16))
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The IP address of the source of the last membership report
+            received for this IP multicast group address on this
+            interface.  If no membership report has been received, this
+            object has a value of 0.  The InetAddressType, e.g., IPv4 or
+            IPv6, is identified by the mgmdHostCacheAddressType variable
+            in the mgmdHostCache table."
+
+    ::= { mgmdHostCacheEntry 5 }
+
+mgmdHostCacheSourceFilterMode OBJECT-TYPE
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 16]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    SYNTAX     INTEGER {include (1),
+                        exclude (2) }
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The state in which the interface is currently set.  The
+            value indicates the relevance of the corresponding source
+            list entries in the mgmdHostSecListTable for MGMDv3
+            interfaces."
+
+    ::= { mgmdHostCacheEntry 6 }
+
+--
+--  The MGMD Router Cache Table
+--
+
+mgmdRouterCacheTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF MgmdRouterCacheEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The (conceptual) table listing the IP multicast groups for
+            which there are members on a particular router interface."
+
+    ::= { mgmdMIBObjects 4 }
+
+mgmdRouterCacheEntry OBJECT-TYPE
+    SYNTAX     MgmdRouterCacheEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "An entry (conceptual row) in the mgmdRouterCacheTable."
+
+    INDEX      { mgmdRouterCacheAddressType, mgmdRouterCacheAddress,
+                 mgmdRouterCacheIfIndex }
+
+    ::= { mgmdRouterCacheTable 1 }
+
+MgmdRouterCacheEntry ::= SEQUENCE {
+    mgmdRouterCacheAddressType        InetAddressType,
+    mgmdRouterCacheAddress            InetAddress,
+    mgmdRouterCacheIfIndex            InterfaceIndex,
+    mgmdRouterCacheLastReporter       InetAddress,
+    mgmdRouterCacheUpTime             TimeTicks,
+    mgmdRouterCacheExpiryTime         TimeTicks,
+    mgmdRouterCacheExcludeModeExpiryTimer
+                                      TimeTicks,
+    mgmdRouterCacheVersion1HostTimer  TimeTicks,
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 17]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    mgmdRouterCacheVersion2HostTimer  TimeTicks,
+    mgmdRouterCacheSourceFilterMode   INTEGER
+}
+
+mgmdRouterCacheAddressType OBJECT-TYPE
+    SYNTAX     InetAddressType { ipv4(1), ipv6(2) }
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The address type of the mgmdRouterCacheTable entry.  This
+            value applies to both the mgmdRouterCacheAddress and the
+            mgmdRouterCacheLastReporter entries."
+
+    ::= { mgmdRouterCacheEntry 1 }
+
+mgmdRouterCacheAddress OBJECT-TYPE
+    SYNTAX      InetAddress (SIZE(4|16))
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The IP multicast group address for which this entry
+            contains information.  The InetAddressType, e.g., IPv4 or
+            IPv6, is identified by the mgmdRouterCacheAddressType
+            variable in the mgmdRouterCache table."
+
+    ::= { mgmdRouterCacheEntry 2 }
+
+mgmdRouterCacheIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The interface for which this entry contains information
+            for an IP multicast group address."
+
+    ::= { mgmdRouterCacheEntry 3 }
+
+mgmdRouterCacheLastReporter OBJECT-TYPE
+    SYNTAX     InetAddress (SIZE(4|16))
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The IP address of the source of the last membership report
+            received for this IP multicast group address on this
+            interface.  If no membership report has been received, this
+            object has the value 0.  The InetAddressType, e.g., IPv4 or
+            IPv6, is identified by the mgmdRouterCacheAddressType
+            variable in the mgmdRouterCache table."
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 18]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    ::= { mgmdRouterCacheEntry 4 }
+
+mgmdRouterCacheUpTime OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The time elapsed since this entry was created."
+
+    ::= { mgmdRouterCacheEntry 5 }
+
+mgmdRouterCacheExpiryTime OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "This value represents the time remaining before the Group
+            Membership Interval state expires.  The value must always be
+            greater than or equal to 1."
+
+    ::= { mgmdRouterCacheEntry 6 }
+
+mgmdRouterCacheExcludeModeExpiryTimer OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "This value is applicable only to MGMDv3-compatible nodes
+            and represents the time remaining before the interface
+            EXCLUDE state expires and the interface state transitions
+            to INCLUDE mode.  This value can never be greater than
+            mgmdRouterCacheExpiryTime."
+
+    ::= { mgmdRouterCacheEntry 7 }
+
+mgmdRouterCacheVersion1HostTimer OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The time remaining until the local router will assume that
+            there are no longer any MGMD version 1 members on the IP
+            subnet attached to this interface.  This entry only applies
+            to IGMPv1 hosts, and is not implemented for MLD.  Upon
+            hearing any MGMDv1 Membership Report (IGMPv1 only), this
+            value is reset to the group membership timer.  While this
+
+
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 19]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+            time remaining is non-zero, the local router ignores any
+            MGMDv2 Leave messages (IGMPv2 only) for this group that it
+            receives on this interface."
+
+    ::= { mgmdRouterCacheEntry 8 }
+
+mgmdRouterCacheVersion2HostTimer OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The time remaining until the local router will assume that
+            there are no longer any MGMD version 2 members on the IP
+            subnet attached to this interface.  This entry applies to
+            both IGMP and MLD hosts.  Upon hearing any MGMDv2 Membership
+            Report, this value is reset to the group membership timer.
+            Assuming no MGMDv1 hosts have been detected, the local
+            router does not ignore any MGMDv2 Leave messages for this
+            group that it receives on this interface."
+
+    ::= { mgmdRouterCacheEntry 9 }
+
+mgmdRouterCacheSourceFilterMode OBJECT-TYPE
+    SYNTAX     INTEGER {include (1),
+                        exclude (2) }
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The current cache state, applicable to MGMDv3-compatible
+            nodes.  The value indicates whether the state is INCLUDE or
+            EXCLUDE."
+
+    ::= { mgmdRouterCacheEntry 10 }
+
+--
+--  The MGMD Inverse Host interface/cache lookup Table
+--
+
+mgmdInverseHostCacheTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF MgmdInverseHostCacheEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The (conceptual) table listing the interfaces that are
+            members of a particular group.  This is an inverse lookup
+            table for entries in the mgmdHostCacheTable."
+
+    ::= { mgmdMIBObjects 5 }
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 20]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+mgmdInverseHostCacheEntry OBJECT-TYPE
+    SYNTAX     MgmdInverseHostCacheEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "An entry (conceptual row) in the
+            mgmdInverseHostCacheTable."
+    INDEX      { mgmdInverseHostCacheIfIndex,
+                 mgmdInverseHostCacheAddressType,
+                 mgmdInverseHostCacheAddress}
+
+    ::= { mgmdInverseHostCacheTable 1 }
+
+MgmdInverseHostCacheEntry ::= SEQUENCE {
+    mgmdInverseHostCacheIfIndex            InterfaceIndex,
+    mgmdInverseHostCacheAddressType        InetAddressType,
+    mgmdInverseHostCacheAddress            InetAddress
+}
+
+mgmdInverseHostCacheIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The interface for which this entry contains information."
+
+    ::= { mgmdInverseHostCacheEntry 1 }
+
+mgmdInverseHostCacheAddressType OBJECT-TYPE
+    SYNTAX     InetAddressType { ipv4(1), ipv6(2) }
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The address type of the mgmdInverseHostCacheTable entry."
+
+    ::= { mgmdInverseHostCacheEntry 2 }
+
+mgmdInverseHostCacheAddress OBJECT-TYPE
+    SYNTAX      InetAddress (SIZE(4|16))
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The IP multicast group address for which this entry
+            contains information about an interface.  The
+            InetAddressType, e.g., IPv4 or IPv6, is identified by the
+            mgmdInverseHostCacheAddressType variable in the
+            mgmdInverseHostCache table."
+
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 21]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    ::= { mgmdInverseHostCacheEntry 3 }
+
+--
+--  The MGMD Inverse Router interface/cache lookup Table
+--
+
+mgmdInverseRouterCacheTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF MgmdInverseRouterCacheEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The (conceptual) table listing the interfaces that
+            are members of a particular group.  This is an inverse
+            lookup table for entries in the mgmdRouterCacheTable."
+
+    ::= { mgmdMIBObjects 6 }
+
+mgmdInverseRouterCacheEntry OBJECT-TYPE
+    SYNTAX     MgmdInverseRouterCacheEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "An entry (conceptual row) in the
+            mgmdInverseRouterCacheTable."
+    INDEX      { mgmdInverseRouterCacheIfIndex,
+                 mgmdInverseRouterCacheAddressType,
+                 mgmdInverseRouterCacheAddress }
+
+    ::= { mgmdInverseRouterCacheTable 1 }
+
+MgmdInverseRouterCacheEntry ::= SEQUENCE {
+    mgmdInverseRouterCacheIfIndex            InterfaceIndex,
+    mgmdInverseRouterCacheAddressType        InetAddressType,
+    mgmdInverseRouterCacheAddress            InetAddress
+}
+
+mgmdInverseRouterCacheIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The interface for which this entry contains information
+            for an IP multicast group address."
+
+    ::= { mgmdInverseRouterCacheEntry 1 }
+
+mgmdInverseRouterCacheAddressType OBJECT-TYPE
+    SYNTAX     InetAddressType { ipv4(1), ipv6(2) }
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 22]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The address type of the mgmdInverseRouterCacheTable entry."
+
+    ::= { mgmdInverseRouterCacheEntry 2 }
+
+mgmdInverseRouterCacheAddress OBJECT-TYPE
+    SYNTAX      InetAddress (SIZE(4|16))
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The IP multicast group address for which this entry
+            contains information.  The InetAddressType, e.g., IPv4 or
+            IPv6, is identified by the mgmdInverseRouterCacheAddressType
+            variable in the mgmdInverseRouterCache table."
+
+    ::= { mgmdInverseRouterCacheEntry 3 }
+
+--
+--  The MGMD Host Source list Table
+--
+
+mgmdHostSrcListTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF MgmdHostSrcListEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The (conceptual) table listing the Source List entries
+             corresponding to each interface and multicast group pair
+             on a host."
+
+    ::= { mgmdMIBObjects 7 }
+
+mgmdHostSrcListEntry OBJECT-TYPE
+    SYNTAX     MgmdHostSrcListEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "An entry (conceptual row) in the mgmdHostSrcListTable."
+    INDEX      { mgmdHostSrcListAddressType, mgmdHostSrcListAddress,
+                 mgmdHostSrcListIfIndex, mgmdHostSrcListHostAddress }
+
+    ::= { mgmdHostSrcListTable 1 }
+
+MgmdHostSrcListEntry ::= SEQUENCE {
+    mgmdHostSrcListAddressType      InetAddressType,
+    mgmdHostSrcListAddress          InetAddress,
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 23]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    mgmdHostSrcListIfIndex          InterfaceIndex,
+    mgmdHostSrcListHostAddress      InetAddress,
+    mgmdHostSrcListExpire           TimeTicks
+}
+
+mgmdHostSrcListAddressType OBJECT-TYPE
+    SYNTAX     InetAddressType { ipv4(1), ipv6(2) }
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The address type of the InetAddress variables in this
+            table.  This value applies to the mgmdHostSrcListHostAddress
+            and mgmdHostSrcListAddress entries."
+
+    ::= { mgmdHostSrcListEntry 1 }
+
+mgmdHostSrcListAddress OBJECT-TYPE
+    SYNTAX      InetAddress (SIZE(4|16))
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The IP multicast group address for which this entry
+            contains information."
+
+    ::= { mgmdHostSrcListEntry 2 }
+
+mgmdHostSrcListIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The interface for which this entry contains information
+            for an IP multicast group address."
+
+    ::= { mgmdHostSrcListEntry 3 }
+
+mgmdHostSrcListHostAddress OBJECT-TYPE
+    SYNTAX      InetAddress (SIZE(4|16))
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The host address to which this entry corresponds.  The
+            mgmdHostCacheSourceFilterMode value for this group address
+            and interface indicates whether this host address is
+            included or excluded."
+
+    ::= { mgmdHostSrcListEntry 4 }
+
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 24]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+mgmdHostSrcListExpire OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "This value indicates the relevance of the SrcList entry,
+            whereby a non-zero value indicates this is an INCLUDE state
+            value, and a zero value indicates this to be an EXCLUDE
+            state value."
+
+    ::= { mgmdHostSrcListEntry 5 }
+
+--
+--  The MGMD Router Source list Table
+--
+
+mgmdRouterSrcListTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF MgmdRouterSrcListEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The (conceptual) table listing the Source List entries
+            corresponding to each interface and multicast group pair on
+            a Router."
+
+    ::= { mgmdMIBObjects 8 }
+
+mgmdRouterSrcListEntry OBJECT-TYPE
+    SYNTAX     MgmdRouterSrcListEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "An entry (conceptual row) in the mgmdRouterSrcListTable."
+    INDEX      { mgmdRouterSrcListAddressType,
+                 mgmdRouterSrcListAddress,
+                 mgmdRouterSrcListIfIndex,
+                 mgmdRouterSrcListHostAddress }
+
+    ::= { mgmdRouterSrcListTable 1 }
+
+MgmdRouterSrcListEntry ::= SEQUENCE {
+    mgmdRouterSrcListAddressType    InetAddressType,
+    mgmdRouterSrcListAddress        InetAddress,
+    mgmdRouterSrcListIfIndex        InterfaceIndex,
+    mgmdRouterSrcListHostAddress    InetAddress,
+    mgmdRouterSrcListExpire         TimeTicks
+}
+
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 25]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+mgmdRouterSrcListAddressType OBJECT-TYPE
+    SYNTAX     InetAddressType { ipv4(1), ipv6(2) }
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The address type of the InetAddress variables in this
+            table.  This value applies to the
+            mgmdRouterSrcListHostAddress and mgmdRouterSrcListAddress
+            entries."
+
+    ::= { mgmdRouterSrcListEntry 1 }
+
+mgmdRouterSrcListAddress OBJECT-TYPE
+    SYNTAX      InetAddress (SIZE(4|16))
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The IP multicast group address for which this entry
+            contains information."
+
+    ::= { mgmdRouterSrcListEntry 2 }
+
+mgmdRouterSrcListIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The interface for which this entry contains information
+            for an IP multicast group address."
+
+    ::= { mgmdRouterSrcListEntry 3 }
+
+mgmdRouterSrcListHostAddress OBJECT-TYPE
+    SYNTAX      InetAddress (SIZE(4|16))
+    MAX-ACCESS  not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The host address to which this entry corresponds.  The
+            mgmdRouterCacheSourceFilterMode value for this group address
+            and interface indicates whether this host address is
+            included or excluded."
+
+    ::= { mgmdRouterSrcListEntry 4 }
+
+mgmdRouterSrcListExpire OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 26]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    DESCRIPTION
+            "This value indicates the relevance of the SrcList entry,
+            whereby a non-zero value indicates this is an INCLUDE state
+            value, and a zero value indicates this to be an EXCLUDE
+            state value."
+
+    ::= { mgmdRouterSrcListEntry 5 }
+
+-- conformance information
+
+mgmdMIBConformance OBJECT IDENTIFIER ::= { mgmdStdMIB 2 }
+mgmdMIBCompliance  OBJECT IDENTIFIER ::= { mgmdMIBConformance 1 }
+mgmdMIBGroups      OBJECT IDENTIFIER ::= { mgmdMIBConformance 2 }
+
+-- Protocol Version Conformance
+
+-- Read Compliance statement for IGMPv1 Hosts
+-- IGMPv1 only supports the IPv4 Address Family
+
+mgmdIgmpV1HostReadMIBCompliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+            "A read-only compliance statement for hosts running IGMPv1
+            [RFC1112] and implementing the MGMD MIB.  IGMPv1 hosts must
+            support the IPv4 address type."
+    MODULE  -- this module
+    MANDATORY-GROUPS { mgmdHostBaseMIBGroup }
+
+    OBJECT mgmdHostInterfaceStatus
+    SYNTAX RowStatus {active(1)}
+    MIN-ACCESS read-only
+    DESCRIPTION
+            "Read-write or read-create access is not required and only
+             the value 'active(1)' needs to be supported."
+
+    OBJECT mgmdHostInterfaceVersion
+    SYNTAX Unsigned32 (1)
+    MIN-ACCESS read-only
+    DESCRIPTION
+            "Write access is not required.  Only version 1 needs to be
+             supported."
+
+    GROUP mgmdHostExtendedMIBGroup
+    DESCRIPTION
+            "Supporting this group can be especially useful in
+             an environment with a router that does not support the
+             MGMD MIB."
+
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 27]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    ::= { mgmdMIBCompliance 1 }
+
+-- Read Compliance statement for IGMPv1 Routers
+-- IGMPv1 only supports the IPv4 Address Family
+
+mgmdIgmpV1RouterReadMIBCompliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+            "A read-only compliance statement for routers running
+            IGMPv1 [RFC1112] and implementing the MGMD MIB.  IGMPv1
+            routers only support the IPv4 address type.
+
+            Non-accessible index objects that only need IPv4
+            support are:
+
+            OBJECT mgmdRouterCacheAddressType
+            SYNTAX InetAddressType { ipv4(1) }
+
+            OBJECT mgmdRouterCacheAddress
+            SYNTAX InetAddress (SIZE(4))
+
+            OBJECT mgmdRouterInterfaceQuerierType
+            SYNTAX InetAddressType { ipv4(1) }
+
+            OBJECT mgmdInverseRouterCacheAddressType
+            SYNTAX InetAddressType { ipv4(1) }
+            "
+
+    MODULE  -- this module
+    MANDATORY-GROUPS { mgmdRouterBaseMIBGroup }
+
+    OBJECT mgmdRouterCacheLastReporter
+    SYNTAX InetAddress (SIZE(4))
+    DESCRIPTION
+            "IGMPv1 routers only support IPv4 addresses."
+
+    OBJECT mgmdRouterInterfaceQuerier
+    SYNTAX InetAddress (SIZE(4))
+    DESCRIPTION
+            "IGMPv1 routers only support IPv4 addresses."
+
+    OBJECT mgmdInverseRouterCacheAddress
+    SYNTAX InetAddress (SIZE(4))
+    DESCRIPTION
+            "IGMPv1 routers only support IPv4 addresses."
+
+    OBJECT mgmdRouterInterfaceVersion
+    SYNTAX Unsigned32 (1)
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 28]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    MIN-ACCESS read-only
+    DESCRIPTION
+            "Write access is not required.  Only version 1 needs to
+             be supported."
+
+    OBJECT mgmdRouterInterfaceStatus
+    SYNTAX RowStatus {active(1)}
+    MIN-ACCESS read-only
+    DESCRIPTION
+            "Read-write or read-create access is not required and only
+             the value 'active(1)' needs to be supported."
+
+    OBJECT mgmdRouterInterfaceQueryInterval
+    MIN-ACCESS read-only
+    DESCRIPTION
+            "Write access is not required."
+
+    ::= { mgmdMIBCompliance 2 }
+
+-- Write Compliance statement for IGMPv1 Routers
+-- IGMPv1 only supports the IPv4 Address Family
+
+mgmdIgmpV1RouterWriteMIBCompliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+            "A read-create compliance statement for routers running
+            IGMPv1 [RFC1112] and implementing the MGMD MIB.  IGMPv1
+            routers only support the IPv4 address type.
+
+            Non-accessible index objects that only need IPv4
+            support are:
+
+            OBJECT mgmdRouterCacheAddressType
+            SYNTAX InetAddressType { ipv4(1) }
+
+            OBJECT mgmdRouterCacheAddress
+            SYNTAX InetAddress (SIZE(4))
+
+            OBJECT mgmdRouterInterfaceQuerierType
+            SYNTAX InetAddressType { ipv4(1) }
+
+            OBJECT mgmdInverseRouterCacheAddressType
+            SYNTAX InetAddressType { ipv4(1) }
+            "
+    MODULE  -- this module
+    MANDATORY-GROUPS { mgmdRouterBaseMIBGroup }
+
+
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 29]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    OBJECT mgmdRouterCacheLastReporter
+    SYNTAX InetAddress (SIZE(4))
+    DESCRIPTION
+            "Only IPv4 addresses needed for IGMPv1 router support."
+
+    OBJECT mgmdRouterInterfaceQuerier
+    SYNTAX InetAddress (SIZE(4))
+    DESCRIPTION
+            "Only IPv4 addresses needed for IGMPv1 router support."
+
+    OBJECT mgmdInverseRouterCacheAddress
+    SYNTAX InetAddress (SIZE(4))
+    DESCRIPTION
+            "Only IPv4 addresses needed for IGMPv1 router support."
+
+    OBJECT mgmdRouterInterfaceVersion
+    SYNTAX Unsigned32 (1)
+    DESCRIPTION
+            "Write access is not required.  Only version 1 needs to
+             be supported."
+
+    ::= { mgmdMIBCompliance 3 }
+
+-- Read Compliance statement for IGMPv2 and MLDv1 Hosts
+-- IGMPv2 only supports the IPv4 Address Family
+-- MLDv1 only supports the IPv6 Address Family
+
+mgmdIgmpV2MldV1HostReadMIBCompliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+            "A read-only compliance statement for hosts running IGMPv2
+            [RFC2236] or MLDv1 [RFC2710] and implementing the MGMD
+            MIB.  IGMPv2 hosts only support the IPv4 address type and
+            MLDv1 hosts only support the IPv6 address type."
+    MODULE  -- this module
+    MANDATORY-GROUPS { mgmdHostBaseMIBGroup,
+                       mgmdV2HostMIBGroup
+                     }
+
+    OBJECT mgmdHostInterfaceStatus
+    SYNTAX RowStatus {active(1)}
+    MIN-ACCESS read-only
+    DESCRIPTION
+            "Read-write or read-create access is not required and only
+             the value 'active(1)' needs to be supported."
+
+    OBJECT mgmdHostInterfaceVersion
+    SYNTAX Unsigned32 (1..2)
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 30]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    MIN-ACCESS read-only
+    DESCRIPTION
+            "Write access is not required.  Only versions 1 and 2 need
+             to be supported."
+
+    GROUP   mgmdHostExtendedMIBGroup
+    DESCRIPTION
+            "Supporting this group can be especially useful in an
+             environment with a router that does not support the
+             MGMD MIB."
+
+    ::= { mgmdMIBCompliance 4 }
+
+-- Write Compliance statement for IGMPv2 and MLDv1 Hosts
+-- IGMPv2 only supports the IPv4 Address Family
+-- MLDv1 only supports the IPv6 Address Family
+
+mgmdIgmpV2MldV1HostWriteMIBCompliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+            "A read-create compliance statement for hosts running
+            IGMPv2 [RFC2236] or MLDv1 [RFC2710] and implementing
+            the MGMD MIB.  IGMPv2 hosts only support the IPv4 address
+            type and MLDv1 hosts only support the IPv6 address type."
+    MODULE  -- this module
+    MANDATORY-GROUPS { mgmdHostBaseMIBGroup,
+                       mgmdV2HostMIBGroup }
+    OBJECT mgmdHostInterfaceVersion
+    SYNTAX Unsigned32 (1..2)
+    DESCRIPTION
+            "Only versions 1 and 2 need to be supported."
+
+    ::= { mgmdMIBCompliance 5 }
+
+-- Read Compliance statement for IGMPv2 and MLDv1 Routers
+-- IGMPv2 only supports the IPv4 Address Family
+-- MLDv1 only supports the IPv6 Address Family
+
+mgmdIgmpV2MldV1RouterReadMIBCompliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+            "A read-only compliance statement for routers running
+            IGMPv2 [RFC2236] or MLDv1 [RFC2710] and implementing
+            the MGMD MIB.  IGMPv2 routers only support the IPv4
+            address type and MLDv1 routers only support the IPv6
+            address type."
+    MODULE  -- this module
+    MANDATORY-GROUPS { mgmdRouterBaseMIBGroup,
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 31]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+                       mgmdV2RouterBaseMIBGroup
+                     }
+
+    OBJECT mgmdRouterInterfaceLastMemberQueryInterval
+    MIN-ACCESS read-only
+    DESCRIPTION
+            "Write access is not required."
+
+    OBJECT mgmdRouterInterfaceRobustness
+    MIN-ACCESS read-only
+    DESCRIPTION
+            "Write access is not required."
+
+    OBJECT mgmdRouterInterfaceQueryMaxResponseTime
+    MIN-ACCESS read-only
+    DESCRIPTION
+            "Write access is not required."
+
+    OBJECT mgmdRouterInterfaceVersion
+    SYNTAX Unsigned32 (1..2)
+    MIN-ACCESS read-only
+    DESCRIPTION
+            "Write access is not required.  Only versions 1 and 2
+             need to be supported."
+
+    OBJECT mgmdRouterInterfaceStatus
+    SYNTAX RowStatus {active(1)}
+    MIN-ACCESS read-only
+    DESCRIPTION
+            "Read-write or read-create access is not required and only
+             the value 'active(1)' needs to be supported."
+
+    OBJECT mgmdRouterInterfaceQueryInterval
+    MIN-ACCESS read-only
+    DESCRIPTION
+            "Write access is not required."
+
+    GROUP   mgmdV2ProxyMIBGroup
+    DESCRIPTION
+            "Write access is not required."
+
+    ::= { mgmdMIBCompliance 6 }
+
+-- Write Compliance statement for IGMPv2, IGMPv3, MLDv1, and MLDv2
+--   Routers
+-- IGMPv2 and IGMPv3 only support the IPv4 Address Family
+-- MLDv1 and MLDv2 only support the IPv6 Address Family
+
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 32]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+mgmdIgmpV2V3MldV1V2RouterWriteMIBCompliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+            "A read-create compliance statement for routers running
+            IGMPv2 [RFC2236], IGMPv3 [RFC3376], MLDv1 [RFC2710], or
+            MLDv2 [RFC3810] and implementing the MGMD MIB.  IGMPv2 and
+            IGMPv3 routers only support the IPv4 address type, while
+            MLDv1 and MLDv2 routers only support the IPv6 address type."
+    MODULE  -- this module
+    MANDATORY-GROUPS { mgmdRouterBaseMIBGroup,
+                       mgmdV2RouterBaseMIBGroup
+                     }
+
+    GROUP   mgmdV2ProxyMIBGroup
+    DESCRIPTION
+            "Read-create access is required."
+
+    ::= { mgmdMIBCompliance 7 }
+
+-- Read Compliance statement for IGMPv2, IGMPv3, MLDv1, and MLDv2 Hosts
+-- IGMPv2 and IGMPv3 only support the IPv4 Address Family
+-- MLDv1 and MLDv2 only support the IPv6 Address Family
+
+mgmdIgmpV3MldV2HostReadMIBCompliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+            "The compliance statement for hosts running IGMPv3
+            [RFC3376] or MLDv2 [RFC3810] and implementing the
+            MGMD MIB.  IGMPv3 hosts only support the IPv4 address
+            type and MLDv2 hosts only support the IPv6 address type."
+    MODULE  -- this module
+    MANDATORY-GROUPS { mgmdHostBaseMIBGroup,
+                       mgmdV2HostMIBGroup,
+                       mgmdV3HostMIBGroup
+                     }
+
+    OBJECT mgmdHostInterfaceVersion
+    MIN-ACCESS read-only
+    DESCRIPTION
+            "Write access is not required."
+
+    OBJECT mgmdHostInterfaceStatus
+    SYNTAX RowStatus {active(1)}
+    MIN-ACCESS read-only
+    DESCRIPTION
+            "Read-write or read-create access is not required and only
+             the value 'active(1)' needs to be supported."
+
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 33]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    OBJECT  mgmdHostInterfaceVersion3Robustness
+    MIN-ACCESS read-only
+    DESCRIPTION
+            "Write access is not required."
+
+    GROUP   mgmdHostExtendedMIBGroup
+    DESCRIPTION
+            "Supporting this group can be especially useful in
+             an environment with a router that does not support the
+             MGMD MIB."
+
+    ::= { mgmdMIBCompliance 8 }
+
+-- Write Compliance statement for IGMPv2, IGMPv3, MLDv1, and MLDv2 Hosts
+-- IGMPv2 and IGMPv3 only support the IPv4 Address Family
+-- MLDv1 and MLDv2 only support the IPv6 Address Family
+
+mgmdIgmpV3MldV2HostWriteMIBCompliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+            "The compliance statement for hosts running IGMPv3
+            [RFC3376] or MLDv2 [RFC3810] and implementing the
+            MGMD MIB.  IGMPv3 hosts only support the IPv4 address
+            type and MLDv2 hosts only support the IPv6 address type."
+    MODULE  -- this module
+    MANDATORY-GROUPS { mgmdHostBaseMIBGroup,
+                       mgmdV2HostMIBGroup,
+
+                       mgmdV3HostMIBGroup
+                     }
+
+    GROUP   mgmdHostExtendedMIBGroup
+    DESCRIPTION
+            "Supporting this group can be especially useful in
+             an environment with a router that does not support the
+             MGMD MIB."
+
+    ::= { mgmdMIBCompliance 9 }
+
+-- Read Compliance statement for IGMPv2, IGMPv3, MLDv1, and MLDv2
+--   Routers
+-- IGMPv2 and IGMPv3 only support the IPv4 Address Family
+-- MLDv1 and MLDv2 only support the IPv6 Address Family
+
+mgmdIgmpV3MldV2RouterReadMIBCompliance MODULE-COMPLIANCE
+    STATUS  current
+
+
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 34]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    DESCRIPTION
+            "A read-only compliance statement for routers running
+            IGMPv3 [RFC3376] or MLDv2 [RFC3810] and implementing
+            the MGMD MIB.  IGMPv3 routers only support the IPv4
+            address type and MLDv2 routers only support the IPv6
+            address type."
+    MODULE  -- this module
+    MANDATORY-GROUPS { mgmdRouterBaseMIBGroup,
+                       mgmdV2RouterBaseMIBGroup,
+                       mgmdV3RouterMIBGroup
+                     }
+
+    OBJECT mgmdRouterInterfaceLastMemberQueryInterval
+    MIN-ACCESS read-only
+    DESCRIPTION
+            "Write access is not required."
+
+    OBJECT mgmdRouterInterfaceRobustness
+    MIN-ACCESS read-only
+    DESCRIPTION
+            "Write access is not required."
+
+    OBJECT mgmdRouterInterfaceQueryMaxResponseTime
+    MIN-ACCESS read-only
+    DESCRIPTION
+            "Write access is not required."
+
+    OBJECT mgmdRouterInterfaceVersion
+    MIN-ACCESS read-only
+    DESCRIPTION
+            "Write access is not required."
+
+    OBJECT mgmdRouterInterfaceStatus
+    SYNTAX RowStatus {active(1)}
+    MIN-ACCESS read-only
+    DESCRIPTION
+            "Read-write or read-create access is not required and only
+             the value 'active(1)' needs to be supported."
+
+    OBJECT mgmdRouterInterfaceQueryInterval
+    MIN-ACCESS read-only
+    DESCRIPTION
+            "Write access is not required."
+
+    GROUP   mgmdV2ProxyMIBGroup
+    DESCRIPTION
+            "Write access is not required."
+
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 35]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    ::= { mgmdMIBCompliance 10 }
+
+-- units of conformance
+
+mgmdHostBaseMIBGroup OBJECT-GROUP
+    OBJECTS { mgmdHostInterfaceStatus,
+              mgmdHostInterfaceVersion
+            }
+    STATUS  current
+    DESCRIPTION
+            "The basic collection of objects providing management of
+            MGMD version 1, 2, or 3 for hosts."
+
+    ::= { mgmdMIBGroups 1 }
+
+mgmdRouterBaseMIBGroup OBJECT-GROUP
+    OBJECTS { mgmdRouterInterfaceStatus,
+              mgmdRouterInterfaceQueryInterval,
+              mgmdRouterCacheUpTime, mgmdRouterCacheExpiryTime,
+              mgmdRouterInterfaceVersion,
+              mgmdRouterInterfaceJoins, mgmdRouterInterfaceGroups,
+              mgmdRouterCacheLastReporter,
+              mgmdRouterInterfaceQuerierUpTime,
+              mgmdRouterInterfaceQuerierExpiryTime,
+              mgmdRouterInterfaceQuerier,
+              mgmdInverseRouterCacheAddress
+            }
+    STATUS  current
+    DESCRIPTION
+            "The basic collection of objects providing management of
+            MGMD version 1, 2, or 3 for routers."
+
+    ::= { mgmdMIBGroups 2 }
+
+mgmdV2HostMIBGroup OBJECT-GROUP
+    OBJECTS { mgmdHostInterfaceVersion1QuerierTimer
+            }
+    STATUS  current
+    DESCRIPTION
+            "A collection of additional read-only objects for management
+            of IGMP version 2 in hosts for MGMD version 2 compliance."
+
+    ::= { mgmdMIBGroups 3 }
+
+mgmdHostExtendedMIBGroup OBJECT-GROUP
+    OBJECTS { mgmdHostCacheLastReporter, mgmdHostCacheUpTime,
+              mgmdHostInterfaceQuerier, mgmdInverseHostCacheAddress }
+    STATUS  current
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 36]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+    DESCRIPTION
+            "A collection of optional objects for MGMD hosts."
+
+    ::= { mgmdMIBGroups 4 }
+
+mgmdV2RouterBaseMIBGroup OBJECT-GROUP
+    OBJECTS { mgmdRouterInterfaceWrongVersionQueries,
+              mgmdRouterInterfaceLastMemberQueryCount,
+              mgmdRouterInterfaceStartupQueryCount,
+              mgmdRouterInterfaceStartupQueryInterval,
+              mgmdRouterCacheVersion1HostTimer,
+              mgmdRouterInterfaceQueryMaxResponseTime,
+              mgmdRouterInterfaceRobustness,
+              mgmdRouterInterfaceLastMemberQueryInterval
+            }
+    STATUS  current
+    DESCRIPTION
+            "A collection of additional read-only objects for
+            management of MGMD version 2 in routers."
+
+    ::= { mgmdMIBGroups 5 }
+
+mgmdV2ProxyMIBGroup OBJECT-GROUP
+    OBJECTS { mgmdRouterInterfaceProxyIfIndex }
+    STATUS  current
+    DESCRIPTION
+            "A collection of additional read-create objects for
+            management of MGMD proxy devices."
+
+    ::= { mgmdMIBGroups 6 }
+
+mgmdV3HostMIBGroup OBJECT-GROUP
+    OBJECTS { mgmdHostInterfaceVersion2QuerierTimer,
+              mgmdHostCacheSourceFilterMode,
+              mgmdHostInterfaceVersion3Robustness,
+              mgmdHostSrcListExpire
+            }
+    STATUS  current
+    DESCRIPTION
+            "A collection of additional objects for
+            management of MGMD version 3 in hosts."
+
+    ::= { mgmdMIBGroups 7 }
+
+mgmdV3RouterMIBGroup OBJECT-GROUP
+    OBJECTS { mgmdRouterCacheSourceFilterMode,
+              mgmdRouterCacheVersion2HostTimer,
+              mgmdRouterCacheExcludeModeExpiryTimer,
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 37]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+              mgmdRouterSrcListExpire
+            }
+    STATUS  current
+    DESCRIPTION
+            "A collection of additional read-only objects for
+            management of MGMD version 3 in routers."
+
+    ::= { mgmdMIBGroups 8 }
+
+END
+
+6.  Security Considerations
+
+   There are a number of management objects defined in this MIB module
+   with a MAX-ACCESS clause of read-write and/or read-create.  Such
+   objects may be considered sensitive or vulnerable in some network
+   environments.  The support for SET operations in a non-secure
+   environment without proper protection can have a negative effect on
+   network operations.  These are the tables and objects and their
+   sensitivity/vulnerability:
+
+   o  The mgmdRouterInterfaceTable provides read-create access to 2
+      values: the mgmdRouterInterfaceStatus and the
+      mgmdRouterInterfaceQueryInterval.  The mgmdRouterInterfaceStatus
+      presents a remote user with the ability to enable or disable
+      multicast support on a given router interface, and therefore
+      presents a significant denial-of-service vulnerability.  The
+      mgmdRouterInterfaceQueryInterval controls the frequency with which
+      host-query packets are sent, providing less of a vulnerability,
+      but still requiring secure access control.
+
+   o  The mgmdRouterCacheTable also provides access to read-create
+      objects.  The mgmdRouterInterfaceVersion controls the protocol
+      conformance of an interface, and is therefore a potential denial-
+      of-service vulnerability.  The
+      mgmdRouterInterfaceQueryMaxResponseTime, the
+      mgmdRouterInterfaceRobustness, and the
+      mgmdRouterInterfaceLastMemberQueryInterval are all tuning
+      parameters to control the characteristic of the host-query
+      packets.  Compromise of these objects can potentially be
+      disruptive to local multicast communication.
+
+   o  The mgmdHostInterfaceTable provides a read-create object, the
+      mgmdHostInterfaceVersion3Robustness, which controls the robustness
+      of the interface to packet loss.  Disabling robustness in the face
+      of packet loss could cause denial of service to hosts; however, in
+      general this presents a low risk.
+
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 38]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+   SNMP versions prior to SNMPv3 did not include adequate security.
+   Even if the network itself is secure (for example by using IPsec),
+   even then, there is no control as to who on the secure network is
+   allowed to access and GET/SET (read/change/create/delete) the objects
+   in this MIB module.
+
+   It is RECOMMENDED that implementers consider the security features as
+   provided by the SNMPv3 framework (see [RFC3410], section 8),
+   including full support for the SNMPv3 cryptographic mechanisms (for
+   authentication and privacy).
+
+   Further, deployment of SNMP versions prior to SNMPv3 is NOT
+   RECOMMENDED.  Instead, it is RECOMMENDED to deploy SNMPv3 and to
+   enable cryptographic security.  It is then a customer/operator
+   responsibility to ensure that the SNMP entity giving access to an
+   instance of this MIB module is properly configured to give access to
+   the objects only to those principals (users) that have legitimate
+   rights to indeed GET or SET (change/create/delete) them.
+
+7.  IANA Considerations
+
+   This MIB introduces a new term to refer to two existing multicast
+   protocols: Multicast Group Membership Discovery.  It encompasses both
+   the IPv4 Multicast discovery protocol, IGMP, and the IPv6 Multicast
+   discovery protocol, MLD, as defined in RFCs 2933 [RFC2933] and 3019
+   [RFC3019], respectively.
+
+        The MIB module in this document uses the following IANA-assigned
+        OBJECT IDENTIFIER value recorded in the SMI Numbers registry:
+
+        Descriptor        OBJECT IDENTIFIER value
+        ----------        -----------------------
+        mgmdStdMIB        { mib-2 185 }
+
+8.  Contributors
+
+   The authors of RFC 2933 [RFC2933] and RFC 3019 [RFC3019] from which
+   this document is derived are:
+
+      Keith McCloghrie
+
+      Dino Farinacci
+
+      Dave Thaler
+
+      Brian Haberman
+
+      Randy Worzella
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 39]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+9.  Acknowledgements
+
+   Special thanks to James Lingard, Bill Fenner, and Dave Thaler for
+   detailed comments on the MIB.
+
+   Bert Wijnen deserves special recognition for his exhaustive reviews
+   and constructive feedback on SNMP and SMI issues related to this MIB.
+
+10.  References
+
+10.1.  Normative References
+
+   [RFC1112]  Deering, S., "Host extensions for IP multicasting", STD 5,
+              RFC 1112, August 1989.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2236]  Fenner, W., "Internet Group Management Protocol, Version
+              2", RFC 2236, November 1997.
+
+   [RFC2578]  McCloghrie, K., Ed., Perkins, D., Ed., and J.
+              Schoenwaelder, Ed., "Structure of Management Information
+              Version 2 (SMIv2)", STD 58, RFC 2578, April 1999.
+
+   [RFC2579]  McCloghrie, K., Ed., Perkins, D., Ed., and J.
+              Schoenwaelder, Ed., "Textual Conventions for SMIv2",
+              STD 58, RFC 2579, April 1999.
+
+   [RFC2580]  McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+              "Conformance Statements for SMIv2", STD 58, RFC 2580,
+              April 1999.
+
+   [RFC2710]  Deering, S., Fenner, W., and B. Haberman, "Multicast
+              Listener Discovery (MLD) for IPv6", RFC 2710,
+              October 1999.
+
+   [RFC2863]  McCloghrie, K. and F. Kastenholz, "The Interfaces Group
+              MIB", RFC 2863, June 2000.
+
+   [RFC3376]  Cain, B., Deering, S., Kouvelas, I., Fenner, B., and A.
+              Thyagarajan, "Internet Group Management Protocol, Version
+              3", RFC 3376, October 2002.
+
+   [RFC3810]  Vida, R. and L. Costa, "Multicast Listener Discovery
+              Version 2 (MLDv2) for IPv6", RFC 3810, June 2004.
+
+
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 40]
+
+RFC 5519                        MGMD MIB                      April 2009
+
+
+   [RFC4001]  Daniele, M., Haberman, B., Routhier, S., and J.
+              Schoenwaelder, "Textual Conventions for Internet Network
+              Addresses", RFC 4001, February 2005.
+
+10.2.  Informative References
+
+   [RFC2933]  McCloghrie, K., Farinacci, D., and D. Thaler, "Internet
+              Group Management Protocol MIB", RFC 2933, October 2000.
+
+   [RFC3019]  Haberman, B. and R. Worzella, "IP Version 6 Management
+              Information Base for The Multicast Listener Discovery
+              Protocol", RFC 3019, January 2001.
+
+   [RFC3410]  Case, J., Mundy, R., Partain, D., and B. Stewart,
+              "Introduction and Applicability Statements for Internet-
+              Standard Management Framework", RFC 3410, December 2002.
+
+   [RFC4605]  Fenner, B., He, H., Haberman, B., and H. Sandick,
+              "Internet Group Management Protocol (IGMP) / Multicast
+              Listener Discovery (MLD)-Based Multicast Forwarding
+              ("IGMP/MLD Proxying")", RFC 4605, August 2006.
+
+Authors' Addresses
+
+   Julian Chesterfield
+   University of Cambridge
+   15 JJ Thompson Avenue
+   Cambridge CB3 0FD
+   UK
+
+   EMail: julian.chesterfield@cl.cam.ac.uk
+
+
+   Brian Haberman (editor)
+   Johns Hopkins University / Applied Physics Laboratory
+   11100 Johns Hopkins Road
+   Laurel, MD  20723
+   USA
+
+   EMail: brian@innovationslab.net
+
+
+
+
+
+
+
+
+
+
+
+Chesterfield & Haberman     Standards Track                    [Page 41]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc5519.txt](<www.ietf.org/rfc/rfc5519.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
