### PR TITLE
Archive rfc565.txt

### DIFF
--- a/www.ietf.org/rfc/rfc565.txt
+++ b/www.ietf.org/rfc/rfc565.txt
@@ -1,0 +1,283 @@
+
+
+
+
+
+
+Network Working Group                                          D. Cantor
+Request for Comments: 565                Computer Corporation of America
+NIC: 18777                                                28 August 1973
+
+
+            Storing Network Survey Data at the Datacomputer
+
+   In November, 1972, Computer Corporation of America (CCA) and the
+   Programming Technology Division of the Dynamics Modeling System (DMS)
+   at M.I.T.'s Project MAC began planning to transmit to CCA's
+   datacomputer [1] information about the behavior of ARPA network hosts
+   collected by DMS's program SURVEY [2].  The information was to be
+   stored at the datacomputer and retrieved by an interactive program
+   that would address the datacomputer from DMS's PDP-10.
+
+   One goal of this joint project was to enable DMS to retain all of the
+   information that SURVEY collects: SURVEY had been running since late
+   1971, saving only a short daily summary of its findings and
+   discarding potentially useful details.  A second goal was to discover
+   and remove shortcomings in the interface between CCA's datacomputer
+   and a program running at a remote host.
+
+   The project was completed last month, and the programs described in
+   this document have been operating successfully with the datacomputer
+   since July 10.
+
+   Part 1, below, describes SURVEY's output.  Part 2 describes a program
+   that retrieves portions of that output from the datacomputer.
+
+Part 1: The Survey Database
+
+   Every twenty minutes, DMS's program SURVEY wakes up and performs the
+   initial connection protocol from the PDP-10 at DMS to the logger
+   socket (socket 1) of each 28 network hosts.
+
+   SURVEY records a date time, host, status,and response time for each
+   host.  A host may be in one of these states:
+
+      undetermined or not surveyed
+
+      disconnect from the network or dead
+
+      network control program not responding
+
+      ICP to logger aborted by the host
+
+      ICP to logger timed out by SURVEY after 20 seconds
+
+
+
+
+Cantor                                                          [Page 1]
+
+RFC 565               Storing Network Survey Data         28 August 1973
+
+
+      logger available and responding within 20 seconds
+
+   SURVEY records response times responding in tenths of seconds.
+
+   When the data for all 28 hosts has been assembled, SURVEY transmits
+   that data to CCA's datacomputer.  If for some reason the datacomputer
+   cannot accept the information, it is held at DMS and sent another
+   time.
+
+   The datacomputer's survey database is inverted by host, status,
+   month, and year.  That is to say that the datacomputer maintains
+   several indices to records of one attempt to establish a full duplex
+   connection to one host's logger: it maintains one such index for each
+   host, one for each status, one for each month, and one for each year.
+   The datacomputer can select records that are specified in boolean
+   expressions by performing boolean operations on the inversion, and
+   without consulting the data itself.  The inversion thus facilitates
+   rapid interaction between the survey retrieval program described
+   below and the survey database at the datacomputer.
+
+   SURVEY expresses the record of each attempt to access one host in 17
+   ASCII characters.  The record of one survey then occupies 17 * 28 =
+   476 characters, and each day the datacomputer receives 3 * 24 * 476 =
+   34,272 characters from DMS.
+
+Part 2: Retrieving Survey Data
+
+   A Program called SURRET, written at DMS in the language MUDDLE,
+   allows one to selectively retrieve material from the survey data base
+   stored at the datacomputer [3].  Its user may specify values, groups
+   of values, or, where appropriate, upper and lower bounds for values
+   of each of five fields: host name, date, time, response time, and
+   host status.  In addition, one may request that all five fields or
+   any subset of the five be retrieved.  A sample interaction with
+   SURRET is reproduced below.
+
+    <HOST (CASE-10)>$
+    "OK"
+    <DATE (AUG 5 73)>$
+    "OK"
+    <TIME (BETWEEN 2000 2400)>$
+    "OK"
+    <REQ ((TIME STATUS RESTIME))>$
+    ;J205 10-08-73 1557:20 RHRUN: SUCCESSFUL COMPILATION
+    .1241 10-08-73 1557:21 OCSOP: (DEFAULT) OUTPUT PORT OPENED
+
+
+
+
+
+
+Cantor                                                          [Page 2]
+
+RFC 565               Storing Network Survey Data         28 August 1973
+
+
+   TIME           STATUS             R.T.(1/10 SEC)
+   2004    LOGGER RESPONDING (UP)        019
+   2024    LOGGER RESPONDING (UP)        024
+   2044    LOGGER RESPONDING (UP)        021
+   2104    LOGGER RESPONDING (UP)        016
+   2124    LOGGER RESPONDING (UP)        046
+   2144    LOGGER RESPONDING (UP)        018
+   2204    LOGGER RESPONDING (UP)        017
+   2224    LOGGER RESPONDING (UP)        017
+   2244    LOGGER RESPONDING (UP)        023
+   2304    LOGGER RESPONDING (UP)        015
+   2324    LOGGER RESPONDING (UP)        016
+   2344    LOGGER RESPONDING (UP)        015
+   "END OF DATCOMPUTER OUTPUT"
+
+   The angle brackets, the material they enclose, and '$' (ESC or
+   altmode) were typed by a person using SURRET.  The remainder was
+   typed by the system.  The phrases in quotation marks are,
+   effectively, SURRET prompts.  The status messages beginning with ';'
+   and '.' were generated by the datacomputer.  The column headings and
+   table were formatted by SURRET using figures retrieved from the
+   datacomputer.
+
+   SURRET generates datalanguage, sends it to the datacomputer, and
+   processes systems diagnostics and data sent to it from the
+   datacomputer.  The datalanguage generated for the foregoing SURRET
+   request was:
+
+   FOR |SURVEY.LOGTRY, SURVEY.LOGTRY WITH
+     ((YEAR EQ '73' AND MONTH EQ '08' AND DAY EQ '05')
+     AND (HRMIN GE '2000' AND HRMIN LE '2400')
+     AND (HOST EQ '013'))
+   HRMIN=HRMIN ;  STATUS=STATUS  ;  RESTIME=RESTIME  ;
+   END;
+
+   The field names in the datalanguage were entered with file
+   descriptors before the first data was loaded.
+
+   One can ask SURRET to retrieve new data by changing the values of any
+   number of fields and issuing a new REQ (request).  The command
+   <state> displays current values for the five prospective retrieval
+   criteria.  Thus:
+
+    <HOST (USC-44)>$
+    "OK"
+    <STATE>$
+    !HOST: (USC-44)STATUS: () RESTIME: () DATE: (AUG 5 73)
+      TIME: (BETWEEN 2000 2400)!
+
+
+
+Cantor                                                          [Page 3]
+
+RFC 565               Storing Network Survey Data         28 August 1973
+
+
+    <REQ ((TIME STATUS RESTIME))>$
+    ;J205 10-08-73 1610:08 RHRUN: SUCCESSFUL COMPILATION
+    .1241 10-08-73 1610:09 OCSOP: (DEFAULT) OUTPUT PORT OPENED
+
+   TIME           STATUS             R.T.(1/10 SEC)
+   2004    LOGGER RESPONDING (UP)        020
+   2024    LOGGER RESPONDING (UP)        008
+   2044    LOGGER RESPONDING (UP)        008
+   2104    LOGGER RESPONDING (UP)        009
+   2124    LOGGER NOT RESPONDING (LNR)   000
+   2144    LOGGER NOT AVAILABLE(DEAD)    000
+   2204    NCP NOT RESPONDING (NNR)      000
+   2224    LOGGER NOT RESPONDING (LNR)   000
+   2244    LOGGER NOT AVAILABLE (DEAD)   000
+   2304    LOGGER NOT AVAILABLE (DEAD    000
+   2324    NCP NOT RESPONDING (NNR)      000
+   2344    LOGGER RESPONDING (UP)        007
+   "END OF DATCOMPUTER OUTPUT"
+
+   We might have retrieved all of the foregoing output with:
+
+         <HOST (CASE-10 OR USC-44)>
+
+      Moreover,
+
+         <HOST (CASE-10 CCA OR USC-44)>
+
+   would cause SURRET to access the database twice, once for information
+   about Case-10, and then a second time for information about the
+   remaining two hosts.
+
+   Detailed Survey data from July 10, 1973 forward is available either
+   directly from the datacomputer or through SURRET.  Persons who wish
+   to use the datacomputer directly may obtain the pertinent documents
+   through the NIC or by contacting Dale Stern at CCA (617-491-3670).
+
+Endnotes
+
+   [1] An overview of the data computer is given in Thomas Marill, The
+   Datacomputer, 18 Oct '71, 7pp. (NIC 7979).  A detailed study of the
+   programming language for addressing the datacomputer is found in
+   Computer Corporation of America, Datacomputer Project Working Paper
+   No. 3, Datalanguage, 29 Oct '71, 78 pp. (NIC 8208).  The current
+   status of the language is reviewed in Richard Winter, Specifications
+   for Datalanguage, Version 0/9, 6 Jun '73, 36 pp. (NIC 16446).  A
+   user's manual for version 0/9, will be released by CCA in September,
+   1973.
+
+
+
+
+Cantor                                                          [Page 4]
+
+RFC 565               Storing Network Survey Data         28 August 1973
+
+
+   [2] SURVEY is described in Abhay Bhushan, A Report on the Survey
+   Project, 22 June '73 (NIC 17375).
+
+   [3] A detailed discussion of SURRET is found in Safwan Bengelloun,
+   MUDDLE Survey Data Retrieval Programs, an internal DMS memo of 14
+   June, '73.  Our purpose here is to describe enough of the program's
+   syntax and structure to show how it interacts with the datacomputer.
+
+
+         [ This RFC was put into machine readable form for entry ]
+            [ into the online RFC archives by Via Genie 08/00]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Cantor                                                          [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc565.txt](<www.ietf.org/rfc/rfc565.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
