### PR TITLE
Archive rfc571.txt

### DIFF
--- a/www.ietf.org/rfc/rfc571.txt
+++ b/www.ietf.org/rfc/rfc571.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                   Robert T. Braden
+Request for Comments: 571                                       UCLA/CCN
+NIC #18974                                             November 15, 1973
+
+
+                           TENEX FTP PROBLEM
+
+   Tenex users of FTP should beware of a problem in the current Tenex
+   implementation which is likely to cause incorrect results when
+   transferring files to a non-Tenex site.  Some Tenex programs create
+   an ASCII US (Unit Separator) character as an end-of-line indicator,
+   instead of CR LF.  The current Tenex FTP user implementation passes
+   these US characters over the Network instead of translating them to
+   CR LF as required by FTP protocol.  If the recipient is not a Tenex,
+   he will not do anything special with these US characters and the line
+   spacing will be lost. In the case of sending to CCN, we will treat it
+   as a very long logical record and fold it into successive 360
+   records.
+
+   A circumvention is to pass the Tenex file through some Tenex program
+   that does the necessary conversion before sending it over the
+   Network.  We know that TECO will remove US's; there are probably
+   other means.  Loading and saving the file with TECO will replace all
+   US's with CR LF sequences.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+         [ This RFC was put into machine readable form for entry ]
+         [ into the online RFC archives by Katsunori Tanaka 4/99 ]
+
+
+
+
+
+
+Braden                                                          [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc571.txt](<www.ietf.org/rfc/rfc571.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
