### PR TITLE
Archive rfc66.txt

### DIFF
--- a/www.ietf.org/rfc/rfc66.txt
+++ b/www.ietf.org/rfc/rfc66.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                                   S. Crocker
+Request for Comments #66                                UCLA
+                                                        26 August 70
+
+
+                    3rd Level Ideas and other Noises
+
+
+On 12 August 70, I met a BBN with representatives from BBN and MIT and
+we discussed third llevel protocol.
+
+
+Dial-up The following proposed dial-up protocol was agreed upon at the
+meeting.
+
+
+The purpose of this piece of protocol is to get a process at one site
+(hereafter the using site) in contact with the logger at the other site
+(hereafter the serving site).
+
+
+To initiate contact, the using process attaches a receive socket US and
+requests connection to socket 1 in the serving host. The using NCP thus
+sends
+
+
+               1            4               4                 1
+             ---------------------------------------------------
+             |RTS |         US     |        1          |      p|
+             ---------------------------------------------------
+             |ALL |     P    |    space    |
+             -------------------------------
+
+over link 1, where US is the user's receive socket, p is the link, and
+space is some nominal spae allocation.
+
+
+The serving Host may decide to refuse contact, in which case it will
+respond with the standard CLS. If it accepts contact, however, it will
+send exactly an even 32 bit number over the connection and close the
+connection. This even 32 bit number is the name of a receive socket in
+the serving Host. This socket and the next higher numbered socket are
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+
+RFC 66              3rd Level Ideas and other Noise
+
+
+Network Working Group                                   S. Crocker
+Request for Comments #66                                UCLA
+                                                        26 August 70
+
+reserved for contact with the user. Thus the serving NCP sends
+
+
+
+                 1           4          1
+               ----------------------------
+               | STR |       1        | US|
+               ----------------------------
+
+
+on link 1, followed by
+
+
+
+                          4
+                     -----------
+                     |    SS   |
+                     -----------
+
+
+
+on link p. Note that SS must be even.
+
+
+After sending the server socket number, SS, the NCP sends
+
+
+
+            1          4                     4
+           -------------------------------------
+           |CLS |         1        |        US |
+           -------------------------------------
+           |STR |      SS+1        |        US |
+           ------------------------------------------
+           |RTS |      SS          |      US+1 |  q |
+           ------------------------------------------
+           |ALL | q |       space      |
+           -----------------------------
+
+
+
+
+
+
+
+
+
+                                                                [Page 2]
+
+RFC 66              3rd Level Ideas and other Noise
+
+
+Network Working Group                                   S. Crocker
+Request for Comments #66                                UCLA
+                                                        26 August 70
+
+
+The using Host also sets up these connections by sending
+
+
+           1           4                    4
+        ----------------------------------------
+        | CLS  |      US         |          1  |
+        ----------------------------------------
+        | STR  |    US+1         |         SS  |
+        --------------------------------------------
+        | RTS  |    US           |       SS+1  | r |
+        --------------------------------------------
+
+
+At this point the user should be connected to the logger at the serving
+site.
+
+Standard Console
+
+    We next agreed on an initial network standard console: 7-bit ASCII
+in 8 bit fields with the eight bit on, transmitted in contiguous
+streams.  The speific codes are listed in appendix H of the IMP
+Operations manual, BBN report #1877. This seems to work only some
+hardship on PDP-10's and be fine for all others.
+
+
+    For break or interrupt many systems use one of the standard
+characters; for those which need another kind of signal,
+
+
+        1       1
+       ------------
+       |INR  |  r |
+       ------------
+
+
+sent over the control link should suffice.
+
+       [ This RFC was put into machine readable form for entry ]
+[ into the online RFC archives by Gottfried Janik 2/98 ]
+
+
+
+
+
+
+
+                                                                [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc66.txt](<www.ietf.org/rfc/rfc66.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
