### PR TITLE
Archive rfc582.txt

### DIFF
--- a/www.ietf.org/rfc/rfc582.txt
+++ b/www.ietf.org/rfc/rfc582.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                        R. Clements
+Request for Comments: 582                                      BBN-TENEX
+NIC: 19962                                               5 November 1973
+
+
+                         Comments on RFC 580 -
+                       Machine Readable Protocols
+
+   I fully support the requirement for machine-readable protocol
+   documents.  In my situation, the line-printer is a much more reliable
+   device than the copying machine.
+
+   However, I object to the phrase "preferably as nls files" in RFC 580.
+   My objection is based on the lack of conversion mechanisms INTO NLS,
+   not to the retrieval process or NLS itself.
+
+   Most sites have their own text editors and RUNOFF's (or their
+   equivalents).  Most large protocol documents are prepared at least
+   partially by secretarial help.  Those persons should be able to
+   prepare the documents in the home machine (or wherever) in languages
+   with which they are familiar.  There should be a general program
+   (preferably clever, but at least generally available and predictable)
+   for converting nicely formatted text to NLS files.
+
+   Perhaps the program which receives mail for the journal will do the
+   trick; if so it needs further documentation beyond the mail-oriented
+   RFC 543, and its existence and usage need to be publicised.
+
+   RECEIVED AT NIC NOVEMBER 14, 1973.
+
+
+         [ This RFC was put into machine readable form for entry ]
+          [ into the online RFC archives by Lorrie Shiota 1/02 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Clements                                                        [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc582.txt](<www.ietf.org/rfc/rfc582.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
