### PR TITLE
Archive rfc6548.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6548.txt
+++ b/www.ietf.org/rfc/rfc6548.txt
@@ -1,0 +1,283 @@
+
+
+
+
+
+
+Internet Architecture Board (IAB)                       N. Brownlee, Ed.
+Request for Comments: 6548                    The University of Auckland
+Obsoletes: 5620                                                      IAB
+Category: Informational                                        June 2012
+ISSN: 2070-1721
+
+
+                  Independent Submission Editor Model
+
+Abstract
+
+   This document describes the function and responsibilities of the RFC
+   Independent Submission Editor (ISE).  The Independent Submission
+   stream is one of the stream producers that create draft RFCs, with
+   the ISE as its stream approver.  The ISE is overall responsible for
+   activities within the Independent Submission stream, working with
+   draft editors and reviewers, and interacts with the RFC Production
+   Center and Publisher, and the RFC Series Editor (RSE).  The ISE is
+   appointed by the IAB, and also interacts with the IETF Administrative
+   Oversight Committee (IAOC).
+
+Status of This Memo
+
+   This document is not an Internet Standards Track specification; it is
+   published for informational purposes.
+
+   This document is a product of the Internet Architecture Board (IAB)
+   and represents information that the IAB has deemed valuable to
+   provide for permanent record.  Documents approved for publication by
+   the IAB are not a candidate for any level of Internet Standard; see
+   Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6548.
+
+Copyright Notice
+
+   Copyright (c) 2012 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.
+
+
+
+
+Brownlee & IAB                Informational                     [Page 1]
+
+RFC 6548           Independent Submission Editor Model         June 2012
+
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . . . 2
+   2.  Independent Submission Editor . . . . . . . . . . . . . . . . . 2
+     2.1.  Qualifications  . . . . . . . . . . . . . . . . . . . . . . 2
+     2.2.  Responsibilities  . . . . . . . . . . . . . . . . . . . . . 3
+   3.  Independent Submission Editorial Board  . . . . . . . . . . . . 4
+   4.  Security Considerations . . . . . . . . . . . . . . . . . . . . 4
+   5.  IAB Members at the Time of Approval . . . . . . . . . . . . . . 4
+   6.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . 4
+   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . . . 4
+     7.1.  Normative References  . . . . . . . . . . . . . . . . . . . 4
+     7.2.  Informative References  . . . . . . . . . . . . . . . . . . 5
+
+1.  Introduction
+
+   The RFC Editor Model [RFC6635] defines a set of streams that produce
+   draft RFCs, which are submitted for publication.  This document
+   defines the management function for the Independent Submission
+   stream, specifically the role of Independent Submission Editor (ISE).
+   This document is a derivative of [RFC5620], Section 3.2, and was
+   separated out from [RFC6635].
+
+   This document obsoletes [RFC5620] in combination with [RFC6635].
+
+2.  Independent Submission Editor
+
+   The ISE is an individual who is responsible for the Independent
+   Submission stream of RFCs, as defined by [RFC4844].  The Independent
+   Submission stream and the ISE are not under the authority or
+   direction of the RSE or the RFC Series Oversight Committee (RSOC)
+   (see [RFC6635]).  As noted below, the ISE is appointed by and is
+   responsible directly to the IAB.
+
+2.1.  Qualifications
+
+   The ISE is a senior position for which the following qualifications
+   are desired:
+
+   1.  Technical competence, i.e., broad technical experience and
+       perspective across a wide range of Internet technologies and
+       applications, and also the ability to work effectively with
+       portions of that spectrum in which they have no personal
+       expertise.
+
+   2.  Thorough familiarity with the RFC series.
+
+
+
+
+
+Brownlee & IAB                Informational                     [Page 2]
+
+RFC 6548           Independent Submission Editor Model         June 2012
+
+
+   3.  An ability to define and constitute advisory and document review
+       arrangements.  If those arrangements include an Editorial Board
+       similar to the current one or some equivalent arrangement, the
+       ability to assess the technical competence of potential Editorial
+       Board members (see Section 3).
+
+   4.  Good standing in the technical community, in and beyond the IETF.
+
+   5.  Demonstrated editorial skills, good command of the English
+       language, and demonstrated history of being able to work
+       effectively with technical documents and materials created by
+       others.
+
+   6.  The ability to work effectively in a multi-actor environment with
+       divided authority and responsibility similar to that described in
+       [RFC6635].
+
+2.2.  Responsibilities
+
+   The ISE is an individual who may have assistants and who is
+   responsible for:
+
+   1.  Maintaining technical quality of the Independent Submission
+       stream.
+
+   2.  Reviewing, approving, and processing Independent Submissions.
+
+   3.  Forwarding draft RFCs in the Independent Submission stream to the
+       RFC Production Center.
+
+   4.  Defining and developing the scope of the Independent Submission
+       stream as a part of the overall RFC Editor function [RFC6635].
+
+   5.  Reviewing and approving RFC errata for Independent Submissions.
+
+   6.  Coordinating work and conforming to general RFC Series policies
+       as specified by the IAB and RSE.
+
+   7.  Providing statistics and documentation as requested by the RSE
+       and/or IAOC.
+
+   The ISE may choose to select individuals to participate in an
+   Advisory Board for assistance in special topics as the ISE deems
+   appropriate.  Such an Advisory Board exists at the pleasure of the
+   ISE, and its members serve at the pleasure of the ISE.
+
+
+
+
+
+
+Brownlee & IAB                Informational                     [Page 3]
+
+RFC 6548           Independent Submission Editor Model         June 2012
+
+
+   The individual with the listed qualifications is selected by the IAB
+   after input has been collected from the community.  An approach
+   similar to the one used by the IAB to select an IAOC member every
+   other year as described in [RFC4333] should be used.
+
+   While the ISE itself is considered a volunteer function, the IAB
+   considers maintaining the Independent Submission stream part of the
+   IAB's supported activities.  Therefore, the IAOC should include these
+   costs in the IASA budget.
+
+3.  Independent Submission Editorial Board
+
+   The ISE is supported by an Editorial Board for the review of
+   Independent Submission stream documents.  This board is known as the
+   Independent Submission Editorial Board.  This volunteer Editorial
+   Board exists at the pleasure of the ISE, and its members serve at the
+   pleasure of the ISE.  The existence of this board is simply noted
+   within this model, and additional discussion of such is considered
+   out of scope of this document.
+
+4.  Security Considerations
+
+   This document has no specific security implications, however the same
+   security considerations as those in [RFC4846] and [RFC4844] apply.
+
+5.  IAB Members at the Time of Approval
+
+   Bernard Aboba, Ross Callon, Alissa Cooper, Joel Halpern, Spencer
+   Dawkins, Russ Housley, David Kessens, Olaf Kolkman, Danny McPherson,
+   Jon Peterson, Andrei Robachevsky, Dave Thaler, Hannes Tschofenig.
+
+6.  Acknowledgements
+
+   Generous thanks to Joel Hapern for all his help with this document,
+   and for all his work on [RFC6635]).  Thanks also to the IAB members,
+   whose comments and suggestions were both welcome and useful.
+
+7.  References
+
+7.1.  Normative References
+
+   [RFC4846]  Klensin, J. and D. Thaler, "Independent Submissions to the
+              RFC Editor", RFC 4846, July 2007.
+
+   [RFC4844]  Daigle, L., Ed. and IAB, "The RFC Series and RFC Editor",
+              RFC 4844, July 2007.
+
+
+
+
+
+Brownlee & IAB                Informational                     [Page 4]
+
+RFC 6548           Independent Submission Editor Model         June 2012
+
+
+7.2.  Informative References
+
+   [RFC4333]  Huston, G. and B. Wijnen, "The IETF Administrative
+              Oversight Committee (IAOC) Member Selection Guidelines and
+              Process", BCP 113, RFC 4333, December 2005.
+
+   [RFC5620]  Kolkman, O. and IAB, "RFC Editor Model (Version 1)",
+              RFC 5620, August 2009.
+
+   [RFC6635]  Kolkman, O., Ed., Halpern, J., Ed., and IAB, "RFC Editor
+              Model (Version 2)", RFC 6635, June 2012.
+
+Authors' Addresses
+
+   Nevil Brownlee (editor)
+   The University of Auckland
+
+   EMail: n.brownlee@auckland.ac.nz
+
+
+   Internet Architecture Board
+
+   EMail: iab@iab.org
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Brownlee & IAB                Informational                     [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6548.txt](<www.ietf.org/rfc/rfc6548.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
