### PR TITLE
Archive rfc5771.txt

### DIFF
--- a/www.ietf.org/rfc/rfc5771.txt
+++ b/www.ietf.org/rfc/rfc5771.txt
@@ -1,0 +1,619 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                         M. Cotton
+Request for Comments: 5771                                     L. Vegoda
+BCP: 51                                                            ICANN
+Updates: 2780                                                   D. Meyer
+Obsoletes: 3138, 3171                                         March 2010
+Category: Best Current Practice
+ISSN: 2070-1721
+
+
+         IANA Guidelines for IPv4 Multicast Address Assignments
+
+Abstract
+
+   This document provides guidance for the Internet Assigned Numbers
+   Authority (IANA) in assigning IPv4 multicast addresses.  It obsoletes
+   RFC 3171 and RFC 3138 and updates RFC 2780.
+
+Status of This Memo
+
+   This memo documents an Internet Best Current Practice.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   BCPs is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc5771.
+
+Copyright Notice
+
+   Copyright (c) 2010 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+Cotton, et al.            Best Current Practice                 [Page 1]
+
+RFC 5771                IPv4 Multicast Guidelines             March 2010
+
+
+Table of Contents
+
+   1. Introduction ....................................................2
+   2. Terminology .....................................................3
+   3. Definition of Current Assignment Practice .......................3
+   4. Local Network Control Block (224.0.0/24) ........................4
+      4.1. Assignment Guidelines ......................................4
+   5. Internetwork Control Block (224.0.1/24) .........................5
+      5.1. Assignment Guidelines ......................................5
+   6. AD-HOC Blocks (I, II, and III) ..................................5
+      6.1. Assignment Guidelines ......................................5
+   7. SDP/SAP Block (224.2/16) ........................................5
+      7.1. Assignment Guidelines ......................................5
+   8. Source-Specific Multicast Block (232/8) .........................6
+      8.1. Assignment Guidelines ......................................6
+   9. GLOP Block (233/8) ..............................................6
+      9.1. Assignment Guidelines ......................................6
+      9.2. AD-HOC Block III ...........................................6
+   10. Administratively Scoped Block (239/8) ..........................7
+      10.1. Assignment Guidelines .....................................7
+           10.1.1. Relative Offsets ...................................7
+   11. Application Form ...............................................7
+      11.1. Size of Assignments of IPv4 Multicast Addresses ...........7
+   12. Annual Review ..................................................8
+      12.1. Address Reclamation .......................................8
+      12.2. Positive Renewal ..........................................8
+   13. Use of IANA Reserved Addresses .................................8
+   14. IANA Considerations ............................................8
+   15. Security Considerations ........................................9
+   16. Acknowledgments ................................................9
+   17. References .....................................................9
+      17.1. Normative References ......................................9
+      17.2. Informative References ....................................9
+
+1.  Introduction
+
+   The Internet Assigned Numbers Authority (IANA) (www.iana.org) is
+   charged with allocating parameter values for fields in protocols that
+   have been designed, created, or are maintained by the Internet
+   Engineering Task Force (IETF).  RFC 2780 [RFC2780] provides the IANA
+   guidance in the assignment of parameters for fields in newly
+   developed protocols.  This memo expands on section 4.4.2 of RFC 2780
+   and attempts to codify existing IANA practice used in the assignment
+   of IPv4 multicast addresses.
+
+
+
+
+
+
+
+Cotton, et al.            Best Current Practice                 [Page 2]
+
+RFC 5771                IPv4 Multicast Guidelines             March 2010
+
+
+   This document is a revision of RFC 3171 [RFC3171], which it
+   obsoletes.  It also obsoletes RFC 3138 [RFC3138] and updates
+   [RFC2780].
+
+   The terms "Specification Required", "Expert Review", "IESG Approval",
+   "IETF Review", and "Standards Action", are used in this memo to refer
+   to the processes described in [RFC5226].
+
+   In general, due to the relatively small size of the IPv4 multicast
+   address space, further assignment of IPv4 multicast address space is
+   recommended only in limited circumstances.  Specifically, the IANA
+   should only assign addresses in those cases where:
+
+      - the dynamic selection Session Description Protocol/Session
+        Announcement Protocol (SDP/SAP);
+
+      - GLOP (not an acronym);
+
+      - Source-Specific Multicast (SSM); or
+
+      - Administratively Scoped address spaces cannot be used.
+
+   The guidelines described below are reflected in [IANA-protocols].
+   Network operators should also be aware of the availability of IPv6
+   multicast addresses and consider using them where feasible.
+
+2.  Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in BCP 14, RFC 2119
+   [RFC2119].
+
+   The word "allocation" designates a block of addresses managed by a
+   registry for the purpose of making assignments and allocations.  The
+   word "assignment" designates a block of addresses, or a single
+   address, registered to an end-user for use on a specific network or
+   set of networks.
+
+3.  Definition of Current Assignment Practice
+
+   Unlike IPv4 unicast address assignment, where blocks of addresses are
+   delegated to Regional Internet Registries (RIRs), IPv4 multicast
+   addresses are assigned directly by the IANA.  Current registration
+   groups appear as follows [IANA]:
+
+
+
+
+
+
+Cotton, et al.            Best Current Practice                 [Page 3]
+
+RFC 5771                IPv4 Multicast Guidelines             March 2010
+
+
+Address Range                 Size       Designation
+-------------                 ----       -----------
+224.0.0.0 - 224.0.0.255       (/24)      Local Network Control Block
+
+224.0.1.0 - 224.0.1.255       (/24)      Internetwork Control Block
+
+224.0.2.0 - 224.0.255.255     (65024)    AD-HOC Block I
+
+224.1.0.0 - 224.1.255.255     (/16)      RESERVED
+
+224.2.0.0 - 224.2.255.255     (/16)      SDP/SAP Block
+
+224.3.0.0 - 224.4.255.255     (2 /16s)   AD-HOC Block II
+
+224.5.0.0 - 224.255.255.255   (251 /16s) RESERVED
+
+225.0.0.0 - 231.255.255.255   (7 /8s)    RESERVED
+
+232.0.0.0 - 232.255.255.255   (/8)       Source-Specific Multicast Block
+
+233.0.0.0 - 233.251.255.255   (16515072) GLOP Block
+
+233.252.0.0 - 233.255.255.255 (/14)      AD-HOC Block III
+
+234.0.0.0 - 238.255.255.255   (5 /8s)    RESERVED
+
+239.0.0.0 - 239.255.255.255   (/8)       Administratively Scoped Block
+
+   The IANA generally assigns addresses from the Local Network Control,
+   Internetwork Control and AD-HOC blocks.  Assignment guidelines for
+   each of these blocks, as well as for the Source-Specific Multicast,
+   GLOP, and Administratively Scoped blocks, are described below.
+
+4.  Local Network Control Block (224.0.0/24)
+
+   Addresses in the Local Network Control Block are used for protocol
+   control traffic that is not forwarded off link.  Examples of this
+   type of use include OSPFIGP All Routers (224.0.0.5) [RFC2328].
+
+4.1.  Assignment Guidelines
+
+   Pursuant to section 4.4.2 of [RFC2780], assignments from the Local
+   Network Control Block follow an Expert Review, IESG Approval, or
+   Standards Action process.  See IANA [IANA] for the current set of
+   assignments.
+
+
+
+
+
+
+Cotton, et al.            Best Current Practice                 [Page 4]
+
+RFC 5771                IPv4 Multicast Guidelines             March 2010
+
+
+5.  Internetwork Control Block (224.0.1/24)
+
+   Addresses in the Internetwork Control Block are used for protocol
+   control traffic that MAY be forwarded through the Internet.  Examples
+   include 224.0.1.1 (Network Time Protocol (NTP) [RFC4330]) and
+   224.0.1.68 (mdhcpdiscover [RFC2730]).
+
+5.1.  Assignment Guidelines
+
+   Pursuant to section 4.4.2 of [RFC2780], assignments from the
+   Internetwork Control Block follow an Expert Review, IESG Approval, or
+   Standards Action process.  See IANA [IANA] for the current set of
+   assignments.
+
+6.  AD-HOC Blocks (I, II, and III)
+
+   Addresses in the AD-HOC blocks (including 224.0.2.0 - 224.0.255.255,
+   224.3.0.0 - 224.4.255.255, and 233.252.0.0 - 233.255.255.255) were
+   traditionally used for assignments for those applications that don't
+   fit in either the Local or Internetwork Control blocks.  These
+   addresses MAY be globally routed and are typically used by
+   applications that require small blocks of addressing (e.g., less than
+   a /24 ).  Future assignments of blocks of addresses that do not fit
+   in the Local Network or Internetwork Control blocks will be made in
+   AD-HOC Block III.
+
+6.1.  Assignment Guidelines
+
+   In general, the IANA SHOULD NOT assign addresses in the AD-HOC
+   blocks.  However, the IANA MAY, under special circumstances, assign
+   addresses from these blocks.  Pursuant to section 4.4.2 of [RFC2780],
+   assignments from the AD-HOC blocks follow an Expert Review, IESG
+   Approval, or Standards Action process.  See [IANA] for the current
+   set of assignments.
+
+7.  SDP/SAP Block (224.2/16)
+
+   Addresses in the SDP/SAP Block are used by applications that receive
+   addresses through the Session Announcement Protocol [RFC2974] for use
+   via applications like the session directory tool (such as [SDR]).
+
+7.1.  Assignment Guidelines
+
+   Since addresses in the SDP/SAP Block are chosen randomly from the
+   range of addresses not already in use [RFC2974], no IANA assignment
+   policy is required.  Note that while no additional IANA assignment is
+   required, addresses in the SDP/SAP Block are explicitly for use by
+   SDP/SAP and MUST NOT be used for other purposes.
+
+
+
+Cotton, et al.            Best Current Practice                 [Page 5]
+
+RFC 5771                IPv4 Multicast Guidelines             March 2010
+
+
+8.  Source-Specific Multicast Block (232/8)
+
+   SSM [RFC4607] is an extension of IP Multicast in which traffic is
+   forwarded to receivers from only those multicast sources for which
+   the receivers have explicitly expressed interest and is primarily
+   targeted at one-to-many (broadcast) applications.  Note that this
+   block was initially assigned to the Versatile Message Transaction
+   Protocol (VMTP) transient groups [IANA].
+
+8.1.  Assignment Guidelines
+
+   Because the SSM model essentially makes the entire multicast address
+   space local to the host, no IANA assignment policy is required.
+   Note, however, that while no additional IANA assignment is required,
+   addresses in the Source-Specific Multicast Block are explicitly for
+   use by SSM and MUST NOT be used for other purposes.
+
+9.  GLOP Block (233/8)
+
+   Addresses in the GLOP Block are globally-scoped, statically-assigned
+   addresses.  The assignment is made, for a domain with a 16-bit
+   Autonomous System Number (ASN), by mapping a domain's autonomous
+   system number, expressed in octets as X.Y, into the middle two octets
+   of the GLOP Block, yielding an assignment of 233.X.Y.0/24.  The
+   mapping and assignment is defined in [RFC3180].  Domains with a
+   32-bit ASN MAY apply for space in AD-HOC Block III, or consider using
+   IPv6 multicast addresses.
+
+9.1.  Assignment Guidelines
+
+   Because addresses in the GLOP Block are algorithmically pre-assigned,
+   no IANA assignment policy is required.
+
+9.2.  AD-HOC Block III
+
+   [RFC3138] delegated to the RIRs the assignment of the GLOP sub-block
+   (233.252.0.0 - 233.255.255.255) mapped by the private Autonomous
+   System (AS) space (64512-65534) and the IANA reserved ASN 65535
+   [RFC1930].  This space was known as Extended GLOP (EGLOP).  RFC 3138
+   should not have asked the RIRs to develop policies for the EGLOP
+   space because [RFC2860] reserves that to the IETF.  It is important
+   to make this space available for use by network operators, and it is
+   therefore appropriate to obsolete RFC 3138 and classify this address
+   range as available for AD-HOC assignment as per the guidelines in
+   section 6.
+
+
+
+
+
+
+Cotton, et al.            Best Current Practice                 [Page 6]
+
+RFC 5771                IPv4 Multicast Guidelines             March 2010
+
+
+   The first /24 in this range, 233.252.0.0/24, is assigned as "MCAST-
+   TEST-NET" for use in documentation and example code. 233.252.0.0/24
+   SHOULD be used in conjunction with the [RFC2606] domain names
+   example.com or example.net in vendor and protocol documentation.
+   Addresses within 233.252.0.0/24 MUST NOT appear on the public
+   Internet.
+
+10.  Administratively Scoped Block (239/8)
+
+   Addresses in the Administratively Scoped Block are for local use
+   within a domain and are described in [RFC2365].
+
+10.1.  Assignment Guidelines
+
+   Since addresses in this block are local to a domain, no IANA
+   assignment policy is required.
+
+10.1.1.  Relative Offsets
+
+   The relative offsets [RFC2365] are used to ensure that a service can
+   be located independent of the extent of the enclosing scope (see
+   [RFC3180] for details).  Since there are only 256 such offsets, the
+   IANA should only assign a relative offset to a protocol that provides
+   an infrastructure supporting service.  Examples of such services
+   include the Session Announcement Protocol [RFC2974].  Pursuant to
+   section 4.4.2 of [RFC2780], assignments of relative offsets follow an
+   Expert Review, IESG Approval, or Standards Action process.  See
+   [IANA] for the current set of assignments.
+
+11.  Application Form
+
+   Requests for multicast address assignments can be submitted through
+   the application form on the IANA web site at [IANA-registration].  It
+   is important to submit sufficient detail to allow the IESG designated
+   expert to review the application.  If the details given in the
+   request are not clear, or further information is needed, the IESG
+   designated expert may request additional information before assigning
+   an address.
+
+11.1.  Size of Assignments of IPv4 Multicast Addresses
+
+   Occasionally, more than one multicast address is required.  In these
+   cases, multiple addresses are available in AD-HOC Block III.  Where
+   there is a requirement for a very large number of addresses, the
+   assignment will be staged.  The additional stages will only be made
+   after the complete use of the initial assignment(s).
+
+
+
+
+
+Cotton, et al.            Best Current Practice                 [Page 7]
+
+RFC 5771                IPv4 Multicast Guidelines             March 2010
+
+
+   A separate document describing the policy governing assignment of
+   addresses in the AD-HOC blocks I, II, and III will be developed and
+   published.  The format, location, and content has not yet been
+   decided and so these will be documented in a future version of this
+   document.
+
+12.  Annual Review
+
+   Given the dynamic nature of IPv4 multicast and its associated
+   infrastructure, and the previously undocumented IPv4 multicast
+   address assignment guidelines, the IANA should conduct an annual
+   review of currently assigned addresses.
+
+12.1.  Address Reclamation
+
+   During the review described above, addresses that were mis-assigned
+   should, where possible, be reclaimed or reassigned.
+
+   The IANA should also review assignments in the AD-HOC, "DIS Transient
+   Groups", and ST Multicast Groups [RFC1819] blocks and reclaim those
+   addresses that are not in use on the global Internet (i.e., those
+   applications that can use SSM, GLOP, or Administratively Scoped
+   addressing, or are not globally routed).
+
+12.2.  Positive Renewal
+
+   It is occasionally appropriate to make temporary assignments that can
+   be renewed as necessary.  In cases where this happens the registrant
+   needs to positively request an extension to the temporary assignment
+   or the addresses assigned.  When the IANA has not received a request
+   to renew the registration of a temporary assignment within 30 days of
+   the expiry of the assignment, it MUST be removed from the multicast
+   registry.
+
+   Addresses returned to the IANA when a temporary assignment ends MUST
+   NOT be assigned to anyone other than the last registrant for at least
+   one calendar year.
+
+13.  Use of IANA Reserved Addresses
+
+   Applications MUST NOT use addressing in the IANA reserved blocks.
+
+14.  IANA Considerations
+
+   IANA has updated its IPv4 multicast request and assignment procedures
+   to reflect this document.
+
+
+
+
+
+Cotton, et al.            Best Current Practice                 [Page 8]
+
+RFC 5771                IPv4 Multicast Guidelines             March 2010
+
+
+15.  Security Considerations
+
+   The assignment guidelines described in this document do not alter the
+   security properties of either the Any Source or Source-Specific
+   Multicast service models.
+
+16.  Acknowledgments
+
+   The authors would like to thank Joe St. Sauver, John Meylor, Randy
+   Bush, Thomas Narten, Marshall Eubanks, Zaid Albanna (co-author of RFC
+   3171), Kevin Almeroth (co-author of RFC 3171), Pekka Savola, and
+   Alfred Hoenes for their constructive feedback and comments.
+
+17.  References
+
+17.1.  Normative References
+
+   [RFC2119] Bradner, S., "Key words for use in RFCs to Indicate
+             Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC5226] Narten, T. and H. Alvestrand, "Guidelines for Writing an
+             IANA Considerations Section in RFCs", BCP 26, RFC 5226, May
+             2008.
+
+17.2.  Informative References
+
+   [IANA]    IANA, "IANA Protocol Registries", <http://www.iana.org/>.
+
+   [IANA-protocols]
+             IANA, "IANA Protocol Registries",
+             <http://www.iana.org/protocols>.
+
+   [IANA-registration]
+             IANA, "IANA Protocol Registration Forms",
+             <http://www.iana.org/protocols/apply>.
+
+   [RFC1819] Delgrossi, L., Ed., and L. Berger, Ed., "Internet Stream
+             Protocol Version 2 (ST2) Protocol Specification - Version
+             ST2+", RFC 1819, August 1995.
+
+   [RFC1930] Hawkinson, J. and T. Bates, "Guidelines for creation,
+             selection, and registration of an Autonomous System (AS)",
+             BCP 6, RFC 1930, March 1996.
+
+   [RFC2328] Moy, J., "OSPF Version 2", STD 54, RFC 2328, April 1998.
+
+   [RFC2365] Meyer, D., "Administratively Scoped IP Multicast", BCP 23,
+             RFC 2365, July 1998.
+
+
+
+Cotton, et al.            Best Current Practice                 [Page 9]
+
+RFC 5771                IPv4 Multicast Guidelines             March 2010
+
+
+   [RFC2606] Eastlake 3rd, D. and A. Panitz, "Reserved Top Level DNS
+             Names", BCP 32, RFC 2606, June 1999.
+
+   [RFC2730] Hanna, S., Patel, B., and M. Shah, "Multicast Address
+             Dynamic Client Allocation Protocol (MADCAP)", RFC 2730,
+             December 1999.
+
+   [RFC2780] Bradner, S. and V. Paxson, "IANA Allocation Guidelines For
+             Values In the Internet Protocol and Related Headers", BCP
+             37, RFC 2780, March 2000.
+
+   [RFC2860] Carpenter, B., Baker, F., and M. Roberts, "Memorandum of
+             Understanding Concerning the Technical Work of the Internet
+             Assigned Numbers Authority", RFC 2860, June 2000.
+
+   [RFC2974] Handley, M., Perkins, C., and E. Whelan, "Session
+             Announcement Protocol", RFC 2974, October 2000.
+
+   [RFC3138] Meyer, D., "Extended Assignments in 233/8", RFC 3138, June
+             2001.
+
+   [RFC3171] Albanna, Z., Almeroth, K., Meyer, D., and M. Schipper,
+             "IANA Guidelines for IPv4 Multicast Address Assignments",
+             BCP 51, RFC 3171, August 2001.
+
+   [RFC3180] Meyer, D. and P. Lothberg, "GLOP Addressing in 233/8", BCP
+             53, RFC 3180, September 2001.
+
+   [RFC4330] Mills, D., "Simple Network Time Protocol (SNTP) Version 4
+             for IPv4, IPv6 and OSI", RFC 4330, January 2006.
+
+   [RFC4607] Holbrook, H. and B. Cain, "Source-Specific Multicast for
+             IP", RFC 4607, August 2006.
+
+   [SDR]     University College London / ISI, "Session Directory Tool",
+             <http://www-mice.cs.ucl.ac.uk/multimedia/software/sdr/>.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Cotton, et al.            Best Current Practice                [Page 10]
+
+RFC 5771                IPv4 Multicast Guidelines             March 2010
+
+
+Authors' Addresses
+
+   Michelle Cotton
+   Internet Corporation for Assigned Names and Numbers
+   4676 Admiralty Way, Suite 330
+   Marina del Rey, CA 90292
+   United States of America
+
+   Phone: +310-823-9358
+   EMail: michelle.cotton@icann.org
+   URI:   http://www.iana.org/
+
+
+   Leo Vegoda
+   Internet Corporation for Assigned Names and Numbers
+   4676 Admiralty Way, Suite 330
+   Marina del Rey, CA 90292
+   United States of America
+
+   Phone: +310-823-9358
+   EMail: leo.vegoda@icann.org
+   URI:   http://www.iana.org/
+
+
+   David Meyer
+
+   EMail: dmm@1-4-5.net
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Cotton, et al.            Best Current Practice                [Page 11]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc5771.txt](<www.ietf.org/rfc/rfc5771.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
