### PR TITLE
Archive rfc629.txt

### DIFF
--- a/www.ietf.org/rfc/rfc629.txt
+++ b/www.ietf.org/rfc/rfc629.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                                       Jeanne North
+Request for Comment: 629                                         SRI-ARC
+NIC 22383                                                 March 27, 1974
+
+                 SCENARIO FOR USING THE NETWORK JOURNAL
+
+Network users may send mail to individuals and to groups, input as
+messages or entire files, through the Network Journal, using SNDMSG or
+their site's mail system.  The mail is converted at NIC into NLS files,
+Journalized, and sent to specified recipients.  Short messages may be
+received as messages, longer ones as citations to files which may be
+retrieved immediately, and also later, by using FTP.  Mail sent to NIC
+with a "/" in the user-name field invokes the Net Journal.
+
+SENDING THE MESSAGE OR FILE BY TELEX SNDMSG
+
+   Construct user field with slash and NIC idents:
+
+      [Users:] sender ident/addressee ident(s)@NIC
+
+   e.g. "JEW/DHC MAP@NIC". To send to a group, use group ident, e.g.
+   "JEW/NLG@NIC". To combine Journal SNDMSG with SNDMSG to others, add
+   others' Network addresses after commas, e.g. "JEW/DHC@NIC,PRATT@ISI".
+   See ARPANET Directory for NIC idents and Network addresses.
+
+   [@] SNDMSG <CR>
+   [Type ? for help]
+   [Users:] JEW/NGG <SP> DHC@NIC, PRATT@ISI <CR>
+   [Subject:] Title of Message <CR>
+   [Message (? for help):] Text of message ...
+      Note: ^B allows insertion of a sequential file as the message or
+      at any point in the test of the message:
+
+      ^B [(Insert file:)] <directory>file <ALT> [ext ...EOF)]
+   <^Z>
+   [jew/ngg dhc@nic -- ok]   (or [ -- queued -- timed-out])
+   [pratt@isi -- ok]
+
+   When using SNDMSG through TELNET, change TELNET escape character, to
+   ^Q for example, allowing ^Z to be used for end-of-message.
+
+RETRIEVING THE FILE FROM NETWORK JOURNAL
+
+   Substitute the citation received, for example "<GJOURNAL>21695", for
+   "<journal>number" and supply a filename in the following:
+
+   [@] FTP <CR>
+   [HOST FTP User process x.xx.x]
+
+
+
+North                                                           [Page 1]
+
+RFC 629                Using the Network Journal              March 1974
+
+
+   [*] CONN <SP> NIC <CR>
+   [   Connection opened]
+   [*< OFFICE-1 FTP Server x.xx.x - at DAY DATE TIME]
+   [*] LOG <SP> ANONYMOUS <SP> NIC <CR>
+   [*] GET <SP> <journal>number.NLS;xnls <CR>
+   [   to local file] filename <CR> [New file] <CR>
+   [<  IMAGE retrieve of <journal>number.NLS; started]
+   [<  transfer completed]
+   [*] DISC <CR>
+   [*] QUIT <CR>
+
+   [@] COP <ALT> [<File list>] file <ALT> [<TO>] LPT: <CR> [OK] <CR>
+
+SENDING A MESSAGE BY TELNET, FTP, OR OTHER MAIL SYSTEM
+
+   TELNET by TENEX Users:
+
+      [@] TELNET <CR>
+      [User Telnet x.x DATE ...]
+      [#] NIC <SP> FTP <CR> [is complete.#]
+      [300 OFFICE-1 FTP Server x.xx.x - at DAY DATE TIME]
+      MAIL <SP> JEW/RWW <SP> DHC <CR>   (pause)
+      [350 Type mail, ended by a line with only a "."]
+      Re: Title of Message <CR>
+      First line of message <CR>
+      second line of message <CR>   ...etc.
+       . <CR>   (pause)
+      [256 Mail completed successfully]
+      <^Z>
+      [#] DISC <CR>
+      [#] QUIT <CR>
+
+   FTP by TENEX Users:
+
+      [@] FTP <CR>
+      [HOST FTP User process x.xx.x]
+      [*] CONN <SP> NIC <CR>
+      [   Connection opened]
+      [*< OFFICE-1 FTP Server x.xx.x - at DAY DATE TIME]
+      [*] QUO <ALT> MAIL <SP> JEW/DHC RWW <CR>
+      [*] (pause) [Type mail, ended by a line with only a "."]
+      [*] QUO <ALT> Re: Title of Message <CR>
+      [*] QUO <ALT> First line of message <CR>
+      [*] QUO <ALT> second line of message <CR>   ...etc.
+      [*] QUO <ALT> . <CR>   (pause)
+      [*< Mail completed successfully]
+      [*] DISC <CR>
+      [*] QUIT <CR>
+
+
+
+North                                                           [Page 2]
+
+RFC 629                Using the Network Journal              March 1974
+
+
+   Using Other Mail Systems:
+
+      It is not possible to give a generalized scenario for use with all
+      local mail systems.
+
+      The general procedure, to be applied to the local mail system, is
+      to supply:
+
+         "NIC" as the host name, and
+
+         Sender's NIC ident / Addressee's NIC ident as user name
+
+   See RFC543, NIC 17777, for more detail on Network Journal.
+
+            [ This RFC was put into machine readable form for entry ]
+              [ into the online RFC archives by Alan Ford 12/99  ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+North                                                           [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc629.txt](<www.ietf.org/rfc/rfc629.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
