### PR TITLE
Archive rfc628.txt

### DIFF
--- a/www.ietf.org/rfc/rfc628.txt
+++ b/www.ietf.org/rfc/rfc628.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                   Marcia L. Keeney
+RFC # 628                                               SRI-ARC
+NIC # 22361                                             March 27, 1974
+
+
+                      Status of RFC Numbers and a
+                  Note on Pre-assigned Journal Numbers
+
+
+This is to announce that RFC numbers can now be obtained on-line through
+NLS at OFFICE-1;  they can no longer be obtained on-line at SRI-ARC.
+You may still call the NIC to get an RFC number, if you do not wish to
+use the on-line facilities.
+
+Also, please note that pre-assigned journal numbers (excepting RFC
+numbers) can be used through NLS only on the system (OFFICE-1 or SRI-
+ARC) from which they were taken.
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.            11/99 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Keeney                                                          [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc628.txt](<www.ietf.org/rfc/rfc628.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
