### PR TITLE
Archive rfc6527.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6527.txt
+++ b/www.ietf.org/rfc/rfc6527.txt
@@ -1,0 +1,1739 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                           K. Tata
+Request for Comments: 6527                                         Nokia
+Obsoletes: 2787                                               March 2012
+Category: Standards Track
+ISSN: 2070-1721
+
+
+                   Definitions of Managed Objects for
+       the Virtual Router Redundancy Protocol Version 3 (VRRPv3)
+
+Abstract
+
+   This specification defines a portion of the Management Information
+   Base (MIB) for use with network management based on the Simple
+   Network Management Protocol (SNMP).  In particular, it defines
+   objects for configuring, monitoring, and controlling routers that
+   employ the Virtual Router Redundancy Protocol Version 3 (VRRPv3) for
+   both IPv4 and IPv6 as defined in RFC 5798.  This memo obsoletes RFC
+   2787.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6527.
+
+Copyright Notice
+
+   Copyright (c) 2012 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+Tata                         Standards Track                    [Page 1]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+   This document may contain material from IETF Documents or IETF
+   Contributions published or made publicly available before November
+   10, 2008.  The person(s) controlling the copyright in some of this
+   material may not have granted the IETF Trust the right to allow
+   modifications of such material outside the IETF Standards Process.
+   Without obtaining an adequate license from the person(s) controlling
+   the copyright in such materials, this document may not be modified
+   outside the IETF Standards Process, and derivative works of it may
+   not be created outside the IETF Standards Process, except to format
+   it for publication as an RFC or to translate it into languages other
+   than English.
+
+Table of Contents
+
+   1. The Internet-Standard Management Framework ......................2
+   2. Introduction ....................................................3
+   3. Terminology .....................................................3
+   4. Relationship to RFC 2787 ........................................3
+   5. Relation to Interface Group (IF-MIB) ............................3
+   6. Multi-Stack Implementations .....................................3
+   7. Interpretation of RFC 5798 ......................................3
+   8. VRRP MIB Structure and Design ...................................4
+   9. VRRP Multi-Stack Scenario .......................................4
+   10. Definitions ....................................................7
+   11. Security Considerations .......................................27
+   12. IANA Considerations ...........................................29
+   13. Normative References ..........................................29
+   14. Informative References ........................................30
+   15. Acknowledgments ...............................................31
+
+1.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This memo specifies a MIB
+   module that is compliant to the SMIv2, which is described in STD 58,
+   RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579] and STD 58, RFC 2580
+   [RFC2580].
+
+
+
+
+
+
+
+Tata                         Standards Track                    [Page 2]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+2.  Introduction
+
+   This specification defines a portion of the MIB for use with SNMP-
+   based network management.  In particular, it defines objects for
+   configuring, monitoring, and controlling routers that employ the
+   Virtual Router Redundancy Protocol Version 3 (VRRPv3) for both IPv4
+   and IPv6 as defined in RFC 5798 [RFC5798].
+
+3.  Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in RFC
+   2119 [RFC2119].
+
+4.  Relationship to RFC 2787
+
+   This document obsoletes RFC 2787 [RFC2787].  The major changes in
+   this document reflect changes in the VRRP protocol between RFC 2338
+   [RFC2338] and RFC 5798 [RFC5798].  This document is also updated to
+   conform to current MIB conventions.
+
+5.  Relation to Interface Group (IF-MIB)
+
+   Since a router can be participating in VRRP on one or more
+   interfaces, "ifIndex" is used as an index into the tables defined in
+   the VRRP MIB.  This MIB module imports ifIndex from the IF-MIB.  At
+   this time, the latest version of the IF-MIB is from RFC 2863
+   [RFC2863].
+
+6.  Multi-Stack Implementations
+
+   This MIB module is designed to support multi-stack implementations
+   that run VRRP over IPv4 and IPv6.  The IP version, Virtual Router
+   Identifier (VRID), and ifIndex are used to uniquely identify rows in
+   a multi-stack implementation.
+
+7.  Interpretation of RFC 5798
+
+   During the review of this document, it emerged that there are
+   different possible interpretations of [RFC5798].  The authors of that
+   document and the VRRP working group were unable to reach consensus as
+   to which interpretation is correct.  This document makes the
+   following assumption:
+
+
+
+
+
+
+
+Tata                         Standards Track                    [Page 3]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+      IPv4 and IPv6 virtual routers are treated as two separate logical
+      entities and represented as two separate entries in the
+      vrrpv3OperationsTable.  This is required due to the undefined
+      behavior of the protocol in [RFC5798] in a multi-stack scenario.
+
+8.  VRRP MIB Structure and Design
+
+   This MIB module contains three tables:
+
+   (1)  The vrrpv3OperationsTable contains objects that define the
+        operational characteristics of a VRRP router.  Rows in this
+        table correspond to instances of virtual routers.
+
+   (2)  The vrrpv3StatisticsTable contains the operating statistics for
+        a VRRP router.
+
+   (3)  The vrrpv3AssociatedIpAddrTable contains the addresses of the
+        virtual router(s) that a given VRRP router is backing up.
+
+   Tables are indexed on ifIndex, VRID, and the IP version to uniquely
+   identify a VRRP router.
+
+   Notifications in this MIB module are controlled using the mechanisms
+   defined in [RFC3413].
+
+9.  VRRP Multi-Stack Scenario
+
+   The following section provides examples of how some of the objects in
+   this MIB are instantiated.
+
+   KEY:
+   ----
+   The labels in the following tables and diagrams correspond to the
+   actual MIB objects as follows:
+
+   if      = IfIndex
+   AddrType= vrrpv3OperationsInetAddrType
+   VrId    = vrrpv3OperationsVrId
+   State   = vrrpv3OperationsStatus
+   Prior   = vrrpv3OperationsPriority
+   IpAddr  = vrrpv3OperationsMasterIpAddr
+
+   The following figure shows a hypothetical network with two VRRP
+   routers, VR1 & VR2, configured with two virtual routers.  Addresses
+   in '()' indicate the address of the default gateway for a given host;
+   H1 to H4 are IPv4 hosts, and H5 to H8 are IPv6 hosts.  A, B, and C
+   are IPv4 addresses, and X, Y, and Z are IPv6 addresses.  In the
+   diagram, "Interface" is used in the context defined in IF-MIB.
+
+
+
+Tata                         Standards Track                    [Page 4]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+                 +------+                      +------+
+                 | VR1  |                      |  VR2 |
+                 |      |                      |      |
+                 +------+                      +------+
+                     |                            |
+                Intf = I1                    Intf = I2
+       IP A          |   IP X         IP B        |    IP Y
+       IP C          |                            |    IP Z
+       VRID = 1      |   VRID=2       VRID=2      |    VRID = 1
+                     |                            |
+   ----+------+------+-+-------+--------+--------++------+--------+---
+       ^      ^        ^       ^        ^        ^       ^        ^
+       |      |        |       |        |        |       |        |
+    (IP A)  (IP A)   (IP B)  (IP B)   (IP X)   (IP X)  (IP Y)   (IP Y)
+       |      |        |       |        |        |       |        |
+    +----+  +----+  +----+  +----+    +----+   +----+  +----+  +----+
+    | H1 |  | H2 |  | H3 |  | H4 |    | H5 |   | H6 |  | H7 |  | H8 |
+    +----+  +----+  +----+  +----+    +----+   +----+  +----+  +----+
+
+           -----   MIB Tables For VRRP Router "VR1":   -----
+
+   vrrpv3OperationsTable
+   -------------------
+
+   | if | VrId |AddrType| State | Prior |IpAddr|        |
+   +----+------+--------+-------+-------+------+--(..)--+
+   | I1 |  01  |    1   |   M   |  255  |   A  |        |
+   +----+------+--------+-------+-------+------+--(..)--+
+   | I1 |  01  |    2   |   B   | 1-254 |   Y  |        |
+   +----+------+--------+-------+-------+------+--(..)--+
+   | I1 |  02  |    1   |   B   | 1-254 |   B  |        |
+   +----+------+--------+-------+-------+------+--(..)--+
+   | I1 |  02  |    2   |   M   |  255  |   X  |        |
+   +----+------+--------+-------+-------+------+--------+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Tata                         Standards Track                    [Page 5]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+   vrrpv3AssociatedIpAddrTable
+   -------------------------
+
+   | if | VrId | AddrType | IP   | RowStat |
+   +----+------+----------+------+---------+
+   | I1 |  01  |    1     |  A   | active  |
+   +----+------+----------+------+---------+
+   | I1 |  01  |    1     |  C   | active  |
+   +----+------+----------+------+---------+
+   | I1 |  01  |    2     |  Y   | active  |
+   +----+------+----------+------+---------+
+   | I1 |  01  |    2     |  Z   | active  |
+   +----+------+----------+------+---------+
+   | I1 |  02  |    1     |  B   | active  |
+   +----+------+----------+------+---------+
+   | I1 |  02  |    2     |  X   | active  |
+   +----+------+----------+------+---------+
+
+           -----   MIB Tables For VRRP Router "VR2":   -----
+
+   vrrpv3OperationsTable
+   -------------------
+
+   | if | VrId |AddrType| State | Prior |IpAddr|        |
+   +----+------+--------+-------+-------+------+--(..)--+
+   | I2 |  01  |    1   |   B   | 1-254 |   A  |        |
+   +----+------+--------+-------+-------|------+--(..)--+
+   | I2 |  01  |    2   |   M   | 255   |   Y  |        |
+   +----+------+--------+-------+-------+------+--(..)--+
+   | I2 |  02  |    1   |   M   |  255  |   B  |        |
+   +----+------+--------+-------+-------+------+--(..)--+
+   | I2 |  02  |    2   |   B   | 1-254 |   X  |        |
+   +----+------+--------+-------+-------+------+--------+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Tata                         Standards Track                    [Page 6]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+   vrrpv3AssociatedIpAddrTable
+   -------------------------
+
+   | if | VrId |AddrType| IP   | RowStat |
+   +----+------+--------+------+---------+
+   | I2 |  01  |   1    |  A   | active  |
+   +----+------+--------+------+---------+
+   | I2 |  01  |   1    |  C   | active  |
+   +----+------+--------+------+---------+
+   | I2 |  01  |   2    |  Y   | active  |
+   +----+------+--------+------+---------+
+   | I2 |  01  |   2    |  Z   | active  |
+   +----+------+--------+------+---------+
+   | I2 |  02  |   1    |  B   | active  |
+   +----+------+--------+------+---------+
+   | I2 |  02  |   2    |  X   | active  |
+   +----+------+--------+------+---------+
+
+   NOTES:
+
+   1) For "State": M = Master;   B = Backup.
+      In the vrrpv3OperationsTable, a "priority" of 255 indicates that
+      the respective router owns the IP address, e.g., this IP address
+      is native to the router (i.e., "the IP Address Owner").
+
+10.  Definitions
+
+   This MIB module makes reference to the following documents [RFC2578],
+   [RFC2579], [RFC2580], [RFC2863], and [RFC4001].
+
+   VRRPV3-MIB DEFINITIONS ::= BEGIN
+
+       IMPORTS
+           MODULE-IDENTITY, OBJECT-TYPE,
+           NOTIFICATION-TYPE, Counter32,
+           Integer32, mib-2, Unsigned32,
+           Counter64, TimeTicks
+               FROM SNMPv2-SMI                 -- RFC2578
+
+           TEXTUAL-CONVENTION, RowStatus,
+           MacAddress, TruthValue, TimeStamp,
+           TimeInterval
+               FROM SNMPv2-TC                  -- RFC2579
+
+           MODULE-COMPLIANCE, OBJECT-GROUP,
+           NOTIFICATION-GROUP
+               FROM SNMPv2-CONF                -- RFC2580
+
+
+
+
+Tata                         Standards Track                    [Page 7]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+           ifIndex
+               FROM IF-MIB                     -- RFC2863
+           InetAddressType, InetAddress
+
+               FROM INET-ADDRESS-MIB;          -- RFC4001
+
+      vrrpv3MIB  MODULE-IDENTITY
+           LAST-UPDATED "201202130000Z"         -- Feb 13, 2012
+           ORGANIZATION "IETF VRRP Working Group"
+           CONTACT-INFO
+                  "WG E-Mail: vrrp@ietf.org
+
+                   Editor:    Kalyan Tata
+                              Nokia
+                              313 Fairchild Dr,
+                              Mountain View, CA 94043
+                              Tata_kalyan@yahoo.com"
+
+           DESCRIPTION
+               "This MIB describes objects used for managing Virtual
+                Router Redundancy Protocol version 3 (VRRPv3).
+
+                Copyright (c) 2012 IETF Trust and the persons
+                identified as authors of the code.  All rights
+                reserved.
+
+                Redistribution and use in source and binary forms,
+                with or without modification, is permitted pursuant
+                to, and subject to the license terms contained in,
+                the Simplified BSD License set forth in Section
+                4.c of the IETF Trust's Legal Provisions Relating
+                to IETF Documents
+                (http://trustee.ietf.org/license-info).
+
+                This version of the MIB module is part of RFC 6527.
+                Please see the RFC for full legal notices."
+
+           REVISION "201202120000Z"    -- Feb 13, 2012
+           DESCRIPTION "Initial version as published in RFC 6527."
+
+           ::= { mib-2 207 }
+
+   -- Textual Conventions
+
+      Vrrpv3VrIdTC ::= TEXTUAL-CONVENTION
+           DISPLAY-HINT "d"
+           STATUS       current
+           DESCRIPTION
+
+
+
+Tata                         Standards Track                    [Page 8]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+               "The value of the Virtual Router Identifier noted as
+               (VRID) in RFC 5798.  This, along with interface index
+               (ifIndex) and IP version, serves to uniquely identify
+               a virtual router on a given VRRP router."
+           REFERENCE "RFC 5798 (Sections 3 and 5.2.3)"
+           SYNTAX      Integer32 (1..255)
+
+   --  VRRPv3 MIB Groups
+
+      vrrpv3Notifications   OBJECT IDENTIFIER ::= { vrrpv3MIB 0 }
+      vrrpv3Objects         OBJECT IDENTIFIER ::= { vrrpv3MIB 1 }
+      vrrpv3Conformance     OBJECT IDENTIFIER ::= { vrrpv3MIB 2 }
+
+   -- VRRPv3 MIB Objects
+
+      vrrpv3Operations      OBJECT IDENTIFIER ::= { vrrpv3Objects 1 }
+      vrrpv3Statistics      OBJECT IDENTIFIER ::= { vrrpv3Objects 2 }
+
+   --  VRRPv3 Operations Table
+
+       vrrpv3OperationsTable OBJECT-TYPE
+           SYNTAX       SEQUENCE OF Vrrpv3OperationsEntry
+           MAX-ACCESS   not-accessible
+           STATUS       current
+           DESCRIPTION
+               "Unified Operations table for a VRRP router that
+                consists of a sequence (i.e., one or more conceptual
+                rows) of 'vrrpv3OperationsEntry' items each of which
+                describe the operational characteristics of a virtual
+                router."
+
+           ::= { vrrpv3Operations 1 }
+
+       vrrpv3OperationsEntry OBJECT-TYPE
+           SYNTAX       Vrrpv3OperationsEntry
+           MAX-ACCESS   not-accessible
+           STATUS       current
+           DESCRIPTION
+               "An entry in the vrrpv3OperationsTable containing the
+                operational characteristics of a virtual router.
+                On a VRRP router, a given virtual router is
+                identified by a combination of ifIndex, VRID, and
+                the IP version.  ifIndex represents an interface of
+                the router.
+
+                A row must be created with vrrpv3OperationsStatus
+                set to initialize(1) and cannot transition to
+                backup(2) or master(3) until
+
+
+
+Tata                         Standards Track                    [Page 9]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+                vrrpv3OperationsRowStatus is transitioned to
+                active(1).
+
+                The information in this table is persistent and when
+                written the entity SHOULD save the change to non-
+                volatile storage."
+
+           INDEX    { ifIndex, vrrpv3OperationsVrId,
+                      vrrpv3OperationsInetAddrType
+                     }
+           ::= { vrrpv3OperationsTable 1 }
+
+       Vrrpv3OperationsEntry ::=
+
+           SEQUENCE {
+               vrrpv3OperationsVrId
+                   Vrrpv3VrIdTC,
+               vrrpv3OperationsInetAddrType
+                   InetAddressType,
+               vrrpv3OperationsMasterIpAddr
+                   InetAddress,
+               vrrpv3OperationsPrimaryIpAddr
+                   InetAddress,
+               vrrpv3OperationsVirtualMacAddr
+                   MacAddress,
+               vrrpv3OperationsStatus
+                   INTEGER,
+               vrrpv3OperationsPriority
+                   Unsigned32,
+               vrrpv3OperationsAddrCount
+                   Integer32,
+               vrrpv3OperationsAdvInterval
+                   TimeInterval,
+               vrrpv3OperationsPreemptMode
+                   TruthValue,
+               vrrpv3OperationsAcceptMode
+                   TruthValue,
+               vrrpv3OperationsUpTime
+                   TimeTicks,
+               vrrpv3OperationsRowStatus
+                   RowStatus
+       }
+       vrrpv3OperationsVrId OBJECT-TYPE
+           SYNTAX       Vrrpv3VrIdTC
+           MAX-ACCESS   not-accessible
+           STATUS       current
+           DESCRIPTION
+
+
+
+
+Tata                         Standards Track                   [Page 10]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+               "This object contains the Virtual Router Identifier
+                (VRID)."
+           REFERENCE "RFC 4001"
+           ::= { vrrpv3OperationsEntry 1 }
+
+       vrrpv3OperationsInetAddrType OBJECT-TYPE
+           SYNTAX       InetAddressType
+           MAX-ACCESS   not-accessible
+           STATUS       current
+           DESCRIPTION
+              "The IP address type of Vrrpv3OperationsEntry and
+               Vrrpv3AssociatedIpAddrEntry.  This value determines
+               the type for vrrpv3OperationsMasterIpAddr,
+               vrrpv3OperationsPrimaryIpAddr, and
+               vrrpv3AssociatedIpAddrAddress.
+
+                ipv4(1) and ipv6(2) are the only two values supported
+                in this MIB module."
+           REFERENCE "RFC 4001"
+           ::= { vrrpv3OperationsEntry 2 }
+
+       vrrpv3OperationsMasterIpAddr OBJECT-TYPE
+           SYNTAX       InetAddress
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+             "The master router's real IP address.  The master router
+             would set this address to vrrpv3OperationsPrimaryIpAddr
+             while transitioning to master state.  For backup
+             routers, this is the IP address listed as the source in
+             the VRRP advertisement last received by this virtual
+             router."
+           REFERENCE "RFC 5798"
+           ::= { vrrpv3OperationsEntry 3 }
+
+       vrrpv3OperationsPrimaryIpAddr OBJECT-TYPE
+           SYNTAX       InetAddress
+           MAX-ACCESS   read-create
+           STATUS       current
+           DESCRIPTION
+               "In the case where there is more than one IP
+               Address (associated IP addresses) for a given
+               'ifIndex', this object is used to specify the IP
+               address that will become the
+               vrrpv3OperationsMasterIpAddr', should the virtual
+               router transition from backup state to master."
+           ::= { vrrpv3OperationsEntry 4 }
+
+
+
+
+Tata                         Standards Track                   [Page 11]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+       vrrpv3OperationsVirtualMacAddr OBJECT-TYPE
+           SYNTAX       MacAddress
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+              "The virtual MAC address of the virtual router.
+              Although this object can be derived from the
+              'vrrpv3OperationsVrId' object, it is defined so that it
+              is easily obtainable by a management application and
+              can be included in VRRP-related SNMP notifications."
+           ::= { vrrpv3OperationsEntry 5 }
+
+       vrrpv3OperationsStatus OBJECT-TYPE
+           SYNTAX       INTEGER {
+               initialize(1),
+               backup(2),
+               master(3)
+           }
+           MAX-ACCESS   read-only
+           STATUS       current
+
+           DESCRIPTION
+               "The current state of the virtual router.  This object
+               has three defined values:
+
+               - 'initialize', which indicates that the
+                  virtual router is waiting for a startup event.
+
+               - 'backup', which indicates that the virtual router is
+                  monitoring the availability of the master router.
+
+               - 'master', which indicates that the virtual router
+                  is forwarding packets for IP addresses that are
+                  associated with this router."
+           REFERENCE "RFC 5798"
+           ::= { vrrpv3OperationsEntry 6 }
+
+       vrrpv3OperationsPriority OBJECT-TYPE
+           SYNTAX       Unsigned32 (0..255)
+           MAX-ACCESS   read-create
+           STATUS       current
+           DESCRIPTION
+             "This object specifies the priority to be used for the
+             virtual router master election process; higher values
+             imply higher priority.
+
+             A priority of '0', although not settable, is sent by
+             the master router to indicate that this router has
+
+
+
+Tata                         Standards Track                   [Page 12]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+             ceased to participate in VRRP, and a backup virtual
+             router should transition to become a new master.
+
+             A priority of 255 is used for the router that owns the
+             associated IP address(es) for VRRP over IPv4 and hence
+             is not settable.
+
+             Setting the values of this object to 0 or 255 should be
+             rejected by the agents implementing this MIB module.
+             For example, an SNMP agent would return 'badValue(3)'
+             when a user tries to set the values 0 or 255 for this
+             object."
+
+           REFERENCE "RFC 5798, Section 6.1"
+           DEFVAL       { 100 }
+           ::= { vrrpv3OperationsEntry 7 }
+
+       vrrpv3OperationsAddrCount OBJECT-TYPE
+           SYNTAX       Integer32 (0..255)
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+               "The number of IP addresses that are associated with
+               this virtual router.  This number is equal to the
+               number of rows in the vrrpv3AssociatedAddrTable that
+               correspond to a given ifIndex/VRID/IP version."
+           REFERENCE "RFC 5798, Section 6.1"
+           ::= { vrrpv3OperationsEntry 8 }
+
+       vrrpv3OperationsAdvInterval OBJECT-TYPE
+           SYNTAX       TimeInterval (1..4095)
+           UNITS        "centiseconds"
+           MAX-ACCESS   read-create
+           STATUS       current
+           DESCRIPTION
+               "The time interval, in centiseconds, between sending
+               advertisement messages.  Only the master router sends
+               VRRP advertisements."
+           REFERENCE "RFC 5798, Section 6.1"
+           DEFVAL       { 100}
+           ::= { vrrpv3OperationsEntry 9 }
+
+       vrrpv3OperationsPreemptMode OBJECT-TYPE
+           SYNTAX       TruthValue
+           MAX-ACCESS   read-create
+           STATUS       current
+           DESCRIPTION
+
+
+
+
+Tata                         Standards Track                   [Page 13]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+             "Controls whether a higher priority virtual router will
+             preempt a lower priority master."
+           REFERENCE "RFC 5798, Section 6.1"
+           DEFVAL       { true }
+           ::= { vrrpv3OperationsEntry 10 }
+
+       vrrpv3OperationsAcceptMode OBJECT-TYPE
+           SYNTAX       TruthValue
+           MAX-ACCESS   read-create
+           STATUS       current
+           DESCRIPTION
+              "Controls whether a virtual router in master state
+              will accept packets addressed to the address owner's
+              IPv6 address as its own if it is not the IPv6 address
+              owner.  Default is false(2).
+              This object is not relevant for rows representing VRRP
+              over IPv4 and should be set to false(2)."
+           DEFVAL       { false }
+           ::= { vrrpv3OperationsEntry 11 }
+
+       vrrpv3OperationsUpTime OBJECT-TYPE
+           SYNTAX       TimeTicks
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+               "This value represents the amount of time, in
+               TimeTicks (hundredth of a second), since this virtual
+               router (i.e., the 'vrrpv3OperationsStatus')
+               transitioned out of 'initialize'."
+           REFERENCE "RFC 5798, Section 6.1"
+           ::= { vrrpv3OperationsEntry 12 }
+
+       vrrpv3OperationsRowStatus OBJECT-TYPE
+           SYNTAX       RowStatus
+           MAX-ACCESS   read-create
+           STATUS       current
+           DESCRIPTION
+             "The RowStatus variable should be used in accordance to
+              installation and removal conventions for conceptual
+              rows.
+
+              To create a row in this table, a manager sets this
+              object to either createAndGo(4) or createAndWait(5).
+              Until instances of all corresponding columns are
+              appropriately configured, the value of the
+              corresponding instance of the
+              'vrrpv3OperationsRowStatus' column will be read as
+              notReady(3).
+
+
+
+Tata                         Standards Track                   [Page 14]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+              In particular, a newly created row cannot be made
+              active(1) until (minimally) the corresponding instance
+              of vrrpv3OperationsInetAddrType, vrrpv3OperationsVrId,
+              and vrrpv3OperationsPrimaryIpAddr has been set, and
+              there is at least one active row in the
+              'vrrpv3AssociatedIpAddrTable' defining an associated
+              IP address.
+
+              notInService(2) should be used to administratively
+              bring the row down.
+
+              A typical order of operation to add a row is:
+              1. Create a row in vrrpv3OperationsTable with
+              createAndWait(5).
+              2. Create one or more corresponding rows in
+              vrrpv3AssociatedIpAddrTable.
+              3. Populate the vrrpv3OperationsEntry.
+              4. Set vrrpv3OperationsRowStatus to active(1).
+
+              A typical order of operation to delete an entry is:
+              1. Set vrrpv3OperationsRowStatus to notInService(2).
+              2. Set the corresponding rows in
+              vrrpv3AssociatedIpAddrTable to destroy(6) to delete
+              the entry.
+              3. Set vrrpv3OperationsRowStatus to destroy(6) to
+              delete the entry."
+           ::= { vrrpv3OperationsEntry 13 }
+
+   --  VRRP Associated Address Table
+
+       vrrpv3AssociatedIpAddrTable OBJECT-TYPE
+           SYNTAX       SEQUENCE OF Vrrpv3AssociatedIpAddrEntry
+           MAX-ACCESS   not-accessible
+           STATUS       current
+           DESCRIPTION
+               "The table of addresses associated with each virtual
+                router."
+           ::= { vrrpv3Operations 2 }
+
+       vrrpv3AssociatedIpAddrEntry OBJECT-TYPE
+           SYNTAX       Vrrpv3AssociatedIpAddrEntry
+           MAX-ACCESS   not-accessible
+           STATUS       current
+           DESCRIPTION
+              "An entry in the table contains an IP address that is
+              associated with a virtual router.  The number of rows
+              for a given IP version, VrID, and ifIndex will equal
+              the number of IP addresses associated (e.g., backed up)
+
+
+
+Tata                         Standards Track                   [Page 15]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+              by the virtual router (equivalent to
+              'vrrpv3OperationsIpAddrCount').
+
+              Rows in the table cannot be modified unless the value
+              of 'vrrpv3OperationsStatus' for the corresponding entry
+              in the vrrpv3OperationsTable has transitioned to
+              initialize(1).
+
+              The information in this table is persistent and when
+              written the entity SHOULD save the change to non-
+              volatile storage."
+
+           INDEX    { ifIndex, vrrpv3OperationsVrId,
+                      vrrpv3OperationsInetAddrType,
+                      vrrpv3AssociatedIpAddrAddress }
+
+           ::= { vrrpv3AssociatedIpAddrTable 1 }
+
+       Vrrpv3AssociatedIpAddrEntry ::=
+           SEQUENCE {
+               vrrpv3AssociatedIpAddrAddress
+
+                   InetAddress,
+               vrrpv3AssociatedIpAddrRowStatus
+                   RowStatus
+       }
+
+       vrrpv3AssociatedIpAddrAddress OBJECT-TYPE
+           SYNTAX       InetAddress (SIZE (0|4|16))
+           MAX-ACCESS   not-accessible
+           STATUS       current
+           DESCRIPTION
+               "The assigned IP addresses that a virtual router is
+               responsible for backing up.
+
+               The IP address type is determined by the value of
+               vrrpv3OperationsInetAddrType in the index of this
+               row."
+           REFERENCE "RFC 5798"
+           ::= { vrrpv3AssociatedIpAddrEntry 1 }
+
+       vrrpv3AssociatedIpAddrRowStatus OBJECT-TYPE
+           SYNTAX       RowStatus
+           MAX-ACCESS   read-create
+           STATUS       current
+           DESCRIPTION
+             "The row status variable, used according to
+             installation and removal conventions for conceptual
+
+
+
+Tata                         Standards Track                   [Page 16]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+             rows.  To create a row in this table, a manager sets
+             this object to either createAndGo(4) or
+             createAndWait(5).  Setting this object to active(1)
+             results in the addition of an associated address for a
+             virtual router.  Setting this object to notInService(2)
+             results in administratively bringing down the row.
+
+             Destroying the entry or setting it to destroy(6)
+             removes the associated address from the virtual router.
+             The use of other values is implementation-dependent.
+
+             Implementations should not allow deletion of the last
+             row corresponding to an active row in
+             vrrpv3OperationsTable.
+
+             Refer to the description of vrrpv3OperationsRowStatus
+             for typical row creation and deletion scenarios."
+           ::= { vrrpv3AssociatedIpAddrEntry 2 }
+
+   --  VRRP Router Statistics
+
+       vrrpv3RouterChecksumErrors OBJECT-TYPE
+           SYNTAX       Counter64
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+               "The total number of VRRP packets received with an
+               invalid VRRP checksum value.
+
+               Discontinuities in the value of this counter can occur
+               at re-initialization of the management system, and at
+               other times as indicated by the value of
+               vrrpv3GlobalStatisticsDiscontinuityTime."
+
+           REFERENCE "RFC 5798, Section 5.2.8"
+           ::= { vrrpv3Statistics 1 }
+
+       vrrpv3RouterVersionErrors OBJECT-TYPE
+           SYNTAX       Counter64
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+               "The total number of VRRP packets received with an
+               unknown or unsupported version number.
+
+               Discontinuities in the value of this counter can occur
+               at re-initialization of the management system, and at
+
+
+
+
+Tata                         Standards Track                   [Page 17]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+               other times as indicated by the value of
+               vrrpv3GlobalStatisticsDiscontinuityTime."
+
+           REFERENCE "RFC 5798, Section 5.2.1"
+           ::= { vrrpv3Statistics 2 }
+
+       vrrpv3RouterVrIdErrors OBJECT-TYPE
+           SYNTAX       Counter64
+           MAX-ACCESS   read-only
+          STATUS       current
+           DESCRIPTION
+               "The total number of VRRP packets received with a
+                VRID that is not valid for any virtual router on this
+                router.
+
+               Discontinuities in the value of this counter can occur
+               at re-initialization of the management system, and at
+               other times as indicated by the value of
+               vrrpv3GlobalStatisticsDiscontinuityTime."
+
+           REFERENCE "RFC 5798, Section 5.2.3"
+           ::= { vrrpv3Statistics 3 }
+
+      vrrpv3GlobalStatisticsDiscontinuityTime OBJECT-TYPE
+          SYNTAX     TimeStamp
+          MAX-ACCESS read-only
+          STATUS     current
+          DESCRIPTION
+            "The value of sysUpTime on the most recent occasion at
+             which one of vrrpv3RouterChecksumErrors,
+             vrrpv3RouterVersionErrors, and vrrpv3RouterVrIdErrors
+             suffered a discontinuity.
+
+             If no such discontinuities have occurred since the last
+             re-initialization of the local management subsystem,
+             then this object contains a zero value."
+
+          ::= { vrrpv3Statistics 4 }
+
+   --  VRRP Router Statistics Table
+
+       vrrpv3StatisticsTable OBJECT-TYPE
+           SYNTAX       SEQUENCE OF Vrrpv3StatisticsEntry
+           MAX-ACCESS   not-accessible
+           STATUS       current
+           DESCRIPTION
+               "Table of virtual router statistics."
+           ::= { vrrpv3Statistics 5 }
+
+
+
+Tata                         Standards Track                   [Page 18]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+       vrrpv3StatisticsEntry OBJECT-TYPE
+           SYNTAX       Vrrpv3StatisticsEntry
+           MAX-ACCESS   not-accessible
+           STATUS       current
+           DESCRIPTION
+               "An entry in the table containing statistics
+               information about a given virtual router."
+           AUGMENTS    { vrrpv3OperationsEntry }
+           ::= { vrrpv3StatisticsTable 1 }
+
+       Vrrpv3StatisticsEntry ::=
+           SEQUENCE {
+               vrrpv3StatisticsMasterTransitions
+                   Counter32,
+               vrrpv3StatisticsNewMasterReason
+                   INTEGER,
+               vrrpv3StatisticsRcvdAdvertisements
+                   Counter64,
+               vrrpv3StatisticsAdvIntervalErrors
+                   Counter64,
+               vrrpv3StatisticsIpTtlErrors
+                   Counter64,
+               vrrpv3StatisticsProtoErrReason
+                   INTEGER,
+               vrrpv3StatisticsRcvdPriZeroPackets
+                   Counter64,
+               vrrpv3StatisticsSentPriZeroPackets
+                   Counter64,
+               vrrpv3StatisticsRcvdInvalidTypePackets
+                   Counter64,
+               vrrpv3StatisticsAddressListErrors
+                   Counter64,
+               vrrpv3StatisticsPacketLengthErrors
+                   Counter64,
+               vrrpv3StatisticsRowDiscontinuityTime
+                    TimeStamp,
+               vrrpv3StatisticsRefreshRate
+                    Unsigned32
+           }
+
+       vrrpv3StatisticsMasterTransitions OBJECT-TYPE
+           SYNTAX       Counter32
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+               "The total number of times that this virtual router's
+               state has transitioned to master state.
+
+
+
+
+Tata                         Standards Track                   [Page 19]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+               Discontinuities in the value of this counter can occur
+               at re-initialization of the management system, and at
+               other times as indicated by the value of
+               vrrpv3StatisticsRowDiscontinuityTime."
+           ::= { vrrpv3StatisticsEntry 1 }
+
+      vrrpv3StatisticsNewMasterReason OBJECT-TYPE
+           SYNTAX        INTEGER {
+               notMaster (0),
+               priority  (1),
+               preempted (2),
+               masterNoResponse (3)
+           }
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+              "This indicates the reason for the virtual router to
+              transition to master state.  If the virtual router
+              never transitioned to master state, the value of this
+              object is notMaster(0).  Otherwise, this indicates the
+              reason this virtual router transitioned to master
+              state the last time.  Used by vrrpv3NewMaster
+              notification."
+           ::= { vrrpv3StatisticsEntry 2 }
+
+       vrrpv3StatisticsRcvdAdvertisements OBJECT-TYPE
+           SYNTAX       Counter64
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+               "The total number of VRRP advertisements received by
+               this virtual router.
+
+               Discontinuities in the value of this counter can occur
+               at re-initialization of the management system, and at
+               other times as indicated by the value of
+               vrrpv3StatisticsRowDiscontinuityTime."
+
+           ::= { vrrpv3StatisticsEntry 3 }
+
+       vrrpv3StatisticsAdvIntervalErrors OBJECT-TYPE
+           SYNTAX       Counter64
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+               "The total number of VRRP advertisement packets
+               received for which the advertisement interval is
+
+
+
+
+Tata                         Standards Track                   [Page 20]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+               different from the vrrpv3OperationsAdvInterval
+               configured on this virtual router.
+
+               Discontinuities in the value of this counter can occur
+               at re-initialization of the management system, and at
+               other times as indicated by the value of
+               vrrpv3StatisticsRowDiscontinuityTime."
+
+           ::= { vrrpv3StatisticsEntry 4 }
+
+       vrrpv3StatisticsIpTtlErrors OBJECT-TYPE
+           SYNTAX       Counter64
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+               "The total number of VRRP packets received by the
+               virtual router with IPv4 TTL (for VRRP over IPv4) or
+               IPv6 Hop Limit (for VRRP over IPv6) not equal to 255.
+
+               Discontinuities in the value of this counter can occur
+               at re-initialization of the management system, and at
+               other times as indicated by the value of
+               vrrpv3StatisticsRowDiscontinuityTime."
+           REFERENCE "RFC 5798, Section 5.1.1.3"
+           ::= { vrrpv3StatisticsEntry 5 }
+
+      vrrpv3StatisticsProtoErrReason OBJECT-TYPE
+           SYNTAX        INTEGER {
+               noError (0),
+               ipTtlError (1),
+               versionError  (2),
+               checksumError (3),
+               vrIdError(4)
+           }
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+               "This indicates the reason for the last protocol
+               error.  This SHOULD be set to noError(0) when no
+               protocol errors are encountered.  Used by
+               vrrpv3ProtoError notification."
+           ::= { vrrpv3StatisticsEntry 6 }
+
+       vrrpv3StatisticsRcvdPriZeroPackets OBJECT-TYPE
+           SYNTAX       Counter64
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+
+
+
+Tata                         Standards Track                   [Page 21]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+               "The total number of VRRP packets received by the
+               virtual router with a priority of '0'.
+
+               Discontinuities in the value of this counter can occur
+               at re-initialization of the management system, and at
+               other times as indicated by the value of
+               vrrpv3StatisticsRowDiscontinuityTime."
+           REFERENCE "RFC 5798, Section 5.2.4"
+           ::= { vrrpv3StatisticsEntry 7 }
+
+       vrrpv3StatisticsSentPriZeroPackets OBJECT-TYPE
+           SYNTAX       Counter64
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+               "The total number of VRRP packets sent by the virtual
+               router with a priority of '0'.
+
+               Discontinuities in the value of this counter can occur
+               at re-initialization of the management system, and at
+               other times as indicated by the value of
+               vrrpv3StatisticsRowDiscontinuityTime."
+           REFERENCE "RFC 5798, Section 5.2.4"
+           ::= { vrrpv3StatisticsEntry 8 }
+
+       vrrpv3StatisticsRcvdInvalidTypePackets OBJECT-TYPE
+           SYNTAX       Counter64
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+               "The number of VRRP packets received by the virtual
+               router with an invalid value in the 'type' field.
+
+               Discontinuities in the value of this counter can occur
+               at re-initialization of the management system, and at
+               other times as indicated by the value of
+               vrrpv3StatisticsRowDiscontinuityTime."
+           ::= { vrrpv3StatisticsEntry 9 }
+
+       vrrpv3StatisticsAddressListErrors OBJECT-TYPE
+           SYNTAX       Counter64
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+               "The total number of packets received for which the
+               address list does not match the locally configured
+               list for the virtual router.
+
+
+
+
+Tata                         Standards Track                   [Page 22]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+               Discontinuities in the value of this counter can occur
+               at re-initialization of the management system, and at
+               other times as indicated by the value of
+               vrrpv3StatisticsRowDiscontinuityTime."
+           ::= { vrrpv3StatisticsEntry 10 }
+
+       vrrpv3StatisticsPacketLengthErrors OBJECT-TYPE
+           SYNTAX       Counter64
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+               "The total number of packets received with a packet
+               length less than the length of the VRRP header.
+
+               Discontinuities in the value of this counter can occur
+               at re-initialization of the management system, and at
+               other times as indicated by the value of
+               vrrpv3StatisticsRowDiscontinuityTime."
+           ::= { vrrpv3StatisticsEntry 11 }
+
+      vrrpv3StatisticsRowDiscontinuityTime OBJECT-TYPE
+          SYNTAX     TimeStamp
+          MAX-ACCESS read-only
+          STATUS     current
+          DESCRIPTION
+             "The value of sysUpTime on the most recent occasion at
+             which any one or more of this entry's counters
+             suffered a discontinuity.
+
+             If no such discontinuities have occurred since the last
+             re-initialization of the local management subsystem,
+             then this object contains a zero value."
+          ::= { vrrpv3StatisticsEntry 12 }
+
+      vrrpv3StatisticsRefreshRate OBJECT-TYPE
+          SYNTAX     Unsigned32
+          UNITS "milliseconds"
+          MAX-ACCESS read-only
+          STATUS     current
+          DESCRIPTION
+            "The minimum reasonable polling interval for this entry.
+             This object provides an indication of the minimum
+             amount of time required to update the counters in this
+             entry."
+          ::= { vrrpv3StatisticsEntry 13 }
+
+   --   Notification Definitions
+   --   Notifications may be controlled using SNMP-NOTIFICATION-MIB
+
+
+
+Tata                         Standards Track                   [Page 23]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+       vrrpv3NewMaster NOTIFICATION-TYPE
+           OBJECTS      {
+                          vrrpv3OperationsMasterIpAddr,
+                          vrrpv3StatisticsNewMasterReason
+                        }
+           STATUS       current
+           DESCRIPTION
+               "The newMaster notification indicates that the sending
+               agent has transitioned to master state."
+           ::= { vrrpv3Notifications 1 }
+
+       vrrpv3ProtoError NOTIFICATION-TYPE
+           OBJECTS      {
+                          vrrpv3StatisticsProtoErrReason
+                        }
+           STATUS       current
+           DESCRIPTION
+               "The notification indicates that the sending agent has
+               encountered the protocol error indicated by
+               vrrpv3StatisticsProtoErrReason."
+           ::= { vrrpv3Notifications 2 }
+
+   --  Conformance Information
+
+    vrrpv3Compliances  OBJECT IDENTIFIER ::= { vrrpv3Conformance 1 }
+    vrrpv3Groups       OBJECT IDENTIFIER ::= { vrrpv3Conformance 2 }
+
+   -- Compliance Statements
+
+       vrrpv3FullCompliance MODULE-COMPLIANCE
+           STATUS current
+           DESCRIPTION
+              "The compliance statement"
+           MODULE -- this module
+           MANDATORY-GROUPS  {
+               vrrpv3OperationsGroup,
+               vrrpv3StatisticsGroup,
+               vrrpv3InfoGroup,
+               vrrpv3NotificationsGroup
+           }
+           OBJECT        vrrpv3OperationsPriority
+           WRITE-SYNTAX  Unsigned32 (1..254)
+           DESCRIPTION  "Setable values are from 1 to 254."
+           ::= { vrrpv3Compliances 1 }
+
+       vrrpv3ReadOnlyCompliance MODULE-COMPLIANCE
+           STATUS current
+           DESCRIPTION
+
+
+
+Tata                         Standards Track                   [Page 24]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+              "When this MIB module is implemented without support
+              for read-create (i.e., in read-only mode), then such
+              an implementation can claim read-only compliance.
+              Such a device can then be monitored, but cannot be
+              configured with this MIB."
+
+           MODULE -- this module
+           MANDATORY-GROUPS  {
+               vrrpv3OperationsGroup,
+               vrrpv3StatisticsGroup,
+               vrrpv3StatisticsDiscontinuityGroup,
+               vrrpv3InfoGroup,
+               vrrpv3NotificationsGroup
+           }
+
+           OBJECT        vrrpv3OperationsPriority
+           MIN-ACCESS    read-only
+           DESCRIPTION  "Write access is not required."
+
+           OBJECT        vrrpv3OperationsPrimaryIpAddr
+           MIN-ACCESS    read-only
+           DESCRIPTION  "Write access is not required."
+           OBJECT        vrrpv3OperationsAdvInterval
+           MIN-ACCESS    read-only
+           DESCRIPTION  "Write access is not required."
+
+           OBJECT        vrrpv3OperationsPreemptMode
+           MIN-ACCESS    read-only
+           DESCRIPTION  "Write access is not required."
+
+           OBJECT        vrrpv3OperationsAcceptMode
+           MIN-ACCESS    read-only
+           DESCRIPTION  "Write access is not required."
+
+           OBJECT        vrrpv3OperationsRowStatus
+           MIN-ACCESS    read-only
+           DESCRIPTION  "Write access is not required."
+
+           OBJECT        vrrpv3AssociatedIpAddrRowStatus
+           MIN-ACCESS    read-only
+           DESCRIPTION  "Write access is not required."
+
+           ::= { vrrpv3Compliances 2 }
+
+   -- Conformance Groups
+
+       vrrpv3OperationsGroup   OBJECT-GROUP
+           OBJECTS  {
+
+
+
+Tata                         Standards Track                   [Page 25]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+               vrrpv3OperationsVirtualMacAddr,
+               vrrpv3OperationsStatus,
+               vrrpv3OperationsPriority,
+               vrrpv3OperationsMasterIpAddr,
+               vrrpv3OperationsAdvInterval,
+               vrrpv3OperationsPreemptMode,
+               vrrpv3OperationsAcceptMode,
+               vrrpv3OperationsUpTime,
+               vrrpv3OperationsRowStatus,
+               vrrpv3OperationsAddrCount,
+               vrrpv3OperationsPrimaryIpAddr,
+               vrrpv3AssociatedIpAddrRowStatus
+               }
+           STATUS current
+           DESCRIPTION
+              "Conformance group for VRRPv3 operations."
+           ::= { vrrpv3Groups 1 }
+
+       vrrpv3StatisticsGroup  OBJECT-GROUP
+           OBJECTS  {
+               vrrpv3RouterChecksumErrors,
+               vrrpv3RouterVersionErrors,
+               vrrpv3RouterVrIdErrors,
+               vrrpv3StatisticsMasterTransitions,
+               vrrpv3StatisticsNewMasterReason,
+               vrrpv3StatisticsRcvdAdvertisements,
+               vrrpv3StatisticsAdvIntervalErrors,
+               vrrpv3StatisticsRcvdPriZeroPackets,
+               vrrpv3StatisticsSentPriZeroPackets,
+               vrrpv3StatisticsRcvdInvalidTypePackets,
+               vrrpv3StatisticsIpTtlErrors,
+               vrrpv3StatisticsProtoErrReason,
+               vrrpv3StatisticsAddressListErrors,
+               vrrpv3StatisticsPacketLengthErrors,
+               vrrpv3StatisticsRowDiscontinuityTime,
+               vrrpv3StatisticsRefreshRate
+               }
+           STATUS current
+           DESCRIPTION
+              "Conformance group for VRRPv3 statistics."
+           ::= { vrrpv3Groups 2 }
+
+       vrrpv3StatisticsDiscontinuityGroup  OBJECT-GROUP
+           OBJECTS  {
+               vrrpv3GlobalStatisticsDiscontinuityTime
+               }
+           STATUS current
+           DESCRIPTION
+
+
+
+Tata                         Standards Track                   [Page 26]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+              "Objects providing information about counter
+               discontinuities."
+           ::= { vrrpv3Groups 3 }
+
+       vrrpv3InfoGroup  OBJECT-GROUP
+           OBJECTS  {
+               vrrpv3StatisticsProtoErrReason,
+               vrrpv3StatisticsNewMasterReason
+               }
+           STATUS current
+           DESCRIPTION
+              "Conformance group for objects contained in VRRPv3
+               notifications."
+           ::= { vrrpv3Groups 4 }
+
+       vrrpv3NotificationsGroup NOTIFICATION-GROUP
+           NOTIFICATIONS {
+               vrrpv3NewMaster,
+               vrrpv3ProtoError
+               }
+           STATUS current
+           DESCRIPTION
+              "The VRRP MIB Notification Group."
+           ::= { vrrpv3Groups 5 }
+
+   END
+
+11.  Security Considerations
+
+   There are a number of management objects defined in this MIB module
+   with a MAX-ACCESS clause of read-write and/or read-create.  Such
+   objects may be considered sensitive or vulnerable in some network
+   environments.  The support for SET operations in a non-secure
+   environment without proper protection can have a negative effect on
+   network operations.  These are the tables and objects and their
+   sensitivity/vulnerability:
+
+   The objects vrrpv3OperationsPriority, vrrpv3OperationsPrimaryIpAddr,
+   vrrpv3OperationsAdvInterval, vrrpv3OperationsPreemptMode,
+   vrrpv3OperationsAcceptMode, vrrpv3OperationsRowStatus, and
+   vrrpv3AssociatedIpAddrRowStatus possess the read-create attribute.
+   Manipulation of these objects is capable of affecting the operation
+   of a virtual router.
+
+   Examples of how these objects could adversely affect the operation of
+   a virtual router include:
+
+
+
+
+
+Tata                         Standards Track                   [Page 27]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+   o An unauthorized change to vrrpv3OperationsPriority can affect the
+     priority used in master election, resulting in this router either
+     becoming master when it should not, or in some other router being
+     elected by preference.  While this will disrupt the operator's
+     plans, it will only replicate the unfortunate failure of multiple
+     routers, and any router that does become master will be capable of
+     filling that role.
+
+   o Modification of vrrpv3OperationsPrimaryIpAddr would cause the
+     configured router to take on an incorrect IP address if it becomes
+     master, which would be potentially very disruptive to the network
+     operation.
+
+   o A malicious change to vrrpv3OperationsAdvInterval could either
+     result in the configured router flooding the network with
+     advertisements when it becomes master, or the new master not
+     advertising frequently enough such that some routers do not learn
+     about the new master.
+
+   o vrrpv3OperationsPreemptMode controls whether this router will
+     preempt another master router.  Setting it inappropriately will at
+     worse cause one router to be master against the operator's plans,
+     but that router will still be qualified to operate as a master.
+
+   o Setting the vrrpv3OperationsAcceptMode could prevent an
+     IPv6-capable VRRP router from accepting packets addressed to the
+     address owner's IPv6 address as its own even if it is not the IPv6
+     address owner.  Although the default for this object is false(2),
+     unauthorized setting of this object to false might restrict the
+     function of some parts of the network.
+
+   o The vrrpv3OperationsRowStatus object that could be used to disable
+     a virtual router.  While there are other columns that, if changed,
+     could disrupt operations, they cannot be changed without first
+     changing the RowStatus object.
+
+   SNMP versions prior to SNMPv3 did not include adequate security.
+   Even if the network itself is secure (for example by using IPsec),
+   there is no control as to who on the secure network is allowed to
+   access and GET/SET (read/change/create/delete) the objects in this
+   MIB module.
+
+   Implementations MUST provide the security features described by the
+   SNMPv3 framework (see [RFC3410]), including full support for
+   authentication and privacy via the User-based Security Model (USM)
+   [RFC3414] with the AES cipher algorithm [RFC3826].  Implementations
+   MAY also provide support for the Transport Security Model (TSM)
+
+
+
+
+Tata                         Standards Track                   [Page 28]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+   [RFC5591] in combination with a secure transport such as SSH
+   [RFC5592] or TLS/DTLS [RFC6353].
+
+   Further, deployment of SNMP versions prior to SNMPv3 is NOT
+   RECOMMENDED.  Instead, it is RECOMMENDED to deploy SNMPv3 and to
+   enable cryptographic security.  It is then a customer/operator
+   responsibility to ensure that the SNMP entity giving access to an
+   instance of this MIB module is properly configured to give access to
+   the objects only to those principals (users) that have legitimate
+   rights to indeed GET or SET (change/create/delete) them.
+
+12.  IANA Considerations
+
+   The MIB module in this document uses the following IANA-assigned
+   OBJECT IDENTIFIER values recorded in the SMI Numbers registry:
+
+        Descriptor        OBJECT IDENTIFIER value
+        ----------        -----------------------
+
+        vrrpv3MIB           { mib-2 207 vrrpv3MIB VRRPV3-MIB }
+
+   This document obsoletes RFC 2787.  Therefore, IANA has deprecated
+   value 68 under 'mib-2', which is assigned to VRRP-MIB.
+
+13.  Normative References
+
+   [RFC2119] Bradner, S., "Key words for use in RFCs to Indicate
+             Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2578] McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+             "Structure of Management Information Version 2 (SMIv2)",
+             STD 58, RFC 2578, April 1999.
+
+   [RFC2579] McCloghrie, K., Perkins, D., and J. Schoenwaelder, "Textual
+             Conventions for SMIv2", STD 58, RFC 2579, April 1999.
+
+   [RFC2580] McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+             "Conformance Statements for SMIv2", STD 58, RFC 2580, April
+             1999.
+
+   [RFC2863] McCloghrie, K. and F. Kastenholz, "The Interfaces Group
+             MIB", RFC 2863, June 2000.
+
+   [RFC3413] Levi, D., Meyer, P., and B. Stewart, "Simple Network
+             Management Protocol (SNMP) Applications", STD 62, RFC 3413,
+             December 2002.
+
+
+
+
+
+Tata                         Standards Track                   [Page 29]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+   [RFC4001] Daniele, M., Haberman, B., Routhier, S., and J.
+             Schoenwaelder, "Textual Conventions for Internet Network
+             Addresses", RFC 4001, February 2005.
+
+   [RFC5798] Nadas, S., Ed., "Virtual Router Redundancy Protocol (VRRP)
+             Version 3 for IPv4 and IPv6", RFC 5798, March 2010.
+
+14.  Informative References
+
+   [RFC2338] Knight, S., Weaver, D., Whipple, D., Hinden, R., Mitzel,
+             D., Hunt, P., Higginson, P., Shand, M., and A. Lindem,
+             "Virtual Router Redundancy Protocol", RFC 2338, April 1998.
+
+   [RFC2787] Jewell, B. and D. Chuang, "Definitions of Managed Objects
+              for the Virtual Router Redundancy Protocol", RFC 2787,
+             March 2000.
+
+   [RFC3410] Case, J., Mundy, R., Partain, D., and B. Stewart,
+             "Introduction and Applicability Statements for Internet-
+             Standard Management Framework", RFC 3410, December 2002.
+
+   [RFC3414] Blumenthal, U. and B. Wijnen, "User-based Security Model
+             (USM) for version 3 of the Simple Network Management
+             Protocol (SNMPv3)", STD 62, RFC 3414, December 2002.
+
+   [RFC3826] Blumenthal, U., Maino, F., and K. McCloghrie, "The Advanced
+             Encryption Standard (AES) Cipher Algorithm in the SNMP
+             User-based Security Model", RFC 3826, June 2004.
+
+   [RFC5591] Harrington, D. and W. Hardaker, "Transport Security Model
+             for the Simple Network Management Protocol (SNMP)", RFC
+             5591, June 2009.
+
+   [RFC5592] Harrington, D., Salowey, J., and W. Hardaker, "Secure Shell
+             Transport Model for the Simple Network Management Protocol
+             (SNMP)", RFC 5592, June 2009.
+
+   [RFC6353] Hardaker, W., "Transport Layer Security (TLS) Transport
+             Model for the Simple Network Management Protocol (SNMP)",
+             RFC 6353, July 2011.
+
+
+
+
+
+
+
+
+
+
+
+Tata                         Standards Track                   [Page 30]
+
+RFC 6527                    VRRP Unified MIB                  March 2012
+
+
+15.  Acknowledgments
+
+   Kripakaran Karlekar and Brain Jewell helped in design and initial
+   drafts of this specification.  This specification is based on RFC
+   2787.  The authors of RFC 2787 are Brian Jewell and David Chuang.
+   The author would also like to thank Bert Wijnen, Dave Thaler, Joan
+   Cucchiara, Mukesh Gupta, Steve Bates, Adrian Farrel, Ben Campbell and
+   Joel M. Halpern for taking time to review the document and provide
+   valuable guidance.
+
+Author's Address
+
+   Srinivas Kalyan Tata
+   Nokia
+   313 Fairchild Dr.
+   Mountain View, CA 94043
+   EMail: Tata_kalyan@yahoo.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Tata                         Standards Track                   [Page 31]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6527.txt](<www.ietf.org/rfc/rfc6527.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
