### PR TITLE
Archive rfc637.txt

### DIFF
--- a/www.ietf.org/rfc/rfc637.txt
+++ b/www.ietf.org/rfc/rfc637.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                   Alex A. McKenzie
+RFC # 637                                               BBN-NET
+NIC # 30519                                             April 23, 1974
+
+
+                  CHANGE OF NETWORK ADDRESS FOR SU-DSL
+
+Effective immediately, the Host at Stanford Electronics Research Lab.
+(SU-DSL), a Very Distant Host connected to the SRI IMP, has its address
+changed from IMP 2, Host 2, to IMP 2 Host 3.  Thus its "Network Address"
+is changed from 130 to 194.
+
+Host 2 on IMP 2 will eventually be a PDP-11 operated by the SRI
+Artificial Intelligence Center.
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.            10/99 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McKenzie                                                        [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc637.txt](<www.ietf.org/rfc/rfc637.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
