### PR TITLE
Archive rfc653.txt

### DIFF
--- a/www.ietf.org/rfc/rfc653.txt
+++ b/www.ietf.org/rfc/rfc653.txt
@@ -1,0 +1,88 @@
+TELNET OUTPUT HORIZONTAL TABSTOPS OPTION
+RFC 653, NIC 31156 (Oct. 25, 1974)
+D. Crocker (UCLA-NMC)
+Online file: [ISI]<DCROCKER>NAOHTS.TXT
+
+               TELNET OUTPUT HORIZONTAL TABSTOPS OPTION
+
+1. Command name and code
+   NAOHTS 11 (Negotiate About Output Horizontal Tabstops)
+
+2. Command meanings
+   In the following, we are discussing a simplex connection, as described in 
+   the NAOL and NAOP Telnet options.
+      IAC DO NAOHTS 
+         The data sender requests or agrees to negotiate about output 
+         horizontal tabstops with the data receiver.  In the case where 
+         agreement has been reached and in the absence of further 
+         subnegotiations, the data receiver is assumed to be handling output 
+         horizontal tabstops.
+      IAC DON'T NAOHTS 
+         The data sender refuses to negotiate about output horizontal tabstops 
+         with the data receiver, or demands a return to the unnegotiated 
+         default mode.
+      IAC WILL NAOHTS 
+         The data receiver requests or agrees to negotiate about output 
+         horizontal tabstops with the sender.  In the case where agreement has 
+         been reached and in the absence of further subnegotiations, the data 
+         receiver alone is assumed to be handling output horizontal tabstops.
+      IAC WON'T NAOHTS 
+         The data receiver refuses to negotiate about output horizontal 
+         tabstops, or demands a return to the unnegotiated default mode. 
+      IAC SB NAOHTS DS <8-bit value> ... <8-bit value> IAC SE
+         The data sender specifies, with the 8-bit value(s), which party should
+         handle output horizontal tabstop considerations and what the stops 
+         should be.  The code for DS is 1.
+      IAC SB NAOHTS DR <8-bit value> ... <8-bit value> IAC SE
+         The data receiver specifies, with the 8-bit value(s), which party 
+         should handle output horizontal tabstop considerations and what the 
+         stops should be.  The code for DR is 0.
+
+3. Default
+   DON'T NAOHTS/WON'T NAOHTS.
+      In the default absence of negotiations concerning which party, data 
+      sender or data receiver, is handling output horizontal tabstops, neither 
+      party is required to handle them and neither party is prohibited from 
+      handling them; but it is appropriate if at least the data receiver 
+      handles horizontal tabstops, albeit primitively.
+
+4. Motivation for the Option
+   Please refer to section 4 of the NAOL and of the NAOP Telnet option 
+   descriptions.
+
+5. Description of the Option
+   The data sender and the data receiver use the 8-bit value(s) along with the 
+   DS and DR SB subcommands as follows (multiple 8-bit values are allowed only 
+   if each is greater than zero and less than 251):
+
+      8-bit value :                     Meaning :
+
+      0            Command sender suggests that he alone will handle  
+                   tabstops, for the connection.                      
+      1 to 250     Command sender suggests that the other party alone 
+                   should handle tabstop considerations, but suggests 
+                   that the indicated value(s) be used. The value(s)  
+                   are the column numbers, relative to the physical   
+                   left side of the printer page or terminal screen,  
+                   that are to be set.                                
+      251 to 254   Not allowed, in order to be compatible with        
+                   related Telnet options. 
+      255          Command sender suggests that the other party alone 
+                   should handle output tabstops and suggests nothing 
+                   about how it should be done. 
+
+   The guiding rules are that:
+      (1) if neither data receiver nor data sender wants to handle output 
+      horizontal tabstops, the data receiver must do it, and
+      (2) if both data receiver and data sender want to handle output 
+      horizontal tabstops, the data sender gets to do it.
+   The reasoning for the former rule is that if neither wants to do it, then 
+   the default in the NAOHTS option dominates. If both want to do it, the 
+   sender, who is presumed to have special knowledge about the data, should be 
+   allowed to do it, taking into account any suggestions the receiver may make.
+   As with all option negotiations, neither party should suggest a state 
+   already in effect except to refuse to negotiate; changes should be 
+   acknowledged; and once refused, an option should not be resuggested until 
+   "something changes" (e.g., another process starts).
+   At any time, either party can disable further negotiation by giving the 
+   appropriate WON'T NAOHTS or DON'T NAOHTS command.


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc653.txt](<www.ietf.org/rfc/rfc653.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
