### PR TITLE
Archive rfc6685.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6685.txt
+++ b/www.ietf.org/rfc/rfc6685.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                       B. Trammell
+Request for Comments: 6685                                    ETH Zurich
+Updates: 5070                                                  July 2012
+Category: Standards Track
+ISSN: 2070-1721
+
+
+ Expert Review for Incident Object Description Exchange Format (IODEF)
+                    Extensions in IANA XML Registry
+
+Abstract
+
+   This document specifies restrictions on additions to the subset of
+   the IANA XML Namespace and Schema registries, to require Expert
+   Review for extensions to Incident Object Description Exchange Format
+   (IODEF).
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6685.
+
+Copyright Notice
+
+   Copyright (c) 2012 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+Trammell                     Standards Track                    [Page 1]
+
+RFC 6685                   IODEF XML Registry                  July 2012
+
+
+1.  Introduction
+
+   IODEF extensions via class extension through AdditionalData and
+   RecordItem elements, per Section 5.2 of [RFC5070], generally register
+   their namespaces and schemas with the IANA XML Namespace registry at
+   http://www.iana.org/assignments/xml-registry/ns.html and the IANA XML
+   Schema registry at
+   http://www.iana.org/assignments/xml-registry/schema.html,
+   respectively [RFC3688].
+
+   In addition to schema reviews required by IANA, these registry
+   requests should be accompanied by a review by IODEF experts to ensure
+   the specified AdditionalData and/or RecordItem contents are
+   compatible with IODEF and with other existing IODEF extensions.  This
+   document specifies that review.
+
+2.  Expert Review of IODEF-Related XML Registry Entries
+
+   Changes to the XML Schema registry for schema names beginning with
+   "urn:ietf:params:xml:schema:iodef" are subject to an additional IODEF
+   Expert Review [RFC5226] for IODEF correctness and appropriateness.
+
+   The IODEF expert(s) for these reviews will be designated by the IETF
+   Security Area Directors.
+
+3.  Security Considerations
+
+   This document has no security considerations.
+
+4.  IANA Considerations
+
+   This document specifies additional expert reviews for IODEF
+   extensions, on the XML Schema registry
+   (http://www.iana.org/assignments/xml-registry/schema.html), in
+   Section 2.
+
+5.  Normative References
+
+   [RFC3688]  Mealling, M., "The IETF XML Registry", BCP 81, RFC 3688,
+              January 2004.
+
+   [RFC5070]  Danyliw, R., Meijer, J., and Y. Demchenko, "The Incident
+              Object Description Exchange Format", RFC 5070,
+              December 2007.
+
+   [RFC5226]  Narten, T. and H. Alvestrand, "Guidelines for Writing an
+              IANA Considerations Section in RFCs", BCP 26, RFC 5226,
+              May 2008.
+
+
+
+Trammell                     Standards Track                    [Page 2]
+
+RFC 6685                   IODEF XML Registry                  July 2012
+
+
+Author's Address
+
+   Brian Trammell
+   Swiss Federal Institute of Technology Zurich
+   Gloriastrasse 35
+   8092 Zurich
+   Switzerland
+
+   Phone: +41 44 632 70 13
+   EMail: trammell@tik.ee.ethz.ch
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Trammell                     Standards Track                    [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6685.txt](<www.ietf.org/rfc/rfc6685.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
