### PR TITLE
Archive rfc6445.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6445.txt
+++ b/www.ietf.org/rfc/rfc6445.txt
@@ -1,0 +1,2971 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                    T. Nadeau, Ed.
+Request for Comments: 6445                               CA Technologies
+Category: Standards Track                                K. Koushik, Ed.
+ISSN: 2070-1721                                      Cisco Systems, Inc.
+                                                           R. Cetin, Ed.
+                                                                 Alcatel
+                                                           November 2011
+
+
+        Multiprotocol Label Switching (MPLS) Traffic Engineering
+              Management Information Base for Fast Reroute
+
+Abstract
+
+   This memo defines a portion of the Management Information Base for
+   use with network management protocols in the Internet community.  In
+   particular, it describes managed objects used to support two fast
+   reroute (FRR) methods for Multiprotocol Label Switching (MPLS)-based
+   traffic engineering (TE).  The two methods are the one-to-one backup
+   method and the facility backup method.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6445.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Nadeau, et al.               Standards Track                    [Page 1]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+Copyright Notice
+
+   Copyright (c) 2011 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+   This document may contain material from IETF Documents or IETF
+   Contributions published or made publicly available before November
+   10, 2008.  The person(s) controlling the copyright in some of this
+   material may not have granted the IETF Trust the right to allow
+   modifications of such material outside the IETF Standards Process.
+   Without obtaining an adequate license from the person(s) controlling
+   the copyright in such materials, this document may not be modified
+   outside the IETF Standards Process, and derivative works of it may
+   not be created outside the IETF Standards Process, except to format
+   it for publication as an RFC or to translate it into languages other
+   than English.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Nadeau, et al.               Standards Track                    [Page 2]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+Table of Contents
+
+   1. Introduction ....................................................4
+      1.1. Conventions Used in This Document ..........................4
+   2. Terminology .....................................................4
+   3. The Internet-Standard Management Framework ......................4
+   4. Overview of the MIB Modules .....................................4
+      4.1. MPLS-FRR-GENERAL-STD-MIB ...................................5
+           4.1.1. mplsFrrConstraintsTable .............................5
+           4.1.2. mplsFrrTunnelARHopTable .............................5
+           4.1.3. Example of Relationship between Various Tables of
+                  MPLS-FRR-GENERAL-STD-MIB ............................6
+      4.2. MPLS-FRR-ONE2ONE-STD-MIB ...................................6
+           4.2.1. mplsFrrOne2OnePlrTable ..............................7
+           4.2.2. mplsFrrOne2OneDetourTable ...........................7
+           4.2.3. Example of Relationship between
+                  mplsFrrOne2OnePlrTable, mplsFrrOne2OneDetourTable,
+                  and mplsTunnelTable..................................8
+      4.3. MPLS-FRR-FACILITY-STD-MIB .................................11
+           4.3.1. mplsFrrFacilityDBTable .............................11
+           4.3.2. Example of Relationship between Various Tables of
+                  MPLS-FRR-FACILITY-STD-MIB ..........................12
+   5. Handling IPv6 Tunnels ..........................................14
+   6. MIB Module Definitions .........................................15
+      6.1. MPLS-FRR-GENERAL-STD-MIB Module Definitions ...............15
+      6.2. MPLS-FRR-ONE2ONE-STD-MIB Module Definitions ...............28
+      6.3. MPLS-FRR-FACILITY-STD-MIB Module Definitions ..............38
+   7. Security Considerations ........................................49
+   8. IANA Considerations ............................................50
+      8.1. IANA Considerations for MPLS-FRR-GENERAL-STD-MIB ..........51
+      8.2. IANA Considerations for MPLS-FRR-ONE2ONE-STD-MIB ..........51
+      8.3. IANA Considerations for MPLS-FRR-FACILITY-STD-MIB .........51
+   9. Acknowledgments ................................................51
+   10. References ....................................................51
+      10.1. Normative References .....................................51
+      10.2. Informative References ...................................52
+   11. Contributors ..................................................52
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Nadeau, et al.               Standards Track                    [Page 3]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+1.  Introduction
+
+   This memo defines a portion of the Management Information Base (MIB)
+   containing objects used to manage Multiprotocol Label Switching
+   (MPLS)-based fast rerouting features on MPLS Label Switching Routers
+   (LSRs) as defined in [RFC4090].  The MIB modules defined in this
+   document should be used in conjunction with [RFC3811], [RFC3812], and
+   [RFC3813].
+
+1.1.  Conventions Used in This Document
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in
+   RFC 2119 [RFC2119].
+
+2.  Terminology
+
+   This document uses terminology from "Multiprotocol Label Switching
+   Architecture" [RFC3031] and from "Fast Reroute Extensions to RSVP-TE
+   for LSP Tunnels" [RFC4090].
+
+3.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB module objects are
+   generally accessed through the Simple Network Management Protocol
+   (SNMP).  Objects in the MIB are defined using the mechanisms defined
+   in the Structure of Management Information (SMI).  This memo
+   specifies MIB modules that are compliant to the SMIv2, which is
+   described in STD 58, RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579]
+   and STD 58, RFC 2580 [RFC2580].
+
+4.  Overview of the MIB Modules
+
+   [RFC4090] stipulates two different approaches to implementing MPLS TE
+   fast reroute: one-to-one backup and facility backup.
+
+   We define three MIB modules to represent the respective components:
+   general, one-to-one backup, and facility backup.
+
+
+
+
+
+
+
+Nadeau, et al.               Standards Track                    [Page 4]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+   They are:
+
+   -  MPLS-FRR-GENERAL-STD-MIB: Contains objects that apply to any MPLS
+      LSR implementing MPLS TE fast-reroute functionality.
+
+   -  MPLS-FRR-ONE2ONE-STD-MIB: Contains objects that apply to the
+      one-to-one backup method.
+
+   -  MPLS-FRR-FACILITY-STD-MIB: Contains objects that apply to the
+      facility backup method.
+
+   Although [RFC4090] specifies that a node is able to support both
+   fast-reroute methods simultaneously, common practice has shown that
+   operators choose to configure either the one-to-one backup method or
+   the facility backup method at any given time.  So, by dividing the
+   MIB modules into three, we allow the developers to choose the MIB
+   modules they want to implement, depending on the method supported on
+   that node.
+
+4.1.  MPLS-FRR-GENERAL-STD-MIB
+
+   This MIB module MUST be implemented if either of the fast-reroute
+   methods is implemented.
+
+4.1.1.  mplsFrrConstraintsTable
+
+   This table contains objects that apply to all LSRs implementing MPLS
+   TE fast-reroute functions.  In particular, this table defines fast-
+   reroute constraints, such as bandwidth, for a tunnel instance to be
+   protected by using backup Label Switched Paths (LSPs) (detour LSPs or
+   bypass tunnels).
+
+   This table MUST be implemented at the ingress node of the protected
+   TE tunnel instance to configure backup LSP setup constraints.
+
+4.1.2.  mplsFrrTunnelARHopTable
+
+   This table extends mplsTunnelARHopTable (defined in the
+   MPLS-TE-STD-MIB [RFC3812]) with fast-reroute objects that specify the
+   local protection type or types of availability, as well as what type
+   or types are actually in use for each tunnel hop traversed by a
+   protected TE tunnel.
+
+
+
+
+
+
+
+
+
+Nadeau, et al.               Standards Track                    [Page 5]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+4.1.3.  Example of Relationship between Various Tables of
+        MPLS-FRR-GENERAL-STD-MIB
+
+              (R1)----(R2)----(R3)----(R4)---(R5)
+                  \       \       \    /
+                  (R6)---(R7)------(R8)
+
+              Protected LSP:  [R1->R2->R3->R4->R5]
+
+              R1's Backup:    [R1->R6->R7->R8->R3]
+
+   In the above topology, the various tables on R1 will be populated as
+   indicated below.
+
+   mplsFrrGeneralConstraintsTable
+   {
+    mplsFrrGeneralConstraintsIfIndexOrZero  = 10,-- interface to protect
+    mplsFrrGeneralConstraintsTunnelIndex    = 1, -- protecting tunnel
+    mplsFrrGeneralConstraintsTunnelInstance = 0, -- use any instance
+    mplsFrrGeneralConstraintsProtectionType = 1, -- linkProtection
+    mplsFrrGeneralConstraintsSetupPrio      = 0,
+    mplsFrrGeneralConstraintsHoldingPrio     = 0,
+    mplsFrrGeneralConstraintsInclAnyAffinity = 0,
+    mplsFrrGeneralConstraintsInclAllAffinity = 0,
+    mplsFrrGeneralConstraintsExclAnyAffinity = 0,
+    mplsFrrGeneralConstraintsHopLimit        = 0,
+    mplsFrrGeneralConstraintsBandwidth       = 0, -- best effort
+    mplsFrrGeneralConstraintsStorageType     = 2, -- volatile
+    mplsFrrGeneralConstraintsRowStatus       = 1, -- active
+    };
+
+   mplsFrrGeneralTunnelARHopEntry
+   {
+    mplsFrrGeneralTunnelARHopSessionAttributeFlags = 5,
+                             -- sestyleDesired | localProtectionDesired
+    mplsFrrGeneralTunnelARHopRROSubObjectFlags = 2
+                             -- localProtectionInUse
+    };
+
+4.2.  MPLS-FRR-ONE2ONE-STD-MIB
+
+   This MIB module MUST be implemented if the one-to-one backup fast-
+   reroute method is implemented.
+
+
+
+
+
+
+
+
+Nadeau, et al.               Standards Track                    [Page 6]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+4.2.1.  mplsFrrOne2OnePlrTable
+
+   The mplsFrrOne2OnePlrTable contains information about Points of Local
+   Repair (PLRs) that initiated detour LSPs to protect tunnel instances.
+   This table MUST be supported for LSRs implementing the one-to-one
+   backup method.  In these cases, the detour LSPs are reflected in the
+   mplsFrrOne2OneDetourTable.
+
+4.2.2.  mplsFrrOne2OneDetourTable
+
+   The mplsFrrOne2OneDetourTable shows the detour LSPs in each node
+   (ingress, transit, and egress nodes).  An entry in this table
+   represents a detour LSP.
+
+   Each detour is identified by the following indexes:
+
+   - mplsTunnelIndex [RFC3812]: set to the Tunnel ID of an LSP protected
+     by a detour.
+
+   - mplsTunnelInstance [RFC3812]: consists of two parts:
+
+        1) the higher 16 bits:  - protected TE tunnel instance
+                                - uniquely identifies a protected
+                                  LSP within a tunnel.
+
+        2) the lower 16 bits:   - detour instance
+                                - uniquely identifies a detour LSP
+                                  of a protected TE tunnel instance.
+                                  Multiple detours of the same
+                                  protected LSP may go through the
+                                  same node.  In this case, the
+                                  higher 16 bits of the tunnel
+                                  instance object is used as a
+                                  detour instance.
+
+   -  ingress node's LSR ID (mplsFrrOne2OnePlrTunnelIngressLSRId): set
+      to the ingress node of an LSP protected by a detour.
+
+   -  egress node's LSR ID (mplsFrrOne2OnePlrTunnelEgressLSRId): set to
+      the egress node of an LSP protected by a detour.
+
+   A detour LSP is also considered as an instance of a protected TE
+   tunnel.  Therefore, each detour LSP SHOULD have an entry in the
+   mplsTunnelTable (defined in the MPLS-TE-STD-MIB [RFC3812]).
+
+   The mplsTunnelTable entries are indexed using mplsTunnelIndex,
+   mplsTunnelInstance, mplsTunnelIngressLSRId, and
+   mplsTunnelEgressLSRId.
+
+
+
+Nadeau, et al.               Standards Track                    [Page 7]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+   Entries where the higher 16 bits of mplsTunnelInstance are set to
+   zero represent detour TE tunnel instances.  All other values of the
+   higher 16 bits represent protected tunnel instances.
+
+   This table MUST be supported if the one-to-one backup method is used.
+
+4.2.3.  Example of Relationship between mplsFrrOne2OnePlrTable,
+        mplsFrrOne2OneDetourTable, and mplsTunnelTable
+
+   This section contains an example depicting the interrelationship
+   between mplsFrrOne2OnePlrTable, mplsFrrOne2OneDetourTable, and
+   mplsTunnelTable.
+
+              (R1)----(R2)----(R3)----(R4)---(R5)
+                  \       \       \    /
+                  (R6)---(R7)------(R8)
+
+              Protected LSP:  [R1->R2->R3->R4->R5]
+
+              R1's Backup:    [R1->R6->R7->R8->R3]
+
+   In the above topology, the various tables will be populated as
+   indicated below.
+
+   In mplsFrrOne2OnePlrTable:
+
+     {
+       mplsFrrOne2OnePlrTunnelIndex           = 1,
+       mplsFrrOne2OnePlrTunnelDetourInstance  = 6553601,
+       --
+       -- (100 << 16 | 1) = 6553601
+       -- 100 is the tunnel instance of the protected tunnel.
+       --
+       mplsFrrOne2OnePlrTunnelIngressLSRId    = 192.0.2.1, -- R1
+       mplsFrrOne2OnePlrTunnelEgressLSRId     = 192.0.2.5, -- R5
+       mplsFrrOne2OnePlrId                    = 192.0.2.1,
+                                                       -- R1 is PLR
+
+       mplsFrrOne2OnePlrSenderAddrType        = ipv4(1),
+       mplsFrrOne2OnePlrSenderAddr            = "192.0.2.1", -- R1
+       mplsFrrOne2OnePlrAvoidNodeAddrType     = ipv4(1),
+       mplsFrrOne2OnePlrAvoidNodeAddr         = "192.0.2.2",
+                                                       -- R1-R2 (Avoid)
+     }
+
+
+
+
+
+
+
+Nadeau, et al.               Standards Track                    [Page 8]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+     In mplsFrrOne2OneDetourTable:
+
+     {
+       mplsFrrOne2OnePlrTunnelIndex           = 1,
+       mplsFrrOne2OnePlrTunnelDetourInstance  = 6553601,
+       --
+       -- (100 << 16 | 1) == 6553601
+       --
+       -- 1 is mplsTunnelInstance for the detour LSP
+       -- from mplsTunnelTable.  Marked by AAA below.
+       -- Shift 16 to put this into the high-order bits
+       --
+       -- 100 is mplsTunnelInstance for the protected tunnel
+       -- from the mplsTunnelTable.  Marked by BBB below.
+       -- Need to OR the index value into low-order bits)
+
+       -- To get all detour LSPs of a protected tunnel (of instance 100)
+       -- we could do an snmpwalk of the mplsFrrOne2OneDetourEntry
+       -- where mplsFrrOne2OnePlrTunnelIndex == 1
+       -- mplsFrrOne2OnePlrTunnelDetourInstance == 6553600
+
+       -- The first value would be:
+       --                 mplsFrrOne2OneDetourActive.1.6553601
+
+       mplsFrrOne2OnePlrTunnelIngressLSRId    = 192.0.2.1, -- R1
+       mplsFrrOne2OnePlrTunnelEgressLSRId     = 192.0.2.3, -- R3
+       mplsFrrOne2OneDetourActive             = false(2),
+       mplsFrrOne2OneDetourMergedStatus       = notMerged(1),
+       mplsFrrOne2OneDetourMergedDetourInst   = 0,
+     }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Nadeau, et al.               Standards Track                    [Page 9]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+     In mplsTunnelTable(protected tunnel entry):
+
+     {
+      mplsTunnelIndex              = 1,
+      mplsTunnelInstance           = 100,-- Indicating protected tunnel
+                                         -- AAA
+
+      mplsTunnelIngressLSRId       = 192.0.2.1,
+      mplsTunnelEgressLSRId        = 192.0.2.5,
+      mplsTunnelName               = "R1-R5",
+      mplsTunnelDescr              = "R1-R5",
+      mplsTunnelIsIf               = true(1),
+      mplsTunnelXCPointer          = 0.0,
+      mplsTunnelSignallingProto    = none(1),
+      mplsTunnelSetupPrio          = 0,
+      mplsTunnelHoldingPrio        = 0,
+      mplsTunnelSessionAttributes  = 0,
+      mplsTunnelLocalProtectInUse  = true(1),
+      mplsTunnelResourcePointer    = mplsTunnelResourceMaxRate.5,
+      mplsTunnelInstancePriority   = 1,
+      mplsTunnelHopTableIndex      = 1,
+      mplsTunnelIncludeAnyAffinity = 0,
+      mplsTunnelIncludeAllAffinity = 0,
+      mplsTunnelExcludeAnyAffinity = 0,
+      mplsTunnelPathInUse          = 1,
+      mplsTunnelRole               = head(1),
+     }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Nadeau, et al.               Standards Track                   [Page 10]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+     In mplsTunnelTable (detour LSP entry):
+
+     {
+      mplsTunnelIndex              = 1,
+      mplsTunnelInstance           = 1,
+                             -- Indicating detour LSP (higher 16 bits)
+                             -- BBB
+
+      mplsTunnelIngressLSRId       = 192.0.2.1,
+      mplsTunnelEgressLSRId        = 192.0.2.3,
+      mplsTunnelName               = "R1-R3",
+      mplsTunnelDescr              = "R1-R3",
+      mplsTunnelIsIf               = true(1),
+      mplsTunnelXCPointer          = 0.0,
+      mplsTunnelSignallingProto    = none(1),
+      mplsTunnelSetupPrio          = 0,
+      mplsTunnelHoldingPrio        = 0,
+      mplsTunnelSessionAttributes  = 0,
+      mplsTunnelLocalProtectInUse  = false(0),
+      mplsTunnelResourcePointer    = mplsTunnelResourceMaxRate.6,
+      mplsTunnelInstancePriority   = 1,
+      mplsTunnelHopTableIndex      = 1,
+      mplsTunnelIncludeAnyAffinity = 0,
+      mplsTunnelIncludeAllAffinity = 0,
+      mplsTunnelExcludeAnyAffinity = 0,
+      mplsTunnelPathInUse          = 1,
+      mplsTunnelRole               = head(1),
+     }
+
+4.3.  MPLS-FRR-FACILITY-STD-MIB
+
+   This MIB module MUST be implemented if the facility backup
+   fast-reroute method is implemented.
+
+4.3.1.  mplsFrrFacilityDBTable
+
+   The mplsFrrFacilityDBTable provides information about the fast-
+   reroute database for facility-based fast reroute.
+
+   An entry is created in this table for each tunnel being protected by
+   a backup tunnel.  Backup tunnels are defined to protect the tunnels
+   traversing an interface.
+
+   The protecting tunnel will exist on the PLR as per [RFC4090].
+   Protected tunnels are the LSPs that traverse the protected link.
+
+
+
+
+
+
+Nadeau, et al.               Standards Track                   [Page 11]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+4.3.2.  Example of Relationship between Various Tables of
+        MPLS-FRR-FACILITY-STD-MIB
+
+               [R1]---[R2]----[R3]-----[R4]---[R5]
+                          \           /
+                           [R6]===[R7]
+
+                Protected LSP 1      :      [R1->R2->R3->R4->R5]
+                Protecting Tunnel 999:      [R2->R6->R7->R4]
+
+                    Facility Backup Technique
+                    -------------------------
+
+   In the above topology, the following tables are populated at R2:
+
+   mplsFrrFacilityDBEntry
+       {
+          mplsFrrFacilityProtectedIfIndex          = 10,
+          mplsFrrFacilityProtectingTunnelIndex     = 999,
+          mplsFrrFacilityBackupTunnelIndex         = 1,
+          mplsFrrFacilityBackupTunnelInstance      = 0,
+          mplsFrrFacilityBackupTunnelIngressLSRId  = 192.0.2.1
+                                                -- 192.0.2.1/24
+          mplsFrrFacilityBackupTunnelEgressLSRId   = 192.0.2.2
+                                                -- 192.0.2.2/24
+          mplsFrrFacilityDBNumProtectingTunnelOnIf = 1,
+          mplsFrrFacilityDBNumProtectedLspOnIf     = 1,
+          mplsFrrFacilityDBNumProtectedTunnels     = 1,
+          mplsFrrFacilityDBProtectingTunnelStatus  = 1, -- active
+          mplsFrrFacilityDBProtectingTunnelResvBw  = 0,
+       };
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Nadeau, et al.               Standards Track                   [Page 12]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+         In mplsTunnelTable (protecting tunnel entry):
+
+         {
+          mplsTunnelIndex              = 999, -- protecting tunnel index
+          mplsTunnelInstance           = 0,   -- head
+          mplsTunnelIngressLSRId       = 192.0.2.2,
+          mplsTunnelEgressLSRId        = 192.0.2.4,
+          mplsTunnelName               = "R2-R4",
+          mplsTunnelDescr              = "R2-R4",
+          mplsTunnelIsIf               = true(1),
+          mplsTunnelXCPointer          = 0.0,
+          mplsTunnelSignallingProto    = none(1),
+          mplsTunnelSetupPrio          = 0,
+          mplsTunnelHoldingPrio        = 0,
+          mplsTunnelSessionAttributes  = 0,
+          mplsTunnelLocalProtectInUse  = false(1),
+          mplsTunnelResourcePointer    = mplsTunnelResourceMaxRate.5,
+          mplsTunnelInstancePriority   = 1,
+          mplsTunnelHopTableIndex      = 1,
+          mplsTunnelIncludeAnyAffinity = 0,
+          mplsTunnelIncludeAllAffinity = 0,
+          mplsTunnelExcludeAnyAffinity = 0,
+          mplsTunnelPathInUse          = 1,
+          mplsTunnelRole               = head(1),
+         }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Nadeau, et al.               Standards Track                   [Page 13]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+         In mplsTunnelTable (protected LSP):
+
+         {
+          mplsTunnelIndex              = 1,
+                                 -- protected LSP tunnel index
+          mplsTunnelInstance           = 100,
+                                 -- specific instance protected
+          mplsTunnelIngressLSRId       = 192.0.2.1,
+          mplsTunnelEgressLSRId        = 192.0.2.5,
+          mplsTunnelName               = "R1-R5",
+          mplsTunnelDescr              = "R1-R5",
+          mplsTunnelIsIf               = false(2),
+          mplsTunnelXCPointer          = 0.0,
+          mplsTunnelSignallingProto    = none(1),
+          mplsTunnelSetupPrio          = 0,
+          mplsTunnelHoldingPrio        = 0,
+          mplsTunnelSessionAttributes  = 0,
+          mplsTunnelLocalProtectInUse  = true(1),
+          mplsTunnelResourcePointer    = mplsTunnelResourceMaxRate.6,
+          mplsTunnelInstancePriority   = 1,
+          mplsTunnelHopTableIndex      = 1,
+          mplsTunnelIncludeAnyAffinity = 0,
+          mplsTunnelIncludeAllAffinity = 0,
+          mplsTunnelExcludeAnyAffinity = 0,
+          mplsTunnelPathInUse          = 1,
+          mplsTunnelRole               = transit(2),
+         }
+
+5.  Handling IPv6 Tunnels
+
+   As described in [RFC4990], in order to support IPv6 MPLS tunnels in
+   the mplsTunnelTable [RFC3812], all LSRs in the network MUST have a
+   32-bit LSR ID that can be used to identify the LSR with the existing
+   mplsTunnelIngressLSRId and mplsTunnelEgressLSRId objects, which are
+   32 bits long.
+
+   In this MIB, the following objects, which refer to ingress/egress
+   LSRs, will therefore have the 32-bit LSR ID to support IPv6 tunnels:
+
+   -  mplsFrrOne2OnePlrTunnelIngressLSRId and
+      mplsFrrOne2OnePlrTunnelEgressLSRId objects of the
+      mplsFrrOne2OnePlrTable
+
+   -  mplsFrrOne2OnePlrTunnelIngressLSRId and
+      mplsFrrOne2OnePlrTunnelEgressLSRId objects of the
+      mplsFrrOne2OneDetourTable
+
+
+
+
+
+Nadeau, et al.               Standards Track                   [Page 14]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+   -  mplsFrrFacilityBackupTunnelIngressLSRId and
+      mplsFrrFacilityBackupTunnelEgressLSRId objects of the
+      mplsFrrFacilityDBTable
+
+6.  MIB Module Definitions
+
+6.1.  MPLS-FRR-GENERAL-STD-MIB Module Definitions
+
+   -- Start of MPLS-FRR-GENERAL-STD-MIB
+
+   MPLS-FRR-GENERAL-STD-MIB DEFINITIONS ::= BEGIN
+
+    IMPORTS
+       MODULE-IDENTITY, OBJECT-TYPE, mib-2,
+       Unsigned32,
+       Counter32
+          FROM SNMPv2-SMI                            -- [RFC2578]
+       MODULE-COMPLIANCE, OBJECT-GROUP
+          FROM SNMPv2-CONF                           -- [RFC2580]
+       RowStatus, StorageType
+          FROM SNMPv2-TC                             -- [RFC2579]
+       InterfaceIndexOrZero,
+       ifGeneralInformationGroup,
+       ifCounterDiscontinuityGroup
+
+          FROM IF-MIB                                -- [RFC2863]
+       MplsTunnelIndex, MplsTunnelInstanceIndex,
+       MplsBitRate,
+       MplsTunnelAffinity
+          FROM MPLS-TC-STD-MIB                       -- [RFC3811]
+       mplsTunnelGroup, mplsTunnelScalarGroup,
+       mplsTunnelARHopListIndex, mplsTunnelARHopIndex
+          FROM MPLS-TE-STD-MIB                       -- [RFC3812]
+       ;
+
+    mplsFrrGeneralMIB MODULE-IDENTITY
+       LAST-UPDATED
+          "201111030000Z" -- 03 Nov 2011 00:00:00 GMT
+       ORGANIZATION
+          "Multiprotocol Label Switching (MPLS) Working Group"
+       CONTACT-INFO
+            "
+                     Riza Cetin
+              Email: riza.cetin@alcatel.be
+
+                     Thomas D. Nadeau
+              Email: thomas.nadeau@ca.com
+
+
+
+
+Nadeau, et al.               Standards Track                   [Page 15]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+                     A S Kiran Koushik
+              Email: kkoushik@cisco.com
+
+                     Stefaan De Cnodder
+              Email: Stefaan.de_cnodder@alcatel.be
+
+                     Der-Hwa Gan
+              Email: dhg@juniper.net
+            "
+
+       DESCRIPTION
+         "Copyright (c) 2011 IETF Trust and the persons
+          identified as authors of the code.  All rights
+          reserved.
+
+          Redistribution and use in source and binary forms,
+          with or without modification, is permitted pursuant
+          to, and subject to the license terms contained in,
+          the Simplified BSD License set forth in Section 4.c
+          of the IETF Trust's Legal Provisions Relating to
+          IETF Documents
+          (http://trustee.ietf.org/license-info).
+
+          This MIB module contains generic object definitions for
+          MPLS Traffic Engineering Fast Reroute as defined in
+          RFC 4090."
+
+    -- Revision history.
+       REVISION
+         "201111030000Z" -- 03 Nov 2011 00:00:00 GMT
+       DESCRIPTION
+         "Initial version.  Published as RFC 6445."
+       ::= { mib-2 202 }
+
+    -- Top-level components of this MIB module
+
+    mplsFrrGeneralObjects
+                OBJECT IDENTIFIER ::= { mplsFrrGeneralMIB 1 }
+
+    mplsFrrGeneralConformance
+                OBJECT IDENTIFIER ::= { mplsFrrGeneralMIB 2 }
+
+    -- MPLS Fast-Reroute generic scalars
+
+    mplsFrrGeneralProtectionMethod OBJECT-TYPE
+       SYNTAX        INTEGER {
+                               unknown(1),
+                               oneToOneBackup(2),
+
+
+
+Nadeau, et al.               Standards Track                   [Page 16]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+                               facilityBackup(3)
+                             }
+       MAX-ACCESS    read-write
+       STATUS        current
+       DESCRIPTION
+         "Indicates which protection method is to be used for fast
+          reroute on this device.  Some devices may require a reboot
+          if this variable is to take effect after being modified."
+       ::= { mplsFrrGeneralObjects 1 }
+
+    mplsFrrGeneralIngressTunnelInstances OBJECT-TYPE
+       SYNTAX        Counter32
+       MAX-ACCESS    read-only
+       STATUS        current
+       DESCRIPTION
+         "The number of tunnel instances for either detour LSPs or
+          bypass tunnels for which this LSR is the ingress."
+       ::= { mplsFrrGeneralObjects 2 }
+
+    --
+    -- General FRR Table section
+    --
+    -- These tables apply to both types of FRR
+    -- and should be implemented by all LSRs supporting
+    -- FRR.
+    --
+    -- MPLS Fast-Reroute Constraints table
+
+    mplsFrrGeneralConstraintsTable OBJECT-TYPE
+       SYNTAX        SEQUENCE OF MplsFrrGeneralConstraintsEntry
+       MAX-ACCESS    not-accessible
+       STATUS        current
+       DESCRIPTION
+         "This table shows detour LSP or bypass tunnel setup
+          constraints."
+       ::= {  mplsFrrGeneralObjects 3 }
+
+    mplsFrrGeneralConstraintsEntry OBJECT-TYPE
+       SYNTAX        MplsFrrGeneralConstraintsEntry
+       MAX-ACCESS    not-accessible
+       STATUS        current
+       DESCRIPTION
+         "An entry in this table represents detour LSP or bypass
+          tunnel setup constraints for an interface or link to be
+          protected by detour LSPs or a bypass tunnel.
+
+          Once the LSP or tunnel instance to be protected is identified
+          in the mplsTunnelTable, the corresponding mplsTunnelIfIndex
+
+
+
+Nadeau, et al.               Standards Track                   [Page 17]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+          value of that tunnel can be used to get the ifIndex of
+          the underlying physical interface using the ifStackTable.
+          That ifIndex of the underlying physical interface will
+          be used as mplsFrrGeneralConstraintsIfIndexOrZero in this
+          table to protect the LSPs or tunnel instances determined
+          earlier.
+
+          It is recommended that ifIndex persistence be enabled
+          across re-initializations.  If persistence is not
+          implemented, then the value of
+          mplsFrrGeneralConstraintsIfIndexOrZero in this
+          table cannot be guaranteed across restarts and all entries
+          in this table MUST NOT be persistent, or the values of
+          mplsFrrGeneralConstraintsIfIndexOrZero MUST be reconstructed
+          on restart.
+
+          SNMP engines must only allow entries in this table
+          to be created for tunnel instances that require fast reroute
+          as indicated by the presence of the FAST_REROUTE object
+          in the signaling for the LSP in question.
+
+          An entry in this table can be created only if a
+          corresponding entry in mplsTunnelTable exists with the
+          same mplsTunnelIndex as mplsFrrGeneralConstraintsTunnelIndex.
+
+          Entries in this table are deleted when the corresponding
+          entries in mplsTunnelTable are deleted.
+
+          It is recommended that entries in this table be persistent
+          across reboots.
+
+          Entries indexed with mplsFrrGeneralConstraintsIfIndexOrZero
+          and set to 0 apply to all interfaces on this device for
+          which the FRR feature can operate.
+
+          If the mplsTunnelInstance object is set to a value of 0,
+          it indicates that the mplsTunnelEntry contains a tunnel
+          ingress.  This is typically how configuration of this
+          feature is performed on devices where the actual
+          protection LSP used is left up to the protecting tunnel.
+          However, in cases where static configuration is
+          possible, any valid tunnel instance is possible;
+          however, it is strongly RECOMMENDED that the instance
+          index SHOULD use the following convention to identify
+          backup LSPs:
+
+          - lower 16 bits : protected tunnel instance
+          - higher 16 bits: must be all zeros"
+
+
+
+Nadeau, et al.               Standards Track                   [Page 18]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+       REFERENCE
+         "Section 4.1 of RFC 4090 and Section 6.1 of RFC 3812."
+       INDEX { mplsFrrGeneralConstraintsIfIndexOrZero,
+               mplsFrrGeneralConstraintsTunnelIndex,
+               mplsFrrGeneralConstraintsTunnelInstance
+             }
+       ::= { mplsFrrGeneralConstraintsTable 1 }
+
+    MplsFrrGeneralConstraintsEntry ::= SEQUENCE {
+       mplsFrrGeneralConstraintsIfIndexOrZero   InterfaceIndexOrZero,
+       mplsFrrGeneralConstraintsTunnelIndex     MplsTunnelIndex,
+       mplsFrrGeneralConstraintsTunnelInstance  MplsTunnelInstanceIndex,
+       mplsFrrGeneralConstraintsProtectionType  INTEGER,
+       mplsFrrGeneralConstraintsSetupPrio       Unsigned32,
+       mplsFrrGeneralConstraintsHoldingPrio     Unsigned32,
+       mplsFrrGeneralConstraintsInclAnyAffinity MplsTunnelAffinity,
+       mplsFrrGeneralConstraintsInclAllAffinity MplsTunnelAffinity,
+       mplsFrrGeneralConstraintsExclAnyAffinity MplsTunnelAffinity,
+       mplsFrrGeneralConstraintsHopLimit        Unsigned32,
+       mplsFrrGeneralConstraintsBandwidth       MplsBitRate,
+       mplsFrrGeneralConstraintsStorageType     StorageType,
+       mplsFrrGeneralConstraintsRowStatus       RowStatus
+    }
+
+    mplsFrrGeneralConstraintsIfIndexOrZero  OBJECT-TYPE
+       SYNTAX        InterfaceIndexOrZero
+       MAX-ACCESS    not-accessible
+       STATUS        current
+       DESCRIPTION
+         "Uniquely identifies an interface that a fast-reroute
+          protection tunnel is configured to potentially protect
+          in the event of a fault.  Entries with this index set to
+          0 indicate that the configured protection tunnel protects
+          all interfaces on this device (i.e., node protection)."
+       ::= { mplsFrrGeneralConstraintsEntry 1 }
+
+    mplsFrrGeneralConstraintsTunnelIndex OBJECT-TYPE
+       SYNTAX        MplsTunnelIndex
+       MAX-ACCESS    not-accessible
+       STATUS        current
+       DESCRIPTION
+         "Uniquely identifies a tunnel in the mplsTunnelTable that
+          is configured to possibly protect the interface(s) specified
+          by mplsFrrGeneralConstraintsIfIndexOrZero in the event of a
+          fault."
+       REFERENCE
+         "mplsTunnelTable from RFC 3812."
+       ::= { mplsFrrGeneralConstraintsEntry 2 }
+
+
+
+Nadeau, et al.               Standards Track                   [Page 19]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+    mplsFrrGeneralConstraintsTunnelInstance OBJECT-TYPE
+       SYNTAX        MplsTunnelInstanceIndex
+       MAX-ACCESS    not-accessible
+       STATUS        current
+       DESCRIPTION
+         "Uniquely identifies an existing instance of this tunnel
+          for which fast reroute is requested.  Note that a value of
+          0 indicates that the configuration points at a tunnel
+          head (as specified in RFC 3812).  This is typically how
+          configuration of this feature is performed on devices
+          where the actual protection LSP used is left up to the
+          protecting tunnel.  However, in cases where static
+          configuration is possible, any valid tunnel instance is
+          permissible.  In these cases, it is recommended that the
+          instance index follow the following convention so as
+          to make identification of backup LSPs easier:
+
+          - lower 16 bits : protected tunnel instance
+          - higher 16 bits: must be all zeros"
+       ::= { mplsFrrGeneralConstraintsEntry 3 }
+
+    mplsFrrGeneralConstraintsProtectionType OBJECT-TYPE
+       SYNTAX        INTEGER { linkProtection(1),
+                               nodeProtection(2)
+                             }
+       MAX-ACCESS    read-create
+       STATUS        current
+       DESCRIPTION
+         "Indicates type of the resource protection:
+
+          linkProtection(1) indicates that this tunnel is
+          set up to protect a particular link's resources.
+
+          nodeProtection(2) indicates that this tunnel is
+          set up to protect an entire node from failure."
+       REFERENCE
+         "Section 3 of RFC 4090."
+       DEFVAL { nodeProtection }
+       ::= { mplsFrrGeneralConstraintsEntry 4 }
+
+    mplsFrrGeneralConstraintsSetupPrio OBJECT-TYPE
+       SYNTAX        Unsigned32 (0..7)
+       MAX-ACCESS    read-create
+       STATUS        current
+       DESCRIPTION
+         "Indicates the setup priority of the detour LSP
+          or bypass tunnel."
+
+
+
+
+Nadeau, et al.               Standards Track                   [Page 20]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+       REFERENCE
+         "Section 4.7 of RFC 3209."
+       DEFVAL { 7 }
+       ::= { mplsFrrGeneralConstraintsEntry 5 }
+
+    mplsFrrGeneralConstraintsHoldingPrio OBJECT-TYPE
+       SYNTAX        Unsigned32 (0..7)
+       MAX-ACCESS    read-create
+       STATUS        current
+       DESCRIPTION
+         "Indicates the holding priority for the detour LSP
+          or bypass tunnel."
+       REFERENCE
+         "Section 4.7 of RFC 3209."
+       DEFVAL { 0 }
+       ::= { mplsFrrGeneralConstraintsEntry 6 }
+
+    mplsFrrGeneralConstraintsInclAnyAffinity OBJECT-TYPE
+       SYNTAX        MplsTunnelAffinity
+       MAX-ACCESS    read-create
+       STATUS        current
+       DESCRIPTION
+         "Indicates the include-any link constraint for the
+          detour LSP or bypass tunnel.  A link satisfies the
+          include-any constraint if and only if the constraint
+          is zero, or the link and the constraint have a
+          resource class in common."
+       REFERENCE
+         "Section 4.7 of RFC 3209."
+       DEFVAL { 0 }
+       ::= { mplsFrrGeneralConstraintsEntry 7 }
+
+    mplsFrrGeneralConstraintsInclAllAffinity OBJECT-TYPE
+       SYNTAX        MplsTunnelAffinity
+       MAX-ACCESS    read-create
+       STATUS        current
+       DESCRIPTION
+         "Indicates the include-all link constraint for the
+          detour LSP or bypass tunnel.  A link satisfies the
+          include-all constraint if and only if the link contains
+          all of the administrative groups specified in the
+          constraint."
+       REFERENCE
+         "Section 4.7 of RFC 3209."
+       DEFVAL { 0 }
+       ::= { mplsFrrGeneralConstraintsEntry 8 }
+
+
+
+
+
+Nadeau, et al.               Standards Track                   [Page 21]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+    mplsFrrGeneralConstraintsExclAnyAffinity OBJECT-TYPE
+       SYNTAX        MplsTunnelAffinity
+       MAX-ACCESS    read-create
+       STATUS        current
+       DESCRIPTION
+         "Indicates the exclude-any link constraint for the
+          detour LSP or bypass tunnel.  A link satisfies the
+          exclude-any constraint if and only if the link contains
+          none of the administrative groups specified in the
+          constraint."
+       REFERENCE
+         "Section 4.7 of RFC 3209."
+       DEFVAL { 0 }
+       ::= { mplsFrrGeneralConstraintsEntry 9 }
+
+    mplsFrrGeneralConstraintsHopLimit OBJECT-TYPE
+       SYNTAX        Unsigned32(0..255)
+       MAX-ACCESS    read-create
+       STATUS        current
+       DESCRIPTION
+         "The maximum number of hops that the detour LSP or
+          bypass tunnel may traverse."
+       REFERENCE
+         "Section 4.1 of RFC 4090."
+       DEFVAL { 32 }
+       ::= { mplsFrrGeneralConstraintsEntry 10 }
+
+    mplsFrrGeneralConstraintsBandwidth OBJECT-TYPE
+       SYNTAX        MplsBitRate
+       UNITS         "kilobits per second"
+       MAX-ACCESS    read-create
+       STATUS        current
+       DESCRIPTION
+         "The maximum bandwidth specifically reserved for a detour
+          LSP or bypass tunnel, in units of thousands of bits
+          per second (kbps).  Note that setting this value to 0
+          indicates best-effort treatment."
+       DEFVAL { 0 }
+       ::= { mplsFrrGeneralConstraintsEntry 11 }
+
+    mplsFrrGeneralConstraintsStorageType OBJECT-TYPE
+       SYNTAX        StorageType
+       MAX-ACCESS    read-create
+       STATUS        current
+       DESCRIPTION
+         "The storage type for this configuration entry.
+          Conceptual rows having the value 'permanent'
+          need not allow write access to any columnar
+
+
+
+Nadeau, et al.               Standards Track                   [Page 22]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+          objects in the row."
+       DEFVAL { volatile }
+       ::= { mplsFrrGeneralConstraintsEntry 12 }
+
+    mplsFrrGeneralConstraintsRowStatus OBJECT-TYPE
+       SYNTAX        RowStatus
+       MAX-ACCESS    read-create
+       STATUS        current
+       DESCRIPTION
+         "This object is used to create, modify, and/or delete a row
+          in this table.  When a row in this table is in active(1)
+          state, no objects in that row can be modified
+          except mplsFrrGeneralConstraintsRowStatus and
+          mplsFrrGeneralConstraintsStorageType."
+       ::= { mplsFrrGeneralConstraintsEntry 13 }
+
+    -- MPLS Fast-Reroute Tunnel Actual Route Hop table
+
+    mplsFrrGeneralTunnelARHopTable OBJECT-TYPE
+       SYNTAX             SEQUENCE OF MplsFrrGeneralTunnelARHopEntry
+       MAX-ACCESS         not-accessible
+       STATUS             current
+       DESCRIPTION
+         "This table sparsely extends mplsTunnelARHopTable defined
+          in the MPLS-TE-STD-MIB module with fast-reroute objects.
+          These objects specify the status of local protection,
+          including availability and active use, on a per-hop basis,
+          of hops traversed by a protected tunnel."
+       ::= {  mplsFrrGeneralObjects 4 }
+
+    mplsFrrGeneralTunnelARHopEntry  OBJECT-TYPE
+       SYNTAX             MplsFrrGeneralTunnelARHopEntry
+       MAX-ACCESS         not-accessible
+       STATUS             current
+       DESCRIPTION
+         "This entry contains fast-reroute protection status of a
+          single protected tunnel hop."
+       INDEX {
+         mplsTunnelARHopListIndex,
+         mplsTunnelARHopIndex
+       }
+       ::= { mplsFrrGeneralTunnelARHopTable 1 }
+
+    MplsFrrGeneralTunnelARHopEntry    ::= SEQUENCE {
+        mplsFrrGeneralTunnelARHopSessionAttributeFlags   BITS,
+        mplsFrrGeneralTunnelARHopRROSubObjectFlags       BITS
+    }
+
+
+
+
+Nadeau, et al.               Standards Track                   [Page 23]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+    mplsFrrGeneralTunnelARHopSessionAttributeFlags  OBJECT-TYPE
+       SYNTAX            BITS { arHopSessionAttrFlagsUnsupported(0),
+                                localProtectionDesired(1),
+                                labelRecordingDesired(2),
+                                sestyleDesired(3),
+                                bandwidthProtectionDesired(4),
+                                nodeProtectionDesired(5)
+                              }
+       MAX-ACCESS                   read-only
+       STATUS                       current
+       DESCRIPTION
+         "This object indicates the desired values for the
+          associated SESSION_ATTRIBUTE flags.  Note that since
+          this object is a BITS type, the bits may be set to
+          indicate various desired combinations of the
+          SESSION_ATTRIBUTE flags.
+
+          If SESSION_ATTRIBUTE flags are not supported, then this
+          object contains the value of
+          arHopSessionAttrFlagsUnsupported(0)."
+       REFERENCE
+         "See Section 4.3 of RFC 4090 for SESSION_ATTRIBUTE flags."
+       ::= { mplsFrrGeneralTunnelARHopEntry 1 }
+
+    mplsFrrGeneralTunnelARHopRROSubObjectFlags OBJECT-TYPE
+       SYNTAX             BITS { arHopRROSubObjectFlagsUnsupported(0),
+                                 localProtectionAvailable(1),
+                                 localProtectionInUse(2),
+                                 bandwidthProtection(3),
+                                 nodeProtection(4)
+                               }
+       MAX-ACCESS                   read-only
+       STATUS                       current
+       DESCRIPTION
+         "This object indicates the flags that are currently
+          in use by the associated Record Route Object (RRO)
+          sub-object.
+
+          Note that since this object is a BITS type,
+          the bits may be set to indicate various combinations of
+          the flags.
+
+          If the RRO sub-object is not supported, then this object
+          contains the value of arHopRROSubObjectFlagsUnsupported(0)."
+       REFERENCE
+          "Section 4.4 of RFC 4090."
+       ::= { mplsFrrGeneralTunnelARHopEntry 2 }
+
+
+
+
+Nadeau, et al.               Standards Track                   [Page 24]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+    -- Notifications
+
+    -- Module Conformance Statement
+
+    mplsFrrGeneralCompliances
+       OBJECT IDENTIFIER ::= {mplsFrrGeneralConformance 1 }
+
+    mplsFrrGeneralGroups
+       OBJECT IDENTIFIER ::= {mplsFrrGeneralConformance 2 }
+
+    mplsFrrGeneralModuleFullCompliance MODULE-COMPLIANCE
+       STATUS current
+       DESCRIPTION
+         "Compliance statements for SNMP engines that support the
+          MPLS-FRR-GENERAL-STD-MIB module."
+
+      MODULE IF-MIB -- The Interfaces Group MIB module, RFC 2863.
+         MANDATORY-GROUPS {
+            ifGeneralInformationGroup,
+            ifCounterDiscontinuityGroup
+         }
+
+      MODULE MPLS-TE-STD-MIB  -- The MPLS Traffic Engineering
+                              -- MIB module, RFC 3812
+         MANDATORY-GROUPS {
+            mplsTunnelGroup,
+            mplsTunnelScalarGroup
+         }
+
+       MODULE -- this module
+           MANDATORY-GROUPS {
+                             mplsFrrGeneralScalarGroup,
+                             mplsFrrGeneralTunnelARHopGroup,
+                             mplsFrrGeneralConstraintsGroup
+                            }
+
+       OBJECT       mplsFrrGeneralConstraintsRowStatus
+       SYNTAX       RowStatus { active(1), notInService(2) }
+       WRITE-SYNTAX RowStatus { active(1), notInService(2),
+                                createAndGo(4), destroy(6)
+                              }
+       DESCRIPTION
+         "Support for createAndWait and notReady is not required."
+
+       ::= { mplsFrrGeneralCompliances 1 }
+
+    mplsFrrGeneralModuleReadOnlyCompliance MODULE-COMPLIANCE
+       STATUS current
+
+
+
+Nadeau, et al.               Standards Track                   [Page 25]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+       DESCRIPTION
+         "Compliance statements for SNMP engines that support the
+          MPLS-FRR-GENERAL-STD-MIB module."
+       MODULE
+
+           MANDATORY-GROUPS {
+                             mplsFrrGeneralScalarGroup,
+                             mplsFrrGeneralTunnelARHopGroup,
+                             mplsFrrGeneralConstraintsGroup
+                            }
+
+       -- Scalars
+
+       OBJECT        mplsFrrGeneralProtectionMethod
+       MIN-ACCESS    read-only
+       DESCRIPTION
+         "Write access is not required."
+
+       -- mplsFrrGeneralConstraintsTable
+
+       OBJECT        mplsFrrGeneralConstraintsSetupPrio
+       MIN-ACCESS    read-only
+       DESCRIPTION
+         "Write access is not required."
+
+       OBJECT        mplsFrrGeneralConstraintsHoldingPrio
+       MIN-ACCESS    read-only
+       DESCRIPTION
+         "Write access is not required."
+
+       OBJECT        mplsFrrGeneralConstraintsInclAnyAffinity
+       MIN-ACCESS    read-only
+       DESCRIPTION
+         "Write access is not required."
+
+       OBJECT        mplsFrrGeneralConstraintsInclAllAffinity
+       MIN-ACCESS    read-only
+       DESCRIPTION
+         "Write access is not required."
+
+       OBJECT        mplsFrrGeneralConstraintsExclAnyAffinity
+       MIN-ACCESS    read-only
+       DESCRIPTION
+         "Write access is not required."
+
+
+
+
+
+
+
+Nadeau, et al.               Standards Track                   [Page 26]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+       OBJECT        mplsFrrGeneralConstraintsBandwidth
+       MIN-ACCESS    read-only
+       DESCRIPTION
+         "Write access is not required."
+
+       OBJECT        mplsFrrGeneralConstraintsProtectionType
+       MIN-ACCESS    read-only
+       DESCRIPTION
+         "Write access is not required."
+
+       OBJECT        mplsFrrGeneralConstraintsHopLimit
+       MIN-ACCESS    read-only
+       DESCRIPTION
+         "Write access is not required."
+
+       OBJECT        mplsFrrGeneralConstraintsStorageType
+       MIN-ACCESS    read-only
+       DESCRIPTION
+         "Write access is not required."
+
+       OBJECT        mplsFrrGeneralConstraintsRowStatus
+       SYNTAX        RowStatus { active(1) }
+       MIN-ACCESS    read-only
+       DESCRIPTION
+         "Write access is not required."
+
+       ::= { mplsFrrGeneralCompliances 2 }
+
+    -- Units of conformance
+
+    mplsFrrGeneralScalarGroup OBJECT-GROUP
+       OBJECTS {
+                mplsFrrGeneralIngressTunnelInstances,
+                mplsFrrGeneralProtectionMethod
+               }
+       STATUS        current
+       DESCRIPTION
+         "Objects that are required to display general fast-reroute
+          information."
+       ::= { mplsFrrGeneralGroups 1 }
+
+    mplsFrrGeneralConstraintsGroup OBJECT-GROUP
+       OBJECTS {
+          mplsFrrGeneralConstraintsProtectionType,
+          mplsFrrGeneralConstraintsSetupPrio,
+          mplsFrrGeneralConstraintsHoldingPrio,
+          mplsFrrGeneralConstraintsInclAnyAffinity,
+          mplsFrrGeneralConstraintsInclAllAffinity,
+
+
+
+Nadeau, et al.               Standards Track                   [Page 27]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+          mplsFrrGeneralConstraintsExclAnyAffinity,
+          mplsFrrGeneralConstraintsHopLimit,
+          mplsFrrGeneralConstraintsBandwidth,
+          mplsFrrGeneralConstraintsStorageType,
+          mplsFrrGeneralConstraintsRowStatus
+       }
+
+       STATUS        current
+       DESCRIPTION
+         "Objects that are required to configure fast-reroute
+          constraints at the ingress LSR of the tunnel that
+          requires fast-reroute service."
+       ::= { mplsFrrGeneralGroups 2 }
+
+    mplsFrrGeneralTunnelARHopGroup         OBJECT-GROUP
+       OBJECTS {
+                 mplsFrrGeneralTunnelARHopSessionAttributeFlags,
+                 mplsFrrGeneralTunnelARHopRROSubObjectFlags
+               }
+       STATUS        current
+       DESCRIPTION
+         "Objects that are required to present per-hop fast-reroute
+          protection status."
+       ::= { mplsFrrGeneralGroups 3}
+
+   END
+
+   -- End of MPLS-FRR-GENERAL-STD-MIB
+
+6.2.  MPLS-FRR-ONE2ONE-STD-MIB Module Definitions
+
+   -- Start of MPLS-FRR-ONE2ONE-STD-MIB
+
+   MPLS-FRR-ONE2ONE-STD-MIB DEFINITIONS ::= BEGIN
+
+    IMPORTS
+       MODULE-IDENTITY, OBJECT-TYPE, mib-2,
+       Integer32, Gauge32
+          FROM SNMPv2-SMI                            -- [RFC2578]
+       MODULE-COMPLIANCE, OBJECT-GROUP
+          FROM SNMPv2-CONF                           -- [RFC2580]
+       TruthValue
+          FROM SNMPv2-TC                             -- [RFC2579]
+       MplsTunnelIndex, MplsTunnelInstanceIndex,
+       MplsLsrIdentifier
+          FROM MPLS-TC-STD-MIB                       -- [RFC3811]
+       InetAddressType, InetAddress
+
+
+
+
+Nadeau, et al.               Standards Track                   [Page 28]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+          FROM INET-ADDRESS-MIB                      -- [RFC4001]
+       mplsFrrGeneralScalarGroup, mplsFrrGeneralTunnelARHopGroup,
+       mplsFrrGeneralConstraintsGroup
+          FROM MPLS-FRR-GENERAL-STD-MIB
+       ;
+
+    mplsFrrOne2OneMIB MODULE-IDENTITY
+       LAST-UPDATED
+          "201111030000Z" -- 03 Nov 2011 00:00:00 GMT
+       ORGANIZATION
+          "Multiprotocol Label Switching (MPLS) Working Group"
+       CONTACT-INFO
+            "
+                     Riza Cetin
+              Email: riza.cetin@alcatel.be
+
+                     Thomas D. Nadeau
+              Email: thomas.nadeau@ca.com
+
+                     A S Kiran Koushik
+              Email: kkoushik@cisco.com
+
+                     Stefaan De Cnodder
+              Email: Stefaan.de_cnodder@alcatel.be
+
+                     Der-Hwa Gan
+              Email: dhg@juniper.net
+            "
+       DESCRIPTION
+         "Copyright (c) 2011 IETF Trust and the persons
+          identified as authors of the code.  All rights
+          reserved.
+
+          Redistribution and use in source and binary forms,
+          with or without modification, is permitted pursuant
+          to, and subject to the license terms contained in,
+          the Simplified BSD License set forth in Section 4.c
+          of the IETF Trust's Legal Provisions Relating to
+          IETF Documents
+          (http://trustee.ietf.org/license-info).
+
+          This MIB module contains object definitions for the
+          MPLS Traffic Engineering one-to-one backup method for
+          Fast Reroute as defined in RFC 4090."
+
+    -- Revision history.
+       REVISION
+         "201111030000Z" -- 03 Nov 2011 00:00:00 GMT
+
+
+
+Nadeau, et al.               Standards Track                   [Page 29]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+       DESCRIPTION
+         "Initial version.  Published as RFC 6445."
+       ::= { mib-2 203 }
+
+    -- Top-level components of this MIB module
+
+    mplsFrrOne2OneObjects OBJECT IDENTIFIER
+                            ::= { mplsFrrOne2OneMIB 1 }
+    mplsFrrOne2OneConformance   OBJECT IDENTIFIER
+                            ::= { mplsFrrOne2OneMIB 2 }
+
+    -- Scalar objects defined for the one-to-one style of FRR
+
+    mplsFrrIncomingDetourLSPs OBJECT-TYPE
+       SYNTAX        Integer32 (0..2147483647)
+       MAX-ACCESS    read-only
+       STATUS        current
+       DESCRIPTION
+         "The number of detour LSPs entering the device."
+       ::= { mplsFrrOne2OneObjects 1 }
+
+    mplsFrrOutgoingDetourLSPs OBJECT-TYPE
+       SYNTAX        Integer32 (0..2147483647)
+       MAX-ACCESS    read-only
+       STATUS        current
+       DESCRIPTION
+         "The number of detour LSPs leaving the device."
+       ::= { mplsFrrOne2OneObjects 2 }
+
+    mplsFrrOne2OneDetourOriginating OBJECT-TYPE
+       SYNTAX        Integer32(0..2147483647)
+       MAX-ACCESS    read-only
+       STATUS        current
+       DESCRIPTION
+         "The number of detour LSPs originating at this PLR."
+       ::= { mplsFrrOne2OneObjects 3 }
+
+    mplsFrrActiveProtectedLSPs OBJECT-TYPE
+       SYNTAX        Gauge32
+       MAX-ACCESS    read-only
+       STATUS        current
+       DESCRIPTION
+         "Indicates the number of LSPs currently protected by
+          the FRR feature where this device acts as the PLR
+          for those LSPs."
+       ::= { mplsFrrOne2OneObjects 4 }
+
+    --
+
+
+
+Nadeau, et al.               Standards Track                   [Page 30]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+    -- One-to-One specific tables
+    --
+    -- Tables in this section pertain only to the one-to-one
+    -- style of FRR.
+    --
+
+    -- MPLS Fast-Reroute Point of Local Repair table
+
+    mplsFrrOne2OnePlrTable  OBJECT-TYPE
+       SYNTAX        SEQUENCE OF MplsFrrOne2OnePlrEntry
+       MAX-ACCESS    not-accessible
+       STATUS        current
+       DESCRIPTION
+         "This table shows a list of protected TE tunnels with
+          the corresponding protecting tunnel, as well as the PLR
+          where the protecting tunnel that initiated the detour
+          LSPs traverses this node."
+       ::= { mplsFrrOne2OneObjects 5 }
+
+    mplsFrrOne2OnePlrEntry  OBJECT-TYPE
+       SYNTAX        MplsFrrOne2OnePlrEntry
+       MAX-ACCESS    not-accessible
+       STATUS        current
+       DESCRIPTION
+         "An entry in this table represents a protected tunnel LSP
+          together with its detour tunnel instance.  An entry in
+          this table is only created by an SNMP engine as instructed
+          by an MPLS signaling protocol.
+
+          The entries of this table are present in all LSRs on the
+          path of the detour LSP.
+
+          The objects mplsFrrOne2OnePlrSenderAddrType and
+          mplsFrrOne2OnePlrSenderAddr can be modified after the row
+          is created.
+
+          The objects mplsFrrOne2OnePlrTunnelIndex,
+          mplsFrrOne2OnePlrTunnelDetourInstance,
+          mplsFrrOne2OnePlrTunnelIngressLSRId,
+          and mplsFrrOne2OnePlrTunnelEgressLSRId have the same
+          values as the objects mplsTunnelIndex, mplsTunnelInstance,
+          mplsTunnelIngressLSRId, and mplsTunnelEgressLSRId of the
+          detour tunnel instance created in the mplsTunnelTable
+          (MPLS-TE-STD-MIB).
+
+          The entries in this table will be deleted when the
+          corresponding entries in the mplsTunnelTable are deleted."
+       INDEX { mplsFrrOne2OnePlrTunnelIndex,     -- from MPLS-TE-STD-MIB
+
+
+
+Nadeau, et al.               Standards Track                   [Page 31]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+               mplsFrrOne2OnePlrTunnelDetourInstance,-- mplsTunnelTable
+               mplsFrrOne2OnePlrTunnelIngressLSRId,-- Tunnels must exist
+               mplsFrrOne2OnePlrTunnelEgressLSRId,  -- a priori
+               mplsFrrOne2OnePlrId    }
+       ::= { mplsFrrOne2OnePlrTable 1 }
+
+    MplsFrrOne2OnePlrEntry ::= SEQUENCE {
+        mplsFrrOne2OnePlrTunnelIndex           MplsTunnelIndex,
+        mplsFrrOne2OnePlrTunnelDetourInstance  MplsTunnelInstanceIndex,
+        mplsFrrOne2OnePlrTunnelIngressLSRId    MplsLsrIdentifier,
+        mplsFrrOne2OnePlrTunnelEgressLSRId     MplsLsrIdentifier,
+        mplsFrrOne2OnePlrId                    MplsLsrIdentifier,
+        mplsFrrOne2OnePlrSenderAddrType        InetAddressType,
+        mplsFrrOne2OnePlrSenderAddr            InetAddress,
+        mplsFrrOne2OnePlrAvoidNodeAddrType     InetAddressType,
+        mplsFrrOne2OnePlrAvoidNodeAddr         InetAddress
+    }
+
+    mplsFrrOne2OnePlrTunnelIndex OBJECT-TYPE
+       SYNTAX        MplsTunnelIndex
+       MAX-ACCESS    not-accessible
+       STATUS        current
+       DESCRIPTION
+         "Uniquely identifies a tunnel between a pair of LSRs
+          from the mplsTunnelEntry."
+       ::= { mplsFrrOne2OnePlrEntry 1 }
+
+    mplsFrrOne2OnePlrTunnelDetourInstance OBJECT-TYPE
+       SYNTAX        MplsTunnelInstanceIndex
+       MAX-ACCESS    not-accessible
+       STATUS        current
+       DESCRIPTION
+         "Uniquely identifies a detour instance of a tunnel from
+          the mplsTunnelEntry.
+
+         - lower 16 bits : protected tunnel instance
+         - higher 16 bits: detour instance"
+       ::= { mplsFrrOne2OnePlrEntry 2 }
+
+    mplsFrrOne2OnePlrTunnelIngressLSRId OBJECT-TYPE
+       SYNTAX        MplsLsrIdentifier
+       MAX-ACCESS    not-accessible
+       STATUS        current
+       DESCRIPTION
+         "The purpose of this object is to uniquely identify a
+          tunnel within a network.  When the MPLS signaling
+          protocol is rsvp(2), this object SHOULD contain the
+          same value as the Extended Tunnel ID field in the
+
+
+
+Nadeau, et al.               Standards Track                   [Page 32]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+          SESSION object.  When the MPLS signaling protocol
+          is crldp(3), this object SHOULD contain the same
+          value as the Ingress LSR Router ID field in the
+          LSPID TLV object.
+
+          This value represents the head-end of the protected
+          tunnel instance."
+       REFERENCE
+         "Section 4.7 of RFC 3209."
+       ::= { mplsFrrOne2OnePlrEntry 3 }
+
+    mplsFrrOne2OnePlrTunnelEgressLSRId OBJECT-TYPE
+       SYNTAX        MplsLsrIdentifier
+       MAX-ACCESS    not-accessible
+       STATUS        current
+       DESCRIPTION
+         "Specifies the egress LSR ID of the protected tunnel instance."
+       ::= { mplsFrrOne2OnePlrEntry 4 }
+
+    mplsFrrOne2OnePlrId OBJECT-TYPE
+       SYNTAX        MplsLsrIdentifier
+       MAX-ACCESS    not-accessible
+       STATUS        current
+       DESCRIPTION
+         "This value represents the PLR that has initiated a detour LSP
+          to protect a tunnel instance.
+
+          This value is signaled via the DETOUR object defined in
+          MPLS RSVP."
+       REFERENCE
+         "Section 4.2 of RFC 4090."
+       ::= { mplsFrrOne2OnePlrEntry 5 }
+
+    mplsFrrOne2OnePlrSenderAddrType OBJECT-TYPE
+       SYNTAX        InetAddressType
+       MAX-ACCESS    read-write
+       STATUS        current
+       DESCRIPTION
+         "Denotes the address type of this detour instance's sender
+          address."
+       DEFVAL        { ipv4 }
+       ::= { mplsFrrOne2OnePlrEntry 6 }
+
+    mplsFrrOne2OnePlrSenderAddr OBJECT-TYPE
+       SYNTAX        InetAddress
+       MAX-ACCESS    read-write
+       STATUS        current
+
+
+
+
+Nadeau, et al.               Standards Track                   [Page 33]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+       DESCRIPTION
+         "The IP address of the PLR that has initiated the detour LSP.
+          The type of this address is determined by the value of the
+          mplsFrrOne2OnePlrSenderAddrType object."
+       ::= { mplsFrrOne2OnePlrEntry 7 }
+
+    mplsFrrOne2OnePlrAvoidNodeAddrType OBJECT-TYPE
+       SYNTAX        InetAddressType
+       MAX-ACCESS    read-only
+       STATUS        current
+       DESCRIPTION
+         "Denotes the address type of the node that this PLR tries to
+          avoid."
+       DEFVAL        { ipv4 }
+       ::= { mplsFrrOne2OnePlrEntry 8 }
+
+    mplsFrrOne2OnePlrAvoidNodeAddr OBJECT-TYPE
+       SYNTAX        InetAddress
+       MAX-ACCESS    read-only
+       STATUS        current
+       DESCRIPTION
+         "The IP address of the node that this PLR tries to avoid.
+          The type of this address is determined by the value of the
+          mplsFrrOne2OnePlrAvoidNodeAddrType object.
+
+          This value is signaled via the DETOUR object defined in
+          MPLS RSVP."
+       REFERENCE
+         "Section 4.2 of RFC 4090."
+       ::= { mplsFrrOne2OnePlrEntry 9 }
+
+    -- MPLS One-to-One Fast-Reroute Detour table
+
+    mplsFrrOne2OneDetourTable OBJECT-TYPE
+       SYNTAX        SEQUENCE OF MplsFrrOne2OneDetourEntry
+       MAX-ACCESS    not-accessible
+       STATUS        current
+       DESCRIPTION
+         "This table shows detour LSPs."
+       ::= { mplsFrrOne2OneObjects 6 }
+
+    mplsFrrOne2OneDetourEntry OBJECT-TYPE
+       SYNTAX        MplsFrrOne2OneDetourEntry
+       MAX-ACCESS    not-accessible
+       STATUS        current
+       DESCRIPTION
+         "An entry in this table represents a detour.  An entry in this
+          table is only created by an SNMP engine as instructed by an
+
+
+
+Nadeau, et al.               Standards Track                   [Page 34]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+          MPLS signaling protocol."
+       INDEX {
+               mplsFrrOne2OnePlrTunnelIndex,     -- from MPLS-TE-STD-MIB
+               mplsFrrOne2OnePlrTunnelDetourInstance, -- mplsTunnelTable
+               mplsFrrOne2OnePlrTunnelIngressLSRId,-- Tunnels must exist
+               mplsFrrOne2OnePlrTunnelEgressLSRId    -- a priori
+          }
+       ::= { mplsFrrOne2OneDetourTable 1 }
+
+    MplsFrrOne2OneDetourEntry ::= SEQUENCE {
+          mplsFrrOne2OneDetourActive             TruthValue,
+          mplsFrrOne2OneDetourMergedStatus       INTEGER,
+          mplsFrrOne2OneDetourMergedDetourInst   MplsTunnelInstanceIndex
+    }
+
+    mplsFrrOne2OneDetourActive OBJECT-TYPE
+       SYNTAX        TruthValue
+       MAX-ACCESS    read-only
+       STATUS        current
+       DESCRIPTION
+         "Indicates whether or not the main LSP has switched over to
+          this detour LSP.
+
+          If the value of this object is 'true', then it means that
+          the main LSP has switched over to this detour LSP.  Otherwise,
+          it contains a value of 'false'.
+          This is only relevant for detours originated by this node."
+       ::= { mplsFrrOne2OneDetourEntry 1 }
+
+    mplsFrrOne2OneDetourMergedStatus OBJECT-TYPE
+       SYNTAX        INTEGER { notMerged(1),
+                               mergedWithProtectedTunnel(2),
+                               mergedWithDetour(3)
+                             }
+       MAX-ACCESS    read-only
+       STATUS        current
+       DESCRIPTION
+         "This value represents whether or not this detour is merged.
+          This value is set to notMerged(1) if this detour is not
+          merged.
+
+          This value is set to mergedWithProtectedTunnel(2) if
+          this detour is merged with the protected tunnel.  This value
+          is mergedWithDetour(3) if this detour is merged
+          with another detour protecting the same tunnel."
+       ::= { mplsFrrOne2OneDetourEntry 2 }
+
+
+
+
+
+Nadeau, et al.               Standards Track                   [Page 35]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+    mplsFrrOne2OneDetourMergedDetourInst OBJECT-TYPE
+       SYNTAX        MplsTunnelInstanceIndex
+       MAX-ACCESS    read-only
+       STATUS        current
+       DESCRIPTION
+         "This value represents the mplsTunnelInstance of the detour
+          with which this detour is merged.  This object is only valid
+          when mplsFrrOne2OneDetourMergedStatus is set to
+          mergedWithDetour(3).
+
+          - lower 16 bits : protected tunnel instance
+          - higher 16 bits: detour instance"
+       ::= { mplsFrrOne2OneDetourEntry 3 }
+
+    -- Module Conformance Statement
+
+    mplsFrrOne2OneCompliances
+       OBJECT IDENTIFIER ::= {mplsFrrOne2OneConformance 1 }
+
+    mplsFrrOne2OneGroups
+       OBJECT IDENTIFIER ::= {mplsFrrOne2OneConformance 2 }
+
+    mplsFrrOne2OneModuleFullCompliance MODULE-COMPLIANCE
+       STATUS current
+       DESCRIPTION
+         "Compliance statements for SNMP engines that support the
+          MPLS-FRR-ONE2ONE-STD-MIB module."
+
+      MODULE MPLS-FRR-GENERAL-STD-MIB -- MPLS FRR Generic MIB
+         MANDATORY-GROUPS {
+                             mplsFrrGeneralScalarGroup,
+                             mplsFrrGeneralTunnelARHopGroup,
+                             mplsFrrGeneralConstraintsGroup
+         }
+
+       MODULE -- this module
+           MANDATORY-GROUPS {
+                             mplsFrrOne2OneScalarsGroup,
+                             mplsFrrOne2OnePLRDetourGroup,
+                             mplsFrrOne2OnePlrGroup
+                            }
+
+       ::= { mplsFrrOne2OneCompliances 1 }
+
+    mplsFrrOne2OneModuleReadOnlyCompliance MODULE-COMPLIANCE
+       STATUS current
+       DESCRIPTION
+         "Compliance statements for SNMP engines that support the
+
+
+
+Nadeau, et al.               Standards Track                   [Page 36]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+          MPLS-FRR-ONE2ONE-STD-MIB module."
+       MODULE
+           MANDATORY-GROUPS {
+                             mplsFrrOne2OneScalarsGroup,
+                             mplsFrrOne2OnePLRDetourGroup,
+                             mplsFrrOne2OnePlrGroup
+                            }
+       -- mplsFrrOne2OnePlrTable
+
+       OBJECT        mplsFrrOne2OnePlrSenderAddrType
+       MIN-ACCESS    read-only
+       DESCRIPTION
+         "Write access is not required."
+
+       OBJECT        mplsFrrOne2OnePlrSenderAddr
+       MIN-ACCESS    read-only
+       DESCRIPTION
+         "Write access is not required."
+
+       ::= { mplsFrrOne2OneCompliances 2 }
+
+    -- Units of conformance
+
+    mplsFrrOne2OneScalarsGroup OBJECT-GROUP
+       OBJECTS {
+                mplsFrrIncomingDetourLSPs,
+                mplsFrrOutgoingDetourLSPs,
+                mplsFrrOne2OneDetourOriginating,
+                mplsFrrActiveProtectedLSPs
+               }
+       STATUS        current
+       DESCRIPTION
+         "Objects that are required for general One-to-One PLR
+          information."
+       ::= { mplsFrrOne2OneGroups 1 }
+
+    mplsFrrOne2OnePLRDetourGroup OBJECT-GROUP
+       OBJECTS {
+                mplsFrrOne2OneDetourActive,
+                mplsFrrOne2OneDetourMergedStatus,
+                mplsFrrOne2OneDetourMergedDetourInst
+               }
+       STATUS        current
+       DESCRIPTION
+         "Objects that are required to present the detour LSP
+          information at the detour ingress, transit, and egress
+          LSRs."
+       ::= { mplsFrrOne2OneGroups 2 }
+
+
+
+Nadeau, et al.               Standards Track                   [Page 37]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+    mplsFrrOne2OnePlrGroup OBJECT-GROUP
+       OBJECTS {
+           mplsFrrOne2OnePlrSenderAddrType,
+           mplsFrrOne2OnePlrSenderAddr,
+           mplsFrrOne2OnePlrAvoidNodeAddrType,
+           mplsFrrOne2OnePlrAvoidNodeAddr
+          }
+       STATUS        current
+       DESCRIPTION
+         "Objects that are required to represent the FRR
+          One-to-One PLR information."
+       ::= { mplsFrrOne2OneGroups 3 }
+
+   END
+
+   -- End of MPLS-FRR-ONE2ONE-STD-MIB
+
+6.3.  MPLS-FRR-FACILITY-STD-MIB Module Definitions
+
+   -- Start of MPLS-FRR-FACILITY-STD-MIB
+
+   MPLS-FRR-FACILITY-STD-MIB DEFINITIONS ::= BEGIN
+
+    IMPORTS
+       MODULE-IDENTITY, OBJECT-TYPE, mib-2,
+       Integer32,
+       NOTIFICATION-TYPE, Gauge32
+          FROM SNMPv2-SMI                            -- [RFC2578]
+       MODULE-COMPLIANCE, OBJECT-GROUP,
+       NOTIFICATION-GROUP
+          FROM SNMPv2-CONF                           -- [RFC2580]
+       TruthValue
+          FROM SNMPv2-TC                             -- [RFC2579]
+       InterfaceIndex
+          FROM IF-MIB                                -- [RFC2863]
+       MplsTunnelIndex, MplsTunnelInstanceIndex,
+       MplsLsrIdentifier, MplsBitRate
+          FROM MPLS-TC-STD-MIB                       -- [RFC3811]
+       mplsFrrGeneralScalarGroup, mplsFrrGeneralTunnelARHopGroup,
+       mplsFrrGeneralConstraintsGroup
+          FROM MPLS-FRR-GENERAL-STD-MIB
+       ;
+
+    mplsFrrFacilityMIB MODULE-IDENTITY
+       LAST-UPDATED
+          "201111030000Z" -- 03 Nov 2011 00:00:00 GMT
+       ORGANIZATION
+          "Multiprotocol Label Switching (MPLS) Working Group"
+
+
+
+Nadeau, et al.               Standards Track                   [Page 38]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+       CONTACT-INFO
+            "
+                     Riza Cetin
+              Email: riza.cetin@alcatel.be
+
+                     Thomas D. Nadeau
+              Email: thomas.nadeau@ca.com
+
+                     A S Kiran Koushik
+              Email: kkoushik@cisco.com
+
+                     Stefaan De Cnodder
+              Email: Stefaan.de_cnodder@alcatel.be
+
+                     Der-Hwa Gan
+              Email: dhg@juniper.net
+            "
+       DESCRIPTION
+         "Copyright (c) 2011 IETF Trust and the persons
+          identified as authors of the code.  All rights
+          reserved.
+
+          Redistribution and use in source and binary forms,
+          with or without modification, is permitted pursuant
+          to, and subject to the license terms contained in,
+          the Simplified BSD License set forth in Section 4.c
+          of the IETF Trust's Legal Provisions Relating to
+          IETF Documents
+          (http://trustee.ietf.org/license-info).
+
+          This MIB module contains object definitions for the
+          MPLS Traffic Engineering facility backup method for
+          Fast Reroute as defined in RFC 4090."
+
+    -- Revision history.
+       REVISION
+         "201111030000Z" -- 03 Nov 2011 00:00:00 GMT
+       DESCRIPTION
+         "Initial version.  Published as RFC 6445."
+       ::= { mib-2 204 }
+
+    -- Top-level components of this MIB module
+
+    mplsFrrFacilityNotifications         OBJECT IDENTIFIER
+                                    ::= { mplsFrrFacilityMIB 0 }
+
+    mplsFrrFacilityObjects               OBJECT IDENTIFIER
+                                    ::= { mplsFrrFacilityMIB 1 }
+
+
+
+Nadeau, et al.               Standards Track                   [Page 39]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+    mplsFrrFacilityConformance           OBJECT IDENTIFIER
+                                    ::= { mplsFrrFacilityMIB 2 }
+
+    -- Scalar objects defined for the facility backup style of FRR
+
+    mplsFrrConfiguredInterfaces OBJECT-TYPE
+       SYNTAX        Integer32(0..2147483647)
+       MAX-ACCESS    read-only
+       STATUS        current
+       DESCRIPTION
+         "Indicates the number of MPLS interfaces configured for
+          protection."
+       DEFVAL { 0 }
+       ::= { mplsFrrFacilityObjects 1 }
+
+    mplsFrrActiveInterfaces OBJECT-TYPE
+       SYNTAX        Gauge32
+       MAX-ACCESS    read-only
+       STATUS        current
+       DESCRIPTION
+         "Indicates the number of interfaces currently being
+          protected.  This value MUST be less than or equal
+          to mplsFrrConfiguredInterfaces."
+       DEFVAL { 0 }
+       ::= { mplsFrrFacilityObjects 2 }
+
+    mplsFrrConfiguredBypassTunnels OBJECT-TYPE
+       SYNTAX        Gauge32
+       MAX-ACCESS    read-only
+       STATUS        current
+       DESCRIPTION
+         "Indicates the number of bypass tunnels configured to
+          protect TE tunnels on this LSR."
+       DEFVAL { 0 }
+       ::= { mplsFrrFacilityObjects 3 }
+
+    mplsFrrActiveBypassTunnels OBJECT-TYPE
+       SYNTAX        Gauge32
+
+       MAX-ACCESS    read-only
+       STATUS        current
+       DESCRIPTION
+         "Indicates the number of bypass tunnels indicated in
+          mplsFrrConfiguredBypassTunnels whose operStatus
+          is up(1), indicating that they are currently protecting
+          TE tunnels on this LSR."
+       DEFVAL { 0 }
+       ::= { mplsFrrFacilityObjects 4 }
+
+
+
+Nadeau, et al.               Standards Track                   [Page 40]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+    mplsFrrFacilityNotificationsEnabled OBJECT-TYPE
+       SYNTAX            TruthValue
+       MAX-ACCESS        read-write
+       STATUS            current
+       DESCRIPTION
+         "Enables or disables FRR notifications defined in this
+          MIB module.  Notifications are disabled by default.
+
+          This object is needed to control the notifications
+          emitted by this implementation."
+       DEFVAL { false }
+       ::= { mplsFrrFacilityObjects 5 }
+
+    mplsFrrFacilityNotificationsMaxRate OBJECT-TYPE
+       SYNTAX       Gauge32
+       UNITS        "Notifications per Second"
+       MAX-ACCESS   read-write
+       STATUS       current
+       DESCRIPTION
+         "This variable indicates the maximum number of
+          notifications issued per second.  If events occur
+          more rapidly, the implementation may simply fail to
+          emit these notifications during that period, or may
+          queue them until an appropriate time.  In case the
+          implementation chooses to drop the events during
+          throttling instead of queuing them to be sent at a later
+          time, it is assumed that there will be no indication
+          that events are being thrown away.
+
+          A value of 0 means no throttling is applied and
+          events may be generated at the rate at which they occur."
+       DEFVAL       { 0 }
+       ::= { mplsFrrFacilityObjects 6 }
+
+    --
+    -- Facility-based FRR-specific tables
+    --
+    -- Tables in this section pertain only to the facility-based
+    -- style of FRR.
+    --
+
+     mplsFrrFacilityDBTable OBJECT-TYPE
+        SYNTAX            SEQUENCE OF MplsFrrFacilityDBEntry
+        MAX-ACCESS        not-accessible
+        STATUS            current
+        DESCRIPTION
+          "The mplsFrrFacilityDBTable provides information about the
+           fast-reroute database.  Each entry belongs to a protected
+
+
+
+Nadeau, et al.               Standards Track                   [Page 41]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+           interface, protecting backup tunnel, and protected tunnel.
+           MPLS interfaces defined on this node are protected by
+           backup tunnels and are indicated by the index
+           mplsFrrFacilityProtectedIfIndex.  If the interface index is
+           set to 0, this indicates that the remaining indexes apply
+           to all configured protected interfaces.
+
+           Note that all objects in this table are read-only, and
+           if new objects are added to this table, they should also
+           be read-only.
+
+           It is recommended that ifIndex persistence be enabled
+           across re-initializations.
+           If persistence is not implemented, then the value of
+           mplsFrrFacilityProtectedIfIndex in this
+           table cannot be guaranteed across restarts and all entries
+           in this table MUST NOT be persistent, or the values of
+           mplsFrrFacilityProtectedIfIndex MUST be reconstructed
+           on restart.
+
+           It is recommended that entries in this table be persistent
+           across reboots.
+
+           The protecting tunnel is indicated by the
+           index mplsFrrFacilityProtectingTunnelIndex and
+           represents a valid mplsTunnelEntry.  Note that the tunnel
+           instance index of the protecting tunnel may be set to 0,
+           which indicates the tunnel head interface for the
+           protecting tunnel, as per RFC 3812, but it may also be
+           defined using the following semantics:
+
+           - lower 16 bits : protected tunnel instance
+           - higher 16 bits: must be all zeros"
+       ::= { mplsFrrFacilityObjects 7 }
+
+    mplsFrrFacilityDBEntry OBJECT-TYPE
+       SYNTAX        MplsFrrFacilityDBEntry
+       MAX-ACCESS    not-accessible
+       STATUS        current
+       DESCRIPTION
+         "An entry in the mplsFrrFacilityDBTable represents a single
+          protected LSP, protected by a backup tunnel on a
+          specific protected interface, or if the interface
+          index is set to 0, on all interfaces.  Note that for
+          brevity, managers should consult the mplsTunnelTable
+          present in the MPLS-TE-STD-MIB module for
+          additional information about the protecting and protected
+          tunnels, and the ifEntry in the IF-MIB module
+
+
+
+Nadeau, et al.               Standards Track                   [Page 42]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+          for the protected interface."
+       INDEX {
+              mplsFrrFacilityProtectedIfIndex,   -- protected ifIndex
+              mplsFrrFacilityProtectingTunnelIndex,-- protecting TE tun
+              mplsFrrFacilityBackupTunnelIndex,    -- protected TE tun
+              mplsFrrFacilityBackupTunnelInstance, -- LSP
+              mplsFrrFacilityBackupTunnelIngressLSRId,
+              mplsFrrFacilityBackupTunnelEgressLSRId }
+       ::= { mplsFrrFacilityDBTable 1 }
+
+    MplsFrrFacilityDBEntry ::= SEQUENCE {
+       mplsFrrFacilityProtectedIfIndex          InterfaceIndex,
+       mplsFrrFacilityProtectingTunnelIndex     MplsTunnelIndex,
+       mplsFrrFacilityBackupTunnelIndex         MplsTunnelIndex,
+       mplsFrrFacilityBackupTunnelInstance      MplsTunnelInstanceIndex,
+       mplsFrrFacilityBackupTunnelIngressLSRId  MplsLsrIdentifier,
+       mplsFrrFacilityBackupTunnelEgressLSRId   MplsLsrIdentifier,
+       mplsFrrFacilityDBNumProtectingTunnelOnIf Gauge32,
+       mplsFrrFacilityDBNumProtectedLspOnIf     Gauge32,
+       mplsFrrFacilityDBNumProtectedTunnels     Gauge32,
+       mplsFrrFacilityDBProtectingTunnelStatus  INTEGER,
+       mplsFrrFacilityDBProtectingTunnelResvBw  MplsBitRate
+    }
+
+    mplsFrrFacilityProtectedIfIndex OBJECT-TYPE
+       SYNTAX        InterfaceIndex
+       MAX-ACCESS    not-accessible
+       STATUS        current
+       DESCRIPTION
+         "Uniquely identifies the interface configured for FRR
+          protection.  If this object is set to 0, this indicates
+          that the remaining indexing combinations for this row
+          apply to all interfaces on this device for which
+          the FRR feature can operate."
+       ::= { mplsFrrFacilityDBEntry 1 }
+
+    mplsFrrFacilityProtectingTunnelIndex OBJECT-TYPE
+       SYNTAX        MplsTunnelIndex
+       MAX-ACCESS    not-accessible
+       STATUS        current
+       DESCRIPTION
+         "Uniquely identifies the mplsTunnelEntry primary index for
+          the tunnel head interface designated to protect the
+          interface as specified in the mplsFrrFacilityProtectedIfIndex
+          (and all of the tunnels using this interface).  Note
+          that the corresponding mplsTunnelInstance MUST BE
+          0 as per the indexing convention stipulated."
+
+
+
+
+Nadeau, et al.               Standards Track                   [Page 43]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+       REFERENCE
+         "Section 6.1 of RFC 3812."
+       ::= { mplsFrrFacilityDBEntry 2 }
+
+    mplsFrrFacilityBackupTunnelIndex OBJECT-TYPE
+       SYNTAX        MplsTunnelIndex
+       MAX-ACCESS    not-accessible
+       STATUS        current
+       DESCRIPTION
+         "Uniquely identifies the mplsTunnelEntry primary index for
+          the TE tunnel LSP being protected on the
+          interface as specified by mplsFrrFacilityProtectedIfIndex."
+       ::= { mplsFrrFacilityDBEntry 3 }
+
+    mplsFrrFacilityBackupTunnelInstance OBJECT-TYPE
+       SYNTAX        MplsTunnelInstanceIndex
+       MAX-ACCESS    not-accessible
+       STATUS        current
+       DESCRIPTION
+         "Uniquely identifies the mplsTunnelEntry secondary index
+          for the TE tunnel LSP being protected on the
+          interface as specified by mplsFrrFacilityProtectedIfIndex."
+       ::= { mplsFrrFacilityDBEntry 4 }
+
+    mplsFrrFacilityBackupTunnelIngressLSRId OBJECT-TYPE
+       SYNTAX        MplsLsrIdentifier
+       MAX-ACCESS    not-accessible
+       STATUS        current
+       DESCRIPTION
+         "Uniquely identifies the mplsTunnelEntry third index
+          for the TE tunnel LSP being protected on the
+          interface as specified by mplsFrrFacilityProtectedIfIndex."
+       REFERENCE
+         "Section 6.1 of RFC 3812."
+       ::= { mplsFrrFacilityDBEntry 5 }
+
+    mplsFrrFacilityBackupTunnelEgressLSRId  OBJECT-TYPE
+       SYNTAX        MplsLsrIdentifier
+       MAX-ACCESS    not-accessible
+       STATUS        current
+       DESCRIPTION
+         "Uniquely identifies the mplsTunnelEntry fourth index
+          for the TE tunnel LSP being protected on the
+          interface as specified by mplsFrrFacilityProtectedIfIndex."
+       ::= { mplsFrrFacilityDBEntry 6 }
+
+
+
+
+
+
+Nadeau, et al.               Standards Track                   [Page 44]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+    mplsFrrFacilityDBNumProtectingTunnelOnIf OBJECT-TYPE
+       SYNTAX            Gauge32
+       MAX-ACCESS        read-only
+       STATUS            current
+       DESCRIPTION
+         "The number of backup tunnels protecting the
+          interface specified by mplsFrrFacilityProtectedIfIndex."
+       ::= { mplsFrrFacilityDBEntry 7 }
+
+    mplsFrrFacilityDBNumProtectedLspOnIf OBJECT-TYPE
+       SYNTAX            Gauge32
+       MAX-ACCESS        read-only
+       STATUS            current
+       DESCRIPTION
+         "The number of LSPs currently being protected on
+          the interface specified by
+          mplsFrrFacilityProtectedIfIndex."
+       ::= { mplsFrrFacilityDBEntry 8 }
+
+    mplsFrrFacilityDBNumProtectedTunnels OBJECT-TYPE
+       SYNTAX            Gauge32
+       MAX-ACCESS        read-only
+       STATUS            current
+       DESCRIPTION
+         "The number of tunnels protected on the interface
+          specified by mplsFrrFacilityProtectedIfIndex."
+       ::= { mplsFrrFacilityDBEntry 9 }
+
+    mplsFrrFacilityDBProtectingTunnelStatus OBJECT-TYPE
+       SYNTAX            INTEGER {
+                             active(1),
+                             ready(2),
+                             partial(3)
+                         }
+       MAX-ACCESS        read-only
+       STATUS            current
+       DESCRIPTION
+         "Specifies the state of the protecting tunnel as
+          specified by mplsFrrFacilityProtectingTunnelIndex.
+
+          active  - This tunnel's label has been placed in the
+                    LFIB and is ready to be applied to incoming
+                    packets.
+          ready   - This tunnel's label entry has been created but
+                    is not yet in the LFIB.
+          partial - This tunnel's label entry has not been fully
+                    created."
+       ::= { mplsFrrFacilityDBEntry 10 }
+
+
+
+Nadeau, et al.               Standards Track                   [Page 45]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+    mplsFrrFacilityDBProtectingTunnelResvBw  OBJECT-TYPE
+       SYNTAX            MplsBitRate
+       UNITS             "kilobits per second"
+       MAX-ACCESS        read-only
+       STATUS            current
+       DESCRIPTION
+         "Specifies the amount of bandwidth in units
+          of '1,000 bits per second', actually reserved by
+          the protecting tunnel for facility backup purposes.
+          This value is repeated here from the MPLS-TE-STD-MIB
+          module because the tunnel entry will reveal the
+          bandwidth reserved by the signaling protocol, which is
+          typically 0 for backup tunnels so as to not over-book
+          bandwidth.  However, internal reservations are
+          typically made on the PLR; thus, this value should be
+          revealed here, as it is often different from
+          mplsTunnelResourceMeanRate found in the MPLS-TE-STD-MIB
+          module."
+       ::= { mplsFrrFacilityDBEntry 11 }
+
+    -- Notifications
+    mplsFrrFacilityInitialBackupTunnelInvoked  NOTIFICATION-TYPE
+       OBJECTS { mplsFrrFacilityDBNumProtectingTunnelOnIf,
+                 mplsFrrFacilityDBNumProtectedLspOnIf,
+                 mplsFrrFacilityDBNumProtectedTunnels,
+                 mplsFrrFacilityDBProtectingTunnelStatus,
+                 mplsFrrFacilityDBProtectingTunnelResvBw
+               }
+       STATUS      current
+       DESCRIPTION
+         "This notification is generated when a tunnel running over an
+          interface as specified in the mplsFrrConstraintsTable is
+          initially protected by the backup tunnel also specified in the
+          mplsFrrConstraintsTable.  In some implementations, there may
+          be a difference between when the control plane triggers
+          this notification and when the hardware is programmed to
+          utilize the protection path.  Due to the urgency of this
+          operation, it is acceptable for the control plane to
+          issue this notification either before or after it programs
+          the hardware.  In cases where it is the latter approach,
+          the notification MUST be sent immediately after the
+          data plane has been altered.
+
+          This notification should not be generated for each subsequent
+          tunnel that is backed up by the FRR feature on this LSR, as
+          this may result in potential scaling issues with regard to
+          LSR performance and network load.  Note also that
+          notifications MUST be generated in accordance with the
+
+
+
+Nadeau, et al.               Standards Track                   [Page 46]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+          mplsFrrNotificationsMaxRate."
+
+       ::= { mplsFrrFacilityNotifications 1 }
+
+    mplsFrrFacilityFinalTunnelRestored NOTIFICATION-TYPE
+       OBJECTS { mplsFrrFacilityDBNumProtectingTunnelOnIf,
+                 mplsFrrFacilityDBNumProtectedLspOnIf,
+                 mplsFrrFacilityDBNumProtectedTunnels,
+                 mplsFrrFacilityDBProtectingTunnelStatus,
+                 mplsFrrFacilityDBProtectingTunnelResvBw
+               }
+       STATUS      current
+       DESCRIPTION
+         "This notification is generated when the final tunnel that is
+          being protected by a backup tunnel as specified in the
+          mplsFrrConstraintsTable is restored to normal operation.  This
+          notification should not be generated for each restored tunnel,
+          as this may result in potential scaling issues with regard to
+          LSR performance and network load.  Note also that
+          notifications MUST be generated in accordance with the
+          mplsFrrNotificationsMaxRate."
+       ::= { mplsFrrFacilityNotifications 2 }
+
+    -- Module Conformance Statement
+
+    mplsFrrFacilityCompliances
+       OBJECT IDENTIFIER ::= {mplsFrrFacilityConformance 1 }
+
+    mplsFrrFacilityGroups
+       OBJECT IDENTIFIER ::= {mplsFrrFacilityConformance 2 }
+
+    mplsFrrFacilityModuleFullCompliance MODULE-COMPLIANCE
+       STATUS current
+       DESCRIPTION
+         "Compliance statements for SNMP engines that support the
+          MPLS-FRR-FACILITY-STD-MIB module."
+
+      MODULE MPLS-FRR-GENERAL-STD-MIB  -- MPLS FRR Generic MIB
+         MANDATORY-GROUPS {
+                             mplsFrrGeneralScalarGroup,
+                             mplsFrrGeneralTunnelARHopGroup,
+                             mplsFrrGeneralConstraintsGroup
+         }
+
+       MODULE -- this module
+           MANDATORY-GROUPS {
+                             mplsFrrFacilityScalarGroup,
+                             mplsFrrFacilityDBGroup,
+
+
+
+Nadeau, et al.               Standards Track                   [Page 47]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+                             mplsFrrFacilityNotificationsGroup
+                            }
+
+       ::= { mplsFrrFacilityCompliances 1 }
+
+    mplsFrrFacilityModuleReadOnlyCompliance MODULE-COMPLIANCE
+       STATUS current
+       DESCRIPTION
+         "Compliance statements for SNMP engines that support the
+          MPLS-FRR-FACILITY-STD-MIB module."
+
+      MODULE MPLS-FRR-GENERAL-STD-MIB -- MPLS FRR Generic MIB
+         MANDATORY-GROUPS {
+                             mplsFrrGeneralScalarGroup,
+                             mplsFrrGeneralTunnelARHopGroup,
+                             mplsFrrGeneralConstraintsGroup
+         }
+
+       MODULE -- this module
+           MANDATORY-GROUPS {
+                             mplsFrrFacilityScalarGroup,
+                             mplsFrrFacilityDBGroup,
+                             mplsFrrFacilityNotificationsGroup
+                            }
+
+       ::= { mplsFrrFacilityCompliances 2 }
+
+    -- Units of conformance
+
+    mplsFrrFacilityScalarGroup OBJECT-GROUP
+       OBJECTS { mplsFrrConfiguredInterfaces,
+                 mplsFrrActiveInterfaces,
+                 mplsFrrConfiguredBypassTunnels,
+                 mplsFrrActiveBypassTunnels,
+                 mplsFrrFacilityNotificationsEnabled,
+                 mplsFrrFacilityNotificationsMaxRate
+         }
+       STATUS        current
+       DESCRIPTION
+         "Objects that are required to represent the FRR
+          Facility Route Database information."
+       ::= { mplsFrrFacilityGroups 1 }
+
+    mplsFrrFacilityDBGroup OBJECT-GROUP
+       OBJECTS { mplsFrrFacilityDBNumProtectingTunnelOnIf,
+                 mplsFrrFacilityDBNumProtectedLspOnIf,
+                 mplsFrrFacilityDBNumProtectedTunnels,
+                 mplsFrrFacilityDBProtectingTunnelStatus,
+
+
+
+Nadeau, et al.               Standards Track                   [Page 48]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+                 mplsFrrFacilityDBProtectingTunnelResvBw
+         }
+       STATUS        current
+       DESCRIPTION
+         "Objects that are required to represent the FRR
+          Facility Route Database information."
+       ::= { mplsFrrFacilityGroups 2 }
+
+    mplsFrrFacilityNotificationsGroup NOTIFICATION-GROUP
+       NOTIFICATIONS { mplsFrrFacilityInitialBackupTunnelInvoked,
+                       mplsFrrFacilityFinalTunnelRestored
+                     }
+       STATUS        current
+       DESCRIPTION
+         "Objects that are required to represent FRR notifications."
+       ::= { mplsFrrFacilityGroups 3 }
+
+   END
+
+   -- End of MPLS-FRR-FACILITY-STD-MIB
+
+7.  Security Considerations
+
+   It is clear that these MIB modules are potentially useful for the
+   monitoring of MPLS LSRs supporting fast reroute.  These MIB modules
+   can also be used for configuration of certain objects; note that
+   anything that can be configured can be incorrectly configured, with
+   potentially disastrous results.
+
+   There are a number of management objects defined in these MIB modules
+   with a MAX-ACCESS clause of read-write and/or read-create.  Such
+   objects may be considered sensitive or vulnerable in some network
+   environments.  The support for SET operations in a non-secure
+   environment without proper protection can have a negative effect on
+   network operations.  These are the tables and objects and their
+   sensitivity/vulnerability:
+
+   o  The mplsFrrGeneralConstraintsTable
+      (mplsFrrGeneralConstraintsProtectionType,
+      mplsFrrGeneralConstraintsSetupPrio, etc.), and some objects in the
+      mplsFrrScalarGroup (mplsFrrGeneralProtectionMethod,
+      mplsFrrFacilityNotificationsEnabled, etc.) contain objects that
+      may be used to provision MPLS fast-reroute features.  Unauthorized
+      access to these objects could result in disruption of traffic on
+      the network.
+
+
+
+
+
+
+Nadeau, et al.               Standards Track                   [Page 49]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+   Some of the readable objects in these MIB modules (i.e., objects with
+   a MAX-ACCESS other than not-accessible) may be considered sensitive
+   or vulnerable in some network environments.  It is thus important to
+   control even GET and/or NOTIFY access to these objects and possibly
+   to even encrypt the values of these objects when sending them over
+   the network via SNMP.  These are the tables and objects and their
+   sensitivity/vulnerability:
+
+   o  The mplsFrrOne2OnePlrTable (mplsFrrOne2OnePlrSenderAddr,
+      mplsFrrOne2OnePlrAvoidNodeAddr, etc.), mplsFrrOne2OneDetourTable
+      (mplsFrrOne2OneDetourActive, mplsFrrOne2OneDetourMergedDetourInst,
+      etc.), and mplsFrrGeneralTunnelARHopTable
+      (mplsFrrGeneralTunnelARHopSessionAttributeFlags,
+      mplsFrrGeneralTunnelARHopRROSubObjectFlags, etc.), and some
+      objects contained in the mplsFrrScalarGroup
+      (mplsFrrGeneralProtectionMethod, mplsFrrActiveInterfaces, etc.),
+      collectively show the MPLS fast-reroute interfaces, tunnels, and
+      other associated fast-reroute feature configurations as well as
+      their linkages to other MPLS-related configuration and/or
+      performance statistics.  Administrators not wishing to reveal this
+      information should consider these objects sensitive/vulnerable and
+      take precautions so they are not revealed.
+
+   SNMP versions prior to SNMPv3 did not include adequate security.
+   Even if the network itself is secure (for example by using IPsec),
+   even then, there is no control as to who on the secure network is
+   allowed to access and GET/SET (read/change/create/delete) the objects
+   in these MIB modules.
+
+   It is RECOMMENDED that implementers consider the security features as
+   provided by the SNMPv3 framework (see [RFC3410], section 8),
+   including full support for the SNMPv3 cryptographic mechanisms (for
+   authentication and privacy).
+
+   Further, deployment of SNMP versions prior to SNMPv3 is NOT
+   RECOMMENDED.  Instead, it is RECOMMENDED to deploy SNMPv3 and to
+   enable cryptographic security.  It is then a customer/operator
+   responsibility to ensure that the SNMP entity giving access to an
+   instance of these MIB modules is properly configured to give access
+   to the objects only to those principals (users) that have legitimate
+   rights to indeed GET or SET (change/create/delete) them.
+
+8.  IANA Considerations
+
+   The MIB modules in this document use the IANA-assigned OBJECT
+   IDENTIFIER values recorded in the SMI Numbers registry.
+
+
+
+
+
+Nadeau, et al.               Standards Track                   [Page 50]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+8.1.  IANA Considerations for MPLS-FRR-GENERAL-STD-MIB
+
+   IANA has assigned { mib-2 202 } to the MPLS-FRR-GENERAL-STD-MIB
+   module specified in this document.
+
+8.2.  IANA Considerations for MPLS-FRR-ONE2ONE-STD-MIB
+
+   IANA has assigned { mib-2 203 } to the MPLS-FRR-ONE2ONE-STD-MIB
+   module specified in this document.
+
+8.3.  IANA Considerations for MPLS-FRR-FACILITY-STD-MIB
+
+   IANA has assigned { mib-2 204 } to the MPLS-FRR-FACILITY-STD-MIB
+   module specified in this document.
+
+9.  Acknowledgments
+
+   This document is a product of the MPLS Working Group.  We would like
+   to thank Alia Atlas, Yeong Tai, Walter Vanhimbeeck, Mike Piecuch,
+   Adrien Grise, Joan Cucchiara, and Adrian Farrel for the helpful and
+   colorful discussions, editorial comments, and contributions related
+   to this document.
+
+10.  References
+
+10.1.  Normative References
+
+   [RFC2119]   Bradner, S., "Key words for use in RFCs to Indicate
+               Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2578]   McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+               "Structure of Management Information Version 2 (SMIv2)",
+               STD 58, RFC 2578, April 1999.
+
+   [RFC2579]   McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+               "Textual Conventions for SMIv2", STD 58, RFC 2579,
+               April 1999.
+
+   [RFC2580]   McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+               "Conformance Statements for SMIv2", STD 58, RFC 2580,
+               April 1999.
+
+   [RFC2863]   McCloghrie, K. and F. Kastenholz, "The Interfaces Group
+               MIB", RFC 2863, June 2000.
+
+   [RFC3031]   Rosen, E., Viswanathan, A., and R. Callon, "Multiprotocol
+               Label Switching Architecture", RFC 3031, January 2001.
+
+
+
+
+Nadeau, et al.               Standards Track                   [Page 51]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+   [RFC3811]   Nadeau, T., Ed., and J. Cucchiara, Ed., "Definitions of
+               Textual Conventions (TCs) for Multiprotocol Label
+               Switching (MPLS) Management", RFC 3811, June 2004.
+
+   [RFC3812]   Srinivasan, C., Viswanathan, A., and T. Nadeau,
+               "Multiprotocol Label Switching (MPLS) Traffic Engineering
+               (TE) Management Information Base (MIB)", RFC 3812,
+               June 2004.
+
+   [RFC3813]   Srinivasan, C., Viswanathan, A., and T. Nadeau,
+               "Multiprotocol Label Switching (MPLS) Label Switching
+               Router (LSR) Management Information Base (MIB)",
+               RFC 3813, June 2004.
+
+   [RFC4001]   Daniele, M., Haberman, B., Routhier, S., and J.
+               Schoenwaelder, "Textual Conventions for Internet Network
+               Addresses", RFC 4001, February 2005.
+
+   [RFC4090]   Pan, P., Ed., Swallow, G., Ed., and A. Atlas, Ed., "Fast
+               Reroute Extensions to RSVP-TE for LSP Tunnels", RFC 4090,
+               May 2005.
+
+10.2.  Informative References
+
+   [RFC3410]   Case, J., Mundy, R., Partain, D., and B. Stewart,
+               "Introduction and Applicability Statements for Internet-
+               Standard Management Framework", RFC 3410, December 2002.
+
+   [RFC4990]   Shiomoto, K., Papneja, R., and R. Rabbat, "Use of
+               Addresses in Generalized Multiprotocol Label Switching
+               (GMPLS) Networks", RFC 4990, September 2007.
+
+11.  Contributors
+
+   Stefaan De Cnodder
+   Alcatel
+   Francis Wellesplein 1
+   B-2018 Antwerp, Belgium
+
+   EMail: stefaan.de_cnodder@alcatel.be
+
+
+   Der-Hwa Gan
+   Juniper Networks, Inc.
+   1194 N. Mathilda Avenue
+   Sunnyvale, CA  94089
+
+   EMail: derhwagan@yahoo.com
+
+
+
+Nadeau, et al.               Standards Track                   [Page 52]
+
+RFC 6445                  MPLS Fast-Reroute MIB            November 2011
+
+
+Editors' Addresses
+
+   Thomas D. Nadeau
+   CA Technologies, Inc.
+   273 Corporate Drive
+   Portsmouth, NH  03801
+
+   EMail: thomas.nadeau@ca.com
+
+
+   A S Kiran Koushik
+   Cisco Systems, Inc.
+   12515 Research Blvd., Bldg. 4
+   Austin, TX  78664
+
+   Phone: +1-512-378-1482
+   EMail: kkoushik@cisco.com
+
+
+   Riza Cetin
+   Alcatel
+   Francis Wellesplein 1
+   B-2018 Antwerp, Belgium
+
+   EMail: riza.cetin@alcatel.be
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Nadeau, et al.               Standards Track                   [Page 53]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6445.txt](<www.ietf.org/rfc/rfc6445.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
