### PR TITLE
Archive rfc6755.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6755.txt
+++ b/www.ietf.org/rfc/rfc6755.txt
@@ -1,0 +1,283 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                       B. Campbell
+Request for Comments: 6755                           Ping Identity Corp.
+Category: Informational                                    H. Tschofenig
+ISSN: 2070-1721                                   Nokia Siemens Networks
+                                                            October 2012
+
+
+                  An IETF URN Sub-Namespace for OAuth
+
+Abstract
+
+   This document establishes an IETF URN Sub-namespace for use with
+   OAuth-related specifications.
+
+Status of This Memo
+
+   This document is not an Internet Standards Track specification; it is
+   published for informational purposes.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Not all documents
+   approved by the IESG are a candidate for any level of Internet
+   Standard; see Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6755.
+
+Copyright Notice
+
+   Copyright (c) 2012 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+
+Campbell & Tschofenig         Informational                     [Page 1]
+
+RFC 6755           An IETF URN Sub-Namespace for OAuth      October 2012
+
+
+Table of Contents
+
+   1. Introduction ....................................................2
+   2. Registration Template ...........................................2
+      2.1. Example Registration Request ...............................3
+   3. Security Considerations .........................................3
+   4. IANA Considerations .............................................3
+      4.1. IETF URN Sub-Namespace Registration urn:ietf:params:oauth ..4
+   5. References ......................................................4
+      5.1. Normative References .......................................4
+      5.2. Informative Reference ......................................4
+   Appendix A.  Acknowledgements ......................................5
+
+1.  Introduction
+
+   Various extensions and companion specifications to the OAuth 2.0
+   Authorization Framework [OAUTH-V2] utilize URIs to identify the
+   extension in use or other relevant context.  This document creates
+   and registers an IETF URN Sub-namespace, as documented in RFC 3553
+   [RFC3553], for use with such specifications.  The new 'oauth' Sub-
+   namespace is urn:ietf:params:oauth, and OAuth relevant parameters
+   will be established underneath it.
+
+2.  Registration Template
+
+   If a registrant wishes to have an OAuth URI registered, then a URN of
+   the form urn:ietf:params:oauth:<value> will be requested where
+   <value> is a suitable representation of the functionality or concept
+   being registered.
+
+   The registration procedure for new entries requires a request in the
+   form of the following template and is "Specification Required" per
+   RFC 5226 [RFC5226].
+
+   URN:
+      The URI that identifies the registered functionality.
+
+   Common Name:
+      The name by which the functionality being registered is generally
+      known.
+
+   Change Controller:  For Standards Track RFCs, state "IETF".  For
+      others, give the name of the responsible party.  Other details
+      (e.g., postal address, email address, and home page URI) may also
+      be included.
+
+
+
+
+
+
+Campbell & Tschofenig         Informational                     [Page 2]
+
+RFC 6755           An IETF URN Sub-Namespace for OAuth      October 2012
+
+
+   Specification Document(s):  Reference to the document that specifies
+      the URI, preferably including a URI that can be used to retrieve a
+      copy of the document.  An indication of the relevant sections may
+      also be included but is not required.
+
+   The registration request for the urn:ietf:params:oauth URN Sub-
+   namespace is found in the IANA Considerations section of this
+   document (Section 4).
+
+2.1.  Example Registration Request
+
+   The following is an example registration request for a URI underneath
+   the urn:ietf:params:oauth Sub-namespace.  The requested URI
+   represents a new OAuth 2.0 grant type.
+
+   This is a request to IANA to please register the value
+   "grant-type:example" in the registry urn:ietf:params:oauth
+   established in an IETF URN Sub-namespace for OAuth.
+
+   o  URN: urn:ietf:params:oauth:grant-type:example
+
+   o  Common Name: An Example Grant Type for OAuth 2.0
+
+   o  Change controller: IETF
+
+   o  Specification Document: [the document URI]
+
+3.  Security Considerations
+
+   There are no additional security considerations beyond those already
+   inherent to using URNs.  Security considerations for URNs in general
+   can be found in RFC 2141 [RFC2141].
+
+   Any work that is related to OAuth would benefit from familiarity with
+   the security considerations of the OAuth 2.0 Authorization Framework
+   [OAUTH-V2].
+
+4.  IANA Considerations
+
+   IANA has created the following:
+
+   o  The registration of a new IANA URN Sub-namespace,
+      urn:ietf:params:oauth:, per RFC 3553 [RFC3553].  The registration
+      request can be found in Section 4.1 below.
+
+   o  A new registry called the "OAuth URI" registry for URNs
+      subordinate to urn:ietf:params:oauth.  The registry "OAuth URI"
+      has been added to a new top-level registry called "OAuth
+
+
+
+Campbell & Tschofenig         Informational                     [Page 3]
+
+RFC 6755           An IETF URN Sub-Namespace for OAuth      October 2012
+
+
+      Parameters" as defined by [OAUTH-V2].  Instructions for a
+      registrant to request the registration of such a URN are in
+      Section 2.
+
+4.1.  IETF URN Sub-Namespace Registration urn:ietf:params:oauth
+
+   Per RFC 3553 [RFC3553], IANA has registered a new URN Sub-namespace,
+   urn:ietf:params:oauth.
+
+   o  Registry name: oauth
+
+   o  Specification: [this document]
+
+   o  Repository: [The registry created in Section 2.]
+
+   o  Index value: values subordinate to urn:ietf:params:oauth are of
+      the form urn:ietf:params:oauth:<value> with <value> as the index
+      value.  It is suggested that <value> include both a "class" and an
+      "identifier-within-class" component, with the two components being
+      separated by a colon (":"); other compositions of the <value> may
+      also be used.
+
+5.  References
+
+5.1.  Normative References
+
+   [RFC2141]   Moats, R., "URN Syntax", RFC 2141, May 1997.
+
+   [RFC3553]   Mealling, M., Masinter, L., Hardie, T., and G. Klyne, "An
+               IETF URN Sub-namespace for Registered Protocol
+               Parameters", BCP 73, RFC 3553, June 2003.
+
+   [RFC5226]   Narten, T. and H. Alvestrand, "Guidelines for Writing an
+               IANA Considerations Section in RFCs", BCP 26, RFC 5226,
+               May 2008.
+
+5.2.  Informative Reference
+
+   [OAUTH-V2]  Hardt, D., "The OAuth 2.0 Authorization Framework", Work
+               in Progress, July 2012.
+
+
+
+
+
+
+
+
+
+
+
+Campbell & Tschofenig         Informational                     [Page 4]
+
+RFC 6755           An IETF URN Sub-Namespace for OAuth      October 2012
+
+
+Appendix A.  Acknowledgements
+
+   The authors thank the following for their helpful contributions:
+   Stephen Farrell, Barry Leiba, Peter Saint-Andre, Eran Hammer, John
+   Bradley, Ben Campbell, and Michael B. Jones.
+
+Authors' Addresses
+
+   Brian Campbell
+   Ping Identity Corp.
+
+   EMail: brian.d.campbell@gmail.com
+
+
+   Hannes Tschofenig
+   Nokia Siemens Networks
+
+   EMail: hannes.tschofenig@gmx.net
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Campbell & Tschofenig         Informational                     [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6755.txt](<www.ietf.org/rfc/rfc6755.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
