### PR TITLE
Archive rfc6702.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6702.txt
+++ b/www.ietf.org/rfc/rfc6702.txt
@@ -1,0 +1,899 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                           T. Polk
+Request for Comments: 6702                                          NIST
+Category: Informational                                   P. Saint-Andre
+ISSN: 2070-1721                                      Cisco Systems, Inc.
+                                                             August 2012
+
+
+      Promoting Compliance with Intellectual Property Rights (IPR)
+                            Disclosure Rules
+
+Abstract
+
+   The disclosure process for intellectual property rights (IPR) in
+   documents produced within the IETF stream is essential to the
+   accurate development of community consensus.  However, this process
+   is not always followed by IETF participants.  Regardless of the cause
+   or motivation, noncompliance with IPR disclosure rules can delay or
+   even derail completion of IETF specifications.  This document
+   describes some strategies for promoting compliance with the IPR
+   disclosure rules.  These strategies are primarily intended for use by
+   area directors, working group chairs, and working group secretaries.
+
+Status of This Memo
+
+   This document is not an Internet Standards Track specification; it is
+   published for informational purposes.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Not all documents
+   approved by the IESG are a candidate for any level of Internet
+   Standard; see Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6702.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Polk & Saint-Andre            Informational                     [Page 1]
+
+RFC 6702                     IPR Disclosure                  August 2012
+
+
+Copyright Notice
+
+   Copyright (c) 2012 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1. Introduction ....................................................3
+      1.1. Terminology ................................................4
+   2. Background ......................................................4
+   3. Strategies for Working Group Documents ..........................5
+      3.1. Presenting an Internet-Draft at an IETF Meeting ............5
+      3.2. Requesting WG Adoption .....................................6
+      3.3. Requesting WG Last Call ....................................6
+      3.4. AD Review ..................................................7
+      3.5. IETF Last Call .............................................7
+   4. Strategies for Individual Submissions ...........................8
+      4.1. Presenting an Internet-Draft at an IETF Meeting ............8
+      4.2. AD Review ..................................................8
+      4.3. IETF Last Call .............................................9
+   5. A Note about Preliminary Disclosures ............................9
+   6. Conclusions .....................................................9
+   7. Security Considerations .........................................9
+   8. References .....................................................10
+      8.1. Normative References ......................................10
+      8.2. Informative References ....................................10
+   Appendix A. Sample Messages .......................................11
+     A.1. General WG Reminder ........................................11
+     A.2. Reminder to Meeting Presenter ..............................12
+     A.3. Reminder before WG Adoption of an Individual
+          Internet-Draft .............................................13
+     A.4. Reminder before Working Group Last Call ....................14
+     A.5. Reminder to Authors and Listed Contributors of a
+          Working Group Document before IETF Last Call ...............15
+     A.6. Reminder to Author of an Individual Submission before
+          IETF Last Call .............................................15
+   Appendix B. Acknowledgements ......................................16
+
+
+
+
+Polk & Saint-Andre            Informational                     [Page 2]
+
+RFC 6702                     IPR Disclosure                  August 2012
+
+
+1.  Introduction
+
+   The disclosure process for intellectual property rights (IPR) in
+   documents produced within the IETF stream [RFC5741] is essential to
+   the efficient and accurate development of community consensus.  In
+   particular, ensuring that IETF working groups and participants have
+   as much information as possible regarding IPR constraints, as early
+   as possible in the process, increases the likelihood that the
+   community can develop an informed consensus regarding technical
+   proposals.  Statements to that effect appear in both the second and
+   third revisions of the Internet Standards Process ([RFC1602],
+   Section 5.5, Clause (B) and [RFC2026], Section 10.4, Clause (B)).
+
+   However, sometimes IPR disclosures do not occur at the earliest
+   possible stage in the IETF process.  There are many reasons why an
+   individual might not disclose IPR early in the process: for example,
+   through a simple oversight, to introduce delay, or to subvert the
+   emergence of consensus.
+
+   Regardless of the cause or motivation, noncompliance with IPR
+   disclosure rules can delay or even derail completion of IETF
+   specifications.  Disclosure of IPR after significant decisions, such
+   as Working Group Last Call (WGLC), might lead to reconsideration of
+   those actions.  As one example, a working group (WG) might change
+   course and use a previously rejected technical proposal with less
+   onerous licensing requirements.  Such "course corrections" produce
+   unnecessary delays in the standardization process.
+
+   This document suggests some strategies for promoting compliance with
+   the IETF's IPR disclosure rules and thereby avoiding such delays.
+   These strategies are primarily intended for use by area directors
+   (ADs), WG chairs, and WG secretaries.
+
+   These strategies are focused on promoting early disclosure by
+   document authors, since late disclosure involving authors has
+   historically caused significant delays in the standardization
+   process.  Many of these strategies also promote early disclosure by
+   other IETF contributors.
+
+   Naturally, even if ADs, WG chairs, and WG secretaries do not apply
+   the strategies described in this document, IETF contributors are
+   still bound by the rules defined in BCP 79 (see [RFC3979] and
+   [RFC4879]) and BCP 78 (see [RFC5378]).  This document does not modify
+   those rules, nor does it normatively extend those rules; it merely
+   provides suggestions intended to aid ADs, WG chairs, and WG
+   secretaries.
+
+
+
+
+
+Polk & Saint-Andre            Informational                     [Page 3]
+
+RFC 6702                     IPR Disclosure                  August 2012
+
+
+   By intent, this document does not claim to define best current
+   practices; instead, it suggests strategies that ADs, WG chairs, and
+   WG secretaries might find useful.  With sufficient use and
+   appropriate modification to incorporate the lessons of experience,
+   these strategies might someday form the basis for documentation of
+   best current practices.
+
+   This document does not consider the parallel, but important, issue of
+   potential actions that can be taken by the IETF itself for lack of
+   conformance with the IETF's IPR policy.  That topic is discussed in
+   [RFC6701].
+
+   At the time of this writing, the Internet Research Task Force (IRTF)
+   follows the same IPR disclosure rules as the IETF (see
+   <http://irtf.org/ipr>); therefore, the strategies described here
+   might also be appropriate for use by IRTF research group chairs.
+
+1.1.  Terminology
+
+   This document relies on the definitions provided in Section 1 of
+   [RFC3979].
+
+   The term "formal disclosure" refers to an IPR disclosure statement
+   that has been officially submitted by using the IPR disclosure tools
+   currently available at <http://www.ietf.org/ipr/file-disclosure> or
+   by sending a message to ietf-ipr@ietf.org.  The term "informal
+   disclosure" refers to a statement that is provided in a less official
+   manner, such as orally during a presentation, in writing within
+   presentation materials, or posted via email to the relevant
+   discussion list before a presentation.
+
+   Since this document is purely informational, by intent it does not
+   use the conformance language described in [RFC2119].
+
+2.  Background
+
+   The responsibilities of IETF contributors regarding IPR disclosure
+   are documented in [RFC3979] and [RFC4879].  These documents do not
+   assign any further responsibilities to ADs, WG chairs, and WG
+   secretaries, other than those imposed by their roles as contributors
+   or participants.  However, late disclosure of IPR has a direct impact
+   on the effectiveness of working groups, WG chairs, and ADs.
+
+   According to [RFC2418], WG chairs are responsible for "making forward
+   progress through a fair and open process" and ADs are responsible for
+   "ensuring that working groups in their area produce ... timely
+   output"; in addition, because WG chairs can appoint one or more WG
+
+
+
+
+Polk & Saint-Andre            Informational                     [Page 4]
+
+RFC 6702                     IPR Disclosure                  August 2012
+
+
+   secretaries to help them with the day-to-day business of running the
+   working group (see [RFC2418]), some of the actions suggested in this
+   document might fall to WG secretaries.
+
+   IPR disclosure at the earliest possible time is an essential feature
+   of a "fair and open process", and late disclosure can impede timely
+   output since it can cause the WG to revisit previous decisions,
+   needlessly revise technical specifications, and face the prospect of
+   appeals.  To better fulfill their responsibilities in the IETF
+   Standards Process, ADs, WG chairs, and WG secretaries might wish to
+   adopt strategies to encourage early disclosure consistent with the
+   responsibilities established in [RFC3979] and [RFC4879], such as the
+   strategies described in this document.
+
+3.  Strategies for Working Group Documents
+
+   Building upon the framework provided in [RFC3669], this section
+   identifies opportunities to promote IPR disclosure within the
+   document lifecycle for IETF working group documents.  These
+   opportunities are typically encountered during initial public
+   discussion, working group adoption, WGLC, and IETF Last Call.  WG
+   chairs might also want to make WG participants aware of the
+   importance of IPR disclosure more generally, as exemplified by the
+   sample message provided under Appendix A.1.
+
+   The strategies described in this section are primarily implemented by
+   WG chairs.  (The exceptions are strategies for IETF Last Call, which
+   would be implemented by ADs.)  In cases where the WG secretary
+   creates meeting agendas or initiates consensus calls, the secretary
+   might also implement these strategies.
+
+3.1.  Presenting an Internet-Draft at an IETF Meeting
+
+   The first opportunity to encourage early IPR disclosure might occur
+   even before a technical proposal becomes a working group document.
+
+   When IETF participants wish to promote public discussion of a
+   personal draft in hopes of future adoption by a working group, one
+   common strategy is to request a slot on the agenda at an upcoming
+   face-to-face meeting.  Before the community commits resources to
+   reviewing and considering the draft, it is very reasonable for the WG
+   chairs to confirm (often via email) that all IPR disclosures have
+   been submitted.  The chairs ought to request confirmation from each
+   of the authors and listed contributors, especially if those
+   individuals are associated with multiple organizations.
+
+
+
+
+
+
+Polk & Saint-Andre            Informational                     [Page 5]
+
+RFC 6702                     IPR Disclosure                  August 2012
+
+
+   If the necessary disclosures have not been submitted, the chairs have
+   a choice: deny the agenda slot unless formal IPR disclosure
+   statements are submitted, or insist on informal disclosure.  One
+   factor in this decision could be the number of revisions that have
+   occurred: the chairs might wish to permit presentation of a -00 draft
+   with informal disclosure, but not after a draft has gone through
+   multiple revision cycles.  If informal disclosure is allowed, the
+   chairs ought to make sure that the disclosure is documented in the
+   minutes, and ought to encourage submission of formal disclosure
+   statements after the meeting.
+
+   In some cases, an IETF participant has not yet submitted an Internet-
+   Draft but might still request a slot on the agenda to discuss a
+   proposal for a new draft, or a new feature for an existing working
+   group document.  Here again, it is very reasonable for the WG chairs
+   to confirm, before approving the agenda slot, that all IPR claims
+   have been disclosed (likely in an informal manner as described above,
+   since the participant has not yet made a Contribution as defined by
+   the Internet Standards Process [RFC3979]).
+
+   A sample message of the kind that might be sent at this stage is
+   provided under Appendix A.2.
+
+3.2.  Requesting WG Adoption
+
+   When a technical proposal is considered for adoption by a working
+   group, the chairs have an opportunity to confirm (or reconfirm) IPR
+   compliance with authors and listed contributors.  In addition, the
+   chairs might wish to explicitly ask the WG participants if anyone is
+   aware of IPR that is associated with the proposal.
+
+   A sample message of the kind that might be sent at this stage is
+   provided under Appendix A.3.
+
+3.3.  Requesting WG Last Call
+
+   Working Group Last Call is a particularly significant milestone for a
+   working group document, measuring consensus within the working group
+   one final time.  If IPR disclosure statements have not been
+   submitted, the judgement of consensus by the chairs would be less
+   than reliable because it would be based on incomplete assumptions.
+   Even if procedures such as those described above have been
+   implemented to promote IPR disclosure during initial public
+   discussion and adoption, features might have evolved in a way that
+   introduces new IPR concerns.  In addition, new participants with
+   knowledge of IPR claims might have become active in the working
+   group.  Therefore, the WG chairs might wish to reconfirm with each of
+   the authors and listed contributors that appropriate IPR disclosure
+
+
+
+Polk & Saint-Andre            Informational                     [Page 6]
+
+RFC 6702                     IPR Disclosure                  August 2012
+
+
+   statements have been filed, even if they all work for the same
+   organization.  The chairs might also wish to include a reminder about
+   the importance of IPR disclosures in any WGLC message communicated to
+   the working group.  (Note: If IPR disclosure statements have been
+   filed, the chairs might wish to include a link in the WGLC message to
+   ensure that the consensus call reflects this information.)
+
+   A sample message of the kind that might be sent at this stage is
+   provided under Appendix A.4.
+
+3.4.  AD Review
+
+   After successfully completing WGLC, a working group document is
+   forwarded to the appropriate area director for AD review, with a
+   request that the AD process the document for publication as an RFC.
+   Such a publication request is accompanied by a Document Shepherd
+   Write-Up as required by [RFC4858] using the template found at
+   <http://www.ietf.org/iesg/template/doc-writeup.html>.  At the time of
+   this writing, the template asks the document shepherd to answer the
+   following question:
+
+      (7) Has each author confirmed that any and all appropriate IPR
+      disclosures required for full conformance with the provisions of
+      BCP 78 and BCP 79 have already been filed?  If not, explain why.
+
+   Shepherds ought to be asking authors that question directly.
+   Additionally, the AD can ask the WG chairs whether they took explicit
+   action to promote disclosure of IPR.
+
+   If the answer to the write-up question is not favorable, or if the
+   chairs did not take any of the actions listed above, the AD might
+   choose to contact the authors and listed contributors to confirm that
+   the appropriate IPR disclosure statements have been filed before
+   advancing the document through the publication process.
+
+   A sample message of the kind that might be sent at this stage is
+   provided under Appendix A.5.
+
+3.5.  IETF Last Call
+
+   IETF Last Call is the mechanism used by the AD and the IESG as a
+   whole to gauge IETF-wide consensus.  It is critical that the
+   community have easy access to all related IPR statements when
+   considering an Internet-Draft.  The current tools automatically
+   include the URL for each IPR statement explicitly linked to the draft
+   when the default IETF Last Call message is generated.  If the AD
+   edits this message, the links to IPR disclosure statements ought to
+   be preserved.
+
+
+
+Polk & Saint-Andre            Informational                     [Page 7]
+
+RFC 6702                     IPR Disclosure                  August 2012
+
+
+4.  Strategies for Individual Submissions
+
+   This section identifies opportunities to promote IPR disclosure
+   within the IETF document lifecycle for documents that are processed
+   outside the context of a working group (so-called "individual
+   submissions").  In general, these opportunities are encountered
+   during initial public discussion, area director review, and IETF
+   Last Call.
+
+4.1.  Presenting an Internet-Draft at an IETF Meeting
+
+   When IETF participants wish to promote public discussion of a
+   personal draft not intended for a working group, it is still common
+   to request a slot on the agenda at an upcoming face-to-face meeting.
+   These requests might be made to related working groups or area
+   meetings, or even during plenary time.  Before the community commits
+   resources to reviewing and considering the draft, it is very
+   reasonable for the chairs of that meeting (WG chair, AD, IESG chair,
+   or IAB chair) to confirm that all IPR disclosures have been
+   submitted.
+
+   The meeting chairs ought to request confirmation from each of the
+   authors and listed contributors, especially if those individuals are
+   associated with multiple organizations.  Where the presentation
+   covers a concept that has not yet been documented as an Internet-
+   Draft, the chairs ought to at least request informal disclosure from
+   the authors and listed contributors, as described above.
+
+   A sample message of the kind that might be sent at this stage is
+   provided under Appendix A.2.
+
+4.2.  AD Review
+
+   When considering the possibility of sponsoring an individual
+   submission, an AD ought to confirm that all IPR disclosures have been
+   submitted.  The AD ought to require confirmation from each of the
+   authors and listed contributors, even if those individuals are
+   associated with the same organization.  As with WG documents, a
+   Document Shepherd Write-Up is also required for AD-sponsored
+   documents, following the template at
+   <http://www.ietf.org/iesg/template/individual-doc-writeup.html>.  At
+   the time of this writing, the template asks the document shepherd to
+   answer the following question:
+
+      (7) Has each author confirmed that any and all appropriate IPR
+      disclosures required for full conformance with the provisions of
+      BCP 78 and BCP 79 have already been filed?  If not, explain why.
+
+
+
+
+Polk & Saint-Andre            Informational                     [Page 8]
+
+RFC 6702                     IPR Disclosure                  August 2012
+
+
+   A sample message of the kind that might be sent at this stage is
+   provided under Appendix A.6.
+
+4.3.  IETF Last Call
+
+   As with working group documents, IETF Last Call is the mechanism used
+   by the AD and the IESG as a whole to gauge IETF-wide consensus.  It
+   is critical that the community have easy access to all related IPR
+   statements when considering an Internet-Draft.  The current tools
+   automatically include the URL for each IPR statement explicitly
+   linked to the draft when the default IETF Last Call message is
+   generated.  If the AD edits this message, the links to IPR disclosure
+   statements ought to be preserved.
+
+5.  A Note about Preliminary Disclosures
+
+   Early disclosures are not necessarily complete disclosures.  Indeed,
+   [RFC3979] can be read as encouraging "preliminary disclosure" (e.g.,
+   when a new patent application is made), yet a preliminary disclosure
+   might not be updated as new information becomes available later in
+   the standardization process (e.g., when a patent is actually
+   granted).  To help prevent early IPR disclosures from becoming stale
+   or incomplete, at important junctures in the standardization process
+   (e.g., at working group adoption, before Working Group Last Call, and
+   before IETF Last Call) WG chairs and ADs are encouraged to request
+   that the Executive Director of the IETF contact those who submitted
+   early IPR disclosures about updating their disclosures.
+
+6.  Conclusions
+
+   WG chairs and ADs are not expected to enforce IPR disclosure rules,
+   and this document does not suggest that they take on such a role.
+   However, lack of compliance with IPR disclosure policies can have a
+   significant impact on the Internet Standards Process.  To support the
+   efficient development of IETF standards and avoid unnecessary delays,
+   WG chairs and ADs are encouraged to look for opportunities to promote
+   awareness and compliance with the IETF's IPR policies.  The
+   strategies in this document promote compliance by raising the
+   question of IPR disclosure at critical junctures in the
+   standardization process.
+
+7.  Security Considerations
+
+   This document suggests strategies for promoting compliance with IPR
+   disclosure rules during the IETF Standards Process.  These procedures
+   do not have a direct impact on the security of the Internet.
+
+
+
+
+
+Polk & Saint-Andre            Informational                     [Page 9]
+
+RFC 6702                     IPR Disclosure                  August 2012
+
+
+8.  References
+
+8.1.  Normative References
+
+   [RFC3979]  Bradner, S., Ed., "Intellectual Property Rights in IETF
+              Technology", BCP 79, RFC 3979, March 2005.
+
+   [RFC4879]  Narten, T., "Clarification of the Third Party Disclosure
+              Procedure in RFC 3979", BCP 79, RFC 4879, April 2007.
+
+8.2.  Informative References
+
+   [RFC1602]  Internet Architecture Board and Internet Engineering
+              Steering Group, "The Internet Standards Process --
+              Revision 2", RFC 1602, March 1994.
+
+   [RFC2026]  Bradner, S., "The Internet Standards Process --
+              Revision 3", BCP 9, RFC 2026, October 1996.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2418]  Bradner, S., "IETF Working Group Guidelines and
+              Procedures", BCP 25, RFC 2418, September 1998.
+
+   [RFC3669]  Brim, S., "Guidelines for Working Groups on Intellectual
+              Property Issues", RFC 3669, February 2004.
+
+   [RFC4858]  Levkowetz, H., Meyer, D., Eggert, L., and A. Mankin,
+              "Document Shepherding from Working Group Last Call to
+              Publication", RFC 4858, May 2007.
+
+   [RFC5378]  Bradner, S., Ed., and J. Contreras, Ed., "Rights
+              Contributors Provide to the IETF Trust", BCP 78, RFC 5378,
+              November 2008.
+
+   [RFC5741]  Daigle, L., Ed., Kolkman, O., Ed., and IAB, "RFC Streams,
+              Headers, and Boilerplates", RFC 5741, December 2009.
+
+   [RFC6701]  Farrel, A. and P. Resnick, "Sanctions Available for
+              Application to Violators of IETF IPR Policy", RFC 6701,
+              August 2012.
+
+
+
+
+
+
+
+
+
+Polk & Saint-Andre            Informational                    [Page 10]
+
+RFC 6702                     IPR Disclosure                  August 2012
+
+
+Appendix A.  Sample Messages
+
+   This section provides sample messages of the kind that ADs, WG
+   chairs, and WG secretaries can send to meeting presenters, document
+   authors, document editors, listed contributors, and working groups
+   during various stages of the Internet Standards Process.  The
+   messages use a hypothetical working group called the "FOO WG",
+   hypothetical WG chairs named "Alice" and "Bob", a hypothetical author
+   named "Nigel Throckmorton", a hypothetical AD named "Christopher",
+   and hypothetical documents about a hypothetical technology called
+   "wiffle"; any resemblance to actual working groups, WG chairs, ADs,
+   or documents is strictly coincidental.  The last two messages might
+   be appropriate for sending to individuals who have requested a slot
+   on the agenda during an IETF meeting or who have requested AD
+   sponsorship of an individual submission.
+
+A.1.  General WG Reminder
+
+   Subject: Reminder about IETF IPR Policy
+
+   Dear FOO WG:
+
+   As FOO WG chairs, we would like to minimize or hopefully even
+   eliminate late disclosures relating to documents under consideration
+   within the FOO WG.  Therefore, you might see us send "reminder"
+   messages in the future to authors or to the FOO WG email list as a
+   whole, asking people whether they know of Intellectual Property
+   Rights (IPR) relating to specific documents.  In order to comply with
+   IETF processes and avoid unnecessary delays, document authors and
+   contributors to our discussions in the FOO WG are asked to pay
+   careful attention to these messages and to reply in a timely fashion.
+
+   Please note that these messages are only reminders of existing IETF
+   policy, and we are all bound by that policy even in the absence of
+   such reminder messages.  Everyone who participates in the Internet
+   Standards Process (whether by posting to IETF mailing lists,
+   authoring documents, attending IETF meetings, or in other ways) needs
+   to be aware of the IETF rules with regard to IPR.  These rules are
+   described in BCP 79 and can be referenced through
+   <http://www.ietf.org/ipr/policy.html>.  In addition, online tools for
+   filing IPR disclosures can be found at
+   <http://www.ietf.org/ipr/file-disclosure>.  Finally, existing
+   disclosures can be searched online at
+   <https://datatracker.ietf.org/ipr/search/>.
+
+
+
+
+
+
+
+Polk & Saint-Andre            Informational                    [Page 11]
+
+RFC 6702                     IPR Disclosure                  August 2012
+
+
+   Also note that these are personal requirements applying to all IETF
+   participants as individuals, and that these requirements also apply
+   to all participants in the FOO WG.
+
+   Thanks,
+
+   Alice and Bob
+
+   (as FOO WG co-chairs)
+
+A.2.  Reminder to Meeting Presenter
+
+   Subject: IPR about draft-throckmorton-wiffle-bar
+
+   Dear Nigel,
+
+   I have received your request to give a talk about
+   draft-throckmorton-wiffle-bar at the next IETF meeting.  Before
+   approving this request, I would like to check whether there are any
+   claims of Intellectual Property Rights (IPR) on this document.
+
+   Are you aware of any IPR that applies to
+   draft-throckmorton-wiffle-bar?  If so, has this IPR been disclosed in
+   compliance with IETF IPR rules?  (See RFCs 3979, 4879, 3669, and 5378
+   for more details.)
+
+   Please reply to this email regardless of whether or not you are
+   personally aware of any relevant IPR.  I might not be able to approve
+   your request for a slot on the agenda until I have received a reply
+   from you and any listed contributor.
+
+   Online tools for filing IPR disclosures can be found at
+   <http://www.ietf.org/ipr/file-disclosure>.
+
+   Thanks,
+
+   Alice
+
+   (as FOO WG co-chair)
+
+
+
+
+
+
+
+
+
+
+
+
+Polk & Saint-Andre            Informational                    [Page 12]
+
+RFC 6702                     IPR Disclosure                  August 2012
+
+
+A.3.  Reminder before WG Adoption of an Individual Internet-Draft
+
+   Subject: Reminder about IPR relating to draft-throckmorton-foo-wiffle
+
+   Dear FOO WG, and Especially Authors and Contributors:
+
+   As you can see from the consensus call the WG chairs have sent out,
+   the authors have asked for draft-throckmorton-foo-wiffle to be
+   considered for adoption as a WG document.  We would like to check
+   whether there are claims of Intellectual Property Rights (IPR) on the
+   document that need to be disclosed.
+
+   Are you personally aware of any IPR that applies to
+   draft-throckmorton-foo-wiffle?  If so, has this IPR been disclosed in
+   compliance with IETF IPR rules?  (See RFCs 3979, 4879, 3669, and 5378
+   for more details.)
+
+   If you are a document author or listed contributor on this document,
+   please reply to this email message regardless of whether or not you
+   are personally aware of any relevant IPR.  We might not be able to
+   advance this document to the next stage until we have received a
+   reply from each author and listed contributor.
+
+   If you are on the FOO WG email list but are not an author or listed
+   contributor for this document, you are reminded of your opportunity
+   for a voluntary IPR disclosure under BCP 79.  Please do not reply
+   unless you want to make such a voluntary disclosure.
+
+   Online tools for filing IPR disclosures can be found at
+   <http://www.ietf.org/ipr/file-disclosure>.
+
+   Thanks,
+
+   Alice
+
+   (as FOO WG co-chair)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Polk & Saint-Andre            Informational                    [Page 13]
+
+RFC 6702                     IPR Disclosure                  August 2012
+
+
+A.4.  Reminder before Working Group Last Call
+
+   Subject: Reminder about IPR relating to draft-ietf-foo-wiffle
+
+   Dear FOO WG:
+
+   The authors of draft-ietf-foo-wiffle have asked for a Working Group
+   Last Call.  Before issuing the Working Group Last Call, we would like
+   to check whether any claims of Intellectual Property Rights (IPR) on
+   the document have not yet been disclosed.
+
+   Are you personally aware of any IPR that applies to
+   draft-ietf-foo-wiffle?  If so, has this IPR been disclosed in
+   compliance with IETF IPR rules?  (See RFCs 3979, 4879, 3669, and 5378
+   for more details.)
+
+   If you are a document author or listed contributor on this document,
+   please reply to this email regardless of whether or not you are
+   personally aware of any relevant IPR.  We might not be able to
+   advance this document to the next stage until we have received a
+   reply from each author and listed contributor.
+
+   If you are on the FOO WG email list but are not an author or listed
+   contributor for this document, you are reminded of your opportunity
+   for a voluntary IPR disclosure under BCP 79.  Please do not reply
+   unless you want to make such a voluntary disclosure.
+
+   Online tools for filing IPR disclosures can be found at
+   <http://www.ietf.org/ipr/file-disclosure>.
+
+   Thanks,
+
+   Bob
+
+   (as FOO WG co-chair)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Polk & Saint-Andre            Informational                    [Page 14]
+
+RFC 6702                     IPR Disclosure                  August 2012
+
+
+A.5.  Reminder to Authors and Listed Contributors of a Working Group
+      Document before IETF Last Call
+
+   Subject: Reminder about IPR relating to draft-ietf-foo-wiffle
+
+   Dear Authors and Contributors (Chairs and Shepherd cc'd),
+
+   Before proceeding with your request to issue an IETF Last Call on
+   draft-ietf-foo-wiffle, I would like to check whether there are any
+   claims of Intellectual Property Rights (IPR) on the document.
+
+   Are you personally aware of any IPR that applies to
+   draft-ietf-foo-wiffle?  If so, has this IPR been disclosed in
+   compliance with IETF IPR rules?  (See RFCs 3979, 4879, 3669, and 5378
+   for more details.)
+
+   Please reply to this email regardless of whether or not you are
+   personally aware of any relevant IPR.  I might not be able to advance
+   this document to the next stage until I have received a reply from
+   you and any listed contributor.
+
+   Online tools for filing IPR disclosures can be found at
+   <http://www.ietf.org/ipr/file-disclosure>.
+
+   Thanks,
+
+   Christopher
+
+   (as AD)
+
+A.6.  Reminder to Author of an Individual Submission before IETF
+      Last Call
+
+   Subject: Reminder about IPR relating to draft-throckmorton-wiffle-bar
+
+   Dear Nigel,
+
+   Before proceeding with your request for AD sponsoring of
+   draft-throckmorton-wiffle-bar, I would like to check whether there
+   are any claims of Intellectual Property Rights (IPR) on the document.
+
+   Are you personally aware of any IPR that applies to
+   draft-throckmorton-wiffle-bar?  If so, has this IPR been disclosed in
+   compliance with IETF IPR rules?  (See RFCs 3979, 4879, 3669, and 5378
+   for more details.)
+
+
+
+
+
+
+Polk & Saint-Andre            Informational                    [Page 15]
+
+RFC 6702                     IPR Disclosure                  August 2012
+
+
+   Please reply to this email regardless of whether or not you are
+   personally aware of any relevant IPR.  I might not be able to advance
+   this document to the next stage until I have received a reply from
+   you and any listed contributor.
+
+   Online tools for filing IPR disclosures can be found at
+   <http://www.ietf.org/ipr/file-disclosure>.
+
+   Thanks,
+
+   Christopher
+
+   (as AD)
+
+Appendix B.  Acknowledgements
+
+   Thanks to Scott Brim, Stewart Bryant, Benoit Claise, Adrian Farrel,
+   Stephen Farrell, Russ Housley, Subramanian Moonesamy, Thomas Narten,
+   Pete Resnick, and Stephan Wenger for their feedback; to Loa
+   Andersson, Ross Callon, and George Swallow for drafts of some of the
+   sample email messages; and to Stephen Farrell for shepherding the
+   document.
+
+Authors' Addresses
+
+   Tim Polk
+   National Institute of Standards and Technology
+   100 Bureau Drive, MS 8930
+   Gaithersburg, MD  20899-8930
+   USA
+
+   EMail: tim.polk@nist.gov
+
+
+   Peter Saint-Andre
+   Cisco Systems, Inc.
+   1899 Wynkoop Street, Suite 600
+   Denver, CO  80202
+   USA
+
+   Phone: +1-303-308-3282
+   EMail: psaintan@cisco.com
+
+
+
+
+
+
+
+
+
+Polk & Saint-Andre            Informational                    [Page 16]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6702.txt](<www.ietf.org/rfc/rfc6702.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
