### PR TITLE
Archive rfc6315.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6315.txt
+++ b/www.ietf.org/rfc/rfc6315.txt
@@ -1,0 +1,339 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                            E. Guy
+Request for Comments: 6315                                   CleverSpoke
+Category: Informational                                      K. Darilion
+ISSN: 2070-1721                                                   nic.at
+                                                               July 2011
+
+
+                IANA Registration for Enumservice 'iax'
+
+Abstract
+
+   This document registers an Enumservice for the Inter-Asterisk
+   eXchange (IAX) protocol according to the guidelines given in RFC
+   6117.
+
+Status of This Memo
+
+   This document is not an Internet Standards Track specification; it is
+   published for informational purposes.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Not all documents
+   approved by the IESG are a candidate for any level of Internet
+   Standard; see Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6315.
+
+Copyright Notice
+
+   Copyright (c) 2011 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+Guy & Darilion                Informational                     [Page 1]
+
+RFC 6315         IANA Registration for Enumservice 'iax'       July 2011
+
+
+   This document may contain material from IETF Documents or IETF
+   Contributions published or made publicly available before November
+   10, 2008.  The person(s) controlling the copyright in some of this
+   material may not have granted the IETF Trust the right to allow
+   modifications of such material outside the IETF Standards Process.
+   Without obtaining an adequate license from the person(s) controlling
+   the copyright in such materials, this document may not be modified
+   outside the IETF Standards Process, and derivative works of it may
+   not be created outside the IETF Standards Process, except to format
+   it for publication as an RFC or to translate it into languages other
+   than English.
+
+Table of Contents
+
+   1. Introduction ....................................................2
+   2. IANA Registration ...............................................3
+   3. Examples ........................................................4
+      3.1. Simple IAX URI .............................................4
+      3.2. IAX URI with a Context .....................................4
+   4. Security Considerations .........................................4
+   5. IANA Considerations .............................................5
+   6. DNS Considerations ..............................................5
+   7. Acknowledgments .................................................5
+   8. References ......................................................5
+      8.1. Normative References .......................................5
+      8.2. Informative References .....................................6
+
+1.  Introduction
+
+   The E.164 to Uniform Resource Identifiers (URIs) [RFC3986] Dynamic
+   Delegation Discovery System (DDDS) Application (ENUM) [RFC6116]
+   transforms E.164 [E164] numbers into URIs using the Domain Name
+   System (DNS) [RFC1035].
+
+   IAX (Inter-Asterisk eXchange) [RFC5456] is an "all-in-one" protocol
+   for handling multimedia in IP networks.  It combines both control and
+   media services in the same protocol.
+
+   This document registers an Enumservice for the IAX [RFC5456] protocol
+   according to the guidelines given in [RFC6117].
+
+
+
+
+
+
+
+
+
+
+
+Guy & Darilion                Informational                     [Page 2]
+
+RFC 6315         IANA Registration for Enumservice 'iax'       July 2011
+
+
+2.  IANA Registration
+
+         <record>
+          <!-- iax -->
+          <class>Protocol-Based</class>
+          <type>iax</type>
+          <!-- No subtype -->
+          <urischeme>iax</urischeme>
+          <functionalspec>
+            <paragraph>
+              The 'iax' Enumservice is used to map E.164 numbers to
+              IAX URIs.  Such URIs identify resources capable of being
+              contacted to provide a communication session using the
+              IAX protocol <xref target="RFC5456"/>.
+            </paragraph>
+            <paragraph>
+              A client selecting this NAPTR needs to be able to support
+              communication utilizing the IAX protocol.
+            </paragraph>
+          </functionalspec>
+          <security>
+            See <xref type="rfc" data="6315"/>, Section 4.
+          </security>
+          <usage>COMMON</usage>
+          <registrationdocs>
+            <xref type="rfc" data="6315"/>
+          </registrationdocs>
+          <requesters>
+            <xref type="person" data="Ed_Guy"/>
+            <xref type="person" data="Klaus_Darilion"/>
+          </requesters>
+        </record>
+
+        <people>
+          <person id="Ed_Guy">
+            <name>Ed Guy</name>
+            <org>CleverSpoke, Inc</org>
+            <uri>mailto:edguy@CleverSpoke.com</uri>
+            <updated>2010-11-01</updated>
+          </person>
+          <person id="Klaus_Darilion">
+            <name>Klaus Darilion</name>
+            <org>nic.at</org>
+            <uri>mailto:klaus.darilion@nic.at</uri>
+            <updated>2011-03-24</updated>
+          </person>
+        </people>
+
+
+
+
+Guy & Darilion                Informational                     [Page 3]
+
+RFC 6315         IANA Registration for Enumservice 'iax'       July 2011
+
+
+3.  Examples
+
+   The following examples are just for illustrative purposes and will in
+   no way limit the usage of the 'iax' Enumservice to other usage
+   scenarios.
+
+3.1.  Simple IAX URI
+
+   The following Naming Authority Pointer (NAPTR) resource record is an
+   example of the 'iax' Enumservice.
+
+     $ORIGIN 8.4.1.0.6.4.9.7.0.2.4.4.e164.arpa.
+
+     @     IN NAPTR ( 10 100 "u" "E2U+iax"
+                "!^.*$!iax:example.com/alice!" . )
+
+   This contact information indicates that the party addressed by the
+   E.164 number +442079460148 can be contacted using the IAX protocol to
+   domain 'example.com'.  The called party, service, or program on that
+   domain is identified by 'alice'.
+
+3.2.  IAX URI with a Context
+
+   The following is an example of the 'iax' Enumservice using an IPv6
+   destination address and a destination 'context'.
+
+     $ORIGIN 9.4.1.0.6.4.9.7.0.2.4.4.e164.arpa.
+
+     @     IN NAPTR ( 10 100 "u" "E2U+iax"
+                "!^.*$!iax:[2001:db8::1]:4569/alice?friends!" . )
+
+   This NAPTR resource record indicates that +442079460149 may be
+   contacted by using the IAX protocol at IPv6 address 2001:db8::1,
+   port 4569 with the called party 'alice' in the context (or user
+   partition) 'friends'.  For further usage of IAX URIs, see Section 5
+   of [RFC5456].
+
+4.  Security Considerations
+
+   The 'iax' Enumservice does not introduce any new security issues
+   beyond any already present in the ENUM, DNS, and IAX protocols,
+   except that this Enumservice provides for disclosure of information
+   that may facilitate an attack or a violation of user privacy in some
+   way.  The primary result of these exploits is unwanted
+   communications.  These issues are discussed in further detail in
+   [RFC3833].
+
+
+
+
+
+Guy & Darilion                Informational                     [Page 4]
+
+RFC 6315         IANA Registration for Enumservice 'iax'       July 2011
+
+
+   The use of DNS Security (DNSSEC) [RFC4033] is recommended to improve
+   operational security.
+
+   For security considerations that apply to all Enumservices, please
+   refer to RFC 6116, Section 7.
+
+5.  IANA Considerations
+
+   This document registers the 'iax' Enumservice according to the
+   guidelines and specifications in [RFC6117] and the definitions in
+   Section 2 in this document.
+
+6.  DNS Considerations
+
+   Misconfiguration or delays in zone changes can result in call loops,
+   perhaps with different protocols or networks.  Implementations should
+   take care to ensure such loops can be detected without interrupting
+   other services, including SIP-based, IAX-based, and DNS itself.
+
+7.  Acknowledgments
+
+   This work was supported by Internet Foundation Austria.  In addition,
+   thanks to Michael Haberler, Bernie Hoeneisen, and Richard Stastny for
+   their support and guidance in writing this document.
+
+8.  References
+
+8.1.  Normative References
+
+   [RFC3986]  Berners-Lee, T., Fielding, R., and L. Masinter, "Uniform
+              Resource Identifier (URI): Generic Syntax", STD 66,
+              RFC 3986, January 2005.
+
+   [RFC5456]  Spencer, M., Capouch, B., Guy, E., Ed., Miller, F., and K.
+              Shumard, "IAX: Inter-Asterisk eXchange Version 2",
+              RFC 5456, February 2010.
+
+   [RFC6116]  Bradner, S., Conroy, L., and K. Fujiwara, "The E.164 to
+              Uniform Resource Identifiers (URI) Dynamic Delegation
+              Discovery System (DDDS) Application (ENUM)", RFC 6116,
+              March 2011.
+
+   [RFC6117]  Hoeneisen, B., Mayrhofer, A., and J. Livingood, "IANA
+              Registration of Enumservices: Guide, Template, and IANA
+              Considerations", RFC 6117, March 2011.
+
+
+
+
+
+
+Guy & Darilion                Informational                     [Page 5]
+
+RFC 6315         IANA Registration for Enumservice 'iax'       July 2011
+
+
+8.2.  Informative References
+
+   [E164]     ITU-T, "The International Public Telecommunication
+              Numbering Plan", Recommendation E.164, May 1997.
+
+   [RFC1035]  Mockapetris, P., "Domain names - implementation and
+              specification", STD 13, RFC 1035, November 1987.
+
+   [RFC3833]  Atkins, D. and R. Austein, "Threat Analysis of the Domain
+              Name System (DNS)", RFC 3833, August 2004.
+
+   [RFC4033]  Arends, R., Austein, R., Larson, M., Massey, D., and S.
+              Rose, "DNS Security Introduction and Requirements",
+              RFC 4033, March 2005.
+
+Authors' Addresses
+
+   Ed Guy
+   CleverSpoke
+   12 Williams Road
+   Chatham, NJ  07928
+   US
+
+   Phone: +1 973 437 4519
+   EMail: edguy@CleverSpoke.com
+   URI:   http://www.cleverspoke.com/
+
+
+   Klaus Darilion
+   nic.at
+   Karlsplatz 1/2/9
+   1010 Wien
+   Austria
+
+   Phone: +43 1 5056416 36
+   EMail: klaus.darilion@nic.at
+   URI:   http://www.nic.at/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Guy & Darilion                Informational                     [Page 6]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6315.txt](<www.ietf.org/rfc/rfc6315.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
