### PR TITLE
Archive rfc6058.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6058.txt
+++ b/www.ietf.org/rfc/rfc6058.txt
@@ -1,0 +1,1963 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                   M. Liebsch, Ed.
+Request for Comments: 6058                                           NEC
+Category: Experimental                                        A. Muhanna
+ISSN: 2070-1721                                                 Ericsson
+                                                                O. Blume
+                                                Alcatel-Lucent Bell Labs
+                                                              March 2011
+
+
+                Transient Binding for Proxy Mobile IPv6
+
+Abstract
+
+   This document specifies a mechanism that enhances Proxy Mobile IPv6
+   protocol signaling to support the creation of a transient binding
+   cache entry that is used to optimize the performance of dual radio
+   handover, as well as single radio handover.  This mechanism is
+   applicable to the mobile node's inter-MAG (Mobility Access Gateway)
+   handover while using a single interface or different interfaces.  The
+   handover problem space using the Proxy Mobile IPv6 base protocol is
+   analyzed and the use of transient binding cache entries at the local
+   mobility anchor is described.  The specified extension to the Proxy
+   Mobile IPv6 protocol ensures optimized forwarding of downlink as well
+   as uplink packets between mobile nodes and the network infrastructure
+   and avoids superfluous packet forwarding delay or even packet loss.
+
+Status of This Memo
+
+   This document is not an Internet Standards Track specification; it is
+   published for examination, experimental implementation, and
+   evaluation.
+
+   This document defines an Experimental Protocol for the Internet
+   community.  This document is a product of the Internet Engineering
+   Task Force (IETF).  It represents the consensus of the IETF
+   community.  It has received public review and has been approved for
+   publication by the Internet Engineering Steering Group (IESG).  Not
+   all documents approved by the IESG are a candidate for any level of
+   Internet Standard; see Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6058.
+
+
+
+
+
+
+
+
+Liebsch, et al.               Experimental                      [Page 1]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+Copyright Notice
+
+   Copyright (c) 2011 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Liebsch, et al.               Experimental                      [Page 2]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+Table of Contents
+
+   1. Introduction ....................................................4
+   2. Conventions and Terminology .....................................5
+      2.1. Conventions Used in This Document ..........................5
+      2.2. Terminology and Functional Components ......................5
+   3. Analysis of the Problem Space ...................................6
+      3.1. Handover Using a Single Interface ..........................6
+      3.2. Handover between Interfaces ................................6
+           3.2.1. Issues with Downlink Traffic ........................7
+           3.2.2. Issues with Uplink Traffic ..........................9
+      3.3. Need for a Common Solution ................................10
+   4. Use of Transient Binding Cache Entries .........................11
+      4.1. General Approach ..........................................11
+      4.2. Impact on Binding Management ..............................13
+      4.3. Role of the LMA and nMAG in Transient State Control .......14
+           4.3.1. Control at the nMAG ................................14
+           4.3.2. Control at the LMA .................................15
+      4.4. LMA Forwarding State Diagram ..............................15
+      4.5. MAG Operation .............................................18
+      4.6. LMA Operation .............................................19
+           4.6.1. Initiation of a Transient BCE ......................19
+           4.6.2. Activation of a Transient BCE ......................20
+      4.7. MN Operation ..............................................22
+      4.8. Status Values .............................................22
+      4.9. Protocol Stability ........................................22
+   5. Message Format .................................................24
+      5.1. Transient Binding Option ..................................24
+   6. IANA Considerations ............................................25
+   7. Security Considerations ........................................25
+   8. Protocol Configuration Variables ...............................26
+   9. Contributors ...................................................26
+   10. Acknowledgments ...............................................26
+   11. References ....................................................26
+      11.1. Normative References .....................................26
+      11.2. Informative References ...................................26
+   Appendix A.  Example Use Cases for Transient BCE ..................28
+     A.1.  Use Case for Single Radio Handover ........................28
+     A.2.  Use Case for Dual Radio Handover ..........................30
+   Appendix B.  Applicability and Use of Static Configuration at
+                the LMA ..............................................33
+     B.1.  Early Uplink Traffic from the nMAG ........................33
+     B.2.  Late Uplink Traffic from the pMAG .........................33
+     B.3.  Late Switching of Downlink Traffic to nMAG ................34
+
+
+
+
+
+
+
+Liebsch, et al.               Experimental                      [Page 3]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+1.  Introduction
+
+   The IETF specified Proxy Mobile IPv6 (PMIPv6) [RFC5213] as a protocol
+   for network-based localized mobility management, which takes basic
+   operation for registration, tunnel management, and deregistration
+   into account.  In order to eliminate the risk of lost packets, this
+   document specifies an extension to PMIPv6 that utilizes a new
+   mobility option in the Proxy Binding Update (PBU) and the Proxy
+   Binding Acknowledgement (PBA) between the new Mobility Access Gateway
+   (nMAG) and the Local Mobility Anchor (LMA).
+
+   According to the PMIPv6 base specification, an LMA updates a mobile
+   node's (MN's) Binding Cache Entry (BCE) and switches the forwarding
+   tunnel after receiving a Proxy Binding Update (PBU) message from the
+   mobile node's new MAG (nMAG).  At the same time, the LMA disables the
+   forwarding entry towards the mobile node's previous MAG (pMAG).  In
+   case of an inter-technology handover, the mobile node's handover
+   target interface must be configured according to the Router
+   Advertisement being sent by the nMAG.  Address configuration as well
+   as possible access-technology-specific radio bearer setup may delay
+   the complete set up of the mobile node's new interface before it is
+   ready to receive or send data packets.  In case the LMA performs
+   operation according to [RFC5213] and forwards packets to the mobile
+   node's new interface after the reception of the PBU from the nMAG,
+   some packets may get lost or experience major packet delay.  The
+   transient BCE extension, as specified in this document, increases
+   handover performance (optimized packet loss and forwarding delay)
+   experienced by MNs, which have multiple network interfaces
+   implemented while handing over from one interface to the other.  The
+   transient BCE extension also increases handover performance for
+   single radio MNs, which build on available radio layer forwarding
+   mechanisms, hence re-use existing active handover techniques.
+
+   Some implementation-specific solutions, such as static configuration
+   on the LMA to accept uplink packets from the old MAG in addition to
+   accepting packets from the new MAG for a short duration during the
+   handover and buffering at the new MAG, can help to address some of
+   the issues identified in this document.  Please see Appendix B for
+   more details.  A dynamic solution by means of the proposed protocol
+   operation helps to optimize the performance for a variety of handover
+   situations and different radio characteristics.
+
+   Additionally, this document specifies an advanced binding cache
+   management mechanism at the LMA according to well-defined transient
+   BCE states.  This mechanism ensures that forwarding states at LMAs
+   are inline with the different handover scenarios.  During a transient
+   state, a mobile node's BCE refers to two proxy Care-of-Address
+   (Proxy-CoA) entries, one from the mobile node's pMAG, another from
+
+
+
+Liebsch, et al.               Experimental                      [Page 4]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+   its nMAG.  MAGs can establish settings of a transient binding on the
+   LMA by means of signaling.  An LMA can establish or change the
+   settings of a transient binding according to events, such as a
+   timeout, a change of the radio technology due to a handover, or a
+   completed set up of a radio bearer or configuration of an MN's IP
+   address.  Such an event may also be triggered by other protocols,
+   e.g., Authentication, Authorization, and Accounting (AAA) messages.
+   This document specifies advanced binding cache control by means of a
+   Transient Binding option, which can be used with PMIPv6 signaling to
+   support transient BCEs.  Furthermore, this document specifies
+   forwarding characteristics according to the current state of a
+   binding to switch the forwarding tunnel at the LMA from the pMAG to
+   the nMAG during inter-MAG handover according to the handover
+   conditions.  As a result of transient binding support, handover
+   performance can considerably be improved to smooth an MN's handover
+   without introducing major complexity into the system.
+
+2.  Conventions and Terminology
+
+2.1.  Conventions Used in This Document
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+2.2.  Terminology and Functional Components
+
+   o  IF - Interface.  Any network interface, which offers a mobile node
+      wireless or wired access to the network infrastructure.  In case a
+      mobile node has multiple interfaces implemented, they are numbered
+      (IF1, IF2, etc.).
+
+   o  Transient Binding Cache Entry.  A temporary state of the mobile
+      node Binding Cache Entry that defines the forwarding
+      characteristics of the mobile node forwarding tunnels to the nMAG
+      and pMAG.  This transient BCE state is created when the Transient
+      Binding option is included in the PBU and PBA as specified in this
+      document.  The LMA forwards the mobile node traffic according to
+      current transient BCE characteristics as specified in this
+      document.  The transient BCE state is transparent to the pMAG.
+
+   o  Active Binding Cache Entry.  A valid mobile node Binding Cache
+      Entry according to [RFC5213], which is not in transient state.
+
+
+
+
+
+
+
+
+Liebsch, et al.               Experimental                      [Page 5]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+3.  Analysis of the Problem Space
+
+   This section summarizes the analysis of the handover problem space
+   for inter-technology handover as well as intra-technology handover
+   when using the PMIPv6 protocol as in [RFC5213].
+
+3.1.  Handover Using a Single Interface
+
+   In some active handover scenarios, it is necessary to prepare the
+   nMAG as the handover target prior to the completion of the link-layer
+   handover procedures.  Packets sent by the LMA to the nMAG before the
+   completion of the link-layer handover procedure will be lost unless
+   they are buffered.
+
+   In some systems, the nMAG will be the recipient of uplink traffic
+   prior to the completion of the procedure that would result in the
+   PBU/PBA handshake.  These packets cannot be forwarded to the LMA.
+
+   During an intra-technology handover, some of the MN's uplink traffic
+   may still be in transit through the pMAG.  Currently, and as per the
+   PMIPv6 base protocol [RFC5213], the LMA forwards the MN's uplink
+   traffic received from a tunnel only as long as the source IP address
+   of the MN's uplink traffic matches the IP address of the mobile
+   node's registered Proxy-CoA in the associated BCE.  As a result,
+   packets received at the LMA from the MN's pMAG after the LMA has
+   already switched the tunnel to point to the nMAG will be dropped.
+
+3.2.  Handover between Interfaces
+
+   In client-based mobility protocols, the handover sequence is fully
+   controlled by the MN, and the MN updates its binding and associated
+   routing information at its mobility anchor after IP connectivity has
+   been established on the new link.  On the contrary, PMIPv6 aims to
+   relieve the MN from the IP mobility signaling, while the mobile node
+   still controls link configuration during a handover.  This introduces
+   a problem during an MN's handover between interfaces.  According to
+   the PMIPv6 base protocol [RFC5213], the Access Authentication and the
+   Proxy Binding Update (PBU) are triggered in the access network by the
+   radio attach procedure, transparently for the MN.  In addition, a
+   delay for the MN's new interface's address configuration is not
+   considered in the handover procedure.  As a consequence, the
+   immediate update of the MN's BCE after the PBU from the MN's nMAG has
+   been received at the LMA impacts the performance of the MN's downlink
+   traffic as well as its uplink traffic.  Performance aspects of
+   downlink as well as uplink traffic during a handover between
+   interfaces are analyzed in the subsequent subsections.
+
+
+
+
+
+Liebsch, et al.               Experimental                      [Page 6]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+3.2.1.  Issues with Downlink Traffic
+
+   Delay of availability of an MN's network interface can be caused by
+   certain protocol operations that the MN needs to perform to configure
+   its new interface, and these operations can take time.  In order to
+   complete the address auto-configuration on its new interface, the MN
+   needs to send a Router Solicitation and awaits a Router
+   Advertisement.  Upon receiving a Router Advertisement from the new
+   MAG, the MN can complete its address configuration and may perform
+   Duplicate Address Detection (DAD) [RFC4862] on the new interface.
+   Only then the MN's new interface is ready to receive packets.
+
+   Address configuration can take more than a second to complete.  If
+   the LMA has already switched the mobile node tunnel to point to the
+   nMAG and started forwarding data packets for the MN to the nMAG
+   during this time, these data packets may get delayed or lost because
+   the MN's new interface is not yet ready to receive data.  However,
+   delaying the PBU, which is sent from the new MAG to the LMA after the
+   MN's new interface has attached to the network, is not possible, as
+   the new MAG retrieves configuration data for the MN from the LMA in
+   the PBA, such as the MN's Home Network Prefixes (HNPs) and the link-
+   local address to be used at the MAG.
+
+   The aforementioned problem is illustrated in Figure 1, which assumes
+   that the HNP(s) will be assigned under control of the LMA.  Hence,
+   the HNP option in the PBU, which is sent by the new MAG to the LMA,
+   is set to ALL_ZERO.  An MN has attached to the network with interface
+   (IF) IF1 and receives data on this interface.  When the MN's new
+   interface IF2 comes up and is detected by the new MAG, the new MAG
+   sends a PBU and receives a PBA from the LMA.  If the LMA decides to
+   forward data packets for the MN via the new MAG, the new MAG has to
+   buffer these packets until address configuration of the MN's new
+   interface has completed and the MN's new interface is ready to
+   receive packets.  While setting up IF2, the MN may not reply to
+   address resolution signaling [RFC4861], as sent by the new MAG [A].
+   If the MAG's buffer overflows or the MN cannot reply to address
+   resolution signaling for too long, data packets for the MN are
+   dropped and the MN can experience severe packet losses during an
+   inter-access handover [B] until IF2 is ready to receive and send data
+   [C].
+
+
+
+
+
+
+
+
+
+
+
+Liebsch, et al.               Experimental                      [Page 7]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+       +------+                 +----+      +----+                 +---+
+       |  MN  |                 |pMAG|      |nMAG|                 |LMA|
+       +------+                 +----+      +----+                 +---+
+       IF2 IF1                    |           |                      |
+        |   |                     |           |                      |
+        |   |- - - - - - - - - Attach         |                      |
+        |   |                     |---------------PBU--------------->|
+        |   |                     |<--------------PBA----------------|
+        |   |--------RtSol------->|           |                      |
+        |   |<-------RtAdv--------|           |                      |
+        |  Addr.                  |           |                      |
+        |  Conf.                  |           |                      |
+        |   |<--------------------|==================data============|--
+        |   |                     |           |                      |
+        |- - - - - - - - - - - - - - - - - Attach                    |
+        |   |                     |           |----------PBU-------->|
+        |   |                     |           |<---------PBA---------|
+        |   |                     |           |<-====data============|--
+    [A]?|<-----------NSol---------------------|<-====data============|--
+        |   |                     |      [B] ?|<-====data============|--
+        |   |                     |          ?|<-====data============|--
+        |-----------RtSol-------------------->|<-====data============|--
+        |<----------RtAdv---------------------|            :         |
+     Addr.  |                     |           |            :         |
+     Conf.  |                     |           |            :         |
+        |<-----------NSol---------------------|            :         |
+        |------------NAdv------------------->[C]                     |
+       !|<------------------------------------|======data============|--
+        |   |                     |           |                      |
+        |   |                     |           |                      |
+
+                 Figure 1: Issue with dual radio handover
+
+   Another risk for a delay in forwarding data packets from a new MAG to
+   the MN's IF2 can be some latency in setting up a particular access
+   technology's radio bearer or access-specific security associations
+   after the new MAG received the MN's HNP(s) from the LMA via the PBA
+   signaling message.
+
+   In case an access network needs the MN's IP address or HNP to set up
+   a radio bearer between an MN's IF2 and the network infrastructure,
+   the access network might have to wait until the nMAG has received the
+   associated information from the LMA in the Proxy Binding
+   Acknowledgment.  Delay in forwarding packets from the nMAG to the
+   MN's IF2 depends now on the latency in setting up the radio bearer.
+
+
+
+
+
+
+Liebsch, et al.               Experimental                      [Page 8]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+   A similar problem can occur in the case in which the setup of a
+   required security association between the MN's IF2 and the network
+   takes time and such a setup can be performed only after the MN's IP
+   address or HNP is available on the nMAG.
+
+   Both scenarios, as depicted above, can be found in [TS23.402], where
+   the protocol sequence during a handover between different accesses
+   considers a PMIPv6 handshake between the nMAG and the LMA to retrieve
+   the MN's HNP(s) before access-specific operations can be completed.
+
+3.2.2.  Issues with Uplink Traffic
+
+   In the case of an inter-technology handover between two interfaces,
+   the MN may be able to maintain connectivity on IF1 while it is
+   completing address configuration on IF2.  Such a handover mechanism
+   is called "make-before-break" and can avoid uplink packet loss in
+   client-based Mobile IP.  However, in a PMIPv6 domain, the attachment
+   of the MN on IF2 will cause the nMAG to send a PBU to the LMA, which
+   will cause the LMA to update the BCE for this mobility session of the
+   MN.  According to Section 5.3.5 of the PMIPv6 base specification
+   [RFC5213], the LMA may drop all subsequent packets being forwarded by
+   the MN's pMAG due to the updated BCE, which refers now to the nMAG as
+   a "Proxy-CoA".
+
+   A further issue for uplink packets arises from differences in the
+   time of travel between the nMAG and LMA in comparison with the time
+   of travel between the pMAG and LMA.  Even if the MN stops sending
+   packets on IF1 before the PBU is sent (i.e., before it attaches IF2
+   to nMAG), uplink packets from pMAG may arrive at the LMA after the
+   LMA has received the PBU from nMAG.  Such a situation can, in
+   particular, occur when the MN's previous link has a high delay (e.g.,
+   a Global System for Mobile Communications (GSM) link) and is slow
+   compared to the handover target link.  This characteristic is
+   illustrated in Figure 2.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Liebsch, et al.               Experimental                      [Page 9]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+      +------+              +----+                   +---+
+      |  MN  |              |nMAG|                   |LMA|
+      +------+              +----+                   +---+
+      IF2 IF1                 |                        |
+       |   |\                 |                        |BCE exists
+       |   |    \             |                        | for pMAG
+       |- -|- - - - \- - - - Attach                    |
+       |   |           s\     |---------PBU----------->|BCE update
+       |   |               l\ |<--------PBA------------| for nMAG
+       |   |                   o\                      |
+       |   |                  |    w\                  |
+       |   |                  |        l\              |
+       |   |                  |            i\          |
+       |   |                  |               n \      |packet dropped
+       |   |                  |                  k --->| as BCE has only
+       |   |                  |                        | entry for nMAG
+       |   |                  |                        |
+       |   |                  |                        |
+
+              Figure 2: Uplink traffic issue with slow links
+
+3.3.  Need for a Common Solution
+
+   To reduce the risk of packet loss, some settings on an MN could be
+   chosen appropriately to speed up the process of network interface
+   configuration.  Also, tuning some network parameters, such as
+   increasing the buffer capacity on MAG components, could improve the
+   handover performance.  However, some network characteristics, such as
+   access link delay or bearer setup latency, cannot be easily fine
+   tuned to suit a particular handover scenario.  Thus, a common
+   solution that dynamically controls and enhances this handover
+   complexity using a simple extension to the PMIPv6 base protocol is
+   preferred.
+
+   This document specifies transient BCEs as an extension to the PMIPv6
+   protocol.  Set up and configuration of a transient BCE can be
+   performed by means of extended PMIPv6 signaling messages between the
+   MAG and the LMA component using a new Transient Binding mobility
+   option.  The transient BCE mechanism supports three clearly
+   distinguished sequences of transient states to suit various handover
+   scenarios and to improve handover performance for both inter- and
+   intra-technology handover.  As a result of using transient BCEs,
+   excessive packet buffering at the nMAG during the MN's handover
+   process is not necessary and packet losses and major jitter can be
+   avoided.
+
+
+
+
+
+
+Liebsch, et al.               Experimental                     [Page 10]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+4.  Use of Transient Binding Cache Entries
+
+4.1.  General Approach
+
+   The use of transient BCE during an MN's handover (HO) enables greater
+   control on the forwarding of uplink (Ul) and downlink (Dl) traffic to
+   harmonize handover performance characteristics with the capabilities
+   of the handover source and target access networks.  Updating of an
+   MN's BCE at an LMA is split into different phases before and after
+   the radio setup and IP configuration being associated with the MN's
+   handover from a pMAG to an nMAG.
+
+   The use of a transient BCE during an MN's handover splits into an
+   initiation phase and a phase turning the transient BCE into an active
+   BCE.  Figure 3 illustrates the procedure to enter and leave a
+   transient BCE during an MN's handover.  As a result of the MN's
+   attachment at the nMAG, the first PBU from the MN's nMAG can turn the
+   MN's BCE at the LMA and the nMAG into transient state by including a
+   Transient Binding option (Section 5.1).  The LMA enters the nMAG as a
+   further forwarding entry to the MN's BCE without deleting the
+   existing forwarding entry and marks the BCE state as 'transient'.
+   Alternatively, in case the nMAG does not include a Transient Binding
+   option, the LMA can make the decision to use a transient BCE during
+   an MN's handover and notify the nMAG about this decision by adding a
+   Transient Binding option in the PBA.  After receiving the PBA, the
+   nMAG enters the MN's data, such as the assigned HNP(s), into its
+   Binding Update List (BUL) and marks the MN's binding with the LMA as
+   'transient', which serves as an indication to the nMAG that the
+   transient BCE needs to be turned into an active BCE.
+
+   During the transient state, the LMA accepts uplink packets from both
+   MAGs, the pMAG and the nMAG, for forwarding.  To benefit from the
+   still available downlink path from pMAG to MN, the LMA forwards
+   downlink packets towards the pMAG until the transient BCE is turned
+   into an active BCE.  Such a downlink forwarding characteristic is
+   denoted as "late path switch" (L).  During a dual radio handover, an
+   MN can receive downlink packets via its previous interface; during a
+   single radio handover, the late path switch supports re-using
+   available forwarding mechanisms in the radio access network.
+   Appendix A describes both use cases.
+
+   Decisions about the classification of an MN's BCE as transient during
+   a handover can be made either by the nMAG or the LMA.  Detailed
+   mechanisms showing how an nMAG or an LMA finds out to use a transient
+   BCE procedure are out of scope of this document.
+
+
+
+
+
+
+Liebsch, et al.               Experimental                     [Page 11]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+   A transient BCE can be turned into an active BCE by different means,
+   such as a timeout at the LMA, a PBU from the nMAG, which has no
+   Transient Binding option included, or a deregistration PBU from the
+   pMAG.  As soon as the MN's BCE has been initiated to turn into an
+   active BCE, the LMA switches the forwarding path for downlink packets
+   from the pMAG to the nMAG.
+
+    +-----+            +----+    +----+                +-----+
+    | MN  |            |pMAG|    |nMAG|                | LMA |
+    +-----+            +----+    +----+                +-----+
+       |                  |         |                     |[pMAG serves
+       |                  |         |                     | MN as
+       |                  |         |                     | Proxy-CoA]
+       |                  |         |                     |
+       |<-----------------|===============data tunnel=====|--->data
+       |                  |         |                     |
+   [Handoff               |         |                     |
+     Start]               |         |                     |
+       |                  |         |                     |
+      e|-----------------------[MN Attach]                |
+      x|                  |         |                     |
+      e|                  |         |---PBU(transient)--->|[Add nMAG to
+      c|                  |         |                     | MN's BCE,
+      u|                  |         |<--PBA(transient)----| enter trans-
+      t|                  |         |                     | ient state]
+      i|                  |         |                     |
+      o|<-----Dl+Ul-------|===============data tunnel=====|--->data
+      n|--------Ul------------------|=====data tunnel=====|--->data
+       |                  |         |                     |
+    [Handoff/             |         |                     |
+   Configuration          |         |                     |
+    Completed]            |   [HO Complete]               |
+       |                  |         |--------PBU--------->|[Activate
+       |                  |         |                     | MN's BCE,
+       |                  |         |<-------PBA ---------| update for-
+       |                  |         |                     | warding path
+       |                  |         |                     | to nMAG]
+       |                  |         |                     |
+       |<---------------------------|=====data tunnel=====|--->data
+       |                  |         |                     |
+
+     Figure 3: General mechanism and forwarding characteristics during
+                        handover with transient BCE
+
+   This specification considers an optional state when turning the
+   transient BCE into an active BCE of a transient BCE with a late path
+   switch, which keeps the pMAG for some more time as the forwarding
+
+
+
+
+Liebsch, et al.               Experimental                     [Page 12]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+   entry in the transient BCE, solely to ensure forwarding of delayed
+   uplink packets from the pMAG.  This optional activation state has a
+   lifetime associated, and termination does not need any signaling.
+
+   Whether or not to enter this optional activation state is decided by
+   the LMA.  The LMA may take information about the access technology
+   associated with the MN's pMAG and nMAG from the MN's BCE to decide if
+   using the activation state is beneficial, e.g., since a slow link is
+   associated with the pMAG and uplink packets from the pMAG may arrive
+   delayed at the LMA.
+
+   The Transient Binding option allows configuration of the transient
+   BCE late path switch and signaling of associated settings.  Signaling
+   of the Transient Binding option and the LMA's decision whether or not
+   to use an optional activation state defines the sequence through the
+   clearly defined transient BCE states, as illustrated and described in
+   Section 4.4.  Section 4.2 describes the required extension to an
+   LMA's binding cache to support transient BCE operation.  Section 4.3
+   provides a concise overview about the possible roles of the nMAG and
+   the LMA to control a transient BCE handover sequence.  Details about
+   the Transient Binding option and its use are described in Sections
+   4.5 and 4.6.
+
+4.2.  Impact on Binding Management
+
+   The use of a transient BCE requires temporary maintenance of two
+   forwarding entries in the MN's BCE at the LMA, one referring to the
+   MN's pMAG and the other referring to its nMAG.  Forwarding entries
+   are represented according to [RFC5213] and comprise the interface
+   identifier of the associated tunnel interface towards each MAG, as
+   well as the associated access technology information.
+
+   Each forwarding entry is assigned a forwarding rule to admit and
+   control forwarding of uplink and downlink traffic to and from the
+   associated MAG.  Hence, according to this specification, a forwarding
+   entry can have either a rule that allows only forwarding of uplink
+   traffic from the associated MAG, or a rule that allows bidirectional
+   forwarding from and to the associated MAG.  At any time, only one of
+   the two forwarding entries can have a bi-directional forwarding rule.
+   The interface identifier and access technology type info can be taken
+   from the PBU received at the LMA and linked to each forwarding entry
+   accordingly.
+
+   MAGs should maintain the status of an MN's binding and the lifetime
+   associated with a transient BCE at the LMA in their binding update
+   list.  This is particularly important if the new MAG needs to
+   explicitly turn a binding into an active BCE after the associated
+   MN's new interface has proven to be ready to handle IP traffic.
+
+
+
+Liebsch, et al.               Experimental                     [Page 13]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+4.3.  Role of the LMA and nMAG in Transient State Control
+
+   This section provides an overview about the nMAG's and the LMA's
+   possibility to control a transient BCE.  Please refer to the Protocol
+   Operations sections for a detailed protocol description (Sections 4.5
+   and 4.6).
+
+4.3.1.  Control at the nMAG
+
+   Initiate a late path switch -  Since the nMAG needs to have knowledge
+      about the nature of a handover to set the Handoff Indicator (HI)
+      option in the PBU and whether or not the handover implies a change
+      in the used radio interface or technology, the nMAG is a suitable
+      entity to make the decision to delay the downlink path switch in a
+      controlled manner by means of a transient BCE.  The nMAG can make
+      the decision to initiate a transient BCE handover for an MN only
+      when it knows that the MN supports a delayed downlink path switch
+      (Section 4.7) according to this specification.  It may know this
+      due to a number of factors.  For instance, during dual radio
+      handover, most cellular networks have controlled handovers where
+      the network knows that the host is moving from one attachment to
+      another.  In this situation, the link-layer mechanism can inform
+      the mobility functions that this is indeed a movement, not a new
+      attachment and that the MN has sufficient control on its
+      interfaces to support a transient BCE handover.  Where no support
+      from the link layer exists and no such indication can be provided
+      to the nMAG by the network, the nMAG MUST assume that the host is
+      incapable of this mode of operation and employ standard behavior
+      as specified in [RFC5213].  In other words, the nMAG initiates a
+      regular [RFC5213] handover.
+
+      The nMAG is also a suitable entity to estimate a maximum delay
+      until the new connection can be used, as it knows about its
+      locally connected radio network characteristics.  Hence, the nMAG
+      can set the maximum lifetime to delimit the transient BCE
+      softstate at the LMA.  The LMA may still override the proposed
+      lifetime and notify the nMAG about the new lifetime in the
+      Transient Binding option included in the PBA.
+
+   Activation of a transient BCE to perform a downlink path switch -
+      During a transient BCE handover, the nMAG may get an indication
+      that the MN's radio link can be used and the MN has completed the
+      setup of the IP address to send and receive data packets via the
+      new link.  In this case, the nMAG can initiate turning a transient
+      BCE into an active BCE before the expiration of the associated
+      maximum transient BCE lifetime.  To do that, the nMAG sends a PBU
+      message without the Transient Binding option to the LMA.  This
+      results in a downlink path switch to the nMAG.
+
+
+
+Liebsch, et al.               Experimental                     [Page 14]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+4.3.2.  Control at the LMA
+
+   Initiate a late path switch -  If the LMA has received a PBU without
+      a Transient Binding option included, the LMA can take a decision
+      to use a transient BCE to optimize the handover performance.  The
+      LMA indicates its selected settings for the late path switch (L)
+      and the associated maximum lifetime in the Transient Binding
+      option, which is included in the PBA and sent to the nMAG.
+
+   Decision to use an optional activation state -  The LMA is a suitable
+      entity to decide about the use of an optional activation state, as
+      the LMA has the knowledge about the MN's previous and new access
+      technology.  Hence, the LMA can make this decision to use an
+      activation state to temporarily keep alive the forwarding of
+      uplink packets from both MAGs, the pMAG, and the nMAG, even though
+      the downlink path has been switched to the nMAG already.  One
+      reason to enter such an activation state may be a slow link
+      between the pMAG and the LMA as described in Section 3.2.2.
+
+4.4.  LMA Forwarding State Diagram
+
+   The current specification of transient BCEs covers three clearly
+   defined transient BCE states at the LMA, which can be used during an
+   MN's handover.  Each state implies a dedicated characteristic
+   regarding forwarding entries, in which forwarding rules for uplink
+   traffic are maintained separately from downlink traffic.  This
+   section explains how the forwarding state sequentially changes during
+   the optimized handoff.  To suit different handover scenarios,
+   different sequences through the forwarding states can be entered.
+   Figure 4 depicts the possible cases, their sequence of forwarding
+   states, and the triggers for the transitions.  Two example use cases
+   are described in detail in Appendix A to illustrate which sequence
+   through the forwarding states suits a particular handover.
+
+   According to this specification, each BCE has a state associated,
+   which can be either 'Active' or any of the specified transient states
+   'Transient-L', 'Transient-LA', or 'Transient-A'.  In the case that a
+   BCE is in 'Active' state, the information in a BCE and associated
+   forwarding conforms to [RFC5213].
+
+   Any of the transient states imply that the transient BCE has two
+   forwarding entries, which are denoted as pMAG and nMAG in the
+   forwarding state diagram.  The diagram includes information about the
+   forwarding rule along with each forwarding entry.  This rule
+   indicates whether a forwarding entry is meant to perform forwarding
+   only for Uplink (Ul) traffic or to perform bi-directional forwarding
+   for Uplink (Ul) and Downlink (Dl) traffic.
+
+
+
+
+Liebsch, et al.               Experimental                     [Page 15]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+   State transitions can be triggered as a result of processing a
+   received PBU or by a local timeout event on the LMA.  In the
+   forwarding state chart below, the presence of a Transient Binding
+   option in a PBU is indicated by 'Topt' as an argument to a PBU or
+   PBA, respectively.  As a further argument to a PBU message, the
+   source of the message is indicated, which can be either the MN's nMAG
+   or pMAG.  A PBA is always sent by the LMA and addressed to the
+   originator of the associated PBU.
+
+   A handover with transient BCE is either triggered when the nMAG sends
+   a PBU with a Transient Binding option or when the LMA decides to
+   answer a normal PBU with a PBA after including a Transient Binding
+   option.  Figure 4 illustrates the possible transitions between an
+   active BCE and a transient BCE from the LMA's point of view.  It also
+   shows the direct transition between two active BCE states during an
+   MN's handover according to [RFC5213], bypassing any transient states.
+
+   The diagram refers to two timeout events.  TIMEOUT_1 is set according
+   to the Lifetime value in a Transient Binding option (see Section 5
+   for the format of the Transient Binding option), whereas TIMEOUT_2 is
+   set to ACTIVATIONDELAY (see Section 8 for the default value).
+
+   The first sequence of a transient BCE handover is followed when the
+   LMA decides not to use the optional activation state and is going
+   through Transient-L state, in which the LMA continues forwarding
+   downlink packets to the pMAG, whereas uplink packets are accepted and
+   forwarded from both, the pMAG and the nMAG.  On reception of a PBU
+   without a Transient Binding option from the nMAG, a TIMEOUT_1 event,
+   or the reception of a deregistration PBU from the pMAG, the
+   forwarding entry of the pMAG is removed from the MN's BCE, and the
+   BCE state changes to active.
+
+   If the LMA decides to use the activation state, the second sequence
+   is used.  In this case, the BCE state turns into Transient-LA.
+   Forwarding characteristics in the Transient-LA state are the same as
+   for the Transient-L state, but the Transient-LA state follows a
+   Transient-A state when the LMA receives a PBU from the nMAG without a
+   Transient Binding option included or a TIMEOUT_1 event occurs.  In
+   the Transient-A state, the LMA performs a downlink forwarding path
+   switch from the pMAG to the nMAG, whereas uplink packets are still
+   accepted and forwarded from both, the pMAG and the nMAG.  The
+   Transient-A state is terminated by a TIMEOUT_2 event, the forwarding
+   entry of the pMAG is removed from the MN's BCE, and the BCE state
+   turns to active.  If the LMA receives a deregistration PBU from the
+   pMAG while the associated MN's BCE is in Transient-LA state, the
+   uplink forwarding rule of the pMAG is no longer valid and the
+   transition through Transient-A state is skipped.  In such a case, the
+   BCE turns into active state immediately.
+
+
+
+Liebsch, et al.               Experimental                     [Page 16]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+                                +----------------+              Before
+          PBU(nMAG) & PBA(LMA)  |    Active      |              Handover
+        +-----------------------|                |              --------
+        |                       |  pMAG [Dl,Ul]  |                   .
+        |                       *----------------*                   .
+        |                               |                            .
+        |                               |                            V
+        |               PBU(nMAG, Topt) | PBU(nMAG) & PBA(LMA, Topt) .
+        |                               |                            .
+        |                               |                            .
+        |                               V                      Handover
+        |                           __________                 Procedure
+        |                          /   LMA    \                      .
+        |               _________ /  selects   \ _________           .
+        |            No|          \ activation /          |Yes       .
+        |              |           \_state_?__/           |          .
+        |              |                                  |          V
+        |              V                                  V          .
+        |       +--------------+                  +--------------+   .
+        |       | Transient-L  |                  | Transient-LA |   .
+        |       |              |                  |              |   .
+        |       | pMAG [Dl,Ul] |          +-------| pMAG [Dl,Ul] |   .
+        |       | nMAG [Ul]    |          |       | nMAG [Ul]    |   .
+        |       +--------------+          |       +--------------+   .
+        |              |                  |               |
+        |              |       PBU(pMAG,  |     PBU(nMAG) | TIMEOUT_1
+        |              |       lifetime=0)|               |          .
+        |              |                  |               V          .
+        |              |                  |       +--------------+   .
+        |              |                  |       | Transient-A  |   .
+        |    PBU(nMAG) | TIMEOUT_1        |       |              |   .
+        |              |                  |       | nMAG [Dl,Ul] |   .
+        |              |PBU(pMAG,         |       | pMAG [Ul]    |   .
+        |              | lifetime=0)      |       +--------------+   .
+        |              |                  |               |
+        |              |                  |   PBU(pMAG,   | TIMEOUT_2
+        |              |                  |    lifetime=0)|          .
+        |              |                  |               |          V
+        |              |                  |               |    -------
+        |              |                  |               |    Handover
+        |              |                  |               V    Complete
+        |              |                  |        +--------------+
+        |              |                  +------->|    Active    |
+        |              +-------------------------->|              |
+        +----------------------------------------->| nMAG [Dl,Ul] |
+                                                   +--------------+
+
+     Figure 4: Possible transient forwarding states during a handover
+
+
+
+Liebsch, et al.               Experimental                     [Page 17]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+4.5.  MAG Operation
+
+   In case of a handover, the MN's nMAG may decide to control the MN's
+   handover at the LMA to perform a late path switch according to the
+   transient BCE procedure.  In such a case, the nMAG includes the
+   Transient Binding option in the PBU and sets the L-flag to 1 to
+   indicate a late path switch.  Furthermore, the nMAG MUST set the
+   Lifetime field of the Transient Binding option to a value larger than
+   0 to propose a maximum lifetime of the transient BCE and to delimit
+   the delay of switching the downlink path to the nMAG.  The chosen
+   lifetime value for the Transient Binding option SHOULD be smaller
+   than the chosen lifetime value for the PBU registration.  Other
+   fields and options of the PBU are used according to [RFC5213].
+
+   In case the nMAG does not include a Transient Binding option but the
+   LMA decides to perform a handover according to the transient BCE
+   procedure, the nMAG may receive a Transient Binding option along with
+   the PBA from the LMA as a result of the PBU it sent to the LMA.
+
+   In case the nMAG receives a PBA with a Transient Binding option
+   having the L-flag set to 1, it SHOULD link the information about the
+   transient BCE sequence and the associated transient BCE lifetime with
+   the MN's entry in the BUL.  Since the L-flag of the Transient Binding
+   option is set to 1 to indicate a late path switch, the nMAG MAY turn
+   an MN's transient BCE into an active BCE before the expiration of the
+   transient BCE lifetime (TIMEOUT_1), e.g., when the MN's nMAG detects
+   or gets informed that address configuration and radio bearer setup
+   has been completed.  To initiate turning a transient BCE into an
+   active BCE, the nMAG sends a PBU to the LMA without including the
+   Transient Binding option.  All fields of the PBU are set according to
+   the procedure for the binding lifetime extension described in Section
+   5.3.3 of [RFC5213].  In case the lifetime of a transient BCE expires
+   or the LMA approves turning a transient BCE into an active BCE as a
+   result of a PBU sent by the nMAG, the nMAG MUST delete all
+   information associated with the transient BCE from the MN's BUL
+   entry.
+
+   In case the nMAG includes a Transient Binding option into the PBU,
+   only one instance of the Transient Binding option per PBU is allowed.
+
+   A MAG, which serves the MN current Proxy-CoA while the LMA already
+   has an active or transient binding for the MN pointing to this MAG,
+   SHALL NOT include a Transient Binding option in any subsequent PBU to
+   create or update a transient BCE for the MN's current registration
+   with this MAG.
+
+
+
+
+
+
+Liebsch, et al.               Experimental                     [Page 18]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+4.6.  LMA Operation
+
+4.6.1.  Initiation of a Transient BCE
+
+   In case the LMA receives a handover PBU from an MN's nMAG that does
+   not include a Transient Binding option and the associated MN's BCE is
+   active and not in transient state, the LMA MAY take the decision to
+   use a transient BCE and inform the nMAG about the transient BCE
+   characteristics by including a Transient Binding option in the PBA.
+   In such a case, the LMA should know about the nMAG's capability to
+   support the Transient Binding option.  The configuration of the MN's
+   transient BCE is performed according to the description in this
+   section and the selected transient state.  Otherwise, the LMA
+   processes the PBU according to the PMIPv6 protocol [RFC5213] and
+   performs a normal update of the MN's BCE.
+
+   In case the PBU from the nMAG has a Transient Binding option
+   included, the LMA must enter the sequence of transient BCE states
+   according to its decision whether or not to use an optional
+   activation state.  In case the LMA decides not to use an activation
+   state, it configures the MN's transient BCE and the forwarding rules
+   according to Transient-L state.  As a result, the LMA performs a late
+   path switch and forwards downlink packets for the MN towards the MN's
+   pMAG, whereas uplink packets being forwarded from both Proxy-CoAs,
+   the MN's pMAG, as well as from its nMAG, will be routed by the LMA.
+
+   In case the PBU from the nMAG has a Transient Binding option included
+   and the LMA decides to use an optional activation state, the LMA
+   configures the MN's transient BCE and the forwarding rules according
+   to Transient-LA state.  As a result, the LMA performs a late path
+   switch and forwards downlink packets for the MN towards the MN's
+   pMAG, whereas uplink packets being forwarded from both Proxy-CoAs,
+   the MN's pMAG, as well as from its nMAG, will be routed by the LMA.
+   In addition, the LMA marks the transient BCE to enter a temporary
+   activation phase in Transient-A state after the LMA received an
+   indication to turn a transient BCE into an active BCE.
+
+   The LMA sets the lifetime of the transient BCE according to the
+   lifetime indicated by the nMAG in the Transient Binding option's
+   lifetime field or may decide to reduce the lifetime according to its
+   policy.  If the lifetime value in the Transient Binding option
+   exceeds the lifetime value associated with the PBU message, the LMA
+   MUST reduce the lifetime of the transient BCE to a value smaller than
+   the registration lifetime value in the PBU message.  In the case of a
+   successful transient BCE registration, the LMA sends a PBA with a
+   Transient Binding option back to the nMAG.  The L-flag of the
+
+
+
+
+
+Liebsch, et al.               Experimental                     [Page 19]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+   Transient Binding option MUST be set to 1 in this version of the
+   specification.  The lifetime field is set to the value finally chosen
+   by the LMA.
+
+   In any case where the LMA finds the L-flag of the received Transient
+   Binding option set to 1, but the lifetime field of the Transient
+   Binding option is set to 0, the LMA MUST ignore the Transient Binding
+   option and process the PBU according to [RFC5213].  After the PBU has
+   been processed successfully, the LMA sends back a PBA with the status
+   field set to PBU_ACCEPTED_TB_IGNORED_SETTINGSMISMATCH.
+
+   In case the LMA receives a Transient Binding option with the L-flag
+   set to 0, this version of the specification mandates the LMA to
+   ignore the Transient Binding option and process the PBU according to
+   [RFC5213].  After the PBU has been processed successfully, the LMA
+   sends back a PBA with the status field set to
+   PBU_ACCEPTED_TB_IGNORED_SETTINGSMISMATCH.
+
+   In case the LMA receives a PBU with a Transient Binding option
+   included from a MAG that serves already as Proxy-CoA to the
+   associated MN in an active or transient BCE, the LMA MUST ignore the
+   Transient Binding option and process the PBU according to [RFC5213].
+   After the PBU has been processed successfully, the LMA sends back a
+   PBA with the status field set to
+   PBU_ACCEPTED_TB_IGNORED_SETTINGSMISMATCH.  In case the MN's BCE was
+   in transient state before receiving such PBU from the MAG, the LMA
+   SHALL interpret this PBU as indication to turn a transient BCE into
+   an active BCE and proceed with leaving the Transient-L or
+   Transient-LA state, respectively.
+
+   In any case where the LMA includes a Transient Binding option in the
+   PBA, only one instance of the Transient Binding option per PBA is
+   allowed.
+
+4.6.2.  Activation of a Transient BCE
+
+   When the LMA receives a PBU from the MN's nMAG that has no Transient
+   Binding option included but the MN's BCE is in a transient state or
+   the LMA receives a local event trigger due to expiration of the MN's
+   transient BCE, the LMA should check whether the forwarding rules for
+   the associated MN are set to route the MN's downlink traffic to the
+   MN's pMAG.  If the forwarding entry for downlink packets refers to
+   the MN's pMAG, the LMA must update the forwarding information to
+   forward downlink packets towards the MN's nMAG.  After the forwarding
+   path has been switched, the LMA must update the MN's BCE accordingly.
+
+
+
+
+
+
+Liebsch, et al.               Experimental                     [Page 20]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+   If the transient BCE indicates that the LMA must consider an
+   activation state Transient-A after leaving a transient BCE has been
+   initiated, the LMA must keep both forwarding entries for the pMAG and
+   the nMAG for uplink packets and perform forwarding of packets it
+   receives from both Proxy-CoAs.  If no activation phase is indicated,
+   the LMA sets the state of the MN's BCE to active and deletes any
+   forwarding entry referring to the MN's pMAG.  The LMA must delete any
+   scheduled timeout event for the MN that is associated with a
+   transient BCE.
+
+   When the LMA receives a deregistration PBU from the MN's pMAG, which
+   has the registration lifetime set to 0 and the MN's BCE is in
+   transient state, the LMA must update the forwarding rules for the MN
+   and switch the downlink traffic path from the pMAG to the nMAG.
+   Furthermore, the LMA sets the state of the MN's BCE to active and
+   removes any forwarding entry towards the pMAG from the MN's BCE,
+   irrespective of whether or not the transient BCE was configured to
+   enter an activation state of Transient-A.
+
+   When the LMA receives a local event trigger due to the expiration of
+   a timer that has been set to ACTIVATIONDELAY and scheduled to
+   terminate the activation state of an MN's transient BCE, the LMA sets
+   the state of the MN's BCE to active and removes any forwarding entry
+   towards the pMAG from the MN's BCE.
+
+   When the LMA receives a PBU for binding lifetime extension from the
+   MN's pMAG while the MN's BCE is in transient state, the LMA must
+   approve the lifetime extension to pMAG according to [RFC5213] and
+   proceed with the transient BCE handover towards nMAG according to
+   this specification.
+
+   When the LMA receives a PBU from pMAG or a (n+1)MAG, which indicates
+   a handover, e.g., according to the indications specified in
+   [RFC5213], while the MN's BCE is in any of the specified transient
+   states, the LMA MUST terminate the transient state and perform a
+   handover to pMAG or (n+1)MAG, respectively, according to [RFC5213].
+   After the PBU has been processed successfully, the LMA sends back a
+   PBA to the MAG that sent the PBU.  If the PBU included a Transient
+   Binding option, the LMA must ignore the Transient Binding option and
+   set the status code of the PBA to
+   PBU_ACCEPTED_TB_IGNORED_SETTINGSMISMATCH.
+
+
+
+
+
+
+
+
+
+
+Liebsch, et al.               Experimental                     [Page 21]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+4.7.  MN Operation
+
+   For a single radio handover, this specification does not require any
+   additional functionality on the mobile node, when compared to
+   [RFC5213].
+
+   During dual radio handover, the MN benefits most from the transient
+   BCE extension to PMIPv6 when it is able to keep communication on the
+   previous interface while it is setting up its handover target
+   interface with the configuration context that has been received as a
+   result of the new interface's attachment to the nMAG.  Various
+   techniques enable support for such an operation, e.g., the use of a
+   virtual interface on top of physical radio interfaces [NETEXT] or
+   implementation-specific extensions to the MN's protocol stack.
+   Details about how to enable such make-before-break support on the MN
+   are out of scope of this document.
+
+4.8.  Status Values
+
+   This section specifies the following PBA status value (6) for
+   transient binding cache entry support.  This status value is smaller
+   than 128 and has been added to the set of status values specified in
+   [RFC5213].
+
+   PBU_ACCEPTED_TB_IGNORED_SETTINGSMISMATCH:  6
+
+      The LMA has processed and accepted the PBU, but the attached
+      Transient Binding option has been ignored.
+
+4.9.  Protocol Stability
+
+   The specification and use of transient BCEs ensures that correct
+   PMIPv6 operation according to [RFC5213] will not be broken in any
+   case.  Such cases include loss of signaling information and
+   incompatibility between an nMAG and an LMA in case one or the other
+   side does not support the transient BCE option.  The following list
+   summarizes such cases and describes how the PMIPv6 protocol operation
+   resolves incompatibility or loss of a signaling message.
+
+   LMA does not support transient BCEs:  In case the nMAG sends a PBU
+      with a Transient Binding option included to an LMA but the LMA
+      does not support transient BCEs, the LMA ignores the unknown
+      option [RFC3775] and processes the PBU according to [RFC5213].
+      Since the nMAG receives a PBA that has no Transient Binding option
+      included, it does not set any transient binding information in the
+      MN's BUL entry and operates according to [RFC5213].
+
+
+
+
+
+Liebsch, et al.               Experimental                     [Page 22]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+   nMAG does not support transient BCEs:  In case the LMA makes the
+      decision to perform a handover according to any of the specified
+      transient BCE sequences and includes a Transient Binding option in
+      the PBA, the receiving nMAG ignores the unknown option [RFC3775]
+      and processes the PBA according to [RFC5213].  As the LMA does not
+      get any further indication or feedback about the incompatibility
+      at the nMAG, the LMA enters the selected transient state, which
+      will be terminated at the latest time after (TIMEOUT_1 +
+      ACTIVATIONDELAY) seconds.  During this period, the nMAG performs
+      according to the PMIPv6 specification [RFC5213], whereas the LMA
+      will accept all uplink packets for the MN, from the pMAG, as well
+      as from the nMAG according to the transient BCE specification.  It
+      is transparent to the nMAG if the LMA forwards downlink packets to
+      the pMAG during the transient BCE phase; thus, no protocol
+      conflict occurs due to the different states on the nMAG and the
+      LMA.
+
+   Loss of Transient Binding option:  As the Transient Binding option is
+      included in the PBU and PBA, recovery from signaling packet loss
+      is according to the PMIPv6 protocol operation and associated
+      re-transmission mechanisms [RFC5213].
+
+   Missing PBU to turn a transient BCE into an active BCE:  According to
+      this specification, a lifetime for TIMEOUT_1 is signaled in the
+      Transient Binding option, and turning a transient BCE into an
+      active BCE is initiated at the latest time after the timer
+      TIMEOUT_1 has elapsed.  In case PBU signaling is lost or the nMAG
+      fails to initiate turning a transient BCE into an active BCE, the
+      transient state of the MN's BCE will be terminated after
+      expiration of the set lifetime, i.e., stable operation of the
+      PMIPv6 protocol [RFC5213] has reliably recovered.
+
+   Lost connection with pMAG during late path switch:  In case an MN
+      loses connectivity to its pMAG during a transient BCE phase with
+      late path switch and the nMAG fails to initiate turning a
+      transient BCE into an active BCE to perform the path switch to the
+      nMAG, in a worst-case scenario, downlink packets are lost until
+      the chosen TIMEOUT_1 expires.  After TIMEOUT_1 seconds, the
+      protocol operation has been recovered successfully.  However, this
+      case is very unlikely for two reasons: If the connectivity to the
+      pMAG is lost, the pMAG will send a deregistration PBU for the MN
+      to the LMA, which results in turning the transient BCE into an
+      active BCE and in a path switch.  Furthermore, the nMAG will
+      initiate turning the transient BCE into an active BCE as soon as
+      the setup of the data link between the MN and the nMAG has been
+      completed (Section 4.4).  Note that this case, in particular,
+      affects downlink packets, whereas uplink packets can be sent
+
+
+
+
+Liebsch, et al.               Experimental                     [Page 23]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+      through the new connection after a broken link to the pMAG has
+      been detected.
+
+   Binding lifetime extension from pMAG while MN's BCE is transient:  As
+      the binding lifetime of the pMAG and the nMAG is not correlated,
+      pMAG may send a PBU for binding lifetime extension to the MN's LMA
+      while the MN's BCE is in transient state.  In such a case, the LMA
+      will approve the binding lifetime extension to pMAG according to
+      [RFC5213] and proceed with the transient BCE handover towards nMAG
+      according to this specification.
+
+   The specification of the transient BCE extension maintains stable
+   operation of PMIPv6 in case the MN performs very frequent handover,
+   e.g., movement while the MN's handover between the pMAG and the nMAG
+   is still in progress.  Such corner cases are summarized in the
+   following list.
+
+   Handover to (n+1)MAG during transient BCE:  In case the MN's BCE is
+      transient due to a handover from the pMAG to nMAG and during the
+      transient BCE, the MN performs a further handover to a MAG that is
+      different from pMAG and nMAG, say to (n+1)MAG, the LMA terminates
+      the transient BCE and performs a handover to (n+1)MAG according to
+      [RFC5213].
+
+   Handover back to pMAG during transient BCE (ping pong):  In case the
+      MN's BCE is transient due to a handover from the pMAG to nMAG and
+      the MN moves back from nMAG to pMAG during the transient BCE, the
+      LMA terminates the transient BCE and performs a handover to pMAG
+      according to [RFC5213].
+
+5.  Message Format
+
+5.1.  Transient Binding Option
+
+   This section describes the format of the Transient Binding option,
+   which can be included in a Proxy Binding Update message and a Proxy
+   Binding Acknowledge message.  The use of this Mobility Header option
+   is optional.
+
+   The Transient Binding option can be included in a PBU message, which
+   is sent by an MN's nMAG as a result of a handover.  In such a case,
+   the nMAG controls the transient BCE on the LMA.  Alternatively, the
+   LMA may attach the Transient Binding option in a PBA for two reasons.
+   Either it replies to a received PBU with an attached Transient
+   Binding option to approve or correct the transient BCE lifetime, or
+   it notifies the nMAG about its decision to enter a transient BCE
+   without having received a Transient Binding option from the nMAG in
+   the associated PBU beforehand.
+
+
+
+Liebsch, et al.               Experimental                     [Page 24]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+   The Transient Binding option has no alignment requirement.  Its
+   format is as follows:
+
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |    Type       |     Length    | Reserved    |L|   Lifetime    |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   Type: Identifies the Transient Binding option (43).
+
+   Length: 8-bit unsigned integer indicating the length of the option in
+   octets, excluding the Type and the Length fields.  This field MUST be
+   set to 2.
+
+   L-Flag: Indicates that the LMA applies late path switch according to
+   the transient BCE state.  If the L-flag is set to 1, the LMA
+   continues to forward downlink packets towards the pMAG.  Different
+   setting of the L-Flag may be for future use.
+
+   Lifetime: Maximum lifetime of a Transient-L state in multiple of 100
+   ms.
+
+6.  IANA Considerations
+
+   This specification adds a new Mobility Header option, the Transient
+   Binding option.  The Transient Binding option is described in
+   Section 5.1.  The Type value (43) for this option has been registered
+   in the Mobility Options registry, the numbering space allocated for
+   the other mobility options, as defined in [RFC3775].
+
+   This specification also adds one status code value to the Proxy
+   Binding Acknowledge message, the
+   PBU_ACCEPTED_TB_IGNORED_SETTINGSMISMATCH status code (6).  The
+   PBU_ACCEPTED_TB_IGNORED_SETTINGSMISMATCH status code is described in
+   Section 4.8.  Its value has been assigned from the Status Codes sub-
+   registry as defined in [RFC3775] and has a value smaller than 128.
+
+7.  Security Considerations
+
+   Signaling between MAGs and LMAs as well as information carried by PBU
+   and PBA messages is protected and authenticated according to the
+   mechanisms described in [RFC5213].  No new security considerations
+   are introduced in addition to those in [RFC5213].  Thus, the security
+   considerations described throughout [RFC5213] apply here as well.
+
+
+
+
+
+
+Liebsch, et al.               Experimental                     [Page 25]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+   In case the MAGs or LMAs make use of a further protocol interface to
+   an external component, such as for support of transient BCE control,
+   the associated protocol must be protected and information must be
+   authenticated.
+
+8.  Protocol Configuration Variables
+
+   LMA values:
+
+   o  'ACTIVATIONDELAY': This value is set by default to 2000 ms and can
+      be administratively adjusted.
+
+9.  Contributors
+
+   Many thanks to Jun Awano, Suresh Krishnan, Long Le, Kent Leung,
+   Basavaraj Patil, and Rolf Sigle for contributing to this document.
+
+10.  Acknowledgments
+
+   The authors would like to thank Telemaco Melia, Vijay Devarapalli,
+   Rajeev Koodli, Ryuji Wakikawa, and Pierrick Seite for their valuable
+   comments to improve this specification.
+
+11.  References
+
+11.1.  Normative References
+
+   [RFC2119]   Bradner, S., "Key words for use in RFCs to Indicate
+               Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC3775]   Johnson, D., Perkins, C., and J. Arkko, "Mobility Support
+               in IPv6", RFC 3775, June 2004.
+
+   [RFC5213]   Gundavelli, S., Leung, K., Devarapalli, V., Chowdhury,
+               K., and B. Patil, "Proxy Mobile IPv6", RFC 5213,
+               August 2008.
+
+11.2.  Informative References
+
+   [NETEXT]    Melia, T., Ed. and S. Gundavelli, Ed., "Logical Interface
+               Support for multi-mode IP Hosts", Work in Progress,
+               October 2010.
+
+   [RFC4861]   Narten, T., Nordmark, E., Simpson, W., and H. Soliman,
+               "Neighbor Discovery for IP version 6 (IPv6)", RFC 4861,
+               September 2007.
+
+
+
+
+
+Liebsch, et al.               Experimental                     [Page 26]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+   [RFC4862]   Thomson, S., Narten, T., and T. Jinmei, "IPv6 Stateless
+               Address Autoconfiguration", RFC 4862, September 2007.
+
+   [TS23.401]  "General Packet Radio Service (GPRS) enhancements for
+               Evolved Universal Terrestrial Radio Access Network
+               (E-UTRAN) access", <http://www.3gpp.org>.
+
+   [TS23.402]  "Architecture enhancements for non-3GPP accesses (Release
+               9)", <http://www.3gpp.org>.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Liebsch, et al.               Experimental                     [Page 27]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+Appendix A.  Example Use Cases for Transient BCE
+
+A.1.  Use Case for Single Radio Handover
+
+   In some systems, such as the 3GPP Evolved Packet Core, PMIPv6 is
+   supported for providing network-based mobility between the Serving
+   Gateway (i.e., MAG) and the Packet Data Network Gateway (i.e., LMA)
+   and handover mechanisms are implemented in the access network to
+   optimize handover for single radio mobile nodes [TS23.401].
+
+   In such a system, a well structured inter-MAG handover procedure has
+   been developed and effectively used.  In order to switch the data
+   tunnel path between the LMA and the pMAG in a systematic way that
+   reduces packet loss and delay, this inter-MAG handover sets up the
+   uplink data path from the mobile node through the nMAG and to the LMA
+   first.  As soon as the uplink data path is set up, the mobile node is
+   able to forward uplink data packets through the nMAG to the LMA.
+
+   Since the downlink data path between the LMA and the nMAG is not set
+   up at the same time as the uplink data path, the LMA must continue to
+   forward downlink data packets to the pMAG.  Additionally, this system
+   utilizes a layer 2 forwarding mechanism from the previous Access
+   Network (pAN) to the new Access Network (nAN), which enables the
+   delivery of the downlink data packets to the mobile node location
+   while being attached to the nMAG.
+
+   In order for the LMA to be able to forward the mobile node uplink
+   data packets to the Internet, the transient BCE mechanism is used at
+   the nMAG to send a PBU with the Transient Binding option to allow the
+   LMA to create a transient BCE for the mobile node with uplink
+   forwarding capabilities while maintaining uplink and downlink
+   forwarding capabilities for the Proxy-CoA that is hosted at the pMAG.
+
+   During the lifetime of the transient BCE, the LMA continues to accept
+   uplink traffic from both previous and new MAG while forwarding
+   downlink traffic to the pMAG only.  While the MN is able to receive
+   downlink traffic via the pMAG, the mechanism used in the pMAG's
+   access network to forward downlink traffic to the current location of
+   the mobile node in the nMAG's access network during an intra-
+   technology handover is out of scope of this description.
+
+   When the nMAG receives an indication that the inter-MAG handover
+   process has completed, the nMAG sends another PBU without including a
+   Transient Binding option to update the mobile node's transient BCE to
+   a regular PMIPv6 BCE with bi-directional capabilities.  This
+   mechanism is used by the LMA as an indication to switch the tunnel to
+   point to the nMAG, which results in a smoother handover for the MN.
+
+
+
+
+Liebsch, et al.               Experimental                     [Page 28]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+   An example of using a transient BCE for intra-technology handover is
+   illustrated in Figure 5.  When the nMAG receives the indication that
+   the MN is moving from the pMAG's access network to the nMAG's area,
+   the nMAG sends a PBU on behalf of the MN to the MN's LMA.  In this
+   PBU, the nMAG includes the MN-ID, the HNP, and the interface ID as
+   per PMIPv6 base protocol [RFC5213].
+
+   Furthermore, the nMAG indicates an intra-technology handover by means
+   of the HI option and includes the Transient Binding option to
+   indicate to the LMA that this registration should result in a
+   transient BCE with a late downlink path switch.  The nMAG sets the
+   value of the transient BCE lifetime to a value that is dependent on
+   the deployment and operator specific [D].
+
+   After the nMAG receives an indication that the MN has completed the
+   handover process and the data path is ready to move the tunnel
+   completely from the pMAG to the nMAG, the nMAG SHOULD send a PBU to
+   allow the LMA to turn the MN's transient BCE into a regular BCE and
+   to switch the data path completely to be delivered through the new
+   Proxy-CoA.  In this case, the nMAG sends a PBU with the MN-ID,
+   Interface ID, and HNP and at the same time indicates an intra-
+   technology handover by means of the HI option.  In this PBU, the nMAG
+   MUST NOT include the Transient Binding option, as shown in Figure 5
+   [E].
+
+   In the event that the nMAG receives downlink traffic destined to the
+   MN from the LMA after sending a PBU with the Transient Binding option
+   included, the nMAG MUST deliver the downlink traffic to the MN.  In
+   this case, the nMAG SHOULD send a PBU to ensure that the transient
+   BCE has been turned into an active BCE.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Liebsch, et al.               Experimental                     [Page 29]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+          +-----+      +----+       +----+                    +-----+
+          | MN  |      |pMAG|       |nMAG|                    | LMA |
+          +-----+      +----+       +----+                    +-----+
+             |            |            |  bi-directional         |
+             |            |<<<<<<<<======================>>>>>>>>|<-->
+             |            |            |                         |
+             |            |            |                         |
+       [Handoff Event]    |            |                         |
+             |      [MN HO Event]      |                         |
+             |            |     [HO Event Acquire]               |
+             |            |            |                         |
+      [LL Attach to       |            |                         |
+           nMAG]          |            |-----PBU(transient)----->|
+             |            |            |                        [D]
+             |            |            |<-----PBA(transient)-----|
+             |            |            |                         |
+             |            |          bi-directional              |
+             |      |<--->|<<<<<<<<======================>>>>>>>>|<-->
+             |     pAN    |            |                         |
+             |      |----------->|     |                         |
+             |            |     nAN    |                         |
+             |<------------------|     |uplink only              |
+             |------------------>|---->|>>>>>>===========>>>>>>>>|--->
+             |            |            |                         |
+             |            |      [HO Complete]                   |
+             |            |            |----------PBU----------->|
+             |            |            |                        [E]
+             |            |            |<---------PBA -----------|
+             |            |`           |                         |
+             |            |            |<<<<<<<<=========>>>>>>>>|<-->
+             |            |            |                         |
+
+     Figure 5: Transient BCE support for an intra-technology handover
+
+A.2.  Use Case for Dual Radio Handover
+
+   During an inter-technology handover, the LMA shall, on the one hand,
+   be able to accept uplink packets of the MN as soon as the MN has
+   finalized address configuration at the new IF2 and may start using
+   the new interface for data traffic, i.e., the PBU for the uplink
+   shall be done before the radio setup procedure is finalized.  But, to
+   allow the MN to keep sending its data traffic on IF1 during the
+   handover, uplink packets with the previously existing binding on IF1
+   shall still be accepted by the LMA until the MN detaches from pMAG
+   with IF1 and the pMAG has deregistered the MN's attachment at the LMA
+   by means of sending a PBU with lifetime 0.  This is of particular
+   importance as sending the registration PBU from the nMAG is
+   transparent to the mobile node, i.e., the MN does not know when the
+
+
+
+Liebsch, et al.               Experimental                     [Page 30]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+   PBU has been sent.  On the other hand, switching the downlink path
+   from the pMAG to the nMAG shall be performed at the LMA only after
+   completion of the IP configuration at the MN's IF2 and after a
+   complete setup of the access link between the MN and the nMAG.  How
+   long this takes depends on some interface-specific settings on the MN
+   as well as on the duration of the target system's radio layer
+   protocols, which is transparent to the LMA but may be known to MAGs.
+
+   Similar to the use case for single radio handover, a transient BCE
+   can be utilized for MNs with dual radio capability.  Such MNs are
+   still able to send and receive data on the previous interface during
+   the address configuration on the new interface.  Forwarding between
+   the nMAG and pMAG is not required, but the case in which the LMA
+   immediately starts forwarding downlink data packets to the nMAG has
+   to be avoided.  This is enabled by a PBU that has the Transient
+   Binding option included, so that it is not necessary that MN and LMA
+   synchronize the point in time for switching interfaces and turning a
+   transient BCE into an active BCE.
+
+   When the handover is finalized, the nMAG sends a second PBU without
+   including the Transient Binding option and the LMA turns the MN's BCE
+   into an active BCE.  This PBU may overtake packets-on-the-fly from MN
+   to LMA via pMAG (e.g., if the previous interface was of type GSM or
+   Universal Mobile Telecommunications System (UMTS) with up to 150
+   milliseconds of uplink delay).  The LMA has to drop all these packets
+   from the pMAG due to the characteristics of the MN's active BCE.
+   This can be avoided by entering another transient BCE state
+   (Transient-A) during the activation phase and is characteristic for
+   this use case.  Whether or not to enter a Transient-A state is
+   decided by the LMA.
+
+   The use of a transient BCE for an inter-technology handover is
+   exemplarily illustrated in Figure 6.  The MN attaches to the PMIPv6
+   network with IF1 according to the procedure described in [RFC5213].
+   The MN starts receiving data packets on IF1.  When the MN activates
+   IF2 to prepare an inter-technology handover, the nMAG receives an
+   attach indication and sends the PBU to the LMA to update the MN's
+   point of attachment and to retrieve configuration information for the
+   MN (e.g., HNP).  The LMA is able to identify an inter-technology
+   handover by means of processing the HI option coming along with the
+   PBU sent by the nMAG.  As in this example, the nMAG includes the
+   Transient Binding option in the PBU to control the transient BCE at
+   the LMA, the LMA updates the MN's BCE according to the transient BCE
+   specification described in this document and marks the state of the
+   BCE as 'transient' [F].
+
+
+
+
+
+
+Liebsch, et al.               Experimental                     [Page 31]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+   As a result of the transient BCE, the LMA keeps using the previous
+   forwarding information towards the pMAG binding as forwarding
+   information until the transient BCE gets turned into active.  The LMA
+   acknowledges the PBU by means of sending a PBA to the nMAG.  The nMAG
+   now has relevant information available, such as the MN's HNP, to set
+   up a radio bearer and send a Router Advertisement to the MN.  While
+   the MN's BCE at the LMA has a transient characteristic, the LMA
+   forwards uplink packets from the MN's pMAG as well as from its nMAG.
+   The nMAG may recognize when the MN's IF2 is able to send and receive
+   data packets and sends a new PBU to the LMA without including the
+   Transient Binding option to initiate turning the MN's transient BCE
+   into an active BCE [G].  As a result of successfully turning the MN's
+   transient BCE into an active BCE, downlink packets will be forwarded
+   towards the MN's IF2 via the nMAG [H].
+
+    +------+                 +----+      +----+                 +---+
+    |  MN  |                 |pMAG|      |nMAG|                 |LMA|
+    +------+                 +----+      +----+                 +---+
+    IF2 IF1                    |           |                      |
+     |   |                     |           |                      |
+     |   |- - - - - - - - - Attach         |                      |
+     |   |                     |---------------PBU--------------->|
+     |   |                     |<--------------PBA----------------|
+     |   |--------RtSol------->|           |                      |
+     |   |<-------RtAdv--------|           |                      |
+     |  Addr.                  |           |                      |
+     |  Conf.                  |           |                      |
+     |   |<------------------->|==================data============|<--->
+     |   |                     |           |                      |
+     |- - - - - - - - - - - - - - - - - Attach                    |
+     |   |                     |           |----PBU(transient)--->|
+     |   |                     |           |<---PBA(transient)---[F]
+     |------RAT Configuration--------------|                      |
+     |   |<--------------------|==================data============|<---
+     |-------RtSol-(optional)------------->|                      |
+     |<-----------RtAdv--------------------|                      |
+   Addr. |                     |           |                      |
+   Conf  |                     |           |                      |
+     |------------NSol-------------------->|---------PBU-------->[G]
+     |   |                     |           |<--------PBA----------|
+     |<------------------------------------|========data=========[H]<-->
+     |   |                     |           |                      |
+     |   |                     |           |                      |
+     |   |                     |           |                      |
+
+           Figure 6: Late path switch with PMIPv6 transient BCEs
+
+
+
+
+
+Liebsch, et al.               Experimental                     [Page 32]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+Appendix B.  Applicability and Use of Static Configuration at the LMA
+
+   During the working group discussion of the functionality introduced
+   by this document, it was mentioned that some current Home Agents are
+   already handling some features and functionality introduced in this
+   document via some static configuration.  This Appendix captures the
+   analysis that describes which functionality can be handled securely
+   using a static configuration and which can not.  In these cases where
+   static configuration can be used, this section documents the possible
+   disadvantages versus using the procedures captured in this document.
+
+B.1.  Early Uplink Traffic from the nMAG
+
+   This use case is related to the handoff scenario when the access
+   network establishes the uplink tunnel to the LMA before the downlink
+   portion is done.  Consequently, when the mobile node is attached to
+   the nMAG and in the case of active handoff, the UE will start sending
+   uplink traffic to the LMA through the nMAG.
+
+   Since the LMA has a proxy BCE for this mobile node that points to the
+   Proxy-CoA that is hosted at the pMAG, the LMA has a routing entry for
+   the MN HNP that points to the pMAG-LMA tunnel.  Any uplink packet
+   coming from the nMAG will be dropped by the LMA.
+
+   Allowing the LMA to forward the received uplink traffic from the nMAG
+   to the Internet while the MN BCE points to the Proxy-CoA hosted at
+   the pMAG is a violation of all mobility protocols that require a
+   secure signaling exchange between the nMAG and the LMA before
+   forwarding such traffic to the Internet.  Otherwise, the LMA will be
+   modifying the mobile node's routing entry based on an unsecured data
+   traffic packet coming from the nMAG.
+
+   Therefore, this case cannot be addressed by any statically configured
+   information on the LMA.  On the contrary, a secure signaling using
+   Transient Binding option as detailed in this document is required to
+   create a transient state for the mobile node BCE at the LMA.  This
+   transient state will allow a temporary routing entry of the mobile
+   node to point to the nMAG Proxy-CoA.
+
+B.2.  Late Uplink Traffic from the pMAG
+
+   This case is a very common case where the mobile node is handing over
+   to another MAG while there is still some uplink traffic in flight
+   coming from the pMAG.  In this case, the LMA has the MN BCE points to
+   the mobile node location before the handoff, i.e., pMAG Proxy-CoA.
+   Then the LMA receives a PBU from the nMAG over a secure signaling
+   tunnel, e.g., IPsec tunnel, which indicates some type of handoff as
+   per the value in the handoff indicator mobility option.
+
+
+
+Liebsch, et al.               Experimental                     [Page 33]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+   If the PBU received from the nMAG was sent using the secure tunnel
+   and successfully processed by the LMA, the LMA according to [RFC5213]
+   switches the IP-in-IP tunnel to point to the nMAG Proxy-CoA.
+   However, as the LMA is fully aware of the mobile node movement via
+   secure signaling from the nMAG and the content of the PBU, which, in
+   particular, contains the Handoff Indicator mobility option, the LMA
+   can process some intelligence to allow the mobile node's late
+   in-flight uplink traffic coming over the pMAG-LMA tunnel to proceed
+   to the Internet.
+
+   In order to handle all handoff circumstances, the activation
+   mechanism as described in this document is preferable over a
+   statically configured timer, and it would dynamically help in ending
+   the late forwarding from the pMAG based on a protected signaling from
+   the pMAG.
+
+B.3.  Late Switching of Downlink Traffic to nMAG
+
+   One main use case of transient bindings is the late switching of
+   downlink traffic routing at the LMA.  This allows IP mobility
+   protocol signaling between nMAG and LMA to be performed decoupled
+   from the setup of the new link-layer connectivity, e.g., for
+   performing a handover to an interface with time-consuming link setup
+   procedures or for a make-before-break handover between interfaces.
+
+   LMA behavior according to [RFC5213] does not allow for late path
+   switching.  The LMA, according to [RFC5213], can only act upon the
+   Handover Indicator and has no information on the time of completion
+   of link layer setup.  Even if an LMA implementation would be
+   configured to delay the path switching by a fixed time, which would
+   violate [RFC5213], this would not lead to smooth handover performance
+   but would even add latency to the handover.  Only additional
+   signaling as provided by this document provides the information that
+   late switching is applicable and enables a synchronization of the
+   handover sequence, i.e., the switching is adapted both to the
+   finalization of the link between mobile terminal and nMAG and to the
+   release of the link between mobile terminal and pMAG, whatever comes
+   first.  Stable handover performance is achieved using protected
+   PMIPv6 signaling as per [RFC5213].
+
+
+
+
+
+
+
+
+
+
+
+
+Liebsch, et al.               Experimental                     [Page 34]
+
+RFC 6058         Transient Binding for Proxy Mobile IPv6      March 2011
+
+
+Authors' Addresses
+
+   Marco Liebsch (editor)
+   NEC Laboratories Europe
+   NEC Europe Ltd.
+   Kurfuersten-Anlage 36
+   69115 Heidelberg,
+   Germany
+
+   Phone: +49 6221 4342146
+   EMail: marco.liebsch@neclab.eu
+
+
+   Ahmad Muhanna
+   Ericsson
+   2201 Lakeside Blvd.
+   Richardson, TX  75082,
+   USA
+
+   Phone: +1 (972) 583-2769
+   EMail: ahmad.muhanna@ericsson.com
+
+
+   Oliver Blume
+   Alcatel-Lucent Deutschland AG
+   Bell Labs
+   Lorenzstr. 10
+   70435 Stuttgart,
+   Germany
+
+   Phone: +49 711 821-47177
+   EMail: oliver.blume@alcatel-lucent.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Liebsch, et al.               Experimental                     [Page 35]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6058.txt](<www.ietf.org/rfc/rfc6058.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
