### PR TITLE
Archive rfc6393.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6393.txt
+++ b/www.ietf.org/rfc/rfc6393.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                    M. Yevstifeyev
+Request for Comments: 6393                                September 2011
+Obsoletes: 4693
+Category: Informational
+ISSN: 2070-1721
+
+                      Moving RFC 4693 to Historic
+
+
+Abstract
+
+   This document moves RFC 4693 to Historic status.  It also obsoletes
+   RFC 4693.
+
+Status of This Memo
+
+   This document is not an Internet Standards Track specification; it is
+   published for informational purposes.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Not all documents
+   approved by the IESG are a candidate for any level of Internet
+   Standard; see Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6393.
+
+Copyright Notice
+
+   Copyright (c) 2011 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+
+M. Yevstifeyev                Informational                     [Page 1]
+
+RFC 6393               Moving RFC 4693 to Historic        September 2011
+
+
+1.  Introduction
+
+   This document moves RFC 4693 [RFC4693] to Historic status.  It also
+   obsoletes that document.
+
+2.  Moving RFC 4693 to Historic Status
+
+   RFC 4693 [RFC4693] established the IETF Operational Notes (IONs)
+   series of documents on the experimental basis [RFC3933].  This series
+   was intended to discuss the set of procedures that the IETF follows,
+   but for which the RFC publication process is an inappropriate
+   documentation vehicle.
+
+   Per RFC 3933 [RFC3933], in March 2008, the IESG decided to terminate
+   the IONs process experiment [IESG-IONS].  This document moves RFC
+   4693 to Historic status, per [HISTORIC], to reflect experiment
+   closure.  Please contact the IESG at <iesg@ietf.org> for further
+   details, including motivation for the termination and further destiny
+   of IONs.
+
+3.  Security Considerations
+
+   This document is of administrative nature only; therefore, there are
+   no security issues related to it.
+
+4.  Acknowledgments
+
+   Various discussions of, valuable comments on, and criticism of
+   previous versions of this document were provided by (in alphabetical
+   order) Harald Alvestrand, Brian Carpenter, Russ Housley, John
+   Klensin, Barry Leiba, and Subramanian Moonesamy.  Harald Alvestrand
+   is also acknowledged for his work on RFC 4693.
+
+5.  References
+
+5.1.  Normative References
+
+   [RFC4693]   Alvestrand, H., "IETF Operational Notes", RFC 4693,
+               October 2006.
+
+5.2.  Informative References
+
+   [IESG-IONS] Housley, R., "IETF Operational Notes", April 2008,
+               <http://www.ietf.org/old/2009/u/iesgcontent/ions.html>.
+
+
+
+
+
+
+
+M. Yevstifeyev                Informational                     [Page 2]
+
+RFC 6393               Moving RFC 4693 to Historic        September 2011
+
+
+   [HISTORIC]  The IESG, "IESG Statement on Designating RFCs as
+               Historic", IESG Statement, June 2011,
+               <http://www.ietf.org/iesg/statement/designating-rfcs-as-
+               historic.html>.
+
+   [RFC3933]   Klensin, J. and S. Dawkins, "A Model for IETF Process
+               Experiments", BCP 93, RFC 3933, November 2004.
+
+Author's Address
+
+   Mykyta Yevstifeyev
+   8 Kuzovkov St., Apt. 25
+   Kotovsk
+   Ukraine
+
+   EMail: evnikita2@gmail.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+M. Yevstifeyev                Informational                     [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6393.txt](<www.ietf.org/rfc/rfc6393.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
