### PR TITLE
Archive rfc5791.txt

### DIFF
--- a/www.ietf.org/rfc/rfc5791.txt
+++ b/www.ietf.org/rfc/rfc5791.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                        J. Reschke
+Request for Comments: 5791                                    greenbytes
+Category: Informational                                         J. Kunze
+ISSN: 2070-1721                                 University of California
+                                                           February 2010
+
+
+     RFC 2731 ("Encoding Dublin Core Metadata in HTML") Is Obsolete
+
+Abstract
+
+   This document obsoletes RFC 2731, "Encoding Dublin Core Metadata in
+   HTML", as further development of this specification has moved to the
+   Dublin Core Metadata Initiative (DCMI).
+
+Status of This Memo
+
+   This document is not an Internet Standards Track specification; it is
+   published for informational purposes.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Not all documents
+   approved by the IESG are a candidate for any level of Internet
+   Standard; see Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc5791.
+
+Copyright Notice
+
+   Copyright (c) 2010 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+Reschke & Kunze               Informational                     [Page 1]
+
+RFC 5791                  RFC 2731 Is Obsolete             February 2010
+
+
+1.  Introduction
+
+   [RFC2731] defines "Encoding Dublin Core Metadata in HTML".  Newer
+   specifications published by the Dublin Core Metadata Initiative
+   (http://dublincore.org/) over the last decade, in particular
+   "Expressing Dublin Core metadata using HTML/XHTML meta and link
+   elements" ([DC-HTML]), have obsoleted this work.
+
+      Note: Implementers of RFC 2731 should note that DC-HTML introduces
+      a new requirement with respect to the use of the "head" element's
+      "profile" attribute.
+
+2.  Security Considerations
+
+   This document is of administrative nature only and therefore there
+   are no security relations related to it.
+
+3.  Normative References
+
+   [DC-HTML]  Johnston, P. and A. Powell, "Expressing Dublin Core
+              metadata using HTML/XHTML meta and link elements", Dublin
+              Core Metadata Initiative , August 2008,
+              <http://dublincore.org/documents/2008/08/04/dc-html/>.
+
+   [RFC2731]  Kunze, J., "Encoding Dublin Core Metadata in HTML",
+              RFC 2731, December 1999.
+
+Authors' Addresses
+
+   Julian F. Reschke
+   greenbytes GmbH
+   Hafenweg 16
+   Muenster, NW  48155
+   Germany
+
+   EMail: julian.reschke@greenbytes.de
+   URI:   http://greenbytes.de/tech/webdav/
+
+
+   John A. Kunze
+   University of California
+   Office of the President
+   415 20th Street, #406
+   Oakland, CA  94612-3550
+   U.S.A.
+
+   EMail: jak@ucop.edu
+
+
+
+
+Reschke & Kunze               Informational                     [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc5791.txt](<www.ietf.org/rfc/rfc5791.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
