### PR TITLE
Archive rfc6639.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6639.txt
+++ b/www.ietf.org/rfc/rfc6639.txt
@@ -1,0 +1,1627 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                      D. King, Ed.
+Request for Comments: 6639                            Old Dog Consulting
+Category: Informational                               M. Venkatesan, Ed.
+ISSN: 2070-1721                                                  Aricent
+                                                               June 2012
+
+
+       Multiprotocol Label Switching Transport Profile (MPLS-TP)
+                     MIB-Based Management Overview
+
+Abstract
+
+   A range of Management Information Base (MIB) modules has been
+   developed to help model and manage the various aspects of
+   Multiprotocol Label Switching (MPLS) networks.  These MIB modules are
+   defined in separate documents that focus on the specific areas of
+   responsibility of the modules that they describe.
+
+   The MPLS Transport Profile (MPLS-TP) is a profile of MPLS
+   functionality specific to the construction of packet-switched
+   transport networks.
+
+   This document describes the MIB-based architecture for MPLS-TP,
+   indicates the interrelationships between different existing MIB
+   modules that can be leveraged for MPLS-TP network management, and
+   identifies areas where additional MIB modules are required.
+
+Status of This Memo
+
+   This document is not an Internet Standards Track specification; it is
+   published for informational purposes.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Not all documents
+   approved by the IESG are a candidate for any level of Internet
+   Standard; see Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6639.
+
+
+
+
+
+
+
+
+
+King & Venkatesan             Informational                     [Page 1]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+Copyright Notice
+
+   Copyright (c) 2012 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+King & Venkatesan             Informational                     [Page 2]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+Table of Contents
+
+   1. Introduction ....................................................4
+      1.1. MPLS-TP Management Function ................................5
+   2. Terminology .....................................................5
+   3. The SNMP Management Framework ...................................5
+   4. Overview of Existing Work .......................................6
+      4.1. MPLS Management Overview and Requirements ..................6
+      4.2. An Introduction to the MPLS and Pseudowire MIB Modules .....6
+           4.2.1. Structure of the MPLS MIB OID Tree ..................6
+           4.2.2. Textual Convention Modules ..........................8
+           4.2.3. Label Switched Path (LSP) Modules ...................8
+           4.2.4. Label Edge Router (LER) Modules .....................8
+           4.2.5. Label Switching Router (LSR) Modules ................9
+           4.2.6. Pseudowire Modules ..................................9
+           4.2.7. Routing and Traffic Engineering ....................10
+           4.2.8. Resiliency .........................................11
+           4.2.9. Fault Management and Performance Management ........11
+           4.2.10. MIB Module Interdependencies ......................13
+           4.2.11. Dependencies on External MIB Modules ..............15
+   5. Applicability of MPLS MIB Modules to MPLS-TP ...................16
+      5.1. MPLS-TP Tunnel ............................................17
+           5.1.1. Gap Analysis .......................................17
+           5.1.2. Recommendations ....................................17
+      5.2. MPLS-TP Pseudowire ........................................17
+           5.2.1. Gap Analysis .......................................17
+           5.2.2. Recommendations ....................................18
+      5.3. MPLS-TP Sections ..........................................18
+           5.3.1. Gap Analysis .......................................18
+           5.3.2. Recommendations ....................................18
+      5.4. MPLS-TP OAM ...............................................18
+           5.4.1. Gap Analysis .......................................18
+           5.4.2. Recommendations ....................................19
+      5.5. MPLS-TP Protection Switching and Recovery .................19
+           5.5.1. Gap Analysis .......................................19
+           5.5.2. Recommendations ....................................19
+      5.6. MPLS-TP Interfaces ........................................19
+           5.6.1. Gap Analysis .......................................19
+           5.6.2. Recommendations ....................................19
+
+
+
+
+
+
+
+
+
+
+
+
+King & Venkatesan             Informational                     [Page 3]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+   6. An Introduction to the MPLS-TP MIB Modules .....................20
+      6.1. MPLS-TP MIB Modules .......................................20
+           6.1.1. New MIB Modules for MPLS-TP ........................20
+           6.1.2. Textual Conventions for MPLS-TP ....................20
+           6.1.3. Identifiers for MPLS-TP ............................21
+           6.1.4. LSR MIB Extensions for MPLS-TP .....................21
+           6.1.5. Tunnel Extensions for MPLS-TP ......................21
+      6.2. PWE3 MIB Modules for MPLS-TP ..............................21
+           6.2.1. New MIB Modules for MPLS-TP Pseudowires ............21
+           6.2.2. Pseudowire Textual Conventions for MPLS-TP .........21
+           6.2.3. Pseudowire Extensions for MPLS-TP ..................22
+           6.2.4. Pseudowire MPLS Extensions for MPLS-TP .............22
+      6.3. OAM MIB Modules for MPLS-TP ...............................22
+           6.3.1. New MIB Modules for OAM for MPLS-TP ................22
+           6.3.2. BFD MIB Module .....................................22
+           6.3.3. OAM MIB Module .....................................23
+      6.4. Protection Switching and Recovery MIB Modules for MPLS-TP .23
+           6.4.1. New MIB Modules for MPLS Protection
+                  Switching and Recovery .............................23
+           6.4.2. Linear Protection Switching MIB Module .............23
+           6.4.3. Ring Protection Switching MIB Module ...............23
+           6.4.4. Mesh Protection Switching MIB Module ...............23
+   7. Management Options .............................................23
+   8. Security Considerations ........................................24
+   9. IANA Considerations ............................................24
+   10. Acknowledgements ..............................................24
+   11. Contributors' Addresses .......................................25
+   12. References ....................................................26
+      12.1. Normative References .....................................26
+      12.2. Informative References ...................................27
+
+1.  Introduction
+
+   The MPLS Transport Profile (MPLS-TP) is a packet transport technology
+   based on a profile of the MPLS functionality specific to the
+   construction of packet-switched transport networks.  MPLS is
+   described in [RFC3031], and requirements for MPLS-TP are specified in
+   [RFC5654].
+
+   A range of Management Information Base (MIB) modules has been
+   developed to help model and manage the various aspects of
+   Multiprotocol Label Switching (MPLS) networks.  These MIB modules are
+   defined in separate documents that focus on the specific areas of
+   responsibility for the modules that they describe.
+
+
+
+
+
+
+
+King & Venkatesan             Informational                     [Page 4]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+   An MPLS-TP network can be operated via static provisioning of
+   transport paths, Label Switched Paths (LSPs) and pseudowires (PWs),
+   or the elective use of a Generalized MPLS (GMPLS) control plane to
+   support dynamic provisioning of transport paths, LSPs, and PWs.
+
+   This document describes the MIB-based management architecture for
+   MPLS, as extended for MPLS-TP.  The document also indicates the
+   interrelationships between existing MIB modules that should be
+   leveraged for MPLS-TP network management and identifies areas where
+   additional MIB modules are required.
+
+   Note that [RFC5951] does not specify a preferred management interface
+   protocol to be used as the standard protocol for managing MPLS-TP
+   networks.
+
+1.1.  MPLS-TP Management Function
+
+   The management of the MPLS-TP networks is separable from that of its
+   client networks so that the same means of management can be used
+   regardless of the client.  The management function of MPLS-TP
+   includes fault management, configuration management, performance
+   monitoring, and security management.
+
+   The purpose of the management function is to provide control and
+   monitoring of the MPLS transport profile protocol mechanisms and
+   procedures.  The requirements for the network management
+   functionality are found in [RFC5951].  A description of the network
+   and element management architectures that can be applied to the
+   management of MPLS-based transport networks is found in [RFC5950].
+
+2.  Terminology
+
+   This document also uses terminology from the MPLS architecture
+   document [RFC3031], Pseudowire Emulation Edge-to-Edge (PWE3)
+   architecture [RFC3985], and the following MPLS-related MIB modules:
+   the MPLS-TC-STD-MIB [RFC3811], MPLS-LSR-STD-MIB [RFC3813],
+   MPLS-TE-STD-MIB [RFC3812], MPLS-LDP-STD-MIB [RFC3815],
+   MPLS-FTN-STD-MIB [RFC3814], and TE-LINK-STD-MIB [RFC4220].
+
+3.  The SNMP Management Framework
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).
+
+
+
+
+King & Venkatesan             Informational                     [Page 5]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to Section 7 of
+   [RFC3410].
+
+   This document discusses MIB modules that are compliant to the SMIv2,
+   which is described in [RFC2578], [RFC2579], and [RFC2580].
+
+4.  Overview of Existing Work
+
+   This section describes the existing tools and techniques for managing
+   and modeling MPLS networks, devices, and protocols.  It is intended
+   to provide a description of the tool kit that is already available.
+
+   Section 5 of this document outlines the applicability of existing
+   MPLS MIB modules to MPLS-TP, describes the optional use of GMPLS MIB
+   modules in MPLS-TP networks, and examines the additional MIB modules
+   and objects that would be required for managing an MPLS-TP network.
+
+4.1.  MPLS Management Overview and Requirements
+
+   [RFC4378] outlines how data-plane protocols can assist in providing
+   the Operations, Administration, and Maintenance (OAM) requirements
+   outlined in [RFC4377] and how it is applied to the management
+   functions of fault, configuration, accounting, performance, and
+   security (commonly known as FCAPS) for MPLS networks.
+
+   [RFC4221] describes the management architecture for MPLS.  In
+   particular, it describes how the managed objects defined in various
+   MPLS-related MIB modules model different aspects of MPLS, as well as
+   the interactions and dependencies between each of these MIB modules.
+
+   [RFC4377] describes the requirements for user- and data-plane OAM and
+   applications for MPLS.
+
+   [RFC5654] describes the requirements for the optional use of a
+   control plane to support dynamic provisioning of MPLS-TP transport
+   paths.  The MPLS-TP LSP control plane is based on GMPLS and is
+   described in [RFC3945].
+
+4.2.  An Introduction to the MPLS and Pseudowire MIB Modules
+
+4.2.1.  Structure of the MPLS MIB OID Tree
+
+   The MPLS MIB Object Identifier (OID) tree has the following
+   structure.  It is based on the tree originally set out in Section 4.1
+   of [RFC4221] and has been enhanced to include other relevant MIB
+   modules.
+
+
+
+
+King & Venkatesan             Informational                     [Page 6]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+    mib-2 -- RFC 2578 [RFC2578]
+     |
+     +-transmission
+     |  |
+     |  +- mplsStdMIB
+     |  |    |
+     |  |    +- mplsTCStdMIB -- MPLS-TC-STD-MIB [RFC3811]
+     |  |    |
+     |  |    +- mplsLsrStdMIB -- MPLS-LSR-STD-MIB [RFC3813]
+     |  |    |
+     |  |    +- mplsTeStdMIB -- MPLS-TE-STD-MIB [RFC3812]
+     |  |    |
+     |  |    +- mplsLdpStdMIB -- MPLS-LDP-STD-MIB [RFC3815]
+     |  |    |
+     |  |    +- mplsLdpGenericStdMIB
+     |  |    |                -- MPLS-LDP-GENERIC-STD-MIB [RFC3815]
+     |  |    |
+     |  |    +- mplsFTNStdMIB -- MPLS-FTN-STD-MIB [RFC3814]
+     |  |    |
+     |  |    +- gmplsTCStdMIB -- GMPLS-TC-STD-MIB [RFC4801]
+     |  |    |
+     |  |    +- gmplsTeStdMIB -- GMPLS-TE-STD-MIB [RFC4802]
+     |  |    |
+     |  |    +- gmplsLsrStdMIB -- GMPLS-LSR-STD-MIB [RFC4803]
+     |  |    |
+     |  |    +- gmplsLabelStdMIB -- GMPLS-LABEL-STD-MIB [RFC4803]
+     |  |
+     |  +- teLinkStdMIB -- TE-LINK-STD-MIB [RFC4220]
+     |  |
+     |  +- pwStdMIB -- PW-STD-MIB [RFC5601]
+     |
+     +- ianaGmpls -- IANA-GMPLS-TC-MIB [RFC4802]
+     |
+     +- ianaPwe3MIB -- IANA-PWE3-MIB [RFC5601]
+     |
+     +- pwEnetStdMIB -- PW-ENET-STD-MIB [RFC5603]
+     |
+     +- pwMplsStdMIB -- PW-MPLS-STD-MIB [RFC5602]
+     |
+     +- pwTDMMIB -- PW-TDM-MIB [RFC5604]
+     |
+     +- pwTcStdMIB -- PW-TC-STD-MIB [RFC5542]
+
+   Note: The OIDs for MIB modules are assigned and managed by IANA.
+   They can be found in the referenced MIB documents.
+
+
+
+
+
+
+King & Venkatesan             Informational                     [Page 7]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+4.2.2.  Textual Convention Modules
+
+   The MPLS-TC-STD-MIB [RFC3811], GMPLS-TC-STD-MIB [RFC4801],
+   IANA-GMPLS-TC-MIB [RFC4802], and PW-TC-STD-MIB [RFC5542] contain the
+   Textual Conventions for MPLS and GMPLS networks.  These Textual
+   Conventions should be imported by MIB modules that manage MPLS and
+   GMPLS networks.  Section 4.2.11 highlights dependencies on additional
+   external MIB modules.
+
+4.2.3.  Label Switched Path (LSP) Modules
+
+   An LSP is a path over which a labeled packet travels across the
+   sequence of Label Switching Routers (LSRs) for a given Forward
+   Equivalence Class (FEC).  When a packet, with or without a label,
+   arrives at an ingress Label Edge Router (LER) of an LSP, it is
+   encapsulated with the label corresponding to the FEC and sent across
+   the LSP.  The labeled packet traverses the LSRs and arrives at the
+   egress LER of the LSP, where it gets forwarded, depending on the
+   packet type it came with.  LSPs could be nested using label stacking,
+   such that an LSP could traverse another LSP.  A more detailed
+   description of an LSP can be found in [RFC3031].
+
+   The MPLS-LSR-STD-MIB [RFC3813] describes the objects required to
+   define the LSP.
+
+4.2.4.  Label Edge Router (LER) Modules
+
+   Ingress and egress LSRs of an LSP are known as Label Edge Routers
+   (LERs).  An ingress LER takes each incoming unlabeled or labeled
+   packet and encapsulates it with the corresponding label of the LSP it
+   represents, and then forwards it to the adjacent LSR of the LSP.
+   Each FEC is mapped to a label-forwarding entry, so that a packet
+   could be encapsulated with one or more label entries; this is
+   referred to as a label stack.
+
+   The packet traverses the LSP.  Upon reaching the egress LER, further
+   action will be taken to handle the packet, depending on the type of
+   packet received.  MPLS Architecture [RFC3031] details the
+   functionality of ingress and egress LERs.
+
+   The MPLS-FTN-STD-MIB [RFC3814] describes the managed objects for
+   mapping FEC to label bindings.
+
+
+
+
+
+
+
+
+
+King & Venkatesan             Informational                     [Page 8]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+4.2.5.  Label Switching Router (LSR) Modules
+
+   A router that performs MPLS forwarding is known as an LSR.  An LSR
+   receives a labeled packet and performs forwarding action based on the
+   label received.
+
+   The LSR maintains a mapping of an incoming label and incoming
+   interface to one or more outgoing labels and outgoing interfaces in
+   its forwarding database.  When a labeled packet is received, the LSR
+   examines the topmost label in the label stack and then does a 'swap',
+   'push', or 'pop' operation based on the contents.
+
+   The MPLS-LSR-STD-MIB [RFC3813] describes the managed objects for
+   modeling an MPLS [RFC3031] LSR.  The MPLS-LSR-STD-MIB [RFC3813]
+   contains the managed objects to maintain mapping of in-segments to
+   out-segments.
+
+4.2.6.  Pseudowire Modules
+
+   The pseudowire (PW) MIB architecture provides a layered modular model
+   into which any supported emulated service such as Frame Relay, ATM,
+   Ethernet, Time-Division Multiplexing (TDM), and Synchronous Optical
+   Network/Synchronous Digital Hierarchy (SONET/SDH) can be connected to
+   any supported Packet Switched Network (PSN) type.  This MIB
+   architecture is modeled based on PW3 architecture [RFC3985].
+
+   The emulated service layer, generic PW layer, and PSN Virtual Circuit
+   (VC) layer constitute the different layers of the model.  A
+   combination of the MIB modules belonging to each layer provides the
+   glue for mapping the emulated service onto the native PSN service.
+   At least three MIB modules, each belonging to a different layer, are
+   required to define a PW emulated service.
+
+   -  The service-specific module is dependent on the emulated signal
+      type and helps in modeling the emulated service layer.
+
+   The PW-ENET-STD-MIB [RFC5603] describes a model for managing Ethernet
+   pseudowire services for transmission over a PSN.  This MIB module is
+   generic and common to all types of PSNs supported in the PWE3
+   Architecture [RFC3985], which describes the transport and
+   encapsulation of L1 and L2 services over supported PSN types.
+
+   In particular, the MIB module associates a port or specific VLANs on
+   top of a physical Ethernet port or a virtual Ethernet interface (for
+   the Virtual Private LAN Service (VPLS)) to a point-to-point PW.  It
+   is complementary to the PW-STD-MIB [RFC5601], which manages the
+   generic PW parameters common to all services, including all supported
+   PSN types.
+
+
+
+King & Venkatesan             Informational                     [Page 9]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+   The PW-TDM-MIB [RFC5604] describes a model for managing TDM
+   pseudowires, i.e., TDM data encapsulated for transmission over a PSN.
+   The term "TDM" in this document is limited to the scope of
+   Plesiochronous Digital Hierarchy (PDH).  It is currently specified to
+   carry any TDM signals in either Structure Agnostic Transport mode
+   (E1, T1, E3, and T3) or Structure Aware Transport mode (E1, T1, and
+   NxDS0) as defined in the PWE3 TDM Requirements document [RFC4197].
+
+   -  The generic PW module configures general parameters of the PW that
+      are common to all types of emulated services and PSN types.
+
+   The PW-STD-MIB [RFC5601] defines a MIB module that can be used to
+   manage PW services for transmission over a PSN [RFC3931] [RFC4447].
+   This MIB module provides generic management of PWs that is common to
+   all types of PSN and PW services defined by the IETF PWE3 Working
+   Group.
+
+   -  The PSN-specific module associates the PW with one or more
+      "tunnels" that carry the service over the PSN.  There is a
+      different module for each type of PSN.
+
+   The PW-MPLS-STD-MIB [RFC5602] describes a model for managing
+   pseudowire services for transmission over different flavors of MPLS
+   tunnels.  The generic PW MIB module [RFC5601] defines the parameters
+   global to the PW, regardless of the underlying PSN and emulated
+   service.  This document is applicable for PWs that use the MPLS PSN
+   type in the PW-STD-MIB.  Additionally, this document describes the
+   MIB objects that define pseudowire association to the MPLS PSN that
+   is not specific to the carried service.
+
+   Together, [RFC3811], [RFC3812], and [RFC3813] describe the modeling
+   of an MPLS tunnel and a tunnel's underlying cross-connects.  This MIB
+   module supports MPLS Traffic Engineering (MPLS-TE) PSNs, non-TE MPLS
+   PSNs (an outer tunnel created by the Label Distribution Protocol
+   (LDP) or manually), and MPLS PW labels only (no outer tunnel).
+
+4.2.7.  Routing and Traffic Engineering
+
+   In MPLS traffic engineering, it's possible to specify explicit routes
+   or choose routes based on QoS metrics in setting up a path such that
+   some specific data can be routed around network hot spots.  TE LSPs
+   can be set up through a management plane or a control plane.
+
+   The MPLS-TE-STD-MIB [RFC3812] describes managed objects for modeling
+   MPLS [RFC3031]-based traffic engineering.  This MIB module should be
+   used in conjunction with the companion document [RFC3813] for MPLS-
+   based traffic engineering configuration and management.
+
+
+
+
+King & Venkatesan             Informational                    [Page 10]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+4.2.8.  Resiliency
+
+   The purpose of MPLS resiliency is to ensure minimal interruption to
+   traffic when a failure occurs within the system or network.
+
+   Various components of MPLS resiliency solutions are as follows:
+
+      1) Graceful restart in LDP and RSVP-TE modules
+
+      2) Make before break
+
+      3) Protection switching for LSPs
+
+      4) Fast reroute for LSPs
+
+      5) PW redundancy
+
+   The MIB modules below only support MIB-based management for MPLS
+   resiliency.
+
+   MPLS Fast Reroute (FRR) is a restoration network resiliency mechanism
+   used in MPLS TE to redirect traffic onto the backup LSPs in tens of
+   milliseconds in case of link or node failure across the LSP.
+
+   The MPLS-FRR-GENERAL-STD-MIB [RFC6445] contains objects that apply to
+   any MPLS LSR implementing MPLS TE fast-reroute functionality.
+
+   The MPLS-FRR-ONE2ONE-STD-MIB [RFC6445] contains objects that apply to
+   the one-to-one backup method.
+
+   The MPLS-FRR-FACILITY-STD-MIB [RFC6445] contains objects that apply
+   to the facility backup method.
+
+   Protection switching mechanisms have been designed to provide network
+   resiliency for MPLS networks.  Different types of protection
+   switching mechanisms, such as 1:1, 1:N, and 1+1, have been designed.
+
+4.2.9.  Fault Management and Performance Management
+
+   MPLS manages LSP and pseudowire faults through the use of LSP ping
+   [RFC4379], Virtual Circuit Connectivity Verification (VCCV)
+   [RFC5085], Bidirectional Forwarding Detection (BFD) for LSPs
+   [RFC5884], and BFD for VCCV [RFC5885] tools.
+
+   MPLS currently focuses on in and/or out packet counters, errored
+   packets, and discontinuity time.
+
+
+
+
+
+King & Venkatesan             Informational                    [Page 11]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+   Some of the MPLS and pseudowire performance tables used for
+   performance management are given below.
+
+   The mplsTunnelPerfTable [RFC3812] provides several counters (e.g.,
+   packets forwarded, packets dropped because of errors) to measure the
+   performance of the MPLS tunnels.
+
+   The mplsInterfacePerfTable [RFC3813] provides performance information
+   (incoming and outgoing labels in use, and lookup failures) on a
+   per-interface basis.
+
+   The mplsInSegmentPerfTable [RFC3813] contains statistical information
+   (total packets received by the in-segment, total errored packets
+   received, total packets discarded, discontinuity time) for incoming
+   MPLS segments to an LSR.
+
+   The mplsOutSegmentPerfTable [RFC3813] contains statistical
+   information (total packets received, total errored packets received,
+   total packets discarded, discontinuity time) for outgoing MPLS
+   segments from an LSR.
+
+   The mplsFTNPerfTable [RFC3814] contains performance information for
+   the specified interface and an FTN entry mapped to this interface.
+
+   The mplsLdpEntityStatsTable [RFC3815] and mplsLdpSessionStatsTable
+   [RFC3815] contain statistical information (session attempts, errored
+   packets, notifications) about an LDP entity.
+
+   The pwPerfCurrentTable [RFC5601], pwPerfIntervalTable [RFC5601], and
+   pwPerf1DayIntervalTable [RFC5601] provide pseudowire performance
+   information (in and/or out packets) based on time (current interval,
+   preconfigured specific interval, 1-day interval).
+
+   The pwEnetStatsTable [RFC5603] contains statistical counters specific
+   for Ethernet PW.
+
+   The pwTDMPerfCurrentTable [RFC5604], pwTDMPerfIntervalTable
+   [RFC5604], and pwTDMPerf1DayIntervalTable [RFC5604] contain
+   statistical information accumulated per 15-minute, 24-hour, and 1-day
+   periods, respectively.
+
+   The gmplsTunnelErrorTable [RFC4802] and gmplsTunnelReversePerfTable
+   [RFC4802] provide information about performance, errored packets, and
+   in/out packet counters.
+
+
+
+
+
+
+
+King & Venkatesan             Informational                    [Page 12]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+4.2.10.  MIB Module Interdependencies
+
+   This section provides an overview of the relationship between the
+   MPLS MIB modules for managing MPLS networks.  More details of these
+   relationships are given below.
+
+   [RFC4221] mainly focuses on MPLS MIB module interdependencies.  This
+   section also highlights GMPLS and PW MIB module interdependencies.
+
+   The relationship "A --> B" means that A depends on B and that MIB
+   module A uses an object, object identifier, or Textual Convention
+   defined in MIB module B, or that MIB module A contains a pointer
+   (index or RowPointer) to an object in MIB module B.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+King & Venkatesan             Informational                    [Page 13]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+   +-------> MPLS-TC-STD-MIB <-----------------------------------------+
+   ^            ^                                                      ^
+   |            |                                                      |
+   |         MPLS-LSR-STD-MIB <--------------------------------+       |
+   |                                                           ^       |
+   |                                                           |       |
+   +<----------------------- MPLS-LDP-STD-MIB ---------------->+       |
+   ^                                    ^                      ^       |
+   |                                    |                      |       |
+   +<-- MPLS-LDP-GENERIC-STD-MIB ------>+                      |       |
+   ^                                                           |       |
+   |                                                           |       |
+   +<------ MPLS-FTN-STD-MIB --------------------------------->+       |
+   ^                 |                                         ^       |
+   |                 V                                         |       |
+   +<------------- MPLS-TE-STD-MIB -->+----------------------->+       |
+                                      ^  GMPLS-TC-STD-MIB ------------>+
+                                      |    ^                           ^
+                                      |    |                           |
+                                  +---+    +<-- GMPLS-LABEL-STD-MIB -->+
+                                  ^   ^    ^      ^                    ^
+                                  |   |    |      |                    |
+   +----> PW-TC-STD-MIB           |  GMPLS-LSR-STD-MIB --------------->+
+   ^                              |      ^       ^                     ^
+   |                              |      |       |                     |
+   |   IANA-PWE3-MIB              |      |       | IANA-GMPLS-TC-MIB   |
+   |         ^                    |      |       |    ^                |
+   |         |                    |      |       |    |                |
+   |         |                    +<--- GMPLS-TE-STD-MIB ------------->+
+   |         |                    ^                                    ^
+   +<--- PW-STD-MIB <------+      |                                    |
+   ^                       ^      |                                    |
+   |                       |      |                                    |
+   +<--- PW-ENET-STD-MIB ->+      |                                    |
+   ^                       ^      |                                    |
+   |                       |      |                                    |
+   |                       |      |                                    |
+   +<---------------- PW-MPLS-STD-MIB--------------------------------->+
+
+   Thus,
+
+   -  All the MPLS MIB modules depend on the MPLS-TC-STD-MIB.
+
+   -  All the GMPLS MIB modules depend on the GMPLS-TC-STD-MIB.
+
+   -  All the PW MIB modules depend on the PW-TC-STD-MIB.
+
+
+
+
+
+King & Venkatesan             Informational                    [Page 14]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+   -  The MPLS-LDP-STD-MIB, MPLS-TE-STD-MIB, MPLS-FTN-STD-MIB,
+      GMPLS-LSR-STD-MIB, and PW-MPLS-STD-MIB contain references to
+      objects in the MPLS-LSR-STD-MIB.
+
+   -  The MPLS-LDP-GENERIC-STD-MIB contains references to objects in the
+      MPLS-LDP-STD-MIB.
+
+   -  The MPLS-FTN-STD-MIB, PW-MPLS-STD-MIB, and GMPLS-TE-STD-MIB
+      contain references to objects in the MPLS-TE-STD-MIB.
+
+   -  The PW-MPLS-STD-MIB and PW-ENET-STD-MIB contain references to
+      objects in the PW-STD-MIB.
+
+   -  The PW-STD-MIB contains references to objects in the
+      IANA-PWE3-MIB.
+
+   -  The GMPLS-TE-STD-MIB contains references to objects in the
+      IANA-GMPLS-TC-MIB.
+
+   -  The GMPLS-LSR-STD-MIB contains references to objects in the
+      GMPLS-LABEL-STD-MIB.
+
+   Note that there is a Textual Convention (MplsIndexType) defined in
+   the MPLS-LSR-STD-MIB that is imported by the MPLS-LDP-STD-MIB.
+
+4.2.11.  Dependencies on External MIB Modules
+
+   With the exception of the MPLS-TC-STD-MIB, all the MPLS MIB modules
+   have dependencies on the Interfaces MIB (also called the Interfaces
+   Group MIB or the IF-MIB) [RFC2863].  The MPLS-FTN-STD-MIB references
+   IP-capable interfaces on which received traffic is to be classified
+   using indexes in the Interfaces Table (ifTable) of the IF-MIB
+   [RFC2863].  The other MPLS MIB modules reference MPLS-capable
+   interfaces in the ifTable.
+
+   The IF-MIB [RFC2863] defines generic managed objects for managing
+   interfaces.  The MPLS MIB modules contain media-specific extensions
+   to the Interfaces Group for managing MPLS interfaces.
+
+   The MPLS MIB modules assume the interpretation of the Interfaces
+   Group to be in accordance with [RFC2863], which states that the
+   ifTable contains information on the managed resource's interfaces and
+   that each sub-layer below the internetwork layer of a network
+   interface is considered an interface.  Thus, the MPLS interface is
+   represented as an entry in the ifTable.
+
+   The interrelation of entries in the ifTable is defined by the
+   Interface Stack Group defined in [RFC2863].
+
+
+
+King & Venkatesan             Informational                    [Page 15]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+   The MPLS MIB modules have dependencies on the TE-LINK-STD-MIB for
+   maintaining traffic engineering information.
+
+   The MPLS MIB modules depend on the Constrained Shortest Path First
+   (CSPF) component to obtain the path required for an MPLS tunnel to
+   reach the end point of the tunnel, and on the BFD component to verify
+   data-plane failures of LSPs and PWs.
+
+   Finally, all of the MIB modules import standard Textual Conventions
+   such as integers, strings, timestamps, etc., from the MIB modules in
+   which they are defined.
+
+5.  Applicability of MPLS MIB Modules to MPLS-TP
+
+   This section highlights gaps in existing MPLS MIB modules in order to
+   determine extensions or additional MIB modules that are required to
+   support MPLS-TP in MPLS networks.
+
+   [RFC5951] specifies the requirements for the management of equipment
+   used in networks supporting MPLS-TP.  It also details the essential
+   network management capabilities for operating networks consisting of
+   MPLS-TP equipment.
+
+   [RFC5950] provides the network management framework for MPLS-TP.  The
+   document explains how network elements and networks that support
+   MPLS-TP can be managed using solutions that satisfy the requirements
+   defined in [RFC5951].  The relationship between MPLS-TP management
+   and OAM is described in the MPLS-TP framework document [RFC5950].
+
+   The MPLS MIB documents MPLS-TE-STD-MIB [RFC3812], PW-STD-MIB
+   [RFC5601], and MPLS-LSR-STD-MIB [RFC3813], and their associated MIB
+   modules, are reused for MPLS-based transport network management.
+
+   Fault management and performance management form key parts of the OAM
+   function.  MPLS-TP OAM is described in [RFC6371].
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+King & Venkatesan             Informational                    [Page 16]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+5.1.  MPLS-TP Tunnel
+
+5.1.1.  Gap Analysis
+
+   An MPLS-TP tunnel can be operated over IP and/or ITU-T Carrier Code
+   (ICC) environments.  The points below capture the gaps in existing
+   MPLS MIB modules for managing MPLS-TP networks.
+
+   -  IP-based environment
+
+       i. The MPLS-TE-STD-MIB [RFC3812] does not support the tunnel
+          Ingress/Egress identifier based on Global_ID and Node_ID
+          [RFC6370].
+
+      ii. The MPLS-TE-STD-MIB [RFC3812] does not support
+          co-routed/associated bidirectional tunnel configurations.
+
+   -  ICC-based environment
+
+       i. The MPLS-TE-STD-MIB [RFC3812] does not support the tunnel LSR
+          identifier based on ICC.
+
+5.1.2.  Recommendations
+
+   -  New MIB definitions may be created for Global_Node_ID and/or ICC
+      configurations.
+
+   -  The MPLS-LSR-STD-MIB [RFC3813] module may be enhanced to identify
+      the next hop based on a Media Access Control (MAC) address for
+      environments that do not use IP.  The mplsOutSegmentTable may be
+      extended to hold the MAC address.
+
+   -  The MPLS-TE-STD-MIB [RFC3812] and MPLS-LSR-STD-MIB may be enhanced
+      to provide static and signaling MIB module extensions for
+      co-routed/associated bidirectional LSPs.
+
+5.2.  MPLS-TP Pseudowire
+
+5.2.1.  Gap Analysis
+
+   MPLS-TP pseudowire can be operated over IP and/or ICC environments.
+   The points below capture the gaps in existing PW MIB modules for
+   managing MPLS-TP networks.
+
+   [RFC6370] specifies an initial set of identifiers to be used in
+   MPLS-TP.  These identifiers were chosen to be compatible with
+   existing MPLS, GMPLS, and PW definitions.
+
+
+
+
+King & Venkatesan             Informational                    [Page 17]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+   -  IP-based environment
+
+       i. The PW-STD-MIB [RFC5601] does not support the PW end point
+          identifier based on Global_ID and Node_ID.
+
+      ii. The PW-MPLS-STD-MIB [RFC5602] does not support operation over
+          co-routed/associated bidirectional tunnels.
+
+   -  ICC-based environment
+
+       i. The PW-STD-MIB [RFC5601] does not support the PW end point
+          identifier based on ICC.
+
+5.2.2.  Recommendations
+
+   -  The PW-MPLS-STD-MIB [RFC5602] can be enhanced to operate over
+      co-routed/associated bidirectional tunnels.
+
+5.3.  MPLS-TP Sections
+
+5.3.1.  Gap Analysis
+
+   The existing MPLS MIB modules do not support MPLS-TP sections.
+
+5.3.2.  Recommendations
+
+   Link-specific and/or path/segment-specific sections can be supported
+   by enhancing the IF-MIB [RFC2863], MPLS-TE-STD-MIB [RFC3812], and
+   PW-STD-MIB [RFC5601] MIB modules.
+
+5.4.  MPLS-TP OAM
+
+5.4.1.  Gap Analysis
+
+   MPLS manages LSP and pseudowire faults through LSP ping [RFC4379],
+   VCCV [RFC5085], BFD for LSPs [RFC5884], and BFD for VCCV [RFC5885]
+   tools.
+
+   The MPLS MIB modules do not support the following MPLS-TP OAM
+   functions:
+
+   o  Continuity Check and Connectivity Verification
+
+   o  Remote Defect Indication
+
+   o  Alarm Reporting
+
+   o  Lock Reporting
+
+
+
+King & Venkatesan             Informational                    [Page 18]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+   o  Lock Instruct
+
+   o  Client Failure Indication
+
+   o  Packet Loss Measurement
+
+   o  Packet Delay Measurement
+
+5.4.2.  Recommendations
+
+   New MIB module for BFD can be created to address all the gaps
+   mentioned in Section 5.4.1.
+
+5.5.  MPLS-TP Protection Switching and Recovery
+
+5.5.1.  Gap Analysis
+
+   An important aspect that MPLS-TP technology provides is protection
+   switching.  In general, the mechanism of protection switching can be
+   described as the substitution of a protection or standby facility for
+   a working or primary facility.
+
+   The MPLS MIB modules do not provide support for protection switching
+   and recovery in the following three topologies: linear, ring, and
+   mesh.
+
+5.5.2.  Recommendations
+
+   New MIB modules can be created to address all the gaps mentioned in
+   Section 5.5.1.
+
+5.6.  MPLS-TP Interfaces
+
+5.6.1.  Gap Analysis
+
+   As per [RFC6370], an LSR requires identification of the node itself
+   and of its interfaces.  An interface is the attachment point to a
+   server layer MPLS-TP section or MPLS-TP tunnel.
+
+   The MPLS MIB modules do not provide support for configuring the
+   interfaces within the context of an operator.
+
+5.6.2.  Recommendations
+
+   New MIB definitions can be created to address the gaps mentioned in
+   Section 5.6.1.
+
+
+
+
+
+King & Venkatesan             Informational                    [Page 19]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+6.  An Introduction to the MPLS-TP MIB Modules
+
+   This section highlights new MIB modules that have been identified as
+   being required for MPLS-TP.  This section also provides an overview
+   of the purpose of each MIB module within the MIB documents, what it
+   can be used for, and how it relates to the other MIB modules.
+
+   Note that each new MIB module (apart from Textual Conventions
+   modules) will contain one or more Compliance Statements to indicate
+   which objects must be supported in what manner to claim a specific
+   level of compliance.  Additional text, either in the documents that
+   define the MIB modules or in separate Applicability Statements, will
+   define which Compliance Statements need to be conformed to in order
+   to provide specific MPLS-TP functionality.  This document does not
+   set any requirements in that respect, although some recommendations
+   are included in the sections that follow.
+
+6.1.  MPLS-TP MIB Modules
+
+6.1.1.  New MIB Modules for MPLS-TP
+
+   Four new MIB modules are identified as follows:
+
+   -  Textual Conventions for MPLS-TP
+
+   -  Identifiers for MPLS-TP
+
+   -  LSR MIB Extensions for MPLS-TP
+
+   -  Tunnel Extensions for MPLS-TP
+
+   Note that the MIB modules mentioned here are applicable for MPLS
+   operations as well.
+
+6.1.2.  Textual Conventions for MPLS-TP
+
+   A new MIB module needs to be written that will define Textual
+   Conventions [RFC2579] for MPLS-TP-related MIB modules.  These
+   conventions allow multiple MIB modules to use the same syntax and
+   format to provide a concept that is shared between the MIB modules.
+
+   For example, a Maintenance Entity Group End Point (MEP) identifier is
+   used to identify a maintenance entity group end point within MPLS-TP
+   networks.  The Textual Convention representing the MEP identifier
+   should be defined in a new Textual Convention MIB module.
+
+   All new extensions related to MPLS-TP are defined in the MIB module
+   and will be referenced by other MIB modules to support MPLS-TP.
+
+
+
+King & Venkatesan             Informational                    [Page 20]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+6.1.3.  Identifiers for MPLS-TP
+
+   New identifiers describe managed objects that are used to model
+   common MPLS-TP identifiers [RFC6370].
+
+6.1.4.  LSR MIB Extensions for MPLS-TP
+
+   The MPLS-LSR-STD-MIB describes managed objects for modeling an MPLS
+   LSR.  This puts it at the heart of the management architecture for
+   MPLS.
+
+   In the case of MPLS-TP, the MPLS-LSR-STD-MIB is extended to support
+   MPLS-TP LSPs, which are co-routed or associated bidirectionally.
+   This extended MIB is also applicable for modeling MPLS-TP tunnels.
+
+6.1.5.  Tunnel Extensions for MPLS-TP
+
+   The MPLS-TE-STD-MIB describes managed objects that are used to model
+   and manage MPLS-TE tunnels.
+
+   MPLS-TP tunnels are very similar to MPLS-TE tunnels but are co-routed
+   or associated bidirectionally.
+
+   The MPLS-TE-STD-MIB must be extended to support the MPLS-TP-specific
+   attributes for the tunnel.
+
+6.2.  PWE3 MIB Modules for MPLS-TP
+
+   This section provides an overview of pseudowire-extension MIB modules
+   used to meet MPLS-based transport network requirements.
+
+6.2.1.  New MIB Modules for MPLS-TP Pseudowires
+
+   Three new MIB modules are identified as follows:
+
+   -  Pseudowire Textual Conventions for MPLS-TP
+
+   -  Pseudowire Extensions for MPLS-TP
+
+   -  Pseudowire MPLS Extensions for MPLS-TP
+
+6.2.2.  Pseudowire Textual Conventions for MPLS-TP
+
+   The PW-TC-STD-MIB defines Textual Conventions used for PW technology
+   and for PWE3 MIB modules.  A new Textual Convention MIB module is
+   required to define textual definitions for MPLS-TP-specific
+   pseudowire attributes.
+
+
+
+
+King & Venkatesan             Informational                    [Page 21]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+6.2.3.  Pseudowire Extensions for MPLS-TP
+
+   The PW-STD-MIB describes managed objects for the modeling of
+   pseudowire edge-to-edge services carried over a general PSN.  This
+   MIB module is extended to support MPLS-TP-specific attributes related
+   to pseudowires.
+
+6.2.4.  Pseudowire MPLS Extensions for MPLS-TP
+
+   The PW-MPLS-STD-MIB defines the managed objects for pseudowire
+   operations over MPLS LSRs.  This MIB module supports
+
+   -  manually and dynamically signaled PWs
+
+   -  point-to-point connections
+
+   -  the use of any emulated service
+
+   -  outer tunnels provisioned using MPLS-TE
+
+   -  PWs with no outer tunnel
+
+   An extended MIB module would define additional objects, extending the
+   PW-MPLS-STD-MIB by continuing to support configurations that operate
+   with or without an outer tunnel.
+
+6.3.  OAM MIB Modules for MPLS-TP
+
+   This section provides an overview of Operations, Administration, and
+   Maintenance (OAM) MIB modules for MPLS LSPs and pseudowires.
+
+6.3.1.  New MIB Modules for OAM for MPLS-TP
+
+   Two new MIB modules are identified as follows:
+
+   -  BFD MIB module
+
+   -  OAM MIB module
+
+6.3.2.  BFD MIB Module
+
+   The BFD-STD-MIB defines managed objects for performing BFD operations
+   in IP networks.  This MIB module is modeled to support the BFD
+   protocol [RFC5880].
+
+   A new MIB module needs to be written that will be an extension to
+   BFD-STD-MIB managed objects to support BFD operations on MPLS LSPs
+   and PWs.
+
+
+
+King & Venkatesan             Informational                    [Page 22]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+6.3.3.  OAM MIB Module
+
+   A new MIB module needs to be written that will define managed objects
+   for OAM maintenance identifiers, i.e., Maintenance Entity Group (MEG)
+   identifiers, the MEP, and the Maintenance Entity Group Intermediate
+   Point (MIP).  Maintenance points are uniquely associated with a MEG.
+   Within the context of a MEG, MEPs and MIPs must be uniquely
+   identified.
+
+6.4.  Protection Switching and Recovery MIB Modules for MPLS-TP
+
+   This section provides an overview of protection switching and
+   recovery MIB modules for MPLS LSPs and pseudowires.
+
+6.4.1.  New MIB Modules for MPLS Protection Switching and Recovery
+
+   Three new MIB modules are identified as follows:
+
+   -  Linear Protection Switching MIB module
+
+   -  Ring Protection Switching MIB module
+
+   -  Mesh Protection Switching MIB module
+
+6.4.2.  Linear Protection Switching MIB Module
+
+   A new MIB module needs to be written that will define managed objects
+   for linear protection switching of MPLS LSPs and pseudowires.
+
+6.4.3.  Ring Protection Switching MIB Module
+
+   A new MIB module needs to be written that will define managed objects
+   for ring protection switching of MPLS LSPs and pseudowires.
+
+6.4.4.  Mesh Protection Switching MIB Module
+
+   A new MIB module needs to be written that will define managed objects
+   for mesh protection switching of MPLS LSPs and pseudowires.
+
+7.  Management Options
+
+   This document applies only to scenarios where MIB modules are used to
+   manage the MPLS-TP network.  It is not the intention of this document
+   to provide instructions or advice to implementers of management
+   systems, management agents, or managed entities.  It is, however,
+   useful to make some observations about how the MIB modules described
+   above might be used to manage MPLS systems, if SNMP is used in the
+   management interface.
+
+
+
+King & Venkatesan             Informational                    [Page 23]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+   For MPLS-specific management options, refer to [RFC4221] Section 12
+   ("Management Options").
+
+8.  Security Considerations
+
+   This document describes the interrelationships amongst the different
+   MIB modules relevant to MPLS-TP management and as such does not have
+   any security implications in and of itself.
+
+   Each IETF MIB document that specifies MIB objects for MPLS-TP must
+   provide a proper Security Considerations section that explains the
+   security aspects of those objects.
+
+   The attention of readers is particularly drawn to the security
+   implications of making MIB objects available for create or write
+   access through an access protocol such as SNMP.  SNMPv1 by itself is
+   an insecure environment.  Even if the network itself is made secure
+   (for example, by using IPsec), there is no control over who on the
+   secure network is allowed to access the objects in the MIB module.
+   It is recommended that the implementers consider the security
+   features as provided by the SNMPv3 framework.  Specifically, the use
+   of the User-based Security Model STD 62, RFC 3414 [RFC3414], and the
+   View-based Access Control Model STD 62, RFC 3415 [RFC3415], is
+   recommended.
+
+   It is then a customer/user responsibility to ensure that the SNMP
+   entity giving access to an instance of each MIB module is properly
+   configured to give access to only those objects, and to those
+   principals (users) that have legitimate rights to access them.
+
+9.  IANA Considerations
+
+   This document has identified areas where additional MIB modules are
+   necessary for MPLS-TP.  The new MIB modules recommended by this
+   document will require OID assignments from IANA.  However, this
+   document makes no specific request for IANA action.
+
+10.  Acknowledgements
+
+   The authors would like to thank Eric Gray, Thomas Nadeau, Benjamin
+   Niven-Jenkins, Saravanan Narasimhan, Joel Halpern, David Harrington,
+   and Stephen Farrell for their valuable comments.
+
+   This document also benefited from review by participants in ITU-T
+   Study Group 15.
+
+
+
+
+
+
+King & Venkatesan             Informational                    [Page 24]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+11.  Contributors' Addresses
+
+   Adrian Farrel
+   Old Dog Consulting
+   UK
+
+   EMail: adrian@olddog.co.uk
+
+
+   Scott Mansfield
+   Ericsson
+   300 Holger Way
+   San Jose, CA  95134
+   US
+
+   Phone: +1 724 931 9316
+   EMail: scott.mansfield@ericsson.com
+
+
+   Jeong-dong Ryoo
+   ETRI
+   161 Gajeong, Yuseong
+   Daejeon, 305-700
+   South Korea
+
+   Phone: +82 42 860 5384
+   EMail: ryoo@etri.re.kr
+
+
+   A S Kiran Koushik
+   Cisco Systems Inc.
+
+   EMail: kkoushik@cisco.com
+
+
+   A. Karmakar
+   Cisco Systems Inc.
+
+   EMail: akarmaka@cisco.com
+
+
+   Sam Aldrin
+   Huawei Technologies Co.
+   2330 Central Expressway
+   Santa Clara, CA  95051
+   USA
+
+   EMail: aldrin.ietf@gmail.com
+
+
+
+King & Venkatesan             Informational                    [Page 25]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+12.  References
+
+12.1.  Normative References
+
+   [RFC2863]   McCloghrie, K. and F. Kastenholz, "The Interfaces Group
+               MIB", RFC 2863, June 2000.
+
+   [RFC3811]   Nadeau, T., Ed., and J. Cucchiara, Ed., "Definitions of
+               Textual Conventions (TCs) for Multiprotocol Label
+               Switching (MPLS) Management", RFC 3811, June 2004.
+
+   [RFC3812]   Srinivasan, C., Viswanathan, A., and T. Nadeau,
+               "Multiprotocol Label Switching (MPLS) Traffic Engineering
+               (TE) Management Information Base (MIB)", RFC 3812,
+               June 2004.
+
+   [RFC3813]   Srinivasan, C., Viswanathan, A., and T. Nadeau,
+               "Multiprotocol Label Switching (MPLS) Label Switching
+               Router (LSR) Management Information Base (MIB)",
+               RFC 3813, June 2004.
+
+   [RFC3814]   Nadeau, T., Srinivasan, C., and A. Viswanathan,
+               "Multiprotocol Label Switching (MPLS) Forwarding
+               Equivalence Class To Next Hop Label Forwarding Entry
+               (FEC-To-NHLFE) Management Information Base (MIB)",
+               RFC 3814, June 2004.
+
+   [RFC3815]   Cucchiara, J., Sjostrand, H., and J. Luciani,
+               "Definitions of Managed Objects for the Multiprotocol
+               Label Switching (MPLS), Label Distribution Protocol
+               (LDP)", RFC 3815, June 2004.
+
+   [RFC4220]   Dubuc, M., Nadeau, T., and J. Lang, "Traffic Engineering
+               Link Management Information Base", RFC 4220,
+               November 2005.
+
+   [RFC4221]   Nadeau, T., Srinivasan, C., and A. Farrel, "Multiprotocol
+               Label Switching (MPLS) Management Overview", RFC 4221,
+               November 2005.
+
+   [RFC4801]   Nadeau, T., Ed., and A. Farrel, Ed., "Definitions of
+               Textual Conventions for Generalized Multiprotocol Label
+               Switching (GMPLS) Management", RFC 4801, February 2007.
+
+   [RFC4802]   Nadeau, T., Ed., and A. Farrel, Ed., "Generalized
+               Multiprotocol Label Switching (GMPLS) Traffic Engineering
+               Management Information Base", RFC 4802, February 2007.
+
+
+
+
+King & Venkatesan             Informational                    [Page 26]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+   [RFC4803]   Nadeau, T., Ed., and A. Farrel, Ed., "Generalized
+               Multiprotocol Label Switching (GMPLS) Label Switching
+               Router (LSR) Management Information Base", RFC 4803,
+               February 2007.
+
+   [RFC5542]   Nadeau, T., Ed., Zelig, D., Ed., and O. Nicklass, Ed.,
+               "Definitions of Textual Conventions for Pseudowire (PW)
+               Management", RFC 5542, May 2009.
+
+   [RFC5601]   Nadeau, T., Ed., and D. Zelig, Ed., "Pseudowire (PW)
+               Management Information Base (MIB)", RFC 5601, July 2009.
+
+   [RFC5602]   Zelig, D., Ed., and T. Nadeau, Ed., "Pseudowire (PW) over
+               MPLS PSN Management Information Base (MIB)", RFC 5602,
+               July 2009.
+
+   [RFC5603]   Zelig, D., Ed., and T. Nadeau, Ed., "Ethernet Pseudowire
+               (PW) Management Information Base (MIB)", RFC 5603,
+               July 2009.
+
+   [RFC5604]   Nicklass, O., "Managed Objects for Time Division
+               Multiplexing (TDM) over Packet Switched Networks (PSNs)",
+               RFC 5604, July 2009.
+
+12.2.  Informative References
+
+   [RFC2578]   McCloghrie, K., Ed., Perkins, D., Ed., and J.
+               Schoenwaelder, Ed., "Structure of Management Information
+               Version 2 (SMIv2)", STD 58, RFC 2578, April 1999.
+
+   [RFC2579]   McCloghrie, K., Ed., Perkins, D., Ed., and J.
+               Schoenwaelder, Ed., "Textual Conventions for SMIv2",
+               STD 58, RFC 2579, April 1999.
+
+   [RFC2580]   McCloghrie, K., Ed., Perkins, D., Ed., and J.
+               Schoenwaelder, Ed., "Conformance Statements for SMIv2",
+               STD 58, RFC 2580, April 1999.
+
+   [RFC3031]   Rosen, E., Viswanathan, A., and R. Callon, "Multiprotocol
+               Label Switching Architecture", RFC 3031, January 2001.
+
+   [RFC3410]   Case, J., Mundy, R., Partain, D., and B. Stewart,
+               "Introduction and Applicability Statements for Internet-
+               Standard Management Framework", RFC 3410, December 2002.
+
+   [RFC3414]   Blumenthal, U. and B. Wijnen, "User-based Security Model
+               (USM) for version 3 of the Simple Network Management
+               Protocol (SNMPv3)", STD 62, RFC 3414, December 2002.
+
+
+
+King & Venkatesan             Informational                    [Page 27]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+   [RFC3415]   Wijnen, B., Presuhn, R., and K. McCloghrie, "View-based
+               Access Control Model (VACM) for the Simple Network
+               Management Protocol (SNMP)", STD 62, RFC 3415,
+               December 2002.
+
+   [RFC3931]   Lau, J., Ed., Townsley, M., Ed., and I. Goyret, Ed.,
+               "Layer Two Tunneling Protocol - Version 3 (L2TPv3)",
+               RFC 3931, March 2005.
+
+   [RFC3945]   Mannie, E., Ed., "Generalized Multi-Protocol Label
+               Switching (GMPLS) Architecture", RFC 3945, October 2004.
+
+   [RFC3985]   Bryant, S., Ed., and P. Pate, Ed., "Pseudo Wire Emulation
+               Edge-to-Edge (PWE3) Architecture", RFC 3985, March 2005.
+
+   [RFC4197]   Riegel, M., Ed., "Requirements for Edge-to-Edge Emulation
+               of Time Division Multiplexed (TDM) Circuits over Packet
+               Switching Networks", RFC 4197, October 2005.
+
+   [RFC4377]   Nadeau, T., Morrow, M., Swallow, G., Allan, D., and S.
+               Matsushima, "Operations and Management (OAM) Requirements
+               for Multi-Protocol Label Switched (MPLS) Networks",
+               RFC 4377, February 2006.
+
+   [RFC4378]   Allan, D., Ed., and T. Nadeau, Ed., "A Framework for
+               Multi-Protocol Label Switching (MPLS) Operations and
+               Management (OAM)", RFC 4378, February 2006.
+
+   [RFC4379]   Kompella, K. and G. Swallow, "Detecting Multi-Protocol
+               Label Switched (MPLS) Data Plane Failures", RFC 4379,
+               February 2006.
+
+   [RFC4447]   Martini, L., Ed., Rosen, E., El-Aawar, N., Smith, T., and
+               G. Heron, "Pseudowire Setup and Maintenance Using the
+               Label Distribution Protocol (LDP)", RFC 4447, April 2006.
+
+   [RFC5085]   Nadeau, T., Ed., and C. Pignataro, Ed., "Pseudowire
+               Virtual Circuit Connectivity Verification (VCCV): A
+               Control Channel for Pseudowires", RFC 5085,
+               December 2007.
+
+   [RFC5654]   Niven-Jenkins, B., Ed., Brungard, D., Ed., Betts, M.,
+               Ed., Sprecher, N., and S. Ueno, "Requirements of an MPLS
+               Transport Profile", RFC 5654, September 2009.
+
+   [RFC5880]   Katz, D. and D. Ward, "Bidirectional Forwarding Detection
+               (BFD)", RFC 5880, June 2010.
+
+
+
+
+King & Venkatesan             Informational                    [Page 28]
+
+RFC 6639          MPLS-TP MIB-Based Management Overview        June 2012
+
+
+   [RFC5884]   Aggarwal, R., Kompella, K., Nadeau, T., and G. Swallow,
+               "Bidirectional Forwarding Detection (BFD) for MPLS Label
+               Switched Paths (LSPs)", RFC 5884, June 2010.
+
+   [RFC5885]   Nadeau, T., Ed., and C. Pignataro, Ed., "Bidirectional
+               Forwarding Detection (BFD) for the Pseudowire Virtual
+               Circuit Connectivity Verification (VCCV)", RFC 5885,
+               June 2010.
+
+   [RFC5950]   Mansfield, S., Ed., Gray, E., Ed., and K. Lam, Ed.,
+               "Network Management Framework for MPLS-based Transport
+               Networks", RFC 5950, September 2010.
+
+   [RFC5951]   Lam, K., Mansfield, S., and E. Gray, "Network Management
+               Requirements for MPLS-based Transport Networks",
+               RFC 5951, September 2010.
+
+   [RFC6370]   Bocci, M., Swallow, G., and E. Gray, "MPLS Transport
+               Profile (MPLS-TP) Identifiers", RFC 6370, September 2011.
+
+   [RFC6371]   Busi, I., Ed., and D. Allan, Ed., "Operations,
+               Administration, and Maintenance Framework for MPLS-Based
+               Transport Networks", RFC 6371, September 2011.
+
+   [RFC6445]   Nadeau, T., Ed., Koushik, A., Ed., and R. Cetin, Ed.,
+               "Multiprotocol Label Switching (MPLS) Traffic Engineering
+               Management Information Base for Fast Reroute", RFC 6445,
+               November 2011.
+
+Authors' Addresses
+
+   Daniel King (editor)
+   Old Dog Consulting
+   UK
+
+   EMail: daniel@olddog.co.uk
+
+
+   Venkatesan Mahalingam (editor)
+   Aricent
+   India
+
+   EMail: venkat.mahalingams@gmail.com
+
+
+
+
+
+
+
+
+King & Venkatesan             Informational                    [Page 29]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6639.txt](<www.ietf.org/rfc/rfc6639.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
