### PR TITLE
Archive rfc6064.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6064.txt
+++ b/www.ietf.org/rfc/rfc6064.txt
@@ -1,0 +1,1235 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                     M. Westerlund
+Request for Comments: 6064                                     P. Frojdh
+Category: Informational                                         Ericsson
+ISSN: 2070-1721                                             January 2011
+
+
+   SDP and RTSP Extensions Defined for 3GPP Packet-Switched Streaming
+           Service and Multimedia Broadcast/Multicast Service
+
+Abstract
+
+   The Packet-switched Streaming Service (PSS) and the Multimedia
+   Broadcast/Multicast Service (MBMS) defined by 3GPP use the Session
+   Description Protocol (SDP) and Real Time Streaming Protocol (RTSP)
+   with some extensions.  This document provides information about these
+   extensions and registers the RTSP and SDP extensions with IANA.
+
+Status of This Memo
+
+   This document is not an Internet Standards Track specification; it is
+   published for informational purposes.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Not all documents
+   approved by the IESG are a candidate for any level of Internet
+   Standard; see Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6064.
+
+Copyright Notice
+
+   Copyright (c) 2011 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+Westerlund & Frojdh           Informational                     [Page 1]
+
+RFC 6064            SDP and RTSP Extensions for 3GPP        January 2011
+
+
+Table of Contents
+
+   1.  Introduction . . . . . . . . . . . . . . . . . . . . . . . . .  3
+     1.1.  Requirements Language  . . . . . . . . . . . . . . . . . .  4
+   2.  Glossary . . . . . . . . . . . . . . . . . . . . . . . . . . .  4
+   3.  Applicability Statement  . . . . . . . . . . . . . . . . . . .  5
+   4.  PSS SDP Extensions . . . . . . . . . . . . . . . . . . . . . .  5
+     4.1.  Video Buffering Attributes . . . . . . . . . . . . . . . .  5
+     4.2.  Video Frame Size Attribute . . . . . . . . . . . . . . . .  6
+     4.3.  Integrity-Protection Configuration Attributes  . . . . . .  6
+     4.4.  The Alternative Attributes . . . . . . . . . . . . . . . .  7
+     4.5.  Adaptation Attribute . . . . . . . . . . . . . . . . . . .  7
+     4.6.  Quality of Experience Attribute  . . . . . . . . . . . . .  7
+     4.7.  Asset Information Attribute  . . . . . . . . . . . . . . .  8
+   5.  MBMS SDP Extensions  . . . . . . . . . . . . . . . . . . . . .  8
+     5.1.  MBMS Bearer Mode Declaration Attribute . . . . . . . . . .  8
+     5.2.  FEC Flow ID Attribute  . . . . . . . . . . . . . . . . . .  8
+     5.3.  MBMS Repair Attribute  . . . . . . . . . . . . . . . . . .  8
+     5.4.  SDP Protocol Identifiers for FEC . . . . . . . . . . . . .  8
+       5.4.1.  RTP Protocol Identifiers . . . . . . . . . . . . . . .  9
+       5.4.2.  FEC Repair Data Identifier . . . . . . . . . . . . . .  9
+     5.5.  Video Buffering Attribute  . . . . . . . . . . . . . . . .  9
+   6.  SDP Offer/Answer Consideration . . . . . . . . . . . . . . . .  9
+   7.  PSS RTSP Extensions  . . . . . . . . . . . . . . . . . . . . . 10
+     7.1.  3GPP-Link-Char Header  . . . . . . . . . . . . . . . . . . 10
+     7.2.  3GPP-Adaptation Header . . . . . . . . . . . . . . . . . . 10
+     7.3.  3GPP-QoE-Metrics Header  . . . . . . . . . . . . . . . . . 10
+     7.4.  3GPP-QoE-Feedback Header . . . . . . . . . . . . . . . . . 11
+     7.5.  Video Buffer Headers . . . . . . . . . . . . . . . . . . . 11
+     7.6.  Integrity Protection . . . . . . . . . . . . . . . . . . . 11
+     7.7.  RTSP URI Extension . . . . . . . . . . . . . . . . . . . . 11
+     7.8.  Fast Start-Up and Content Switching  . . . . . . . . . . . 12
+   8.  IANA Considerations  . . . . . . . . . . . . . . . . . . . . . 12
+     8.1.  SDP Registrations  . . . . . . . . . . . . . . . . . . . . 12
+     8.2.  RTSP Registrations . . . . . . . . . . . . . . . . . . . . 17
+   9.  Security Considerations  . . . . . . . . . . . . . . . . . . . 20
+   10. References . . . . . . . . . . . . . . . . . . . . . . . . . . 20
+     10.1. Normative References . . . . . . . . . . . . . . . . . . . 20
+     10.2. Informative References . . . . . . . . . . . . . . . . . . 21
+
+
+
+
+
+
+
+
+
+
+
+
+Westerlund & Frojdh           Informational                     [Page 2]
+
+RFC 6064            SDP and RTSP Extensions for 3GPP        January 2011
+
+
+1.  Introduction
+
+   3GPP has specified the Packet-switched Streaming Service (PSS) that
+   uses both RTSP [RFC2326] and SDP [RFC4566].  The service is specified
+   in technical specifications TS 26.233 [PSS-233] and TS 26.234
+   [PSS-234] in Release 4 and subsequent releases.  The basic service
+   defined in Release 4 is enhanced in Release 5 with capability
+   exchange, and in Release 6 with a number of features, such as
+   adaptation, digital rights management (DRM), progressive download, as
+   well as a streaming server file format defined in [PSS-3GP].  Fast
+   start-up and content switching are addressed in Release 7.
+
+   3GPP has also specified the Multimedia Broadcast/Multicast Service
+   (MBMS) that uses SDP.  The IP-layer protocols used by this service
+   are specified in technical specification TS 26.346 Release 6 [MBMS].
+   Release 7 extends the MBMS User Service to also work with unicast
+   bearers for interactive and streaming traffic classes.
+
+   In the process of defining these services, there has occasionally
+   been a need to extend both SDP and RTSP functionalities.  These
+   extensions have mostly been in the form of SDP attributes and RTSP
+   headers and option tags. 3GPP uses the name "feature tags" (like RTSP
+   2.0 for what RTSP 1.0 calls "option tags"); "option tag" is the name
+   that will be used in this document.  The purpose of this
+   informational document is to register these SDP and RTSP extensions,
+   in order to avoid future conflicts, and also to raise the awareness
+   of their existence within IETF.
+
+   In Section 5.4, this document defines three SDP protocol identifiers
+   used in MBMS to enable the usage of block-based FEC.  The SDP
+   protocol identifiers require an RFC to be defined and registered.  As
+   this is an RFC from the IETF stream, any semantic change will require
+   a new IETF-approved RFC.  The other SDP and RTSP extensions
+   registered by this document are not normatively defined in this
+   document.  Instead, the normative definitions are referenced by the
+   registrations. 3GPP can update the normative definition in future
+   versions of their specifications.  However, to ensure that such a
+   change is visible in the IETF, at minimum, IANA should be notified
+   and the reference to the 3GPP specification updated, and preferably
+   an updated version of this RFC published.
+
+   The document begins with two sections presenting the SDP extensions
+   for PSS and MBMS, respectively.  They are followed by a section
+   noting that offer/answer considerations are not applicable here.  The
+   subsequent section presents the extensions of RTSP for PSS.  The IANA
+   registration of SDP attributes and protocol identifiers is given in
+
+
+
+
+
+Westerlund & Frojdh           Informational                     [Page 3]
+
+RFC 6064            SDP and RTSP Extensions for 3GPP        January 2011
+
+
+   Section 8.1, and the RTSP headers and option tags in Section 8.2.
+   For normative descriptions of all SDP and RTSP extensions, we refer
+   to TS 26.234 [PSS-234] and TS 26.346 [MBMS].
+
+1.1.  Requirements Language
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+2.  Glossary
+
+   3GP:     3GPP file format, a multimedia file format based on the ISO
+            base media file format, existing in different profiles
+            intended for multimedia messages, direct playback on
+            clients, progressive download, usage on servers to deliver
+            on-demand multimedia sessions in PSS, or servers sending
+            MBMS sessions.
+
+   3GPP:    Third Generation Partnership Project; see
+            http://www.3gpp.org for more information about this
+            organization.
+
+   FEC:     Forward Error Correction
+
+   MBMS:    Multimedia Broadcast/Multicast Service, a service defined by
+            3GPP that utilizes broadcast or multicast technology in
+            combination with unicast for delivery of a wide range of
+            content to mobile terminals.
+
+   PSS:     Packet-switched Streaming Service, a unicast-based streaming
+            service for delivery of on-demand or live streaming
+            multimedia content to mobile terminals.
+
+   RTSP:    Real Time Streaming Protocol; see [RFC2326].
+
+   SDP:     Session Description Protocol; see [RFC4566].
+
+   SRTP:    Secure Real-time Transport Protocol; see [RFC3711].
+
+   QoE:     Quality of Experience, the quality level of the user
+            experience of a service.  In PSS, this is estimated by a
+            combination of application-level metrics.
+
+   QoS:     Quality of Service, the quality (properties) that the
+            network provides toward the upper-layer service.
+
+
+
+
+
+Westerlund & Frojdh           Informational                     [Page 4]
+
+RFC 6064            SDP and RTSP Extensions for 3GPP        January 2011
+
+
+3.  Applicability Statement
+
+   This document describes 3GPP-defined extensions to SDP [RFC4566] and
+   RTSP [RFC2326] and registers attributes that are normatively defined
+   in 3GPP technical specifications 26.234, 26.244, and 26.346, up to
+   the referenced versions of the respective documents.
+
+   The SDP and RTSP extensions have only been defined for usage with the
+   3GPP service in mind.  The applicability for usage outside of these
+   services has not been considered nor addressed.  Usage of these
+   attributes in other contexts may require further definitions or
+   clarifications.  For example, all SDP attributes lack offer/answer
+   usage rules [RFC3264], which currently makes it impossible to use
+   them with offer/answer.  Please note that change control of these SDP
+   and RTSP extensions belongs to 3GPP.
+
+4.  PSS SDP Extensions
+
+   The PSS specification [PSS-234] defines a number of different SDP
+   attributes for different purposes.  They are listed below, grouped by
+   their purpose.  The text is intentionally not specific enough to
+   allow implementation from this document.  The normative definition is
+   in the 3GPP technical specification cited.
+
+4.1.  Video Buffering Attributes
+
+   The following attributes are used to provide parameters for the video
+   buffer model provided in Annex G and Section 5.3.3.2 of [PSS-234].
+   The attributes were defined in Release 5 as "X-" attributes and, at
+   the time, were not considered for registration.  In hindsight,
+   however, they should not have been "X-" attributes, and they should
+   have been registered, as the registration rules of SDP [RFC4566]
+   point out.  Changing their names today is impossible due to the
+   deployed base of millions of mobile handsets supporting PSS, and
+   therefore they are registered in their current form.
+
+   All attributes are defined at media level.
+
+   o  The "a=X-predecbufsize" attribute provides the size of the pre-
+      decoder buffer in bytes.
+
+   o  The "a=X-initpredecbufperiod" attribute provides the time during
+      which a receiver should initially buffer, in 90 kHz ticks, before
+      starting to consume the data in the buffer in order to ensure that
+      underflow does not occur, assuming correct data delivery.
+
+
+
+
+
+
+Westerlund & Frojdh           Informational                     [Page 5]
+
+RFC 6064            SDP and RTSP Extensions for 3GPP        January 2011
+
+
+   o  The "a=X-initpostdecbufperiod" attribute provides the initial
+      buffering period, in 90 kHz ticks, for the post-decoder buffer
+      present in H.263 and MPEG-4 Visual.
+
+   o  The "a=X-decbyterate" attribute indicates the maximum peak byte-
+      decoding rate used in the verification of the Annex G buffer model
+      expressed in bytes per second.
+
+   o  The "a=3gpp-videopostdecbufsize" attribute is used to indicate the
+      value used in determining the H.264 video post-decoder buffer
+      size.
+
+   Note that complete descriptions of these attributes can be found in
+   Section 5.3.3.2 of [PSS-234].
+
+4.2.  Video Frame Size Attribute
+
+   This media-level attribute provides the receiver with the largest
+   picture size that a specific H.263 payload type will carry within the
+   session.  The attribute has the following form (see Section 5.3.3.2
+   of [PSS-234]):
+
+   "a=framesize:<payload type number> <width>-<height>"
+
+4.3.  Integrity-Protection Configuration Attributes
+
+   These attributes are all used to configure the integrity-protection
+   mechanism defined in Annex K (Sections K.2.2.1, K.2.2.2, and K.2.2.3)
+   of [PSS-234].
+
+   o  The session-level attribute "a=3GPP-Integrity-Key" carries the
+      integrity key used to derive SRTP master keys for integrity
+      protection.  The key is protected in different ways depending on a
+      method identifier.  When using Open Mobile Alliance (OMA) DRM key
+      management, the key is encrypted using AES [AES] before it is
+      base64 encoded [RFC4648].
+
+   o  The media-level attribute "a=3GPP-SRTP-Config" is used to
+      configure SRTP for integrity protection and contains an integrity
+      nonce, a key salt used in deriving the SRTP master key from the
+      integrity key, and any SRTP configuration parameters, such as the
+      integrity tag length.
+
+   o  The session-level attribute "a=3GPP-SDP-Auth" is used to carry an
+      authentication tag calculated over certain parts of the SDP to
+      prevent manipulation of the security attributes.
+
+
+
+
+
+Westerlund & Frojdh           Informational                     [Page 6]
+
+RFC 6064            SDP and RTSP Extensions for 3GPP        January 2011
+
+
+4.4.  The Alternative Attributes
+
+   Two media-level and one session-level attributes are used in a
+   mechanism for providing alternative SDP lines.  One or more SDP lines
+   at media level can be replaced, if desired, by alternatives.  The
+   mechanism is backwards compatible in the way that a receiver that
+   does not support the attributes will get the default configuration.
+   The different alternatives can be grouped using different attributes
+   that can be specified hierarchically with a top and a lower level.
+   3GPP Release 6 supports grouping based on bit-rate, according to the
+   SDP bandwidth modifiers AS [RFC4566] and TIAS [RFC3890], and
+   language.
+
+   The SDP attributes (see Sections 5.3.3.3 and 5.3.3.4 of [PSS-234])
+   are:
+
+   o  The media-level attribute "a=alt:<id>:<SDP-Line>" carries any SDP
+      line and an alternative identifier.
+
+   o  The media-level attribute "a=alt-default-id:<id>" identifies the
+      default configuration to be used in groupings.
+
+   o  The session-level attribute "a=alt-group" is used to group
+      different recommended media alternatives.  This allows providing
+      aggregated properties for the whole group according to the
+      grouping type.  Language and bit-rate are two defined grouping
+      types.
+
+4.5.  Adaptation Attribute
+
+   The media-level SDP attribute "a=3GPP-Adaptation-Support" (see
+   Section 5.3.3.5 in [PSS-234]) is defined as part of the negotiation
+   procedure of the PSS adaptation mechanism.  The attribute carries a
+   single value indicating how often the RTCP "Next Application Data
+   Unit" (NADU) APP packet shall be included in sent RTCP compound
+   packets.  The adaptation mechanism allows the client to provide the
+   server with information on the available transmission bit-rate and
+   receiver buffer status.
+
+4.6.  Quality of Experience Attribute
+
+   The session- and media-level attribute "a=3GPP-QoE-Metrics" (see
+   Section 5.3.3.6 of [PSS-234]) is used to negotiate the usage of the
+   QoE metrics.  The included parameters indicate which metrics should
+   be used, over which duration there should be measurements, and how
+   often reports should be sent.
+
+
+
+
+
+Westerlund & Frojdh           Informational                     [Page 7]
+
+RFC 6064            SDP and RTSP Extensions for 3GPP        January 2011
+
+
+4.7.  Asset Information Attribute
+
+   The session- and media-level attribute "a=3GPP-Asset-Information"
+   (see Section 5.3.3.7 of [PSS-234]) can exist in multiple instances in
+   a description and describes different types of asset information.
+   The different asset classes defined in Release 6 are Title,
+   Description, Copyright, Performer, Author, Genre, Rating,
+   Classification, Keywords, Location, Album, and Recording Year.  The
+   different assets are described with a base64-encoded asset box from
+   the 3GP file format [PSS-3GP].
+
+5.  MBMS SDP Extensions
+
+   The MBMS specification [MBMS] defines a number of different SDP
+   attributes for different purposes.  They are informatively listed
+   below.
+
+5.1.  MBMS Bearer Mode Declaration Attribute
+
+   The session- and media-level attribute "a=mbms-mode" (see Section
+   7.3.2.7 of [MBMS]) is used to describe MBMS broadcast mode media.
+   The attribute may be used at the session level to set the default for
+   all media and at the media level to specify differences between
+   media.  However, the attribute is never used at the session level
+   when the session includes MBMS multicast mode media, nor at the media
+   level to describe MBMS multicast mode media.
+
+5.2.  FEC Flow ID Attribute
+
+   The media-level attribute "a=mbms-flowid" (see Section 8.3.1.9 of
+   [MBMS]) maps one or more FEC source block flow IDs to their
+   corresponding destination IP addresses and UDP port numbers.  It is
+   present in each SDP media block for repair packet streams.
+
+5.3.  MBMS Repair Attribute
+
+   The session- and media-level attribute "a=mbms-repair" (see Section
+   8.3.1.8 of [MBMS]) is used to provide FEC repair packets with non-FEC
+   specific parameters.  For Release 6, one such parameter is defined to
+   specify the required minimum receiver buffer time.
+
+5.4.  SDP Protocol Identifiers for FEC
+
+   MBMS defines a mechanism to provide block-based FEC for UDP-based
+   traffic.  This solution uses the SDP protocol "proto" identifier to
+   identify the media streams that use the FEC shim layer.  The media
+
+
+
+
+
+Westerlund & Frojdh           Informational                     [Page 8]
+
+RFC 6064            SDP and RTSP Extensions for 3GPP        January 2011
+
+
+   streams may be either source streams or repair streams.  As required
+   by SDP [RFC4566], these protocol identifiers are normatively defined
+   in this document in accordance with their usage specified by 3GPP.
+
+5.4.1.  RTP Protocol Identifiers
+
+   For FEC-protected RTP streams, the following two "proto" identifiers
+   are defined:
+
+   o  UDP/MBMS-FEC/RTP/AVP
+
+   o  UDP/MBMS-FEC/RTP/SAVP
+
+   They indicate the usage of UDP [RFC0768] with MBMS FEC source packet
+   formats, as defined in Section 8.2.2.4 of [MBMS], that transport RTP
+   packets in accordance with the AVP [RFC3551] or SAVP (Secure RTP)
+   [RFC3711] profiles, respectively.  These protocol identifiers SHALL
+   use the media formats ("fmt") namespace rules that are used for RTP/
+   AVP and RTP/SAVP, respectively.
+
+5.4.2.  FEC Repair Data Identifier
+
+   A media stream carrying MBMS FEC repair information over UDP requires
+   its own "proto" identifier.  Protocol identifier "UDP/MBMS-REPAIR"
+   identifies the FEC repair packet containing the protocol combination
+   of UDP [RFC0768], FEC repair payload ID, and repair symbols as
+   specified in Section 8.2.2.5 of [MBMS].  The "fmt" namespace is not
+   used and SHALL be set to "*".
+
+5.5.  Video Buffering Attribute
+
+   The PSS media-level buffer attribute "a=X-initpredecbufperiod" (see
+   Section 4.1) that specifies an initial buffering time is also used
+   for MBMS in Release 7.  It is mainly intended for video streams, but
+   may be used for other media types as well (see Section 8.3.1.1 of
+   [MBMS]).
+
+6.  SDP Offer/Answer Consideration
+
+   The usage of the SDP attributes in an offer/answer [RFC3264] context
+   is not defined.  These SDP attributes are defined for use in a
+   declarative context, and for PSS specifically in the RTSP [RFC2326]
+   context.
+
+
+
+
+
+
+
+
+Westerlund & Frojdh           Informational                     [Page 9]
+
+RFC 6064            SDP and RTSP Extensions for 3GPP        January 2011
+
+
+7.  PSS RTSP Extensions
+
+   The RTSP extensions for PSS consist of a number of new RTSP headers
+   and option tags and a narrowing of URI usage in regards to 3GP files.
+   The headers and option tags are informatively described here; see
+   [PSS-234] for the normative declaration.
+
+7.1.  3GPP-Link-Char Header
+
+   The "3GPP-Link-Char" header (see Section 5.3.2.1 of [PSS-234]) is
+   used by clients to provide the server with QoS information about the
+   wireless link it is currently using.  The header can be used to
+   provide the server with three different QoS parameters:
+
+   o  Guaranteed Bandwidth
+
+   o  Maximum Bandwidth
+
+   o  Maximum Transfer Delay
+
+   The header may be included in RTSP requests using either of the
+   methods SETUP, PLAY, OPTIONS, or SET_PARAMETER.
+
+7.2.  3GPP-Adaptation Header
+
+   The "3GPP-Adaptation" header (see Section 5.3.2.2 of [PSS-234]) is
+   used by the client to provide the server with adaptation-related
+   parameters and to indicate support of the adaptation function.  The
+   header carries the resource identification as a URI, the client's
+   buffer size, and the desired target time.
+
+   The header may be included in requests using the methods SETUP, PLAY,
+   OPTIONS, and SET_PARAMETER.  The response to a request using this
+   method shall include this header.
+
+7.3.  3GPP-QoE-Metrics Header
+
+   The "3GPP-QoE-Metrics" header (see Section 5.3.2.3.1 of [PSS-234]) is
+   used to negotiate the usage of the QoE metrics (see Section 11 of
+   [PSS-234]).
+
+   The header may be included in requests and responses using the SETUP,
+   SET_PARAMETER, OPTIONS, or PLAY method.
+
+
+
+
+
+
+
+
+Westerlund & Frojdh           Informational                    [Page 10]
+
+RFC 6064            SDP and RTSP Extensions for 3GPP        January 2011
+
+
+7.4.  3GPP-QoE-Feedback Header
+
+   The "3GPP-QoE-Feedback" header (see Section 5.3.2.3.2 of [PSS-234])
+   is used to carry QoE metrics from the client to the server when it
+   reports, which happens either during or at the end of the media
+   delivery.
+
+   The header may be included in requests using the SET_PARAMETER,
+   PAUSE, or TEARDOWN method.
+
+7.5.  Video Buffer Headers
+
+   PSS uses several headers to provide the client with the different
+   buffer parameters.  They provide the buffer status at the point of a
+   stream from which a PLAY request plays.  These headers may only be
+   used in PLAY responses.  See Section 5.3.2.4 and Annex G of [PSS-234]
+   for normative definitions.
+
+   The three "x-" headers were defined in 3GPP Release 5.  When it was
+   realized that they should not have been given "x-" names, it was too
+   late to rename them due to deployment.
+
+   The RTSP headers are:
+
+   o  x-predecbufsize
+
+   o  x-initpredecbufperiod
+
+   o  x-initpostdecbufperiod
+
+   o  3gpp-videopostdecbufsize
+
+7.6.  Integrity Protection
+
+   The integrity-protection mechanism defined in PSS Annex K uses the
+   "3GPP-Freshness-Token" RTSP header (see Section K.2.2.4 of [PSS-234])
+   to carry a freshness token in DESCRIBE requests.
+
+7.7.  RTSP URI Extension
+
+   The PSS specification also defines syntax for referencing tracks
+   within the 3GP file format [PSS-3GP].  The 3GP format is based on the
+   ISO base media file format and is defined in several different
+   profiles, including a streaming-server profile, in Release 6.
+
+
+
+
+
+
+
+Westerlund & Frojdh           Informational                    [Page 11]
+
+RFC 6064            SDP and RTSP Extensions for 3GPP        January 2011
+
+
+   This syntax is fully contained within the generic URI syntax defined
+   for RTSP URIs.  It is only a syntax restriction that server
+   manufacturers follow to allow clients or proxies to understand what
+   encodes the track number in the URI.  This is provided for
+   information only.
+
+   To identify a track within a 3GP file, the last URI segment has to
+   contain a structure that is <alpha string>=<track nr>.  (See Section
+   5.3.3.1 of [PSS-234].)
+
+7.8.  Fast Start-Up and Content Switching
+
+   Release 7 of PSS defines a number of extensions in terms of headers
+   and option tags (see Section 5.5 of [PSS-234]) for support of fast
+   start-up and switching of content for on-demand and live applications
+   built on top of PSS.  Clients are enabled to reuse the existing RTSP
+   control session and RTP resources while switching to new content.
+
+   The RTSP headers are:
+
+   o  Switch-Stream
+
+   o  SDP-Requested
+
+   o  Pipelined-Requests
+
+   The RTSP option tags are:
+
+   o  3gpp-pipelined
+
+   o  3gpp-switch
+
+   o  3gpp-switch-req-sdp
+
+   o  3gpp-switch-stream
+
+8.  IANA Considerations
+
+8.1.  SDP Registrations
+
+   IANA has registered the SDP attributes listed below in the "Session
+   Description Protocol (SDP) Parameters" registry available from
+   http://www.iana.org/.
+
+   The contact person for this registration is Magnus Westerlund (email:
+   magnus.westerlund@ericsson.com; phone: +46 8 719 0000).
+
+
+
+
+
+Westerlund & Frojdh           Informational                    [Page 12]
+
+RFC 6064            SDP and RTSP Extensions for 3GPP        January 2011
+
+
+  SDP Protocol Identifiers ("proto"):
+
+     Name:               UDP/MBMS-FEC/RTP/AVP
+     Long form:          3GPP MBMS FEC-protected RTP/AVP over UDP
+     Type of name:       proto
+     Purpose:            3GPP MBMS defines a mechanism to provide block-
+                         based FEC for UDP-based traffic.  This solution
+                         uses the SDP protocol "proto" identifier to
+                         identify the media streams that use the FEC
+                         shim layer.  This protocol identifier indicates
+                         that the FEC-protected data is RTP using the
+                         AVP profile.
+     Reference:          RFC 6064, 3GPP TS 26.346
+
+     Name:               UDP/MBMS-FEC/RTP/SAVP
+     Long form:          3GPP MBMS FEC-protected RTP/SAVP over UDP
+     Type of name:       proto
+     Purpose:            3GPP MBMS defines a mechanism to provide block-
+                         based FEC for UDP-based traffic.  This solution
+                         uses the SDP protocol "proto" identifier to
+                         identify the media streams that use the FEC
+                         shim layer.  This protocol identifier indicates
+                         that the FEC-protected data is RTP using the
+                         Secure AVP profile (SAVP).
+     Reference:          RFC 6064, 3GPP TS 26.346
+
+     Name:               UDP/MBMS-REPAIR
+     Long form:          3GPP MBMS FEC repair symbols over UDP
+     Type of name:       proto
+     Purpose:            3GPP MBMS defines a mechanism to provide block-
+                         based FEC for UDP-based traffic.  This solution
+                         uses the SDP protocol "proto" identifier to
+                         identify the media streams that use the FEC
+                         shim layer.  This protocol identifier indicates
+                         that the FEC repair data is sent over UDP.
+     Reference:          RFC 6064, 3GPP TS 26.346
+
+   SDP Attribute ("att-field"):
+
+      Attribute name:     X-predecbufsize
+      Long form:          Pre-decoder buffer size
+      Type of name:       att-field
+      Type of attribute:  Media level only
+      Subject to charset: No
+      Purpose:            See Section 4.1
+      Reference:          3GPP TS 26.234, Section 5.3.3.2
+      Values:             See Reference
+
+
+
+
+Westerlund & Frojdh           Informational                    [Page 13]
+
+RFC 6064            SDP and RTSP Extensions for 3GPP        January 2011
+
+
+      Attribute name:     X-initpredecbufperiod
+      Long form:          Pre-decoder initial buffering period
+      Type of name:       att-field
+      Type of attribute:  Media level only
+      Subject to charset: No
+      Purpose:            See Section 4.1
+      Reference:          3GPP TS 26.234, Section 5.3.3.2
+      Values:             See Reference
+
+      Attribute name:     X-initpostdecbufperiod
+      Long form:          Post-decoder initial buffering period
+      Type of name:       att-field
+      Type of attribute:  Media level only
+      Subject to charset: No
+      Purpose:            See Section 4.1
+      Reference:          3GPP TS 26.234, Section 5.3.3.2
+      Values:             See Reference
+
+      Attribute name:     X-decbyterate
+      Long form:          Peak decoding rate in bytes per second
+      Type of name:       att-field
+      Type of attribute:  Media level only
+      Subject to charset: No
+      Purpose:            See Section 4.1
+      Reference:          3GPP TS 26.234, Section 5.3.3.2
+      Values:             See Reference
+
+      Attribute name:     3gpp-videopostdecbufsize
+      Long form:          Post decoder buffer size
+      Type of name:       att-field
+      Type of attribute:  Media level only
+      Subject to charset: No
+      Purpose:            See Section 4.1
+      Reference:          3GPP TS 26.234, Section 5.3.3.2
+      Values:             See Reference
+
+      Attribute name:     framesize
+      Long form:          Maximum Video Frame Size
+      Type of name:       att-field
+      Type of attribute:  Media level only
+      Subject to charset: No
+      Purpose:            See Section 4.2
+      Reference:          3GPP TS 26.234, Section 5.3.3.2
+      Values:             See Reference
+
+
+
+
+
+
+
+Westerlund & Frojdh           Informational                    [Page 14]
+
+RFC 6064            SDP and RTSP Extensions for 3GPP        January 2011
+
+
+      Attribute name:     3GPP-Integrity-Key
+      Long form:          3GPP DRM Integrity Key
+      Type of name:       att-field
+      Type of attribute:  Session level only
+      Subject to charset: No
+      Purpose:            See Section 4.3
+      Reference:          3GPP TS 26.234, Sections 5.3.3.2 and K.2.2.1
+      Values:             See Reference
+
+      Attribute name:     3GPP-SRTP-Config
+      Long form:          3GPP DRM SRTP Configuration
+      Type of name:       att-field
+      Type of attribute:  Media level only
+      Subject to charset: No
+      Purpose:            See Section 4.3
+      Reference:          3GPP TS 26.234, Sections 5.3.3.2 and K.2.2.2
+      Values:             See Reference
+
+      Attribute name:     3GPP-SDP-Auth
+      Long form:          3GPP DRM Integrity SDP Authentication
+      Type of name:       att-field
+      Type of attribute:  Session level only
+      Subject to charset: No
+      Purpose:            See Section 4.3
+      Reference:          3GPP TS 26.234, Sections 5.3.3.2 and K.2.2.3
+      Values:             See Reference
+
+      Attribute name:     alt
+      Long form:          Alternative SDP line
+      Type of name:       att-field
+      Type of attribute:  Media level only
+      Subject to charset: No
+      Purpose:            See Section 4.4
+      Reference:          3GPP TS 26.234, Section 5.3.3.3
+      Values:             See Reference
+
+      Attribute name:     alt-default-id
+      Long form:          Default alternative ID
+      Type of name:       att-field
+      Type of attribute:  Media level only
+      Subject to charset: No
+      Purpose:            See Section 4.4
+      Reference:          3GPP TS 26.234, Section 5.3.3.3
+      Values:             See Reference
+
+
+
+
+
+
+
+Westerlund & Frojdh           Informational                    [Page 15]
+
+RFC 6064            SDP and RTSP Extensions for 3GPP        January 2011
+
+
+      Attribute name:     alt-group
+      Long form:          Grouping of SDP Line alternatives
+      Type of name:       att-field
+      Type of attribute:  Session level only
+      Subject to charset: No
+      Purpose:            See Section 4.4
+      Reference:          3GPP TS 26.234, Section 5.3.3.4
+      Values:             See Reference
+
+      Attribute name:     3GPP-Adaptation-Support
+      Long form:          3GPP Adaptation Support
+      Type of name:       att-field
+      Type of attribute:  Media level only
+      Subject to charset: No
+      Purpose:            See Section 4.5
+      Reference:          3GPP TS 26.234, Section 5.3.3.5
+      Values:             See Reference
+
+      Attribute name:     3GPP-QoE-Metrics
+      Long form:          3GPP Quality of Experience Metrics
+      Type of name:       att-field
+      Type of attribute:  Session and Media level
+      Subject to charset: No
+      Purpose:            See Section 4.6
+      Reference:          3GPP TS 26.234, Section 5.3.3.6
+      Values:             See Reference
+
+      Attribute name:     3GPP-Asset-Information
+      Long form:          3GPP Asset Information
+      Type of name:       att-field
+      Type of attribute:  Session and Media level
+      Subject to charset: No
+      Purpose:            See Section 4.7
+      Reference:          3GPP TS 26.234, Section 5.3.3.7
+      Values:             See Reference
+
+      Attribute name:     mbms-mode
+      Long form:          MBMS Bearer Mode Declaration
+      Type of name:       att-field
+      Type of attribute:  Session and Media level
+      Subject to charset: No
+      Purpose:            See Section 5.1
+      Reference:          3GPP TS 26.346, Section 7.3.2.7
+      Values:             See Reference
+
+
+
+
+
+
+
+Westerlund & Frojdh           Informational                    [Page 16]
+
+RFC 6064            SDP and RTSP Extensions for 3GPP        January 2011
+
+
+      Attribute name:     mbms-flowid
+      Long form:          FEC Flow ID
+      Type of name:       att-field
+      Type of attribute:  Media level
+      Subject to charset: No
+      Purpose:            See Section 5.2
+      Reference:          3GPP TS 26.346, Section 8.3.1.9
+      Values:             See Reference
+
+      Attribute name:     mbms-repair
+      Long form:          MBMS Repair
+      Type of name:       att-field
+      Type of attribute:  Session and Media level
+      Subject to charset: No
+      Purpose:            See Section 5.3
+      Reference:          3GPP TS 26.346, Section 8.3.1.8
+      Values:             See Reference
+
+8.2.  RTSP Registrations
+
+   IANA has registered the RTSP headers listed below in the RTSP/1.0
+   Headers table of the "Real Time Streaming Protocol (RTSP)/1.0
+   Parameters" registry available from http://www.iana.org/.
+
+   Note: This registry requires a Standards document, preferably an IETF
+   RFC.  The document that defines the registered headers below is a
+   technical standards document from 3GPP, although the request for
+   registration is submitted using this document to achieve further
+   information spreading within IETF.
+
+   The contact person for this registration is Magnus Westerlund (email:
+   magnus.westerlund@ericsson.com; phone: +46 8 719 0000).
+
+      Header Name:     3GPP-Freshness-Token
+      Purpose:         See Section K.2 of 3GPP TS 26.234
+      Methods:         DESCRIBE Requests
+      Reference:       Section K.2.2.4 of 3GPP TS 26.234
+      Values:          See Reference
+
+      Header Name:     3GPP-Link-Char
+      Purpose:         See Section 5.3.2.1 of 3GPP TS 26.234
+      Methods:         SETUP, PLAY, OPTIONS, or SET_PARAMETER Requests
+      Reference:       Section 5.3.2.1 of 3GPP TS 26.234
+      Values:          See Reference
+
+
+
+
+
+
+
+Westerlund & Frojdh           Informational                    [Page 17]
+
+RFC 6064            SDP and RTSP Extensions for 3GPP        January 2011
+
+
+      Header Name:     3GPP-Adaptation
+      Purpose:         See Section 5.3.2.2 of 3GPP TS 26.234
+      Methods:         SETUP, PLAY, OPTIONS, or SET_PARAMETER Requests
+                       and Responses
+      Reference:       Section 5.3.2.2 of 3GPP TS 26.234
+      Values:          See Reference
+
+      Header Name:     3GPP-QoE-Metrics
+      Purpose:         See Section 5.3.2.3.1 of 3GPP TS 26.234
+      Methods:         SETUP, PLAY, OPTIONS, or SET_PARAMETER Requests
+                       and Responses
+      Reference:       Section 5.3.2.3.1 of 3GPP TS 26.234
+      Values:          See Reference
+
+      Header Name:     3GPP-QoE-Feedback
+      Purpose:         See Section 5.3.2.3.2 of 3GPP TS 26.234
+      Methods:         SET_PARAMETER, PAUSE, or TEARDOWN Requests
+      Reference:       Section 5.3.2.3.2 of 3GPP TS 26.234
+      Values:          See Reference
+
+      Header Name:     Switch-Stream
+      Purpose:         See Section 5.5.4.2 of 3GPP TS 26.234
+      Methods:         PLAY Requests and Responses
+      Reference:       Section 5.5.4.2 of 3GPP TS 26.234
+      Values:          See Reference
+
+      Header Name:     SDP-Requested
+      Purpose:         See Section 5.5.4.4 of 3GPP TS 26.234
+      Methods:         PLAY Requests
+      Reference:       Section 5.5.4.4 of 3GPP TS 26.234
+      Values:          See Reference
+
+      Header Name:     Pipelined-Requests
+      Purpose:         See Section 5.5.3 of 3GPP TS 26.234
+      Methods:         SETUP and PLAY Requests
+      Reference:       Section 5.5.3 of 3GPP TS 26.234
+      Values:          See Reference
+
+      Header Name:     x-predecbufsize
+      Purpose:         See Section 5.3.2.4 of 3GPP TS 26.234
+      Methods:         PLAY Response
+      Reference:       Section 5.3.2.4 of 3GPP TS 26.234
+      Values:          See Reference
+
+
+
+
+
+
+
+
+Westerlund & Frojdh           Informational                    [Page 18]
+
+RFC 6064            SDP and RTSP Extensions for 3GPP        January 2011
+
+
+      Header Name:     x-initpredecbufperiod
+      Purpose:         See Section 5.3.2.4 of 3GPP TS 26.234
+      Methods:         PLAY Response
+      Reference:       Section 5.3.2.4 of 3GPP TS 26.234
+      Values:          See Reference
+
+      Header Name:     x-initpostdecbufperiod
+      Purpose:         See Section 5.3.2.4 of 3GPP TS 26.234
+      Methods:         PLAY Response
+      Reference:       Section 5.3.2.4 of 3GPP TS 26.234
+      Values:          See Reference
+
+      Header Name:     3gpp-videopostdecbufsize
+      Purpose:         See Section 5.3.2.4 of 3GPP TS 26.234
+      Methods:         PLAY Response
+      Reference:       Section 5.3.2.4 of 3GPP TS 26.234
+      Values:          See Reference
+
+      Header Name:     Supported
+      Purpose:         See Section 5.5.2.2.2 of 3GPP TS 26.234
+      Methods:         Any Request and Response
+      Reference:       Section 5.5.2.2.2 of 3GPP TS 26.234
+      Values:          See Reference
+
+   IANA has registered the RTSP Option tags (option tags) listed below
+   in the RTSP/1.0 Option Tags table of the "Real Time Streaming
+   Protocol (RTSP)/1.0 Parameters" registry available from
+   http://www.iana.org/.
+
+      Option tag:      3gpp-pipelined
+      Purpose:         See Section 5.5.3 of 3GPP TS 26.234
+      Applies to:      Client and Server
+      Reference:       Section 5.5.3 of 3GPP TS 26.234
+      Values:          See Reference
+
+      Option tag:      3gpp-switch
+      Purpose:         See Section 5.5.4.2 of 3GPP TS 26.234
+      Applies to:      Client and Server
+      Reference:       Section 5.5.4.2 of 3GPP TS 26.234
+      Values:          See Reference
+
+      Option tag:      3gpp-switch-req-sdp
+      Purpose:         See Section 5.5.4.4 of 3GPP TS 26.234
+      Applies to:      Client and Server
+      Reference:       Section 5.5.4.4 of 3GPP TS 26.234
+      Values:          See Reference
+
+
+
+
+
+Westerlund & Frojdh           Informational                    [Page 19]
+
+RFC 6064            SDP and RTSP Extensions for 3GPP        January 2011
+
+
+      Option tag:      3gpp-switch-stream
+      Purpose:         See Section 5.5.4.5 of 3GPP TS 26.234
+      Applies to:      Client and Server
+      Reference:       Section 5.5.4.5 of 3GPP TS 26.234
+      Values:          See Reference
+
+9.  Security Considerations
+
+   SDP attributes are subject to modification by an attacker unless they
+   are integrity protected and authenticated.  The security
+   considerations of the SDP specification [RFC4566] should be reviewed
+   in this regard.  The registered SDP attributes are vulnerable to
+   modification attacks or removal, which may result in problems of a
+   serious nature, including failure to use service and reduced quality.
+
+   The registered RTSP headers are also vulnerable to insertion,
+   deletion, or modification attacks similar to SDP attributes.  Also in
+   this case, attacks can result in failure of the service or reduced
+   quality of streaming content.
+
+   The three SDP protocol identifiers do not by themselves introduce any
+   additional security threats that don't exist for other protocol
+   identifiers in SDP.  The media stream and the used protocols
+   identified and configured by the SDP protocol identifier may,
+   however, contain security issues by themselves.
+
+10.  References
+
+10.1.  Normative References
+
+   [MBMS]     3GPP TS 26.346 version 7.10.0 (2009-03), "Multimedia
+              Broadcast/Multicast Service (MBMS); Protocols and codecs".
+
+   [PSS-234]  3GPP TS 26.234 version 7.7.0 (2009-03), "Transparent end-
+              to-end Packet-switched Streaming Service (PSS); Protocols
+              and codecs".
+
+   [PSS-3GP]  3GPP TS 26.244 version 7.3.0 (2007-12), "Transparent end-
+              to-end packet switched streaming service (PSS); 3GPP file
+              format (3GP)".
+
+   [RFC0768]  Postel, J., "User Datagram Protocol", STD 6, RFC 768,
+              August 1980.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+
+
+
+
+Westerlund & Frojdh           Informational                    [Page 20]
+
+RFC 6064            SDP and RTSP Extensions for 3GPP        January 2011
+
+
+   [RFC3551]  Schulzrinne, H. and S. Casner, "RTP Profile for Audio and
+              Video Conferences with Minimal Control", STD 65, RFC 3551,
+              July 2003.
+
+   [RFC3711]  Baugher, M., McGrew, D., Naslund, M., Carrara, E., and K.
+              Norrman, "The Secure Real-time Transport Protocol (SRTP)",
+              RFC 3711, March 2004.
+
+10.2.  Informative References
+
+   [AES]      NIST, "Advanced Encryption Standard (AES)", FIPS PUB 197,
+              <http://www.nist.gov/itl/fipscurrent.cfm>.
+
+   [PSS-233]  3GPP TS 26.233 version 7.0.0 (2007-06), "Transparent end-
+              to-end packet switched streaming service (PSS) General
+              Description".
+
+   [RFC2326]  Schulzrinne, H., Rao, A., and R. Lanphier, "Real Time
+              Streaming Protocol (RTSP)", RFC 2326, April 1998.
+
+   [RFC3264]  Rosenberg, J. and H. Schulzrinne, "An Offer/Answer Model
+              with Session Description Protocol (SDP)", RFC 3264,
+              June 2002.
+
+   [RFC3890]  Westerlund, M., "A Transport Independent Bandwidth
+              Modifier for the Session Description Protocol (SDP)",
+              RFC 3890, September 2004.
+
+   [RFC4566]  Handley, M., Jacobson, V., and C. Perkins, "SDP: Session
+              Description Protocol", RFC 4566, July 2006.
+
+   [RFC4648]  Josefsson, S., "The Base16, Base32, and Base64 Data
+              Encodings", RFC 4648, October 2006.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Westerlund & Frojdh           Informational                    [Page 21]
+
+RFC 6064            SDP and RTSP Extensions for 3GPP        January 2011
+
+
+Authors' Addresses
+
+   Magnus Westerlund
+   Ericsson
+   Farogatan 6
+   Stockholm  SE-164 80
+   SWEDEN
+
+   Phone: +46 10 7190000
+   Fax:   +46 10 757 55 50
+   EMail: magnus.westerlund@ericsson.com
+
+
+   Per Frojdh
+   Ericsson
+   Farogatan 6
+   Stockholm  SE-164 80
+   SWEDEN
+
+   Phone: +46 10 7190000
+   Fax:   +46 10 757 55 50
+   EMail: per.frojdh@ericsson.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Westerlund & Frojdh           Informational                    [Page 22]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6064.txt](<www.ietf.org/rfc/rfc6064.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
