### PR TITLE
Archive rfc6233.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6233.txt
+++ b/www.ietf.org/rfc/rfc6233.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                             T. Li
+Request for Comments: 6233                                   L. Ginsberg
+Updates: 3563, 5304, 5310                            Cisco Systems, Inc.
+Category: Standards Track                                       May 2011
+ISSN: 2070-1721
+
+
+                  IS-IS Registry Extension for Purges
+
+Abstract
+
+   IANA maintains the "IS-IS TLV Codepoints" registry.  This registry
+   documents which TLVs can appear in different types of IS-IS Protocol
+   Data Units (PDUs), but does not document which TLVs can be found in
+   zero Remaining Lifetime Link State PDUs (LSPs), a.k.a. purges.  This
+   document extends the existing registry to record the set of TLVs that
+   are permissible in purges and updates the rules for generating and
+   processing purges in the presence of authentication.  This document
+   updates RFC 3563, RFC 5304, and RFC 5310.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6233.
+
+Copyright Notice
+
+   Copyright (c) 2011 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+Li & Ginsberg                Standards Track                    [Page 1]
+
+RFC 6233              Registry Extension for Purges             May 2011
+
+
+Table of Contents
+
+   1. Introduction ....................................................2
+      1.1. Requirements Language ......................................2
+   2. Registry Changes ................................................2
+   3. Purges and Authentication .......................................3
+   4. IANA Considerations .............................................3
+   5. Security Considerations .........................................3
+   6. Normative References ............................................4
+
+1.  Introduction
+
+   The IS-IS [ISO-10589] routing protocol maintains a link state
+   database of the topology of its routing domain by flooding a set of
+   Link State Protocol Data Units (LSPs).  When the protocol no longer
+   needs the information stored in an LSP, it uses the purge mechanism
+   to cause the Intermediate Systems (ISs) in its domain to discard the
+   information contained in the LSP.  The process for generating purges
+   can be found in Section 7.3.16.4 of [ISO-10589].  This process
+   retains only the LSP header, discarding any TLVs that had been
+   carried within the LSP.
+
+   Subsequent enhancements to IS-IS, such as [RFC5304] [RFC5310], amend
+   the process of generating a purge and allow the inclusion of certain
+   TLVs in purges.
+
+1.1.  Requirements Language
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+2.  Registry Changes
+
+   This document extends the current "IS-IS TLV Codepoints" registry,
+   defined in [RFC3563], to record the set of TLVs that MAY be found in
+   purges.  All other TLVs MUST NOT appear in purges.  This will serve
+   as an aid to subsequent documents, which can then refer to the
+   registry as the definitive list of the TLVs allowed in purges.  This
+   will also act as an aid to implementers, providing them with an
+   easily accessible compendium of allowable TLVs.
+
+   The purge status defined for a given TLV applies to all sub-TLVs
+   defined for that TLV.
+
+
+
+
+
+
+
+Li & Ginsberg                Standards Track                    [Page 2]
+
+RFC 6233              Registry Extension for Purges             May 2011
+
+
+3.  Purges and Authentication
+
+   Previous documents on authentication [RFC5304] [RFC5310] required
+   that an IS only accept a purge if it only contained the
+   Authentication TLV.
+
+   This document updates and generalizes that behavior as follows: an
+   implementation that implements authentication MUST NOT accept a purge
+   that contains any TLV listed in the registry that is not acceptable
+   in a purge.  An implementation MUST NOT accept a purge that contains
+   a TLV not listed in the registry unless the purge also contains the
+   Purge Originator Identification (POI) TLV [RFC6232].  Purges that are
+   accepted MUST be propagated without removal of TLVs.  If multiple
+   purges are received for the same LSP, then the implementation MAY
+   propagate any one of the purges.
+
+   If an implementation that implements authentication accepts a purge
+   that does not include the POI TLV and it chooses to insert the POI
+   TLV, it MUST also recompute authentication.
+
+   ISs MUST NOT accept LSPs with a non-zero Remaining Lifetime that
+   contain the POI TLV.
+
+   Purge generation is updated as follows: an implementation that
+   implements authentication generates a purge by first removing any
+   TLVs that are not listed in the registry as being acceptable in
+   purges.  The POI TLV MUST be added.  Then any other TLVs that MAY be
+   in purges, as shown by the registry, MAY be added.  Finally,
+   authentication, if any, is added.
+
+4.  IANA Considerations
+
+   IANA has modified the "IS-IS TLV Codepoints" registry by adding a
+   column in the registry for 'Purge'.  A 'y' in this column indicates
+   that the TLV for this row MAY be found in a purge.  An 'n' in this
+   column indicates that the TLV for this row MUST NOT be found in a
+   purge.
+
+   The 'Purge' column should initially contain a 'y' for TLV type 10
+   (Authentication) and for TLV type 137 (Dynamic hostname).  All other
+   entries in this column should have an 'n'.  Other additions to this
+   registry should explicitly specify their value for this column.
+
+5.  Security Considerations
+
+   This document introduces no new security issues.
+
+
+
+
+
+Li & Ginsberg                Standards Track                    [Page 3]
+
+RFC 6233              Registry Extension for Purges             May 2011
+
+
+6.  Normative References
+
+   [ISO-10589]  ISO, "Intermediate system to Intermediate system
+                intra-domain routeing information exchange protocol for
+                use in conjunction with the protocol for providing the
+                connectionless-mode Network Service (ISO 8473)",
+                ISO/IEC 10589:2002.
+
+   [RFC2119]    Bradner, S., "Key words for use in RFCs to Indicate
+                Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC3563]    Zinin, A., "Cooperative Agreement Between the ISOC/IETF
+                and ISO/IEC Joint Technical Committee 1/Sub Committee 6
+                (JTC1/SC6) on IS-IS Routing Protocol Development",
+                RFC 3563, July 2003.
+
+   [RFC5304]    Li, T. and R. Atkinson, "IS-IS Cryptographic
+                Authentication", RFC 5304, October 2008.
+
+   [RFC5310]    Bhatia, M., Manral, V., Li, T., Atkinson, R., White, R.,
+                and M. Fanto, "IS-IS Generic Cryptographic
+                Authentication", RFC 5310, February 2009.
+
+   [RFC6232]    Wei, F., Qin, Y., Li, Z., Li, T., and J. Dong, "Purge
+                Originator Identification TLV for IS-IS", RFC 6232,
+                May 2011.
+
+Authors' Addresses
+
+   Tony Li
+   Cisco Systems, Inc.
+   170 W. Tasman Dr.
+   San Jose, CA  95134
+   USA
+
+   EMail: tony.li@tony.li
+
+
+   Les Ginsberg
+   Cisco Systems, Inc.
+   170 W. Tasman Dr.
+   San Jose, CA  95134
+   USA
+
+   EMail: ginsberg@cisco.com
+
+
+
+
+
+
+Li & Ginsberg                Standards Track                    [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6233.txt](<www.ietf.org/rfc/rfc6233.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
