### PR TITLE
Archive rfc6423.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6423.txt
+++ b/www.ietf.org/rfc/rfc6423.txt
@@ -1,0 +1,283 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                             H. Li
+Request for Comments: 6423                                  China Mobile
+Updates: 5586                                                 L. Martini
+Category: Standards Track                                   Cisco System
+ISSN: 2070-1721                                                    J. He
+                                                                  Huawei
+                                                                F. Huang
+                                                          Alcatel-Lucent
+                                                           November 2011
+
+
+      Using the Generic Associated Channel Label for Pseudowire in
+                  the MPLS Transport Profile (MPLS-TP)
+
+Abstract
+
+   This document describes the requirements for using the Generic
+   Associated Channel Label (GAL) in pseudowires (PWs) in MPLS Transport
+   Profile (MPLS-TP) networks, and provides an update to the description
+   of GAL usage in RFC 5586 by removing the restriction that is imposed
+   on using GAL for PWs, especially in MPLS-TP environments.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6423.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Li, et al.                   Standards Track                    [Page 1]
+
+RFC 6423                 Using GAL in MPLS-TP PW           November 2011
+
+
+Copyright Notice
+
+   Copyright (c) 2011 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1. Introduction ....................................................2
+   2. Conventions Used in This Document ...............................2
+      2.1. Terminology ................................................3
+   3. GAL Usage for MPLS-TP PW ........................................3
+   4. Security Considerations .........................................4
+   5. Acknowledgments .................................................4
+   6. References ......................................................5
+      6.1. Normative References .......................................5
+      6.2. Informative References .....................................5
+
+1.  Introduction
+
+   [RFC5586] generalizes the Associated Channel mechanism of [RFC5085]
+   to be used for Sections, Label Switched Paths (LSPs), and Pseudowires
+   (PWs) in MPLS networks.  [RFC5085] defines the Associated Channel
+   Header (ACH), and [RFC5586] generalizes this for use as the Generic
+   Associated Channel (G-ACh).
+
+   [RFC5586] defines a generalized label-based exception mechanism using
+   the Generic Associated Channel Label (GAL) to work together with the
+   ACH for use with LSPs but prohibits GAL usage with PWs.
+
+   This document removes the restriction imposed by [RFC5586].
+
+2.  Conventions Used in This Document
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+
+
+
+
+Li, et al.                   Standards Track                    [Page 2]
+
+RFC 6423                 Using GAL in MPLS-TP PW           November 2011
+
+
+2.1.  Terminology
+
+   ACH      Associated Channel Header
+
+   CW       Control Word
+
+   G-ACh    Generic Associated Channel
+
+   GAL      Generic Associated Channel Label
+
+   MPLS-TP  MPLS Transport Profile
+
+   OAM      Operation, Administration, and Maintenance
+
+3.  GAL Usage for MPLS-TP PW
+
+   According to the MPLS-TP requirements document [RFC5654], it is
+   necessary that MPLS-TP mechanisms and capabilities be able to
+   interoperate with the existing IETF MPLS [RFC3031] and IETF PWE3
+   [RFC3985] architectures as appropriate.  [RFC5586] differentiates
+   between the usage of the GAL with PWs in MPLS and MPLS-TP
+   environments in Section 4.2 as follows:
+
+      In MPLS-TP, the GAL MUST be used with packets on a G-ACh on LSPs,
+      Concatenated Segments of LSPs, and with Sections, and MUST NOT be
+      used with PWs.
+
+   This indicates that the GAL can be used for MPLS-TP LSPs and
+   Sections, but not for PWs in an MPLS-TP network.
+
+   However, there is no restriction imposed on the usage of the GAL in
+   MPLS PWs, which is described immediately afterwards in the same
+   section (Section 4.2) of [RFC5586]:
+
+      However, in other MPLS environments, this document places no
+      restrictions on where the GAL may appear within the label stack or
+      its use with PWs.
+
+   The inconsistency between the usage of the GAL with MPLS PWs and
+   MPLS-TP PWs may cause unnecessary implementation differences and is
+   in disagreement with the MPLS-TP requirements.
+
+   Therefore, this document specifies that the GAL can be used with
+   packets on a G-ACh on LSPs, Concatenated Segments of LSPs, Sections,
+   and PWs in both MPLS and MPLS-TP environments without discrimination.
+
+
+
+
+
+
+Li, et al.                   Standards Track                    [Page 3]
+
+RFC 6423                 Using GAL in MPLS-TP PW           November 2011
+
+
+   [RFC5586] is updated by removing the restrictions on using GAL for PW
+   as follows:
+
+   -  Section 1 (Introduction) in [RFC5586], the original text:
+
+         The GAL mechanism is defined to work together with the ACH for
+         LSPs and MPLS Sections.
+
+      is replaced by:
+
+         The GAL mechanism is defined to work together with the ACH for
+         LSPs and MPLS Sections, and for PWs.
+
+   -  Section 4.2.  (GAL Applicability and Usage) in [RFC5586], the
+      original text:
+
+         In MPLS-TP, the GAL MUST be used with packets on a G-ACh on
+         LSPs, Concatenated Segments of LSPs, and with Sections, and
+         MUST NOT be used with PWs.  It MUST always be at the bottom of
+         the label stack (i.e., S bit set to 1).  However, in other MPLS
+         environments, this document places no restrictions on where the
+         GAL may appear within the label stack or its use with PWs.
+
+      is replaced by:
+
+         In MPLS-TP, the GAL MUST be used with packets on a G-ACh on
+         LSPs, Concatenated Segments of LSPs, and with Sections, and MAY
+         be used with PWs.  The presence of a GAL indicates that an ACH
+         immediately follows the MPLS label stack.
+
+4.  Security Considerations
+
+   There are no further security considerations than those in [RFC5586].
+
+5.  Acknowledgments
+
+   The authors would like to thank Luyuan Fang, Adrian Farrel, Haiyan
+   Zhang, Guanghui Sun, Italo Busi, and Matthew Bocci for their
+   contributions to this work.
+
+   The authors would also like to thank the authors of [RFC5586] and
+   people who were involved in the development of [RFC5586].
+
+
+
+
+
+
+
+
+
+Li, et al.                   Standards Track                    [Page 4]
+
+RFC 6423                 Using GAL in MPLS-TP PW           November 2011
+
+
+6.  References
+
+6.1.  Normative References
+
+   [RFC2119] Bradner, S., "Key words for use in RFCs to Indicate
+             Requirement Levels", BCP 14, RFC 2119, March 1997
+
+   [RFC3031] Rosen, E., Viswanathan, A., and R. Callon, "Multiprotocol
+             Label Switching Architecture", RFC 3031, January 2001.
+
+   [RFC3985] Bryant, S., Ed., and P. Pate, Ed., "Pseudo Wire Emulation
+             Edge-to-Edge (PWE3) Architecture", RFC 3985, March 2005.
+
+   [RFC5586] Bocci, M., Ed., Vigoureux, M., Ed., and S. Bryant, Ed.,
+             "MPLS Generic Associated Channel", RFC 5586, June 2009.
+
+6.2.  Informative References
+
+   [RFC5085] Nadeau, T., Ed., and C. Pignataro, Ed., "Pseudowire Virtual
+             Circuit Connectivity Verification (VCCV): A Control Channel
+             for Pseudowires", RFC 5085, December 2007.
+
+   [RFC5654] Niven-Jenkins, B., Ed., Brungard, D., Ed., Betts, M., Ed.,
+             Sprecher, N.,and S. Ueno, "Requirements of an MPLS
+             Transport Profile", RFC 5654, September 2009.
+
+Authors' Addresses
+
+   Han Li
+   China Mobile Communications Corporation
+   EMail: lihan@chinamobile.com
+
+
+   Luca Martini
+   Cisco Systems, Inc.
+   EMail: lmartini@cisco.com
+
+
+   Jia He
+   Huawei Technologies Co., Ltd.
+   EMail: hejia@huawei.com
+
+
+   Feng Huang
+   Alcatel-Lucent shanghai Bell
+   EMail: feng.f.huang@alcatel-sbell.com.cn
+
+
+
+
+
+Li, et al.                   Standards Track                    [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6423.txt](<www.ietf.org/rfc/rfc6423.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
