### PR TITLE
Archive rfc6096.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6096.txt
+++ b/www.ietf.org/rfc/rfc6096.txt
@@ -1,0 +1,451 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                         M. Tuexen
+Request for Comments: 6096            Muenster Univ. of Applied Sciences
+Updates: 4960                                                 R. Stewart
+Category: Standards Track                                         Huawei
+ISSN: 2070-1721                                             January 2011
+
+
+  Stream Control Transmission Protocol (SCTP) Chunk Flags Registration
+
+Abstract
+
+   This document defines the procedure for registering chunk flags with
+   the Internet Assigned Numbers Authority (IANA) for the Stream Control
+   Transmission Protocol (SCTP).  It updates RFC 4960 and also defines
+   the IANA registry for contents for currently defined chunk types.  It
+   does not change SCTP in any other way.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6096.
+
+Copyright Notice
+
+   Copyright (c) 2011 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+Tuexen & Stewart             Standards Track                    [Page 1]
+
+RFC 6096              SCTP Chunk Flags Registration         January 2011
+
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . . . 3
+   2.  Conventions . . . . . . . . . . . . . . . . . . . . . . . . . . 3
+   3.  IANA Considerations . . . . . . . . . . . . . . . . . . . . . . 3
+     3.1.  Updated IETF-Defined Chunk Extension  . . . . . . . . . . . 3
+     3.2.  New IETF Chunk Flags Registration . . . . . . . . . . . . . 4
+     3.3.  Initial Registrations . . . . . . . . . . . . . . . . . . . 4
+       3.3.1.  DATA Chunk Flags  . . . . . . . . . . . . . . . . . . . 4
+       3.3.2.  INIT Chunk Flags  . . . . . . . . . . . . . . . . . . . 5
+       3.3.3.  INIT ACK Chunk Flags  . . . . . . . . . . . . . . . . . 5
+       3.3.4.  SACK Chunk Flags  . . . . . . . . . . . . . . . . . . . 5
+       3.3.5.  HEARTBEAT Chunk Flags . . . . . . . . . . . . . . . . . 5
+       3.3.6.  HEARTBEAT ACK Chunk Flags . . . . . . . . . . . . . . . 5
+       3.3.7.  ABORT Chunk Flags . . . . . . . . . . . . . . . . . . . 5
+       3.3.8.  SHUTDOWN Chunk Flags  . . . . . . . . . . . . . . . . . 5
+       3.3.9.  SHUTDOWN ACK Chunk Flags  . . . . . . . . . . . . . . . 6
+       3.3.10. ERROR Chunk Flags . . . . . . . . . . . . . . . . . . . 6
+       3.3.11. COOKIE ECHO Chunk Flags . . . . . . . . . . . . . . . . 6
+       3.3.12. COOKIE ACK Chunk Flags  . . . . . . . . . . . . . . . . 6
+       3.3.13. ECNE Chunk Flags  . . . . . . . . . . . . . . . . . . . 6
+       3.3.14. CWR Chunk Flags . . . . . . . . . . . . . . . . . . . . 6
+       3.3.15. SHUTDOWN COMPLETE Chunk Flags . . . . . . . . . . . . . 6
+       3.3.16. AUTH Chunk Flags  . . . . . . . . . . . . . . . . . . . 7
+       3.3.17. ASCONF ACK Chunk Flags  . . . . . . . . . . . . . . . . 7
+       3.3.18. PAD Chunk Flags . . . . . . . . . . . . . . . . . . . . 7
+       3.3.19. FORWARD TSN Chunk Flags . . . . . . . . . . . . . . . . 7
+       3.3.20. ASCONF Chunk Flags  . . . . . . . . . . . . . . . . . . 7
+   4.  Security Considerations . . . . . . . . . . . . . . . . . . . . 7
+   5.  Acknowledgments . . . . . . . . . . . . . . . . . . . . . . . . 7
+   6.  Normative References  . . . . . . . . . . . . . . . . . . . . . 8
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Tuexen & Stewart             Standards Track                    [Page 2]
+
+RFC 6096              SCTP Chunk Flags Registration         January 2011
+
+
+1.  Introduction
+
+   [RFC4960], which currently defines the Stream Control Transmission
+   Protocol (SCTP), provides a procedure to define new chunk types.
+   However, several protocol extensions currently being discussed need
+   to define new chunk flags for existing chunks.
+
+   This document updates RFC 4960 to overcome this limitation.  It
+   defines the procedure to register chunk flags and specifies the
+   registry entries for existing chunk types.  The protocol is not
+   changed in any other way.  Therefore, only Section 14.1 of [RFC4960]
+   is affected.
+
+2.  Conventions
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+3.  IANA Considerations
+
+   Section 3.1 provides the updated procedure for SCTP Chunk Type
+   registration; it replaces Section 14.1 of [RFC4960].
+
+   Section 3.2 provides a new procedure for SCTP Chunk Flag
+   registration.  A registry entry must be created for each SCTP Chunk
+   Type.
+
+   Section 3.3 provides the SCTP Chunk Flag registry values for the SCTP
+   Chunk Types specified in [RFC3758], [RFC4820], [RFC4960], [RFC4895],
+   and [RFC5061].
+
+3.1.  Updated IETF-Defined Chunk Extension
+
+   The assignment of new chunk type codes is done through an IETF Review
+   action, as defined in [RFC5226].  Documentation of a new chunk MUST
+   contain the following information:
+
+   a)  A long and short name for the new chunk type;
+
+   b)  A detailed description of the structure of the chunk, which MUST
+       conform to the basic structure defined in Section 3.2 of
+       [RFC4960];
+
+   c)  A detailed definition and description of intended use of each
+       field within the chunk, including the chunk flags if any.
+       Defined chunk flags will be used as initial entries in the chunk
+       flags table for the new chunk type;
+
+
+
+Tuexen & Stewart             Standards Track                    [Page 3]
+
+RFC 6096              SCTP Chunk Flags Registration         January 2011
+
+
+   d)  A detailed procedural description of the use of the new chunk
+       type within the operation of the protocol.
+
+   The last chunk type (255) is reserved for future extension if
+   necessary.
+
+   For each new chunk type, IANA creates a registration table for the
+   chunk flags of that type.  The procedure for registering particular
+   chunk flags is described in the following Section 3.2.
+
+3.2.  New IETF Chunk Flags Registration
+
+   The assignment of new chunk flags is done through an RFC required
+   action, as defined in [RFC5226].  Documentation of the chunk flags
+   MUST contain the following information:
+
+   a)  A name for the new chunk flag;
+
+   b)  A detailed procedural description of the use of the new chunk
+       flag within the operation of the protocol.  It MUST be considered
+       that implementations not supporting the flag will send '0' on
+       transmit and just ignore it on receipt.
+
+   IANA selects a chunk flags value.  This must be one of 0x01, 0x02,
+   0x04, 0x08, 0x10, 0x20, 0x40, or 0x80, which MUST be unique within
+   the chunk flag values for the specific chunk type.
+
+3.3.  Initial Registrations
+
+   This section describes the initial values of the chunk flag tables,
+   one table for each chunk.  Most tables are currently empty.  IANA
+   used these values to create the new registry.
+
+3.3.1.  DATA Chunk Flags
+
+            +------------------+-----------------+-----------+
+            | Chunk Flag Value | Chunk Flag Name | Reference |
+            +------------------+-----------------+-----------+
+            | 0x01             | E bit           | [RFC4960] |
+            | 0x02             | B bit           | [RFC4960] |
+            | 0x04             | U bit           | [RFC4960] |
+            +------------------+-----------------+-----------+
+
+
+
+
+
+
+
+
+
+Tuexen & Stewart             Standards Track                    [Page 4]
+
+RFC 6096              SCTP Chunk Flags Registration         January 2011
+
+
+3.3.2.  INIT Chunk Flags
+
+            +------------------+-----------------+-----------+
+            | Chunk Flag Value | Chunk Flag Name | Reference |
+            +------------------+-----------------+-----------+
+
+3.3.3.  INIT ACK Chunk Flags
+
+            +------------------+-----------------+-----------+
+            | Chunk Flag Value | Chunk Flag Name | Reference |
+            +------------------+-----------------+-----------+
+
+3.3.4.  SACK Chunk Flags
+
+            +------------------+-----------------+-----------+
+            | Chunk Flag Value | Chunk Flag Name | Reference |
+            +------------------+-----------------+-----------+
+
+3.3.5.  HEARTBEAT Chunk Flags
+
+            +------------------+-----------------+-----------+
+            | Chunk Flag Value | Chunk Flag Name | Reference |
+            +------------------+-----------------+-----------+
+
+3.3.6.  HEARTBEAT ACK Chunk Flags
+
+            +------------------+-----------------+-----------+
+            | Chunk Flag Value | Chunk Flag Name | Reference |
+            +------------------+-----------------+-----------+
+
+3.3.7.  ABORT Chunk Flags
+
+            +------------------+-----------------+-----------+
+            | Chunk Flag Value | Chunk Flag Name | Reference |
+            +------------------+-----------------+-----------+
+            | 0x01             | T bit           | [RFC4960] |
+            +------------------+-----------------+-----------+
+
+3.3.8.  SHUTDOWN Chunk Flags
+
+            +------------------+-----------------+-----------+
+            | Chunk Flag Value | Chunk Flag Name | Reference |
+            +------------------+-----------------+-----------+
+
+
+
+
+
+
+
+
+Tuexen & Stewart             Standards Track                    [Page 5]
+
+RFC 6096              SCTP Chunk Flags Registration         January 2011
+
+
+3.3.9.  SHUTDOWN ACK Chunk Flags
+
+            +------------------+-----------------+-----------+
+            | Chunk Flag Value | Chunk Flag Name | Reference |
+            +------------------+-----------------+-----------+
+
+3.3.10.  ERROR Chunk Flags
+
+            +------------------+-----------------+-----------+
+            | Chunk Flag Value | Chunk Flag Name | Reference |
+            +------------------+-----------------+-----------+
+
+3.3.11.  COOKIE ECHO Chunk Flags
+
+            +------------------+-----------------+-----------+
+            | Chunk Flag Value | Chunk Flag Name | Reference |
+            +------------------+-----------------+-----------+
+
+3.3.12.  COOKIE ACK Chunk Flags
+
+            +------------------+-----------------+-----------+
+            | Chunk Flag Value | Chunk Flag Name | Reference |
+            +------------------+-----------------+-----------+
+
+3.3.13.  ECNE Chunk Flags
+
+            +------------------+-----------------+-----------+
+            | Chunk Flag Value | Chunk Flag Name | Reference |
+            +------------------+-----------------+-----------+
+
+3.3.14.  CWR Chunk Flags
+
+            +------------------+-----------------+-----------+
+            | Chunk Flag Value | Chunk Flag Name | Reference |
+            +------------------+-----------------+-----------+
+
+3.3.15.  SHUTDOWN COMPLETE Chunk Flags
+
+            +------------------+-----------------+-----------+
+            | Chunk Flag Value | Chunk Flag Name | Reference |
+            +------------------+-----------------+-----------+
+            | 0x01             | T bit           | [RFC4960] |
+            +------------------+-----------------+-----------+
+
+
+
+
+
+
+
+
+Tuexen & Stewart             Standards Track                    [Page 6]
+
+RFC 6096              SCTP Chunk Flags Registration         January 2011
+
+
+3.3.16.  AUTH Chunk Flags
+
+            +------------------+-----------------+-----------+
+            | Chunk Flag Value | Chunk Flag Name | Reference |
+            +------------------+-----------------+-----------+
+
+3.3.17.  ASCONF ACK Chunk Flags
+
+            +------------------+-----------------+-----------+
+            | Chunk Flag Value | Chunk Flag Name | Reference |
+            +------------------+-----------------+-----------+
+
+3.3.18.  PAD Chunk Flags
+
+            +------------------+-----------------+-----------+
+            | Chunk Flag Value | Chunk Flag Name | Reference |
+            +------------------+-----------------+-----------+
+
+3.3.19.  FORWARD TSN Chunk Flags
+
+            +------------------+-----------------+-----------+
+            | Chunk Flag Value | Chunk Flag Name | Reference |
+            +------------------+-----------------+-----------+
+
+3.3.20.  ASCONF Chunk Flags
+
+            +------------------+-----------------+-----------+
+            | Chunk Flag Value | Chunk Flag Name | Reference |
+            +------------------+-----------------+-----------+
+
+4.  Security Considerations
+
+   This document does not add any additional security considerations in
+   addition to the ones given in [RFC4960].
+
+5.  Acknowledgments
+
+   The authors wish to thank Anna Brunstroem, Gorry Fairhurst, Russ
+   Housley, Suresh Krishnan, and Dan Romascanu for their invaluable
+   comments.
+
+
+
+
+
+
+
+
+
+
+
+Tuexen & Stewart             Standards Track                    [Page 7]
+
+RFC 6096              SCTP Chunk Flags Registration         January 2011
+
+
+6.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC3758]  Stewart, R., Ramalho, M., Xie, Q., Tuexen, M., and P.
+              Conrad, "Stream Control Transmission Protocol (SCTP)
+              Partial Reliability Extension", RFC 3758, May 2004.
+
+   [RFC4820]  Tuexen, M., Stewart, R., and P. Lei, "Padding Chunk and
+              Parameter for the Stream Control Transmission Protocol
+              (SCTP)", RFC 4820, March 2007.
+
+   [RFC4895]  Tuexen, M., Stewart, R., Lei, P., and E. Rescorla,
+              "Authenticated Chunks for the Stream Control Transmission
+              Protocol (SCTP)", RFC 4895, August 2007.
+
+   [RFC4960]  Stewart, R., "Stream Control Transmission Protocol",
+              RFC 4960, September 2007.
+
+   [RFC5061]  Stewart, R., Xie, Q., Tuexen, M., Maruyama, S., and M.
+              Kozuka, "Stream Control Transmission Protocol (SCTP)
+              Dynamic Address Reconfiguration", RFC 5061,
+              September 2007.
+
+   [RFC5226]  Narten, T. and H. Alvestrand, "Guidelines for Writing an
+              IANA Considerations Section in RFCs", BCP 26, RFC 5226,
+              May 2008.
+
+Authors' Addresses
+
+   Michael Tuexen
+   Muenster University of Applied Sciences
+   Stegerwaldstr. 39
+   48565 Steinfurt
+   DE
+
+   EMail: tuexen@fh-muenster.de
+
+
+   Randall R. Stewart
+   Huawei
+   Chapin, SC  29036
+   US
+
+   EMail: randall@lakerest.net
+
+
+
+
+
+Tuexen & Stewart             Standards Track                    [Page 8]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6096.txt](<www.ietf.org/rfc/rfc6096.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
