### PR TITLE
Archive rfc6173.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6173.txt
+++ b/www.ietf.org/rfc/rfc6173.txt
@@ -1,0 +1,1739 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                P. Venkatesen, Ed.
+Request for Comments: 6173                              HCL Technologies
+Obsoletes: 4369                                               March 2011
+Category: Standards Track
+ISSN: 2070-1721
+
+
+                     Definitions of Managed Objects
+             for the Internet Fibre Channel Protocol (iFCP)
+
+Abstract
+
+   This document defines Management Information Base (MIB) objects to
+   monitor and control the Internet Fibre Channel Protocol (iFCP)
+   gateway instances and their associated sessions, for use with network
+   management protocols.
+
+   This document obsoletes RFC 4369.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6173.
+
+Copyright Notice
+
+   Copyright (c) 2011 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+Venkatesen                   Standards Track                    [Page 1]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+   This document may contain material from IETF Documents or IETF
+   Contributions published or made publicly available before November
+   10, 2008.  The person(s) controlling the copyright in some of this
+   material may not have granted the IETF Trust the right to allow
+   modifications of such material outside the IETF Standards Process.
+   Without obtaining an adequate license from the person(s) controlling
+   the copyright in such materials, this document may not be modified
+   outside the IETF Standards Process, and derivative works of it may
+   not be created outside the IETF Standards Process, except to format
+   it for publication as an RFC or to translate it into languages other
+   than English.
+
+Table of Contents
+
+   1. The Internet-Standard Management Framework.....................2
+   2. Introduction...................................................3
+   3. Technical Description..........................................4
+   4. Differences from RFC 4369......................................4
+   5. MIB Definition.................................................5
+   6. Security Considerations.......................................28
+   7. IANA Considerations...........................................29
+   8. References....................................................29
+      8.1. Normative References.....................................29
+      8.2. Informative References...................................30
+   9. Acknowledgments...............................................31
+
+1.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This memo specifies a MIB
+   module that is compliant to the SMIv2, which is described in STD 58,
+   RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579] and STD 58, RFC 2580
+   [RFC2580].
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+
+
+
+
+
+
+Venkatesen                   Standards Track                    [Page 2]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+2.  Introduction
+
+   iFCP (RFC 4172 [RFC4172]) provides Fibre Channel fabric functionality
+   on an IP network in which TCP/IP switching and routing elements
+   replace Fibre Channel components.  iFCP is used between iFCP
+   gateways.  This protocol can be used by FC-to-IP-based storage
+   gateways for Fibre Channel Protocol (FCP) storage interconnects.
+
+   Figure 1 provides an example of an interconnect between iFCP
+   gateways.
+
+           Gateway Region                   Gateway Region
+    +--------+  +--------+           +--------+  +--------+
+    |   FC   |  |  FC    |           |   FC   |  |   FC   |
+    | Device |  | Device |           | Device |  | Device |  Fibre
+    |........|  |........| FC        |........|  |........|  Channel
+    | N_PORT |  | N_PORT |<.........>| N_PORT |  | N_PORT |  Device
+    +---+----+  +---+----+ Traffic   +----+---+  +----+---+  Domain
+        |           |                     |           |         ^
+    +---+----+  +---+----+           +----+---+  +----+---+     |
+    | F_PORT |  | F_PORT |           | F_PORT |  | F_PORT |     |
+   =+========+==+========+===========+========+==+========+==========
+    |    iFCP Layer      |<--------->|     iFCP Layer     |     |
+    |....................|     ^     |....................|     |
+    |     iFCP Portal    |     |     |     iFCP Portal    |     v
+    +--------+-----------+     |     +----------+---------+    IP
+         iFCP|Gateway      Control          iFCP|Gateway      Network
+             |              Data                |
+             |                                  |
+             |                                  |
+             |<------Encapsulated Frames------->|
+             |      +------------------+        |
+             |      |                  |        |
+             +------+    IP Network    +--------+
+                    |                  |
+                    +------------------+
+
+          Figure 1: Interconnect between iFCP Gateways
+
+   The iFCP MIB module is designed to allow a network management
+   protocol such as SNMP to be used to monitor and manage local iFCP
+   gateway instances, including the configuration of iFCP sessions
+   between gateways.
+
+
+
+
+
+
+
+
+Venkatesen                   Standards Track                    [Page 3]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+3.  Technical Description
+
+   The iFCP MIB module is divided into sections for iFCP local gateway
+   instance management, iFCP session management, and iFCP session
+   statistics.
+
+   The section for iFCP gateway management provides default settings and
+   information about each local instance.  A single management entity
+   can monitor multiple local gateway instances.  Each local gateway is
+   conceptually an independent gateway that has both Fibre Channel and
+   IP interfaces.  The default IP Time Out Value (IP_TOV) is
+   configurable for each gateway.  Other standard MIBs, such as the
+   Fibre Management MIB [RFC4044] or Interfaces Group MIB [RFC2863], can
+   be used to manage non-iFCP-specific gateway parameters.  The local
+   gateway instance section provides iFCP-specific information as well
+   as optional links to other standard management MIBs.
+
+   The iFCP session management section provides information on iFCP
+   sessions that use one of the local iFCP gateway instances.  This
+   section allows the management of specific iFCP parameters, including
+   changing the IP_TOV from the default setting of the gateway.
+
+   The iFCP session statistics section provides statistical information
+   on the iFCP sessions that use one of the local iFCP gateways.  These
+   tables augment the session management table.  Additional statistical
+   information for an iFCP gateway or session, that is not iFCP-
+   specific, can be obtained using other standard MIBs.  The iFCP
+   statistics are provided in both high-capacity (Counter64) and low-
+   capacity (Counter32) methods.
+
+   The following MIB module imports from SNMPv2-SMI [RFC2578], SNMPv2-TC
+   [RFC2579], SNMPv2-CONF [RFC2580], HCNUM-TC [RFC2856], IF-MIB
+   [RFC2863], SNMP-FRAMEWORK-MIB [RFC3411], INET-ADDRESS-MIB [RFC4001],
+   FC-MGMT-MIB [RFC4044], ENTITY-MIB (v3) [RFC4133], and RMON2-MIB
+   [RFC4502].
+
+4.  Differences from RFC 4369
+
+   As explained in [RFC6172], the iFCP address translation mode is
+   deprecated.  This document obsoletes the iFCP MIB module [RFC4369]
+   for this change.
+
+
+
+
+
+
+
+
+
+
+Venkatesen                   Standards Track                    [Page 4]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+5.  MIB Definition
+
+   IFCP-MGMT-MIB DEFINITIONS ::= BEGIN
+
+   IMPORTS
+       MODULE-IDENTITY,
+       OBJECT-TYPE,
+       Gauge32,
+       Integer32,
+       Unsigned32,
+       transmission
+            FROM SNMPv2-SMI
+
+       OBJECT-GROUP,
+       MODULE-COMPLIANCE
+            FROM SNMPv2-CONF
+
+       TEXTUAL-CONVENTION,
+       TimeStamp,
+       TruthValue,
+       StorageType
+            FROM SNMPv2-TC
+
+   --  From RFC 4502
+       ZeroBasedCounter32
+            FROM RMON2-MIB
+
+   --  From RFC 2856
+       ZeroBasedCounter64
+            FROM HCNUM-TC
+
+   --  From RFC 2863
+       InterfaceIndexOrZero
+            FROM IF-MIB
+
+   --  From RFC 3411
+       SnmpAdminString
+            FROM SNMP-FRAMEWORK-MIB
+
+   --  From RFC 4001
+       InetAddressType,
+       InetAddress,
+       InetPortNumber
+            FROM INET-ADDRESS-MIB
+
+
+
+
+
+
+
+Venkatesen                   Standards Track                    [Page 5]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+   --  From RFC 4044
+       FcNameIdOrZero,
+       FcAddressIdOrZero
+            FROM FC-MGMT-MIB
+
+   --  From RFC 4133
+       PhysicalIndexOrZero
+            FROM ENTITY-MIB
+         ;
+
+   ifcpMgmtMIB   MODULE-IDENTITY
+         LAST-UPDATED "201103090000Z"
+         ORGANIZATION "IETF STORage Maintenance (STORM) Working Group"
+         CONTACT-INFO "
+           Working Group Email : storm@ietf.org
+           Attn: Prakash Venkatesen
+                 HCL Technologies
+                 Email: prakashvn@hcl.com"
+
+         DESCRIPTION
+                 "This module defines management information specific
+                  to Internet Fibre Channel Protocol (iFCP) gateway
+                  management.
+
+                  Copyright (c) 2011 IETF Trust and the persons
+                  identified as authors of the code. All rights
+                  reserved.
+
+                  Redistribution and use in source and binary forms,
+                  with or without modification, is permitted pursuant
+                  to, and subject to the license terms contained in, the
+                  Simplified BSD License set forth in Section 4.c of the
+                  IETF Trust's Legal Provisions Relating to IETF
+                  Documents (http://trustee.ietf.org/license-info)."
+             REVISION    "201103090000Z"
+         DESCRIPTION
+                  "Second version of iFCP Management Module.  The iFCP
+                   address translation mode is deprecated.
+                   This MIB module published as RFC 6173."
+             REVISION    "200601170000Z"
+         DESCRIPTION
+                  "Initial version of iFCP Management Module.
+                   This MIB module published as RFC 4369."
+         ::=  { transmission 230 }
+
+   --
+   --  Textual Conventions
+   --
+
+
+
+Venkatesen                   Standards Track                    [Page 6]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+     IfcpIpTOVorZero ::= TEXTUAL-CONVENTION
+       DISPLAY-HINT   "d"
+       STATUS         current
+       DESCRIPTION    "The maximum propagation delay, in seconds,
+                       for an encapsulated FC frame to traverse the
+                       IP network.  A value of 0 implies fibre
+                       channel frame lifetime limits will not be
+                       enforced."
+       REFERENCE      "RFC 4172, iFCP Protocol Specification"
+       SYNTAX         Unsigned32 (0..3600)
+
+     IfcpLTIorZero ::= TEXTUAL-CONVENTION
+       DISPLAY-HINT   "d"
+       STATUS         current
+       DESCRIPTION    "The value for the Liveness Test Interval
+                       (LTI) being used in an iFCP connection, in
+                       seconds.  A value of 0 implies no Liveness
+                       Test Interval will be used."
+       REFERENCE      "RFC 4172, iFCP Protocol Specification"
+       SYNTAX         Unsigned32 (0..65535)
+
+     IfcpSessionStates ::= TEXTUAL-CONVENTION
+       STATUS         current
+       DESCRIPTION    "The value for an iFCP session state."
+       SYNTAX         INTEGER {down(1), openPending(2), open(3)}
+
+     IfcpAddressMode ::= TEXTUAL-CONVENTION
+       STATUS         current
+       DESCRIPTION    "The values for iFCP Address Translation
+                       Mode."
+       REFERENCE      "RFC 6172, Deprecation of iFCP Address
+                       Translation Mode"
+       SYNTAX         INTEGER {addressTransparent(1),
+                               addressTranslation(2)}
+
+   --
+   -- Internet Fibre Channel Protocol (iFCP)
+   --
+
+   ifcpGatewayObjects      OBJECT IDENTIFIER ::= {ifcpMgmtMIB 1}
+   ifcpGatewayConformance  OBJECT IDENTIFIER ::= {ifcpMgmtMIB 2}
+
+   --
+   -- Local iFCP Gateway Instance Information ==================
+   --
+
+
+
+
+
+
+Venkatesen                   Standards Track                    [Page 7]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+   ifcpLclGatewayInfo OBJECT IDENTIFIER ::= {ifcpGatewayObjects 1}
+
+   ifcpLclGtwyInstTable OBJECT-TYPE
+       SYNTAX           SEQUENCE OF IfcpLclGtwyInstEntry
+       MAX-ACCESS       not-accessible
+       STATUS           current
+       DESCRIPTION
+   "Information about all local iFCP gateway instances that can
+    be monitored and controlled.  This table contains an entry
+    for each local iFCP gateway instance that is being managed."
+       ::= {ifcpLclGatewayInfo 1}
+
+   ifcpLclGtwyInstEntry OBJECT-TYPE
+       SYNTAX           IfcpLclGtwyInstEntry
+       MAX-ACCESS       not-accessible
+       STATUS           current
+       DESCRIPTION
+   "An entry in the local iFCP gateway instance table.
+    Parameters and settings for the gateway are found here."
+       INDEX { ifcpLclGtwyInstIndex }
+       ::= {ifcpLclGtwyInstTable 1}
+
+   IfcpLclGtwyInstEntry ::= SEQUENCE {
+       ifcpLclGtwyInstIndex             Unsigned32,
+       ifcpLclGtwyInstPhyIndex          PhysicalIndexOrZero,
+       ifcpLclGtwyInstVersionMin        Unsigned32,
+       ifcpLclGtwyInstVersionMax        Unsigned32,
+       ifcpLclGtwyInstAddrTransMode     IfcpAddressMode,
+       ifcpLclGtwyInstFcBrdcstSupport   TruthValue,
+       ifcpLclGtwyInstDefaultIpTOV      IfcpIpTOVorZero,
+       ifcpLclGtwyInstDefaultLTInterval IfcpLTIorZero,
+       ifcpLclGtwyInstDescr             SnmpAdminString,
+       ifcpLclGtwyInstNumActiveSessions Gauge32,
+       ifcpLclGtwyInstStorageType       StorageType
+                                     }
+
+   ifcpLclGtwyInstIndex  OBJECT-TYPE
+       SYNTAX            Unsigned32 (1..2147483647)
+       MAX-ACCESS        not-accessible
+       STATUS            current
+       DESCRIPTION
+   "An arbitrary integer value to uniquely identify this iFCP
+    gateway from other local gateway instances."
+       ::= {ifcpLclGtwyInstEntry      1}
+
+
+
+
+
+
+
+Venkatesen                   Standards Track                    [Page 8]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+   ifcpLclGtwyInstPhyIndex OBJECT-TYPE
+       SYNTAX            PhysicalIndexOrZero
+       MAX-ACCESS        read-only
+       STATUS            current
+       DESCRIPTION
+   "An index indicating the location of this local gateway within
+    a larger entity, if one exists.  If supported, this is the
+    entPhysicalIndex from the Entity MIB (Version 3), for this
+    iFCP gateway.  If not supported, or if not related to a
+    physical entity, then the value of this object is 0."
+       REFERENCE      "Entity MIB (Version 3)"
+       ::= {ifcpLclGtwyInstEntry      2}
+
+   ifcpLclGtwyInstVersionMin OBJECT-TYPE
+       SYNTAX            Unsigned32 (0..255)
+       MAX-ACCESS        read-only
+       STATUS            current
+       DESCRIPTION
+   "The minimum iFCP protocol version supported by the local iFCP
+    gateway instance."
+       REFERENCE      "RFC 4172, iFCP Protocol Specification"
+       ::= {ifcpLclGtwyInstEntry      3}
+
+   ifcpLclGtwyInstVersionMax OBJECT-TYPE
+       SYNTAX            Unsigned32 (0..255)
+       MAX-ACCESS        read-only
+       STATUS            current
+       DESCRIPTION
+   "The maximum iFCP protocol version supported by the local iFCP
+    gateway instance."
+       REFERENCE      "RFC 4172, iFCP Protocol Specification"
+       ::= {ifcpLclGtwyInstEntry      4}
+
+   ifcpLclGtwyInstAddrTransMode OBJECT-TYPE
+       SYNTAX            IfcpAddressMode
+       MAX-ACCESS        read-write
+       STATUS            current
+       DESCRIPTION
+   "The local iFCP gateway operating mode.  Changing this value
+    may cause existing sessions to be disrupted."
+       REFERENCE      "RFC 4172, iFCP Protocol Specification;
+                       RFC 6172, Deprecation of iFCP Address
+                       Translation Mode"
+       DEFVAL            { addressTransparent }
+       ::= {ifcpLclGtwyInstEntry      5}
+
+
+
+
+
+
+Venkatesen                   Standards Track                    [Page 9]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+   ifcpLclGtwyInstFcBrdcstSupport OBJECT-TYPE
+       SYNTAX            TruthValue
+       MAX-ACCESS        read-write
+       STATUS            current
+       DESCRIPTION
+   "This value indicates whether the local iFCP gateway supports
+    FC Broadcast.  Changing this value may cause existing sessions
+    to be disrupted."
+       REFERENCE      "RFC 4172, iFCP Protocol Specification"
+       DEFVAL            { false }
+       ::= {ifcpLclGtwyInstEntry      6}
+
+   ifcpLclGtwyInstDefaultIpTOV OBJECT-TYPE
+       SYNTAX            IfcpIpTOVorZero
+       UNITS             "seconds"
+       MAX-ACCESS        read-write
+       STATUS            current
+       DESCRIPTION
+   "The default IP_TOV used for iFCP sessions at this gateway.
+    This is the default maximum propagation delay that will be
+    used for an iFCP session.  The value can be changed on a
+    per-session basis.  The valid range is 0 - 3600 seconds.
+    A value of 0 implies that fibre channel frame lifetime limits
+    will not be enforced."
+       REFERENCE      "RFC 4172, iFCP Protocol Specification"
+       DEFVAL            { 6 }
+       ::= {ifcpLclGtwyInstEntry      7}
+
+   ifcpLclGtwyInstDefaultLTInterval OBJECT-TYPE
+       SYNTAX            IfcpLTIorZero
+       UNITS             "seconds"
+       MAX-ACCESS        read-write
+       STATUS            current
+       DESCRIPTION
+   "The default Liveness Test Interval (LTI), in seconds, used
+    for iFCP sessions at this gateway.  This is the default
+    value for an iFCP session and can be changed on a
+    per-session basis.  The valid range is 0 - 65535 seconds.
+    A value of 0 implies no Liveness Test Interval will be
+    performed on a session."
+       REFERENCE      "RFC 4172, iFCP Protocol Specification"
+       DEFVAL            { 10 }
+       ::= {ifcpLclGtwyInstEntry      8}
+
+
+
+
+
+
+
+
+Venkatesen                   Standards Track                   [Page 10]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+   ifcpLclGtwyInstDescr  OBJECT-TYPE
+       SYNTAX            SnmpAdminString (SIZE (0..64))
+       MAX-ACCESS        read-write
+       STATUS            current
+       DESCRIPTION
+   "A user-entered description for this iFCP gateway."
+       DEFVAL            { "" }
+       ::= {ifcpLclGtwyInstEntry      9}
+
+   ifcpLclGtwyInstNumActiveSessions OBJECT-TYPE
+       SYNTAX            Gauge32 (0..4294967295)
+       MAX-ACCESS        read-only
+       STATUS            current
+       DESCRIPTION
+   "The current total number of iFCP sessions in the open or
+    open-pending state."
+       ::= {ifcpLclGtwyInstEntry      10}
+
+   ifcpLclGtwyInstStorageType OBJECT-TYPE
+       SYNTAX            StorageType
+       MAX-ACCESS        read-only
+       STATUS            current
+       DESCRIPTION
+   "The storage type for this row.  Parameter values defined
+    for a gateway are usually non-volatile, but may be volatile
+    or permanent in some configurations.  If permanent, then
+    the following parameters must have read-write access:
+    ifcpLclGtwyInstAddrTransMode, ifcpLclGtwyInstDefaultIpTOV,
+    and ifcpLclGtwyInstDefaultLTInterval."
+       DEFVAL            { nonVolatile }
+       ::= {ifcpLclGtwyInstEntry      11}
+
+   --
+   -- iFCP N Port Session Information ============================
+   --
+
+   ifcpNportSessionInfo
+              OBJECT IDENTIFIER ::= {ifcpGatewayObjects 2}
+
+   ifcpSessionAttributesTable OBJECT-TYPE
+       SYNTAX                         SEQUENCE OF
+                                       IfcpSessionAttributesEntry
+       MAX-ACCESS                     not-accessible
+       STATUS                         current
+       DESCRIPTION
+   "An iFCP session consists of the pair of N_PORTs comprising
+    the session endpoints joined by a single TCP/IP connection.
+    This table provides information on each iFCP session
+
+
+
+Venkatesen                   Standards Track                   [Page 11]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+    currently using a local iFCP gateway instance.  iFCP sessions
+    are created and removed by the iFCP gateway instances, which
+    are reflected in this table."
+       ::= {ifcpNportSessionInfo 1}
+
+   ifcpSessionAttributesEntry OBJECT-TYPE
+       SYNTAX                         IfcpSessionAttributesEntry
+       MAX-ACCESS                     not-accessible
+       STATUS                         current
+       DESCRIPTION
+   "Each entry contains information about one iFCP session consisting
+    of a pair of N_PORTs joined by a single TCP/IP connection.  This
+    table's INDEX includes ifcpLclGtwyInstIndex, which identifies the
+    local iFCP gateway instance that created the session for the
+    entry.
+
+    Soon after an entry is created in this table for an iFCP session, it
+    will correspond to an entry in the tcpConnectionTable of the TCP-MIB
+    (RFC 4022).  The corresponding entry might represent a preexisting
+    TCP connection, or it might be a newly created entry.  (Note that if
+    IPv4 is being used, an entry in RFC 2012's tcpConnTable may also
+    correspond.)  The values of ifcpSessionLclPrtlAddrType and
+    ifcpSessionRmtPrtlIfAddrType in this table and the values of
+    tcpConnectionLocalAddressType and tcpConnectionRemAddressType used
+    as INDEX values for the corresponding entry in the
+    tcpConnectionTable should be the same; this makes it simpler to
+    locate a session's TCP connection in the TCP-MIB.  (Of course, all
+    four values need to be 'ipv4' if there's a corresponding entry in
+    the tcpConnTable.)
+
+    If an entry is created in this table for a session, prior to
+    knowing which local and/or remote port numbers will be used for
+    the TCP connection, then ifcpSessionLclPrtlTcpPort and/or
+    ifcpSessionRmtPrtlTcpPort have the value zero until such time as
+    they can be updated to the port numbers (to be) used for the
+    connection.  (Thus, a port value of zero should not be used to
+    locate a session's TCP connection in the TCP-MIB.)
+
+    When the TCP connection terminates, the entry in the
+    tcpConnectionTable and the entry in this table both get deleted
+    (and, if applicable, so does the entry in the tcpConnTable)."
+       INDEX { ifcpLclGtwyInstIndex, ifcpSessionIndex }
+       ::= {ifcpSessionAttributesTable 1}
+
+   IfcpSessionAttributesEntry ::= SEQUENCE {
+       ifcpSessionIndex               Integer32,
+       ifcpSessionLclPrtlIfIndex      InterfaceIndexOrZero,
+       ifcpSessionLclPrtlAddrType     InetAddressType,
+
+
+
+Venkatesen                   Standards Track                   [Page 12]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+       ifcpSessionLclPrtlAddr         InetAddress,
+       ifcpSessionLclPrtlTcpPort      InetPortNumber,
+       ifcpSessionLclNpWwun           FcNameIdOrZero,
+       ifcpSessionLclNpFcid           FcAddressIdOrZero,
+       ifcpSessionRmtNpWwun           FcNameIdOrZero,
+       ifcpSessionRmtPrtlIfAddrType   InetAddressType,
+       ifcpSessionRmtPrtlIfAddr       InetAddress,
+       ifcpSessionRmtPrtlTcpPort      InetPortNumber,
+       ifcpSessionRmtNpFcid           FcAddressIdOrZero,
+       ifcpSessionRmtNpFcidAlias      FcAddressIdOrZero,
+       ifcpSessionIpTOV               IfcpIpTOVorZero,
+       ifcpSessionLclLTIntvl          IfcpLTIorZero,
+       ifcpSessionRmtLTIntvl          IfcpLTIorZero,
+       ifcpSessionBound               TruthValue,
+       ifcpSessionStorageType         StorageType
+                                          }
+
+   ifcpSessionIndex                   OBJECT-TYPE
+       SYNTAX                         Integer32 (1..2147483647)
+       MAX-ACCESS                     not-accessible
+       STATUS                         current
+       DESCRIPTION
+   "The iFCP session index is a unique value used as an index
+    to the table, along with a specific local iFCP gateway
+    instance.  This index is used because the local N Port and
+    remote N Port information would create a complex index that
+    would be difficult to implement."
+       ::= {ifcpSessionAttributesEntry 1}
+
+   ifcpSessionLclPrtlIfIndex          OBJECT-TYPE
+       SYNTAX                         InterfaceIndexOrZero
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "This is the interface index in the IF-MIB ifTable being used
+    as the local portal in this session, as described in the
+    IF-MIB.  If the local portal is not associated with an entry
+    in the ifTable, then the value is 0.  The ifType of the
+    interface will generally be a type that supports IP, but an
+    implementation may support iFCP using other protocols.  This
+    object can be used to obtain additional information about the
+    interface."
+       REFERENCE     "RFC 2863, The Interfaces Group MIB (IF-MIB)"
+       ::= {ifcpSessionAttributesEntry 2}
+
+   ifcpSessionLclPrtlAddrType         OBJECT-TYPE
+       SYNTAX                         InetAddressType
+       MAX-ACCESS                     read-only
+
+
+
+Venkatesen                   Standards Track                   [Page 13]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+       STATUS                         current
+       DESCRIPTION
+   "The type of address in ifcpSessionLclIfAddr."
+       ::= {ifcpSessionAttributesEntry 3}
+
+   ifcpSessionLclPrtlAddr             OBJECT-TYPE
+       SYNTAX                         InetAddress
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "This is the external IP address of the interface being used
+    for the iFCP local portal in this session.  The address type
+    is defined in ifcpSessionLclPrtlAddrType.  If the value is a
+    DNS name, then the name is resolved once, during the initial
+    session instantiation."
+       ::= {ifcpSessionAttributesEntry 4}
+
+   ifcpSessionLclPrtlTcpPort          OBJECT-TYPE
+       SYNTAX                         InetPortNumber
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "This is the TCP port number that is being used for the iFCP
+    local portal in this session.  This is normally an ephemeral
+    port number selected by the gateway.  The value may be 0
+    during an initial setup period."
+       ::= {ifcpSessionAttributesEntry 5}
+
+   ifcpSessionLclNpWwun               OBJECT-TYPE
+       SYNTAX                         FcNameIdOrZero
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "World Wide Unique Name of the local N Port.  For an unbound
+    session, this variable will be a zero-length string."
+       REFERENCE      "RFC 4172, iFCP Protocol Specification"
+       DEFVAL                         { "" }
+       ::= {ifcpSessionAttributesEntry 6}
+
+   ifcpSessionLclNpFcid               OBJECT-TYPE
+       SYNTAX                         FcAddressIdOrZero
+       MAX-ACCESS                     read-only
+       STATUS                         current
+
+
+
+
+
+
+
+
+Venkatesen                   Standards Track                   [Page 14]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+       DESCRIPTION
+   "Fibre Channel Identifier of the local N Port.  For an unbound
+    session, this variable will be a zero-length string."
+       REFERENCE      "RFC 4172, iFCP Protocol Specification"
+       ::= {ifcpSessionAttributesEntry 7}
+
+   ifcpSessionRmtNpWwun               OBJECT-TYPE
+       SYNTAX                         FcNameIdOrZero
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "World Wide Unique Name of the remote N Port.  For an unbound
+    session, this variable will be a zero-length string."
+       REFERENCE      "RFC 4172, iFCP Protocol Specification"
+       DEFVAL                         { "" }
+       ::= {ifcpSessionAttributesEntry 8}
+
+   ifcpSessionRmtPrtlIfAddrType       OBJECT-TYPE
+       SYNTAX                         InetAddressType
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "The type of address in ifcpSessionRmtPrtlIfAddr."
+       ::= {ifcpSessionAttributesEntry 9}
+
+   ifcpSessionRmtPrtlIfAddr           OBJECT-TYPE
+       SYNTAX                         InetAddress
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "This is the remote gateway IP address being used for the
+    portal on the remote iFCP gateway.  The address type is
+    defined in ifcpSessionRmtPrtlIfAddrType.  If the value is a
+    DNS name, then the name is resolved once, during the initial
+    session instantiation."
+       ::= {ifcpSessionAttributesEntry 10}
+
+   ifcpSessionRmtPrtlTcpPort          OBJECT-TYPE
+       SYNTAX                         InetPortNumber
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "This is the TCP port number being used for the portal on the
+    remote iFCP gateway.  Generally, this will be the iFCP
+    canonical port.  The value may be 0 during an initial setup
+    period."
+       DEFVAL                         { 3420 }
+       ::= {ifcpSessionAttributesEntry 11}
+
+
+
+Venkatesen                   Standards Track                   [Page 15]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+   ifcpSessionRmtNpFcid               OBJECT-TYPE
+       SYNTAX                         FcAddressIdOrZero
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "Fibre Channel Identifier of the remote N Port.  For an
+    unbound session, this variable will be a zero-length string."
+       REFERENCE      "RFC 4172, iFCP Protocol Specification"
+       ::= {ifcpSessionAttributesEntry 12}
+
+   ifcpSessionRmtNpFcidAlias          OBJECT-TYPE
+       SYNTAX                         FcAddressIdOrZero
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "Fibre Channel Identifier Alias assigned by the local gateway
+    for the remote N Port.  For an unbound session, this variable
+    will be a zero-length string."
+       REFERENCE      "RFC 4172, iFCP Protocol Specification"
+       ::= {ifcpSessionAttributesEntry 13}
+
+   ifcpSessionIpTOV                   OBJECT-TYPE
+       SYNTAX                         IfcpIpTOVorZero
+       UNITS                          "seconds"
+       MAX-ACCESS                     read-write
+       STATUS                         current
+       DESCRIPTION
+   "The IP_TOV being used for this iFCP session.  This is the
+    maximum propagation delay that will be used for the iFCP
+    session.  The value can be changed on a per-session basis
+    and initially defaults to ifcpLclGtwyInstDefaultIpTOV for
+    the local gateway instance.  The valid range is 0 - 3600
+    seconds.  A value of 0 implies fibre channel frame lifetime
+    limits will not be enforced."
+       REFERENCE      "RFC 4172, iFCP Protocol Specification"
+       ::= {ifcpSessionAttributesEntry 14}
+
+   ifcpSessionLclLTIntvl              OBJECT-TYPE
+       SYNTAX                         IfcpLTIorZero
+       UNITS                          "seconds"
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "The Liveness Test Interval (LTI) used for this iFCP session.
+    The value can be changed on a per-session basis and initially
+    defaults to ifcpLclGtwyInstDefaultLTInterval for the local
+
+
+
+
+
+Venkatesen                   Standards Track                   [Page 16]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+    gateway instance.  The valid range is 0 - 65535 seconds.
+    A value of 0 implies that the gateway will not originate
+    Liveness Test messages for the session."
+       REFERENCE      "RFC 4172, iFCP Protocol Specification"
+       ::= {ifcpSessionAttributesEntry 15}
+
+   ifcpSessionRmtLTIntvl              OBJECT-TYPE
+       SYNTAX                         IfcpLTIorZero
+       UNITS                          "seconds"
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "The Liveness Test Interval (LTI) as requested by the remote
+    gateway instance to use for this iFCP session.  This value may
+    change over the life of the session.  The valid range is 0 -
+    65535 seconds.  A value of 0 implies that the remote gateway
+    has not been requested to originate Liveness Test messages for
+    the session."
+       REFERENCE      "RFC 4172, iFCP Protocol Specification"
+       ::= {ifcpSessionAttributesEntry 16}
+
+   ifcpSessionBound                   OBJECT-TYPE
+       SYNTAX                         TruthValue
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "This value indicates whether this session is bound to a
+    specific local and remote N Port.  Sessions by default are
+    unbound and ready for future assignment to a local and remote
+    N Port."
+       REFERENCE      "RFC 4172, iFCP Protocol Specification"
+       ::= {ifcpSessionAttributesEntry 17}
+
+   ifcpSessionStorageType             OBJECT-TYPE
+       SYNTAX                         StorageType
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "The storage type for this row.  Parameter values defined
+    for a session are usually non-volatile, but may be volatile
+    or permanent in some configurations.  If permanent, then
+    ifcpSessionIpTOV must have read-write access."
+       DEFVAL            { nonVolatile }
+       ::= {ifcpSessionAttributesEntry 18}
+
+   --
+   -- Local iFCP Gateway Instance Session Statistics =============
+   --
+
+
+
+Venkatesen                   Standards Track                   [Page 17]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+   ifcpSessionStatsTable              OBJECT-TYPE
+       SYNTAX                         SEQUENCE OF
+                                         IfcpSessionStatsEntry
+       MAX-ACCESS                     not-accessible
+       STATUS                         current
+       DESCRIPTION
+   "This table provides statistics on an iFCP session."
+       ::= {ifcpNportSessionInfo 2}
+
+   ifcpSessionStatsEntry              OBJECT-TYPE
+       SYNTAX                         IfcpSessionStatsEntry
+       MAX-ACCESS                     not-accessible
+       STATUS                         current
+       DESCRIPTION
+   "Provides iFCP-specific statistics per session."
+       AUGMENTS {ifcpSessionAttributesEntry}
+       ::= {ifcpSessionStatsTable 1}
+
+   IfcpSessionStatsEntry ::= SEQUENCE {
+       ifcpSessionState               IfcpSessionStates,
+       ifcpSessionDuration            Unsigned32,
+       ifcpSessionTxOctets            ZeroBasedCounter64,
+       ifcpSessionRxOctets            ZeroBasedCounter64,
+       ifcpSessionTxFrames            ZeroBasedCounter64,
+       ifcpSessionRxFrames            ZeroBasedCounter64,
+       ifcpSessionStaleFrames         ZeroBasedCounter64,
+       ifcpSessionHeaderCRCErrors     ZeroBasedCounter64,
+       ifcpSessionFcPayloadCRCErrors  ZeroBasedCounter64,
+       ifcpSessionOtherErrors         ZeroBasedCounter64,
+       ifcpSessionDiscontinuityTime   TimeStamp
+                                      }
+
+   ifcpSessionState                   OBJECT-TYPE
+       SYNTAX                         IfcpSessionStates
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "The current session operating state."
+       ::= {ifcpSessionStatsEntry 1}
+
+   ifcpSessionDuration                OBJECT-TYPE
+       SYNTAX                         Unsigned32 (0..4294967295)
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "This indicates, in seconds, how long the iFCP session has
+    been in an open or open-pending state.  When a session is
+    down, the value is reset to 0."
+
+
+
+Venkatesen                   Standards Track                   [Page 18]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+       ::= {ifcpSessionStatsEntry 2}
+
+   ifcpSessionTxOctets                OBJECT-TYPE
+       SYNTAX                         ZeroBasedCounter64
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "The total number of octets transmitted by the iFCP gateway
+    for this session.  Discontinuities in the value of this
+    counter can occur at reinitialization of the management
+    system, and at other times as indicated by the value of
+    ifcpSessionDiscontinuityTime."
+       ::= {ifcpSessionStatsEntry 3}
+
+   ifcpSessionRxOctets                OBJECT-TYPE
+       SYNTAX                         ZeroBasedCounter64
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "The total number of octets received by the iFCP gateway for
+    this session.  Discontinuities in the value of this
+    counter can occur at reinitialization of the management
+    system, and at other times as indicated by the value of
+    ifcpSessionDiscontinuityTime."
+       ::= {ifcpSessionStatsEntry 4}
+
+   ifcpSessionTxFrames                OBJECT-TYPE
+       SYNTAX                         ZeroBasedCounter64
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "The total number of iFCP frames transmitted by the gateway
+    for this session.  Discontinuities in the value of this
+    counter can occur at reinitialization of the management
+    system, and at other times as indicated by the value of
+    ifcpSessionDiscontinuityTime."
+       ::= {ifcpSessionStatsEntry 5}
+
+   ifcpSessionRxFrames                OBJECT-TYPE
+       SYNTAX                         ZeroBasedCounter64
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "The total number of iFCP frames received by the gateway
+    for this session.  Discontinuities in the value of this
+    counter can occur at reinitialization of the management
+    system, and at other times as indicated by the value of
+    ifcpSessionDiscontinuityTime."
+
+
+
+Venkatesen                   Standards Track                   [Page 19]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+       ::= {ifcpSessionStatsEntry 6}
+
+   ifcpSessionStaleFrames             OBJECT-TYPE
+       SYNTAX                         ZeroBasedCounter64
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "The total number of received iFCP frames that were stale and
+    discarded by the gateway for this session.  Discontinuities
+    in the value of this counter can occur at reinitialization
+    of the management system, and at other times as indicated by
+    the value of ifcpSessionDiscontinuityTime."
+       ::= {ifcpSessionStatsEntry 7}
+
+   ifcpSessionHeaderCRCErrors         OBJECT-TYPE
+       SYNTAX                         ZeroBasedCounter64
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "The total number of Cyclic Redundancy Check (CRC) errors that
+    occurred in the frame header, detected by the gateway for this
+    session.  Usually, a single Header CRC error is sufficient to
+    terminate an iFCP session.  Discontinuities in the value of this
+    counter can occur at reinitialization of the management system,
+    and at other times as indicated by the value of
+    ifcpSessionDiscontinuityTime."
+       ::= {ifcpSessionStatsEntry 8}
+
+   ifcpSessionFcPayloadCRCErrors      OBJECT-TYPE
+       SYNTAX                         ZeroBasedCounter64
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "The total number of CRC errors that occurred in the Fibre
+    Channel frame payload, detected by the gateway for this
+    session.  Discontinuities in the value of this counter can
+    occur at reinitialization of the management system, and
+    at other times as indicated by the value of
+    ifcpSessionDiscontinuityTime."
+       ::= {ifcpSessionStatsEntry 9}
+
+   ifcpSessionOtherErrors             OBJECT-TYPE
+       SYNTAX                         ZeroBasedCounter64
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "The total number of errors, other than errors explicitly
+    measured, detected by the gateway for this session.
+
+
+
+Venkatesen                   Standards Track                   [Page 20]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+    Discontinuities in the value of this counter can occur at
+    reinitialization of the management system, and at other
+    times as indicated by the value of
+    ifcpSessionDiscontinuityTime."
+       ::= {ifcpSessionStatsEntry 10}
+
+   ifcpSessionDiscontinuityTime       OBJECT-TYPE
+       SYNTAX                         TimeStamp
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "The value of sysUpTime on the most recent occasion at which
+    any one (or more) of the ifcpSessionStatsTable counters
+    suffered a discontinuity.  The relevant counters are the
+    specific Counter64-based instances associated with the
+    ifcpSessionStatsTable: ifcpSessionTxOctets,
+    ifcpSessionRxOctets, ifcpSessionTxFrames,
+    ifcpSessionRxFrames, ifcpSessionStaleFrames,
+    ifcpSessionHeaderCRCErrors, ifcpSessionFcPayloadCRCErrors,
+    and ifcpSessionOtherErrors.  If no such discontinuities have
+    occurred since the last reinitialization of the local
+    management subsystem, then this object contains a zero value."
+       ::= {ifcpSessionStatsEntry 11}
+
+   --
+   -- Low-Capacity Statistics
+   --
+
+   ifcpSessionLcStatsTable            OBJECT-TYPE
+       SYNTAX                         SEQUENCE OF
+                                        IfcpSessionLcStatsEntry
+       MAX-ACCESS                     not-accessible
+       STATUS                         current
+       DESCRIPTION
+   "This table provides low-capacity statistics for an iFCP
+    session.  These are provided for backward compatibility with
+    systems that do not support Counter64-based objects.  At
+    1-Gbps rates, a Counter32-based object can wrap as often as
+    every 34 seconds.  Counter32-based objects can be sufficient
+    for many situations.  However, when possible, it is
+    recommended to use the high-capacity statistics in
+    ifcpSessionStatsTable based on Counter64 objects."
+       ::= {ifcpNportSessionInfo 3}
+
+   ifcpSessionLcStatsEntry            OBJECT-TYPE
+       SYNTAX                         IfcpSessionLcStatsEntry
+       MAX-ACCESS                     not-accessible
+       STATUS                         current
+
+
+
+Venkatesen                   Standards Track                   [Page 21]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+       DESCRIPTION
+   "Provides iFCP-specific statistics per session."
+       AUGMENTS {ifcpSessionAttributesEntry}
+       ::= {ifcpSessionLcStatsTable 1}
+
+   IfcpSessionLcStatsEntry ::= SEQUENCE {
+       ifcpSessionLcTxOctets            ZeroBasedCounter32,
+       ifcpSessionLcRxOctets            ZeroBasedCounter32,
+       ifcpSessionLcTxFrames            ZeroBasedCounter32,
+       ifcpSessionLcRxFrames            ZeroBasedCounter32,
+       ifcpSessionLcStaleFrames         ZeroBasedCounter32,
+       ifcpSessionLcHeaderCRCErrors     ZeroBasedCounter32,
+       ifcpSessionLcFcPayloadCRCErrors  ZeroBasedCounter32,
+       ifcpSessionLcOtherErrors         ZeroBasedCounter32
+                                      }
+   ifcpSessionLcTxOctets              OBJECT-TYPE
+       SYNTAX                         ZeroBasedCounter32
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "The total number of octets transmitted by the iFCP gateway
+    for this session."
+       ::= {ifcpSessionLcStatsEntry 1}
+
+   ifcpSessionLcRxOctets              OBJECT-TYPE
+       SYNTAX                         ZeroBasedCounter32
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "The total number of octets received by the iFCP gateway for
+    this session."
+       ::= {ifcpSessionLcStatsEntry 2}
+
+   ifcpSessionLcTxFrames              OBJECT-TYPE
+       SYNTAX                         ZeroBasedCounter32
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "The total number of iFCP frames transmitted by the gateway
+    for this session."
+       ::= {ifcpSessionLcStatsEntry 3}
+
+   ifcpSessionLcRxFrames              OBJECT-TYPE
+       SYNTAX                         ZeroBasedCounter32
+       MAX-ACCESS                     read-only
+       STATUS                         current
+
+
+
+
+
+Venkatesen                   Standards Track                   [Page 22]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+       DESCRIPTION
+   "The total number of iFCP frames received by the gateway
+    for this session."
+       ::= {ifcpSessionLcStatsEntry 4}
+
+   ifcpSessionLcStaleFrames           OBJECT-TYPE
+       SYNTAX                         ZeroBasedCounter32
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "The total number of received iFCP frames that were stale and
+    discarded by the gateway for this session."
+       ::= {ifcpSessionLcStatsEntry 5}
+
+   ifcpSessionLcHeaderCRCErrors       OBJECT-TYPE
+       SYNTAX                         ZeroBasedCounter32
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "The total number of CRC errors that occurred in the frame
+    header, detected by the gateway for this session.  Usually,
+    a single Header CRC error is sufficient to terminate an
+    iFCP session."
+       ::= {ifcpSessionLcStatsEntry 6}
+
+   ifcpSessionLcFcPayloadCRCErrors    OBJECT-TYPE
+       SYNTAX                         ZeroBasedCounter32
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "The total number of CRC errors that occurred in the Fibre
+    Channel frame payload, detected by the gateway for this
+    session."
+       ::= {ifcpSessionLcStatsEntry 7}
+
+   ifcpSessionLcOtherErrors           OBJECT-TYPE
+       SYNTAX                         ZeroBasedCounter32
+       MAX-ACCESS                     read-only
+       STATUS                         current
+       DESCRIPTION
+   "The total number of errors, other than errors explicitly
+    measured, detected by the gateway for this session."
+       ::= {ifcpSessionLcStatsEntry 8}
+
+   --==========================================================
+
+
+
+
+
+
+Venkatesen                   Standards Track                   [Page 23]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+   ifcpCompliances
+           OBJECT IDENTIFIER ::= {ifcpGatewayConformance 1}
+
+   ifcpGatewayCompliance MODULE-COMPLIANCE
+       STATUS deprecated
+       DESCRIPTION
+   "This MODULE-COMPLIANCE has been deprecated because address
+   translation mode has been deprecated in the iFCP standard.  It has
+   the implementation requirements for iFCP MIB module compliance."
+       MODULE       -- this module
+       MANDATORY-GROUPS {
+           ifcpLclGatewayGroup,
+           ifcpLclGatewaySessionGroup,
+           ifcpLclGatewaySessionStatsGroup,
+           ifcpLclGatewaySessionLcStatsGroup
+                        }
+
+           OBJECT      ifcpSessionLclPrtlAddrType
+           SYNTAX      InetAddressType { ipv4(1), ipv6(2) }
+           DESCRIPTION
+                  "Support is only required for global IPv4
+                  and IPv6 address types."
+           OBJECT      ifcpSessionRmtPrtlIfAddrType
+           SYNTAX      InetAddressType { ipv4(1), ipv6(2) }
+           DESCRIPTION
+                  "Support is only required for global IPv4
+                  and IPv6 address types."
+
+           OBJECT      ifcpLclGtwyInstAddrTransMode
+           SYNTAX      IfcpAddressMode {addressTransparent(1),
+                                        addressTranslation(2)}
+           DESCRIPTION
+                  "This object must support addressTransparent(1) and
+                    addressTranslation(2)."
+
+       ::= {ifcpCompliances 1}
+
+   ifcpGatewayComplianceNoTranslation MODULE-COMPLIANCE
+       STATUS current
+       DESCRIPTION
+   "Implementation requirements for iFCP MIB module compliance.
+    Address translation mode has been deprecated in the iFCP standard."
+       REFERENCE      "RFC 4172, iFCP Protocol Specification;
+                       RFC 6172, Deprecation of iFCP Address
+                       Translation Mode"
+       MODULE       -- this module
+
+
+
+
+
+Venkatesen                   Standards Track                   [Page 24]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+       MANDATORY-GROUPS {
+           ifcpLclGatewayGroup,
+           ifcpLclGatewaySessionGroupNoTranslation,
+           ifcpLclGatewaySessionStatsGroup,
+           ifcpLclGatewaySessionLcStatsGroup
+                        }
+
+           OBJECT      ifcpSessionLclPrtlAddrType
+           SYNTAX      InetAddressType { ipv4(1), ipv6(2) }
+           DESCRIPTION
+                  "Support is only required for global IPv4
+                  and IPv6 address types."
+
+           OBJECT      ifcpSessionRmtPrtlIfAddrType
+           SYNTAX      InetAddressType { ipv4(1), ipv6(2) }
+           DESCRIPTION
+                  "Support is only required for global IPv4
+                  and IPv6 address types."
+
+           OBJECT      ifcpLclGtwyInstAddrTransMode
+           SYNTAX      IfcpAddressMode {addressTransparent(1)}
+           DESCRIPTION
+                  "Support is only required for addressTransparent(1)."
+
+       ::= {ifcpCompliances 2}
+
+   ifcpGroups OBJECT IDENTIFIER ::= {ifcpGatewayConformance 2}
+
+   ifcpLclGatewayGroup OBJECT-GROUP
+       OBJECTS {
+       ifcpLclGtwyInstPhyIndex,
+       ifcpLclGtwyInstVersionMin,
+       ifcpLclGtwyInstVersionMax,
+       ifcpLclGtwyInstAddrTransMode,
+       ifcpLclGtwyInstFcBrdcstSupport,
+       ifcpLclGtwyInstDefaultIpTOV,
+       ifcpLclGtwyInstDefaultLTInterval,
+       ifcpLclGtwyInstDescr,
+       ifcpLclGtwyInstNumActiveSessions,
+       ifcpLclGtwyInstStorageType
+              }
+       STATUS current
+       DESCRIPTION
+   "iFCP local device info group.  This group provides
+    information about each gateway."
+       ::= {ifcpGroups 1}
+
+
+
+
+
+Venkatesen                   Standards Track                   [Page 25]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+   ifcpLclGatewaySessionGroup OBJECT-GROUP
+       OBJECTS {
+       ifcpSessionLclPrtlIfIndex,
+       ifcpSessionLclPrtlAddrType,
+       ifcpSessionLclPrtlAddr,
+       ifcpSessionLclPrtlTcpPort,
+       ifcpSessionLclNpWwun,
+       ifcpSessionLclNpFcid,
+       ifcpSessionRmtNpWwun,
+       ifcpSessionRmtPrtlIfAddrType,
+       ifcpSessionRmtPrtlIfAddr,
+       ifcpSessionRmtPrtlTcpPort,
+       ifcpSessionRmtNpFcid,
+       ifcpSessionRmtNpFcidAlias,
+       ifcpSessionIpTOV,
+       ifcpSessionLclLTIntvl,
+       ifcpSessionRmtLTIntvl,
+       ifcpSessionBound,
+       ifcpSessionStorageType
+              }
+       STATUS deprecated
+       DESCRIPTION
+   "This OBJECT-GROUP has been deprecated because address translation
+   mode has been deprecated in the iFCP standard. iFCP Session group.
+   This group provides information about each iFCP session currently
+   active between iFCP gateways."
+       ::= {ifcpGroups 4}
+
+   ifcpLclGatewaySessionStatsGroup OBJECT-GROUP
+       OBJECTS {
+       ifcpSessionState,
+       ifcpSessionDuration,
+       ifcpSessionTxOctets,
+       ifcpSessionRxOctets,
+       ifcpSessionTxFrames,
+       ifcpSessionRxFrames,
+       ifcpSessionStaleFrames,
+       ifcpSessionHeaderCRCErrors,
+       ifcpSessionFcPayloadCRCErrors,
+       ifcpSessionOtherErrors,
+       ifcpSessionDiscontinuityTime
+              }
+       STATUS current
+
+
+
+
+
+
+
+
+Venkatesen                   Standards Track                   [Page 26]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+       DESCRIPTION
+   "iFCP Session Statistics group.  This group provides
+    statistics with 64-bit counters for each iFCP session
+    currently active between iFCP gateways.  This group
+    is only required for agents that can support Counter64-
+    based data types."
+       ::= {ifcpGroups 5}
+
+   ifcpLclGatewaySessionLcStatsGroup OBJECT-GROUP
+       OBJECTS {
+       ifcpSessionLcTxOctets,
+       ifcpSessionLcRxOctets,
+       ifcpSessionLcTxFrames,
+       ifcpSessionLcRxFrames,
+       ifcpSessionLcStaleFrames,
+       ifcpSessionLcHeaderCRCErrors,
+       ifcpSessionLcFcPayloadCRCErrors,
+       ifcpSessionLcOtherErrors
+              }
+       STATUS current
+       DESCRIPTION
+   "iFCP Session Low-Capacity Statistics group.  This group
+    provides statistics with low-capacity 32-bit counters
+    for each iFCP session currently active between iFCP
+    gateways.  This group is only required for agents that
+    do not support Counter64-based data types, or that need
+    to support SNMPv1 applications."
+       ::= {ifcpGroups 6}
+
+   ifcpLclGatewaySessionGroupNoTranslation OBJECT-GROUP
+       OBJECTS {
+       ifcpSessionLclPrtlIfIndex,
+       ifcpSessionLclPrtlAddrType,
+       ifcpSessionLclPrtlAddr,
+       ifcpSessionLclPrtlTcpPort,
+       ifcpSessionLclNpWwun,
+       ifcpSessionLclNpFcid,
+       ifcpSessionRmtNpWwun,
+       ifcpSessionRmtPrtlIfAddrType,
+       ifcpSessionRmtPrtlIfAddr,
+       ifcpSessionRmtPrtlTcpPort,
+       ifcpSessionRmtNpFcid,
+       ifcpSessionIpTOV,
+       ifcpSessionLclLTIntvl,
+       ifcpSessionRmtLTIntvl,
+       ifcpSessionBound,
+       ifcpSessionStorageType
+              }
+
+
+
+Venkatesen                   Standards Track                   [Page 27]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+       STATUS current
+       DESCRIPTION
+   "iFCP Session group.  This group provides information
+    about each iFCP session currently active between iFCP
+    gateways."
+       ::= {ifcpGroups 7}
+
+   END
+
+6.  Security Considerations
+
+   There are a number of management objects defined in this MIB module
+   with a MAX-ACCESS clause of read-write and/or read-create.  Such
+   objects may be considered sensitive or vulnerable in some network
+   environments.  The support for SET operations in a non-secure
+   environment without proper protection can have a negative effect on
+   network operations.
+
+   Changing the following object values, with a MAX-ACCESS of read-
+   write, may cause disruption in storage traffic:
+
+        ifcpLclGtwyInstAddrTransMode
+        ifcpLclGtwyInstFcBrdcstSupport
+        ifcpLclGtwyInstDefaultIpTOV
+        ifcpLclGtwyInstDefaultLTInterval
+        ifcpSessionIpTOV
+
+   Changing the following object value, with a MAX-ACCESS of read-write,
+   may cause a user to lose track of the iFCP gateway:
+
+        ifcpLclGtwyInstDescr
+
+   Some of the readable objects in this MIB module (i.e., objects with a
+   MAX-ACCESS other than not-accessible) may be considered sensitive or
+   vulnerable in some network environments.  It is thus important to
+   control even GET and/or NOTIFY access to these objects and possibly
+   to even encrypt the values of these objects when sending them over
+   the network via SNMP.
+
+   The following object tables provide information about storage traffic
+   sessions, and can indicate to a user who is communicating and
+   exchanging storage data:
+
+        ifcpLclGtwyInstTable
+        ifcpSessionAttributesTable
+
+
+
+
+
+
+Venkatesen                   Standards Track                   [Page 28]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+   SNMP versions prior to SNMPv3 did not include adequate security.
+   Even if the network itself is secure (for example, by using IPsec),
+   even then, there is no control as to who on the secure network is
+   allowed to access and GET/SET (read/change/create/delete) the objects
+   in this MIB module.
+
+   It is RECOMMENDED that implementers consider the security features as
+   provided by the SNMPv3 framework (see [RFC3410], section 8),
+   including full support for the SNMPv3 cryptographic mechanisms (for
+   authentication and privacy).
+
+   Further, deployment of SNMP versions prior to SNMPv3 is NOT
+   RECOMMENDED.  Instead, it is RECOMMENDED to deploy SNMPv3 and to
+   enable cryptographic security.  It is then a customer/operator
+   responsibility to ensure that the SNMP entity giving access to an
+   instance of this MIB module is properly configured to give access to
+   the objects only to those principals (users) that have legitimate
+   rights to indeed GET or SET (change/create/delete) them.
+
+7.  IANA Considerations
+
+   The MIB module in this document uses the following IANA-assigned
+   OBJECT IDENTIFIER value recorded in the SMI Numbers registry:
+
+   Descriptor        OBJECT IDENTIFIER value
+   ----------        -----------------------
+   ifcpMgmtMIB       { transmission 230 }
+
+8.  References
+
+8.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2578]  McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+              "Structure of Management Information Version 2 (SMIv2)",
+              STD 58, RFC 2578, April 1999.
+
+   [RFC2579]  McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+              "Textual Conventions for SMIv2", STD 58, RFC 2579, April
+              1999.
+
+   [RFC2580]  McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+              "Conformance Statements for SMIv2", STD 58, RFC 2580,
+              April 1999.
+
+
+
+
+
+Venkatesen                   Standards Track                   [Page 29]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+   [RFC2856]  Bierman, A., McCloghrie, K., and R. Presuhn, "Textual
+              Conventions for Additional High Capacity Data Types", RFC
+              2856, June 2000.
+
+   [RFC2863]  McCloghrie, K. and F. Kastenholz, "The Interfaces Group
+              MIB", RFC 2863, June 2000.
+
+   [RFC3411]  Harrington, D., Presuhn, R., and B. Wijnen, "An
+              Architecture for Describing Simple Network Management
+              Protocol (SNMP) Management Frameworks", STD 62, RFC 3411,
+              December 2002.
+
+   [RFC4001]  Daniele, M., Haberman, B., Routhier, S., and J.
+              Schoenwaelder, "Textual Conventions for Internet Network
+              Addresses", RFC 4001, February 2005.
+
+   [RFC4044]  McCloghrie, K., "Fibre Channel Management MIB", RFC 4044,
+              May 2005.
+
+   [RFC4133]  Bierman, A. and K. McCloghrie, "Entity MIB (Version 3)",
+              RFC 4133, August 2005.
+
+   [RFC4172]  Monia, C., Mullendore, R., Travostino, F., Jeong, W., and
+              M. Edwards, "iFCP - A Protocol for Internet Fibre Channel
+              Storage Networking", RFC 4172, September 2005.
+
+   [RFC4369]  Gibbons, K., Monia, C., Tseng, J., and F. Travostino,
+              "Definitions of Managed Objects for Internet Fibre Channel
+              Protocol (iFCP)", RFC 4369, January 2006.
+
+   [RFC4502]  Waldbusser, S., "Remote Network Monitoring Management
+              Information Base Version 2", RFC 4502, May 2006.
+
+   [RFC6172]  Black, D. and D. Peterson, "Deprecation of the Internet
+              Fibre Channel Protocol (iFCP) Address Translation Mode",
+              RFC 6172, March 2011.
+
+8.2.  Informative References
+
+   [RFC3410]  Case, J., Mundy, R., Partain, D., and B. Stewart,
+              "Introduction and Applicability Statements for Internet
+              Standard Management Framework", RFC 3410, December 2002.
+
+
+
+
+
+
+
+
+
+Venkatesen                   Standards Track                   [Page 30]
+
+RFC 6173                        iFCP MIB                      March 2011
+
+
+9.  Acknowledgments
+
+   Credit goes to the authors of [RFC4369] (listed below) for preparing
+   the first version of the iFCP MIB module.  I wish to thank David
+   Black, Tom Talpey, and David Harrington for their significant inputs
+   on this update.
+
+   Authors of RFC 4369:
+
+      Kevin Gibbons
+      2Wire Corporation
+      1704 Automation Parkway
+      San Jose, CA 95131 USA
+      Phone: (408)895-1387
+      EMail: kgibbons@yahoo.com
+
+      Charles Monia
+      Consultant
+      7553 Morevern Circle
+      San Jose, CA 95135 USA
+      EMail: charles_monia@yahoo.com
+
+      Josh Tseng
+      Riverbed Technology
+      501 2nd Street, Suite 410
+      San Francisco, CA 94107 USA
+      Phone: (650)274-2109
+      EMail: joshtseng@yahoo.com
+
+      Franco Travostino
+      eBay Inc.
+      2145 Hamilton Avenue
+      San Jose, CA 95125
+      EMail: travos@ieee.org
+
+Author's Address
+
+   Prakash Venkatesen (editor)
+   HCL Technologies Ltd.
+   50-53, Greams Road,
+   Chennai - 600006
+   India
+   EMail: prakashvn@hcl.com
+
+
+
+
+
+
+
+
+Venkatesen                   Standards Track                   [Page 31]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6173.txt](<www.ietf.org/rfc/rfc6173.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
