### PR TITLE
Archive rfc6701.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6701.txt
+++ b/www.ietf.org/rfc/rfc6701.txt
@@ -1,0 +1,675 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                         A. Farrel
+Request for Comments: 6701                              Juniper Networks
+Category: Informational                                       P. Resnick
+ISSN: 2070-1721                                                 Qualcomm
+                                                             August 2012
+
+
+  Sanctions Available for Application to Violators of IETF IPR Policy
+
+Abstract
+
+   The IETF has developed and documented policies that govern the
+   behavior of all IETF participants with respect to Intellectual
+   Property Rights (IPR) about which they might reasonably be aware.
+
+   The IETF takes conformance to these IPR policies very seriously.
+   However, there has been some ambiguity as to what the appropriate
+   sanctions are for the violation of these policies, and how and by
+   whom those sanctions are to be applied.
+
+   This document discusses these issues and provides a suite of
+   potential actions that can be taken within the IETF community in
+   cases related to patents.
+
+Status of This Memo
+
+   This document is not an Internet Standards Track specification; it is
+   published for informational purposes.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Not all documents
+   approved by the IESG are a candidate for any level of Internet
+   Standard; see Section 2 of RFC 5741.
+
+   Information about the current status of this document, any
+   errata, and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6701.
+
+
+
+
+
+
+
+
+
+
+
+
+Farrel & Resnick              Informational                     [Page 1]
+
+RFC 6701       Sanctions for Violators of IETF IPR Policy    August 2012
+
+
+Copyright Notice
+
+   Copyright (c) 2012 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+1.  Introduction
+
+   The IETF has developed and documented policies that govern the
+   behavior of all IETF participants with respect to intellectual
+   property about which they might reasonably be aware.  These are
+   documented in RFC 3979 [BCP79] and are frequently brought to the
+   attention of IETF participants.  This document summarizes and
+   references those policies, but does not replace or stand in for the
+   full statement of the policies found in [BCP79].  Readers and IETF
+   participants need to be aware of the content of [BCP79].
+
+   The policies set out in RFC 3979 [BCP79] state that each individual
+   participant is responsible for disclosing or ensuring the disclosure
+   of Intellectual Property Rights (IPR) where all of the following
+   apply:
+
+   -  they are aware of the IPR
+
+   -  the IPR is relevant to the IETF work they are participating in
+
+   -  the IPR is owned by the individual or by a company that employs or
+      sponsors the individual's work.
+
+   Conformance to these IPR policies is very important, and there is a
+   need to understand both what sanctions can be applied to participants
+   who violate the policies, and who is in a position to apply the
+   sanctions.
+
+   This document discusses these issues and provides a suite of
+   potential actions that can be taken within the IETF community in
+   cases related to patents.  All of these sanctions are currently
+   available in IETF processes, and at least two instances of violation
+   of the IPR policy have been handled using some of the sanctions
+
+
+
+Farrel & Resnick              Informational                     [Page 2]
+
+RFC 6701       Sanctions for Violators of IETF IPR Policy    August 2012
+
+
+   listed.  As explicitly called out in Section 4, a posting rights (PR)
+   action (described in [BCP25] and [RFC3683]) is an applicable sanction
+   for the case of a breach of the IETF's IPR policy.
+
+   Note: This document specifies some administrative sanctions that can
+   be imposed by and through IETF administrative processes.  In
+   particular, this document does not address or limit other legal
+   sanctions, rights, or remedies that are available outside of the IETF
+   or any of the legal rights or remedies that anyone has regarding IPR.
+
+   This document does not consider the parallel, but important, issue of
+   ways to actively promote conformance with the IETF's IPR policy.
+   That topic is discussed in [RFC6702].
+
+2.  Description of IETF IPR Policy
+
+   The IETF's IPR policy is set out in [BCP79].  Nothing in this
+   document defines or redefines the IETF's IPR policy.  This section
+   simply highlights some important aspects of those policies.
+   Additional information on the IETF's IPR policy may be found at
+   [URLIPR] and [URLIESGIPR].
+
+2.1.  Responsibilities of IETF Participants and Timeliness
+
+   According to RFC 3979 [BCP79], individual IETF participants have a
+   personal responsibility to disclose or ensure the timely disclosure
+   of IPR of which they are aware and which they own or which is owned
+   by a company that employs or sponsors them, and which impinges upon
+   the contribution that they make to the IETF.
+
+   A "contribution" is also defined in RFC 3979 [BCP79] and includes
+   Internet-Drafts, emails to IETF mailing lists, presentations at IETF
+   meetings, and comments made at the microphone during IETF meetings.
+   Remote participants as well as those participating in person at IETF
+   meetings are bound by this definition.
+
+   The timeliness of disclosure is very important within RFC 3979
+   [BCP79].  No precise definition of "timeliness" is given in RFC 3979
+   [BCP79], and it is not the purpose of this document to do so.  But it
+   is important to understand that the impact that an IPR disclosure has
+   on the smooth working of the IETF is directly related to how late in
+   the process the disclosure is made.  Thus, a disclosure made on a
+   published RFC is very likely to be more disruptive to the IETF than
+   such a disclosure on an early revision of an individual submission of
+   an Internet-Draft.
+
+
+
+
+
+
+Farrel & Resnick              Informational                     [Page 3]
+
+RFC 6701       Sanctions for Violators of IETF IPR Policy    August 2012
+
+
+   Third-party disclosures can also be made by anyone who has cause to
+   believe that IPR exists.  Such disclosures must be accompanied by the
+   reasons for the disclosures.
+
+   It is important to note that each individual IETF participant has a
+   choice under the IETF's IPR policy.  If the individual is unwilling
+   or unable to disclose the existence of relevant IPR in a timely
+   manner, that individual has the option to refrain from contributing
+   to and participating in IETF activities about the technology covered
+   by the IPR.
+
+2.2.  How Attention Is Drawn to These Responsibilities
+
+   The IETF draws the attention of all participants to the IPR policy
+   [BCP79] through the "Note Well" statement that appears on the IETF
+   web pages [URLNoteWell], in presentations at working group and
+   plenary meetings, as well as in the boilerplate text appearing in
+   each Internet-Draft and RFC.  Additionally, the Note Well statement
+   is accepted by any person signing up to join an email list hosted at
+   ietf.org.
+
+   [RFC6702] suggests a number of additional ways in which the attention
+   of IETF participants can be drawn to the IPR policy.
+
+2.3.  How IPR Disclosures Are Made
+
+   The procedure for filing IPR disclosures is shown on the IETF's web
+   site at [URLDisclose].  Third-party disclosures can also be made by
+   email to the IETF Secretariat or via the web page.
+
+   Note that early disclosures or warnings that there might be IPR on a
+   technology can also be made.
+
+2.4.  How Working Groups Consider IPR Disclosures
+
+   In the normal course of events, a working group that is notified of
+   the existence of IPR must make a decision about whether to continue
+   with the work as it is, or whether to revise the work to attempt to
+   avoid the IPR claim.  This decision is made on the working group's
+   mailing list using normal rough consensus procedures.  However,
+   discussions of the applicability of an IPR claim or of the
+   appropriateness or merit of the IPR licensing terms are outside the
+   scope of the WG.  The IPR situation is considered by working group
+   participants as the document advances through the development process
+   [RFC2026], in particular at key times such as adoption of the
+   document by the working group and during last call.
+
+
+
+
+
+Farrel & Resnick              Informational                     [Page 4]
+
+RFC 6701       Sanctions for Violators of IETF IPR Policy    August 2012
+
+
+   It needs to be clearly understood that the way that the working group
+   handles an IPR disclosure is distinct from the sanctions that can be
+   applied to the individuals who violated the IETF's IPR policy.  That
+   is, the decision by a working group to, for example, entirely re-work
+   an Internet-Draft in order to avoid a piece of IPR that has been
+   disclosed should not be seen as a sanction against the authors.
+   Indeed, and especially in the case of a late IPR disclosure, that a
+   working group decides to do this can be considered a harmful side
+   effect on the working group (in that it slows down the publication of
+   an RFC and might derail other work the working group could be doing)
+   and should be considered as one of the reasons to apply sanctions to
+   the individuals concerned as described in the next two sections.
+
+2.5.  The Desire for Sanctions
+
+   Not conforming to the IETF's IPR policy undermines the work of the
+   IETF, and sanctions ought to be applied against offenders.
+
+2.6.  Severity of Violations
+
+   Clearly there are different sorts of violations of IPR policy.
+   Sometimes, a working group participant simply does not realize that
+   the IPR that they invented applies to a particular working group
+   draft.  Sanctions (if any) need not be at all severe.  However, a
+   working group document editor who waits until near the publication of
+   a document to reveal IPR of which they themselves are the author
+   should be subject to more serious sanctions.  These are judgments
+   that can be made by the working group chairs and area director.
+
+   This topic forms the bulk of the material in Sections 5 and 6.
+
+3.  Who Initiates Sanctions
+
+   Any IETF participant can draw attention to an apparent violation of
+   the IETF's IPR policy.  This can be done by sending email with a
+   short summary of the relevant facts and events to the appropriate
+   IETF mailing list.  Normally, the working group chairs and area
+   directors assume the responsibility for ensuring the smooth running
+   of the IETF and for the enforcement of IETF policies including the
+   IPR policy.  Thus, when sanctions are appropriate, working group
+   chairs will be the first actors when there is an active working group
+   involved in the technical work, and area directors will be the first
+   actors in other cases.  The first step will usually be the working
+   group chairs or area director to gather the facts and discuss the
+   matter with the IETF participants involved.
+
+   Working group chairs are already empowered to take action against
+   working group participants who flout the IPR rules and so disrupt the
+
+
+
+Farrel & Resnick              Informational                     [Page 5]
+
+RFC 6701       Sanctions for Violators of IETF IPR Policy    August 2012
+
+
+   smooth running of the IETF or a specific working group, just as they
+   can take such action in the face of other disruptions.
+
+   The working group chairs have the responsibility to select the
+   appropriate actions since they are closest to the details of the
+   issue.  Where there is no working group involved or where making the
+   decision or applying the sanctions is uncomfortable or difficult for
+   the working group chairs, the responsible AD is available to guide or
+   direct the action if necessary.
+
+4.  Available Sanctions
+
+   This section lists some of the sanctions available to handle the case
+   of an individual who violates the IETF's IPR policies.  It is not
+   intended to be an exhaustive list, nor is it suggested that only one
+   sanction be applied in any case.  Furthermore, it is not suggested
+   here that every case of IPR policy infringement is the same or that
+   the severest sanctions may be applied in each case.
+
+   In many cases, it may be appropriate to notify a wider IETF community
+   of the violation and sanctions so that patterns of behavior can be
+   spotted and handled.
+
+   The sanctions are listed in approximate order of severity, but the
+   ordering should not be taken as definitive or as driving different
+   decisions in different cases.  Section 5 provides some notes on
+   fairness, while Section 6 gives some guidance on selecting an
+   appropriate sanction in any specific case.
+
+   a. A private discussion between the working group chair or area
+      director and the individual to understand what went wrong and how
+      it can be prevented in the future.
+
+   b. A formal, but private, warning that the individuals must improve
+      their behavior or risk one of the other sanctions.
+
+   c. A formal warning on an IETF mailing list that the individuals must
+      improve their behavior or risk one of the other sanctions.
+
+   d. Announcement to the working group of the failure by the
+      individuals ("name and shame").
+
+   e. On-going refusal to accept the individuals as editors of any new
+      working group documents.  The appointment of editors of working
+      group documents is entirely at the discretion of the working group
+      chairs acting for the working group as explained in RFC 2418
+      [BCP25].
+
+
+
+
+Farrel & Resnick              Informational                     [Page 6]
+
+RFC 6701       Sanctions for Violators of IETF IPR Policy    August 2012
+
+
+   f. Removal of the individuals as working group document editors on
+      specific documents or across the whole working group.
+
+   g. Re-positioning of the individuals' attribution in a document to
+      the "Acknowledgements" section with or without a note explaining
+      why they are listed there and not in the "Authors' Addresses"
+      section (viz. the IPR policy violation).  This action can also be
+      recorded by the area director in the Datatracker entries for the
+      documents concerned.
+
+   h. Deprecation or rejection of the individual document (whether it be
+      an RFC or Internet-Draft) or cessation of work on the affected
+      technology.
+
+   i. Application of a temporary suspension of indiviuals' posting
+      rights to a specific mailing list according to the guidelines
+      expressed in [BCP25].  Such bans are applied to specific
+      individuals and to individual working group mailing lists at the
+      discretion of the working group chairs for a period of no more
+      than 30 days.
+
+   j. The removal of individuals' posting privileges using a Posting
+      Rights Action (PR Action) as per [RFC3683].  This is a more
+      drastic measure that can be applied when other sanctions are
+      considered insufficient or to have been ineffective.  When a PR
+      action is in place, the subjects have their posting rights to a
+      particular IETF mailing list removed for a period of a year
+      (unless the action is revoked or extended), and maintainers of any
+      IETF mailing list may, at their discretion and without further
+      recourse to explanation or discussion, also remove posting rights.
+
+      PR actions are introduced by an area director and are considered
+      by the IETF community and the IESG in order to determine IETF
+      consensus.
+
+   Note that individuals who have supplied text that is included in an
+   IETF document (RFC or Internet-Draft) have a right to be recognized
+   for their contribution.  This means that authors' names cannot be
+   entirely removed from a document in the event that they violate the
+   IETF's IPR policy unless the text they contributed is also completely
+   removed.  But an individual's name can be removed from the front page
+   and even moved from the "Authors' Addresses" section so long as
+   proper acknowledgement of the contribution is given in the
+   "Acknowledgements" section.
+
+
+
+
+
+
+
+Farrel & Resnick              Informational                     [Page 7]
+
+RFC 6701       Sanctions for Violators of IETF IPR Policy    August 2012
+
+
+4.1.  An Additional Note on the Applicability of PR Actions
+
+   The applicability of PR actions in the event of IPR policy possibly
+   needs some explanation.  According to [RFC3683], a PR action may be
+   considered as a practice for use by the IETF in the case that "a
+   participant has engaged in a 'denial-of-service' attack to disrupt
+   the consensus-driven process".
+
+   [RFC3683] further cites RFC 2418 [BCP25] and [RFC3005] for guidelines
+   for dealing with abusive behavior.  RFC 2418 is updated by RFC 3934
+   in this matter (see [BCP25]).
+
+   In some cases, ignoring or flouting the IETF's IPR policy may be
+   considered as disruptive to the smooth operation of a working group
+   or of the whole IETF such that the offender might be deemed to be a
+   disruptive individual under the terms of [BCP25] and [RFC3683], and
+   so is liable to be the subject of a sanction that restricts their
+   rights to post to IETF mailing lists as described in bullets h and i
+   of Section 4 of this document.
+
+5.  A Note on Fairness and Appealing Decisions
+
+   As with all decisions made within the IETF, any person who feels that
+   they have been subject to unfair treatment or who considers that a
+   decision has been made incorrectly may appeal the decision.  The
+   IETF's appeals procedures are described in Section 6.5 of [RFC2026]
+   and reinforced in the IESG statement at [URLIESG2026].  Any sanctions
+   described above may be appealed using these procedures.
+
+6.  Guidance on Selecting and Applying Sanctions
+
+   Whoever is applying sanctions for breaching the IETF's IPR policy
+   will want to be sure that the chosen sanction matches the severity of
+   the offense and considers all circumstances.  The judgment needs to
+   be applied equitably should similar situations arise in the future.
+
+   If in any doubt, the person selecting and applying the sanctions
+   should seek the opinion of the relevant part of the IETF community or
+   the community as a whole.  Furthermore, the person should not
+   hesitate to seek the advice of their colleagues (co-chairs, area
+   directors, or the whole IESG).
+
+   This is a judgment call based on all circumstances of each specific
+   case.  Some notes on guidance are supplied in Appendix A.
+
+
+
+
+
+
+
+Farrel & Resnick              Informational                     [Page 8]
+
+RFC 6701       Sanctions for Violators of IETF IPR Policy    August 2012
+
+
+7.  Security Considerations
+
+   While nothing in this document directly affects the operational
+   security of the Internet, failing to follow the IETF's IPR policies
+   can be disruptive to the IETF's standards development processes and
+   so may be regarded as an attack on the correct operation of the IETF.
+   Furthermore, a late IPR disclosure (or a complete failure to
+   disclose) could represent an attack on the use of deployed and
+   operational equipment in the Internet.
+
+8.  Acknowledgments
+
+   Thanks to Lou Berger, Ross Callon, Stewart Bryant, Jari Arkko, and
+   Peter Saint-Andre for comments on an early version of this document.
+
+   Thanks to Subramanian Moonesamy and Tom Petch for their comments on
+   the work.  Thanks to Dan Wing, Tony Li, and Steve Bellovin for
+   discussions.  Thanks to Stephen Farrell for providing a thorough
+   review as document shepherd.
+
+   Additional thanks for textual improvements around IETF last call go
+   to Randy Bush, Brian Carpenter, Jorge Contreras, Russ Housley, Barry
+   Leiba, Murray S. Kucherawy, Benoit Claise, Sean Turner, and Stewart
+   Bryant.
+
+9.  References
+
+9.1.  Normative References
+
+   [BCP25]       Bradner, S., "IETF Working Group Guidelines and
+                 Procedures", BCP 25, RFC 2418, September 1998.
+
+                 Wasserman, M., "Updates to RFC 2418 Regarding the
+                 Management of IETF Mailing Lists", BCP 25, RFC 3934,
+                 October 2004.
+
+   [BCP79]       Bradner, S., Ed., "Intellectual Property Rights in IETF
+                 Technology", BCP 79, RFC 3979, March 2005.
+
+                 Narten, T., "Clarification of the Third Party
+                 Disclosure Procedure in RFC 3979", BCP 79, RFC 4879,
+                 April 2007.
+
+   [RFC2026]     Bradner, S., "The Internet Standards Process --
+                 Revision 3", BCP 9, RFC 2026, October 1996.
+
+   [RFC3683]     Rose, M., "A Practice for Revoking Posting Rights to
+                 IETF Mailing Lists", BCP 83, RFC 3683, March 2004.
+
+
+
+Farrel & Resnick              Informational                     [Page 9]
+
+RFC 6701       Sanctions for Violators of IETF IPR Policy    August 2012
+
+
+9.2.  Informative References
+
+   [RFC3005]     Harris, S., "IETF Discussion List Charter", BCP 45, RFC
+                 3005, November 2000.
+
+   [RFC6702]     Polk, T. and P. Saint-Andre, "Promoting Compliance with
+                 Intellectual Property Rights (IPR) Disclosure Rules",
+                 RFC 6702, August 2012.
+
+   [URLDisclose] IETF, "File an IPR Disclosure",
+                 http://www.ietf.org/ipr/file-disclosure.
+
+   [URLIESG2026] IETF, "On Appeals of IESG and Area Director Actions and
+                 Decisions",
+                 http://www.ietf.org/iesg/statement/appeal.html.
+
+   [URLIESGIPR]  IETF Tools, "Intellectual Property",
+                 http://trac.tools.ietf.org/group/iesg/trac/
+                 wiki/IntellectualProperty.
+
+   [URLIPR]      IETF, "Intellectual Property Rights (IPR) Policy",
+                 http://www.ietf.org/ipr/policy.html.
+
+   [URLNoteWell] IETF, "Note Well",
+                 http://www.ietf.org/about/note-well.html.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Farrel & Resnick              Informational                    [Page 10]
+
+RFC 6701       Sanctions for Violators of IETF IPR Policy    August 2012
+
+
+Appendix A.  Guidance on Selecting and Applying Sanctions
+
+   As discussed in Section 6, the selection of sanctions needs to be a
+   carefully made judgment call that considers all relevant
+   circumstances and events.  This Appendix provides a list of questions
+   that might form part of that judgment.
+
+   This list of considerations is for guidance and is not prescriptive
+   or exhaustive, and it does not imply any weighting of the
+   considerations.
+
+   -  How long has the participant been active in the IETF?
+
+   -  Is there some exceptional circumstance?
+
+   -  Are there special circumstances that imply that the individual
+      would not have seen or understood the pointers to and content of
+      [BCP79]?
+
+   -  How late is the disclosure?  Is the document already a working
+      group document?  How many revisions have been published?  How much
+      time has elapsed?  Have last calls been held?  Has the work been
+      published as an RFC?
+
+   -  Is the individual a minor contributor to the IETF work, or is the
+      individual clearly a major contributor?
+
+   -  Is there a reason for the individual forgetting the existence of
+      the IPR (for example, it was filed many years previous to the work
+      in the IETF)?
+
+   -  Was the individual told by their company that disclosure was
+      imminent, but then something different happened?
+
+   -  How speedy and humble was the individual's apology?
+
+   -  How disruptive to the IETF work are the disclosure and the
+      associated license terms?  A factor in this will be whether or not
+      the IETF community sees the need to re-work the document.
+
+   -  Does the large number of patents that the individual has invented
+      provide any level of excuse for failing to notice that one of
+      their patents covered the IETF work?
+
+
+
+
+
+
+
+
+Farrel & Resnick              Informational                    [Page 11]
+
+RFC 6701       Sanctions for Violators of IETF IPR Policy    August 2012
+
+
+Authors' Addresses
+
+   Adrian Farrel
+   Juniper Networks
+   EMail: adrian@olddog.co.uk
+
+   Pete Resnick
+   Qualcomm
+   EMail: presnick@qualcomm.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Farrel & Resnick              Informational                    [Page 12]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6701.txt](<www.ietf.org/rfc/rfc6701.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
