### PR TITLE
Archive rfc604.txt

### DIFF
--- a/www.ietf.org/rfc/rfc604.txt
+++ b/www.ietf.org/rfc/rfc604.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                   Jon Postel
+RFC # 604                                               MITRE
+NIC # 21186                                             26 December 1973
+
+
+                         Assigned Link Numbers
+
+This announcement modifies the official host-to-host protocol, and
+updates the defining documents [NIC 8246, NIC 9347].  Please note that
+the information on page 28 of "Host/Host Protocol for the ARPA Network"
+about link number assignments is updated by this note, and that a
+previous update [RFC 317, NIC 9347] is completely replaced.  The
+modification is minor and should have no effect on existing network
+programs or usage.  Four of the reserved link numbers are hereby
+assigned for experimental use in the testing of an internetworking
+protocol defined by Kahn and Cerf.
+
+Description:
+
+    Control Link
+
+        Link 0 is assigned for use as the host-to-host protocol control
+        link.
+
+    Data Links
+
+        Links 2-71 are available for use in connections as provided by
+        the host-to-host protocol.
+
+    Internetworking Protocol
+
+        Links 155-158 are to be used for experiments with the
+        Internetworking Protocol.
+
+    Measurements
+
+        Links 159-191 are assigned for use in measurements under the
+        direction of the Network Measurement Center at UCLA.
+
+    Message Switching
+
+        Links 192-195 are to be used for experiments with the Message
+        Switching Protocol.
+
+    Private Experiments
+
+        Links 196-255 are available for private experimental use.
+
+
+
+
+Postel                                                          [Page 1]
+
+RFC 604                  Assigned Link Numbers             December 1973
+
+
+    Reserved
+
+        Link 1, and links 72-154 are reserved for future developments
+        and experiments and currently are not to be used.
+
+Table:
+        Link Number              Assignment
+
+            0                    Control Link
+            1                    Reserved
+           2-71                  Connections
+          72-154                 Reserved
+         155-158                 Internetworking Protocol
+         159-191                 Measurements
+         192-195                 Message Switching Protocol
+         196-255                 Experimental
+
+References:
+
+        Host-to-host Protocol           NIC 8246
+        Internetworking Protocol        NIC 18764
+        Message Switching Protocol      NIC 9926
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.            10/99 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Postel                                                          [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc604.txt](<www.ietf.org/rfc/rfc604.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
