### PR TITLE
Archive rfc5650.txt

### DIFF
--- a/www.ietf.org/rfc/rfc5650.txt
+++ b/www.ietf.org/rfc/rfc5650.txt
@@ -1,0 +1,12211 @@
+
+
+
+
+
+
+Network Working Group                                     M. Morgenstern
+Request for Comments: 5650                              ECI Telecom Ltd.
+Category: Standards Track                                     S. Baillie
+                                                              U. Bonollo
+                                                           NEC Australia
+                                                          September 2009
+
+
+                   Definitions of Managed Objects for
+           Very High Speed Digital Subscriber Line 2 (VDSL2)
+
+Abstract
+
+   This document defines a Management Information Base (MIB) module for
+   use with network management protocols in the Internet community.  In
+   particular, it describes objects used for managing parameters of the
+   "Very High Speed Digital Subscriber Line 2 (VDSL2)" interface type,
+   which are also applicable for managing Asymmetric Digital Subscriber
+   Line (ADSL), ADSL2, and ADSL2+ interfaces.
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright and License Notice
+
+   Copyright (c) 2009 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the BSD License.
+
+
+
+
+
+
+
+
+
+Morgenstern, et al.         Standards Track                     [Page 1]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+Table of Contents
+
+   1. The Internet-Standard Management Framework ......................2
+   2. Overview ........................................................2
+      2.1. Relationship to Other MIBs .................................4
+      2.2. IANA Considerations ........................................7
+      2.3. Conventions Used in the MIB Module .........................7
+      2.4. Structure .................................................11
+      2.5. Persistence ...............................................13
+      2.6. Line Topology .............................................16
+      2.7. Counters, Interval Buckets, and Thresholds ................17
+      2.8. Profiles ..................................................19
+      2.9. Notifications .............................................23
+   3. Definitions ....................................................24
+   4. Implementation Analysis .......................................204
+   5. Security Considerations .......................................204
+   6. Acknowledgments ...............................................215
+   7. References ....................................................216
+      7.1. Normative References .....................................216
+      7.2. Informative References ...................................217
+
+1.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to Section 7 of
+   RFC 3410 [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This memo specifies a MIB
+   module that is compliant to the SMIv2, which is described in STD 58,
+   RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579], and STD 58, RFC 2580
+   [RFC2580].
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+2.  Overview
+
+   This document defines a Management Information Base (MIB) module for
+   use with network management protocols in the Internet community for
+   the purpose of managing VDSL2, ADSL, ADSL2, and ADSL2+ lines.
+
+
+
+
+
+
+Morgenstern, et al.         Standards Track                     [Page 2]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   The MIB module described in RFC 2662 [RFC2662] describes objects used
+   for managing Asymmetric Bit-Rate DSL (ADSL) interfaces per
+   [T1E1.413], [G.992.1], and [G.992.2].  These object descriptions are
+   based upon the specifications for the ADSL Embedded Operations
+   Channel (EOC) as defined in American National Standards Institute
+   (ANSI) T1E1.413/1995 [T1E1.413] and International Telecommunication
+   Union (ITU-T) G.992.1 [G.992.1] and G.992.2 [G.992.2].
+
+   The MIB module described in RFC 4706 [RFC4706] is a wider management
+   model that includes, in addition to ADSL technology, the ADSL2 and
+   ADSL2+ technologies per G.992.3, G.992.4, and G.992.5 ([G.992.3],
+   [G.992.4], and [G.992.5], respectively).
+
+   This document does not obsolete RFC 2662 [RFC2662] or RFC 4706
+   [RFC4706], but rather provides a more comprehensive management model
+   that addresses the VDSL2 technology per G.993.2 ([G.993.2]) as well
+   as ADSL, ADSL2, and ADSL2+ technologies.
+
+   This document does not obsolete RFC 2662 [RFC2662] or RFC 4706
+   [RFC4706].  RFC 2662 is relevant only for managing modems that do not
+   support any DSL technology other than ADSL (e.g., G.992.1 [G.992.1]
+   and G.992.2 [G.992.2]) especially if the modems were produced prior
+   to approval of ITU-T G.997.1 standard revision 3 [G.997.1].  RFC 4706
+   is more appropriate for managing modems that support ADSL2 technology
+   variants (with or without being able to support the legacy ADSL).
+   This document supports all ADSL, ADSL2, and VDSL2 standards, but it
+   assumes a more sophisticated management model, which older modems
+   (even ADSL2 ones) may not be able to support.  The selection of the
+   appropriate MIB module for any DSL modem is based on the ifType value
+   it reports, as explained in the next section.
+
+   The management framework for VDSL2 lines [TR-129] specified by the
+   Digital Subscriber Line Forum (DSLF) has been taken into
+   consideration.  That framework is based on the ITU-T G.997.1 standard
+   [G.997.1] and its amendment 1 [G.997.1-Am1].
+
+   Note that the management model, according to this document, does not
+   allow managing VDSL technology per G.993.1 [G.993.1].  VDSL lines
+   MUST be managed by RFC 3728 [RFC3728].
+
+   The MIB module is located in the MIB tree under MIB 2 transmission,
+   as discussed in the MIB-2 Integration (RFC 2863 [RFC2863]) section of
+   this document.
+
+
+
+
+
+
+
+
+Morgenstern, et al.         Standards Track                     [Page 3]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+2.1.  Relationship to Other MIBs
+
+   This section outlines the relationship of this MIB module with other
+   MIB modules described in RFCs.  Specifically, IF-MIB as defined in
+   RFC 2863 [RFC2863] and ENTITY-MIB as defined in RFC 4133 [RFC4133]
+   are discussed.
+
+2.1.1.  Relationship with IF-MIB (RFC 2863)
+
+2.1.1.1.  General IF-MIB Integration
+
+   The VDSL2 Line MIB specifies the detailed objects of a data
+   interface.  As such, it needs to integrate with RFC 2863 [RFC2863].
+   The IANA has assigned the following ifTypes, which may be applicable
+   for VDSL2 lines as well as for ADSL, ADSL2, and ADSL2+ lines:
+
+   IANAifType ::= TEXTUAL-CONVENTION
+       ...
+   SYNTAX INTEGER {
+       ...
+       channel(70),     -- Channel
+       adsl(94),        -- Asymmetric Digital Subscriber Loop
+       ...
+       interleave(124), -- Interleaved Channel
+       fast(125),       -- Fast Channel
+       ...
+       adsl2plus(238),  -- Asymmetric Digital Subscriber Loop Version 2,
+                           Version 2 Plus, and all variants
+       vdsl2(251),      -- Very High Speed Digital Subscriber Loop 2
+       ...
+       }
+
+   ADSL lines that are identified with ifType=adsl(94) MUST be managed
+   with the MIB specified by RFC 2662.  ADSL, ADSL2, and ADSL2+ lines
+   identified with ifType=adsl2plus(238) MUST be managed with the MIB
+   specified by RFC 4706 [RFC4706].  VDSL2, ADSL, ADSL2, and ADSL2+
+   lines identified with ifType=vdsl2(251) MUST be managed with the MIB
+   specified by this document.
+
+   In any case, the SNMP agent may use either ifType=interleave(124) or
+   fast(125) for each channel, e.g., depending on whether or not it is
+   capable of using an interleaver on that channel.  It may use the
+   ifType=channel (70) when all channels are capable of using an
+   interleaver (e.g., for ADSL2 xTUs).
+
+   Note that the ifFixedLengthGroup from RFC 2863 [RFC2863] MUST be
+   supported and that the ifRcvAddressGroup does not apply to this MIB
+   module.
+
+
+
+Morgenstern, et al.         Standards Track                     [Page 4]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+2.1.1.2.  Usage of ifTable
+
+   The MIB branch identified by ifType contains tables appropriate for
+   the interface types described above.  Most such tables extend the
+   ifEntry table, and are indexed by ifIndex.  For interfaces in systems
+   implementing this MIB module, those table entries indexed by ifIndex
+   MUST be persistent.
+
+   The following objects are part of the mandatory
+   ifGeneralInformationGroup in the Interfaces MIB [RFC2863], and are
+   not duplicated in the VDSL2 Line MIB.
+
+      ifIndex                  Interface index.
+
+      ifDescr                  See interfaces MIB.
+
+      ifType                   vdsl2(251), channel(70),
+                               interleave(124), or fast(125)
+
+      ifSpeed                  Set as appropriate.
+
+      ifPhysAddress            This object MUST have an octet
+                               string with zero length.
+
+      ifAdminStatus            See interfaces MIB.
+
+      ifOperStatus             See interfaces MIB.
+
+      ifLastChange             See interfaces MIB.
+
+      ifName                   See interfaces MIB.
+
+      ifAlias                  See interfaces MIB.
+
+      ifLinkUpDownTrapEnable   Default to enabled(1).
+
+      ifHighSpeed              Set as appropriate.
+
+      ifConnectorPresent       Set as appropriate.
+   -------------------------------------------------------------------
+                     Figure 1: Use of ifTable Objects
+
+2.1.1.3.  Usage of ifStackTable
+
+   Use of the ifStackTable to associate the entries for physical, fast,
+   interleaved channels, and higher layers (e.g., ATM) is shown below.
+   Use of the ifStackTable is necessary because configuration
+   information is stored in profile tables associated with the physical-
+
+
+
+Morgenstern, et al.         Standards Track                     [Page 5]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   layer ifEntry only.  The channels' ifEntrys need the ifStackTable to
+   find their associated physical-layer entry and thus their
+   configuration parameters.  The following example shows the
+   ifStackTable entries for an xDSL line with a single channel that uses
+   an ATM data path.
+
+                       HigherLayer      LowerLayer
+                       -----------------------------
+                            0               ATM
+                           ATM           XdslChannel
+                        XdslChannel      XdslPhysical
+                        XdslPhysical         0
+
+   Figure 2: ifStackTable Entries for ATM Path over a Single xDSL
+   Channel
+
+2.1.2.  Relationship with the ENTITY-MIB (RFC 4133)
+
+   Implementation of the Entity MIB [RFC4133] is optional.  It in no way
+   alters the information required in the VDSL2 Line MIB, nor does it
+   alter the relationship with IF-MIB.
+
+   The Entity MIB introduces a standardized way of presenting the
+   components of complex systems, such as a Digital Subscriber Line
+   Access Multiplexer (DSLAM), that may contain multiple racks, shelves,
+   line cards, and/or ports.  The Entity MIB's main goal is to present
+   these system components, their containment relationship, and mapping
+   information with other MIBs such as the Interface MIB and the VDSL2
+   Line MIB.
+
+   The Entity MIB is capable of supporting the local DSL termination
+   unit.  Thus, assuming the SNMP agent is in the DSLAM, the Entity MIB
+   should include entities for the xTU-C in the entPhysicalTable.  The
+   MIB's entAliasMappingTable would contain mapping information
+   identifying the 'ifIndex' object associated with each xTU-C.  In case
+   the SNMP agent is actually in the Customer Premise Equipment (CPE),
+   the Entity MIB should include entities for the xTU-R in the
+   entPhysicalTable.  In this case, the MIB's entAliasMappingTable would
+   contain mapping information identifying the 'ifIndex' object
+   associated with each xTU-R.
+
+   Also associating the relationship between the ifTable and Entity MIB,
+   the entPhysicalTable contains an 'entPhysicalName' object, which
+   approximates the semantics of the 'ifName' object from the Interface
+   MIB.
+
+
+
+
+
+
+Morgenstern, et al.         Standards Track                     [Page 6]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+2.2.  IANA Considerations
+
+   A new ifType value (251) for Very High Speed Digital Subscriber Loop
+   Version 2 has been allocated for the VDSL2-LINE-MIB module, to
+   distinguish between ADSL lines that are managed with the RFC 2662
+   management model, ADSL/ADSL2 and ADSL2+ lines that are managed with
+   the RFC 4706 [RFC4706] management model, and VDSL2/ADSL/ADSL2 and
+   ADSL2+ lines that are managed with the model defined in this
+   document.
+
+   Also, the VDSL2-LINE-MIB module has been assigned a single object
+   identifier (251) for its MODULE-IDENTITY.  The IANA has allocated
+   this object identifier in the transmission subtree.
+
+   As performed in the past for the ADSL2-LINE-MIB module, the IANA has
+   ensured that the allocated ifType value is the same as the allocated
+   branch number in the transmission subtree.
+
+2.3.  Conventions Used in the MIB Module
+
+2.3.1.  Naming Conventions
+
+    ADSL   Asymmetric (bit rate) DSL
+    ATM    Asynchronous Transfer Mode
+    atuc   ADSL/ADSL2 or ADSL2+ line termination unit -
+           central office
+    atur   ADSL/ADSL2 or ADSL2+ line termination unit -
+           Remote site
+    BER    Bit Error Rate
+    CO     Central Office
+    CPE    Customer Premise Equipment
+    CRC    Cyclic Redundancy Check
+    DELT   Dual Ended Loop Test
+    DMT    Discrete Multitone
+    DPBO   Downstream PBO
+    DRA    Dynamic Rate Adaptation
+    DSL    Digital Subscriber Line/Loop
+    DSLF   DSL Forum
+    EOC    Embedded Operations Channel
+    ES     Errored Second
+    FE     Far-End (unit)
+    FEBE   Far-End Block Error
+    FEC    Forward Error Correction
+    FFEC   Far-End FEC
+    IMA    Inverse Multiplexing over ATM
+    INP    Impulse Noise Protection
+    ISDN   Integrated Services Digital Network
+    LDSF   Loop Diagnostic State Forced
+
+
+
+Morgenstern, et al.         Standards Track                     [Page 7]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+    LOF    Loss Of Frame
+    LOS    Loss Of Signal
+    LOSS   LOS Seconds
+    LPR    Loss of Power
+    NE     Network Element or Near-End (unit)
+    NSC    Highest transmittable subcarriers index
+    NSCds  NSC for downstream transmission direction
+    NSCus  NSC for upstream transmission direction
+    OLR    Online Reconfiguration
+    PBO    Power Backoff
+    PM     Performance Monitoring
+    PMS-TC Physical Media Specific-Transmission Convergence
+    POTS   Plain Old Telephone Service
+    PSD    Power Spectral Density
+    PTM    Packet Transfer Mode
+    QLN    Quiet Line
+    RDI    Remote Defect Indication
+    RFI    Radio Frequency Interference
+    SEF    Severely Errored Frame
+    SES    Severely Errored Second
+    SNR    Signal-to-Noise Ratio
+    TC     Transmission Convergence (e.g., ATM sub layer)
+    TCM    (TCM-ISDN) Time Compression Multiplexed ISDN
+    UAS    Unavailable Seconds
+    U-C    Loop interface-central office end
+    UPBO   Upstream PBO
+    U-R    Loop interface-remote side (i.e., subscriber end of the loop)
+    US0    Upstream band number 0
+    VDSL   Very high speed DSL
+    VTU-O  VDSL2 Transceiver Unit - central office or
+           Network Element End
+    VTU-R  VTU at the remote site (i.e., subscriber end of the loop)
+    vtuc   VDSL2 line termination unit - central office
+    vtur   VDSL2 line termination unit - Remote site
+    xDSL   Either VDSL2, ADSL, ADSL2 or ADSL2+
+    xTU-C  ADSL/ADSL2/ADSL2+ or VDSL2 line termination unit -
+           central office
+    xTU-R  ADSL/ADSL2/ADSL2+ or VDSL2 line termination unit -
+           Remote site
+    xTU    A line termination unit; either an xTU-C or xTU-R
+
+
+
+
+
+
+
+
+
+
+
+Morgenstern, et al.         Standards Track                     [Page 8]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+2.3.2.  Textual Conventions
+
+   The following lists the textual conventions defined by VDSL2-LINE-TC-
+   MIB in this document:
+
+   o  Xdsl2Unit
+
+   o  Xdsl2Direction
+
+   o  Xdsl2Band
+
+   o  Xdsl2TransmissionModeType
+
+   o  Xdsl2RaMode
+
+   o  Xdsl2InitResult
+
+   o  Xdsl2OperationModes
+
+   o  Xdsl2PowerMngState
+
+   o  Xdsl2ConfPmsForce
+
+   o  Xdsl2LinePmMode
+
+   o  Xdsl2LineLdsf
+
+   o  Xdsl2LdsfResult
+
+   o  Xdsl2LineBpsc
+
+   o  Xdsl2BpscResult
+
+   o  Xdsl2LineReset
+
+   o  Xdsl2LineProfiles
+
+   o  Xdsl2LineClassMask
+
+   o  Xdsl2LineLimitMask
+
+   o  Xdsl2LineUs0Disable
+
+   o  Xdsl2LineUs0Mask
+
+   o  Xdsl2SymbolProtection
+
+   o  Xdsl2SymbolProtection8
+
+
+
+Morgenstern, et al.         Standards Track                     [Page 9]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   o  Xdsl2MaxBer
+
+   o  Xdsl2ChInitPolicy
+
+   o  Xdsl2ScMaskDs
+
+   o  Xdsl2ScMaskUs
+
+   o  Xdsl2CarMask
+
+   o  Xdsl2RfiBands
+
+   o  Xdsl2PsdMaskDs
+
+   o  Xdsl2PsdMaskUs
+
+   o  Xdsl2Tssi
+
+   o  Xdsl2LastTransmittedState
+
+   o  Xdsl2LineStatus
+
+   o  Xdsl2ChInpReport
+
+   o  Xdsl2ChAtmStatus
+
+   o  Xdsl2ChPtmStatus
+
+   o  Xdsl2UpboKLF
+
+   o  Xdsl2BandUs
+
+   o  Xdsl2LinePsdMaskSelectUs
+
+   o  Xdsl2LineCeFlag
+
+   o  Xdsl2LineSnrMode
+
+   o  Xdsl2LineTxRefVnDs
+
+   o  Xdsl2LineTxRefVnUs
+
+   o  Xdsl2BitsAlloc
+
+   o  Xdsl2MrefPsdDs
+
+   o  Xdsl2MrefPsdUs
+
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 10]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+2.4.  Structure
+
+   The MIB module is structured into the following MIB groups:
+
+   o  Line Configuration, Maintenance, and Status Group:
+
+      This group supports MIB objects for configuring parameters for the
+      VDSL2/ADSL/ADSL2 or ADSL2+ line and retrieving line status
+      information.  It also supports MIB objects for configuring a
+      requested power state or initiating a Dual Ended Loop Test (DELT)
+      process in the VDSL2/ADSL/ADSL2 or ADSL2+ line.  It contains the
+      following tables:
+
+         - xdsl2LineTable
+         - xdsl2LineSegmentTable
+         - xdsl2LineBandTable
+
+   o  Channel Status Group:
+
+      This group supports MIB objects for retrieving channel layer
+      status information.  It contains the following table:
+
+         - xdsl2ChannelStatusTable
+
+   o  Subcarrier Status Group:
+
+      This group supports MIB objects for retrieving the subcarrier
+      layer status information, mostly collected by a Dual Ended Loop
+      Test (DELT) process.  It contains the following tables:
+
+         - xdsl2SCStatusTable
+         - xdsl2SCStatusBandTable
+         - xdsl2SCStatusSegmentTable
+
+   o  Unit Inventory Group:
+
+      This group supports MIB objects for retrieving Unit inventory
+      information about units in VDSL2/ADSL/ADSL2 or ADSL2+ lines via
+      the EOC.  It contains the following table:
+
+         - xdsl2LineInventoryTable
+
+   o  Current Performance Group:
+
+      This group supports MIB objects that provide the current
+      performance information relating to VDSL2/ADSL/ADSL2 and ADSL2+
+      line, unit, and channel levels.  It contains the following tables:
+
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 11]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+         - xdsl2PMLineCurrTable
+         - xdsl2PMLineInitCurrTable
+         - xdsl2PMChCurrTable
+
+   o  15-Minute Interval Performance Group:
+
+      This group supports MIB objects that provide historic performance
+      information relating to VDSL2/ADSL/ADSL2 and ADSL2+ line, unit,
+      and channel levels in 15-minute intervals.  It contains the
+      following tables:
+
+         - xdsl2PMLineHist15MinTable
+         - xdsl2PMLineInitHist15MinTable
+         - xdsl2PMChHist15MinTable
+
+   o  1-Day Interval Performance Group:
+
+      This group supports MIB objects that provide historic performance
+      information relating to VDSL2/ADSL/ADSL2 and ADSL2+ line, unit,
+      and channel levels in 1-day intervals.  It contains the following
+      tables:
+
+         - xdsl2PMLineHist1DayTable
+         - xdsl2PMLineInitHist1DayTable
+         - xdsl2PMChHist1DTable
+
+   o  Configuration Template and Profile Group:
+
+      This group supports MIB objects for defining configuration
+      profiles for VDSL2/ADSL/ADSL2 and ADSL2+ lines and channels, as
+      well as configuration templates.  Each configuration template is
+      comprised of a one-line configuration profile and one or more
+      channel configuration profiles.  This group contains the following
+      tables:
+
+         - xdsl2LineConfTemplateTable
+         - xdsl2LineConfProfTable
+         - xdsl2LineConfProfModeSpecTable
+         - xdsl2LineConfProfModeSpecBandUsTable
+         - xdsl2ChConfProfileTable
+
+   o  Alarm Configuration Template and Profile Group:
+
+      This group supports MIB objects for defining alarm profiles for
+      VDSL2/ADSL/ADSL2 and ADSL2+ lines and channels, as well as alarm
+      templates.  Each alarm template is comprised of one line alarm
+      profile and one or more channel-alarm profiles.  This group
+      contains the following tables:
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 12]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+         - xdsl2LineAlarmConfTemplateTable
+         - xdsl2LineAlarmConfProfileTable
+         - xdsl2ChAlarmConfProfileTable
+
+   o  Notifications Group:
+
+      This group defines the notifications supported for VDSL2/ADSL/
+      ADSL2 and ADSL2+ lines:
+
+         - xdsl2LinePerfFECSThreshXtuc
+         - xdsl2LinePerfFECSThreshXtur
+         - xdsl2LinePerfESThreshXtuc
+         - xdsl2LinePerfESThreshXtur
+         - xdsl2LinePerfSESThreshXtuc
+         - xdsl2LinePerfSESThreshXtur
+         - xdsl2LinePerfLOSSThreshXtuc
+         - xdsl2LinePerfLOSSThreshXtur
+         - xdsl2LinePerfUASThreshXtuc
+         - xdsl2LinePerfUASThreshXtur
+         - xdsl2LinePerfCodingViolationsThreshXtuc
+         - xdsl2LinePerfCodingViolationsThreshXtur
+         - xdsl2LinePerfCorrectedThreshXtuc
+         - xdsl2LinePerfCorrectedThreshXtur
+         - xdsl2LinePerfFailedFullInitThresh
+         - xdsl2LinePerfFailedShortInitThresh
+         - xdsl2LineStatusChangeXtuc
+         - xdsl2LineStatusChangeXtur
+
+2.5.  Persistence
+
+   All read-create objects and most read-write objects defined in this
+   MIB module SHOULD be stored persistently.  The following is an
+   exhaustive list of these persistent objects:
+
+         xdsl2LineConfTemplate
+         xdsl2LineAlarmConfTemplate
+         xdsl2LineCmndConfPmsf
+         xdsl2LConfTempTemplateName
+         xdsl2LConfTempLineProfile
+         xdsl2LConfTempChan1ConfProfile
+         xdsl2LConfTempChan1RaRatioDs
+         xdsl2LConfTempChan1RaRatioUs
+         xdsl2LConfTempChan2ConfProfile
+         xdsl2LConfTempChan2RaRatioDs
+         xdsl2LConfTempChan2RaRatioUs
+         xdsl2LConfTempChan3ConfProfile
+         xdsl2LConfTempChan3RaRatioDs
+         xdsl2LConfTempChan3RaRatioUs
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 13]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+         xdsl2LConfTempChan4ConfProfile
+         xdsl2LConfTempChan4RaRatioDs
+         xdsl2LConfTempChan4RaRatioUs
+         xdsl2LConfTempRowStatus
+         xdsl2LConfProfProfileName
+         xdsl2LConfProfScMaskDs
+         xdsl2LConfProfScMaskUs
+         xdsl2LConfProfVdsl2CarMask
+         xdsl2LConfProfRfiBandsDs
+         xdsl2LConfProfRaModeDs
+         xdsl2LConfProfRaModeUs
+         xdsl2LConfProfRaUsNrmDs
+         xdsl2LConfProfRaUsNrmUs
+         xdsl2LConfProfRaUsTimeDs
+         xdsl2LConfProfRaUsTimeUs
+         xdsl2LConfProfRaDsNrmDs
+         xdsl2LConfProfRaDsNrmUs
+         xdsl2LConfProfRaDsTimeDs
+         xdsl2LConfProfRaDsTimeUs
+         xdsl2LConfProfTargetSnrmDs
+         xdsl2LConfProfTargetSnrmUs
+         xdsl2LConfProfMaxSnrmDs
+         xdsl2LConfProfMaxSnrmUs
+         xdsl2LConfProfMinSnrmDs
+         xdsl2LConfProfMinSnrmUs
+         xdsl2LConfProfMsgMinUs
+         xdsl2LConfProfMsgMinDs
+         xdsl2LConfProfXtuTransSysEna
+         xdsl2LConfProfPmMode
+         xdsl2LConfProfL0Time
+         xdsl2LConfProfL2Time
+         xdsl2LConfProfL2Atpr
+         xdsl2LConfProfL2Atprt
+         xdsl2LConfProfProfiles
+         xdsl2LConfProfDpboEPsd
+         xdsl2LConfProfDpboEsEL
+         xdsl2LConfProfDpboEsCableModelA
+         xdsl2LConfProfDpboEsCableModelB
+         xdsl2LConfProfDpboEsCableModelC
+         xdsl2LConfProfDpboMus
+         xdsl2LConfProfDpboFMin
+         xdsl2LConfProfDpboFMax
+         xdsl2LConfProfUpboKL
+         xdsl2LConfProfUpboKLF
+         xdsl2LConfProfUs0Mask
+         xdsl2LConfProfRowStatus
+         xdsl2LConfProfXdslMode
+         xdsl2LConfProfMaxNomPsdDs
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 14]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+         xdsl2LConfProfMaxNomPsdUs
+         xdsl2LConfProfMaxNomAtpDs
+         xdsl2LConfProfMaxNomAtpUs
+         xdsl2LConfProfMaxAggRxPwrUs
+         xdsl2LConfProfPsdMaskDs
+         xdsl2LConfProfPsdMaskUs
+         xdsl2LConfProfPsdMaskSelectUs
+         xdsl2LConfProfClassMask
+         xdsl2LConfProfLimitMask
+         xdsl2LConfProfUs0Disabl
+         xdsl2LConfProfModeSpecRowStatus
+         xdsl2LConfProfXdslBandUs
+         xdsl2LConfProfUpboPsdA
+         xdsl2LConfProfUpboPsdB
+         xdsl2LConfProfModeSpecBandUsRowStatus
+         xdsl2ChConfProfProfileName
+         xdsl2ChConfProfMinDataRateDs
+         xdsl2ChConfProfMinDataRateUs
+         xdsl2ChConfProfMinResDataRateDs
+         xdsl2ChConfProfMinResDataRateUs
+         xdsl2ChConfProfMaxDataRateDs
+         xdsl2ChConfProfMaxDataRateUs
+         xdsl2ChConfProfMinDataRateLowPwrDs
+         xdsl2ChConfProfMaxDelayDs
+         xdsl2ChConfProfMaxDelayUs
+         xdsl2ChConfProfMinProtectionDs
+         xdsl2ChConfProfMinProtectionUs
+         xdsl2ChConfProfMaxBerDs
+         xdsl2ChConfProfMaxBerUs
+         xdsl2ChConfProfUsDataRateDs
+         xdsl2ChConfProfDsDataRateDs
+         xdsl2ChConfProfUsDataRateUs
+         xdsl2ChConfProfDsDataRateUs
+         xdsl2ChConfProfImaEnabled
+         xdsl2ChConfProfMaxDelayVar
+         xdsl2ChConfProfInitPolicy
+         xdsl2ChConfProfRowStatus
+         xdsl2LAlarmConfTempTemplateName
+         xdsl2LAlarmConfTempLineProfile
+         xdsl2LAlarmConfTempChan1ConfProfile
+         xdsl2LAlarmConfTempChan2ConfProfile
+         xdsl2LAlarmConfTempChan3ConfProfile
+         xdsl2LAlarmConfTempChan4ConfProfile
+         xdsl2LAlarmConfTempRowStatus
+         xdsl2LineAlarmConfProfileName
+         xdsl2LineAlarmConfProfileXtucThresh15MinFecs
+         xdsl2LineAlarmConfProfileXtucThresh15MinEs
+         xdsl2LineAlarmConfProfileXtucThresh15MinSes
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 15]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+         xdsl2LineAlarmConfProfileXtucThresh15MinLoss
+         xdsl2LineAlarmConfProfileXtucThresh15MinUas
+         xdsl2LineAlarmConfProfileXturThresh15MinFecs
+         xdsl2LineAlarmConfProfileXturThresh15MinEs
+         xdsl2LineAlarmConfProfileXturThresh15MinSes
+         xdsl2LineAlarmConfProfileXturThresh15MinLoss
+         xdsl2LineAlarmConfProfileXturThresh15MinUas
+         xdsl2LineAlarmConfProfileThresh15MinFailedFullInt
+         xdsl2LineAlarmConfProfileThresh15MinFailedShrtInt
+         xdsl2LineAlarmConfProfileRowStatus
+         xdsl2ChAlarmConfProfileName
+         xdsl2ChAlarmConfProfileXtucThresh15MinCodingViolations
+         xdsl2ChAlarmConfProfileXtucThresh15MinCorrected
+         xdsl2ChAlarmConfProfileXturThresh15MinCodingViolations
+         xdsl2ChAlarmConfProfileXturThresh15MinCorrected
+         xdsl2ChAlarmConfProfileRowStatus
+
+   Note, also, that the interface indices in this MIB are maintained
+   persistently.  View-based Access Control Model (VACM) data relating
+   to these SHOULD be stored persistently as well [RFC3410].
+
+2.6.  Line Topology
+
+   A VDSL2/ADSL/ADSL2 and ADSL2+ line consists of two units: atuc or
+   vtuc (a central office termination unit) and atur or vtur (a remote
+   termination unit).  There are up to 4 channels (maximum number of
+   channels depends on the specific DSL technology), each carrying an
+   independent information flow, as shown in the figure below.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 16]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       <-- Network Side                            Customer Side -->
+
+       |<///////////// VDSL2/ADSL/ADSL2/ADSL2+ Span //////////////>|
+
+       +-------+                                           +-------+
+       |       |<---------------------1------------------->|       |
+       | atuc  |<---------------------2------------------->|  atur |
+       |  or   |<~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~>|   or  |
+       | vtuc  |<---------------------3------------------->|  vtuc |
+       |       |<---------------------4------------------->|       |
+       +-------+                                           +-------+
+
+       Key:  <////> VDSL2/ADSL/ADSL2/ADSL2+ Span
+             <~~~~> VDSL2/ADSL/ADSL2/ADSL2+ twisted-pair
+             -1-    Channel #1 carried over the line
+             -2-    Optional channel #2 carried over the line
+             -3-    Optional channel #3 carried over the line
+             -4-    Optional channel #4 carried over the line
+
+   Figure 3: General Topology for a VDSL2/ADSL/ADSL2/ADSL2+ Line
+
+2.7.  Counters, Interval Buckets, and Thresholds
+
+2.7.1.  Counters Managed
+
+   There are various types of counters specified in this MIB.  Each
+   counter refers either to the whole VDSL2/ADSL/ADSL2/ADSL2+ line, to
+   one of the xTU entities, or to one of the bearer channels.
+
+   o  On the whole line level
+
+      For full initializations, failed full initializations, short
+      initializations, and for failed short initializations, there are
+      event counters, current 15-minute and 0 to 96 15-minute history
+      bucket(s) of "interval-counters", as well as current and 0 to 30
+      previous 1-day interval-counter(s).  Each current 15-minute
+      "failed" event bucket has an associated threshold notification.
+
+   o  On the xTU level
+
+      For the LOS seconds, ES, SES, FEC seconds, and UAS, there are
+      event counters, current 15-minute and 0 to 96 15-minute history
+      bucket(s) of "interval-counters", as well as current and 0 to 30
+      previous 1-day interval-counter(s).  Each current 15-minute event
+      bucket has an associated threshold notification.
+
+
+
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 17]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   o  On the bearer channel level
+
+      For the coding violations (CRC anomalies) and corrected blocks
+      (i.e., FEC events), there are event counters, current 15-minute
+      and 0 to 96 15-minute history bucket(s) of "interval-counters", as
+      well as current and 0 to 30 previous 1-day interval-counter(s).
+      Each current 15-minute event bucket has an associated threshold
+      notification.
+
+2.7.2.  Minimum Number of Buckets
+
+   Although it is possible to support up to 96 15-minute history buckets
+   of "interval-counters", systems implementing this MIB module SHOULD
+   practically support at least 16 buckets, as specified in ITU-T
+   G.997.1, paragraph #7.2.7.9.
+
+   Similarly, it is possible to support up to 30 previous 1-day
+   "interval-counters", but systems implementing this MIB module SHOULD
+   support at least 1 previous day bucket.
+
+2.7.3.  Interval Buckets Initialization
+
+   There is no requirement for an agent to ensure a fixed relationship
+   between the start of a 15-minute interval and any wall clock;
+   however, some implementations may align the 15-minute intervals with
+   quarter hours.  Likewise, an implementation may choose to align 1-day
+   intervals with the start of a day.
+
+   Counters are not reset when an xTU is reinitialized, only when the
+   agent is reset or reinitialized (or under specific request outside
+   the scope of this MIB module).
+
+2.7.4.  Interval Buckets Validity
+
+   As in RFC 3593 [RFC3593] and RFC 2662 [RFC2662], in case the data for
+   an interval is suspect or known to be invalid, the agent MUST report
+   the interval as invalid.  If the current 15-minute event bucket is
+   determined to be invalid, the element management system SHOULD ignore
+   its content and the agent MUST NOT generate notifications based upon
+   the value of the event bucket.
+
+   A valid 15-minute event bucket SHOULD usually count the events for
+   exactly 15 minutes.  Similarly, a valid 1-day event bucket SHOULD
+   usually count the events for exactly 24 hours.  However, the
+   following scenarios are exceptional:
+
+
+
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 18]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   1) For implementations that align the 15-minute intervals with
+      quarter hours and the 1-day intervals with start of a day, the
+      management system may still start the PM process not aligned with
+      the wall clock.  Such a management system may wish to retrieve
+      even partial information for the first event buckets, rather than
+      declaring them all as invalid.
+
+   2) For an event bucket that suffered relatively short outages, the
+      management system may wish to retrieve the available PM outcomes,
+      rather than declaring the whole event bucket as invalid.  This is
+      more important for 1-day event buckets.
+
+   3) An event bucket may be shorter or longer than the formal duration
+      if a clock adjustment was performed during the interval.
+
+   This MIB module allows supporting the exceptional scenarios described
+   above by reporting the actual Monitoring Time of a monitoring
+   interval.  This parameter is relevant only for Valid intervals, but
+   is useful for these exceptional scenarios:
+
+   a) The management system MAY still declare a partial PM interval as
+      Valid and report the actual number of seconds the interval lasted.
+
+   b) If the interval was shortened or extended due to clock
+      corrections, the management system SHOULD report the actual number
+      of seconds the interval lasted, in addition to reporting that the
+      interval is Valid.
+
+2.8.  Profiles
+
+   As a managed node can handle a large number of xTUs, (e.g., hundreds
+   or perhaps thousands of lines), provisioning every parameter on every
+   xTU may become burdensome.  Moreover, most lines are provisioned
+   identically with the same set of parameters.  To simplify the
+   provisioning process, this MIB module makes use of profiles and
+   templates.
+
+   A configuration profile is a set of parameters that can be shared by
+   multiple entities.  There is a configuration profile to address line-
+   level provisioning and another type of profile that addresses
+   channel-level provisioning parameters.
+
+   A configuration template is actually a profile-of-profiles.  That is,
+   a template is comprised of one-line configuration profile and one or
+   more channel configuration profiles.  A template provides the
+   complete configuration of a line.  The same configuration can be
+   shared by multiple lines.
+
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 19]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   In a similar manner to the configuration profiles and templates, this
+   MIB module makes use of templates and profiles for specifying the
+   alarm thresholds associated with performance parameters.  This allows
+   provisioning multiple lines with the same criteria for generating
+   threshold crossing notifications.
+
+   The following paragraphs describe templates and profiles used in this
+   MIB module.
+
+2.8.1.  Configuration Profiles and Templates
+
+   o  Line Configuration Profiles - Line configuration profiles contain
+      line-level parameters for configuring VDSL2/ADSL/ADSL2 and ADSL2+
+      lines.  They are defined in the xdsl2LineConfProfTable.
+
+      The line configuration includes settings such as the specific
+      VDSL2/ADSL/ADSL2 or ADSL2+ modes to enable on the respective line,
+      power spectrum parameters, rate adaptation criteria, and SNR
+      margin-related parameters.  A subset of the line configuration
+      parameters depends upon the specific xDSL Mode allowed (i.e., does
+      the profile allow VDSL2, ADSL, ADSL2 and/or ADSL2+?) as well as
+      what annex/annexes of the standard are allowed.  This is the
+      reason a line profile MUST include one or more mode-specific
+      extensions.
+
+   o  Channel Configuration Profiles - Channel configuration profiles
+      contain parameters for configuring bearer channels over the VDSL2/
+      ADSL/ADSL2 and ADSL2+ lines.  They are sometimes considered as the
+      service layer configuration of the VDSL2/ADSL/ADSL2 and ADSL2+
+      lines.  They are defined in the xdsl2ChConfProfTable.
+
+      The channel configuration includes issues such as the desired
+      minimum and maximum rate on each traffic flow direction and
+      impulse noise protection parameters.
+
+   o  Line Configuration Templates - Line configuration templates allow
+      combining line configuration profiles and channel configuration
+      profiles into a comprehensive configuration of the VDSL2/ADSL/
+      ADSL2 and ADSL2+ line.  They are defined in the
+      xdsl2LineConfTemplateTable.
+
+      The line configuration template includes one index of a line
+      configuration profile and one to four indices of channel
+      configuration profiles.  The template also addresses the issue of
+      distributing the excess available data rate on each traffic flow
+
+
+
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 20]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      direction (i.e., the data rate left after each channel is
+      allocated a data rate to satisfy its minimum requested data rate)
+      among the various channels.
+
+2.8.2.  Alarm Configuration Profiles and Templates
+
+   o  Line Alarm Configuration Profiles - Line-level Alarm configuration
+      profiles contain the threshold values for Performance Monitoring
+      (PM) parameters, counted either on the whole line level or on an
+      xTU level.  Thresholds are required only for failures and
+      anomalies.  For example, there are thresholds for failed
+      initializations and LOS seconds, but not for the aggregate number
+      of full initializations.  These profiles are defined in the
+      xdsl2LineAlarmConfProfileTable.
+
+   o  Channel Alarm Configuration Profiles - Channel-level Alarm
+      configuration profiles contain the threshold values for PM
+      parameters counted on a bearer channel level.  Thresholds are
+      defined for two types of anomalies: corrected blocks and coding
+      violations.  These profiles are defined in the
+      xdsl2ChAlarmConfProfileTable.
+
+   o  Line Alarm Configuration Templates - Line Alarm configuration
+      templates allow combining line-level alarm configuration profiles
+      and channel-level alarm configuration profiles into a
+      comprehensive configuration of the PM thresholds for the VDSL2/
+      ADSL/ADSL2 and ADSL2+ line.  They are defined in the
+      xdsl2LineAlarmConfTemplateTable.
+
+      The line alarm configuration template includes one index of a
+      line-level alarm configuration profile and one to four indices of
+      channel-level alarm configuration profiles.
+
+2.8.3.  Managing Profiles and Templates
+
+   The index value for each profile and template is a locally unique,
+   administratively assigned name having the textual convention
+   'SnmpAdminString' (RFC 3411 [RFC3411]).
+
+   One or more lines may be configured to share parameters of a single
+   configuration template (e.g., xdsl2LConfTempTemplateName = 'silver')
+   by setting its xdsl2LineConfTemplate object to the value of this
+   template.
+
+   One or more lines may be configured to share parameters of a single
+   Alarm configuration template (e.g., xdsl2LAlarmConfTempTemplateName =
+   'silver') by setting its xdsl2LineAlarmConfTemplate object to the
+   value of this template.
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 21]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   Before a template can be deleted or taken out of service, it MUST be
+   first unreferenced from all associated lines.  Implementations MAY
+   also reject template modification while it is associated with any
+   line.
+
+   Before a profile can be deleted or taken out of service, it MUST be
+   first unreferenced from all associated templates.  Implementations
+   MAY also reject profile modification while it is referenced by any
+   template.
+
+   Implementations MUST provide a default profile whose name is 'DEFVAL'
+   for each profile and template type.  The values of the associated
+   parameters will be vendor-specific unless otherwise indicated in this
+   document.  Before a line's templates have been set, these templates
+   will be automatically used by setting xdsl2LineConfTemplate and
+   xdsl2LineAlarmConfTemplate to 'DEFVAL' where appropriate.  This
+   default profile name, 'DEFVAL', is considered reserved in the context
+   of profiles and templates defined in this MIB module.
+
+   Profiles and templates are created, assigned, and deleted dynamically
+   using the profile name and profile row status in each of the profile
+   tables.
+
+   If the implementation allows modifying a profile or template while it
+   is associated with a line, then such changes MUST take effect
+   immediately.  These changes MAY result in a restart (hard reset or
+   soft restart) of the units on the line.
+
+   Network Elements MAY optionally implement a fallback line
+   configuration template (see xdsl2LineConfFallbackTemplate).  The
+   fallback template will be tried if the xDSL2 line fails to operate
+   using the primary template.  If the xDSL2 line fails to operate using
+   the fallback template, then the primary template should be retried.
+   The xTU-C SHOULD continue to alternate between the primary and
+   fallback templates until one of them succeeds.
+
+2.8.4.  Managing Multiple Bearer Channels
+
+   The number of bearer channels is configured by setting the template
+   objects xdsl2LConfTempChan1ConfProfile,
+   xdsl2LConfTempChan2ConfProfile, xdsl2LConfTempChan3ConfProfile, and
+   xdsl2LConfTempChan4ConfProfile and then assigning that template to a
+   DSL line using the xdsl2LineConfTemplate object.  When the number of
+   bearer channels for a DSL line changes, the SNMP agent will
+   automatically create or destroy rows in channel-related tables
+   associated with that line.  For example, when a DSL line is operating
+
+
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 22]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   with one bearer channel, there will be zero rows in channel-related
+   tables for channels two, three, and four.  The SNMP agent MUST create
+   and destroy channel-related rows as follows:
+
+   o  When the number of bearer channels for a DSL line changes to a
+      higher number, the SNMP agent will automatically create rows in
+      the xdsl2ChannelStatusTable and xdsl2PMChCurrTable tables for that
+      line.
+
+   o  When the number of bearer channels for a DSL line changes to a
+      lower number, the SNMP agent will automatically destroy rows in
+      the xdsl2ChannelStatusTable,
+      xdsl2PMChCurrTable,xdsl2PMChHist15MinTable, and
+      xdsl2PMChHist1DTable tables for that line.
+
+2.9.  Notifications
+
+   The ability to generate the SNMP notifications coldStart/WarmStart
+   (per [RFC3418]), which are per agent (e.g., per Digital Subscriber
+   Line Access Multiplexer, or DSLAM, in such a device), and linkUp/
+   linkDown (per [RFC2863]), which are per interface (i.e., VDSL2/ADSL/
+   ADSL2 or ADSL2+ line) is required.
+
+   A linkDown notification MAY be generated whenever any of ES, SES, CRC
+   anomaly, LOS, LOF, or UAS events occur.  The corresponding linkUp
+   notification MAY be sent when all link failure conditions are
+   cleared.
+
+   The notifications defined in this MIB module are for status change
+   (e.g., initialization failure) and for the threshold crossings
+   associated with the following events: full initialization failures,
+   short initialization failures, ES, SES, LOS seconds, UAS, FEC
+   seconds, FEC events, and CRC anomalies.  Each threshold has its own
+   enable/threshold value.  When that value is 0, the notification is
+   disabled.
+
+   The xdsl2LineStatusXtur and xdsl2LineStatusXtuc are bitmasks
+   representing all outstanding error conditions associated with the
+   xTU-R and xTU-C (respectively).  Note that since the xTU-R status is
+   obtained via the EOC, this information may be unavailable in case the
+   xTU-R is unreachable via EOC during a line error condition.
+   Therefore, not all conditions may always be included in its current
+   status.  Notifications corresponding to the bit fields in those two
+   status objects are defined.
+
+
+
+
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 23]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   Note that there are other status parameters that refer to the xTU-R
+   (e.g., downstream line attenuation).  Those parameters also depend on
+   the availability of EOC between the central office xTU and the remote
+   xTU.
+
+   A threshold notification occurs whenever the corresponding current
+   15-minute interval error counter becomes equal to, or exceeds the
+   threshold value.  Only one notification SHOULD be sent per interval
+   per interface.  Since the current 15-minute counter is reset to 0
+   every 15 minutes, and if the condition persists, the notification may
+   recur as often as every 15 minutes.  For example, to get a
+   notification whenever a "loss of" event occurs (but at most once
+   every 15 minutes), set the corresponding threshold to 1.  The agent
+   will generate a notification when the event originally occurs.
+
+   Note that the Network Management System, or NMS, may receive a
+   linkDown notification, as well, if enabled (via
+   ifLinkUpDownTrapEnable [RFC2863]).  At the beginning of the next 15-
+   minute interval, the counter is reset.  When the first second goes by
+   and the event occurs, the current interval bucket will be 1, which
+   equals the threshold, and the notification will be sent again.
+
+3.  Definitions
+
+VDSL2-LINE-TC-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+   MODULE-IDENTITY,
+   transmission
+      FROM SNMPv2-SMI
+
+   TEXTUAL-CONVENTION
+      FROM SNMPv2-TC;
+
+vdsl2TCMIB MODULE-IDENTITY
+   LAST-UPDATED "200909300000Z" -- September 30, 2009
+   ORGANIZATION "ADSLMIB Working Group"
+   CONTACT-INFO "WG-email:  adslmib@ietf.org
+   Info:      https://www1.ietf.org/mailman/listinfo/adslmib
+
+             Chair:     Mike Sneed
+                        Sand Channel Systems
+             Postal:    P.O. Box 37324
+                        Raleigh NC 27627-732
+             Email:     sneedmike@hotmail.com
+             Phone:     +1 206 600 7022
+
+             Co-Chair:  Menachem Dodge
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 24]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+                        ECI Telecom Ltd.
+             Postal:    30 Hasivim St.
+                        Petach Tikva 49517,
+                        Israel.
+             Email:     mbdodge@ieee.org
+             Phone:     +972 3 926 8421
+
+             Co-editor: Moti Morgenstern
+                        ECI Telecom Ltd.
+             Postal:    30 Hasivim St.
+                        Petach Tikva 49517,
+                        Israel.
+             Email:     moti.morgenstern@ecitele.com
+             Phone:     +972 3 926 6258
+
+             Co-editor: Scott Baillie
+                        NEC Australia
+             Postal:    649-655 Springvale Road,
+                        Mulgrave, Victoria 3170,
+                        Australia.
+             Email:     scott.baillie@nec.com.au
+             Phone:     +61 3 9264 3986
+
+             Co-editor: Umberto Bonollo
+                        NEC Australia
+             Postal:    649-655 Springvale Road,
+                        Mulgrave, Victoria 3170,
+                        Australia.
+             Email:     umberto.bonollo@nec.com.au
+             Phone:     +61 3 9264 3385
+            "
+   DESCRIPTION
+        "This MIB Module provides Textual Conventions to be
+         used by the VDSL2-LINE-MIB module for the purpose of
+         managing VDSL2, ADSL, ADSL2, and ADSL2+ lines.
+
+         Copyright (c) 2009 IETF Trust and the persons
+         identified as authors of the code.  All rights
+         reserved.
+
+         Redistribution and use in source and binary
+         forms, with or without modification, are
+         permitted provided that the following
+         conditions are met:
+
+         - Redistributions of source code must retain the
+           above copyright notice, this list of conditions
+           and the following disclaimer.
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 25]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+         - Redistributions in binary form must reproduce
+           the above copyright notice, this list of
+           conditions and the following disclaimer in
+           the documentation and/or other materials provided
+           with the distribution.
+
+         - Neither the name of Internet Society, IETF or
+           IETF Trust, nor the names of specific contributors,
+           may be used to endorse or promote products derived
+           from this software without specific prior written
+           permission.
+
+         THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+         CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED
+         WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+         WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+         PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL
+         THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY
+         DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+         CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+         PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+         DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+         AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+         LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+         ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+         ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+         This version of this MIB module is part of RFC 5650;
+         see the RFC itself for full legal notices."
+
+   REVISION "200909300000Z" -- September 30, 2009
+   DESCRIPTION "Initial version, published as RFC 5650."
+      ::= { transmission 251 3} -- vdsl2MIB 3
+
+------------------------------------------------
+--          Textual Conventions               --
+------------------------------------------------
+
+Xdsl2Unit ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Identifies a transceiver as being either xTU-C or xTU-R.
+       A VDSL2/ADSL/ADSL2 or ADSL2+ line consists of two
+       transceivers: an xTU-C and an xTU-R.
+       In the case of ADSL/ADSL2 and ADSL2+, those two transceivers are
+       also called atuc and atur.
+       In the case of VDSL2, those two transceivers are also called
+       vtuc and vtur.
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 26]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       Specified as an INTEGER, the two values are:
+        xtuc(1)  -- central office transceiver
+        xtur(2)  -- remote site transceiver"
+   SYNTAX      INTEGER {
+                  xtuc(1),
+                  xtur(2)
+               }
+
+Xdsl2Direction ::= TEXTUAL-CONVENTION
+     STATUS current
+     DESCRIPTION
+        "Identifies the direction of a band in a VDSL2/ADSL/ADSL2/
+         ADSL2+ link.
+         The upstream direction is a transmission from the remote end
+         (xTU-R) towards the central office end (xTU-C).  The downstream
+         direction is a transmission from the xTU-C towards the xTU-R.
+         Specified as an INTEGER, the values are defined as
+         follows:"
+     SYNTAX INTEGER {
+        upstream(1),   -- Transmission from the xTU-R to the xTU-C.
+        downstream(2)  -- Transmission from the xTU-C to the xTU-R.
+            }
+
+Xdsl2Band ::= TEXTUAL-CONVENTION
+     STATUS current
+     DESCRIPTION
+        "Identifies a band in a VDSL2/ADSL/ADSL2/ADSL2+ link.
+         For a band in the upstream direction, transmission is from the
+         remote end (xTU-R) towards the central office end (xTU-C).
+         For a band in the downstream direction, transmission is from
+         the xTU-C towards the xTU-R.
+         For ADSL, ADSL2 and ADSL2+, which use a single band in the
+         upstream direction and a single band
+         in the downstream direction,
+         the only relevant values are upstream(1) and downstream(2).
+         For VDSL2, which uses multiple bands in each transmission
+         direction, a band in the upstream direction is indicated by any
+         of us0(3), us1(5), us2(7), us3(9), or us4(11), and a band in
+         the downstream direction is indicated by any of ds1(4),
+         ds2(6), ds3(8), or ds4(10).
+         For VDSL2, the values upstream(1) and downstream(2) may be used
+         when there is a need to refer to the whole upstream or
+         downstream traffic (e.g., report the average signal-to-noise
+         ratio on any transmission direction).
+         Specified as an INTEGER, the values are defined as
+         follows:"
+     SYNTAX INTEGER {
+        upstream(1),   -- Transmission from the xTU-R to the xTU-C
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 27]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+                       -- (refers to the single upstream band for
+                       -- ADSL/ADSL2/ADSL2+ or to the whole
+                       -- upstream traffic for VDSL2).
+        downstream(2), -- Transmission from the xTU-C to the xTU-R
+                       -- (refers to the single downstream band
+                       -- for ADSL/ADSL2/ADSL2+ or to the whole
+                       -- downstream traffic for VDSL2).
+        us0(3),        -- Upstream band number 0   (US0) (VDSL2).
+        ds1(4),        -- Downstream band number 1 (DS1) (VDSL2).
+        us1(5),        -- Upstream band number 1   (US1) (VDSL2).
+        ds2(6),        -- Downstream band number 2 (DS2) (VDSL2).
+        us2(7),        -- Upstream band number 2   (US2) (VDSL2).
+        ds3(8),        -- Downstream band number 3 (DS3) (VDSL2).
+        us3(9),        -- Upstream band number 3   (US3) (VDSL2).
+        ds4(10),       -- Downstream band number 4 (DS4) (VDSL2).
+        us4(11)        -- Upstream band number 4   (US4) (VDSL2).
+            }
+
+Xdsl2TransmissionModeType ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "A set of xDSL line transmission modes, with one bit
+       per mode.  The notes (F) and (L) denote Full-Rate and
+       Lite/splitterless, respectively:
+          Bit 00 : Regional Std. (ANSI T1.413) (F)
+          Bit 01 : Regional Std. (ETSI DTS/TM06006) (F)
+          Bit 02 : G.992.1 POTS non-overlapped (F)
+          Bit 03 : G.992.1 POTS overlapped (F)
+          Bit 04 : G.992.1 ISDN non-overlapped (F)
+          Bit 05 : G.992.1 ISDN overlapped (F)
+          Bit 06 : G.992.1 TCM-ISDN non-overlapped (F)
+          Bit 07 : G.992.1 TCM-ISDN overlapped (F)
+          Bit 08 : G.992.2 POTS non-overlapped (L)
+          Bit 09 : G.992.2 POTS overlapped (L)
+          Bit 10 : G.992.2 with TCM-ISDN non-overlapped (L)
+          Bit 11 : G.992.2 with TCM-ISDN overlapped (L)
+          Bit 12 : G.992.1 TCM-ISDN symmetric (F) --- not in G.997.1
+          Bit 13-17: Reserved
+          Bit 18 : G.992.3 POTS non-overlapped (F)
+          Bit 19 : G.992.3 POTS overlapped (F)
+          Bit 20 : G.992.3 ISDN non-overlapped (F)
+          Bit 21 : G.992.3 ISDN overlapped (F)
+          Bit 22-23: Reserved
+          Bit 24 : G.992.4 POTS non-overlapped (L)
+          Bit 25 : G.992.4 POTS overlapped (L)
+          Bit 26-27: Reserved
+          Bit 28 : G.992.3 Annex I All-Digital non-overlapped (F)
+          Bit 29 : G.992.3 Annex I All-Digital overlapped (F)
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 28]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+          Bit 30 : G.992.3 Annex J All-Digital non-overlapped (F)
+          Bit 31 : G.992.3 Annex J All-Digital overlapped (F)
+          Bit 32 : G.992.4 Annex I All-Digital non-overlapped (L)
+          Bit 33 : G.992.4 Annex I All-Digital overlapped (L)
+          Bit 34 : G.992.3 Annex L POTS non-overlapped, mode 1,
+                                   wide U/S (F)
+          Bit 35 : G.992.3 Annex L POTS non-overlapped, mode 2,
+                                   narrow U/S(F)
+          Bit 36 : G.992.3 Annex L POTS overlapped, mode 3,
+                                   wide U/S (F)
+          Bit 37 : G.992.3 Annex L POTS overlapped, mode 4,
+                                   narrow U/S (F)
+          Bit 38 : G.992.3 Annex M POTS non-overlapped (F)
+          Bit 39 : G.992.3 Annex M POTS overlapped (F)
+          Bit 40 : G.992.5 POTS non-overlapped (F)
+          Bit 41 : G.992.5 POTS overlapped (F)
+          Bit 42 : G.992.5 ISDN non-overlapped (F)
+          Bit 43 : G.992.5 ISDN overlapped (F)
+          Bit 44-45: Reserved
+          Bit 46 : G.992.5 Annex I All-Digital non-overlapped (F)
+          Bit 47 : G.992.5 Annex I All-Digital overlapped (F)
+          Bit 48 : G.992.5 Annex J All-Digital non-overlapped (F)
+          Bit 49 : G.992.5 Annex J All-Digital overlapped (F)
+          Bit 50 : G.992.5 Annex M POTS non-overlapped (F)
+          Bit 51 : G.992.5 Annex M POTS overlapped (F)
+          Bit 52-55: Reserved
+          Bit 56 : G.993.2 Annex A
+          Bit 57 : G.993.2 Annex B
+          Bit 58 : G.993.2 Annex C
+          Bit 59-63: Reserved"
+
+   SYNTAX      BITS {
+                  ansit1413(0),
+                  etsi(1),
+                  g9921PotsNonOverlapped(2),
+                  g9921PotsOverlapped(3),
+                  g9921IsdnNonOverlapped(4),
+                  g9921isdnOverlapped(5),
+                  g9921tcmIsdnNonOverlapped(6),
+                  g9921tcmIsdnOverlapped(7),
+                  g9922potsNonOverlapped(8),
+                  g9922potsOverlapped(9),
+                  g9922tcmIsdnNonOverlapped(10),
+                  g9922tcmIsdnOverlapped(11),
+                  g9921tcmIsdnSymmetric(12),
+                  reserved1(13),
+                  reserved2(14),
+                  reserved3(15),
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 29]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+                  reserved4(16),
+                  reserved5(17),
+                  g9923PotsNonOverlapped(18),
+                  g9923PotsOverlapped(19),
+                  g9923IsdnNonOverlapped(20),
+                  g9923isdnOverlapped(21),
+                  reserved6(22),
+                  reserved7(23),
+                  g9924potsNonOverlapped(24),
+                  g9924potsOverlapped(25),
+                  reserved8(26),
+                  reserved9(27),
+                  g9923AnnexIAllDigNonOverlapped(28),
+                  g9923AnnexIAllDigOverlapped(29),
+                  g9923AnnexJAllDigNonOverlapped(30),
+                  g9923AnnexJAllDigOverlapped(31),
+                  g9924AnnexIAllDigNonOverlapped(32),
+                  g9924AnnexIAllDigOverlapped(33),
+                  g9923AnnexLMode1NonOverlapped(34),
+                  g9923AnnexLMode2NonOverlapped(35),
+                  g9923AnnexLMode3Overlapped(36),
+                  g9923AnnexLMode4Overlapped(37),
+                  g9923AnnexMPotsNonOverlapped(38),
+                  g9923AnnexMPotsOverlapped(39),
+                  g9925PotsNonOverlapped(40),
+                  g9925PotsOverlapped(41),
+                  g9925IsdnNonOverlapped(42),
+                  g9925isdnOverlapped(43),
+                  reserved10(44),
+                  reserved11(45),
+                  g9925AnnexIAllDigNonOverlapped(46),
+                  g9925AnnexIAllDigOverlapped(47),
+                  g9925AnnexJAllDigNonOverlapped(48),
+                  g9925AnnexJAllDigOverlapped(49),
+                  g9925AnnexMPotsNonOverlapped(50),
+                  g9925AnnexMPotsOverlapped(51),
+                  reserved12(52),
+                  reserved13(53),
+                  reserved14(54),
+                  reserved15(55),
+                  g9932AnnexA(56),
+                  g9932AnnexB(57),
+                  g9932AnnexC(58),
+                  reserved16(59),
+                  reserved17(60),
+                  reserved18(61),
+                  reserved19(62),
+                  reserved20(63)
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 30]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+               }
+
+Xdsl2RaMode ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Specifies the rate adaptation behavior for the line.
+       The three possible behaviors are:
+        manual (1)   - No Rate-Adaptation.  The initialization
+                       process attempts to synchronize to a
+                       specified rate.
+        raInit (2)   - Rate-Adaptation during initialization process
+                       only, which attempts to synchronize to a rate
+                       between minimum and maximum specified values.
+        dynamicRa (3)- Dynamic Rate-Adaptation during initialization
+                       process as well as during Showtime."
+   SYNTAX      INTEGER {
+                  manual(1),
+                  raInit(2),
+                  dynamicRa(3)
+               }
+
+Xdsl2InitResult ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Specifies the result of full initialization attempt; the
+       six possible result values are:
+        noFail (0)            - Successful initialization
+        configError (1)       - Configuration failure
+        configNotFeasible (2) - Configuration details not supported
+        commFail (3)          - Communication failure
+        noPeerAtu (4)         - Peer ATU not detected
+        otherCause (5)        - Other initialization failure reason"
+
+   SYNTAX      INTEGER {
+                  noFail(0),
+                  configError(1),
+                  configNotFeasible(2),
+                  commFail(3),
+                  noPeerAtu(4),
+                  otherCause(5)
+               }
+
+Xdsl2OperationModes ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "The VDSL2 management model specified includes an xDSL Mode
+       object that identifies an instance of xDSL Mode-Specific
+       PSD Configuration object in the xDSL Line Profile.  The
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 31]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       following classes of xDSL operating mode are defined.
+       The notes (F) and (L) denote Full-Rate and Lite/splitterless,
+       respectively:
+       +-------+--------------------------------------------------+
+       | Value |         xDSL operation mode description          |
+       +-------+--------------------------------------------------+
+           1   - The default/generic PSD configuration.  Default
+                 configuration will be used when no other matching
+                 mode-specific configuration can be found.
+           2   - Regional Std. (ANSI T1.413) (F)
+           3   - Regional Std. (ETSI DTS/TM06006) (F)
+           4   - G.992.1 POTS non-overlapped (F)
+           5   - G.992.1 POTS overlapped (F)
+           6   - G.992.1 ISDN non-overlapped (F)
+           7   - G.992.1 ISDN overlapped (F)
+           8   - G.992.1 TCM-ISDN non-overlapped (F)
+           9   - G.992.1 TCM-ISDN overlapped (F)
+          10   - G.992.2 POTS non-overlapped (L)
+          11   - G.992.2 POTS overlapped (L)
+          12   - G.992.2 with TCM-ISDN non-overlapped (L)
+          13   - G.992.2 with TCM-ISDN overlapped (L)
+          14   - G.992.1 TCM-ISDN symmetric (F) --- not in G.997.1
+        15-19  - Unused. Reserved for future ITU-T specification.
+          20   - G.992.3 POTS non-overlapped (F)
+          21   - G.992.3 POTS overlapped (F)
+          22   - G.992.3 ISDN non-overlapped (F)
+          23   - G.992.3 ISDN overlapped (F)
+        24-25  - Unused. Reserved for future ITU-T specification.
+          26   - G.992.4 POTS non-overlapped (L)
+          27   - G.992.4 POTS overlapped (L)
+        28-29  - Unused. Reserved for future ITU-T specification.
+          30   - G.992.3 Annex I All-Digital non-overlapped (F)
+          31   - G.992.3 Annex I All-Digital overlapped (F)
+          32   - G.992.3 Annex J All-Digital non-overlapped (F)
+          33   - G.992.3 Annex J All-Digital overlapped (F)
+          34   - G.992.4 Annex I All-Digital non-overlapped (L)
+          35   - G.992.4 Annex I All-Digital overlapped (L)
+          36   - G.992.3 Annex L POTS non-overlapped, mode 1,
+                 wide U/S (F)
+          37   - G.992.3 Annex L POTS non-overlapped, mode 2,
+                 narrow U/S(F)
+          38   - G.992.3 Annex L POTS overlapped, mode 3,
+                 wide U/S (F)
+          39   - G.992.3 Annex L POTS overlapped, mode 4,
+                 narrow U/S (F)
+          40   - G.992.3 Annex M POTS non-overlapped (F)
+          41   - G.992.3 Annex M POTS overlapped (F)
+          42   - G.992.5 POTS non-overlapped (F)
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 32]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+          43   - G.992.5 POTS overlapped (F)
+          44   - G.992.5 ISDN non-overlapped (F)
+          45   - G.992.5 ISDN overlapped (F)
+        46-47  - Unused. Reserved for future ITU-T specification.
+          48   - G.992.5 Annex I All-Digital non-overlapped (F)
+          49   - G.992.5 Annex I All-Digital overlapped (F)
+          50   - G.992.5 Annex J All-Digital non-overlapped (F)
+          51   - G.992.5 Annex J All-Digital overlapped (F)
+          52   - G.992.5 Annex M POTS non-overlapped (F)
+          53   - G.992.5 Annex M POTS overlapped (F)
+        54-57  - Unused. Reserved for future ITU-T specification.
+          58   - G.993.2 Annex A
+          59   - G.993.2 Annex B
+          60   - G.993.2 Annex C
+      "
+   SYNTAX      INTEGER {
+                  defMode(1),
+                  ansit1413(2),
+                  etsi(3),
+                  g9921PotsNonOverlapped(4),
+                  g9921PotsOverlapped(5),
+                  g9921IsdnNonOverlapped(6),
+                  g9921isdnOverlapped(7),
+                  g9921tcmIsdnNonOverlapped(8),
+                  g9921tcmIsdnOverlapped(9),
+                  g9922potsNonOverlapped(10),
+                  g9922potsOverlapped(11),
+                  g9922tcmIsdnNonOverlapped(12),
+                  g9922tcmIsdnOverlapped(13),
+                  g9921tcmIsdnSymmetric(14),
+                  g9923PotsNonOverlapped(20),
+                  g9923PotsOverlapped(21),
+                  g9923IsdnNonOverlapped(22),
+                  g9923isdnOverlapped(23),
+                  g9924potsNonOverlapped(26),
+                  g9924potsOverlapped(27),
+                  g9923AnnexIAllDigNonOverlapped(30),
+                  g9923AnnexIAllDigOverlapped(31),
+                  g9923AnnexJAllDigNonOverlapped(32),
+                  g9923AnnexJAllDigOverlapped(33),
+                  g9924AnnexIAllDigNonOverlapped(34),
+                  g9924AnnexIAllDigOverlapped(35),
+                  g9923AnnexLMode1NonOverlapped(36),
+                  g9923AnnexLMode2NonOverlapped(37),
+                  g9923AnnexLMode3Overlapped(38),
+                  g9923AnnexLMode4Overlapped(39),
+                  g9923AnnexMPotsNonOverlapped(40),
+                  g9923AnnexMPotsOverlapped(41),
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 33]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+                  g9925PotsNonOverlapped(42),
+                  g9925PotsOverlapped(43),
+                  g9925IsdnNonOverlapped(44),
+                  g9925isdnOverlapped(45),
+                  g9925AnnexIAllDigNonOverlapped(48),
+                  g9925AnnexIAllDigOverlapped(49),
+                  g9925AnnexJAllDigNonOverlapped(50),
+                  g9925AnnexJAllDigOverlapped(51),
+                  g9925AnnexMPotsNonOverlapped(52),
+                  g9925AnnexMPotsOverlapped(53),
+                  g9932AnnexA(58),
+                  g9932AnnexB(59),
+                  g9932AnnexC(60)
+               }
+
+Xdsl2PowerMngState ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Objects with this syntax uniquely identify each power
+       management state defined for the VDSL2/ADSL/ADSL2 or ADSL2+
+       link.
+       In VDSL2, only L0 and L3 states are defined.
+       The possible values are:
+         l0(1)              - L0: Full power.  Synchronized and
+                                  full transmission (i.e., Showtime).
+         l1(2)              - L1: Low power with reduced net data rate
+                                  (for G.992.2 only).
+         l2(3)              - L2: Low power with reduced net data rate
+                                  (for G.992.3, G.992.4 and G.992.5).
+         l3(4)              - L3: Idle power management state / No
+         power."
+
+   SYNTAX      INTEGER {
+                  l0(1),
+                  l1(2),
+                  l2(3),
+                  l3(4)
+               }
+
+Xdsl2ConfPmsForce ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Objects with this syntax are configuration parameters
+       that specify the desired power management state transition
+       for the VDSL2/ADSL/ADSL2 or ADSL2+ link.
+       In VDSL2, only L0 and L3 states are defined:
+         l3toL0 (0)         - Perform a transition from L3 to L0
+                              (Full power management state).
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 34]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+         l0toL2 (2)         - Perform a transition from L0 to L2
+                              (Low power management state).
+         l0orL2toL3 (3)     - Perform a transition into L3 (Idle
+                              power management state)."
+
+   SYNTAX      INTEGER {
+                  l3toL0 (0),
+                  l0toL2 (2),
+                  l0orL2toL3 (3)
+               }
+
+Xdsl2LinePmMode ::= TEXTUAL-CONVENTION
+   STATUS current
+   DESCRIPTION
+      "Objects with this syntax are configuration parameters
+       that reference the power modes/states into which the xTU-C or
+       xTU-R may autonomously transit.
+
+       It is a BITS structure that allows control of the following
+       transit options:
+        allowTransitionsToIdle (0)    - xTU may autonomously transit
+                                        to idle (L3) state.
+        allowTransitionsToLowPower (1)- xTU may autonomously transit
+                                        to low-power (L1/L2)
+                                        state."
+
+   SYNTAX BITS {
+       allowTransitionsToIdle(0),
+       allowTransitionsToLowPower(1)
+     }
+
+Xdsl2LineLdsf ::= TEXTUAL-CONVENTION
+   STATUS current
+   DESCRIPTION
+      "Objects with this syntax are configuration parameters
+       that control the Loop Diagnostic mode for a VDSL2/ADSL/ADSL2
+       or ADSL2+ link.  The possible values are:
+         inhibit (0)  - Inhibit Loop Diagnostic mode
+         force   (1)  - Force/Initiate Loop Diagnostic mode"
+
+   SYNTAX INTEGER {
+       inhibit(0),
+       force(1)
+     }
+
+Xdsl2LdsfResult ::= TEXTUAL-CONVENTION
+     STATUS current
+     DESCRIPTION
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 35]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+        "Possible failure reasons associated with performing
+         Dual Ended Loop Test (DELT) on a DSL line.
+         Possible values are:
+          none        (1) - The default value in case LDSF was never
+                            requested for the associated line.
+          success     (2) - The recent command completed
+                            successfully.
+          inProgress  (3) - The Loop Diagnostics process is in
+                            progress.
+          unsupported (4) - The NE or the line card doesn't support
+                            LDSF.
+          cannotRun   (5) - The NE cannot initiate the command, due
+                            to a nonspecific reason.
+          aborted     (6) - The Loop Diagnostics process aborted.
+          failed      (7) - The Loop Diagnostics process failed.
+          illegalMode (8) - The NE cannot initiate the command, due
+                            to the specific mode of the relevant
+                            line.
+          adminUp     (9) - The NE cannot initiate the command, as
+                            the relevant line is administratively
+                            'Up'.
+          tableFull   (10)- The NE cannot initiate the command, due
+                            to reaching the maximum number of rows
+                            in the results table.
+          noResources (11)- The NE cannot initiate the command, due
+                            to lack of internal memory resources."
+     SYNTAX INTEGER {
+          none (1),
+          success (2),
+          inProgress (3),
+          unsupported (4),
+          cannotRun (5),
+          aborted (6),
+          failed (7),
+          illegalMode (8),
+          adminUp (9),
+          tableFull (10),
+          noResources (11)
+     }
+
+Xdsl2LineBpsc ::= TEXTUAL-CONVENTION
+   STATUS current
+   DESCRIPTION
+      "Objects with this syntax are configuration parameters
+       that control the bits per subcarrier measurement for a
+       VDSL2/ADSL/ADSL2 or ADSL2+ link.  The possible values are:
+         idle    (1)  - Idle state
+         measure (2)  - Measure the bits per subcarrier"
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 36]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   SYNTAX INTEGER {
+       idle(1),
+       measure(2)
+     }
+
+Xdsl2BpscResult ::= TEXTUAL-CONVENTION
+     STATUS current
+     DESCRIPTION
+        "Possible failure reasons associated with performing
+         a bits per subcarrier measurement on a DSL line.
+         Possible values are:
+
+          none        (1) - The default value, in case a measurement
+                            was never requested for the associated
+                            line.
+          success     (2) - The recent measurement request completed
+                            successfully.
+          inProgress  (3) - The bits per subcarrier measurement is
+                            in progress.
+          unsupported (4) - The bits per subcarrier request
+                            mechanism is not supported.
+          failed      (5) - The measurement request has failed and no
+                            results are available.
+          noResources (6) - The NE cannot initiate the command, due
+                            to lack of internal memory resources."
+     SYNTAX INTEGER {
+          none(1),
+          success(2),
+          inProgress(3),
+          unsupported(4),
+          failed(5),
+          noResources(6)
+     }
+
+Xdsl2LineReset ::= TEXTUAL-CONVENTION
+   STATUS current
+   DESCRIPTION
+      "This type is used to request a line reset to occur.
+          idle        (1) - This state indicates that there is
+                            currently no request for a line reset.
+          reset       (2) - This state indicates that a line reset
+                            request has been issued."
+   SYNTAX INTEGER {
+       idle(1),
+       reset(2)
+     }
+
+Xdsl2LineProfiles ::= TEXTUAL-CONVENTION
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 37]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   STATUS current
+   DESCRIPTION
+     "Objects with this syntax reference the list of
+      ITU-T G.993.2 implementation profiles supported by an
+      xTU, enabled on the VDSL2 line or active on that line."
+
+      SYNTAX BITS {
+          profile8a(0),
+          profile8b(1),
+          profile8c(2),
+          profile8d(3),
+          profile12a(4),
+          profile12b(5),
+          profile17a(6),
+          profile30a(7)
+     }
+
+Xdsl2LineClassMask ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "VDSL2 PSD Mask Class.
+       The limit Power Spectral Density masks are grouped in
+       the following PSD mask classes:
+
+       Class 998     Annex A: D-32, D-48, D-64, D-128.
+       Class 997-M1c Annex B: 997-M1c-A-7.
+       Class 997-M1x Annex B: 997-M1x-M-8, 997-M1x-M.
+       Class 997-M2x Annex B: 997-M2x-M-8, 997-M2x-A, 997-M2x-M,
+                              997E17-M2x-NUS0, 997E30-M2x-NUS0.
+       Class 998-M1x Annex B: 998-M1x-A, 998-M1x-B, 998-M1x-NUS0.
+       Class 998-M2x Annex B: 998-M2x-A, 998-M2x-M, 998-M2x-B,
+                              998-M2x-NUS0, 998E17-M2x-NUS0,
+                              998E17-M2x-NUS0-M, 998E30-M2x-NUS0,
+                              998E30-M2x-NUS0-M.
+       Class 998ADE-M2x Annex B: Annex B: 998-M2x-A, 998-M2x-M,
+                              998-M2x-B, 998-M2x-NUS0,
+                              998ADE17-M2x-A, 998ADE17-M2x-B,
+                              998ADE17-M2x-NUS0-M,
+                              998ADE30-M2x-NUS0-A,
+                              998ADE30-M2x-NUS0-M.
+       Class 998-B   Annex C: POTS-138b, POTS-276b per C.2.1.1
+                              in G.993.2, TCM-ISDN per C.2.1.2
+                              in G.993.2.
+       Class 998-CO  Annex C: POTS-138co, POTS-276co per C.2.1.1
+                              in G.993.2.
+       Class HPE-M1  Annex B: HPE17-M1-NUS0, HPE30-M1-NUS0."
+
+   SYNTAX      INTEGER {
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 38]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+                  none(1),
+                  a998ORb997M1cORc998B(2),
+                  b997M1xOR998co(3),
+                  b997M2x(4),
+                  b998M1x(5),
+                  b998M2x(6),
+                  b998AdeM2x(7),
+                  bHpeM1(8)
+               }
+
+Xdsl2LineLimitMask ::= TEXTUAL-CONVENTION
+   STATUS current
+   DESCRIPTION
+     "The G.993.2 limit PSD mask for each class of profile.
+      The profiles are grouped in following profile classes:
+      - Class 8: Profiles 8a, 8b, 8c, 8d.
+      - Class 12: Profiles 12a, 12b.
+      - Class 17: Profile 17a.
+      - Class 30: Profile 30a."
+
+      SYNTAX BITS {
+          profile8Limit1(0),
+          profile8Limit2(1),
+          profile8Limit3(2),
+          profile8Limit4(3),
+          profile8Limit5(4),
+          profile8Limit6(5),
+          profile8Limit7(6),
+          profile8Limit8(7),
+          profile8Limit9(8),
+          profile8Limit10(9),
+          profile8Limit11(10),
+          profile8Limit12(11),
+          profile8Limit13(12),
+          profile8Limit14(13),
+          profile8Limit15(14),
+          profile8Limit16(15),
+          --
+          profile12Limit1(16),
+          profile12Limit2(17),
+          profile12Limit3(18),
+          profile12Limit4(19),
+          profile12Limit5(20),
+          profile12Limit6(21),
+          profile12Limit7(22),
+          profile12Limit8(23),
+          profile12Limit9(24),
+          profile12Limit10(25),
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 39]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+          profile12Limit11(26),
+          profile12Limit12(27),
+          profile12Limit13(28),
+          profile12Limit14(29),
+          profile12Limit15(30),
+          profile12Limit16(31),
+          --
+          profile17Limit1(32),
+          profile17Limit2(33),
+          profile17Limit3(34),
+          profile17Limit4(35),
+          profile17Limit5(36),
+          profile17Limit6(37),
+          profile17Limit7(38),
+          profile17Limit8(39),
+          profile17Limit9(40),
+          profile17Limit10(41),
+          profile17Limit11(42),
+          profile17Limit12(43),
+          profile17Limit13(44),
+          profile17Limit14(45),
+          profile17Limit15(46),
+          profile17Limit16(47),
+          --
+          profile30Limit1(48),
+          profile30Limit2(49),
+          profile30Limit3(50),
+          profile30Limit4(51),
+          profile30Limit5(52),
+          profile30Limit6(53),
+          profile30Limit7(54),
+          profile30Limit8(55),
+          profile30Limit9(56),
+          profile30Limit10(57),
+          profile30Limit11(58),
+          profile30Limit12(59),
+          profile30Limit13(60),
+          profile30Limit14(61),
+          profile30Limit15(62),
+          profile30Limit16(63)
+     }
+
+Xdsl2LineUs0Disable ::= TEXTUAL-CONVENTION
+   STATUS current
+   DESCRIPTION
+     "Indicates if US0 is disabled for each limit PSD mask.
+      The profiles are grouped in following profile classes:
+      - Class 8: Profiles 8a, 8b, 8c, 8d.
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 40]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      - Class 12: Profiles 12a, 12b.
+      - Class 17: Profile 17a.
+      - Class 30: Profile 30a."
+
+      SYNTAX BITS {
+          profile8Us0Disable1(0),
+          profile8Us0Disable2(1),
+          profile8Us0Disable3(2),
+          profile8Us0Disable4(3),
+          profile8Us0Disable5(4),
+          profile8Us0Disable6(5),
+          profile8Us0Disable7(6),
+          profile8Us0Disable8(7),
+          profile8Us0Disable9(8),
+          profile8Us0Disable10(9),
+          profile8Us0Disable11(10),
+          profile8Us0Disable12(11),
+          profile8Us0Disable13(12),
+          profile8Us0Disable14(13),
+          profile8Us0Disable15(14),
+          profile8Us0Disable16(15),
+          --
+          profile12Us0Disable1(16),
+          profile12Us0Disable2(17),
+          profile12Us0Disable3(18),
+          profile12Us0Disable4(19),
+          profile12Us0Disable5(20),
+          profile12Us0Disable6(21),
+          profile12Us0Disable7(22),
+          profile12Us0Disable8(23),
+          profile12Us0Disable9(24),
+          profile12Us0Disable10(25),
+          profile12Us0Disable11(26),
+          profile12Us0Disable12(27),
+          profile12Us0Disable13(28),
+          profile12Us0Disable14(29),
+          profile12Us0Disable15(30),
+          profile12Us0Disable16(31),
+          --
+          profile17Us0Disable1(32),
+          profile17Us0Disable2(33),
+          profile17Us0Disable3(34),
+          profile17Us0Disable4(35),
+          profile17Us0Disable5(36),
+          profile17Us0Disable6(37),
+          profile17Us0Disable7(38),
+          profile17Us0Disable8(39),
+          profile17Us0Disable9(40),
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 41]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+          profile17Us0Disable10(41),
+          profile17Us0Disable11(42),
+          profile17Us0Disable12(43),
+          profile17Us0Disable13(44),
+          profile17Us0Disable14(45),
+          profile17Us0Disable15(46),
+          profile17Us0Disable16(47),
+          --
+          profile30Us0Disable1(48),
+          profile30Us0Disable2(49),
+          profile30Us0Disable3(50),
+          profile30Us0Disable4(51),
+          profile30Us0Disable5(52),
+          profile30Us0Disable6(53),
+          profile30Us0Disable7(54),
+          profile30Us0Disable8(55),
+          profile30Us0Disable9(56),
+          profile30Us0Disable10(57),
+          profile30Us0Disable11(58),
+          profile30Us0Disable12(59),
+          profile30Us0Disable13(60),
+          profile30Us0Disable14(61),
+          profile30Us0Disable15(62),
+          profile30Us0Disable16(63)
+     }
+
+Xdsl2LineUs0Mask ::= TEXTUAL-CONVENTION
+   STATUS current
+   DESCRIPTION
+     "The US0 PSD masks to be allowed by the near-end xTU on
+      the line.  This parameter is only defined for G.993.2 Annex A.
+      It is represented as a bitmap (0 if not allowed and 1 if
+      allowed) with the following definitions."
+
+      SYNTAX BITS {
+          eu32(0),
+          eu36(1),
+          eu40(2),
+          eu44(3),
+          eu48(4),
+          eu52(5),
+          eu56(6),
+          eu60(7),
+          --
+          eu64(8),
+          eu128(9),
+          reserved1(10),
+          reserved2(11),
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 42]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+          reserved3(12),
+          reserved4(13),
+          reserved5(14),
+          reserved6(15),
+          --
+          adlu32(16),
+          adlu36(17),
+          adlu40(18),
+          adlu44(19),
+          adlu48(20),
+          adlu52(21),
+          adlu56(22),
+          adlu60(23),
+          --
+          adlu64(24),
+          adlu128(25),
+          reserved7(26),
+          reserved8(27),
+          reserved9(28),
+          reserved10(29),
+          reserved11(30),
+          reserved12(31)
+     }
+
+Xdsl2SymbolProtection ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This type specifies the minimum impulse noise protection
+       for the bearer channel if it is transported over DMT symbols
+       with a subcarrier spacing of 4.3125 kHz.
+       The possible values are:
+       'noProtection' (i.e., INP not required), 'halfSymbol' (i.e., INP
+       length is 1/2 symbol), and 1-16 symbols in steps of 1
+       symbol."
+
+   SYNTAX      INTEGER {
+               noProtection (1),
+               halfSymbol (2),
+               singleSymbol (3),
+               twoSymbols (4),
+               threeSymbols (5),
+               fourSymbols (6),
+               fiveSymbols (7),
+               sixSymbols (8),
+               sevenSymbols (9),
+               eightSymbols (10),
+               nineSymbols (11),
+               tenSymbols (12),
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 43]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+               elevenSymbols (13),
+               twelveSymbols (14),
+               thirteeSymbols (15),
+               fourteenSymbols (16),
+               fifteenSymbols (17),
+               sixteenSymbols (18)
+             }
+
+Xdsl2SymbolProtection8 ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This type specifies the minimum impulse noise protection
+       for the bearer channel if it is transported over DMT symbols
+       with a subcarrier spacing of 8.625 kHz.
+       The possible values are:
+       'noProtection' (i.e., INP not required) and 1-16 symbols in
+       steps of 1 symbol."
+
+   SYNTAX      INTEGER {
+               noProtection (1),
+               singleSymbol (2),
+               twoSymbols (3),
+               threeSymbols (4),
+               fourSymbols (5),
+               fiveSymbols (6),
+               sixSymbols (7),
+               sevenSymbols (8),
+               eightSymbols (9),
+               nineSymbols (10),
+               tenSymbols (11),
+               elevenSymbols (12),
+               twelveSymbols (13),
+               thirteeSymbols (14),
+               fourteenSymbols (15),
+               fifteenSymbols (16),
+               sixteenSymbols (17)
+             }
+
+Xdsl2MaxBer ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Objects with this syntax are configuration parameters
+       that reference the maximum Bit Error Rate (BER).
+       The possible values are:
+         eminus3 (1)  - Maximum BER=E^-3
+         eminus5 (2)  - Maximum BER=E^-5
+         eminus7 (3)  - Maximum BER=E^-7"
+   SYNTAX      INTEGER {
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 44]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+                  eminus3(1),
+                  eminus5(2),
+                  eminus7(3)
+               }
+
+Xdsl2ChInitPolicy ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This syntax serves for channel configuration parameters
+       that reference the channel initialization policy.
+       The possible values are:
+         policy0 (1) - Policy 0 according to the applicable standard.
+         policy1 (2) - Policy 1 according to the applicable
+                       standard."
+   SYNTAX      INTEGER {
+                  policy0(1),
+                  policy1(2)
+               }
+
+Xdsl2ScMaskDs ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Each one of the 4096 bits in this OCTET STRING array
+       represents the corresponding subcarrier in the downstream
+       direction.
+       A bit value of one indicates that a subcarrier is masked."
+   SYNTAX      OCTET STRING (SIZE(0..512))
+
+Xdsl2ScMaskUs ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Each one of the 4096 bits in this OCTET STRING array
+       represents the corresponding subcarrier in the upstream
+       direction.  A bit value of one indicates that a subcarrier
+       is masked."
+   SYNTAX      OCTET STRING (SIZE(0..512))
+
+Xdsl2CarMask ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This type defines an array of bands.  Each band is
+       represented by 4 octets and there is a maximum of 32 bands
+       allowed.
+       Each band consists of a 16-bit start subcarrier index followed by
+       a 16-bit stop subcarrier index.
+       The subcarrier index is an unsigned number in the range 0 to
+       NSC-1."
+   SYNTAX      OCTET STRING (SIZE(0..128))
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 45]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+Xdsl2RfiBands ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This type defines a subset of downstream PSD mask
+       breakpoints used to notch radio frequency interference (RFI)
+       bands.
+       Each RFI band is represented by 4 octets: a 16-bit start
+       subcarrier index followed by a 16-bit stop subcarrier
+       index.
+       There is a maximum of 16 RFI bands allowed.
+       The subcarrier index is an unsigned number in the range 0 to
+       NSC-1."
+   SYNTAX      OCTET STRING (SIZE(0..64))
+
+Xdsl2PsdMaskDs ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This is a structure that represents up to 32 PSD mask
+       breakpoints.
+       Each breakpoint occupies 3 octets: The first
+       two octets hold the index of the subcarrier associated with the
+       breakpoint.  The third octet holds the PSD reduction at the
+       breakpoint from 0 (0 dBm/Hz) to 255 (-127.5 dBm/Hz) using units
+       of 0.5 dBm/Hz.
+       The subcarrier index is an unsigned number in the range 0 to
+       NSCds-1."
+   SYNTAX      OCTET STRING (SIZE(0..96))
+
+Xdsl2PsdMaskUs ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This is a structure that represents up to 16 PSD mask
+       breakpoints.
+       Each breakpoint occupies 3 octets: The first two octets hold the
+       index of the subcarrier associated with the breakpoint.  The
+       third octet holds the PSD reduction at the breakpoint from 0
+       (0 dBm/Hz) to 255 (-127.5 dBm/Hz) using units of
+       0.5 dBm/Hz.
+       The subcarrier index is an unsigned number in the range 0 to
+       NSCus-1."
+   SYNTAX      OCTET STRING (SIZE(0..48))
+
+Xdsl2Tssi ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This is a structure that represents up to 32 transmit
+       spectrum shaping (TSSi) breakpoints.
+       Each breakpoint is a pair of values occupying 3 octets with the
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 46]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       following structure:
+       First 2 octets - Index of the subcarrier used in the context of
+                        the breakpoint.
+       Third octet    - The shaping parameter at the breakpoint.
+       The shaping parameter value is in the range 0 to 126 (units of
+       -0.5 dB).  The special value 127 indicates that the subcarrier is
+       not transmitted.
+       The subcarrier index is an unsigned number in the range 0 to
+       NSC-1."
+   SYNTAX      OCTET STRING (SIZE(0..96))
+
+Xdsl2LastTransmittedState ::= TEXTUAL-CONVENTION
+     STATUS current
+     DESCRIPTION
+        "This parameter represents the last successful transmitted
+         initialization state in the last full initialization performed
+         on the line.  States are per the specific xDSL technology and
+         are numbered from 0 (if G.994.1 is used) or 1 (if G.994.1 is
+         not used) up to Showtime."
+     SYNTAX      INTEGER {
+       -- ADSL family ATU-C side --
+       atucG9941(0),
+       atucQuiet1(1),
+       atucComb1(2),
+       atucQuiet2(3),
+       atucComb2(4),
+       atucIcomb1(5),
+       atucLineprob(6),
+       atucQuiet3(7),
+       atucComb3(8),
+       atucIComb2(9),
+       atucMsgfmt(10),
+       atucMsgpcb(11),
+       atucQuiet4(12),
+       atucReverb1(13),
+       atucTref1(14),
+       atucReverb2(15),
+       atucEct(16),
+       atucReverb3(17),
+       atucTref2(18),
+       atucReverb4(19),
+       atucSegue1(20),
+       atucMsg1(21),
+       atucReverb5(22),
+       atucSegue2(23),
+       atucMedley(24),
+       atucExchmarker(25),
+       atucMsg2(26),
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 47]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       atucReverb6(27),
+       atucSegue3(28),
+       atucParams(29),
+       atucReverb7(30),
+       atucSegue4(31),
+       atucShowtime(32),
+       -- ADSL family ATU-R side --
+       aturG9941(100),
+       aturQuiet1(101),
+       aturComb1(102),
+       aturQuiet2(103),
+       aturComb2(104),
+       aturIcomb1(105),
+       aturLineprob(106),
+       aturQuiet3(107),
+       aturComb3(108),
+       aturIcomb2(109),
+       aturMsgfmt(110),
+       aturMsgpcb(111),
+       aturReverb1(112),
+       aturQuiet4(113),
+       aturReverb2(114),
+       aturQuiet5(115),
+       aturReverb3(116),
+       aturEct(117),
+       aturReverb4(118),
+       aturSegue1(119),
+       aturReverb5(120),
+       aturSegue2(121),
+       aturMsg1(122),
+       aturMedley(123),
+       aturExchmarker(124),
+       aturMsg2(125),
+       aturReverb6(126),
+       aturSegue3(127),
+       aturParams(128),
+       aturReverb7(129),
+       aturSegue4(130),
+       aturShowtime(131),
+       -- VDSL2 VTU-C side --
+       vtucG9941(200),
+       vtucQuiet1(201),
+       vtucChDiscov1(202),
+       vtucSynchro1(203),
+       vtucPilot1(204),
+       vtucQuiet2(205),
+       vtucPeriodic1(206),
+       vtucSynchro2(207),
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 48]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       vtucChDiscov2(208),
+       vtucSynchro3(209),
+       vtucTraining1(210),
+       vtucSynchro4(211),
+       vtucPilot2(212),
+       vtucTeq(213),
+       vtucEct(214),
+       vtucPilot3(215),
+       vtucPeriodic2(216),
+       vtucTraining2(217),
+       vtucSynchro5(218),
+       vtucMedley(219),
+       vtucSynchro6(220),
+       vtucShowtime(221),
+       -- VDSL2 VTU-R side --
+       vturG9941(300),
+       vturQuiet1(301),
+       vturChDiscov1(302),
+       vturSynchro1(303),
+       vturLineprobe(304),
+       vturPeriodic1(305),
+       vturSynchro2(306),
+       vturChDiscov2(307),
+       vturSynchro3(308),
+       vturQuiet2(309),
+       vturTraining1(310),
+       vturSynchro4(311),
+       vturTeq(312),
+       vturQuiet3(313),
+       vturEct(314),
+       vturPeriodic2(315),
+       vturTraining2(316),
+       vturSynchro5(317),
+       vturMedley(318),
+       vturSynchro6(319),
+       vturShowtime(320)
+     }
+
+Xdsl2LineStatus ::= TEXTUAL-CONVENTION
+   STATUS current
+   DESCRIPTION
+      "Objects with this syntax are status parameters
+       that reflect the failure status for a given endpoint of a
+       VDSL2/ADSL/ADSL2 or ADSL2+ link.
+
+       This BITS structure can report the following failures:
+
+        noDefect (0)      - This bit position positively reports
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 49]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+                            that no defect or failure exist.
+        lossOfFraming (1) - Loss of frame synchronization.
+        lossOfSignal (2)  - Loss of signal.
+        lossOfPower (3)   - Loss of power.  Usually this failure may
+                            be reported for CPE units only.
+        initFailure (4)   - Recent initialization process failed.
+                            Never active on xTU-R."
+   SYNTAX BITS {
+       noDefect(0),
+       lossOfFraming(1),
+       lossOfSignal(2),
+       lossOfPower(3),
+        initFailure(4)
+     }
+
+Xdsl2ChInpReport ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This type is used to indicate the method used to compute the
+       Actual Impulse Noise Protection (ACTINP).  If set to
+       'inpComputedUsingFormula', the ACTINP is computed
+       according to the INP_no_erasure formula (9.6/G.993.2).
+       If set to 'inpEstimatedByXtur', the ACTINP is the value
+       estimated by the xTU receiver.
+        inpComputedUsingFormula (1) - ACTINP computed using
+                                      INP_no_erasure formula.
+        inpEstimatedByXtur (2)      - ACTINP estimated by
+                                      the xTU receiver."
+   SYNTAX      INTEGER {
+                  inpComputedUsingFormula(1),
+                  inpEstimatedByXtur(2)
+               }
+
+Xdsl2ChAtmStatus ::= TEXTUAL-CONVENTION
+   STATUS current
+   DESCRIPTION
+     "Objects with this syntax are status parameters that
+      reflect the failure status for the Transmission Convergence (TC)
+      layer of a given ATM interface (data path over a VDSL2/ADSL/
+      ADSL2 or ADSL2+ link).
+
+      This BITS structure can report the following failures:
+       noDefect (0)             - This bit position positively
+                                  reports that no defect or failure
+                                  exists.
+       noCellDelineation (1)    - The link was successfully
+                                  initialized, but cell delineation
+                                  was never acquired on the
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 50]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+                                  associated ATM data path.
+       lossOfCellDelineation (2)- Loss of cell delineation on the
+                                  associated ATM data path."
+   SYNTAX BITS {
+       noDefect(0),
+       noCellDelineation(1),
+       lossOfCellDelineation(2)
+     }
+
+Xdsl2ChPtmStatus ::= TEXTUAL-CONVENTION
+   STATUS current
+   DESCRIPTION
+     "Objects with this syntax are status parameters that
+      reflect the failure status for a given PTM interface (packet
+      data path over a VDSL2/ADSL/ADSL2 or ADSL2+ link).
+
+      This BITS structure can report the following failures:
+          noDefect (0)    - This bit position positively
+                            reports that no defect or failure exists.
+          outOfSync (1)   - Out of synchronization."
+   SYNTAX BITS {
+          noDefect(0),
+          outOfSync(1)
+     }
+
+Xdsl2UpboKLF ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Defines the upstream power backoff force mode (UPBOKLF).
+       The three possible mode values are:
+          auto(1)         - The VDSL Transceiver Unit (VTUs) will
+                            autonomously determine the
+                            electrical length.
+          override(2)     - Forces the VTU-R to use the electrical
+                            length, kl0, of the CO-MIB (UPBOKL) to
+                            compute the UPBO.
+          disableUpbo(3)  - Disables UPBO such that UPBO is not
+                            utilized."
+   SYNTAX INTEGER {
+     auto(1),
+     override(2),
+     disableUpbo(3)
+     }
+
+Xdsl2BandUs ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Each value identifies a specific band in the upstream
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 51]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       transmission direction (excluding the US0 band.).
+       The possible values that identify a band are as follows:
+          us1(5)          - Upstream band number 1 (US1).
+          us2(7)          - Upstream band number 2 (US2).
+          us3(9)          - Upstream band number 3 (US3).
+          us4(11)         - Upstream band number 4 (US4)."
+   SYNTAX        INTEGER {
+     us1(5),
+     us2(7),
+     us3(9),
+     us4(11)
+     }
+
+Xdsl2LinePsdMaskSelectUs ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This type is used to define which upstream PSD mask is
+       enabled.  This type is used only for Annexes J and M of ITU-T
+       Recommendations G.992.3 and G.992.5.
+
+       adlu32Eu32 (1),   - ADLU-32 / EU-32
+       adlu36Eu36 (2),   - ADLU-36 / EU-36
+       adlu40Eu40 (3),   - ADLU-40 / EU-40
+       adlu44Eu44 (4),   - ADLU-44 / EU-44
+       adlu48Eu48 (5),   - ADLU-48 / EU-48
+       adlu52Eu52 (6),   - ADLU-52 / EU-52
+       adlu56Eu56 (7),   - ADLU-56 / EU-56
+       adlu60Eu60 (8),   - ADLU-60 / EU-60
+       adlu64Eu64 (9)    - ADLU-64 / EU-64"
+   SYNTAX        INTEGER {
+     adlu32Eu32(1),
+     adlu36Eu36(2),
+     adlu40Eu40(3),
+     adlu44Eu44(4),
+     adlu48Eu48(5),
+     adlu52Eu52(6),
+     adlu56Eu56(7),
+     adlu60Eu60(8),
+     adlu64Eu64(9)
+     }
+
+Xdsl2LineCeFlag ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This type is used to enable the use of the optional
+       cyclic extension values.  If the bit is set to '1', the optional
+       cyclic extension values may be used.  Otherwise, the cyclic
+       extension shall be forced to the mandatory length (5N/32).
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 52]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       enableCyclicExtension (0) - Enable use of optional
+                                   Cyclic Extension values."
+   SYNTAX        BITS {
+     enableCyclicExtension(0)
+     }
+
+Xdsl2LineSnrMode ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This type is used to enable the transmitter-referred
+       virtual noise.  The value of 1, indicates that virtual
+       noise is disabled.  The value of 2, indicates that virtual
+       noise is enabled.
+
+      virtualNoiseDisabled (1) - virtual noise is disabled.
+      virtualNoiseEnabled (2)  - virtual noise is enabled."
+   SYNTAX        INTEGER {
+     virtualNoiseDisabled(1),
+     virtualNoiseEnabled(2)
+     }
+
+Xdsl2LineTxRefVnDs ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This is a structure that represents up to 32 PSD mask
+       breakpoints.
+       Each breakpoint occupies 3 octets: The first two octets hold the
+       index of the subcarrier associated with the breakpoint.  The
+       third octet holds the PSD reduction at the breakpoint from 0
+       (-140 dBm/Hz) to 200 (-40 dBm/Hz) using units of 0.5 dBm/Hz.
+       A special value of 255 indicates a noise level of 0 W/Hz.
+       The subcarrier index is an unsigned number in the range 0 to
+       NSCds-1."
+   SYNTAX      OCTET STRING (SIZE(0..96))
+
+Xdsl2LineTxRefVnUs ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This is a structure that represents up to 16 PSD mask
+       breakpoints.
+       Each breakpoint occupies 3 octets: The first two octets hold the
+       index of the subcarrier associated with the breakpoint.  The
+       third octet holds the PSD reduction at the breakpoint from 0
+       (-140 dBm/Hz) to 200 (-40 dBm/Hz) using units of 0.5 dBm/Hz.
+       A special value of 255 indicates a noise level of 0 W/Hz.
+       The subcarrier index is an unsigned number in the range 0 to
+       NSCus-1."
+   SYNTAX      OCTET STRING (SIZE(0..48))
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 53]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+Xdsl2BitsAlloc ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This type specifies an array of nibbles, where each nibble
+       indicates the bits allocation for a subcarrier.
+       Each nibble has a value in the range 0 to 15 to indicate
+       the bits allocation."
+   SYNTAX      OCTET STRING (SIZE(0..256))
+
+Xdsl2MrefPsdDs ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Objects with this syntax are MEDLEY Reference PSD status
+       parameters in the downstream direction.  This is expressed as
+       the set of
+       breakpoints exchanged at initialization.
+       The OCTET STRING contains up to 48 pairs of values in the
+       following structure:
+       Octets 0-1 -- Index of the first subcarrier used in the
+                   context of a first breakpoint.
+       Octets 2-3 -- The PSD level for the subcarrier indicated
+                   in octets 0-1.
+       Octets 4-7 -- Same, for a second breakpoint
+       Octets 8-11 -- Same, for a third breakpoint
+       And so on until
+       Octets 188-191 -- Same, for a 48th breakpoint.
+       The subcarrier index is an unsigned number in the range 0
+       to NSCds-1.
+       The PSD level is an integer value in the 0 to 4095 range.  It is
+       represented in units of 0.1 dB offset from -140 dBm/Hz."
+   SYNTAX      OCTET STRING (SIZE(0..192))
+
+Xdsl2MrefPsdUs ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Objects with this syntax are MEDLEY Reference PSD status
+       parameters in the upstream direction.  This is expressed
+       as the set of
+       breakpoints exchanged at initialization.
+       The OCTET STRING contains up to 32 pairs of values in the
+       following structure:
+       Octets 0-1 -- Index of the first subcarrier used in the
+                   context of a first breakpoint.
+       Octets 2-3 -- The PSD level for the subcarrier indicated
+                   in octets 0-1.
+       Octets 4-7 -- Same, for a second breakpoint
+       Octets 8-11 -- Same, for a third breakpoint
+       And so on until
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 54]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       Octets 124-127 -- Same, for a 32nd breakpoint.
+       The subcarrier index is an unsigned number in the range 0
+       to NSCus-1.
+       The PSD level is an integer value in the 0 to 4095 range.  It is
+       represented in units of 0.1 dB offset from -140 dBm/Hz."
+   SYNTAX      OCTET STRING (SIZE(0..128))
+
+END
+
+
+VDSL2-LINE-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+   MODULE-IDENTITY,
+   OBJECT-TYPE,
+   transmission,
+   Unsigned32,
+   NOTIFICATION-TYPE,
+   Integer32,
+   Counter32
+      FROM SNMPv2-SMI
+
+   ifIndex
+      FROM IF-MIB
+
+   TruthValue,
+   RowStatus
+       FROM SNMPv2-TC
+   SnmpAdminString
+      FROM SNMP-FRAMEWORK-MIB
+
+   HCPerfIntervalThreshold,
+   HCPerfTimeElapsed
+      FROM  HC-PerfHist-TC-MIB   -- [RFC3705]
+
+   Xdsl2Unit,
+   Xdsl2Direction,
+   Xdsl2Band,
+   Xdsl2TransmissionModeType,
+   Xdsl2RaMode,
+   Xdsl2InitResult,
+   Xdsl2OperationModes,
+   Xdsl2PowerMngState,
+   Xdsl2ConfPmsForce,
+   Xdsl2LinePmMode,
+   Xdsl2LineLdsf,
+   Xdsl2LdsfResult,
+   Xdsl2LineBpsc,
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 55]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   Xdsl2BpscResult,
+   Xdsl2LineReset,
+   Xdsl2SymbolProtection,
+   Xdsl2SymbolProtection8,
+   Xdsl2MaxBer,
+   Xdsl2ChInitPolicy,
+   Xdsl2ScMaskDs,
+   Xdsl2ScMaskUs,
+   Xdsl2CarMask,
+   Xdsl2RfiBands,
+   Xdsl2PsdMaskDs,
+   Xdsl2PsdMaskUs,
+   Xdsl2Tssi,
+   Xdsl2LastTransmittedState,
+   Xdsl2LineStatus,
+   Xdsl2ChInpReport,
+   Xdsl2ChAtmStatus,
+   Xdsl2ChPtmStatus,
+   Xdsl2UpboKLF,
+   Xdsl2BandUs,
+   Xdsl2LineProfiles,
+   Xdsl2LineUs0Mask,
+   Xdsl2LineClassMask,
+   Xdsl2LineLimitMask,
+   Xdsl2LineUs0Disable,
+   Xdsl2LinePsdMaskSelectUs,
+   Xdsl2LineCeFlag,
+   Xdsl2LineSnrMode,
+   Xdsl2LineTxRefVnDs,
+   Xdsl2LineTxRefVnUs,
+   Xdsl2BitsAlloc,
+   Xdsl2MrefPsdDs,
+   Xdsl2MrefPsdUs
+
+          FROM   VDSL2-LINE-TC-MIB       -- [This document]
+
+   MODULE-COMPLIANCE,
+   OBJECT-GROUP,
+   NOTIFICATION-GROUP
+      FROM SNMPv2-CONF;
+
+vdsl2MIB MODULE-IDENTITY
+   LAST-UPDATED "200909300000Z" -- September 30, 2009
+   ORGANIZATION "ADSLMIB Working Group"
+   CONTACT-INFO "WG-email:  adslmib@ietf.org
+   Info:      https://www1.ietf.org/mailman/listinfo/adslmib
+
+
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 56]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+             Chair:     Mike Sneed
+                        Sand Channel Systems
+             Postal:    P.O. Box 37324
+                        Raleigh NC 27627-732
+             Email:     sneedmike@hotmail.com
+             Phone:     +1 206 600 7022
+
+             Co-Chair:  Menachem Dodge
+                        ECI Telecom Ltd.
+             Postal:    30 Hasivim St.
+                        Petach Tikva 49517,
+                        Israel.
+             Email:     mbdodge@ieee.org
+             Phone:     +972 3 926 8421
+
+             Co-editor: Moti Morgenstern
+                        ECI Telecom Ltd.
+             Postal:    30 Hasivim St.
+                        Petach Tikva 49517,
+                        Israel.
+             Email:     moti.morgenstern@ecitele.com
+             Phone:     +972 3 926 6258
+
+             Co-editor: Scott Baillie
+                        NEC Australia
+             Postal:    649-655 Springvale Road,
+                        Mulgrave, Victoria 3170,
+                        Australia.
+             Email:     scott.baillie@nec.com.au
+             Phone:     +61 3 9264 3986
+
+             Co-editor: Umberto Bonollo
+                        NEC Australia
+             Postal:    649-655 Springvale Road,
+                        Mulgrave, Victoria 3170,
+                        Australia.
+             Email:     umberto.bonollo@nec.com.au
+             Phone:     +61 3 9264 3385
+            "
+   DESCRIPTION
+        "
+         This document defines a Management Information Base (MIB)
+         module for use with network management protocols in the
+         Internet community for the purpose of managing VDSL2, ADSL,
+         ADSL2, and ADSL2+ lines.
+
+         The MIB module described in RFC 2662 [RFC2662] defines
+         objects used for managing Asymmetric Bit-Rate DSL (ADSL)
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 57]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+         interfaces per [T1E1.413], [G.992.1], and [G.992.2].
+         These object descriptions are based upon the specifications
+         for the ADSL Embedded Operations Channel (EOC) as defined
+         in American National Standards Institute (ANSI) T1E1.413
+         [T1E1.413] and International Telecommunication Union (ITU-T)
+         G.992.1 [G.992.1] and G.992.2 [G.992.2].
+
+         The MIB module described in RFC 4706 [RFC4706] defines
+         objects used for managing ADSL2 interfaces per [G.992.3]
+         and [G.992.4], and ADSL2+ interfaces per [G.992.5].  That MIB
+         is also capable of managing ADSL interfaces per [T1E1.413],
+         [G.992.1], and [G.992.2].
+
+         This document does not obsolete RFC 2662 [RFC2662] or
+         RFC 4706 [RFC4706], but rather provides a more comprehensive
+         management model that manages VDSL2 interfaces per G.993.2
+         [G.993.2] as well as ADSL, ADSL2, and ADSL2+ technologies
+         per T1E1.413, G.992.1, G.992.2, G.992.3, G.992.4, and
+         G.992.5
+         ([T1E1.413], [G.992.1], [G.992.2], [G.992.3], [G.992.4], and
+         [G.992.5], respectively).
+
+         Additionally, the management framework for VDSL2 lines
+         specified by the Digital Subscriber Line Forum
+         (DSLF) has been taken into consideration [TR-129].  That
+         framework is based on the ITU-T G.997.1 standard [G.997.1] and
+         its amendment 1 [G.997.1-Am1].
+
+         The MIB module is located in the MIB tree under MIB 2
+         transmission, as discussed in the MIB-2 Integration (RFC 2863
+         [RFC2863]) section of this document.
+
+         Copyright (c) 2009 IETF Trust and the persons identified
+         as authors of the code.  All rights reserved.
+
+         Redistribution and use in source and binary forms, with
+         or without modification, are permitted provided that the
+         following conditions are met:
+
+         - Redistributions of source code must retain the above
+           copyright notice, this list of conditions and the
+           following disclaimer.
+
+         - Redistributions in binary form must reproduce the above
+           copyright notice, this list of conditions and the
+           following disclaimer in the documentation and/or other
+           materials provided with the distribution.
+
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 58]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+         - Neither the name of Internet Society, IETF or IETF Trust,
+           nor the names of specific contributors, may be used to
+           endorse or promote products derived from this software
+           without specific prior written permission.
+
+         THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+         CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+         INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+         MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+         DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+         CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+         SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+         NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+         LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+         HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+         CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+         OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+         SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+         This version of this MIB module is part of RFC 5650;
+         see the RFC itself for full legal notices."
+
+   REVISION "200909300000Z" -- September 30, 2009
+   DESCRIPTION "Initial version, published as RFC 5650."
+      ::= { transmission 251 }
+
+  xdsl2Notifications OBJECT IDENTIFIER ::= { vdsl2MIB 0 }
+  xdsl2Objects       OBJECT IDENTIFIER ::= { vdsl2MIB 1 }
+  xdsl2Conformance   OBJECT IDENTIFIER ::= { vdsl2MIB 2 }
+  ------------------------------------------------
+  xdsl2Line          OBJECT IDENTIFIER ::= { xdsl2Objects 1 }
+  xdsl2Status        OBJECT IDENTIFIER ::= { xdsl2Objects 2 }
+  xdsl2Inventory     OBJECT IDENTIFIER ::= { xdsl2Objects 3 }
+  xdsl2PM            OBJECT IDENTIFIER ::= { xdsl2Objects 4 }
+  xdsl2Profile       OBJECT IDENTIFIER ::= { xdsl2Objects 5 }
+  xdsl2Scalar        OBJECT IDENTIFIER ::= { xdsl2Objects 6 }
+  ------------------------------------------------
+  xdsl2PMLine      OBJECT IDENTIFIER ::= { xdsl2PM 1 }
+  xdsl2PMChannel   OBJECT IDENTIFIER ::= { xdsl2PM 2 }
+  ------------------------------------------------
+  xdsl2ProfileLine      OBJECT IDENTIFIER ::= { xdsl2Profile 1 }
+  xdsl2ProfileChannel   OBJECT IDENTIFIER ::= { xdsl2Profile 2 }
+  xdsl2ProfileAlarmConf OBJECT IDENTIFIER ::= { xdsl2Profile 3 }
+  ------------------------------------------------
+  xdsl2ScalarSC         OBJECT IDENTIFIER ::= { xdsl2Scalar 1 }
+  ------------------------------------------------
+
+------------------------------------------------
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 59]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+--          xdsl2LineTable                    --
+------------------------------------------------
+
+xdsl2LineTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2LineEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineTable contains configuration, command and
+       status parameters of the VDSL2/ADSL/ADSL2 or ADSL2+ line.
+
+       Several objects in this table MUST be maintained in a persistent
+       manner."
+   ::= { xdsl2Line 1 }
+
+xdsl2LineEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2LineEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The index of this table is an interface index where the
+       interface has an ifType of vdsl2(251)."
+   INDEX  { ifIndex }
+   ::= { xdsl2LineTable 1 }
+
+Xdsl2LineEntry  ::=
+   SEQUENCE {
+      xdsl2LineConfTemplate            SnmpAdminString,
+      xdsl2LineConfFallbackTemplate    SnmpAdminString,
+      xdsl2LineAlarmConfTemplate       SnmpAdminString,
+      xdsl2LineCmndConfPmsf            Xdsl2ConfPmsForce,
+      xdsl2LineCmndConfLdsf            Xdsl2LineLdsf,
+      xdsl2LineCmndConfLdsfFailReason  Xdsl2LdsfResult,
+      xdsl2LineCmndConfBpsc            Xdsl2LineBpsc,
+      xdsl2LineCmndConfBpscFailReason  Xdsl2BpscResult,
+      xdsl2LineCmndConfBpscRequests    Counter32,
+      xdsl2LineCmndAutomodeColdStart   TruthValue,
+      xdsl2LineCmndConfReset           Xdsl2LineReset,
+      xdsl2LineStatusActTemplate       SnmpAdminString,
+      xdsl2LineStatusXtuTransSys       Xdsl2TransmissionModeType,
+      xdsl2LineStatusPwrMngState       Xdsl2PowerMngState,
+      xdsl2LineStatusInitResult        Xdsl2InitResult,
+      xdsl2LineStatusLastStateDs       Xdsl2LastTransmittedState,
+      xdsl2LineStatusLastStateUs       Xdsl2LastTransmittedState,
+      xdsl2LineStatusXtur              Xdsl2LineStatus,
+      xdsl2LineStatusXtuc              Xdsl2LineStatus,
+      xdsl2LineStatusAttainableRateDs  Unsigned32,
+      xdsl2LineStatusAttainableRateUs  Unsigned32,
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 60]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      xdsl2LineStatusActPsdDs          Integer32,
+      xdsl2LineStatusActPsdUs          Integer32,
+      xdsl2LineStatusActAtpDs          Integer32,
+      xdsl2LineStatusActAtpUs          Integer32,
+      xdsl2LineStatusActProfile        Xdsl2LineProfiles,
+      xdsl2LineStatusActLimitMask      Xdsl2LineLimitMask,
+      xdsl2LineStatusActUs0Mask        Xdsl2LineUs0Mask,
+      xdsl2LineStatusActSnrModeDs      Xdsl2LineSnrMode,
+      xdsl2LineStatusActSnrModeUs      Xdsl2LineSnrMode,
+      xdsl2LineStatusElectricalLength  Unsigned32,
+      xdsl2LineStatusTssiDs            Xdsl2Tssi,
+      xdsl2LineStatusTssiUs            Xdsl2Tssi,
+      xdsl2LineStatusMrefPsdDs         Xdsl2MrefPsdDs,
+      xdsl2LineStatusMrefPsdUs         Xdsl2MrefPsdUs,
+      xdsl2LineStatusTrellisDs         TruthValue,
+      xdsl2LineStatusTrellisUs         TruthValue,
+      xdsl2LineStatusActualCe          Unsigned32
+   }
+
+xdsl2LineConfTemplate  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  read-write
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the xDSL2
+       Line Configuration Template Table, xdsl2LineConfTemplateTable,
+       that applies for this line.
+
+       This object MUST be maintained in a persistent manner."
+   REFERENCE    "DSL Forum TR-129, paragraph #5.1"
+   DEFVAL       { "DEFVAL" }
+   ::= { xdsl2LineEntry 1 }
+
+xdsl2LineConfFallbackTemplate  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(0..32))
+   MAX-ACCESS  read-write
+   STATUS      current
+   DESCRIPTION
+      "This object is used to identify the template that will be
+       used if the xDSL2 line fails to operate using the primary
+       template.  The primary template is identified using the
+       xdsl2LineConfTemplate object.
+
+       For example, a xDSL2 line may fall back to a template with a
+       lower rate if the rate specified in the primary template
+       cannot be achieved.
+
+       The value of this object identifies a row in the xDSL2 Line
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 61]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       Configuration Template Table, xdsl2LineConfTemplateTable.
+       Any row in the xdsl2LineConfTemplateTable table may be used as a
+       fall-back template.
+
+       If the xDSL2 line fails to operate using the fall-back template,
+       then the primary template should be retried.
+       The xTU-C should continue to alternate between the primary and
+       fall-back templates until one of them succeeds.
+
+       If the value of this object is a zero-length string, then no
+       fall-back template is defined and only the primary template will
+       be used.
+
+       Note that implementation of this object is not mandatory.
+       If this object is not supported, any attempt to modify this
+       object should result in the SET request being rejected.
+
+       This object MUST be maintained in a persistent manner."
+   ::= { xdsl2LineEntry 2 }
+
+xdsl2LineAlarmConfTemplate  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  read-write
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the xDSL2
+       Line Alarm Configuration Template Table,
+       xdsl2LineAlarmConfTemplateTable, which applies to this line.
+
+       This object MUST be maintained in a persistent manner."
+   REFERENCE    "DSL Forum TR-129, paragraph #5.1"
+   DEFVAL       { "DEFVAL" }
+   ::= { xdsl2LineEntry 3 }
+
+xdsl2LineCmndConfPmsf  OBJECT-TYPE
+   SYNTAX      Xdsl2ConfPmsForce
+   MAX-ACCESS  read-write
+   STATUS      current
+   DESCRIPTION
+      "Power management state forced (PMSF).  Defines the line
+       states to be forced by the near-end xTU on this line.
+       This object MUST be maintained in a persistent manner."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.1.3 (PMSF)"
+   DEFVAL       { l3toL0 }
+   ::= { xdsl2LineEntry 4 }
+
+xdsl2LineCmndConfLdsf  OBJECT-TYPE
+   SYNTAX      Xdsl2LineLdsf
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 62]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   MAX-ACCESS  read-write
+   STATUS      current
+   DESCRIPTION
+      "Loop diagnostic state forced (LDSF).
+       Defines whether the line should be forced into the loop
+       diagnostics mode by the near-end xTU of this line.  Note that
+       a loop diagnostic may be initiated by the far-end xTU at any
+       time.
+
+       Only when the xdsl2LineStatusPwrMngState object is in the
+       'l3' state and the xdsl2LineCmndConfPmsf object is in the
+       'l0orL2toL3' state, can the line be forced into loop diagnostic
+       mode procedures.  Upon successful completion of the loop
+       diagnostic mode procedures, the Access Node shall set this
+       object to 'inhibit', and xdsl2LineStatusPwrMngState will
+       remain in the 'l3' state.  The loop diagnostic data shall be
+       available at least until xdsl2LineCmndConfPmsf is set to the
+       'l3toL0' state.
+
+       The results of the loop diagnostic procedure are stored in the
+       tables xdsl2SCStatusTable, xdsl2SCStatusBandTable, and
+       xdsl2SCStatusSegmentTable.  The status of the loop diagnostic
+       procedure is indicated by xdsl2LineCmndConfLdsfFailReason.
+
+       As long as loop diagnostic procedures are not completed
+       successfully, attempts shall be made to do so, until the loop
+       diagnostic mode is no longer forced on the line through this
+       configuration parameter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.1.8 (LDSF)"
+   DEFVAL       { inhibit }
+   ::= { xdsl2LineEntry 5 }
+
+xdsl2LineCmndConfLdsfFailReason  OBJECT-TYPE
+   SYNTAX      Xdsl2LdsfResult
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The status of the most recent occasion when the loop
+       diagnostics state forced (LDSF) command was issued for the
+       associated line."
+   DEFVAL       { none }
+   ::= { xdsl2LineEntry 6 }
+
+xdsl2LineCmndConfBpsc  OBJECT-TYPE
+   SYNTAX      Xdsl2LineBpsc
+   MAX-ACCESS  read-write
+   STATUS      current
+   DESCRIPTION
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 63]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      "Request a bits-per-subcarrier measurement to be made.
+
+       A request for a bits-per-subcarrier measurement is made by
+       setting this object to the value of 'measure'.  Upon
+       completion of the measurement request, the Access Node shall set
+       this object to 'idle'.
+
+       The SNMP agent should allow initiating a bits-per-subcarrier
+       measurement process only if there is no other bits-per-subcarrier
+       measurement already running, and respond with an SNMP error
+       (e.g., wrongValue) otherwise.
+
+       Note that a bits-per-subcarrier measurement is also performed
+       during a line diagnostic procedure.  This object provides an
+       additional mechanism to fetch the bits-per-subcarrier data.  This
+       additional mechanism is provided so that bits-per-subcarrier
+       data may be fetched without forcing the line into no power state.
+       This is useful because the bits-per-subcarrier allocation may be
+       adjusted at show time due to rate adaption and bit swapping.
+
+       The implementation of this additional mechanism for measuring
+       bits per subcarrier is not mandatory.
+
+       The results of the bits-per-subcarrier measurement are stored in
+       xdsl2LineSegmentTable.  The status of the bits-per-subcarrier
+       measurement is indicated by
+       xdsl2LineCmndConfBpscFailReason."
+   DEFVAL       { idle }
+   ::= { xdsl2LineEntry 7 }
+
+xdsl2LineCmndConfBpscFailReason  OBJECT-TYPE
+   SYNTAX      Xdsl2BpscResult
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The status of the most recent bits-per-subcarrier
+       measurement request issued for the associated line."
+   DEFVAL       { none }
+   ::= { xdsl2LineEntry 8 }
+
+xdsl2LineCmndConfBpscRequests  OBJECT-TYPE
+   SYNTAX      Counter32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Measurement request counter.
+       This counter is incremented by one every time a request for a
+       bits-per-subcarrier measurement is made.  A measurement request
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 64]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       is made by modifying the xdsl2LineCmndConfBpsc object from
+       idle(1) to the value measure(2).
+
+       The measurement results may be very large and will not fit
+       into a single PDU; hence, multiple SNMP GET requests may be
+       required to fetch the measurement results.
+       Because the measurement results cannot be fetched atomically,
+       it is possible for a second manager to start a new measurement
+       before a first manager has fetched all of its results.
+       An SNMP manager can use this object to ensure that the
+       measurement results retrieved using one or more GET requests
+       all belong to the measurement initiated by that manager.
+
+       The following steps are suggested in order for the SNMP
+       manager to initiate the bits-per-subcarrier measurement:
+
+       1. Wait for xdsl2LineCmndConfBpsc value to be idle(1).
+       2. Perform an SNMP GET for xdsl2LineCmndConfBpscRequests.
+       3. Wait a short delay (4 -> 8 seconds).
+       4. Perform an SNMP SET on xdsl2LineCmndConfBpsc with
+          the value measure(2).
+       5. If step 4 returns an error, then go to step 1.
+       6. Wait for xdsl2LineCmndConfBpsc value to be idle(1).
+       7. Fetch measurement results using one or more GET PDUs.
+       8. Perform an SNMP GET for xdsl2LineCmndConfBpscRequests.
+       9. Compute the difference between the two values of
+          xdsl2LineCmndConfBpscRequests.  If the value is one,
+          then the results are valid, else go to step 1."
+   ::= { xdsl2LineEntry 9 }
+
+xdsl2LineCmndAutomodeColdStart   OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-write
+   STATUS      current
+   DESCRIPTION
+      "Automode cold start forced.  This parameter is defined in
+       order to improve testing of the performance of xTUs supporting
+       automode when it is enabled in the MIB.
+       Change the value of this parameter to 'true' to indicate a change
+       in loop conditions applied to the devices under the test.  The
+       xTUs shall reset any historical information used for automode
+       and for shortening G.994.1 handshake and initialization.
+
+       Automode is the case where multiple operation-modes are enabled
+       through the xdsl2LConfProfXtuTransSysEna object in the line
+       configuration profile being used for the line, and where the
+       selection of the actual operation-mode depends not only on the
+       common capabilities of both xTUs (as exchanged in G.994.1), but
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 65]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       also on achievable data rates under given loop conditions."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.1.10
+                (Automode Cold Start Forced)"
+   DEFVAL       { false }
+   ::= { xdsl2LineEntry 10 }
+
+xdsl2LineCmndConfReset   OBJECT-TYPE
+      SYNTAX      Xdsl2LineReset
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "Request a line reset to occur.
+          If this object is set to the value of 'reset', then force
+          the line to reset (i.e., the modems will retrain).
+          When the line has successfully reset, the SNMP agent will
+          set the value of this object to 'idle'.
+
+          Note that the xdsl2LineCmndConfPmsf object will always take
+          precedence over this object.
+          If the xdsl2LineCmndConfPmsf object is set to the value
+          'l0orL2toL3', then the line MUST NOT return to the Showtime
+          state due to a reset request action performed using this
+          object."
+   DEFVAL       { idle }
+      ::= { xdsl2LineEntry 11 }
+
+xdsl2LineStatusActTemplate  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(0..32))
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This object is used to identify the template that is
+       currently in use for this line.
+       This object is updated when a successful line initialization
+       occurs.
+       This object indicates if the primary template
+       (xdsl2LineConfTemplate) is in use or the fall-back template
+       (xdsl2LineConfFallbackTemplate) is in use.
+       If the line is not successfully initialized, then the value of
+       this object will be a zero-length string."
+   ::= { xdsl2LineEntry 12 }
+
+xdsl2LineStatusXtuTransSys  OBJECT-TYPE
+   SYNTAX      Xdsl2TransmissionModeType
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The xTU Transmission System (xTS) in use.
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 66]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       It is coded in a bitmap representation with one bit set to
+       '1' (the selected coding for the DSL line).  This
+       parameter may be derived from the handshaking procedures defined
+       in Recommendation G.994.1.  A set of xDSL line transmission
+       modes, with one bit per mode."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.1
+                (xDSL transmission system)"
+   DEFVAL       { {} }
+   ::= { xdsl2LineEntry 13 }
+
+xdsl2LineStatusPwrMngState  OBJECT-TYPE
+   SYNTAX      Xdsl2PowerMngState
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The current power management state."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.5
+                (Line power management state)"
+   DEFVAL       { l3 }
+      ::= { xdsl2LineEntry 14 }
+
+xdsl2LineStatusInitResult  OBJECT-TYPE
+   SYNTAX      Xdsl2InitResult
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Indicates the result of the last full initialization
+       performed on the line."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.6
+                (Initialization success/failure cause)"
+   DEFVAL       { noFail }
+   ::= { xdsl2LineEntry 15 }
+
+xdsl2LineStatusLastStateDs  OBJECT-TYPE
+   SYNTAX      Xdsl2LastTransmittedState
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The last successful transmitted initialization state in
+       the downstream direction in the last full initialization
+       performed on the line."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.7
+                (Downstream last transmitted state)"
+   DEFVAL       { atucG9941 }
+   ::= { xdsl2LineEntry 16 }
+
+xdsl2LineStatusLastStateUs  OBJECT-TYPE
+   SYNTAX      Xdsl2LastTransmittedState
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 67]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The last successful transmitted initialization state in the
+       upstream direction in the last full initialization performed on
+       the line."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.8
+                (Upstream last transmitted state)"
+   DEFVAL       { aturG9941 }
+   ::= { xdsl2LineEntry 17 }
+
+xdsl2LineStatusXtur  OBJECT-TYPE
+   SYNTAX      Xdsl2LineStatus
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Indicates the current state (existing failures) of the xTU-R.
+       This is a bitmap of possible conditions."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.1.1.2
+                (Line far-end failures)"
+   DEFVAL       { { noDefect } }
+   ::= { xdsl2LineEntry 18 }
+
+xdsl2LineStatusXtuc  OBJECT-TYPE
+   SYNTAX      Xdsl2LineStatus
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Indicates the current state (existing failures) of the xTU-C.
+       This is a bitmap of possible conditions."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.1.1.1
+                (Line near-end failures)"
+   DEFVAL       { { noDefect } }
+   ::= { xdsl2LineEntry 19 }
+
+xdsl2LineStatusAttainableRateDs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Maximum Attainable Data Rate Downstream.
+       The maximum downstream net data rate currently attainable by
+       the xTU-C transmitter and the xTU-R receiver, coded in
+       bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.19 (ATTNDRds)"
+   DEFVAL       { 0 }
+   ::= { xdsl2LineEntry 20 }
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 68]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+xdsl2LineStatusAttainableRateUs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Maximum Attainable Data Rate Upstream.
+       The maximum upstream net data rate currently attainable by the
+       xTU-R transmitter and the xTU-C receiver, coded in bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.20 (ATTNDRus)"
+   DEFVAL       { 0 }
+   ::= { xdsl2LineEntry 21 }
+
+xdsl2LineStatusActPsdDs OBJECT-TYPE
+   SYNTAX      Integer32 (-900..0 | 2147483647)
+   UNITS       "0.1 dBm/Hz"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Actual Power Spectral Density (PSD) Downstream.  The average
+       downstream transmit PSD over the subcarriers used for downstream.
+       It ranges from -900 to 0 units of 0.1 dBm/Hz (physical values are
+       -90 to 0 dBm/Hz).
+       A value of 0x7FFFFFFF (2147483647) indicates the measurement is
+       out of range to be represented."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.21 (ACTPSDds)"
+   DEFVAL       { 2147483647 }
+   ::= { xdsl2LineEntry 22 }
+
+xdsl2LineStatusActPsdUs OBJECT-TYPE
+   SYNTAX      Integer32 (-900..0 | 2147483647)
+   UNITS       "0.1 dBm/Hz"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Actual Power Spectral Density (PSD) Upstream.  The average
+       upstream transmit PSD over the subcarriers used for upstream.
+       It ranges from -900 to 0 units of 0.1 dBm/Hz (physical values are
+       -90 to 0 dBm/Hz).
+       A value of 0x7FFFFFFF (2147483647) indicates the measurement is
+       out of range to be represented."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.22 (ACTPSDus)"
+   DEFVAL       { 2147483647 }
+   ::= { xdsl2LineEntry 23 }
+
+xdsl2LineStatusActAtpDs  OBJECT-TYPE
+   SYNTAX      Integer32 (-310..310 | 2147483647)
+   UNITS       "0.1 dBm"
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 69]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Actual Aggregate Transmit Power Downstream.
+       The total amount of transmit power delivered by the xTU-C at
+       the U-C reference point, at the instant of measurement.  It
+       ranges from -310 to 310 units of 0.1 dBm (physical values are -31
+       to 31 dBm).
+       A value of 0x7FFFFFFF (2147483647) indicates the measurement is
+       out of range to be represented."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.24 (ACTATPds)"
+   DEFVAL       { 2147483647 }
+   ::= { xdsl2LineEntry 24 }
+
+xdsl2LineStatusActAtpUs  OBJECT-TYPE
+   SYNTAX      Integer32 (-310..310 | 2147483647)
+   UNITS       "0.1 dBm"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Actual Aggregate Transmit Power Upstream.
+       The total amount of transmit power delivered by the xTU-R at the
+       U-R reference point, at the instant of measurement.  It ranges
+       from -310 to 310 units of 0.1 dBm (physical values are -31
+       to 31 dBm).
+       A value of 0x7FFFFFFF (2147483647) indicates the measurement is
+       out of range to be represented."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.25 (ACTATPus)"
+   DEFVAL       { 2147483647 }
+   ::= { xdsl2LineEntry 25 }
+
+xdsl2LineStatusActProfile  OBJECT-TYPE
+   SYNTAX      Xdsl2LineProfiles
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The G.993.2 profile in use.
+       The configuration parameter xdsl2LConfProfProfiles defines
+       the set of allowed G.993.2 profiles.  This parameter indicates
+       the profile in use on this line.
+       This parameter may be derived from the handshaking procedures
+       defined in ITU-T Recommendation G.994.1."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.2 (VDSL2 Profile)"
+   DEFVAL       { {} }
+   ::= { xdsl2LineEntry 26 }
+
+xdsl2LineStatusActLimitMask  OBJECT-TYPE
+   SYNTAX      Xdsl2LineLimitMask
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 70]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The Limit PSD mask and band plan in use.
+       The configuration parameter xdsl2LConfProfLimitMask defines
+       the set of allowed G.993.2 limit PSD masks.
+       This parameter indicates the limit PSD mask in use on this
+       line."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.3
+                (VDSL2 Limit PSD Mask and Band plan)"
+   DEFVAL       { {} }
+   ::= { xdsl2LineEntry 27 }
+
+xdsl2LineStatusActUs0Mask  OBJECT-TYPE
+   SYNTAX      Xdsl2LineUs0Mask
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The US0 PSD mask in use.
+       The configuration parameter xdsl2LConfProfUs0Mask defines
+       the set of allowed US0 PSD masks.
+       This parameter indicates the US0 PSD mask in use on this line.
+       This parameter may be derived from the handshaking procedures
+       defined in ITU-T Recommendation G.994.1."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.4
+                (VDSL2 US0 PSD Mask)"
+   DEFVAL       { {} }
+   ::= { xdsl2LineEntry 28 }
+
+xdsl2LineStatusActSnrModeDs  OBJECT-TYPE
+   SYNTAX      Xdsl2LineSnrMode
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This parameter indicates if the transmitter-referred
+       virtual noise is active on the line in the downstream
+       direction.
+       The configuration parameter xdsl2LConfProfSnrModeDs is used to
+       configure referred virtual noise."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.15 (ACTSNRMODEds)"
+   DEFVAL       { virtualNoiseDisabled }
+   ::= { xdsl2LineEntry 29 }
+
+xdsl2LineStatusActSnrModeUs  OBJECT-TYPE
+   SYNTAX      Xdsl2LineSnrMode
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 71]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      "This parameter indicates if the transmitter-referred virtual
+       noise is active on the line in the upstream direction.
+       The configuration parameter xdsl2LConfProfSnrModeUs is used to
+       configure referred virtual noise."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.18 (ACTSNRMODEus)"
+   DEFVAL       { virtualNoiseDisabled }
+   ::= { xdsl2LineEntry 30 }
+
+xdsl2LineStatusElectricalLength  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..1280)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This parameter contains the estimated electrical length
+       expressed in dB at 1 MHz, kl0.  This is the final electrical
+       length that would have been sent from the VTU-O to VTU-R if the
+       electrical length was not forced by the CO-MIB.
+       The value ranges from 0 to 128 dB in steps of 0.1 dB."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.23 (UPBOKLE)"
+   DEFVAL       { 0 }
+   ::= { xdsl2LineEntry 31 }
+
+xdsl2LineStatusTssiDs  OBJECT-TYPE
+     SYNTAX      Xdsl2Tssi
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "The transmit spectrum shaping (TSSi) breakpoints expressed
+      as the set of breakpoints exchanged
+      during G.994.1 (Downstream)."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.29.5 (TSSpsds)"
+     ::= { xdsl2LineEntry 32 }
+
+xdsl2LineStatusTssiUs  OBJECT-TYPE
+     SYNTAX      Xdsl2Tssi
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "The transmit spectrum shaping (TSSi) breakpoints expressed
+      as the set of breakpoints exchanged
+      during G.994.1 (Upstream)."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.29.6 (TSSpsus)"
+     ::= { xdsl2LineEntry 33 }
+
+xdsl2LineStatusMrefPsdDs  OBJECT-TYPE
+     SYNTAX      Xdsl2MrefPsdDs
+     MAX-ACCESS  read-only
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 72]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+     STATUS      current
+     DESCRIPTION
+     "The MEDLEY Reference PSD status parameters
+      in the downstream
+      direction expressed as the set of breakpoints exchanged at
+      initialization."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.29.7 (MREFPSDds)"
+     ::= { xdsl2LineEntry 34 }
+
+xdsl2LineStatusMrefPsdUs  OBJECT-TYPE
+     SYNTAX      Xdsl2MrefPsdUs
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "The MEDLEY Reference PSD status parameters in the
+      upstream direction expressed as the set of breakpoints
+      exchanged at initialization."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.29.8 (MREFPSDus)"
+     ::= { xdsl2LineEntry 35 }
+
+xdsl2LineStatusTrellisDs  OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This parameter reports whether trellis coding is in use in
+      the downstream direction."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.30 (TRELLISds)"
+   DEFVAL       { false }
+   ::= { xdsl2LineEntry 36 }
+
+xdsl2LineStatusTrellisUs  OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This parameter reports whether trellis coding is in use in
+      the upstream direction."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.31 (TRELLISus)"
+   DEFVAL       { false }
+   ::= { xdsl2LineEntry 37 }
+
+xdsl2LineStatusActualCe  OBJECT-TYPE
+   SYNTAX      Unsigned32 (2..16)
+   UNITS       "N/32 samples"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 73]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      "(ACTUALCE)
+       This parameter reports the cyclic extension used on the line.  It
+       is coded as an unsigned integer from 2 to 16 in units of N/32
+       samples, where 2N is the Inverse Discrete Fourier Transform
+       (IDFT) size."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.32 (ACTUALCE)"
+   DEFVAL       { 2 }
+   ::= { xdsl2LineEntry 38 }
+
+------------------------------------------------
+--          xdsl2LineSegmentTable             --
+------------------------------------------------
+
+xdsl2LineSegmentTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2LineSegmentEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineSegmentTable contains status parameters
+       of VDSL2/ADSL/ADSL2 and ADSL2+ subcarriers.
+       The parameters in this table are updated when a measurement
+       request is made using the xdsl2LineCmndConfBpsc object.
+
+       Note that a bits-per-subcarrier measurement is also performed
+       during a line diagnostic procedure.  This table provides an
+       additional mechanism to fetch the bits-per-subcarrier data.  This
+       additional mechanism is provided so that bits-per-subcarrier
+       data may be fetched without forcing the line into no power state.
+       This is useful because the bits-per-subcarrier allocation may be
+       adjusted at Showtime due to rate adaption and bit swapping.
+
+       The implementation of this additional mechanism for measuring
+       bits per subcarrier is not mandatory."
+   ::= { xdsl2Status 1 }
+
+xdsl2LineSegmentEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2LineSegmentEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineSegmentEntry contains status parameters
+       of VDSL2/ADSL/ADSL2 and ADSL2+ subcarriers.
+
+       Objects in the table refer to NSus and NSds.  For G.993.2, the
+       value of NSus and NSds are, respectively, the indices of the
+       highest supported upstream and downstream subcarriers according
+       to the selected implementation profile.  For ADSL, NSus is equal
+       to NSCus-1 and NSds is equal to NSCds-1.
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 74]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       One index of this table is an interface index where the interface
+       has an ifType of vdsl2(251).  A second index of this table is the
+       transmission direction.  A third index identifies the specific
+       segment of the subcarriers status addressed."
+   INDEX  { ifIndex,
+            xdsl2LineSegmentDirection,
+            xdsl2LineSegment   }
+   ::= { xdsl2LineSegmentTable 1 }
+
+Xdsl2LineSegmentEntry  ::=
+   SEQUENCE {
+      xdsl2LineSegmentDirection         Xdsl2Direction,
+      xdsl2LineSegment                  Unsigned32,
+      xdsl2LineSegmentBitsAlloc         Xdsl2BitsAlloc,
+      xdsl2LineSegmentRowStatus         RowStatus
+   }
+
+xdsl2LineSegmentDirection  OBJECT-TYPE
+     SYNTAX      Xdsl2Direction
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+     "The direction of the subcarrier either
+      upstream or downstream."
+     ::= { xdsl2LineSegmentEntry 1 }
+
+xdsl2LineSegment  OBJECT-TYPE
+     SYNTAX      Unsigned32(1..8)
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+     "The segment of the subcarriers status information
+      provided by this row.
+      Status parameters in this table are retrieved in segments.
+      The first segment of the status information is retrieved with
+      xdsl2LineSegment=1, the second segment is retrieved with
+      xdsl2LineSegment=2, and so on.  When a status parameter is
+      retrieved in n segments where n<8) then, for that parameter,
+      GET operations for the remaining segment numbers (n+1 to 8) will
+      respond with a zero-length OCTET STRING."
+     ::= { xdsl2LineSegmentEntry 2 }
+
+xdsl2LineSegmentBitsAlloc  OBJECT-TYPE
+     SYNTAX      Xdsl2BitsAlloc
+     UNITS       "bits"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 75]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+     "The bits allocation per subcarrier.  An array of 256 octets
+      (512 nibbles), designed for supporting up to 512 (downstream)
+      subcarriers.  When more than 512 subcarriers are supported, the
+      status information is reported through multiple (up to 8)
+      segments.  The first segment is then used for the first 512
+      subcarriers.  The second segment is used for the subcarriers
+      512 to 1023 and so on.
+      The aggregate number of utilized nibbles in the downstream
+      direction (in all segments) depends on NSds; in the
+      upstream direction, it depends on NSus.
+      This value is referred to here as NS.  The segment number is in
+      xdsl2SCStatusSegment.
+      Nibble i (0 <= i < MIN((NS+1)-(segment-1)*512,512)) in each
+      segment is set to a value in the range 0 to 15 to indicate that
+      the respective downstream or upstream subcarrier j
+      (j=(segement-1)*512+i) has the same amount of bits
+      allocation."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.29.1 (BITSpsds)
+                 and paragraph #7.5.1.29.2 (BITSpsus)"
+     ::= { xdsl2LineSegmentEntry 3 }
+
+xdsl2LineSegmentRowStatus  OBJECT-TYPE
+     SYNTAX      RowStatus
+     MAX-ACCESS  read-write
+     STATUS      current
+     DESCRIPTION
+     "Row Status.  The SNMP agent will create a row in this table
+      for storing the results of a measurement performed on the
+      associated line, if the row does not already exist.
+
+      The SNMP manager is not permitted to create rows in this table or
+      set the row status to 'notInService'.  In the first case,
+      if the SNMP manager tries to create a new row, the SNMP agent
+      responds with the value 'noCreation' in the error status
+      field of the response-PDU.  In the latter case, the SNMP agent
+      responds with the value 'wrongValue' in the error status
+      field of the response-PDU.
+
+      The SNMP agent may have limited resources; therefore, if multiple
+      rows coexist in this table, it may fail to add new rows to this
+      table or allocate memory resources.
+      If that occurs, the SNMP agent responds with the value
+      'noResources' (for the xdsl2LineCmndConfBpscFailReason
+      object in xdsl2LineTable).
+
+      The management system (the operator) may delete rows from this
+      table according to any scheme.  For example, after retrieving
+      the results.
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 76]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      When the SNMP manager deletes any row in this table, the SNMP
+      agent MUST delete all rows in this table that have the same
+      ifIndex value."
+     ::= { xdsl2LineSegmentEntry 4 }
+
+------------------------------------------------
+--          xdsl2LineBandTable                --
+------------------------------------------------
+
+xdsl2LineBandTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2LineBandEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineBandTable contains the, per-band line
+       status parameters of the VDSL2/ADSL/ADSL2 or ADSL2+ line.
+       The parameters in this table are updated at line initialization
+       time and at Showtime."
+   ::= { xdsl2Line 2 }
+
+xdsl2LineBandEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2LineBandEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+       "One index of this table is an interface index where the
+       interface
+       has an ifType of vdsl2(251).  A second index of this table is a
+       per-band index covering both VDSL2 and ADSL/ADSL2/ADSL2+."
+   INDEX  { ifIndex, xdsl2LineBand }
+   ::= { xdsl2LineBandTable 1 }
+
+Xdsl2LineBandEntry  ::=
+   SEQUENCE {
+      xdsl2LineBand                        Xdsl2Band,
+      xdsl2LineBandStatusLnAtten           Unsigned32,
+      xdsl2LineBandStatusSigAtten          Unsigned32,
+      xdsl2LineBandStatusSnrMargin         Integer32
+   }
+
+xdsl2LineBand OBJECT-TYPE
+     SYNTAX      Xdsl2Band
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+     "Identifies the band(s) associated with this line.
+      For ADSL/ADSL2/ADSL2+, the values 'upstream' and 'downstream'
+      will always be present.
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 77]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      For VDSL2, a subset of {'us0', 'ds1', 'us1' ... 'ds4', 'us4' }
+      will always be present, together with rows for
+      'upstream' and 'downstream', in which only the
+      xdsl2LineBandStatusSnrMargin object is expected to hold a valid
+      (average) measurement."
+     ::= { xdsl2LineBandEntry 1 }
+
+xdsl2LineBandStatusLnAtten  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..1270 | 2147483646 | 2147483647)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Line Attenuation.
+       When referring to a band in the downstream direction, it is
+       the measured difference in the total power transmitted by the
+       xTU-C and the total power received by the xTU-R over all
+       subcarriers of that band during initialization.
+
+       When referring to a band in the upstream direction, it is the
+       measured difference in the total power transmitted by the xTU-R
+       and the total power received by the xTU-C over all subcarriers of
+       that band during initialization.
+
+       Values range from 0 to 1270 in units of 0.1 dB (physical values
+       are 0 to 127 dB).
+       A special value of 0x7FFFFFFF (2147483647) indicates the line
+       attenuation is out of range to be represented.
+       A special value of 0x7FFFFFFE (2147483646) indicates the line
+       attenuation measurement is unavailable."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.9 (LATNds)
+               and paragraph #7.5.1.10 (LATNus)6"
+   DEFVAL       { 2147483646 }
+   ::= { xdsl2LineBandEntry 2 }
+
+xdsl2LineBandStatusSigAtten  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..1270 | 2147483646 | 2147483647)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Signal Attenuation.
+       When referring to a band in the downstream direction, it is
+       the measured difference in the total power transmitted by the
+       xTU-C and the total power received by the xTU-R over all
+       subcarriers of that band during Showtime.
+
+       When referring to a band in the upstream direction, it is the
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 78]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       measured difference in the total power transmitted by the xTU-R
+       and the total power received by the xTU-C over all subcarriers of
+       that band during Showtime.
+
+       Values range from 0 to 1270 in units of 0.1 dB (physical values
+       are 0 to 127 dB).
+       A special value of 0x7FFFFFFF (2147483647) indicates the line
+       attenuation is out of range to be represented.
+       A special value of 0x7FFFFFFE (2147483646) indicates the line
+       attenuation measurement is unavailable."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.11 (SATNds)
+                 and paragraph #7.5.1.12 (SATNus)"
+   DEFVAL       { 2147483646 }
+   ::= { xdsl2LineBandEntry 3 }
+
+xdsl2LineBandStatusSnrMargin  OBJECT-TYPE
+   SYNTAX      Integer32 (-640..630 | 2147483646 | 2147483647)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "SNR Margin is the maximum increase in dB of the noise power
+       received at the xTU (xTU-R for a band in the downstream direction
+       and xTU-C for a band in the upstream direction), such that the
+       BER requirements are met for all bearer channels received at the
+       xTU.  Values range from -640 to 630 in units of 0.1 dB (physical
+       values are -64 to 63 dB).
+       A special value of 0x7FFFFFFF (2147483647) indicates the SNR
+       Margin is out of range to be represented.
+       A special value of 0x7FFFFFFE (2147483646) indicates the SNR
+       Margin measurement is currently unavailable."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.13 (SNRMds)
+                 and paragraph #7.5.1.14 (SNRMpbds)
+                 and paragraph #7.5.1.16 (SNRMus)
+                 and paragraph #7.5.1.17 (SNRMpbus)"
+   DEFVAL       { 2147483646 }
+   ::= { xdsl2LineBandEntry 4 }
+
+------------------------------------------------
+--        xdsl2ChannelStatusTable             --
+------------------------------------------------
+
+xdsl2ChannelStatusTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2ChannelStatusEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2ChannelStatusTable contains status
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 79]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       parameters of VDSL2/ADSL/ADSL2 or ADSL2+ channel.
+       This table contains live data from equipment."
+   ::= { xdsl2Status 2 }
+
+xdsl2ChannelStatusEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2ChannelStatusEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+       "One index of this table is an interface index where the
+        interface has an ifType of a DSL channel.  A second index of
+        this table is the termination unit."
+   INDEX  { ifIndex, xdsl2ChStatusUnit }
+   ::= { xdsl2ChannelStatusTable 1 }
+
+Xdsl2ChannelStatusEntry  ::=
+   SEQUENCE {
+      xdsl2ChStatusUnit                Xdsl2Unit,
+      xdsl2ChStatusActDataRate         Unsigned32,
+      xdsl2ChStatusPrevDataRate        Unsigned32,
+      xdsl2ChStatusActDelay            Unsigned32,
+      xdsl2ChStatusActInp              Unsigned32,
+      xdsl2ChStatusInpReport           Xdsl2ChInpReport,
+      xdsl2ChStatusNFec                Unsigned32,
+      xdsl2ChStatusRFec                Unsigned32,
+      xdsl2ChStatusLSymb               Unsigned32,
+      xdsl2ChStatusIntlvDepth          Unsigned32,
+      xdsl2ChStatusIntlvBlock          Unsigned32,
+      xdsl2ChStatusLPath               Unsigned32,
+      xdsl2ChStatusAtmStatus           Xdsl2ChAtmStatus,
+      xdsl2ChStatusPtmStatus           Xdsl2ChPtmStatus
+   }
+
+xdsl2ChStatusUnit  OBJECT-TYPE
+   SYNTAX      Xdsl2Unit
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The termination unit."
+   ::= { xdsl2ChannelStatusEntry 1 }
+
+xdsl2ChStatusActDataRate  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The actual net data rate at which the bearer channel is
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 80]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       operating, if in L0 power management state.  In L1 or L2
+       states, it relates to the previous L0 state.  The data rate is
+       coded in bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.2.1
+                (Actual data rate)"
+   DEFVAL       { 0 }
+   ::= { xdsl2ChannelStatusEntry 2 }
+
+xdsl2ChStatusPrevDataRate  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The previous net data rate that the bearer channel was
+       operating at just before the latest rate change event.  This
+       could be a full or short initialization, fast retrain, DRA or
+       power management transitions, excluding transitions between L0
+       state and L1 or L2 states.  The data rate is coded in
+       bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.2.2
+                (Previous data rate)"
+   DEFVAL       { 0 }
+   ::= { xdsl2ChannelStatusEntry 3 }
+
+xdsl2ChStatusActDelay  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..8176)
+   UNITS       "milliseconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The actual one-way interleaving delay introduced by the
+       PMS-TC in the direction of the bearer channel, if in L0 power
+       management state.  In L1 or L2 states, it relates to the previous
+       L0 state.  It is coded in ms (rounded to the nearest ms)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.2.3
+                (Actual interleaving delay)"
+   DEFVAL       { 0 }
+   ::= { xdsl2ChannelStatusEntry 4 }
+
+xdsl2ChStatusActInp  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..255)
+   UNITS       "0.1 symbols"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Actual impulse noise protection.
+       This parameter reports the actual impulse noise protection (INP)
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 81]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       on the bearer channel in the L0 state.  In the L1 or L2 state,
+       the parameter contains the INP in the previous L0 state.  For
+       ADSL, this value is computed according to the formula specified
+       in the relevant Recommendation based on the actual framing
+       parameters.  For ITU-T Recommendation G.993.2, the method to
+       report this value is according to the INPREPORT parameter.
+       The value is coded in fractions of DMT symbols with a
+       granularity of 0.1 symbols.  The range is from 0 to 25.4.
+       The special value of 255 indicates an ACTINP higher
+       than 25.4."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.2.4 (ACTINP)"
+   DEFVAL       { 0 }
+   ::= { xdsl2ChannelStatusEntry 5 }
+
+xdsl2ChStatusInpReport  OBJECT-TYPE
+   SYNTAX      Xdsl2ChInpReport
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Impulse noise protection reporting mode."
+   REFERENCE    "ITU-T G.997.1 Amendment 1, paragraph #7.5.2.5
+                (INPREPORT)"
+   DEFVAL       { inpComputedUsingFormula }
+   ::= { xdsl2ChannelStatusEntry 6 }
+
+xdsl2ChStatusNFec  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..255)
+   UNITS       "bytes"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Actual size of Reed-Solomon codeword.
+       This parameter reports the actual number of Reed-Solomon
+       redundancy bytes per codeword used in the latency path in which
+       the bearer channel is transported.  The value is coded in bytes.
+       It ranges from 0 to 16.
+       The value 0 indicates no Reed-Solomon coding."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.2.6.1 (NFEC)"
+   DEFVAL       { 0 }
+   ::= { xdsl2ChannelStatusEntry 7 }
+
+xdsl2ChStatusRFec  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..16)
+   UNITS       "bits"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Actual number of Reed-Solomon redundancy bytes.
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 82]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       This parameter reports the actual number of Reed-Solomon
+       redundancy bytes per codeword used in the latency path in which
+       the bearer channel is transported.  The value is coded in bytes.
+       It ranges from 0 to 16.
+       The value 0 indicates no Reed-Solomon coding."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.2.6.2 (RFEC)"
+   DEFVAL       { 0 }
+   ::= { xdsl2ChannelStatusEntry 8 }
+
+xdsl2ChStatusLSymb  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..65535)
+   UNITS       "bits"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Actual number of bits per symbol.
+       This parameter reports the actual number of bits per symbol
+       assigned to the latency path in which the bearer channel is
+       transported.  This value does not include trellis overhead.  The
+       value is coded in bits.
+       It ranges from 0 to 65535."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.2.6.3 (LSYMB)"
+   DEFVAL       { 0 }
+   ::= { xdsl2ChannelStatusEntry 9 }
+
+xdsl2ChStatusIntlvDepth  OBJECT-TYPE
+   SYNTAX      Unsigned32(1..4096)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Actual interleaving depth.
+       This parameter reports the actual depth of the interleaver used
+       in the latency path in which the bearer channel is transported.
+       The value ranges from 1 to 4096 in steps of 1.
+       The value 1 indicates no interleaving."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.2.6.4 (INTLVDEPTH)"
+   DEFVAL       { 1 }
+   ::= { xdsl2ChannelStatusEntry 10 }
+
+xdsl2ChStatusIntlvBlock  OBJECT-TYPE
+   SYNTAX      Unsigned32(4..255)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Actual interleaving block length.
+       This parameter reports the actual block length of the interleaver
+       used in the latency path in which the bearer channel is
+       transported.
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 83]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       The value ranges from 4 to 255 in steps of 1."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.2.6.5 (INTLVBLOCK)"
+   DEFVAL       { 4 }
+   ::= { xdsl2ChannelStatusEntry 11 }
+
+xdsl2ChStatusLPath  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..3)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Actual latency path.
+       This parameter reports the index of the actual latency path in
+       which the bearer is transported.
+       The valid values are 0, 1, 2 and 3.
+       For G.992.1, the FAST path shall be mapped to the latency
+       index 0, and the INTERLEAVED path shall be mapped to the latency
+       index 1."
+   REFERENCE    "ITU-T G.997.1 amendment 1, paragraph #7.5.2.7
+                 (LPATH)"
+   DEFVAL       { 0 }
+   ::= { xdsl2ChannelStatusEntry 12 }
+
+xdsl2ChStatusAtmStatus  OBJECT-TYPE
+   SYNTAX      Xdsl2ChAtmStatus
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Indicates current state (existing failures) of the DSL
+       channel in case its Data Path is ATM.  This is a bitmap of
+       possible conditions.
+       In case the channel is not of ATM Data Path, the object is set
+       to '0'."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.1.4
+                 (ATM data path failures)"
+   DEFVAL       { { noDefect } }
+   ::= { xdsl2ChannelStatusEntry 13 }
+
+xdsl2ChStatusPtmStatus  OBJECT-TYPE
+   SYNTAX      Xdsl2ChPtmStatus
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Indicates current state (existing failures) of the DSL
+       channel in case its Data Path is PTM (Packet Transfer Mode).
+       This is a bitmap of possible conditions.
+      In case the channel is not of PTM Data Path, the object is set
+      to '0'."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.1.5
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 84]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+                 (PTM Data Path failures)"
+   DEFVAL       { { noDefect } }
+   ::= { xdsl2ChannelStatusEntry 14 }
+
+------------------------------------------------
+--    Scalars that relate to the SC Status Tables
+------------------------------------------------
+
+xdsl2ScalarSCMaxInterfaces  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This value determines the maximum number of
+       interfaces supported by xdsl2SCStatusTable,
+       xdsl2SCStatusBandTable, and xdsl2SCStatusSegmentTable."
+   ::= { xdsl2ScalarSC 1 }
+
+xdsl2ScalarSCAvailInterfaces  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This value determines the currently available number of
+       interfaces listed in xdsl2SCStatusTable,
+       xdsl2SCStatusBandTable, and xdsl2SCStatusSegmentTable."
+   ::= { xdsl2ScalarSC 2 }
+
+------------------------------------------------
+--        xdsl2SCStatusTable                  --
+------------------------------------------------
+
+xdsl2SCStatusTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2SCStatusEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2SCStatusTable contains
+       status parameters for VDSL2/ADSL/ADSL2 and ADSL2+ that
+       provide information about the size of parameters in
+       xdsl2SCStatusSegmentTable.
+       The parameters in this table MUST be updated after a loop
+       diagnostic procedure, MAY be updated after a line
+       initialization, and MAY be updated at Showtime."
+   ::= { xdsl2Status 3 }
+
+xdsl2SCStatusEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2SCStatusEntry
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 85]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+       "One index of this table is an interface index where the
+        interface has an ifType of vdsl2(251).  A second index of this
+        table is the transmission direction."
+   INDEX  { ifIndex, xdsl2SCStatusDirection }
+   ::= { xdsl2SCStatusTable 1 }
+
+Xdsl2SCStatusEntry  ::=
+   SEQUENCE {
+      xdsl2SCStatusDirection         Xdsl2Direction,
+      xdsl2SCStatusLinScale          Unsigned32,
+      xdsl2SCStatusLinScGroupSize    Unsigned32,
+      xdsl2SCStatusLogMt             Unsigned32,
+      xdsl2SCStatusLogScGroupSize    Unsigned32,
+      xdsl2SCStatusQlnMt             Unsigned32,
+      xdsl2SCStatusQlnScGroupSize    Unsigned32,
+      xdsl2SCStatusSnrMtime          Unsigned32,
+      xdsl2SCStatusSnrScGroupSize    Unsigned32,
+      xdsl2SCStatusAttainableRate    Unsigned32,
+      xdsl2SCStatusRowStatus         RowStatus
+   }
+
+xdsl2SCStatusDirection  OBJECT-TYPE
+     SYNTAX      Xdsl2Direction
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+     "The direction of the subcarrier either
+      upstream or downstream."
+     ::= { xdsl2SCStatusEntry 1 }
+
+xdsl2SCStatusLinScale  OBJECT-TYPE
+     SYNTAX      Unsigned32 (1..65535)
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "The scale factor to be applied to the H(f) linear
+      representation values for the respective transmission direction.
+      This parameter is only available after a loop diagnostic
+      procedure.  It is represented as an unsigned integer in the range
+      from 1 to 2^16-1."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.26.1 (HLINSCds)
+               and paragraph #7.5.1.26.7 (HLINSCus)"
+     ::= { xdsl2SCStatusEntry 2 }
+
+xdsl2SCStatusLinScGroupSize OBJECT-TYPE
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 86]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+     SYNTAX      Unsigned32(1 | 2 | 4 | 8)
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "Number of subcarriers per group used to report the H(f)
+      linear representation values for the respective transmission
+      direction.  The valid values are 1, 2, 4, and 8.  For ADSL, this
+      parameter is equal to one and, for VDSL2, it is equal to the size
+      of a subcarrier group used to compute these parameters.
+      This parameter is only available after a loop diagnostic
+      procedure."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.26.2 (HLINGds)
+               and paragraph #7.5.1.26.8 (HLINGus)"
+     ::= { xdsl2SCStatusEntry 3 }
+
+xdsl2SCStatusLogMt  OBJECT-TYPE
+     SYNTAX      Unsigned32 (1..65535)
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "This parameter contains the number of symbols used to
+      measure the Hlog(f) values.  It is represented as an unsigned
+      integer in the range from 1 to 2^16-1.
+      After a loop diagnostic procedure, this parameter shall contain
+      the number of symbols used to measure the Hlog(f).  It should
+      correspond to the value specified in the Recommendation (e.g., the
+      number of symbols in 1 s time interval for ITU-T Recommendation.
+      G.992.3)."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.26.4 (HLOGMTds)
+               and paragraph #7.5.1.26.10 (HLOGMTus)"
+     ::= { xdsl2SCStatusEntry 4 }
+
+xdsl2SCStatusLogScGroupSize OBJECT-TYPE
+     SYNTAX      Unsigned32(1 | 2 | 4 | 8)
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "Number of subcarriers per group used to report the H(f)
+      logarithmic representation values for the respective
+      transmission direction.  The valid values are 1, 2, 4, and 8.
+      For ADSL, this parameter is equal to 1, and for VDSL2, it is
+      equal to the size of a subcarrier group used to compute these
+      parameters."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.26.5 (HLOGGds)
+               and paragraph #7.5.1.26.11 (HLOGGus)"
+     ::= { xdsl2SCStatusEntry 5 }
+
+xdsl2SCStatusQlnMt  OBJECT-TYPE
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 87]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+     SYNTAX      Unsigned32 (1..65535)
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "This parameter contains the number of symbols used to
+      measure the QLN(f) values.  It is an unsigned integer in the range
+      from 1 to 2^16-1.  After a loop diagnostic procedure, this
+      parameter shall contain the number of symbols used to measure the
+      QLN(f).  It should correspond to the value specified in the
+      Recommendation (e.g., the number of symbols in 1 s time interval
+      for ITU-T Recommendation G.992.3)."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.27.1 (QLNMTds)
+               and paragraph #7.5.1.27.4 (QLNMTus)"
+     ::= { xdsl2SCStatusEntry 6 }
+
+xdsl2SCStatusQlnScGroupSize OBJECT-TYPE
+     SYNTAX      Unsigned32(1 | 2 | 4 | 8)
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "Number of subcarriers per group used to report the Quiet
+      Line Noise values for the respective transmission direction.
+      The valid values are 1, 2, 4, and 8.
+      For ADSL, this parameter is equal to 1, and for VDSL2, it is
+      equal to the size of a subcarrier group used to compute these
+      parameters."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.27.2 (QLNGds)
+               and paragraph #7.5.1.27.5 (QLNGus)"
+     ::= { xdsl2SCStatusEntry 7 }
+
+xdsl2SCStatusSnrMtime  OBJECT-TYPE
+     SYNTAX      Unsigned32 (1..65535)
+     UNITS       "symbols"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "This parameter contains the number of symbols used to measure
+      the SNR(f) values.  It is an unsigned integer in the range from 1
+      to 2^16-1.  After a loop diagnostic procedure, this parameter
+      shall contain the number of symbols used to measure the SNR(f).
+      It should correspond to the value specified in the Recommendation
+      (e.g., the number of symbols in 1 s time interval for ITU-T
+      Recommendation G.992.3)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.28.1 (SNRMTds)
+                 and paragraph #7.5.1.28.4 (SNRMTus)"
+     ::= { xdsl2SCStatusEntry 8 }
+
+xdsl2SCStatusSnrScGroupSize OBJECT-TYPE
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 88]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+     SYNTAX      Unsigned32(1 | 2 | 4 | 8)
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "Number of subcarriers per group used to report the SNR values
+      on the respective transmission direction.
+      The valid values are 1, 2, 4, and 8.
+      For ADSL, this parameter is equal to 1, and for VDSL2, it is
+      equal to the size of a subcarrier group used to compute these
+      parameters."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.28.2 (SNRGds)
+               and paragraph #7.5.1.28.5 (SNRGus)"
+     ::= { xdsl2SCStatusEntry 9 }
+
+xdsl2SCStatusAttainableRate  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Maximum Attainable Data Rate.  The maximum net data rate
+       currently attainable by the xTU-C transmitter and xTU-R receiver
+       (when referring to downstream direction) or by the xTU-R
+       transmitter and xTU-C receiver (when referring to upstream
+       direction).  Value is coded in bits/s.
+       This object reflects the value of the parameter following the
+       most recent DELT performed on the associated line.  Once the DELT
+       process is over, the parameter no longer changes until the row is
+       deleted or a new DELT process is initiated."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.19 (ATTNDRds)
+               and paragraph #7.5.1.20 (ATTNDRus)"
+   ::= { xdsl2SCStatusEntry 10 }
+
+xdsl2SCStatusRowStatus  OBJECT-TYPE
+     SYNTAX      RowStatus
+     MAX-ACCESS  read-write
+     STATUS      current
+     DESCRIPTION
+     "Row Status.  The SNMP agent will create a row in this table
+      for storing the results of a DELT performed on the associated
+      line, if the row does not already exist.
+
+      When a row is created in this table, the SNMP agent should also
+      create corresponding rows in the tables xdsl2SCStatusBandTable and
+      xdsl2SCStatusSegmentTable.
+
+      The SNMP manager is not permitted to create rows in this table or
+      set the row status to 'notInService'.  In the first case,
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 89]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      if the SNMP manager tries to create a new row, the SNMP agent
+      responds with the value 'noCreation' in the error status
+      field of the response-PDU.  In the latter case the SNMP agent
+      responds with the value 'wrongValue' in the error status
+      field of the response-PDU.
+
+      When a row is deleted in this table, the SNMP agent should also
+      delete corresponding rows in the tables xdsl2SCStatusBandTable and
+      xdsl2SCStatusSegmentTable.
+
+      The SNMP agent may have limited resources; therefore, if multiple
+      rows coexist in this table, it may fail to add new rows to this
+      table or allocate memory resources for a new DELT process.  If
+      that occurs, the SNMP agent responds with either the value
+      'tableFull' or the value 'noResources' (for
+      the xdsl2LineCmndConfLdsfFailReason object in xdsl2LineTable).
+
+      The management system (the operator) may delete rows from this
+      table according to any scheme.  For example, after retrieving the
+      results."
+     ::= { xdsl2SCStatusEntry 11 }
+
+------------------------------------------------
+--        xdsl2SCStatusBandTable              --
+------------------------------------------------
+
+xdsl2SCStatusBandTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2SCStatusBandEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2SCStatusBandTable contains subcarrier status
+       parameters for VDSL2/ADSL/ADSL2 and ADSL2+ that are grouped per-
+       band.
+       For ADSL/ADSL2/ADSL2+, there is a single upstream band and a
+       single downstream band.  For VDSL2, there are several downstream
+       bands and several upstream bands.
+       The parameters in this table are only available after a loop
+       diagnostic procedure."
+   ::= { xdsl2Status 4 }
+
+xdsl2SCStatusBandEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2SCStatusBandEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+       "One index of this table is an interface index where the
+       interface
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 90]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       has an ifType of vdsl2(251).  A second index of this table is the
+       transmission band."
+   INDEX  { ifIndex, xdsl2SCStatusBand }
+   ::= { xdsl2SCStatusBandTable 1 }
+
+Xdsl2SCStatusBandEntry  ::=
+   SEQUENCE {
+      xdsl2SCStatusBand                  Xdsl2Band,
+      xdsl2SCStatusBandLnAtten           Unsigned32,
+      xdsl2SCStatusBandSigAtten          Unsigned32
+   }
+
+xdsl2SCStatusBand OBJECT-TYPE
+     SYNTAX      Xdsl2Band
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+     "The transmission band."
+     ::= { xdsl2SCStatusBandEntry 1 }
+
+xdsl2SCStatusBandLnAtten  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..1270 | 2147483646 | 2147483647)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "When referring to a band in the downstream direction, it is
+       the measured difference in the total power transmitted by the
+       xTU-C and the total power received by the xTU-R over all
+       subcarriers during diagnostics mode.
+       When referring to a band in the upstream direction, it is the
+       measured difference in the total power transmitted by the xTU-R
+       and the total power received by the xTU-C over all subcarriers
+       during diagnostics mode.
+       It ranges from 0 to 1270 units of 0.1 dB (physical values are 0
+       to 127 dB).
+       A special value of 0x7FFFFFFF (2147483647) indicates the line
+       attenuation is out of range to be represented.
+       A special value of 0x7FFFFFFE (2147483646) indicates the line
+       attenuation measurement is unavailable.
+       This object reflects the value of the parameter following the
+       most recent DELT performed on the associated line.  Once the DELT
+       process is over, the parameter no longer changes until the row is
+       deleted or a new DELT process is initiated."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.9 (LATNds)
+               and paragraph #7.5.1.10 (LATNus)"
+   DEFVAL       { 2147483646 }
+   ::= { xdsl2SCStatusBandEntry 2 }
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 91]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+xdsl2SCStatusBandSigAtten  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..1270 | 2147483646 | 2147483647)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "When referring to a band in the downstream direction, it is the
+       measured difference in the total power transmitted by the xTU-C
+       and the total power received by the xTU-R over all subcarriers
+       during Showtime after the diagnostics mode.
+       When referring to the upstream direction, it is the measured
+       difference in the total power transmitted by the xTU-R and the
+       total power received by the xTU-C over all subcarriers during
+       Showtime after the diagnostics mode.
+       It ranges from 0 to 1270 units of 0.1 dB (physical values are 0
+       to 127 dB).
+       A special value of 0x7FFFFFFF (2147483647) indicates the line
+       attenuation is out of range to be represented.
+       A special value of 0x7FFFFFFE (2147483646) indicates the line
+       attenuation measurement is unavailable.
+       This object reflects the value of the parameter following the
+       most recent DELT performed on the associated line.  Once the DELT
+       process is over, the parameter no longer changes until the row is
+       deleted or a new DELT process is initiated."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.11 (SATNds)
+               and paragraph #7.5.1.12 (SATNus)"
+   DEFVAL       { 2147483646 }
+   ::= { xdsl2SCStatusBandEntry 3 }
+
+------------------------------------------------
+--        xdsl2SCStatusSegmentTable           --
+------------------------------------------------
+
+xdsl2SCStatusSegmentTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2SCStatusSegmentEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2SCStatusSegmentTable contains status
+       parameters of VDSL2/ADSL/ADSL2 and ADSL2+ subcarriers.
+
+       Several objects in the table refer to NSus and NSds.  For
+       G.993.2, the value of NSus and NSds are, respectively, the
+       indices of the highest supported upstream and downstream
+       subcarriers according to the selected implementation profile.
+       For ADSL, NSus is equal to NSCus-1 and NSds is equal to NSCds-1.
+
+       The parameters in this table MUST be updated after a loop
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 92]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       diagnostic procedure and MAY be updated after a line
+       initialization and MAY be updated at Showtime."
+   ::= { xdsl2Status 5 }
+
+xdsl2SCStatusSegmentEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2SCStatusSegmentEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "One index of this table is an interface index where the
+       interface has an ifType of vdsl2(251).  A second index of this
+       table is the transmission direction.  A third index identifies
+       the specific segment of the subcarriers status addressed."
+   INDEX  { ifIndex,
+            xdsl2SCStatusDirection,
+            xdsl2SCStatusSegment   }
+   ::= { xdsl2SCStatusSegmentTable 1 }
+
+Xdsl2SCStatusSegmentEntry  ::=
+   SEQUENCE {
+      xdsl2SCStatusSegment                  Unsigned32,
+      xdsl2SCStatusSegmentLinReal           OCTET STRING,
+      xdsl2SCStatusSegmentLinImg            OCTET STRING,
+      xdsl2SCStatusSegmentLog               OCTET STRING,
+      xdsl2SCStatusSegmentQln               OCTET STRING,
+      xdsl2SCStatusSegmentSnr               OCTET STRING,
+      xdsl2SCStatusSegmentBitsAlloc         Xdsl2BitsAlloc,
+      xdsl2SCStatusSegmentGainAlloc         OCTET STRING
+   }
+
+xdsl2SCStatusSegment  OBJECT-TYPE
+     SYNTAX      Unsigned32(1..8)
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+     "The segment of the subcarriers status information provided by
+      this row.
+      Several status parameters in this table are retrieved in segments.
+      The first segment of the status information is retrieved with
+      xdsl2SCStatusSegment=1, the second segment is retrieved with
+      xdsl2SCStatusSegment=2, and so on.  When any status parameter is
+      retrieved in n segments where n<8), then for that parameter,
+      GET operations for the remaining segment numbers (n+1 to 8) will
+      respond with a zero-length OCTET STRING."
+     ::= { xdsl2SCStatusSegmentEntry 1 }
+
+xdsl2SCStatusSegmentLinReal  OBJECT-TYPE
+     SYNTAX      OCTET STRING  (SIZE(0..1024))
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 93]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "An array of up to 512 complex H(f) linear representation
+      values in linear scale for the respective transmission direction.
+      It is designed to support up to 512 (downstream) subcarrier
+      groups and can be retrieved in a single segment.
+      The number of utilized values in the downstream direction depends
+      on NSds; in the upstream direction, it depends on NSus.  This
+      value is referred to here as NS.
+      Each array entry represents the real component (referred to here
+      as a(i)) of Hlin(f = i*Df) value for a particular subcarrier
+      group index i (0 <= i <= NS).
+      Hlin(f) is represented as ((scale/2^15)*((a(i)+j*b(i))/2^15)),
+      where scale is xdsl2SCStatusLinScale and a(i) and b(i)
+      (provided by the xdsl2SCStatusSegmentLinImg object) are in the
+      range (-2^15+1) to (+2^15-1).
+      A special value a(i)=b(i)= -2^15 indicates that no measurement
+      could be done for the subcarrier group because it is out of the
+      passband or that the attenuation is out of range to be
+      represented.  This parameter is only available after a loop
+      diagnostic procedure.
+      Each value in this array is 16 bits wide and is stored in big
+      endian format."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.26.3 (HLINpsds)
+               and paragraph #7.5.1.26.9 (HLINpsus)"
+     ::= { xdsl2SCStatusSegmentEntry 2 }
+
+xdsl2SCStatusSegmentLinImg  OBJECT-TYPE
+     SYNTAX      OCTET STRING  (SIZE(0..1024))
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "An array of up to 512 complex H(f) linear representation
+      values in linear scale for the respective transmission direction.
+      It is designed to support up to 512 (downstream) subcarrier
+      groups and can be retrieved in a single segment.
+      The number of utilized values in the downstream direction depends
+      on NSds; in the upstream direction, it depends on NSus.  This
+      value is referred to here as NS.
+      Each array entry represents the imaginary component (referred to
+      here as b(i)) of Hlin(f = i*Df) value for a particular
+      subcarrier group index i (0 <= i <= NS).
+      Hlin(f) is represented as ((scale/2^15)*((a(i)+j*b(i))/2^15)),
+      where scale is xdsl2SCStatusLinScale and a(i) (provided by the
+      xdsl2SCStatusSegmentLinReal object) and b(i) are in the range
+      (-2^15+1) to (+2^15-1).
+      A special value a(i)=b(i)= -2^15 indicates that no measurement
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 94]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      could be done for the subcarrier group because it is out of the
+      passband or that the attenuation is out of range to be
+      represented.  This parameter is only available after a loop
+      diagnostic procedure.
+      Each value in this array is 16 bits wide and is stored in big
+      endian format."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.26.3 (HLINpsds)
+               and paragraph #7.5.1.26.9 (HLINpsus)"
+     ::= { xdsl2SCStatusSegmentEntry 3 }
+
+xdsl2SCStatusSegmentLog  OBJECT-TYPE
+     SYNTAX      OCTET STRING  (SIZE(0..1024))
+     UNITS       "dB"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "An array of up to 512 real H(f) logarithmic representation
+      values in dB for the respective transmission direction.  It is
+      designed to support up to 512 (downstream) subcarrier groups
+      and can be retrieved in a single segment.
+      The number of utilized values in the downstream direction depends
+      on NSds; in the upstream direction, it depends on NSus.  This
+      value is referred to here as NS.
+      Each array entry represents the real Hlog(f = i*Df) value for a
+      particular subcarrier group index i, (0 <= i <= NS).
+      The real Hlog(f) value is represented as (6-m(i)/10), with m(i)
+      in the range 0 to 1022.  A special value m=1023 indicates that
+      no measurement could be done for the subcarrier group because
+      it is out of the passband or that the attenuation is out of
+      range to be represented.  This parameter is applicable in loop
+      diagnostic procedure and initialization.
+      Each value in this array is 16 bits wide and is stored in big
+      endian format."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.26.6 (HLOGpsds)
+               and paragraph #7.5.1.26.12 (HLOGpsus)"
+     ::= { xdsl2SCStatusSegmentEntry 4 }
+
+xdsl2SCStatusSegmentQln  OBJECT-TYPE
+     SYNTAX      OCTET STRING  (SIZE(0..512))
+     UNITS       "dBm/Hz"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "An array of up to 512 real Quiet Line Noise values in dBm/Hz
+      for the respective transmission direction.  It is designed for up
+      to 512 (downstream) subcarrier groups and can be retrieved in a
+      single segment.
+      The number of utilized values in the downstream direction depends
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 95]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      on NSds; in the upstream direction, it depends on NSus.  This
+      value is referred to here as NS.
+      Each array entry represents the QLN(f = i*Df) value for a
+      particular subcarrier index i, (0 <= i <= NS).
+      The QLN(f) is represented as ( -23-n(i)/2), with n(i) in the range
+      0 to 254.  A special value n(i)=255 indicates that no measurement
+      could be done for the subcarrier group because it is out of the
+      passband or that the noise PSD is out of range to be represented.
+      This parameter is applicable in loop diagnostic procedure and
+      initialization.  Each value in this array is 8 bits wide."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.27.3 (QLNpsds)
+               and paragraph #7.5.1.27.6 (QLNpsus)"
+     ::= { xdsl2SCStatusSegmentEntry 5 }
+
+xdsl2SCStatusSegmentSnr  OBJECT-TYPE
+     SYNTAX      OCTET STRING  (SIZE(0..512))
+     UNITS       "0.5 dB"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "The SNR Margin per subcarrier group, expressing the ratio
+      between the received signal power and received noise power per
+      subscriber group.  It is an array of 512 octets, designed for
+      supporting up to 512 (downstream) subcarrier groups and can be
+      retrieved in a single segment.
+      The number of utilized octets in the downstream direction depends
+      on NSds; in the upstream direction, it depends on NSus.  This
+      value is referred to here as NS.
+      Octet i (0 <= i <= NS) is set to a value in the range 0 to
+      254 to indicate that the respective downstream or upstream
+      subcarrier group i has an SNR of:
+      (-32 + xdsl2SCStatusSegmentSnr(i)/2) in dB (i.e., -32 to 95 dB).
+      The special value 255 means that no measurement could be done for
+      the subcarrier group because it is out of the PSD mask passband or
+      that the noise PSD is out of range to be represented.  Each value
+      in this array is 8 bits wide."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.28.3 (SNRpsds)
+                 and paragraph #7.5.1.28.6 (SNRpsus)"
+     ::= { xdsl2SCStatusSegmentEntry 6 }
+
+xdsl2SCStatusSegmentBitsAlloc  OBJECT-TYPE
+     SYNTAX      Xdsl2BitsAlloc
+     UNITS       "bits"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "The bits allocation per subcarrier.  An array of 256 octets
+      (512 nibbles) designed for supporting up to 512 (downstream)
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 96]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      subcarriers.  When more than 512 subcarriers are supported, the
+      status information is reported through multiple (up to 8)
+      segments.  The first segment is then used for the first 512
+      subcarriers.  The second segment is used for the subcarriers
+      512 to 1023 and so on.
+      The aggregate number of utilized nibbles in the downstream
+      direction (in all segments) depends on NSds; in the upstream
+      direction, it depends on NSus.
+      This value is referred to here as NS.  The segment number is in
+      xdsl2SCStatusSegment.
+      Nibble i (0 <= i < MIN((NS+1)-(segment-1)*512,512)) in each
+      segment is set to a value in the range 0 to 15 to indicate that
+      the respective downstream or upstream subcarrier j
+      (j=(segement-1)*512+i) has the same amount of bits
+      allocation."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.29.1 (BITSpsds)
+                 and paragraph #7.5.1.29.2 (BITSpsus)"
+     ::= { xdsl2SCStatusSegmentEntry 7 }
+
+xdsl2SCStatusSegmentGainAlloc  OBJECT-TYPE
+     SYNTAX      OCTET STRING  (SIZE(0..1024))
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "The gain allocation per subcarrier.  An array of 512 16-bit
+      values, designed for supporting up to 512 (downstream)
+      subcarriers.  When more then 512 subcarriers are supported, the
+      status information is reported through multiple (up to 8)
+      segments.  The first segment is then used for the first 512
+      subcarriers.  The second segment is used for the subcarriers 512
+      to 1023 and so on.
+      The aggregate number of utilized octets in the downstream
+      direction depends on NSds; in the upstream direction, it depends
+      on NSus.  This value is referred to here as NS.  The segment
+      number is in xdsl2SCStatusSegment.
+      Value i (0 <= i < MIN((NS+1)-(segment-1)*512,512)) in each
+      segment is set to a value in the range 0 to 4093 to indicate that
+      the respective downstream or upstream subcarrier j
+      (j=(segement-1)*512+i) has the same amount of gain value.
+      The gain value is represented as a multiple of 1/512 on a linear
+      scale.  Each value in this array is 16 bits wide and is stored in
+      big endian format."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.29.3 (GAINSpsds)
+                 and paragraph #7.5.1.29.4 (GAINSpsus)"
+     ::= { xdsl2SCStatusSegmentEntry 8 }
+
+------------------------------------------------
+--        xdsl2LineInventoryTable             --
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 97]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+------------------------------------------------
+
+xdsl2LineInventoryTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2LineInventoryEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineInventoryTable contains an inventory of the
+       DSL termination unit."
+   ::= { xdsl2Inventory 1 }
+
+xdsl2LineInventoryEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2LineInventoryEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+       "One index of this table is an interface index where the
+       interface
+       has an ifType of vdsl2(251).  A second index of this table is the
+       termination unit."
+   INDEX  { ifIndex, xdsl2LInvUnit }
+   ::= { xdsl2LineInventoryTable 1 }
+
+Xdsl2LineInventoryEntry  ::=
+   SEQUENCE {
+      xdsl2LInvUnit                      Xdsl2Unit,
+      xdsl2LInvG994VendorId              OCTET STRING,
+      xdsl2LInvSystemVendorId            OCTET STRING,
+      xdsl2LInvVersionNumber             OCTET STRING,
+      xdsl2LInvSerialNumber              OCTET STRING,
+      xdsl2LInvSelfTestResult            Unsigned32,
+      xdsl2LInvTransmissionCapabilities  Xdsl2TransmissionModeType
+   }
+
+xdsl2LInvUnit  OBJECT-TYPE
+   SYNTAX      Xdsl2Unit
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The termination unit."
+   ::= { xdsl2LineInventoryEntry 1 }
+
+xdsl2LInvG994VendorId  OBJECT-TYPE
+   SYNTAX      OCTET STRING  (SIZE(8))
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The ADSL Transceiver Unit (ATU) G.994.1 Vendor ID as
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 98]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       inserted in the G.994.1 CL/CLR message.
+       It consists of 8 binary octets, including a country
+       code followed by a (regionally allocated) provider code, as
+       defined in Recommendation T.35."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.4.1-7.4.2"
+   ::= { xdsl2LineInventoryEntry 2 }
+
+xdsl2LInvSystemVendorId  OBJECT-TYPE
+   SYNTAX      OCTET STRING  (SIZE(8))
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The ATU System Vendor ID (identifies the xTU system
+       integrator) as inserted in the Overhead Messages (both xTUs for
+       G.992.3, G.992.4, G.992.5, and G.993.2) or in the Embedded
+       Operations Channel (xTU-R in G.992.1 and G.992.2).
+       It consists of 8 binary octets, with same format as used for
+       Xdsl2InvG994VendorId."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.4.3-7.4.4"
+   ::= { xdsl2LineInventoryEntry 3 }
+
+xdsl2LInvVersionNumber  OBJECT-TYPE
+   SYNTAX      OCTET STRING  (SIZE(0..16))
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The xTU version number (vendor-specific information) as
+       inserted in the Overhead Messages (both xTUs for G.992.3,
+       G.992.4, G.992.5, and G.993.2) or in the Embedded Operations
+       Channel (xTU-R in G.992.1 and G.992.2).  It consists of up to 16
+       binary octets."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.4.5-7.4.6"
+   ::= { xdsl2LineInventoryEntry 4 }
+
+xdsl2LInvSerialNumber  OBJECT-TYPE
+   SYNTAX      OCTET STRING  (SIZE(0..32))
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The xTU serial number (vendor-specific information) as
+       inserted in the Overhead Messages (both xTUs for G.992.3,
+       G.992.4, G.992.5, and G.993.2) or in the Embedded Operations
+       Channel (xTU-R in G.992.1 and G.992.2).  It is vendor-specific
+       information consisting of up to 32 ASCII characters."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.4.7-7.4.8"
+   ::= { xdsl2LineInventoryEntry 5 }
+
+xdsl2LInvSelfTestResult  OBJECT-TYPE
+
+
+
+Morgenstern, et al.         Standards Track                    [Page 99]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The xTU self-test result, coded as a 32-bit value.  The
+       most significant octet of the result is '0' if the
+       self-test passed, and '1' if the self-test failed.  The
+       interpretation of the other octets is vendor discretionary."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.4.9-7.4.10"
+   DEFVAL       { 0 }
+   ::= { xdsl2LineInventoryEntry 6 }
+
+xdsl2LInvTransmissionCapabilities  OBJECT-TYPE
+   SYNTAX      Xdsl2TransmissionModeType
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The xTU transmission system capability list of the different
+       coding types.  It is coded in a bitmap representation with 1 or
+       more bits set.  A bit set to '1' means that the xTU
+       supports the respective coding.  The value may be derived from
+       the handshaking procedures defined in G.994.1.  A set of xDSL
+       line transmission modes, with one bit per mode."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.4.11-7.4.12"
+   ::= { xdsl2LineInventoryEntry 7 }
+
+------------------------------------------------
+--        xdsl2LineConfTemplateTable          --
+------------------------------------------------
+
+xdsl2LineConfTemplateTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2LineConfTemplateEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineConfTemplateTable contains VDSL2/ADSL/
+       ADSL2 and ADSL2+ line configuration templates.
+
+       Note that this table is also used to configure the number of
+       bearer channels.
+       When the number of bearer channels is increased, the SNMP agent
+       SHOULD create rows in all tables indexed by a channel index.
+       When the number of bearer channels is decreased, the SNMP agent
+       SHOULD delete rows in all tables indexed by a channel index.
+       For example, if the value of xdsl2LConfTempChan4ConfProfile is
+       set to a non-null value, then rows SHOULD be created in
+       xdsl2ChannelStatusTable, xdsl2PMChCurrTable, and all other tables
+       indexed by a channel index.
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 100]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       For example, if the value of xdsl2LConfTempChan2ConfProfile is
+       set to a null value, then rows SHOULD be deleted in
+       xdsl2ChannelStatusTable, xdsl2PMChCurrTable, and all other
+       tables indexed by a channel index.
+
+       Entries in this table MUST be maintained in a persistent
+       manner."
+   ::= { xdsl2ProfileLine 1 }
+
+xdsl2LineConfTemplateEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2LineConfTemplateEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "A default template with an index of 'DEFVAL' will always
+       exist, and its parameters will be set to vendor-specific values,
+       unless otherwise specified in this document."
+   INDEX  { xdsl2LConfTempTemplateName }
+   ::= { xdsl2LineConfTemplateTable 1 }
+
+Xdsl2LineConfTemplateEntry  ::=
+   SEQUENCE {
+      xdsl2LConfTempTemplateName      SnmpAdminString,
+      xdsl2LConfTempLineProfile       SnmpAdminString,
+      xdsl2LConfTempChan1ConfProfile  SnmpAdminString,
+      xdsl2LConfTempChan1RaRatioDs    Unsigned32,
+      xdsl2LConfTempChan1RaRatioUs    Unsigned32,
+      xdsl2LConfTempChan2ConfProfile  SnmpAdminString,
+      xdsl2LConfTempChan2RaRatioDs    Unsigned32,
+      xdsl2LConfTempChan2RaRatioUs    Unsigned32,
+      xdsl2LConfTempChan3ConfProfile  SnmpAdminString,
+      xdsl2LConfTempChan3RaRatioDs    Unsigned32,
+      xdsl2LConfTempChan3RaRatioUs    Unsigned32,
+      xdsl2LConfTempChan4ConfProfile  SnmpAdminString,
+      xdsl2LConfTempChan4RaRatioDs    Unsigned32,
+      xdsl2LConfTempChan4RaRatioUs    Unsigned32,
+      xdsl2LConfTempRowStatus         RowStatus
+   }
+
+xdsl2LConfTempTemplateName  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "This object identifies a row in this table."
+   REFERENCE    "DSL Forum TR-129, paragraph #5.4"
+   ::= { xdsl2LineConfTemplateEntry 1 }
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 101]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+xdsl2LConfTempLineProfile  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the
+       VDSL2/ADSL/ADSL2 and ADSL2+ line configuration Profile Table
+       (xdsl2LineConfProfTable) that applies for this DSL line."
+   REFERENCE    "DSL Forum TR-129, paragraph #5.4"
+   DEFVAL       { "DEFVAL" }
+   ::= { xdsl2LineConfTemplateEntry 2 }
+
+xdsl2LConfTempChan1ConfProfile  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the VDSL2/
+       ADSL/ADSL2 and ADSL2+ channel configuration Profile Table
+       (xdsl2ChConfProfileTable) that applies to DSL bearer channel #1.
+       The channel profile name specified here MUST match the name of an
+       existing row in the xdsl2ChConfProfileTable table."
+   DEFVAL       { "DEFVAL" }
+   ::= { xdsl2LineConfTemplateEntry 3 }
+
+xdsl2LConfTempChan1RaRatioDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..100)
+   UNITS       "percent"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Rate Adaptation Ratio.  The ratio (in percent) that should be
+       taken into account for the bearer channel #1 when performing rate
+       adaptation on Downstream.  The ratio refers to the available data
+       rate in excess of the Minimum Data Rate, summed over all bearer
+       channels.
+       Also, the 100 - xdsl2LConfTempChan1RaRatioDs is the ratio of
+       excess data rate to be assigned to all other bearer channels on
+       Downstream direction.  The sum of rate adaptation ratios over all
+       bearers on the same direction shall be equal to 100%."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.4
+                (Rate adaptation ratio)"
+   DEFVAL       { 100 }
+   ::= { xdsl2LineConfTemplateEntry 4 }
+
+xdsl2LConfTempChan1RaRatioUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..100)
+   UNITS       "percent"
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 102]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Rate Adaptation Ratio.  The ratio (in percent) that should be
+       taken into account for the bearer channel #1 when performing
+       rate adaptation on Upstream.  The ratio refers to the available
+       data rate in excess of the Minimum Data Rate, summed over all
+       bearer channels.
+       Also, the 100 - xdsl2LConfTempChan1RaRatioUs is the ratio of
+       excess data rate to be assigned to all other bearer channels on
+       Upstream direction.  The sum of rate adaptation ratios over all
+       bearers on the same direction shall be equal to 100%."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.4
+                 (Rate adaptation ratio)"
+   DEFVAL       { 100 }
+   ::= { xdsl2LineConfTemplateEntry 5 }
+
+xdsl2LConfTempChan2ConfProfile  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(0..32))
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the VDSL2/
+       ADSL/ADSL2 and ADSL2+ channel configuration Profile Table
+       (xdsl2ChConfProfileTable) that applies to DSL bearer channel #2.
+       If the channel is unused, then the object is set to a zero-length
+       string.
+       This object may be set to a zero-length string only if
+       xdsl2LConfTempChan3ConfProfile contains a zero-length
+       string."
+   DEFVAL       { "" }
+   ::= { xdsl2LineConfTemplateEntry 6 }
+
+xdsl2LConfTempChan2RaRatioDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..100)
+   UNITS       "percent"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Rate Adaptation Ratio.  The ratio (in percent) that should be
+       taken into account for the bearer channel #2 when performing
+       rate adaptation on Downstream.  The ratio refers to the available
+       data rate in excess of the Minimum Data Rate, summed over all
+       bearer channels.
+       Also, the 100 - xdsl2LConfTempChan2RaRatioDs is the ratio of
+       excess data rate to be assigned to all other bearer channels on
+       Downstream direction.  The sum of rate adaptation ratios over all
+       bearers on the same direction shall be equal to
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 103]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       100%."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.4
+                 (Rate adaptation ratio)"
+   DEFVAL       { 0 }
+   ::= { xdsl2LineConfTemplateEntry 7 }
+
+xdsl2LConfTempChan2RaRatioUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..100)
+   UNITS       "percent"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Rate Adaptation Ratio.  The ratio (in percent) that should be
+       taken into account for the bearer channel #2 when performing
+       rate adaptation on Upstream.  The ratio refers to the available
+       data rate in excess of the Minimum Data Rate, summed over all
+       bearer channels.
+       Also, the 100 - xdsl2LConfTempChan2RaRatioUs is the ratio of
+       excess data rate to be assigned to all other bearer channels on
+       Upstream direction.  The sum of rate adaptation ratios over all
+       bearers on the same direction shall be equal to 100%."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.4
+                 (Rate adaptation ratio)"
+   DEFVAL       { 0 }
+   ::= { xdsl2LineConfTemplateEntry 8 }
+
+xdsl2LConfTempChan3ConfProfile  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(0..32))
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the VDSL2/
+       ADSL/ADSL2 and ADSL2+ channel configuration Profile Table
+       (xdsl2ChConfProfileTable) that applies to DSL bearer channel #3.
+       If the channel is unused, then the object is set to a zero-length
+       string.
+       This object may be set to a zero-length string only if
+       xdsl2LConfTempChan4ConfProfile contains a zero-length string.
+       This object may be set to a non-zero-length string only if
+       xdsl2LConfTempChan2ConfProfile contains a non-zero-length
+       string."
+   DEFVAL       { "" }
+   ::= { xdsl2LineConfTemplateEntry 9 }
+
+xdsl2LConfTempChan3RaRatioDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..100)
+   UNITS       "percent"
+   MAX-ACCESS  read-create
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 104]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   STATUS      current
+   DESCRIPTION
+      "Rate Adaptation Ratio.  The ratio (in percent) that should be
+       taken into account for the bearer channel #3 when performing
+       rate adaptation on Downstream.  The ratio refers to the available
+       data rate in excess of the Minimum Data Rate, summed over all
+       bearer channels.
+       Also, the 100 - xdsl2LConfTempChan3RaRatioDs is the ratio of
+       excess data rate to be assigned to all other bearer channels on
+       Downstream direction.  The sum of rate adaptation ratios over all
+       bearers on the same direction shall be equal to 100%."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.4
+                 (Rate adaptation ratio)"
+   DEFVAL       { 0 }
+   ::= { xdsl2LineConfTemplateEntry 10 }
+
+xdsl2LConfTempChan3RaRatioUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..100)
+   UNITS       "percent"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Rate Adaptation Ratio.  The ratio (in percent) that should be
+       taken into account for the bearer channel #3 when performing
+       rate adaptation on Upstream.  The ratio refers to the available
+       data rate in excess of the Minimum Data Rate, summed over all
+       bearer channels.
+       Also, the 100 - xdsl2LConfTempChan3RaRatioUs is the ratio of
+       excess data rate to be assigned to all other bearer channels on
+       Upstream direction.  The sum of rate adaptation ratios over all
+       bearers on the same direction shall be equal to 100%."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.4
+                 (Rate adaptation ratio)"
+   DEFVAL       { 0 }
+   ::= { xdsl2LineConfTemplateEntry 11 }
+
+xdsl2LConfTempChan4ConfProfile  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(0..32))
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the VDSL2/
+       ADSL/ADSL2 and ADSL2+ channel configuration Profile Table
+       (xdsl2ChConfProfileTable) that applies to DSL bearer channel #4.
+       If the channel is unused, then the object is set to a zero-length
+       string.
+       This object may be set to a non-zero-length string only if
+       xdsl2LConfTempChan3ConfProfile contains a non-zero-length
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 105]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       string."
+   DEFVAL       { "" }
+   ::= { xdsl2LineConfTemplateEntry 12 }
+
+xdsl2LConfTempChan4RaRatioDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..100)
+   UNITS       "percent"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Rate Adaptation Ratio.  The ratio (in percent) that should be
+       taken into account for the bearer channel #4 when performing rate
+       adaptation on Downstream.  The ratio refers to the available data
+       rate in excess of the Minimum Data Rate, summed over all bearer
+       channels.
+       Also, the 100 - xdsl2LConfTempChan4RaRatioDs is the ratio of
+       excess data rate to be assigned to all other bearer channels.
+       The sum of rate adaptation ratios over all bearers on the same
+       direction shall sum to 100%."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.4
+                 (Rate adaptation ratio)"
+   DEFVAL       { 0 }
+   ::= { xdsl2LineConfTemplateEntry 13 }
+
+xdsl2LConfTempChan4RaRatioUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..100)
+   UNITS       "percent"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Rate Adaptation Ratio.  The ratio (in percent) that should be
+       taken into account for the bearer channel #4 when performing rate
+       adaptation on Upstream.  The ratio refers to the available data
+       rate in excess of the Minimum Data Rate, summed over all bearer
+       channels.
+       Also, the 100 - xdsl2LConfTempChan4RaRatioUs is the ratio of
+       excess data rate to be assigned to all other bearer channels.
+       The sum of rate adaptation ratios over all bearers on the same
+       direction shall sum to 100%."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.4
+                 (Rate adaptation ratio)"
+   DEFVAL       { 0 }
+   ::= { xdsl2LineConfTemplateEntry 14 }
+
+xdsl2LConfTempRowStatus  OBJECT-TYPE
+   SYNTAX      RowStatus
+   MAX-ACCESS  read-create
+   STATUS      current
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 106]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   DESCRIPTION
+      "This object is used to create a new row or to modify or
+       delete an existing row in this table.
+       A template is activated by setting this object to 'active'.
+       Before a profile can be deleted or taken out of service (by
+       setting this object to 'destroy' or 'notInService'), it MUST be
+       first unreferenced from all associated lines.
+       A row in this table is said to be unreferenced when there is no
+       instance of xdsl2LineConfTemplate or
+       xdsl2LineConfFallbackTemplate that refers to the row."
+   ::= { xdsl2LineConfTemplateEntry 15 }
+
+------------------------------------------
+--        xdsl2LineConfProfTable        --
+------------------------------------------
+
+xdsl2LineConfProfTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2LineConfProfEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineConfProfTable contains VDSL2/ADSL/
+       ADSL2 and ADSL2+ line configuration profiles.
+
+       Entries in this table MUST be maintained in a persistent
+       manner."
+   ::= { xdsl2ProfileLine 2 }
+
+xdsl2LineConfProfEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2LineConfProfEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "A default profile with an index of 'DEFVAL' will always
+      exist, and its parameters will be set to vendor-specific values,
+      unless otherwise specified in this document."
+   INDEX  { xdsl2LConfProfProfileName }
+   ::= { xdsl2LineConfProfTable 1 }
+
+Xdsl2LineConfProfEntry  ::=
+   SEQUENCE {
+      xdsl2LConfProfProfileName          SnmpAdminString,
+      xdsl2LConfProfScMaskDs             Xdsl2ScMaskDs,
+      xdsl2LConfProfScMaskUs             Xdsl2ScMaskUs,
+      xdsl2LConfProfVdsl2CarMask         Xdsl2CarMask,
+      xdsl2LConfProfRfiBands             Xdsl2RfiBands,
+      xdsl2LConfProfRaModeDs             Xdsl2RaMode,
+      xdsl2LConfProfRaModeUs             Xdsl2RaMode,
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 107]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      xdsl2LConfProfRaUsNrmDs            Unsigned32,
+      xdsl2LConfProfRaUsNrmUs            Unsigned32,
+      xdsl2LConfProfRaUsTimeDs           Unsigned32,
+      xdsl2LConfProfRaUsTimeUs           Unsigned32,
+      xdsl2LConfProfRaDsNrmDs            Unsigned32,
+      xdsl2LConfProfRaDsNrmUs            Unsigned32,
+      xdsl2LConfProfRaDsTimeDs           Unsigned32,
+      xdsl2LConfProfRaDsTimeUs           Unsigned32,
+      xdsl2LConfProfTargetSnrmDs         Unsigned32,
+      xdsl2LConfProfTargetSnrmUs         Unsigned32,
+      xdsl2LConfProfMaxSnrmDs            Unsigned32,
+      xdsl2LConfProfMaxSnrmUs            Unsigned32,
+      xdsl2LConfProfMinSnrmDs            Unsigned32,
+      xdsl2LConfProfMinSnrmUs            Unsigned32,
+      xdsl2LConfProfMsgMinUs             Unsigned32,
+      xdsl2LConfProfMsgMinDs             Unsigned32,
+      xdsl2LConfProfCeFlag               Xdsl2LineCeFlag,
+      xdsl2LConfProfSnrModeDs            Xdsl2LineSnrMode,
+      xdsl2LConfProfSnrModeUs            Xdsl2LineSnrMode,
+      xdsl2LConfProfTxRefVnDs            Xdsl2LineTxRefVnDs,
+      xdsl2LConfProfTxRefVnUs            Xdsl2LineTxRefVnUs,
+      xdsl2LConfProfXtuTransSysEna       Xdsl2TransmissionModeType,
+      xdsl2LConfProfPmMode               Xdsl2LinePmMode,
+      xdsl2LConfProfL0Time               Unsigned32,
+      xdsl2LConfProfL2Time               Unsigned32,
+      xdsl2LConfProfL2Atpr               Unsigned32,
+      xdsl2LConfProfL2Atprt              Unsigned32,
+      xdsl2LConfProfProfiles             Xdsl2LineProfiles,
+      xdsl2LConfProfDpboEPsd             Xdsl2PsdMaskDs,
+      xdsl2LConfProfDpboEsEL             Unsigned32,
+      xdsl2LConfProfDpboEsCableModelA    Unsigned32,
+      xdsl2LConfProfDpboEsCableModelB    Unsigned32,
+      xdsl2LConfProfDpboEsCableModelC    Unsigned32,
+      xdsl2LConfProfDpboMus              Unsigned32,
+      xdsl2LConfProfDpboFMin             Unsigned32,
+      xdsl2LConfProfDpboFMax             Unsigned32,
+      xdsl2LConfProfUpboKL               Unsigned32,
+      xdsl2LConfProfUpboKLF              Xdsl2UpboKLF,
+      xdsl2LConfProfUs0Mask              Xdsl2LineUs0Mask,
+      xdsl2LConfProfForceInp             TruthValue,
+      xdsl2LConfProfRowStatus            RowStatus
+   }
+
+xdsl2LConfProfProfileName  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 108]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      "This object identifies a row in this table."
+     ::= { xdsl2LineConfProfEntry 1 }
+
+xdsl2LConfProfScMaskDs  OBJECT-TYPE
+   SYNTAX      Xdsl2ScMaskDs
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Subcarrier mask.  A bitmap of 4096 bits that allows masking
+       up to 4096 downstream subcarriers.  If bit i (0 <= i <
+       NSCds) is set to '1', the respective downstream
+       subcarrier is masked, and if set to '0', the respective
+       subcarrier is unmasked.
+       Note that there should always be unmasked subcarriers (i.e.,
+       this object cannot be all 1's).
+       Also note that if NSCds < 4096, all bits i
+       (NSCds < i <= 4096) should be set to '1'."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.6 (CARMASKds)"
+   ::= { xdsl2LineConfProfEntry 2 }
+
+xdsl2LConfProfScMaskUs  OBJECT-TYPE
+   SYNTAX      Xdsl2ScMaskUs
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Subcarrier mask.  A bitmap of 4096 bits that allows masking
+       up to 4096 upstream subcarriers.  If bit i (0 <= i < NSCus)
+       is set to '1', the respective upstream subcarrier is
+       masked, and if set to '0', the respective subcarrier
+       is unmasked.
+       Note that there should always be unmasked subcarriers (i.e.,
+       this object cannot be all 1's).
+       Also note that if NSCus < 4096, all bits i
+       (NSCus < i <= 4096) should be set to '1'."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.7 (CARMASKus)"
+   ::= { xdsl2LineConfProfEntry 3 }
+
+xdsl2LConfProfVdsl2CarMask  OBJECT-TYPE
+   SYNTAX      Xdsl2CarMask
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "VDSL2-specific subcarrier mask.  This configuration
+       parameter defines the restrictions, additional to the band plan,
+       to determine the set of subcarriers allowed for transmission in
+       both the upstream and downstream directions.
+       The parameter shall describe the not masked subcarriers as one or
+       more frequency bands.  Each band is represented by start and stop
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 109]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       subcarrier indices with a subcarrier spacing of 4.3125 kHz.  The
+       valid range of subcarrier indices runs from 0 to at least the
+       index of the highest allowed subcarrier in both transmission
+       directions among all profiles enabled by the parameter
+       xdsl2LConfProfProfiles.
+       Up to 32 bands may be specified.  Other subcarriers shall be
+       masked."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.8 (VDSL2-
+                 CARMASK)"
+   ::= { xdsl2LineConfProfEntry 4 }
+
+xdsl2LConfProfRfiBands  OBJECT-TYPE
+   SYNTAX      Xdsl2RfiBands
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "For ITU-T Recommendation G.992.5, this configuration
+       parameter defines
+       the subset of downstream PSD mask breakpoints, as specified in
+       xdsl2LConfProfPsdMaskDs (PSDMASKds), that shall be used to notch
+       an RFI band.  This subset consists of pairs of consecutive
+       subcarrier indices belonging to breakpoints: [ti; ti + 1],
+       corresponding to the low level of the notch.
+       The specific interpolation around these points is defined in the
+       relevant Recommendations (e.g., ITU-T Recommendation G.992.5).
+       The CO-MIB shall define the RFI notches using breakpoints in
+       xdsl2LConfProfPsdMaskDs (PSDMASKds) as specified in the relevant
+       Recommendations (e.g., ITU-T Recommendation G.992.5).
+
+       For ITU-T Recommendation G.993.2, this configuration parameter
+       defines the bands where the PSD shall be reduced as
+       specified in #7.2.1.2/G.993.2.  Each band shall be represented
+       by a start and stop subcarrier indices with a subcarrier
+       spacing of 4.3125 kHz.  Up to 16 bands may be specified.
+       This parameter defines the RFI bands for both the upstream
+       and downstream directions."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.10 (RFIBANDS)"
+   ::= { xdsl2LineConfProfEntry 5 }
+
+xdsl2LConfProfRaModeDs  OBJECT-TYPE
+   SYNTAX      Xdsl2RaMode
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The mode of operation of a rate-adaptive xTU-C in the
+       transmit direction."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.4.1 (RA-MODEds)"
+   DEFVAL      { manual }
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 110]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   ::= { xdsl2LineConfProfEntry 6 }
+
+xdsl2LConfProfRaModeUs  OBJECT-TYPE
+   SYNTAX      Xdsl2RaMode
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The mode of operation of a rate-adaptive xTU-R in the
+       transmit direction."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.4.2 (RA-MODEus)"
+   DEFVAL      { manual }
+   ::= { xdsl2LineConfProfEntry 7 }
+
+xdsl2LConfProfRaUsNrmDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..310)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The Downstream Up-Shift Noise Margin value, to be used when
+       xdsl2LConfProfRaModeDs is set to 'dynamicRa'.  If the downstream
+       noise margin is above this value, and stays above it,
+       for more than the time specified by the
+       xdsl2LConfProfRaUsTimeDs, the xTU-R shall attempt to increase
+       the downstream net data rate.  The Downstream Up-Shift Noise
+       Margin ranges from 0 to 310 units of 0.1 dB (physical values
+       are 0 to 31 dB)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.4.3 (RA-USNRMds)"
+   DEFVAL       { 10 }
+   ::= { xdsl2LineConfProfEntry 8 }
+
+xdsl2LConfProfRaUsNrmUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..310)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The Upstream Up-Shift Noise Margin value, to be used when
+       xdsl2LConfProfRaModeUs is set to 'dynamicRa'.  If the upstream
+       noise margin is above this value, and stays above it,
+       for more than
+       the time specified by the xdsl2LConfProfRaUsTimeUs, the xTU-C
+       shall attempt to increase the upstream net data rate.
+       The Upstream Up-Shift Noise Margin ranges from 0 to 310 units of
+       0.1 dB (physical values are 0 to 31 dB)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.4.4 (RA-USNRMus)"
+   DEFVAL       { 10 }
+   ::= { xdsl2LineConfProfEntry 9 }
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 111]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+xdsl2LConfProfRaUsTimeDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..16383)
+   UNITS       "seconds"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The Downstream Up-Shift Time Interval, to be used when
+       xdsl2LConfProfRaModeDs is set to 'dynamicRa'.  The interval of
+       time that the downstream noise margin should stay above the
+       Downstream Up-Shift Noise Margin before the xTU-R shall attempt
+       to increase the downstream net data rate.  The time interval
+       ranges from 0 to 16383 seconds."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.4.5 (RA-UTIMEds)"
+   DEFVAL       { 3600 }
+   ::= { xdsl2LineConfProfEntry 10 }
+
+xdsl2LConfProfRaUsTimeUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..16383)
+   UNITS       "seconds"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The Upstream Up-Shift Time Interval, to be used when
+       xdsl2LConfProfRaModeUs is set to 'dynamicRa'.  The interval of
+       time the upstream noise margin should stay above the Upstream
+       Up-Shift Noise Margin before the xTU-C shall attempt to increase
+       the upstream net data rate.  The time interval ranges from 0 to
+       16383 seconds."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.4.6 (RA-UTIMEus)"
+   DEFVAL       { 3600 }
+   ::= { xdsl2LineConfProfEntry 11 }
+
+xdsl2LConfProfRaDsNrmDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..310)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The Downstream Down-Shift Noise Margin value, to be used
+       when xdsl2LConfProfRaModeDs is set to 'dynamicRa'.  If the
+       downstream noise margin is below this value and stays
+       below that value, for more than the time specified by the
+       xdsl2LConfProfRaDsTimeDs, the xTU-R shall attempt to decrease
+       the downstream net data rate.  The Downstream Down-Shift Noise
+       Margin ranges from 0 to 310 units of 0.1 dB (physical values
+       are 0 to 31 dB)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.4.7 (RA-DSNRMds)"
+   DEFVAL       { 10 }
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 112]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   ::= { xdsl2LineConfProfEntry 12 }
+
+xdsl2LConfProfRaDsNrmUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..310)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The Upstream Downshift Noise Margin value, to be used when
+       xdsl2LConfProfRaModeUs is set to 'dynamicRa'.  If the upstream
+       noise margin is below this value and stays below that value,
+       for more than the time specified by the xdsl2LConfProfRaDsTimeUs,
+       the xTU-C shall attempt to decrease the upstream net data rate.
+       The Upstream Down-Shift Noise Margin ranges from 0 to 310 units
+       of 0.1 dB (physical values are 0 to 31 dB)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.4.8 (RA-DSNRMus)"
+   DEFVAL       { 10 }
+   ::= { xdsl2LineConfProfEntry 13 }
+
+xdsl2LConfProfRaDsTimeDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..16383)
+   UNITS       "seconds"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The Downstream Downshift Time Interval, to be used when
+       xdsl2LConfProfRaModeDs is set to 'dynamicRa'.  The interval of
+       time the downstream noise margin should stay below the Downstream
+       Down-Shift Noise Margin before the xTU-R shall attempt to
+       decrease the downstream net data rate.  The time interval ranges
+       from 0 to 16383 seconds."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.4.9 (RA-DTIMEds)"
+   DEFVAL       { 3600 }
+   ::= { xdsl2LineConfProfEntry 14 }
+
+xdsl2LConfProfRaDsTimeUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..16383)
+   UNITS       "seconds"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The Upstream Down-Shift Time Interval, to be used when
+       xdsl2LConfProfRaModeUs is set to 'dynamicRa'.  The interval of
+       time the upstream noise margin should stay below the Upstream
+       Down-Shift Noise Margin before the xTU-C shall attempt to
+       decrease the upstream net data rate.  The time interval ranges
+       from 0 to 16383 seconds."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.4.10 (RA-DTIMEus)"
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 113]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   DEFVAL       { 3600 }
+   ::= { xdsl2LineConfProfEntry 15 }
+
+xdsl2LConfProfTargetSnrmDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..310)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The minimum Noise Margin the xTU-R receiver shall achieve,
+       relative to the BER requirement for each of the downstream bearer
+       channels, to successfully complete initialization.
+       The target noise margin ranges from 0 to 310 units of 0.1 dB
+       (physical values are 0 to 31 dB)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.3.1 (TARSNRMds)"
+   DEFVAL       { 60 }
+   ::= { xdsl2LineConfProfEntry 16 }
+
+xdsl2LConfProfTargetSnrmUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..310)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The minimum Noise Margin the xTU-C receiver shall achieve,
+       relative to the BER requirement for each of the upstream bearer
+       channels, to successfully complete initialization.
+       The target noise margin ranges from 0 to 310 units of 0.1 dB
+       (physical values are 0 to 31 dB)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.3.2 (TARSNRMus)"
+   DEFVAL       { 60 }
+   ::= { xdsl2LineConfProfEntry 17 }
+
+xdsl2LConfProfMaxSnrmDs  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..310 | 2147483647)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The maximum Noise Margin the xTU-R receiver shall try to
+       sustain.  If the Noise Margin is above this level, the xTU-R
+       shall request that the xTU-C reduce the xTU-C transmit power to
+       get a noise margin below this limit (if this functionality is
+       supported).  The maximum noise margin ranges from 0 to 310 units
+       of 0.1 dB (physical values are 0 to 31 dB).  A value of
+       0x7FFFFFFF (2147483647) means that there is no maximum."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.3.3 (MAXSNRMds)"
+   DEFVAL       { 310 }
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 114]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   ::= { xdsl2LineConfProfEntry 18 }
+
+xdsl2LConfProfMaxSnrmUs  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..310 | 2147483647)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The maximum Noise Margin the xTU-C receiver shall try to
+       sustain.  If the Noise Margin is above this level, the xTU-C
+       shall request that the xTU-R reduce the xTU-R transmit power to
+       get a noise margin below this limit (if this functionality is
+       supported).  The maximum noise margin ranges from 0 to 310 units
+       of 0.1 dB (physical values are 0 to 31 dB).  A value of
+       0x7FFFFFFF (2147483647) means that there is no maximum."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.3.4 (MAXSNRMus)"
+   DEFVAL       { 310 }
+   ::= { xdsl2LineConfProfEntry 19 }
+
+xdsl2LConfProfMinSnrmDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..310)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The minimum Noise Margin the xTU-R receiver shall tolerate.
+       If the noise margin falls below this level, the xTU-R shall
+       request that the xTU-C increase the xTU-C transmit power.
+       If an increase to xTU-C transmit power is not possible, a loss-
+       of-margin (LOM) defect occurs, the xTU-R shall fail and attempt
+       to reinitialize and the NMS shall be notified.  The minimum noise
+       margin ranges from 0 to 310 units of 0.1 dB (physical values are
+       0 to 31 dB).  A value of 0 means that there is no minimum."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.3.5 (MINSNRMds)"
+   DEFVAL       { 10 }
+   ::= { xdsl2LineConfProfEntry 20 }
+
+xdsl2LConfProfMinSnrmUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..310)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The minimum Noise Margin the xTU-C receiver shall tolerate.
+       If the noise margin falls below this level, the xTU-C shall
+       request that the xTU-R increase the xTU-R transmit power.
+       If an increase of xTU-R transmit power is not possible, a loss-
+       of-margin (LOM) defect occurs, the xTU-C shall fail and attempt
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 115]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       to re-initialize and the NMS shall be notified.  The minimum
+       noise margin ranges from 0 to 310 units of 0.1 dB (physical
+       values are 0 to 31 dB).  A value of 0 means that there is no
+       minimum."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.3.6 (MINSNRMus)"
+   DEFVAL       { 10 }
+   ::= { xdsl2LineConfProfEntry 21 }
+
+xdsl2LConfProfMsgMinUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(4000..248000)
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Minimum Overhead Rate Upstream.  Defines the minimum rate of
+       the message-based overhead that shall be maintained by the xTU in
+       upstream direction.  Expressed in bits per second and ranges from
+       4000 to 248000 bits/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.5.1 (MSGMINus)"
+   DEFVAL       { 4000 }
+  ::= { xdsl2LineConfProfEntry 22 }
+
+xdsl2LConfProfMsgMinDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(4000..248000)
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Minimum Overhead Rate Downstream.  Defines the minimum rate
+       of the message-based overhead that shall be maintained by the xTU
+       in the downstream direction.  Expressed in bits per second and
+       ranges from 4000 to 248000 bits/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.5.2 (MSGMINds)"
+   DEFVAL       { 4000 }
+   ::= { xdsl2LineConfProfEntry 23 }
+
+xdsl2LConfProfCeFlag  OBJECT-TYPE
+   SYNTAX      Xdsl2LineCeFlag
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This parameter is a bit that enables the use of the optional
+       cyclic extension values."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.6.1 (CEFLAG)"
+   DEFVAL       { { } }
+   ::= { xdsl2LineConfProfEntry 24 }
+
+xdsl2LConfProfSnrModeDs  OBJECT-TYPE
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 116]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   SYNTAX      Xdsl2LineSnrMode
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This parameter enables the transmitter-referred virtual
+       noise in the downstream direction."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.7.1 (SNRMODEds)"
+   DEFVAL       { virtualNoiseDisabled }
+   ::= { xdsl2LineConfProfEntry 25 }
+
+xdsl2LConfProfSnrModeUs  OBJECT-TYPE
+   SYNTAX      Xdsl2LineSnrMode
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This parameter enables the transmitter-referred virtual
+       noise in the upstream direction."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.7.2 (SNRMODEus)"
+   DEFVAL       { virtualNoiseDisabled }
+   ::= { xdsl2LineConfProfEntry 26 }
+
+xdsl2LConfProfTxRefVnDs  OBJECT-TYPE
+   SYNTAX      Xdsl2LineTxRefVnDs
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This configuration parameter defines the downstream
+       transmitter-referred virtual noise.
+       The TXREFVNds shall be specified through a set of breakpoints.
+       Each breakpoint shall consist of a subcarrier index t, with a
+       subcarrier spacing of 4.3125 kHz, and a noise PSD level
+       (expressed in dBm/Hz) at that subcarrier.  The set of breakpoints
+       can then be represented as:
+       [(t1,PSD1), (t2, PSD2), ... , (tN, PSDN)]."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.7.3 (TXREFVNds)"
+   ::= { xdsl2LineConfProfEntry 27 }
+
+xdsl2LConfProfTxRefVnUs  OBJECT-TYPE
+   SYNTAX      Xdsl2LineTxRefVnUs
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This configuration parameter defines the upstream
+       transmitter-referred virtual noise.
+       The TXREFVNus shall be specified through a set of breakpoints.
+       Each breakpoint shall consist of a subcarrier index t, with a
+       subcarrier spacing of 4.3125 kHz, and a noise PSD level
+       (expressed in dBm/Hz) at that subcarrier.  The set of breakpoints
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 117]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       can then be represented as:
+       [(t1, PSD1), (t2, PSD2), ... , (tN, PSDN)]."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.7.4 (TXREFVNus)"
+   ::= { xdsl2LineConfProfEntry 28 }
+
+xdsl2LConfProfXtuTransSysEna  OBJECT-TYPE
+   SYNTAX      Xdsl2TransmissionModeType
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "xTU Transmission System Enabling (XTSE).  A list of the
+       different coding types enabled in this profile.  It is coded in a
+       bitmap representation with 1 or more bits set.  A bit set to
+       '1' means that the xTUs may apply the respective
+       coding for the DSL line.  A bit set to '0' means that
+       the xTUs cannot apply the respective coding for the ADSL line.
+       All 'reserved' bits should be set to '0'."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.1.1 (XTSE)"
+   ::= { xdsl2LineConfProfEntry 29 }
+
+xdsl2LConfProfPmMode  OBJECT-TYPE
+   SYNTAX      Xdsl2LinePmMode
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Power management state Enabling (PMMode).  Defines the power
+       states the xTU-C or xTU-R may autonomously transition to on
+       this line.
+       This is a set of bits, where any bit with a '1' value
+       means that the xTU is allowed to transit into the respective
+       state and any bit with a '0' value means that the xTU
+       is not allowed to transit into the respective state."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.1.4 (PMMode)"
+   DEFVAL  { { allowTransitionsToIdle, allowTransitionsToLowPower } }
+   ::= { xdsl2LineConfProfEntry 30 }
+
+xdsl2LConfProfL0Time  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..255)
+   UNITS       "seconds"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The minimum time (in seconds) between an Exit from the L2
+       state and the next Entry into the L2 state.
+       It ranges from 0 to 255 seconds."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.1.5 (L0-TIME)"
+   DEFVAL       { 255 }
+   ::= { xdsl2LineConfProfEntry 31 }
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 118]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+xdsl2LConfProfL2Time  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..255)
+   UNITS       "seconds"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The minimum time (in seconds) between an Entry into the
+       L2 state and the first Power Trim in the L2 state and between two
+       consecutive Power Trims in the L2 state.
+       It ranges from 0 to 255 seconds."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.1.6 (L2-TIME)"
+   DEFVAL       { 255 }
+   ::= { xdsl2LineConfProfEntry 32 }
+
+xdsl2LConfProfL2Atpr  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..31)
+   UNITS       "dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The maximum aggregate transmit power reduction (in dB) that
+       can be performed at transition of L0 to L2 state or through a
+       single Power Trim in the L2 state.
+       It ranges from 0 dB to 31 dB."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.1.7 (L2-ATPR)"
+   DEFVAL       { 10 }
+   ::= { xdsl2LineConfProfEntry 33 }
+
+xdsl2LConfProfL2Atprt  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..31)
+   UNITS       "dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The total maximum aggregate transmit power reduction (in dB)
+       that can be performed in an L2 state.  This is the sum of all
+       reductions of L2 Requests (i.e., at transition of L0 to L2 state)
+       and Power Trims."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.1.9 (L2-ATPRT)"
+   DEFVAL       { 31 }
+   ::= { xdsl2LineConfProfEntry 34 }
+
+xdsl2LConfProfProfiles  OBJECT-TYPE
+   SYNTAX      Xdsl2LineProfiles
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The configuration parameter contains the G.993.2 profiles
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 119]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       to be allowed by the near-end xTU on this line.
+       It is coded in a bitmap representation (0 if not allowed, 1 if
+       allowed)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.1.11 (PROFILES)"
+   DEFVAL       { { profile8a,  profile8b,  profile8c,
+                    profile8d,  profile12a, profile12b,
+                    profile17a, profile30a } }
+   ::= { xdsl2LineConfProfEntry 35 }
+
+xdsl2LConfProfDpboEPsd  OBJECT-TYPE
+   SYNTAX      Xdsl2PsdMaskDs
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This configuration parameter defines the PSD mask that is
+       assumed to be permitted at the exchange.  This parameter shall
+       use the same format as xdsl2LConfProfPsdMaskDs (PSDMASKds).
+       The maximum number of breakpoints for xdsl2LConfProfDpboEPsd
+       is 16."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.13 (DPBOEPSD)"
+   ::= { xdsl2LineConfProfEntry 36 }
+
+xdsl2LConfProfDpboEsEL  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..511)
+   UNITS       "0.5 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This configuration parameter defines the assumed electrical
+       length of cables (E-side cables) connecting exchange-based DSL
+       services to a remote flexibility point (cabinet), that hosts the
+       xTU-C that is subject to spectrally shaped downstream power back-
+       off (DPBO) depending on this length.  The electrical length is
+       defined as the loss (in dB) of an equivalent length of
+       hypothetical cable at a reference frequency defined by the
+       network operator or in spectrum management regulations.
+       This parameter shall be coded as an unsigned integer representing
+       an electrical length from 0 dB (coded as 0) to 255.5 dB (coded as
+       511) in steps of 0.5 dB.  All values in the range are valid.  If
+       this parameter is set to '0', the DPBO shall be disabled."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.13 (DPBOESEL)"
+   DEFVAL      { 0 }
+   ::= { xdsl2LineConfProfEntry 37 }
+
+xdsl2LConfProfDpboEsCableModelA  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..640)
+   UNITS       "2^-8"
+   MAX-ACCESS  read-create
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 120]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   STATUS      current
+   DESCRIPTION
+      "The E-side Cable Model parameter A (DPBOESCMA) of the cable
+       model (DPBOESCM) for cables connecting exchange-based DSL
+       services to a remote flexibility point (cabinet), that hosts the
+       xTU-C that is subject to spectrally shaped downstream power back-
+       off (DPBO) depending on this value.
+       The cable model is in terms of three scalars
+       xdsl2LConfProfDpboEsCableModelA (DPBOESCMA),
+       xdsl2LConfProfDpboEsCableModelB(DPBOESCMB), and
+       xdsl2LConfProfDpboEsCableModelC (DPBOESCMC), that are used to
+       estimate the frequency dependent loss of E-side cables calculated
+       from the xdsl2LConfProfDpboEsEL (DPBOESEL) parameter.  Possible
+       values shall be coded as unsigned integers representing a scalar
+       value from -1 (coded as 0) to 1.5 (coded as 640) in steps of
+       2^-8.  All values in the range are valid.  This parameter is used
+       only for G.993.2."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.13 (DPBOESCMA)"
+   DEFVAL      { 0 }
+   ::= { xdsl2LineConfProfEntry 38 }
+
+xdsl2LConfProfDpboEsCableModelB  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..640)
+   UNITS       "2^-8"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The E-side Cable Model parameter B (DPBOESCMB) of the cable
+       model (DPBOESCM) for cables connecting exchange-based DSL
+       services to a remote flexibility point (cabinet), that hosts the
+       xTU-C that is subject to spectrally shaped downstream power back-
+       off (DPBO) depending on this value.
+       The cable model is in terms of three scalars
+       dsl2LConfProfDpboEsCableModelA (DPBOESCMA),
+       xdsl2LConfProfDpboEsCableModelB(DPBOESCMB), and
+       xdsl2LConfProfDpboEsCableModelC (DPBOESCMC), that are used to
+       estimate the frequency dependent loss of E-side cables calculated
+       from the xdsl2LConfProfDpboEsEL (DPBOESEL) parameter.  Possible
+       values shall be coded as unsigned integers representing a scalar
+       value from -1 (coded as 0) to 1.5 (coded as 640) in steps of
+       2^-8.  All values in the range are valid.  This parameter is used
+       only for G.993.2."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.13 (DPBOESCMB)"
+   DEFVAL      { 0 }
+   ::= { xdsl2LineConfProfEntry 39 }
+
+xdsl2LConfProfDpboEsCableModelC  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..640)
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 121]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   UNITS       "2^-8"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The E-side Cable Model parameter C (DPBOESCMC) of the cable
+       model (DPBOESCM) for cables connecting exchange-based DSL
+       services to a remote flexibility point (cabinet), that hosts the
+       xTU-C that is subject to spectrally shaped downstream power back-
+       off (DPBO) depending on this value.
+       The cable model is in terms of three scalars
+       xdsl2LConfProfDpboEsCableModelA (DPBOESCMA),
+       xdsl2LConfProfDpboEsCableModelB(DPBOESCMB), and
+       xdsl2LConfProfDpboEsCableModelC (DPBOESCMC), that are used to
+       estimate the frequency dependent loss of E-side cables calculated
+       from the xdsl2LConfProfDpboEsEL (DPBOESEL) parameter.  Possible
+       values shall be coded as unsigned integers representing a scalar
+       value from -1 (coded as 0) to 1.5 (coded as 640) in steps of
+       2^-8.  All values in the range are valid.  This parameter is used
+       only for G.993.2."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.13 (DPBOESCMC)"
+   DEFVAL      { 0 }
+   ::= { xdsl2LineConfProfEntry 40 }
+
+xdsl2LConfProfDpboMus OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..255)
+   UNITS       "0.5 dBm/Hz"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This configuration parameter defines the assumed Minimum
+       Usable receive PSD mask (in dBm/Hz) for exchange-based services,
+       used to modify parameter xdsl2LConfProfDpboFMax (DPBOFMAX)
+       defined below (to determine the DPBO).  It shall be coded as an
+       unsigned integer representing a PSD mask level from 0 dBm/Hz
+       (coded as 0) to -127.5 dBm/Hz (coded as 255) in steps of 0.5
+       dBm/Hz.  All values in the range are valid.
+       NOTE - The PSD mask level is 3.5 dB above the signal PSD level.
+       This parameter is used only for G.993.2."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.13 (DPBOMUS)"
+   DEFVAL      { 0 }
+   ::= { xdsl2LineConfProfEntry 41 }
+
+xdsl2LConfProfDpboFMin OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..2048)
+   UNITS       "4.3125 kHz"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 122]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      "This configuration parameter defines the minimum frequency
+       from which the DPBO shall be applied.  It ranges from 0 kHz
+       (coded as 0) to 8832 kHz (coded as 2048) in steps of
+       4.3125 kHz.  This parameter is used only for G.993.2."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.13 (DPBOFMIN)"
+   DEFVAL      { 32 }
+   ::= { xdsl2LineConfProfEntry 42 }
+
+xdsl2LConfProfDpboFMax OBJECT-TYPE
+   SYNTAX      Unsigned32 (32..6956)
+   UNITS       "4.3125 kHz"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This configuration parameter defines the maximum frequency
+       at which DPBO may be applied.  It ranges from 138 kHz (coded as
+       32) to 29997.75 kHz (coded as 6956) in steps of 4.3125 kHz.
+       This parameter is used only for G.993.2."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.13 (DPBOFMAX)"
+   DEFVAL      { 512 }
+   ::= { xdsl2LineConfProfEntry 43 }
+
+xdsl2LConfProfUpboKL  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..1280)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This configuration parameter defines the electrical length
+       expressed in dB at 1 MHz, kl0, configured by the CO-MIB.
+       The value ranges from 0 (coded as 0) to 128 dB (coded as 1280) in
+       steps of 0.1 dB.  This parameter is relevant only if
+       xdsl2LConfProfUpboKLF is set to 'override(2)', which indicates
+       that this parameter's value will override the VTUs'
+       determination of the electrical length.
+       If xdsl2LConfProfUpboKLF is set either to auto(1) or
+       disableUpbo(3), then this parameter will be ignored."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.14 (UPBOKL)"
+   DEFVAL      { 0 }
+   ::= { xdsl2LineConfProfEntry 44 }
+
+xdsl2LConfProfUpboKLF OBJECT-TYPE
+   SYNTAX      Xdsl2UpboKLF
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Defines the upstream power backoff force mode."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.14 (UPBOKLF)
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 123]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   "
+   DEFVAL      { disableUpbo }
+   ::= { xdsl2LineConfProfEntry 45 }
+
+xdsl2LConfProfUs0Mask  OBJECT-TYPE
+   SYNTAX      Xdsl2LineUs0Mask
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The configuration parameter contains the US0 PSD masks to be
+       allowed by the near-end xTU on the line.  This parameter is only
+       defined for G.993.2 Annex A.  It is represented as a bitmap (0
+       if not allowed and 1 if allowed)."
+   REFERENCE    "ITU-T G.997.1 Amendment 1, paragraph #7.3.1.2.18
+                 (US0MASK)"
+   DEFVAL       { {} }
+   ::= { xdsl2LineConfProfEntry 46 }
+
+xdsl2LConfProfForceInp  OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+       "This parameter, when set to 'true' indicates that the framer
+        settings of the bearer shall be selected such that the impulse
+        noise protection computed according to the formula specified in
+        the relevant Recommendation is greater than or equal to the
+        minimal impulse noise protection requirement.
+        This flag shall have the same value for all the bearers of one
+        line in the same direction."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.5 (FORCEINP)"
+   DEFVAL       { false }
+   ::= { xdsl2LineConfProfEntry 47 }
+
+xdsl2LConfProfRowStatus  OBJECT-TYPE
+   SYNTAX      RowStatus
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This object is used to create a new row or to modify or
+       delete an existing row in this table.
+
+       A profile is activated by setting this object to 'active'.
+
+       Before a profile can be deleted or taken out of service (by
+       setting this object to 'destroy' or 'notInService'), it MUST be
+       first unreferenced from all templates.
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 124]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       A row in this table is said to be unreferenced when there is no
+       instance of xdsl2LConfTempLineProfile that refers to the row.
+
+       When a row is created in this table, the SNMP agent should also
+       create corresponding rows in the tables
+       xdsl2LineConfProfModeSpecTable and
+       xdsl2LineConfProfModeSpecBandUsTable.
+       When a row is deleted in this table, the SNMP agent should also
+       delete corresponding rows in the tables
+       xdsl2LineConfProfModeSpecTable and
+       xdsl2LineConfProfModeSpecBandUsTable."
+   ::= { xdsl2LineConfProfEntry 48 }
+
+------------------------------------------
+--    xdsl2LineConfProfModeSpecTable    --
+------------------------------------------
+
+xdsl2LineConfProfModeSpecTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2LineConfProfModeSpecEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineConfProfModeSpecTable extends the DSL
+       line configuration profile by xDSL Mode-Specific parameters.
+       A row in this table that has an index of xdsl2LConfProfXdslMode
+       == defMode(1), is called a 'mandatory' row or 'default' row.
+       A row in this table that has an index such that
+       xdsl2LConfProfXdslMode is not equal to defMode(1), is called an
+       'optional' row or 'mode-specific' row.
+       When a row in the xdsl2LineConfProfTable table (the parent row)
+       is created, the SNMP agent will automatically create a
+       'mandatory' row in this table.
+       When the parent row is deleted, the SNMP agent will automatically
+       delete all associated rows in this table.
+       Any attempt to delete the 'mandatory' row using the
+       xdsl2LConfProfModeSpecRowStatus object will be rejected by the
+       SNMP agent.
+       The manager MAY create an 'optional' row in this table using the
+       xdsl2LConfProfModeSpecRowStatus object if the parent row
+       exists.
+       The manager MAY delete an 'optional' row in this table using the
+       xdsl2LConfProfModeSpecRowStatus object at any time.
+       If the actual transmission mode of a DSL line does not match one
+       of the 'optional' rows in this table, then the line will use the
+       PSD configuration from the 'mandatory' row.
+
+       Entries in this table MUST be maintained in a persistent
+       manner."
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 125]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   ::= { xdsl2ProfileLine 3 }
+
+xdsl2LineConfProfModeSpecEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2LineConfProfModeSpecEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineConfProfModeSpecTable extends the
+       DSL line configuration profile by DSL Mode-Specific
+       parameters."
+   INDEX  { xdsl2LConfProfProfileName, xdsl2LConfProfXdslMode }
+   ::= { xdsl2LineConfProfModeSpecTable 1 }
+
+Xdsl2LineConfProfModeSpecEntry  ::=
+   SEQUENCE {
+      xdsl2LConfProfXdslMode             Xdsl2OperationModes,
+      xdsl2LConfProfMaxNomPsdDs          Integer32,
+      xdsl2LConfProfMaxNomPsdUs          Integer32,
+      xdsl2LConfProfMaxNomAtpDs          Unsigned32,
+      xdsl2LConfProfMaxNomAtpUs          Unsigned32,
+      xdsl2LConfProfMaxAggRxPwrUs        Integer32,
+      xdsl2LConfProfPsdMaskDs            Xdsl2PsdMaskDs,
+      xdsl2LConfProfPsdMaskUs            Xdsl2PsdMaskUs,
+      xdsl2LConfProfPsdMaskSelectUs      Xdsl2LinePsdMaskSelectUs,
+      xdsl2LConfProfClassMask            Xdsl2LineClassMask,
+      xdsl2LConfProfLimitMask            Xdsl2LineLimitMask,
+      xdsl2LConfProfUs0Disable           Xdsl2LineUs0Disable,
+      xdsl2LConfProfModeSpecRowStatus    RowStatus
+   }
+
+xdsl2LConfProfXdslMode    OBJECT-TYPE
+   SYNTAX      Xdsl2OperationModes
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The DSL Mode is a way of categorizing the various xDSL
+       transmission modes into groups, each group (xDSL Mode) shares
+       the same PSD configuration.
+       There should be multiple entries in this table for a given line
+       profile in case multiple bits are set in
+       xdsl2LConfProfXtuTransSysEna for that profile."
+   REFERENCE    "DSL Forum TR-129, paragraph #5.5"
+   ::= { xdsl2LineConfProfModeSpecEntry 1 }
+
+xdsl2LConfProfMaxNomPsdDs  OBJECT-TYPE
+   SYNTAX      Integer32(-600..-300)
+   UNITS       "0.1 dBm/Hz"
+   MAX-ACCESS  read-create
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 126]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   STATUS      current
+   DESCRIPTION
+      "The maximum nominal transmit PSD in the downstream direction
+       during initialization and Showtime.  It ranges from -600 to -300
+       units of 0.1 dBm/Hz (physical values are -60 to -30
+       dBm/Hz)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.1 (MAXNOMPSDds)"
+   DEFVAL       { -300 }
+  ::= { xdsl2LineConfProfModeSpecEntry 2 }
+
+xdsl2LConfProfMaxNomPsdUs  OBJECT-TYPE
+   SYNTAX      Integer32(-600..-300)
+   UNITS       "0.1 dBm/Hz"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The maximum nominal transmit PSD in the upstream direction
+       during initialization and Showtime.  It ranges from -600 to
+       -300 units of 0.1 dBm/Hz (physical values are -60 to -30
+       dBm/Hz)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.2 (MAXNOMPSDus)"
+   DEFVAL       { -300 }
+   ::= { xdsl2LineConfProfModeSpecEntry 3 }
+
+xdsl2LConfProfMaxNomAtpDs  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..255)
+   UNITS       "0.1 dBm"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The maximum nominal aggregate to transmit power in the
+       downstream direction during initialization and Showtime.  It
+       ranges from 0 to 255 units of 0.1 dBm (physical values are 0
+       to 25.5 dBm)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.3 (MAXNOMATPds)"
+   DEFVAL       { 255 }
+   ::= { xdsl2LineConfProfModeSpecEntry 4 }
+
+xdsl2LConfProfMaxNomAtpUs  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..255)
+   UNITS       "0.1 dBm"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The maximum nominal aggregate transmit power in the upstream
+       direction during initialization and Showtime.  It ranges from
+       0 to 255 units of 0.1 dBm (physical values are 0 to 25.5
+       dBm)."
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 127]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.4 (MAXNOMATPus)"
+   DEFVAL       { 255 }
+   ::= { xdsl2LineConfProfModeSpecEntry 5 }
+
+xdsl2LConfProfMaxAggRxPwrUs  OBJECT-TYPE
+   SYNTAX      Integer32(-255..255 | 2147483647)
+   UNITS       "0.1 dBm"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The maximum upstream aggregate receive power over the
+       relevant set of subcarriers.  The xTU-C should verify that the
+       upstream power cutback is such that this maximum aggregate
+       receive power value is honored.  It ranges from -255 to 255
+       units of 0.1 dBm (physical values are -25.5 to 25.5 dBm).
+       A value of 0x7FFFFFFF (2147483647) means that there is no
+       limit."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.5 (MAXRXPWRus)"
+   DEFVAL       { 255 }
+   ::= { xdsl2LineConfProfModeSpecEntry 6 }
+
+xdsl2LConfProfPsdMaskDs   OBJECT-TYPE
+   SYNTAX      Xdsl2PsdMaskDs
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "The downstream PSD mask applicable at the U-C2 reference
+      point.
+      This parameter is used only for G.992.5 and it may impose PSD
+      restrictions (breakpoints) in addition to the Limit PSD mask
+      defined in G.992.5.
+      This is a string of 32 pairs of values in the following
+      structure:
+      Octets 0-1 - Index of the first subcarrier used in the context of
+                   a first breakpoint.
+      Octet 2    - The PSD reduction for the subcarrier indicated in
+                   octets 0 and 1.
+      Octets 3-5 - Same, for a second breakpoint.
+      Octets 6-8 - Same, for a third breakpoint.
+      This architecture continues until octets 94-95, which are
+      associated with a 32nd breakpoint.
+      Each subcarrier index is an unsigned number in the range 0 and
+      NSCds-1.  Each PSD reduction value is in the range 0 (0 dBm/Hz) to
+      255 (-127.5 dBm/Hz) with steps of 0.5 dBm/Hz.  Valid values are in
+      the range 0 to 190 (0 to -95 dBm/Hz).
+      When the number of breakpoints is less than 32, all remaining
+      octets are set to the value '0'.  Note that the content of this
+      object should be correlated with the subcarrier mask and with
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 128]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      the RFI setup."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.9 (PSDMASKds)"
+     ::= { xdsl2LineConfProfModeSpecEntry 7 }
+
+xdsl2LConfProfPsdMaskUs   OBJECT-TYPE
+   SYNTAX      Xdsl2PsdMaskUs
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "The upstream PSD mask applicable at the U-R2 reference
+      point.
+      This parameter is used only for G.992.5, and it may impose PSD
+      restrictions (breakpoints) in addition to the Limit PSD mask
+      defined in G.992.5.
+      This is a string of 16 pairs of values in the following
+      structure:
+      Octets 0-1 - Index of the first subcarrier used in the context of
+                   a first breakpoint.
+      Octet 2    - The PSD reduction for the subcarrier indicated in
+                   octets 0 and 1.
+      Octets 3-5 - Same, for a second breakpoint.
+      Octets 6-8 - Same, for a third breakpoint.
+      This architecture continues until octets 9-47, which are
+      associated with a 16th breakpoint.
+      Each subcarrier index is an unsigned number in the range 0 and
+      NSCus-1.  Each PSD reduction value is in the range 0 (0 dBm/Hz) to
+      255 (-127.5 dBm/Hz) with steps of 0.5 dBm/Hz.  Valid values are in
+      the range 0 to 190 (0 to -95 dBm/Hz).
+      When the number of breakpoints is less than 16, all remaining
+      octets are set to the value '0'.  Note that the content of this
+      object should be correlated with the subcarrier mask and with
+      the RFI setup."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.12 (PSDMASKus)"
+     ::= { xdsl2LineConfProfModeSpecEntry 8 }
+
+xdsl2LConfProfPsdMaskSelectUs  OBJECT-TYPE
+   SYNTAX      Xdsl2LinePsdMaskSelectUs
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "The selected upstream PSD mask.  This parameter is used only
+      for Annexes J and M of G.992.3 and G.992.5, and the same
+      selection is used for all relevant enabled bits in
+      xdsl2LConfProfXtuTransSysEna."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.11
+                (Upstream PSD mask selection)"
+   DEFVAL       { adlu32Eu32 }
+    ::= { xdsl2LineConfProfModeSpecEntry 9 }
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 129]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+xdsl2LConfProfClassMask  OBJECT-TYPE
+   SYNTAX      Xdsl2LineClassMask
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "In order to reduce the number of configuration
+       possibilities, the limit Power Spectral Density masks (see
+       LIMITMASK) are grouped in PSD mask classes.
+       Each class is designed such that the PSD levels of each limit PSD
+       mask of a specific class are equal in their respective passband
+       above 552 kHz.
+       This parameter is defined per VDSL2 Annex enabled in the
+       xdsl2LConfProfXtuTransSysEna object.  It selects a single PSD
+       mask class per Annex that is activated at the VTU-O."
+   REFERENCE    "ITU-T G.997.1 Amendment 1, paragraph #7.3.1.2.15
+                (CLASSMASK)"
+   DEFVAL       { a998ORb997M1cORc998B }
+   ::= { xdsl2LineConfProfModeSpecEntry 10 }
+
+xdsl2LConfProfLimitMask  OBJECT-TYPE
+   SYNTAX      Xdsl2LineLimitMask
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This configuration parameter contains the G.993.2 limit
+       PSD masks of the selected PSD mask class, enabled by the near-end
+       xTU on this line for each class of profiles.
+       This parameter is defined per VDSL2 Annex enabled in the
+       xdsl2LConfProfXtuTransSysEna object.
+       Through this parameter, several limit PSD masks of the selected
+       PSD mask class (xdsl2LConfProfClassMask) may be enabled.  The
+       enabling parameter is coded in a bitmap representation (0 if the
+       associated mask is not allowed, 1 if it is allowed)."
+   REFERENCE    "ITU-T G.997.1 Amendment 1, paragraph #7.3.1.2.16
+                 (LIMITMASK)"
+   DEFVAL       { {} }
+   ::= { xdsl2LineConfProfModeSpecEntry 11 }
+
+xdsl2LConfProfUs0Disable  OBJECT-TYPE
+   SYNTAX      Xdsl2LineUs0Disable
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This configuration parameter indicates if the use of the US0 is
+       disabled for each limit PSD mask enabled in the
+       xdsl2LConfProfLimitMask parameter.
+       This parameter is defined per VDSL2 Annex enabled in the
+       xdsl2LConfProfXtuTransSysEna object.
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 130]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       For each limit PSD mask enabled in the xdsl2LConfProfLimitMask
+       parameter, a bit shall indicate if the US0 is disabled.  The
+       disabling parameter is coded as a bitmap.  The bit is set to '1'
+       if the US0 is disabled for the associated limit mask.
+       This parameter and the xdsl2LConfProfLimitMask parameter use the
+       same structure."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.17 (US0DISABLE)"
+   DEFVAL       { {} }
+   ::= { xdsl2LineConfProfModeSpecEntry 12 }
+
+xdsl2LConfProfModeSpecRowStatus  OBJECT-TYPE
+   SYNTAX      RowStatus
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This object is used to create a new row or to modify or
+       delete an existing row in this table.
+
+       This row is activated by setting this object to 'active'.
+
+       A 'mandatory' row, as defined in the DESCRIPTION clause of
+       xdsl2LineConfProfModeSpecTable, cannot be deleted at all.
+
+       A 'mandatory' row can be taken out of service
+       (by setting this object to 'notInService') if the parent
+       row in the xdsl2LineConfProfTable table is not in
+       the 'active' state.
+
+       An 'optional' row (or 'mode-specific' row) can be deleted or
+       taken out of service (by setting this object to 'destroy' or
+       'notInService') at any time."
+
+   ::= { xdsl2LineConfProfModeSpecEntry 13 }
+
+----------------------------------------------
+--   xdsl2LineConfProfModeSpecBandUsTable   --
+----------------------------------------------
+
+xdsl2LineConfProfModeSpecBandUsTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2LineConfProfModeSpecBandUsEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineConfProfModeSpecBandUsTable extends
+       xdsl2LineConfProfModeSpecTable with upstream-band-specific
+       parameters for VDSL2, such as upstream power back-off
+       parameters xdsl2LConfProfUpboPsdA and xdsl2LConfProfUpboPsdB
+       (UPBOPSD-pb).
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 131]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       When a parent 'mandatory row' is created in
+       xdsl2LineConfProfModeSpecTable, the SNMP agent will automatically
+       create several 'mandatory' rows in this table -- one for each
+       upstream band:
+       Note: A mandatory row is one where xdsl2LConfProfXdslMode =
+       defMode(1).  When the parent row is deleted, the SNMP agent will
+       automatically delete all associated rows in this table.  Any
+       attempt to delete a 'mandatory' row using the
+       xdsl2LConfProfModeSpecBandUsRowStatus object will be rejected
+       by the SNMP agent.  The manager MAY create a new 'optional'
+       row in this table using the xdsl2LConfProfModeSpecBandUsRowStatus
+       object if the associated parent row exists, and the
+       value of xdsl2LConfProfXdslMode is a G.993.2 value.  The manager
+       MAY delete an 'optional' row in this table using the
+       xdsl2LConfProfModeSpecBandUsRowStatus object at any time.
+
+       With respect to the xdsl2LConfProfUpboPsdA and
+       xdsl2LConfProfUpboPsdB parameters, for a given upstream band,
+       if an optional row is missing from this table, then that
+       means upstream power back-off is disabled for that upstream
+       band.
+
+       Entries in this table MUST be maintained in a persistent
+       manner."
+   ::= { xdsl2ProfileLine 4 }
+
+xdsl2LineConfProfModeSpecBandUsEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2LineConfProfModeSpecBandUsEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineConfProfModeSpecBandUsTable extends
+       xdsl2LineConfProfModeSpecTable with upstream-band-specific
+       parameters for VDSL2, such as upstream power back-off parameters
+       xdsl2LConfProfUpboPsdA and xdsl2LConfProfUpboPsdB (UPBOPSD-
+       pb)."
+   INDEX       { xdsl2LConfProfProfileName, xdsl2LConfProfXdslMode,
+                 xdsl2LConfProfXdslBandUs}
+   ::= { xdsl2LineConfProfModeSpecBandUsTable 1 }
+
+Xdsl2LineConfProfModeSpecBandUsEntry  ::=
+   SEQUENCE {
+      xdsl2LConfProfXdslBandUs                 Xdsl2BandUs,
+      xdsl2LConfProfUpboPsdA                   Integer32,
+      xdsl2LConfProfUpboPsdB                   Integer32,
+      xdsl2LConfProfModeSpecBandUsRowStatus    RowStatus
+   }
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 132]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+xdsl2LConfProfXdslBandUs    OBJECT-TYPE
+   SYNTAX      Xdsl2BandUs
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "Each value identifies a specific band in the upstream
+       transmission direction (excluding the US0 band)."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.14"
+   ::= { xdsl2LineConfProfModeSpecBandUsEntry 1 }
+
+xdsl2LConfProfUpboPsdA  OBJECT-TYPE
+   SYNTAX      Integer32(4000..8095)
+   UNITS       "0.01 dBm/Hz"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This configuration parameter defines the 'a' reference
+       parameter of the UPBO reference PSD used to compute the
+       upstream power back-off for the upstream band.  A UPBO PSD
+       defined for each band shall consist of two parameters [a, b].
+       Parameter 'a' (xdsl2LConfProfUpboPsdA) ranges from 40 dBm/Hz
+       (coded as 4000) to 80.95 dBm/Hz (coded as 8095) in steps of 0.01
+       dBm/Hz; and parameter 'b' (xdsl2LConfProfUpboPsdB) ranges from 0
+       dBm/Hz (coded as 0) to 40.95 dBm/Hz (coded as 4095) in steps of
+       0.01 dBm/Hz.  The UPBO reference PSD at the frequency 'f'
+       expressed in MHz shall be equal to '-a-b(SQRT(f))'.  Setting
+       xdsl2LConfProfUpboPsdA to 4000 and xdsl2LConfProfUpboPsdB to 0 is
+       a special configuration to disable UPBO in the respective
+       upstream band."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.14 (UPBOPSD-pb)"
+   DEFVAL      { 4000 }
+  ::= { xdsl2LineConfProfModeSpecBandUsEntry 2 }
+
+xdsl2LConfProfUpboPsdB  OBJECT-TYPE
+   SYNTAX      Integer32(0..4095)
+   UNITS       "0.01 dBm/Hz"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This configuration parameter defines the 'b' reference
+       parameter of the UPBO reference PSD used to compute the
+       upstream power back-off for the upstream band.  A UPBO PSD
+       defined for each band shall consist of two parameters [a, b].
+       Parameter 'a' (xdsl2LConfProfUpboPsdA) ranges from 40 dBm/Hz
+       (coded as 4000) to 80.95 dBm/Hz (coded as 8095) in steps of 0.01
+       dBm/Hz; and parameter 'b' (xdsl2LConfProfUpboPsdB) ranges from 0
+       dBm/Hz (coded as 0) to 40.95 dBm/Hz (coded as 4095) in steps of
+       0.01 dBm/Hz.  The UPBO reference PSD at the frequency 'f'
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 133]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       expressed in MHz shall be equal to '-a-b(SQRT(f))'.  Setting
+       xdsl2LConfProfUpboPsdA to 4000 and xdsl2LConfProfUpboPsdB to 0 is
+       a special configuration to disable UPBO in the respective
+       upstream band."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.14 (UPBOPSD-pb)"
+   DEFVAL      { 0 }
+  ::= { xdsl2LineConfProfModeSpecBandUsEntry 3 }
+
+xdsl2LConfProfModeSpecBandUsRowStatus  OBJECT-TYPE
+   SYNTAX      RowStatus
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This object is used to create a new row or to modify or
+       delete an existing row in this table.
+
+       This row is activated by setting this object to 'active'.
+
+       A 'mandatory' row, as defined in the DESCRIPTION clause of
+       xdsl2LineConfProfModeSpecBandUsTable, cannot be deleted at all.
+
+       A 'mandatory' row can be taken out of service
+       (by setting this object to 'notInService') if the parent
+       row in the xdsl2LineConfProfModeSpecTable table is not in
+       the 'active' state.
+
+       An 'optional' row (or 'mode-specific' row) can be deleted or
+       taken out of service (by setting this object to 'destroy' or
+       'notInService') at any time."
+   ::= { xdsl2LineConfProfModeSpecBandUsEntry 4 }
+
+------------------------------------------------
+--          xdsl2ChConfProfileTable           --
+------------------------------------------------
+
+xdsl2ChConfProfileTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2ChConfProfileEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2ChConfProfileTable contains DSL channel
+       profile configuration.
+
+       Entries in this table MUST be maintained in a persistent
+       manner."
+   ::= { xdsl2ProfileChannel 1 }
+
+xdsl2ChConfProfileEntry  OBJECT-TYPE
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 134]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   SYNTAX      Xdsl2ChConfProfileEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "A default profile with an index of 'DEFVAL' will always
+      exist, and its parameters will be set to vendor-specific values,
+      unless otherwise specified in this document."
+   INDEX  { xdsl2ChConfProfProfileName }
+   ::= { xdsl2ChConfProfileTable 1 }
+
+Xdsl2ChConfProfileEntry  ::=
+   SEQUENCE {
+      xdsl2ChConfProfProfileName          SnmpAdminString,
+      xdsl2ChConfProfMinDataRateDs        Unsigned32,
+      xdsl2ChConfProfMinDataRateUs        Unsigned32,
+      xdsl2ChConfProfMinResDataRateDs     Unsigned32,
+      xdsl2ChConfProfMinResDataRateUs     Unsigned32,
+      xdsl2ChConfProfMaxDataRateDs        Unsigned32,
+      xdsl2ChConfProfMaxDataRateUs        Unsigned32,
+      xdsl2ChConfProfMinDataRateLowPwrDs  Unsigned32,
+      xdsl2ChConfProfMinDataRateLowPwrUs  Unsigned32,
+      xdsl2ChConfProfMaxDelayDs           Unsigned32,
+      xdsl2ChConfProfMaxDelayUs           Unsigned32,
+      xdsl2ChConfProfMinProtectionDs      Xdsl2SymbolProtection,
+      xdsl2ChConfProfMinProtectionUs      Xdsl2SymbolProtection,
+      xdsl2ChConfProfMinProtection8Ds     Xdsl2SymbolProtection8,
+      xdsl2ChConfProfMinProtection8Us     Xdsl2SymbolProtection8,
+      xdsl2ChConfProfMaxBerDs             Xdsl2MaxBer,
+      xdsl2ChConfProfMaxBerUs             Xdsl2MaxBer,
+      xdsl2ChConfProfUsDataRateDs         Unsigned32,
+      xdsl2ChConfProfDsDataRateDs         Unsigned32,
+      xdsl2ChConfProfUsDataRateUs         Unsigned32,
+      xdsl2ChConfProfDsDataRateUs         Unsigned32,
+      xdsl2ChConfProfImaEnabled           TruthValue,
+      xdsl2ChConfProfMaxDelayVar          Unsigned32,
+      xdsl2ChConfProfInitPolicy           Xdsl2ChInitPolicy,
+      xdsl2ChConfProfRowStatus            RowStatus
+   }
+
+xdsl2ChConfProfProfileName  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "This object identifies a row in this table."
+   ::= { xdsl2ChConfProfileEntry 1 }
+
+xdsl2ChConfProfMinDataRateDs  OBJECT-TYPE
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 135]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Minimum Data Rate on Downstream direction.  The minimum net
+       data rate for the bearer channel, coded in bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.1
+                 (Minimum data rate)"
+   ::= { xdsl2ChConfProfileEntry 2 }
+
+xdsl2ChConfProfMinDataRateUs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Minimum Data Rate on Upstream direction.  The minimum net
+       data rate for the bearer channel, coded in bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.1
+                 (Minimum data rate)"
+   ::= { xdsl2ChConfProfileEntry 3 }
+
+xdsl2ChConfProfMinResDataRateDs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Minimum Reserved Data Rate on Downstream direction.  The
+       minimum reserved net data rate for the bearer channel, coded
+       in bit/s.  This parameter is used only if the Rate Adaptation
+       Mode in the direction of the bearer channel (i.e.,
+       xdsl2LConfProfRaModeDs) is set to 'dynamicRa'."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.2
+                 (Minimum reserved data rate)"
+   ::= { xdsl2ChConfProfileEntry 4 }
+
+xdsl2ChConfProfMinResDataRateUs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Minimum Reserved Data Rate on Upstream direction.  The
+       minimum reserved net data rate for the bearer channel, coded in
+       bit/s.  This parameter is used only if the Rate Adaptation Mode
+       in the direction of the bearer channel (i.e.,
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 136]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       xdsl2LConfProfRaModeUs) is set to 'dynamicRa'."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.2
+                 (Minimum reserved data rate)"
+   ::= { xdsl2ChConfProfileEntry 5 }
+
+xdsl2ChConfProfMaxDataRateDs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Maximum Data Rate on Downstream direction.  The maximum net
+       data rate for the bearer channel, coded in bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.3
+                 (Maximum data rate)"
+   ::= { xdsl2ChConfProfileEntry 6 }
+
+xdsl2ChConfProfMaxDataRateUs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Maximum Data Rate on Upstream direction.  The maximum net
+       data rate for the bearer channel, coded in bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.3
+                 (Maximum data rate)"
+   ::= { xdsl2ChConfProfileEntry 7 }
+
+xdsl2ChConfProfMinDataRateLowPwrDs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This parameter specifies the minimum net data rate for
+       the bearer channel as desired by the operator of the system
+       during the low power state (L1/L2).  The power management low
+       power states L1 and L2 are defined in ITU-T Recommendations
+       G.992.2 and G.992.3, respectively.
+       The data rate is coded in steps of bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.5
+                 (Minimum Data Rate in low power state)"
+   ::= { xdsl2ChConfProfileEntry 8 }
+
+xdsl2ChConfProfMinDataRateLowPwrUs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 137]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This parameter specifies the minimum net data rate for
+       the bearer channel as desired by the operator of the system
+       during the low power state (L1/L2).  The power management low
+       power states L1 and L2 are defined in ITU-T Recommendations
+       G.992.2 and G.992.3, respectively.
+       The data rate is coded in steps of bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.5
+                 (Minimum Data Rate in low power state)"
+   ::= { xdsl2ChConfProfileEntry 9 }
+
+xdsl2ChConfProfMaxDelayDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..63)
+   UNITS       "milliseconds"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Maximum Interleave Delay on Downstream direction.  The
+       maximum one-way interleaving delay introduced by the PMS-TC on
+       Downstream direction.  The xTUs shall choose the S (factor) and D
+       (depth) values such that the actual one-way interleaving delay
+       (Xdsl2ChStatusActDelay) is as close as possible to, but less than
+       or equal to, xdsl2ChConfProfMaxDelayDs.  The delay is coded in
+       ms, with the value 0 indicating no delay bound is being
+       imposed."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.2
+                 (Maximum interleaving delay)"
+   ::= { xdsl2ChConfProfileEntry 10 }
+
+xdsl2ChConfProfMaxDelayUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..63)
+   UNITS       "milliseconds"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Maximum Interleave Delay on Upstream direction.  The maximum
+       one-way interleaving delay introduced by the PMS-TC on Upstream
+       direction.  The xTUs shall choose the S (factor) and D (depth)
+       values such that the actual one-way interleaving delay
+       (Xdsl2ChStatusActDelay) is as close as possible to, but less than
+       or equal to, xdsl2ChConfProfMaxDelayUs.  The delay is coded in
+       ms, with the value 0 indicating no delay bound is being
+       imposed."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.2
+                 (Maximum interleaving delay)"
+   ::= { xdsl2ChConfProfileEntry 11 }
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 138]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+xdsl2ChConfProfMinProtectionDs  OBJECT-TYPE
+   SYNTAX      Xdsl2SymbolProtection
+   UNITS       "symbols"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This parameter specifies the minimum impulse noise
+       protection for the bearer channel if it is transported over DMT
+       symbols with a subcarrier spacing of 4.3125 kHz.  The impulse
+       noise protection is expressed in DMT symbols with a subcarrier
+       spacing of 4.3125 kHz and can take the values 1/2 and any integer
+       from 0 to 16, inclusive.  If the xTU does not support the
+       configured INPMIN value, it shall use the nearest supported
+       impulse noise protection greater than INPMIN."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.3 (INPMINds)"
+   DEFVAL       { noProtection }
+   ::= { xdsl2ChConfProfileEntry 12 }
+
+xdsl2ChConfProfMinProtectionUs  OBJECT-TYPE
+   SYNTAX      Xdsl2SymbolProtection
+   UNITS       "symbols"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This parameter specifies the minimum impulse noise
+       protection for the bearer channel if it is transported over DMT
+       symbols with a subcarrier spacing of 4.3125 kHz.  The impulse
+       noise protection is expressed in DMT symbols with a subcarrier
+       spacing of 4.3125 kHz and can take the values 1/2 and any integer
+       from 0 to 16, inclusive.  If the xTU does not support the
+       configured INPMIN value, it shall use the nearest supported
+       impulse noise protection greater than INPMIN."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.3 (INPMINus)"
+   DEFVAL       { noProtection }
+   ::= { xdsl2ChConfProfileEntry 13 }
+
+xdsl2ChConfProfMinProtection8Ds  OBJECT-TYPE
+   SYNTAX      Xdsl2SymbolProtection8
+   UNITS       "symbols"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This parameter specifies the minimum impulse noise
+       protection for the bearer channel if it is transported over DMT
+       symbols with a subcarrier spacing of 8.625 kHz.  The impulse
+       noise protection is expressed in DMT symbols with a subcarrier
+       spacing of 8.625 kHz."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.4 (INPMIN8ds)"
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 139]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   DEFVAL       { noProtection }
+   ::= { xdsl2ChConfProfileEntry 14 }
+
+xdsl2ChConfProfMinProtection8Us  OBJECT-TYPE
+   SYNTAX      Xdsl2SymbolProtection8
+   UNITS       "symbols"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This parameter specifies the minimum impulse noise
+       protection for the bearer channel if it is transported over DMT
+       symbols with a subcarrier spacing of 8.625 kHz.  The impulse
+       noise protection is expressed in DMT symbols with a subcarrier
+       spacing of 8.625 kHz."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.4 (INPMIN8us)"
+   DEFVAL       { noProtection }
+   ::= { xdsl2ChConfProfileEntry 15 }
+
+xdsl2ChConfProfMaxBerDs  OBJECT-TYPE
+   SYNTAX      Xdsl2MaxBer
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Maximum Bit Error Ratio on Downstream direction.  The
+       maximum bit error ratio for the bearer channel."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.6
+                 (Maximum bit error ratio)"
+   DEFVAL       { eminus5 }
+  ::= { xdsl2ChConfProfileEntry 16 }
+
+xdsl2ChConfProfMaxBerUs  OBJECT-TYPE
+   SYNTAX      Xdsl2MaxBer
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Maximum Bit Error Ratio on Upstream direction.  The maximum
+       bit error ratio for the bearer channel."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.6
+                 (Maximum bit error ratio)"
+   DEFVAL       { eminus5 }
+   ::= { xdsl2ChConfProfileEntry 17 }
+
+xdsl2ChConfProfUsDataRateDs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 140]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      "Data Rate Threshold Upshift for Downstream direction.  An
+       'Up-Shift rate change' event is triggered when the
+       actual downstream data rate exceeds, by more than the threshold,
+       the data rate at the last entry into Showtime.  The parameter is
+       coded in bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.8.1
+                 (Data rate threshold upshift)"
+   ::= { xdsl2ChConfProfileEntry 18 }
+
+xdsl2ChConfProfDsDataRateDs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Data Rate Threshold Downshift for Downstream direction.  A
+       'Down-Shift rate change' event is triggered when the
+       actual downstream data rate is below the data rate at the last
+       entry into Showtime, by more than the threshold.  The parameter
+       is coded in bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.8.2
+                 (Data rate threshold downshift)"
+   ::= { xdsl2ChConfProfileEntry 19 }
+
+xdsl2ChConfProfUsDataRateUs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Data Rate Threshold Upshift for Upstream direction.  An
+       'Up-Shift rate change' event is triggered when the
+       actual upstream data rate exceeds, by more than the threshold,
+       the data rate at the last entry into Showtime.  The parameter is
+       coded in bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.8.1
+                 (Data rate threshold upshift)"
+   ::= { xdsl2ChConfProfileEntry 20 }
+
+xdsl2ChConfProfDsDataRateUs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Data Rate Threshold Downshift for Upstream direction.  A
+       'Down-Shift rate change' event is triggered when the
+       actual upstream data rate is below the data rate at the last
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 141]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       entry into Showtime, by more than the threshold.  The parameter
+       is coded in bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.8.2
+                 (Data rate threshold downshift)"
+   ::= { xdsl2ChConfProfileEntry 21 }
+
+xdsl2ChConfProfImaEnabled  OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "IMA Mode Enable.  The parameter enables the IMA operation
+       mode in the ATM Data Path.  Relevant only if the channel is of
+       ATM Data Path.  When in 'enable' state, the ATM Data
+       Path should comply with the requirements for IMA
+       transmission."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.4.1
+                 (IMA operation mode enable parameter)"
+   DEFVAL       { false }
+ ::= { xdsl2ChConfProfileEntry 22 }
+
+xdsl2ChConfProfMaxDelayVar  OBJECT-TYPE
+   SYNTAX      Unsigned32(1..255)
+   UNITS       "0.1 milliseconds"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Maximum delay variation (DVMAX).
+       This optional VDSL2-specific parameter specifies the maximum
+       value for the delay variation allowed in an OLR procedure.
+       It is ranges from 1 to 254 units of 0.1 milliseconds (i.e., 0.1
+       to 25.4 milliseconds) with the special value 255, which indicates
+       that no delay variation bound is imposed."
+   REFERENCE    "ITU-T G.997.1 Amendment 1, paragraph #7.3.2.9
+                 (DVMAX)"
+   DEFVAL       { 255 }
+ ::= { xdsl2ChConfProfileEntry 23 }
+
+xdsl2ChConfProfInitPolicy  OBJECT-TYPE
+   SYNTAX      Xdsl2ChInitPolicy
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Channel Initialization Policy Selection (CIPOLICY).
+       This optional parameter indicates which policy shall be applied
+       to determine the transceiver configuration parameters at
+       initialization.  Those policies are defined in the respective
+       Recommendations."
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 142]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   REFERENCE    "ITU-T G.997.1 Amendment 1, paragraph #7.3.2.10
+                 (CIPOLICY)"
+   DEFVAL       { policy0 }
+ ::= { xdsl2ChConfProfileEntry 24 }
+
+xdsl2ChConfProfRowStatus  OBJECT-TYPE
+   SYNTAX      RowStatus
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This object is used to create a new row or to modify or
+       delete an existing row in this table.
+
+       A profile is activated by setting this object to 'active'.
+
+       Before a profile can be deleted or taken out of service (by
+       setting this object to 'destroy' or 'notInService'), it MUST be
+       first unreferenced from all associated templates.
+
+       A row in xdsl2ChConfProfTable is said to be unreferenced when
+       there is no instance of xdsl2LConfTempChan1ConfProfile,
+       xdsl2LConfTempChan2ConfProfile, xdsl2LConfTempChan3ConfProfile,
+       or xdsl2LConfTempChan4ConfProfile that refers to
+       the row."
+   ::= { xdsl2ChConfProfileEntry 25 }
+
+------------------------------------------------
+--      xdsl2LineAlarmConfTemplateTable       --
+------------------------------------------------
+
+xdsl2LineAlarmConfTemplateTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2LineAlarmConfTemplateEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineAlarConfTemplateTable contains DSL
+       line alarm configuration templates.
+
+        Entries in this table MUST be maintained in a persistent
+        manner."
+   ::= { xdsl2ProfileAlarmConf 1 }
+
+xdsl2LineAlarmConfTemplateEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2LineAlarmConfTemplateEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "A default template with an index of 'DEFVAL' will always
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 143]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       exist, and its parameters will be set to vendor-specific values,
+       unless otherwise specified in this document."
+   INDEX  { xdsl2LAlarmConfTempTemplateName }
+   ::= { xdsl2LineAlarmConfTemplateTable 1 }
+
+Xdsl2LineAlarmConfTemplateEntry  ::=
+   SEQUENCE {
+      xdsl2LAlarmConfTempTemplateName      SnmpAdminString,
+      xdsl2LAlarmConfTempLineProfile       SnmpAdminString,
+      xdsl2LAlarmConfTempChan1ConfProfile  SnmpAdminString,
+      xdsl2LAlarmConfTempChan2ConfProfile  SnmpAdminString,
+      xdsl2LAlarmConfTempChan3ConfProfile  SnmpAdminString,
+      xdsl2LAlarmConfTempChan4ConfProfile  SnmpAdminString,
+      xdsl2LAlarmConfTempRowStatus         RowStatus
+   }
+
+xdsl2LAlarmConfTempTemplateName  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "This object identifies a row in this table."
+   ::= { xdsl2LineAlarmConfTemplateEntry 1 }
+
+xdsl2LAlarmConfTempLineProfile  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the DSL Line
+       Thresholds Configuration Profile Table
+       (xdsl2LineAlarmConfProfileTable) that applies to this line."
+   REFERENCE    "DSL Forum TR-129, paragraph #8.2"
+   DEFVAL       { "DEFVAL" }
+   ::= { xdsl2LineAlarmConfTemplateEntry 2 }
+
+xdsl2LAlarmConfTempChan1ConfProfile  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the DSL
+       Channel Thresholds Configuration Profile Table
+       (xdsl2ChAlarmConfProfileTable) that applies for DSL bearer
+       channel #1.  The channel profile name specified here MUST match
+       the name of an existing row in the xdsl2ChAlarmConfProfileTable
+       table."
+   REFERENCE    "DSL Forum TR-129, paragraph #8.4"
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 144]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   DEFVAL       { "DEFVAL" }
+   ::= { xdsl2LineAlarmConfTemplateEntry 3 }
+
+xdsl2LAlarmConfTempChan2ConfProfile  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(0..32))
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the DSL
+       Channel Thresholds Configuration Profile Table
+       (xdsl2ChAlarmConfProfileTable) that applies for DSL bearer
+       channel #2.  The channel profile name specified here MUST match
+       the name of an existing row in the xdsl2ChAlarmConfProfileTable
+       table.  If the channel is unused, then the object is set to a
+       zero-length string."
+   REFERENCE    "DSL Forum TR-129, paragraph #8.4"
+   DEFVAL       { "" }
+   ::= { xdsl2LineAlarmConfTemplateEntry 4 }
+
+xdsl2LAlarmConfTempChan3ConfProfile  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(0..32))
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the DSL
+       Channel Thresholds Configuration Profile Table
+       (xdsl2ChAlarmConfProfileTable) that applies for DSL bearer
+       channel #3.  The channel profile name specified here MUST match
+       the name of an existing row in the xdsl2ChAlarmConfProfileTable
+       table.
+       This object may be set to a non-zero-length string only if
+       xdsl2LAlarmConfTempChan2ConfProfile contains a non-zero-length
+       string."
+   REFERENCE    "DSL Forum TR-129, paragraph #8.4"
+   DEFVAL       { "" }
+   ::= { xdsl2LineAlarmConfTemplateEntry 5 }
+
+xdsl2LAlarmConfTempChan4ConfProfile  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(0..32))
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the DSL
+       Channel Thresholds Configuration Profile Table
+       (xdsl2ChAlarmConfProfileTable) that applies for DSL bearer
+       channel #4.  The channel profile name specified here MUST match
+       the name of an existing row in the xdsl2ChAlarmConfProfileTable
+       table.
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 145]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       This object may be set to a non-zero-length string only if
+       xdsl2LAlarmConfTempChan3ConfProfile contains a non-zero-length
+       string."
+   REFERENCE    "DSL Forum TR-129, paragraph #8.4"
+   DEFVAL       { "" }
+   ::= { xdsl2LineAlarmConfTemplateEntry 6 }
+
+xdsl2LAlarmConfTempRowStatus  OBJECT-TYPE
+   SYNTAX      RowStatus
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This object is used to create a new row or to modify or
+       delete an existing row in this table.
+
+       A template is activated by setting this object to 'active'.
+
+       Before a template can be deleted or taken out of service (by
+       setting this object to 'destroy' or 'notInService'), it MUST be
+       first unreferenced from all associated lines.
+
+       A row in this table is said to be unreferenced when there is no
+       instance of xdsl2LineAlarmConfTemplate that refers to the
+       row."
+   ::= { xdsl2LineAlarmConfTemplateEntry 7 }
+
+------------------------------------------------
+--      xdsl2LineAlarmConfProfileTable        --
+------------------------------------------------
+
+xdsl2LineAlarmConfProfileTable  OBJECT-TYPE
+     SYNTAX      SEQUENCE  OF  Xdsl2LineAlarmConfProfileEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+      "The table xdsl2LineAlarmConfProfileTable contains DSL
+       line performance threshold values.
+
+       If a performance counter exceeds the threshold value specified
+       in this table, then the SNMP agent will issue a threshold trap.
+       Each performance counter has a unique trap type
+       (see NOTIFICATION-TYPE definitions below).
+       One trap will be sent per interval, per interface, per trap type.
+       A value of 0 will disable the trap.
+
+       Entries in this table MUST be maintained in a persistent
+       manner."
+     ::= { xdsl2ProfileAlarmConf 2 }
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 146]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+xdsl2LineAlarmConfProfileEntry  OBJECT-TYPE
+     SYNTAX      Xdsl2LineAlarmConfProfileEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+      "A default profile with an index of 'DEFVAL' will always
+       exist, and its parameters will be set to vendor-specific values,
+       unless otherwise specified in this document."
+     INDEX  { xdsl2LineAlarmConfProfileName }
+     ::= { xdsl2LineAlarmConfProfileTable 1 }
+
+Xdsl2LineAlarmConfProfileEntry ::=
+     SEQUENCE {
+     xdsl2LineAlarmConfProfileName                SnmpAdminString,
+     xdsl2LineAlarmConfProfileXtucThresh15MinFecs
+                                          HCPerfIntervalThreshold,
+     xdsl2LineAlarmConfProfileXtucThresh15MinEs
+                                          HCPerfIntervalThreshold,
+     xdsl2LineAlarmConfProfileXtucThresh15MinSes
+                                           HCPerfIntervalThreshold,
+     xdsl2LineAlarmConfProfileXtucThresh15MinLoss
+                                           HCPerfIntervalThreshold,
+     xdsl2LineAlarmConfProfileXtucThresh15MinUas
+                                           HCPerfIntervalThreshold,
+     xdsl2LineAlarmConfProfileXturThresh15MinFecs
+                                           HCPerfIntervalThreshold,
+     xdsl2LineAlarmConfProfileXturThresh15MinEs
+                                           HCPerfIntervalThreshold,
+     xdsl2LineAlarmConfProfileXturThresh15MinSes
+                                           HCPerfIntervalThreshold,
+     xdsl2LineAlarmConfProfileXturThresh15MinLoss
+                                           HCPerfIntervalThreshold,
+     xdsl2LineAlarmConfProfileXturThresh15MinUas
+                                           HCPerfIntervalThreshold,
+
+     xdsl2LineAlarmConfProfileThresh15MinFailedFullInt   Unsigned32,
+     xdsl2LineAlarmConfProfileThresh15MinFailedShrtInt   Unsigned32,
+
+     xdsl2LineAlarmConfProfileRowStatus                   RowStatus
+     }
+
+xdsl2LineAlarmConfProfileName  OBJECT-TYPE
+     SYNTAX      SnmpAdminString (SIZE(1..32))
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+     "This object identifies a row in this table."
+     ::= { xdsl2LineAlarmConfProfileEntry 1 }
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 147]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+xdsl2LineAlarmConfProfileXtucThresh15MinFecs  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMLCurr15MFecs counter, when
+      xdsl2PMLCurrUnit is xtuc {1}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2LineAlarmConfProfileEntry 2 }
+
+xdsl2LineAlarmConfProfileXtucThresh15MinEs  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMLCurr15MEs counter, when
+      xdsl2PMLCurrUnit is xtuc {1}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2LineAlarmConfProfileEntry 3 }
+
+xdsl2LineAlarmConfProfileXtucThresh15MinSes  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMLCurr15MSes counter, when
+      xdsl2PMLCurrUnit is xtuc {1}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2LineAlarmConfProfileEntry 4 }
+
+xdsl2LineAlarmConfProfileXtucThresh15MinLoss  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 148]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+     "A threshold for the xdsl2PMLCurr15MLoss counter, when
+      xdsl2PMLCurrUnit is xtuc {1}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2LineAlarmConfProfileEntry 5 }
+
+xdsl2LineAlarmConfProfileXtucThresh15MinUas  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMLCurr15MUas counter, when
+      xdsl2PMLCurrUnit is xtuc {1}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2LineAlarmConfProfileEntry 6 }
+
+xdsl2LineAlarmConfProfileXturThresh15MinFecs  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMLCurr15MFecs counter, when
+      xdsl2PMLCurrUnit is xtur {2}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2LineAlarmConfProfileEntry 7 }
+
+xdsl2LineAlarmConfProfileXturThresh15MinEs  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMLCurr15MEs counter, when
+      xdsl2PMLCurrUnit is xtur {2}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 149]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+     ::= { xdsl2LineAlarmConfProfileEntry 8 }
+
+xdsl2LineAlarmConfProfileXturThresh15MinSes  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMLCurr15MSes counter, when
+      xdsl2PMLCurrUnit is xtur {2}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2LineAlarmConfProfileEntry 9 }
+
+xdsl2LineAlarmConfProfileXturThresh15MinLoss  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMLCurr15MLoss counter, when
+      xdsl2PMLCurrUnit is xtur {2}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2LineAlarmConfProfileEntry 10 }
+
+xdsl2LineAlarmConfProfileXturThresh15MinUas  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMLCurr15MUas counter, when
+      xdsl2PMLCurrUnit is xtur {2}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2LineAlarmConfProfileEntry 11 }
+
+xdsl2LineAlarmConfProfileThresh15MinFailedFullInt  OBJECT-TYPE
+     SYNTAX      Unsigned32
+     MAX-ACCESS  read-create
+     STATUS      current
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 150]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+     DESCRIPTION
+     "A threshold for the xdsl2PMLInitCurr15MfailedFullInits
+      counter.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2LineAlarmConfProfileEntry 12 }
+
+xdsl2LineAlarmConfProfileThresh15MinFailedShrtInt  OBJECT-TYPE
+     SYNTAX      Unsigned32
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMLInitCurr15MFailedShortInits
+      counter.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2LineAlarmConfProfileEntry 13 }
+
+xdsl2LineAlarmConfProfileRowStatus  OBJECT-TYPE
+     SYNTAX      RowStatus
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+      "This object is used to create a new row or to modify or
+       delete an existing row in this table.
+
+       A profile is activated by setting this object to 'active'.
+
+       Before a profile can be deleted or taken out of service (by
+       setting this object to 'destroy' or 'notInService'), it MUST be
+       first unreferenced from all associated templates.
+
+       A row in this table is said to be unreferenced when there is no
+       instance of xdsl2LAlarmConfTempLineProfile that refers to the
+       row."
+     ::= { xdsl2LineAlarmConfProfileEntry 14 }
+
+------------------------------------------------
+--       xdsl2ChAlarmConfProfileTable         --
+------------------------------------------------
+
+xdsl2ChAlarmConfProfileTable  OBJECT-TYPE
+     SYNTAX      SEQUENCE  OF  Xdsl2ChAlarmConfProfileEntry
+     MAX-ACCESS  not-accessible
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 151]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+     STATUS      current
+     DESCRIPTION
+      "The table xdsl2ChAlarmConfProfileTable contains DSL channel
+       performance threshold values.
+
+       If a performance counter exceeds the threshold value specified
+       in this table, then the SNMP agent will issue a threshold trap.
+       Each performance counter has a unique trap type
+       (see NOTIFICATION-TYPE definitions below).
+       One trap will be sent per interval per interface per trap type.
+       A value of 0 will disable the trap.
+
+       Entries in this table MUST be maintained in a persistent
+       manner."
+     ::= { xdsl2ProfileAlarmConf 3 }
+
+xdsl2ChAlarmConfProfileEntry  OBJECT-TYPE
+     SYNTAX      Xdsl2ChAlarmConfProfileEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+      "A default profile with an index of 'DEFVAL' will always
+       exist, and its parameters will be set to vendor-specific values,
+       unless otherwise specified in this document."
+     INDEX  { xdsl2ChAlarmConfProfileName }
+     ::= { xdsl2ChAlarmConfProfileTable 1 }
+
+Xdsl2ChAlarmConfProfileEntry ::=
+     SEQUENCE {
+     xdsl2ChAlarmConfProfileName
+                                                     SnmpAdminString,
+     xdsl2ChAlarmConfProfileXtucThresh15MinCodingViolations
+                                                     Unsigned32,
+     xdsl2ChAlarmConfProfileXtucThresh15MinCorrected Unsigned32,
+     xdsl2ChAlarmConfProfileXturThresh15MinCodingViolations
+                                                     Unsigned32,
+     xdsl2ChAlarmConfProfileXturThresh15MinCorrected Unsigned32,
+     xdsl2ChAlarmConfProfileRowStatus                RowStatus
+     }
+
+xdsl2ChAlarmConfProfileName  OBJECT-TYPE
+     SYNTAX      SnmpAdminString (SIZE(1..32))
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+     "This object identifies a row in this table."
+     ::= { xdsl2ChAlarmConfProfileEntry 1 }
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 152]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+xdsl2ChAlarmConfProfileXtucThresh15MinCodingViolations OBJECT-TYPE
+     SYNTAX      Unsigned32
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMChCurr15MCodingViolations
+      counter, when xdsl2PMChCurrUnit is xtuc {1}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2ChAlarmConfProfileEntry 2 }
+
+xdsl2ChAlarmConfProfileXtucThresh15MinCorrected  OBJECT-TYPE
+     SYNTAX      Unsigned32
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMChCurr15MCorrectedBlocks
+      counter, when xdsl2PMChCurrUnit is xtuc {1}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2ChAlarmConfProfileEntry 3 }
+
+xdsl2ChAlarmConfProfileXturThresh15MinCodingViolations  OBJECT-TYPE
+     SYNTAX      Unsigned32
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMChCurr15MCodingViolations
+      counter, when xdsl2PMChCurrUnit is xtur {2}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2ChAlarmConfProfileEntry 4 }
+
+xdsl2ChAlarmConfProfileXturThresh15MinCorrected  OBJECT-TYPE
+     SYNTAX      Unsigned32
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMChCurr15MCorrectedBlocks
+      counter, when xdsl2PMChCurrUnit is xtur {2}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 153]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2ChAlarmConfProfileEntry 5 }
+
+xdsl2ChAlarmConfProfileRowStatus  OBJECT-TYPE
+     SYNTAX      RowStatus
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+      "This object is used to create a new row or to modify or
+       delete an existing row in this table.
+
+       A profile is activated by setting this object to 'active'.
+
+       Before a profile can be deleted or taken out of service (by
+       setting this object to 'destroy' or 'notInService'), it MUST be
+       first unreferenced from all associated templates.
+
+       A row in xdsl2ChConfProfTable is said to be unreferenced when
+       there is no instance of xdsl2LAlarmConfTempChan1ConfProfile,
+       xdsl2LAlarmConfTempChan2ConfProfile,
+       xdsl2LAlarmConfTempChan3ConfProfile, or
+       xdsl2LAlarmConfTempChan4ConfProfile that refers to
+       the row."
+     ::= { xdsl2ChAlarmConfProfileEntry 6 }
+
+------------------------------------------------
+--          PM line current counters          --
+------------------------------------------------
+
+xdsl2PMLineCurrTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2PMLineCurrEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2PMLineCurrTable contains current Performance
+       Monitoring results for DSL lines."
+   ::= { xdsl2PMLine 1 }
+
+xdsl2PMLineCurrEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2PMLineCurrEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+       "One index of this table is an interface index where the
+        interface has an ifType of vdsl2(251).  A second index of this
+        table is the termination unit."
+   INDEX  { ifIndex, xdsl2PMLCurrUnit }
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 154]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   ::= { xdsl2PMLineCurrTable 1 }
+
+Xdsl2PMLineCurrEntry  ::=
+   SEQUENCE {
+      xdsl2PMLCurrUnit                    Xdsl2Unit,
+      xdsl2PMLCurr15MValidIntervals       Unsigned32,
+      xdsl2PMLCurr15MInvalidIntervals     Unsigned32,
+      xdsl2PMLCurr15MTimeElapsed          HCPerfTimeElapsed,
+      xdsl2PMLCurr15MFecs                 Counter32,
+      xdsl2PMLCurr15MEs                   Counter32,
+      xdsl2PMLCurr15MSes                  Counter32,
+      xdsl2PMLCurr15MLoss                 Counter32,
+      xdsl2PMLCurr15MUas                  Counter32,
+      xdsl2PMLCurr1DayValidIntervals      Unsigned32,
+      xdsl2PMLCurr1DayInvalidIntervals    Unsigned32,
+      xdsl2PMLCurr1DayTimeElapsed         HCPerfTimeElapsed,
+      xdsl2PMLCurr1DayFecs                Counter32,
+      xdsl2PMLCurr1DayEs                  Counter32,
+      xdsl2PMLCurr1DaySes                 Counter32,
+      xdsl2PMLCurr1DayLoss                Counter32,
+      xdsl2PMLCurr1DayUas                 Counter32
+   }
+
+xdsl2PMLCurrUnit  OBJECT-TYPE
+   SYNTAX      Xdsl2Unit
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The termination unit."
+   ::= { xdsl2PMLineCurrEntry 1 }
+
+xdsl2PMLCurr15MValidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..96)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The number of 15-minute PM intervals for which data
+       was collected.  The value will typically be equal to the maximum
+       number of 15-minute intervals the implementation is planned to
+       store (i.e., beyond the scope of this MIB module) unless the
+       measurement was (re-)started recently, in which case the value
+       will be the number of complete 15-minute intervals for which
+       the agent has at least some data.  In certain cases (e.g., in
+       the case where the agent is a proxy), it is possible that some
+       intervals are unavailable.  In this case, this interval is the
+       maximum interval number for which data is available."
+   ::= { xdsl2PMLineCurrEntry 2 }
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 155]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+xdsl2PMLCurr15MInvalidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..96)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The number of 15-minute PM intervals for which no data is
+       available.  The value will typically be zero except in cases
+       where the data for some intervals are not available (e.g.,
+       in proxy situations)."
+   ::= { xdsl2PMLineCurrEntry 3 }
+
+xdsl2PMLCurr15MTimeElapsed  OBJECT-TYPE
+   SYNTAX      HCPerfTimeElapsed
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total elapsed seconds in this interval."
+   ::= { xdsl2PMLineCurrEntry 4 }
+
+xdsl2PMLCurr15MFecs  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was at
+       least one FEC correction event for one or more bearer channels in
+       this line.  This parameter is inhibited during UAS or SES."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.1 (FECS-L)
+                 and paragraph #7.2.1.2.1 (FECS-LFE)"
+   ::= { xdsl2PMLineCurrEntry 5 }
+
+xdsl2PMLCurr15MEs  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was:
+          xTU-C: CRC-8 >= 1 for one or more bearer channels OR
+                 LOS >= 1 OR SEF >=1 OR LPR >= 1.
+          xTU-R: FEBE >= 1 for one or more bearer channels OR
+                 LOS-FE >=1 OR RDI >=1 OR LPR-FE >=1.
+       This parameter is inhibited during UAS."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.2 (ES-L)
+                 and paragraph #7.2.1.2.2 (ES-LFE)"
+   ::= { xdsl2PMLineCurrEntry 6 }
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 156]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+xdsl2PMLCurr15MSes  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was:
+          xTU-C: (CRC-8 anomalies in one or more of the
+                 received bearer channels) >= 18 OR LOS >= 1
+                 OR SEF >= 1 OR LPR >= 1.
+          xTU-R: (FEBE anomalies in one or more of the
+                 received bearer channels) >= 18 OR LOS-FE >= 1
+                 OR RDI >= 1 OR LPR-FE >= 1.
+       This parameter is inhibited during UAS."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.3 (SES-L)
+                 and paragraph #7.2.1.2.3 (SES-LFE)"
+   ::= { xdsl2PMLineCurrEntry 7 }
+
+xdsl2PMLCurr15MLoss  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was LOS (or
+       LOS-FE for xTU-R)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.4 (LOSS-L)
+                 and paragraph #7.2.1.2.4 (LOSS-LFE)"
+   ::= { xdsl2PMLineCurrEntry 8 }
+
+xdsl2PMLCurr15MUas  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds in Unavailability State during this
+       interval.  Unavailability begins at the onset of 10 contiguous
+       severely errored seconds, and ends at the onset of 10 contiguous
+       seconds with no severely errored seconds."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.5 (UAS-L)
+                 and paragraph #7.2.1.2.5 (UAS-LFE)"
+   ::= { xdsl2PMLineCurrEntry 9 }
+
+xdsl2PMLCurr1DayValidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..30)
+   MAX-ACCESS  read-only
+   STATUS      current
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 157]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   DESCRIPTION
+      "The number of 24-hour PM intervals for which data was
+       collected.  The value will typically be equal to the maximum
+       number of 24-hour intervals the implementation is planned to
+       store (i.e., beyond the scope of this MIB module) unless the
+       measurement was (re-)started recently, in which case the value
+       will be the number of complete 24-hour intervals for which
+       the agent has at least some data.  In certain cases (e.g., in
+       the case where the agent is a proxy), it is possible that some
+       intervals are unavailable.  In this case, this interval is the
+       maximum interval number for which data is available."
+   ::= { xdsl2PMLineCurrEntry 10 }
+
+xdsl2PMLCurr1DayInvalidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..30)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The number of 24-hour PM intervals for which no data is
+       available.  The value will typically be zero except in cases
+       where the data for some intervals are not available (e.g.,
+       in proxy situations)."
+   ::= { xdsl2PMLineCurrEntry 11 }
+
+xdsl2PMLCurr1DayTimeElapsed  OBJECT-TYPE
+   SYNTAX      HCPerfTimeElapsed
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total elapsed seconds in this interval."
+   ::= { xdsl2PMLineCurrEntry 12 }
+
+xdsl2PMLCurr1DayFecs  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was at
+       least one FEC correction event for one or more bearer channels in
+       this line.  This parameter is inhibited during UAS or SES."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.1 (FECS-L)
+                 and paragraph #7.2.1.2.1 (FECS-LFE)"
+   ::= { xdsl2PMLineCurrEntry 13 }
+
+xdsl2PMLCurr1DayEs  OBJECT-TYPE
+   SYNTAX      Counter32
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 158]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was:
+          xTU-C: CRC-8 >= 1 for one or more bearer channels OR
+                 LOS >= 1 OR SEF >= 1 OR LPR >= 1.
+          xTU-R: FEBE >= 1 for one or more bearer channels OR
+                 LOS-FE >= 1 OR RDI >= 1 OR LPR-FE >= 1.
+       This parameter is inhibited during UAS."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.2 (ES-L)
+                 and paragraph #7.2.1.2.2 (ES-LFE)"
+   ::= { xdsl2PMLineCurrEntry 14 }
+
+xdsl2PMLCurr1DaySes  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was:
+          xTU-C: (CRC-8 anomalies in one or more of the
+                 received bearer channels) >= 18 OR LOS >= 1
+                 OR SEF >= 1 OR LPR >= 1.
+          xTU-R: (FEBE anomalies in one or more of the
+                 received bearer channels) >= 18 OR LOS-FE >= 1.
+                 OR RDI >= 1 OR LPR-FE >= 1.
+       This parameter is inhibited during UAS."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.3 (SES-L)
+                 and paragraph #7.2.1.2.3 (SES-LFE)"
+   ::= { xdsl2PMLineCurrEntry 15 }
+
+xdsl2PMLCurr1DayLoss  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was LOS (or
+       LOS-FE for xTU-R)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.4 (LOSS-L)
+                 and paragraph #7.2.1.2.4 (LOSS-LFE)"
+   ::= { xdsl2PMLineCurrEntry 16 }
+
+xdsl2PMLCurr1DayUas  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 159]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds in Unavailability State during this
+       interval.
+       Unavailability begins at the onset of 10 contiguous severely
+       errored seconds, and ends at the onset of 10 contiguous seconds
+       with no severely errored seconds."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.5 (UAS-L)
+                 and paragraph #7.2.1.2.5 (UAS-LFE)"
+   ::= { xdsl2PMLineCurrEntry 17 }
+
+------------------------------------------------
+--          PM line init current counters     --
+------------------------------------------------
+
+xdsl2PMLineInitCurrTable   OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2PMLineInitCurrEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2PMLineInitCurrTable contains current
+       initialization counters for DSL lines."
+   ::= { xdsl2PMLine 2 }
+
+xdsl2PMLineInitCurrEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2PMLineInitCurrEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The index of this table is an interface index where the
+       interface has an ifType of vdsl2(251)."
+   INDEX  { ifIndex }
+   ::= { xdsl2PMLineInitCurrTable 1 }
+
+Xdsl2PMLineInitCurrEntry  ::=
+   SEQUENCE {
+      xdsl2PMLInitCurr15MValidIntervals       Unsigned32,
+      xdsl2PMLInitCurr15MInvalidIntervals     Unsigned32,
+      xdsl2PMLInitCurr15MTimeElapsed          Unsigned32,
+      xdsl2PMLInitCurr15MFullInits            Unsigned32,
+      xdsl2PMLInitCurr15MFailedFullInits      Unsigned32,
+      xdsl2PMLInitCurr15MShortInits           Unsigned32,
+      xdsl2PMLInitCurr15MFailedShortInits     Unsigned32,
+      xdsl2PMLInitCurr1DayValidIntervals      Unsigned32,
+      xdsl2PMLInitCurr1DayInvalidIntervals    Unsigned32,
+      xdsl2PMLInitCurr1DayTimeElapsed         Unsigned32,
+      xdsl2PMLInitCurr1DayFullInits           Unsigned32,
+      xdsl2PMLInitCurr1DayFailedFullInits     Unsigned32,
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 160]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      xdsl2PMLInitCurr1DayShortInits          Unsigned32,
+      xdsl2PMLInitCurr1DayFailedShortInits    Unsigned32
+   }
+
+xdsl2PMLInitCurr15MValidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..96)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The number of 15-minute PM intervals for which data
+       was collected.  The value will typically be equal to the maximum
+       number of 15-minute intervals the implementation is planned to
+       store (i.e., beyond the scope of this MIB module) unless the
+       measurement was (re-)started recently, in which case the value
+       will be the number of complete 15-minute intervals for which
+       the agent has at least some data.  In certain cases (e.g., in
+       the case where the agent is a proxy), it is possible that some
+       intervals are unavailable.  In this case, this interval is the
+       maximum interval number for which data is available."
+   ::= { xdsl2PMLineInitCurrEntry 1 }
+
+xdsl2PMLInitCurr15MInvalidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..96)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The number of 15-minute PM intervals for which no data is
+       available.  The value will typically be zero except in cases
+       where the data for some intervals are not available (e.g.,
+       in proxy situations)."
+   ::= { xdsl2PMLineInitCurrEntry 2 }
+
+xdsl2PMLInitCurr15MTimeElapsed  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total elapsed seconds in this interval."
+   ::= { xdsl2PMLineInitCurrEntry 3 }
+
+xdsl2PMLInitCurr15MFullInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of full initializations attempted on the line
+       (successful and failed) during this interval."
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 161]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.1"
+   ::= { xdsl2PMLineInitCurrEntry 4 }
+
+xdsl2PMLInitCurr15MFailedFullInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of failed full initializations on the line during this
+       interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.2"
+   ::= { xdsl2PMLineInitCurrEntry 5 }
+
+xdsl2PMLInitCurr15MShortInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of short initializations attempted on the line
+       (successful and failed) during this interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.3"
+   ::= { xdsl2PMLineInitCurrEntry 6 }
+
+xdsl2PMLInitCurr15MFailedShortInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of failed short initializations on the line during
+       this interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.4"
+   ::= { xdsl2PMLineInitCurrEntry 7 }
+
+xdsl2PMLInitCurr1DayValidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..30)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The number of 24-hour PM intervals for which data was
+       collected.  The value will typically be equal to the maximum
+       number of 24-hour intervals the implementation is planned to
+       store (i.e., beyond the scope of this MIB module) unless the
+       measurement was (re-)started recently, in which case the value
+       will be the number of complete 24-hour intervals for which
+       the agent has at least some data.  In certain cases (e.g., in
+       the case where the agent is a proxy), it is possible that some
+       intervals are unavailable.  In this case, this interval is the
+       maximum interval number for which data is available."
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 162]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   ::= { xdsl2PMLineInitCurrEntry 8 }
+
+xdsl2PMLInitCurr1DayInvalidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..30)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The number of 24-hour PM intervals for which no data is
+       available.  The value will typically be zero except in cases
+       where the data for some intervals are not available (e.g.,
+       in proxy situations)."
+   ::= { xdsl2PMLineInitCurrEntry 9 }
+
+xdsl2PMLInitCurr1DayTimeElapsed  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total elapsed seconds in this interval."
+   ::= { xdsl2PMLineInitCurrEntry 10 }
+
+xdsl2PMLInitCurr1DayFullInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of full initializations attempted on the line
+       (successful and failed) during this interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.1"
+   ::= { xdsl2PMLineInitCurrEntry 11 }
+
+xdsl2PMLInitCurr1DayFailedFullInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of failed full initializations on the line during this
+       interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.2"
+   ::= { xdsl2PMLineInitCurrEntry 12 }
+
+xdsl2PMLInitCurr1DayShortInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of short initializations attempted on the line
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 163]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       (successful and failed) during this interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.3"
+   ::= { xdsl2PMLineInitCurrEntry 13 }
+
+xdsl2PMLInitCurr1DayFailedShortInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of failed short initializations on the line during
+       this interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.4"
+   ::= { xdsl2PMLineInitCurrEntry 14 }
+
+-------------------------------------------
+--       PM line history 15 Minutes      --
+-------------------------------------------
+
+xdsl2PMLineHist15MinTable    OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2PMLineHist15MinEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2PMLineHist15MinTable contains PM line history
+       for 15-minute intervals of DSL line."
+   ::= { xdsl2PMLine 3 }
+
+xdsl2PMLineHist15MinEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2PMLineHist15MinEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "One index of this table is an interface index where the
+      interface has an ifType of vdsl2(251).  A second index of this
+      table is the transmission unit.  The third index is the interval
+      number."
+   INDEX  { ifIndex,
+            xdsl2PMLHist15MUnit,
+            xdsl2PMLHist15MInterval }
+   ::= { xdsl2PMLineHist15MinTable 1 }
+
+Xdsl2PMLineHist15MinEntry  ::=
+   SEQUENCE {
+      xdsl2PMLHist15MUnit                 Xdsl2Unit,
+      xdsl2PMLHist15MInterval             Unsigned32,
+      xdsl2PMLHist15MMonitoredTime        Unsigned32,
+      xdsl2PMLHist15MFecs                 Counter32,
+      xdsl2PMLHist15MEs                   Counter32,
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 164]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      xdsl2PMLHist15MSes                  Counter32,
+      xdsl2PMLHist15MLoss                 Counter32,
+      xdsl2PMLHist15MUas                  Counter32,
+      xdsl2PMLHist15MValidInterval        TruthValue
+   }
+
+xdsl2PMLHist15MUnit  OBJECT-TYPE
+   SYNTAX      Xdsl2Unit
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The termination unit."
+   ::= { xdsl2PMLineHist15MinEntry 1 }
+
+xdsl2PMLHist15MInterval  OBJECT-TYPE
+   SYNTAX      Unsigned32 (1..96)
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The interval number."
+   ::= { xdsl2PMLineHist15MinEntry 2 }
+
+xdsl2PMLHist15MMonitoredTime  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total seconds monitored in this interval."
+   ::= { xdsl2PMLineHist15MinEntry 3 }
+
+xdsl2PMLHist15MFecs  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was at
+       least one FEC correction event for one or more bearer channels in
+       this line.  This parameter is inhibited during UAS or SES."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.1 (FECS-L)
+                 and paragraph #7.2.1.2.1 (FECS-LFE)"
+   ::= { xdsl2PMLineHist15MinEntry 4 }
+
+xdsl2PMLHist15MEs  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 165]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was:
+          xTU-C: CRC-8 >= 1 for one or more bearer channels OR
+                 LOS >= 1 OR SEF >= 1 OR LPR >= 1.
+          xTU-R: FEBE >= 1 for one or more bearer channels OR
+                 LOS-FE >= 1 OR RDI >= 1 OR LPR-FE >= 1.
+       This parameter is inhibited during UAS."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.2 (ES-L)
+                 and paragraph #7.2.1.2.2 (ES-LFE)"
+   ::= { xdsl2PMLineHist15MinEntry 5 }
+
+xdsl2PMLHist15MSes  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was:
+          xTU-C: (CRC-8 anomalies in one or more of the
+                 received bearer channels) >= 18 OR LOS >= 1
+                 OR SEF >= 1 OR LPR >= 1.
+          xTU-R: (FEBE anomalies in one or more of the
+                 received bearer channels) >= 18 OR LOS-FE >= 1
+                 OR RDI >= 1 OR LPR-FE >= 1.
+       This parameter is inhibited during UAS."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.3 (SES-L)
+                 and paragraph #7.2.1.2.3 (SES-LFE)"
+   ::= { xdsl2PMLineHist15MinEntry 6 }
+
+xdsl2PMLHist15MLoss  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was LOS (or
+       LOS-FE for xTU-R)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.4 (LOSS-L)
+                 and paragraph #7.2.1.2.4 (LOSS-LFE)"
+   ::= { xdsl2PMLineHist15MinEntry 7 }
+
+xdsl2PMLHist15MUas  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 166]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      "Count of seconds in Unavailability State during this
+       interval.
+       Unavailability begins at the onset of 10 contiguous severely
+       errored seconds, and ends at the onset of 10 contiguous seconds
+       with no severely errored seconds."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.5 (UAS-L)
+                 and paragraph #7.2.1.2.5 (UAS-LFE)"
+   ::= { xdsl2PMLineHist15MinEntry 8 }
+
+xdsl2PMLHist15MValidInterval  OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This variable indicates if the data for this interval is
+       valid."
+   ::= { xdsl2PMLineHist15MinEntry 9 }
+
+---------------------------------------
+--       PM line history 1 Day       --
+---------------------------------------
+
+xdsl2PMLineHist1DayTable     OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2PMLineHist1DayEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2PMLineHist1DayTable contains PM line history
+       for 24-hour intervals of DSL line."
+   ::= { xdsl2PMLine 4 }
+
+xdsl2PMLineHist1DayEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2PMLineHist1DayEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "One index of this table is an interface index where the
+      interface has an ifType of vdsl2(251).  A second index of this
+      table is the transmission unit.The third index is the interval
+      number."
+   INDEX  { ifIndex,
+            xdsl2PMLHist1DUnit,
+            xdsl2PMLHist1DInterval }
+   ::= { xdsl2PMLineHist1DayTable 1 }
+
+Xdsl2PMLineHist1DayEntry  ::=
+   SEQUENCE {
+      xdsl2PMLHist1DUnit              Xdsl2Unit,
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 167]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      xdsl2PMLHist1DInterval          Unsigned32,
+      xdsl2PMLHist1DMonitoredTime     Unsigned32,
+      xdsl2PMLHist1DFecs              Counter32,
+      xdsl2PMLHist1DEs                Counter32,
+      xdsl2PMLHist1DSes               Counter32,
+      xdsl2PMLHist1DLoss              Counter32,
+      xdsl2PMLHist1DUas               Counter32,
+      xdsl2PMLHist1DValidInterval     TruthValue
+   }
+
+xdsl2PMLHist1DUnit  OBJECT-TYPE
+   SYNTAX      Xdsl2Unit
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The termination unit."
+   ::= { xdsl2PMLineHist1DayEntry 1 }
+
+xdsl2PMLHist1DInterval  OBJECT-TYPE
+   SYNTAX      Unsigned32 (1..30)
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The interval number."
+   ::= { xdsl2PMLineHist1DayEntry 2 }
+
+xdsl2PMLHist1DMonitoredTime  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total seconds monitored in this interval."
+   ::= { xdsl2PMLineHist1DayEntry 3 }
+
+xdsl2PMLHist1DFecs  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was at
+       least one FEC correction event for one or more bearer channels in
+       this line.  This parameter is inhibited during UAS or SES."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.1 (FECS-L)
+                 and paragraph #7.2.1.2.1 (FECS-LFE)"
+   ::= { xdsl2PMLineHist1DayEntry 4 }
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 168]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+xdsl2PMLHist1DEs  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was:
+          xTU-C: CRC-8 >= 1 for one or more bearer channels OR
+                 LOS >= 1 OR SEF >= 1 OR LPR >= 1.
+          xTU-R: FEBE >= 1 for one or more bearer channels OR
+                 LOS-FE >= 1 OR RDI >= 1 OR LPR-FE >= 1.
+       This parameter is inhibited during UAS."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.2 (ES-L)
+                 and paragraph #7.2.1.2.2 (ES-LFE)"
+   ::= { xdsl2PMLineHist1DayEntry 5 }
+
+xdsl2PMLHist1DSes  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was:
+          xTU-C: (CRC-8 anomalies in one or more of the
+                 received bearer channels) >= 18 OR LOS >= 1
+                 OR SEF >= 1 OR LPR >= 1.
+          xTU-R: (FEBE anomalies in one or more of the
+                 received bearer channels) >= 18 OR LOS-FE >= 1
+                 OR RDI >= 1 OR LPR-FE >= 1.
+       This parameter is inhibited during UAS."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.3 (SES-L)
+                 and paragraph #7.2.1.2.3 (SES-LFE)"
+   ::= { xdsl2PMLineHist1DayEntry 6 }
+
+xdsl2PMLHist1DLoss  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was LOS (or
+       LOS-FE for xTU-R)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.4 (LOSS-L)
+                 and paragraph #7.2.1.2.4 (LOSS-LFE)"
+   ::= { xdsl2PMLineHist1DayEntry 7 }
+
+xdsl2PMLHist1DUas  OBJECT-TYPE
+   SYNTAX      Counter32
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 169]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds in Unavailability State during this
+       interval.
+       Unavailability begins at the onset of 10 contiguous severely
+       errored seconds, and ends at the onset of 10 contiguous seconds
+       with no severely errored seconds."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.5 (UAS-L)
+                 and paragraph #7.2.1.2.5 (UAS-LFE)"
+   ::= { xdsl2PMLineHist1DayEntry 8 }
+
+xdsl2PMLHist1DValidInterval  OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This variable indicates if the data for this interval is
+       valid."
+   ::= { xdsl2PMLineHist1DayEntry 9 }
+
+-------------------------------------------
+--     PM line init history 15 Minutes   --
+-------------------------------------------
+
+xdsl2PMLineInitHist15MinTable      OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2PMLineInitHist15MinEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2PMLineInitHist15MinTable contains PM line
+       initialization history for 15-minute intervals of DSL
+       line."
+   ::= { xdsl2PMLine 5 }
+
+xdsl2PMLineInitHist15MinEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2PMLineInitHist15MinEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+       "One index of this table is an interface index where the
+        interface has an ifType of vdsl2(251).  A second index is the
+        interval number."
+   INDEX  { ifIndex,
+            xdsl2PMLInitHist15MInterval }
+   ::= { xdsl2PMLineInitHist15MinTable 1 }
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 170]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+Xdsl2PMLineInitHist15MinEntry  ::=
+   SEQUENCE {
+      xdsl2PMLInitHist15MInterval              Unsigned32,
+      xdsl2PMLInitHist15MMonitoredTime         Unsigned32,
+      xdsl2PMLInitHist15MFullInits             Unsigned32,
+      xdsl2PMLInitHist15MFailedFullInits       Unsigned32,
+      xdsl2PMLInitHist15MShortInits            Unsigned32,
+      xdsl2PMLInitHist15MFailedShortInits      Unsigned32,
+      xdsl2PMLInitHist15MValidInterval         TruthValue
+   }
+
+xdsl2PMLInitHist15MInterval  OBJECT-TYPE
+   SYNTAX      Unsigned32 (1..96)
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The interval number."
+   ::= { xdsl2PMLineInitHist15MinEntry 1 }
+
+xdsl2PMLInitHist15MMonitoredTime  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total seconds monitored in this interval."
+   ::= { xdsl2PMLineInitHist15MinEntry 2 }
+
+xdsl2PMLInitHist15MFullInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of full initializations attempted on the line
+       (successful and failed) during this interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.1"
+   ::= { xdsl2PMLineInitHist15MinEntry 3 }
+
+xdsl2PMLInitHist15MFailedFullInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of failed full initializations on the line during this
+       interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.2"
+   ::= { xdsl2PMLineInitHist15MinEntry 4 }
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 171]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+xdsl2PMLInitHist15MShortInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of short initializations attempted on the line
+       (successful and failed) during this interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.3"
+   ::= { xdsl2PMLineInitHist15MinEntry 5 }
+
+xdsl2PMLInitHist15MFailedShortInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of failed short initializations on the line during
+       this interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.4"
+   ::= { xdsl2PMLineInitHist15MinEntry 6 }
+
+xdsl2PMLInitHist15MValidInterval  OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This variable indicates if the data for this interval is
+       valid."
+   ::= { xdsl2PMLineInitHist15MinEntry 7 }
+
+-------------------------------------------
+--       PM line init history 1 Day      --
+-------------------------------------------
+
+xdsl2PMLineInitHist1DayTable       OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2PMLineInitHist1DayEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2PMLineInitHist1DayTable contains PM line
+       initialization history for 24-hour intervals for DSL
+       lines."
+   ::= { xdsl2PMLine 6 }
+
+xdsl2PMLineInitHist1DayEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2PMLineInitHist1DayEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 172]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       "One index of this table is an interface index where the
+        interface has an ifType of vdsl2(251).  A second index is the
+        interval number."
+   INDEX  { ifIndex,
+            xdsl2PMLInitHist1DInterval }
+   ::= { xdsl2PMLineInitHist1DayTable 1 }
+
+Xdsl2PMLineInitHist1DayEntry  ::=
+   SEQUENCE {
+      xdsl2PMLInitHist1DInterval              Unsigned32,
+      xdsl2PMLInitHist1DMonitoredTime         Unsigned32,
+      xdsl2PMLInitHist1DFullInits             Unsigned32,
+      xdsl2PMLInitHist1DFailedFullInits       Unsigned32,
+      xdsl2PMLInitHist1DShortInits            Unsigned32,
+      xdsl2PMLInitHist1DFailedShortInits      Unsigned32,
+      xdsl2PMLInitHist1DValidInterval         TruthValue
+   }
+
+xdsl2PMLInitHist1DInterval  OBJECT-TYPE
+   SYNTAX      Unsigned32 (1..30)
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The interval number."
+   ::= { xdsl2PMLineInitHist1DayEntry 1 }
+
+xdsl2PMLInitHist1DMonitoredTime  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total seconds monitored in this interval."
+   ::= { xdsl2PMLineInitHist1DayEntry 2 }
+
+xdsl2PMLInitHist1DFullInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of full initializations attempted on the line
+       (successful and failed) during this interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.1"
+    ::= { xdsl2PMLineInitHist1DayEntry 3 }
+
+xdsl2PMLInitHist1DFailedFullInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 173]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   STATUS      current
+   DESCRIPTION
+      "Count of failed full initializations on the line during this
+       interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.2"
+   ::= { xdsl2PMLineInitHist1DayEntry 4 }
+
+xdsl2PMLInitHist1DShortInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of short initializations attempted on the line
+       (successful and failed) during this interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.3"
+   ::= { xdsl2PMLineInitHist1DayEntry 5 }
+
+xdsl2PMLInitHist1DFailedShortInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of failed short initializations on the line during
+       this interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.4"
+   ::= { xdsl2PMLineInitHist1DayEntry 6 }
+
+xdsl2PMLInitHist1DValidInterval  OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This variable indicates if the data for this interval is
+       valid."
+   ::= { xdsl2PMLineInitHist1DayEntry 7 }
+
+---------------------------------------------------
+--          PM channel current counters          --
+---------------------------------------------------
+
+xdsl2PMChCurrTable        OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2PMChCurrEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2PMChCurrTable contains current Performance
+       Monitoring results for DSL channels."
+   ::= { xdsl2PMChannel 1 }
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 174]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+xdsl2PMChCurrEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2PMChCurrEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+       "One index of this table is an interface index where the
+       interface has an ifType of a DSL channel.  A second index of
+       this table is the termination unit."
+   INDEX  { ifIndex, xdsl2PMChCurrUnit }
+   ::= { xdsl2PMChCurrTable 1 }
+
+Xdsl2PMChCurrEntry  ::=
+   SEQUENCE {
+      xdsl2PMChCurrUnit                     Xdsl2Unit,
+      xdsl2PMChCurr15MValidIntervals        Unsigned32,
+      xdsl2PMChCurr15MInvalidIntervals      Unsigned32,
+      xdsl2PMChCurr15MTimeElapsed           HCPerfTimeElapsed,
+      xdsl2PMChCurr15MCodingViolations      Unsigned32,
+      xdsl2PMChCurr15MCorrectedBlocks       Unsigned32,
+      xdsl2PMChCurr1DayValidIntervals       Unsigned32,
+      xdsl2PMChCurr1DayInvalidIntervals     Unsigned32,
+      xdsl2PMChCurr1DayTimeElapsed          HCPerfTimeElapsed,
+      xdsl2PMChCurr1DayCodingViolations     Unsigned32,
+      xdsl2PMChCurr1DayCorrectedBlocks      Unsigned32
+   }
+
+xdsl2PMChCurrUnit  OBJECT-TYPE
+   SYNTAX      Xdsl2Unit
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+   "The termination unit."
+   ::= { xdsl2PMChCurrEntry 1 }
+
+xdsl2PMChCurr15MValidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..96)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The number of 15-minute PM intervals for which data
+       was collected.  The value will typically be equal to the maximum
+       number of 15-minute intervals the implementation is planned to
+       store (i.e., beyond the scope of this MIB module) unless the
+       measurement was (re-)started recently, in which case the value
+       will be the number of complete 15-minute intervals for which
+       the agent has at least some data.  In certain cases (e.g., in
+       the case where the agent is a proxy), it is possible that some
+       intervals are unavailable.  In this case, this interval is the
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 175]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       maximum interval number for which data is available."
+   ::= { xdsl2PMChCurrEntry 2 }
+
+xdsl2PMChCurr15MInvalidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..96)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The number of 15-minute PM intervals for which no data is
+       available.  The value will typically be zero except in cases
+       where the data for some intervals are not available (e.g.,
+       in proxy situations)."
+    ::= { xdsl2PMChCurrEntry 3 }
+
+xdsl2PMChCurr15MTimeElapsed  OBJECT-TYPE
+   SYNTAX      HCPerfTimeElapsed
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total elapsed seconds in this interval."
+   ::= { xdsl2PMChCurrEntry 4 }
+
+xdsl2PMChCurr15MCodingViolations  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of CRC-8 (FEBE for xTU-R) anomalies occurring in the
+       channel during the interval.  This parameter is inhibited during
+       UAS or SES.  If the CRC is applied over multiple channels, then
+       each related CRC-8 (or FEBE) anomaly SHOULD increment each of the
+       counters related to the individual channels."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.2.1.1 (CV-C)
+                 and paragraph #7.2.2.2.1 (CV-CFE)"
+  ::= { xdsl2PMChCurrEntry 5 }
+
+xdsl2PMChCurr15MCorrectedBlocks  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of FEC (FFEC for xTU-R) anomalies (corrected code
+       words) occurring in the channel during the interval.  This
+       parameter is inhibited during UAS or SES.  If the FEC is applied
+       over multiple channels, then each related FEC (or FFEC) anomaly
+       SHOULD increment each of the counters related to the individual
+       channels."
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 176]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.2.1.2 (FEC-C)
+                 and paragraph #7.2.2.2.2 (FEC-CFE)"
+   ::= { xdsl2PMChCurrEntry 6 }
+
+xdsl2PMChCurr1DayValidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..30)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The number of 24-hour PM intervals for which data was
+       collected.  The value will typically be equal to the maximum
+       number of 24-hour intervals the implementation is planned to
+       store (i.e., beyond the scope of this MIB module) unless the
+       measurement was (re-)started recently, in which case the value
+       will be the number of complete 24-hour intervals for which
+       the agent has at least some data.  In certain cases (e.g., in
+       the case where the agent is a proxy), it is possible that some
+       intervals are unavailable.  In this case, this interval is the
+       maximum interval number for which data is available."
+   ::= { xdsl2PMChCurrEntry 7 }
+
+xdsl2PMChCurr1DayInvalidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..30)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The number of 24-hour PM intervals for which no data is
+       available.  The value will typically be zero except in cases
+       where the data for some intervals are not available (e.g.,
+       in proxy situations)."
+   ::= { xdsl2PMChCurrEntry 8 }
+
+xdsl2PMChCurr1DayTimeElapsed  OBJECT-TYPE
+   SYNTAX      HCPerfTimeElapsed
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total elapsed seconds in this interval."
+   ::= { xdsl2PMChCurrEntry 9 }
+
+xdsl2PMChCurr1DayCodingViolations  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of CRC-8 (FEBE for xTU-R) anomalies occurring in the
+       channel during the interval.  This parameter is inhibited during
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 177]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       UAS or SES.  If the CRC is applied over multiple channels, then
+       each related CRC-8 (or FEBE) anomaly SHOULD increment each of the
+       counters related to the individual channels."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.2.1.1 (CV-C)
+                 and paragraph #7.2.2.2.1 (CV-CFE)"
+   ::= { xdsl2PMChCurrEntry 10 }
+
+xdsl2PMChCurr1DayCorrectedBlocks  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of FEC (FFEC for xTU-R) anomalies (corrected code
+       words) occurring in the channel during the interval.  This
+       parameter is inhibited during UAS or SES.  If the FEC is applied
+       over multiple channels, then each related FEC (or FFEC) anomaly
+       SHOULD increment each of the counters related to the individual
+       channels."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.2.1.2 (FEC-C)
+                 and paragraph #7.2.2.2.2 (FEC-CFE)"
+   ::= { xdsl2PMChCurrEntry 11 }
+
+-------------------------------------------
+--    PM channel history 15 Minutes      --
+-------------------------------------------
+
+xdsl2PMChHist15MinTable         OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2PMChHist15MinEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2PMChHist15MinTable contains Performance
+       Monitoring (PM) history for 15-minute intervals for DSL channels
+       PM."
+   ::= { xdsl2PMChannel 2 }
+
+xdsl2PMChHist15MinEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2PMChHist15MinEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "One index of this table is an interface index where the
+       interface has an ifType of a DSL channel.  A second index of
+       this table is the transmission unit.  The third index is the
+       interval number."
+   INDEX  { ifIndex,
+            xdsl2PMChHist15MUnit,
+            xdsl2PMChHist15MInterval }
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 178]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   ::= { xdsl2PMChHist15MinTable 1 }
+
+Xdsl2PMChHist15MinEntry  ::=
+   SEQUENCE {
+      xdsl2PMChHist15MUnit                     Xdsl2Unit,
+      xdsl2PMChHist15MInterval                 Unsigned32,
+      xdsl2PMChHist15MMonitoredTime            Unsigned32,
+      xdsl2PMChHist15MCodingViolations         Unsigned32,
+      xdsl2PMChHist15MCorrectedBlocks          Unsigned32,
+      xdsl2PMChHist15MValidInterval            TruthValue
+   }
+
+xdsl2PMChHist15MUnit  OBJECT-TYPE
+   SYNTAX      Xdsl2Unit
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The termination unit."
+   ::= { xdsl2PMChHist15MinEntry 1 }
+
+xdsl2PMChHist15MInterval  OBJECT-TYPE
+   SYNTAX      Unsigned32 (1..96)
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The interval number."
+   ::= { xdsl2PMChHist15MinEntry 2 }
+
+xdsl2PMChHist15MMonitoredTime  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total seconds monitored in this interval."
+   ::= { xdsl2PMChHist15MinEntry 3 }
+
+xdsl2PMChHist15MCodingViolations  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of CRC-8 (FEBE for xTU-R) anomalies occurring in the
+       channel during the interval.  This parameter is inhibited during
+       UAS or SES.  If the CRC is applied over multiple channels, then
+       each related CRC-8 (or FEBE) anomaly SHOULD increment each of the
+       counters related to the individual channels."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.2.1.1 (CV-C)
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 179]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+                 and paragraph #7.2.2.2.1 (CV-CFE)"
+  ::= { xdsl2PMChHist15MinEntry 4 }
+
+xdsl2PMChHist15MCorrectedBlocks  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of FEC (FFEC for xTU-R) anomalies (corrected code
+       words) occurring in the channel during the interval.  This
+       parameter is inhibited during UAS or SES.  If the FEC is applied
+       over multiple channels, then each related FEC (or FFEC) anomaly
+       SHOULD increment each of the counters related to the individual
+       channels."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.2.1.2 (FEC-C)
+                 and paragraph #7.2.2.2.2 (FEC-CFE)"
+   ::= { xdsl2PMChHist15MinEntry 5 }
+
+xdsl2PMChHist15MValidInterval  OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This variable indicates if the data for this interval is
+       valid."
+   ::= { xdsl2PMChHist15MinEntry 6 }
+
+------------------------------------------
+--        PM channel history 1 Day      --
+------------------------------------------
+
+xdsl2PMChHist1DTable         OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2PMChHist1DEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2PMChHist1DTable contains Performance
+       Monitoring (PM) history for 1-day intervals for DSL channels
+       PM."
+   ::= { xdsl2PMChannel 3 }
+
+xdsl2PMChHist1DEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2PMChHist1DEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "One index of this table is an interface index where the
+       interface has an ifType of a DSL channel.  A second index of
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 180]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       this table is the transmission unit.  The third index is the
+       interval number."
+   INDEX  { ifIndex,
+            xdsl2PMChHist1DUnit,
+            xdsl2PMChHist1DInterval }
+   ::= { xdsl2PMChHist1DTable 1 }
+
+Xdsl2PMChHist1DEntry  ::=
+   SEQUENCE {
+      xdsl2PMChHist1DUnit                      Xdsl2Unit,
+      xdsl2PMChHist1DInterval                  Unsigned32,
+      xdsl2PMChHist1DMonitoredTime             Unsigned32,
+      xdsl2PMChHist1DCodingViolations          Unsigned32,
+      xdsl2PMChHist1DCorrectedBlocks           Unsigned32,
+      xdsl2PMChHist1DValidInterval             TruthValue
+   }
+
+xdsl2PMChHist1DUnit  OBJECT-TYPE
+   SYNTAX      Xdsl2Unit
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The termination unit."
+    ::= { xdsl2PMChHist1DEntry 1 }
+
+xdsl2PMChHist1DInterval  OBJECT-TYPE
+   SYNTAX      Unsigned32 (1..30)
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The interval number."
+   ::= { xdsl2PMChHist1DEntry 2 }
+
+xdsl2PMChHist1DMonitoredTime  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total seconds monitored in this interval."
+   ::= { xdsl2PMChHist1DEntry 3 }
+
+xdsl2PMChHist1DCodingViolations  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of CRC-8 (FEBE for xTU-R) anomalies occurring in the
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 181]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+       channel during the interval.  This parameter is inhibited during
+       UAS or SES.  If the CRC is applied over multiple channels, then
+       each related CRC-8 (or FEBE) anomaly SHOULD increment each of the
+       counters related to the individual channels."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.2.1.1 (CV-C)
+                 and paragraph #7.2.2.2.1 (CV-CFE)"
+   ::= { xdsl2PMChHist1DEntry 4 }
+
+xdsl2PMChHist1DCorrectedBlocks  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of FEC (FFEC for xTU-R) anomalies (corrected code
+       words) occurring in the channel during the interval.  This
+       parameter is inhibited during UAS or SES.  If the FEC is applied
+       over multiple channels, then each related FEC (or FFEC) anomaly
+       SHOULD increment each of the counters related to the individual
+       channels."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.2.1.2 (FEC-C)
+                 and paragraph #7.2.2.2.2 (FEC-CFE)"
+   ::= { xdsl2PMChHist1DEntry 5 }
+
+xdsl2PMChHist1DValidInterval  OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This variable indicates if the data for this interval is
+       valid."
+   ::= { xdsl2PMChHist1DEntry 6 }
+
+-------------------------------------------
+--          Notifications Group          --
+-------------------------------------------
+
+xdsl2LinePerfFECSThreshXtuc NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLCurr15MFecs,
+   xdsl2LineAlarmConfProfileXtucThresh15MinFecs
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the FEC seconds threshold
+      has been reached/exceeded for the referred xTU-C."
+   ::= { xdsl2Notifications 1 }
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 182]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+xdsl2LinePerfFECSThreshXtur NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLCurr15MFecs,
+   xdsl2LineAlarmConfProfileXturThresh15MinFecs
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the FEC seconds threshold
+      has been reached/exceeded for the referred xTU-R."
+   ::= { xdsl2Notifications 2 }
+
+xdsl2LinePerfESThreshXtuc NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLCurr15MEs,
+   xdsl2LineAlarmConfProfileXtucThresh15MinEs
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the errored seconds
+      threshold has been reached/exceeded for the referred xTU-C."
+   ::= { xdsl2Notifications 3 }
+
+xdsl2LinePerfESThreshXtur NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLCurr15MEs,
+   xdsl2LineAlarmConfProfileXturThresh15MinEs
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the errored seconds
+      threshold has been reached/exceeded for the referred xTU-R."
+   ::= { xdsl2Notifications 4 }
+
+xdsl2LinePerfSESThreshXtuc NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLCurr15MSes,
+   xdsl2LineAlarmConfProfileXtucThresh15MinSes
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the severely errored seconds
+      threshold has been reached/exceeded for the referred xTU-C."
+   ::= { xdsl2Notifications 5 }
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 183]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+xdsl2LinePerfSESThreshXtur NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLCurr15MSes,
+   xdsl2LineAlarmConfProfileXturThresh15MinSes
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the severely errored seconds
+      threshold has been reached/exceeded for the referred xTU-R."
+   ::= { xdsl2Notifications 6 }
+
+xdsl2LinePerfLOSSThreshXtuc NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLCurr15MLoss,
+   xdsl2LineAlarmConfProfileXtucThresh15MinLoss
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the LOS seconds
+      threshold has been reached/exceeded for the referred xTU-C."
+   ::= { xdsl2Notifications 7 }
+
+xdsl2LinePerfLOSSThreshXtur NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLCurr15MLoss,
+   xdsl2LineAlarmConfProfileXturThresh15MinLoss
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the LOS seconds
+      threshold has been reached/exceeded for the referred xTU-R."
+   ::= { xdsl2Notifications 8 }
+
+xdsl2LinePerfUASThreshXtuc NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLCurr15MUas,
+   xdsl2LineAlarmConfProfileXtucThresh15MinUas
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the unavailable seconds
+      threshold has been reached/exceeded for the referred xTU-C."
+   ::= { xdsl2Notifications 9 }
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 184]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+xdsl2LinePerfUASThreshXtur NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLCurr15MUas,
+   xdsl2LineAlarmConfProfileXturThresh15MinUas
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the unavailable seconds
+      threshold has been reached/exceeded for the referred xTU-R."
+   ::= { xdsl2Notifications 10 }
+
+xdsl2LinePerfCodingViolationsThreshXtuc NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMChCurr15MCodingViolations,
+   xdsl2ChAlarmConfProfileXtucThresh15MinCodingViolations
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the coding violations
+      threshold has been reached/exceeded for the referred xTU-C."
+   ::= { xdsl2Notifications 11 }
+
+xdsl2LinePerfCodingViolationsThreshXtur NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMChCurr15MCodingViolations,
+   xdsl2ChAlarmConfProfileXturThresh15MinCodingViolations
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the coding violations
+      threshold has been reached/exceeded for the referred xTU-R."
+   ::= { xdsl2Notifications 12 }
+
+xdsl2LinePerfCorrectedThreshXtuc NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMChCurr15MCorrectedBlocks,
+   xdsl2ChAlarmConfProfileXtucThresh15MinCorrected
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the corrected blocks
+      (FEC events) threshold has been reached/exceeded for the
+      referred xTU-C."
+   ::= { xdsl2Notifications 13 }
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 185]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+xdsl2LinePerfCorrectedThreshXtur NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMChCurr15MCorrectedBlocks,
+   xdsl2ChAlarmConfProfileXturThresh15MinCorrected
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the corrected blocks
+      (FEC events) threshold has been reached/exceeded for the
+      referred xTU-R."
+   ::= { xdsl2Notifications 14 }
+
+xdsl2LinePerfFailedFullInitThresh NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLInitCurr15MFailedFullInits,
+   xdsl2LineAlarmConfProfileThresh15MinFailedFullInt
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the failed full
+      initializations threshold has been reached/exceeded for the
+      referred ADSL/ADSL2 or ADSL2 line."
+   ::= { xdsl2Notifications 15 }
+
+xdsl2LinePerfFailedShortInitThresh NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLInitCurr15MFailedShortInits,
+   xdsl2LineAlarmConfProfileThresh15MinFailedShrtInt
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the failed short
+      initializations threshold has been reached/exceeded for the
+      referred VDSL2/ADSL/ADSL2 or ADSL2+ line."
+   ::= { xdsl2Notifications 16 }
+
+xdsl2LineStatusChangeXtuc NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2LineStatusXtuc
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that a status change is
+      detected for the referred xTU-C."
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 186]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   ::= { xdsl2Notifications 17 }
+
+xdsl2LineStatusChangeXtur NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2LineStatusXtur
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that a status change is
+      detected for the referred xTU-R."
+   ::= { xdsl2Notifications 18 }
+
+
+   -- conformance information
+
+   xdsl2Groups OBJECT IDENTIFIER ::= { xdsl2Conformance 1 }
+   xdsl2Compliances OBJECT IDENTIFIER ::= { xdsl2Conformance 2 }
+
+   xdsl2LineMibCompliance MODULE-COMPLIANCE
+      STATUS  current
+      DESCRIPTION
+         "The compliance statement for SNMP entities which
+          manage VDSL2/ADSL/ADSL2 and ADSL2+ interfaces."
+      MODULE  -- this module
+      MANDATORY-GROUPS
+          {
+          xdsl2LineGroup,
+          xdsl2ChannelStatusGroup,
+          xdsl2SCStatusGroup,
+          xdsl2LineInventoryGroup,
+          xdsl2LineConfTemplateGroup,
+          xdsl2LineConfProfGroup,
+          xdsl2LineConfProfModeSpecGroup,
+          xdsl2LineConfProfModeSpecBandUsGroup,
+          xdsl2ChConfProfileGroup,
+          xdsl2LineAlarmConfTemplateGroup,
+          xdsl2PMLineCurrGroup,
+          xdsl2PMLineInitCurrGroup,
+          xdsl2PMLineHist15MinGroup,
+          xdsl2PMLineHist1DayGroup,
+          xdsl2PMLineInitHist15MinGroup,
+          xdsl2PMLineInitHist1DayGroup,
+          xdsl2PMChCurrGroup,
+          xdsl2PMChHist15MinGroup,
+          xdsl2PMChHist1DGroup
+          }
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 187]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   GROUP  xdsl2LineFallbackGroup
+      DESCRIPTION
+        "The group of configuration, status, and commands
+         objects on the line level that are associated with the fallback
+         feature."
+
+   GROUP  xdsl2LineBpscGroup
+      DESCRIPTION
+        "The group of configuration, status, and commands objects
+         on the line level that are associated with requesting a bits
+         per subcarrier measurement."
+
+   GROUP  xdsl2LineSegmentGroup
+      DESCRIPTION
+        "The group of status and commands objects on the line
+         level that are used to hold the results of the
+         bits-per-subcarrier measurement."
+
+   GROUP  xdsl2ChannelStatusAtmGroup
+      DESCRIPTION
+        "The group of status objects required when the data path
+         is ATM."
+
+   GROUP  xdsl2ChannelStatusPtmGroup
+      DESCRIPTION
+        "The group of status objects required when the data path
+         is PTM."
+
+   GROUP  xdsl2LineConfProfRaGroup
+      DESCRIPTION
+        "The group of objects required for controlling the
+         rate-adaptive behavior of the line."
+
+   GROUP  xdsl2LineConfProfMsgMinGroup
+      DESCRIPTION
+        "The group of objects required for controlling the rate
+         reserved for Overhead traffic."
+
+   GROUP  xdsl2LineAlarmConfProfileGroup
+      DESCRIPTION
+        "The group of objects that define the alarm thresholds
+         on line-level PM counters."
+
+   GROUP  xdsl2ChAlarmConfProfileGroup
+      DESCRIPTION
+        "The group of objects that define the alarm thresholds
+        on channel-level PM counters."
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 188]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   GROUP  xdsl2ChConfProfileAtmGroup
+      DESCRIPTION
+        "The group of configuration objects required when the data
+         path is ATM."
+
+   GROUP  xdsl2ChConfProfileMinResGroup
+      DESCRIPTION
+        "The group of configuration objects required for the
+         reserved data rate."
+
+   GROUP  xdsl2ChConfProfileOptAttrGroup
+      DESCRIPTION
+        "The group of various optional channel configuration
+        objects."
+
+   GROUP  xdsl2PMLineInitCurrShortGroup
+      DESCRIPTION
+        "The group of PM counters for the current intervals short
+         initializations."
+
+   GROUP  xdsl2PMLineInitHist15MinShortGroup
+      DESCRIPTION
+        "The group of PM counters for the previous 15-minute
+         intervals short initializations."
+
+   GROUP  xdsl2PMLineInitHist1DayShortGroup
+      DESCRIPTION
+        "The group of PM counters for the previous 24-hour
+         intervals short initializations."
+
+   GROUP  xdsl2ScalarSCGroup
+      DESCRIPTION
+        "The group of objects that report the available memory
+         resources for the DELT processes."
+
+   GROUP  xdsl2ThreshNotificationGroup
+      DESCRIPTION
+        "The group of thresholds crossing notifications."
+
+   GROUP  xdsl2StatusChangeNotificationGroup
+      DESCRIPTION
+        "The group of status change notifications."
+
+      ::= { xdsl2Compliances 1 }
+
+   -- units of conformance
+
+   xdsl2LineGroup OBJECT-GROUP
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 189]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      OBJECTS
+          {
+          xdsl2LineConfTemplate,
+          xdsl2LineAlarmConfTemplate,
+          xdsl2LineCmndConfPmsf,
+          xdsl2LineCmndConfLdsf,
+          xdsl2LineCmndConfLdsfFailReason,
+          xdsl2LineCmndAutomodeColdStart,
+          xdsl2LineCmndConfReset,
+          xdsl2LineStatusXtuTransSys,
+          xdsl2LineStatusPwrMngState,
+          xdsl2LineStatusInitResult,
+          xdsl2LineStatusLastStateDs,
+          xdsl2LineStatusLastStateUs,
+          xdsl2LineStatusXtur,
+          xdsl2LineStatusXtuc,
+          xdsl2LineStatusAttainableRateDs,
+          xdsl2LineStatusAttainableRateUs,
+          xdsl2LineStatusActPsdDs,
+          xdsl2LineStatusActPsdUs,
+          xdsl2LineStatusActAtpDs,
+          xdsl2LineStatusActAtpUs,
+          xdsl2LineStatusActProfile,
+          xdsl2LineStatusActLimitMask,
+          xdsl2LineStatusActUs0Mask,
+          xdsl2LineStatusActSnrModeDs,
+          xdsl2LineStatusActSnrModeUs,
+          xdsl2LineStatusElectricalLength,
+          xdsl2LineStatusTssiDs,
+          xdsl2LineStatusTssiUs,
+          xdsl2LineStatusMrefPsdDs,
+          xdsl2LineStatusMrefPsdUs,
+          xdsl2LineStatusTrellisDs,
+          xdsl2LineStatusTrellisUs,
+          xdsl2LineStatusActualCe,
+          xdsl2LineBandStatusLnAtten,
+          xdsl2LineBandStatusSigAtten,
+          xdsl2LineBandStatusSnrMargin
+           }
+      STATUS     current
+      DESCRIPTION
+         "The group of configuration, status, and commands objects
+          on the line level."
+      ::= { xdsl2Groups 1 }
+
+   xdsl2LineFallbackGroup OBJECT-GROUP
+      OBJECTS
+          {
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 190]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+          xdsl2LineConfFallbackTemplate,
+          xdsl2LineStatusActTemplate
+           }
+      STATUS     current
+      DESCRIPTION
+         "The group of configuration, status, and commands
+          objects on the line level that are associated with the
+          fallback feature."
+      ::= { xdsl2Groups 2 }
+
+   xdsl2LineBpscGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2LineCmndConfBpsc,
+          xdsl2LineCmndConfBpscFailReason,
+          xdsl2LineCmndConfBpscRequests
+           }
+      STATUS     current
+      DESCRIPTION
+         "The group of configuration, status, and commands
+          objects on the line level that are associated with requesting
+          a bits-per-subcarrier measurement."
+      ::= { xdsl2Groups 3 }
+
+   xdsl2LineSegmentGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2LineSegmentBitsAlloc,
+          xdsl2LineSegmentRowStatus
+           }
+      STATUS     current
+      DESCRIPTION
+         "The group of status and commands objects on the line
+          level that are used to hold the results of the
+          bits-per-subcarrier measurement."
+      ::= { xdsl2Groups 4 }
+
+   xdsl2ChannelStatusGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2ChStatusActDataRate,
+          xdsl2ChStatusPrevDataRate,
+          xdsl2ChStatusActDelay,
+          xdsl2ChStatusActInp,
+          xdsl2ChStatusInpReport,
+          xdsl2ChStatusNFec,
+          xdsl2ChStatusRFec,
+          xdsl2ChStatusLSymb,
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 191]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+          xdsl2ChStatusIntlvDepth,
+          xdsl2ChStatusIntlvBlock,
+          xdsl2ChStatusLPath
+          }
+      STATUS     current
+      DESCRIPTION
+          "The group of status objects on the channel level."
+      ::= { xdsl2Groups 5 }
+
+   xdsl2ChannelStatusAtmGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2ChStatusAtmStatus
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of status objects on the data path level
+          when it is ATM."
+      ::= { xdsl2Groups 6 }
+
+   xdsl2ChannelStatusPtmGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2ChStatusPtmStatus
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of status objects on the data path level
+          when it is PTM."
+      ::= { xdsl2Groups 7 }
+
+   xdsl2SCStatusGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2SCStatusLinScale,
+          xdsl2SCStatusLinScGroupSize,
+          xdsl2SCStatusLogMt,
+          xdsl2SCStatusLogScGroupSize,
+          xdsl2SCStatusQlnMt,
+          xdsl2SCStatusQlnScGroupSize,
+          xdsl2SCStatusSnrMtime,
+          xdsl2SCStatusSnrScGroupSize,
+          xdsl2SCStatusBandLnAtten,
+          xdsl2SCStatusBandSigAtten,
+          xdsl2SCStatusAttainableRate,
+          xdsl2SCStatusRowStatus,
+          xdsl2SCStatusSegmentLinReal,
+          xdsl2SCStatusSegmentLinImg,
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 192]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+          xdsl2SCStatusSegmentLog,
+          xdsl2SCStatusSegmentQln,
+          xdsl2SCStatusSegmentSnr,
+          xdsl2SCStatusSegmentBitsAlloc,
+          xdsl2SCStatusSegmentGainAlloc
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of status objects on the subcarrier level.
+          They are updated as a result of a DELT process."
+      ::= { xdsl2Groups 8 }
+
+   xdsl2LineInventoryGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2LInvG994VendorId,
+          xdsl2LInvSystemVendorId,
+          xdsl2LInvVersionNumber,
+          xdsl2LInvSerialNumber,
+          xdsl2LInvSelfTestResult,
+          xdsl2LInvTransmissionCapabilities
+          }
+      STATUS     current
+      DESCRIPTION
+          "The group of inventory objects per xTU."
+      ::= { xdsl2Groups 9 }
+
+   xdsl2LineConfTemplateGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2LConfTempLineProfile,
+          xdsl2LConfTempChan1ConfProfile,
+          xdsl2LConfTempChan1RaRatioDs,
+          xdsl2LConfTempChan1RaRatioUs,
+          xdsl2LConfTempChan2ConfProfile,
+          xdsl2LConfTempChan2RaRatioDs,
+          xdsl2LConfTempChan2RaRatioUs,
+          xdsl2LConfTempChan3ConfProfile,
+          xdsl2LConfTempChan3RaRatioDs,
+          xdsl2LConfTempChan3RaRatioUs,
+          xdsl2LConfTempChan4ConfProfile,
+          xdsl2LConfTempChan4RaRatioDs,
+          xdsl2LConfTempChan4RaRatioUs,
+          xdsl2LConfTempRowStatus
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects in a line configuration
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 193]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+          template."
+      ::= { xdsl2Groups 10 }
+
+   xdsl2LineConfProfGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2LConfProfScMaskDs,
+          xdsl2LConfProfScMaskUs,
+          xdsl2LConfProfVdsl2CarMask,
+          xdsl2LConfProfRfiBands,
+          xdsl2LConfProfRaModeDs,
+          xdsl2LConfProfRaModeUs,
+          xdsl2LConfProfTargetSnrmDs,
+          xdsl2LConfProfTargetSnrmUs,
+          xdsl2LConfProfMaxSnrmDs,
+          xdsl2LConfProfMaxSnrmUs,
+          xdsl2LConfProfMinSnrmDs,
+          xdsl2LConfProfMinSnrmUs,
+          xdsl2LConfProfCeFlag,
+          xdsl2LConfProfSnrModeDs,
+          xdsl2LConfProfSnrModeUs,
+          xdsl2LConfProfTxRefVnDs,
+          xdsl2LConfProfTxRefVnUs,
+          xdsl2LConfProfXtuTransSysEna,
+          xdsl2LConfProfPmMode,
+          xdsl2LConfProfL0Time,
+          xdsl2LConfProfL2Time,
+          xdsl2LConfProfL2Atpr,
+          xdsl2LConfProfL2Atprt,
+          xdsl2LConfProfProfiles,
+          xdsl2LConfProfDpboEPsd,
+          xdsl2LConfProfDpboEsEL,
+          xdsl2LConfProfDpboEsCableModelA,
+          xdsl2LConfProfDpboEsCableModelB,
+          xdsl2LConfProfDpboEsCableModelC,
+          xdsl2LConfProfDpboMus,
+          xdsl2LConfProfDpboFMin,
+          xdsl2LConfProfDpboFMax,
+          xdsl2LConfProfUpboKL,
+          xdsl2LConfProfUpboKLF,
+          xdsl2LConfProfUs0Mask,
+          xdsl2LConfProfForceInp,
+          xdsl2LConfProfRowStatus
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects in a line configuration
+          profile."
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 194]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      ::= { xdsl2Groups 11 }
+
+   xdsl2LineConfProfRaGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2LConfProfRaUsNrmDs,
+          xdsl2LConfProfRaUsNrmUs,
+          xdsl2LConfProfRaUsTimeDs,
+          xdsl2LConfProfRaUsTimeUs,
+          xdsl2LConfProfRaDsNrmDs,
+          xdsl2LConfProfRaDsNrmUs,
+          xdsl2LConfProfRaDsTimeDs,
+          xdsl2LConfProfRaDsTimeUs
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects required for controlling the
+          rate-adaptive behavior of the line."
+      ::= { xdsl2Groups 12 }
+
+   xdsl2LineConfProfMsgMinGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2LConfProfMsgMinUs,
+          xdsl2LConfProfMsgMinDs
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects required for controlling the rate
+          reserved for Overhead traffic."
+      ::= { xdsl2Groups 13 }
+
+   xdsl2LineConfProfModeSpecGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2LConfProfMaxNomPsdDs,
+          xdsl2LConfProfMaxNomPsdUs,
+          xdsl2LConfProfMaxNomAtpDs,
+          xdsl2LConfProfMaxNomAtpUs,
+          xdsl2LConfProfMaxAggRxPwrUs,
+          xdsl2LConfProfPsdMaskDs,
+          xdsl2LConfProfPsdMaskUs,
+          xdsl2LConfProfPsdMaskSelectUs,
+          xdsl2LConfProfClassMask,
+          xdsl2LConfProfLimitMask,
+          xdsl2LConfProfUs0Disable,
+          xdsl2LConfProfModeSpecRowStatus
+          }
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 195]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      STATUS     current
+      DESCRIPTION
+         "The group of objects in a line configuration profile
+          that have an instance for each operation mode allowed."
+      ::= { xdsl2Groups 14 }
+
+   xdsl2LineConfProfModeSpecBandUsGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2LConfProfUpboPsdA,
+          xdsl2LConfProfUpboPsdB,
+          xdsl2LConfProfModeSpecBandUsRowStatus
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects in a line configuration profile
+          that have several per-upstream-band instances for each
+          operation mode allowed."
+      ::= { xdsl2Groups 15 }
+
+   xdsl2ChConfProfileGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2ChConfProfMinDataRateDs,
+          xdsl2ChConfProfMinDataRateUs,
+          xdsl2ChConfProfMaxDataRateDs,
+          xdsl2ChConfProfMaxDataRateUs,
+          xdsl2ChConfProfMinDataRateLowPwrDs,
+          xdsl2ChConfProfMinDataRateLowPwrUs,
+          xdsl2ChConfProfMaxDelayDs,
+          xdsl2ChConfProfMaxDelayUs,
+          xdsl2ChConfProfMinProtectionDs,
+          xdsl2ChConfProfMinProtectionUs,
+          xdsl2ChConfProfMinProtection8Ds,
+          xdsl2ChConfProfMinProtection8Us,
+          xdsl2ChConfProfMaxBerDs,
+          xdsl2ChConfProfMaxBerUs,
+          xdsl2ChConfProfUsDataRateDs,
+          xdsl2ChConfProfDsDataRateDs,
+          xdsl2ChConfProfUsDataRateUs,
+          xdsl2ChConfProfDsDataRateUs,
+          xdsl2ChConfProfRowStatus
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects in a channel configuration
+          profile."
+      ::= { xdsl2Groups 16 }
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 196]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   xdsl2ChConfProfileAtmGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2ChConfProfImaEnabled,
+          xdsl2ChStatusAtmStatus
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of configuration objects required when the data
+          path is ATM."
+      ::= { xdsl2Groups 17 }
+
+   xdsl2ChConfProfileMinResGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2ChConfProfMinResDataRateDs,
+          xdsl2ChConfProfMinResDataRateUs
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of configuration objects required for the
+          reserved data rate."
+      ::= { xdsl2Groups 18 }
+   xdsl2ChConfProfileOptAttrGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2ChConfProfMaxDelayVar,
+          xdsl2ChConfProfInitPolicy
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of various optional channel configuration
+          parameters."
+      ::= { xdsl2Groups 19 }
+
+   xdsl2LineAlarmConfTemplateGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2LAlarmConfTempLineProfile,
+          xdsl2LAlarmConfTempChan1ConfProfile,
+          xdsl2LAlarmConfTempChan2ConfProfile,
+          xdsl2LAlarmConfTempChan3ConfProfile,
+          xdsl2LAlarmConfTempChan4ConfProfile,
+          xdsl2LAlarmConfTempRowStatus
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects in a line alarm template."
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 197]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      ::= { xdsl2Groups 20 }
+
+   xdsl2LineAlarmConfProfileGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2LineAlarmConfProfileXtucThresh15MinFecs,
+          xdsl2LineAlarmConfProfileXtucThresh15MinEs,
+          xdsl2LineAlarmConfProfileXtucThresh15MinSes,
+          xdsl2LineAlarmConfProfileXtucThresh15MinLoss,
+          xdsl2LineAlarmConfProfileXtucThresh15MinUas,
+          xdsl2LineAlarmConfProfileXturThresh15MinFecs,
+          xdsl2LineAlarmConfProfileXturThresh15MinEs,
+          xdsl2LineAlarmConfProfileXturThresh15MinSes,
+          xdsl2LineAlarmConfProfileXturThresh15MinLoss,
+          xdsl2LineAlarmConfProfileXturThresh15MinUas,
+          xdsl2LineAlarmConfProfileThresh15MinFailedFullInt,
+          xdsl2LineAlarmConfProfileThresh15MinFailedShrtInt,
+          xdsl2LineAlarmConfProfileRowStatus
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects in a line alarm profile."
+      ::= { xdsl2Groups 21 }
+
+   xdsl2ChAlarmConfProfileGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2ChAlarmConfProfileXtucThresh15MinCodingViolations,
+          xdsl2ChAlarmConfProfileXtucThresh15MinCorrected,
+          xdsl2ChAlarmConfProfileXturThresh15MinCodingViolations,
+          xdsl2ChAlarmConfProfileXturThresh15MinCorrected,
+          xdsl2ChAlarmConfProfileRowStatus
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects in a channel alarm profile."
+      ::= { xdsl2Groups 22 }
+
+   xdsl2PMLineCurrGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMLCurr15MValidIntervals,
+          xdsl2PMLCurr15MInvalidIntervals,
+          xdsl2PMLCurr15MTimeElapsed,
+          xdsl2PMLCurr15MFecs,
+          xdsl2PMLCurr15MEs,
+          xdsl2PMLCurr15MSes,
+          xdsl2PMLCurr15MLoss,
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 198]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+          xdsl2PMLCurr15MUas,
+          xdsl2PMLCurr1DayValidIntervals,
+          xdsl2PMLCurr1DayInvalidIntervals,
+          xdsl2PMLCurr1DayTimeElapsed,
+          xdsl2PMLCurr1DayFecs,
+          xdsl2PMLCurr1DayEs,
+          xdsl2PMLCurr1DaySes,
+          xdsl2PMLCurr1DayLoss,
+          xdsl2PMLCurr1DayUas
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects that report the line-level
+          counters for current PM intervals."
+      ::= { xdsl2Groups 23 }
+
+   xdsl2PMLineInitCurrGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMLInitCurr15MValidIntervals,
+          xdsl2PMLInitCurr15MInvalidIntervals,
+          xdsl2PMLInitCurr15MTimeElapsed,
+          xdsl2PMLInitCurr15MFullInits,
+          xdsl2PMLInitCurr15MFailedFullInits,
+          xdsl2PMLInitCurr1DayValidIntervals,
+          xdsl2PMLInitCurr1DayInvalidIntervals,
+          xdsl2PMLInitCurr1DayTimeElapsed,
+          xdsl2PMLInitCurr1DayFullInits,
+          xdsl2PMLInitCurr1DayFailedFullInits
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects that report the full
+          initialization counters for current PM intervals."
+      ::= { xdsl2Groups 24 }
+
+   xdsl2PMLineInitCurrShortGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMLInitCurr15MShortInits,
+          xdsl2PMLInitCurr15MFailedShortInits,
+          xdsl2PMLInitCurr1DayShortInits,
+          xdsl2PMLInitCurr1DayFailedShortInits
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects that report the short
+          initialization counters for current PM intervals."
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 199]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      ::= { xdsl2Groups 25 }
+
+   xdsl2PMLineHist15MinGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMLHist15MMonitoredTime,
+          xdsl2PMLHist15MFecs,
+          xdsl2PMLHist15MEs,
+          xdsl2PMLHist15MSes,
+          xdsl2PMLHist15MLoss,
+          xdsl2PMLHist15MUas,
+          xdsl2PMLHist15MValidInterval
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of line-level PM counters for the previous
+          15-minute intervals."
+      ::= { xdsl2Groups 26 }
+
+   xdsl2PMLineHist1DayGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMLHist1DMonitoredTime,
+          xdsl2PMLHist1DFecs,
+          xdsl2PMLHist1DEs,
+          xdsl2PMLHist1DSes,
+          xdsl2PMLHist1DLoss,
+          xdsl2PMLHist1DUas,
+          xdsl2PMLHist1DValidInterval
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of line-level PM counters for the previous
+          24-hour intervals."
+      ::= { xdsl2Groups 27 }
+
+   xdsl2PMLineInitHist15MinGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMLInitHist15MMonitoredTime,
+          xdsl2PMLInitHist15MFullInits,
+          xdsl2PMLInitHist15MFailedFullInits,
+          xdsl2PMLInitHist15MValidInterval
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of PM counters for the previous 15-minute
+          interval full initializations."
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 200]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      ::= { xdsl2Groups 28 }
+
+   xdsl2PMLineInitHist15MinShortGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMLInitHist15MShortInits,
+          xdsl2PMLInitHist15MFailedShortInits
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of PM counters for the previous 15-minute
+          interval short initializations."
+      ::= { xdsl2Groups 29 }
+
+   xdsl2PMLineInitHist1DayGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMLInitHist1DMonitoredTime,
+          xdsl2PMLInitHist1DFullInits,
+          xdsl2PMLInitHist1DFailedFullInits,
+          xdsl2PMLInitHist1DValidInterval
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of PM counters for the previous 24-hour
+          interval full initializations."
+      ::= { xdsl2Groups 30 }
+
+   xdsl2PMLineInitHist1DayShortGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMLInitHist1DShortInits,
+          xdsl2PMLInitHist1DFailedShortInits
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of PM counters for the previous 24-hour
+          interval short initializations."
+      ::= { xdsl2Groups 31 }
+
+   xdsl2PMChCurrGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMChCurr15MValidIntervals,
+          xdsl2PMChCurr15MInvalidIntervals,
+          xdsl2PMChCurr15MTimeElapsed,
+          xdsl2PMChCurr15MCodingViolations,
+          xdsl2PMChCurr15MCorrectedBlocks,
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 201]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+          xdsl2PMChCurr1DayValidIntervals,
+          xdsl2PMChCurr1DayInvalidIntervals,
+          xdsl2PMChCurr1DayTimeElapsed,
+          xdsl2PMChCurr1DayCodingViolations,
+          xdsl2PMChCurr1DayCorrectedBlocks
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects that report the channel-level
+          counters for current PM intervals."
+      ::= { xdsl2Groups 32 }
+
+   xdsl2PMChHist15MinGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMChHist15MMonitoredTime,
+          xdsl2PMChHist15MCodingViolations,
+          xdsl2PMChHist15MCorrectedBlocks,
+          xdsl2PMChHist15MValidInterval
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects that report the channel-level
+          counters for previous 15-minute PM intervals."
+      ::= { xdsl2Groups 33 }
+
+   xdsl2PMChHist1DGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMChHist1DMonitoredTime,
+          xdsl2PMChHist1DCodingViolations,
+          xdsl2PMChHist1DCorrectedBlocks,
+          xdsl2PMChHist1DValidInterval
+          }
+      STATUS     current
+      DESCRIPTION
+        "The group of objects that report the channel-level
+        counters for previous 24-hour PM intervals."
+      ::= { xdsl2Groups 34 }
+
+   xdsl2ScalarSCGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2ScalarSCMaxInterfaces,
+          xdsl2ScalarSCAvailInterfaces
+          }
+      STATUS     current
+      DESCRIPTION
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 202]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+         "The group of objects that report the available memory
+          resources for DELT processes."
+      ::= { xdsl2Groups 35 }
+
+   xdsl2ThreshNotificationGroup NOTIFICATION-GROUP
+      NOTIFICATIONS
+      {
+      xdsl2LinePerfFECSThreshXtuc,
+      xdsl2LinePerfFECSThreshXtur,
+      xdsl2LinePerfESThreshXtuc,
+      xdsl2LinePerfESThreshXtur,
+      xdsl2LinePerfSESThreshXtuc,
+      xdsl2LinePerfSESThreshXtur,
+      xdsl2LinePerfLOSSThreshXtuc,
+      xdsl2LinePerfLOSSThreshXtur,
+      xdsl2LinePerfUASThreshXtuc,
+      xdsl2LinePerfUASThreshXtur,
+      xdsl2LinePerfCodingViolationsThreshXtuc,
+      xdsl2LinePerfCodingViolationsThreshXtur,
+      xdsl2LinePerfCorrectedThreshXtuc,
+      xdsl2LinePerfCorrectedThreshXtur,
+      xdsl2LinePerfFailedFullInitThresh,
+      xdsl2LinePerfFailedShortInitThresh
+      }
+      STATUS      current
+      DESCRIPTION
+         "This group supports notifications of significant
+          conditions associated with DSL lines."
+      ::= { xdsl2Groups 36 }
+
+   xdsl2StatusChangeNotificationGroup NOTIFICATION-GROUP
+      NOTIFICATIONS
+      {
+      xdsl2LineStatusChangeXtuc,
+      xdsl2LineStatusChangeXtur
+      }
+      STATUS      current
+      DESCRIPTION
+         "This group supports notifications of thresholds crossing
+          associated with DSL lines."
+      ::= { xdsl2Groups 37 }
+
+END
+
+4.  Implementation Analysis
+
+   A management application intended to manage ADSL links (e.g.,
+   G.992.1) with this MIB module MUST be modified to adapt itself to
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 203]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   certain differences between RFC 2662 [RFC2662] and this MIB module,
+   including the following aspects:
+
+   o  Though the configuration templates/profiles allow referring to 1-4
+      bearer channels, ADSL links are limited to two channels at most.
+
+   o  Though the channel configuration profile allows higher data rates,
+      ADSL links are limited to downstream/upstream data rate as assumed
+      in RFC 2662 [RFC2662].
+
+   o  The Impulse Noise Protection (INP) configuration parameters are
+      given by minimum protection and maximum delay parameters.
+
+   o  The line configuration profile includes a sub-table that addresses
+      mode-specific parameters.  For ADSL links, the management
+      application SHOULD create a row in that table for the ADSL modes
+      only.
+
+   o  The line configuration profile includes parameters that are
+      irrelevant for ADSL links.  Similarly, many status parameters in
+      the MIB are irrelevant for certain ADSL modes.  Therefore, it is
+      advised to consult with ITU G.997.1 standard [G.997.1] regarding
+      the scope and relevance of each parameter in this MIB.
+
+5.  Security Considerations
+
+   There are a number of management objects defined in this MIB module
+   with a MAX-ACCESS clause of read-write and/or read-create.  Such
+   objects may be considered sensitive or vulnerable in some network
+   environments.  The support for SET operations in a non-secure
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 204]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   environment without proper protection can have a negative effect on
+   network operations.  These are the tables and objects and their
+   sensitivity/vulnerability:
+
+   o  xdsl2LineTable
+
+      The table consists of the following objects that support SET
+      operations:
+
+      *  xdsl2LineConfTemplate
+
+      *  xdsl2LineConfFallbackTemplate
+
+      *  xdsl2LineAlarmConfTemplate
+
+      *  xdsl2LineCmndConfPmsf
+
+      *  xdsl2LineCmndConfLdsf
+
+      *  xdsl2LineCmndConfBpsc
+
+      *  xdsl2LineCmndAutomodeColdStart
+
+      *  xdsl2LineCmndConfReset
+
+
+      Unauthorized changes to xdsl2LineConfTemplate could have a major
+      adverse operational effect on many lines simultaneously.
+
+      Unauthorized changes to xdsl2LineConfFallbackTemplate could have a
+      major adverse operational effect on many lines simultaneously.
+
+      Unauthorized changes to xdsl2LineAlarmConfTemplate could have a
+      contrary effect on notifications.
+
+      Unauthorized changes to xdsl2LineCmndConfPmsf could have an
+      adverse affect on the power consumption of a line and may disrupt
+      an operational service.
+
+      Unauthorized changes to xdsl2LineCmndConfLdsf could cause an
+      unscheduled line test to be carried out on the line.
+
+      Unauthorized changes to xdsl2LineCmndConfBpsc could cause an
+      unscheduled bits-per-subcarrier measurement to be carried out on
+      the line.
+
+      Unauthorized changes to xdsl2LineCmndAutomodeColdStart could cause
+      an unscheduled cold reset to the line.
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 205]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      Unauthorized changes to xdsl2LineCmndConfReset could cause a
+      unscheduled retrain of a line.
+
+   o  xdsl2LineSegmentTable
+
+      This table contains one object, xdsl2LineSegmentRowStatus, that
+      supports SET operations.  Unauthorized changes could result in
+      measurement results being deleted prematurely.
+
+   o  xdsl2SCStatusTable
+
+      This table contains one object, xdsl2SCStatusRowStatus, that
+      supports SET operations.  Unauthorized changes could result in
+      line test results being deleted prematurely.
+
+
+   o  xdsl2LineConfTemplateTable
+
+      The table consists of the following objects that support SET
+      operations:
+
+      *  xdsl2LConfTempLineProfile
+
+      *  xdsl2LConfTempChan1ConfProfile
+
+      *  xdsl2LConfTempChan1RaRatioDs
+
+      *  xdsl2LConfTempChan1RaRatioUs
+
+      *  xdsl2LConfTempChan2ConfProfile
+
+      *  xdsl2LConfTempChan2RaRatioDs
+
+      *  xdsl2LConfTempChan2RaRatioUs
+
+      *  xdsl2LConfTempChan3ConfProfile
+
+      *  xdsl2LConfTempChan3RaRatioDs
+
+      *  xdsl2LConfTempChan3RaRatioUs
+
+      *  xdsl2LConfTempChan4ConfProfile
+
+      *  xdsl2LConfTempChan4RaRatioDs
+
+      *  xdsl2LConfTempChan4RaRatioUs
+
+      *  xdsl2LConfTempRowStatus
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 206]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      Unauthorized changes to xdsl2LConfTempLineProfile,
+      xdsl2LConfTempChan1ConfProfile, xdsl2LConfTempChan2ConfProfile,
+      xdsl2LConfTempChan3ConfProfile, or xdsl2LConfTempChan4ConfProfile
+      could have an adverse operational effect on several lines; could
+      change several lines over to running in unwanted levels of
+      operation; or could result in several services undergoing changes
+      in the number of channels that carry the service.
+
+      Unauthorized changes to xdsl2LConfTempChan1RaRatioDs,
+      xdsl2LConfTempChan2RaRatioDs, xdsl2LConfTempChan3RaRatioDs, or
+      xdsl2LConfTempChan4RaRatioDs would alter the relative rate
+      allocations among all channels belonging to a line.  This could
+      have an adverse operational effect on several lines.
+
+      Unauthorized changes to xdsl2LConfTempRowStatus could result in
+      templates being created or brought into service prematurely, or
+      they could result in templates being inadvertently deleted or
+      taken out of service.
+
+   o  xdsl2LineConfProfTable
+
+      The table consists of the following objects that support SET
+      operations:
+
+      *  xdsl2LConfProfScMaskDs
+
+      *  xdsl2LConfProfScMaskUs
+
+      *  xdsl2LConfProfRfiBandsDs
+
+      *  xdsl2LConfProfRaModeDs
+
+      *  xdsl2LConfProfRaModeUs
+
+      *  xdsl2LConfProfRaUsNrmDs
+
+      *  xdsl2LConfProfRaUsNrmUs
+
+      *  xdsl2LConfProfRaUsTimeDs
+
+      *  xdsl2LConfProfRaUsTimeUs
+
+      *  xdsl2LConfProfRaDsNrmDs
+
+      *  xdsl2LConfProfRaDsNrmUs
+
+      *  xdsl2LConfProfRaDsTimeDs
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 207]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      *  xdsl2LConfProfRaDsTimeUs
+
+      *  xdsl2LConfProfTargetSnrmDs
+
+      *  xdsl2LConfProfTargetSnrmUs
+
+      *  xdsl2LConfProfMaxSnrmDs
+
+      *  xdsl2LConfProfMaxSnrmUs
+
+      *  xdsl2LConfProfMinSnrmDs
+
+      *  xdsl2LConfProfMinSnrmUs
+
+      *  xdsl2LConfProfMsgMinUs
+
+      *  xdsl2LConfProfMsgMinDs
+
+      *  xdsl2LConfProfCeFlag
+
+      *  xdsl2LConfProfSnrModeDs
+
+      *  xdsl2LConfProfSnrModeUs
+
+      *  xdsl2LConfProfTxRefVnDs
+
+      *  xdsl2LConfProfTxRefVnUs
+
+      *  xdsl2LConfProfXtuTransSysEna
+
+      *  xdsl2LConfProfPmMode
+
+      *  xdsl2LConfProfL0Time
+
+      *  xdsl2LConfProfL2Time
+
+      *  xdsl2LConfProfL2Atpr
+
+      *  xdsl2LConfProfL2Atprt
+
+      *  xdsl2LConfProfProfiles
+
+      *  xdsl2LConfProfDpboEPsd
+
+      *  xdsl2LConfProfDpboEsEL
+
+      *  xdsl2LConfProfDpboEsCableModelA
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 208]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      *  xdsl2LConfProfDpboEsCableModelB
+
+      *  xdsl2LConfProfDpboEsCableModelC
+
+      *  xdsl2LConfProfDpboMus
+
+      *  xdsl2LConfProfDpboFMin
+
+      *  xdsl2LConfProfDpboFMax
+
+      *  xdsl2LConfProfUpboKL
+
+      *  xdsl2LConfProfUpboKLF
+
+      *  xdsl2LConfProfUs0Mask
+
+      *  xdsl2LConfProfForceInp
+
+      *  xdsl2LConfProfRowStatus
+
+      Unauthorized changes resulting in the setting of any of the above
+      objects to an incorrect value could have an adverse operational
+      effect on several lines.
+
+      Also, unauthorized changes to xdsl2LConfProfRowStatus could result
+      in unwanted line profiles being created or brought into service
+      prematurely, or they could result in line profiles being
+      inadvertently deleted or taken out of service.
+
+   o  xdsl2LineConfProfModeSpecTable
+
+      The table consists of the following objects that support SET
+      operations:
+
+      *  xdsl2LConfProfMaxNomPsdDs
+
+      *  xdsl2LConfProfMaxNomPsdUs
+
+      *  xdsl2LConfProfMaxNomAtpDs
+
+      *  xdsl2LConfProfMaxNomAtpUs
+
+      *  xdsl2LConfProfMaxAggRxPwrUs
+
+      *  xdsl2LConfProfPsdMaskDs
+
+      *  xdsl2LConfProfPsdMaskUs
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 209]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      *  xdsl2LConfProfPsdMaskSelectUs
+
+      *  xdsl2LConfProfClassMask
+
+      *  xdsl2LConfProfLimitMask
+
+      *  xdsl2LConfProfUs0Disable
+
+      *  xdsl2LConfProfModeSpecRowStatus
+
+      Unauthorized changes resulting in the setting of any of the above
+      objects to an incorrect value could have an adverse operational
+      effect on several lines.
+
+      Also, unauthorized changes to xdsl2LConfProfModeSpecRowStatus
+      could result in unwanted PSD configurations being created or
+      brought into service prematurely, or they could result in PSD
+      configurations being inadvertently deleted or taken out of
+      service.
+
+   o  xdsl2LineConfProfModeSpecBandUsTable
+
+      The table consists of the following objects that support SET
+      operations:
+
+      *  xdsl2LConfProfUpboPsdA
+
+      *  xdsl2LConfProfUpboPsdB
+
+      *  xdsl2LConfProfModeSpecRowStatus
+
+      Unauthorized changes resulting in the setting of any of the above
+      objects to an incorrect value could have an adverse operational
+      effect on several lines.
+
+      Also, unauthorized changes to
+      xdsl2LConfProfModeSpecBandUsRowStatus could result in unwanted PSD
+      configurations being created or brought into service prematurely,
+      or they could result in PSD configurations being inadvertently
+      deleted or taken out of service.
+
+   o  xdsl2ChConfProfileTable
+
+      The table consists of the following objects that support SET
+      operations:
+
+      *  xdsl2ChConfProfMinDataRateDs
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 210]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      *  xdsl2ChConfProfMinDataRateUs
+
+      *  xdsl2ChConfProfMinResDataRateDs
+
+      *  xdsl2ChConfProfMinResDataRateUs
+
+      *  xdsl2ChConfProfMaxDataRateDs
+
+      *  xdsl2ChConfProfMaxDataRateUs
+
+      *  xdsl2ChConfProfMinDataRateLowPwrDs
+
+      *  xdsl2ChConfProfMinDataRateLowPwrUs
+
+      *  xdsl2ChConfProfMaxDelayDs
+
+      *  xdsl2ChConfProfMaxDelayUs
+
+      *  xdsl2ChConfProfMinProtectionDs
+
+      *  xdsl2ChConfProfMinProtectionUs
+
+      *  xdsl2ChConfProfMinProtection8Ds
+
+      *  xdsl2ChConfProfMinProtection8Us
+
+      *  xdsl2ChConfProfMaxBerDs
+
+      *  xdsl2ChConfProfMaxBerUs
+
+      *  xdsl2ChConfProfUsDataRateDs
+
+      *  xdsl2ChConfProfDsDataRateDs
+
+      *  xdsl2ChConfProfUsDataRateUs
+
+      *  xdsl2ChConfProfDsDataRateUs
+
+      *  xdsl2ChConfProfImaEnabled
+
+      *  xdsl2ChConfProfMaxDelayVar
+
+      *  xdsl2ChConfProfInitPolicy
+
+      *  xdsl2ChConfProfRowStatus
+
+
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 211]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      Unauthorized changes resulting in the setting of any of the above
+      objects to an incorrect value could have an adverse operational
+      effect on several lines.
+
+      Also, unauthorized changes to xdsl2ChConfProfRowStatus could
+      result in unwanted channel profiles being created or brought into
+      service prematurely, or they could result in channel profiles
+      being inadvertently deleted or taken out of service.
+
+   o  xdsl2LineAlarmConfTemplateTable
+
+      The table consists of the following objects that support SET
+      operations:
+
+      *  xdsl2LAlarmConfTempLineProfile
+
+      *  xdsl2LAlarmConfTempChan1ConfProfile
+
+      *  xdsl2LalarmConfTempChan2ConfProfile
+
+      *  xdsl2LalarmConfTempChan3ConfProfile
+
+      *  xdsl2LalarmConfTempChan4ConfProfile
+
+      *  xdsl2LAlarmConfTempRowStatus
+
+      Unauthorized changes to xdsl2LAlarmConfTempLineProfile,
+      xdsl2LAlarmConfTempChan1ConfProfile,
+      xdsl2LAlarmConfTempChan2ConfProfile,
+      xdsl2LAlarmConfTempChan3ConfProfile, or
+      xdsl2LAlarmConfTempChan4ConfProfile could have an adverse effect
+      on the management of notifications generated at the scope of
+      several to many lines, or they could change several to many lines
+      over to running with unwanted management rates for generated
+      notifications.
+
+      Unauthorized changes to xdsl2LAlarmConfTempRowStatus could result
+      in alarm templates being created or brought into service
+      prematurely, or they could result in alarm templates being
+      inadvertently deleted or taken out of service.
+
+   o  xdsl2LineAlarmConfProfileTable
+
+      The table consists of the following objects that support SET
+      operations:
+
+      *  xdsl2LineAlarmConfProfileXtucThresh15MinFecs
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 212]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      *  xdsl2LineAlarmConfProfileXtucThresh15MinEs
+
+      *  xdsl2LineAlarmConfProfileXtucThresh15MinSes
+
+      *  xdsl2LineAlarmConfProfileXtucThresh15MinLoss
+
+      *  xdsl2LineAlarmConfProfileXtucThresh15MinUas
+
+      *  xdsl2LineAlarmConfProfileXturThresh15MinFecs
+
+      *  xdsl2LineAlarmConfProfileXturThresh15MinEs
+
+      *  xdsl2LineAlarmConfProfileXturThresh15MinSes
+
+      *  xdsl2LineAlarmConfProfileXturThresh15MinLoss
+
+      *  xdsl2LineAlarmConfProfileXturThresh15MinUas
+
+      *  xdsl2LineAlarmConfProfileThresh15MinFailedFullInt
+
+      *  xdsl2LineAlarmConfProfileThresh15MinFailedShrtInt
+
+      *  xdsl2LineAlarmConfProfileRowStatus
+
+      Increasing any of the threshold values could result in a
+      notification being suppressed or deferred.  Setting a threshold to
+      '0' could result in a notification being suppressed.  Suppressing
+      or deferring a notification could prevent the timely delivery of
+      important diagnostic information.  Decreasing any of the threshold
+      values could result in a notification being sent from the network
+      falsely reporting a threshold crossing.
+
+      Unauthorized changes to row status could result in unwanted line
+      alarm profiles being created or brought into service.  Also,
+      changes to the row status could result in line alarm profiles
+      being inadvertently deleted or taken out of service.
+
+   o  xdsl2ChAlarmConfProfileTable
+
+      The table consists of the following objects that support SET
+      operations:
+
+      *  xdsl2ChAlarmConfProfileXtucThresh15MinCodingViolations
+
+      *  xdsl2ChAlarmConfProfileXtucThresh15MinCorrected
+
+      *  xdsl2ChAlarmConfProfileXturThresh15MinCodingViolations
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 213]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      *  xdsl2ChAlarmConfProfileXturThresh15MinCorrected
+
+      *  xdsl2ChAlarmConfProfileRowStatus
+
+      *  xdsl2LineAlarmConfProfileXturThresh15MinFecs
+
+      *  xdsl2LineAlarmConfProfileXturThresh15MinEs
+
+      *  xdsl2LineAlarmConfProfileXturThresh15MinSes
+
+      *  xdsl2LineAlarmConfProfileXturThresh15MinLoss
+
+      *  xdsl2LineAlarmConfProfileXturThresh15MinUas
+
+      *  xdsl2LineAlarmConfProfileThresh15MinFailedFullInt
+
+      *  xdsl2LineAlarmConfProfileThresh15MinFailedShrtInt
+
+      *  xdsl2LineAlarmConfProfileRowStatus
+
+      Increasing any of the threshold values could result in a
+      notification being suppressed or deferred.  Setting a threshold to
+      '0' could result in a notification being suppressed.  Suppressing
+      or deferring a notification could prevent the timely delivery of
+      important diagnostic information.  Decreasing any of the threshold
+      values could result in a notification being sent from the network
+      falsely reporting a threshold crossing.
+
+      Unauthorized changes to row status could result in unwanted
+      channel alarm profiles being created or brought into service.
+      Also, changes to the row status could result in channel alarm
+      profiles being inadvertently deleted or taken out of service.
+
+   Some of the readable objects in this MIB module (i.e., objects with a
+   MAX-ACCESS other than not-accessible) may be considered sensitive or
+   vulnerable in some network environments.  It is thus important to
+   control even GET and/or NOTIFY access to these objects and possibly
+   to even encrypt the values of these objects when sending them over
+   the network via SNMP.  These are the tables and objects and their
+   sensitivity/vulnerability:
+
+   o  xdsl2LineInventoryTable
+
+      Access to these objects would allow an intruder to obtain
+      information about which vendor's equipment is in use on the
+      network.  Further, such information is considered sensitive in
+      many environments for competitive reasons.
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 214]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+      *  xdsl2LInvG994VendorId
+
+      *  xdsl2LInvSystemVendorId
+
+      *  xdsl2LInvVersionNumber
+
+      *  xdsl2LInvSerialNumber
+
+      *  xdsl2LInvSelfTestResult
+
+      *  xdsl2LInvTransmissionCapabilities
+
+   SNMP versions prior to SNMPv3 did not include adequate security.
+   Even if the network itself is secure (for example, by using IPsec),
+   even then, there is no control as to who on the secure network is
+   allowed to access and GET/SET (read/change/create/delete) the objects
+   in this MIB module.
+
+   It is RECOMMENDED that implementers consider the security features as
+   provided by the SNMPv3 framework (see [RFC3410], Section 8),
+   including full support for the SNMPv3 cryptographic mechanisms (for
+   authentication and privacy).
+
+   It is RECOMMENDED to deploy SNMPv3 and to enable cryptographic
+   security.  It is then a customer/operator responsibility to ensure
+   that the SNMP entity giving access to an instance of this MIB module
+   is properly configured to give access only to those objects whose
+   principals (users) have legitimate rights to indeed GET or SET
+   (change/create/delete) them.
+
+6.  Acknowledgments
+
+   The authors are deeply grateful to the authors of the HDSL2 LINE MIB
+   (RFC 4319), Clay Sikes and Bob Ray, for contributing to accelerating
+   the work on this document.  The structure of this document as well as
+   several paragraphs originate in their document.
+
+   Other contributions and advice were received from the following:
+
+         Randy Presuhn (Mindspring)
+         Chen  Jian    (Huawei)
+         Bert  Wijnen  (Lucent)
+         Brian Johnson (NEC Australia)
+         Andrew Cheers (NEC Australia)
+         Sedat Akca    (NEC Australia)
+         Victor Sperry (Calix Networks)
+         Narendranath Nair (Wipro)
+         Uwe Pauluhn   (Infineon)
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 215]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+         John D. Boyle (Alcatel)
+         Edward Beili  (Actelis)
+         Dan Romascanu (Avaya)
+         David Harrington (Comcast)
+         Smadar Tauber (RAD Data Communications)
+         Richard Barnes (BBN Technologies)
+
+7.  References
+
+7.1.  Normative References
+
+   [G.992.1]      "Asymmetric digital subscriber line (ADSL)
+                  transceivers", ITU-T G.992.1, 1999.
+
+   [G.992.2]      "Splitterless asymmetric digital subscriber line
+                  (ADSL) transceivers", ITU-T G.992.2, 1999.
+
+   [G.992.3]      "Asymmetric digital subscriber line transceivers 2
+                  (ADSL2)", ITU-T G.992.3, 2002.
+
+   [G.992.4]      "Splitterless asymmetric digital subscriber line
+                  transceivers 2 (Splitterless ADSL2)", ITU-T G.992.4,
+                  2002.
+
+   [G.992.5]      "Asymmetric digital subscriber line (ADSL)
+                  transceivers - Extended bandwidth ADSL2 (ADSL2+)",
+                  ITU-T G.992.5, 2005.
+
+   [G.993.1]      "Very-high speed Digital Subscriber Line
+                  Transceivers", ITU-T G.993.1, June 2004.
+
+   [G.993.2]      "Very-high speed Digital Subscriber Line Transceivers
+                  2 (VDSL2 draft)", ITU-T G.993.2, February 2006.
+
+   [G.997.1]      "Physical layer management for digital subscriber line
+                  (DSL) transceivers", ITU-T G.997.1, June 2006.
+
+   [G.997.1-Am1]  "Physical layer management for digital subscriber line
+                  (DSL) transceivers - Amendment 1", ITU-T G.997.1-
+                  Amendment 1, December 2006.
+
+   [RFC2119]      Bradner, S., "Key words for use in RFCs to Indicate
+                  Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2578]      McCloghrie, K., Ed., Perkins, D., Ed., and J.
+                  Schoenwaelder, Ed., "Structure of Management
+                  Information Version 2 (SMIv2)", STD 58, RFC 2578,
+                  April 1999.
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 216]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   [RFC2579]      McCloghrie, K., Ed., Perkins, D., Ed., and J.
+                  Schoenwaelder, Ed., "Textual Conventions for SMIv2",
+                  STD 58, RFC 2579, April 1999.
+
+   [RFC2580]      McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+                  "Conformance Statements for SMIv2", STD 58, RFC 2580,
+                  April 1999.
+
+   [RFC2863]      McCloghrie, K. and F. Kastenholz, "The Interfaces
+                  Group MIB", RFC 2863, June 2000.
+
+   [RFC3411]      Harrington, D., Presuhn, R., and B. Wijnen, "An
+                  Architecture for Describing Simple Network Management
+                  Protocol (SNMP) Management Frameworks", STD 62,
+                  RFC 3411, December 2002.
+
+   [RFC3593]      Tesink, K., "Textual Conventions for MIB Modules Using
+                  Performance History Based on 15 Minute Intervals",
+                  RFC 3593, September 2003.
+
+   [RFC3705]      Ray, B. and R. Abbi, "High Capacity Textual
+                  Conventions for MIB Modules Using Performance History
+                  Based on 15 Minute Intervals", RFC 3705,
+                  February 2004.
+
+   [T1E1.413]     J. Bingham & F. Van der Putten, "Network and Customer
+                  Installation Interfaces - Asymmetric Digital
+                  Subscriber Line (ADSL) Metallic Interface (T1.413
+                  Issue 2)", ANSI T1E1.413-1998, June 1998.
+
+7.2.  Informative References
+
+   [RFC2662]      Bathrick, G. and F. Ly, "Definitions of Managed
+                  Objects for the ADSL Lines", RFC 2662, August 1999.
+
+   [RFC3410]      Case, J., Mundy, R., Partain, D., and B. Stewart,
+                  "Introduction and Applicability Statements for
+                  Internet-Standard Management Framework", RFC 3410,
+                  December 2002.
+
+   [RFC3418]      Presuhn, R., "Management Information Base (MIB) for
+                  the Simple Network Management Protocol (SNMP)",
+                  STD 62, RFC 3418, December 2002.
+
+   [RFC3728]      Ray, B. and R. Abbi, "Definitions of Managed Objects
+                  for Very High Speed Digital Subscriber Lines (VDSL)",
+                  RFC 3728, February 2004.
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 217]
+
+RFC 5650                     VDSL2-LINE MIB               September 2009
+
+
+   [RFC4133]      Bierman, A. and K. McCloghrie, "Entity MIB (Version
+                  3)", RFC 4133, August 2005.
+
+   [RFC4706]      Morgenstern, M., Dodge, M., Baillie, S., and U.
+                  Bonollo, "Definitions of Managed Objects for
+                  Asymmetric Digital Subscriber Line 2 (ADSL2)",
+                  RFC 4706, November 2006.
+
+   [TR-129]       Adams, P., "Protocol Independent Management Model for
+                  Next Generation DSL Technologies", DSL Forum TR-129,
+                  December 2006.
+
+Authors' Addresses
+
+   Moti Morgenstern
+   ECI Telecom Ltd.
+   30 Hasivim St.
+   Petach Tikva  49517
+   Israel
+
+   Phone: +972 3 926 6258
+   Fax:   +972 3 928 7342
+   EMail: moti.Morgenstern@ecitele.com
+
+
+   Scott Baillie
+   NEC Australia
+   649-655 Springvale Road
+   Mulgrave, Victoria  3170
+   Australia
+
+   Phone: +61 3 9264 3986
+   Fax:   +61 3 9264 3892
+   EMail: scott.baillie@nec.com.au
+
+
+   Umberto Bonollo
+   NEC Australia
+   649-655 Springvale Road
+   Mulgrave, Victoria  3170
+   Australia
+
+   Phone: +61 3 9264 3385
+   Fax:   +61 3 9264 3892
+   EMail: umberto.bonollo@nec.com.au
+
+
+
+
+
+
+Morgenstern, et al.         Standards Track                   [Page 218]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc5650.txt](<www.ietf.org/rfc/rfc5650.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
