### PR TITLE
Archive rfc6165.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6165.txt
+++ b/www.ietf.org/rfc/rfc6165.txt
@@ -1,0 +1,395 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                       A. Banerjee
+Request for Comments: 6165                                 Cisco Systems
+Category: Standards Track                                        D. Ward
+ISSN: 2070-1721                                         Juniper Networks
+                                                              April 2011
+
+
+                Extensions to IS-IS for Layer-2 Systems
+
+Abstract
+
+   This document specifies the Intermediate System to Intermediate
+   System (IS-IS) extensions necessary to support link state routing for
+   any protocols running directly over Layer-2.  While supporting this
+   concept involves several pieces, this document only describes
+   extensions to IS-IS.  Furthermore, the Type, Length, Value pairs
+   (TLVs) described in this document are generic Layer-2 additions, and
+   specific ones as needed are defined in the IS-IS technology-specific
+   extensions.  We leave it to the systems using these IS-IS extensions
+   to explain how the information carried in IS-IS is used.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6165.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Banerjee & Ward              Standards Track                    [Page 1]
+
+RFC 6165                      Layer-2-IS-IS                   April 2011
+
+
+Copyright Notice
+
+   Copyright (c) 2011 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1. Overview ........................................................2
+      1.1. Terminology ................................................3
+   2. TLV Enhancements to IS-IS .......................................3
+      2.1. Multi-Topology-Aware Port Capability TLV ...................3
+      2.2. The MAC-Reachability TLV ...................................4
+   3. Acknowledgements ................................................5
+   4. Security Considerations .........................................5
+   5. IANA Considerations .............................................5
+   6. References ......................................................6
+      6.1. Normative References .......................................6
+      6.2. Informative References .....................................6
+
+1.  Overview
+
+   There are a number of systems (for example, [RBRIDGES], [802.1aq],
+   and [OTV]) that use Layer-2 addresses carried in a link state routing
+   protocol, specifically Intermediate System to Intermediate System
+   [IS-IS] [RFC1195], to provide true Layer-2 routing.  In almost all
+   the technologies mentioned above, classical Layer-2 packets are
+   encapsulated with an outer header.  The outer header format varies
+   across all these technologies.  This outer header is used to route
+   the encapsulated packets to their destination.
+
+   Each Intermediate System (IS) advertises one or more IS-IS Link State
+   Protocol Data Units (PDUs) with routing information.  Each Link State
+   PDU (LSP) is composed of a fixed header and a number of tuples, each
+   consisting of a Type, a Length, and a Value.  Such tuples are
+
+
+
+
+
+
+
+Banerjee & Ward              Standards Track                    [Page 2]
+
+RFC 6165                      Layer-2-IS-IS                   April 2011
+
+
+   commonly known as TLVs.  In this document, we specify a set of TLVs
+   to be added to [IS-IS] PDUs, to support these proposed systems.  The
+   TLVs are generic Layer-2 additions, and specific ones, as needed, are
+   defined in the IS-IS technology-specific extensions.  This document
+   does not propose any new forwarding mechanisms using this additional
+   information carried within IS-IS.
+
+1.1.  Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+2.  TLV Enhancements to IS-IS
+
+   This section specifies the enhancements for the TLVs that are needed
+   in common by Layer-2 technologies.
+
+2.1.  Multi-Topology-Aware Port Capability TLV
+
+   The Multi-Topology-aware Port Capability (MT-PORT-CAP) is IS-IS TLV
+   type 143 and has the following format:
+
+   +-+-+-+-+-+-+-+-+
+   | Type=MTPORTCAP|                  (1 byte)
+   +-+-+-+-+-+-+-+-+
+   |   Length      |                  (1 byte)
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |R|R|R|R|  Topology Identifier  |  (2 bytes)
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                sub-TLVs         (variable bytes)              |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   o  Type: TLV Type, set to MT-PORT-CAP TLV 143.
+
+   o  Length: Total number of bytes contained in the value field,
+      including the length of the sub-TLVs carried in this TLV.
+
+   o  R: Reserved 4 bits, MUST be sent as zero and ignored on receipt.
+
+   o  Topology Identifier: MT ID is a 12-bit field containing the MT ID
+      of the topology being announced.  This field when set to zero
+      implies that it is being used to carry base topology information.
+
+   o  Sub-TLVs: The MT-PORT-CAP TLV value contains sub-TLVs formatted as
+      described in [RFC5305].  They are defined in the technology-
+      specific documents.
+
+
+
+
+Banerjee & Ward              Standards Track                    [Page 3]
+
+RFC 6165                      Layer-2-IS-IS                   April 2011
+
+
+   The MT-PORT-CAP TLV may occur multiple times and is carried within an
+   IS-IS Hello (IIH) PDU.
+
+2.2.  The MAC-Reachability TLV
+
+   The MAC-Reachability (MAC-RI) TLV is IS-IS TLV type 147 and has the
+   following format:
+
+   +-+-+-+-+-+-+-+-+
+   | Type= MAC-RI  |                  (1 byte)
+   +-+-+-+-+-+-+-+-+
+   |   Length      |                  (1 byte)
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |   Topology-id/Nickname        |  (2 bytes)
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |   Confidence  |                  (1 byte)
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |  RESV |      VLAN-ID          |  (2 bytes)
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-...+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                          MAC (1)       (6 bytes)                 |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-...+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                      .................                           |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-...+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                          MAC (N)       (6 bytes)                 |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-...+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   o  Type: TLV Type, set to 147 (MAC-RI).
+
+   o  Length: Total number of bytes contained in the value field given
+      by 5 + 6*n bytes.
+
+   o  Topology-id/Nickname : Depending on the technology in which it is
+      used, this carries the topology-id or nickname.  When this field
+      is set to zero, this implies that the Media Access Control (MAC)
+      addresses are reachable across all topologies or across all
+      nicknames of the originating IS.
+
+   o  Confidence: This carries an 8-bit quantity indicating the
+      confidence level in the MAC addresses being transported.  Whether
+      this field is used, and its semantics if used, are further defined
+      by the specific protocol using Layer-2 IS-IS.  If not used, it
+      MUST be set to zero on transmission and be ignored on receipt.
+
+   o  RESV: (4 bits) MUST be sent as zero and ignored on receipt.
+
+
+
+
+
+
+
+Banerjee & Ward              Standards Track                    [Page 4]
+
+RFC 6165                      Layer-2-IS-IS                   April 2011
+
+
+   o  VLAN-ID: This carries a 12-bit VLAN identifier that is valid for
+      all subsequent MAC addresses in this TLV, or the value zero if no
+      VLAN is specified.
+
+   o  MAC(i): This is the 48-bit MAC address reachable from the IS that
+      is announcing this TLV.
+
+   The MAC-RI TLV is carried in a standard Link State PDU (LSP).  This
+   TLV can be carried multiple times in an LSP and in multiple LSPs.  It
+   MUST contain only unicast addresses.  The manner in which these TLVs
+   are generated by the various Layer-2 routing technologies and the
+   manner in which they are consumed are detailed in the technology-
+   specific documents.
+
+   In most of the technologies, these MAC-RI TLVs will translate to
+   populating the hardware with these entries and with appropriate next-
+   hop information as derived from the advertising IS.
+
+3.  Acknowledgements
+
+   The authors would like to thank Peter Ashwood-Smith, Donald E.
+   Eastlake 3rd, Dino Farinacci, Don Fedyk, Les Ginsberg, Radia Perlman,
+   Mike Shand, and Russ White for their useful comments.
+
+4.  Security Considerations
+
+   This document adds no additional security risks to IS-IS, nor does it
+   provide any additional security for IS-IS.
+
+5.  IANA Considerations
+
+   This document specifies the definition of a set of new IS-IS TLVs --
+   the Port-Capability TLV (type 143) and the MAC-Reachability TLV
+   (type 147).  They are listed in the IS-IS TLV codepoint registry.
+
+                                         IIH  LSP  SNP
+   MT-Port-Cap-TLV (143)                  X    -    -
+   MAC-RI TLV  (147)                      -    X    -
+
+
+
+
+
+
+
+
+
+
+
+
+
+Banerjee & Ward              Standards Track                    [Page 5]
+
+RFC 6165                      Layer-2-IS-IS                   April 2011
+
+
+6.  References
+
+6.1.  Normative References
+
+   [IS-IS]    ISO/IEC 10589:2002, Second Edition, "Intermediate System
+              to Intermediate System Intra-Domain Routing Information
+              Exchange Protocol for use in Conjunction with the Protocol
+              for Providing the Connectionless-mode Network Service
+              (ISO 8473)", 2002.
+
+   [RFC1195]  Callon, R., "Use of OSI IS-IS for routing in TCP/IP and
+              dual environments", RFC 1195, December 1990.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC5305]  Li, T. and H. Smit, "IS-IS Extensions for Traffic
+              Engineering", RFC 5305, October 2008.
+
+6.2.  Informative References
+
+   [802.1aq]  "Standard for Local and Metropolitan Area Networks /
+              Virtual Bridged Local Area Networks / Amendment 8:
+              Shortest Path Bridging, Draft IEEE P802.1aq/D1.5", 2008.
+
+   [OTV]      Grover, H., Rao, D., and D. Farinacci, "Overlay Transport
+              Virtualization", Work in Progress, October 2010.
+
+   [RBRIDGES]
+              Perlman, R., Eastlake 3rd, D., Dutt, D., Gai, S., and A.
+              Ghanwani, "RBridges: Base Protocol Specification", Work
+              in Progress, March 2010.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Banerjee & Ward              Standards Track                    [Page 6]
+
+RFC 6165                      Layer-2-IS-IS                   April 2011
+
+
+Authors' Addresses
+
+   Ayan Banerjee
+   Cisco Systems
+   170 W. Tasman Drive
+   San Jose, CA  95138
+   USA
+
+   EMail: ayabaner@cisco.com
+
+
+   David Ward
+   Juniper Networks
+   1194 N. Mathilda Ave.
+   Sunnyvale, CA  94089-1206
+   USA
+
+   Phone: +1-408-745-2000
+   EMail: dward@juniper.net
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Banerjee & Ward              Standards Track                    [Page 7]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6165.txt](<www.ietf.org/rfc/rfc6165.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
