### PR TITLE
Archive rfc669.txt

### DIFF
--- a/www.ietf.org/rfc/rfc669.txt
+++ b/www.ietf.org/rfc/rfc669.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                                         D.W. Dodds
+Request for Comments: 669                                     BBN-TENEXA
+NIC: 31435                                              December 4, 1974
+
+
+         November, 1974, Survey of New-Protocol TELNET Servers
+
+
+   Two months have elapsed since our last survey, and the appearance of
+   additional New-Protocol servers has progressed at the usual snail's
+   pace.  The changes in this list are (with host numbers in octal):
+
+   SRI-AI (102) now has a New-Protocol server;
+   SDC-LAB (10) is back on the net and the list;
+   SDC-CC (110) is coming on the net but status is as yet unknown;
+   USC-ISI (126) and USC-ISIB (226) (formerly ISI-DEVTENEX) now have
+   New-Protocol servers;
+   SDAC-44 (32) has been removed -- no longer classed as a server host;
+   HAWAII-500 (344) is coming on the net, status presently unknown;
+   LONDON (52) has been added;
+   BBN-TENEXD is now host 162 (formerly 205).
+
+   What follows is an update of the summary and tabulation that appeared
+   in RFC #702.*  Is there light at the end of the tunnel?
+
+         total server hosts             37      100%
+         no New-Prot server             19       51%
+         unknown status (new host)       2        6%
+         total New-Prot implem.         16       43%
+             New-Prot on socket 27,
+                 Old on socket 1 (2)     9       24%
+             New-Prot on 1 and 27 (3)    6       16%
+             New-Prot on 1 only (3)      1        3%
+
+         Notes:
+
+   *   All data in this report were gathered via a surveying program run
+       at various times, plus a few manual checks to fill out the data.
+       What is reported here is the way the various servers work as seen
+       by the new-Protocol User Telnet at BBNA, as of 4 Dec. 1974.
+
+   (2) These are the sites whose operation is 100% correct according to
+       all protocols and conventions, as I understand them.
+
+   (3) We realize that some of the servers that appear here as New-
+       Protocol servers on socket 1 are actually servers which attempt
+       to communicate with both Old- and New-Protocol User TELNETs
+       according to what control sequences are received.
+
+
+
+Dodds                                                           [Page 1]
+
+RFC 669          Survey of New-Protocol TELNET Servers     December 1974
+
+
+               Tabulation of server status for all server sites:
+
+Host     Host          Socket  Socket   New-Prot, Options
+ No.     Name            1       27     Implementation (if any)
+
+101     UCLA-CCN        Old     X
+201     UCLA-CCBS       Old     X
+  2     SRI-ARC         Old     X
+102     SRI-AI          Old     New      I1,3,6; O3
+  3     UCSB-MOD75      Old     X
+  4     UTAH-10         Old     X
+105     BBN-TENEX       Old     New      I1,3,6; O3
+305     BBN-TENEXA      Old     New      I1,3,6; O3
+106     MIT-DMS         New     New      I1,3; O3
+206     MIT-AI          Old     X
+306     MIT-ML          Old     X
+  7     RAND-RCC        Old     X
+ 10     SDC-LAB         Old     X
+110     SDC-CC          ?       ?
+ 11     HARV-10         New     X        I1,3; O3
+ 12     LL-67           Old*    X
+112     LL-TX-2         Old     X
+ 13     SU-AI           New*    New*     I1,3
+ 15     CASE-10         Old     X
+ 16     CMU-10B         New     New      I1,3; O3
+116     CMU-10A         New     New      I1,3; O3
+ 17     I4-TENEX        Old     X
+217     KI4B-TENEX      Old     X
+ 20     AMES-67         New     New      None
+126     USC-ISI         Old     New      I1,3,6; O3
+226     USC-ISIB        Old     New      I1,3,6; O3
+ 27     USC-44          Old     X
+327     USC-ECL         Old     X
+ 37     CCA-TENEX       Old     X
+ 40     PARC-MAXC       Old     New      I1,3,6; O3
+ 43     UCSD-CC         Old     New      I0(!),3; O0,3
+344     HAWAII-500      ?       ?
+ 52     LONDON          Old*    X
+ 53     OFFICE-1        Old     X
+ 54     MIT-MULTICS     New     New      None
+ 61     BBN-TENEXB      Old     New      I1,3,6; O3
+162     BBN-TENEXD      Old     New      I1,3,6; O3
+
+
+
+
+
+
+
+
+
+Dodds                                                           [Page 2]
+
+RFC 669          Survey of New-Protocol TELNET Servers     December 1974
+
+
+Key:    X  No server at this socket
+        ?  Status not ascertained -- unable to connect to host
+        I# Option # implemented incoming to user (Server says "Will #")
+        O# Option # implemented outgoing from user (Server says "Do #")
+           (# is option number in new Protocol. All options implemented
+            by anyone are:
+                0    Transmit-Binary
+                1    Echo
+                3    Suppress-Go-Ahead
+                6    Timing-Mark )
+
+   Note: * These servers return improper responses to some TELNET option
+   requests.
+
+
+
+
+
+
+
+
+
+
+         [ This RFC was put into machine readable form for entry ]
+         [ into the online RFC archives by Alex McKenzie with    ]
+         [ support from GTE, formerly BBN Corp.           2/2000 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Dodds                                                           [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc669.txt](<www.ietf.org/rfc/rfc669.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
