### PR TITLE
Archive rfc6360.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6360.txt
+++ b/www.ietf.org/rfc/rfc6360.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                        R. Housley
+Request for Comments: 6360                                Vigil Security
+Obsoletes: 1150                                              August 2011
+Category: Informational
+ISSN: 2070-1721
+
+
+                    Conclusion of FYI RFC Sub-Series
+
+Abstract
+
+   This document concludes the For Your Information (FYI) sub-series of
+   RFCs, established by RFC 1150 for use by the IETF User Services Area,
+   which no longer exists.  The IESG does not intend to make any further
+   additions to this RFC sub-series, and this document provides a record
+   of this decision.  This document also obsoletes RFC 1150 and changes
+   the status of RFC 1150 to Historic.
+
+Status of This Memo
+
+   This document is not an Internet Standards Track specification; it is
+   published for informational purposes.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Not all documents
+   approved by the IESG are a candidate for any level of Internet
+   Standard; see Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6360.
+
+Copyright Notice
+
+   Copyright (c) 2011 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+Housley                       Informational                     [Page 1]
+
+RFC 6360            Conclusion of FYI RFC Sub-Series         August 2011
+
+
+1.  Background
+
+   The For Your Information (FYI) sub-series of RFCs was established by
+   RFC 1150 [RFC1150] in 1990 for use by the IETF User Services Area,
+   which has not met since IETF 53 held in March 2001.  This RFC sub-
+   series was designed to provide Internet users with a repository of
+   information regarding the Internet that might be interesting to a
+   wide range of people.
+
+   The publication of RFC 1150 [RFC1150] introduced the FYI sub-series
+   of RFCs.  Since that time, a total of 38 FYI numbers have been
+   assigned.  Many other Informational RFCs have been published that are
+   not part of the FYI sub-series.
+
+   The list of documents in the FYI sub-series can be found on the RFC
+   Editor web site [INDEX].
+
+2.  Conclusion of the FYI Sub-Series
+
+   The IESG does not intend to make any further additions to the FYI
+   sub-series.  The IESG intends to continue to produce Informational
+   RFCs, but none of them will be assigned an FYI number.
+
+   All published RFCs that are currently part of the FYI sub-series will
+   retain their FYI numbers.  The FYI numbers continue to provide
+   reference points for these documents, and the FYI number can be used
+   in citations to these documents.
+
+   If a future RFC is published that obsoletes an existing member of the
+   FYI sub-series, the new RFC will not be assigned an FYI number.
+
+3.  RFC 1150 Moved to Historic
+
+   This document moves RFC 1150 [RFC1150] to Historic.  The procedural
+   information in RFC 1150 is no longer valid.  If it becomes desirable
+   to make additions to the FYI sub-series in the future, new procedures
+   can be developed to replace this document.
+
+4.  Security Considerations
+
+   No Internet security issues are anticipated by the actions described
+   in this document.
+
+
+
+
+
+
+
+
+
+Housley                       Informational                     [Page 2]
+
+RFC 6360            Conclusion of FYI RFC Sub-Series         August 2011
+
+
+5.  References
+
+5.1. Normative Reference
+
+   [RFC1150] Malkin, G. and J. Reynolds, "FYI on FYI: Introduction to
+             the FYI Notes", FYI 1, RFC 1150, March 1990.
+
+5.2.  Informative Reference
+
+   [INDEX]   "FYI Index", http://www.rfc-editor.org/fyi-index.html
+
+Author's Address
+
+   Russell Housley
+   Vigil Security, LLC
+   918 Spring Knoll Drive
+   Herndon, VA 20170
+   USA
+   EMail: housley@vigilsec.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Housley                       Informational                     [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6360.txt](<www.ietf.org/rfc/rfc6360.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
