### PR TITLE
Archive rfc6128.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6128.txt
+++ b/www.ietf.org/rfc/rfc6128.txt
@@ -1,0 +1,339 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                          A. Begen
+Request for Comments: 6128                                         Cisco
+Updates: 5760                                              February 2011
+Category: Standards Track
+ISSN: 2070-1721
+
+
+                  RTP Control Protocol (RTCP) Port for
+                Source-Specific Multicast (SSM) Sessions
+
+Abstract
+
+   The Session Description Protocol (SDP) has an attribute that allows
+   RTP applications to specify an address and a port associated with the
+   RTP Control Protocol (RTCP) traffic.  In RTP-based source-specific
+   multicast (SSM) sessions, the same attribute is used to designate the
+   address and the RTCP port of the Feedback Target in the SDP
+   description.  However, the RTCP port associated with the SSM session
+   itself cannot be specified by the same attribute to avoid ambiguity,
+   and thus, is required to be derived from the "m=" line of the media
+   description.  Deriving the RTCP port from the "m=" line imposes an
+   unnecessary restriction.  This document removes this restriction by
+   introducing a new SDP attribute.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6128.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Begen                        Standards Track                    [Page 1]
+
+RFC 6128            RTCP Port for Multicast Sessions       February 2011
+
+
+Copyright Notice
+
+   Copyright (c) 2011 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1. Introduction ....................................................2
+   2. The 'multicast-rtcp' Attribute ..................................3
+   3. SDP Example .....................................................3
+   4. Security Considerations .........................................4
+   5. IANA Considerations .............................................4
+      5.1. Registration of SDP Attributes .............................5
+   6. Acknowledgments .................................................5
+   7. References ......................................................5
+      7.1. Normative References .......................................5
+      7.2. Informative References .....................................5
+
+1.  Introduction
+
+   The Session Description Protocol (SDP) [RFC4566] has an attribute
+   that allows RTP applications [RFC3550] to specify an address and a
+   port associated with the RTP Control Protocol (RTCP) traffic
+   [RFC3605].  This attribute is called 'rtcp'.
+
+   Now consider a network where one or more media senders send RTP
+   packets to a distribution source, which then multicasts these RTP
+   packets to multicast receivers using a source-specific multicast
+   (SSM) arrangement [RFC5760].  The distribution source also multicasts
+   the forward RTCP traffic (i.e., RTCP sender reports and receiver
+   reports or their summaries) to the receivers in the same SSM session.
+
+   In RTP-based SSM sessions, the 'rtcp' attribute is used to designate
+   the address and the RTCP port of the Feedback Target in the SDP
+   description [RFC5760].  However, the RTCP port associated with the
+   SSM session itself cannot be specified by the same attribute since it
+   could potentially cause ambiguity.  Thus, the multicast RTCP port is
+   required to be derived from the "m=" line of the media description
+
+
+
+Begen                        Standards Track                    [Page 2]
+
+RFC 6128            RTCP Port for Multicast Sessions       February 2011
+
+
+   (see Section 10.2 of [RFC5760]) by following the +1 rule (see Section
+   11 of [RFC3550]).  However, [RFC3550] lifted the requirement for the
+   +1 rule since it imposed an unnecessary restriction on RTCP port
+   selection.
+
+   In this specification, we introduce a new SDP attribute to remove
+   this restriction.  The new attribute allows the multicast sender to
+   use its desired port in the RTCP session.  This document updates
+   [RFC5760].
+
+2.  The 'multicast-rtcp' Attribute
+
+   In RTP-based SSM sessions, the distribution source can use different
+   multicast RTP and RTCP ports to send the RTP and RTCP packets,
+   respectively.  Alternatively, the distribution source can use RTP/
+   RTCP port muxing [RFC5761], in which case the RTP and RTCP packets
+   are sent to the same destination port in the SSM session.
+
+   For the cases when the distribution source does not want to use the
+   one higher port for the RTCP traffic, this document defines a new SDP
+   attribute, called 'multicast-rtcp'.  By using this attribute, the
+   distribution source uses a desired port for the SSM RTCP session.  In
+   the absence of the 'multicast-rtcp' attribute, the +1 rule applies
+   following [RFC5760].
+
+   The following ABNF [RFC5234] syntax formally describes the
+   'multicast-rtcp' attribute:
+
+               rtcp-attribute = "a=multicast-rtcp:" port CRLF
+
+         Figure 1: ABNF syntax for the 'multicast-rtcp' attribute
+
+   Here, the 'port' token is defined as specified in Section 9 of
+   [RFC4566].
+
+   The 'multicast-rtcp' attribute is defined as both a media-level and
+   session-level attribute.  Except where stated otherwise in this
+   document, the rules of [RFC3550] apply.
+
+3.  SDP Example
+
+   In the session description shown in Figure 2, a source stream is
+   multicast from a distribution source (with a source IP address of
+   198.51.100.1) to the multicast destination address of 233.252.0.2 and
+   port 41000.  The forward RTCP traffic is multicast in the same
+   multicast group but to port 42000 as specified by the "a=multicast-
+   rtcp:42000" line.  A feedback target with an address of 192.0.2.1 and
+   port of 43000 is specified by the 'rtcp' attribute.
+
+
+
+Begen                        Standards Track                    [Page 3]
+
+RFC 6128            RTCP Port for Multicast Sessions       February 2011
+
+
+           v=0
+           o=ali 1122334455 1122334466 IN IP4 ssm.example.com
+           s='multicast-rtcp' Example
+           t=0 0
+           a=rtcp-unicast:rsi
+           m=video 41000 RTP/AVPF 98
+           i=Multicast Stream
+           c=IN IP4 233.252.0.2/255
+           a=source-filter:incl IN IP4 233.252.0.2 198.51.100.1
+           a=rtpmap:98 MP2T/90000
+           a=multicast-rtcp:42000
+           a=rtcp:43000 IN IP4 192.0.2.1
+           a=mid:1
+
+       Figure 2: Example SDP showing the use of the 'multicast-rtcp'
+                                 attribute
+
+4.  Security Considerations
+
+   The 'multicast-rtcp' attribute is not believed to introduce any
+   significant security risk to multimedia applications.  A malevolent
+   third party could use this attribute to redirect the RTCP traffic,
+   but this requires intercepting and rewriting the packets carrying the
+   SDP description; and if an interceptor can do that, many more attacks
+   are possible, including a wholesale change of the addresses and port
+   numbers at which the media will be sent.
+
+   In order to avoid attacks of this sort, the SDP description needs to
+   be integrity protected and provided with source authentication.  This
+   can, for example, be achieved on an end-to-end basis using S/MIME
+   [RFC5652] [RFC5751] when SDP is used in a signaling packet using MIME
+   types (application/sdp).  Alternatively, HTTPS [RFC2818] or the
+   authentication method in the Session Announcement Protocol (SAP)
+   [RFC2974] could be used as well.
+
+5.  IANA Considerations
+
+   The following contact information shall be used for all registrations
+   in this document:
+
+   Ali Begen
+   abegen@cisco.com
+
+
+
+
+
+
+
+
+
+Begen                        Standards Track                    [Page 4]
+
+RFC 6128            RTCP Port for Multicast Sessions       February 2011
+
+
+5.1.  Registration of SDP Attributes
+
+   This document registers a new attribute name in SDP.
+
+        SDP Attribute ("att-field"):
+        Attribute name:     multicast-rtcp
+        Long form:          Port in the multicast RTCP session
+        Type of name:       att-field
+        Type of attribute:  Media or session level
+        Subject to charset: No
+        Purpose:            Specifies the port for the SSM RTCP session
+        Reference:          [RFC6128]
+        Values:             See [RFC6128]
+
+6.  Acknowledgments
+
+   Thanks to Colin Perkins and Magnus Westerlund for suggesting the name
+   for the 'multicast-rtcp' attribute and providing text for portions of
+   this specification.  Some parts of this specification are based on
+   [RFC3605] and [RFC5760].  So, also thanks to those who contributed to
+   those specifications.
+
+7.  References
+
+7.1.  Normative References
+
+   [RFC3550]  Schulzrinne, H., Casner, S., Frederick, R., and V.
+              Jacobson, "RTP: A Transport Protocol for Real-Time
+              Applications", STD 64, RFC 3550, July 2003.
+
+   [RFC4566]  Handley, M., Jacobson, V., and C. Perkins, "SDP: Session
+              Description Protocol", RFC 4566, July 2006.
+
+   [RFC5760]  Ott, J., Chesterfield, J., and E. Schooler, "RTP Control
+              Protocol (RTCP) Extensions for Single-Source Multicast
+              Sessions with Unicast Feedback", RFC 5760, February 2010.
+
+   [RFC5234]  Crocker, D. and P. Overell, "Augmented BNF for Syntax
+              Specifications: ABNF", STD 68, RFC 5234, January 2008.
+
+7.2.  Informative References
+
+   [RFC3605]  Huitema, C., "Real Time Control Protocol (RTCP) attribute
+              in Session Description Protocol (SDP)", RFC 3605,
+              October 2003.
+
+   [RFC5761]  Perkins, C. and M. Westerlund, "Multiplexing RTP Data and
+              Control Packets on a Single Port", RFC 5761, April 2010.
+
+
+
+Begen                        Standards Track                    [Page 5]
+
+RFC 6128            RTCP Port for Multicast Sessions       February 2011
+
+
+   [RFC5652]  Housley, R., "Cryptographic Message Syntax (CMS)", STD 70,
+              RFC 5652, September 2009.
+
+   [RFC2818]  Rescorla, E., "HTTP Over TLS", RFC 2818, May 2000.
+
+   [RFC2974]  Handley, M., Perkins, C., and E. Whelan, "Session
+              Announcement Protocol", RFC 2974, October 2000.
+
+   [RFC5751]  Ramsdell, B. and S. Turner, "Secure/Multipurpose Internet
+              Mail Extensions (S/MIME) Version 3.2 Message
+              Specification", RFC 5751, January 2010.
+
+Author's Address
+
+   Ali Begen
+   Cisco
+   181 Bay Street
+   Toronto, ON  M5J 2T3
+   Canada
+
+   EMail: abegen@cisco.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Begen                        Standards Track                    [Page 6]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6128.txt](<www.ietf.org/rfc/rfc6128.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
