### PR TITLE
Archive rfc6547.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6547.txt
+++ b/www.ietf.org/rfc/rfc6547.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                         W. George
+Request for Comments: 6547                             Time Warner Cable
+Obsoletes: 3627                                            February 2012
+Updates: 6164
+Category: Informational
+ISSN: 2070-1721
+
+
+                      RFC 3627 to Historic Status
+
+Abstract
+
+   This document moves "Use of /127 Prefix Length Between Routers
+   Considered Harmful" (RFC 3627) to Historic status to reflect the
+   updated guidance contained in "Using 127-Bit IPv6 Prefixes on Inter-
+   Router Links" (RFC 6164).  A Standards Track document supersedes an
+   informational document; therefore, guidance provided in RFC 6164 is
+   to be followed when the two documents are in conflict.  This document
+   links the two RFCs so that the IETF's updated guidance on this topic
+   is clearer.
+
+Status of This Memo
+
+   This document is not an Internet Standards Track specification; it is
+   published for informational purposes.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Not all documents
+   approved by the IESG are a candidate for any level of Internet
+   Standard; see Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6547.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+George                        Informational                     [Page 1]
+
+RFC 6547                  RFC 3627 Is Historic             February 2012
+
+
+Copyright Notice
+
+   Copyright (c) 2012 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . . . 3
+   2.  Security Considerations . . . . . . . . . . . . . . . . . . . . 3
+   3.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . 3
+   4.  References  . . . . . . . . . . . . . . . . . . . . . . . . . . 4
+     4.1.  Normative References  . . . . . . . . . . . . . . . . . . . 4
+     4.2.  Informative References  . . . . . . . . . . . . . . . . . . 4
+
+1.  Introduction
+
+   This document moves "Use of /127 Prefix Length Between Routers
+   Considered Harmful" [RFC3627] to Historic status in accordance with
+   RFC 2026 [RFC2026].  RFC 3627 has been superseded by "Using 127-Bit
+   IPv6 Prefixes on Inter-Router Links" [RFC6164].  A Standards Track
+   document supersedes an informational document; therefore, guidance
+   provided in RFC 6164 is to be followed when the two documents are in
+   conflict.  This may not have been clear to casual readers who are not
+   familiar with the differences in IETF document types.  This document
+   adds the necessary link between the two RFCs so that users referring
+   to RFC 3627 for guidance will see that it has been obsoleted by
+   updated guidance on the matter, thus hopefully eliminating any
+   confusion that may be present.
+
+2.  Security Considerations
+
+   This document introduces no new security considerations.
+
+3.  Acknowledgements
+
+   Thanks to Brian Carpenter, Bob Hinden, and Ron Bonica for guidance on
+   the matter, and to Pekka Savola and Miya Kohno and the other authors
+   of 6164 for their support.
+
+
+
+George                        Informational                     [Page 2]
+
+RFC 6547                  RFC 3627 Is Historic             February 2012
+
+
+4.  References
+
+4.1.  Normative References
+
+   [RFC3627]  Savola, P., "Use of /127 Prefix Length Between Routers
+              Considered Harmful", RFC 3627, September 2003.
+
+   [RFC6164]  Kohno, M., Nitzan, B., Bush, R., Matsuzaki, Y., Colitti,
+              L., and T. Narten, "Using 127-Bit IPv6 Prefixes on Inter-
+              Router Links", RFC 6164, April 2011.
+
+4.2.  Informative References
+
+   [RFC2026]  Bradner, S., "The Internet Standards Process -- Revision
+              3", BCP 9, RFC 2026, October 1996.
+
+Author's Address
+
+   Wesley George
+   Time Warner Cable
+   13820 Sunrise Valley Drive
+   Herndon, VA  20171
+   US
+
+   Phone: +1 703-561-2540
+   EMail: wesley.george@twcable.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+George                        Informational                     [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6547.txt](<www.ietf.org/rfc/rfc6547.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
