### PR TITLE
Archive rfc580.txt

### DIFF
--- a/www.ietf.org/rfc/rfc580.txt
+++ b/www.ietf.org/rfc/rfc580.txt
@@ -1,0 +1,41 @@
+
+NWG/RFC# 580                                  JBP 25-OCT-73 06:00  19849
+note to protocol designers and implementers
+
+
+
+ Hereafter proposed protocols shall be submitted in the form of
+on-line documents, preferably as nls files at the Network
+Information Center. This will greatly facilitate the review
+process and enable editorial and substantive changes to proceed
+quickly. This also will permit timely updating of protocol
+documents as may be neccessitated by future decisions. On-line
+documents are also easily distributed to the network community.
+If you find great difficulty in complying with this request
+please contact me.                                                     
+
+
+It should be noted by all Telnet protocol readers and especially
+implementers that all the existing Telnet Options that involve
+subnegotiation are modified [see RFC 562] to terminate the
+subnegotiation strings with IAC SE. The value of SE is 240. Also
+note that within subnegotiations the occurance of a byte with the
+value 255 [IAC] requires doubling that byte on transmission.           
+
+
+Please note that my address has changed to:
+     Jon Postel
+     The MITRE Corporation
+     Mail Stop W185
+     Westgate Research Park
+     McLean, Virginia 22101
+
+     Phone: (703) 893-3500 x2350
+
+On-line messages will reach me addressed to either
+     POSTEL@ISI
+or
+     JBP in the NIC Journal.
+                                                                       
+
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc580.txt](<www.ietf.org/rfc/rfc580.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
