### PR TITLE
Archive rfc6756.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6756.txt
+++ b/www.ietf.org/rfc/rfc6756.txt
@@ -1,0 +1,899 @@
+
+
+
+
+
+
+Internet Architecture Board (IAB)                     S. Trowbridge, Ed.
+Request for Comments: 6756                                Alcatel-Lucent
+Obsoletes: 3356                                             E. Lear, Ed.
+Category: Informational                                    Cisco Systems
+ISSN: 2070-1721                                          G. Fishman, Ed.
+                                               Pearlfisher International
+                                                         S. Bradner, Ed.
+                                                      Harvard University
+                                                          September 2012
+
+
+                  Internet Engineering Task Force and
+       International Telecommunication Union - Telecommunication
+            Standardization Sector Collaboration Guidelines
+
+Abstract
+
+   This document provides guidance to aid in the understanding of
+   collaboration on standards development between the Telecommunication
+   Standardization Sector of the International Telecommunication Union
+   (ITU-T) and the Internet Engineering Task Force (IETF) of the
+   Internet Society (ISOC).  It is an update of and obsoletes RFC 3356.
+   The updates reflect changes in the IETF and ITU-T since RFC 3356 was
+   written.  The bulk of this document is common text with ITU-T A
+   Series Supplement 3 (07/2012).
+
+   Note: This was approved by TSAG on 4 July 2012 as Supplement 3 to the
+   ITU-T A-Series of Recommendations.
+
+Status of This Memo
+
+   This document is not an Internet Standards Track specification; it is
+   published for informational purposes.
+
+   This document is a product of the Internet Architecture Board (IAB)
+   and represents information that the IAB has deemed valuable to
+   provide for permanent record.  It represents the consensus of the
+   Internet Architecture Board (IAB).  Documents approved for
+   publication by the IAB are not a candidate for any level of Internet
+   Standard; see Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6756.
+
+
+
+
+
+
+
+Trowbridge, et al.            Informational                     [Page 1]
+
+RFC 6756         IETF and ITU-T Collaboration Guidelines  September 2012
+
+
+Copyright Notice
+
+   Copyright (c) 2012 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Trowbridge, et al.            Informational                     [Page 2]
+
+RFC 6756         IETF and ITU-T Collaboration Guidelines  September 2012
+
+
+Table of Contents
+
+   1. Introduction and Scope ..........................................4
+   2. Guidance on Collaboration .......................................5
+      2.1. How to Interact on ITU-T or IETF Work Items ................5
+           2.1.1. How the ITU-T Is Informed about Existing
+                  IETF Work Items .....................................6
+           2.1.2. How the IETF Is Informed about Existing
+                  ITU-T Work Items ....................................6
+           2.1.3. How the ITU-T Is Informed about Proposed New
+                  IETF Work Items .....................................6
+           2.1.4. How the IETF Is Informed about ITU-T Work Items .....7
+      2.2. Representation .............................................7
+           2.2.1. IETF Recognition at ITU-T ...........................7
+           2.2.2. ITU-T Recognition at ISOC/IETF ......................7
+      2.3. Communication outside of Meetings ..........................8
+      2.4. Mailing Lists ..............................................8
+      2.5. Document Sharing ...........................................9
+           2.5.1. Contributions and Liaison Statements from
+                  the IETF to ITU-T ...................................9
+           2.5.2. Contributions and Liaison Statements from
+                  the ITU-T to IETF ..................................10
+           2.5.3. ITU-T and IETF .....................................10
+      2.6. Simple Cross Referencing ..................................11
+      2.7. Preliminary Work Efforts ..................................11
+      2.8. Additional Items ..........................................11
+           2.8.1. IETF Information That May Be Useful to
+                  ITU-T Participants .................................11
+           2.8.2. ITU-T Information That May Be Useful to
+                  IETF Participants ..................................12
+   3. Security Considerations ........................................13
+   4. Acknowledgements ...............................................13
+   5. References .....................................................13
+      5.1. Normative References ......................................13
+      5.2. Informative References ....................................14
+   6. Changes since RFC 3356 .........................................15
+   7. IAB Members at the Time of Approval ............................15
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Trowbridge, et al.            Informational                     [Page 3]
+
+RFC 6756         IETF and ITU-T Collaboration Guidelines  September 2012
+
+
+1.  Introduction and Scope
+
+   This document provides non-normative guidance to aid in the
+   understanding of collaboration on standards development between the
+   Telecommunication Standardization Sector of the International
+   Telecommunication Union (ITU-T) and the Internet Engineering Task
+   Force (IETF) of the Internet Society (ISOC).  Early identification of
+   topics of mutual interest will allow for constructive efforts between
+   the two organizations based on mutual respect.
+
+   In the IETF, work is done in working groups (WGs), mostly through
+   open, public mailing lists rather than face-to-face meetings.  WGs
+   are organized into areas, each area being managed by two co-area
+   directors.  Collectively, the area directors comprise the Internet
+   Engineering Steering Group (IESG).
+
+   In the ITU-T, work is defined by study Questions which are worked on
+   mostly through meetings led by rapporteurs (these are sometimes
+   called "rapporteur's group" meetings).  Questions are generally
+   grouped within working parties (WPs) led by a WP chairman.  Working
+   parties report to a parent study group (SG) led by an SG chairman.
+   Work may also be conducted in ITU-T focus groups (see Section 2.7).
+
+   To foster ongoing communication between the ITU-T and IETF, it is
+   important to identify and establish contact points within each
+   organization.  Contact points may include:
+
+   1. ITU-T Study Group Chairman and IETF Area Director
+
+      An IETF area director is the individual responsible for overseeing
+      a major focus of activity with a scope similar to that of an ITU-T
+      study group chairman.  These positions are both relatively long-
+      term (of several years) and offer the stability of contact points
+      between the two organizations for a given topic.
+
+   2. ITU-T Rapporteur and IETF Working Group Chair
+
+      An IETF working group chair is an individual who is assigned to
+      lead the work on a specific task within one particular area with a
+      scope similar to that of an ITU-T rapporteur.  These positions are
+      working positions (of a year or more) that typically end when the
+      work on a specific topic ends.  Collaboration here is very
+      beneficial to ensure the actual work gets done.
+
+
+
+
+
+
+
+
+Trowbridge, et al.            Informational                     [Page 4]
+
+RFC 6756         IETF and ITU-T Collaboration Guidelines  September 2012
+
+
+   3. Other Contact Points
+
+      It may be beneficial to establish additional contact points for
+      specific topics of mutual interest.  These contact points should
+      be established early in the work effort, and in some cases the
+      contact point identified by each organization may be the same
+      individual.  ITU-T has an additional level of management, the
+      working party chairman.  From time to time, it may be beneficial
+      for this person to exchange views with IETF working group chairs
+      and area directors.
+
+   Note: The current list of IETF area directors and working group
+   chairs can be found in the IETF working group charters.  The current
+   ITU-T study group chairmen and rapporteurs are listed on the ITU-T
+   study group web pages.
+
+2.  Guidance on Collaboration
+
+   This section describes how the existing processes within the IETF and
+   ITU-T may be utilized to enable collaboration between the
+   organizations.
+
+2.1.  How to Interact on ITU-T or IETF Work Items
+
+   Study groups that have identified work topics that are related to the
+   Internet Protocol (IP) should evaluate the relationship with topics
+   defined in the IETF. Current IETF working groups and their charters
+   (IETF definition of the scope of work) are listed in the IETF
+   archives (see Section 2.8.1).
+
+   A study group may decide that development of a Recommendation on a
+   particular topic may benefit from collaboration with the IETF.  The
+   study group should identify this collaboration in its work plan
+   (specifically in that of each Question involved), describing the goal
+   of the collaboration and its expected outcome.
+
+   An IETF working group should also evaluate and identify areas of
+   relationship with the ITU-T and document the collaboration with the
+   ITU-T study group in its charter.
+
+   The following sections outline a process that can be used to enable
+   each group to be informed about the other's new work items.
+
+
+
+
+
+
+
+
+
+Trowbridge, et al.            Informational                     [Page 5]
+
+RFC 6756         IETF and ITU-T Collaboration Guidelines  September 2012
+
+
+2.1.1.  How the ITU-T Is Informed about Existing IETF Work Items
+
+   The responsibility is on individual study groups to review the
+   current IETF working groups to determine if there are any topics of
+   mutual interest.  Working group charters and active Internet-Drafts
+   can be found on the IETF web site (http://datatracker.ietf.org/wg/).
+   If a study group identifies a common area of work, the study group
+   leadership should contact both the IETF working group chair and the
+   area director(s) responsible.  This may be accompanied by a formal
+   liaison statement (see Section 2.3).
+
+2.1.2.  How the IETF Is Informed about Existing ITU-T Work Items
+
+   The IETF through its representatives will review the current work of
+   the various study groups from time to time.  Each ITU-T study group's
+   web page on the ITU-T web site contains its current list of Questions
+   as well as its current work programme.  When an area or working group
+   identifies a common area of work, the matter is referred to
+   appropriate working group chairs and area directors, where they may
+   consider sending a liaison statement to the appropriate study group.
+
+2.1.3.  How the ITU-T Is Informed about Proposed New IETF Work Items
+
+   The IETF maintains a mailing list for the distribution of proposed
+   new work items among standards development organizations.  Many such
+   items can be identified in proposed Birds-of-a-Feather (BOF)
+   sessions, as well as draft charters for working groups.  The IETF
+   forwards all such draft charters for all new and revised working
+   groups and BOF session announcements to the IETF new-work mailing
+   list.  An ITU-T mailing list is subscribed to this list. Leadership
+   of study groups may subscribe to this ITU-T mailing list, which is
+   maintained by the Telecommunication Standardization Bureau (TSB).
+   Members of the SG-specific listname may include the SG chairman, SG
+   vice-chairmen, working party chairmen, concerned rapporteurs, other
+   experts designated by the SG, and the SG Counsellor.  This will
+   enable the SGs to monitor the new work items for possible overlap or
+   interest to their study group.  It is expected that this mailing list
+   will see a few messages per month.
+
+   Each SG chairman, or designated representative, may provide comments
+   on these charters by responding to the IESG mailing list at
+   iesg@ietf.org clearly indicating their ITU-T position and the nature
+   of their concern.  Plain-text email is preferred on the IESG mailing
+   list.
+
+   It should be noted that the IETF turnaround time for new working
+   group charters can be as short as two weeks.  As a result, the
+   mailing list should be consistently monitored.
+
+
+
+Trowbridge, et al.            Informational                     [Page 6]
+
+RFC 6756         IETF and ITU-T Collaboration Guidelines  September 2012
+
+
+2.1.4.  How the IETF Is Informed about ITU-T Work Items
+
+   The ITU-T accepts new areas of work through the creation or update of
+   Questions and these can be found on the ITU-T study group web pages.
+   In addition, the ITU-T work programme is documented on each ITU-T
+   study group's web page on the ITU-T web site.
+
+   Study groups send updates to the IETF new-work mailing list as new
+   Questions are first drafted or created, terms of reference for
+   Questions are first drafted or updated, or otherwise when there is
+   reason to believe that a particular effort might be of interest to
+   the IETF.  Area directors or WG chairs should provide comments
+   through liaison statements or direct email to the relevant SG
+   chairman in cases of possible overlap or interest.
+
+2.2.  Representation
+
+   ISOC, including its standards body IETF, is a Sector Member of the
+   ITU-T.  As a result, ISOC delegates are afforded the same rights as
+   other ITU-T Sector Members (see Section 2.2.1).  Conversely, ITU-T
+   delegates may participate in the work of the IETF as representatives
+   of the ITU-T (see Section 2.2.2).  To promote collaboration, it is
+   useful to facilitate communication between the organizations as
+   further described below.
+
+2.2.1.  IETF Recognition at ITU-T
+
+   Experts and representatives from the IETF that are chosen by IETF
+   leadership normally participate in ITU-T meetings as ISOC delegates.
+   The ISOC focal point will facilitate registration and verification of
+   these people, as appropriate.
+
+2.2.2.  ITU-T Recognition at ISOC/IETF
+
+   ITU-T study group chairmen can authorize one or more members to
+   attend an IETF meeting as an official ITU-T delegate speaking
+   authoritatively on behalf of the activities of the study group (or a
+   particular rapporteur group).  The study group chairman sends the
+   ITU-T list of delegates by email to the working group chair, with a
+   copy to the area directors, and also to the study group.  According
+   to IETF process, opinions expressed by any such delegate are given
+   equal weight with opinions expressed by any other working group
+   participant.
+
+
+
+
+
+
+
+
+Trowbridge, et al.            Informational                     [Page 7]
+
+RFC 6756         IETF and ITU-T Collaboration Guidelines  September 2012
+
+
+2.3.  Communication outside of Meetings
+
+   Informal communication between contact points and experts of both
+   organizations is encouraged.  However, formal communication from an
+   ITU-T study group, working party, or rapporteur group to an
+   associated IETF contact point must be explicitly approved and
+   identified as coming from the study group, working party, or
+   rapporteur group, respectively.  Formal liaison statements from the
+   ITU-T to the IETF are transmitted according to the procedures
+   described in RFC 4053 [2].  These liaison statements are placed by
+   the IETF onto a liaison statements web page at
+   https://datatracker.ietf.org/liaison/.  An individual at the IETF is
+   assigned responsibility for dealing with each liaison statement that
+   is received.  The name and contact information of the responsible
+   person and any applicable deadline is listed with the links to the
+   liaison statement on this web page.
+
+   Formal liaison statements from the Internet Architecture Board (IAB),
+   the IESG, the IETF, an IETF working group or area to the ITU-T are
+   generated, approved, and transmitted according to the procedures
+   described in RFC 4053 [2] and Recommendation ITU-T A.1 [15].  Formal
+   communication is intended to allow the sharing of positions between
+   the IETF and the ITU-T outside of actual documents (as described in
+   Section 2.5.1).  This covers such things as comments on documents and
+   requests for input.
+
+2.4.  Mailing Lists
+
+   All IETF working groups and all ITU-T study group Questions have
+   associated mailing lists.
+
+   In the IETF, the mailing list is the primary vehicle for discussion
+   and decision-making.  It is recommended that the ITU-T experts
+   interested in particular IETF working group topics subscribe to and
+   participate in these lists.  IETF WG mailing lists are open to all
+   subscribers.  The IETF working group mailing list subscription and
+   archive information are noted in each working group's charter.  In
+   the ITU-T, the TSB has set up formal mailing lists for Questions,
+   working parties, and other topics within study groups (more detail
+   can be found on the ITU-T web site).  These mailing lists are
+   typically used for ITU-T correspondence, including technical
+   discussion, meeting logistics, reports, etc.
+
+   Note: Individual subscribers to this list must be affiliated with an
+   ITU-T member or associate (at this time, there is no blanket
+   inclusion of all IETF participants as members, however, as a member,
+   the ISOC focal point can facilitate access by IETF technical experts,
+   liaison representatives, or liaison managers).
+
+
+
+Trowbridge, et al.            Informational                     [Page 8]
+
+RFC 6756         IETF and ITU-T Collaboration Guidelines  September 2012
+
+
+   IETF participants may subscribe to ITU-T focus group email lists if
+   they are individuals from a country that is a member of ITU-T.
+
+2.5.  Document Sharing
+
+   During the course of ITU-T and IETF collaboration, it is important to
+   share working drafts and documents among the technical working
+   groups.  Initially proposed concepts and specifications typically can
+   be circulated by email (often just repeating the concept and not
+   including the details of the specification) on both the IETF and
+   ITU-T mailing lists.  In addition, working texts (or URLs) of draft
+   Recommendations, Internet-Drafts, or RFCs may also be sent between
+   the organizations as described below.
+
+   Internet-Drafts are available on the IETF web site.  The ITU-T can
+   make selected ITU-T documents at any stage of development available
+   to the IETF by attaching them to a formal liaison statement.
+   Although a communication can point to a URL where a non-ASCII
+   document (e.g., Word) can be downloaded, attachments in proprietary
+   formats to an IETF mailing list are discouraged.  It should also be
+   recognized that the official versions of all IETF documents are in
+   ASCII.
+
+2.5.1.  Contributions and Liaison Statements from the IETF to ITU-T
+
+   IETF documents (e.g., Internet-Drafts) or URLs of those documents are
+   most commonly transmitted to ITU-T study groups as liaison statements
+   (see RFC 4053 [2]), but exceptionally can be submitted to a study
+   group as a contribution from ISOC in accordance with Recommendation
+   ITU-T A.2 [16].  In order to ensure that the IETF has properly
+   authorized this, the IETF working group must agree that the specific
+   drafts are of mutual interest; that there is a benefit in forwarding
+   them to the ITU-T for review, comment, and potential use; and that
+   the document status is accurately represented in the cover letter.
+   Once agreed, the appropriate area directors review the working group
+   request and give approval.  The rules of the IETF Trust are followed
+   in these circumstances [3].  The contributions are then forwarded
+   (with the noted approval) to the TSB for circulation as a
+   contribution to the appropriate ITU-T study group.  Material
+   submitted to the ITU-T as an ISOC contribution is governed by clause
+   3.1.5 of Recommendation ITU-T A.1 [15].  Any such contribution will
+   be made only after receiving necessary approval of owners of the work
+   in question.  In other circumstances, a liaison statement may be
+   appropriate.  See RFC 5378 [3] and Recommendation ITU-T A.1 [15] for
+   more information.
+
+
+
+
+
+
+Trowbridge, et al.            Informational                     [Page 9]
+
+RFC 6756         IETF and ITU-T Collaboration Guidelines  September 2012
+
+
+2.5.2.  Contributions and Liaison Statements from the ITU-T to IETF
+
+   An ITU-T study group or working party may send texts of draft new or
+   revised Recommendations, clearly indicating their status, to the IETF
+   as contributions in the form of liaison statements or Internet-
+   Drafts.  Internet-Drafts are IETF temporary documents that expire six
+   months after being published.  The study group or working party must
+   decide that there is a benefit in forwarding them to the IETF for
+   review, comment, and potential use.  Terms of reference for
+   rapporteur group meetings may authorize rapporteur groups to send
+   working documents, in the form of Internet-Drafts, to the IETF.
+
+   If the study group or working party elects to transmit the text as an
+   Internet-Draft, the document editor would be instructed to prepare
+   the contribution in Internet-Draft format (in ASCII and optionally
+   postscript format as per RFC 2223 [8]) and upload it via
+   https://datatracker.ietf.org/idst/upload.cgi.  Material submitted as
+   an Internet-Draft or intended for inclusion in an Internet-Draft or
+   RFC is governed by the rules set forth in RFCs 5378 [3], 3979 [4],
+   and 4879 [5].  Alternatively, the study group, working party, or
+   rapporteur group could attach the text to a formal liaison statement.
+
+   Both the rapporteur and the document editor should be identified as
+   contacts in the contribution.  The document should also clearly
+   indicate the state of development in a particular ITU-T study group.
+
+   Note: Liaison statements and their attachments sent to the IETF are
+   made publicly available on the IETF web site.
+
+2.5.3.  ITU-T and IETF
+
+   It is envisaged that the processes of Sections 2.5.1 and 2.5.2 will
+   often be used simultaneously by both an IETF working group and an
+   ITU-T study group to collaborate on a topic of mutual interest.
+
+   It is also envisaged that the outcome of the collaboration will be
+   the documentation in full by one body and its referencing by the
+   other (see Section 2.6 for details).  That is, common or joint text
+   is discouraged because of the current differences in procedures for
+   document approval and revision.  Where complementary work is being
+   undertaken in both organizations that will result in Recommendations
+   or RFCs, due allowance should be given to the differing perspectives,
+   working methods, and procedures of the two organizations.  That is,
+   each organization should understand the other organization's
+   procedures and strive to respect them in the collaboration.
+
+
+
+
+
+
+Trowbridge, et al.            Informational                    [Page 10]
+
+RFC 6756         IETF and ITU-T Collaboration Guidelines  September 2012
+
+
+2.6.  Simple Cross Referencing
+
+   Recommendation ITU-T A.5 [6] describes the process for including
+   references to documents of other organizations in ITU-T
+   Recommendations.  Recommendation ITU-T A.5 also addresses the
+   situation where a study group or working party decides to incorporate
+   the text of another organization into the text of a Recommendation,
+   rather than referencing it.  Information specific to referencing IETF
+   RFCs is found at http://itu.int/ITU-T/go/ref-ietf-isoc.
+
+   Section 6.1.1 of RFC 2026 [7] describes the process for referencing
+   other open standards (like ITU-T Recommendations) in IETF RFCs.
+
+2.7.  Preliminary Work Efforts
+
+   Both ITU-T and IETF provide mechanisms for early discussion of
+   potential new work areas prior to the official start of work in an
+   ITU-T study group or creation of an IETF working group.
+
+   Objectives, methods, and procedures for the creation and operation of
+   ITU-T focus groups are defined in Recommendation ITU-T A.7 [17].
+   Focus groups are frequently created in new work areas where there is
+   a need for deliverables to be produced on a specific topic within a
+   short timeframe.  IETF participants who are not members or associates
+   of ITU-T may participate fully in the work of ITU-T focus groups if
+   they are from a country that is a member of ITU-T.
+
+   In the IETF, guidance for BOF sessions is provided in RFC 5434 [13].
+   Efforts that have not yet reached the working group stage may be
+   discussed in BOF sessions.  These sessions typically gauge interest
+   in pursuing creation of working groups.  In some cases, these
+   discussions continue on mailing lists.
+
+2.8.  Additional Items
+
+2.8.1.  IETF Information That May Be Useful to ITU-T Participants
+
+   Information on IETF procedures may be found in the documents in the
+   informative references, and URLs below.
+
+   Note: RFCs do not change after they are published.  Rather, they are
+   either obsoleted or updated by other RFCs.  Such updates are tracked
+   in the rfc-index.txt file.
+
+   Current list and status of all IETF RFCs:
+      ftp://ftp.ietf.org/rfc/rfc-index.txt
+
+
+
+
+
+Trowbridge, et al.            Informational                    [Page 11]
+
+RFC 6756         IETF and ITU-T Collaboration Guidelines  September 2012
+
+
+   Current list and description of all IETF Internet-Drafts:
+      ftp://ftp.ietf.org/internet-drafts/1id-abstracts.txt
+
+   Current list of IETF working groups and their Charters: (includes
+   area directors and chair contacts, mailing list information, etc.)
+      http://www.ietf.org/dyn/wg/charter.html
+
+   Current list of registered BOFs
+      http://trac.tools.ietf.org/bof/trac/
+
+   RFC Editor pages about publishing RFCs, including available tools and
+   lots of guidance:
+      http://www.rfc-editor.org/pubprocess.html
+
+   Current list of liaison statements:
+      https://datatracker.ietf.org/liaison/
+
+   IETF Intellectual Property Rights Policy and Notices:
+      http://www.ietf.org/ipr/
+
+   The Tao of the IETF - A Novice's Guide to the Internet Engineering
+   Task Force:
+      http://www.ietf.org/tao.html
+
+2.8.2.  ITU-T Information That May Be Useful to IETF Participants
+
+   Information about the ITU-T can be found in the informative
+   references and at the URLs below.
+
+   ITU-T Main page:
+      http://itu.int/ITU-T
+
+   List of all ITU-T Recommendations:
+      http://itu.int/itu-t/recommendations/
+
+   ITU-T study group main page for Study Group NN (where NN is the
+   2-digit SG number):
+      http://itu.int/ITU-T/studygroups/comNN/
+
+   Intellectual Property policies, forms, and databases:
+      http://itu.int/en/ITU-T/ipr/Pages/default.aspx
+
+   Current list of active ITU-T focus Groups
+      http://itu.int/en/ITU-T/focusgroups/Pages/default.aspx
+
+
+
+
+
+
+
+Trowbridge, et al.            Informational                    [Page 12]
+
+RFC 6756         IETF and ITU-T Collaboration Guidelines  September 2012
+
+
+   ITU-T Procedures including:
+      WTSA Resolution 1, Rules of procedure of the ITU Telecommunication
+      Standardization Sector (ITU-T)
+      WTSA Resolution 2, Study Group responsibility and mandates
+      http://itu.int/publ/T-RES/en
+
+   Author's Guide for drafting ITU-T Recommendations:
+      http://itu.int/ITU-T/go/author-guide
+
+   Templates for contributions, ITU-T Recommendations, and liaison
+   statements:
+      http://itu.int/ITU-T/studygroups/templates/index.html
+
+3.  Security Considerations
+
+   Documents that describe cooperation procedures, like this one does,
+   have no direct Internet security implications.
+
+4.  Acknowledgements
+
+   This document is based on the text from RFCs 2436 and 3356 [10] and
+   benefited greatly from discussions during the January 2012 ITU-T
+   Telecommunication Standardization Advisory Group (TSAG) meeting.
+
+5.  References
+
+5.1.  Normative References
+
+   [1]   Daigle, L., Ed., and Internet Architecture Board, "IAB
+         Processes for Management of IETF Liaison Relationships", BCP
+         102, RFC 4052, April 2005.
+
+   [2]   Trowbridge, S., Bradner, S., and F. Baker, "Procedures for
+         Handling Liaison Statements to and from the IETF", BCP 103, RFC
+         4053, April 2005.
+
+   [3]   Bradner, S., Ed., and J. Contreras, Ed., "Rights Contributors
+         Provide to the IETF Trust", BCP 78, RFC 5378, November 2008.
+
+   [4]   Bradner, S., Ed., "Intellectual Property Rights in IETF
+         Technology", BCP 79, RFC 3979, March 2005.
+
+   [5]   Narten, T., "Clarification of the Third Party Disclosure
+         Procedure in RFC 3979", BCP 79, RFC 4879, April 2007.
+
+   [6]   Recommendation ITU-T A.5 (2008), Generic procedures for
+         including references to documents of other organizations in
+         ITU-T Recommendations, International Telecommunication Union.
+
+
+
+Trowbridge, et al.            Informational                    [Page 13]
+
+RFC 6756         IETF and ITU-T Collaboration Guidelines  September 2012
+
+
+5.2.  Informative References
+
+   [7]   Bradner, S., "The Internet Standards Process -- Revision 3",
+         BCP 9, RFC 2026, October 1996.
+
+   [8]   Postel, J. and J. Reynolds, "Instructions to RFC Authors", RFC
+         2223, October 1997.
+
+   [9]   Brett, R., Bradner, S., and G. Parsons, "Collaboration between
+         ISOC/IETF and ITU-T", RFC 2436, October 1998.
+
+   [10]  Fishman, G. and S. Bradner, "Internet Engineering Task Force
+         and International Telecommunication Union - Telecommunications
+         Standardization Sector Collaboration Guidelines", RFC 3356,
+         August 2002.
+
+   [11]  Hovey, R. and S. Bradner, "The Organizations Involved in the
+         IETF Standards Process", BCP 11, RFC 2028, October 1996.
+
+   [12]  Bradner, S., "IETF Working Group Guidelines and Procedures",
+         BCP 25, RFC 2418, September 1998.
+
+   [13]  Narten, T., "Considerations for Having a Successful Birds-of-a-
+         Feather (BOF) Session", RFC 5434, February 2009.
+
+   [14]  Alvestrand, H., "A Mission Statement for the IETF", BCP 95, RFC
+         3935, October 2004.
+
+   [15]  Recommendation ITU-T A.1 (2008), Work methods for study groups
+         of the ITU Telecommunication Standardization Sector (ITU-T),
+         International Telecommunication Union.
+
+   [16]  Recommendation ITU-T A.2 (2008), Presentation of contributions
+         to the ITU-T, International Telecommunication Union.
+
+   [17]  Recommendation ITU-T A.7 (2008), Focus groups: Working methods
+         and procedures, International Telecommunication Union.
+
+   [18]  Recommendation ITU-T A.8 (2008), Alternative approval process
+         for new and revised ITU-T Recommendations, International
+         Telecommunication Union.
+
+
+
+
+
+
+
+
+
+
+Trowbridge, et al.            Informational                    [Page 14]
+
+RFC 6756         IETF and ITU-T Collaboration Guidelines  September 2012
+
+
+6.  Changes since RFC 3356
+
+   The introduction has been integrated with the scope section.
+
+   Additional information has been added about copyright and IPR issues.
+
+   Authorization of liaison managers and liaison representatives from
+   IETF to ITU-T are updated per current IETF procedures documented in
+   [1].
+
+   Transmission of formal liaison statements between ITU-T and IETF are
+   updated per current IETF procedures documented in [2].
+
+   Description is added of preliminary efforts including ITU-T focus
+   groups and IETF BOFs.  ITU-T focus group participation is not limited
+   to ITU-T members.
+
+   Obsolete URLs in RFC 3356 from both the ITU-T and IETF web sites are
+   updated, more references have been moved to the References section.
+
+7.  IAB Members at the Time of Approval
+
+   Bernard Aboba
+   Jari Arkko
+   Marc Blanchet
+   Ross Callon
+   Alissa Cooper
+   Spencer Dawkins
+   Joel Halpern
+   Russ Housley
+   David Kessens
+   Danny McPherson
+   Jon Peterson
+   Dave Thaler
+   Hannes Tschofenig
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Trowbridge, et al.            Informational                    [Page 15]
+
+RFC 6756         IETF and ITU-T Collaboration Guidelines  September 2012
+
+
+Authors' Addresses
+
+   Steve Trowbridge
+   Alcatel-Lucent
+   5280 Centennial Trail
+   Boulder, CO 80303-1262 USA
+
+   Phone: +1 720 945 6885
+   EMail: steve.trowbridge@alcatel-lucent.com
+
+
+   Eliot Lear
+   Cisco Systems GmbH
+   Richtistrasse 7
+   8304 Wallisellen
+   Switzerland
+
+   Phone: +41 44 878 9200
+   EMail: lear@cisco.com
+
+
+   Gary Fishman
+   Pearlfisher International
+   12 Chestnut Drive
+   Matawan, NJ 07747
+
+   Phone: +1 732 778 9572
+   EMail: gryfishman@aol.com
+
+
+   Scott Bradner
+   Harvard University
+   1 Oxford St.
+   Cambridge, MA 02138
+
+   Phone: +1 617 495 3864
+   EMail: sob@harvard.edu
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Trowbridge, et al.            Informational                    [Page 16]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6756.txt](<www.ietf.org/rfc/rfc6756.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
