### PR TITLE
Archive rfc574.txt

### DIFF
--- a/www.ietf.org/rfc/rfc574.txt
+++ b/www.ietf.org/rfc/rfc574.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                     M. Krilanovich
+Request for Comments: 574                                           UCSB
+NIC: 19144                                             26 September 1973
+
+
+                Announcement of a Mail Facility at UCSB
+
+   There now exists a server program at UCSB, resident under socket 3,
+   which supports that subset of the File Transfer Protocol necessary
+   for mail delivery.  Only the MAIL and BYE commands are implemented at
+   this time.
+
+   Mail may be sent to an individual at UCSB by specifying his local
+   user name in the MAIL command.  The following is a list of those
+   individuals currently defined as valid recipients of Network mail,
+   each with their respective user name:  Ed Faeh (FAEH), Jim Guyton
+   (GUYTON), Mark Krilanovich (KRILANOV), Curtis Mosso (MOSSO), John
+   Pickens (PICKENS), and Ron Stoughton (STOUGHTN).  In addition, any
+   general comments or complaints about UCSB services may be sent to
+   user name GRIPE.
+
+
+         [ This RFC was put into machine readable form for entry ]
+          [ into the online RFC archives by Dave Bachmann 1/98 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Krilanovich                                                     [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc574.txt](<www.ietf.org/rfc/rfc574.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
