### PR TITLE
Archive rfc5871.txt

### DIFF
--- a/www.ietf.org/rfc/rfc5871.txt
+++ b/www.ietf.org/rfc/rfc5871.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                          J. Arkko
+Request for Comments: 5871                                      Ericsson
+Updates: 2460                                                 S. Bradner
+Category: Standards Track                             Harvard University
+ISSN: 2070-1721                                                 May 2010
+
+
+         IANA Allocation Guidelines for the IPv6 Routing Header
+
+Abstract
+
+   This document specifies the IANA guidelines for allocating new values
+   for the Routing Type field in the IPv6 Routing Header.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc5871.
+
+Copyright Notice
+
+   Copyright (c) 2010 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+
+
+
+Arkko & Bradner              Standards Track                    [Page 1]
+
+RFC 5871                   IPv6 RH IANA Rules                   May 2010
+
+
+1.  Introduction
+
+   This document specifies the IANA guidelines [RFC5226] for allocating
+   new values for the Routing Type field in the IPv6 Routing Header
+   [RFC2460].  Previously, no IANA guidance existed for such
+   allocations.
+
+2.  IANA Considerations
+
+   New Routing Type values are allocated through IETF Review or IESG
+   Approval [RFC5226].
+
+   Note that two experimental values (253 and 254) are already available
+   for use [RFC4727].
+
+3.  Security Considerations
+
+   This specification does not change the security properties of the
+   Routing Header.  However, past experience shows that it is easy to
+   design routing headers that have significant problems [RFC5095].
+
+4.  References
+
+4.1.  Normative References
+
+   [RFC2460]  Deering, S. and R. Hinden, "Internet Protocol, Version 6
+              (IPv6) Specification", RFC 2460, December 1998.
+
+   [RFC5226]  Narten, T. and H. Alvestrand, "Guidelines for Writing an
+              IANA Considerations Section in RFCs", BCP 26, RFC 5226,
+              May 2008.
+
+4.2.  Informative References
+
+   [RFC4727]  Fenner, B., "Experimental Values In IPv4, IPv6, ICMPv4,
+              ICMPv6, UDP, and TCP Headers", RFC 4727, November 2006.
+
+   [RFC5095]  Abley, J., Savola, P., and G. Neville-Neil, "Deprecation
+              of Type 0 Routing Headers in IPv6", RFC 5095,
+              December 2007.
+
+
+
+
+
+
+
+
+
+
+
+Arkko & Bradner              Standards Track                    [Page 2]
+
+RFC 5871                   IPv6 RH IANA Rules                   May 2010
+
+
+Appendix A.  Changes from RFC 2460
+
+   This document specifies only the IANA rules associated with the
+   Routing Type field.
+
+Authors' Addresses
+
+   Jari Arkko
+   Ericsson
+   Jorvas  02420
+   Finland
+
+   EMail: jari.arkko@piuha.net
+
+
+   Scott Bradner
+   Harvard University
+   Cambridge, MA  02138
+   US
+
+   Phone: +1 617 495 3864
+   EMail: sob@harvard.edu
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Arkko & Bradner              Standards Track                    [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc5871.txt](<www.ietf.org/rfc/rfc5871.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
