### PR TITLE
Archive rfc5955.txt

### DIFF
--- a/www.ietf.org/rfc/rfc5955.txt
+++ b/www.ietf.org/rfc/rfc5955.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                        A. Santoni
+Request for Comments: 5955                                Actalis S.p.A.
+Updates: 5544                                                August 2010
+Category: Informational
+ISSN: 2070-1721
+
+
+              The application/timestamped-data Media Type
+
+Abstract
+
+   This document defines a new media type for TimeStampedData envelopes
+   as described in RFC 5544.
+
+Status of This Memo
+
+   This document is not an Internet Standards Track specification; it is
+   published for informational purposes.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Not all documents
+   approved by the IESG are a candidate for any level of Internet
+   Standard; see Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc5955.
+
+Copyright Notice
+
+   Copyright (c) 2010 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+
+Santoni                       Informational                     [Page 1]
+
+RFC 5955              application/timestamped-data           August 2010
+
+
+Table of Contents
+
+   1. Introduction...................................................2
+   2. Registration...................................................2
+   3. Security Considerations........................................3
+   4. IANA Considerations............................................3
+   5. Normative References...........................................3
+
+1.  Introduction
+
+   This document defines a new media type for TimeStampedData envelopes.
+   A TimeStampedData envelope, described in [RFC5544], binds a file with
+   one or more time-stamp tokens obtained for that file.  A media type
+   registration, lacking in [RFC5544], enhances shareability.
+
+2.  Registration
+
+   Type name: application
+
+   Subtype name: timestamped-data
+
+   Required parameters: none
+
+   Optional parameters: none
+
+   Encoding considerations: binary
+
+   Security considerations:
+
+      See the Security Considerations in the published specification.
+
+   Interoperability considerations: none
+
+   Published specification: RFC 5544
+
+   Applications which use this media type:
+
+      Any application that exchanges TimeStampedData envelopes over a
+      MIME-based transport and possibly processes them, either directly
+      or via external handlers or viewers.  Such applications may be,
+      for instance, digital signature applications, archival systems,
+      email clients, web browsers, etc.
+
+   Additional information:
+
+      Magic number(s):
+
+      File extension(s): .tsd
+
+
+
+Santoni                       Informational                     [Page 2]
+
+RFC 5955              application/timestamped-data           August 2010
+
+
+      Macintosh file type code(s):
+
+   Person & email address to contact for further information:
+
+      Adriano Santoni
+      <adriano.santoni@actalis.it>
+
+   Intended usage: COMMON
+
+   Restrictions on usage: none
+
+   Author:
+
+      Adriano Santoni
+      <adriano.santoni@actalis.it>
+
+   Change controller: the IESG
+
+3.  Security Considerations
+
+   The security considerations of [RFC5544] apply; no new security
+   considerations are introduced by this document.
+
+4.  IANA Considerations
+
+   Section 2 of this document registers one media subtype.
+
+5.  Normative References
+
+   [RFC5544]  Santoni, A., "Syntax for Binding Documents with Time-
+              Stamps", RFC 5544, February 2010.
+
+Author's Address
+
+   Adriano Santoni
+   Actalis S.p.A.
+   Via dell'Aprica 18
+   20158 Milano
+   Italy
+
+   EMail: adriano.santoni@actalis.it
+
+
+
+
+
+
+
+
+
+
+Santoni                       Informational                     [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc5955.txt](<www.ietf.org/rfc/rfc5955.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
