### PR TITLE
Archive rfc5540.txt

### DIFF
--- a/www.ietf.org/rfc/rfc5540.txt
+++ b/www.ietf.org/rfc/rfc5540.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                                         RFC Editor
+Request for Comments: 5540                                       USC/ISI
+Category: Informational                                     7 April 2009
+
+
+                            40 Years of RFCs
+
+Status of This Memo
+
+   This memo provides information for the Internet community.  It does
+   not specify an Internet standard of any kind.  Distribution of this
+   memo is unlimited.
+
+Copyright Notice
+
+   Copyright (c) 2009 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents in effect on the date of
+   publication of this document (http://trustee.ietf.org/license-info).
+   Please review these documents carefully, as they describe your rights
+   and restrictions with respect to this document.
+
+Abstract
+
+   This RFC marks the 40th anniversary of the RFC document series.
+
+1.  RFCs and Jon Postel
+
+   Forty years ago today, the first Request for Comments document, RFC
+   1, was published at UCLA [RFC1].  This was the first of a series that
+   currently contains more than 5400 documents (roughly 160,000 pages)
+   on computer networking in general and on the Internet protocols in
+   particular.  The RFC series emerged from the US government-funded
+   research efforts that created the ARPANET and later the Internet.
+   When the IETF was formed in the mid-1980s, RFCs became the primary
+   publication vehicle for IETF standards, and thus became centered on
+   the vendor and user communities.
+
+   For the first 29 years, Jon Postel [Postel] was *the* RFC Editor,
+   until his untimely death in October 1998.  Postel, with substantial
+   help from Joyce K. Reynolds, was responsible for the collection,
+   editing, online publication, and archiving of the RFC documents.
+   From 1978 until 1998, Postel was a research scientist at the USC
+   Information Sciences Institute (USC/ISI) in Marina del Rey,
+   California.  Postel was also the original IANA as well as Director of
+   the Computer Networks Division at ISI.
+
+
+
+RFC Editor                   Informational                      [Page 1]
+
+RFC 5540                    40th Anniversary                7 April 2009
+
+
+   Upon the occasion of the 30th anniversary of RFC 1 and as a tribute
+   to the massive contribution of Jon Postel, the RFC Editor published
+   RFC 2555 [RFC2555] on April 7, 1999.  This RFC contained
+   recollections from three networking pioneers: Steve Crocker who wrote
+   RFC 1, Vint Cerf whose long-range vision continues to guide us, and
+   Jake Feinler who played a key role in the middle years of the RFC
+   series.
+
+   Ten more years have now passed, and we have reached the 40th
+   anniversary of the RFC series.  The series has more than doubled in
+   size during the last ten years, and it is expected to continue far
+   into the future.  All the good things said in RFC 2555 still hold
+   true ten years later.
+
+   We should, however, note some changes that have occurred over the
+   past ten years.
+
+   o  After Jon passed away, Joyce Reynolds and Bob Braden put together
+      a small organization at USC/ISI to continue the RFC Editor
+      function.  This was motivated by a desire to honor Postel by
+      continuing his remarkable effort and to provide a service to the
+      Internet community.
+
+   o  Funding of the RFC Editor, which had been supported by the US
+      government until 1998, was taken over by the Internet Society.
+      During 1998-2006, ISOC funded the RFC Editor under a series of
+      annual contracts and extensions.  ISOC put the function out for
+      competitive bid for 2007 (USC/ISI was selected to provide RFC
+      Editor services from 2007-2009), and the contract will be put out
+      to bid again for post-2009.
+
+      During 2009 there will be a significant transition for the RFC
+      Editor function, as some new organization or set of organizations
+      takes over this service that has been performed at USC/ISI
+      continuously since 1978.
+
+   o  Many improvements have increased the efficiency and transparency
+      of the RFC editorial process [RFCed09].
+
+   o  The RFC Editor formed an RFC Editorial Board, a group of people
+      with broad and deep knowledge of the Internet and networking.  One
+      of its major functions is to assist the RFC Editor by reviewing
+      RFCs in the Independent Submission stream.
+
+   o  An email list, rfc-interest@rfc-editor.org, was created to obtain
+      community input on the RFC Editor functions.
+
+
+
+
+
+RFC Editor                   Informational                      [Page 2]
+
+RFC 5540                    40th Anniversary                7 April 2009
+
+
+2.  Security Considerations
+
+   This document does not raise any security issues.
+
+3.  Acknowledgments
+
+   It has been an honor for USC/ISI to serve the community during the
+   past 31 years.
+
+4.  Informative References
+
+   [Postel]  "Remembering Jonathan B. Postel",
+             <http://www.postel.org/remembrances/>.
+
+   [RFCed09] Braden, R., Ginoza, S., and A. Hagens, "The RFC Editor
+             Function at ISI", <http://www.rfc-editor.org/
+             RFCeditor.at.ISI.pdf>, January 2009.
+
+   [RFC1]    Crocker, S., "Host Software", RFC 1, April 1969.
+
+   [RFC2555] RFC Editor, et al., "30 Years of RFCs", RFC 2555, April
+             1999.
+
+Author's Address
+
+   RFC Editor
+
+   EMail: rfc-editor@rfc-editor.org
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+RFC Editor                   Informational                      [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc5540.txt](<www.ietf.org/rfc/rfc5540.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
