### PR TITLE
Archive rfc591.txt

### DIFF
--- a/www.ietf.org/rfc/rfc591.txt
+++ b/www.ietf.org/rfc/rfc591.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                   D. Walden
+Request for Comments: #591                              BBN-Net
+NIC: #20327                                             29 November 1973
+
+
+            Addition to the Very Distant Host Specification
+
+
+     It has been brought to my attention that the following sentence
+should be added to the Very Distant Host specification in Appendix F of
+BBN report 1822, Specifications for the Interconnection of a Host and an
+IMP, to the paragraph beginning on page F-5 and ending on page F-7:
+
+"Null packets do not use a channel (nor a channel number) when sent and
+are not acknowledged when received."
+
+     Please file this RFC with your copy of BBN report 1822 until 1822
+is next updated.
+
+
+
+
+
+
+
+DCW/nlg
+
+
+
+
+
+
+
+RECEIVED AT NIC DECEMBER 3, 1973
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Walden                                                          [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc591.txt](<www.ietf.org/rfc/rfc591.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
