### PR TITLE
Archive rfc6322.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6322.txt
+++ b/www.ietf.org/rfc/rfc6322.txt
@@ -1,0 +1,619 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                        P. Hoffman
+Request for Comments: 6322                                VPN Consortium
+Category: Informational                                        July 2011
+ISSN: 2070-1721
+
+
+                 Datatracker States and Annotations for
+           the IAB, IRTF, and Independent Submission Streams
+
+Abstract
+
+   This document describes extending the IETF Datatracker to capture and
+   display the progression of Internet-Drafts that are intended to be
+   published as RFCs by the IAB, IRTF, or Independent Submissions
+   Editor.  The states and annotations that are to be added to the
+   Datatracker will be applied to Internet-Drafts as soon as any of
+   these streams identify the Internet-Draft as a potential eventual
+   RFC, and will continue through the lifetime of the Internet-Draft.
+   The goal of adding this information to the Datatracker is to give the
+   whole Internet community more information about the status of these
+   Internet-Drafts and the streams from which they originate.
+
+Status of This Memo
+
+   This document is not an Internet Standards Track specification; it is
+   published for informational purposes.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Not all documents
+   approved by the IESG are a candidate for any level of Internet
+   Standard; see Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6322.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hoffman                       Informational                     [Page 1]
+
+RFC 6322        Datatracker States for Alternate Streams       July 2011
+
+
+Copyright Notice
+
+   Copyright (c) 2011 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+   This document may contain material from IETF Documents or IETF
+   Contributions published or made publicly available before November
+   10, 2008.  The person(s) controlling the copyright in some of this
+   material may not have granted the IETF Trust the right to allow
+   modifications of such material outside the IETF Standards Process.
+   Without obtaining an adequate license from the person(s) controlling
+   the copyright in such materials, this document may not be modified
+   outside the IETF Standards Process, and derivative works of it may
+   not be created outside the IETF Standards Process, except to format
+   it for publication as an RFC or to translate it into languages other
+   than English.
+
+1.  Introduction
+
+   As described in Section 5 of [RFC4844], there are currently four
+   streams that feed into the RFC publication process: the IETF document
+   stream, the Internet Architecture Board (IAB) document stream, the
+   Internet Research Task Force (IRTF) document stream, and the
+   Independent Submissions stream that is administered by the
+   Independent Submissions Editor (ISE).  Each of these streams consist
+   of Internet-Drafts (often abbreviated "I-Ds") that have been
+   identified by an organization or role as being part of their stream.
+   Each stream maintainer progresses documents towards RFC publication
+   in its own fashion.  A document can only be in one stream at a time.
+
+   In recent years, there has been a desire by IETF participants and
+   others to see more of the process used by each stream.  For example,
+   some people want to know how close the IAB is to finishing a
+   particular document; IETF participants might want to know the
+   progress of IRTF research documents that are in areas related to
+   their engineering work; people who have asked for the ISE to publish
+
+
+
+
+
+Hoffman                       Informational                     [Page 2]
+
+RFC 6322        Datatracker States for Alternate Streams       July 2011
+
+
+   their document want to track its progress.  If the IETF Datatracker
+   ("tracker") has more information about each stream's states, this
+   information is much more easily accessible.
+
+   In this document, the term "IETF Datatracker" is used as a generic
+   name for the existing tool used to track state changes as Internet-
+   Drafts are processed.  The word "IETF" in the name "IETF Datatracker"
+   is not meant to limit use of the tool to the IETF document stream;
+   this document expands use of the tool to the other streams described
+   in RFC 4844.
+
+   This document describes the additional tracker states that are
+   specific to each of the IAB, the IRTF, and the ISE document flows.  A
+   document might also have one or more annotations assigned as well.
+   Because each stream is controlled by a different organization, this
+   document separates out the proposed states and annotations for each
+   stream, and associates specific semantics stream-by-stream.
+
+   Annotations may be applied at any time to a document that is intended
+   for the particular stream.  A document may have more than one
+   annotation applied to it.  It is likely that the comments for these
+   annotations will supply valuable information about the annotation.
+   Each stream owner needs to have write access to the states and
+   annotations for all the documents in their stream.  They should also
+   be able to assign others to have the same write privileges.
+
+   This document does not describe which person in each stream might be
+   able to edit these states and annotations; it is assumed that this is
+   a simple enough task that it can be negotiated between each stream
+   administrator and the tracker administrator.  Also, this document
+   assumes that whoever is making the edits to the state and annotations
+   can enter comments that will be publicly visible.
+
+   Some streams have comments that are very long, such as document
+   reviews and document poll results.  The tracker needs to be able to
+   store long annotation comments.
+
+   Note that this document does not discuss documents in the IETF
+   stream.  The states and permissions for IETF stream documents that
+   have been requested for publication are already implemented in the
+   tracker.  A separate set of documents, [RFC6174] and [RFC6175],
+   describe the tracker states and associated permissions proposed for
+   documents in the IETF stream that have been adopted, or are being
+   considered for adoption, by IETF Working Groups.
+
+   The intent of this document is to inform an initial development
+   effort for the tool described here.  It is not intended to stand as
+   the requirements against the tool once it is deployed.  That is,
+
+
+
+Hoffman                       Informational                     [Page 3]
+
+RFC 6322        Datatracker States for Alternate Streams       July 2011
+
+
+   there is no current intention to update this document frequently as
+   the tool evolves and small features are added and changed.
+
+   This document defines three state machines that fit into the IETF
+   Datatracker.  The Datatracker will have multiple state machines.
+   This document was prepared in coordination with the IAB, IRTF, and
+   ISE, at the request of the IETF Administrative Oversight Committee
+   (IAOC).
+
+2.  IAB Stream
+
+   This section describes the desired states and annotations for the IAB
+   stream.
+
+2.1.  States for the IAB Stream
+
+   o  Candidate IAB Document -- A document being considered for the IAB
+      stream.
+
+   o  Active IAB Document -- This document has been adopted by the IAB
+      and is being actively developed.
+
+   o  Parked IAB Document -- This document has lost its author or
+      editor, is waiting for another document to be written, or cannot
+      currently be worked on by the IAB for some other reason.
+      Annotations probably explain why this document is parked.
+
+   o  IAB Review -- This document is awaiting the IAB itself to come to
+      internal consensus.
+
+   o  Community Review -- This document has completed internal consensus
+      within the IAB and is now under community review.  (The IAB
+      normally allows community input during earlier stages of the
+      process as well.)
+
+   o  Approved by IAB, To Be Sent to RFC Editor -- The consideration of
+      this document is complete, but it has not yet been sent to the RFC
+      Editor for publication (although that is going to happen soon).
+
+   o  Sent to a Different Organization for Publication -- The IAB does
+      not expect to publish the document itself, but has passed it on to
+      a different organization that might continue work on the document.
+      The expectation is that the other organization will eventually
+      publish the document.
+
+
+
+
+
+
+
+Hoffman                       Informational                     [Page 4]
+
+RFC 6322        Datatracker States for Alternate Streams       July 2011
+
+
+   o  Sent to the RFC Editor -- The IAB processing of this document is
+      complete and it has been sent to the RFC Editor for publication.
+      The document may be in the RFC Editor's queue, or it may have been
+      published as an RFC; this state doesn't distinguish between
+      different states occurring after the document has left the IAB.
+
+   o  Dead IAB Document -- This document was an active IAB document, but
+      for some reason it is no longer being pursued for the IAB stream.
+      It is possible that the document might be revived later, possibly
+      in another stream.
+
+2.2.  Annotations for the IAB Stream
+
+   o  Editor Needed -- The document has lost its editor but it is still
+      intended to be part of the IAB stream.
+
+   o  Waiting for Dependency on Other Document -- Activity on this
+      document is expected to be low or non-existent while waiting for
+      another document (probably listed in the comments) to progress.
+
+   o  Waiting for Partner Feedback -- The IAB often produces documents
+      that need to be socialized with outside organizations (such as the
+      IEEE) or other internal organizations (such as the IESG or the
+      IAOC).  This document has been sent out for feedback from one of
+      these partner groups.
+
+   o  Awaiting Reviews -- Activity on this document is expected to be
+      low or non-existent while waiting for reviews that were solicited
+      by the IAB.
+
+   o  Revised I-D Needed -- Comments that will cause changes have been
+      submitted, and no processing is expected until a new draft is
+      issued.
+
+   o  Document Shepherd Followup -- The document's shepherd is expected
+      to take some action before the document can proceed.
+
+2.3.  Access Control for IAB States and Annotations
+
+   Some IAB members, and members of the IAB Executive Directorate, need
+   to be able to set the states and annotations for IAB documents during
+   their life cycle.  The IAB Chair needs to be able to grant access to
+   individuals to modify the state and annotations; such access applies
+   to all IAB Stream documents.
+
+
+
+
+
+
+
+Hoffman                       Informational                     [Page 5]
+
+RFC 6322        Datatracker States for Alternate Streams       July 2011
+
+
+3.  IRTF Stream
+
+   This section describes the desired states and annotations for the
+   IRTF stream.  Some of the steps take place in IRTF Research Groups
+   (RGs), while others take place in the Internet Research Steering
+   Group (IRSG).
+
+3.1.  States for the IRTF Stream
+
+   o  Candidate RG Document -- This document is under consideration in
+      an RG for becoming an IRTF document.  A document in this state
+      does not imply any RG consensus and does not imply any precedence
+      or selection.  It's simply a way to indicate that somebody has
+      asked for a document to be considered for adoption by an RG.
+
+   o  Active RG Document -- This document has been adopted by an RG and
+      is being actively developed.
+
+   o  Parked RG Document -- This document has lost its author or editor,
+      is waiting for another document to be written, or cannot currently
+      be worked on by the RG that adopted it for some other reason.
+
+   o  In RG Last Call -- The document is in its final review in the RG.
+
+   o  Waiting for Document Shepherd -- IRTF documents have document
+      shepherds who help RG documents through the process after the RG
+      has finished with the document.
+
+   o  Waiting for IRTF Chair -- The IRTF Chair is meant to be performing
+      some task such as sending a request for IESG Review.
+
+   o  Awaiting IRSG Reviews -- The document shepherd has taken the
+      document to the IRSG and solicited reviews from one or more IRSG
+      members.
+
+   o  In IRSG Poll -- The IRSG is taking a poll on whether or not the
+      document is ready to be published.
+
+   o  In IESG Review -- The IRSG has asked the IESG to do a review of
+      the document, as described in [RFC5742].
+
+   o  Sent to the RFC Editor -- The document has been submitted for
+      publication (and not returned to the IRTF for further action).
+      The document may be in the RFC Editor's queue, or it may have been
+      published as an RFC; this state doesn't distinguish between
+      different states occurring after the document has left the IRTF.
+
+
+
+
+
+Hoffman                       Informational                     [Page 6]
+
+RFC 6322        Datatracker States for Alternate Streams       July 2011
+
+
+   o  Document on Hold Based on IESG Request -- The IESG has requested
+      that the document be held pending further review, as specified in
+      RFC 5742, and the IRTF has agreed to such a hold.
+
+   o  Dead IRTF Document -- This document was an active IRTF document,
+      but for some reason it is no longer being pursued for the IRTF
+      stream.  It is possible that the document might be revived later,
+      possibly in another stream.
+
+3.2.  Annotations for the IRTF Stream
+
+   o  Editor Needed -- The document has lost its editor but it still
+      intended to be the output of an RG.
+
+   o  Shepherd Needed -- The document needs a shepherd assigned to it.
+
+   o  Waiting for Dependency on Other Document -- Activity on this
+      document is expected to be low or non-existent while waiting for
+      another document (probably listed in the comments) to progress.
+
+   o  Revised I-D Needed -- Discussion has ensued that is expected to
+      cause changes, and no progress is expected until a new draft is
+      issued.
+
+   o  IESG Review Completed -- The IESG has completed its review on the
+      document, as described in [RFC5742].
+
+3.3.  Access Control for IRTF States and Annotations
+
+   An RG Chair needs to be able to set the states and annotations for an
+   IRTF document before the RG has sent the document to the IRSG for
+   review.  The RG Chair also needs to be able to give the same ability
+   to a shepherd that is assigned by the RG chair.  This access control
+   is similar to the access control that is specified in [RFC6175] for
+   IETF WG chairs and their document shepherds.
+
+   The RG chairs should be able to modify the state and annotations for
+   any of that RG's documents at any time.  The IRTF Chair should be
+   able to modify the state and annotations for any IRTF Stream document
+   at any time.
+
+   RG chairs and document shepherds may change at any point in a
+   document's life cycle.  The Datatracker must allow for and log these
+   changes.
+
+
+
+
+
+
+
+Hoffman                       Informational                     [Page 7]
+
+RFC 6322        Datatracker States for Alternate Streams       July 2011
+
+
+4.  Independent Submission Stream
+
+   This section describes the desired states and annotations for the
+   Independent Submission stream.  The ISE will do his or her own
+   record-keeping for data not related to states and annotations.
+
+   Many documents in the Independent Submission stream come from the
+   other three streams.  Because of this, the tracker needs to preserve
+   previous states and annotations on drafts that come to the
+   Independent Submission stream.
+
+4.1.  States for the Independent Submission Stream
+
+   o  Submission Received -- The draft has been sent to the ISE with a
+      request for publication.
+
+   o  Finding Reviewers -- The ISE is finding initial reviewers for the
+      document.
+
+   o  In ISE Review -- The ISE is actively working on the document.
+
+   o  Response to Review Needed -- One or more reviews have been sent to
+      the author(s), and the ISE is awaiting response.
+
+   o  In IESG Review -- The ISE has asked the IESG to do a review on the
+      document, as described in [RFC5742].
+
+   o  Sent to the RFC Editor -- The ISE processing of this document is
+      complete and it has been sent to the RFC Editor for publication.
+      The document may be in the RFC Editor's queue, or it may have been
+      published as an RFC; this state doesn't distinguish between
+      different states occurring after the document has left the ISE.
+
+   o  No Longer In Independent Submission Stream -- This document was
+      actively considered in the Independent Submission stream, but the
+      ISE chose not to publish it.  It is possible that the document
+      might be revived later.  A document in this state may have a
+      comment explaining the reasoning of the ISE (such as if the
+      document was going to move to a different stream).
+
+   o  Document on Hold Based on IESG Request -- The IESG has requested
+      that the document be held pending further review, as specified in
+      RFC 5742, and the ISE has agreed to such a hold.
+
+
+
+
+
+
+
+
+Hoffman                       Informational                     [Page 8]
+
+RFC 6322        Datatracker States for Alternate Streams       July 2011
+
+
+4.2.  Annotations for the Independent Submission Stream
+
+   o  Waiting for Dependency on Other Document -- Activity on this
+      document is expected to be low or non-existent while waiting for
+      another document (probably listed in the comments) to progress.
+      The other documents may or may not be in the Independent
+      Submission stream.
+
+   o  Awaiting Reviews -- Activity on this document is expected to be
+      low or non-existent while waiting for reviews that were solicited
+      by the ISE.
+
+   o  Revised I-D Needed -- Requests for revisions have been sent to the
+      author(s), and no further ISE processing is expected until a new
+      draft is issued.
+
+   o  IESG Review Completed -- The IESG has completed its review on the
+      document, as described in [RFC5742].
+
+5.  Display in the Datatracker
+
+   When the Datatracker displays the metadata for an individual draft in
+   the IAB stream, IRTF stream, or ISE stream, it should show at least
+   the following information:
+
+   Document stream:           IAB / IRTF / Independent Submission
+   I-D availability status:   Active / Expired / Withdrawn / RFC
+                                Replaces / Replaced I-D or RFC
+                                (if applicable)
+   Last updated:              year-mm-dd  (e.g. 2010-07-25)
+   IRTF RG status: *          Applicable RG state *and* name of
+                                RG (or RGs)
+   Intended RFC status:       Informational / Experimental / etc.
+   Document shepherd: **      Name of Document Shepherd (if assigned)
+   Approval status:           Name of applicable state from the IAB /
+                                IRTF / Independent Submission stream
+
+   *  The "IRTF RG status" is only shown for the IRTF stream; it is to
+      be completely removed for the IAB and Independent Stream
+
+   ** This field displays the name and email of the person assigned as
+      the shepherd for the I-D; the line is omitted if the shepherd has
+      not yet been assigned
+
+
+
+
+
+
+
+
+Hoffman                       Informational                     [Page 9]
+
+RFC 6322        Datatracker States for Alternate Streams       July 2011
+
+
+6.  Movement between Streams
+
+   Internet-Drafts sometimes move between streams.  For example, a draft
+   might start out in the IETF stream but then move to the Independent
+   Submission stream, or a draft might move from an IRTF RG to the IETF
+   stream.  Thus, the IETF Datatracker needs to be able to change the
+   designated stream of a draft.  It is expected that this will be done
+   by the stream managers.  In addition, the IETF Datatracker should
+   preserve all data from the earlier stream(s) when a document moves
+   between streams.
+
+   Internet-Drafts sometimes move out of a stream into a non-stream
+   state.  For example, a draft that is in the "Candidate IAB Document",
+   "Candidate RG Document", or "Submission Received" state might not be
+   adopted by the stream and revert back to having no stream-specific
+   state.  The IETF Datatracker needs to be able to handle the
+   transition from having a stream-related state to a null state.
+
+   New streams may be added in the future, and the tool needs to be able
+   to handle additional streams.
+
+7.  IESG Mail Sent for the IRTF and Independent Stream
+
+   After the IESG performs a review of potential RFCs from the IRTF and
+   Independent streams, as described in RFC 5742, the IETF Datatracker
+   sends out email to the IANA, the IESG, ietf-announce@ietf.org, and
+   the stream manager with the results of the IESG's review.  In the
+   past, the subject line and body of that message has been misleading
+   about the scope and purpose of the message.  There is now a
+   requirement that the message clearly state that the message is about
+   the IETF-conflict review of a particular Internet-Draft.
+
+   Note that these letters have effects on the state machine for the
+   IESG, although those effects are not covered in this document.
+
+8.  Security Considerations
+
+   Changing the states in the Datatracker does not affect the security
+   of the Internet in any significant fashion.
+
+9.  Review of These Requirements
+
+   The IAB has reviewed this document and agrees that this document
+   meets the IAB's consent requirements.
+
+   The IRTF Chair has reviewed this document and agrees that this
+   document meets the requirements for the IRTF stream.
+
+
+
+
+Hoffman                       Informational                    [Page 10]
+
+RFC 6322        Datatracker States for Alternate Streams       July 2011
+
+
+   The ISE has reviewed this document and agrees that this document
+   meets the requirements of the technical community, as represented by
+   the Independent Submission stream.
+
+10.  Acknowledgements
+
+   This document draws heavily on, including wholesale copying from,
+   earlier work done by Henrik Levkowetz, Phil Roberts, and Aaron Falk.
+   Additional significant input has been received from Aaron Falk, Nevil
+   Brownlee, Olaf Kolkman, Ross Callon, Ed Juskevicius, Subramanian SM
+   Moonesamy, and Alfred Hoenes.
+
+11.  References
+
+11.1.  Normative References
+
+   [RFC4844]  Daigle, L., Ed., and Internet Architecture Board, "The RFC
+   Series and RFC Editor", RFC 4844, July 2007.
+
+11.2.  Informative References
+
+   [RFC5742]  Alvestrand, H. and R. Housley, "IESG Procedures for
+              Handling of Independent and IRTF Stream Submissions", BCP
+              92, RFC 5742, December 2009.
+
+   [RFC6174]  Juskevicius, E., "Definition of IETF Working Group
+              Document States", RFC 6174, March 2011.
+
+   [RFC6175]  Juskevicius, E., "Requirements to Extend the Datatracker
+              for IETF Working Group Chairs and Authors", RFC 6175,
+              March 2011.
+
+Author's Address
+
+   Paul Hoffman
+   VPN Consortium
+
+   EMail: paul.hoffman@vpnc.org
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hoffman                       Informational                    [Page 11]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6322.txt](<www.ietf.org/rfc/rfc6322.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
