### PR TITLE
Archive rfc6623.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6623.txt
+++ b/www.ietf.org/rfc/rfc6623.txt
@@ -1,0 +1,339 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                         E. Burger
+Request for Comments: 6623                         Georgetown University
+Updates: 6231                                                   May 2012
+Category: Standards Track
+ISSN: 2070-1721
+
+
+ IANA Registry for MEDIACTRL Interactive Voice Response Control Package
+
+Abstract
+
+   This document creates an IANA registry for the response codes for the
+   MEDIACTRL Interactive Voice Response Control Package, as described in
+   RFC 6231.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6623.
+
+Copyright Notice
+
+   Copyright (c) 2012 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+
+
+Burger                       Standards Track                    [Page 1]
+
+RFC 6623                   6231 IANA Registry                   May 2012
+
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . . . 2
+   2.  Security Considerations . . . . . . . . . . . . . . . . . . . . 2
+   3.  IANA Considerations . . . . . . . . . . . . . . . . . . . . . . 2
+   4.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . 6
+   5.  Normative References  . . . . . . . . . . . . . . . . . . . . . 6
+
+1.  Introduction
+
+   This document creates an IANA registry for the response codes for the
+   MEDIACTRL Interactive Voice Response Control Package [RFC6231].
+
+2.  Security Considerations
+
+   There are no security considerations, other than those described in
+   the MEDIACTRL Interactive Voice Response Control Package [RFC6231].
+
+3.  IANA Considerations
+
+   IANA has created the "MEDIACTRL Interactive Voice Response Control
+   Package Status Codes" registry per this document.  New status codes
+   are assigned using the Standards Action process defined in RFC 5226
+   [RFC5226].
+
+   +-------+---------------+-----------------------+-------------------+
+   | Code  | Summary       | Description           | Reference         |
+   +-------+---------------+-----------------------+-------------------+
+   | 200   | OK            | Request has           | RFC6231           |
+   |       |               | succeeded.            |                   |
+   | 400   | Syntax error  | Request is            | RFC6231           |
+   |       |               | syntactically         |                   |
+   |       |               | invalid: it is not    |                   |
+   |       |               | valid with respect to |                   |
+   |       |               | the XML schema or it  |                   |
+   |       |               | violates a            |                   |
+   |       |               | co-occurrence         |                   |
+   |       |               | constraint for a      |                   |
+   |       |               | request element.      |                   |
+   | 405   | dialogid      | Request uses a        | RFC6231           |
+   |       | already       | dialogid identifier   |                   |
+   |       | exists        | for a new dialog that |                   |
+   |       |               | is already used by    |                   |
+   |       |               | another dialog on the |                   |
+   |       |               | MS.                   |                   |
+
+
+
+
+
+
+Burger                       Standards Track                    [Page 2]
+
+RFC 6623                   6231 IANA Registry                   May 2012
+
+
+   | 406   | dialogid does | Request uses a        | RFC6231           |
+   |       | not exist     | dialogid identifier   |                   |
+   |       |               | for a dialog that     |                   |
+   |       |               | does not exist on the |                   |
+   |       |               | MS.                   |                   |
+   | 407   | connectionid  | Request uses a        | RFC6231           |
+   |       | does not      | connectionid          |                   |
+   |       | exist         | identifier for a      |                   |
+   |       |               | connection that does  |                   |
+   |       |               | not exist on the MS.  |                   |
+   | 408   | conferenceid  | Request uses a        | RFC6231           |
+   |       | does not      | conferenceid          |                   |
+   |       | exist         | identifier for a      |                   |
+   |       |               | conference that does  |                   |
+   |       |               | not exist on the MS.  |                   |
+   | 409   | Resource      | Request uses a URI to | RFC6231           |
+   |       | cannot be     | reference an external |                   |
+   |       | retrieved     | resource (e.g.,       |                   |
+   |       |               | dialog, media or      |                   |
+   |       |               | grammar) that cannot  |                   |
+   |       |               | be retrieved within   |                   |
+   |       |               | the timeout interval. |                   |
+   | 410   | Dialog        | Request to prepare or | RFC6231           |
+   |       | execution     | start a dialog that   |                   |
+   |       | canceled      | has been terminated   |                   |
+   |       |               | by a                  |                   |
+   |       |               | <dialogterminate>.    |                   |
+   | 411   | Incompatible  | Request specifies a   | RFC6231           |
+   |       | stream        | media stream          |                   |
+   |       | configuration | configuration that is |                   |
+   |       |               | in conflict with      |                   |
+   |       |               | itself, or the        |                   |
+   |       |               | connection or         |                   |
+   |       |               | conference            |                   |
+   |       |               | capabilities.         |                   |
+   | 412   | Media stream  | Request specifies an  | RFC6231           |
+   |       | not available | operation for which a |                   |
+   |       |               | media stream is not   |                   |
+   |       |               | available; for        |                   |
+   |       |               | example, playing a    |                   |
+   |       |               | video media resource  |                   |
+   |       |               | on a connection or    |                   |
+   |       |               | conference without    |                   |
+   |       |               | video streams.        |                   |
+   | 413   | Control keys  | The request contains  | RFC6231           |
+   |       | with same     | a <control> element   |                   |
+   |       | value         | where some keys have  |                   |
+   |       |               | the same value.       |                   |
+
+
+
+Burger                       Standards Track                    [Page 3]
+
+RFC 6623                   6231 IANA Registry                   May 2012
+
+
+   | 419   | Other         | Requested operation   | RFC6231           |
+   |       | execution     | cannot be executed by |                   |
+   |       | error         | the MS.               |                   |
+   | 420   | Unsupported   | Request specifies a   | RFC6231           |
+   |       | URI scheme    | URI whose scheme is   |                   |
+   |       |               | not supported by the  |                   |
+   |       |               | MS.                   |                   |
+   | 421   | Unsupported   | Request references an | RFC6231           |
+   |       | dialog        | external dialog       |                   |
+   |       | language      | language not          |                   |
+   |       |               | supported by the MS.  |                   |
+   | 422   | Unsupported   | Request references a  | RFC6231           |
+   |       | playback      | media resource for    |                   |
+   |       | format        | playback whose format |                   |
+   |       |               | is not supported by   |                   |
+   |       |               | the MS.               |                   |
+   | 423   | Unsupported   | Request references a  | RFC6231           |
+   |       | record format | media resource for    |                   |
+   |       |               | recording whose       |                   |
+   |       |               | format is not         |                   |
+   |       |               | supported by the MS.  |                   |
+   | 424   | Unsupported   | Request references a  | RFC6231           |
+   |       | grammar       | grammar whose format  |                   |
+   |       | format        | is not supported by   |                   |
+   |       |               | the MS.               |                   |
+   | 425   | Unsupported   | Request contains a    | RFC6231           |
+   |       | variable      | prompt <variable>     |                   |
+   |       | configuration | element not supported |                   |
+   |       |               | by the MS.            |                   |
+   | 426   | Unsupported   | Request contains a    | RFC6231           |
+   |       | DTMF          | prompt <dtmf> element |                   |
+   |       | configuration | not supported by the  |                   |
+   |       |               | MS.                   |                   |
+   | 427   | Unsupported   | Request contains a    | RFC6231           |
+   |       | parameter     | <param> element not   |                   |
+   |       |               | supported by the MS.  |                   |
+   | 428   | Unsupported   | Request contains a    | RFC6231           |
+   |       | media stream  | <stream> element      |                   |
+   |       | configuration | whose configuration   |                   |
+   |       |               | is not supported by   |                   |
+   |       |               | the MS.               |                   |
+   | 429   | Unsupported   | Request contains a    | RFC6231           |
+   |       | playback      | <prompt> element that |                   |
+   |       | configuration | the MS is unable to   |                   |
+   |       |               | play on the available |                   |
+   |       |               | output media streams. |                   |
+
+
+
+
+
+Burger                       Standards Track                    [Page 4]
+
+RFC 6623                   6231 IANA Registry                   May 2012
+
+
+   | 430   | Unsupported   | Request contains a    | RFC6231           |
+   |       | record        | <record> element that |                   |
+   |       | configuration | the MS is unable to   |                   |
+   |       |               | record with on the    |                   |
+   |       |               | available input media |                   |
+   |       |               | streams.              |                   |
+   | 431   | Unsupported   | The request contains  | RFC6231           |
+   |       | foreign       | attributes or         |                   |
+   |       | namespace     | elements from another |                   |
+   |       | attribute or  | namespace that the MS |                   |
+   |       | element       | does not support.     |                   |
+   | 432   | Unsupported   | The request tries to  | RFC6231           |
+   |       | multiple      | start another dialog  |                   |
+   |       | dialog        | on the same           |                   |
+   |       | capability    | conference or         |                   |
+   |       |               | connection where a    |                   |
+   |       |               | dialog is already     |                   |
+   |       |               | running.              |                   |
+   | 433   | Unsupported   | The request contains  | RFC6231           |
+   |       | collect and   | <collect> and         |                   |
+   |       | record        | <record> elements and |                   |
+   |       | capability    | the MS does not       |                   |
+   |       |               | support these         |                   |
+   |       |               | operations            |                   |
+   |       |               | simultaneously.       |                   |
+   | 434   | Unsupported   | The request contains  | RFC6231           |
+   |       | VAD           | a <record> element    |                   |
+   |       | capability    | where Voice Activity  |                   |
+   |       |               | Detection (VAD) is    |                   |
+   |       |               | required, but the MS  |                   |
+   |       |               | does not support VAD. |                   |
+   | 435   | Unsupported   | The request contains  | RFC6231           |
+   |       | parallel      | a prompt <par>        |                   |
+   |       | playback      | element whose         |                   |
+   |       |               | configuration is not  |                   |
+   |       |               | supported by the MS.  |                   |
+   | 439   | Other         | Request requires      | RFC6231           |
+   |       | unsupported   | another capability    |                   |
+   |       | capability    | not supported by the  |                   |
+   |       |               | MS.                   |                   |
+   +-------+---------------+-----------------------+-------------------+
+
+                           Table 1: Status Codes
+
+
+
+
+
+
+
+
+Burger                       Standards Track                    [Page 5]
+
+RFC 6623                   6231 IANA Registry                   May 2012
+
+
+4.  Acknowledgements
+
+   I lifted the table in Section 3 directly from the excellent text
+   written by Scott McGlashan, Tim Melanchuk, and Chris Boulton in RFC
+   6231.  Any transcription errors are mine.
+
+5.  Normative References
+
+   [RFC6231]  McGlashan, S., Melanchuk, T., and C. Boulton, "An
+              Interactive Voice Response (IVR) Control Package for the
+              Media Control Channel Framework", RFC 6231, May 2011.
+
+   [RFC5226]  Narten, T. and H. Alvestrand, "Guidelines for Writing an
+              IANA Considerations Section in RFCs", BCP 26, RFC 5226,
+              May 2008.
+
+Author's Address
+
+   Eric Burger
+   Georgetown University
+   37th and O St., NW
+   Washington, DC  20007
+   USA
+
+   EMail: eburger@standardstrack.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Burger                       Standards Track                    [Page 6]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6623.txt](<www.ietf.org/rfc/rfc6623.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
