### PR TITLE
Archive rfc6328.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6328.txt
+++ b/www.ietf.org/rfc/rfc6328.txt
@@ -1,0 +1,507 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                   D. Eastlake 3rd
+Request for Comments: 6328                                        Huawei
+BCP: 164                                                       July 2011
+Category: Best Current Practice
+ISSN: 2070-1721
+
+
+       IANA Considerations for Network Layer Protocol Identifiers
+
+Abstract
+
+   Some protocols being developed or extended by the IETF make use of
+   the ISO/IEC (International Organization for Standardization /
+   International Electrotechnical Commission) Network Layer Protocol
+   Identifier (NLPID).  This document provides NLPID IANA
+   considerations.
+
+Status of This Memo
+
+   This memo documents an Internet Best Current Practice.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   BCPs is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6328.
+
+Copyright Notice
+
+   Copyright (c) 2011 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+Eastlake                  Best Current Practice                 [Page 1]
+
+RFC 6328             IANA Considerations for NLPIDs            July 2011
+
+
+Table of Contents
+
+   1. Introduction ....................................................2
+   2. NLPIDs ..........................................................3
+      2.1. Sub-Ranges of the NLPID ....................................3
+      2.2. Code Point 0x80 ............................................4
+      2.3. NLPIDs Available for IANA Allocation .......................4
+   3. IANA Considerations .............................................5
+   4. Security Considerations .........................................5
+   5. References ......................................................5
+      5.1. Normative References .......................................5
+      5.2. Informative References .....................................6
+   6. Acknowledgements ................................................7
+   Appendix A. Initial IANA NLPID Web Page ............................8
+   Appendix B. RFC References to NLPID ................................9
+
+1.  Introduction
+
+   Some protocols being developed or extended by the IETF make use of
+   the ISO/IEC (International Organization for Standardization /
+   International Electrotechnical Commission) Network Layer Protocol
+   Identifier (NLPID).
+
+   The term "NLPID" is not actually used in [ISO9577], which refers to
+   one-octet IPIs (Initial Protocol Identifiers) and SPIs (Subsequent
+   Protocol Identifiers).  While these are two logically separate kinds
+   of one-octet identifiers, most values are usable as both an IPI and
+   an SPI.  In the remainder of this document, the term NLPID is used
+   for such values.
+
+   The registry of NLPID values is maintained by ISO/IEC by updating
+   [ISO9577].  The procedure specified by ISO/IEC in that document is
+   that an NLPID code point can be allocated without approval by
+   ISO/IEC, as long as the code point is not in a range of values
+   categorized for an organization other than the organization
+   allocating the code point and as long as ISO/IEC JTC1 SC6 is
+   informed.
+
+   This document provides NLPID IANA considerations.  That is, it
+   specifies the level of IETF approval necessary for a code point to be
+   allocated for IETF use, the procedures to be used and actions to be
+   taken by IANA in connection with NLPIDs, and related guidelines.
+
+   [RFC5226] is incorporated herein except to the extent that there are
+   contrary provisions in this document.
+
+
+
+
+
+
+Eastlake                  Best Current Practice                 [Page 2]
+
+RFC 6328             IANA Considerations for NLPIDs            July 2011
+
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+2.  NLPIDs
+
+   [ISO9577] defines one-octet network layer protocol identifiers that
+   are commonly called NLPIDs, which is the term used in this document.
+
+   NLPIDs are used in a number of protocols.  For example, in the
+   mar$pro.type field of the multicast address resolution server
+   protocol [RFC2022], the ar$pro.type field of the NBMA (Non-Broadcast
+   Multi-Access) next hop resolution protocol [RFC2332] and in the IS-IS
+   Protocols Supported TLV [RFC1195].  See Appendix B.
+
+2.1.  Sub-Ranges of the NLPID
+
+   Sub-ranges of the possible NLPID values are categorized by [ISO9577]
+   for organizations as shown below, primarily for the ISO/IEC
+   (International Organization for Standardization / International
+   Electrotechnical Commission) and the ITU-T (International
+   Telecommunication Union - Telecommunication Standardization Sector):
+
+      Code Point  Category
+      ----------  --------
+      0x00        ISO/IEC
+      0x01-0x0F   ITU-T
+      0x10-0x3F   ITU-T Rec. X.25 and ISO/IEC 8208
+      0x40-0x43   ISO/IEC
+      0x44        ITU-T
+      0x45-0x4F   ISO/IEC
+      0x50-0x6F   ITU-T Rec. X.25 and ISO/IEC 8208
+      0x70-0x7F   Joint ITU-T and ISO/IEC
+      0x80        ISO/IEC (see Section 2.2)
+      0x81-0x8F   ISO/IEC
+      0x90-0xAF   ITU-T Rec. X.25 and ISO/IEC 8208
+      0xB0-0xBF   ITU-T
+      0xC0-0xCF   Potentially available for IANA (see Section 2.3)
+      0xD0-0xEF   ITU-T Rec. X.25 and ISO/IEC 8208
+      0xF0-0xFE   Joint ITU-T and ISO/IEC
+      0xFF        Reserved for an Extension mechanism to be
+                  jointly developed by ITU-T and ISO/IEC
+
+
+
+
+
+
+
+
+
+Eastlake                  Best Current Practice                 [Page 3]
+
+RFC 6328             IANA Considerations for NLPIDs            July 2011
+
+
+2.2.  Code Point 0x80
+
+   NLPID 0x80 is known as the IEEE (Institute of Electrical &
+   Electronics Engineers) SNAP (SubNetwork Access Protocol) code point.
+   It is followed by five octets, using the IEEE SNAP SAP (Service
+   Access Point) conventions, to specify the protocol.  Those
+   conventions are described in Section 3 of [RFC5342].  In particular,
+   it is valid for such a five-octet sequence to start with the IANA OUI
+   (Organizationally Unique Identifier) followed by two further octets
+   assigned by IANA as provided in [RFC5342].  The same IANA registry is
+   used for such protocol identifiers whether they are planned to be
+   introduced by the 0x80 NLPID or the IEEE SNAP SAP LSAPs (Link-Layer
+   Service Access Points) (0xAAAA).  Values allocated by IANA may be
+   used in either context as appropriate.
+
+   Because of the limited number of NLPID code points available for IANA
+   allocation, use of the IEEE SNAP NLPID is RECOMMENDED rather than
+   allocation of a new one-octet NLPID code point.
+
+2.3.  NLPIDs Available for IANA Allocation
+
+   A limited number of code points are available that could be allocated
+   by IANA under [ISO9577].  Because of this, it is desirable, where
+   practical, to use code point 0x80, as discussed in Section 2.2 above,
+   or to get code points allocated from the ranges categorized to other
+   organizations.  For example, code point 0x8E was allocated for IPv6
+   [RFC2460], although it is in a range of code points categorized for
+   ISO/IEC.  One-byte code points are assigned to TRILL and IEEE 802.1aq
+   as they are intended for use within the IS-IS Protocols Supported TLV
+   [RFC1195].
+
+   The table below, which includes two new code point allocations made
+   by this document, shows those still available.
+
+      Code Point  Status
+      ----------  --------
+      0xC0        TRILL [RFC6325]
+      0xC1        IEEE 802.1aq [802.1aq]
+      0xC2-0xCB   Available
+      0xCC        IPv4 [RFC791]
+      0xCD-0xCE   Available
+      0xCF        PPP [RFC1661]
+
+
+
+
+
+
+
+
+
+Eastlake                  Best Current Practice                 [Page 4]
+
+RFC 6328             IANA Considerations for NLPIDs            July 2011
+
+
+3.  IANA Considerations
+
+   As long as code points are available, IANA will allocate additional
+   values when required by applying the IETF Review policy as per
+   [RFC5226].
+
+   Whenever it allocates an NLPID, IANA will inform the IETF liaison to
+   ISO/IEC JTC1 SC6 (Joint Technical Committee 1, Study Committee 6)
+   [JTC1SC6], or if IANA is unable to determine that IETF liaison, the
+   IAB.  The liaison (or the IAB) will then ensure that ISO/IEC JTC1 SC6
+   is informed so that [ISO9577] can be updated since ISO/IEC JTC1 SC6
+   is the body that maintains [ISO9577].  To simplify this process, it
+   is desirable that the IAB maintain an IETF liaison to ISO/IEC JTC1
+   SC6.
+
+   This document allocates the code points 0xC0 and 0xC1 as shown in
+   Section 2.3 and IANA shall request the liaison (or the IAB) to so
+   inform ISO/IEC JTC1 SC6.
+
+   IANA maintains a web page showing NLPIDs that have been allocated to
+   a protocol being developed or extended by the IETF or are otherwise
+   of interest.  The initial state of the web page is as shown in
+   Appendix A.  IANA will update this web page for (1) NLPIDs allocated
+   by IANA and (2) other allocations or de-allocations when IANA is
+   requested to make such changes to this web page by the IETF liaison
+   mentioned above.
+
+4.  Security Considerations
+
+   This document is concerned with allocation of NLPIDs.  It is not
+   directly concerned with security.
+
+5.  References
+
+5.1.  Normative References
+
+   [ISO9577] International Organization for Standardization "Information
+             technology - Telecommunications and Information exchange
+             between systems - Protocol identification in the network
+             layer", ISO/IEC TR 9577:1999, 1999-12-15.
+
+   [RFC2119] Bradner, S., "Key words for use in RFCs to Indicate
+             Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC5226] Narten, T. and H. Alvestrand, "Guidelines for Writing an
+             IANA Considerations Section in RFCs", BCP 26, RFC 5226, May
+             2008.
+
+
+
+
+Eastlake                  Best Current Practice                 [Page 5]
+
+RFC 6328             IANA Considerations for NLPIDs            July 2011
+
+
+   [RFC5342] Eastlake 3rd., D., "IANA Considerations and IETF Protocol
+             Usage for IEEE 802 Parameters", BCP 141, RFC 5342,
+             September 2008.
+
+   [RFC6325] Radia, P., Eastlake, D., Dutt, D., Gai, S., and A.
+             Ghanwani, "RBridges: Base Protocol Specification", RFC
+             6325, July 2011.
+
+5.2.  Informative References
+
+   [802.1aq] Standard for Local and Metropolitan Area Networks / Virtual
+             Bridged Local Area Networks / Amendment 9: Shortest Path
+             Bridging, Draft IEEE P802.1aq/D2.1, 21 August 2009.
+
+   [JTC1SC6] ISO/IEC JTC1 SC6 (International Organization for
+             Standardization / International Electrotechnical
+             Commission, Joint Technical Committee 1, Study Committee
+             6), http://www.iso.org/iso/
+             iso_technical_committee.html?commid=45072
+
+   [RFC791]  Postel, J., "Internet Protocol", STD 5, RFC 791, September
+             1981.
+
+   [RFC1195] Callon, R., "Use of OSI IS-IS for routing in TCP/IP and
+             dual environments", RFC 1195, December 1990.
+
+   [RFC1661] Simpson, W., Ed., "The Point-to-Point Protocol (PPP)", STD
+             51, RFC 1661, July 1994.
+
+   [RFC1707] McGovern, M. and R. Ullmann, "CATNIP: Common Architecture
+             for the Internet", RFC 1707, October 1994.
+
+   [RFC2022] Armitage, G., "Support for Multicast over UNI 3.0/3.1 based
+             ATM Networks", RFC 2022, November 1996.
+
+   [RFC2332] Luciani, J., Katz, D., Piscitello, D., Cole, B., and N.
+             Doraswamy, "NBMA Next Hop Resolution Protocol (NHRP)", RFC
+             2332, April 1998.
+
+   [RFC2460] Deering, S. and R. Hinden, "Internet Protocol, Version 6
+             (IPv6) Specification", RFC 2460, December 1998.
+
+
+
+
+
+
+
+
+
+
+Eastlake                  Best Current Practice                 [Page 6]
+
+RFC 6328             IANA Considerations for NLPIDs            July 2011
+
+
+6.  Acknowledgements
+
+   The contributions and support of the following people, listed in
+   alphabetic order, are gratefully acknowledged:
+
+      Ayan Banerjee, Gonzalo Camarillo, Dinesh Dutt, Don Fedyk, Alfred
+      Hines, Russ Housley, Andrew Malis, Radia Perlman, Dan Romascanu,
+      and Peter Ashwood-Smith.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Eastlake                  Best Current Practice                 [Page 7]
+
+RFC 6328             IANA Considerations for NLPIDs            July 2011
+
+
+Appendix A.  Initial IANA NLPID Web Page
+
+   NLPIDs of Interest
+
+      Code Point  Use
+      ----------  --------
+       0x00       Null
+       0x08       Q.933 (RFC 2427)
+       0x80       IEEE SNAP (RFC 6328)
+       0x81       ISO CLNP (Connectionless Network Protocol)
+       0x82       ISO ES-IS
+       0x83       IS-IS (RFC 1195)
+       0x8E       IPv6 (RFC 2460)
+       0xB0       FRF.9 (RFC 2427)
+       0xB1       FRF.12 (RF C2427)
+       0xC0       TRILL (RFC 6325)
+       0xC1       IEEE 802.1aq
+       0xCC       IPv4 (RFC 791)
+       0xCF       PPP (RFC 1661)
+
+   Note: According to [RFC1707], NLPID 0x70 was assigned to IPv7.  That
+   assignment appears to no longer be in effect as it is not listed in
+   ISO/IEC 9577.  IPv7 was itself a temporary code point assignment made
+   while a decision was being made between three candidates for the next
+   generation of IP after IPv4.  Those candidates were assigned IPv6,
+   IPv7, and IPv8.  IPv6 was selected.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Eastlake                  Best Current Practice                 [Page 8]
+
+RFC 6328             IANA Considerations for NLPIDs            July 2011
+
+
+Appendix B.  RFC References to NLPID
+
+   The following RFCs, issued before the end of March 2009, excluding
+   other survey RFCs and obsolete RFCs, reference the NLPID as such:
+
+   RFC 1195  Use of OSI IS-IS for Routing in TCP/IP and Dual
+               Environments
+   RFC 1356  Multiprotocol Interconnect on X.25 and ISDN in the Packet
+               Mode
+   RFC 1377  The PPP OSI Network Layer Control Protocol (OSINLCP)
+   RFC 1661  The Point-to-Point Protocol (PPP)
+   RFC 1707  CATNIP: Common Architecture for the Internet
+   RFC 1755  ATM Signaling Support for IP over ATM
+   RFC 2022  Support for Multicast over UNI 3.0/3.1 based ATM Networks
+   RFC 2332  NBMA Next Hop Resolution Protocol (NHRP)
+   RFC 2337  Intra-LIS IP multicast among routers over ATM using Sparse
+               Mode PIM
+   RFC 2363  PPP Over FUNI
+   RFC 2390  Inverse Address Resolution Protocol
+   RFC 2427  Multiprotocol Interconnect over Frame Relay
+   RFC 2590  Transmission of IPv6 Packets over Frame Relay Networks
+               Specification
+   RFC 2684  Multiprotocol Encapsulation over ATM Adaptation Layer 5
+   RFC 2955  Definitions of Managed Objects for Monitoring and
+               Controlling the Frame Relay/ATM PVC Service Interworking
+               Function
+   RFC 3070  Layer Two Tunneling Protocol (L2TP) over Frame Relay
+   RFC 5308  Routing IPv6 with IS-IS
+
+Author's Address
+
+   Donald E. Eastlake 3rd
+   Huawei Technologies
+   155 Beaver Street
+   Milford, MA 01757 USA
+
+   Phone: +1-508-333-2270
+   EMail: d3e3e3@gmail.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+Eastlake                  Best Current Practice                 [Page 9]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6328.txt](<www.ietf.org/rfc/rfc6328.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
