### PR TITLE
Archive rfc6432.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6432.txt
+++ b/www.ietf.org/rfc/rfc6432.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                         R. Jesske
+Request for Comments: 6432                                      L. Liess
+Category: Standards Track                               Deutsche Telekom
+ISSN: 2070-1721                                            November 2011
+
+
+              Carrying Q.850 Codes in Reason Header Fields
+             in SIP (Session Initiation Protocol) Responses
+
+Abstract
+
+   Although the use of the SIP (Session Initiation Protocol) Reason
+   header field in responses is considered in general in RFC 3326, its
+   use is not specified for any particular response code.  Nonetheless,
+   existing deployments have been using Reason header fields to carry
+   failure-related Q.850 cause codes in SIP responses to INVITE requests
+   that have been gatewayed to Public Switched Telephone Network (PSTN)
+   systems.  This document normatively describes the use of the Reason
+   header field in carrying Q.850 cause codes in SIP responses.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6432.
+
+Copyright Notice
+
+   Copyright (c) 2011 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+Jesske & Liess               Standards Track                    [Page 1]
+
+RFC 6432                   Reason Header Field             November 2011
+
+
+   This document may contain material from IETF Documents or IETF
+   Contributions published or made publicly available before November
+   10, 2008.  The person(s) controlling the copyright in some of this
+   material may not have granted the IETF Trust the right to allow
+   modifications of such material outside the IETF Standards Process.
+   Without obtaining an adequate license from the person(s) controlling
+   the copyright in such materials, this document may not be modified
+   outside the IETF Standards Process, and derivative works of it may
+   not be created outside the IETF Standards Process, except to format
+   it for publication as an RFC or to translate it into languages other
+   than English.
+
+Table of Contents
+
+   1. Overview ........................................................2
+   2. Terminology .....................................................2
+   3. Applicability ...................................................3
+   4. Security Considerations .........................................3
+   5. Acknowledgments .................................................3
+   6. Normative References ............................................3
+
+1.  Overview
+
+   Although the use of the SIP (Session Initiation Protocol) Reason
+   header field in responses is considered in general in RFC 3326
+   [RFC3326], its use is not specified for any particular response code.
+   Nonetheless, existing deployments have been using Reason header
+   fields to carry failure-related Q.850 [Q.850] cause codes in SIP
+   responses to INVITE requests that have been gatewayed to PSTN
+   systems.  This document normatively describes the use of the Reason
+   header field in SIP responses to carry Q.850 [Q.850] cause codes.
+
+2.  Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+   This document uses terms from [RFC3261].
+
+
+
+
+
+
+
+
+
+
+
+
+Jesske & Liess               Standards Track                    [Page 2]
+
+RFC 6432                   Reason Header Field             November 2011
+
+
+3.  Applicability
+
+   This document allows SIP responses to carry Reason header fields as
+   follows:
+
+      Any SIP Response message, with the exception of a 100 (Trying),
+      MAY contain a Reason header field with a Q.850 [Q.850] cause code.
+
+      The Reason header field is not needed in the 100 (Trying)
+      responses, since they are transmitted hop by hop, not end to end.
+      SIP responses with Reason header fields carrying values other than
+      Q.850 [Q.850] cause codes are outside of the scope of this
+      document.
+
+4.  Security Considerations
+
+   This specification allows the presence of the Reason header field
+   containing Q.850 [Q.850] cause codes in responses.  The presence of
+   the Reason header field in a response does not affect the treatment
+   of the response.  Nevertheless, there could be situations where a
+   wrong Q.850 [Q.850] cause code could, for example, cause an
+   announcement system to play the wrong information.  To avoid such
+   situations, it is RECOMMENDED that this header field be protected by
+   a suitable integrity mechanism.  The use of transport- or network-
+   layer hop-by-hop security mechanisms, such as Transport Layer
+   Security (TLS) or IPsec with appropriate cipher suites, can satisfy
+   this requirement.
+
+5.  Acknowledgments
+
+   Thanks to Gonzalo Camarillo and Mary Barnes for the detailed review
+   of this document.
+
+   Thanks to Paul Kyzivat, Mary Barnes, John Elwell, Keith Drage, and
+   Thomas Belling, who provided helpful comments, feedback, and
+   suggestions.
+
+6.  Normative References
+
+   [Q.850]    "Usage of cause and location in the Digital Subscriber
+              Signalling System No. 1 and the Signalling System No. 7
+              ISDN User Part", ITU Recommendation Q.850, May 1998.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+
+
+
+
+
+Jesske & Liess               Standards Track                    [Page 3]
+
+RFC 6432                   Reason Header Field             November 2011
+
+
+   [RFC3261]  Rosenberg, J., Schulzrinne, H., Camarillo, G., Johnston,
+              A., Peterson, J., Sparks, R., Handley, M., and E.
+              Schooler, "SIP: Session Initiation Protocol", RFC 3261,
+              June 2002.
+
+   [RFC3326]  Schulzrinne, H., Oran, D., and G. Camarillo, "The Reason
+              Header Field for the Session Initiation Protocol (SIP)",
+              RFC 3326, December 2002.
+
+Authors' Addresses
+
+   Roland Jesske
+   Deutsche Telekom
+   Heinrich-Hertz-Strasse 3-7
+   Darmstadt  64307
+   Germany
+
+   Phone: +4961515812766
+   EMail: r.jesske@telekom.de
+
+
+   Laura Liess
+   Deutsche Telekom
+   Heinrich-Hertz-Strasse 3-7
+   Darmstadt  64307
+   Germany
+
+   Phone: +4961515812761
+   EMail: L.Liess@telekom.de
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Jesske & Liess               Standards Track                    [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6432.txt](<www.ietf.org/rfc/rfc6432.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
