### PR TITLE
Archive rfc552.txt

### DIFF
--- a/www.ietf.org/rfc/rfc552.txt
+++ b/www.ietf.org/rfc/rfc552.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                           Buz Owen
+RFC # 552                                                       SDAC-TIP
+NIC # 17809                                                13 July, 1973
+
+
+                  Single access to Standard Protocols
+
+
+Isn't the idea of a single access protocol simple enough that one could
+be specified, and a socket reserved for it, before the proposed mail
+protocol becomes official?  The result would be that MP could be the
+first protocol implemented under UULP (or whatever it is to be called),
+and the other protocols could be "moved" as soon as any problems in the
+official specifications could be worked out, and at the convenience of
+implementors.
+
+The single access protocol might have the following commands:
+
+    USER
+    PASS
+    ACCT
+    MAIL
+    FTP
+    RJS
+    DRS (?)
+    HELP (?)
+    BYE
+
+following Jim White's idea of nested command and reply spaces.
+
+This doesn't address the question of "what is free", or of the
+interrelationships between the various protocols, but it doesn't make
+those problem any worse, only a little different.
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.            10/99 ]
+
+
+
+
+
+Owen                                                            [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc552.txt](<www.ietf.org/rfc/rfc552.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
