### PR TITLE
Archive rfc6270.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6270.txt
+++ b/www.ietf.org/rfc/rfc6270.txt
@@ -1,0 +1,339 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                    M. Yevstifeyev
+Request for Comments: 6270                                     June 2011
+Updates: 1041, 1738, 2355
+Category: Standards Track
+ISSN: 2070-1721
+
+
+                        The 'tn3270' URI Scheme
+
+Abstract
+
+   This document is the specification of the 'tn3270' Uniform Resource
+   Identifier (URI) scheme, which is used to designate the access to the
+   resources available via Telnet 3270 mode (TN3270) and Telnet 3270
+   Enhanced mode (TN3270E).  It updates RFC 1041 and RFC 2355, which
+   specify these protocols, and RFC 1738, which firstly mentioned this
+   URI scheme without defining its syntax and semantics.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6270.
+
+Copyright Notice
+
+   Copyright (c) 2011 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+Yevstifeyev                  Standards Track                    [Page 1]
+
+RFC 6270                 The 'tn3270' URI Scheme               June 2011
+
+
+Table of Contents
+
+   1. Introduction ....................................................2
+      1.1. Terminology ................................................3
+   2. URI Scheme Definition ...........................................3
+      2.1. URI Scheme Syntax ..........................................3
+      2.2. URI Scheme Semantics .......................................3
+   3. Security Considerations .........................................3
+   4. IANA Considerations .............................................4
+   5. References ......................................................4
+      5.1. Normative References .......................................4
+      5.2. Informative References .....................................5
+   Appendix A. Acknowledgments ........................................6
+
+1.  Introduction
+
+   This document specifies the 'tn3270' Uniform Resource Identifier
+   (URI) scheme, which is used to designate the access to the resources
+   available via Telnet 3270 mode (TN3270) and Telnet 3270 Enhanced mode
+   (TN3270E).
+
+   Telnet 3270 mode (TN3270) is a name used to denote the special mode
+   of Telnet session [RFC0854].  If it is used, the 3270 data stream
+   [GA23-0059] is used when transmitting data during the Telnet session,
+   whereas the Telnet 3270 Regime option [RFC1041] is used to enable and
+   negotiate its use.  (See [RFC1576] for some other background
+   information on TN3270.)  Telnet 3270 Enhanced mode (TN3270E) has a
+   similar principle; see RFC 2355 [RFC2355] for its specification.
+
+   The 'tn3270' URI scheme was firstly mentioned in RFC 1738 [RFC1738]
+   as used in URIs that designate the access to "Interactive 3270
+   emulation sessions".  Following the creation of the URI schemes
+   registry per RFC 4395 [RFC4395], this scheme was added to the
+   "Provisional URI Schemes" sub-registry in the "Uniform Resource
+   Identifier (URI) Schemes" IANA registry [URIREG].  However, RFC 1738
+   [RFC1738] does not give any definition of syntax or semantics of the
+   'tn3270' URIs and does not have any guidelines for registration of
+   this scheme.
+
+   Since there is no acceptable specification of the 'tn3270' URI, there
+   is a risk that somebody might try to implement it with some new,
+   possibly undocumented, syntax, just by looking at the IANA registry.
+   In order to minimize such risk, this document gives a precise
+   definition of syntax, semantics, use of this URI, and it registers
+   the corresponding scheme.  It also updates RFC 2355 [RFC2355], RFC
+   1738 [RFC1738], and RFC 1041 [RFC1041].
+
+
+
+
+
+Yevstifeyev                  Standards Track                    [Page 2]
+
+RFC 6270                 The 'tn3270' URI Scheme               June 2011
+
+
+   The generic syntax of URIs is described in RFC 3986 [RFC3986].
+   Registration procedures for new URI schemes are defined in RFC 4395
+   [RFC4395].
+
+1.1.  Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+2.  URI Scheme Definition
+
+2.1.  URI Scheme Syntax
+
+   The 'tn3270' URI takes the following form (the syntax below is non-
+   normative):
+
+      tn3270://<userinfo>@<host>:<port>/
+
+   where the <userinfo> part with the "@" (at) sign character, as well
+   as the <port> part with the preceding ":" (colon) character, is
+   OPTIONAL.
+
+   The normative syntax of the 'tn3270' URI is defined in <tn3270-uri>
+   ABNF [RFC5234] rule:
+
+     tn3270-uri       = "tn3270:" "//" authority ["/"]
+
+   where the <authority> rule is specified in RFC 3986 [RFC3986].
+
+   The semantics of each part of the 'tn3270' URI are defined below, in
+   Section 2.2.
+
+2.2. URI Scheme Semantics
+
+   The <host> part of the 'tn3270' URI, which is REQUIRED, denotes the
+   host to which the TN3270 or TN3270E connection is to be established.
+   The <userinfo> part is considered to define the information for use
+   in the Telnet Authentication option [RFC2941], which might be used
+   during the TN3270 or TN3270E session.  The <port> part, if present,
+   denotes the port on which the TCP connection to the <host> is to be
+   established.  If it is absent, the default port SHALL be 23, as
+   registered in [PORTREG].
+
+3.  Security Considerations
+
+   Generic security considerations for the usage of URIs are discussed
+   in Section 7 of [RFC3986].
+
+
+
+Yevstifeyev                  Standards Track                    [Page 3]
+
+RFC 6270                 The 'tn3270' URI Scheme               June 2011
+
+
+   Since 'tn3270' URIs provide access to services that are available via
+   TN3270 and TN3270E, which do not add any new security issues to the
+   Telnet session, as they are a modified form of it, there are no other
+   security considerations for 'tn3270' URIs that are not discussed in
+   RFC 4248 [RFC4248], the 'telnet' URI scheme specification.
+
+   The Telnet protocol, as well as TN3270 and TN3270E, is inherently
+   insecure.  Those needing remote login access and related services are
+   encouraged to use a more secure technology, such as Secure Shell
+   [RFC4251].
+
+4.  IANA Considerations
+
+   IANA updated the registration of the 'tn3270' URI scheme using the
+   following registration template (see [RFC4395]):
+
+      URI scheme name: tn3270
+
+      Status: Permanent
+
+      URI scheme syntax: see Section 2.1 of RFC 6270
+
+      URI scheme semantics: see Section 2.2 of RFC 6270
+
+      URI scheme encoding considerations: there are no other encoding
+      considerations for 'tn3270' URIs that are not described in RFC
+      3986 [RFC3986]
+
+      Protocols that use the scheme: Telnet 3270 mode (TN3270) [RFC1041]
+      and Telnet 3270 Enhanced Mode (TN3270E) [RFC2355]
+
+      Security considerations: see Section 3 of RFC 6270
+
+      Contact: IESG <iesg@ietf.org>
+
+      Author/Change controller: IETF <ietf@ietf.org>
+
+      References: see Section 5 of RFC 6270
+
+5.  References
+
+5.1.  Normative References
+
+   [RFC1041]   Rekhter, Y., "Telnet 3270 regime option", RFC 1041,
+               January 1988.
+
+   [RFC2119]   Bradner, S., "Key words for use in RFCs to Indicate
+               Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+
+
+Yevstifeyev                  Standards Track                    [Page 4]
+
+RFC 6270                 The 'tn3270' URI Scheme               June 2011
+
+
+   [RFC2355]   Kelly, B., "TN3270 Enhancements", RFC 2355, June 1998.
+
+   [RFC3986]   Berners-Lee, T., Fielding, R., and L. Masinter, "Uniform
+               Resource Identifier (URI): Generic Syntax", STD 66, RFC
+               3986, January 2005.
+
+   [RFC4248]   Hoffman, P., "The telnet URI Scheme", RFC 4248, October
+               2005.
+
+   [RFC5234]   Crocker, D., Ed., and P. Overell, "Augmented BNF for
+               Syntax Specifications: ABNF", STD 68, RFC 5234, January
+               2008.
+
+5.2.  Informative References
+
+   [GA23-0059] IBM Corporation, "IBM 3270 Information Display System.
+               Data Stream Programmer's Reference", IBM Publication
+               GA23-0059, July 1992.
+
+   [PORTREG]   Internet Assigned Numbers Authority (IANA) Registry,
+               "Port Numbers", <http://www.iana.org>.
+
+   [RFC0854]   Postel, J. and J. Reynolds, "Telnet Protocol
+               Specification", STD 8, RFC 854, May 1983.
+
+   [RFC1576]   Penner, J., "TN3270 Current Practices", RFC 1576, January
+               1994.
+
+   [RFC1738]   Berners-Lee, T., Masinter, L., and M. McCahill, "Uniform
+               Resource Locators (URL)", RFC 1738, December 1994.
+
+   [RFC2941]   Ts'o, T., Ed., and J. Altman, "Telnet Authentication
+               Option", RFC 2941, September 2000.
+
+   [RFC4251]   Ylonen, T. and C. Lonvick, Ed., "The Secure Shell (SSH)
+               Protocol Architecture", RFC 4251, January 2006.
+
+   [RFC4395]   Hansen, T., Hardie, T., and L. Masinter, "Guidelines and
+               Registration Procedures for New URI Schemes", BCP 35, RFC
+               4395, February 2006.
+
+   [URIREG]    Internet Assigned Numbers Authority (IANA) Registry,
+               "Uniform Resource Identifier (URI) Schemes",
+               <http://www.iana.org>.
+
+
+
+
+
+
+
+Yevstifeyev                  Standards Track                    [Page 5]
+
+RFC 6270                 The 'tn3270' URI Scheme               June 2011
+
+
+Appendix A.  Acknowledgments
+
+   Many thanks to Alfred Hoenes, Graham Klyne, Alexey Melnikov, Julian
+   Reschke, and Peter Saint-Andre for their input to this document.
+
+Author's Addresses
+
+   Mykyta Yevstifeyev
+   8 Kuzovkov St., flat 25,
+   Kotovsk
+   Ukraine
+
+   EMail: evnikita2@gmail.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Yevstifeyev                  Standards Track                    [Page 6]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6270.txt](<www.ietf.org/rfc/rfc6270.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
