### PR TITLE
Archive rfc590.txt

### DIFF
--- a/www.ietf.org/rfc/rfc590.txt
+++ b/www.ietf.org/rfc/rfc590.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                       M. Padlipsky
+Request for Comments: 590                                    MIT-Multics
+NIC: 20326                                              19 November 1973
+
+
+                         Multics Address Change
+
+   We will be changing the Network address of MIT-Multics from 6 to 44
+   (decimal) on Monday, December 17, 1973.  Please make any necessary
+   table and program changes then, and accept our apologies for the
+   inconvenience.
+
+   The change was necessitated by the fact that 1) there were some nine
+   uses for the four ports on IMP 6, making the second MIT IMP
+   desirable; 2) there were four very active Hosts on IMP 6, making the
+   shift of at least one of them to the new, less busy IMP desirable;
+   and 3) the new Multics machine is some 2000 feet from the old IMP,
+   making it the logical candidate for the move.
+
+   It is likely that we will have one or two additional test sessions on
+   the new IMP prior to the changeover date.  These will be announced in
+   our "message of the day", and would only affect -- temporarily --
+   users who cannot employ numeric Host addresses directly.
+
+
+   RECEIVED AT NIC 11-21-73
+
+
+         [ This RFC was put into machine readable form for entry ]
+          [ into the online RFC archives by Lorrie Shiota 1/02 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Padlipsky                                                       [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc590.txt](<www.ietf.org/rfc/rfc590.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
