### PR TITLE
Archive rfc567.txt

### DIFF
--- a/www.ietf.org/rfc/rfc567.txt
+++ b/www.ietf.org/rfc/rfc567.txt
@@ -1,0 +1,43 @@
+Network Working Group                             L. Peter Deutsch  (PARC-MAXC)
+Request for Comments: 567                                     September 6, 1973
+NIC #18970
+
+
+
+            CROSS-COUNTRY NETWORK BANDWIDTH
+
+
+
+The following computation of cross-country network bandwidth was
+contributed by Butler Lampson of PARC.
+
+Consider what happens when a TIP user on the West Coast, connected to a
+full-duplex Host on the East Coast, strikes a key on his terminal.
+
+The TIP sends a one-character message (1 packet).
+
+The destination IMP sends a RFNM (1 packet).
+
+The destination Host sends an ALLocate - this seems to be the strategy
+used by TENEX Hosts, at least (1 packet).
+
+Thc TIP sends a RFNM for the ALLocate (1 packet).
+
+The same sequence repeats itself, with roles interchanged, for the echo
+character (4 packets).
+
+This constitutes 4 packets or 4OOO bits in each direction. The current
+cross-country transmission capability of the ARPANET is 3 5OKb phone
+lines; ergo, it can only support 3*50000/4000=37.5 such characters per
+second!
+
+It may be that RFNMs are transmitted between IMPs more efficiently; at
+best this can only double the network capacity.
+
+This computation may help explain why cross-country TIP users (e.g. the
+substantial West Coast community of BBN-TENEX users) experience such
+bad echo response, at least in bursts: the network itself may be
+experiencing momentary peak loads.
+
+If this argument is correct, the proposed remote echoing facilities of
+the new TELNET protocol could have a major effect on network operation.


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc567.txt](<www.ietf.org/rfc/rfc567.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
