### PR TITLE
Archive rfc6475.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6475.txt
+++ b/www.ietf.org/rfc/rfc6475.txt
@@ -1,0 +1,3531 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                          G. Keeni
+Request for Comments: 6475                         Cyber Solutions, Inc.
+Category: Standards Track                                       K. Koide
+ISSN: 2070-1721                                         KDDI Corporation
+                                                           S. Gundavelli
+                                                                   Cisco
+                                                             R. Wakikawa
+                                                              Toyota ITC
+                                                                May 2012
+
+
+             Proxy Mobile IPv6 Management Information Base
+
+Abstract
+
+   This memo defines a portion of the Proxy Mobile IPv6 Management
+   Information Base (MIB) for use with network management protocols in
+   the Internet community.  In particular, the Proxy Mobile IPv6 MIB can
+   be used to monitor and control the mobile access gateway (MAG) and
+   the local mobility anchor (LMA) functions of a Proxy Mobile IPv6
+   (PMIPv6) entity.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6475.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Keeni, et al.                Standards Track                    [Page 1]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+Copyright Notice
+
+   Copyright (c) 2012 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1. The Internet-Standard Management Framework ......................3
+   2. Overview ........................................................3
+      2.1. The Proxy Mobile IPv6 Protocol Entities ....................3
+      2.2. Terminology ................................................4
+   3. Proxy Mobile IPv6 Monitoring and Control Requirements ...........4
+   4. MIB Design ......................................................4
+      4.1. Textual Conventions ........................................6
+   5. MIB Definitions .................................................6
+      5.1. Proxy Mobile IPv6 Textual Conventions MIB ..................6
+      5.2. The Proxy Mobile IPv6 MIB .................................10
+   6. Security Considerations ........................................58
+   7. IANA Considerations ............................................60
+   8. References .....................................................60
+      8.1. Normative References ......................................60
+      8.2. Informative References ....................................61
+   9. Acknowledgements ...............................................62
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Keeni, et al.                Standards Track                    [Page 2]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+1.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This memo specifies a MIB
+   module that is compliant to the SMIv2, which is described in STD 58,
+   RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579] and STD 58, RFC 2580
+   [RFC2580].
+
+2.  Overview
+
+2.1.  The Proxy Mobile IPv6 Protocol Entities
+
+   Proxy Mobile IPv6 (PMIPv6) [RFC5213] is an extension to the Mobile
+   IPv6 (MIPv6) protocol that facilitates network-based localized
+   mobility management (NETLMM) for IPv6 nodes in a PMIPv6 domain.
+   There are three types of entities envisaged by the PMIPv6 protocol.
+
+   mobile node (MN): In the PMIPv6 context, this term is used to refer
+   to an IP host or router whose mobility is managed by the network.
+
+   local mobility anchor (LMA): Local Mobility Anchor is the home agent
+   for the mobile node in a Proxy Mobile IPv6 domain.  It is the
+   topological anchor point for the mobile node's home network
+   prefix(es) and is the entity that manages the mobile node's binding
+   state.  The local mobility anchor has the functional capabilities of
+   a home agent as defined in the Mobile IPv6 base specification
+   [RFC6275] with the additional capabilities required for supporting
+   the Proxy Mobile IPv6 protocol as defined in the PMIPv6 specification
+   [RFC5213].
+
+   mobile access gateway (MAG): Mobile Access Gateway is the entity on
+   an access router that manages the mobility-related signaling for a
+   mobile node that is attached to its access link.  It is responsible
+   for tracking the mobile node's movements to and from the access link
+   and for signaling the mobile node's local mobility anchor.
+
+   This document defines a set of managed objects (MOs) that can be used
+   to monitor and control PMIPv6 entities.
+
+
+
+
+
+Keeni, et al.                Standards Track                    [Page 3]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+2.2.  Terminology
+
+   The terminology used in this document is consistent with the
+   definitions used in the Mobile IPv6 protocol specification [RFC6275]
+   and in the NETLMM goals document [RFC4831].
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in BCP
+   14, RFC 2119 [RFC2119].
+
+3.  Proxy Mobile IPv6 Monitoring and Control Requirements
+
+   For managing a PMIPv6 entity, it is necessary to monitor the
+   following:
+
+      o  capabilities of PMIPv6 entities
+      o  signaling traffic due to PMIPv6 signaling
+      o  binding-related details (at LMA and MAG)
+      o  binding-related statistics (at LMA and MAG)
+
+4.  MIB Design
+
+   The basic principle has been to keep the MIB as simple as possible
+   and, at the same time, to make it effective enough so that the
+   essential needs of monitoring and control are met.
+
+   The Proxy Mobile IPv6 Management Information Base (PMIPV6-MIB)
+   extends the Mobile IPv6 Management Information Base (MIPV6-MIB)
+   [RFC4295].  It is assumed that PMIPV6-MIB will always be implemented
+   in conjunction with the MOBILEIPV6-MIB [RFC4295].  The PMIPV6-MIB
+   uses the textual conventions defined in the INET-ADDRESS-MIB
+   [RFC4001] and IP-MIB [RFC4293].
+
+   The PMIPV6-MIB is composed of the following groups of definitions:
+
+      - pmip6Core: a generic group containing objects that are common to
+        all the Proxy Mobile IPv6 entities.  Objects belonging to this
+        group will be implemented on the corresponding Proxy Mobile IPv6
+        entity. pmip6BindingCacheTable belongs to this group.
+
+      - pmip6Mag: this group models the mobile access gateway service.
+        Objects belonging to this group have the "pmip6Mag" prefix and
+        will be implemented on the corresponding MAG.
+
+      - pmip6Lma: this group models the local mobility anchor service.
+        Objects belonging to this group have the "pmip6Lma" prefix and
+        will be implemented on the corresponding LMA.
+
+
+
+Keeni, et al.                Standards Track                    [Page 4]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+      - pmip6Notifications: defines the set of notifications that will
+        be used to asynchronously monitor the Proxy Mobile IPv6
+        entities.
+
+        The tables contained in the above groups are as follows:
+
+      - pmip6BindingCacheTable: models the Binding Cache on the local
+        mobility anchor.
+
+      - pmip6MagProxyCOATable: models the Proxy Care-of Addresses
+        configured on the egress interfaces of the mobile access
+        gateway.
+
+      - pmip6MagMnIdentifierTable: provides a mapping from the MAG-
+        internal pmip6MagMnIndex to the mobile node identifier.
+
+      - pmip6MagMnLLIdentifierTable: provides a mapping from the MAG-
+        internal pmip6MagMnLLIndex to the corresponding interface of the
+        mobile node link-layer identifier.
+
+      - pmip6MagHomeNetworkPrefixTable: contains the home network
+        prefixes assigned to interfaces of all mobile nodes attached to
+        the MAG.  Each interface is distinguished by the attached mobile
+        node identifier (MN-Identifier) and the link-layer identifier
+        (MN-LL-Identifier).
+
+      - pmip6MagBLTable: models the Binding Update List (BL) that
+        includes PMIPv6-related information and is maintained by the
+        mobile access gateway.
+
+      - pmip6MagMnProfileTable: contains the mobile node's policy
+        profile that includes the essential operational parameters that
+        are required by the network entities for managing the mobile
+        node's mobility service.
+
+      - pmip6LmaLMAATable: contains the LMA Addresses (LMAAs) that are
+        configured on the local mobility anchor.  Each LMA Address acts
+        as a transport endpoint of the tunnel between the local mobility
+        anchor and the mobile access gateway.
+
+      - pmip6LmaMnIdentifierTable: provides a mapping from the LMA-
+        internal pmip6BindingMnIndex to the mobile node identifier.
+
+      - pmip6LmaMnLLIdentifierTable: provides a mapping from the LMA-
+        internal pmip6BindingMnLLIndex to the corresponding interface of
+        the mobile node link-layer identifier.
+
+
+
+
+
+Keeni, et al.                Standards Track                    [Page 5]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+      - pmip6LmaHomeNetworkPrefixTable: contains the list of home
+        network prefixes assigned to the connected interfaces of the
+        mobile nodes anchored on an LMA.
+
+4.1.  Textual Conventions
+
+        A Proxy Mobile IPv6 Textual Conventions MIB module containing
+        Textual Conventions to represent commonly used Proxy Mobile IPv6
+        management information is defined.  The intent is that these
+        TEXTUAL CONVENTIONS (TCs) will be imported and used in
+        PMIPv6-related MIB modules that would otherwise define their own
+        representation(s).  This MIB module includes references to RFC
+        4283 [RFC4283] and RFC 5213 [RFC5213].
+
+5.  MIB Definitions
+
+5.1.  Proxy Mobile IPv6 Textual Conventions MIB
+
+    PMIPV6-TC-MIB DEFINITIONS ::= BEGIN
+       IMPORTS
+         MODULE-IDENTITY, mib-2, Unsigned32
+                    FROM SNMPv2-SMI                   -- [RFC2578]
+         TEXTUAL-CONVENTION
+                    FROM SNMPv2-TC;                   -- [RFC2579]
+
+       pmip6TCMIB  MODULE-IDENTITY
+          LAST-UPDATED "201205070000Z"     --  7th May, 2012
+          ORGANIZATION "IETF NETLMM Working Group"
+          CONTACT-INFO
+          "                 Glenn Mansfield Keeni
+                    Postal: Cyber Solutions, Inc.
+                            6-6-3, Minami Yoshinari
+                            Aoba-ku, Sendai, Japan 989-3204.
+                       Tel: +81-22-303-4012
+                       Fax: +81-22-303-4015
+                     EMail: glenn@cysols.com
+
+                            Sri Gundavelli
+                    Postal: Cisco Systems
+                            170 W.Tasman Drive,
+                            San Jose, CA 95134
+                            USA
+                       Tel: +1-408-527-6109
+                     EMail: sgundave@cisco.com
+
+
+
+
+
+
+
+Keeni, et al.                Standards Track                    [Page 6]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                            Kazuhide Koide
+                    Postal: KDDI Corporation
+                            GARDEN AIR TOWER 3-10-10, Iidabashi
+                            Chiyoda-ku, Tokyo 102-8460, Japan.
+                       Tel: +81-3-6678-3378
+                     EMail: ka-koide@kddi.com
+
+                            Ryuji Wakikawa
+                    Postal: TOYOTA InfoTechnology Center, U.S.A., Inc.
+                            465 Bernardo Avenue
+                            Mountain View, CA
+                            94043
+                            USA
+                     EMail: ryuji@us.toyota-itc.com
+           Support Group EMail: netlmm@ietf.org
+           "
+
+        DESCRIPTION
+            "This MIB module provides textual conventions for
+             Proxy Mobile IPv6 Management information.
+
+             Copyright (c) 2012 IETF Trust and the persons
+             identified as authors of the code.  All rights
+             reserved.
+
+             Redistribution and use in source and binary forms,
+             with or without modification, is permitted pursuant
+             to, and subject to the license terms contained in,
+             the Simplified BSD License set forth in Section 4.c
+             of the IETF Trust's Legal Provisions Relating to IETF
+             Documents (http://trustee.ietf.org/license-info).
+            "
+
+        REVISION "201205070000Z"     --  7th May, 2012
+        DESCRIPTION
+            "The initial version, published as RFC 6475."
+        ::= { mib-2 205 }
+
+    -- -------------------------------------------------------------
+    -- Textual Conventions
+    -- -------------------------------------------------------------
+       Pmip6TimeStamp64  ::=  TEXTUAL-CONVENTION
+           DISPLAY-HINT "6d:2d"
+           STATUS  current
+           DESCRIPTION
+               "A 64-bit unsigned integer field containing a timestamp.
+                The value indicates the elapsed time since January 1,
+                1970, 00:00 UTC, by using a fixed-point format.  In this
+
+
+
+Keeni, et al.                Standards Track                    [Page 7]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                format, the integer number of seconds is contained in
+                the first 48 bits of the field, and the remaining 16
+                bits indicate the number of 1/65536 fractions of a
+                second.
+               "
+           REFERENCE
+               "RFC 5213: Section 8.8"
+           SYNTAX  OCTET STRING (SIZE (8))
+
+       Pmip6MnIdentifier  ::=  TEXTUAL-CONVENTION
+           DISPLAY-HINT "255a"
+           STATUS  current
+           DESCRIPTION
+               "The identity of a mobile node in the Proxy Mobile IPv6
+                domain.  This is the stable identifier of a mobile node
+                that the mobility entities in a Proxy Mobile IPv6 domain
+                can always acquire and use for predictably identifying
+                a mobile node.  Various forms of identifiers can be used
+                to identify a mobile node (MN).  Two examples are a
+                Network Access Identifier (NAI) and an opaque
+                identifier applicable to a particular application.
+               "
+           REFERENCE
+               "RFC 4283: Section 3"
+           SYNTAX  OCTET STRING (SIZE (0..255))
+       Pmip6MnLLIdentifier ::=  TEXTUAL-CONVENTION
+           DISPLAY-HINT "255a"
+           STATUS  current
+           DESCRIPTION
+               "An identifier that identifies the attached interface of
+                a mobile node.
+               "
+           REFERENCE
+               "RFC 5213: Section 8.6"
+           SYNTAX  OCTET STRING (SIZE (0..255))
+
+       Pmip6MnIndex ::= TEXTUAL-CONVENTION
+           DISPLAY-HINT "d"
+           STATUS       current
+           DESCRIPTION
+               "A unique integer value, greater than zero, assigned to
+                each mobile node that is currently attached to the
+                Proxy Mobile IPv6 domain by the management system.
+                It is recommended that the values are assigned in a
+                monotonically increasing order starting from 1.  It may
+                wrap after reaching its maximum value.  The value for
+                each mobile node must remain constant at least from one
+                re-initialization of the entity's network management
+
+
+
+Keeni, et al.                Standards Track                    [Page 8]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                system to the next re-initialization.
+               "
+           SYNTAX       Unsigned32 (1..4294967295)
+       Pmip6MnLLIndex ::= TEXTUAL-CONVENTION
+           DISPLAY-HINT "d"
+           STATUS       current
+           DESCRIPTION
+               "A unique integer value, greater than zero, assigned to
+                each interface of a mobile node that is currently
+                attached to the Proxy Mobile IPv6 domain by the
+                management system.
+                It is recommended that the values are assigned in a
+                monotonically increasing order starting from 1.  It may
+                wrap after reaching its maximum value.  The value for
+                each interface of a mobile node must remain constant at
+                least from one re-initialization of the entity's network
+                management system to the next re-initialization.
+               "
+           SYNTAX       Unsigned32 (1..4294967295)
+       Pmip6MnInterfaceATT ::=  TEXTUAL-CONVENTION
+           STATUS  current
+           DESCRIPTION
+               "The object specifies the access technology that
+                connects the mobile node to the access link on the
+                mobile access gateway.
+                The enumerated values and the corresponding access
+                technology are as follows:
+                 reserved                (0): Reserved (Not used)
+                 logicalNetworkInterface (1): Logical network interface
+                 pointToPointInterface   (2): Point-to-point interface
+                 ethernet                (3): Ethernet interface
+                 wirelessLan             (4): Wireless LAN interface
+                 wimax                   (5): Wimax interface
+                 threeGPPGERAN           (6): 3GPP GERAN
+                 threeGPPUTRAN           (7): 3GPP UTRAN
+                 threeGPPEUTRAN          (8): 3GPP E-UTRAN
+                 threeGPP2eHRPD          (9): 3GPP2 eHRPD
+                 threeGPP2HRPD          (10): 3GPP2 HRPD
+                 threeGPP21xRTT         (11): 3GPP2 1xRTT
+                 threeGPP2UMB           (12): 3GPP2 UMB
+               "
+           REFERENCE
+               "RFC 5213: Section 8.5,
+                Mobile IPv6 parameters registry on
+                http://www.iana.org/mobility-parameters"
+
+           SYNTAX INTEGER
+           {
+
+
+
+Keeni, et al.                Standards Track                    [Page 9]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                reserved               (0),
+                logicalNetworkInterface(1),
+                pointToPointInterface  (2),
+                ethernet               (3),
+                wirelessLan            (4),
+                wimax                  (5),
+                threeGPPGERAN          (6),
+                threeGPPUTRAN          (7),
+                threeGPPEUTRAN         (8),
+                threeGPP2eHRPD         (9),
+                threeGPP2HRPD          (10),
+                threeGPP21xRTT         (11),
+                threeGPP2UMB           (12)
+           }
+    END
+
+5.2.  The Proxy Mobile IPv6 MIB
+
+    PMIPV6-MIB DEFINITIONS ::= BEGIN
+       IMPORTS
+         MODULE-IDENTITY,  mib-2, Integer32, Counter32, Gauge32,
+         Unsigned32, OBJECT-TYPE, NOTIFICATION-TYPE
+                    FROM SNMPv2-SMI                   -- RFC 2578
+         PhysAddress, TimeStamp,
+         TruthValue
+                    FROM SNMPv2-TC                    -- RFC 2579
+         MODULE-COMPLIANCE, OBJECT-GROUP, NOTIFICATION-GROUP
+                    FROM SNMPv2-CONF                  -- RFC 2580
+         InetAddressType, InetAddress, InetAddressPrefixLength
+                    FROM INET-ADDRESS-MIB             -- RFC 4001
+         Ipv6AddressIfIdentifierTC
+                    FROM IP-MIB                       -- RFC 4293
+         mip6MnBLEntry, mip6BindingCacheEntry
+                    FROM MOBILEIPV6-MIB               -- RFC 4295
+         Pmip6TimeStamp64,    Pmip6MnIdentifier,
+         Pmip6MnLLIdentifier, Pmip6MnIndex, Pmip6MnLLIndex,
+         Pmip6MnInterfaceATT
+                    FROM PMIPV6-TC-MIB                -- RFC 6475
+         ;
+
+       pmip6MIB MODULE-IDENTITY
+          LAST-UPDATED "201205070000Z"        --  7th May, 2012
+          ORGANIZATION "IETF NETLMM Working Group"
+          CONTACT-INFO
+              "             Glenn Mansfield Keeni
+                    Postal: Cyber Solutions, Inc.
+                            6-6-3, Minami Yoshinari
+                            Aoba-ku, Sendai 989-3204, Japan.
+
+
+
+Keeni, et al.                Standards Track                   [Page 10]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                       Tel: +81-22-303-4012
+                       Fax: +81-22-303-4015
+                     EMail: glenn@cysols.com
+
+                            Kazuhide Koide
+                    Postal: KDDI Corporation
+                            GARDEN AIR TOWER 3-10-10, Iidabashi
+                            Chiyoda-ku, Tokyo 102-8460, Japan.
+                       Tel: +81-3-6678-3378
+                     EMail: ka-koide@kddi.com
+
+                            Sri Gundavelli
+                    Postal: Cisco
+                            170 W.Tasman Drive,
+                            San Jose, CA 95134
+                            USA
+                       Tel: +1-408-527-6109
+                     EMail: sgundave@cisco.com
+
+                            Ryuji Wakikawa
+                    Postal: TOYOTA InfoTechnology Center, U.S.A., Inc.
+                            465 Bernardo Avenue
+                            Mountain View, CA
+                            94043
+                            USA
+                     EMail: ryuji@us.toyota-itc.com
+
+             Support Group EMail: netlmm@ietf.org"
+
+             DESCRIPTION
+              "The MIB module for monitoring and controlling PMIPv6
+               entities.
+
+               Copyright (c) 2012 IETF Trust and the persons
+               identified as authors of the code. All rights
+               reserved.
+
+               Redistribution and use in source and binary forms,
+               with or without modification, is permitted pursuant
+               to, and subject to the license terms contained in,
+               the Simplified BSD License set forth in Section 4.c
+               of the IETF Trust's Legal Provisions Relating to IETF
+               Documents (http://trustee.ietf.org/license-info).
+              "
+
+              REVISION    "201205070000Z"      -- 7th May 2012
+              DESCRIPTION "Initial version, published as RFC 6475."
+           ::= { mib-2  206 }
+
+
+
+Keeni, et al.                Standards Track                   [Page 11]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+       -- The PMIPv6 MIB has the following 5 primary groups
+
+       pmip6Notifications     OBJECT IDENTIFIER ::= { pmip6MIB 0 }
+       pmip6Objects           OBJECT IDENTIFIER ::= { pmip6MIB 1 }
+       pmip6Conformance       OBJECT IDENTIFIER ::= { pmip6MIB 2 }
+       pmip6Core              OBJECT IDENTIFIER ::= { pmip6Objects 1 }
+       pmip6Mag               OBJECT IDENTIFIER ::= { pmip6Objects 2 }
+       pmip6Lma               OBJECT IDENTIFIER ::= { pmip6Objects 3 }
+
+        -- The sub groups
+
+       pmip6System            OBJECT IDENTIFIER ::= { pmip6Core 1 }
+       pmip6Bindings          OBJECT IDENTIFIER ::= { pmip6Core 2 }
+       pmip6Conf              OBJECT IDENTIFIER ::= { pmip6Core 3 }
+       pmip6Stats             OBJECT IDENTIFIER ::= { pmip6Core 4 }
+
+       pmip6MagSystem         OBJECT IDENTIFIER ::= { pmip6Mag 1 }
+       pmip6MagConf           OBJECT IDENTIFIER ::= { pmip6Mag 2 }
+       pmip6MagRegistration   OBJECT IDENTIFIER ::= { pmip6Mag 3 }
+
+       pmip6LmaSystem         OBJECT IDENTIFIER ::= { pmip6Lma 1 }
+       pmip6LmaConf           OBJECT IDENTIFIER ::= { pmip6Lma 2 }
+
+       -- The pmip6Stats group has the following sub groups
+
+       pmip6BindingRegCounters OBJECT IDENTIFIER ::= { pmip6Stats 1 }
+
+       --
+       --
+       -- pmip6System group
+       --
+       --
+       pmip6Capabilities OBJECT-TYPE
+           SYNTAX      BITS {
+                mobilityAccessGateway  (0),
+                localMobilityAnchor    (1)
+                       }
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "This object indicates the PMIPv6 functions that
+                are supported by this managed entity.  Multiple
+                Proxy Mobile IPv6 functions may be supported by
+                a single entity.
+                mobilityAccessGateway(0) indicates the availability
+                of the mobility access gateway function.
+                localMobilityAnchor(1) indicates the availability
+                of the local mobility anchor function.
+
+
+
+Keeni, et al.                Standards Track                   [Page 12]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+               "
+           REFERENCE
+                   "RFC 6275: Sections 3.2, 4.1"
+           ::= { pmip6System 1 }
+
+       pmip6MobileNodeGeneratedTimestampInUse OBJECT-TYPE
+           SYNTAX      TruthValue
+           MAX-ACCESS  read-write
+           STATUS      current
+           DESCRIPTION
+               "This flag indicates whether or not the
+                MN-generated timestamp mechanism is in use in that
+                Proxy Mobile IPv6 domain.
+                true(1) indicates that the local mobility anchors and
+                mobile access gateways in that Proxy Mobile IPv6
+                domain apply the MN-generated timestamp considerations.
+                false(0) indicates that the MN-generated timestamp
+                mechanism is not in use in that Proxy Mobile IPv6
+                domain.
+                The default value for this flag is 'false'.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.5, 9.3"
+           DEFVAL { false }
+           ::= { pmip6Conf 1 }
+       pmip6FixedMagLinkLocalAddressOnAllAccessLinksType OBJECT-TYPE
+           SYNTAX      InetAddressType
+           MAX-ACCESS  read-write
+           STATUS      current
+           DESCRIPTION
+               "The InetAddressType of the
+                pmip6FixedMagLinkLocalAddressOnAllAccessLinks
+                that follows.
+               "
+              ::= { pmip6Conf 2 }
+
+       pmip6FixedMagLinkLocalAddressOnAllAccessLinks OBJECT-TYPE
+           SYNTAX      InetAddress
+           MAX-ACCESS  read-write
+           STATUS      current
+           DESCRIPTION
+               "This variable indicates the link-local address value
+                that all the mobile access gateways should use on
+                any of the access links shared with any of the
+                mobile nodes in that Proxy Mobile IPv6 domain.  If
+                this variable is initialized with all zeroes, it
+                implies that the use of fixed link-local address mode
+                is not enabled for that Proxy Mobile IPv6 domain."
+
+
+
+Keeni, et al.                Standards Track                   [Page 13]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+           REFERENCE
+               "RFC 5213: Sections 2.2, 6.8, 6.9.1.1, 6.9.3, 9.3"
+           ::= { pmip6Conf 3 }
+
+       pmip6FixedMagLinkLayerAddressOnAllAccessLinks OBJECT-TYPE
+           SYNTAX      PhysAddress
+           MAX-ACCESS  read-write
+           STATUS      current
+           DESCRIPTION
+               "This variable indicates the link-layer address value
+                that all the mobile access gateways should use on
+                any of the access links shared with any of the mobile
+                nodes in that Proxy Mobile IPv6 domain.  For access
+                technologies where there is no link-layer address,
+                this variable MUST be initialized with all zeroes.
+               "
+           REFERENCE
+               "RFC 5213: Sections 6.9.3, 9.3"
+           ::= { pmip6Conf 4 }
+       pmip6MagStatus OBJECT-TYPE
+           SYNTAX      INTEGER { enabled(1), disabled(2) }
+           MAX-ACCESS  read-write
+           STATUS      current
+           DESCRIPTION
+               "This object indicates whether the PMIPv6 mobile
+                access gateway function is enabled for the managed
+                entity.
+
+                Changing the status from enabled(1) to disabled(2)
+                will terminate the PMIPv6 mobile access gateway
+                function.  On the other hand, changing the status
+                from disabled(2) to enabled(1) will start the PMIPv6
+                mobile access gateway function.
+
+                The value of this object MUST remain unchanged
+                across reboots of the managed entity.
+               "
+           DEFVAL { disabled }
+           ::= { pmip6MagSystem 1 }
+
+       pmip6MagProxyCOATable OBJECT-TYPE
+           SYNTAX      SEQUENCE OF Pmip6MagProxyCOAEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+               "This table models the Proxy Care-of Addresses
+                configured on the egress interfaces of the mobile access
+                gateway.  This address is the transport endpoint of the
+
+
+
+Keeni, et al.                Standards Track                   [Page 14]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                tunnel between the local mobility anchor and the mobile
+                access gateway.
+
+                Entries in this table are not required to survive
+                a reboot of the managed entity.
+               "
+           REFERENCE
+               "RFC 5213: Sections 2.2, 6.10"
+           ::= { pmip6MagSystem 2 }
+       pmip6MagProxyCOAEntry OBJECT-TYPE
+           SYNTAX      Pmip6MagProxyCOAEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+               "This entry represents a conceptual row in the
+                Proxy-CoA table.  It represents a Proxy Care-of
+                Address on the mobile access gateway.
+
+                Implementers need to be aware that if the total
+                number of octets in pmip6MagProxyCOA
+                exceeds 113, then OIDs of column
+                instances in this row will have more than 128
+                sub-identifiers and cannot be accessed using
+                SNMPv1, SNMPv2c, or SNMPv3.
+               "
+           INDEX  { pmip6MagProxyCOAType, pmip6MagProxyCOA }
+           ::= { pmip6MagProxyCOATable 1 }
+
+       Pmip6MagProxyCOAEntry ::=
+           SEQUENCE {
+            pmip6MagProxyCOAType   InetAddressType,
+            pmip6MagProxyCOA       InetAddress,
+            pmip6MagProxyCOAState  INTEGER
+           }
+
+       pmip6MagProxyCOAType OBJECT-TYPE
+           SYNTAX      InetAddressType
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+               "The InetAddressType of the pmip6MagProxyCOA
+                that follows.
+               "
+           ::= { pmip6MagProxyCOAEntry 1 }
+       pmip6MagProxyCOA OBJECT-TYPE
+           SYNTAX      InetAddress
+           MAX-ACCESS  not-accessible
+           STATUS      current
+
+
+
+Keeni, et al.                Standards Track                   [Page 15]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+           DESCRIPTION
+               "The Proxy-CoA configured on the egress interface of the
+                mobile access gateway.
+
+                The type of the address represented by this object
+                is specified by the corresponding
+                pmip6MagProxyCOAType object.
+               "
+           REFERENCE
+               "RFC 5213: Sections 2.2, 6.10"
+           ::= { pmip6MagProxyCOAEntry 2 }
+
+       pmip6MagProxyCOAState  OBJECT-TYPE
+           SYNTAX      INTEGER {
+                                  unknown(1),
+                                  activated(2),
+                                  tunneled(3)
+                          }
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "This object indicates the state of the Proxy-CoA:
+                   unknown     -- The state of the Proxy-CoA
+                                  cannot be determined.
+                   activated   -- The Proxy-CoA is ready to establish
+                                  a tunnel.  This state SHOULD be
+                                  indicated when the MAG is up but has
+                                  no mobile node.
+                   tunneled    -- Bidirectional tunnel is established
+                                  using the Proxy-CoA.
+               "
+           ::= { pmip6MagProxyCOAEntry 3 }
+       pmip6MagEnableMagLocalRouting OBJECT-TYPE
+           SYNTAX      TruthValue
+           MAX-ACCESS  read-write
+           STATUS      current
+           DESCRIPTION
+               "This flag indicates whether or not the mobile access
+                gateway is allowed to enable local routing of the
+                traffic exchanged between a visiting mobile node and
+                a correspondent node that is locally connected to one
+                of the interfaces of the mobile access gateway.
+                The correspondent node can be another visiting mobile
+                node as well, or a local fixed node.
+                true(1) indicates that the mobile access gateway routes
+                the traffic locally.
+                false(0) indicates that the mobile access gateway
+                reverse tunnels all the traffic to the mobile node's
+
+
+
+Keeni, et al.                Standards Track                   [Page 16]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                local mobility anchor.
+
+                The default value for this flag is 'false'.
+               "
+           REFERENCE
+               "RFC 5213: Section 9.2"           DEFVAL { false }
+           ::= { pmip6MagConf 1 }
+
+       pmip6MagMnIdentifierTable OBJECT-TYPE
+            SYNTAX      SEQUENCE OF Pmip6MagMnIdentifierEntry
+            MAX-ACCESS  not-accessible
+            STATUS      current
+            DESCRIPTION
+                "A table containing the identifiers of mobile nodes
+                 attached to the MAG.
+                 Entries in this table are not required to survive
+                 a reboot of the managed entity.
+                "
+            REFERENCE
+                "RFC 5213: Sections 2.2, 6.1"
+            ::= { pmip6MagConf 2 }
+
+       pmip6MagMnIdentifierEntry OBJECT-TYPE
+            SYNTAX      Pmip6MagMnIdentifierEntry
+            MAX-ACCESS  not-accessible
+            STATUS      current
+            DESCRIPTION
+                "An entry in the mobile node identifier table.
+                "
+            INDEX  { pmip6MagBLMnIndex
+                   }
+            ::= { pmip6MagMnIdentifierTable 1 }
+
+       Pmip6MagMnIdentifierEntry ::=
+            SEQUENCE {
+             pmip6MagMnIdentifier      Pmip6MnIdentifier
+           }
+
+       pmip6MagMnIdentifier  OBJECT-TYPE
+            SYNTAX      Pmip6MnIdentifier
+            MAX-ACCESS  read-only
+            STATUS      current
+            DESCRIPTION
+                "The identity of a mobile node in the Proxy Mobile IPv6
+                 domain.
+                "
+           REFERENCE
+               "RFC 5213: Sections 2.2, 6.1"
+
+
+
+Keeni, et al.                Standards Track                   [Page 17]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+            ::= { pmip6MagMnIdentifierEntry 1 }
+
+       pmip6MagMnLLIdentifierTable OBJECT-TYPE
+            SYNTAX      SEQUENCE OF Pmip6MagMnLLIdentifierEntry
+            MAX-ACCESS  not-accessible
+            STATUS      current
+            DESCRIPTION
+                "A table containing the link-layer identifiers
+                 of the interfaces of the mobile nodes attached
+                 to the MAG.
+                 Entries in this table are not required to survive
+                 a reboot of the managed entity.
+                "
+            REFERENCE
+                "RFC 5213: Sections 2.2, 6.1"
+            ::= { pmip6MagConf 3 }
+
+       pmip6MagMnLLIdentifierEntry OBJECT-TYPE
+            SYNTAX      Pmip6MagMnLLIdentifierEntry
+            MAX-ACCESS  not-accessible
+            STATUS      current
+            DESCRIPTION
+                "An entry in the mobile node link-layer identifier
+                 table.
+                "
+            INDEX  { pmip6MagBLMnIndex, pmip6MagBLMnLLIndex
+                   }
+            ::= { pmip6MagMnLLIdentifierTable 1 }
+
+       Pmip6MagMnLLIdentifierEntry ::=
+            SEQUENCE {
+             pmip6MagMnLLIdentifier      Pmip6MnLLIdentifier
+           }
+
+       pmip6MagMnLLIdentifier  OBJECT-TYPE
+            SYNTAX      Pmip6MnLLIdentifier
+            MAX-ACCESS  read-only
+            STATUS      current
+            DESCRIPTION
+                "The link-layer identifier of the mobile node's
+                 connected interface on the access link.
+                "
+            REFERENCE
+                "RFC 5213: Sections 2.2, 6.1"
+            ::= { pmip6MagMnLLIdentifierEntry 1 }
+
+       pmip6MagHomeNetworkPrefixTable   OBJECT-TYPE
+            SYNTAX      SEQUENCE OF Pmip6MagHomeNetworkPrefixEntry
+
+
+
+Keeni, et al.                Standards Track                   [Page 18]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+            MAX-ACCESS  not-accessible
+            STATUS      current
+            DESCRIPTION
+                "A table representing the home network prefixes
+                 assigned to the connected interfaces of mobile nodes
+                 attached to the MAG.
+                "
+            REFERENCE
+                "RFC 5213: Sections 2, 6.1, 6.2"
+            ::= { pmip6MagConf 4 }
+
+       pmip6MagHomeNetworkPrefixEntry OBJECT-TYPE
+            SYNTAX      Pmip6MagHomeNetworkPrefixEntry
+            MAX-ACCESS  not-accessible
+            STATUS      current
+            DESCRIPTION
+                "An entry in the home network prefixes table.
+
+                 Implementers need to be aware that if the total
+                 number of octets in pmip6MagHomeNetworkPrefix
+                 exceeds 111, then OIDs of column instances in
+                 this row will have more than 128 sub-identifiers
+                 and cannot be accessed using SNMPv1, SNMPv2c, or
+                 SNMPv3.
+                "
+            INDEX  { pmip6MagBLMnIndex, pmip6MagBLMnLLIndex,
+                     pmip6MagHomeNetworkPrefixType,
+                     pmip6MagHomeNetworkPrefix }
+            ::= { pmip6MagHomeNetworkPrefixTable 1 }
+
+       Pmip6MagHomeNetworkPrefixEntry ::=
+            SEQUENCE {
+             pmip6MagHomeNetworkPrefixType      InetAddressType,
+             pmip6MagHomeNetworkPrefix          InetAddress,
+             pmip6MagHomeNetworkPrefixLength    InetAddressPrefixLength,
+             pmip6MagHomeNetworkPrefixLifeTime  Unsigned32
+           }
+
+       pmip6MagHomeNetworkPrefixType  OBJECT-TYPE
+            SYNTAX      InetAddressType
+            MAX-ACCESS  not-accessible
+            STATUS      current
+            DESCRIPTION
+                "The InetAddressType of the pmip6MagHomeNetworkPrefix
+                 that follows.
+                "
+            ::= { pmip6MagHomeNetworkPrefixEntry 1 }
+
+
+
+
+Keeni, et al.                Standards Track                   [Page 19]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+       pmip6MagHomeNetworkPrefix   OBJECT-TYPE
+            SYNTAX      InetAddress
+            MAX-ACCESS  not-accessible
+            STATUS      current
+            DESCRIPTION
+                "The mobile network prefix that is delegated to the
+                 mobile node.  The type of the address represented by
+                 this object is specified by the corresponding
+                 pmip6MagHomeNetworkPrefixType object.
+                "
+            REFERENCE
+                "RFC 5213: Section 2"
+            ::= { pmip6MagHomeNetworkPrefixEntry 2 }
+
+       pmip6MagHomeNetworkPrefixLength   OBJECT-TYPE
+            SYNTAX      InetAddressPrefixLength
+            MAX-ACCESS  read-only
+            STATUS      current
+            DESCRIPTION
+                "The prefix length of the home network prefix.
+                "
+            ::= { pmip6MagHomeNetworkPrefixEntry 3 }
+
+       pmip6MagHomeNetworkPrefixLifeTime   OBJECT-TYPE
+            SYNTAX      Unsigned32
+            UNITS       "seconds"
+            MAX-ACCESS  read-only
+            STATUS      current
+            DESCRIPTION
+                "The lifetime parameter (in seconds) that will be
+                 advertised in Router Advertisements by the MAG for
+                 this home network prefix.
+                "
+            REFERENCE
+                "RFC 5213: Sections 6.2, 6.7"
+            ::= { pmip6MagHomeNetworkPrefixEntry 4 }
+
+       pmip6MagBLTable OBJECT-TYPE
+           SYNTAX      SEQUENCE OF Pmip6MagBLEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+               "This table corresponds to the Binding Update List (BL)
+                that includes PMIPv6-related information and is
+                maintained by the mobile access gateway.
+                Entries from the table are deleted as the lifetime of
+                the binding expires.
+               "
+
+
+
+Keeni, et al.                Standards Track                   [Page 20]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+           REFERENCE
+               "RFC 6275: Sections 4.5, 11.1
+                RFC 5213: Section 6.1"
+           ::= { pmip6MagRegistration 1 }
+       pmip6MagBLEntry  OBJECT-TYPE
+           SYNTAX      Pmip6MagBLEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+               "An entry containing additional information from
+                a Binding Update sent by the mobile access gateway
+                to the local mobility anchor.
+               "
+           AUGMENTS {mip6MnBLEntry}
+           ::= { pmip6MagBLTable 1 }
+
+       Pmip6MagBLEntry ::= SEQUENCE {
+           pmip6MagBLFlag                    TruthValue,
+           pmip6MagBLMnIndex                 Pmip6MnIndex,
+           pmip6MagBLMnLLIndex               Pmip6MnLLIndex,
+           pmip6MagBLMagLinkLocalAddressType InetAddressType,
+           pmip6MagBLMagLinkLocalAddress     InetAddress,
+           pmip6MagBLMagIfIdentifierToMn     Ipv6AddressIfIdentifierTC,
+           pmip6MagBLTunnelIfIdentifier      Ipv6AddressIfIdentifierTC,
+           pmip6MagBLMnInterfaceATT  Pmip6MnInterfaceATT,
+           pmip6MagBLTimeRecentlyAccepted    Pmip6TimeStamp64
+           }
+
+       pmip6MagBLFlag OBJECT-TYPE
+           SYNTAX      TruthValue
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "true(1) indicates that the mobile access gateway sent
+                the Proxy Binding Update with Proxy Registration Flag
+                that indicates to the local mobility anchor that the
+                registration is the Proxy Binding Update and is from a
+                mobile access gateway.
+                false(0) implies that the mobile access gateway is
+                behaving as a simple mobile node.
+               "
+           REFERENCE
+               "RFC 5213: Section 8.1"
+           ::= { pmip6MagBLEntry 1 }
+
+       pmip6MagBLMnIndex OBJECT-TYPE
+           SYNTAX     Pmip6MnIndex
+           MAX-ACCESS  read-only
+
+
+
+Keeni, et al.                Standards Track                   [Page 21]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+           STATUS      current
+           DESCRIPTION
+               "The index to the identifier of the attached mobile
+                node in the pmip6MagMnIdentifierTable.
+               "
+           REFERENCE
+               "RFC 5213: Sections 2.2, 6.1, 8.1"
+           ::= { pmip6MagBLEntry 2 }
+
+       pmip6MagBLMnLLIndex OBJECT-TYPE
+           SYNTAX      Pmip6MnLLIndex
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "The index to the link-layer identifier of the mobile
+                node's connected interface in the
+                pmip6MagMnLLIdentifierTable.
+               "
+           REFERENCE
+               "RFC 5213: Sections 2.2, 6.1, 8.1"
+           ::= { pmip6MagBLEntry 3 }
+
+       pmip6MagBLMagLinkLocalAddressType OBJECT-TYPE
+           SYNTAX     InetAddressType
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "The InetAddressType of the pmip6MagBLMagLinkLocalAddress
+                that follows.
+               "
+           ::= { pmip6MagBLEntry 4 }
+
+       pmip6MagBLMagLinkLocalAddress OBJECT-TYPE
+           SYNTAX     InetAddress
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "The link-local address of the mobile access gateway on
+                the access link shared with the mobile node.
+                This is the address that is present in the Link-local
+                Address option of the corresponding Proxy Binding Update
+                message.
+               "
+           REFERENCE
+               "RFC 3963: Sections 4.1, 5.1"
+           ::= { pmip6MagBLEntry 5 }
+
+       pmip6MagBLMagIfIdentifierToMn OBJECT-TYPE
+
+
+
+Keeni, et al.                Standards Track                   [Page 22]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+           SYNTAX     Ipv6AddressIfIdentifierTC
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "The interface identifier (if-id) of the point-to-point
+                link between the mobile node and the mobile access
+                gateway.  This is internal to the mobile access gateway
+                and is used to associate the Proxy Mobile IPv6 tunnel
+                to the access link where the mobile node is attached.
+               "
+           REFERENCE
+               "RFC 5213: Sections 6.1, 8.1"
+           ::= { pmip6MagBLEntry 6 }
+
+       pmip6MagBLTunnelIfIdentifier OBJECT-TYPE
+           SYNTAX     Ipv6AddressIfIdentifierTC
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "The tunnel interface identifier (tunnel-if-id) of the
+                bidirectional tunnel between the mobile node's local
+                mobility anchor and the mobile access gateway.  This
+                is internal to the mobile access gateway.  The tunnel
+                interface identifier is acquired during the tunnel
+                creation.
+               "
+           REFERENCE
+               "RFC 5213: Sections 6.1, 8.1"
+           ::= { pmip6MagBLEntry 7 }
+
+        pmip6MagBLMnInterfaceATT OBJECT-TYPE
+           SYNTAX      Pmip6MnInterfaceATT
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "The type of the access technology by which the mobile
+                node is currently attached to the mobile access gateway.
+               "
+           REFERENCE
+               "RFC 5213: Sections 6.9.1.1, 6.9.1.5, 8.1"
+           ::= { pmip6MagBLEntry 8 }
+        pmip6MagBLTimeRecentlyAccepted OBJECT-TYPE
+           SYNTAX      Pmip6TimeStamp64
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "The 64-bit timestamp value of the most recently
+                accepted Proxy Binding Update message sent for this
+
+
+
+Keeni, et al.                Standards Track                   [Page 23]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                mobile node.  This is the time of day on the mobile
+                access gateway, when the Proxy Binding Acknowledgement
+                message with the Status field set to 0
+                was received.  If the Timestamp option is not present
+                in the Proxy Binding Update message (i.e., when the
+                sequence-number-based scheme is in use), the value MUST
+                be initialized with all zeroes.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.1, 8.1"
+           ::= { pmip6MagBLEntry 9 }
+
+       pmip6MagMnProfileTable OBJECT-TYPE
+           SYNTAX      SEQUENCE OF Pmip6MagMnProfileEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+               "This table corresponds to the mobile node's policy
+                profile that includes the essential operational
+                parameters that are required by the network entities
+                for managing the mobile node's mobility service.
+                It contains policy profiles of mobile nodes that are
+                connected to the mobile access gateway.
+                Entries in this table are not required to survive
+                a reboot of the managed entity.
+               "
+           REFERENCE
+               "RFC 5213: Section 6.2"
+           ::= { pmip6MagRegistration 2 }
+
+       pmip6MagMnProfileEntry  OBJECT-TYPE
+           SYNTAX      Pmip6MagMnProfileEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+               "An entry containing information about the
+                mobile node's policy profile.
+               "
+           INDEX { pmip6MagProfMnIndex }
+           ::= { pmip6MagMnProfileTable 1 }
+
+       Pmip6MagMnProfileEntry ::=
+           SEQUENCE {
+            pmip6MagProfMnIndex                      Pmip6MnIndex,
+            pmip6MagProfMnIdentifier                 Pmip6MnIdentifier,
+            pmip6MagProfMnLocalMobilityAnchorAddressType
+                                                     InetAddressType,
+            pmip6MagProfMnLocalMobilityAnchorAddress InetAddress
+
+
+
+Keeni, et al.                Standards Track                   [Page 24]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+           }
+
+       pmip6MagProfMnIndex OBJECT-TYPE
+           SYNTAX      Pmip6MnIndex
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+               "The index for a mobile node in the Proxy Mobile IPv6
+                domain.
+               "
+           ::= { pmip6MagMnProfileEntry 1 }
+
+       pmip6MagProfMnIdentifier OBJECT-TYPE
+           SYNTAX      Pmip6MnIdentifier
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "The identity of a mobile node in the Proxy Mobile IPv6
+                domain.
+               "
+           REFERENCE
+               "RFC 5213: Section 2.2"
+           ::= { pmip6MagMnProfileEntry 2 }
+
+       pmip6MagProfMnLocalMobilityAnchorAddressType OBJECT-TYPE
+           SYNTAX     InetAddressType
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "The InetAddressType of the
+                pmip6MagMnLocalMobilityAnchorAddress that follows.
+               "
+           ::= { pmip6MagMnProfileEntry 3 }
+       pmip6MagProfMnLocalMobilityAnchorAddress OBJECT-TYPE
+           SYNTAX     InetAddress
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "The global address that is configured on the interface
+                of the local mobility anchor and is the transport
+                endpoint of the bidirectional tunnel established
+                between the local mobility anchor and the mobile access
+                gateway.  This is the address to which the mobile
+                access gateway sends the Proxy Binding Update messages.
+               "
+           REFERENCE
+               "RFC 5213: Section 2.2"
+           ::= { pmip6MagMnProfileEntry 4 }
+
+
+
+Keeni, et al.                Standards Track                   [Page 25]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+       pmip6BindingCacheTable OBJECT-TYPE
+           SYNTAX      SEQUENCE OF Pmip6BindingCacheEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+               "This table models the Binding Cache on the local
+                mobility anchor.
+
+                Entries from the table are deleted as the lifetime
+                of the binding expires.
+
+                Entries in this table are not required to survive
+                a reboot of the managed entity.
+               "
+           REFERENCE
+               "RFC 6275: Sections 4.5, 9.1, 10.1
+                RFC 5213: Section 5.1"
+           ::= { pmip6Bindings 1 }
+
+       pmip6BindingCacheEntry  OBJECT-TYPE
+           SYNTAX      Pmip6BindingCacheEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+               "An entry containing additional information contained
+                in the Binding Cache table of the local mobility anchor.
+               "
+           AUGMENTS {mip6BindingCacheEntry}
+       ::= { pmip6BindingCacheTable 1 }
+
+       Pmip6BindingCacheEntry ::= SEQUENCE {
+            pmip6BindingPBUFlag                 TruthValue,
+            pmip6BindingMnIndex                 Pmip6MnIndex,
+            pmip6BindingMnLLIndex               Pmip6MnLLIndex,
+            pmip6BindingMagLinkLocalAddressType InetAddressType,
+            pmip6BindingMagLinkLocalAddress     InetAddress,
+            pmip6BindingTunnelIfIdentifier    Ipv6AddressIfIdentifierTC,
+            pmip6BindingMnInterfaceATT
+                                           Pmip6MnInterfaceATT,
+            pmip6BindingTimeRecentlyAccepted     Pmip6TimeStamp64
+           }
+
+       pmip6BindingPBUFlag OBJECT-TYPE
+           SYNTAX      TruthValue
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "true(1) indicates that the local mobility anchor
+
+
+
+Keeni, et al.                Standards Track                   [Page 26]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                accepted the binding update with Proxy Registration
+                Flag from a mobile access gateway.
+                false(0) implies that the binding cache is from a
+                mobile node.  In this case, the remaining objects will
+                not be accessible.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.1, 8.1"
+           ::= { pmip6BindingCacheEntry 1 }
+
+       pmip6BindingMnIndex OBJECT-TYPE
+           SYNTAX      Pmip6MnIndex
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "An index to the identifier of the registered mobile
+                node.
+               "
+           REFERENCE
+               "RFC 5213: Sections 2.2, 5.1, 8.1
+                RFC 4283: Section 3"
+           ::= { pmip6BindingCacheEntry 2 }
+       pmip6BindingMnLLIndex OBJECT-TYPE
+           SYNTAX      Pmip6MnLLIndex
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "The index to the link-layer identifier of the mobile
+                node's connected interface on the access link.
+               "
+           REFERENCE
+               "RFC 5213: Sections 2.2, 5.1, 8.1"
+           ::= { pmip6BindingCacheEntry 3 }
+
+       pmip6BindingMagLinkLocalAddressType OBJECT-TYPE
+           SYNTAX      InetAddressType
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "The InetAddressType of the
+                pmip6BindingMagLinkLocalAddress that follows.
+               "
+           ::= { pmip6BindingCacheEntry 4 }
+
+       pmip6BindingMagLinkLocalAddress OBJECT-TYPE
+           SYNTAX      InetAddress
+           MAX-ACCESS  read-only
+           STATUS      current
+
+
+
+Keeni, et al.                Standards Track                   [Page 27]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+           DESCRIPTION
+               "The link-local address of the mobile access gateway on
+                the point-to-point link shared with the mobile node.
+                This is generated by the local mobility anchor after
+                accepting the initial Proxy Binding Update message.
+                This is the address that is present in the Link-local
+                Address option of the corresponding Proxy Binding
+                Acknowledgement message.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.1, 6.9.1.2, 8.2"
+           ::= { pmip6BindingCacheEntry 5 }
+
+       pmip6BindingTunnelIfIdentifier OBJECT-TYPE
+           SYNTAX      Ipv6AddressIfIdentifierTC
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "The tunnel interface identifier (tunnel-if-id) of the
+                bidirectional tunnel between the local mobility anchor
+                and the mobile access gateway where the mobile node is
+                currently anchored.  This is internal to the local
+                mobility anchor.  The tunnel interface identifier is
+                acquired during the tunnel creation.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.1, 8.1"
+           ::= { pmip6BindingCacheEntry 6 }
+
+       pmip6BindingMnInterfaceATT OBJECT-TYPE
+           SYNTAX      Pmip6MnInterfaceATT
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "The access technology type by which the mobile node
+                is currently attached.  This is obtained from the
+                Access Technology Type option, present in the Proxy
+                Binding Update message.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.1, 8.1"
+           ::= { pmip6BindingCacheEntry 7 }
+
+       pmip6BindingTimeRecentlyAccepted OBJECT-TYPE
+           SYNTAX      Pmip6TimeStamp64
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+
+
+
+Keeni, et al.                Standards Track                   [Page 28]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+               "The 64-bit timestamp value of the most recently
+                accepted Proxy Binding Update message sent for this
+                mobile node.  This is the time of day on the local
+                mobility anchor, when the message was received.  If
+                the Timestamp option is not present in the Proxy
+                Binding Update message (i.e., when the sequence number
+                based scheme is in use), the value MUST be initialized
+                with all zeroes.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.1, 8.1"
+           ::= { pmip6BindingCacheEntry 8 }
+
+       ---
+       ---
+       --- pmip6Stats group
+       ---
+       ---
+
+       --
+       -- pmip6Stats:pmip6BindingRegCounters
+       --
+
+       pmip6MissingMnIdentifierOption  OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "Total number of Proxy Binding Update messages
+                rejected by the local mobility anchor with status
+                code in the Binding Acknowledgement message indicating
+                'Missing mobile node identifier option' (Code 160).
+
+                Discontinuities in the value of this counter can
+                occur at re-initialization of the mobile router,
+                and at other times as indicated by the value of
+                pmip6CounterDiscontinuityTime.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.3.1, 8.9"
+               ::= { pmip6BindingRegCounters 1 }
+
+       pmip6MagNotAuthorizedForProxyReg OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "Total number of Proxy Binding Update messages
+
+
+
+Keeni, et al.                Standards Track                   [Page 29]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                rejected by the local mobility anchor with status
+                code in the Binding Acknowledgement message indicating
+                'Not authorized to send Proxy Binding Updates'
+                (Code 154).
+
+                Discontinuities in the value of this counter can
+                occur at re-initialization of the mobile router,
+                and at other times as indicated by the value of
+                pmip6CounterDiscontinuityTime.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.3.1, 8.9"
+               ::= { pmip6BindingRegCounters 2 }
+
+       pmip6NotLMAForThisMobileNode  OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "Total number of Proxy Binding Update messages rejected
+                by the local mobility anchor with status code in the
+                Binding Acknowledgement message indicating
+                'Not local mobility anchor for this mobile node'
+                (Code 153).
+
+                Discontinuities in the value of this counter can
+                occur at re-initialization of the management system,
+                and at other times as indicated by the value of
+                pmip6CounterDiscontinuityTime.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.3.1, 8.9"
+               ::= { pmip6BindingRegCounters 3 }
+
+       pmip6ProxyRegNotEnabled  OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "Total number of Proxy Binding Update messages rejected
+                by the local mobility anchor with status code in the
+                Binding Acknowledgement message indicating
+                'Proxy Registration not enabled' (Code 152).
+                Discontinuities in the value of this counter can
+                occur at re-initialization of the management system,
+                and at other times as indicated by the value of
+                pmip6CounterDiscontinuityTime.
+               "
+
+
+
+Keeni, et al.                Standards Track                   [Page 30]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+           REFERENCE
+               "RFC 5213: Sections 5.3.1, 6.9.1.2, 8.9"
+               ::= { pmip6BindingRegCounters 4 }
+       pmip6MissingHomeNetworkPrefixOption  OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "Total number of Proxy Binding Update messages rejected
+                by the local mobility anchor with status code in the
+                Binding Acknowledgement message indicating
+                'Missing home network prefix option' (Code 158).
+                Discontinuities in the value of this counter can
+                occur at re-initialization of the management system,
+                and at other times as indicated by the value of
+                pmip6CounterDiscontinuityTime.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.3.1, 8.9"
+               ::= { pmip6BindingRegCounters 5 }
+
+       pmip6MissingHandOffIndicatorOption OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "Total number of Proxy Binding Update messages rejected
+                by the local mobility anchor with status code in the
+                Binding Acknowledgement message indicating
+                'Missing handoff indicator option' (Code 161).
+                Discontinuities in the value of this counter can
+                occur at re-initialization of the management system,
+                and at other times as indicated by the value of
+                pmip6CounterDiscontinuityTime.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.3.1, 8.9"
+               ::= { pmip6BindingRegCounters 6 }
+
+       pmip6MissingAccessTechTypeOption OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "Total number of Proxy Binding Update messages rejected
+                by the local mobility anchor with status code in the
+                Binding Acknowledgement message indicating
+                'Missing access technology type option' (Code 162).
+
+
+
+Keeni, et al.                Standards Track                   [Page 31]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                Discontinuities in the value of this counter can
+                occur at re-initialization of the management system,
+                and at other times as indicated by the value of
+                pmip6CounterDiscontinuityTime.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.3.1, 8.9"
+               ::= { pmip6BindingRegCounters 7 }
+
+       pmip6NotAuthorizedForHomeNetworkPrefix OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "Total number of Proxy Binding Update messages rejected
+                by the local mobility anchor with status code in the
+                Binding Acknowledgement message indicating
+                'Mobile node not authorized for one or more of the
+                requesting home network prefixes' (Code 155).
+
+                Discontinuities in the value of this counter can
+                occur at re-initialization of the management system,
+                and at other times as indicated by the value of
+                pmip6CounterDiscontinuityTime.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.3.2, 6.9.1.2, 8.9"
+               ::= { pmip6BindingRegCounters 8 }
+
+       pmip6TimestampMismatch OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "Total number of Proxy Binding Update messages rejected
+                by the local mobility anchor with status code in the
+                Binding Acknowledgement message indicating
+                'Invalid timestamp value (the clocks are out of sync)'
+                (Code 156).
+                Discontinuities in the value of this counter can
+                occur at re-initialization of the management system,
+                and at other times as indicated by the value of
+                pmip6CounterDiscontinuityTime.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.5, 6.9.1.2, 8.9"
+               ::= { pmip6BindingRegCounters 9 }
+
+
+
+
+Keeni, et al.                Standards Track                   [Page 32]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+       pmip6TimestampLowerThanPrevAccepted OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "Total number of Proxy Binding Update messages rejected
+                by the local mobility anchor with status code in the
+                Binding Acknowledgement message indicating
+                'The timestamp value is lower than the previously
+                accepted value' (Code 157).
+                Discontinuities in the value of this counter can
+                occur at re-initialization of the management system,
+                and at other times as indicated by the value of
+                pmip6CounterDiscontinuityTime.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.5, 6.9.1.2, 8.9"
+               ::= { pmip6BindingRegCounters 10 }
+
+       pmip6BcePbuPrefixSetDoNotMatch OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "Total number of Proxy Binding Update messages rejected
+                by the local mobility anchor with status code in the
+                Binding Acknowledgement message indicating
+                'All the home network prefixes listed in the Binding
+                Cache entry do not match all the prefixes in the
+                received Proxy Binding Update' (Code 159).
+                Discontinuities in the value of this counter can
+                occur at re-initialization of the management system,
+                and at other times as indicated by the value of
+                pmip6CounterDiscontinuityTime.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.4.1.1, 8.9"
+               ::= { pmip6BindingRegCounters 11 }
+
+       pmip6InitialBindingRegistrations OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "Total number of Proxy Binding Update messages that
+                newly creates the Binding Cache entry.
+                Discontinuities in the value of this counter can
+                occur at re-initialization of the management system,
+
+
+
+Keeni, et al.                Standards Track                   [Page 33]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                and at other times as indicated by the value of
+                pmip6CounterDiscontinuityTime.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.3.2"
+               ::= { pmip6BindingRegCounters 12 }
+
+       pmip6BindingLifeTimeExtensionNoHandOff OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "Total number of Proxy Binding Update messages for
+                extending the binding lifetime, received from the
+                same mobile access gateway that last updated the
+                binding.
+                Discontinuities in the value of this counter can
+                occur at re-initialization of the management system,
+                and at other times as indicated by the value of
+                pmip6CounterDiscontinuityTime.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.3.3"
+               ::= { pmip6BindingRegCounters 13 }
+
+       pmip6BindingLifeTimeExtensionAfterHandOff OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "Total number of Proxy Binding Update messages for
+                extending the binding lifetime, received from a new
+                mobile access gateway where the mobile node's
+                mobility session is handed off.
+                Discontinuities in the value of this counter can
+                occur at re-initialization of the management system,
+                and at other times as indicated by the value of
+                pmip6CounterDiscontinuityTime.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.3.4"
+               ::= { pmip6BindingRegCounters 14 }
+
+       pmip6BindingDeRegistrations OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+
+
+
+Keeni, et al.                Standards Track                   [Page 34]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+               "Total number of Proxy Binding Update messages with
+                the lifetime value of zero.
+                Discontinuities in the value of this counter can
+                occur at re-initialization of the management system,
+                and at other times as indicated by the value of
+                pmip6CounterDiscontinuityTime.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.3.5"
+               ::= { pmip6BindingRegCounters 15 }
+
+       pmip6BindingBindingAcks OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "Total number of Proxy Binding Acknowledgement
+                messages.
+                Discontinuities in the value of this counter can
+                occur at re-initialization of the management system,
+                and at other times as indicated by the value of
+                pmip6CounterDiscontinuityTime.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.3.5"
+               ::= { pmip6BindingRegCounters 16 }
+
+       pmip6CounterDiscontinuityTime OBJECT-TYPE
+           SYNTAX      TimeStamp
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "The value of sysUpTime on the most recent occasion
+                at which any one or more of this PMIPv6 entity's
+                global counters, viz., counters with OID prefix
+                'pmip6BindingRegCounters' suffered a discontinuity.
+                If no such discontinuities have occurred since the
+                last re-initialization of the local management
+                subsystem, then this object will have a zero value.
+               "
+               ::= { pmip6BindingRegCounters 17 }
+
+       pmip6LmaStatus OBJECT-TYPE
+           SYNTAX      INTEGER { enabled(1), disabled(2) }
+           MAX-ACCESS  read-write
+           STATUS      current
+           DESCRIPTION
+               "This object indicates whether the PMIPv6 local
+
+
+
+Keeni, et al.                Standards Track                   [Page 35]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                mobility anchor function is enabled for the managed
+                entity.
+
+                Changing the status from enabled(1) to disabled(2)
+                will terminate the PMIPv6 local mobility anchor
+                function.  On the other hand, changing the status
+                from disabled(2) to enabled(1) will start the PMIPv6
+                local mobility anchor function.
+
+                The value of this object MUST remain unchanged
+                across reboots of the managed entity.
+               "
+           DEFVAL { disabled }
+           ::= { pmip6LmaSystem 1 }
+
+       pmip6LmaLMAATable OBJECT-TYPE
+           SYNTAX      SEQUENCE OF Pmip6LmaLMAAEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+               "This table models the LMA Addresses configured
+                on the local mobility anchor.  Each LMA Address acts as
+                a transport endpoint of the tunnel between the local
+                mobility anchor and the mobile access gateway and is
+                the transport endpoint of the tunnel between the local
+                mobility anchor and the mobile access gateway.
+
+                Entries in this table are not required to survive
+                a reboot of the managed entity.
+               "
+           REFERENCE
+               "RFC 5213: Sections 2.2, 5.6"
+           ::= { pmip6LmaSystem 2 }
+
+       pmip6LmaLMAAEntry OBJECT-TYPE
+           SYNTAX      Pmip6LmaLMAAEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+               "This entry represents a conceptual row in the
+                LMAA table.  It represents each LMAA on the
+                local mobility anchor.
+
+                Implementers need to be aware that if the total
+                number of octets in pmip6LmaLMAA exceeds 113,
+                then OIDs of column instances in this row will
+                have more than 128 sub-identifiers and cannot
+                be accessed using SNMPv1, SNMPv2c, or SNMPv3.
+
+
+
+Keeni, et al.                Standards Track                   [Page 36]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+               "
+           INDEX  { pmip6LmaLMAAType, pmip6LmaLMAA }
+           ::= { pmip6LmaLMAATable 1 }
+
+       Pmip6LmaLMAAEntry ::=
+           SEQUENCE {
+            pmip6LmaLMAAType   InetAddressType,
+            pmip6LmaLMAA       InetAddress,
+            pmip6LmaLMAAState  INTEGER
+           }
+
+       pmip6LmaLMAAType OBJECT-TYPE
+           SYNTAX      InetAddressType
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+                   "The InetAddressType of the pmip6LmaLMAA
+                    that follows.
+                   "
+           ::= { pmip6LmaLMAAEntry 1 }
+
+       pmip6LmaLMAA OBJECT-TYPE
+           SYNTAX      InetAddress
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+               "The LMAA configured on the local mobility anchor.
+
+                The type of the address represented by this object
+                is specified by the corresponding
+                pmip6LmaLMAAType object.
+               "
+           REFERENCE
+               "RFC 5213: Sections 2.2, 5.6"
+           ::= { pmip6LmaLMAAEntry 2 }
+
+       pmip6LmaLMAAState  OBJECT-TYPE
+           SYNTAX      INTEGER {
+                                  unknown(1),
+                                  activated(2),
+                                  tunneled(3)
+                          }
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "This object indicates the state of the LMAA:
+                   unknown     -- The state of the LMAA
+                                  cannot be determined.
+
+
+
+Keeni, et al.                Standards Track                   [Page 37]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                   activated   -- The LMAA is ready to establish
+                                  a tunnel.
+                   tunneled    -- The LMAA is used to set up the
+                                  bidirectional tunnel.
+               "
+           ::= { pmip6LmaLMAAEntry 3 }
+
+       pmip6LmaMinDelayBeforeBCEDelete OBJECT-TYPE
+           SYNTAX      Integer32 (1..65535)
+           UNITS       "milliseconds"
+           MAX-ACCESS  read-write
+           STATUS      current
+           DESCRIPTION
+               "This variable specifies the length of time in
+                milliseconds the local mobility anchor MUST wait before
+                it deletes a Binding Cache entry of a mobile node, upon
+                receiving a Proxy Binding Update message from a mobile
+                access gateway with a lifetime value of 0.
+                During this wait time, if the local mobility anchor
+                receives a Proxy Binding Update for the same mobility
+                binding, with a lifetime value greater than 0, then it
+                must update the Binding Cache entry with the accepted
+                binding values.  By the end of this wait time, if the
+                local mobility anchor did not receive any valid Proxy
+                Binding Update message for that mobility binding, it
+                MUST delete the Binding Cache entry.  This delay
+                essentially ensures that a mobile node's Binding Cache
+                entry is not deleted too quickly and allows some time
+                for the new mobile access gateway to complete the
+                signaling for the mobile node.
+                The default value for this variable is 10000
+                milliseconds.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.3.5, 9.1"
+           DEFVAL { 10000 }
+              ::= { pmip6LmaConf 1 }
+
+       pmip6LmaMaxDelayBeforeNewBCEAssign OBJECT-TYPE
+           SYNTAX      Integer32 (1..65535)
+           UNITS       "milliseconds"
+           MAX-ACCESS  read-write
+           STATUS      current
+           DESCRIPTION
+               "This variable specifies the length of time in
+                milliseconds the local mobility anchor MUST wait for
+                the de-registration message for an existing mobility
+                session before it decides to create a new mobility
+
+
+
+Keeni, et al.                Standards Track                   [Page 38]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                session.
+
+                The default value for this variable is 1500
+                milliseconds.  Note that there is a dependency between
+                this value and the values used in the retransmission
+                algorithm for Proxy Binding Updates.  The
+                retransmissions need to happen before
+                MaxDelayBeforeNewBCEAssign runs out, as otherwise there
+                are situations where a de-registration from a previous
+                mobile access gateway may be lost, and the local
+                mobility anchor creates, needlessly, a new mobility
+                session and new prefixes for the mobile node.  However,
+                this affects situations where there is no information
+                from the lower layers about the type of a handoff or
+                other parameters that can be used for identifying the
+                mobility session.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.4.1.2, 5.4.1.3, 9.1"
+           DEFVAL { 1500 }
+              ::= { pmip6LmaConf 2 }
+       pmip6LmaTimestampValidityWindow OBJECT-TYPE
+           SYNTAX      Integer32 (1..65535)
+           UNITS       "milliseconds"
+           MAX-ACCESS  read-write
+           STATUS      current
+           DESCRIPTION
+               "This variable specifies the maximum length of time
+                difference in milliseconds between the timestamp in the
+                received Proxy Binding Update message and the current
+                time of day on the local mobility anchor that is
+                allowed by the local mobility anchor for the received
+                message to be considered valid.
+                The default value for this variable is 300 milliseconds.
+                This variable must be adjusted to suit the deployments.
+               "
+           REFERENCE
+               "RFC 5213: Sections 5.5, 9.1"
+           DEFVAL { 300 }
+              ::= { pmip6LmaConf 3 }
+
+       pmip6LmaMnIdentifierTable OBJECT-TYPE
+           SYNTAX      SEQUENCE OF Pmip6LmaMnIdentifierEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+               "A table containing the identifiers of mobile nodes
+                served by the LMA.
+
+
+
+Keeni, et al.                Standards Track                   [Page 39]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                Entries in this table are not required to survive
+                a reboot of the managed entity.
+               "
+           REFERENCE
+               "RFC 5213: Sections 2, 6.1"
+           ::= { pmip6LmaConf 4 }
+
+       pmip6LmaMnIdentifierEntry OBJECT-TYPE
+           SYNTAX      Pmip6LmaMnIdentifierEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+               "An entry in the mobile node identifier table.
+               "
+           INDEX  { pmip6BindingMnIndex
+                  }
+           ::= { pmip6LmaMnIdentifierTable 1 }
+
+       Pmip6LmaMnIdentifierEntry ::=
+           SEQUENCE {
+            pmip6LmaMnIdentifier      Pmip6MnIdentifier
+           }
+
+       pmip6LmaMnIdentifier  OBJECT-TYPE
+           SYNTAX      Pmip6MnIdentifier
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "The identity of a mobile node in the Proxy Mobile IPv6
+                domain.
+               "
+           REFERENCE
+               "RFC 5213: Section 2.2"
+           ::= { pmip6LmaMnIdentifierEntry 1 }
+
+       pmip6LmaMnLLIdentifierTable OBJECT-TYPE
+           SYNTAX      SEQUENCE OF Pmip6LmaMnLLIdentifierEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+               "A table containing the link-layer identifiers
+                of the interfaces of the mobile nodes served
+                by the LMA.
+                Entries in this table are not required to survive
+                a reboot of the managed entity.
+               "
+           REFERENCE
+               "RFC 5213: Sections 2, 6.1"
+
+
+
+Keeni, et al.                Standards Track                   [Page 40]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+           ::= { pmip6LmaConf 5 }
+
+       pmip6LmaMnLLIdentifierEntry OBJECT-TYPE
+           SYNTAX      Pmip6LmaMnLLIdentifierEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+               "An entry in the mobile node link-layer identifier
+                table.
+               "
+           INDEX  { pmip6BindingMnIndex, pmip6BindingMnLLIndex
+                  }
+           ::= { pmip6LmaMnLLIdentifierTable 1 }
+
+       Pmip6LmaMnLLIdentifierEntry ::=
+           SEQUENCE {
+            pmip6LmaMnLLIdentifier      Pmip6MnLLIdentifier
+           }
+
+       pmip6LmaMnLLIdentifier  OBJECT-TYPE
+            SYNTAX      Pmip6MnLLIdentifier
+            MAX-ACCESS  read-only
+            STATUS      current
+            DESCRIPTION
+                "The link-layer identifier of the mobile node's
+                 connected interface on the access link.
+                "
+            ::= { pmip6LmaMnLLIdentifierEntry 1 }
+
+       pmip6LmaHomeNetworkPrefixTable   OBJECT-TYPE
+            SYNTAX      SEQUENCE OF Pmip6LmaHomeNetworkPrefixEntry
+            MAX-ACCESS  not-accessible
+            STATUS      current
+            DESCRIPTION
+                "A table representing the home network prefixes
+                 assigned to the connected interfaces of all the
+                 mobile nodes anchored at the LMA.
+                "
+            REFERENCE
+                "RFC 5213: Sections 2, 5.1, 5.2"
+            ::= { pmip6LmaConf 6 }
+
+       pmip6LmaHomeNetworkPrefixEntry OBJECT-TYPE
+            SYNTAX      Pmip6LmaHomeNetworkPrefixEntry
+            MAX-ACCESS  not-accessible
+            STATUS      current
+            DESCRIPTION
+                "An entry in the home network prefixes table.
+
+
+
+Keeni, et al.                Standards Track                   [Page 41]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                 Implementers need to be aware that if the total
+                 number of octets in pmip6LmaHomeNetworkPrefix
+                 exceeds 111 then OIDs of column instances in this
+                 row will have more than 128 sub-identifiers and
+                 cannot be accessed using SNMPv1, SNMPv2c, or
+                 SNMPv3.
+                "
+            INDEX  { pmip6BindingMnIndex, pmip6BindingMnLLIndex,
+                     pmip6LmaHomeNetworkPrefixType,
+                     pmip6LmaHomeNetworkPrefix }
+            ::= { pmip6LmaHomeNetworkPrefixTable 1 }
+
+       Pmip6LmaHomeNetworkPrefixEntry ::=
+            SEQUENCE {
+             pmip6LmaHomeNetworkPrefixType      InetAddressType,
+             pmip6LmaHomeNetworkPrefix          InetAddress,
+             pmip6LmaHomeNetworkPrefixLength    InetAddressPrefixLength,
+             pmip6LmaHomeNetworkPrefixLifeTime  Gauge32
+           }
+
+       pmip6LmaHomeNetworkPrefixType  OBJECT-TYPE
+            SYNTAX      InetAddressType
+            MAX-ACCESS  not-accessible
+            STATUS      current
+            DESCRIPTION
+                "The InetAddressType of the pmip6LmaHomeNetworkPrefix
+                 that follows.
+                "
+            ::= { pmip6LmaHomeNetworkPrefixEntry 1 }
+
+       pmip6LmaHomeNetworkPrefix   OBJECT-TYPE
+            SYNTAX      InetAddress
+            MAX-ACCESS  not-accessible
+            STATUS      current
+            DESCRIPTION
+                "The mobile network prefix that is delegated to the
+                 mobile node.  The type of the address represented by
+                 this object is specified by the corresponding
+                 pmip6LmaHomeNetworkPrefixType object.
+                "
+            REFERENCE
+                "RFC 5213: Section 2"
+
+            ::= { pmip6LmaHomeNetworkPrefixEntry 2 }
+
+       pmip6LmaHomeNetworkPrefixLength   OBJECT-TYPE
+            SYNTAX      InetAddressPrefixLength
+            MAX-ACCESS  read-only
+
+
+
+Keeni, et al.                Standards Track                   [Page 42]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+            STATUS      current
+            DESCRIPTION
+                    "The prefix length of the home network prefix.
+                    "
+            ::= { pmip6LmaHomeNetworkPrefixEntry 3 }
+
+       pmip6LmaHomeNetworkPrefixLifeTime   OBJECT-TYPE
+            SYNTAX      Gauge32
+            UNITS       "seconds"
+            MAX-ACCESS  read-write
+            STATUS      current
+            DESCRIPTION
+                "The lifetime (in seconds) granted to the mobile
+                 node for this registration.
+                "
+            REFERENCE
+                "RFC 5213: Section 5.3"
+            ::= { pmip6LmaHomeNetworkPrefixEntry 4 }
+
+       --
+       -- pmip6Notifications
+       --
+       --
+
+       pmip6MagHomeTunnelEstablished NOTIFICATION-TYPE
+           OBJECTS   {
+                       pmip6MagBLTunnelIfIdentifier,
+                       pmip6MagProxyCOAState
+                     }
+           STATUS    current
+           DESCRIPTION
+               "This notification is sent by the Proxy Mobile IPv6
+                entities every time the tunnel is established between
+                the local mobility anchor and mobile access gateway.
+               "
+           REFERENCE
+               "RFC 5213: Section 5.6.1"
+               ::= { pmip6Notifications 1 }
+
+       pmip6MagHomeTunnelReleased NOTIFICATION-TYPE
+           OBJECTS {
+                     pmip6MagBLTunnelIfIdentifier,
+                     pmip6MagProxyCOAState
+                   }
+           STATUS    current
+           DESCRIPTION
+               "This notification is sent by the Proxy Mobile IPv6
+                entities every time the tunnel between the local
+
+
+
+Keeni, et al.                Standards Track                   [Page 43]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                mobility anchor and mobile access gateway is released.
+               "
+           REFERENCE
+               "RFC 5213: Section 5.6.1"
+               ::= { pmip6Notifications 2}
+
+       pmip6LmaHomeTunnelEstablished NOTIFICATION-TYPE
+           OBJECTS   {
+                       pmip6BindingTunnelIfIdentifier,
+                       pmip6LmaLMAAState
+                     }
+           STATUS    current
+           DESCRIPTION
+               "This notification is sent by the Proxy Mobile IPv6
+                entities every time the tunnel is established between
+                the local mobility anchor and mobile access gateway.
+               "
+           REFERENCE
+               "RFC 5213: Section 5.6.1"
+               ::= { pmip6Notifications 3 }
+
+       pmip6LmaHomeTunnelReleased NOTIFICATION-TYPE
+           OBJECTS {
+                     pmip6BindingTunnelIfIdentifier,
+                     pmip6LmaLMAAState
+                   }
+           STATUS    current
+           DESCRIPTION
+               "This notification is sent by the Proxy Mobile IPv6
+                entities every time the tunnel between the local
+                mobility anchor and mobile access gateway is released.
+               "
+           REFERENCE
+               "RFC 5213: Section 5.6.1"
+               ::= { pmip6Notifications 4}
+
+        -- Conformance information
+       pmip6Groups      OBJECT IDENTIFIER ::= { pmip6Conformance 1 }
+       pmip6Compliances OBJECT IDENTIFIER ::= { pmip6Conformance 2 }
+
+        -- Units of conformance
+       pmip6SystemGroup    OBJECT-GROUP
+            OBJECTS {
+                pmip6Capabilities,
+                pmip6MobileNodeGeneratedTimestampInUse,
+                pmip6FixedMagLinkLocalAddressOnAllAccessLinksType,
+                pmip6FixedMagLinkLocalAddressOnAllAccessLinks,
+                pmip6FixedMagLinkLayerAddressOnAllAccessLinks
+
+
+
+Keeni, et al.                Standards Track                   [Page 44]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+           }
+            STATUS  current
+            DESCRIPTION
+                " A collection of objects for basic PMIPv6
+                  monitoring."
+            ::= { pmip6Groups 1 }
+
+       pmip6BindingCacheGroup    OBJECT-GROUP
+            OBJECTS {
+                pmip6BindingPBUFlag,
+                pmip6BindingMnIndex,
+                pmip6BindingMnLLIndex,
+                pmip6BindingMagLinkLocalAddressType,
+                pmip6BindingMagLinkLocalAddress,
+                pmip6BindingTunnelIfIdentifier,
+                pmip6BindingMnInterfaceATT,
+                pmip6BindingTimeRecentlyAccepted,
+                pmip6LmaMnIdentifier,
+                pmip6LmaMnLLIdentifier
+           }
+            STATUS  current
+            DESCRIPTION
+                " A collection of objects for monitoring the
+                  PMIPv6 extensions of the Binding Cache."
+            ::= { pmip6Groups 2 }
+
+       pmip6StatsGroup    OBJECT-GROUP
+            OBJECTS {
+                pmip6MissingMnIdentifierOption,
+                pmip6MagNotAuthorizedForProxyReg,
+                pmip6NotLMAForThisMobileNode,
+                pmip6ProxyRegNotEnabled,
+                pmip6MissingHomeNetworkPrefixOption,
+                pmip6MissingHandOffIndicatorOption,
+                pmip6MissingAccessTechTypeOption,
+                pmip6NotAuthorizedForHomeNetworkPrefix,
+                pmip6TimestampMismatch,
+                pmip6TimestampLowerThanPrevAccepted,
+                pmip6BcePbuPrefixSetDoNotMatch,
+                pmip6InitialBindingRegistrations,
+                pmip6BindingLifeTimeExtensionNoHandOff,
+                pmip6BindingLifeTimeExtensionAfterHandOff,
+                pmip6BindingDeRegistrations,
+                pmip6BindingBindingAcks,
+                pmip6CounterDiscontinuityTime
+           }
+            STATUS  current
+            DESCRIPTION
+
+
+
+Keeni, et al.                Standards Track                   [Page 45]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                " A collection of objects for basic PMIPv6
+                  statistics monitoring.
+                "
+            ::= { pmip6Groups 3 }
+
+       pmip6MagSystemGroup    OBJECT-GROUP
+            OBJECTS {
+              pmip6MagStatus,
+              pmip6MagProxyCOAState
+           }
+            STATUS  current
+            DESCRIPTION
+                " A collection of objects for monitoring the
+                  PMIPv6-system-related objects on a mobile router."
+            ::= { pmip6Groups 4 }
+
+       pmip6MagConfigurationGroup    OBJECT-GROUP
+            OBJECTS {
+                pmip6MagHomeNetworkPrefixLength,
+                pmip6MagHomeNetworkPrefixLifeTime,
+                pmip6MagEnableMagLocalRouting
+           }
+            STATUS  current
+            DESCRIPTION
+                " A collection of objects for monitoring the
+                  configuration-related objects on a mobile access
+                  gateway.
+                "
+            ::= { pmip6Groups 5 }
+       pmip6MagRegistrationGroup    OBJECT-GROUP
+            OBJECTS {
+                pmip6MagBLFlag,
+                pmip6MagBLMnIndex,
+                pmip6MagBLMnLLIndex,
+                pmip6MagBLMagLinkLocalAddressType,
+                pmip6MagBLMagLinkLocalAddress,
+                pmip6MagBLMagIfIdentifierToMn,
+                pmip6MagBLTunnelIfIdentifier,
+                pmip6MagBLMnInterfaceATT,
+                pmip6MagBLTimeRecentlyAccepted,
+                pmip6MagMnIdentifier,
+                pmip6MagMnLLIdentifier,
+                pmip6MagProfMnIdentifier,
+                pmip6MagProfMnLocalMobilityAnchorAddressType,
+                pmip6MagProfMnLocalMobilityAnchorAddress
+           }
+            STATUS  current
+            DESCRIPTION
+
+
+
+Keeni, et al.                Standards Track                   [Page 46]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                " A collection of objects for monitoring the
+                  registration-related objects on a mobile access
+                  gateway.
+                "
+            ::= { pmip6Groups 6 }
+
+       pmip6LmaSystemGroup    OBJECT-GROUP
+            OBJECTS {
+                pmip6LmaStatus,
+                pmip6LmaLMAAState
+           }
+            STATUS  current
+            DESCRIPTION
+                " A collection of objects for monitoring the
+                  system-related objects on an LMA."
+            ::= { pmip6Groups 7 }
+
+       pmip6LmaConfigurationGroup    OBJECT-GROUP
+            OBJECTS {
+                pmip6LmaMinDelayBeforeBCEDelete,
+                pmip6LmaMaxDelayBeforeNewBCEAssign,
+                pmip6LmaTimestampValidityWindow,
+                pmip6LmaHomeNetworkPrefixLength,
+                pmip6LmaHomeNetworkPrefixLifeTime
+           }
+            STATUS  current
+            DESCRIPTION
+                " A collection of objects for Monitoring the
+                  configuration-related objects on an LMA."
+            ::= { pmip6Groups 8 }
+
+       pmip6MagNotificationGroup   NOTIFICATION-GROUP
+            NOTIFICATIONS {
+                     pmip6MagHomeTunnelEstablished,
+                     pmip6MagHomeTunnelReleased
+           }
+            STATUS  current
+            DESCRIPTION
+                "A collection of notifications from a home agent
+                 or correspondent node to the Manager about the
+                 tunnel status of the mobile router.
+                "
+            ::= { pmip6Groups 9 }
+
+       pmip6LmaNotificationGroup   NOTIFICATION-GROUP
+            NOTIFICATIONS {
+                     pmip6LmaHomeTunnelEstablished,
+                     pmip6LmaHomeTunnelReleased
+
+
+
+Keeni, et al.                Standards Track                   [Page 47]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+           }
+            STATUS  current
+            DESCRIPTION
+                "A collection of notifications from a home agent
+                 or correspondent node to the Manager about the
+                 tunnel status of the mobile router.
+                "
+            ::= { pmip6Groups 10 }
+
+       -- Compliance statements
+       pmip6CoreCompliance MODULE-COMPLIANCE
+            STATUS  current
+            DESCRIPTION
+                "The compliance statement for SNMP entities
+                 that implement the PMIPV6-MIB.
+                 There are a number of INDEX objects that cannot be
+                 represented in the form of OBJECT clauses in
+                 SMIv2, but for which there are compliance
+                 requirements, expressed in OBJECT clause form in
+                 this description:
+                 -- OBJECT      pmip6BindingHomeAddressType
+                 -- SYNTAX      InetAddressType { ipv6(2) }
+                 -- DESCRIPTION
+                 --   This MIB module requires support for global
+                 --   ipv6 addresses for the pmip6BindingHomeAddress
+                 --   object.
+                 --
+                 "
+            MODULE  -- this module
+                MANDATORY-GROUPS { pmip6SystemGroup
+                                 }
+            ::= { pmip6Compliances 1 }
+
+       pmip6Compliance2 MODULE-COMPLIANCE
+            STATUS  current
+            DESCRIPTION
+                "The compliance statement for SNMP entities
+                 that implement the PMIPV6-MIB.
+                 "
+            MODULE  -- this module
+                MANDATORY-GROUPS { pmip6SystemGroup,
+                                   pmip6BindingCacheGroup,
+                                   pmip6StatsGroup
+                                 }
+            ::= { pmip6Compliances 2 }
+
+       pmip6CoreReadOnlyCompliance MODULE-COMPLIANCE
+            STATUS  current
+
+
+
+Keeni, et al.                Standards Track                   [Page 48]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+            DESCRIPTION
+                "The compliance statement for SNMP entities
+                 that implement the PMIPV6-MIB without support
+                 for read-write (i.e., in read-only mode).
+                 "
+            MODULE  -- this module
+                MANDATORY-GROUPS { pmip6SystemGroup
+                                 }
+            OBJECT  pmip6MobileNodeGeneratedTimestampInUse
+            MIN-ACCESS  read-only
+            DESCRIPTION
+                   "Write access is not required."
+            OBJECT  pmip6FixedMagLinkLocalAddressOnAllAccessLinksType
+            MIN-ACCESS  read-only
+            DESCRIPTION
+                   "Write access is not required."
+            OBJECT  pmip6FixedMagLinkLocalAddressOnAllAccessLinks
+            MIN-ACCESS  read-only
+            DESCRIPTION
+                   "Write access is not required."
+            OBJECT  pmip6FixedMagLinkLayerAddressOnAllAccessLinks
+            MIN-ACCESS  read-only
+            DESCRIPTION
+                   "Write access is not required."
+
+            ::= { pmip6Compliances 3 }
+
+       pmip6ReadOnlyCompliance2 MODULE-COMPLIANCE
+            STATUS  current
+            DESCRIPTION
+                "The compliance statement for SNMP entities
+                 that implement the PMIPV6-MIB without support
+                 for read-write (i.e., in read-only mode).
+                 "
+            MODULE  -- this module
+                MANDATORY-GROUPS { pmip6SystemGroup,
+                                   pmip6BindingCacheGroup,
+                                   pmip6StatsGroup
+                                 }
+            OBJECT  pmip6MobileNodeGeneratedTimestampInUse
+            MIN-ACCESS  read-only
+            DESCRIPTION
+                   "Write access is not required."
+            OBJECT  pmip6FixedMagLinkLocalAddressOnAllAccessLinksType
+            MIN-ACCESS  read-only
+            DESCRIPTION
+                   "Write access is not required."
+            OBJECT  pmip6FixedMagLinkLocalAddressOnAllAccessLinks
+
+
+
+Keeni, et al.                Standards Track                   [Page 49]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+            MIN-ACCESS  read-only
+            DESCRIPTION
+                   "Write access is not required."
+            OBJECT  pmip6FixedMagLinkLayerAddressOnAllAccessLinks
+            MIN-ACCESS  read-only
+            DESCRIPTION
+                   "Write access is not required."
+
+            ::= { pmip6Compliances 4 }
+
+       pmip6MagCoreCompliance MODULE-COMPLIANCE
+            STATUS  current
+            DESCRIPTION
+                "The compliance statement for SNMP entities
+                 that implement the PMIPV6-MIB.
+
+                 There are a number of INDEX objects that cannot be
+                 represented in the form of OBJECT clauses in
+                 SMIv2, but for which there are compliance
+                 requirements, expressed in OBJECT clause form in
+                 this description:
+                  -- OBJECT      pmip6MagProxyCOAType
+                  -- SYNTAX      InetAddressType { ipv6(2) }
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the pmip6MagProxyCOAType
+                  --     object.
+                  --
+                  -- OBJECT      pmip6MagProxyCOA
+                  -- SYNTAX      InetAddress (SIZE(16))
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the pmip6MagProxyCOA
+                  --     object.
+                  --
+                 "
+            MODULE  -- this module
+                MANDATORY-GROUPS { pmip6MagSystemGroup
+                                 }
+            ::= { pmip6Compliances 5 }
+
+       pmip6MagCompliance2 MODULE-COMPLIANCE
+            STATUS  current
+            DESCRIPTION
+                "The compliance statement for SNMP entities that
+                 implement the PMIPV6-MIB for monitoring configuration-
+                 related information, registration details, and
+                 statistics on a mobile access gateway.
+
+
+
+Keeni, et al.                Standards Track                   [Page 50]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                 There are a number of INDEX objects that cannot be
+                 represented in the form of OBJECT clauses in
+                 SMIv2, but for which there are compliance
+                 requirements, expressed in OBJECT clause form in
+                 this description:
+
+                  -- OBJECT      pmip6MagProxyCOAType
+                  -- SYNTAX      InetAddressType { ipv6(2) }
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the pmip6MagProxyCOA
+                  --     object.
+                  --
+                  -- OBJECT      pmip6MagProxyCOA
+                  -- SYNTAX      InetAddress (SIZE(16))
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the pmip6MagProxyCOAType
+                  --     object.
+                  --
+                  -- OBJECT      pmip6MagHomeNetworkPrefixType
+                  -- SYNTAX      InetAddressType { ipv6(2) }
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the
+                  --     pmip6MagHomeNetworkPrefix object.
+                  --
+                  -- OBJECT      pmip6MagHomeNetworkPrefix
+                  -- SYNTAX      InetAddress (SIZE(16))
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the
+                  --     pmip6MagHomeNetworkPrefix object.
+                  --
+                 "
+            MODULE  -- this module
+                MANDATORY-GROUPS { pmip6MagSystemGroup,
+                                   pmip6MagConfigurationGroup,
+                                   pmip6MagRegistrationGroup
+                                 }
+            ::= { pmip6Compliances 6 }
+
+       pmip6MagCoreReadOnlyCompliance MODULE-COMPLIANCE
+            STATUS  current
+            DESCRIPTION
+                "The compliance statement for SNMP entities
+                 that implement the PMIPV6-MIB without support
+                 for read-write (i.e., in read-only mode).
+
+
+
+Keeni, et al.                Standards Track                   [Page 51]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                 There are a number of INDEX objects that cannot be
+                 represented in the form of OBJECT clauses in
+                 SMIv2, but for which there are compliance
+                 requirements, expressed in OBJECT clause form in
+                 this description:
+                  -- OBJECT      pmip6MagProxyCOAType
+                  -- SYNTAX      InetAddressType { ipv6(2) }
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the pmip6MagProxyCOA
+                  --     object.
+                  --
+                  -- OBJECT      pmip6MagProxyCOA
+                  -- SYNTAX      InetAddress (SIZE(16))
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the pmip6MagProxyCOAType
+                  --     object.
+                  --
+                  -- OBJECT      pmip6MagHomeNetworkPrefixType
+                  -- SYNTAX      InetAddressType { ipv6(2) }
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the
+                  --     pmip6MagHomeNetworkPrefix object.
+                  --
+                 "
+            MODULE  -- this module
+                MANDATORY-GROUPS { pmip6MagSystemGroup
+                                 }
+            OBJECT  pmip6MagStatus
+            MIN-ACCESS  read-only
+            DESCRIPTION
+                   "Write access is not required."
+            ::= { pmip6Compliances 7 }
+
+       pmip6MagReadOnlyCompliance2 MODULE-COMPLIANCE
+            STATUS  current
+            DESCRIPTION
+                "The compliance statement for SNMP entities that
+                 implement the PMIPV6-MIB without support for read-
+                 write (i.e., in read-only mode) and with support
+                 for monitoring configuration-related information,
+                 registration details, and statistics on a mobile
+                 access gateway.
+
+                 There are a number of INDEX objects that cannot be
+                 represented in the form of OBJECT clauses in
+
+
+
+Keeni, et al.                Standards Track                   [Page 52]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                 SMIv2, but for which there are compliance
+                 requirements, expressed in OBJECT clause form in
+                 this description:
+
+                  -- OBJECT      pmip6MagProxyCOAType
+                  -- SYNTAX      InetAddressType { ipv6(2) }
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the pmip6MagProxyCOA
+                  --     object.
+                  --
+                  -- OBJECT      pmip6MagProxyCOA
+                  -- SYNTAX      InetAddress (SIZE(16))
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the pmip6MagProxyCOAType
+                  --     object.
+                  --
+                  -- OBJECT      pmip6MagHomeNetworkPrefixType
+                  -- SYNTAX      InetAddressType { ipv6(2) }
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the
+                  --     pmip6MagHomeNetworkPrefix object.
+                  --
+                  -- OBJECT      pmip6MagHomeNetworkPrefix
+                  -- SYNTAX      InetAddress (SIZE(16))
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the
+                  --     pmip6MagHomeNetworkPrefix object.
+                  --
+                 "
+            MODULE  -- this module
+                MANDATORY-GROUPS { pmip6MagSystemGroup,
+                                   pmip6MagConfigurationGroup,
+                                   pmip6MagRegistrationGroup
+                                 }
+            OBJECT  pmip6MagStatus
+            MIN-ACCESS  read-only
+            DESCRIPTION
+                   "Write access is not required."
+            OBJECT      pmip6MagEnableMagLocalRouting
+            MIN-ACCESS  read-only
+            DESCRIPTION
+                   "Write access is not required."
+
+            ::= { pmip6Compliances 8 }
+
+
+
+Keeni, et al.                Standards Track                   [Page 53]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+       pmip6LmaCoreCompliance MODULE-COMPLIANCE
+            STATUS  current
+            DESCRIPTION
+                "The compliance statement for SNMP entities
+                 that implement the PMIPV6-MIB.
+                 There are a number of INDEX objects that cannot be
+                 represented in the form of OBJECT clauses in
+                 SMIv2, but for which there are compliance
+                 requirements, expressed in OBJECT clause form in
+                 this description:
+                  -- OBJECT      pmip6LmaLMAAType
+                  -- SYNTAX      InetAddressType { ipv6(2) }
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the pmip6LmaLMAA
+                  --     object.
+                  --
+                  -- OBJECT      pmip6LmaLMAA
+                  -- SYNTAX      InetAddress (SIZE(16))
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the pmip6LmaLMAA
+                  --     object.
+                  --
+                 "
+            MODULE  -- this module
+                MANDATORY-GROUPS { pmip6LmaSystemGroup
+                                 }
+            ::= { pmip6Compliances 9 }
+
+       pmip6LmaCompliance2 MODULE-COMPLIANCE
+            STATUS  current
+            DESCRIPTION
+                "The compliance statement for SNMP entities that
+                 implement the PMIPV6-MIB for monitoring configuration-
+                 related information, registration details, and
+                 statistics on a mobile access gateway.
+
+                 There are a number of INDEX objects that cannot be
+                 represented in the form of OBJECT clauses in
+                 SMIv2, but for which there are compliance
+                 requirements, expressed in OBJECT clause form in
+                 this description:
+
+                  -- OBJECT      pmip6LmaLMAAType
+                  -- SYNTAX      InetAddressType { ipv6(2) }
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+
+
+
+Keeni, et al.                Standards Track                   [Page 54]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                  --     IPv6 addresses for the pmip6LmaLMAA
+                  --     object.
+                  --
+                  -- OBJECT      pmip6LmaLMAA
+                  -- SYNTAX      InetAddress (SIZE(16))
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the pmip6LmaLMAA
+                  --     object.
+                  --
+                  -- OBJECT      pmip6LmaHomeNetworkPrefixType
+                  -- SYNTAX      InetAddressType { ipv6(2) }
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the
+                  --     pmip6LmaHomeNetworkPrefix object.
+                  --
+                  -- OBJECT      pmip6LmaHomeNetworkPrefix
+                  -- SYNTAX      InetAddress (SIZE(16))
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the
+                  --     pmip6LmaHomeNetworkPrefix object.
+                  --
+                 "
+            MODULE  -- this module
+                MANDATORY-GROUPS { pmip6LmaSystemGroup,
+                                   pmip6LmaConfigurationGroup
+                                 }
+            ::= { pmip6Compliances 10 }
+
+       pmip6LmaReadOnlyCompliance MODULE-COMPLIANCE
+            STATUS  current
+            DESCRIPTION
+                "The compliance statement for SNMP entities
+                 that implement the PMIPV6-MIB.
+                 There are a number of INDEX objects that cannot be
+                 represented in the form of OBJECT clauses in
+                 SMIv2, but for which there are compliance
+                 requirements, expressed in OBJECT clause form in
+                 this description:
+                  -- OBJECT      pmip6LmaLMAAType
+                  -- SYNTAX      InetAddressType { ipv6(2) }
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the pmip6LmaLMAA
+                  --     object.
+                  --
+
+
+
+Keeni, et al.                Standards Track                   [Page 55]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                  -- OBJECT      pmip6LmaLMAA
+                  -- SYNTAX      InetAddress (SIZE(16))
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the pmip6LmaLMAA
+                  --     object.
+                  --
+                 "
+            MODULE  -- this module
+                MANDATORY-GROUPS { pmip6LmaSystemGroup
+                                 }
+            OBJECT  pmip6LmaStatus
+            MIN-ACCESS  read-only
+            DESCRIPTION
+                   "Write access is not required."
+            ::= { pmip6Compliances 11 }
+
+       pmip6LmaReadOnlyCompliance2 MODULE-COMPLIANCE
+            STATUS  current
+            DESCRIPTION
+                "The compliance statement for SNMP entities that
+                 implement the PMIPV6-MIB without support
+                 for read-write (i.e., in read-only mode) and for
+                 monitoring configuration-related information,
+                 registration details, and statistics on a mobile
+                 access gateway.
+
+                 There are a number of INDEX objects that cannot be
+                 represented in the form of OBJECT clauses in
+                 SMIv2, but for which there are compliance
+                 requirements, expressed in OBJECT clause form in
+                 this description:
+
+                  -- OBJECT      pmip6LmaLMAAType
+                  -- SYNTAX      InetAddressType { ipv6(2) }
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the pmip6LmaLMAA
+                  --     object.
+
+                  --
+                  -- OBJECT      pmip6LmaLMAA
+                  -- SYNTAX      InetAddress (SIZE(16))
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the pmip6LmaLMAA
+                  --     object.
+                  --
+
+
+
+Keeni, et al.                Standards Track                   [Page 56]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                  -- OBJECT      pmip6LmaHomeNetworkPrefixType
+                  -- SYNTAX      InetAddressType { ipv6(2) }
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the
+                  --     pmip6LmaHomeNetworkPrefix object.
+                  --
+                  -- OBJECT      pmip6LmaHomeNetworkPrefix
+                  -- SYNTAX      InetAddress (SIZE(16))
+                  -- DESCRIPTION
+                  --     This MIB module requires support for global
+                  --     IPv6 addresses for the
+                  --     pmip6LmaHomeNetworkPrefix object.
+                  --
+                 "
+            MODULE  -- this module
+                MANDATORY-GROUPS { pmip6LmaSystemGroup,
+                                   pmip6LmaConfigurationGroup
+                                 }
+            OBJECT  pmip6LmaStatus
+            MIN-ACCESS  read-only
+            DESCRIPTION
+                   "Write access is not required."
+            OBJECT      pmip6LmaMinDelayBeforeBCEDelete
+            MIN-ACCESS  read-only
+            DESCRIPTION
+                   "Write access is not required."
+            OBJECT      pmip6LmaMaxDelayBeforeNewBCEAssign
+            MIN-ACCESS  read-only
+            DESCRIPTION
+                   "Write access is not required."
+            OBJECT      pmip6LmaTimestampValidityWindow
+            MIN-ACCESS  read-only
+            DESCRIPTION
+                   "Write access is not required."
+            OBJECT      pmip6LmaHomeNetworkPrefixLifeTime
+            MIN-ACCESS  read-only
+            DESCRIPTION
+                   "Write access is not required."
+
+            ::= { pmip6Compliances 12 }
+
+       pmip6MagNotificationCompliance MODULE-COMPLIANCE
+            STATUS  current
+            DESCRIPTION
+                   "The compliance statement for SNMP entities that
+                    implement the PMIPV6-MIB and support notification
+                    from the mobile access gateway.
+
+
+
+Keeni, et al.                Standards Track                   [Page 57]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+                    "
+            MODULE  -- this module
+                MANDATORY-GROUPS { pmip6MagNotificationGroup
+                                 }
+            ::= { pmip6Compliances 13 }
+
+       pmip6LmaNotificationCompliance MODULE-COMPLIANCE
+            STATUS  current
+            DESCRIPTION
+                   "The compliance statement for SNMP entities that
+                    implement the PMIPV6-MIB and support notification
+                    from the LMA.
+                    "
+            MODULE  -- this module
+                MANDATORY-GROUPS { pmip6LmaNotificationGroup
+                                 }
+            ::={  pmip6Compliances 14 }
+
+       END
+
+6.  Security Considerations
+
+   There are a number of management objects defined in this MIB module
+   with a MAX-ACCESS clause of read-write.  Such objects may be
+   considered sensitive or vulnerable in some network environments.  The
+   support for SET operations in a non-secure environment without proper
+   protection can have a negative effect on network operations.  These
+   are the tables and objects and the corresponding
+   sensitivity/vulnerability:
+
+      The value of the following objects is used to enable or disable
+      the PMIPv6 functionality on the corresponding PMIPv6 entity.
+      Access to these MOs may be abused to disrupt the communication
+      that depends on the PMIPv6 functionality.
+         pmip6MagStatus
+         pmip6LmaStatus
+
+      Access to the following MOs may be abused to misconfigure PMIPv6
+      entities and disrupt communications.
+         pmip6MobileNodeGeneratedTimestampInUse
+         pmip6FixedMagLinkLocalAddressOnAllAccessLinksType
+         pmip6FixedMagLinkLocalAddressOnAllAccessLinks
+         pmip6FixedMagLinkLayerAddressOnAllAccessLinks
+         pmip6MagEnableMagLocalRouting
+         pmip6MagHomeNetworkPrefixLifeTime
+         pmip6LmaMinDelayBeforeBCEDelete
+         pmip6LmaMaxDelayBeforeNewBCEAssign
+         pmip6LmaTimestampValidityWindow
+
+
+
+Keeni, et al.                Standards Track                   [Page 58]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+         pmip6LmaHomeNetworkPrefixLifeTime
+
+   Some of the readable objects in this MIB module (i.e., objects with a
+   MAX-ACCESS other than not-accessible) may be considered sensitive or
+   vulnerable in some network environments.  It is thus important to
+   control even GET and/or NOTIFY access to these objects and possibly
+   to even encrypt the values of these objects when sending them over
+   the network via SNMP.  These are the tables and objects and their
+   sensitivity/vulnerability:
+
+      The following address-related objects may be considered to be
+      particularly sensitive and/or private.
+
+         pmip6LmaHomeNetworkPrefixType
+         pmip6LmaHomeNetworkPrefix
+         pmip6LmaHomeNetworkPrefixLength
+
+      The following MN Identifier-related MOs may be used to identify
+      users.  These may be considered to be sensitive and/or private.
+
+         pmip6MagMnIdentifier
+         pmip6MagMnLLIdentifier
+         pmip6LmaMnIdentifier
+         pmip6LmaMnLLIdentifier
+         pmip6MagProfMnIdentifier
+
+   SNMP versions prior to SNMPv3 did not include adequate security.
+   Even if the network itself is secure (for example by using IPsec),
+   even then, there is no control as to who on the secure network is
+   allowed to access and GET/SET (read/change/create/delete) the objects
+   in this MIB module.
+
+   It is RECOMMENDED that implementers consider the security features as
+   provided by the SNMPv3 framework (see [RFC3410], section 8),
+   including full support for the SNMPv3 cryptographic mechanisms (for
+   authentication and privacy).
+
+   Implementations MUST provide the security features described by the
+   SNMPv3 framework (see [RFC3410]), including full support for
+   authentication and privacy via the User-based Security Model (USM)
+   [RFC3414] with the AES cipher algorithm [RFC3826].  Implementations
+   MAY also provide support for the Transport Security Model (TSM)
+   [RFC5591] in combination with a secure transport such as SSH
+   [RFC5592] or TLS/DTLS [RFC6353].
+
+   Further, deployment of SNMP versions prior to SNMPv3 is NOT
+   RECOMMENDED.  Instead, it is RECOMMENDED to deploy SNMPv3 and to
+   enable cryptographic security.  It is then a customer/operator
+
+
+
+Keeni, et al.                Standards Track                   [Page 59]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+   responsibility to ensure that the SNMP entity giving access to an
+   instance of this MIB module is properly configured to give access to
+   the objects only to those principals (users) that have legitimate
+   rights to indeed GET or SET (change/create/delete) them.
+
+7.  IANA Considerations
+
+   IANA has assigned the following:
+
+      1. a base arc in the 'mib-2' (Standards Track) OID tree for the
+         'pmip6TCMIB' MODULE-IDENTITY defined in the PMIPV6-TC-MIB.
+
+      2. a base arc in the 'mib-2' (Standards Track) OID tree for the
+         'pmip6MIB' MODULE-IDENTITY defined in the PMIPV6-MIB.
+
+8.  References
+
+8.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2578]  McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+              "Structure of Management Information Version 2 (SMIv2)",
+              STD 58, RFC 2578, April 1999.
+
+   [RFC2579]  McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+              "Textual Conventions for SMIv2", STD 58, RFC 2579, April
+              1999.
+
+   [RFC2580]  McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+              "Conformance Statements for SMIv2", STD 58, RFC 2580,
+              April 1999.
+
+   [RFC4001]  Daniele, M., Haberman, B., Routhier, S., and J.
+              Schoenwaelder, "Textual Conventions for Internet Network
+              Addresses", RFC 4001, February 2005.
+
+   [RFC4283]  Patel, A., Leung, K., Khalil, M., Akhtar, H., and K.
+              Chowdhury, "Mobile Node Identifier Option for Mobile IPv6
+              (MIPv6)", RFC 4283, November 2005.
+
+   [RFC4293]  Routhier, S., Ed., "Management Information Base for the
+              Internet Protocol (IP)", RFC 4293, April 2006.
+
+   [RFC4295]  Keeni, G., Koide, K., Nagami, K., and S. Gundavelli,
+              "Mobile IPv6 Management Information Base", RFC 4295, April
+              2006.
+
+
+
+Keeni, et al.                Standards Track                   [Page 60]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+   [RFC5213]  Gundavelli, S., Ed., Leung, K., Devarapalli, V.,
+              Chowdhury, K., and B. Patil, "Proxy Mobile IPv6", RFC
+              5213, August 2008.
+
+   [RFC6275]  Perkins, C., Ed., Johnson, D., and J. Arkko, "Mobility
+              Support in IPv6", RFC 6275, July 2011.
+
+8.2.  Informative References
+
+   [RFC3410]  Case, J., Mundy, R., Partain, D., and B. Stewart,
+              "Introduction and Applicability Statements for Internet-
+              Standard Management Framework", RFC 3410, December 2002.
+
+   [RFC3414]  Blumenthal, U. and B. Wijnen, "User-based Security Model
+              (USM) for version 3 of the Simple Network Management
+              Protocol (SNMPv3)", STD 62, RFC 3414, December 2002.
+
+   [RFC3826]  Blumenthal, U., Maino, F., and K. McCloghrie, "The
+              Advanced Encryption Standard (AES) Cipher Algorithm in the
+              SNMP User-based Security Model", RFC 3826, June 2004.
+
+   [RFC4831]  Kempf, J., Ed., "Goals for Network-Based Localized
+              Mobility Management (NETLMM)", RFC 4831, April 2007.
+
+   [RFC5591]  Harrington, D. and W. Hardaker, "Transport Security Model
+              for the Simple Network Management Protocol (SNMP)", RFC
+              5591, June 2009.
+
+   [RFC5592]  Harrington, D., Salowey, J., and W. Hardaker, "Secure
+              Shell Transport Model for the Simple Network Management
+              Protocol (SNMP)", RFC 5592, June 2009.
+
+   [RFC6353]  Hardaker, W., "Transport Layer Security (TLS) Transport
+              Model for the Simple Network Management Protocol (SNMP)",
+              RFC 6353, July 2011.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Keeni, et al.                Standards Track                   [Page 61]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+9.  Acknowledgements
+
+   The following individuals and groups have contributed to this
+   document with discussions and comments:
+
+      Adrian Farrel
+      Dan Romascanu
+      David Harrington
+      Dirk von-Hugo
+      Francis Dupont
+      Harrie Hazewinkel
+      Jari Arkko
+      Sean Turner
+      Stephen Farrell
+      Vincent Roca
+      WIDE Project netman-WG
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Keeni, et al.                Standards Track                   [Page 62]
+
+RFC 6475                       PMIPV6-MIB                       May 2012
+
+
+Authors' Addresses
+
+   Glenn Mansfield Keeni
+   Cyber Solutions, Inc.
+   6-6-3 Minami Yoshinari
+   Aoba-ku, Sendai 989-3204
+   Japan
+
+   Phone: +81-22-303-4012
+   EMail: glenn@cysols.com
+
+
+   Kazuhide Koide
+   KDDI Corporation
+   GARDEN AIR TOWER 3-10-10, Iidabashi
+   Chiyoda-ku, Tokyo, 102-8460
+   Japan
+
+   Phone: +81-3-6678-3378
+   EMail: ka-koide@kddi.com
+
+
+   Sri Gundavelli
+   Cisco Systems
+   170 W.Tasman Drive,
+   San Jose, CA 95134
+   USA
+
+   Phone: +1-408-527-6109
+   EMail: sgundave@cisco.com
+
+
+   Ryuji Wakikawa
+   TOYOTA InfoTechnology Center, U.S.A., Inc.
+   465 Bernardo Avenue
+   Mountain View, CA 94043
+   USA
+   EMail: ryuji@us.toyota-itc.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+Keeni, et al.                Standards Track                   [Page 63]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6475.txt](<www.ietf.org/rfc/rfc6475.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
