### PR TITLE
Archive rfc638.txt

### DIFF
--- a/www.ietf.org/rfc/rfc638.txt
+++ b/www.ietf.org/rfc/rfc638.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Network Working Group                                   Alex A. McKenzie
+Request for Comments: 638                                        BBN-NET
+NIC: 30538                                                April 25, 1974
+
+
+                IMP/TIP Preventive Maintenance Schedule
+
+      This RFC corrects numerous inaccuracies in RFC #633.  Rather than
+      trying to list all the changes, I urge all Liaisons and other
+      interested parties to look carefully at the times now listed for
+      the sites they are interested in.
+
+   This note presents the current IMP/TIP Preventive Maintenance
+   schedule.  Preventive Maintenance is scheduled on a monthly basis and
+   a given machine is normally scheduled at the same time each month;
+   wherever possible the time is chosen to coincide with the PM time for
+   the Host(s) at the site.
+
+   It is sometimes necessary to reschedule PM's because of network
+   connectivity considerations or for other reasons.  Whenever this is
+   necessary we will follow the usual procedure for scheduling down time
+   with our "primary contact" at the site.  Permanent changes to the
+   schedule will he announced via the RFC mechanism.
+
+   PM's normally do not require the IMP/TIP to be taken down.  However,
+   machines must be taken down in some cases, so no one should rely on
+   the machine remaining available through the PM period.
+
+   PLEASE REMEMBER THAT TUESDAY MORNINGS FROM 7am TO 9am ARE RESERVED
+   FOR NETWORK SOFTWARE MAINTENANCE.
+
+
+   All times shown below are Eastern Time.
+
+    First Monday (of each month)
+
+         5 BBN IMP  [0830-1130]
+
+        40 NCC TIP  [1130-1430]
+
+        47 WRIGHT-PATTERSON  [1300-1700]
+
+    First Tuesday
+
+        30 BBN TIP  [0830-1130]
+
+         3 UCSB  [1130-1430]
+
+
+
+
+McKenzie                                                        [Page 1]
+
+RFC 638         IMP/TIP Preventive Maintenance Schedule       April 1974
+
+
+    First Wednesday
+
+        14 CARNEGIE  [0830-1130]
+
+         2 SRI [1200-1500]
+
+    First Thursday
+
+        26 SDAC  [0830-1130]
+
+         4 UTAH  [1030-1330]
+
+        41 NORSAR  [0830-1130]
+
+        42 LONDON  [0830-1130]
+
+    Second Monday
+
+         6 MIT-MAC  [0830-1130]
+
+        44 MIT-IPC  [1200-1500]
+
+        25 DOCB  [1030-1330]
+
+    Second Tuesday
+
+        17 MITRE  [0830-1130]
+
+        23 USC [1130-1430]
+
+    Second Wednesday
+
+        31 CCA  [0830-1130]
+
+        11 STANFORD  [1200-1500]
+
+        32 XEROX  [1400-1700]
+
+        18 RADC [0900-1200]
+
+    Second Thursday
+
+        27 BELVOIR  [0830-1130]
+
+        35 UCSD  [1130-1430]
+
+        37 RML  [0930-1230]
+
+
+
+
+McKenzie                                                        [Page 2]
+
+RFC 638         IMP/TIP Preventive Maintenance Schedule       April 1974
+
+
+    Second Friday
+
+        43 TYMSHARE  [1200-1500]
+
+    Third Monday
+
+         9 HARVARD  [0830-1130]
+
+         1 UCLA  [1000-1300]
+
+        48 KIRTLAND  [1600-1900]
+
+    Third Tuesday
+
+         7 RAND  [1130-1430]
+
+         8 SDC  [1530-1830]
+
+    Third Wednesday
+
+        12 ILLINOIS [0930-1230]
+
+        28 ARPA  [1700-2000]
+
+        15 AMES IMP  [1200-1500]
+
+        16 AMES TIP  [1300-1600]
+
+        36 HAWAII  [1430-1730]
+
+        45 MOFFETT  [1400-1700]
+
+    Third Thursday
+
+        20 ETAC  [0830-1130]
+
+        33 FNWC  [1300-1600]
+
+    Third Friday
+
+        21 LLL  [1230-1530]
+
+    Fourth Monday
+
+        13 CASE  [0830-1130]
+
+
+
+
+
+
+McKenzie                                                        [Page 3]
+
+RFC 638         IMP/TIP Preventive Maintenance Schedule       April 1974
+
+
+    Fourth Tuesday
+
+        19 NBS  [0830-1130]
+
+    Fourth Wednesday
+
+        10 LINCOLN  [0830-1130]
+
+        46 RUTGERS  [1000-1400]
+
+    Fourth Thursday
+
+        24 GWC  [1500-1800]
+
+        22 ISI  [1300-1600]
+
+        29 ABERDEEN  [1300-1600]
+
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.           2/2000 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McKenzie                                                        [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc638.txt](<www.ietf.org/rfc/rfc638.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
