### PR TITLE
Archive rfc562.txt

### DIFF
--- a/www.ietf.org/rfc/rfc562.txt
+++ b/www.ietf.org/rfc/rfc562.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                        A. McKenzie
+Request for Comments: 562                                      BBN-TENEX
+NIC: 18638                                                28 August 1973
+Updates: RFC 495
+References: RFCs 513, 529
+
+
+               Modifications to the TELNET Specification
+
+   Almost four months have passed since the new TELNET Protocol
+   specification was published.  Since then, only two RFCs have been
+   issued suggesting modifications, and the most recent of these was
+   distributed two months ago.  Further, the date from the old TELNET to
+   the new TELNET (1 January 1974) is only four months away.  It
+   therefore seems appropriate to officially modify the specification to
+   account for the suggested modifications, and to declare a moratorium
+   on the incorporation of additional suggestions until after the
+   switchover. (Of course, no moratorium on the specification of
+   additional options is required.)
+
+   The two attached documents represent the revised TELNET Protocol
+   specifications; they replace NIC #15372, TELNET Protocol
+   Specification, and NIC #15373, TELNET Option Specifications.  The
+   remainder of this RFC summarizes the changes.  Page numbers refer to
+   the earlier documents.
+
+Changes to TELNET Protocol Specification
+
+   Page 8        - The phrase "blocked on input" is removed (see RFC
+                   #513).
+
+   Page 9, 10    - An additional use of IP is mentioned (see RFC #529).
+
+   Page 10       - The explanation of AO is expanded (see RFC #513).
+
+   Page 11       - The definition of "'print position' (e.g., an
+                   overstrike)" is clarified (see RFC #513).
+
+   Page 11, 12   - The description of the TELNET Synch Signal is
+                   reworked to be in conformance with the ideas of RFC
+                   #529 (also see RFC #513).
+
+   Page 14       - The explanation of the CR-NUL convention is expanded
+                   (see RFC #513).
+
+   Page 16       - An additional command, End of Subnegotiation
+                   Parameters (SE) is defined (see RFCs 513, 529).
+
+
+
+
+A. McKenzie                                                     [Page 1]
+
+RFC 562        Modifications to the TELNET Specification  28 August 1973
+
+
+Changes to TELNET Option Specifications
+
+   Pages 2, 3    - Use of the command SE is explained (see RFCs 513,
+                   529).
+
+   Page 3        - Doubling of IAC in subnegotiation parameters is
+                   required (see RFC #513).
+
+
+          [This RFC was put into machine readable form for entry]
+      [into the online RFC archives by Helene Morin, Via Genie 12/99]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+A. McKenzie                                                     [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc562.txt](<www.ietf.org/rfc/rfc562.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
