### PR TITLE
Archive rfc603.txt

### DIFF
--- a/www.ietf.org/rfc/rfc603.txt
+++ b/www.ietf.org/rfc/rfc603.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                  J.D. Burchfiel
+RFC # 603                                              BBN-TENEX
+NIC # 21022                                            31 December, 1973
+
+
+                   Response to RFC # 597: Host Status
+
+
+    I have several questions about the November 1973 ARPANET
+topographical map:
+
+    1.  AMES is 4-connected, i.e. four network connections will go down
+        if the IMP fails.  Is there some aspiration that IMPs should be
+        no more than three connected?
+
+    2.  The seven IMPS in the Washington area are arranged into a loop.
+        This guarantees that local communication can take place even if
+        one connection fails, and is probably a worthwhile preparation
+        for area routing.  On the other hand, for example, a break
+        between MIT-IPC and MIT-MAC will require them to communicate
+        through a 12-hop path through Washington.  This can be remedied
+        by a short (inexpensive) connection between Harvard and Lincoln
+        Labs.  Is there a plan to pull the Boston area, the San
+        Francisco area, and the Los Angeles area into loops like the
+        Washington area?
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.            10/99 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+Burchfiel                                                       [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc603.txt](<www.ietf.org/rfc/rfc603.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
