### PR TITLE
Archive rfc634.txt

### DIFF
--- a/www.ietf.org/rfc/rfc634.txt
+++ b/www.ietf.org/rfc/rfc634.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                     Alex McKenzie
+RFC # 634                                                 BBN-NET
+NIC # 30445                                               April 10, 1974
+
+
+               Change in Network Address for Haskins Lab
+
+
+Sometime between May 8 and May 22, probably toward the end of that
+period, the Haskins Laboratory "Very Distant Host" connection will be
+moved from BBN (IMP #5) to Harvard (IMP #9).  The Host Number of the
+Haskins machine will remain Host 3 (numbering from zero to three).
+Thus, the Network Address of the Haskins Laboratory Host will change
+from 197 to 201.  Since the date of the change is dependent on
+installation of new circuits by the local telephone company, I am unable
+to give the actual date more precisely.
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.            11/99 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McKenzie                                                        [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc634.txt](<www.ietf.org/rfc/rfc634.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
