### PR TITLE
Archive rfc5781.txt

### DIFF
--- a/www.ietf.org/rfc/rfc5781.txt
+++ b/www.ietf.org/rfc/rfc5781.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                         S. Weiler
+Request for Comments: 5781                                  SPARTA, Inc.
+Category: Informational                                          D. Ward
+ISSN: 2070-1721                                                  Juniper
+                                                              R. Housley
+                                                          Vigil Security
+                                                           February 2010
+
+
+                          The rsync URI Scheme
+
+Abstract
+
+   This document specifies the rsync Uniform Resource Identifier (URI)
+   scheme.
+
+Status of This Memo
+
+   This document is not an Internet Standards Track specification; it is
+   published for informational purposes.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Not all documents
+   approved by the IESG are a candidate for any level of Internet
+   Standard; see Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc5781.
+
+Copyright Notice
+
+   Copyright (c) 2010 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+Weiler, et al.                Informational                     [Page 1]
+
+RFC 5781                        rsync URI                  February 2010
+
+
+1.  Introduction
+
+   URIs were previously defined in RFC 2396, which was obsoleted by RFC
+   3986 [RFC3986].  The procedures for registering new URI schemes are
+   defined in RFC 4395 [RFC4395].  The rsync utility provides fast
+   incremental file transfer [rsync].  This document defines a URI
+   scheme for rsync.
+
+2.  rsync URI registration
+
+   This section contains the registration template for the rsync URI
+   scheme in accordance with RFC 4395 [RFC4395].  This URI scheme is for
+   the rsync protocol using TCP as the transport protocol.  Other
+   transports, such as rsync over SSH, are not supported by this URI
+   scheme.
+
+   URI scheme name: rsync
+
+   Status: provisional
+
+   URI scheme syntax: An rsync URI describes a source or destination for
+   the rsync application including a hostname, path, and optional user
+   and port.  The generic form of the rsync URI is:
+
+   rsync://[user@]host[:PORT]/Source
+
+   The rsync URI follows the general syntax from RFC 3986 and is defined
+   by the following ABNF [RFC5234]:
+
+      rsyncuri        = "rsync:" hier-part
+                        ; See RFC 3986 for the definition
+                        ; of hier-part
+
+   URI scheme semantics: An rsync URI may be used as either a source or
+   destination for the rsync application.  If the port is not specified,
+   it defaults to 873.
+
+   Encoding considerations: Since the rsync URI is defined using
+   standard elements from RFC 3986, no special encoding considerations
+   are present.
+
+   Applications/protocols that use this URI scheme name: The only
+   application that uses rsync URIs is rsync.
+
+   Interoperability considerations: Since only one application is
+   expected to make use of rsync URIs, this URI scheme is expected to
+   have few interoperability concerns.
+
+
+
+
+Weiler, et al.                Informational                     [Page 2]
+
+RFC 5781                        rsync URI                  February 2010
+
+
+   Security considerations: Section 7 of RFC 3986 describes general
+   security considerations for URI schemes.  The considerations about
+   reliability and consistency, malicious construction, rare IP address
+   formats, sensitive information, and semantic attacks all apply to
+   rsync URIs.  The considerations about transcoding do not apply.
+   Given how rsync is regularly used, it is expected that most
+   applications will not be bothered by data accessed via a given rsync
+   URI changing over time.
+
+   Contact: Russ Housley <housley@vigilsec.com>
+
+   Author/Change controller: Russ Housley <housley@vigilsec.com>
+
+   References: see Section 5.
+
+3.  IANA Considerations
+
+   IANA has registered the rsync provisional URI scheme using the
+   template in Section 2.
+
+4.  Security Considerations
+
+   Many security considerations for the usage of URIs are discussed in
+   Section 7 of [RFC3986].  The considerations about reliability and
+   consistency, malicious construction, rare IP address formats,
+   sensitive information, and semantic attacks all apply to rsync URIs.
+   The considerations about transcoding do not apply.  The rsync URI
+   scheme has no particularly unique security considerations.
+
+   The security considerations of the rsync protocol are not covered in
+   this document.
+
+5.  Normative References
+
+   [RFC3986]  Berners-Lee, T., Fielding, R., and L. Masinter, "Uniform
+              Resource Identifier (URI): Generic Syntax", STD 66, RFC
+              3986, January 2005.
+
+   [RFC4395]  Hansen, T., Hardie, T., and L. Masinter, "Guidelines and
+              Registration Procedures for New URI Schemes", BCP 35, RFC
+              4395, February 2006.
+
+   [RFC5234]  Crocker, D., Ed., and P. Overell, "Augmented BNF for
+              Syntax Specifications: ABNF", STD 68, RFC 5234, January
+              2008.
+
+
+
+
+
+
+Weiler, et al.                Informational                     [Page 3]
+
+RFC 5781                        rsync URI                  February 2010
+
+
+6.  Informative References
+
+   [rsync]  http://rsync.samba.org/.
+
+Authors' Addresses
+
+   Samuel Weiler
+   SPARTA, Inc.
+   7110 Samuel Morse Drive
+   Columbia, Maryland  21046
+   US
+
+   EMail: weiler@tislabs.com
+
+
+   Dave Ward
+   Juniper Networks
+   1194 North Mathilda Avenue
+   Sunnyvale, California  94089-1206
+   US
+
+   EMail: dward@juniper.net
+
+
+   Russ Housley
+   Vigil Security, LLC
+   918 Spring Knoll Drive
+   Herndon, Virginia  20170
+   US
+
+   EMail: housley@vigilsec.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Weiler, et al.                Informational                     [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc5781.txt](<www.ietf.org/rfc/rfc5781.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
