### PR TITLE
Archive rfc661.txt

### DIFF
--- a/www.ietf.org/rfc/rfc661.txt
+++ b/www.ietf.org/rfc/rfc661.txt
@@ -1,0 +1,1179 @@
+
+
+
+
+
+
+Network Working Group                                          J. Postel
+Request for Comments: 661                                        SRI-ARC
+NIC: 31203                                                 November 1974
+
+
+                          Protocol Information
+
+   This file contains information on the various protocols in the ARPA
+   Network.  An effort will be made to keep the information current, but
+   this depends on the cooperation of the users of this file to convey
+   any information about protocol developments, or corrections to this
+   information to Jon Postel at SRI-ARC.
+
+   This is a compendium of all the protocol related activity and most of
+   this activity is with experimental protocols, for those protocols,
+   which are official standards the designation "[Official]" will be
+   appended to the name.
+
+   Much of the documentation of protocols appears as Requests for
+   Comments (RFCs) and many of these are available online.  When a
+   document is accessible online, a pointer to that source will be
+   given.  Also note that recent RFCs are online at Office-1 in
+   directory <NETINFO> with names of the form RFCnnn.TXT where nnn is
+   replaced by the RFC number.
+
+   This file is online as:
+
+      Pathname: [SRI-ARC] <POSTEL> PROTOCOL-INFORMATION.TXT
+
+      and also [SRI-ARC] <POSTEL> PROTOCOL-INFORMATION.NLS
+
+   IMP-IMP
+
+      surface
+
+         Contact:
+
+            McKenzie, Alex. (MCKENZIE@BBN)
+
+         Documents:
+
+            Heart, F. et. Al. "The Interface Message Processor for the
+            ARPA Computer Network," AFIPS Conference Proceedings,
+            36:551-567, SJCC 1970.
+
+         People:
+
+            John McQuillan (MCQUILLAN@BBN)
+
+
+
+Postel                                                          [Page 1]
+
+RFC 661                                                    November 1974
+
+
+         Schedule:
+
+         Recent developments:
+
+      satellite
+
+         Contact:
+
+            Randy Rettberg (RETTEBERG@BBN)
+
+         Documents:
+
+         People:
+
+            Kahn, Robert. (Kahn@ISI)
+
+         Schedule:
+
+         Recent developments:
+
+   IMP-HOST
+
+      IMP-Host [Official]
+
+         Contact:
+
+            McKenzie, A. (McKenzie@BBN)
+
+         Documents:
+
+            "Specification for the Interconnection of a Host and an
+            IMP," BBN Report 1822, Revised March 1974.
+
+            McQuillan, J. "Host Alive/Dead Logic," BBN Memorandum to
+            Technical Liaisons, 18-July-74.
+
+            Burchfiel, J. "Ready Line Philosophy and Implementation,"
+            NIC 30872, RFC 642, 5-July-74.
+
+            Walden, D. "Some Changes to the IMP and the IMP/HOST
+            Interface," RFC 660, 23-Oct-74.
+
+               [Office-1 <NETINFO> RFC660.TXT
+
+         People:
+
+            McKenzie (MCKENZIE@BBN)
+
+
+
+
+Postel                                                          [Page 2]
+
+RFC 661                                                    November 1974
+
+
+            Walden (WALDEN@BBN)
+
+            Postel (POSTEL@SRI-ARC)
+
+            Burchfiel (BURCHFIEL@BBN)
+
+            McQuillan (MCQUILLAN@BBN)
+
+         Schedule:
+
+         Recent developments:
+
+            The "link number" filed has been extended from 8 to 12 bits
+            and renamed the "message identification" field.  Message
+            type 6 now is used to indicate a reason for a type 7
+            (destination dead) message. (See BBN1822).
+
+            There has been some recent changes to the Ready line
+            interpretation by the IMP for deciding the alive/dead status
+            of a host.
+
+            Important changes to the IMP and IMP/HOST interface
+            announced in RFC 660 23-Oct-74.
+
+   HOST-HOST
+
+      ncp - standard host-to-host [Official]
+
+         Contact:
+
+            Postel, Jon. (POSTEL@SRI-ARC)
+
+         Documents:
+
+            McKenzie, A. "Host/Host Protocol for the ARPA Network," NIC
+            8246.  Jan 1972.
+
+            Postel, J. "Assigned Link Numbers," RFC604, NIC21186, 26-
+            Dec-73.
+
+         People:
+
+            Postel, Jon. (POSTEL@SRI-ARC)
+
+            McKenzie, Alex. (MCKENZIE@BBN)
+
+         Schedule:
+
+
+
+
+Postel                                                          [Page 3]
+
+RFC 661                                                    November 1974
+
+
+         Recent developments:
+
+      ncp - standard host-to-host [Experimental]
+
+         Contact:
+
+            Postel, Jon. (POSTEL@SRI-ARC)
+
+         Documents:
+
+            McKenzie, A. "Host/Host Protocol for the ARPA Network," NICE
+            3246. Jan 1972.
+
+            Postel, J. "Assigned Link Numbers," RFC604, NIC22186, 26-
+            Dec-73.
+
+            Burchfiel, et. Al. "Tip-Tenex Reliability Improvements" RFC
+            636 NIC 30490 June 1974.
+
+         People:
+
+            Postel, Jon. (POSTEL@SRI-ARC)
+
+            McKenzie, Alex. (MCKENZIE@BBN)
+
+            Burchfiel, Jerry (BURCHFIEL@BBN)
+
+            Walden, Dave (WALDEN@BBN)
+
+         Schedule:
+
+         Recent developments:
+
+            The BBN TIP and TENEX groups have specified and are
+            implementing additional protocol commands with the intention
+            of providing better reliability and survivability over
+            system malfunctions.  The additional protocol commands are
+            for cleaning up partly closed connections and
+            resynchronizing the allocation values on open connections.
+            (See RFC 636).
+
+   tcp - Transmission Control Protocol
+
+      Contact:
+
+         Cerf, Vint. (CERF@ISI)
+
+
+
+
+
+Postel                                                          [Page 4]
+
+RFC 661                                                    November 1974
+
+
+      Documents:
+
+         Cert, V. and R. Kahn. "A Protocol for Packet Network
+         Intercommunication," IEEE Transactions on Communication Vol
+         COM-22 No 5, May 1974.
+
+         [parc-maxc] <cerf> TCPSPEC3.NLS
+
+         Mader, E. "A Protocol Experiment," RFC 700, NIC 31020.
+
+         [ISI] <CERF> TCP-CHANGES.
+
+      People:
+
+         Cerf at SU-DSL
+
+         Tomlinson at BBN
+
+         Kirstein at London
+
+         Postel at SRI-ARC
+
+      Schedule:
+
+         Some experiments now running.  Implementation of full protocol
+         to begin by 15-Oct-74.
+
+      Recent developments:
+
+         Specification completed August 4th, but some work still in
+         progress on handling of single message conversations.  A new
+         sequencing scheme (proposed by Tomlinson) may be utilized.  The
+         addressing field is now used as 4-bit format, 4-bit network, 16
+         bit TCP, and 24 bit process&port.  Crocker has suggested a 64-
+         bit path address to be parsed and reformatted by the gateways
+         along the route.  There is reluctance to experiment with too
+         many things at one though.
+
+         (28-Oct-74) A file indicating some of the changes in the
+         specifications since the 4-Aug-74 document is now available as
+         [ISI] <CERF> TCP-CHANGES.  The areas of change are "Initial
+         Sequence Number", "Socket definition", "Additional user System
+         Calls", "Packet format", and "Discussion of opening and closing
+         (SYN,REL)".
+
+         (23-NOV-74) Specifications for test implementation are now said
+         to be ready on 1-DEC-74, and an implementation completed by 1-
+         FEB-74.
+
+
+
+Postel                                                          [Page 5]
+
+RFC 661                                                    November 1974
+
+
+   nvp - Network Voice Protocol
+
+      Contact:
+
+         Cohen, Danny. (COHEN@ISI)
+
+      Documents:
+
+         The current specification is in an online file at isi in the
+         directory voice as nvp.lst.
+
+         Pathname = [isi] <voice> nvp.lst
+
+      People:
+
+      Recent developments:
+
+         New specification document available (10-Oct-74).
+
+            "Specifications for the Network Voice Protocol (NVP)" NSC
+            Note 43
+
+   packet radio
+
+      Contact:
+
+         Kahn, Robert. (KAHN@ISI)
+
+      Documents:
+
+      People:
+
+      Schedule:
+
+      Recent developments:
+
+   Network Debugging Protocol
+
+      Contact:
+
+         Eric Mader (Mader@BBN)
+
+      Documents:
+
+         Mader, E. "Network Debugging Protocol," NIC 30873, RFC 643,
+         July-74.
+
+      People:
+
+
+
+Postel                                                          [Page 6]
+
+RFC 661                                                    November 1974
+
+
+      Schedule:
+
+      Recent Developments:
+
+         This is a protocol for a PDP-11 cross-network debugger.
+
+   HOST-FRONTEND
+
+      Host-Front End
+
+         Contact:
+
+            Michael Padlipsky (MAP@CASE-10)
+
+         Documents:
+
+            Padlipsky, M. "A Proposed Protocol for Connecting Host
+            Computers to ARPA-Like Networks via Front-End Processors,"
+            RFC 647, NIC 31117, 12-Nov-74.
+
+               [Office-1] <NETINFO>RFC647.TXT
+
+         People:
+
+            Padlipsky at MITRE Washington (MAP@CASE-10)
+
+            Postel at SRI-ARC (POSTEL@SRI-ARC)
+
+            McConnell at Illiac (JOHN@I4-TENEX)
+
+         Schedule:
+
+         Recent developments:
+
+            This is a suggested simple protocol for connecting to host
+            to front end computers, which are in turn connected to the
+            network.
+
+   PROCESS-PROCESS
+
+      ICP - Initial Connection Protocol [Official]
+
+         Contact:
+
+            Postel, Jon. [POSTEL@SRI-ARC)
+
+
+
+
+
+
+Postel                                                          [Page 7]
+
+RFC 661                                                    November 1974
+
+
+         Documents:
+
+            Postel, J. "Official Initial Connection Protocol," NIC 7101
+            11-June-71.
+
+            Wolfe, S. [no title] RFC 202 NIC 7155 26-July-71.
+
+            Postel, J. "Official Telnet-Logger Initial Connection
+            Protocol," NIC 7103 15-June-71.
+
+         People:
+
+            Postel at Sri-arc
+
+         Schedule:
+
+         Recent developments:
+
+      Telnet
+
+         Old Telnet
+
+            Contact:
+
+               Postel, Jon. (POSTEL@SRI-ARC)
+
+            Documents:
+
+               Postel, J. "Telnet Protocol," RFC 318 3-April-72.
+
+            People:
+
+            Schedule:
+
+            Recent developments:
+
+         New Telnet [Official]
+
+            Contact:
+
+               Postel at SRI-ARC
+
+            Documents:
+
+               NIC 18639 "TELNET Protocol Specifications" AUG 73
+
+               NIC 1864C "Telnet Option Specification" Aug 73
+
+
+
+
+Postel                                                          [Page 8]
+
+RFC 661                                                    November 1974
+
+
+                  Telnet Options
+
+                     NIC 15389 "Binary Transmission"
+
+                     NIC 15390 "Echo"
+
+                     NIC 15391 "Reconnection"
+
+                     NIC 15392 "Suppress Go Ahead Option"
+
+                     NIC 15393 "Approximate Message Size Negotiation"
+
+                     NIC 31154 "Status" RFC 65125-Oct-74.
+
+                        [Office] <NETINFO>RFC651.TXT
+
+                     NIC 16236 "Timing Mark"
+
+                     NIC 19859 "Remote Controlled Transmission and
+                     Echoing" 1-Nov-73.
+
+                     NIC 20196 "Output Line Width" 13-Nov-73.
+
+                     NIC 20197 "Output Page Size" 13-Nov-73.
+
+                     NIC 31155 "Output Carriage Return Disposition" RFC
+                     652 25-Oct-74.
+
+                        [Office-1] <NETINFO>RFC652.TXT
+
+                     NIC 31157 "Output Horizontal Tab Disposition" RFC
+                     654 25-Oct-74.
+
+                        [Office-1] <NETINFO>RFC653.TXT
+
+                     NIC 31156 "Output Horizontal Tab Stops" RFC 653
+                     25-Oct-74.
+
+                        [Office-1] <NETINFO>RFC653.TXT
+
+                     NIC31157 "Output Form Feed Disposition" RFC 655
+                     25-Oct-74.
+
+                        [Office-1] <NETINFO>RFC655.TXT
+
+                     NIC 31159 "Output Vertical Tab Stops" RFC 656 25-
+                     Oct-74.
+
+
+
+
+Postel                                                          [Page 9]
+
+RFC 661                                                    November 1974
+
+
+                        [Office-1] <NETINFO>RFC656.TXT
+
+                     NIC 31160 "Output Vertical Tab Disposition" RFC 657
+                     25-Oct-74
+
+                        [Office-1] <NETINFO>RFC657.TXT
+
+                     NIC 31161 "Output Line Feed Disposition" RFC 658
+                     25-Oct-74.
+
+                        [Office-1] <NETINFO>RFC658.TXT
+
+                     NIC 16239 "Extended Options List"
+
+            People:
+
+               Jon Postel at Sri-Arc (POSTEL@SRI-ARC)
+
+               Alex McKenzie at BBN (MCKENZIE@BBN)
+
+               Doug Dodds at BBN (DODDS@BBN)
+
+               Dave Crocker at UCLA-NMC (DCROCKER@ISI)
+
+               Kurt Barthelmess at UCSD (BOWLES@ISI)
+
+            Schedule:
+
+               All Hosts were to have been running the new Telnet (both
+               user and server) by 1 January 1974.
+
+            Recent developments:
+
+               A significant number of server systems now have new
+               telnet implementations. (See RFC 702).
+
+                  Note: the server program is to be available on socket
+                  23 decimal (27 octal).
+
+               The Status Option has been revised to take advantage of
+               the subcommand feature and to reduce the amount of data
+               transmitted to report the option status.
+
+               Seven new options have been defined to allow control of
+               the format effectors Carriage Return, Line Feed, Form
+               Feed, Horizontal Tab, and Vertical Tab.
+
+
+
+
+
+Postel                                                         [Page 10]
+
+RFC 661                                                    November 1974
+
+
+   FTP
+
+      Old File Transfer
+
+         Contact:
+
+            Jon Postel at SRI-ARC (POSTEL@SRI-ARC)
+
+         Documents:
+
+            McKenzie, A. "File Transfer Protocol," NIC 14333, RFC 454,
+            16-Feb-73.
+
+         People:
+
+         Schedule:
+
+         Recent developments:
+
+      New File Transfer
+
+         Contact:
+
+            Jon Postel at SRI-ARC (POSTEL@SRI-ARC)
+
+         Documents:
+
+            Neigus, N. "File Transfer Protocol," NIC 17759 RFC 542 12-
+            July-73.
+
+            Postel, J. "Revised FTP Reply codes," NIC 30843 RFC 640 5-
+            June-74.
+
+         People:
+
+            Jon Postel at SRI-ARC (POSTEL@SRI-ARC)
+
+            Nancy Neigus at BBN (NEIGUS@BBN)
+
+            Ken Pogran at MIT-Multics (Pogran.CompNet@MIT-Multics)
+
+            Wayne Hathaway at NASA AMES (Hathaway@AMES-67)
+
+            Mark Krilanovich at UCSB (Krilanovich@UCSB-MOD75)
+
+            Kurt Barthelmess at UCSD (BOWLES@ISI)
+
+         Schedule:
+
+
+
+Postel                                                         [Page 11]
+
+RFC 661                                                    November 1974
+
+
+         Recent developments:
+
+      Pathnames
+
+         Contact:
+
+            Jon Postel at SRI-ARC (POSTEL@SRI-ARC)
+
+         Documents:
+
+            Crocker, D. "Network Standard Data Specification Syntax,"
+            RFC 645, NIC 30899, Jul-74.
+
+         People:
+
+            Dave Crocker at UCLA-NMC (DCROCKER@ISI)
+
+         Schedule:
+
+         Recent developments:
+
+      File Access Protocol
+
+         Contact:
+
+            John Day (Day. CAC@MIT-Multics)
+
+         Documents:
+
+            Day, J. "Memo to FTP Group: File Access Protocol," RFC 520,
+            NIC 16819, 25-Jun-73
+
+         People:
+
+            Ken Pogran (Pogran.CompNet@MIT-Multics)
+
+         Schedule:
+
+         Recent developments:
+
+   Mail
+
+      Current Mail
+
+         Contact:
+
+            Jon Postel at SRI-ARC (POSTEL@SRI-ARC)
+
+
+
+
+Postel                                                         [Page 12]
+
+RFC 661                                                    November 1974
+
+
+         Documents:
+
+            page 26 of RFC 454 (see old file transfer).
+
+            Bhushan, A. "Standardizing Network Mail Headers," NIC 18516,
+            RFC 561, 5-Sep-73
+
+            Sussman, J. "FTP Error Code Usage for More Reliable Mail
+            Service," RFC 630, NIC 30874, RFC 644, 22-July-74.
+
+         People:
+
+            Julie Sussman at bbn (SUSSMAN@BBN)
+
+            Bob Thomas at bbn (BTHOMAS@BBN)
+
+         Schedule:
+
+         Recent developments:
+
+            Concern over the authentication of the author of network
+            messages has led to the concept of an authorized mail
+            sending process (see RFC 644).
+
+      Proposed Mail
+
+         Contact:
+
+            Postel at SRI-ARC (POSTEL@SRI-ARC)
+
+         Documents:
+
+            White, J. "A Proposed Mail Protocol," NIC 17140, RFC 524,
+            13-Jun-73.
+
+            Crocker, D. "Thoughts on the Mail Protocol Proposed in RFC
+            524," NIC 17644, RFC 539, 7-July-73.
+
+            White, J. "Response to Critiques of the Proposed Mail
+            Protocol," NIC 17993, RFC 555, 27-July-73.
+
+         People:
+
+            Jim White at SRI-ARC (WHITE@SRI-ARC)
+
+            Postel at Sri-ARC (POSTEL@SIR-ARC)
+
+         Schedule:
+
+
+
+Postel                                                         [Page 13]
+
+RFC 661                                                    November 1974
+
+
+         Recent developments:
+
+      RJE - Remote Job Entry
+
+         Contact:
+
+            Jon Postel at SRI-ARC (POSTEL@SRI-ARC)
+
+         Documents:
+
+            Bressler, B. "Remote Job Entry Protocol," RFC 407, NIC
+            12112, 16-Oct-72
+
+            Krilanovich, M. "Announcement of RJS at UCSB," RFC 436, NIC
+            13700, 10-Jan-73.
+
+         People:
+
+         Schedule:
+
+         Recent developments:
+
+      RJS - CCNs Remote Job Service
+
+         Contact:
+
+            Robert Braden at UCLA-CCN (BRADEN@UCLA-CCN)
+
+         Documents:
+
+            Braden, R. "Interim NETRJS Specification," RFC 18@ nic
+            July-71.
+
+            Braden, R. "Update on NETRJS," RFC 599, NIC 20854, 13-Dec-
+            73.
+
+         People:
+
+            Robert Braden (BRADEN@UCLA-CCN)
+
+            Steve Wolfe (WOLFE@UCLAL-CCN)
+
+         Schedule:
+
+         Recent developments:
+
+
+
+
+
+
+Postel                                                         [Page 14]
+
+RFC 661                                                    November 1974
+
+
+      Graphics
+
+         Contact:
+
+            Robert Sproull (SPROULL@PARC-MAXC)
+
+         Documents:
+
+            Sproull, R, and E. Thomas. "A Networks Graphics Protocol,"
+            NIC 24308, 16-Aug-74.
+
+         People:
+
+            Robert Sproull (SPROULL@PARC-MAXC)
+
+            Elaine Thomas (Thomas@MIT-Multics)
+
+            James Michener at MIT-DMS (JCM@MIT-DMS)
+
+         Schedule:
+
+         Recent developments:
+
+            New document available from Robert Sproull.
+
+      Data Reconfiguration Service
+
+         Contact:
+
+            Jon Postel at SRI-ARC (POSTEL@SRI-ARC)
+
+         Documents:
+
+            Anderson, B. "Status Report on Proposed Data Reconfiguration
+            Service," NIC 6715, RFC 138, 28-April-71.
+
+            Feah, "Data Reconfiguration Service at UCSB," RFC 437, NIC
+            13701, 30-June-74.
+
+         People:
+
+         Schedule:
+
+         Recent developments:
+
+
+
+
+
+
+
+Postel                                                         [Page 15]
+
+RFC 661                                                    November 1974
+
+
+      RSEXEC
+
+         Contact:
+
+            Thomas, Bob. (BTHOMAS@BBN)
+
+         Documents:
+
+         People:
+
+         Schedule:
+
+         Recent developments:
+
+      Line Processor Protocol
+
+         Contact:
+
+            Don Andrews at SRI-ARC (ANDREWS@SRI-ARC)
+
+         Documents:
+
+            [SRI-ARC] <hardy>1pprot.nls
+
+            [SRI-ARC] <hardy>prot.txt
+
+         People:
+
+            Martin Hardy at SRI-ARC (HARDY@SRI-ARC)
+
+            Don Andrews at Sri-ARC (ANDREWS@SRI-ARC)
+
+         Schedule:
+
+         Recent developments:
+
+   PROGRAMS
+
+      Neted - Network Standard Editor [Official]
+
+         Contact:
+
+            Michael Padlipsky (MAP@CASE-10)
+
+         Documents:
+
+            Padlipsky, M. "NETED: A Common Editor for the ARPA Network,"
+            RFC 569, NIC 18972, 15-Oct-73.
+
+
+
+Postel                                                         [Page 16]
+
+RFC 661                                                    November 1974
+
+
+         People:
+
+            Padlipsky at MITRE (MAP@CASE-10)
+
+            Postel at SRI-ARC (POSTEL@SRI-ARC0
+
+            Hathaway at AMES (HATHAWAY@AMES-67)
+
+         Schedule:
+
+         Recent developments:
+
+NATIONAL SOFTWARE WORKS
+
+   The National Software Works is developing a set of protocols for its
+   use of the ARPA Network, other uses of these protocols is encouraged.
+
+   The procedure call protocol is intended to facilitate the sharing of
+   resources in the network at the subroutine level.  The procedure call
+   protocol will be used to split nls into a front end and back end
+   components.  Procedure call protocol is also to be used in the nsw as
+   the basis for communication between the works manager, the tool
+   bearing hosts, and front desk procedure packages.
+
+   The documents cited below give a view of the Procedure Call Protocol
+   and its use.
+
+      Contact:
+
+         Jim White (WHITE@SRI-ARC)
+
+         Jon Postel (POSTEL@SIR-ARC)
+
+      Documents:
+
+         These documents are the second published version of the
+         Procedure Call Protocol and NSW protocol - PCP/NSW Version 2.
+         Version 2 is SUBSTANTIALLY different than Version 1; it and all
+         intermediate, informally distributed PCP/NSW documents are
+         obsoleted by this release.
+
+         The first document, PCP, is the place the interested ready
+         should start.  It gives the required motivation for the use
+         Protocol and states the substance of the Protocol proper.  The
+         ready may then, if he chooses, read the next three documents:
+         PIP, PSP, and PMP.  The latter has the most to offer the casual
+         reader; the programmer faced with coding in the PCP environment
+         should ready all three.  The next three documents - PCPFMT,
+
+
+
+Postel                                                         [Page 17]
+
+RFC 661                                                    November 1974
+
+
+         PCPHST, and PCPFRK - are of interest only to the PCP
+         implementer.  The next document - HOST - is a preliminary
+         thought about how the NSW might use the standard HOST-HOST
+         protocol NCP.  The last four documents - EXEC, FILE, BATCH, and
+         LLDBUG - describe procedure packages needed to carry out NSW
+         functions, but such packages may well be useful in other
+         contexts.
+
+         Version 2 consists of the following documents.  Each is
+         available online in two forms: as an NLS file and as a
+         formatted text file.  The journal number (e.g., 24459) refers
+         to the former, of course and the pathname (e.g., [SRI-ARI]
+         <NLS> PCP.TXT) to the latter, accessible via FTP using
+         USER=ANONYMOUS and PASSWORD=GUEST (no account required).
+         Hardcopy is being forwarded by US Mail to all those who have
+         expressed an interest in PCP.  If you don't receive a copy and
+         would like one of this and/or future releases, send a note to
+         that effect to WHITE@SRI-ARC:
+
+            PCP (24459,) "The Procedure Call Protocol"
+
+               This document describes the virtual programming
+               environment provided by PCP, and the inter-process
+               exchanges that implement it.
+
+               Pathname: [SRI-ARC] <NLS>PCP.TXT
+
+            PIP (24460,) "The Procedure Interface Package"
+
+               This document describes a packages that runs in the
+               setting provided by PCP and that serves as a procedure-
+               call-level interface to PCP proper.  It includes
+               procedures for calling, resuming, interrupting, and
+               aborting remote procedures.
+
+               Pathname: [SRI-ARC] <NLS>PIP.TXT
+
+            PSP (24461,) "The PCP Support Packages"
+
+               This document describes a package that runs in the
+               setting provided by PCP and that augments PCP proper,
+               largely in the area of data store manipulation.  It
+               includes procedures for obtaining access to groups of
+               remote procedures and data stores, manipulating remote
+               data stores, and creating temporary ones.
+
+               Pathname: [SRI-ARC] <NLS>PSP.TXT
+
+
+
+
+Postel                                                         [Page 18]
+
+RFC 661                                                    November 1974
+
+
+            PMP (24462,) "The Process Management Package"
+
+               This document describes a package that runs in the
+               setting provided by PCP and that provides the necessary
+               tools for interconnecting two or more processes to form a
+               multi-process system (e.g., NSW).  It includes procedures
+               for creating, deleting, logically and physically
+               interconnecting processes, and for allocating and
+               releasing processors.
+
+               Pathname: [SRI-ARC] <NLS>PMP.TXT
+
+            PCPFMT (24576,) "PCP Data Structure Formats"
+
+               This document defines formats for PCP data structures,
+               each of which is appropriate for one or more physical
+               channel types.
+
+               Pathname: [SRI-ARC] <NLS>POPFMT.TXT
+
+            PCPHST (24577,) "PCP ARPANET Inter-Host IPC Implementation"
+
+               This document defines an implementation, appropriate for
+               mediating communication between Tenex folks, of the IPC
+               primitives required by PCP.
+
+               Pathname: [SRI-ARC] <NLS.PCPHST.TXT
+
+            PCPFRK (24578,) "PCP Tenex Inter-Fork IPC Implementation"
+
+               This document defines an implementation, appropriate for
+               mediating communication between processes on different
+               hosts within the ARPANET, of the IPC primitives required
+               by PCP.
+
+               Pathname: [SRI-ARC] <NLS.PCPFRK.TXT
+
+            HOST (24581,) "NSW Host Protocol"
+
+               This document describes the host level protocol used in
+               the NSW.  The protocol is a slightly constrained version
+               of the standard ARPANET host to host protocol.  The
+               constraints affect the allocation, RFNM wait, and
+               retransmission policies.
+
+               Pathname: [SRI-ARC] <NLS>HOST.TXT
+
+
+
+
+
+Postel                                                         [Page 19]
+
+RFC 661                                                    November 1974
+
+
+            EXEC (24580,) "The Executive Package"
+
+               This document describes a package that runs in the
+               setting provided by PCP.  It includes procedures and data
+               stores for user identification, accounting, and usage
+               information.
+
+               Pathname: [SRI-ARC] <NLS> EXEC.TXT
+
+            FILE (24582,) "The File Package"
+
+               This document describes a package that runs in the
+               setting provided by PCP.  It includes procedures and data
+               stores for opening, closing, and listing directories, for
+               creating, deleting, and renaming files, and for
+               transferring files and file elements between processes.
+
+               Pathname: [SRI-ARC] <NLS>FILE.TXT
+
+            BATCH (24583,) "The Batch Job Package"
+
+               This document describes a package that runs in the
+               setting provided by PCP.  It includes procedures for
+               creating and deleting batch jobs, obtaining the status of
+               a batch job, and communicating with the operator of a
+               batch processing host.  This package is implemented at
+               the host that provides the batch processing facility.
+
+               Pathname: [SRI-ARC] <NLS>BATCH.TXT
+
+            LLDBUG (24579,) "The Low-Level Debug Package"
+
+               This document describes a package that runs in the
+               setting provided by PCP.  It includes procedures for a
+               remote process to debug at the assembly-language level,
+               any process known to the local process.  The package
+               contains procedures for manipulating and searching the
+               process' address space, for manipulating and searching
+               its symbol tables, and for setting and removing
+               breakpoints from its address space.  Its data stores hold
+               process characteristics and state information, and the
+               contents of program symbol tables.
+
+               Pathname: [SRI-ARC] <NLS>LLDBUG.TXT
+
+         People:
+
+
+
+
+
+Postel                                                         [Page 20]
+
+RFC 661                                                    November 1974
+
+
+         Schedule:
+
+            A demonstration of the National Software Works concept is to
+            be performed in July 1975.
+
+         Recent developments:
+
+            The set of documents cited above is available.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Postel                                                         [Page 21]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc661.txt](<www.ietf.org/rfc/rfc661.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
