### PR TITLE
Archive rfc667.txt

### DIFF
--- a/www.ietf.org/rfc/rfc667.txt
+++ b/www.ietf.org/rfc/rfc667.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Network Working Group                                         S. Chipman
+Request for Comments: 667                                      BBN-TENEX
+NIC: 31422                                                 December 1974
+
+
+                                Host Ports
+
+
+   The following is the approved scheme to connect our computers to the
+   network.  This configuration will become effective December 18, 1974.
+
+    __________________
+   | PDP-11           |
+   | SPEECH FRONT END |________
+   | 50.=62(8)        |      __|_________
+   |__________________|     |            |
+    __________________      |   IMP-50   |________\ NCC-TIP
+   | PDP-10           |     |____________|        /
+   | SYSTEM D         |________|   |   |
+   | 114.=162(8)      |            |   |
+   |__________________|            |   |________________________
+    __________________             |                            |
+   | PDP-10           |            |                            |
+   | SYSTEM A         |________    |                            |
+   | 197.=305(8)      |        |   |                            |
+   |__________________|        |   |                            |
+    __________________       __|___|_____                       |
+   | PDP-11           |     |            |                      |
+   | LPT              |_____|   IMP-5    |________\ CCA         |
+   | 69.=105(8)       |     |____________|        /             |
+   |__________________|        |   |                            |
+    __________________         |   |                            |
+   | PDP-11           |        |   |                            |
+   | PACKET RADIO     |________|   |                            |
+   | 133.=205(8)      |            |                            |
+   |__________________|            |                            |
+    __________________             |    ________________________|
+   | PDP-10           |            |   |
+   | SYSTEM B         |________    |   |
+   | 49.=61(8)        |      __|___|___|_       ____________
+   |__________________|     |     49     |_____|    161     |
+    __________________      | BBN10X-TIP | VDH | ANALOG TIP |  Local
+   | PDP-10           |     |____________|     |____________|  Terminals
+   | SYSTEM C         |________|
+   | 241.=361(8)      |
+   |__________________|
+
+
+
+
+
+Chipman                                                         [Page 1]
+
+RFC 667                        Host Ports                  December 1974
+
+
+   All host interfaces are local (except host number 005 which is an
+   easily convertible local/distant interface and we have been asked by
+   Div 6 to avoid using it so Div 6 can more easily check out PDP-10 IMP
+   interfaces).  The PDP-11 with the line printer is intentionally on
+   host 105 so that a simple minded program can respond when someone
+   tries to ICP to its logger socket "To login to BBN (System C) use
+   host number 241(10)".
+
+
+         [ This RFC was put into machine readable form for entry ]
+         [ into the online RFC archives by Alex McKenzie with    ]
+         [ support from GTE, formerly BBN Corp.           2/2000 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Chipman                                                         [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc667.txt](<www.ietf.org/rfc/rfc667.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
