### PR TITLE
Archive rfc6543.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6543.txt
+++ b/www.ietf.org/rfc/rfc6543.txt
@@ -1,0 +1,283 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                     S. Gundavelli
+Request for Comments: 6543                                         Cisco
+Updates: 5213                                                   May 2012
+Category: Standards Track
+ISSN: 2070-1721
+
+
+        Reserved IPv6 Interface Identifier for Proxy Mobile IPv6
+
+Abstract
+
+   Proxy Mobile IPv6 (RFC 5213) requires that all mobile access gateways
+   use a fixed link-local address and a fixed link-layer address on any
+   of their access links that they share with mobile nodes.  This
+   requirement was intended to ensure that a mobile node does not detect
+   any change with respect to its Layer 3 attachment, even after it
+   roams from one mobile access gateway to another.  In the absence of
+   any reserved addresses for this use, coordination across vendors and
+   manual configuration of these addresses on all of the mobility
+   elements in a Proxy Mobile IPv6 domain are required.  This document
+   attempts to simplify this operational requirement by making a
+   reservation for special addresses that can be used for this purpose.
+   This document also updates RFC 5213.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6543.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Gundavelli                   Standards Track                    [Page 1]
+
+RFC 6543              Reserved IPv6 IID for PMIPv6              May 2012
+
+
+Copyright Notice
+
+   Copyright (c) 2012 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1. Introduction ....................................................2
+   2. Conventions and Terminology .....................................3
+      2.1. Conventions ................................................3
+      2.2. Terminology ................................................3
+   3. IANA Considerations .............................................4
+   4. Security Considerations .........................................4
+   5. Acknowledgements ................................................4
+   6. References ......................................................5
+      6.1. Normative References .......................................5
+      6.2. Informative References .....................................5
+
+1.  Introduction
+
+   Proxy Mobile IPv6 [RFC5213] is a network-based mobility management
+   protocol that enables IP mobility support for a mobile node without
+   requiring its participation in any mobility-related signaling.  The
+   mobility elements in the network ensure that the mobile node does not
+   detect any change with respect to its Layer 3 attachment, even after
+   it roams from one mobile access gateway to another and changes its
+   point of attachment in the network.  All mobile access gateways in a
+   Proxy Mobile IPv6 domain use a fixed link-local address and a fixed
+   link-layer address on any of their access links that they share with
+   the mobile nodes.  This essentially ensures that a mobile node, after
+   performing a handoff, does not detect any change with respect to the
+   IP network configuration.
+
+
+
+
+
+
+
+
+
+Gundavelli                   Standards Track                    [Page 2]
+
+RFC 6543              Reserved IPv6 IID for PMIPv6              May 2012
+
+
+   Although the base Proxy Mobile IPv6 specification [RFC5213] requires
+   the use of a fixed link-local and a fixed link-layer address, it did
+   not reserve any specific addresses for this purpose.  This is proving
+   to be an operational challenge in deployments involving multi-vendor
+   equipment.  To address this problem, this specification makes the
+   following two reservations.
+
+   1.  This specification reserves one Ethernet unicast address,
+       00-00-5E-00-52-13, for use with Proxy Mobile IPv6.  This reserved
+       link-layer address SHOULD be used by the mobile access gateway in
+       a Proxy Mobile IPv6 domain, on all of the access links that it
+       shares with the mobile nodes.  The protocol configuration
+       variable FixedMAGLinkLayerAddressOnAllAccessLinks [RFC5213]
+       SHOULD be set to this reserved address.  The mobile access
+       gateway can use this address in all packet communication with the
+       mobile node on the access links.  Considerations from [RFC5342]
+       apply with respect to the use of Ethernet parameters in IETF
+       protocols.  This address is allocated from the registry "IANA
+       Ethernet Address Block - Unicast Use".
+
+   2.  This specification reserves an IPv6 interface identifier,
+       0200:5EFF:FE00:5213.  This interface identifier is a modified
+       EUI-64 interface identifier generated from the allocated Ethernet
+       unicast address 00-00-5E-00-52-13.  This reserved IPv6 interface
+       identifier SHOULD be used by all of the mobile access gateways in
+       a Proxy Mobile IPv6 domain on all of the access links that they
+       share with the mobile nodes.  The protocol configuration variable
+       FixedMAGLinkLocalAddressOnAllAccessLinks [RFC5213] SHOULD be set
+       to the link-local address generated using this reserved IPv6
+       interface identifier.  The mobile access gateway can use this
+       link-local address generated using this reserved IPv6 interface
+       identifier in all Neighbor Discovery-related [RFC4861]
+       communication with the mobile node.
+
+2.  Conventions and Terminology
+
+2.1.  Conventions
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+2.2.  Terminology
+
+   All of the mobility-related terms used in this document are to be
+   interpreted as defined in the base Proxy Mobile IPv6 specifications
+   ([RFC5213], [RFC5844]).  All of the terminology related to IPv6
+   addressing is to be interpreted as specified in [RFC4291].
+
+
+
+Gundavelli                   Standards Track                    [Page 3]
+
+RFC 6543              Reserved IPv6 IID for PMIPv6              May 2012
+
+
+3.  IANA Considerations
+
+   o  This specification reserves one Ethernet unicast address,
+      00-00-5E-00-52-13, for Proxy Mobile IPv6.  This address has been
+      reserved in the registry "IANA Ethernet Address Block - Unicast
+      Use".
+
+   o  This specification reserves an IPv6 interface identifier,
+      0200:5EFF:FE00:5213, for Proxy Mobile IPv6 [RFC5213] in the
+      registry "Reserved IPv6 Interface Identifiers" [RFC5453].  This
+      interface identifier is a modified EUI-64 interface identifier
+      generated from the allocated Ethernet unicast address
+      00-00-5E-00-52-13, as specified in Appendix A of [RFC4291].
+
+4.  Security Considerations
+
+   All of the security considerations specified in [RFC5213] and
+   [RFC5844] continue to apply to the mobility elements in a Proxy
+   Mobile IPv6 domain when those elements conform to this specification.
+   Specifically, the issues related to the use of fixed link-local and
+   link-layer addresses as documented in Section 6.9.3 of the base Proxy
+   Mobile IPv6 specification are equally relevant here.  In some sense,
+   the reservations made in this specification result in the use of the
+   same set of link-local and link-layer address values beyond a single
+   Proxy Mobile IPv6 domain, thereby expanding the scope of the existing
+   problem related to asserting ownership of the configured addresses
+   from a single domain to a multi-domain environment.  Future work may
+   be needed to address these issues.
+
+5.  Acknowledgements
+
+   The author would like to thank Jari Arkko and Dave Thaler for all of
+   the discussions around the use of fixed link-local and link-layer
+   addresses during work related to the standardization of Proxy Mobile
+   IPv6 [RFC5213].  The author would also like to thank Tero Kivinen,
+   Donald Eastlake 3rd, Stephen Farrell, Suresh Krishnan, Margaret
+   Wasserman, Thomas Narten, Basavaraj Patil, and Eric Voit for their
+   reviews and participation in the discussions related to this
+   document.
+
+
+
+
+
+
+
+
+
+
+
+
+Gundavelli                   Standards Track                    [Page 4]
+
+RFC 6543              Reserved IPv6 IID for PMIPv6              May 2012
+
+
+6.  References
+
+6.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC4291]  Hinden, R. and S. Deering, "IP Version 6 Addressing
+              Architecture", RFC 4291, February 2006.
+
+   [RFC5213]  Gundavelli, S., Ed., Leung, K., Devarapalli, V.,
+              Chowdhury, K., and B. Patil, "Proxy Mobile IPv6",
+              RFC 5213, August 2008.
+
+   [RFC5453]  Krishnan, S., "Reserved IPv6 Interface Identifiers",
+              RFC 5453, February 2009.
+
+6.2.  Informative References
+
+   [RFC4861]  Narten, T., Nordmark, E., Simpson, W., and H. Soliman,
+              "Neighbor Discovery for IP version 6 (IPv6)", RFC 4861,
+              September 2007.
+
+   [RFC5342]  Eastlake 3rd, D., "IANA Considerations and IETF Protocol
+              Usage for IEEE 802 Parameters", BCP 141, RFC 5342,
+              September 2008.
+
+   [RFC5844]  Wakikawa, R. and S. Gundavelli, "IPv4 Support for Proxy
+              Mobile IPv6", RFC 5844, May 2010.
+
+Author's Address
+
+   Sri Gundavelli
+   Cisco
+   170 West Tasman Drive
+   San Jose, CA  95134
+   USA
+
+   EMail: sgundave@cisco.com
+
+
+
+
+
+
+
+
+
+
+
+
+Gundavelli                   Standards Track                    [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6543.txt](<www.ietf.org/rfc/rfc6543.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
