### PR TITLE
Archive rfc6671.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6671.txt
+++ b/www.ietf.org/rfc/rfc6671.txt
@@ -1,0 +1,283 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                          M. Betts
+Request for Comments: 6671                                           ZTE
+Category: Informational                                    November 2012
+ISSN: 2070-1721
+
+
+       Allocation of a Generic Associated Channel Type for ITU-T
+   MPLS Transport Profile Operation, Maintenance, and Administration
+                             (MPLS-TP OAM)
+
+Abstract
+
+   This document assigns a Generic Associated Channel (G-ACh) Type for
+   carrying ITU-T MPLS Transport Profile Operations, Administration, and
+   Management (MPLS-TP OAM) messages in the MPLS Generic Associated
+   Channel.
+
+Status of This Memo
+
+   This document is not an Internet Standards Track specification; it is
+   published for informational purposes.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Not all documents
+   approved by the IESG are a candidate for any level of Internet
+   Standard; see Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6671.
+
+IESG Note
+
+   The IESG notes that the IETF has developed a set of OAM tools for
+   MPLS-TP that have been published as Standards Track RFCs.  A list of
+   the relevant RFCs can be found in RFC 6669.  The approval of this
+   document and the assignment of an ACh Type does not constitute
+   endorsement by the IETF of the alternate MPLS-TP OAM documented in
+   G.8113.1.  The IESG recommends instead that the RFCs noted above
+   should be implemented.
+
+
+
+
+
+
+
+
+
+Betts                         Informational                     [Page 1]
+
+RFC 6671               G-ACh Type for G.8113.1 OAM         November 2012
+
+
+Copyright Notice
+
+   Copyright (c) 2012 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+1.  Introduction
+
+   The Transport Profile of MPLS (MPLS-TP) defined in [RFC5654] is a
+   profile of MPLS technology for use in packet transport networks.  The
+   MPLS-TP profile includes a set of Operations, Administration, and
+   Management (OAM) tools defined by the IETF [RFC6669] that are used to
+   meet the OAM functional requirements defined in [RFC5860].
+
+   ITU-T Recommendation [G.8113.1] documents MPLS-TP OAM.  This
+   Recommendation builds upon Ethernet OAM as documented in [Y.1731].
+   The messages in [G.8113.1] are defined to be carried in a new Generic
+   Associated Channel (G-ACh) Type in the MPLS Generic Associated
+   Channel.  In order to carry these messages in an interoperable
+   fashion, a Generic Associated Channel Type from the IANA maintained
+   registry "Pseudowire Associated Channel Types" is to be used.
+
+   To fulfill the request from ITU-T SG15 in [LS370] and to allow
+   deployment of the [G.8113.1] OAM solution without using an
+   experimental G-ACh Type, IANA has assigned a G-ACh Type <0x8902> for
+   use by the ITU-T for [G.8113.1].  This G-ACh Type is known as the
+   "G.8113.1 OAM G-ACh Type".
+
+   A number of experts in the IETF do not consider that the development
+   or deployment of a second protocol solution within the same
+   architectural problem space is necessary or advisable [RFC6670].
+
+
+
+
+
+
+
+
+
+
+
+Betts                         Informational                     [Page 2]
+
+RFC 6671               G-ACh Type for G.8113.1 OAM         November 2012
+
+
+2.  Conventions Used in This Document
+
+2.1.  Requirements Notation
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+3.  Scope of the G.8113.1 OAM G-ACh Type
+
+   The G-ACh Type assigned by this document MUST only be used for OAM
+   messages, as defined in the ITU-T Recommendation [G.8113.1], carried
+   in the G-ACh.  The OAM messages and procedures carried behind this
+   G-ACh Type are restricted to only those that address the OAM
+   functional requirements defined in [RFC5860].  Other message types
+   MUST NOT be carried behind this G-ACh Type.
+
+   All ITU-T Recommendations are subject to updates by errata,
+   corrigenda, amendments, or complete revisions.  In any update of
+   [G.8113.1], the G-ACh Type assigned by this document MUST NOT be used
+   for any functions not identified as OAM functional requirements in
+   [RFC5860].  An update of [G.8113.1] may use the G-ACh Type assigned
+   by this document to support the OAM functions identified in
+   [RFC5860].  When an amendment or complete revision of G.8113.1 is
+   approved, the reference to [G.8113.1], provided in this document,
+   should be updated to show the approval date of the new version.
+
+   The G-ACh Type assigned by this document may be used on any transport
+   construct that uses the G-ACh, e.g., MPLS-TP Sections, MPLS-TP LSPs,
+   or PWs as described in [G.8113.1].
+
+4.  Security Considerations
+
+   As noted in [RFC5586], when new G-ACh Types are defined, the
+   "security considerations MUST be described in the relevant associated
+   channel type specification".  The IETF takes this opportunity to
+   remind the ITU-T of the need to describe security considerations in
+   [G.8113.1].
+
+
+
+
+
+
+
+
+
+
+
+
+
+Betts                         Informational                     [Page 3]
+
+RFC 6671               G-ACh Type for G.8113.1 OAM         November 2012
+
+
+5.  IANA Considerations
+
+   IANA maintains the "Pseudowire Associated Channel Types" sub-registry
+   of the "Pseudowire Name Spaces (PWE3)" registry.
+
+   IANA has allocated a new G-ACh Type as follows:
+
+      Value        Description              TLV Follows  Reference
+      -----------  -----------------------  -----------  ---------
+      0x8902       G.8113.1 OAM             No           [RFC6671]
+
+6.  References
+
+6.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC5586]  Bocci, M., Ed., Vigoureux, M., Ed., and S. Bryant, Ed.,
+              "MPLS Generic Associated Channel", RFC 5586, June 2009.
+
+   [RFC5654]  Niven-Jenkins, B., Ed., Brungard, D., Ed., Betts, M., Ed.,
+              Sprecher, N., and S. Ueno, "Requirements of an MPLS
+              Transport Profile", RFC 5654, September 2009.
+
+   [RFC5860]  Vigoureux, M., Ed., Ward, D., Ed., and M. Betts, Ed.,
+              "Requirements for Operations, Administration, and
+              Maintenance (OAM) in MPLS Transport Networks", RFC 5860,
+              May 2010.
+
+   [G.8113.1] ITU-T Recommendation G.8113.1/Y.1372.1, "Operations,
+              Administration and Maintenance mechanism for MPLS-TP in
+              Packet Transport Network (PTN)", 11/2012,
+              http://www.itu.int/rec/T-REC-G.8113.1/en.
+
+   [Y.1731]   ITU-T Recommendation G.8013/Y.1731, "OAM functions and
+              mechanisms for Ethernet based networks" 07/2011 as updated
+              by Corrigendum 1, 10/2011, and Amendment 1, 05/2012,
+              http://www.itu.int/rec/T-REC-G.8013/en.
+
+6.2.  Informative References
+
+   [LS370]    "Liaison Statement: LS370 - Current status of
+              Recommendation ITU-T G.8113.1/Y.1372.1, Operations,
+              Administration and Maintenance mechanism for MPLS-TP in
+              Packet Transport Network (PTN)", January 2012,
+              https://datatracker.ietf.org/liaison/1125/.
+
+
+
+
+Betts                         Informational                     [Page 4]
+
+RFC 6671               G-ACh Type for G.8113.1 OAM         November 2012
+
+
+   [RFC6669]  Sprecher, N. and L. Fang, "An Overview of the Operations,
+              Administration, and Maintenance (OAM) Tool Set for MPLS-
+              Based Transport Networks", RFC 6669, July 2012.
+
+   [RFC6670]  Sprecher, N. and KY. Hong, "The Reasons for Selecting a
+              Single Solution for MPLS Transport Profile (MPLS-TP)
+              Operations, Administration, and Maintenance (OAM)", RFC
+              6670, July 2012.
+
+Author's Address
+
+   Malcolm Betts
+   ZTE
+
+   EMail: malcolm.betts@zte.com.cn
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Betts                         Informational                     [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6671.txt](<www.ietf.org/rfc/rfc6671.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
