### PR TITLE
Archive rfc5525.txt

### DIFF
--- a/www.ietf.org/rfc/rfc5525.txt
+++ b/www.ietf.org/rfc/rfc5525.txt
@@ -1,0 +1,2579 @@
+
+
+
+
+
+
+Network Working Group                                       T. Dreibholz
+Request for Comments: 5525                  University of Duisburg-Essen
+Category: Experimental                                          J. Mulik
+                                               Delaware State University
+                                                              April 2009
+
+
+             Reliable Server Pooling MIB Module Definition
+
+Status of This Memo
+
+   This memo defines an Experimental Protocol for the Internet
+   community.  It does not specify an Internet standard of any kind.
+   Discussion and suggestions for improvement are requested.
+   Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (c) 2009 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents in effect on the date of
+   publication of this document (http://trustee.ietf.org/license-info).
+   Please review these documents carefully, as they describe your rights
+   and restrictions with respect to this document.
+
+Abstract
+
+   Reliable Server Pooling (RSerPool) is a framework to provide reliable
+   server pooling.  The RSerPool framework consists of two protocols:
+   ASAP (Aggregate Server Access Protocol) and ENRP (Endpoint
+   Handlespace Redundancy Protocol).  This document defines an SMIv2-
+   compliant (Structure of Management Information Version 2) Management
+   Information Base (MIB) module providing access to managed objects in
+   an RSerPool implementation.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Dreibholz & Mulik             Experimental                      [Page 1]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+Table of Contents
+
+   1. Introduction ....................................................2
+   2. The Reliable Server Pooling (RSerPool) Framework ................2
+   3. Conventions .....................................................2
+   4. The Internet-Standard Management Framework ......................2
+   5. Structure of the MIB ............................................3
+      5.1. Access to Managed Objects on ENRP Servers .................10
+      5.2. Access to Managed Objects on Pool Elements ................10
+      5.3. Access to Managed Objects on Pool Users ...................11
+      5.4. Persistency Behavior ......................................11
+   6. Definitions ....................................................11
+   7. Operational Considerations .....................................42
+   8. Security Considerations ........................................42
+   9. IANA Considerations ............................................43
+   10. Acknowledgments ...............................................43
+   11. References ....................................................44
+      11.1. Normative References .....................................44
+      11.2. Informative References ...................................44
+
+1.  Introduction
+
+   This memo defines a Management Information Base (MIB) module that
+   describes managed objects for RSerPool implementations.
+
+2.  The Reliable Server Pooling (RSerPool) Framework
+
+   For a detailed overview of the documents that describe the current
+   Reliable Server Pooling (RSerPool) framework, please refer to
+   [RFC3237], [RFC5351], [RFC5352], [RFC5353], [RFC5354], [RFC5355], and
+   [RFC5356].  A more informal introduction can be found at
+   [RSerPoolPage] as well as in [Dre2006], [LCN2005], and [IJHIT2008].
+
+3.  Conventions
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+4.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+
+
+
+Dreibholz & Mulik             Experimental                      [Page 2]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This memo specifies a MIB
+   module that is compliant to the SMIv2, which is described in STD 58,
+   RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579] and STD 58, RFC 2580
+   [RFC2580].  The textual conventions are compliant to RFC 4001
+   [RFC4001].
+
+5.  Structure of the MIB
+
+   The following diagram illustrates the structure of the MIB.
+
+   Structure of MIB
+
+  +--rserpoolMIB(125)
+     |
+     +--rserpoolMIBObjects(1)
+     |  |
+     |  +--rserpoolENRPServers(1)
+     |  |  |
+     |  |  +--rserpoolENRPTable(1)
+     |  |  |  |
+     |  |  |  +--rserpoolENRPEntry(1)
+     |  |  |     |  Index: rserpoolENRPIndex
+     |  |  |     |
+     |  |  |     +-- ---- Unsigned  rserpoolENRPIndex(1)
+     |  |  |     |        Range: 1..4294967295
+     |  |  |     +-- -R-- String    rserpoolENRPOperationScope(2)
+     |  |  |     |        Textual Conv.: RSerPoolOperationScopeTC
+     |  |  |     |        Size: 0..65535
+     |  |  |     +-- -R-- Unsigned  rserpoolENRPIdentifier(3)
+     |  |  |     |        Textual Conv.: RSerPoolENRPServerIdentifierTC
+     |  |  |     |        Range: 1..4294967295
+     |  |  |     +-- -RW- String    rserpoolENRPDescription(4)
+     |  |  |     |        Size: 0..255
+     |  |  |     +-- -R-- TimeTicks rserpoolENRPUptime(5)
+     |  |  |     +-- -R-- Unsigned  rserpoolENRPPort(6)
+     |  |  |     |        Textual Conv.: InetPortNumber
+     |  |  |     |        Range: 0..65535
+     |  |  |     +-- -R-- Unsigned  rserpoolENRPASAPAnnouncePort(7)
+     |  |  |     |        Textual Conv.: InetPortNumber
+     |  |  |     |        Range: 0..65535
+     |  |  |     +-- -R-- EnumVal   rserpoolENRPASAPAnnounceAddrType(8)
+     |  |  |     |        Textual Conv.: InetAddressType
+     |  |  |     |        Values: ipv4(1), ipv6(2)
+     |  |  |     +-- -R-- String    rserpoolENRPASAPAnnounceAddr(9)
+     |  |  |     |        Textual Conv.: InetAddress
+     |  |  |     |        Size: 4 | 16
+
+
+
+
+Dreibholz & Mulik             Experimental                      [Page 3]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+     |  |  |     +-- -R-- Unsigned  rserpoolENRPENRPAnnouncePort(10)
+     |  |  |     |        Textual Conv.: InetPortNumber
+     |  |  |     |        Range: 0..65535
+     |  |  |     +-- -R-- EnumVal   rserpoolENRPENRPAnnounceAddrType(11)
+     |  |  |     |        Textual Conv.: InetAddressType
+     |  |  |     |        Values: ipv4(1), ipv6(2)
+     |  |  |     +-- -R-- String    rserpoolENRPENRPAnnounceAddr(12)
+     |  |  |              Textual Conv.: InetAddress
+     |  |  |              Size: 4 | 16
+     |  |  |
+     |  |  +--rserpoolENRPPoolTable(3)
+     |  |  |  |
+     |  |  |  +--rserpoolENRPPoolEntry(1)
+     |  |  |     |  Index: rserpoolENRPIndex, rserpoolENRPPoolIndex
+     |  |  |     |
+     |  |  |     +-- ---- Unsigned  rserpoolENRPPoolIndex(1)
+     |  |  |     |        Range: 1..4294967295
+     |  |  |     +-- -R-- String    rserpoolENRPPoolHandle(2)
+     |  |  |              Textual Conv.: RSerPoolPoolHandleTC
+     |  |  |              Size: 0..65535
+     |  |  |
+     |  |  +--rserpoolENRPPoolElementTable(4)
+     |  |  |  |
+     |  |  |  +--rserpoolENRPPoolElementEntry(1)
+     |  |  |     |  Index: rserpoolENRPIndex, rserpoolENRPPoolIndex,
+     |  |  |     |         rserpoolENRPPoolElementIndex
+     |  |  |     |
+     |  |  |     +-- ---- Unsigned  rserpoolENRPPoolElementIndex(1)
+     |  |  |     |        Range: 1..4294967295
+     |  |  |     +-- -R-- Unsigned  rserpoolENRPPoolElementID(2)
+     |  |  |     |        Textual Conv.: RserpoolPoolElementIdentifierTC
+     |  |  |     |        Range: 1..4294967295
+     |  |  |     +-- -R-- Unsigned  rserpoolENRPASAPTransportPort(3)
+     |  |  |     |        Textual Conv.: InetPortNumber
+     |  |  |     |        Range: 0..65535
+     |  |  |     +-- -R-- Unsigned  rserpoolENRPUserTransportProto(4)
+     |  |  |     |        Range: 0..255
+     |  |  |     +-- -R-- Unsigned  rserpoolENRPUserTransportPort(5)
+     |  |  |     |        Textual Conv.: InetPortNumber
+     |  |  |     |        Range: 0..65535
+     |  |  |     +-- -R-- EnumVal   rserpoolENRPUserTransportUse(6)
+     |  |  |     |        Textual Conv.: RSerPoolTransportUseTypeTC
+     |  |  |     |        Values: dataOnly(0), dataPlusControl(1)
+     |  |  |     +-- -R-- Unsigned  rserpoolENRPPolicyID(7)
+     |  |  |     |        Textual Conv.: RSerPoolPolicyIdentifierTC
+     |  |  |     |        Range: 1..4294967295
+     |  |  |     +-- -R-- String    rserpoolENRPPolicyDescription(8)
+     |  |  |     |        Size: 0..255
+
+
+
+Dreibholz & Mulik             Experimental                      [Page 4]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+     |  |  |     +-- -R-- Unsigned  rserpoolENRPPolicyWeight(9)
+     |  |  |     |        Textual Conv.: RSerPoolPolicyWeightTC
+     |  |  |     |        Range: 0..4294967295
+     |  |  |     +-- -R-- Unsigned  rserpoolENRPPolicyLoad(10)
+     |  |  |     |        Textual Conv.: RSerPoolPolicyLoadTC
+     |  |  |     |        Range: 0..4294967295
+     |  |  |     +-- -R-- Unsigned  rserpoolENRPPolicyLoadDeg(11)
+     |  |  |     |        Textual Conv.: RSerPoolPolicyLoadTC
+     |  |  |     |        Range: 0..4294967295
+     |  |  |     +-- -R-- TimeTicks rserpoolENRPRegistrationLife(12)
+     |  |  |     +-- -R-- Unsigned  rserpoolENRPHomeENRPServer(13)
+     |  |  |              Textual Conv.: RSerPoolENRPServerIdentifierTC
+     |  |  |              Range: 1..4294967295
+     |  |  |
+     |  |  +--rserpoolENRPASAPAddrTable(5)
+     |  |  |  |
+     |  |  |  +--rserpoolENRPASAPAddrTableEntry(1)
+     |  |  |     |  Index: rserpoolENRPIndex, rserpoolENRPPoolIndex,
+     |  |  |     |         rserpoolENRPPoolElementIndex,
+     |  |  |     |         rserpoolENRPASAPAddrTableIndex
+     |  |  |     |
+     |  |  |     +-- ---- Unsigned  rserpoolENRPASAPAddrTableIndex(1)
+     |  |  |     |        Range: 1..4294967295
+     |  |  |     +-- -R-- EnumVal   rserpoolENRPASAPL3Type(2)
+     |  |  |     |        Textual Conv.: InetAddressType
+     |  |  |     |        Values: ipv4(1), ipv6(2)
+     |  |  |     +-- -R-- String    rserpoolENRPASAPL3Addr(3)
+     |  |  |              Textual Conv.: InetAddress
+     |  |  |              Size: 4 | 16
+     |  |  |
+     |  |  +--rserpoolENRPUserAddrTable(6)
+     |  |  |  |
+     |  |  |  +--rserpoolENRPUserAddrTableEntry(1)
+     |  |  |     |  Index: rserpoolENRPIndex, rserpoolENRPPoolIndex,
+     |  |  |     |         rserpoolENRPPoolElementIndex,
+     |  |  |     |         rserpoolENRPUserAddrTableIndex
+     |  |  |     |
+     |  |  |     +-- ---- Unsigned  rserpoolENRPUserAddrTableIndex(1)
+     |  |  |     |        Range: 1..4294967295
+     |  |  |     +-- -R-- EnumVal   rserpoolENRPUserL3Type(2)
+     |  |  |     |        Textual Conv.: InetAddressType
+     |  |  |     |        Values: unknown(0), ipv4(1), ipv6(2)
+     |  |  |     +-- -R-- String    rserpoolENRPUserL3Addr(3)
+     |  |  |     |        Textual Conv.: InetAddress
+     |  |  |     |        Size: 0 | 4 | 16
+     |  |  |     +-- -R-- String    rserpoolENRPUserL3Opaque(4)
+     |  |  |              Textual Conv.: RSerPoolOpaqueAddressTC
+     |  |  |              Size: 0..65535
+
+
+
+Dreibholz & Mulik             Experimental                      [Page 5]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+     |  |  |
+     |  |  +--rserpoolENRPENRPAddrTable(7)
+     |  |  |  |
+     |  |  |  +--rserpoolENRPENRPAddrTableEntry(1)
+     |  |  |     |  Index: rserpoolENRPIndex,
+     |  |  |     |         rserpoolENRPENRPAddrTableIndex
+     |  |  |     |
+     |  |  |     +-- ---- Unsigned  rserpoolENRPENRPAddrTableIndex(1)
+     |  |  |     |        Range: 1..4294967295
+     |  |  |     +-- -R-- EnumVal   rserpoolENRPENRPL3Type(2)
+     |  |  |     |        Textual Conv.: InetAddressType
+     |  |  |     |        Values: ipv4(1), ipv6(2)
+     |  |  |     +-- -R-- String    rserpoolENRPENRPL3Addr(3)
+     |  |  |              Textual Conv.: InetAddress
+     |  |  |              Size: 4 | 16
+     |  |  |
+     |  |  +--rserpoolENRPPeerTable(8)
+     |  |  |  |
+     |  |  |  +--rserpoolENRPPeerEntry(1)
+     |  |  |     |  Index: rserpoolENRPPeerIndex
+     |  |  |     |
+     |  |  |     +-- ---- Unsigned  rserpoolENRPPeerIndex(1)
+     |  |  |     |        Range: 1..4294967295
+     |  |  |     +-- -R-- Unsigned  rserpoolENRPPeerIdentifier(2)
+     |  |  |     |        Textual Conv.: RSerPoolENRPServerIdentifierTC
+     |  |  |     |        Range: 1..4294967295
+     |  |  |     +-- -R-- Unsigned  rserpoolENRPPeerPort(3)
+     |  |  |     |        Textual Conv.: InetPortNumber
+     |  |  |     |        Range: 0..65535
+     |  |  |     +-- -R-- TimeTicks rserpoolENRPPeerLastHeard(4)
+     |  |  |
+     |  |  +--rserpoolENRPPeerAddrTable(9)
+     |  |     |
+     |  |     +--rserpoolENRPPeerAddrTableEntry(1)
+     |  |        |  Index: rserpoolENRPPeerIndex,
+     |  |  |     |         rserpoolENRPPeerAddrTableIndex
+     |  |        |
+     |  |        +-- ---- Unsigned  rserpoolENRPPeerAddrTableIndex(1)
+     |  |        |        Range: 1..4294967295
+     |  |        +-- -R-- EnumVal   rserpoolENRPPeerL3Type(2)
+     |  |        |        Textual Conv.: InetAddressType
+     |  |        |        Values: ipv4(1), ipv6(2)
+     |  |        +-- -R-- String    rserpoolENRPPeerL3Addr(3)
+     |  |                 Textual Conv.: InetAddress
+     |  |                 Size: 4 | 16
+     |  |
+     |  +--rserpoolPoolElements(2)
+     |  |  |
+
+
+
+Dreibholz & Mulik             Experimental                      [Page 6]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+     |  |  +--rserpoolPETable(1)
+     |  |  |  |
+     |  |  |  +--rserpoolPEEntry(1)
+     |  |  |     |  Index: rserpoolPEIndex
+     |  |  |     |
+     |  |  |     +-- ---- Unsigned  rserpoolPEIndex(1)
+     |  |  |     |        Range: 1..4294967295
+     |  |  |     +-- -R-- String    rserpoolPEOperationScope(2)
+     |  |  |     |        Textual Conv.: RSerPoolOperationScopeTC
+     |  |  |     |        Size: 0..65535
+     |  |  |     +-- -RW- String    rserpoolPEPoolHandle(3)
+     |  |  |     |        Textual Conv.: RSerPoolPoolHandleTC
+     |  |  |     |        Size: 0..65535
+     |  |  |     +-- -R-- Unsigned  rserpoolPEIdentifier(4)
+     |  |  |     |        Textual Conv.: RserpoolPoolElementIdentifierTC
+     |  |  |     |        Range: 1..4294967295
+     |  |  |     +-- -RW- String    rserpoolPEDescription(5)
+     |  |  |     |        Size: 0..255
+     |  |  |     +-- -R-- TimeTicks rserpoolPEUptime(6)
+     |  |  |     +-- -R-- Unsigned  rserpoolPEASAPTransportPort(7)
+     |  |  |     |        Textual Conv.: InetPortNumber
+     |  |  |     |        Range: 0..65535
+     |  |  |     +-- -R-- Unsigned  rserpoolPEUserTransportProto(8)
+     |  |  |     |        Range: 0..255
+     |  |  |     +-- -R-- Unsigned  rserpoolPEUserTransportPort(9)
+     |  |  |     |        Textual Conv.: InetPortNumber
+     |  |  |     |        Range: 0..65535
+     |  |  |     +-- -R-- EnumVal   rserpoolPEUserTransportUse(10)
+     |  |  |     |        Textual Conv.: RSerPoolTransportUseTypeTC
+     |  |  |     |        Values: dataOnly(0), dataPlusControl(1)
+     |  |  |     +-- -RW- Unsigned  rserpoolPEPolicyID(11)
+     |  |  |     |        Textual Conv.: RSerPoolPolicyIdentifierTC
+     |  |  |     |        Range: 1..4294967295
+     |  |  |     +-- -RW- String    rserpoolPEPolicyDescription(12)
+     |  |  |     |        Size: 0..255
+     |  |  |     +-- -RW- Unsigned  rserpoolPEPolicyWeight(13)
+     |  |  |     |        Textual Conv.: RSerPoolPolicyWeightTC
+     |  |  |     |        Range: 0..4294967295
+     |  |  |     +-- -R-- Unsigned  rserpoolPEPolicyLoad(14)
+     |  |  |     |        Textual Conv.: RSerPoolPolicyLoadTC
+     |  |  |     |        Range: 0..4294967295
+     |  |  |     +-- -RW- Unsigned  rserpoolPEPolicyLoadDeg(15)
+     |  |  |     |        Textual Conv.: RSerPoolPolicyLoadTC
+     |  |  |     |        Range: 0..4294967295
+     |  |  |     +-- -RW- TimeTicks rserpoolPERegistrationLife(16)
+     |  |  |     +-- -R-- Unsigned  rserpoolPEHomeENRPServer(17)
+     |  |  |              Textual Conv.: RSerPoolENRPServerIdentifierTC
+     |  |  |              Range: 1..4294967295
+
+
+
+Dreibholz & Mulik             Experimental                      [Page 7]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+     |  |  |
+     |  |  +--rserpoolPEASAPAddrTable(2)
+     |  |  |  |
+     |  |  |  +--rserpoolPEASAPAddrTableEntry(1)
+     |  |  |     |  Index: rserpoolPEIndex, rserpoolPEASAPAddrTableIndex
+     |  |  |     |
+     |  |  |     +-- ---- Unsigned  rserpoolPEASAPAddrTableIndex(1)
+     |  |  |     |        Range: 1..4294967295
+     |  |  |     +-- -R-- EnumVal   rserpoolPEASAPL3Type(2)
+     |  |  |     |        Textual Conv.: InetAddressType
+     |  |  |     |        Values: ipv4(1), ipv6(2)
+     |  |  |     +-- -R-- String    rserpoolPEASAPL3Addr(3)
+     |  |  |              Textual Conv.: InetAddress
+     |  |  |              Size: 4 | 16
+     |  |  |
+     |  |  +--rserpoolPEUserAddrTable(6)
+     |  |     |
+     |  |     +--rserpoolPEUserAddrTableEntry(1)
+     |  |        |  Index: rserpoolPEIndex, rserpoolPEUserAddrTableIndex
+     |  |        |
+     |  |        +-- ---- Unsigned  rserpoolPEUserAddrTableIndex(1)
+     |  |        |        Range: 1..4294967295
+     |  |        +-- -R-- EnumVal   rserpoolPEUserL3Type(2)
+     |  |        |        Textual Conv.: InetAddressType
+     |  |        |        Values: unknown(0), ipv4(1), ipv6(2)
+     |  |        +-- -R-- String    rserpoolPEUserL3Addr(3)
+     |  |        |        Textual Conv.: InetAddress
+     |  |        |        Size: 0 | 4 | 16
+     |  |        +-- -R-- String    rserpoolPEUserL3Opaque(4)
+     |  |                 Textual Conv.: RSerPoolOpaqueAddressTC
+     |  |                 Size: 0..65535
+     |  |
+     |  +--rserpoolPoolUsers(3)
+     |     |
+     |     +--rserpoolPUTable(1)
+     |        |
+     |        +--rserpoolPUEntry(1)
+     |           |  Index: rserpoolPUIndex
+     |           |
+     |           +-- ---- Unsigned  rserpoolPUIndex(1)
+     |           |        Range: 1..4294967295
+     |           +-- -R-- String    rserpoolPUOperationScope(2)
+     |           |        Textual Conv.: RSerPoolOperationScopeTC
+     |           |        Size: 0..65535
+     |           +-- -RW- String    rserpoolPUPoolHandle(3)
+     |           |        Textual Conv.: RSerPoolPoolHandleTC
+     |           |        Size: 0..65535
+     |           +-- -RW- String    rserpoolPUDescription(4)
+
+
+
+Dreibholz & Mulik             Experimental                      [Page 8]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+     |           |        Size: 0..255
+     |           +-- -R-- TimeTicks rserpoolPUUptime(5)
+     |
+     +--rserpoolMIBConformance(2)
+        |
+        +--rserpoolMIBCompliances(1)
+        |  |
+        |  +--rserpoolMIBCompliance(1)
+        |
+        +--rserpoolMIBGroups(2)
+           |
+           +--rserpoolENRPGroup(1)
+           +--rserpoolPEGroup(2)
+           +--rserpoolPUGroup(3)
+
+   As the figure shows, the MIB consists of three main branches:
+   "rserpoolENRPServers", "rserpoolPoolElements", and
+   "rserpoolPoolUsers".  The first branch, "rserpoolENRPServers", is
+   used to access managed objects in the set of ENRP servers running on
+   a given host.  While it is assumed that it does not make much sense
+   to run multiple ENRP servers for the same operation scope on one
+   host, running multiple ENRP servers for different operation scopes is
+   very likely when the ENRP server processes run on routers.
+   Therefore, the MIB has to be able to manage multiple ENRP servers on
+   the same host.
+
+   "rserpoolPoolElements" is used to access managed objects in the set
+   of pool elements that are running on a given host.
+
+   The third branch, "rserpoolPoolUsers", is used to access managed
+   objects in the set of pool users that are running on a given host.
+
+   Note: "rserpoolENRPServers" is filled on hosts running ENRP server
+   instances, "rserpoolPoolElements" is filled on hosts running pool
+   element instances, and "rserpoolPoolUsers" is filled on hosts running
+   pool user instances.  Of course, multiple different components may
+   run on the same host, which leads to filling of multiple different
+   branches.
+
+   In fact, the structure of the three branches is very similar.
+   Because the other two branches are so similar, we describe only the
+   first branch in detail, and provide a summary description of the
+   second and third branch.  We now proceed with a description of the
+   branches.
+
+
+
+
+
+
+
+Dreibholz & Mulik             Experimental                      [Page 9]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+5.1.  Access to Managed Objects on ENRP Servers
+
+   The first branch describes managed objects at a set of ENRP servers.
+   Any given ENRP server of this set will, at a certain moment in time,
+   have registration information for a set of active pools.  Each of
+   these pools in turn may have a list of pool elements that are
+   registered under that pool.  To allow this information to be
+   retrieved via SNMP, the ERNP server branch of the RSerPool MIB uses
+   the table-in-table technique described in [SNMPMIBS].
+
+   Specifically, the ENRP servers branch creates four levels of nesting,
+   as indicated in the following diagram:
+
+   Nesting of the ENRP Server Branch
+
+   Nesting Structure:
+
+    Level 1: rserpoolENRPTable
+
+    Level 2:    rserpoolENRPPoolTable
+    Level 3:       rserpoolENRPPoolElementTable
+    Level 4:          rserpoolENRPASAPAddrTable
+                      rserpoolENRPUserAddrTable
+
+    Level 2:    rserpoolENRPENRPAddrTable
+
+    Level 2:    rserpoolENRPPeerTable
+    Level 3:       rserpoolENRPPeerAddrTable
+
+5.2.  Access to Managed Objects on Pool Elements
+
+   The construction of the Pool Elements branch is very similar to the
+   pool elements table of the ENRP servers branch.  But instead of
+   grouping the pool elements into pools (which does not make sense
+   here), the pool elements table is the top of the hierarchy, and each
+   pool element entry specifies its operation scope and pool handle.
+
+   That is, the nesting structure is as follows:
+
+   Nesting of the Pool Elements Branch
+
+    Level 1:    rserpoolPETable
+    Level 2:       rserpoolPEASAPAddrTable
+                   rserpoolPEUserAddrTable
+
+
+
+
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 10]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+5.3.  Access to Managed Objects on Pool Users
+
+   For the Pool Users branch, it is only necessary to list the pool user
+   instances, including their operation scope and pool handle.
+
+5.4.  Persistency Behavior
+
+   Upon changes of writable objects, an implementation SHOULD store the
+   new values in a persistent manner if it has the capability to do
+   this.  An implementation SHOULD use these stored values upon reset or
+   reinitialization.
+
+6.  Definitions
+
+RSERPOOL-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+   MODULE-IDENTITY, OBJECT-TYPE, experimental,
+   TimeTicks, Unsigned32
+      FROM SNMPv2-SMI
+   TEXTUAL-CONVENTION
+      FROM SNMPv2-TC
+   MODULE-COMPLIANCE, OBJECT-GROUP
+      FROM SNMPv2-CONF
+   InetAddressType, InetAddress, InetPortNumber
+      FROM INET-ADDRESS-MIB;
+
+-- ## Module definition ###########################################
+rserpoolMIB MODULE-IDENTITY
+   LAST-UPDATED
+      "200904070000Z" -- April 07, 2009
+   ORGANIZATION
+      "IEM-TdR, UNIVERSITY OF DUISBURG-ESSEN"
+   CONTACT-INFO
+      " THOMAS-DREIBHOLZ
+
+         Postal:  University of Duisburg-Essen
+                  Institute for Experimental Mathematics
+                  Ellernstrasse 29
+                  D-45326 Essen
+                  Germany
+         Phone:   +49-201-183-7637
+         Fax:     +49-201-183-7673
+         Email:   dreibh@iem.uni-due.de
+
+
+
+
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 11]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+      JAIWANT-MULIK
+
+         Postal:  Delaware State University
+                  CIS Department
+                  1200 N. DuPont Hw
+                  Dover, DE
+                  USA 19904
+         Phone:   +1-302-857-7910
+         Fax:     +1-302-857-6552
+         Email:   jaiwant@mulik.com"
+      DESCRIPTION
+         "The MIB module for managing an RSerPool implementation.
+
+          Copyright (c) 2009 IETF Trust and the persons identified as
+          authors of the code.  All rights reserved.
+
+          Redistribution and use in source and binary forms, with or
+          without modification, are permitted provided that the
+          following conditions are met:
+
+          - Redistributions of source code must retain the above
+            copyright notice, this list of conditions and the
+            following disclaimer.
+
+          - Redistributions in binary form must reproduce the above
+            copyright notice, this list of conditions and the
+            following disclaimer in the documentation and/or other
+            materials provided with the distribution.
+
+          - Neither the name of Internet Society, IETF or IETF Trust,
+            nor the names of specific contributors, may be used to
+            endorse or promote products derived from this software
+            without specific prior written permission.
+
+          THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+          CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+          INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+          MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+          DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+          CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+          SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+          NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+          LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+          HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+          CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+          OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+          SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+          DAMAGE.
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 12]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+          This version of this MIB module is part of RFC 5525;
+          see the RFC itself for full legal notices."
+
+      REVISION
+         "200904070000Z" -- April 07, 2009
+      DESCRIPTION
+         "This version of the MIB module is published as RFC 5525"
+      ::= { experimental 125 }
+
+-- ## RSerPool type definitions ###################################
+RSerPoolENRPServerIdentifierTC ::= TEXTUAL-CONVENTION
+   DISPLAY-HINT "x"
+   STATUS       current
+   DESCRIPTION  "The ID of an ENRP server"
+   SYNTAX       Unsigned32 (1..4294967295)
+
+RSerPoolOperationScopeTC ::= TEXTUAL-CONVENTION
+   DISPLAY-HINT "1024t"
+   STATUS       current
+   DESCRIPTION  "The ID of an operation scope"
+   SYNTAX       OCTET STRING (SIZE (0..65535))
+
+RSerPoolPoolHandleTC ::= TEXTUAL-CONVENTION
+   DISPLAY-HINT "1024t"
+   STATUS       current
+   DESCRIPTION  "The pool handle"
+   SYNTAX       OCTET STRING (SIZE (0..65535))
+
+RserpoolPoolElementIdentifierTC ::= TEXTUAL-CONVENTION
+   DISPLAY-HINT "x"
+   STATUS       current
+   DESCRIPTION  "The pool element ID"
+   SYNTAX       Unsigned32 (1..4294967295)
+
+RSerPoolPolicyIdentifierTC ::= TEXTUAL-CONVENTION
+   DISPLAY-HINT "x"
+   STATUS       current
+   DESCRIPTION  "The ID of the pool policy"
+   SYNTAX       Unsigned32 (1..4294967295)
+
+RSerPoolPolicyLoadTC ::= TEXTUAL-CONVENTION
+   DISPLAY-HINT "d"
+   STATUS       current
+   DESCRIPTION  "The load status of a pool element"
+   SYNTAX       Unsigned32 (0..4294967295)
+
+
+
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 13]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+RSerPoolPolicyWeightTC ::= TEXTUAL-CONVENTION
+   DISPLAY-HINT "d"
+   STATUS       current
+   DESCRIPTION  "The weight of a pool element"
+   SYNTAX       Unsigned32 (0..4294967295)
+
+RSerPoolTransportUseTypeTC ::= TEXTUAL-CONVENTION
+   STATUS       current
+   DESCRIPTION "The transport use of a pool element"
+   SYNTAX       INTEGER {
+      dataOnly(0),
+      dataPlusControl(1)
+   }
+
+RSerPoolOpaqueAddressTC ::= TEXTUAL-CONVENTION
+   DISPLAY-HINT "1024t"
+   STATUS       current
+   DESCRIPTION  "Opaque address"
+   SYNTAX       OCTET STRING  (SIZE (0..65535))
+
+-- ## Top-level definitions #######################################
+rserpoolMIBObjects     OBJECT IDENTIFIER ::= { rserpoolMIB 1 }
+rserpoolMIBConformance OBJECT IDENTIFIER ::= { rserpoolMIB 2 }
+
+rserpoolENRPServers    OBJECT IDENTIFIER ::= { rserpoolMIBObjects 1 }
+rserpoolPoolElements   OBJECT IDENTIFIER ::= { rserpoolMIBObjects 2 }
+rserpoolPoolUsers      OBJECT IDENTIFIER ::= { rserpoolMIBObjects 3 }
+
+-- ################################################################
+-- #### ENRP Servers Section                                   ####
+-- ################################################################
+
+-- ## Definition of the ENRP server table #########################
+rserpoolENRPTable OBJECT-TYPE
+   SYNTAX     SEQUENCE OF RserpoolENRPEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "The table listing of ENRP servers."
+   ::= { rserpoolENRPServers 1 }
+
+rserpoolENRPEntry OBJECT-TYPE
+   SYNTAX     RserpoolENRPEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+
+
+
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 14]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+   DESCRIPTION
+      "An ENRP server entry in the table listing of ENRP
+      servers."
+   INDEX { rserpoolENRPIndex }
+   ::= { rserpoolENRPTable 1 }
+
+RserpoolENRPEntry ::= SEQUENCE {
+rserpoolENRPIndex                Unsigned32,
+rserpoolENRPOperationScope       RSerPoolOperationScopeTC,
+rserpoolENRPIdentifier           RSerPoolENRPServerIdentifierTC,
+rserpoolENRPDescription          OCTET STRING,
+rserpoolENRPUptime               TimeTicks,
+rserpoolENRPPort                 InetPortNumber,
+rserpoolENRPASAPAnnouncePort     InetPortNumber,
+rserpoolENRPASAPAnnounceAddrType InetAddressType,
+rserpoolENRPASAPAnnounceAddr     InetAddress,
+rserpoolENRPENRPAnnouncePort     InetPortNumber,
+rserpoolENRPENRPAnnounceAddrType InetAddressType,
+rserpoolENRPENRPAnnounceAddr     InetAddress }
+
+rserpoolENRPIndex OBJECT-TYPE
+   SYNTAX     Unsigned32 (1..4294967295)
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "An integer to uniquely identify an ENRP server."
+   ::= { rserpoolENRPEntry 1 }
+
+rserpoolENRPOperationScope OBJECT-TYPE
+   SYNTAX     RSerPoolOperationScopeTC
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The definition of the operation scope of this ENRP server."
+   REFERENCE
+      "Section 1.2 of RFC 3237 defines the term operation scope."
+   ::= { rserpoolENRPEntry 2 }
+
+rserpoolENRPIdentifier OBJECT-TYPE
+   SYNTAX     RSerPoolENRPServerIdentifierTC
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The ENRP server identifier of this ENRP server."
+   REFERENCE
+      "Section 3.1 of RFC 5351 explains the ENRP server identifier."
+   ::= { rserpoolENRPEntry 3 }
+
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 15]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+rserpoolENRPDescription OBJECT-TYPE
+   SYNTAX     OCTET STRING (SIZE (0..255))
+   MAX-ACCESS read-write
+   STATUS     current
+   DESCRIPTION
+      "A textual description of this ENRP server, e.g., its location
+      and a contact address of its administrator.
+
+      This object SHOULD be maintained in a persistent manner."
+   ::= { rserpoolENRPEntry 4 }
+
+rserpoolENRPUptime OBJECT-TYPE
+   SYNTAX     TimeTicks
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The ENRP service uptime of this ENRP server."
+   ::= { rserpoolENRPEntry 5 }
+
+rserpoolENRPPort OBJECT-TYPE
+   SYNTAX     InetPortNumber
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The Stream Control Transmission Protocol (SCTP) port number of
+      the ENRP protocol endpoint of this ENRP server."
+   REFERENCE
+      "RFC 5353 defines the ENRP protocol."
+   ::= { rserpoolENRPEntry 6 }
+
+rserpoolENRPASAPAnnouncePort OBJECT-TYPE
+   SYNTAX     InetPortNumber
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The destination UDP port number to which ASAP multicast announce
+      messages are sent."
+   REFERENCE
+      "Section 3.2 of RFC 5351 explains the server-discovery mechanism
+      using ASAP announces."
+   ::= { rserpoolENRPEntry 7 }
+
+rserpoolENRPASAPAnnounceAddrType OBJECT-TYPE
+   SYNTAX     InetAddressType { ipv4(1), ipv6(2) }
+   MAX-ACCESS read-only
+   STATUS     current
+
+
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 16]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+   DESCRIPTION
+      "The network-layer protocol over which ASAP multicast announce
+      messages are sent."
+   REFERENCE
+      "Section 3.2 of RFC 5351 explains the server-discovery mechanism
+      using ASAP announces."
+   ::= { rserpoolENRPEntry 8 }
+
+rserpoolENRPASAPAnnounceAddr OBJECT-TYPE
+   SYNTAX     InetAddress (SIZE(4|16))
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The destination IP multicast address to which ASAP multicast
+      announce messages are sent.  The type of this address is
+      given in rserpoolENRPASAPAnnounceAddrType."
+   REFERENCE
+      "Section 3.2 of RFC 5351 explains the server-discovery mechanism
+      using ASAP announces."
+   ::= { rserpoolENRPEntry 9 }
+
+rserpoolENRPENRPAnnouncePort OBJECT-TYPE
+   SYNTAX     InetPortNumber
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The destination UDP port number to which ENRP multicast announce
+      messages are sent."
+   REFERENCE
+      "Section 3.1 of RFC 5353 explains the ENRP multicast
+      announce mechanism."
+   ::= { rserpoolENRPEntry 10 }
+
+rserpoolENRPENRPAnnounceAddrType OBJECT-TYPE
+   SYNTAX     InetAddressType { ipv4(1), ipv6(2) }
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The network-layer protocol over which ENRP multicast announce
+      messages are sent."
+   REFERENCE
+      "Section 3.1 of RFC 5353 explains the ENRP multicast
+      announce mechanism."
+   ::= { rserpoolENRPEntry 11 }
+
+rserpoolENRPENRPAnnounceAddr OBJECT-TYPE
+   SYNTAX     InetAddress (SIZE(4|16))
+   MAX-ACCESS read-only
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 17]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+   STATUS     current
+   DESCRIPTION
+      "The destination multicast IP address to which ENRP multicast
+      announce messages are sent.  The type of this address
+      is given in rserpoolENRPENRPAnnounceAddrType."
+   REFERENCE
+      "Section 3.1 of RFC 5353 explains the ENRP multicast
+      announce mechanism."
+   ::= { rserpoolENRPEntry 12 }
+
+-- ## Definition of the pool table ################################
+rserpoolENRPPoolTable OBJECT-TYPE
+   SYNTAX     SEQUENCE OF RserpoolENRPPoolEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "The table listing of pools."
+   ::= { rserpoolENRPServers 3 }
+
+rserpoolENRPPoolEntry OBJECT-TYPE
+   SYNTAX     RserpoolENRPPoolEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "The pool entry in the table listing of pools."
+   INDEX { rserpoolENRPIndex, rserpoolENRPPoolIndex }
+   ::= { rserpoolENRPPoolTable 1 }
+
+RserpoolENRPPoolEntry ::= SEQUENCE {
+   rserpoolENRPPoolIndex  Unsigned32,
+   rserpoolENRPPoolHandle RSerPoolPoolHandleTC }
+
+rserpoolENRPPoolIndex OBJECT-TYPE
+   SYNTAX     Unsigned32 (1..4294967295)
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "An integer to uniquely identify a pool."
+   ::= { rserpoolENRPPoolEntry 1 }
+
+rserpoolENRPPoolHandle OBJECT-TYPE
+   SYNTAX     RSerPoolPoolHandleTC
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The pool handle of this pool."
+   REFERENCE
+      "Section 1.2 of RFC 3237 defines the term pool handle."
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 18]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+   ::= { rserpoolENRPPoolEntry 2 }
+
+-- ## Definition of the pool element table ########################
+rserpoolENRPPoolElementTable OBJECT-TYPE
+   SYNTAX     SEQUENCE OF RserpoolENRPPoolElementEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "The table listing of pool elements."
+   ::= { rserpoolENRPServers 4 }
+
+rserpoolENRPPoolElementEntry OBJECT-TYPE
+   SYNTAX     RserpoolENRPPoolElementEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "A pool element in the table listing of pool elements."
+   INDEX {
+      rserpoolENRPIndex,
+      rserpoolENRPPoolIndex,
+      rserpoolENRPPoolElementIndex }
+   ::= { rserpoolENRPPoolElementTable 1 }
+
+RserpoolENRPPoolElementEntry ::= SEQUENCE {
+   rserpoolENRPPoolElementIndex   Unsigned32,
+   rserpoolENRPPoolElementID      RserpoolPoolElementIdentifierTC,
+   rserpoolENRPASAPTransportPort  InetPortNumber,
+   rserpoolENRPUserTransportProto Unsigned32,
+   rserpoolENRPUserTransportPort  InetPortNumber,
+   rserpoolENRPUserTransportUse   RSerPoolTransportUseTypeTC,
+   rserpoolENRPPolicyID           RSerPoolPolicyIdentifierTC,
+   rserpoolENRPPolicyDescription  OCTET STRING,
+   rserpoolENRPPolicyWeight       RSerPoolPolicyWeightTC,
+   rserpoolENRPPolicyLoad         RSerPoolPolicyLoadTC,
+   rserpoolENRPPolicyLoadDeg      RSerPoolPolicyLoadTC,
+   rserpoolENRPRegistrationLife   TimeTicks,
+   rserpoolENRPHomeENRPServer     RSerPoolENRPServerIdentifierTC }
+
+
+rserpoolENRPPoolElementIndex OBJECT-TYPE
+   SYNTAX     Unsigned32 (1..4294967295)
+   MAX-ACCESS not-accessible
+   STATUS     current
+
+
+
+
+
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 19]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+   DESCRIPTION
+      "An integer to uniquely identify a pool element.  Note,
+      that uniqueness of a pool element identifier in the pool
+      is not enforced; therefore, this index is required here!"
+   ::={ rserpoolENRPPoolElementEntry 1 }
+
+rserpoolENRPPoolElementID OBJECT-TYPE
+   SYNTAX     RserpoolPoolElementIdentifierTC
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The pool element identifier of this pool element."
+   REFERENCE
+      "Section 2.2 of RFC 5351 explains the pool element identifier
+      usage."
+   ::={ rserpoolENRPPoolElementEntry 2 }
+
+rserpoolENRPASAPTransportPort OBJECT-TYPE
+   SYNTAX     InetPortNumber
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The SCTP port number of the ASAP endpoint of this pool
+      element."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the ASAP Transport Parameter of
+      which the port number is given here."
+   ::= { rserpoolENRPPoolElementEntry 3 }
+
+rserpoolENRPUserTransportProto OBJECT-TYPE
+   SYNTAX     Unsigned32 (0..255)
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The transport protocol number of the service endpoint
+      of this pool element."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the User Transport Parameter of
+      which the transport protocol number is given here."
+   ::= { rserpoolENRPPoolElementEntry 4 }
+
+rserpoolENRPUserTransportPort OBJECT-TYPE
+   SYNTAX     InetPortNumber
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The transport protocol's port number of the service
+      endpoint of this pool element."
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 20]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the User Transport Parameter of
+      which the port number is given here."
+   ::= { rserpoolENRPPoolElementEntry 5 }
+
+rserpoolENRPUserTransportUse OBJECT-TYPE
+   SYNTAX     RSerPoolTransportUseTypeTC
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The transport use of the service endpoint of this pool
+      element."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the User Transport Parameter of
+      which the transport use is given here."
+   ::= { rserpoolENRPPoolElementEntry 6 }
+
+rserpoolENRPPolicyID OBJECT-TYPE
+   SYNTAX     RSerPoolPolicyIdentifierTC
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The pool policy of this pool element."
+   REFERENCE
+      "Section 3.8 of RFC 5354 defines the Member Selection Policy
+      Parameter of which the policy identifier is given here."
+   ::= { rserpoolENRPPoolElementEntry 7 }
+
+rserpoolENRPPolicyDescription OBJECT-TYPE
+   SYNTAX     OCTET STRING (SIZE (0..255))
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The textual description of the pool policy of this pool
+      element."
+   ::= { rserpoolENRPPoolElementEntry 8 }
+
+rserpoolENRPPolicyWeight OBJECT-TYPE
+   SYNTAX     RSerPoolPolicyWeightTC
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The pool policy's weight parameter for this pool element."
+   REFERENCE
+      "Section 3.8 of RFC 5354 defines the Member Selection Policy
+      Parameter of which the policy's weight parameter is given here."
+   ::= { rserpoolENRPPoolElementEntry 9 }
+
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 21]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+rserpoolENRPPolicyLoad OBJECT-TYPE
+   SYNTAX     RSerPoolPolicyLoadTC
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The pool policy's load status for this pool element."
+   REFERENCE
+      "Section 3.8 of RFC 5354 defines the Member Selection Policy
+      Parameter of which the policy's load parameter is given here."
+   ::= { rserpoolENRPPoolElementEntry 10 }
+
+rserpoolENRPPolicyLoadDeg OBJECT-TYPE
+   SYNTAX     RSerPoolPolicyLoadTC
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The pool policy's load degradation parameter for this pool
+      element."
+   REFERENCE
+      "Section 3.8 of RFC 5354 defines the Member Selection Policy
+      Parameter of which the policy's load degradation parameter is
+      given here."
+   ::= { rserpoolENRPPoolElementEntry 11 }
+
+rserpoolENRPRegistrationLife OBJECT-TYPE
+   SYNTAX     TimeTicks
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The registration life of this pool element."
+  REFERENCE
+      "Section 3.10 of RFC 5354 defines the Registration Life."
+   ::= { rserpoolENRPPoolElementEntry 12 }
+
+rserpoolENRPHomeENRPServer OBJECT-TYPE
+   SYNTAX     RSerPoolENRPServerIdentifierTC
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The ID of the Home ENRP server of this pool element."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the Home ENRP Server
+      Identifier."
+   ::= { rserpoolENRPPoolElementEntry 13 }
+
+-- ## Definition of the ASAP transport address list table #########
+rserpoolENRPASAPAddrTable OBJECT-TYPE
+   SYNTAX     SEQUENCE OF RserpoolENRPASAPAddrTableEntry
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 22]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "A table listing of all IP addresses of the ASAP transport
+      endpoint."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the ASAP Transport Parameter of
+      which the addresses are listed in this table."
+   ::= { rserpoolENRPServers 5 }
+
+rserpoolENRPASAPAddrTableEntry  OBJECT-TYPE
+   SYNTAX     RserpoolENRPASAPAddrTableEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "An IP address of the ASAP transport endpoint."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the ASAP Transport Parameter of
+      which an address is contained by this entry."
+   INDEX {
+      rserpoolENRPIndex,
+      rserpoolENRPPoolIndex,
+      rserpoolENRPPoolElementIndex,
+      rserpoolENRPASAPAddrTableIndex }
+   ::= { rserpoolENRPASAPAddrTable 1 }
+
+RserpoolENRPASAPAddrTableEntry ::= SEQUENCE {
+   rserpoolENRPASAPAddrTableIndex Unsigned32,
+   rserpoolENRPASAPL3Type         InetAddressType,
+   rserpoolENRPASAPL3Addr         InetAddress }
+
+rserpoolENRPASAPAddrTableIndex OBJECT-TYPE
+   SYNTAX     Unsigned32 (1..4294967295)
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "A unique identifier for the IP address of an ASAP transport
+      endpoint."
+   ::= { rserpoolENRPASAPAddrTableEntry 1 }
+
+rserpoolENRPASAPL3Type OBJECT-TYPE
+   SYNTAX     InetAddressType { ipv4(1), ipv6(2) }
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The network-layer protocol (IPv4 or IPv6) of an IP address of
+      an ASAP transport endpoint."
+   REFERENCE
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 23]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+      "Section 3.10 of RFC 5354 defines the ASAP Transport Parameter of
+      which the network-layer protocol number is given here."
+   ::= { rserpoolENRPASAPAddrTableEntry 2 }
+
+rserpoolENRPASAPL3Addr OBJECT-TYPE
+   SYNTAX     InetAddress (SIZE(4|16))
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The IP address of an ASAP transport endpoint.  The type of
+      this address is given in rserpoolENRPASAPL3Type."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the ASAP Transport Parameter of
+      which the network-layer address (IPv4 or IPv6) is given here."
+   ::= { rserpoolENRPASAPAddrTableEntry 3 }
+
+-- ## Definition of the user transport address list table #########
+rserpoolENRPUserAddrTable OBJECT-TYPE
+   SYNTAX     SEQUENCE OF RserpoolENRPUserAddrTableEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "A table listing of all IP addresses of the user
+      transport endpoint."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the User Transport Parameter of
+      which the addresses are listed in this table."
+   ::= { rserpoolENRPServers 6 }
+
+rserpoolENRPUserAddrTableEntry  OBJECT-TYPE
+   SYNTAX     RserpoolENRPUserAddrTableEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "An IP address of the user transport endpoint."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the User Transport Parameter of
+      which an address is contained by this entry."
+   INDEX {
+      rserpoolENRPIndex,
+      rserpoolENRPPoolIndex,
+      rserpoolENRPPoolElementIndex,
+      rserpoolENRPUserAddrTableIndex }
+   ::= { rserpoolENRPUserAddrTable 1 }
+
+RserpoolENRPUserAddrTableEntry ::= SEQUENCE {
+   rserpoolENRPUserAddrTableIndex Unsigned32,
+   rserpoolENRPUserL3Type         InetAddressType,
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 24]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+   rserpoolENRPUserL3Addr         InetAddress,
+   rserpoolENRPUserL3Opaque       RSerPoolOpaqueAddressTC }
+
+rserpoolENRPUserAddrTableIndex OBJECT-TYPE
+   SYNTAX     Unsigned32 (1..4294967295)
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "A unique identifier for the IP address of a user transport
+      endpoint."
+   ::= { rserpoolENRPUserAddrTableEntry 1 }
+
+rserpoolENRPUserL3Type OBJECT-TYPE
+   SYNTAX     InetAddressType { unknown(0), ipv4(1), ipv6(2) }
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The network-layer protocol (IPv4 or IPv6) of an IP address
+      of a user transport endpoint.  Set to unknown for an opaque
+      address."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the User Transport Parameter of
+      which the network-layer protocol number is given here."
+   ::= { rserpoolENRPUserAddrTableEntry 2 }
+
+rserpoolENRPUserL3Addr OBJECT-TYPE
+   SYNTAX     InetAddress (SIZE(0|4|16))
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The IP address of a user transport endpoint.  The type of
+      this address is given in rserpoolENRPUserL3Type."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the User Transport Parameter of
+      which the network-layer address (IPv4 or IPv6) is given here."
+   ::= { rserpoolENRPUserAddrTableEntry 3 }
+
+rserpoolENRPUserL3Opaque OBJECT-TYPE
+   SYNTAX     RSerPoolOpaqueAddressTC
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The opaque address of a user transport endpoint."
+   REFERENCE
+      "Section 3.16 of RFC 5354 defines the opaque transport address."
+   ::= { rserpoolENRPUserAddrTableEntry 4 }
+
+
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 25]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+-- ## Definition of ENRP address list table #######################
+rserpoolENRPENRPAddrTable OBJECT-TYPE
+   SYNTAX     SEQUENCE OF RserpoolENRPENRPAddrTableEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "A table listing of all IP addresses of the ENRP
+      transport endpoint."
+   ::= { rserpoolENRPServers 7 }
+
+rserpoolENRPENRPAddrTableEntry  OBJECT-TYPE
+   SYNTAX     RserpoolENRPENRPAddrTableEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "An IP address of the ENRP transport endpoint."
+   INDEX {
+      rserpoolENRPIndex,
+      rserpoolENRPENRPAddrTableIndex }
+   ::= { rserpoolENRPENRPAddrTable 1 }
+
+RserpoolENRPENRPAddrTableEntry ::= SEQUENCE {
+   rserpoolENRPENRPAddrTableIndex Unsigned32,
+   rserpoolENRPENRPL3Type         InetAddressType,
+   rserpoolENRPENRPL3Addr         InetAddress }
+
+rserpoolENRPENRPAddrTableIndex OBJECT-TYPE
+   SYNTAX     Unsigned32 (1..4294967295)
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "A unique identifier for the IP address of an ENRP transport
+      endpoint."
+   ::= { rserpoolENRPENRPAddrTableEntry 1 }
+
+rserpoolENRPENRPL3Type OBJECT-TYPE
+   SYNTAX     InetAddressType { ipv4(1), ipv6(2) }
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The network-layer protocol (IPv4 or IPv6) of an IP address of
+      an ENRP transport endpoint."
+   REFERENCE
+      "RFC 5353 defines the ENRP protocol."
+   ::= { rserpoolENRPENRPAddrTableEntry 2 }
+
+
+
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 26]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+rserpoolENRPENRPL3Addr OBJECT-TYPE
+   SYNTAX     InetAddress (SIZE(4|16))
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The IP address of an ENRP transport endpoint.  The type of
+      this address is given in rserpoolENRPENRPL3Type."
+   REFERENCE
+      "RFC 5353 defines the ENRP protocol."
+   ::= { rserpoolENRPENRPAddrTableEntry 3 }
+
+-- ## Definition of peer table ####################################
+rserpoolENRPPeerTable OBJECT-TYPE
+   SYNTAX     SEQUENCE OF RserpoolENRPPeerEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "The table listing of a peer table."
+   ::= { rserpoolENRPServers 8 }
+
+rserpoolENRPPeerEntry OBJECT-TYPE
+   SYNTAX     RserpoolENRPPeerEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "A peer entry in the table listing of a peer table."
+   INDEX { rserpoolENRPPeerIndex }
+   ::= { rserpoolENRPPeerTable 1 }
+
+RserpoolENRPPeerEntry ::= SEQUENCE {
+   rserpoolENRPPeerIndex      Unsigned32,
+   rserpoolENRPPeerIdentifier RSerPoolENRPServerIdentifierTC,
+   rserpoolENRPPeerPort       InetPortNumber,
+   rserpoolENRPPeerLastHeard  TimeTicks }
+
+rserpoolENRPPeerIndex OBJECT-TYPE
+   SYNTAX     Unsigned32 (1..4294967295)
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "A unique identifier for a peer entry in the table
+      listing of a peer table."
+   ::= { rserpoolENRPPeerEntry 1 }
+
+rserpoolENRPPeerIdentifier OBJECT-TYPE
+   SYNTAX     RSerPoolENRPServerIdentifierTC
+   MAX-ACCESS read-only
+   STATUS     current
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 27]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+   DESCRIPTION
+      "The ENRP identifier of this peer."
+   REFERENCE
+      "RFC 5353 explains the usage of the ENRP server identifier."
+   ::= { rserpoolENRPPeerEntry 2 }
+
+rserpoolENRPPeerPort OBJECT-TYPE
+   SYNTAX     InetPortNumber
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The SCTP port number of the ENRP transport endpoint of
+      this peer."
+   REFERENCE
+      "RFC 5353 defines the ENRP protocol."
+   ::= { rserpoolENRPPeerEntry 3 }
+
+rserpoolENRPPeerLastHeard OBJECT-TYPE
+   SYNTAX     TimeTicks
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The time since the reception of the last ENRP Presence
+      message of this peer."
+   REFERENCE
+      "Section 4.1 of RFC 5353 defines the last heard value."
+   ::= { rserpoolENRPPeerEntry 4 }
+
+-- ## Definition of peer address list table #######################
+rserpoolENRPPeerAddrTable OBJECT-TYPE
+   SYNTAX     SEQUENCE OF RserpoolENRPPeerAddrTableEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "A table listing of the peer endpoint addresses."
+   ::= { rserpoolENRPServers 9 }
+
+rserpoolENRPPeerAddrTableEntry  OBJECT-TYPE
+   SYNTAX     RserpoolENRPPeerAddrTableEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "A table listing of all IP addresses of the ENRP
+      transport endpoint of a peer referenced by rserpoolENRPPeerIndex."
+   INDEX {
+      rserpoolENRPPeerIndex,
+      rserpoolENRPPeerAddrTableIndex }
+   ::= { rserpoolENRPPeerAddrTable 1 }
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 28]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+RserpoolENRPPeerAddrTableEntry ::= SEQUENCE {
+   rserpoolENRPPeerAddrTableIndex Unsigned32,
+   rserpoolENRPPeerL3Type         InetAddressType,
+   rserpoolENRPPeerL3Addr         InetAddress }
+
+rserpoolENRPPeerAddrTableIndex OBJECT-TYPE
+   SYNTAX     Unsigned32 (1..4294967295)
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "A unique identifier for the IP address of a peer ENRP
+      transport endpoint."
+   ::= { rserpoolENRPPeerAddrTableEntry 1 }
+
+rserpoolENRPPeerL3Type OBJECT-TYPE
+   SYNTAX     InetAddressType { ipv4(1), ipv6(2) }
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The network-layer protocol (IPv4 or IPv6) of an IP address
+      of a peer ENRP transport endpoint."
+   REFERENCE
+      "RFC 5353 defines the ENRP protocol."
+   ::= { rserpoolENRPPeerAddrTableEntry 2 }
+
+rserpoolENRPPeerL3Addr OBJECT-TYPE
+   SYNTAX     InetAddress (SIZE(4|16))
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The IP address of a peer ENRP transport endpoint.  The type
+      of this address is given in rserpoolENRPPeerL3Type."
+   REFERENCE
+      "RFC 5353 defines the ENRP protocol."
+   ::= { rserpoolENRPPeerAddrTableEntry 3 }
+
+-- ################################################################
+-- #### Pool Elements Section                                  ####
+-- ################################################################
+
+-- ## Definition of the pool element table ########################
+rserpoolPETable OBJECT-TYPE
+   SYNTAX     SEQUENCE OF RserpoolPEEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "The table listing of pool elements."
+   ::= { rserpoolPoolElements 1 }
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 29]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+rserpoolPEEntry OBJECT-TYPE
+   SYNTAX     RserpoolPEEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "A pool element in the table listing of pool elements."
+   INDEX { rserpoolPEIndex }
+   ::= { rserpoolPETable 1 }
+
+RserpoolPEEntry ::= SEQUENCE {
+   rserpoolPEIndex              Unsigned32,
+   rserpoolPEOperationScope     RSerPoolOperationScopeTC,
+   rserpoolPEPoolHandle         RSerPoolPoolHandleTC,
+   rserpoolPEIdentifier         RserpoolPoolElementIdentifierTC,
+   rserpoolPEDescription        OCTET STRING,
+   rserpoolPEUptime             TimeTicks,
+   rserpoolPEASAPTransportPort  InetPortNumber,
+   rserpoolPEUserTransportProto Unsigned32,
+   rserpoolPEUserTransportPort  InetPortNumber,
+   rserpoolPEUserTransportUse   RSerPoolTransportUseTypeTC,
+   rserpoolPEPolicyID           RSerPoolPolicyIdentifierTC,
+   rserpoolPEPolicyDescription  OCTET STRING,
+   rserpoolPEPolicyWeight       RSerPoolPolicyWeightTC,
+   rserpoolPEPolicyLoad         RSerPoolPolicyLoadTC,
+   rserpoolPEPolicyLoadDeg      RSerPoolPolicyLoadTC,
+   rserpoolPERegistrationLife   TimeTicks,
+   rserpoolPEHomeENRPServer     RSerPoolENRPServerIdentifierTC }
+
+
+rserpoolPEIndex OBJECT-TYPE
+   SYNTAX     Unsigned32 (1..4294967295)
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "An integer to uniquely identify a pool element.  Note,
+      that uniqueness of a pool element identifier in the pool
+      is not enforced; therefore, this index is required here!"
+   ::={ rserpoolPEEntry 1 }
+
+rserpoolPEOperationScope OBJECT-TYPE
+   SYNTAX     RSerPoolOperationScopeTC
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The operation scope of this pool element."
+   REFERENCE
+      "Section 1.2 of RFC 3237 defines the term operation scope."
+   ::= { rserpoolPEEntry 2 }
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 30]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+rserpoolPEPoolHandle OBJECT-TYPE
+   SYNTAX     RSerPoolPoolHandleTC
+   MAX-ACCESS read-write
+   STATUS     current
+   DESCRIPTION
+      "The pool handle of this pool element.  Changing this object
+      will update the pool element's pool handle and result in a
+      re-registration.
+
+      This object SHOULD be maintained in a persistent manner."
+   REFERENCE
+      "Section 1.2 of RFC 3237 defines the term pool handle."
+   ::={ rserpoolPEEntry 3 }
+
+rserpoolPEIdentifier OBJECT-TYPE
+   SYNTAX     RserpoolPoolElementIdentifierTC
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The pool element identifier of this pool element."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the pool element identifier."
+   ::={ rserpoolPEEntry 4 }
+
+rserpoolPEDescription OBJECT-TYPE
+   SYNTAX     OCTET STRING (SIZE (0..255))
+   MAX-ACCESS read-write
+   STATUS     current
+   DESCRIPTION
+      "A textual description of this pool element, e.g., its location
+      and a contact address of its administrator.
+
+      This object SHOULD be maintained in a persistent manner."
+   ::= { rserpoolPEEntry 5 }
+
+rserpoolPEUptime OBJECT-TYPE
+   SYNTAX     TimeTicks
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The ENRP service uptime of this pool element."
+   ::= { rserpoolPEEntry 6 }
+
+rserpoolPEASAPTransportPort OBJECT-TYPE
+   SYNTAX     InetPortNumber
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 31]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+      "The SCTP port number of the ASAP endpoint of this pool element."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the ASAP Transport Parameter of
+      which the port number is given here."
+   ::= { rserpoolPEEntry 7 }
+
+rserpoolPEUserTransportProto OBJECT-TYPE
+   SYNTAX     Unsigned32 (0..255)
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The transport protocol number of the service endpoint
+      of this pool element."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the User Transport Parameter of
+      which the transport protocol number is given here."
+   ::= { rserpoolPEEntry 8 }
+
+rserpoolPEUserTransportPort OBJECT-TYPE
+   SYNTAX     InetPortNumber
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The transport protocol's port number of the service
+      endpoint of this pool element."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the User Transport Parameter of
+      which the port number is given here."
+   ::= { rserpoolPEEntry 9 }
+
+rserpoolPEUserTransportUse OBJECT-TYPE
+   SYNTAX     RSerPoolTransportUseTypeTC
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The transport use of the service endpoint of this pool element."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the User Transport Parameter of
+      which the transport use is given here."
+   ::= { rserpoolPEEntry 10 }
+
+rserpoolPEPolicyID OBJECT-TYPE
+   SYNTAX     RSerPoolPolicyIdentifierTC
+   MAX-ACCESS read-write
+   STATUS     current
+   DESCRIPTION
+      "The pool policy of this pool element.  Changing this object
+      will update the pool element's policy and result in a
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 32]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+      re-registration.
+
+      This object SHOULD be maintained in a persistent manner."
+   REFERENCE
+      "Section 3.8 of RFC 5354 defines the Member Selection Policy
+      Parameter of which the policy identifier is given here."
+   ::= { rserpoolPEEntry 11 }
+
+rserpoolPEPolicyDescription OBJECT-TYPE
+   SYNTAX     OCTET STRING (SIZE (0..255))
+   MAX-ACCESS read-write
+   STATUS     current
+   DESCRIPTION
+      "The textual description of the pool policy of this pool element.
+
+      This object SHOULD be maintained in a persistent manner."
+   ::= { rserpoolPEEntry 12 }
+
+rserpoolPEPolicyWeight OBJECT-TYPE
+   SYNTAX     RSerPoolPolicyWeightTC
+   MAX-ACCESS read-write
+   STATUS     current
+   DESCRIPTION
+      "The pool policy's weight parameter for this pool element.
+      Changing this object will update the pool element's policy
+      weight setting and result in a re-registration.
+
+      This object SHOULD be maintained in a persistent manner."
+   REFERENCE
+      "Section 3.8 of RFC 5354 defines the Member Selection Policy
+      Parameter of which the policy's weight parameter is given here."
+   ::= { rserpoolPEEntry 13 }
+
+rserpoolPEPolicyLoad OBJECT-TYPE
+   SYNTAX     RSerPoolPolicyLoadTC
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The pool policy's load status for this pool element."
+   REFERENCE
+      "Section 3.8 of RFC 5354 defines the Member Selection Policy
+      Parameter of which the policy's load parameter is given here."
+   ::= { rserpoolPEEntry 14 }
+
+
+
+
+
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 33]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+rserpoolPEPolicyLoadDeg OBJECT-TYPE
+   SYNTAX     RSerPoolPolicyLoadTC
+   MAX-ACCESS read-write
+   STATUS     current
+   DESCRIPTION
+      "The pool policy's load degradation parameter for this pool
+      element.  Changing this object will update the pool element's
+      load degradation setting and result in a re-registration.
+
+      This object SHOULD be maintained in a persistent manner."
+   REFERENCE
+      "Section 3.8 of RFC 5354 defines the Member Selection Policy
+      Parameter of which the policy's load degradation parameter is
+      given here."
+   ::= { rserpoolPEEntry 15 }
+
+rserpoolPERegistrationLife OBJECT-TYPE
+   SYNTAX     TimeTicks
+   MAX-ACCESS read-write
+   STATUS     current
+   DESCRIPTION
+      "The registration life of this pool element.  Changing this
+      object will update the pool element's lifetime setting and
+      result in a re-registration.
+
+      This object SHOULD be maintained in a persistent manner."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the Registration Life."
+   ::= { rserpoolPEEntry 16 }
+
+rserpoolPEHomeENRPServer OBJECT-TYPE
+   SYNTAX     RSerPoolENRPServerIdentifierTC
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The ID of the Home ENRP server of this pool element."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the Home ENRP Server
+      Identifier."
+   ::= { rserpoolPEEntry 17 }
+
+-- ## Definition of the ASAP transport address list table #########
+rserpoolPEASAPAddrTable OBJECT-TYPE
+   SYNTAX     SEQUENCE OF RserpoolPEASAPAddrTableEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+
+
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 34]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+   DESCRIPTION
+      "A table listing of all IP addresses of the ASAP transport
+      endpoint."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the ASAP Transport Parameter of
+      which the addresses are listed in this table."
+   ::= { rserpoolPoolElements 2 }
+
+rserpoolPEASAPAddrTableEntry  OBJECT-TYPE
+   SYNTAX     RserpoolPEASAPAddrTableEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "An IP address of the ASAP transport endpoint."
+  REFERENCE
+      "Section 3.10 of RFC 5354 defines the ASAP Transport Parameter of
+      which an address is contained by this entry."
+  INDEX {
+      rserpoolPEIndex,
+      rserpoolPEASAPAddrTableIndex }
+   ::= { rserpoolPEASAPAddrTable 1 }
+
+RserpoolPEASAPAddrTableEntry ::= SEQUENCE {
+   rserpoolPEASAPAddrTableIndex Unsigned32,
+   rserpoolPEASAPL3Type         InetAddressType,
+   rserpoolPEASAPL3Addr         InetAddress }
+
+rserpoolPEASAPAddrTableIndex OBJECT-TYPE
+   SYNTAX     Unsigned32 (1..4294967295)
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "A unique identifier for the IP address of an ASAP transport
+      endpoint."
+   ::= { rserpoolPEASAPAddrTableEntry 1 }
+
+rserpoolPEASAPL3Type OBJECT-TYPE
+   SYNTAX     InetAddressType { ipv4(1), ipv6(2) }
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The network-layer protocol (IPv4 or IPv6) of an IP address of
+      an ASAP transport endpoint."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the ASAP Transport Parameter of
+      which the network-layer protocol number is given here."
+   ::= { rserpoolPEASAPAddrTableEntry 2 }
+
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 35]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+rserpoolPEASAPL3Addr OBJECT-TYPE
+   SYNTAX     InetAddress (SIZE(4|16))
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The IP address of an ASAP transport endpoint.  The type of
+      this address is given in rserpoolPEASAPL3Type."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the ASAP Transport Parameter of
+      which the network-layer address (IPv4 or IPv6) is given here."
+   ::= { rserpoolPEASAPAddrTableEntry 3 }
+
+-- ## Definition of the user transport address list table #########
+rserpoolPEUserAddrTable OBJECT-TYPE
+   SYNTAX     SEQUENCE OF RserpoolPEUserAddrTableEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "A table listing of all IP addresses of the user
+      transport endpoint."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the User Transport Parameter of
+      which the addresses are listed in this table."
+   ::= { rserpoolPoolElements 6 }
+
+rserpoolPEUserAddrTableEntry  OBJECT-TYPE
+   SYNTAX     RserpoolPEUserAddrTableEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "An IP address of the user transport endpoint."
+  REFERENCE
+      "Section 3.10 of RFC 5354 defines the User Transport Parameter of
+      which an address is contained by this entry."
+   INDEX {
+      rserpoolPEIndex,
+      rserpoolPEUserAddrTableIndex }
+   ::= { rserpoolPEUserAddrTable 1 }
+
+RserpoolPEUserAddrTableEntry ::= SEQUENCE {
+   rserpoolPEUserAddrTableIndex Unsigned32,
+   rserpoolPEUserL3Type         InetAddressType,
+   rserpoolPEUserL3Addr         InetAddress,
+   rserpoolPEUserL3Opaque       RSerPoolOpaqueAddressTC }
+
+rserpoolPEUserAddrTableIndex OBJECT-TYPE
+   SYNTAX     Unsigned32 (1..4294967295)
+   MAX-ACCESS not-accessible
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 36]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+   STATUS     current
+   DESCRIPTION
+      "A unique identifier for the IP address of a user transport
+      endpoint."
+   ::= { rserpoolPEUserAddrTableEntry 1 }
+
+rserpoolPEUserL3Type OBJECT-TYPE
+   SYNTAX     InetAddressType { unknown(0), ipv4(1), ipv6(2) }
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The network-layer protocol of an IP address of a user transport
+      endpoint.  Set to unknown for opaque address."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the User Transport Parameter of
+      which the network-layer protocol number is given here."
+   ::= { rserpoolPEUserAddrTableEntry 2 }
+
+rserpoolPEUserL3Addr OBJECT-TYPE
+   SYNTAX     InetAddress (SIZE(0|4|16))
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The IP address of a user transport endpoint.  The type of
+      this address is given in rserpoolPEUserL3Addr."
+   REFERENCE
+      "Section 3.10 of RFC 5354 defines the User Transport Parameter of
+      which the network-layer address (IPv4 or IPv6) is given here."
+   ::= { rserpoolPEUserAddrTableEntry 3 }
+
+rserpoolPEUserL3Opaque OBJECT-TYPE
+   SYNTAX     RSerPoolOpaqueAddressTC
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The opaque address of a user transport endpoint."
+   REFERENCE
+      "Section 3.16 of RFC 5354 defines the opaque transport address."
+   ::= { rserpoolPEUserAddrTableEntry 4 }
+
+-- ################################################################
+-- #### Pool Users Section                                     ####
+-- ################################################################
+
+-- ## Definition of the pool user table ###########################
+rserpoolPUTable OBJECT-TYPE
+   SYNTAX     SEQUENCE OF RserpoolPUEntry
+   MAX-ACCESS not-accessible
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 37]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+   STATUS     current
+   DESCRIPTION
+      "The table listing of pool users."
+   ::= { rserpoolPoolUsers 1 }
+
+rserpoolPUEntry OBJECT-TYPE
+   SYNTAX     RserpoolPUEntry
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "A pool user in the table listing of pool users."
+   INDEX { rserpoolPUIndex }
+   ::= { rserpoolPUTable 1 }
+
+RserpoolPUEntry ::= SEQUENCE {
+   rserpoolPUIndex          Unsigned32,
+   rserpoolPUOperationScope RSerPoolOperationScopeTC,
+   rserpoolPUPoolHandle     RSerPoolPoolHandleTC,
+   rserpoolPUDescription    OCTET STRING,
+   rserpoolPUUptime         TimeTicks }
+
+rserpoolPUIndex OBJECT-TYPE
+   SYNTAX     Unsigned32 (1..4294967295)
+   MAX-ACCESS not-accessible
+   STATUS     current
+   DESCRIPTION
+      "An integer to uniquely identify a pool user."
+   ::= { rserpoolPUEntry 1 }
+
+rserpoolPUOperationScope OBJECT-TYPE
+   SYNTAX     RSerPoolOperationScopeTC
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The operation scope of this pool user."
+   REFERENCE
+      "Section 1.2 of RFC 3237 defines the term operation scope."
+   ::= { rserpoolPUEntry 2 }
+
+rserpoolPUPoolHandle OBJECT-TYPE
+   SYNTAX     RSerPoolPoolHandleTC
+   MAX-ACCESS read-write
+   STATUS     current
+
+
+
+
+
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 38]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+   DESCRIPTION
+      "The pool handle of this pool user.  Changing this object
+      will update the pool user's pool handle for all future
+      sessions.
+
+      This object SHOULD be maintained in a persistent manner."
+   REFERENCE
+      "Section 1.2 of RFC 3237 defines the term pool handle."
+   ::={ rserpoolPUEntry 3 }
+
+rserpoolPUDescription OBJECT-TYPE
+   SYNTAX     OCTET STRING (SIZE (0..255))
+   MAX-ACCESS read-write
+   STATUS     current
+   DESCRIPTION
+      "A textual description of this pool user, e.g., its location
+      and a contact address of its administrator.
+
+      This object SHOULD be maintained in a persistent manner."
+   ::= { rserpoolPUEntry 4 }
+
+rserpoolPUUptime OBJECT-TYPE
+   SYNTAX     TimeTicks
+   MAX-ACCESS read-only
+   STATUS     current
+   DESCRIPTION
+      "The ENRP service uptime of this pool user."
+   ::= { rserpoolPUEntry 5 }
+
+-- ## MIB conformance and compliance ##############################
+rserpoolMIBCompliances OBJECT IDENTIFIER ::= {
+   rserpoolMIBConformance 1
+}
+
+rserpoolMIBGroups OBJECT IDENTIFIER ::= {
+   rserpoolMIBConformance 2
+}
+
+rserpoolMIBCompliance MODULE-COMPLIANCE
+   STATUS  current
+   DESCRIPTION
+      "The compliance statement for SNMP entities that implement
+      RSerPool."
+   MODULE
+   MANDATORY-GROUPS {
+      rserpoolENRPGroup,
+      rserpoolPEGroup,
+      rserpoolPUGroup }
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 39]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+   ::= { rserpoolMIBCompliances 1 }
+
+rserpoolENRPGroup OBJECT-GROUP
+   OBJECTS {
+      rserpoolENRPOperationScope,
+      rserpoolENRPIdentifier,
+      rserpoolENRPDescription,
+      rserpoolENRPUptime,
+      rserpoolENRPPort,
+      rserpoolENRPASAPAnnouncePort,
+      rserpoolENRPASAPAnnounceAddr,
+      rserpoolENRPASAPAnnounceAddrType,
+      rserpoolENRPENRPAnnounceAddrType,
+      rserpoolENRPENRPAnnouncePort,
+      rserpoolENRPENRPAnnounceAddr,
+
+      rserpoolENRPPoolHandle,
+      rserpoolENRPPoolElementID,
+
+      rserpoolENRPASAPTransportPort,
+      rserpoolENRPUserTransportProto,
+      rserpoolENRPUserTransportUse,
+      rserpoolENRPUserTransportPort,
+      rserpoolENRPPolicyID,
+      rserpoolENRPPolicyDescription,
+      rserpoolENRPPolicyWeight,
+      rserpoolENRPPolicyLoad,
+      rserpoolENRPPolicyLoadDeg,
+      rserpoolENRPRegistrationLife,
+      rserpoolENRPHomeENRPServer,
+
+      rserpoolENRPASAPL3Type,
+      rserpoolENRPASAPL3Addr,
+
+      rserpoolENRPUserL3Type,
+      rserpoolENRPUserL3Addr,
+      rserpoolENRPUserL3Opaque,
+
+      rserpoolENRPENRPL3Type,
+      rserpoolENRPENRPL3Addr,
+
+      rserpoolENRPPeerIdentifier,
+      rserpoolENRPPeerPort,
+      rserpoolENRPPeerLastHeard,
+      rserpoolENRPPeerL3Type,
+      rserpoolENRPPeerL3Addr }
+   STATUS current
+   DESCRIPTION
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 40]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+      "The group contains all ENRP server instances
+      running on the system"
+   ::= { rserpoolMIBGroups 1 }
+
+rserpoolPEGroup OBJECT-GROUP
+   OBJECTS {
+      rserpoolPEOperationScope,
+      rserpoolPEPoolHandle,
+      rserpoolPEIdentifier,
+      rserpoolPEDescription,
+      rserpoolPEUptime,
+      rserpoolPEASAPTransportPort,
+      rserpoolPEUserTransportProto,
+      rserpoolPEUserTransportPort,
+      rserpoolPEUserTransportUse,
+      rserpoolPEPolicyID,
+      rserpoolPEPolicyDescription,
+      rserpoolPEPolicyWeight,
+      rserpoolPEPolicyLoad,
+      rserpoolPEPolicyLoadDeg,
+      rserpoolPERegistrationLife,
+      rserpoolPEHomeENRPServer,
+
+      rserpoolPEASAPL3Type,
+      rserpoolPEASAPL3Addr,
+
+      rserpoolPEUserL3Type,
+      rserpoolPEUserL3Addr,
+      rserpoolPEUserL3Opaque }
+   STATUS current
+   DESCRIPTION
+      "The group contains all pool element instances
+      running on the system"
+   ::= { rserpoolMIBGroups 2 }
+
+rserpoolPUGroup OBJECT-GROUP
+   OBJECTS { rserpoolPUOperationScope,
+      rserpoolPUPoolHandle,
+      rserpoolPUDescription,
+      rserpoolPUUptime }
+   STATUS current
+   DESCRIPTION
+      "The group contains all pool user instances
+      running on the system"
+   ::= { rserpoolMIBGroups 3 }
+
+END
+
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 41]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+7.  Operational Considerations
+
+   The RSerPool MIB is an Experimental track MIB module, since the
+   RSerPool documents are Experimental RFCs.
+
+8.  Security Considerations
+
+   There are a number of management objects defined in this MIB module
+   with a MAX-ACCESS clause of read-write and/or read-create.  Such
+   objects may be considered sensitive or vulnerable in some network
+   environments.  The support for SET operations in a non-secure
+   environment without proper protection can have a negative effect on
+   network operations.  These are the tables and objects and their
+   sensitivity/vulnerability:
+
+      rserpoolENRPDescription (textual description change)
+
+      rserpoolPEPoolHandle (pool handle of pool element change, similar
+      to ASAP)
+
+      rserpoolPEDescription (textual description change)
+
+      rserpoolPEPolicyID (pool element ID change, similar to ASAP)
+
+      rserpoolPEPolicyDescription (textual description change)
+
+      rserpoolPEPolicyWeight (policy weight change, similar to ASAP)
+
+      rserpoolPEPolicyLoadDeg (policy load degradation change, similar
+      to ASAP)
+
+      rserpoolPERegistrationLife (registration lifetime change, similar
+      to ASAP)
+
+      rserpoolPUPoolHandle (pool handle of accessed pool change, similar
+      to ASAP)
+
+      rserpoolPUDescription (textual description change)
+
+   The security implications of changing these items are similar to
+   changes via ASAP; the corresponding security implications are
+   described in the threats document [RFC5355].  Modifying the textual
+   descriptions of components may result in wrong administrator
+   decisions upon malicious information.
+
+
+
+
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 42]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+   Some of the readable objects in this MIB module (i.e., objects with a
+   MAX-ACCESS other than not-accessible) may be considered sensitive or
+   vulnerable in some network environments.  It is thus important to
+   control even GET and/or NOTIFY access to these objects and possibly
+   to even encrypt the values of these objects when sending them over
+   the network via SNMP.  Read access reveals the same information which
+   is also available by ASAP and ENRP access.  The security implications
+   of these two protocols are explained in detail by the threats
+   document [RFC5355].
+
+   SNMP versions prior to SNMPv3 did not include adequate security.
+   Even if the network itself is secure (for example by using IPsec),
+   even then, there is no control as to who on the secure network is
+   allowed to access and GET/SET (read/change/create/delete) the objects
+   in this MIB module.
+
+   It is RECOMMENDED that implementers consider the security features as
+   provided by the SNMPv3 framework (see [RFC3410], section 8),
+   including full support for the SNMPv3 cryptographic mechanisms (for
+   authentication and privacy).
+
+   Further, deployment of SNMP versions prior to SNMPv3 is NOT
+   RECOMMENDED.  Instead, it is RECOMMENDED to deploy SNMPv3 and to
+   enable cryptographic security.  It is then a customer/operator
+   responsibility to ensure that the SNMP entity giving access to an
+   instance of this MIB module is properly configured to give access to
+   the objects only to those principals (users) that have legitimate
+   rights to indeed GET or SET (change/create/delete) them.
+
+9.  IANA Considerations
+
+   The MIB module in this document uses the following IANA-assigned
+   OBJECT IDENTIFIER values recorded in the SMI Numbers registry:
+
+   Descriptor OBJECT IDENTIFIER Value
+   ----------  -----------------------
+   rserpoolMIB { experimental 125 }
+
+10.  Acknowledgments
+
+   The authors would like to express a special note of thanks to Phillip
+   Conrad and Kevin Pinzhoffer for their efforts in the early formation
+   of this document.  Furthermore, the authors would like to thank Bert
+   Wijnen and Dan Romascanu for their valuable comments on this
+   document.  Finally, the authors would like to thank Nihad Cosic, Dirk
+   Hoffstadt, Michael Kohnen, Jobin Pulinthanath, Randall Stewart,
+   Michael Tuexen, and Xing Zhou for their support.
+
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 43]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+11.  References
+
+11.1.  Normative References
+
+   [RFC2119]       Bradner, S., "Key words for use in RFCs to Indicate
+                   Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2578]       McCloghrie, K., Ed., Perkins, D., Ed., and J.
+                   Schoenwaelder, Ed., "Structure of Management
+                   Information Version 2 (SMIv2)", STD 58, RFC 2578,
+                   April 1999.
+
+   [RFC2579]       McCloghrie, K., Ed., Perkins, D., Ed., and J.
+                   Schoenwaelder, Ed., "Textual Conventions for SMIv2",
+                   STD 58, RFC 2579, April 1999.
+
+   [RFC2580]       McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+                   "Conformance Statements for SMIv2", STD 58, RFC 2580,
+                   April 1999.
+
+   [RFC4001]       Daniele, M., Haberman, B., Routhier, S., and J.
+                   Schoenwaelder, "Textual Conventions for Internet
+                   Network Addresses", RFC 4001, February 2005.
+
+   [RFC5352]       Stewart, R., Xie, Q., Stillman, M., and M. Tuexen,
+                   "Aggregate Server Access Protocol (ASAP)", RFC 5352,
+                   September 2008.
+
+   [RFC5353]       Xie, Q., Stewart, R., Stillman, M., Tuexen, M., and
+                   A. Silverton, "Endpoint Handlespace Redundancy
+                   Protocol (ENRP)", RFC 5353, September 2008.
+
+   [RFC5354]       Stewart, R., Xie, Q., Stillman, M., and M. Tuexen,
+                   "Aggregate Server Access Protocol (ASAP) and Endpoint
+                   Handlespace Redundancy Protocol (ENRP) Parameters",
+                   RFC 5354, September 2008.
+
+   [RFC5356]       Dreibholz, T. and M. Tuexen, "Reliable Server Pooling
+                   Policies", RFC 5356, September 2008.
+
+11.2.  Informative References
+
+   [RFC3237]       Tuexen, M., Xie, Q., Stewart, R., Shore, M., Ong, L.,
+                   Loughney, J., and M. Stillman, "Requirements for
+                   Reliable Server Pooling", RFC 3237, January 2002.
+
+
+
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 44]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+   [RFC3410]       Case, J., Mundy, R., Partain, D., and B. Stewart,
+                   "Introduction and Applicability Statements for
+                   Internet-Standard Management Framework", RFC 3410,
+                   December 2002.
+
+   [RFC5351]       Lei, P., Ong, L., Tuexen, M., and T. Dreibholz, "An
+                   Overview of Reliable Server Pooling Protocols",
+                   RFC 5351, September 2008.
+
+   [RFC5355]       Stillman, M., Gopal, R., Guttman, E., Sengodan, S.,
+                   and M. Holdrege, "Threats Introduced by Reliable
+                   Server Pooling (RSerPool) and Requirements for
+                   Security in Response to Threats", RFC 5355,
+                   September 2008.
+
+   [Dre2006]       Dreibholz, T., "Reliable Server Pooling --
+                   Evaluation, Optimization and Extension of a Novel
+                   IETF Architecture", Ph.D. Thesis University of
+                   Duisburg-Essen, Faculty of Economics, Institute for
+                   Computer Science and Business Information Systems,
+                   March 2007, <http://duepublico.uni-duisburg-essen.de/
+                   servlets/DerivateServlet/Derivate-16326/
+                   Dre2006-final.pdf>.
+
+   [LCN2005]       Dreibholz, T. and E. Rathgeb, "On the Performance of
+                   Reliable Server Pooling Systems", Proceedings of the
+                   30th IEEE Local Computer Networks Conference,
+                   November 2005.
+
+   [IJHIT2008]     Dreibholz, T. and E. Rathgeb, "An Evaluation of the
+                   Pool Maintenance Overhead in Reliable Server Pooling
+                   Systems", International Journal of Hybrid Information
+                   Technology (IJHIT) Volume 1, Number 2, April 2008.
+
+   [RSerPoolPage]  Dreibholz, T., "Thomas Dreibholz's RSerPool Page",
+                   <http://tdrwww.iem.uni-due.de/dreibholz/rserpool/>.
+
+   [SNMPMIBS]      Perkins, D. and E. McGinnis, "Understanding SNMP
+                   MIBs", 1997.
+
+
+
+
+
+
+
+
+
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 45]
+
+RFC 5525                  RSerPool MIB Module                 April 2009
+
+
+Authors' Addresses
+
+   Thomas Dreibholz
+   University of Duisburg-Essen, Institute for Experimental Mathematics
+   Ellernstrasse 29
+   45326 Essen, Nordrhein-Westfalen
+   Germany
+
+   Phone: +49-201-1837637
+   Fax:   +49-201-1837673
+   EMail: dreibh@iem.uni-due.de
+   URI:   http://www.iem.uni-due.de/~dreibh/
+
+
+   Jaiwant Mulik
+   Delaware State University
+   CIS Department
+   Room 306A, Science Center North
+   1200 N. DuPont Hwy
+   Dover, DE  19904
+   USA
+
+   Phone: +1-302-857-7910
+   Fax:   +1-302-857-6552
+   EMail: jaiwant@mulik.com
+   URI:   http://netlab.cis.desu.edu
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Dreibholz & Mulik             Experimental                     [Page 46]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc5525.txt](<www.ietf.org/rfc/rfc5525.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
