### PR TITLE
Archive rfc588.txt

### DIFF
--- a/www.ietf.org/rfc/rfc588.txt
+++ b/www.ietf.org/rfc/rfc588.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                                          A. Stokes
+Request for Comments: 588                                          UKICS
+NIC: 20217                                                  October 1973
+
+
+                         LONDON NODE IS NOW UP
+
+   The London node of the ARPANET has been on the Net (Address 42) since
+   early September.  It consists of a TIP (Address 170) and, at present,
+   a local HOST (0), a PDP-9, which front-ends the Rutherford High
+   Energy Laboratory 360/195 located 60 miles from London and connect to
+   it by a 2.4 Kbps line.  The specific details of the 360 will soon
+   appear in the Resource Notebook, but, in brief, it has 2 megabytes of
+   fast store (750ns), a fixed head disk and a large number of other
+   peripherals.  It operates under OS/MVT release 21.7 and HASP II
+   version 3.1, with a locally written message switching system MAST and
+   an interactive editor ELECTRIC.  In addition to the local hardware,
+   it supports about 20 remote workstations, which are, in many cases
+   GEC 2050s simulating IBM 1130s.  Eventually, other Hosts will be
+   attached to the Very Distant Host Interface (Address 234).
+
+   The PDP-9 at the Institute of Computer Science also simulates a 1130
+   with 2 card readers, 2 card punches, two line printers, three MAST
+   consoles, and a system console.  It has a 16K (18 bit) words store, a
+   256K word drum and a number of devices usually attached by modem
+   interfaces.  The 1130 simulator software has been interfaced to an
+   ARPA system, which, at present, has IMP-HOST, HOST-HOST, ICP, and
+   TELNET protocols.  The TELNET link is initially to the PDP-9 from
+   whence the user may login to the 360 provided one of the two MAST
+   ports is available (the third being for local use).  The access is to
+   ELECTRIC, and the user may enter and edit files, submit them to the
+   batch stream, and inspect the output interactively from a terminal.
+   The facilities will be extended soon to allow the printing of jobs at
+   TIPS and later the RJE and FTP protocols will be implemented.
+
+   The 360 is available for limited experimental use, and a free login
+   facility has been provided (GUEST).  This account has a very limited
+   allowance (currently, 1min CPU time/week), and is designed only for
+   demonstration purposes.
+
+   All jobs under this account must be Class X, which has a maximum run
+   time of 10secs.  Proper accounts, for which there will be no charge,
+   can be arranged for appropriate users by contacting KIRSTEIN@ISI.  It
+   is not planned, at present, to make the 360/195 a normal service
+   HOST, like for example, the CCN machine.  However, the machine will
+   be made available for cooperative projects involving a US group and
+
+
+
+
+
+Stokes                                                          [Page 1]
+
+RFC 588                   London Node is Now Up             October 1973
+
+
+   an interested party in the UK.  Of particular interest to us are
+   applications in Network measurements, high energy physics, and
+   accelerator design, though other projects would be considered.
+
+   Primitive HELP facilities exist on both the PDP-9 and the 360, and
+   they are accessed by %H and TYPE JB=HELP, respectively.  Up to date
+   details will be given in the message obtained on connecting to the
+   PDP-9 and in the PDP-9 Help file.
+
+   ... A typical scenario is attached.
+
+   The intention is to keep the PDP-9/360 available as a HOST between
+   19.00 and 09.00 local time, as well as a number of periods during the
+   day (the local time is 8 or 9 hours ahead of California, and 5 hours
+   ahead of the East Coast).  There will be no operator available on the
+   PDP-9, although during the day and at least the early part of the
+   evening, there will be users in the computer room who will give
+   assistance where necessary.  The "operator's console" is a Teletype,
+   so any messages sent during the night will be read in the morning,
+   and we will try to send replies to all queries (if you tell us where
+   to reply to Network mail for our site may be send to KRISTEIN@ISI, or
+   to myself (IDENT=AVS) at the NIC.  Connection problems should be
+   referred to Peter Higginson (NIC ident = PLH).
+
+   ... Enc.
+
+   HELLO 315
+   @1 42
+   LOGGER
+    OPEN
+   INDRA COMPUTING SERVICE - 17 27 GMT ON 06 NOV 73
+   TYPE %H<CR> FOR HELP
+
+   &h
+   THE HOST AT ULICS IS A PDP-9 FRONT END TO AN IBM 360/195
+   COMMANDS TO THE PDP-9 ARE:
+   %HELP (%H)
+   %LOGIN ID=**.ACCT=**
+   %LOGOUT
+   %OPERATOR (%O)
+   %STATUS (%S)
+
+   ALL COMMANDS TERMINATE WITH CARRIAGE RETURN
+   WHEN NOT LOGGED IN TO 360 ALL LINES GO TO OPERATOR
+
+   WILL USA USERS PLEASE TYPE A COUPLE OF LINES SAYING WHO THEY
+   ARE BEFORE THEY LOG IN TO THE 360
+
+
+
+
+Stokes                                                          [Page 2]
+
+RFC 588                   London Node is Now Up             October 1973
+
+
+   FOR FURTHER HELP LOGIN TO THE 360 WITH:
+   %LOGIN GUEST
+   AND IF SUCCESSFUL TYPE:
+   TYPE JB=HELP
+
+   THE IMB 360/195 IS UP
+
+   THE SYSTEM HAS NO PROMPT AND ONLY TWO CONTROL CHARS:
+   CTRL U TO CANCEL A LINE
+   DELETE (177) TO DELETE A CHAR
+
+   % login guest
+   USER 8 F7 BL= 113/250 TL= 197 NL= 13 TG= 8 NG= 2 TJ= 0.01 NJ=  3
+   SYSTEM DEVELOPMENT TONIGHT AS PER THE SCHEDULE BETWEEN 1730-
+   1854HRS.
+   **ELECTRIC TERMINATING IN 0 MINS 50 SECS. AVAILABLE AGAIN AT 1847
+   HRS **
+   %logout
+   OK   F7 BL= 113/ 250 TL= 198 NL= 14 TG= 8 NG= 2 TJ= 0.01 NJ=  3
+   @c
+
+   CLOSED T
+   CLOSED R
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Stokes                                                          [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc588.txt](<www.ietf.org/rfc/rfc588.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
