### PR TITLE
Archive rfc6.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6.txt
+++ b/www.ietf.org/rfc/rfc6.txt
@@ -1,0 +1,52 @@
+Network Working Note                                    Steve Crocker, UCLA
+RFC-6                                                   10 April 1969
+
+
+
+                        CONVERSATION WITH BOB KAHN
+
+
+
+
+
+I talked with Bob Kahn at BB&N yesterday.  We talked about code conversion
+in the IMP's, IMP-HOST communication, and HOST software.
+
+BB&N is prepared to convert 6, 7, 8, or 9 bit character codes into 8-bit
+ASCII for transmission and convert again upon assembly at the destination
+IMP.  BB&N plans a one for one conversion scheme with tables unique to the
+HOST.  I suggested that places with 6-bit codes may also want case shifting.
+Bob said this may result in overflow if too many case shifts are necessary.
+I suggested that this is rare and we could probably live with an overflow
+indication instead of a guarantee.
+
+With respect to HOST-IMP communication, we now have a five bit link field
+and a bit to indicate conversion.  Also possible is a 2-bit conversion
+indicator, one for converting before sending and one for converting after.
+This would allow another handle for checking or controlling the system.
+
+The HOST can send messages or portions of a message to its IMP specifying
+
+        1.  Tracing
+        2.  Conversion
+        3.  Whether message is for destination IMP or HOST
+        4.  Send RFNM
+        5.  HOST up or down
+        6.  Synchronization
+        7.  Format Error Messages
+        8.  Master Link Clear
+        9.  Status Requested
+
+The IMP can send to its HOST information on
+
+        1.  Conversion
+        2.  REFNM Arrived
+        3.  IMP up or down
+        4.  Synchornization
+        5.  Called HOST not Responding
+        6.  Format Error
+        7.  Status in IMP
+
+I also summarized for Bob the contents of Network Notes l, 2, and 3.
+
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6.txt](<www.ietf.org/rfc/rfc6.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
