### PR TITLE
Archive rfc6085.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6085.txt
+++ b/www.ietf.org/rfc/rfc6085.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                     S. Gundavelli
+Request for Comments: 6085                                   M. Townsley
+Updates: 2464                                                   O. Troan
+Category: Standards Track                                         W. Dec
+ISSN: 2070-1721                                                    Cisco
+                                                            January 2011
+
+
+         Address Mapping of IPv6 Multicast Packets on Ethernet
+
+Abstract
+
+   When transmitting an IPv6 packet with a multicast destination
+   address, the IPv6 destination address is mapped to an Ethernet link-
+   layer multicast address.  This document clarifies that a mapping of
+   an IPv6 packet with a multicast destination address may in some
+   circumstances map to an Ethernet link-layer unicast address.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6085.
+
+Copyright Notice
+
+   Copyright (c) 2011 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+Gundavelli, et al.           Standards Track                    [Page 1]
+
+RFC 6085           Unicast Transmission on Link Layer       January 2011
+
+
+1.  Introduction
+
+   "Transmission of IPv6 Packets over Ethernet Networks" ([RFC2464],
+   Section 7) specifies how an IPv6 packet with a multicast destination
+   address is mapped into an Ethernet link-layer address.  This document
+   extends this mapping to explicitly allow for a mapping of an IPv6
+   packet with a multicast destination address into an Ethernet link-
+   layer unicast address, when it is clear that only one address is
+   relevant.
+
+   This mapping does not replace the mapping described in [RFC2464],
+   Section 7.  The determination of the unicast Ethernet link-layer
+   address and the construction of the outgoing IPv6 packet are out of
+   scope for this document.
+
+2.  Conventions
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+3.  Receiving IPv6 Multicast Packets
+
+   An IPv6 node receiving an IPv6 packet with a multicast destination
+   address and an Ethernet link-layer unicast address MUST NOT drop the
+   packet as a result of the use of this form of address mapping.
+
+4.  Security Considerations
+
+   This document does not introduce any new security vulnerabilities.
+
+5.  Acknowledgements
+
+   The authors would like to acknowledge Bernard Aboba, Fred Baker, Wes
+   Beebee, Ron Bonica, Olaf Bonness, Jean-Michel Combes, Ralph Droms,
+   Alain Durand, Suresh Krishnan, Eric Levy-Abegnoli, Phil Roberts,
+   Behcet Sarikaya, Hemant Singh, Mark Smith, Dave Thaler, Pascal
+   Thubert, Stig Venaas, and Eric Voit for their contributions and
+   discussions on this topic.
+
+6.  Normative References
+
+   [RFC2119]   Bradner, S., "Key words for use in RFCs to Indicate
+               Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2464]   Crawford, M., "Transmission of IPv6 Packets over Ethernet
+               Networks", RFC 2464, December 1998.
+
+
+
+
+Gundavelli, et al.           Standards Track                    [Page 2]
+
+RFC 6085           Unicast Transmission on Link Layer       January 2011
+
+
+Authors' Addresses
+
+   Sri Gundavelli
+   Cisco
+   170 West Tasman Drive
+   San Jose, CA  95134
+   USA
+
+   EMail: sgundave@cisco.com
+
+
+   Mark Townsley
+   Cisco
+   L'Atlantis, 11, Rue Camille Desmoulins
+   ISSY LES MOULINEAUX, ILE DE FRANCE  92782
+   France
+
+   EMail: townsley@cisco.com
+
+
+   Ole Troan
+   Cisco
+   Oslo,
+   Norway
+
+   EMail: ot@cisco.com
+
+
+   Wojciech Dec
+   Cisco
+   Haarlerbergweg 13-19
+   Amsterdam, Noord-Holland  1101 CH
+   Netherlands
+
+   EMail: wdec@cisco.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Gundavelli, et al.           Standards Track                    [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6085.txt](<www.ietf.org/rfc/rfc6085.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
