### PR TITLE
Archive rfc633.txt

### DIFF
--- a/www.ietf.org/rfc/rfc633.txt
+++ b/www.ietf.org/rfc/rfc633.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Network Working Group                                        A. McKenzie
+Request for Comments: 633                                        BBN-NET
+NIC: 30240                                                March 18, 1974
+
+
+                  IMP/TIP Preventive Maintenance Schedule
+
+   This note presents the current IMP/TIP Preventive Maintenance
+   schedule.  Preventive Maintenance is scheduled on a monthly basis and
+   a given machine is normally scheduled at the same time each month;
+   wherever possible the time is chosen to coincide with the PM time for
+   the Host(s) at the site.
+
+   It is sometimes necessary to reschedule PM's because of network
+   connectivity considerations or for other reasons.  Whenever this is
+   necessary we will follow the usual procedure for scheduling down time
+   with our "primary contact" at the site.  Permanent changes to the
+   schedule will he announced via the RFC mechanism.
+
+   PM's normally do not require the IMP/TIP to be taken down.  However,
+   machines must be taken down in some cases, so no one should rely on
+   the machine remaining available through the PM period.
+
+   PLEASE REMEMBER THAT TUESDAY MORNINGS FROM 7am TO 9am ARE RESERVED
+   FOR NETWORK SOFTWARE MAINTENANCE.
+
+
+   All times shown below are Eastern Time.
+
+    First Monday (of each month)
+
+        BBN IMP  [0830-1130]
+
+        NCC TIP  [1130-1430]
+
+        WRIGHT-PATTERSON  [1300-1700]
+
+    First Tuesday
+
+        BBN TIP  [0830-1130]
+
+        UCSB  [1130-1430]
+
+
+
+
+
+
+
+
+
+McKenzie                                                        [Page 1]
+
+RFC 633         IMP/TIP Preventive Maintenance Schedule       March 1974
+
+
+    First Wednesday
+
+        CARNEGIE  [0830-1130]
+
+        SRI [1130-1430]
+
+    First Thursday
+
+        SDAC  [0830-1130]
+
+        UTAH  [1030-1330]
+
+        NORSAR  [0830-1130]
+
+        LONDON  [0830-1130]
+
+    Second Monday
+
+        MIT-MAC  [0830-1130]
+
+        MIT-IPC  [1200-1500]
+
+        DOCB  [1030-1330]
+
+    Second Tuesday
+
+        MITRE  [0830-1130]
+
+        USC [1130-1430]
+
+    Second Wednesday
+
+        CCA  [0830-1130]
+
+        STANFORD  [1130-1430]
+
+        XEROX  [1500-1800]
+
+        RADC [1430-1730]
+
+    Second Thursday
+
+        BELVOIR  [0830-1130]
+
+        UCSD  [1130-1430]
+
+        RML  [0930-1230]
+
+
+
+
+McKenzie                                                        [Page 2]
+
+RFC 633         IMP/TIP Preventive Maintenance Schedule       March 1974
+
+
+    Second Friday
+
+        TYMSHARE  [1300-1600]
+
+    Third Monday
+
+        HARVARD  [0830-1130]
+
+        UCLA  [1000-1300]
+
+        KIRTLAND  [1600-1900]
+
+    Third Tuesday
+
+        RAND  [1130-1430]
+
+        SDC  [1530-1830]
+
+    Third Wednesday
+
+        ILLINOIS [0930-1230]
+
+        ARPA  [1800-2100]
+
+        AMES IMP  [1130-1430]
+
+        AMES TIP  [0800-1130]
+
+        HAWAII  [1130-1430]
+
+        MOFFETT  [1500-1600]
+
+    Third Thursday
+
+        ETAC  [0830-1130]
+
+        FNWC  [1130-1430]
+
+    Fourth Monday
+
+        CASE  [0830-1130]
+
+    Fourth Tuesday
+
+        NBS  [0830-1130]
+
+        LBL  [1130-1430]
+
+
+
+
+McKenzie                                                        [Page 3]
+
+RFC 633         IMP/TIP Preventive Maintenance Schedule       March 1974
+
+
+    Fourth Wednesday
+
+        LINCOLN  [0830-1130]
+
+        RUTGERS  [1000-1400]
+
+    Fourth Thursday
+
+        GWC  [0930-1230]
+
+        ISI  [1300-1600]
+
+        ABERDEEN  [0830-1130]
+
+    Fourth Friday
+
+        LLL  [1330-1730]
+
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.           2/2000 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McKenzie                                                        [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc633.txt](<www.ietf.org/rfc/rfc633.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
