### PR TITLE
Archive rfc587.txt

### DIFF
--- a/www.ietf.org/rfc/rfc587.txt
+++ b/www.ietf.org/rfc/rfc587.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                         Jon Postel
+Request for Comments: 587                                          MITRE
+                                                           November 1973
+
+
+                     Announcing New Telnet Options
+
+   This is to announce that two new TELNET options have been specified.
+
+      Negotiate About Output Line Width (NAOL)  NIC#20196
+
+      Negotiate About Output Page Size (NAOP)  NIC#20197
+
+   These were prepared by Dave Walden (BBN-NET) and put on-line by Anita
+   Coley (UCLA-NMC) and Dave Crocker (UCLA-NMC).
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+         [ This RFC was put into machine readable form for entry ]
+           [ into the online RFC archives by Rich Bowen 11/97. ]
+
+
+
+
+Postel                                                          [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc587.txt](<www.ietf.org/rfc/rfc587.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
