### PR TITLE
Archive rfc659.txt

### DIFF
--- a/www.ietf.org/rfc/rfc659.txt
+++ b/www.ietf.org/rfc/rfc659.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                          J. Postel
+Request for Comments: 659                                        SRI-ARC
+NIC: 31177                                               18 October 1974
+
+
+                  Announcing Addtional Telnet Options
+
+   This is to announce the set of Telnet Options defined in Request For
+   Comments 651 through 658 (NIC 31154 through 31161) are part of the
+   official Telnet Options and should be added to the Protocol Notebook.
+
+   RFC 651 is a revision of the Status Option to utilize the subcommand
+   feature and reduce the number of bits required to convey the status
+   information.  This revised Status Option replaces the previous Status
+   Option.
+
+   The other RFCs (652 through 658) are new Options for controlling the
+   behavior of the format effector characters Carriage Return,
+   Horizontal Tab, Form Feed, Vertical Tab, and Line Feed.
+
+   Your attention is also called to RFC 645 (NIC 30899) "Network
+   Standard Data Specification Syntax" which was prepared some time ago
+   but has not received wide circulation.
+
+   Unfortunately the Network Information Center can not provide hardcopy
+   documents.  Currently the author is responsible for distribution of
+   RFCs.
+
+   The documents are available online as:
+
+      [ISI]<DCROCKER>STATUS-OPTION-REVISION.TXT
+      [ISI]<DCROCKER>NAOCRD.TXT
+      [ISI]<DCROCKER>NAOHTS.TXT
+      [ISI]<DCROCKER>NAOHTD.TXT
+      [ISI]<DCROCKER>NAOFFD.TXT
+      [ISI]<DCROCKER>NAOVTS.TXT
+      [ISI]<DCROCKER>NAOVTD.TXT
+      [ISI]<DCROCKER>NAOLFD.TXT
+      [SRI-ARC]<POSTEL>RFC645.TXT
+      [SRI-ARC]<POSTEL>RFC659.TXT (This Announcement)
+         (If these files are not found online they may have been
+         archived, in this case the files should be accessable via the
+         "interogate" command.)
+
+
+             [This RFC was put into machine readable form for entry]
+              [into the online RFC archives by Lorrie Shiota, 2/02]
+
+
+
+
+Postel                                                          [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc659.txt](<www.ietf.org/rfc/rfc659.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
